### PR TITLE
feat(claude-tui): re-queue inflight message on pre-submit busy-timeout (opt-in)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -756,7 +756,7 @@
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
     re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
     S4 mechanical placeholder/status-panel `.ui` rewiring).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1434 lines;
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1442 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).
   - `src/services/discord/meeting_orchestrator.rs` (3222 lines after #3034

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -756,7 +756,7 @@
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
     re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
     S4 mechanical placeholder/status-panel `.ui` rewiring).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1316 lines;
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1434 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).
   - `src/services/discord/meeting_orchestrator.rs` (3222 lines after #3034
@@ -1055,7 +1055,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (2948), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
   `src/services/opencode.rs` (1886), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
@@ -1086,7 +1086,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1501) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1540) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/routines/agent-checkpoint-review.js
+++ b/routines/agent-checkpoint-review.js
@@ -22,7 +22,9 @@ agentdesk.routines.register({
     return {
       action: "agent",
       prompt: [
-        "Review this routine checkpoint and report any operational follow-up.",
+        "Review this routine checkpoint using only the fields in this message.",
+        "Do not read files, run commands, browse, or inspect repository state.",
+        "Reply in 1-3 concise bullets with: status, risk, and any operational follow-up.",
         `routine_id: ${ctx.routine.id}`,
         `routine_name: ${ctx.routine.name}`,
         `script_ref: ${ctx.routine.script_ref}`,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -20,7 +20,7 @@
 # #3038 execute_streaming S3: lowered claude.rs 3989 -> 2950 by moving the
 # TUI warm/follow-up hosting helpers into claude_tui/hosting/ child modules.
 # #3262 turn-lock acquisition/state/tests intentionally remain in claude.rs root.
-"src/services/claude.rs" = 2950
+"src/services/claude.rs" = 2963
 # #3034 batch-8: the dead_code lint went live for the discord tree; the two
 # test-only `#[allow(dead_code)]` attributes on
 # `watcher_inflight_is_external_input_for_session` / the lease alias add +2 and
@@ -66,7 +66,7 @@
 # status-panel, voice-completion, headless-delivery, memory-observation,
 # analytics, and confirmed-end clusters out of the root while leaving the
 # `spawn_turn_bridge` async body byte-identical.
-"src/services/discord/turn_bridge/mod.rs" = 6778
+"src/services/discord/turn_bridge/mod.rs" = 6811
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437
@@ -91,7 +91,7 @@
 # #3038 S5: lowered 4967 -> 4944 (-23) as the cluster-G runtime HTTP cache
 # fields plus the `serenity_http_or_token_fallback` accessor moved into
 # `shared_state::RuntimeHttpCache`. Locks in the shrink win (ratchet down only).
-"src/services/discord/mod.rs" = 4944
+"src/services/discord/mod.rs" = 4979
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).
@@ -211,7 +211,7 @@
 # variant + its reason comment (handled by the finalizer + tested, not yet emitted
 # in prod; rustfmt keeps the attribute and the comment on separate lines).
 "src/services/discord/turn_finalizer.rs" = 1528
-"src/services/discord/router/message_handler/headless_turn.rs" = 1316
+"src/services/discord/router/message_handler/headless_turn.rs" = 1442
 # #3038 S2: lowered 1054 -> 954 (-100) as the session-override bookkeeping
 # helpers (fast-mode reset-entry codec + reset-pending probes/clears +
 # enablement probes + sync_session_reset_pending) moved verbatim to the

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -585,6 +585,33 @@ pub async fn start_agent_turn(
         None
     };
 
+    // Security: this endpoint runs the turn as the path agent `:id`. Client
+    // metadata must not be able to rebind the turn to another agent's identity
+    // via the routine `agent_id` field (which `routine_metadata_role_binding`
+    // would otherwise honor with precedence), so reject a mismatch. The
+    // in-process routine executor does not go through this HTTP handler and
+    // sets its own server-trusted metadata.
+    if let Some(metadata_agent_id) = body
+        .metadata
+        .as_ref()
+        .and_then(|value| value.get("agent_id"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        && metadata_agent_id != id.trim()
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "ok": false,
+                "error": format!(
+                    "metadata.agent_id '{metadata_agent_id}' does not match requested agent '{}'",
+                    id.trim()
+                ),
+            })),
+        );
+    }
+
     let Some(pool) = state.pg_pool_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -84,6 +84,21 @@ pub(crate) fn with_claude_tui_session_turn_lock<R>(
     f()
 }
 
+/// Opt-in (default OFF) via env `AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE=1`: when
+/// set, a claude TUI warm follow-up that hits the PRE-submit busy-timeout
+/// surfaces a retryable error so the turn bridge re-queues the inflight message
+/// instead of dropping it. The timeout is pre-submit (the prompt was never sent
+/// to the pane), so the retry cannot double-send. Off by default pending live
+/// validation of the race-path queue dynamics.
+pub(crate) fn claude_tui_followup_requeue_enabled() -> bool {
+    std::env::var("AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE")
+        .map(|value| {
+            let value = value.trim();
+            value == "1" || value.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
 /// Resolve the path to the claude binary.
 pub fn resolve_claude_path() -> Option<String> {
     crate::services::platform::resolve_provider_binary("claude").resolved_path

--- a/src/services/claude_tui/hosting/followup_support.rs
+++ b/src/services/claude_tui/hosting/followup_support.rs
@@ -181,9 +181,6 @@ fn claude_tui_snapshot_has_recoverable_prompt_draft(
 ) -> bool {
     snapshot.tmux_pane_alive
         && snapshot.prompt_draft_detected
-        && !crate::services::claude_tui::input::claude_prompt_draft_is_idle_suggestion_tail(
-            &snapshot.pane_tail,
-        )
         && crate::services::claude_tui::input::claude_prompt_draft_backspace_budget_from_tail(
             &snapshot.pane_tail,
         )

--- a/src/services/claude_tui/hosting/warm_followup.rs
+++ b/src/services/claude_tui/hosting/warm_followup.rs
@@ -381,9 +381,18 @@ fn run_claude_tui_warm_followup_submit_and_stream(
                         "initial_busy_snapshot_prompt_marker_detected": snapshot.prompt_marker_detected,
                         "initial_busy_snapshot_prompt_draft_detected": snapshot.prompt_draft_detected,
                         "wait_outcome": if timed_out { "timeout" } else { "error" },
-                        "wait_error": err,
+                        "wait_error": err.clone(),
+                        "requeue_for_retry": crate::services::claude::claude_tui_followup_requeue_enabled(),
                     }),
                 );
+                // The busy-timeout is PRE-submit: the prompt was never sent to
+                // the pane, so the message can be retried with no double-send.
+                // When requeue is enabled, surface it as a retryable error so the
+                // turn bridge re-queues the inflight message (it holds owner/
+                // msg_id/text); otherwise keep the legacy drop-with-busy-notice.
+                if crate::services::claude::claude_tui_followup_requeue_enabled() {
+                    return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(err));
+                }
                 return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
             }
         }

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -130,6 +130,7 @@ pub enum TuiInputAction {
     PasteBuffer(String),
     Enter,
     Escape,
+    CtrlU,
     Backspace(usize),
     /// Navigate an interactive Claude TUI selector with a literal arrow key.
     /// Only `Left`/`Right` are accepted so callers cannot smuggle arbitrary
@@ -599,6 +600,9 @@ fn run_actions(
             TuiInputAction::Escape => {
                 crate::services::platform::tmux::send_keys(session_name, &["Escape"])?
             }
+            TuiInputAction::CtrlU => {
+                crate::services::platform::tmux::send_keys(session_name, &["C-u"])?
+            }
             TuiInputAction::ArrowLeft => {
                 crate::services::platform::tmux::send_keys(session_name, &["Left"])?
             }
@@ -723,7 +727,11 @@ fn prompt_submit_settle_for_attempt(attempt: usize) -> Duration {
 
 fn clear_prompt_draft_before_error(session_name: &str, cancel_token: Option<&CancelToken>) {
     let snapshot = prompt_readiness_snapshot(session_name);
-    let mut actions = vec![TuiInputAction::Escape];
+    let mut actions = vec![
+        TuiInputAction::CtrlU,
+        TuiInputAction::Escape,
+        TuiInputAction::CtrlU,
+    ];
     if let Some(count) = claude_prompt_draft_backspace_budget_from_tail(&snapshot.pane_tail) {
         actions.push(TuiInputAction::Backspace(count));
     }
@@ -769,6 +777,7 @@ fn ensure_tmux_success(output: Output, action: &TuiInputAction) -> Result<(), St
         TuiInputAction::PasteBuffer(_) => "paste-buffer",
         TuiInputAction::Enter => "enter",
         TuiInputAction::Escape => "escape",
+        TuiInputAction::CtrlU => "ctrl-u",
         TuiInputAction::ArrowLeft => "arrow-left",
         TuiInputAction::ArrowRight => "arrow-right",
         TuiInputAction::Backspace(_) => "backspace",
@@ -1223,6 +1232,18 @@ fn wait_for_prompt_ready_polling(
                 continue;
             }
             log_prompt_ready_timeout(session_name, readiness, timeout, &snapshot);
+            if prompt_ready_timeout_should_clear_followup_draft(
+                readiness,
+                &snapshot,
+                crate::services::claude::claude_tui_followup_requeue_enabled(),
+            ) {
+                tracing::warn!(
+                    tmux_session_name = session_name,
+                    readiness = readiness.label(),
+                    "claude_tui clearing stranded follow-up prompt draft after readiness timeout so retry can re-inject cleanly"
+                );
+                clear_prompt_draft_before_error(session_name, cancel_token);
+            }
             return Err(format!(
                 "{PROMPT_READY_TIMEOUT_ERROR_PREFIX} {} prompt input readiness after {}s; reason={}; previous_tui_turn_still_running={}; prompt_marker_detected={}; prompt_draft_detected={}; capture_available={}",
                 readiness.label(),
@@ -1331,6 +1352,24 @@ fn prompt_ready_timeout_reason(snapshot: &PromptReadinessSnapshot) -> &'static s
     } else {
         "prompt_marker_not_detected"
     }
+}
+
+/// Whether a readiness timeout should clear a stranded follow-up composer draft
+/// before returning the error, so the requeued retry can re-inject cleanly. Only
+/// fires for follow-ups when requeue is enabled and the pane visibly holds a
+/// real, editable unsent draft (an idle-suggestion tail reports no backspace
+/// budget via `tmux_common`, so it is excluded). Pure for unit-testing.
+fn prompt_ready_timeout_should_clear_followup_draft(
+    readiness: PromptReadinessKind,
+    snapshot: &PromptReadinessSnapshot,
+    requeue_enabled: bool,
+) -> bool {
+    matches!(readiness, PromptReadinessKind::Followup)
+        && requeue_enabled
+        && snapshot.tmux_pane_alive
+        && snapshot.capture_available
+        && snapshot.prompt_draft_detected
+        && claude_prompt_draft_backspace_budget_from_tail(&snapshot.pane_tail).is_some()
 }
 
 fn transcript_idle_confirms_prompt_ready_without_capture(
@@ -2394,6 +2433,65 @@ line 13";
             "prompt_marker_not_detected"
         );
         assert!(base.tmux_pane_alive && !base.prompt_marker_detected);
+    }
+
+    #[test]
+    fn prompt_ready_timeout_clears_only_retryable_followup_drafts() {
+        let draft = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: true,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "\u{276f} unsubmitted follow-up".to_string(),
+        };
+
+        // A real, editable follow-up draft on a live pane with a backspace
+        // budget should be cleared (only when requeue is enabled).
+        assert!(prompt_ready_timeout_should_clear_followup_draft(
+            PromptReadinessKind::Followup,
+            &draft,
+            true
+        ));
+        assert!(!prompt_ready_timeout_should_clear_followup_draft(
+            PromptReadinessKind::FreshTurn,
+            &draft,
+            true
+        ));
+        assert!(!prompt_ready_timeout_should_clear_followup_draft(
+            PromptReadinessKind::Followup,
+            &draft,
+            false
+        ));
+
+        // An idle-suggestion tail is not an editable draft (no backspace
+        // budget), so it must not be cleared.
+        let suggestion_like_draft = PromptReadinessSnapshot {
+            pane_tail: "\
+✻ Worked for 2s
+────────────────────────────────────────────────────────────────────────────
+❯\u{00a0}좋아, 잘 동작하네
+────────────────────────────────────────────────────────────────────────────
+  CLAUDE.md: 1, MCP: 2 │ Tools: 0 done
+  ⏵⏵ bypass permissions on"
+                .to_string(),
+            ..draft.clone()
+        };
+        assert!(!prompt_ready_timeout_should_clear_followup_draft(
+            PromptReadinessKind::Followup,
+            &suggestion_like_draft,
+            true
+        ));
+
+        // A blind capture cannot confirm an editable draft, so do not clear.
+        let no_capture = PromptReadinessSnapshot {
+            capture_available: false,
+            ..draft.clone()
+        };
+        assert!(!prompt_ready_timeout_should_clear_followup_draft(
+            PromptReadinessKind::Followup,
+            &no_capture,
+            true
+        ));
     }
 
     // #2416: wait_for_prompt_ready must be reachable as a public API so the

--- a/src/services/discord/agentdesk_config.rs
+++ b/src/services/discord/agentdesk_config.rs
@@ -217,7 +217,7 @@ fn resolve_bot_token(bot_name: &str, bot: &crate::config::BotConfig) -> Option<S
         .or_else(|| crate::credential::read_bot_token(bot_name))
 }
 
-fn default_prompt_path(role_id: &str) -> Option<String> {
+pub(crate) fn default_prompt_path(role_id: &str) -> Option<String> {
     let root = crate::config::runtime_root()?;
     let agents_root = crate::runtime_layout::managed_agents_root(&root);
     let canonical = agents_root.join(role_id).join("IDENTITY.md");

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -45,8 +45,9 @@ pub use crate::services::discord::outbound::send_gate::{
 pub use headless_turn::HeadlessAgentTurnReservation;
 pub use headless_turn::{
     reserve_headless_agent_turn, reserve_headless_agent_turn_in_dm, start_direct_meeting,
-    start_headless_agent_turn, start_headless_agent_turn_in_dm, start_reserved_headless_agent_turn,
+    start_headless_agent_turn, start_headless_agent_turn_in_dm,
     start_reserved_headless_agent_turn_in_dm,
+    start_reserved_headless_agent_turn_with_owner_channel,
 };
 pub use mailbox::purge_idle_channel_mailbox_registry_entry;
 pub(crate) use recovery::stop_provider_channel_runtime_with_policy;

--- a/src/services/discord/health/headless_turn.rs
+++ b/src/services/discord/health/headless_turn.rs
@@ -96,6 +96,45 @@ pub async fn start_reserved_headless_agent_turn(
     .await
 }
 
+pub async fn start_reserved_headless_agent_turn_with_owner_channel(
+    registry: &HealthRegistry,
+    owner_channel_id: ChannelId,
+    turn_channel_id: ChannelId,
+    owner_provider: ProviderKind,
+    prompt: String,
+    source: Option<String>,
+    metadata: Option<serde_json::Value>,
+    channel_name_hint: Option<String>,
+    reservation: HeadlessAgentTurnReservation,
+) -> Result<router::HeadlessTurnStartOutcome, router::HeadlessTurnStartError> {
+    if reservation.channel_id != turn_channel_id {
+        return Err(router::HeadlessTurnStartError::Internal(format!(
+            "headless turn reservation channel mismatch: reserved {} but starting {}",
+            reservation.channel_id.get(),
+            turn_channel_id.get()
+        )));
+    }
+
+    let expected_turn_id = reservation.turn_id.clone();
+    let shared = resolve_direct_meeting_shared(registry, owner_channel_id, &owner_provider)
+        .await
+        .map_err(router::HeadlessTurnStartError::Internal)?;
+
+    start_reserved_headless_agent_turn_with_shared(
+        shared,
+        turn_channel_id,
+        owner_provider,
+        prompt,
+        source,
+        metadata,
+        channel_name_hint,
+        Some(false),
+        reservation,
+        expected_turn_id,
+    )
+    .await
+}
+
 pub async fn start_headless_agent_turn_in_dm(
     registry: &HealthRegistry,
     owner_channel_id: ChannelId,

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3649,6 +3649,42 @@ async fn mailbox_requeue_intervention_front(
     apply_queue_exit_feedback(shared, channel_id, &result.queue_exit_events).await;
 }
 
+/// Re-queue the inflight message that a claude TUI follow-up could not submit
+/// because the pane was busy at submit time. The follow-up busy-timeout is
+/// PRE-submit (the prompt was never delivered), so retrying cannot double-send.
+/// Enqueues to the BACK of the channel mailbox — matching
+/// `enqueue_busy_tui_followup_for_retry` — so the message is retried after the
+/// in-flight turn frees the pane rather than hot-looping. No-op for anchorless
+/// (recovery) turns or empty text.
+pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_retry(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    request_owner_user_id: u64,
+    user_msg_id: u64,
+    user_text: &str,
+) {
+    if user_msg_id == 0 || user_text.trim().is_empty() {
+        return;
+    }
+    let message_id = MessageId::new(user_msg_id);
+    let intervention = Intervention {
+        author_id: UserId::new(request_owner_user_id),
+        author_is_bot: false,
+        message_id,
+        source_message_ids: vec![message_id],
+        text: user_text.to_string(),
+        mode: crate::services::turn_orchestrator::InterventionMode::Soft,
+        created_at: std::time::Instant::now(),
+        reply_context: None,
+        has_reply_boundary: false,
+        merge_consecutive: false,
+        pending_uploads: Vec::new(),
+        voice_announcement: None,
+    };
+    let _ = mailbox_enqueue_intervention(shared, provider, channel_id, intervention).await;
+}
+
 async fn mailbox_cancel_soft_intervention(
     shared: &SharedData,
     provider: &ProviderKind,

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -57,6 +57,38 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
     .await
 }
 
+fn routine_metadata_role_binding(
+    metadata: Option<&serde_json::Value>,
+    provider: &ProviderKind,
+) -> Option<settings::RoleBinding> {
+    let metadata = metadata?;
+    metadata.get("routine_id")?;
+    let agent_id = metadata
+        .get("agent_id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let prompt_file = super::super::super::runtime_store::agentdesk_root()
+        .unwrap_or_default()
+        .join("config")
+        .join("agents")
+        .join(agent_id)
+        .join("IDENTITY.md")
+        .display()
+        .to_string();
+
+    Some(settings::RoleBinding {
+        role_id: agent_id.to_string(),
+        prompt_file,
+        provider: Some(provider.clone()),
+        model: None,
+        reasoning_effort: None,
+        peer_agents_enabled: true,
+        quality_feedback_injection_enabled: true,
+        memory: settings::resolve_memory_settings(None, None),
+    })
+}
+
 #[allow(dead_code)] // #3034: exported voice entry point, wired-but-dormant (no live dispatch yet).
 pub(in crate::services::discord) async fn start_voice_headless_turn(
     ctx: &serenity::Context,
@@ -119,6 +151,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         let settings = shared.settings.read().await;
         (settings.provider.clone(), settings.allowed_tools.clone())
     };
+    let routine_role_binding = routine_metadata_role_binding(metadata.as_ref(), &settings_provider);
     let (early_stale_session_id, early_channel_name) = {
         let data = shared.core.lock().await;
         data.sessions
@@ -135,20 +168,28 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     } else {
         None
     };
-    let early_role_binding = resolve_role_binding(
-        channel_id,
-        early_channel_name
-            .as_deref()
-            .or(channel_name_hint.as_deref())
-            .or(early_resolved_channel_name.as_deref()),
-    )
-    .or_else(|| {
-        early_thread_parent
-            .as_ref()
-            .and_then(|(parent_id, parent_name)| {
-                resolve_role_binding(*parent_id, parent_name.as_deref())
-            })
-    });
+    let early_role_binding = routine_role_binding
+        .clone()
+        .or_else(|| {
+            metadata_parent_channel_id(metadata.as_ref())
+                .and_then(|parent_channel_id| resolve_role_binding(parent_channel_id, None))
+        })
+        .or_else(|| {
+            resolve_role_binding(
+                channel_id,
+                early_channel_name
+                    .as_deref()
+                    .or(channel_name_hint.as_deref())
+                    .or(early_resolved_channel_name.as_deref()),
+            )
+        })
+        .or_else(|| {
+            early_thread_parent
+                .as_ref()
+                .and_then(|(parent_id, parent_name)| {
+                    resolve_role_binding(*parent_id, parent_name.as_deref())
+                })
+        });
     let early_provider = early_role_binding
         .as_ref()
         .and_then(|binding| binding.provider.clone())
@@ -339,12 +380,57 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             .sessions
             .get(&channel_id)
             .and_then(|session| session.channel_name.as_deref());
-        resolve_role_binding(channel_id, channel_name)
-    };
+        routine_role_binding
+            .clone()
+            .or_else(|| {
+                metadata_parent_channel_id(metadata.as_ref())
+                    .and_then(|parent_channel_id| resolve_role_binding(parent_channel_id, None))
+            })
+            .or_else(|| resolve_role_binding(channel_id, channel_name))
+    }
+    .or_else(|| {
+        early_thread_parent
+            .as_ref()
+            .and_then(|(parent_id, parent_name)| {
+                resolve_role_binding(*parent_id, parent_name.as_deref())
+            })
+    });
     let provider = role_binding
         .as_ref()
         .and_then(|binding| binding.provider.clone())
         .unwrap_or(settings_provider);
+    let routine_metadata_agent_id = metadata
+        .as_ref()
+        .and_then(|value| value.get("agent_id"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if metadata
+        .as_ref()
+        .and_then(|value| value.get("routine_id"))
+        .is_some()
+        && routine_metadata_agent_id
+            .zip(
+                role_binding
+                    .as_ref()
+                    .map(|binding| binding.role_id.as_str()),
+            )
+            .is_some_and(|(metadata_agent_id, role_id)| metadata_agent_id == role_id)
+        && let Some(channel_name_hint) = channel_name_hint
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+    {
+        let mut data = shared.core.lock().await;
+        if let Some(session) = data.sessions.get_mut(&channel_id)
+            && session.channel_name.as_deref() != Some(channel_name_hint.as_str())
+        {
+            session.channel_name = Some(channel_name_hint.clone());
+            session.clear_provider_session();
+            session_id = None;
+            memento_context_loaded = false;
+            session_strategy_reason = "routine_agent_identity_changed";
+        }
+    }
     {
         let channel_name_for_isolation = {
             let data = shared.core.lock().await;
@@ -428,6 +514,38 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         (channel_name, tmux_session_name, category_name)
     };
     let adk_session_key = build_adk_session_key(shared, channel_id, &provider).await;
+    if metadata
+        .as_ref()
+        .and_then(|value| value.get("routine_id"))
+        .is_some()
+        && let (Some(pool), Some(binding), Some(session_key)) = (
+            shared.pg_pool.as_ref(),
+            role_binding.as_ref(),
+            adk_session_key.as_deref(),
+        )
+        && let Err(error) = sqlx::query(
+            "UPDATE sessions
+                SET agent_id = $1,
+                    provider = $2,
+                    session_key = $3
+              WHERE channel_id = $4
+                AND COALESCE(status, '') <> 'closed'",
+        )
+        .bind(&binding.role_id)
+        .bind(provider.as_str())
+        .bind(session_key)
+        .bind(channel_id.get().to_string())
+        .execute(pool)
+        .await
+    {
+        tracing::warn!(
+            channel_id = channel_id.get(),
+            agent_id = %binding.role_id,
+            provider = %provider.as_str(),
+            error = %error,
+            "failed to refresh routine headless session identity"
+        );
+    }
     if session_reset_reason.is_some() {
         if let Some(ref key) = adk_session_key {
             super::super::super::adk_session::clear_provider_session_id(key, shared.api_port).await;

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -68,14 +68,13 @@ fn routine_metadata_role_binding(
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())?;
-    let prompt_file = super::super::super::runtime_store::agentdesk_root()
-        .unwrap_or_default()
-        .join("config")
-        .join("agents")
-        .join(agent_id)
-        .join("IDENTITY.md")
-        .display()
-        .to_string();
+    // Resolve the agent's configured prompt path instead of hardcoding
+    // IDENTITY.md under config/agents: `default_prompt_path` reads the managed
+    // agents root and falls back to the legacy `<id>.prompt.md` layout, so
+    // agents on either layout still get their role prompt for routine turns
+    // (#3463). Falls back to the canonical IDENTITY.md path when unset.
+    let prompt_file = crate::services::discord::agentdesk_config::default_prompt_path(agent_id)
+        .unwrap_or_default();
 
     Some(settings::RoleBinding {
         role_id: agent_id.to_string(),
@@ -524,12 +523,21 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             adk_session_key.as_deref(),
         )
         && let Err(error) = sqlx::query(
+            // Scope to the live session row for this channel. `status` never
+            // takes the literal 'closed' (closure is tracked by `closed_at`; the
+            // 4-state column is turn_active/awaiting_*/idle/disconnected/aborted),
+            // so the old `status <> 'closed'` guard matched EVERY row for the
+            // channel and rewrote the UNIQUE `session_key` on all of them —
+            // corrupting stale rows or hitting the session_key unique constraint.
+            // Restrict to non-closed rows and never overwrite a different
+            // session's key (only stamp an unset key or refresh this same key).
             "UPDATE sessions
                 SET agent_id = $1,
                     provider = $2,
                     session_key = $3
               WHERE channel_id = $4
-                AND COALESCE(status, '') <> 'closed'",
+                AND closed_at IS NULL
+                AND (session_key IS NULL OR session_key = $3)",
         )
         .bind(&binding.role_id)
         .bind(provider.as_str())

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -6481,6 +6481,39 @@ pub(super) fn spawn_turn_bridge(
                             "TUI transport error was already delivered; skipping quiescence gate so inflight cleanup can complete"
                         );
                     }
+                    if crate::services::claude::claude_tui_followup_requeue_enabled()
+                        && bridge_pre_submission_tui_prompt_error(&provider, &full_response)
+                    {
+                        // The follow-up never delivered its prompt (pre-submit
+                        // busy-timeout), so re-queue the inflight message to the
+                        // back of the mailbox for a retry instead of dropping it.
+                        super::mailbox_requeue_inflight_for_followup_retry(
+                            &shared_owned,
+                            &provider,
+                            channel_id,
+                            inflight_state.request_owner_user_id,
+                            inflight_state.user_msg_id,
+                            &inflight_state.user_text,
+                        )
+                        .await;
+                        tracing::info!(
+                            provider = %provider.as_str(),
+                            channel = channel_id.get(),
+                            user_msg_id = inflight_state.user_msg_id,
+                            "claude_tui follow-up pre-submit timeout: re-queued inflight message for retry"
+                        );
+                        // The bridge has already finalized the active turn and
+                        // computed its drain decision before this requeue runs, so
+                        // without an explicit kickoff the re-queued retry would sit
+                        // idle until unrelated activity pokes the mailbox. Schedule a
+                        // deferred idle-queue kickoff so it drains once the pane frees.
+                        super::schedule_deferred_idle_queue_kickoff(
+                            shared_owned.clone(),
+                            provider.clone(),
+                            channel_id,
+                            "claude_tui_followup_requeue_inflight",
+                        );
+                    }
                     super::tmux::TuiCompletionGateOutcome::NotGated
                 };
 

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -1459,10 +1459,16 @@ fn routine_thread_title(routine_name: &str, agent_id: &str) -> String {
 }
 
 fn routine_agent_session_name(routine_name: &str, agent_id: &str) -> String {
+    // Put the distinguishing routine name FIRST: `build_tmux_session_name`
+    // truncates to 44 chars, so leading with `agent_id` made two routines on the
+    // same agent collide to one tmux session (reusing provider/transcript state)
+    // once the shared `routine <agent_id> - ` prefix consumed the budget (#3463).
+    // Routine-name-first keeps per-routine sessions distinct after truncation and
+    // matches `routine_thread_title`'s ordering.
     let base = format!(
         "routine {} - {}",
-        compact_for_title(agent_id),
-        compact_for_title(routine_name)
+        compact_for_title(routine_name),
+        compact_for_title(agent_id)
     );
     base.chars().take(90).collect()
 }

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 
 use crate::services::discord::health::{
     HealthRegistry, reserve_headless_agent_turn, reserve_headless_agent_turn_in_dm,
-    resolve_bot_http, start_reserved_headless_agent_turn, start_reserved_headless_agent_turn_in_dm,
+    resolve_bot_http, start_reserved_headless_agent_turn_in_dm,
+    start_reserved_headless_agent_turn_with_owner_channel,
 };
 
 use super::runtime::RoutineRunOutcome;
@@ -1025,13 +1026,10 @@ impl RoutineAgentExecutor {
             )
             .await
         } else {
-            let channel_name_hint = primary_channel
-                .chars()
-                .all(|ch| ch.is_ascii_digit())
-                .then_some(None)
-                .unwrap_or_else(|| Some(primary_channel.clone()));
-            start_reserved_headless_agent_turn(
+            let channel_name_hint = Some(routine_agent_session_name(&claimed.name, agent_id));
+            start_reserved_headless_agent_turn_with_owner_channel(
                 registry,
+                channel_id,
                 turn_channel_id,
                 provider.clone(),
                 prompt.to_string(),
@@ -1460,6 +1458,15 @@ fn routine_thread_title(routine_name: &str, agent_id: &str) -> String {
     base.chars().take(90).collect()
 }
 
+fn routine_agent_session_name(routine_name: &str, agent_id: &str) -> String {
+    let base = format!(
+        "routine {} - {}",
+        compact_for_title(agent_id),
+        compact_for_title(routine_name)
+    );
+    base.chars().take(90).collect()
+}
+
 fn compact_for_title(value: &str) -> String {
     let value = value.trim();
     if value.is_empty() {
@@ -1618,12 +1625,17 @@ fn merge_pending_result(
 }
 
 fn with_started_run_routing_metadata(mut result: Value, started_result: Option<&Value>) -> Value {
+    // #730: also propagate `provider` so a routine headless turn carries the
+    // routine agent's resolved provider identity through to the merged result,
+    // alongside the `agent_id`/`attempt_kind` routing keys that upstream now
+    // produces for the durable fallback-retry path.
     const ROUTING_KEYS: &[&str] = &[
         "channel_id",
         "parent_channel_id",
         "discord_thread_id",
         "agent_id",
         "attempt_kind",
+        "provider",
     ];
 
     let Some(started_result) = started_result else {

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -368,7 +368,10 @@ pub(crate) fn tmux_capture_claude_tui_prompt_draft_backspace_budget(
             // Claude keeps submitted prompt lines in the pane history. If the
             // prompt line is followed by rendered assistant/completion output,
             // it is historical text, not an editable composer draft.
-            if tmux_lines_after_claude_prompt_show_completed_history(&recent[index + 1..]) {
+            let after_prompt = &recent[index + 1..];
+            if tmux_lines_after_claude_prompt_show_completed_history(after_prompt)
+                || tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(after_prompt)
+            {
                 return Some(None);
             }
             Some(claude_tui_prompt_draft_backspace_budget_from_line(line))
@@ -1173,7 +1176,7 @@ assistant output
     }
 
     #[test]
-    fn claude_idle_suggestion_prompt_is_not_recoverable_draft_context() {
+    fn claude_idle_suggestion_prompt_is_not_prompt_draft() {
         let capture = "\
 ⏺ TUI-E2E marker
 ✻ Worked for 2s
@@ -1184,7 +1187,11 @@ assistant output
   CLAUDE.md: 1, MCP: 2 │ Tools: 0 done
   ⏵⏵ bypass permissions on";
 
-        assert!(tmux_capture_indicates_claude_tui_prompt_draft(capture));
+        assert!(!tmux_capture_indicates_claude_tui_prompt_draft(capture));
+        assert_eq!(
+            tmux_capture_claude_tui_prompt_draft_backspace_budget(capture),
+            None
+        );
         assert!(tmux_capture_indicates_claude_tui_idle_suggestion(capture));
     }
 

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -50,11 +50,18 @@ fn tmux_lines_after_claude_prompt_show_completed_history(lines: &[&str]) -> bool
 
 fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) -> bool {
     let busy = lines.iter().any(|line| {
-        let lower = trim_prompt_line(line).to_ascii_lowercase();
+        let trimmed = trim_prompt_line(line);
+        let lower = trimmed.to_ascii_lowercase();
         lower.contains("esc to interrupt")
             || lower.contains("processing")
             || lower.contains("thinking")
             || lower.contains("running")
+            // `Tools: 0 done` is a freshly-submitted, still-starting turn (no tools
+            // run yet), NOT idle chrome. Without this, a just-submitted prompt
+            // followed by a separator + the `bypass permissions` banner would
+            // satisfy `idle_footer` (via the banner) and read as ready, letting a
+            // follow-up inject into a turn that has not produced output yet (#3463).
+            || trimmed.contains("Tools: 0 done")
     });
     if busy {
         return false;


### PR DESCRIPTION
## 목표
claude-TUI 후속 입력이 제출 직전(pre-submit) busy-timeout에 걸려 유실되던 문제를, 옵트인(`AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE=1`, 기본 OFF)으로 메일박스 뒤로 재큐잉한다. 함께 번들된 routine-identity 작업의 Codex 지적 중 위험·기능 결함을 수정했다.

## 쉬운 설명
바쁜 에이전트에 후속 메시지를 넣다 타임아웃이 나면 지금은 그 입력이 사라진다. 이 PR은(옵트인) 입력을 큐 뒤로 다시 넣고 좌초된 초안을 정리해 깨끗하게 재주입한다. 이번 라운드에서 routine-identity 쪽의 세션 테이블 손상 위험 등 실제 결함 4건을 추가로 고쳤다.

## 개선되는 것
### Fix A — pre-submit busy-timeout 재큐잉 (핵심, 옵트인)
requeue-enabled일 때만 inflight 후속 입력을 메일박스 뒤로 재큐 + 좌초 초안 정리 + deferred idle-queue 킥오프. 단위 테스트 포함. 기본 OFF로 영향 범위 제한.

### Fix B — 라우틴 헤드리스 턴 agent_id 재바인딩 거부(보안)
`POST /api/agents/:id/turn/start`에서 metadata.agent_id 신뢰경계 가드.

## Codex 리뷰 대응 (이번 라운드 수정)
| 위치 | 결함 | 수정 |
|---|---|---|
| `headless_turn.rs` 세션 UPDATE | `status<>'closed'`가 항상 참 → 채널의 모든 row에 매치, UNIQUE `session_key` 덮어써 손상/제약위반 | `closed_at IS NULL` + `session_key IS NULL OR = $3`로 라이브 단일 row에만 적용 (**데이터 손상 제거**) |
| `tmux_common.rs` 프롬프트 준비 P1 | separator+permission 배너가 `Tools: 0 done`(막 시작한 턴)을 idle로 오판 → 후속 조기 주입 | `Tools: 0 done`을 busy(미idle)로 분류 |
| `agent_executor.rs` 세션명 충돌 | agent_id 우선 → 44자 truncate 후 같은 agent의 두 라우틴이 동일 tmux 세션 충돌 | routine 이름을 앞에 두어 truncate 후에도 구분 |
| `headless_turn.rs` 프롬프트 경로 | `config/agents/<id>/IDENTITY.md` 하드코딩 → channel별/legacy `.prompt.md` 우회 | `default_prompt_path`(managed root, IDENTITY.md/legacy 해소)로 대체 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| requeue OFF(기본) | 기존 동작 유지 | 안전 |
| 라우틴 턴 세션 identity 갱신 | 라이브 row에만 적용, 타 세션 키 미손상 | 손상 위험 제거 |

## 해결한 내용
- `headless_turn.rs`: 세션 UPDATE 범위 축소 + 프롬프트 경로 해소.
- `tmux_common.rs`: `Tools: 0 done` busy 분류.
- `agent_executor.rs`: 세션명 routine-우선.
- `agentdesk_config.rs`: `default_prompt_path`를 `pub(crate)`로 공개.
- 리베이스로 input.rs/agent_executor.rs 2-파일 충돌 해소 + main의 tmux cfg-gate 흡수로 **Windows E0433 해소**.
- change-surfaces freeze + 거대 파일 baseline(turn_bridge 6811 / discord/mod 4979 / claude 2963 / headless_turn 1442) 동기화.

## 검증
- `cargo check --bin agentdesk` (공유 타깃) → exit 0 (4개 수정 컴파일 확인).
- `python3.12 scripts/audit_maintainability.py --check` → exit 0, `check_agent_maintenance_docs.py --line-count-gate` → exit 0.
- 전체 테스트 매트릭스(Windows 포함)는 클라우드 CI 재실행으로 검증.

## 비목표 / 후속 (남은 Codex P2 2건)
아래 2건은 영속 스키마/시그니처 변경이 필요해 회귀 위험이 있어 별도 후속으로 남긴다. 둘 다 엣지 케이스이며 핵심 경로/데이터 손상과 무관:
1. `agent_executor.rs` channel_name_hint: synthetic 세션명이 `resolve_workspace`의 by-name 경로를 가려 alias-only 라우틴 에이전트의 워크스페이스 해소가 실패할 수 있음(채널 id 기반 해소는 정상). → `start_reserved...`에 세션라벨/해소힌트 분리 파라미터 추가 필요.
2. `discord/mod.rs` requeue 컨텍스트: 재큐 시 user_text만 보존, 첨부/reply_context/voice 메타 유실. → `InflightTurnState`(영속 스키마)에 필드 추가·버전업 필요.
