### PR TITLE
fix: replace silent unwraps in dispatch thread-reuse routes with explicit 500 + warn

### DIFF
--- a/src/server/routes/dispatches/thread_reuse.rs
+++ b/src/server/routes/dispatches/thread_reuse.rs
@@ -58,9 +58,27 @@ pub async fn link_dispatch_thread(
 
     match dispatch_row {
         Some(row) => {
-            let cid: String = row.try_get("kanban_card_id").unwrap_or_default();
+            let cid: String = match row.try_get("kanban_card_id") {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::warn!(%error, "[dispatch] failed to read kanban_card_id from row");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": error.to_string() })),
+                    );
+                }
+            };
             let dispatch_type: Option<String> = row.try_get("dispatch_type").ok().flatten();
-            let to_agent_id: String = row.try_get("to_agent_id").unwrap_or_default();
+            let to_agent_id: String = match row.try_get("to_agent_id") {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::warn!(%error, "[dispatch] failed to read to_agent_id from row");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": error.to_string() })),
+                    );
+                }
+            };
 
             if let Err(error) = sqlx::query(
                 "UPDATE task_dispatches
@@ -194,8 +212,26 @@ pub async fn get_card_thread(
 
     match result {
         Some(row) => {
-            let card_id: String = row.try_get("card_id").unwrap_or_default();
-            let card_title: String = row.try_get("card_title").unwrap_or_default();
+            let card_id: String = match row.try_get("card_id") {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::warn!(%error, "[dispatch] failed to read card_id from row");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": error.to_string() })),
+                    );
+                }
+            };
+            let card_title: String = match row.try_get("card_title") {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::warn!(%error, "[dispatch] failed to read card_title from row");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": error.to_string() })),
+                    );
+                }
+            };
             let github_issue_url: Option<String> = row.try_get("github_issue_url").ok().flatten();
             let github_issue_number: Option<i64> =
                 row.try_get("github_issue_number").ok().flatten();
@@ -203,7 +239,16 @@ pub async fn get_card_thread(
             let deferred_dod_json: Option<String> = row.try_get("deferred_dod_json").ok().flatten();
             let dispatch_type: Option<String> = row.try_get("dispatch_type").ok().flatten();
             let dispatch_title: Option<String> = row.try_get("dispatch_title").ok().flatten();
-            let to_agent_id: String = row.try_get("dispatch_agent_id").unwrap_or_default();
+            let to_agent_id: String = match row.try_get("dispatch_agent_id") {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::warn!(%error, "[dispatch] failed to read dispatch_agent_id from row");
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": error.to_string() })),
+                    );
+                }
+            };
             let dispatch_context: Option<String> = row.try_get("dispatch_context").ok().flatten();
 
             let primary_channel = resolve_agent_primary_channel_pg(pool, &to_agent_id)


### PR DESCRIPTION
## 목표

dispatch thread-reuse 라우트(`link_dispatch_thread`, `get_card_thread`)에서 DB 행의 필수 컬럼을 읽을 때 사용하던 `try_get(...).unwrap_or_default()` 패턴을 제거한다. 컬럼 읽기에 실패하면 빈 문자열로 조용히 대체하는 대신, `tracing::warn!`으로 원인을 남기고 HTTP 500을 명시적으로 반환하도록 바꾼다. 결과적으로 DB 스키마/타입 불일치가 빈 값으로 덮여 잘못된 응답이 나가는 일을 막고, 실패를 관측 가능하게 만든다.

## 쉬운 설명

기존에는 dispatch 스레드 연동 API가 DB에서 카드 ID나 에이전트 ID 같은 값을 못 읽어도 빈 문자열로 처리하고 그대로 진행했습니다. 그래서 잘못된 빈 값으로 후속 동작이 이어지거나, 운영자가 문제를 눈치채기 어려웠습니다. 이제는 그런 경우 명확하게 500 에러를 돌려주고 서버 로그에 어떤 컬럼에서 실패했는지 경고를 남깁니다. 동작 자체는 정상 경로에서 달라지지 않고, 실패만 더 정직하게 드러납니다.

## 개선되는 것

### Fix 1 — `link_dispatch_thread`의 `kanban_card_id`/`to_agent_id`

Before: `row.try_get("kanban_card_id").unwrap_or_default()`, `row.try_get("to_agent_id").unwrap_or_default()`로 읽기 실패 시 빈 문자열을 채워 그대로 후속 UPDATE 쿼리까지 진행했다.
After: 각 컬럼을 `match`로 처리해, 실패 시 `tracing::warn!(%error, ...)`로 해당 컬럼명을 기록하고 `(StatusCode::INTERNAL_SERVER_ERROR, Json({"error": ...}))`를 즉시 반환한다.

### Fix 2 — `get_card_thread`의 `card_id`/`card_title`

Before: `card_id`, `card_title`를 `unwrap_or_default()`로 읽어 실패해도 빈 문자열로 응답을 구성했다.
After: 두 컬럼을 각각 `match`로 처리해 실패 시 경고 로그 후 500을 반환한다. 부분적으로 비어 있는 카드 정보가 클라이언트로 나가지 않는다.

### Fix 3 — `get_card_thread`의 `dispatch_agent_id`

Before: `dispatch_agent_id`를 `unwrap_or_default()`로 읽어, 빈 `to_agent_id`로 이후 `resolve_agent_primary_channel_pg` 채널 해석까지 진행했다.
After: `match`로 처리해 실패 시 경고 로그 후 500을 반환하므로, 빈 에이전트 ID로 채널 해석을 시도하지 않는다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `kanban_card_id` 컬럼 읽기 실패 | 빈 문자열로 대체 후 UPDATE 진행, 로그 없음 | `warn` 로그 + HTTP 500, 후속 쿼리 중단 |
| `get_card_thread`에서 `card_title` 읽기 실패 | 빈 제목으로 응답 200 반환 | `warn` 로그 + HTTP 500 |
| `dispatch_agent_id` 읽기 실패 | 빈 ID로 채널 해석 시도 | `warn` 로그 + HTTP 500, 채널 해석 미진행 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 정상적으로 모든 컬럼이 읽히는 경우 | `match`의 `Ok(value)` 분기로 기존과 동일한 값 사용 | 정상 경로 동작 불변 |
| `dispatch_type` 등 기존 `.ok().flatten()` Optional 컬럼 | 이번 변경 대상 아님, 그대로 유지 | 선택적 컬럼 처리 동작 변화 없음 |
| 컬럼 읽기 실패로 500 반환 시 | `error.to_string()`을 JSON 본문에 포함 | 디버깅에 유용하나 DB 오류 메시지가 응답에 노출될 수 있음(에러 경로 한정) |

## 해결한 내용

- `src/server/routes/dispatches/thread_reuse.rs` (단일 파일, +50 / -5): 핸들러 두 곳에서 필수 문자열 컬럼 5개(`kanban_card_id`, `to_agent_id`, `card_id`, `card_title`, `dispatch_agent_id`)의 `unwrap_or_default()`를 명시적 `match` + `warn` 로그 + 500 반환으로 교체. WHY: 조용한 기본값 대체가 DB 타입/스키마 오류를 가려 잘못된 빈 값으로 응답을 구성하거나 후속 쿼리/채널 해석을 진행하게 만들었기 때문. 범위는 에러 경로 한정이며 정상 경로 로직과 응답 형태는 변경되지 않음.

## 검증

- CI(GitHub Actions, run 27498602867) 기준 현재 결과:
  - 통과: Fast check (ubuntu), Fast check + non-PG tests (ubuntu), Fast targeted tests, Lint, Script checks, PostgreSQL tests, High-risk recovery, Changed paths, Dashboard required context 등.
  - 실패: `Fast check + non-PG tests (windows-latest)`, `Fast check cross OS required context (ubuntu-latest)`.
- windows fast-check 실패는 이 PR과 무관한 base/systemic 이슈(windows `cargo check` E0433 "could not find tmux")이며, 본 PR diff는 해당 의존성/코드를 건드리지 않는다. `Fast check cross OS required context`는 위 windows 결과를 집계하는 게이트라 같은 원인으로 동반 실패한 것이다.
- 로컬 `cargo`/`tsc` 실행은 이 작업에서 수행하지 않았다(주장하지 않음).
