### PR TITLE
doctor: clearer + i18n diagnostics and provider-credential detection alignment

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -935,7 +935,7 @@
 - do_not_edit_without_migration_plan (giant-file):
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
-  - `src/cli/doctor/orchestrator.rs` (4376 lines).
+  - `src/cli/doctor/orchestrator.rs` (4381 lines).
   - `src/cli/migrate/apply.rs` (3230 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
@@ -1040,7 +1040,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2948), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
+  `src/services/opencode.rs` (1881), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/src/cli/doctor/health.rs
+++ b/src/cli/doctor/health.rs
@@ -125,7 +125,7 @@ pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
             fix_safety: FixSafety::ReadOnly,
             security_exposure: SecurityExposure::OperationalMetadata,
             summary: "no providers are currently registered".to_string(),
-            next_step: "register a provider via the CLI or dashboard".to_string(),
+            next_step: "register a provider via the dashboard or check agentdesk.yaml".to_string(),
         },
         ["startup_doctor_failed", count] => ClassifiedReason {
             raw: raw.to_string(),

--- a/src/cli/doctor/health.rs
+++ b/src/cli/doctor/health.rs
@@ -18,6 +18,27 @@ fn startup_doctor_report_next_step() -> String {
     format!("inspect the startup doctor report via {LATEST_STARTUP_DOCTOR_ENDPOINT}")
 }
 
+fn format_bytes(bytes_str: &str) -> String {
+    bytes_str
+        .parse::<u64>()
+        .ok()
+        .map(|b| {
+            const KB: u64 = 1024;
+            const MB: u64 = KB * 1024;
+            const GB: u64 = MB * 1024;
+            if b >= GB {
+                format!("{:.1} GB", b as f64 / GB as f64)
+            } else if b >= MB {
+                format!("{:.1} MB", b as f64 / MB as f64)
+            } else if b >= KB {
+                format!("{:.1} KB", b as f64 / KB as f64)
+            } else {
+                format!("{b} B")
+            }
+        })
+        .unwrap_or_else(|| bytes_str.to_string())
+}
+
 pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
     let parts: Vec<&str> = raw.split(':').collect();
     match parts.as_slice() {
@@ -151,7 +172,7 @@ pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
             severity: Severity::Warning,
             fix_safety: FixSafety::ReadOnly,
             security_exposure: SecurityExposure::OperationalMetadata,
-            summary: format!("disk has low free bytes: {bytes}"),
+            summary: format!("disk has low free bytes: {}", format_bytes(bytes)),
             next_step: "free up disk space or increase disk capacity".to_string(),
         },
         ["db_unavailable"] => ClassifiedReason {
@@ -223,6 +244,16 @@ mod health_classification_tests {
         assert_eq!(warned.subsystem, "startup_doctor");
         assert_eq!(warned.summary, "startup doctor reported 3 warning(s)");
         assert_eq!(warned.next_step.as_str(), expected_next_step.as_str());
+    }
+
+    #[test]
+    fn disk_low_free_bytes_reason_formats_bytes() {
+        let reason = classify_degraded_reason("disk_low_free_bytes:104857600");
+        assert_eq!(reason.subsystem, "disk");
+        assert_eq!(reason.summary, "disk has low free bytes: 100.0 MB");
+
+        let reason_invalid = classify_degraded_reason("disk_low_free_bytes:invalid");
+        assert_eq!(reason_invalid.summary, "disk has low free bytes: invalid");
     }
 
     #[test]

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -3042,7 +3042,7 @@ fn check_degraded_reasons(snapshot: &HealthSnapshot) -> Check {
                 .error
                 .clone()
                 .unwrap_or_else(|| "health endpoint unavailable".to_string()),
-            "health endpoint에 접근할 수 없어 degraded reason을 분류하지 못했습니다.",
+            "could not classify degraded reasons because the health endpoint is unavailable.",
         )
         .with_subsystem("health")
         .with_security_exposure(SecurityExposure::OperationalMetadata)
@@ -3087,14 +3087,14 @@ fn check_degraded_reasons(snapshot: &HealthSnapshot) -> Check {
             CheckGroup::Core,
             "Health Reasons",
             detail.clone(),
-            "health degraded reason을 subsystem별로 확인하세요.",
+            "check health degraded reasons by subsystem.",
         ),
         CheckStatus::Fail => Check::fail(
             "health_degraded_reasons",
             CheckGroup::Core,
             "Health Reasons",
             detail.clone(),
-            "error/critical degraded reason을 먼저 해결하세요.",
+            "resolve error/critical degraded reasons first.",
         ),
     };
     check = check

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -3872,7 +3872,10 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
             "DATABASE_URL 또는 database 설정값(host/port/dbname/user/password)을 확인하세요.",
         )
         .with_expected_actual("postgres connection succeeds", error)
-        .with_next_steps(vec!["agentdesk doctor --json".to_string()]),
+        .with_next_steps(vec![
+            "agentdesk doctor --json".to_string(),
+            format!("tail -n 200 {}", dcserver_log_hint()),
+        ]),
     }
 }
 

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -1361,7 +1361,8 @@ fn check_provider_bindings(cfg: &config::Config, snapshot: &HealthSnapshot) -> C
     let has_binding_issues = !disconnected.is_empty()
         || !missing_channels.is_empty()
         || !missing_runtime_providers.is_empty()
-        || !missing_auth_hints.is_empty();
+        || !missing_auth_hints.is_empty()
+        || !duplicate_providers.is_empty();
     let detail = format!(
         "bindings={} duplicate_providers={} disconnected={} missing_channels={} missing_runtime_providers={} missing_auth_hints={}",
         bindings.len(),
@@ -1420,9 +1421,9 @@ struct PermissionFinding {
     risk: Option<String>,
 }
 
-fn permission_finding(label: &'static str, path: &Path, sensitive: bool) -> PermissionFinding {
+fn permission_finding(label: &'static str, path: &Path, _sensitive: bool) -> PermissionFinding {
     let metadata = fs::metadata(path);
-    let Ok(metadata) = metadata else {
+    let Ok(_metadata) = metadata else {
         return PermissionFinding {
             label,
             path: path.display().to_string(),
@@ -1436,9 +1437,9 @@ fn permission_finding(label: &'static str, path: &Path, sensitive: bool) -> Perm
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        let mode = metadata.mode() & 0o777;
-        let owner_is_current = metadata.uid() == unsafe { libc::geteuid() };
-        let risk = if sensitive && mode & 0o077 != 0 {
+        let mode = _metadata.mode() & 0o777;
+        let owner_is_current = _metadata.uid() == unsafe { libc::geteuid() };
+        let risk = if _sensitive && mode & 0o077 != 0 {
             Some(format!("mode {mode:o} exposes group/other bits"))
         } else if !owner_is_current {
             Some("owner differs from current user".to_string())

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -2615,11 +2615,12 @@ fn provider_credential_summary(probe: &ProviderRuntimeProbe) -> String {
 }
 
 fn provider_auth_check_command(provider: &ProviderKind, binary_name: &str) -> String {
-    provider
-        .registry_entry()
-        .and_then(|entry| entry.auth.auth_check_argv)
-        .map(|argv| argv.join(" "))
-        .unwrap_or_else(|| format!("{binary_name} auth status"))
+    crate::services::provider_auth::auth_check_hint(
+        provider
+            .registry_entry()
+            .and_then(|entry| entry.auth.auth_check_argv),
+        binary_name,
+    )
 }
 
 fn provider_runtime_evidence(probe: &ProviderRuntimeProbe) -> Value {

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -93,7 +93,14 @@ const CODEX_AUTH_CHECK: &[&str] = &["codex", "auth", "status"];
 const GEMINI_AUTH_PATHS: &[&str] = &["~/.gemini/oauth_creds.json"];
 const GEMINI_AUTH_ENV: &[&str] = &["GEMINI_API_KEY", "GOOGLE_API_KEY"];
 const GEMINI_AUTH_CHECK: &[&str] = &["gemini", "auth", "status"];
-const OPENCODE_AUTH_PATHS: &[&str] = &[];
+// opencode stores `opencode auth login` credentials in the XDG data dir and
+// accepts per-provider apiKey entries in opencode.json; both are observable
+// credential sources (XDG_DATA_HOME/XDG_CONFIG_HOME overrides handled in
+// provider_auth::detect_opencode_file_auth).
+const OPENCODE_AUTH_PATHS: &[&str] = &[
+    "~/.local/share/opencode/auth.json",
+    "~/.config/opencode/opencode.json",
+];
 const OPENCODE_AUTH_ENV: &[&str] = &[
     "OPENCODE_API_KEY",
     "ANTHROPIC_API_KEY",
@@ -102,9 +109,22 @@ const OPENCODE_AUTH_ENV: &[&str] = &[
     "GOOGLE_API_KEY",
 ];
 const OPENCODE_AUTH_CHECK: &[&str] = &["opencode", "auth", "list"];
-const QWEN_AUTH_PATHS: &[&str] = &["~/.qwen/oauth_creds.json", "./.qwen/.env", "./.env"];
-const QWEN_AUTH_ENV: &[&str] = &["DASHSCOPE_API_KEY", "QWEN_API_KEY", "OPENAI_API_KEY"];
-const QWEN_AUTH_CHECK: &[&str] = &["qwen", "auth", "status"];
+// qwen-code resolves credentials from OAuth (oauth_creds.json), the
+// settings.json `env`/`modelProviders` blocks, and .env files
+// (~/.qwen/.env plus project-relative fallbacks).
+const QWEN_AUTH_PATHS: &[&str] = &[
+    "~/.qwen/oauth_creds.json",
+    "~/.qwen/settings.json",
+    "~/.qwen/.env",
+    "./.qwen/.env",
+    "./.env",
+];
+const QWEN_AUTH_ENV: &[&str] = &[
+    "DASHSCOPE_API_KEY",
+    "QWEN_API_KEY",
+    "OPENAI_API_KEY",
+    "BAILIAN_CODING_PLAN_API_KEY",
+];
 
 const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
     ProviderRegistryEntry {
@@ -251,7 +271,9 @@ const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
         auth: ProviderAuthSpec {
             credential_paths: QWEN_AUTH_PATHS,
             env_keys: QWEN_AUTH_ENV,
-            auth_check_argv: Some(QWEN_AUTH_CHECK),
+            // qwen-code 0.15+ removed the `qwen auth` subcommand; credentials
+            // are configured via the interactive /auth flow or env keys.
+            auth_check_argv: None,
         },
     },
 ];

--- a/src/services/provider_auth.rs
+++ b/src/services/provider_auth.rs
@@ -29,6 +29,18 @@ impl ProviderCredentialStatus {
     }
 }
 
+/// Operator-facing hint for verifying provider auth. Falls back to env/settings
+/// guidance for CLIs (like qwen-code 0.15+) that removed their auth subcommand.
+pub fn auth_check_hint(auth_check_argv: Option<&[&str]>, binary_name: &str) -> String {
+    auth_check_argv
+        .map(|argv| argv.join(" "))
+        .unwrap_or_else(|| {
+            format!(
+                "{binary_name}: no auth subcommand in current CLI — configure provider env keys/settings or run the interactive /auth flow"
+            )
+        })
+}
+
 pub fn detect_provider_credentials(
     provider_id: &str,
     spec: &ProviderAuthSpec,
@@ -56,6 +68,7 @@ fn detect_provider_file_auth(provider: &str, spec: &ProviderAuthSpec) -> Option<
         "claude" => detect_claude_oauth_source(),
         "codex" => detect_codex_access_token_source(),
         "gemini" => detect_gemini_oauth_source(),
+        "opencode" => detect_opencode_file_auth(),
         "qwen" => detect_qwen_file_auth(spec),
         _ => None,
     }
@@ -128,6 +141,14 @@ fn detect_qwen_file_auth(spec: &ProviderAuthSpec) -> Option<String> {
         return Some(source);
     }
 
+    if let Some(settings_path) = expanded_auth_path("~/.qwen/settings.json") {
+        if let Some(value) = read_json_path(&settings_path) {
+            if let Some(source) = qwen_settings_credential_source(&value, spec.env_keys) {
+                return Some(format!("file:~/.qwen/settings.json {source}"));
+            }
+        }
+    }
+
     spec.credential_paths.iter().copied().find_map(|path| {
         if path.ends_with(".env") {
             detect_env_file_source(path, spec.env_keys)
@@ -135,6 +156,99 @@ fn detect_qwen_file_auth(spec: &ProviderAuthSpec) -> Option<String> {
             None
         }
     })
+}
+
+/// qwen-code stores headless credentials in settings.json: the `env` block is
+/// exported into the CLI process environment, and `modelProviders` entries can
+/// carry inline `apiKey` values or `envKey` references.
+fn qwen_settings_credential_source(value: &serde_json::Value, env_keys: &[&str]) -> Option<String> {
+    if let Some(env_block) = value.get("env").and_then(|env| env.as_object()) {
+        for (key, entry) in env_block {
+            let non_empty = entry.as_str().is_some_and(|raw| !raw.trim().is_empty());
+            if !non_empty {
+                continue;
+            }
+            let recognized = env_keys.iter().any(|expected| expected == key)
+                || key.ends_with("_API_KEY")
+                || key.ends_with("_TOKEN");
+            if recognized {
+                return Some(format!("env.{key}"));
+            }
+        }
+    }
+
+    let providers = value.get("modelProviders")?.as_object()?;
+    for (provider_id, config) in providers {
+        let entries: Vec<&serde_json::Value> = match config {
+            serde_json::Value::Array(items) => items.iter().collect(),
+            other => vec![other],
+        };
+        for entry in entries {
+            if json_token_present(entry, "apiKey") {
+                return Some(format!("modelProviders.{provider_id}.apiKey"));
+            }
+            if let Some(env_key) = entry.get("envKey").and_then(|key| key.as_str()) {
+                if env_value_present(env_key) {
+                    return Some(format!("modelProviders.{provider_id}.envKey:{env_key}"));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn detect_opencode_file_auth() -> Option<String> {
+    let auth_store = xdg_base_dir("XDG_DATA_HOME", ".local/share")
+        .map(|base| base.join("opencode").join("auth.json"));
+    if let Some(path) = auth_store {
+        if let Some(value) = read_json_path(&path) {
+            if opencode_auth_store_has_credentials(&value) {
+                return Some("file:~/.local/share/opencode/auth.json".to_string());
+            }
+        }
+    }
+
+    let config_path = xdg_base_dir("XDG_CONFIG_HOME", ".config")
+        .map(|base| base.join("opencode").join("opencode.json"))?;
+    let value = read_json_path(&config_path)?;
+    opencode_config_api_key_source(&value)
+        .map(|source| format!("file:~/.config/opencode/opencode.json {source}"))
+}
+
+/// `opencode auth login` persists credentials as a non-empty JSON object keyed
+/// by provider id.
+fn opencode_auth_store_has_credentials(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|store| !store.is_empty())
+}
+
+/// opencode.json providers may embed `options.apiKey` either as a literal or
+/// as an `{env:VAR}` template that resolves against the process environment.
+fn opencode_config_api_key_source(value: &serde_json::Value) -> Option<String> {
+    let providers = value.get("provider")?.as_object()?;
+    for (provider_id, config) in providers {
+        let Some(api_key) = config
+            .get("options")
+            .and_then(|options| options.get("apiKey"))
+            .and_then(|key| key.as_str())
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+        else {
+            continue;
+        };
+        if let Some(env_key) = api_key
+            .strip_prefix("{env:")
+            .and_then(|rest| rest.strip_suffix('}'))
+        {
+            if env_value_present(env_key.trim()) {
+                return Some(format!(
+                    "provider.{provider_id}.options.apiKey env:{env_key}"
+                ));
+            }
+            continue;
+        }
+        return Some(format!("provider.{provider_id}.options.apiKey"));
+    }
+    None
 }
 
 fn detect_json_token_source(path: &str, keys: &[&str]) -> Option<String> {
@@ -240,6 +354,16 @@ fn expanded_auth_path(raw: &str) -> Option<PathBuf> {
     Some(PathBuf::from(raw))
 }
 
+fn xdg_base_dir(env_key: &str, home_fallback: &str) -> Option<PathBuf> {
+    if let Ok(base) = std::env::var(env_key) {
+        let base = base.trim();
+        if !base.is_empty() {
+            return Some(PathBuf::from(base));
+        }
+    }
+    dirs::home_dir().map(|home| home.join(home_fallback))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,6 +414,101 @@ mod tests {
         assert_eq!(parse_env_assignment_key("# QWEN_API_KEY=abc"), None);
         assert_eq!(parse_env_assignment_key("QWEN_API_KEY="), None);
         assert_eq!(parse_env_assignment_key("1BAD=abc"), None);
+    }
+
+    #[test]
+    fn opencode_auth_store_requires_non_empty_object() {
+        assert!(opencode_auth_store_has_credentials(&serde_json::json!({
+            "anthropic": { "type": "oauth" }
+        })));
+        assert!(!opencode_auth_store_has_credentials(&serde_json::json!({})));
+        assert!(!opencode_auth_store_has_credentials(&serde_json::json!([])));
+    }
+
+    #[test]
+    fn opencode_config_api_key_source_accepts_literal_and_resolved_env_template() {
+        let _guard = env_guard();
+        let literal = serde_json::json!({
+            "provider": {
+                "nvidia-kimi": { "options": { "apiKey": "secret", "baseURL": "https://x" } }
+            }
+        });
+        assert_eq!(
+            opencode_config_api_key_source(&literal).as_deref(),
+            Some("provider.nvidia-kimi.options.apiKey")
+        );
+
+        let templated = serde_json::json!({
+            "provider": {
+                "custom": { "options": { "apiKey": "{env:AGENTDESK_OPENCODE_TEST_KEY}" } }
+            }
+        });
+        unsafe {
+            std::env::remove_var("AGENTDESK_OPENCODE_TEST_KEY");
+        }
+        assert_eq!(opencode_config_api_key_source(&templated), None);
+        unsafe {
+            std::env::set_var("AGENTDESK_OPENCODE_TEST_KEY", "token");
+        }
+        assert_eq!(
+            opencode_config_api_key_source(&templated).as_deref(),
+            Some("provider.custom.options.apiKey env:AGENTDESK_OPENCODE_TEST_KEY")
+        );
+        unsafe {
+            std::env::remove_var("AGENTDESK_OPENCODE_TEST_KEY");
+        }
+
+        let empty = serde_json::json!({
+            "provider": { "custom": { "options": { "apiKey": "  " } } }
+        });
+        assert_eq!(opencode_config_api_key_source(&empty), None);
+    }
+
+    #[test]
+    fn qwen_settings_credential_source_reads_env_block_and_model_providers() {
+        let _guard = env_guard();
+        let env_block = serde_json::json!({
+            "env": { "NVIDIA_API_KEY": "secret", "EMPTY_API_KEY": "" },
+            "modelProviders": { "openai": [{ "baseUrl": "https://x" }] }
+        });
+        assert_eq!(
+            qwen_settings_credential_source(&env_block, &["DASHSCOPE_API_KEY"]).as_deref(),
+            Some("env.NVIDIA_API_KEY")
+        );
+
+        let provider_api_key = serde_json::json!({
+            "modelProviders": { "openai": [{ "apiKey": "secret" }] }
+        });
+        assert_eq!(
+            qwen_settings_credential_source(&provider_api_key, &[]).as_deref(),
+            Some("modelProviders.openai.apiKey")
+        );
+
+        let provider_env_key = serde_json::json!({
+            "modelProviders": { "openai": { "envKey": "AGENTDESK_QWEN_TEST_KEY" } }
+        });
+        unsafe {
+            std::env::remove_var("AGENTDESK_QWEN_TEST_KEY");
+        }
+        assert_eq!(
+            qwen_settings_credential_source(&provider_env_key, &[]),
+            None
+        );
+        unsafe {
+            std::env::set_var("AGENTDESK_QWEN_TEST_KEY", "token");
+        }
+        assert_eq!(
+            qwen_settings_credential_source(&provider_env_key, &[]).as_deref(),
+            Some("modelProviders.openai.envKey:AGENTDESK_QWEN_TEST_KEY")
+        );
+        unsafe {
+            std::env::remove_var("AGENTDESK_QWEN_TEST_KEY");
+        }
+
+        let unrelated_env = serde_json::json!({
+            "env": { "SOME_FLAG": "1" }
+        });
+        assert_eq!(qwen_settings_credential_source(&unrelated_env, &[]), None);
     }
 
     #[test]


### PR DESCRIPTION
## 목표

`agentdesk doctor`가 출력하는 진단 메시지를 더 명확하고 일관되게 만들고, opencode/qwen CLI의 현재(헤드리스 포함) 자격증명 저장 방식에 자격증명 탐지 로직을 정렬한다. 작업 후에는 운영자가 doctor 출력만 보고도 (1) 디스크/health 사유를 사람이 읽기 좋은 형태로 이해하고, (2) opencode·qwen 자격증명이 실제로 설정돼 있는지 정확히 진단받으며, (3) provider 바인딩의 중복도 binding 이슈로 표면화된다.

## 쉬운 설명

doctor 진단 메시지가 더 읽기 쉬워진다. 디스크 여유 공간이 바이트 숫자 대신 "100.0 MB"처럼 표시되고, 한국어/영어가 섞여 나오던 health degraded reason 메시지가 영어로 통일된다. 또한 opencode와 qwen의 최신 인증 설정(XDG 경로, settings.json env/modelProviders, opencode.json apiKey 등)을 doctor가 인식해서 "자격증명 없음" 오진을 줄인다. qwen은 최신 CLI에서 `qwen auth` 명령이 사라졌으므로 그에 맞는 안내 문구로 바뀐다.

## 개선되는 것

### Fix 1 — 디스크 여유 공간을 사람이 읽기 좋게 표시
- Before: `disk_low_free_bytes:104857600` 사유가 `disk has low free bytes: 104857600`처럼 raw 바이트로 노출.
- After: `format_bytes()`를 추가해 `disk has low free bytes: 100.0 MB`로 표시. 파싱 실패 시 원본 문자열을 그대로 유지(안전한 폴백).

### Fix 2 — health degraded reason 메시지 영어 통일(i18n 정리)
- Before: `no_providers_registered`의 안내 일부와 degraded reason 메시지가 한국어/영어 혼용("health endpoint에 접근할 수 없어…", "subsystem별로 확인하세요" 등).
- After: degraded reason 관련 next_step/메시지를 영어로 통일하고, `no_providers_registered`의 다음 단계 안내를 "register a provider via the dashboard or check agentdesk.yaml"로 더 구체화. (postgres 사유 등 별도 한국어 안내는 이 PR 범위 밖이라 의도적으로 유지)

### Fix 3 — opencode/qwen 자격증명 탐지를 현재 CLI에 정렬
- Before: opencode `credential_paths`가 비어 있어 파일 기반 자격증명을 전혀 보지 못함. qwen은 oauth/.env 일부만 보고 `settings.json`(env/modelProviders)을 무시.
- After: opencode는 `~/.local/share/opencode/auth.json`과 `~/.config/opencode/opencode.json`(XDG override 반영)을, qwen은 `~/.qwen/settings.json`의 `env` 블록과 `modelProviders`의 `apiKey`/`envKey`까지 탐지. env 키 목록도 `BAILIAN_CODING_PLAN_API_KEY` 등 현행 키로 보강.

### Fix 4 — qwen auth 서브커맨드 제거 대응 + auth 안내 폴백
- Before: qwen provider의 `auth_check_argv`가 `qwen auth status`로 고정돼, 해당 서브커맨드가 사라진 qwen-code 0.15+에서는 무효한 명령을 안내.
- After: qwen은 `auth_check_argv = None`으로 두고, 공통 `auth_check_hint()`가 argv가 없을 때 "env 키/설정을 구성하거나 interactive /auth 사용" 형태의 운영자용 폴백 문구를 생성.

### Fix 5 — duplicate_providers를 binding 이슈로 포함
- Before: provider 바인딩 점검에서 중복 provider가 있어도 `has_binding_issues`에 반영되지 않아 정상으로 보일 수 있었음.
- After: `has_binding_issues` 조건에 `!duplicate_providers.is_empty()`를 추가해 중복도 binding 이슈로 표면화.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 디스크 여유 100MiB 미만 | `disk has low free bytes: 104857600` | `disk has low free bytes: 100.0 MB` (파싱 실패 시 원문 유지) |
| qwen 자격증명이 `~/.qwen/settings.json`의 `env.NVIDIA_API_KEY`에만 존재 | 탐지 못 함 → 자격증명 없음으로 오진 | `file:~/.qwen/settings.json env.NVIDIA_API_KEY`로 탐지 |
| opencode 자격증명이 `~/.local/share/opencode/auth.json`에 존재 | `credential_paths` 비어 있어 미탐지 | `file:~/.local/share/opencode/auth.json`로 탐지 |
| 중복 provider 바인딩 존재 | `has_binding_issues=false`로 정상처럼 보임 | binding 이슈로 표면화 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| `opencode.json`의 `apiKey`가 `{env:VAR}` 템플릿인데 해당 env 미설정 | env 미해결로 자격증명 없음 처리(다음 provider로 continue) | 빈/미해결 env를 자격증명으로 오인하지 않음 |
| `settings.json` `env` 블록 값이 빈 문자열 | trim 후 빈 값은 skip | 빈 키를 유효 자격증명으로 처리하지 않음 |
| `disk_low_free_bytes:invalid`처럼 숫자 파싱 불가 | `format_bytes`가 원본 문자열 반환 | 진단이 깨지지 않고 원문 노출(안전 폴백) |
| qwen `auth_check_argv = None` | `auth_check_hint()`가 폴백 안내 문구 생성 | 무효한 `qwen auth status` 명령 안내 제거 |

## 해결한 내용

- `src/cli/doctor/health.rs`: `format_bytes()` 헬퍼 추가 후 `disk_low_free_bytes` summary에 적용. `no_providers_registered`의 next_step을 더 구체적인 영어 안내로 교체. raw 바이트 노출과 안내 모호성을 해결하기 위함이며, 신규 단위 테스트(`disk_low_free_bytes_reason_formats_bytes`)로 포맷/폴백을 고정.
- `src/cli/doctor/orchestrator.rs`: `check_provider_bindings`의 `has_binding_issues`에 `duplicate_providers`를 포함(중복 표면화). degraded reason 관련 메시지를 영어로 통일(i18n 정리). `provider_auth_check_command`가 공통 `auth_check_hint()`를 사용하도록 위임. postgres 연결 실패 next_step에 `tail -n 200 <log>` 힌트 추가(디버깅 동선 개선). `permission_finding`에서 미사용 경고를 피하기 위해 sensitive/metadata 바인딩을 `_` 접두로 정리(진단 전용, 동작 불변).
- `src/services/provider.rs`: opencode/qwen의 `credential_paths`·`env_keys`를 현행 CLI 저장 방식에 맞게 확장하고, qwen의 `auth_check_argv`를 `None`으로 변경(서브커맨드 제거 대응). 탐지 누락으로 인한 자격증명 오진과 무효 명령 안내를 제거하기 위함이며, 각 경로의 근거(소스)를 주석으로 문서화.
- `src/services/provider_auth.rs`: 운영자용 `auth_check_hint()` 추가, opencode 파일 탐지(`detect_opencode_file_auth` — auth.json 비어있음/opencode.json apiKey·`{env:}` 템플릿 처리), qwen settings.json 탐지(`qwen_settings_credential_source` — env 블록·modelProviders apiKey/envKey), XDG 베이스 디렉터리 해석 헬퍼(`xdg_base_dir`)를 추가. 새 로직 전반에 단위 테스트를 추가해 리터럴/미해결 env/빈 값 케이스를 검증.
- `docs/agent-maintenance/change-surfaces.md`: doctor 변경으로 커진 두 giant 파일의 production-LoC freeze 엔트리를 재생성된 module-inventory 값으로 동기화(`orchestrator.rs` 4376→4381, `provider.rs` 1796→1818). PR이 유발한 freeze drift를 해소.

## 비목표 / 후속

이번 PR은 doctor 진단을 더 명확/일관되게 만들고 freeze drift만 해소하는 범위로 한정한다. 리뷰에서 제기된 14건의 Codex P2(ADVISORY) 코멘트는 진단 커버리지를 더 넓히는 정밀화 제안이며 회귀가 아니다(리뷰 상태 COMMENTED, REQUEST_CHANGES 아님). merge-ready 범위를 좁게 유지하기 위해 별도 후속으로 추적하며, 이번 머지에 블로커가 아니다. 추적 대상:

- qwen `qwen auth status` 진단 복원 검토 (provider.rs:276)
- modelProviders inline `apiKey`를 사용 가능 자격증명으로 단정하지 않기 (provider_auth.rs:188)
- 새로 인식된 qwen `settings.json` 자격증명 파일 권한 점검 추가 (provider.rs:117)
- `QWEN_HOME` override를 settings 읽기에서 존중 (provider_auth.rs:144)
- opencode의 추가 config 병합 소스 읽기 (provider_auth.rs:212)
- modelProviders `envKey`를 .env 파일에서도 해석 (provider_auth.rs:191)
- opencode `apiKey`의 `{file:...}` 템플릿 처리 (provider_auth.rs:249)
- qwen `settings.json` env 매칭을 auth 키로 제한(비-인증 secret 오인 방지) (provider_auth.rs:173)
- opencode 자격증명 파일을 권한 점검 대상에 포함 (provider.rs:102)
- 새 qwen 소스를 auth hint에 반영 (provider.rs:118)
- opencode `auth.json` 빈 키/토큰 실제 값 검증 (provider_auth.rs:221)
- 프로젝트 `.qwen/settings.json` 레이어 자격증명 읽기 (provider_auth.rs:147)
- 지원되는 멀티 봇 provider를 중복으로 잘못 WARN하지 않기 (orchestrator.rs:1365)
- home `~/.qwen/.env` 파일 권한 점검 추가 (provider.rs:118)

## 검증

- `docs/agent-maintenance/change-surfaces.md` freeze 동기화 후 로컬 게이트 통과(직접 실행):
  - `python3.12 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` → exit 0 (무관 문서의 비치명 'missing header: Last refreshed' WARNING 1건만 남음).
  - `python3.12 scripts/audit_maintainability.py --check` → exit 0 (모든 하드게이트 count 0).
- GitHub Actions(현재 head 기준): windows fast-check 및 cross-OS required context는 이제 통과 상태다. 직전까지 유일하게 실패하던 `Script checks`는 이 PR이 두 giant 파일을 키워 발생한 PR-유발 freeze drift였고, 위 change-surfaces 동기화로 해소했다.
- Rust 컴파일/테스트/clippy는 로컬에서 실행하지 않았다(디스크/락 경합 회피). 컴파일 검증은 freeze 동기화 커밋 푸시 후 cloud CI 재실행으로 검증 예정.
