### PR TITLE
robustness: raise dcserver fd limit, recover poisoned OpenCode locks, consistent worker log fields, reduce reconcile alloc churn

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,24 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-13 (against #3358 round 2 — synthetic-inflight carry-forward now gated on same-generation evidence: `tmux.rs` re-exports the new `committed_frontier_for_current_generation` reader from `tmux_session_files.rs`, which pairs the per-channel committed watermark with the `.generation` mtime wrapper-identity signal so a stale pre-restart frontier cannot clamp a freshly-reset synthetic forward — the content-skip guard; `tui_prompt_relay.rs::synthetic_start_offset_carry_forward` now takes `Option<u64>` where `None` means no clamp. On top of #3089 completion-footer slice — `tmux.rs` suppression exposure tests strip completion-only footer blocks so internal turns still delete cleanly; generated inventory includes `placeholder_live_events/completion_footer.rs`; on top of #3038 run_bot S5 closing pass).
+> Last refreshed: 2026-06-15 (against `main` @ `9594a4d94`).
+>
+> PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
+> row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
+> OpenCode poisoned-lock recovery (`src/services/opencode.rs` now 1886 prod
+> lines); no new logic added to either giant file, the line deltas are
+> bugfix-only. On top of #3358 round 2 — synthetic-inflight carry-forward now
+> gated on same-generation evidence: `tmux.rs` re-exports the new
+> `committed_frontier_for_current_generation` reader from `tmux_session_files.rs`,
+> which pairs the per-channel committed watermark with the `.generation` mtime
+> wrapper-identity signal so a stale pre-restart frontier cannot clamp a
+> freshly-reset synthetic forward — the content-skip guard;
+> `tui_prompt_relay.rs::synthetic_start_offset_carry_forward` now takes
+> `Option<u64>` where `None` means no clamp. On top of #3089 completion-footer
+> slice — `tmux.rs` suppression exposure tests strip completion-only footer
+> blocks so internal turns still delete cleanly; generated inventory includes
+> `placeholder_live_events/completion_footer.rs`; on top of #3038 run_bot S5
+> closing pass.
 
 ## Read This First
 
@@ -963,7 +980,7 @@
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
-  - `src/reconcile.rs` (1821 lines; periodic reconcile loop covering stale
+  - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).
 - active_callsite_coverage: n/a.
@@ -1040,7 +1057,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2948), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (1881), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (1886), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -4,7 +4,14 @@
 > moving any AgentDesk runtime, worker, dispatch, provider, MCP, merge, or test
 > execution path from one dcserver node to multiple nodes.
 >
-> Last refreshed: 2026-06-12 (against #3038 run_bot S5 closing pass).
+> Last refreshed: 2026-06-15 (against `main` @ `9594a4d94`).
+>
+> PR #3456 made the `src/server/worker_registry.rs` worker-lifecycle log fields
+> consistent: every started / stopped / future-exited / self-fenced /
+> supervisor-shutdown tracing event now emits the same structured spec fields
+> (stage, order, restart, shutdown, owner, health, responsibility, notes), so
+> failover/observability correlation across nodes no longer depends on which
+> lifecycle edge logged it.
 
 ## Read This First
 

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1042,11 +1042,28 @@ fn raise_fd_soft_limit(desired: u64) {
         }
         let hard = lim.rlim_max;
         // rlim_max can be RLIM_INFINITY; cap the request at `desired` either way.
-        let target = if hard == libc::RLIM_INFINITY {
+        let hard_capped = if hard == libc::RLIM_INFINITY {
             desired as libc::rlim_t
         } else {
             std::cmp::min(desired as libc::rlim_t, hard)
         };
+        // macOS rejects setrlimit(RLIMIT_NOFILE) with EINVAL when the requested
+        // soft limit exceeds the kernel per-process ceiling (OPEN_MAX, surfaced
+        // via sysconf(_SC_OPEN_MAX), itself derived from kern.maxfilesperproc).
+        // A tmux-inherited soft=256 with an "unlimited" hard limit would push
+        // target=16384 past that ceiling and silently leave the limit at 256.
+        // Clamp to the kernel cap so the raise actually takes effect.
+        #[cfg(target_os = "macos")]
+        let target = {
+            let open_max = libc::sysconf(libc::_SC_OPEN_MAX);
+            if open_max > 0 {
+                std::cmp::min(hard_capped, open_max as libc::rlim_t)
+            } else {
+                hard_capped
+            }
+        };
+        #[cfg(not(target_os = "macos"))]
+        let target = hard_capped;
         if lim.rlim_cur >= target {
             return; // already at or above target
         }

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1024,7 +1024,59 @@ pub fn handle_restart_dcserver(
     }
 }
 
+/// Raise the process file-descriptor soft limit toward `desired`, clamped to
+/// the inherited hard limit. Best-effort: logs and continues on failure so the
+/// server never refuses to start over an rlimit tweak.
+#[cfg(unix)]
+fn raise_fd_soft_limit(desired: u64) {
+    // SAFETY: getrlimit/setrlimit with a valid resource id and a local rlimit
+    // struct; no aliasing or lifetime concerns.
+    unsafe {
+        let mut lim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) != 0 {
+            eprintln!("  ⚠ getrlimit(RLIMIT_NOFILE) failed; leaving fd limit unchanged");
+            return;
+        }
+        let hard = lim.rlim_max;
+        // rlim_max can be RLIM_INFINITY; cap the request at `desired` either way.
+        let target = if hard == libc::RLIM_INFINITY {
+            desired as libc::rlim_t
+        } else {
+            std::cmp::min(desired as libc::rlim_t, hard)
+        };
+        if lim.rlim_cur >= target {
+            return; // already at or above target
+        }
+        let new_lim = libc::rlimit {
+            rlim_cur: target,
+            rlim_max: hard,
+        };
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &new_lim) != 0 {
+            eprintln!(
+                "  ⚠ setrlimit(RLIMIT_NOFILE, {target}) failed; fd limit stays at {}",
+                lim.rlim_cur
+            );
+        } else {
+            eprintln!("  ✓ raised RLIMIT_NOFILE soft limit to {target}");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn raise_fd_soft_limit(_desired: u64) {}
+
 pub fn handle_dcserver(token: Option<String>) {
+    // Raise the file-descriptor soft limit before anything opens fds. A
+    // tmux-launched dcserver otherwise inherits the tmux server's low default
+    // (256 on macOS), which voice STT exhausts during WAV convert / transcript
+    // sidecar reads / foreground process spawn -> "Too many open files (os error
+    // 24)". This makes the limit launch-model independent (works whether started
+    // via launchd, tmux, or directly).
+    raise_fd_soft_limit(16_384);
+
     // Ensure directory structure exists first (needed for lock file)
     if let Some(root) = agentdesk_runtime_root() {
         for subdir in ["config", "credential", "runtime", "logs", "scripts"] {

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -2134,7 +2134,7 @@ mod dispatch_delivery_reconcile_tests {
             classify_delivery_kv_guard_mismatches(
                 &mut stats,
                 &mut mismatches,
-                &DeliveryKvGuardRow {
+                DeliveryKvGuardRow {
                     dispatch_id: format!("dispatch-completed-{status}"),
                     reserving_count: 0,
                     notified_count: 1,
@@ -2155,7 +2155,7 @@ mod dispatch_delivery_reconcile_tests {
             classify_delivery_typed_guard_mismatches(
                 &mut typed_stats,
                 &mut typed_mismatches,
-                &DeliveryTypedGuardRow {
+                DeliveryTypedGuardRow {
                     dispatch_id: format!("dispatch-guardless-{status}"),
                     typed_status: status.to_string(),
                     reserved_until: None,

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -823,15 +823,15 @@ pub(crate) async fn dispatch_delivery_event_reconcile_report_pg(
         if rows.is_empty() {
             break;
         }
-        for row in &rows {
-            stats.kv_reserving_checked += row.reserving_count.max(0) as usize;
-            stats.kv_notified_checked += row.notified_count.max(0) as usize;
-            classify_delivery_kv_guard_mismatches(&mut stats, &mut mismatches, row);
-        }
         if let Some(last_row) = rows.last() {
             cursor.clone_from(&last_row.dispatch_id);
         } else {
             cursor.clear();
+        }
+        for row in rows {
+            stats.kv_reserving_checked += row.reserving_count.max(0) as usize;
+            stats.kv_notified_checked += row.notified_count.max(0) as usize;
+            classify_delivery_kv_guard_mismatches(&mut stats, &mut mismatches, row);
         }
     }
 
@@ -846,14 +846,14 @@ pub(crate) async fn dispatch_delivery_event_reconcile_report_pg(
         if rows.is_empty() {
             break;
         }
-        for row in &rows {
-            stats.typed_events_checked += 1;
-            classify_delivery_typed_guard_mismatches(&mut stats, &mut mismatches, row);
-        }
         if let Some(last_row) = rows.last() {
             cursor.clone_from(&last_row.dispatch_id);
         } else {
             cursor.clear();
+        }
+        for row in rows {
+            stats.typed_events_checked += 1;
+            classify_delivery_typed_guard_mismatches(&mut stats, &mut mismatches, row);
         }
     }
 
@@ -863,14 +863,13 @@ pub(crate) async fn dispatch_delivery_event_reconcile_report_pg(
 fn classify_delivery_kv_guard_mismatches(
     stats: &mut DispatchDeliveryEventReconcileStats,
     mismatches: &mut Vec<DispatchDeliveryEventMismatch>,
-    row: &DeliveryKvGuardRow,
+    row: DeliveryKvGuardRow,
 ) {
     let has_notified = row.notified_count > 0;
     let typed_status = row.typed_status.as_deref();
     if typed_status.is_none() {
         let expected = if has_notified { "sent" } else { "reserved" };
-        let mismatch =
-            DispatchDeliveryEventMismatch::missing_typed(row.dispatch_id.clone(), expected);
+        let mismatch = DispatchDeliveryEventMismatch::missing_typed(row.dispatch_id, expected);
         stats.record_mismatch(&mismatch.kind);
         mismatches.push(mismatch);
         return;
@@ -886,10 +885,8 @@ fn classify_delivery_kv_guard_mismatches(
         {
             return;
         }
-        let mismatch = DispatchDeliveryEventMismatch::notified_status(
-            row.dispatch_id.clone(),
-            row.typed_status.clone(),
-        );
+        let mismatch =
+            DispatchDeliveryEventMismatch::notified_status(row.dispatch_id, row.typed_status);
         stats.record_mismatch(&mismatch.kind);
         mismatches.push(mismatch);
         return;
@@ -899,7 +896,7 @@ fn classify_delivery_kv_guard_mismatches(
 fn classify_delivery_typed_guard_mismatches(
     stats: &mut DispatchDeliveryEventReconcileStats,
     mismatches: &mut Vec<DispatchDeliveryEventMismatch>,
-    row: &DeliveryTypedGuardRow,
+    row: DeliveryTypedGuardRow,
 ) {
     if row.has_reserving || row.has_notified {
         return;
@@ -913,15 +910,13 @@ fn classify_delivery_typed_guard_mismatches(
         {
             return;
         }
-        let mismatch =
-            DispatchDeliveryEventMismatch::missing_kv_meta(row.dispatch_id.clone(), "reserved");
+        let mismatch = DispatchDeliveryEventMismatch::missing_kv_meta(row.dispatch_id, "reserved");
         stats.record_mismatch(&mismatch.kind);
         mismatches.push(mismatch);
     } else if is_completed_delivery_status(status) {
         // A completed delivery (sent/fallback/duplicate/skipped) with no guard
         // key lost its `dispatch_notified:*` dedupe guard; recovery rebuilds it.
-        let mismatch =
-            DispatchDeliveryEventMismatch::missing_kv_meta(row.dispatch_id.clone(), "sent");
+        let mismatch = DispatchDeliveryEventMismatch::missing_kv_meta(row.dispatch_id, "sent");
         stats.record_mismatch(&mismatch.kind);
         mismatches.push(mismatch);
     }
@@ -2080,7 +2075,7 @@ mod dispatch_delivery_reconcile_tests {
         classify_delivery_kv_guard_mismatches(
             &mut stats,
             &mut mismatches,
-            &DeliveryKvGuardRow {
+            DeliveryKvGuardRow {
                 dispatch_id: "dispatch-missing-typed".to_string(),
                 reserving_count: 1,
                 notified_count: 0,
@@ -2091,7 +2086,7 @@ mod dispatch_delivery_reconcile_tests {
         classify_delivery_kv_guard_mismatches(
             &mut stats,
             &mut mismatches,
-            &DeliveryKvGuardRow {
+            DeliveryKvGuardRow {
                 dispatch_id: "dispatch-notified-status".to_string(),
                 reserving_count: 0,
                 notified_count: 1,
@@ -2102,7 +2097,7 @@ mod dispatch_delivery_reconcile_tests {
         classify_delivery_typed_guard_mismatches(
             &mut stats,
             &mut mismatches,
-            &DeliveryTypedGuardRow {
+            DeliveryTypedGuardRow {
                 dispatch_id: "dispatch-typed-only".to_string(),
                 typed_status: "sent".to_string(),
                 reserved_until: None,

--- a/src/server/worker_registry.rs
+++ b/src/server/worker_registry.rs
@@ -39,7 +39,15 @@ fn record_leader_only_worker_started(spec: WorkerSpec) {
         worker = spec.name,
         target = spec.target,
         kind = spec.kind.as_doc_str(),
+        stage = spec.start_stage.as_doc_str(),
+        order = spec.start_order,
+        restart = spec.restart_policy.as_doc_str(),
+        shutdown = spec.shutdown_policy.as_doc_str(),
         execution_scope = spec.execution_scope.as_doc_str(),
+        owner = spec.owner,
+        health = spec.health_owner,
+        responsibility = spec.responsibility,
+        notes = spec.notes,
         "leader-only worker epoch started"
     );
 }
@@ -54,7 +62,15 @@ fn record_leader_only_worker_stopped(spec: WorkerSpec, reason: &str) {
         worker = spec.name,
         target = spec.target,
         kind = spec.kind.as_doc_str(),
+        stage = spec.start_stage.as_doc_str(),
+        order = spec.start_order,
+        restart = spec.restart_policy.as_doc_str(),
+        shutdown = spec.shutdown_policy.as_doc_str(),
         execution_scope = spec.execution_scope.as_doc_str(),
+        owner = spec.owner,
+        health = spec.health_owner,
+        responsibility = spec.responsibility,
+        notes = spec.notes,
         reason,
         "leader-only worker epoch stopped"
     );
@@ -856,7 +872,15 @@ impl SupervisedWorkerRegistry {
                         worker = spec.name,
                         target = spec.target,
                         kind = spec.kind.as_doc_str(),
+                        stage = spec.start_stage.as_doc_str(),
+                        order = spec.start_order,
+                        restart = spec.restart_policy.as_doc_str(),
+                        shutdown = spec.shutdown_policy.as_doc_str(),
                         execution_scope = spec.execution_scope.as_doc_str(),
+                        owner = spec.owner,
+                        health = spec.health_owner,
+                        responsibility = spec.responsibility,
+                        notes = spec.notes,
                         "leader-only worker future exited"
                     );
                 }
@@ -865,7 +889,15 @@ impl SupervisedWorkerRegistry {
                         worker = spec.name,
                         target = spec.target,
                         kind = spec.kind.as_doc_str(),
+                        stage = spec.start_stage.as_doc_str(),
+                        order = spec.start_order,
+                        restart = spec.restart_policy.as_doc_str(),
+                        shutdown = spec.shutdown_policy.as_doc_str(),
                         execution_scope = spec.execution_scope.as_doc_str(),
+                        owner = spec.owner,
+                        health = spec.health_owner,
+                        responsibility = spec.responsibility,
+                        notes = spec.notes,
                         instance_id = cluster_runtime.instance_id(),
                         "leader-only worker self-fenced after cluster leadership was lost"
                     );
@@ -875,7 +907,15 @@ impl SupervisedWorkerRegistry {
                         worker = spec.name,
                         target = spec.target,
                         kind = spec.kind.as_doc_str(),
+                        stage = spec.start_stage.as_doc_str(),
+                        order = spec.start_order,
+                        restart = spec.restart_policy.as_doc_str(),
+                        shutdown = spec.shutdown_policy.as_doc_str(),
                         execution_scope = spec.execution_scope.as_doc_str(),
+                        owner = spec.owner,
+                        health = spec.health_owner,
+                        responsibility = spec.responsibility,
+                        notes = spec.notes,
                         "leader-only worker supervisor shutting down"
                     );
                     break;
@@ -932,7 +972,14 @@ impl SupervisedWorkerRegistry {
             target = spec.target,
             kind = spec.kind.as_doc_str(),
             stage = spec.start_stage.as_doc_str(),
+            order = spec.start_order,
+            restart = spec.restart_policy.as_doc_str(),
+            shutdown = spec.shutdown_policy.as_doc_str(),
             execution_scope = spec.execution_scope.as_doc_str(),
+            owner = spec.owner,
+            health = spec.health_owner,
+            responsibility = spec.responsibility,
+            notes = spec.notes,
             reason,
             "skipping supervised worker"
         );

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -306,11 +306,13 @@ fn drain_startup_output<R>(
                 Err(_) => break,
             };
             let chunk = String::from_utf8_lossy(&buffer[..read]);
-            if let Ok(mut output) = output.lock() {
-                match stream {
-                    StartupStream::Stdout => append_bounded(&mut output.stdout, &chunk),
-                    StartupStream::Stderr => append_bounded(&mut output.stderr, &chunk),
-                }
+            let mut output = output.lock().unwrap_or_else(|e| {
+                tracing::warn!("Recovered poisoned lock for OpenCodeStartupOutput");
+                e.into_inner()
+            });
+            match stream {
+                StartupStream::Stdout => append_bounded(&mut output.stdout, &chunk),
+                StartupStream::Stderr => append_bounded(&mut output.stderr, &chunk),
             }
         }
     });
@@ -329,9 +331,10 @@ fn append_bounded(target: &mut String, chunk: &str) {
 }
 
 fn summarize_startup_output(output: &Arc<Mutex<OpenCodeStartupOutput>>) -> String {
-    let Ok(output) = output.lock() else {
-        return String::new();
-    };
+    let output = output.lock().unwrap_or_else(|e| {
+        tracing::warn!("Recovered poisoned lock for OpenCodeStartupOutput");
+        e.into_inner()
+    });
     let stdout = compact_log_fragment(&output.stdout);
     let stderr = compact_log_fragment(&output.stderr);
     match (stdout.is_empty(), stderr.is_empty()) {
@@ -849,8 +852,10 @@ fn consume_sse(
                         // behaviour. PID is registered via
                         // `register_child_pid` during server startup.
                         if !stop.load(Ordering::Relaxed)
-                            && let Ok(guard) = cancel.child_pid.lock()
-                            && let Some(pid) = *guard
+                            && let Some(pid) = *cancel.child_pid.lock().unwrap_or_else(|e| {
+                                tracing::warn!("Recovered poisoned lock for CancelToken::child_pid in OpenCode watchdog");
+                                e.into_inner()
+                            })
                         {
                             kill_pid_tree(pid);
                         }


### PR DESCRIPTION
## 목표

dcserver 런타임의 견고성을 높이는 4개 영역의 버그픽스를 묶고, 그 과정에서 발생한 빌드 깨짐(E0308)과 유지보수 문서 신선도 게이트 실패를 함께 해소한다. 대상 파일은 `src/cli/dcserver.rs`, `src/reconcile.rs`, `src/server/worker_registry.rs`, `src/services/opencode.rs`다.

## 쉬운 설명

dcserver가 tmux에서 시작될 때 파일 디스크립터 한도가 너무 낮아 음성 STT가 "Too many open files"로 죽는 문제, reconcile 루프의 불필요한 행 복제, OpenCode 락이 오염(poisoned)되면 스타트업 로그 수집이 통째로 멈추는 문제, 워커 생명주기 로그 필드가 이벤트마다 들쭉날쭉한 문제를 한 번에 손봤다. 그 과정에서 reconcile 테스트 호출부가 옛 시그니처(참조 전달)를 그대로 써서 빌드가 깨졌고, macOS에서는 fd 한도 상향이 커널 상한을 넘겨 조용히 무시되는 함정이 있었다. 이 PR은 그 두 가지를 마저 고치고 신선도/감사 게이트를 통과시킨다.

## 개선되는 것

### Fix 1 — dcserver fd soft limit 상향 (macOS 상한 클램프 포함)

- before: tmux가 띄운 dcserver는 tmux 서버의 낮은 기본값(macOS 256)을 상속받아 음성 STT의 WAV 변환/트랜스크립트 사이드카 읽기/포그라운드 프로세스 spawn 중 fd가 고갈되어 `Too many open files (os error 24)`로 실패.
- after: `handle_dcserver` 진입 직후 `raise_fd_soft_limit(16_384)`로 soft 한도를 올린다. macOS에서는 `sysconf(_SC_OPEN_MAX)` 커널 상한으로 target을 클램프하여 `setrlimit`이 EINVAL로 거부되어 256에 그대로 머무는 일을 막는다. 실패 시에는 기존 best-effort 경고 후 계속 진행(서버 기동을 막지 않음).

### Fix 2 — reconcile 행 할당 churn 감소

- before: `dispatch_delivery_event_reconcile_report_pg`의 두 스캔 루프가 `for row in &rows`로 행을 빌려 분류 함수에 `&row`를 넘기면서, 분류 함수 내부에서 `dispatch_id`/`typed_status`를 `.clone()`으로 복제.
- after: 커서를 먼저 갱신한 뒤 `for row in rows`로 소유권을 이동시키고, 분류 함수가 행을 값으로 받아 불필요한 `String` 복제를 제거.

### Fix 3 — OpenCode 오염 락 복구

- before: `drain_startup_output`/`summarize_startup_output`/watchdog가 `if let Ok(..) = lock()`로 락을 잡아, 다른 스레드 panic으로 Mutex가 poisoned 되면 스타트업 출력 수집과 자식 PID 종료가 조용히 스킵됨.
- after: `unwrap_or_else(|e| { warn!(..); e.into_inner() })`로 오염된 락에서도 내부 데이터를 회수하여 로그 수집과 watchdog kill을 계속 수행.

### Fix 4 — 워커 생명주기 로그 필드 일관화

- before: `worker_registry.rs`의 started/stopped/future-exited/self-fenced/supervisor-shutdown 트레이싱 이벤트가 서로 다른 부분 필드 집합만 기록.
- after: 모든 생명주기 이벤트가 동일한 spec 필드(stage, order, restart, shutdown, owner, health, responsibility, notes)를 함께 방출하여 노드 간 failover/관측 상관관계 분석이 어느 엣지에서 로깅됐는지에 의존하지 않도록 함.

### CI Fix — E0308 테스트 호출부 정리

- before: Fix 2가 `classify_delivery_kv_guard_mismatches`/`classify_delivery_typed_guard_mismatches`를 값-전달로 바꿨는데, reconcile 테스트의 두 호출부가 여전히 `&DeliveryKvGuardRow {..}` / `&DeliveryTypedGuardRow {..}`로 참조를 넘겨 E0308로 전체 빌드 매트릭스가 깨짐.
- after: 두 호출부의 선두 `&`를 제거해 소유 값을 전달. 빌드 매트릭스 복구.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| tmux로 dcserver 기동 후 음성 STT 다량 처리 | fd 256 고갈 → `os error 24` 실패 | 16384(또는 커널 상한)로 상향되어 정상 동작 |
| macOS에서 hard=unlimited, soft=256 | target=16384가 OPEN_MAX 초과 → setrlimit EINVAL → 256 유지 | OPEN_MAX로 클램프 → 상향이 실제로 적용 |
| reconcile 대량 행 스캔 | 행마다 `dispatch_id` 등 String clone | 소유권 이동으로 복제 제거 |
| OpenCode 스타트업 중 다른 스레드 panic | Mutex poisoned → 출력 수집/PID kill 스킵 | `into_inner`로 회수하여 계속 수행 |
| 워커 생명주기 로그 grep | 이벤트별 필드 불일치 | 전 이벤트 동일 필드 집합 |
| `cargo build --tests` | E0308 (참조 vs 값) | 컴파일 통과 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| Linux/비-macOS에서 fd 상향 | macOS 클램프 분기는 cfg로 제외, `hard_capped` 그대로 사용 | 기존 동작 유지, 안전 |
| `_SC_OPEN_MAX`가 -1 반환(미지원) | `open_max > 0` 가드로 클램프 생략 | 회귀 없음 |
| 이미 soft >= target | 조기 return | setrlimit 미호출, 변화 없음 |
| reconcile 값-전달 전환 | 분류 함수는 행을 소비만 하고 재사용 안 함 | 동작 동일, 복제만 감소 |
| OpenCode 락 정상 경로 | poisoned 아니면 `unwrap_or_else`가 정상 guard 반환 | 정상 경로 영향 없음 |
| 워커 로그 필드 추가 | 출력 필드만 늘어남, 제어 흐름 불변 | 관측성만 향상 |

## 해결한 내용

- `src/cli/dcserver.rs`: macOS에서 `setrlimit(RLIMIT_NOFILE)` 직전에 target을 `sysconf(_SC_OPEN_MAX)` 커널 상한으로 클램프(Codex P2). cfg 분기로 비-macOS는 영향 없음, best-effort 경고 유지. 범위: fd 한도 상향 로직 한 곳.
- `src/reconcile.rs`: 두 reconcile 테스트 호출부의 선두 `&` 제거로 값-전달 시그니처에 맞춤(E0308, Codex P1). 프로덕션 분류 함수/스캔 루프는 PR 커밋에서 이미 값-전달로 전환됨. 범위: 테스트 호출부 2곳.
- `docs/agent-maintenance/change-surfaces.md`: 인벤토리 재생성 후 freeze 값을 Prod 기준으로 동기화(`reconcile.rs` 1816, `services/opencode.rs` 1886), `Last refreshed` 헤더를 `2026-06-15 (against main @ 9594a4d94)`로 갱신. 범위: freeze 엔트리 2개 + 헤더.
- `docs/agent-maintenance/multinode-transition.md`: `worker_registry.rs` 변경에 대응해 문서 touch + 헤더 갱신, 워커 생명주기 로그 필드 일관화 1줄 노트 추가. 범위: 헤더 + 노트.

## 검증

- `/opt/homebrew/bin/python3.12 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` → exit 0 (PR 유발 4개 에러 모두 해소; 남은 항목은 무관 문서 `discord-outbound-migration.md`의 비치명 헤더 WARNING뿐).
- `/opt/homebrew/bin/python3.12 scripts/audit_maintainability.py --check` → exit 0.
- `/opt/homebrew/bin/python3.12 scripts/generate_inventory_docs.py` 재생성으로 Prod 값 확인(생성물은 gitignore라 커밋하지 않음).
- Rust 컴파일(E0308 해소 + macOS fd 클램프 cfg 분기): 로컬 `cargo build/check/test` 미실행, cloud CI 재실행으로 검증 예정.
