### PR TITLE
fix(#3459): flush unrelayed TUI tail on quiescence-gate watcher handoff

### DIFF
--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -382,14 +382,31 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
             RelayOwnerKind::Watcher,
             shared_owned,
         );
-        // Resume the watcher from the bridge's confirmed offset and clear the
-        // delivered flag so it relays the still-producing output (NOT marked
-        // delivered → no suppression). The bridge owned relay for this turn, so
-        // the watcher is paused; unpause it now.
-        if let Some(offset) = tmux_last_offset
+        // Resume the watcher from the bridge's CONFIRMED relay frontier (not the
+        // produced offset) and clear the delivered flag so it relays the still-
+        // unrelayed tail `[confirmed_end, last_offset]` (NOT marked delivered → no
+        // suppression). #3459: seeding the produced `tmux_last_offset` here made the
+        // watcher seek PAST that tail, so it was never relayed and was permanently
+        // lost when the next turn superseded the inflight. Gate on the CURRENT
+        // wrapper generation (#3358 TOCTOU-safe) so a post-restart/rotated frontier
+        // never re-seeds the watcher into a different wrapper's content; fall back
+        // to the produced offset when there is no current-generation frontier or no
+        // unrelayed tail (byte-identical to the pre-#3459 seed in those cases). The
+        // bridge owned relay for this turn, so the watcher is paused; unpause now.
+        if let Some(produced) = tmux_last_offset
             && let Ok(mut guard) = watcher.resume_offset.lock()
         {
-            *guard = Some(offset);
+            let confirmed_frontier = inflight_state
+                .tmux_session_name
+                .as_deref()
+                .and_then(|name| {
+                    crate::services::discord::tmux::committed_frontier_for_current_generation(
+                        shared_owned,
+                        channel_id,
+                        name,
+                    )
+                });
+            *guard = Some(watcher_resume_seed_offset(produced, confirmed_frontier));
         }
         watcher
             .turn_delivered
@@ -405,9 +422,43 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
     }
 }
 
+/// #3459 (pure, testable): the watcher's resume-offset seed at a quiescence-gate
+/// handoff. Resume from the CONFIRMED relay frontier when it lags the PRODUCED
+/// offset (an unrelayed tail `[confirmed, produced]` exists → the watcher reads
+/// it forward and relays it once). Fall back to `produced` when there is no
+/// current-generation frontier (`None`, #3358 gate failed → content-skip-safe) or
+/// when the frontier is not behind (`confirmed >= produced`, no tail) — both
+/// byte-identical to the pre-#3459 seed. Never returns a value above `produced`,
+/// so the watcher can never seek past produced EOF. `#[cfg(unix)]`-gated to match
+/// its sole caller `maybe_hand_off_busy_turn_to_watcher` (no dead code off-unix).
+#[cfg(unix)]
+fn watcher_resume_seed_offset(produced: u64, confirmed_frontier: Option<u64>) -> u64 {
+    confirmed_frontier
+        .filter(|&confirmed| confirmed < produced)
+        .unwrap_or(produced)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #3459 truth table: the handoff resume seed flushes the unrelayed tail by
+    /// resuming from the confirmed frontier ONLY when it lags the produced offset,
+    /// and never seeks past produced EOF. `#[cfg(unix)]` to match the gated helper.
+    #[cfg(unix)]
+    #[test]
+    fn watcher_resume_seed_offset_flushes_tail_else_falls_back() {
+        // Unrelayed tail exists (confirmed < produced) → resume from confirmed so
+        // the watcher reads [confirmed, produced] forward and relays it (#3459 fix).
+        assert_eq!(watcher_resume_seed_offset(376_405, Some(331_575)), 331_575);
+        // No current-generation frontier (#3358 gate failed) → fall back to produced
+        // (content-skip-safe; byte-identical to pre-#3459).
+        assert_eq!(watcher_resume_seed_offset(376_405, None), 376_405);
+        // Frontier not behind (no tail) → fall back to produced (no re-relay).
+        assert_eq!(watcher_resume_seed_offset(376_405, Some(376_405)), 376_405);
+        // Stale-high frontier can never seek the watcher PAST produced EOF.
+        assert_eq!(watcher_resume_seed_offset(376_405, Some(999_999)), 376_405);
+    }
 
     /// #3277 (Defect A) truth table: ONLY a `Done` signal with the relay offset
     /// advanced PAST the turn start proves the turn delivered (and suppresses


### PR DESCRIPTION
## #3459 (residual of closed #3268) — handoff tail-flush loss

On a long-running TUI session, when the bridge's TUI quiescence gate times out it hands relay ownership to the tmux watcher (#3268's fix). The handoff seeded the watcher's `resume_offset` with the **PRODUCED** offset (`tmux_last_offset` = `inflight.last_offset`) instead of the **CONFIRMED relay frontier** (`confirmed_end_offset`) that the in-code comment promised. The watcher then sought PAST the unrelayed tail `[confirmed_end, last_offset]`, never relayed it, and it was permanently lost when the next user turn superseded the inflight (also drove `tui_direct_pending_start` backstop to ABORT).

Confirmed in production twice on 2026-06-14: cookingheart-ad-cc (21:28, ~45KB tail lost) and adk-cc (21:42, backstop ABORT).

## Fix (`turn_bridge/watcher_handoff.rs`, uncapped)
Seed `resume_offset` from the confirmed relay frontier via `committed_frontier_for_current_generation` (#3358 TOCTOU-safe, generation-gated) when it lags the produced offset, so the watcher reads `[confirmed, produced]` forward and relays the tail exactly once.
- Falls back to the produced offset when there is no current-generation frontier (gate failed → content-skip-safe) or no unrelayed tail (`confirmed >= produced`) — **byte-identical to the pre-fix seed** in those cases.
- Never seeds above produced EOF (a stale-high frontier cannot push past produced).
- Decision extracted to pure `watcher_resume_seed_offset()` + truth-table test. `#[cfg(unix)]`-gated to match its sole caller (no off-unix dead code).
- Reuses the #3089 single delivery authority (`confirmed_end_offset`); reads only, no frozen file touched, #3268/#3277/#3089 paths unchanged.

## Verification
- `cargo build` 0 warnings, clippy clean, fmt clean
- `cargo test -p agentdesk watcher_handoff` 6/6 (incl. the new truth-table test)
- `audit_maintainability.py --check` green, `ci-script-checks.sh` await_holding_lock 34
- codex CLI adversarial review: **VERDICT CLEAN** (no-double-relay, coordinate-system, byte-identical fallback, generation-gate safety, never-past-EOF, #3268/#3277/#3089 unchanged all verified; non-equivalent mutations killed)

Closes #3459

🤖 Generated with [Claude Code](https://claude.com/claude-code)