### PR TITLE
fix(windows): cfg-gate tmux call sites for cross-platform compile

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -10,7 +10,7 @@
 > Turn-owned delivery paths can pass a `CancelToken` so post-cancel sends,
 > fallback retries, split chunks, and headless outbox enqueue are suppressed.
 >
-> Last refreshed: 2026-06-13 (against #3089 A2b r2 — session_relay_sink short-replace cut over to the turn-output controller behind a default-OFF flag; controller now RAII-releases its held lease on future cancel/panic via ControllerLeaseGuard).
+> Last refreshed: 2026-06-14 (against #3461 — `effective_committed_offset` in `outbound/delivery_record.rs` now `#[cfg(unix)]`-gates its tmux generation read with a behavior-preserving `0` fallback on non-unix targets, for cross-platform compile; outbound delivery semantics unchanged on unix).
 >
 > Companion docs: [`docs/discord-outbound-remaining-producers.md`](../discord-outbound-remaining-producers.md) (#1175 closure), [`docs/source-of-truth.md`](../source-of-truth.md).
 

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -95,7 +95,9 @@
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).
-"src/services/discord/tui_prompt_relay.rs" = 5429
+# windows-tmux cfg fix (#3461): +5 prod LoC for the `#[cfg(not(unix))]`
+# committed-frontier carry-forward fallback (cross-platform compile). 5429 -> 5434.
+"src/services/discord/tui_prompt_relay.rs" = 5434
 # #3038: lowered 4728 -> 4657 (-71) as `SensitivityState` (definition + impl)
 # moved to the `voice_sensitivity` sibling module. Locks in the shrink win.
 # #3038 VoiceBargeInRuntime S1: lowered 4657 -> 4350 (-307) as the STT

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -414,8 +414,18 @@ pub(in crate::services::discord) fn effective_committed_offset(
     if !delivery_record_authority_enabled() {
         return in_memory;
     }
+    // The `tmux` module is `#[cfg(unix)]`; on non-unix targets (windows CI
+    // cross-compile check) there is no wrapper generation file, so treat the
+    // generation as absent (`0`) — `durable_frontier_generation_current`
+    // returns false for `0`, which falls back to the in-memory offset.
+    #[cfg(unix)]
     let current_gen =
         crate::services::discord::tmux::read_generation_file_mtime_ns(tmux_session_name);
+    #[cfg(not(unix))]
+    let current_gen: i64 = {
+        let _ = tmux_session_name;
+        0
+    };
     let durable_end = read_record(provider, channel.get())
         .and_then(|r| r.delivered_frontier)
         .filter(|f| durable_frontier_generation_current(f.generation_mtime_ns, current_gen))

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1330,11 +1330,17 @@ async fn claim_tui_direct_synthetic_turn(
         .unwrap_or(0);
     // #3358 round 2: carry the committed frontier forward, but ONLY for the
     // CURRENT wrapper generation (stale → `None` → no content skip).
+    // The `tmux` module is `#[cfg(unix)]`; on non-unix targets (windows CI
+    // cross-compile check) there is no committed frontier to carry forward, so
+    // `None` (no carry-forward) is the correct, behavior-preserving default.
+    #[cfg(unix)]
     let committed_relay_offset = super::tmux::committed_frontier_for_current_generation(
         shared,
         channel_id,
         tmux_session_name,
     );
+    #[cfg(not(unix))]
+    let committed_relay_offset: Option<u64> = None;
     let start_offset =
         synthetic_start_offset_carry_forward(relay_last_offset, committed_relay_offset);
     if start_offset > relay_last_offset {


### PR DESCRIPTION
## 목표
`tmux` 모듈이 `#[cfg(unix)]`인데 두 곳에서 무조건 참조해 windows-latest `cargo check`가 E0433로 실패한다. 두 호출부를 cfg 게이팅해 **모든 PR이 공유하던 windows 컴파일 블로커**를 제거하고, unix 동작은 그대로 유지한다.

## 쉬운 설명
이 저장소는 실제로 unix에서 돌지만 CI는 windows 빌드도 확인합니다. tmux는 unix 전용 모듈이라 windows에서는 존재하지 않는데, 두 곳이 이를 그냥 호출해 windows 빌드가 깨졌습니다. 그 두 곳만 OS별로 갈라, windows에서는 안전한 기본값을 쓰도록 했습니다. unix 쪽 코드 경로와 동작은 전혀 바뀌지 않습니다.

## 개선되는 것
### Fix 1 — `outbound/delivery_record.rs::effective_committed_offset`
- before: `crate::services::discord::tmux::read_generation_file_mtime_ns(...)`를 무조건 호출 → windows에서 E0433.
- after: `#[cfg(unix)]`는 기존대로, `#[cfg(not(unix))]`에서는 `current_gen = 0`. `durable_frontier_generation_current`가 `0`이면 false를 반환하므로 durable 프런티어를 무시하고 in-memory offset으로 자연 폴백.

### Fix 2 — `tui_prompt_relay.rs` synthetic start-offset carry-forward
- before: `super::tmux::committed_frontier_for_current_generation(...)`를 무조건 호출 → windows에서 E0433.
- after: `#[cfg(unix)]`는 기존대로, `#[cfg(not(unix))]`에서는 `Option::<u64>::None`. `synthetic_start_offset_carry_forward(relay_last_offset, None)`는 `relay_last_offset`을 그대로 반환(캐리포워드 없음).

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| windows-latest `cargo check` | E0433 `could not find tmux` 2건으로 실패 | 컴파일 통과 (cfg 폴백) |
| unix(런타임) 동작 | tmux 세대/프런티어 사용 | 동일 (cfg(unix) 분기 무변경) |
| non-unix 커밋 오프셋 | (컴파일 불가) | in-memory offset 폴백 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| unix에서 실행 | cfg(unix) 분기만 컴파일·실행 | 행위 변화 없음 |
| windows에서 컴파일 | cfg(not(unix)) 폴백 컴파일 | 빌드 성공, tmux 의존 로직은 중립값 |
| not(unix)에서 unused 인자 | `tmux_session_name`을 `let _ =`로 소비 | unused 경고 없음 |

## 해결한 내용
- `src/services/discord/outbound/delivery_record.rs`: `effective_committed_offset`의 `current_gen` 산출을 cfg 분기(이유: tmux 세대 파일은 unix 전용; non-unix는 세대 부재=`0`).
- `src/services/discord/tui_prompt_relay.rs`: committed 프런티어 캐리포워드 호출을 cfg 분기(이유: 동일; non-unix는 캐리포워드 없음=`None`).

## 검증
- `cargo fmt` — 클린(추가 포맷 변경 없음).
- unix 컴파일 경로는 `#[cfg(unix)]` 분기가 기존 코드와 동일하여 행위 불변.
- windows 빌드는 로컬(macOS) 검증 불가 → **이 PR의 windows-latest CI 결과로 확인**(E0433 해소 목표). 로컬 cargo 실행은 하지 않음.
