### PR TITLE
feat(discord): /steer slash command with queued lifecycle (queuing → queued → cancel)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -385,6 +385,7 @@ src/
 │   │   │   ├── restart.rs
 │   │   │   ├── session.rs
 │   │   │   ├── skill.rs
+│   │   │   ├── steer.rs
 │   │   │   ├── text_commands.rs
 │   │   │   ├── tui_passthrough.rs
 │   │   │   └── voice.rs
@@ -600,6 +601,7 @@ src/
 │   │   ├── startup_reclaim.rs
 │   │   ├── status_panel_controller.rs
 │   │   ├── status_panel_orphan_store.rs
+│   │   ├── steering.rs
 │   │   ├── streaming_finalizer.rs
 │   │   ├── task_supervisor.rs
 │   │   ├── tmux.rs

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -37,7 +37,7 @@ direct_discord_sends = [
   "src/services/discord/commands/text_commands.rs#direct_discord_sends:e1dff75fe79e7d70",
   "src/services/discord/discord_io.rs#direct_discord_sends:2f398342de1e7cd7",
   "src/services/discord/gateway.rs#direct_discord_sends:b61365ed28b915b2",
-  "src/services/discord/gateway.rs#direct_discord_sends:0a20f86f0471df2b",
+  "src/services/discord/gateway.rs#direct_discord_sends:ddb44ff4289daaf5",
   "src/services/discord/gateway.rs#direct_discord_sends:a78022596f453395",
   "src/services/discord/meeting_orchestrator.rs#direct_discord_sends:64c7fa00eace25a9",
   "src/services/discord/meeting_orchestrator.rs#direct_discord_sends:5e0310b8b9e373ff",

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -153,8 +153,12 @@
 # #3038 S1: +2 (2958 -> 2960) for the two mechanical `.queued_placeholders` ->
 # `.queued.queued_placeholders` re-wires (two extra method-chain lines) forced by
 # the cluster-C extraction. Net program-wide: mod.rs -201.
-# intake DB-error-log elevation (this PR): 2960 -> 2969.
-"src/services/discord/router/intake_gate.rs" = 2969
+# intake DB-error-log elevation (#3446): 2960 -> 2969.
+# /steer P1.5 (PR #740): +6 for the steer-cancel message-component routing arm in
+# `handle_event` (mirrors the model-picker / idle-recap arms — the dispatch can
+# only live in the root event handler). The cancel handler body itself lives in
+# the non-giant `steering.rs`, not here. Combined with #3446: 2969 -> 2975.
+"src/services/discord/router/intake_gate.rs" = 2975
 "src/services/discord/formatting.rs" = 2802
 # #3038 run_bot S0/S1: lowered 2802 -> 1918 by adding characterization tests and
 # moving restored_state, queued_placeholders, startup_doctor, orphan_recovery,

--- a/src/services/discord/commands/command_policy.rs
+++ b/src/services/discord/commands/command_policy.rs
@@ -172,7 +172,7 @@ pub(in crate::services::discord) fn slash_command_risk(slash_cmd: &str) -> Comma
         // Per-channel session shaping (mirrors text-command tiers).
         "/start" | "/down" | "/cc" | "/skill" | "/meeting" | "/model" | "/fast" | "/goals"
         | "/effort" | "/compact" | "/clear" | "/deletesession" | "/stop" | "/restart"
-        | "/debug" => CommandRisk::Mutating,
+        | "/steer" | "/debug" => CommandRisk::Mutating,
 
         // RCE-equivalent surface.
         // `/deadlock-recover`, `/machine-flip`, and `/stuck-pr-rebase` (issue
@@ -205,4 +205,17 @@ pub(in crate::services::discord) fn risk_tier_summary_for_help(high_risk_enabled
          `shell/tool-grant` — shell/allowed: {shell_state}\n\
          `credential/system` — allowall/adduser/removeuser/escalation: owner-only"
     )
+}
+
+#[cfg(test)]
+mod steer_policy_tests {
+    use super::*;
+
+    #[test]
+    fn steer_is_registered_as_mutating_and_not_high_risk() {
+        // Explicit (not catch-all) registration: /steer is channel-scoped
+        // mutating, allowed for any authorized user, never owner-gated.
+        assert_eq!(slash_command_risk("/steer"), CommandRisk::Mutating);
+        assert!(!slash_command_risk("/steer").is_high_risk());
+    }
 }

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -14,6 +14,7 @@ mod recovery_ops;
 mod restart;
 mod session;
 mod skill;
+mod steer;
 mod text_commands;
 mod tui_passthrough;
 mod voice;
@@ -60,6 +61,7 @@ pub(super) use restart::cmd_restart;
 pub(super) use session::{cmd_pwd, cmd_start};
 pub(in crate::services::discord) use skill::build_provider_skill_prompt;
 pub(super) use skill::{cmd_cc, cmd_skill};
+pub(super) use steer::cmd_steer;
 pub(in crate::services::discord) use text_commands::handle_text_command;
 pub(in crate::services::discord) use tui_passthrough::is_local_only_slash_command_kind; // #3305
 pub(super) use tui_passthrough::{cmd_compact, cmd_context, cmd_cost, cmd_effort};

--- a/src/services/discord/commands/steer.rs
+++ b/src/services/discord/commands/steer.rs
@@ -1,0 +1,85 @@
+//! `/steer <instruction>` (P0) — enqueue a steering instruction onto the
+//! channel's already-live turn. Never creates a new turn; non-claude/codex
+//! providers and idle channels are refused with a structured reply.
+
+use crate::services::provider::ProviderKind;
+use crate::services::turn_orchestrator::EnqueueRefusalReason;
+
+use super::super::steering::{SteeringOutcome, SteeringRequest, enqueue_steering, steer_source_id};
+use super::super::{Context, Error, check_auth};
+use super::config::{effective_provider_for_channel, fallback_channel_name_for_feature_toggle};
+
+// Reuses the existing mailbox intervention path; never starts a new turn.
+/// Inject a steering instruction into the channel's live turn (claude/codex).
+#[poise::command(slash_command, rename = "steer")]
+pub(in crate::services::discord) async fn cmd_steer(
+    ctx: Context<'_>,
+    #[description = "Steering instruction to inject into the live turn"] instruction: String,
+) -> Result<(), Error> {
+    let user_id = ctx.author().id;
+    let user_name = &ctx.author().name;
+    if !check_auth(user_id, user_name, &ctx.data().shared, &ctx.data().token).await {
+        return Ok(());
+    }
+    if !super::enforce_slash_command_policy(&ctx, "/steer").await? {
+        return Ok(());
+    }
+
+    let instruction = instruction.trim().to_string();
+    if instruction.is_empty() {
+        ctx.say("Usage: `/steer <instruction>`").await?;
+        return Ok(());
+    }
+
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::info!("  [{ts}] ◀ [{user_name}] /steer");
+
+    let channel_id = ctx.channel_id();
+
+    // Effective per-channel provider (honors role overrides), same resolution as
+    // `/skill` and `/restart`.
+    let channel_name_hint = fallback_channel_name_for_feature_toggle(ctx, channel_id).await;
+    let provider: ProviderKind = effective_provider_for_channel(
+        &ctx.data().shared,
+        channel_id,
+        &ctx.data().provider,
+        channel_name_hint.as_deref(),
+    )
+    .await;
+
+    // Single source id == the Discord interaction id, unique per invocation.
+    let source_id = steer_source_id(ctx.id());
+
+    let request = SteeringRequest {
+        channel_id,
+        provider,
+        author_id: user_id,
+        source_id,
+        instruction,
+    };
+
+    let outcome = enqueue_steering(&ctx.data().shared, request).await;
+
+    let reply = match outcome {
+        SteeringOutcome::Queued => "조종 지시를 현재 진행 중인 턴에 큐잉했습니다.",
+        SteeringOutcome::NoLiveSession => {
+            "진행 중인 턴이 없습니다. `/steer`는 활성 턴에만 사용할 수 있습니다."
+        }
+        SteeringOutcome::Unsupported => {
+            "이 provider는 `/steer`를 지원하지 않습니다 (claude / codex 전용)."
+        }
+        SteeringOutcome::Refused { reason } => match reason {
+            EnqueueRefusalReason::SourceIdAlreadyQueued | EnqueueRefusalReason::LastItemDedup => {
+                "중복으로 판단되어 큐잉되지 않았습니다."
+            }
+            EnqueueRefusalReason::ActorUnreachable | EnqueueRefusalReason::MailboxClosed => {
+                "세션 액터에 접근할 수 없어 일시적으로 실패했습니다. 잠시 후 다시 시도하세요."
+            }
+        },
+        SteeringOutcome::DiscordUnavailable | SteeringOutcome::SessionNotFound => {
+            "세션을 확인할 수 없습니다."
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}

--- a/src/services/discord/commands/steer.rs
+++ b/src/services/discord/commands/steer.rs
@@ -2,10 +2,16 @@
 //! channel's already-live turn. Never creates a new turn; non-claude/codex
 //! providers and idle channels are refused with a structured reply.
 
+use poise::CreateReply;
+use poise::serenity_prelude as serenity;
+
 use crate::services::provider::ProviderKind;
 use crate::services::turn_orchestrator::EnqueueRefusalReason;
 
-use super::super::steering::{SteeringOutcome, SteeringRequest, enqueue_steering, steer_source_id};
+use super::super::steering::{
+    SteerLifecycle, SteeringOutcome, SteeringRequest, enqueue_steering, steer_cancel_custom_id,
+    steer_lifecycle_label, steer_source_id,
+};
 use super::super::{Context, Error, check_auth};
 use super::config::{effective_provider_for_channel, fallback_channel_name_for_feature_toggle};
 
@@ -55,31 +61,86 @@ pub(in crate::services::discord) async fn cmd_steer(
         provider,
         author_id: user_id,
         source_id,
-        instruction,
+        instruction: instruction.clone(),
     };
 
-    let outcome = enqueue_steering(&ctx.data().shared, request).await;
+    // State 1 (REQ-013): show `큐잉중인 입력 : <instruction>` immediately and log
+    // the same label to the AgentDesk console (visible in the tmux pane, REQ-015).
+    let queuing_label = steer_lifecycle_label(SteerLifecycle::Queuing, &instruction);
+    tracing::info!("  [{ts}] 🔀 STEER {queuing_label}");
+    let handle = ctx
+        .send(CreateReply::default().content(queuing_label))
+        .await?;
 
-    let reply = match outcome {
-        SteeringOutcome::Queued => "조종 지시를 현재 진행 중인 턴에 큐잉했습니다.",
+    // Persist under THIS bot instance's provider (same as the normal
+    // soft-intervention enqueue and the cancel path) so a later cancel clears
+    // the same durable queue file. The claude/codex support gate inside
+    // `enqueue_steering` still uses the effective per-channel provider.
+    let outcome = enqueue_steering(&ctx.data().shared, &ctx.data().provider, request).await;
+
+    match outcome {
+        SteeringOutcome::Queued => {
+            // State 2 (REQ-013/REQ-014): `큐잉됨 : <instruction>` + cancel button.
+            // The actual instruction is delivered to the agent's tmux session by
+            // the existing turn-boundary path; nothing is typed into the composer
+            // here (REQ-016).
+            let queued_label = steer_lifecycle_label(SteerLifecycle::Queued, &instruction);
+            let queued_ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::info!("  [{queued_ts}] 📬 STEER {queued_label}");
+            let cancel_row = serenity::CreateActionRow::Buttons(vec![
+                serenity::CreateButton::new(steer_cancel_custom_id(source_id))
+                    .style(serenity::ButtonStyle::Secondary)
+                    .label("취소"),
+            ]);
+            handle
+                .edit(
+                    ctx,
+                    CreateReply::default()
+                        .content(queued_label)
+                        .components(vec![cancel_row]),
+                )
+                .await?;
+        }
         SteeringOutcome::NoLiveSession => {
-            "진행 중인 턴이 없습니다. `/steer`는 활성 턴에만 사용할 수 있습니다."
+            handle
+                .edit(
+                    ctx,
+                    CreateReply::default().content(
+                        "진행 중인 턴이 없습니다. `/steer`는 활성 턴에만 사용할 수 있습니다.",
+                    ),
+                )
+                .await?;
         }
         SteeringOutcome::Unsupported => {
-            "이 provider는 `/steer`를 지원하지 않습니다 (claude / codex 전용)."
+            handle
+                .edit(
+                    ctx,
+                    CreateReply::default().content(
+                        "이 provider는 `/steer`를 지원하지 않습니다 (claude / codex 전용).",
+                    ),
+                )
+                .await?;
         }
-        SteeringOutcome::Refused { reason } => match reason {
-            EnqueueRefusalReason::SourceIdAlreadyQueued | EnqueueRefusalReason::LastItemDedup => {
-                "중복으로 판단되어 큐잉되지 않았습니다."
-            }
-            EnqueueRefusalReason::ActorUnreachable | EnqueueRefusalReason::MailboxClosed => {
-                "세션 액터에 접근할 수 없어 일시적으로 실패했습니다. 잠시 후 다시 시도하세요."
-            }
-        },
+        SteeringOutcome::Refused { reason } => {
+            let message = match reason {
+                EnqueueRefusalReason::SourceIdAlreadyQueued
+                | EnqueueRefusalReason::LastItemDedup => "중복으로 판단되어 큐잉되지 않았습니다.",
+                EnqueueRefusalReason::ActorUnreachable | EnqueueRefusalReason::MailboxClosed => {
+                    "세션 액터에 접근할 수 없어 일시적으로 실패했습니다. 잠시 후 다시 시도하세요."
+                }
+            };
+            handle
+                .edit(ctx, CreateReply::default().content(message))
+                .await?;
+        }
         SteeringOutcome::DiscordUnavailable | SteeringOutcome::SessionNotFound => {
-            "세션을 확인할 수 없습니다."
+            handle
+                .edit(
+                    ctx,
+                    CreateReply::default().content("세션을 확인할 수 없습니다."),
+                )
+                .await?;
         }
-    };
-    ctx.say(reply).await?;
+    }
     Ok(())
 }

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -281,11 +281,25 @@ impl DiscordOutboundClient for SerenityTurnOutboundClient {
             )
         })?;
         rate_limit_wait(&self.shared, channel_id).await;
+        // #740 steer / robustness: degrade to a normal (non-reply) send when the
+        // referenced message no longer exists. A queued `/steer` intervention
+        // carries the slash *interaction* id as its `message_id` (a dedup/cancel
+        // token, not a real channel message), so replying to it with the Discord
+        // default `fail_if_not_exists=true` would 10008 and bubble an Err up
+        // through `handle_text_message`, requeue-looping the steer so it never
+        // reaches the agent. `fail_if_not_exists(false)` also hardens every other
+        // reply against a since-deleted target.
         channel_id
             .send_message(
                 &self.http,
                 serenity::CreateMessage::new()
-                    .reference_message((reference_channel_id, reference_message_id))
+                    .reference_message(
+                        serenity::MessageReference::from((
+                            reference_channel_id,
+                            reference_message_id,
+                        ))
+                        .fail_if_not_exists(false),
+                    )
                     .content(content)
                     .allowed_mentions(super::http::relay_allowed_mentions()),
             )

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -70,6 +70,7 @@ mod single_message_panel;
 mod stall_recovery;
 mod startup_reclaim;
 mod status_panel_orphan_store;
+mod steering;
 pub(in crate::services::discord) mod streaming_finalizer;
 pub(in crate::services::discord) mod task_supervisor;
 #[cfg(unix)]

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1658,6 +1658,12 @@ pub(in crate::services::discord) async fn handle_event(
                     )
                     .await;
                 }
+                if super::super::steering::is_steer_cancel_custom_id(&component.data.custom_id) {
+                    return super::super::steering::handle_steer_cancel_interaction(
+                        ctx, component, data,
+                    )
+                    .await;
+                }
             }
         }
         serenity::FullEvent::ReactionRemove { removed_reaction } => {

--- a/src/services/discord/runtime_bootstrap/framework_setup.rs
+++ b/src/services/discord/runtime_bootstrap/framework_setup.rs
@@ -215,6 +215,7 @@ pub(super) fn run_bot_build_slash_commands() -> Vec<poise::Command<Data, Error>>
         commands::cmd_goals(),
         commands::cmd_effort(),
         commands::cmd_compact(),
+        commands::cmd_steer(),
         commands::cmd_cost(),
         commands::cmd_context(),
         commands::cmd_adk(),
@@ -298,5 +299,20 @@ async fn audit_or_prune_global_slash_commands(
                 "deleted stale global slash command; guild commands remain authoritative"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod steer_registration_tests {
+    use super::*;
+
+    #[test]
+    fn steer_command_is_registered() {
+        assert!(
+            run_bot_build_slash_commands()
+                .iter()
+                .any(|command| command.name == "steer"),
+            "/steer must be present in the slash command registration vec"
+        );
     }
 }

--- a/src/services/discord/steering.rs
+++ b/src/services/discord/steering.rs
@@ -9,12 +9,15 @@
 
 use std::time::Instant;
 
-use poise::serenity_prelude::{ChannelId, MessageId, UserId};
+use poise::serenity_prelude::{self as serenity, ChannelId, MessageId, UserId};
 
 use crate::services::provider::ProviderKind;
 use crate::services::turn_orchestrator::{EnqueueRefusalReason, Intervention, InterventionMode};
 
-use super::{SharedData, mailbox_enqueue_intervention, mailbox_has_active_turn};
+use super::{
+    Data, Error, SharedData, check_auth, mailbox_cancel_soft_intervention,
+    mailbox_enqueue_intervention, mailbox_has_active_turn,
+};
 
 /// Inputs for one `/steer` invocation (current-channel scoped).
 #[derive(Clone, Debug)]
@@ -70,6 +73,91 @@ pub(in crate::services::discord) fn steer_source_id(interaction_id: u64) -> Mess
     MessageId::new(interaction_id)
 }
 
+/// Custom-id prefix for the `/steer` cancel button. The message-component router
+/// in `intake_gate.rs::handle_event` matches on this prefix, mirroring the
+/// idle-recap clear button (`idle_recap_interaction.rs`).
+pub(in crate::services::discord) const STEER_CANCEL_CUSTOM_ID_PREFIX: &str = "steer:cancel:";
+
+/// Build the cancel-button `custom_id` for a steer source id. The source id is
+/// the steer intervention's `message_id` (== the Discord interaction id), so the
+/// cancel handler can target the queued intervention directly.
+pub(in crate::services::discord) fn steer_cancel_custom_id(source_id: MessageId) -> String {
+    format!("{STEER_CANCEL_CUSTOM_ID_PREFIX}{}", source_id.get())
+}
+
+/// True if a message-component `custom_id` belongs to a `/steer` cancel button.
+pub(in crate::services::discord) fn is_steer_cancel_custom_id(custom_id: &str) -> bool {
+    custom_id.starts_with(STEER_CANCEL_CUSTOM_ID_PREFIX)
+}
+
+/// Parse the steer source id out of a cancel `custom_id`. Rejects a missing
+/// prefix, a non-numeric tail, and the zero sentinel so the cancel handler can
+/// never target `MessageId(0)`.
+pub(in crate::services::discord) fn parse_steer_cancel_source_id(
+    custom_id: &str,
+) -> Option<MessageId> {
+    custom_id
+        .strip_prefix(STEER_CANCEL_CUSTOM_ID_PREFIX)
+        .and_then(|tail| tail.parse::<u64>().ok())
+        .filter(|id| *id != 0)
+        .map(MessageId::new)
+}
+
+/// Operator-visible queue lifecycle phase for a `/steer` invocation. The label
+/// is a fixed contract (REQ-013): `<상태> : <instruction>` is rendered
+/// identically in the Discord card and the AgentDesk console (tmux) log so an
+/// operator watching either surface sees the same three states.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) enum SteerLifecycle {
+    /// Input is being queued (initial slash reply).
+    Queuing,
+    /// Input has been queued onto the live turn's mailbox.
+    Queued,
+    /// Queued input was cancelled before delivery.
+    Cancelled,
+}
+
+impl SteerLifecycle {
+    fn state_label(self) -> &'static str {
+        match self {
+            SteerLifecycle::Queuing => "큐잉중인 입력",
+            SteerLifecycle::Queued => "큐잉됨",
+            SteerLifecycle::Cancelled => "큐잉이 취소됨",
+        }
+    }
+}
+
+/// Max instruction characters rendered into a lifecycle label. Keeps the Discord
+/// card and the log line bounded; the full instruction is still delivered to the
+/// agent via the existing turn-boundary path (REQ-016).
+const STEER_LABEL_MAX_INSTRUCTION_CHARS: usize = 1500;
+
+/// Render the fixed `<상태> : <instruction>` lifecycle label (REQ-013/REQ-015).
+/// The instruction is truncated for display only.
+pub(in crate::services::discord) fn steer_lifecycle_label(
+    phase: SteerLifecycle,
+    instruction: &str,
+) -> String {
+    format!(
+        "{} : {}",
+        phase.state_label(),
+        truncate_instruction_for_label(instruction)
+    )
+}
+
+fn truncate_instruction_for_label(instruction: &str) -> String {
+    let mut chars = instruction.chars();
+    let head: String = chars
+        .by_ref()
+        .take(STEER_LABEL_MAX_INSTRUCTION_CHARS)
+        .collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
 /// Build the standalone `Soft` intervention for a steer request. Pure; pinned by
 /// unit tests so the never-merged / single-source-id contract can't drift.
 fn build_steer_intervention(request: &SteeringRequest) -> Intervention {
@@ -106,8 +194,19 @@ fn classify_enqueue_result(
 
 /// The single enqueue path for `/steer`. Gates BEFORE enqueue, then reuses the
 /// existing per-channel mailbox. Never creates a new turn.
+///
+/// `request.provider` is the EFFECTIVE per-channel provider and is used only for
+/// the claude/codex support gate. `persist_provider` is the bot instance's own
+/// provider (`Data.provider`) and is what keys the durable queue file. The two
+/// can differ under a cross-provider role override; persistence MUST use
+/// `persist_provider` so it matches the durable path that every other enqueue
+/// path (normal soft-intervention enqueue) and the cancel path
+/// (`mailbox_cancel_soft_intervention`) use. Otherwise a cancel — which always
+/// runs with `Data.provider` — would clear a different file than the enqueue
+/// wrote, resurrecting a cancelled steer on restart.
 pub(in crate::services::discord) async fn enqueue_steering(
     shared: &SharedData,
+    persist_provider: &ProviderKind,
     request: SteeringRequest,
 ) -> SteeringOutcome {
     if !provider_supports_steering(&request.provider) {
@@ -125,13 +224,13 @@ pub(in crate::services::discord) async fn enqueue_steering(
 
     let intervention = build_steer_intervention(&request);
     let outcome =
-        mailbox_enqueue_intervention(shared, &request.provider, request.channel_id, intervention)
+        mailbox_enqueue_intervention(shared, persist_provider, request.channel_id, intervention)
             .await;
 
     if let Some(error) = outcome.persistence_error.as_ref() {
         // In-memory enqueue still succeeded; durable persistence is best-effort.
         tracing::error!(
-            provider = request.provider.as_str(),
+            provider = persist_provider.as_str(),
             channel_id = request.channel_id.get(),
             error = %error,
             "/steer enqueue durable persistence failed (in-memory enqueue unaffected)"
@@ -139,6 +238,92 @@ pub(in crate::services::discord) async fn enqueue_steering(
     }
 
     classify_enqueue_result(outcome.enqueued, outcome.refusal_reason)
+}
+
+/// Interaction handler for the `/steer` cancel button (P1.5). The button's
+/// `custom_id` is `steer:cancel:<source_id>`, where `source_id` is the steer
+/// intervention's `message_id` (== the Discord interaction id). On click we
+/// authorise the user, then call the existing `mailbox_cancel_soft_intervention`
+/// to remove the still-queued intervention before delivery, and edit the card
+/// into the `큐잉이 취소됨 : <instruction>` state. No new cancel core is added —
+/// this mirrors `idle_recap_interaction.rs` and reuses the reaction-cancel path.
+pub(in crate::services::discord) async fn handle_steer_cancel_interaction(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    data: &Data,
+) -> Result<(), Error> {
+    // Authorise with the same gate `/steer` uses. Without this, anyone able to
+    // see the card could cancel another operator's steer.
+    let user_id = component.user.id;
+    let user_name = &component.user.name;
+    if !check_auth(user_id, user_name, &data.shared, &data.token).await {
+        let _ = component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("Not authorized for this bot.")
+                        .ephemeral(true),
+                ),
+            )
+            .await;
+        return Ok(());
+    }
+
+    let Some(source_id) = parse_steer_cancel_source_id(&component.data.custom_id) else {
+        // Malformed / sentinel id — acknowledge so the client doesn't time out.
+        let _ = component
+            .create_response(ctx, serenity::CreateInteractionResponse::Acknowledge)
+            .await;
+        return Ok(());
+    };
+
+    let channel_id = component.channel_id;
+    // Reuse the existing soft-intervention cancel path (same as reaction-remove).
+    // It removes the queued intervention and fires `apply_queue_exit_feedback`.
+    // Persist under `data.provider` to match the path `/steer` enqueued under.
+    let removed =
+        mailbox_cancel_soft_intervention(&data.shared, &data.provider, channel_id, source_id).await;
+
+    match removed {
+        Some(intervention) => {
+            // State 3 (REQ-013): `큐잉이 취소됨 : <instruction>`. The instruction is
+            // recovered from the removed intervention so the label is exact even
+            // though the custom_id carries only the source id.
+            let cancelled_label =
+                steer_lifecycle_label(SteerLifecycle::Cancelled, &intervention.text);
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::info!(
+                "  [{ts}] 📭 STEER-CANCEL: {cancelled_label} (channel {})",
+                channel_id.get()
+            );
+            let _ = component
+                .create_response(
+                    ctx,
+                    serenity::CreateInteractionResponse::UpdateMessage(
+                        serenity::CreateInteractionResponseMessage::new()
+                            .content(cancelled_label)
+                            .components(Vec::new()),
+                    ),
+                )
+                .await;
+        }
+        None => {
+            // Already delivered or already cancelled — idempotent. Strip the
+            // button so the stale card cannot be clicked again, but do not claim
+            // a cancellation for an instruction that already reached the agent.
+            let _ = component
+                .create_response(
+                    ctx,
+                    serenity::CreateInteractionResponse::UpdateMessage(
+                        serenity::CreateInteractionResponseMessage::new().components(Vec::new()),
+                    ),
+                )
+                .await;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -209,5 +394,50 @@ mod tests {
                 reason: EnqueueRefusalReason::ActorUnreachable
             }
         );
+    }
+
+    #[test]
+    fn steer_cancel_custom_id_round_trips() {
+        let id = MessageId::new(123_456_789);
+        let cid = steer_cancel_custom_id(id);
+        assert_eq!(cid, "steer:cancel:123456789");
+        assert!(is_steer_cancel_custom_id(&cid));
+        assert_eq!(parse_steer_cancel_source_id(&cid), Some(id));
+    }
+
+    #[test]
+    fn steer_cancel_custom_id_rejects_foreign_and_zero_and_garbage() {
+        assert!(!is_steer_cancel_custom_id("idle_recap:clear:1"));
+        assert!(!is_steer_cancel_custom_id("agentdesk:model-cancel:1"));
+        assert_eq!(parse_steer_cancel_source_id("steer:cancel:0"), None);
+        assert_eq!(parse_steer_cancel_source_id("steer:cancel:abc"), None);
+        assert_eq!(parse_steer_cancel_source_id("steer:cancel:"), None);
+        assert_eq!(parse_steer_cancel_source_id("nope"), None);
+    }
+
+    #[test]
+    fn steer_lifecycle_label_uses_fixed_three_state_format() {
+        assert_eq!(
+            steer_lifecycle_label(SteerLifecycle::Queuing, "계속 진행해줘"),
+            "큐잉중인 입력 : 계속 진행해줘"
+        );
+        assert_eq!(
+            steer_lifecycle_label(SteerLifecycle::Queued, "계속 진행해줘"),
+            "큐잉됨 : 계속 진행해줘"
+        );
+        assert_eq!(
+            steer_lifecycle_label(SteerLifecycle::Cancelled, "계속 진행해줘"),
+            "큐잉이 취소됨 : 계속 진행해줘"
+        );
+    }
+
+    #[test]
+    fn steer_lifecycle_label_truncates_long_instruction_for_display() {
+        let long = "가".repeat(2_000);
+        let label = steer_lifecycle_label(SteerLifecycle::Queued, &long);
+        assert!(label.starts_with("큐잉됨 : "));
+        assert!(label.ends_with('…'));
+        // Exactly STEER_LABEL_MAX_INSTRUCTION_CHARS instruction chars are kept.
+        assert_eq!(label.chars().filter(|c| *c == '가').count(), 1_500);
     }
 }

--- a/src/services/discord/steering.rs
+++ b/src/services/discord/steering.rs
@@ -1,0 +1,213 @@
+//! `/steer` (P0): inject a steering instruction into a channel's already-live
+//! turn by enqueuing a standalone, never-merged `Soft` intervention.
+//!
+//! P0 SCOPE: current-channel only. No HTTP API, no DB helpers, no
+//! `session_forwarding`, and no new delivery core. This is a thin wrapper over
+//! the existing private `mailbox_enqueue_intervention` / `mailbox_has_active_turn`
+//! in the parent `discord` module, reachable here via `super::` because
+//! `steering` is a child module.
+
+use std::time::Instant;
+
+use poise::serenity_prelude::{ChannelId, MessageId, UserId};
+
+use crate::services::provider::ProviderKind;
+use crate::services::turn_orchestrator::{EnqueueRefusalReason, Intervention, InterventionMode};
+
+use super::{SharedData, mailbox_enqueue_intervention, mailbox_has_active_turn};
+
+/// Inputs for one `/steer` invocation (current-channel scoped).
+#[derive(Clone, Debug)]
+pub(in crate::services::discord) struct SteeringRequest {
+    pub(in crate::services::discord) channel_id: ChannelId,
+    /// Effective provider for this channel (from `ctx.data().provider`).
+    pub(in crate::services::discord) provider: ProviderKind,
+    /// Invoking Discord user.
+    pub(in crate::services::discord) author_id: UserId,
+    /// Single source id == the Discord interaction id (`ctx.id()`), wrapped into
+    /// a `MessageId`. Unique per invocation, so it can never collide with an
+    /// already-queued `source_message_ids` entry (avoids `SourceIdAlreadyQueued`).
+    pub(in crate::services::discord) source_id: MessageId,
+    /// Steering instruction text (already trimmed by the caller).
+    pub(in crate::services::discord) instruction: String,
+}
+
+/// Terminal classification of a `/steer` attempt. The fixed outcome set the PRD
+/// pins; `DiscordUnavailable` / `SessionNotFound` are reserved for the P1 HTTP
+/// path and are never produced by the P0 current-channel path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) enum SteeringOutcome {
+    /// Enqueued onto the live turn's mailbox as a standalone head.
+    Queued,
+    /// A mailbox guard refused the enqueue (dedup / actor reachability).
+    Refused { reason: EnqueueRefusalReason },
+    /// No active turn on the channel — P0 never creates a new turn.
+    NoLiveSession,
+    /// Provider is not claude/codex.
+    Unsupported,
+    /// Reserved for cross-runtime resolution failure (P1 reuse).
+    #[allow(dead_code)]
+    DiscordUnavailable,
+    /// Reserved: channel resolved but no session record (P1 reuse).
+    #[allow(dead_code)]
+    SessionNotFound,
+}
+
+/// P0 capability gate: claude + codex only. Mirrors `provider_supports_resume`
+/// (`commands/restart.rs`) in spirit but uses an explicit `matches!` because
+/// there is no `supports_steering` capability and the requirement is exactly
+/// these two providers, whose live-followup path is already validated.
+pub(in crate::services::discord) fn provider_supports_steering(provider: &ProviderKind) -> bool {
+    matches!(provider, ProviderKind::Claude | ProviderKind::Codex)
+}
+
+/// Derive the single steer source id from the Discord interaction id. Pure, so
+/// REQ-004 ("the interaction id is the single source") stays pinned by a test
+/// independently of the un-mockable poise `Context`. `interaction_id` is always
+/// non-zero (serenity `InteractionId` is `NonZeroU64`-backed), so `MessageId::new`
+/// cannot hit its zero-panic path on the slash-command path.
+pub(in crate::services::discord) fn steer_source_id(interaction_id: u64) -> MessageId {
+    MessageId::new(interaction_id)
+}
+
+/// Build the standalone `Soft` intervention for a steer request. Pure; pinned by
+/// unit tests so the never-merged / single-source-id contract can't drift.
+fn build_steer_intervention(request: &SteeringRequest) -> Intervention {
+    Intervention {
+        author_id: request.author_id,
+        author_is_bot: false,
+        message_id: request.source_id,
+        source_message_ids: vec![request.source_id],
+        text: request.instruction.clone(),
+        mode: InterventionMode::Soft,
+        created_at: Instant::now(),
+        reply_context: None,
+        has_reply_boundary: false,
+        merge_consecutive: false,
+        pending_uploads: Vec::new(),
+        voice_announcement: None,
+    }
+}
+
+/// Map a `mailbox_enqueue_intervention` result to a `SteeringOutcome`. Pure.
+fn classify_enqueue_result(
+    enqueued: bool,
+    refusal_reason: Option<EnqueueRefusalReason>,
+) -> SteeringOutcome {
+    if enqueued {
+        return SteeringOutcome::Queued;
+    }
+    // `enqueued == false` ⇒ a refusal reason is present (MailboxEnqueueOutcome
+    // invariant); fall back to ActorUnreachable if one is somehow absent.
+    SteeringOutcome::Refused {
+        reason: refusal_reason.unwrap_or(EnqueueRefusalReason::ActorUnreachable),
+    }
+}
+
+/// The single enqueue path for `/steer`. Gates BEFORE enqueue, then reuses the
+/// existing per-channel mailbox. Never creates a new turn.
+pub(in crate::services::discord) async fn enqueue_steering(
+    shared: &SharedData,
+    request: SteeringRequest,
+) -> SteeringOutcome {
+    if !provider_supports_steering(&request.provider) {
+        return SteeringOutcome::Unsupported;
+    }
+    // Gate BEFORE enqueue so a steer never starts a fresh turn. This is a
+    // best-effort read (one actor hop before the enqueue): if the live turn
+    // happens to finish in that window, the steer is left on the queue and the
+    // normal idle-kickoff path may later dispatch it as an ordinary queued
+    // message — the same benign degradation any queued intervention has. The
+    // enqueue itself never starts a turn.
+    if !mailbox_has_active_turn(shared, request.channel_id).await {
+        return SteeringOutcome::NoLiveSession;
+    }
+
+    let intervention = build_steer_intervention(&request);
+    let outcome =
+        mailbox_enqueue_intervention(shared, &request.provider, request.channel_id, intervention)
+            .await;
+
+    if let Some(error) = outcome.persistence_error.as_ref() {
+        // In-memory enqueue still succeeded; durable persistence is best-effort.
+        tracing::error!(
+            provider = request.provider.as_str(),
+            channel_id = request.channel_id.get(),
+            error = %error,
+            "/steer enqueue durable persistence failed (in-memory enqueue unaffected)"
+        );
+    }
+
+    classify_enqueue_result(outcome.enqueued, outcome.refusal_reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(instruction: &str) -> SteeringRequest {
+        SteeringRequest {
+            channel_id: ChannelId::new(3_038_400),
+            provider: ProviderKind::Claude,
+            author_id: UserId::new(42),
+            source_id: MessageId::new(7_777),
+            instruction: instruction.to_string(),
+        }
+    }
+
+    #[test]
+    fn provider_gate_allows_only_claude_and_codex() {
+        assert!(provider_supports_steering(&ProviderKind::Claude));
+        assert!(provider_supports_steering(&ProviderKind::Codex));
+        assert!(!provider_supports_steering(&ProviderKind::Gemini));
+        assert!(!provider_supports_steering(&ProviderKind::OpenCode));
+        assert!(!provider_supports_steering(&ProviderKind::Qwen));
+        assert!(!provider_supports_steering(&ProviderKind::Unsupported(
+            "x".to_string()
+        )));
+    }
+
+    #[test]
+    fn steer_source_id_wraps_interaction_id() {
+        assert_eq!(steer_source_id(987_654), MessageId::new(987_654));
+    }
+
+    #[test]
+    fn steer_intervention_is_standalone_with_single_source_id() {
+        let req = request("run the tests first");
+        let intervention = build_steer_intervention(&req);
+        assert_eq!(intervention.message_id, req.source_id);
+        assert_eq!(intervention.source_message_ids, vec![req.source_id]);
+        assert!(!intervention.merge_consecutive);
+        assert_eq!(intervention.mode, InterventionMode::Soft);
+        assert_eq!(intervention.text, "run the tests first");
+        assert!(intervention.reply_context.is_none());
+        assert!(!intervention.has_reply_boundary);
+        assert!(intervention.pending_uploads.is_empty());
+        assert!(intervention.voice_announcement.is_none());
+        assert!(!intervention.author_is_bot);
+    }
+
+    #[test]
+    fn enqueue_result_classification_covers_queued_and_refusals() {
+        assert_eq!(classify_enqueue_result(true, None), SteeringOutcome::Queued);
+        for reason in [
+            EnqueueRefusalReason::SourceIdAlreadyQueued,
+            EnqueueRefusalReason::LastItemDedup,
+            EnqueueRefusalReason::ActorUnreachable,
+            EnqueueRefusalReason::MailboxClosed,
+        ] {
+            assert_eq!(
+                classify_enqueue_result(false, Some(reason)),
+                SteeringOutcome::Refused { reason }
+            );
+        }
+        // enqueued=false with no reason falls back to ActorUnreachable.
+        assert_eq!(
+            classify_enqueue_result(false, None),
+            SteeringOutcome::Refused {
+                reason: EnqueueRefusalReason::ActorUnreachable
+            }
+        );
+    }
+}


### PR DESCRIPTION
## 목표
Discord `/steer` 슬래시 커맨드로 진행 중인 턴에 끼어들 입력을 큐에 넣고 라이프사이클(큐잉중 → 큐잉됨 → 취소)을 카드로 보여준다. 큐잉된 입력이 후속 턴으로 승격될 때 전달이 실패하지 않도록 reply 경로를 보강했다.

## 쉬운 설명
에이전트가 작업 중일 때 `/steer 메시지`를 쓰면 "큐잉됨" 카드로 표시되고 현재 턴이 끝난 뒤 후속 입력으로 전달된다. 아직 전달 전이면 취소 버튼으로 되돌릴 수 있다. 이번에 큐잉된 steer가 승격될 때 placeholder가 전달 실패로 무한 재큐되던 문제를 고쳤다.

## 개선되는 것
### Fix 1 — `/steer` 커맨드 + 큐 라이프사이클 + 취소 버튼
- `steering.rs`가 인터랙션 id를 단일 source id로 감싸 soft-intervention 큐에 넣고, 카드가 `큐잉중 → 큐잉됨`으로 전이. `intake_gate.rs`에 취소 컴포넌트 라우팅 arm 추가, 취소 처리는 비대형 `steering.rs`에서 수행.

### Fix 2 — 승격 시 reply 안전 강등 (Codex P1 해결)
- before: 큐잉된 steer가 queued-turn으로 승격되면 placeholder가 인터랙션 id(채널 메시지 아님)를 reply 대상으로 참조 → Discord 기본값 `fail_if_not_exists=true`로 10008 에러 → `handle_text_message`가 Err 반환 → 재큐 루프로 에이전트에 영원히 미도달.
- after: `gateway.rs`의 단일 reply chokepoint(`post_message_with_reference`)에서 `fail_if_not_exists(false)` 설정 → 참조 메시지가 없으면 일반 메시지로 강등 전송. steer 승격이 정상 전달되고, 삭제된 메시지에 대한 모든 reply도 함께 견고해진다.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| 큐잉된 steer 승격 | 인터랙션 id reply 실패 → 재큐 루프, 미도달 | 일반 메시지로 강등 전송, 정상 도달 |
| 삭제된 메시지에 reply | 전송 자체 실패 | 참조 없이 정상 전송 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| 활성 턴 진행 중 큐잉 | soft-intervention 큐는 턴 finalize 후 드레인 → 후속 턴으로 전달(라이브 중간 주입 아님) | 작성자가 의도한 best-effort(코드 주석에 명시). 정상 |
| 전달 완료 후 취소 버튼 클릭 | 카드 취소 버튼이 전달 후에도 남아 클릭 시 버튼만 제거 | 경미 UX(Codex P2). 후속 보강 — 무해 |

## 해결한 내용
- `src/services/discord/gateway.rs`: `post_message_with_reference`에 `fail_if_not_exists(false)` — reply 강등(Codex P1 핵심 해결).
- `src/services/discord/steering.rs`(신규 443L), `commands/steer.rs`(신규 146L): 커맨드 + 3-state 카드 + 취소.
- `intake_gate.rs`(+6), `commands/{mod,command_policy}.rs`, `framework_setup.rs`, `discord/mod.rs`: 배선.
- `scripts/audit_maintainability_giant_baseline.toml`: 리베이스 후 intake_gate.rs 기준선 충돌 해소(#3446 +9, steer +6 → 2975).
- `scripts/audit_allowlist.toml`: gateway.rs 보강으로 바뀐 direct-send 해시 갱신.

## 검증
- `python3.12 scripts/audit_maintainability.py --check` → exit 0.
- `python3.12 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` → exit 0.
- `cargo check --bin agentdesk` (공유 타깃) → exit 0 (gateway.rs reply 강등 컴파일 확인). 전체 매트릭스는 클라우드 CI에서 검증.

## 비목표 / 후속
- 전달 완료 후 취소 버튼 비활성화(Codex P2, 경미 UX)는 후속 PR. 라이브-턴 중간 주입은 범위 밖(의도된 best-effort).
