### PR TITLE
fix(voice): scope voice announcements to the owning agent (stop multi-agent reply storm)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -460,6 +460,7 @@ src/
 │   │   │   │   ├── session_strategy_lifecycle_tests.rs
 │   │   │   │   ├── tui_followup.rs
 │   │   │   │   ├── turn_lifecycle.rs
+│   │   │   │   ├── voice_announcement_scope.rs
 │   │   │   │   └── watchdog.rs
 │   │   │   ├── authorization.rs
 │   │   │   ├── dispatch_trigger.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -725,9 +725,11 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3769 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3766 lines;
     Discord message intake turn orchestration split from the router message
-    handler; bugfix only outside a further extraction plan; +9 from #3082
+    handler; bugfix only outside a further extraction plan; #3464 extracted the
+    unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;
+    +9 from #3082
     queued-only answer-flush gate (`is_queued_notice` on the two
     `send_intake_placeholder` call sites: `true` for the race-lost queued card,
     `false` for the active-turn placeholder); +57 from #3182 normal-dequeue

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -48,6 +48,7 @@ mod intake_turn;
 mod provider_isolation;
 mod tui_followup;
 mod turn_lifecycle;
+mod voice_announcement_scope;
 mod watchdog;
 
 use self::goal_lifecycle::*;

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -124,23 +124,6 @@ pub(crate) struct IntakeRequest {
     pub turn_kind: TurnKind,
 }
 
-fn should_drop_unauthorized_voice_announcement(
-    has_stored_voice_announcement: bool,
-    has_legacy_voice_announcement: bool,
-    is_readable_voice_announcement: bool,
-    voice_announcement_resolved: bool,
-    announce_bot_id: Option<u64>,
-    request_owner: UserId,
-) -> bool {
-    if voice_announcement_resolved {
-        return false;
-    }
-
-    has_stored_voice_announcement
-        || (announce_bot_id == Some(request_owner.get())
-            && (has_legacy_voice_announcement || is_readable_voice_announcement))
-}
-
 /// Worker-callable entry point for executing an intake turn. Phase 2-pre.3
 /// of intake-node-routing: this is the public surface a worker node will
 /// invoke after claiming an `intake_outbox` row from its target queue. Pass
@@ -443,43 +426,20 @@ pub(in crate::services::discord) async fn handle_text_message(
     } else {
         None
     };
-    let drop_unauthorized_voice_announcement = should_drop_unauthorized_voice_announcement(
+    // #3464: scope unauthorized voice announcements to the owning agent — a
+    // non-owning agent must not fall through to generic handling and answer
+    // (multi-agent reply storm). Decision + one-shot warn live in
+    // `voice_announcement_scope` (this file is LoC-frozen).
+    if super::voice_announcement_scope::drop_unauthorized_voice_announcement(
         has_stored_voice_announcement,
         has_legacy_voice_announcement,
         is_readable_voice_announcement,
         voice_announcement.is_some(),
         announce_bot_id,
         request_owner,
-    );
-
-    if drop_unauthorized_voice_announcement
-        && has_stored_voice_announcement
-        && announce_bot_id.is_none()
-    {
-        tracing::warn!(
-            channel_id = channel_id.get(),
-            message_id = user_msg_id.get(),
-            author_id = request_owner.get(),
-            "dropping stored voice transcript announcement because announce bot user id is unavailable"
-        );
-        // The message is an announce-bot voice transcript but we cannot
-        // authorize it. Do not fall through to generic text handling, or every
-        // voice-enabled agent that observes the announce message in the shared
-        // voice channel answers it (multi-agent reply storm). Only the owning
-        // agent, which successfully claims the durable metadata, should reply.
-        return Ok(());
-    } else if drop_unauthorized_voice_announcement {
-        tracing::warn!(
-            channel_id = channel_id.get(),
-            message_id = user_msg_id.get(),
-            author_id = request_owner.get(),
-            announce_bot_id = ?announce_bot_id,
-            "ignoring voice transcript announcement without authorized durable metadata"
-        );
-        // Same scoping guard: an unclaimed voice transcript announcement must
-        // not be answered by non-owning agents. The owning agent claims the
-        // durable metadata (`voice_announcement.is_some()`) and proceeds; all
-        // others stop here instead of emitting a generic chat reply.
+        channel_id,
+        user_msg_id,
+    ) {
         return Ok(());
     }
     let is_voice_announcement = voice_announcement.is_some();
@@ -3801,59 +3761,6 @@ pub(in crate::services::discord) async fn handle_text_message(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod unauthorized_voice_announcement_scope_tests {
-    use super::*;
-
-    #[test]
-    fn human_readable_voice_shape_is_not_dropped() {
-        assert!(!should_drop_unauthorized_voice_announcement(
-            false,
-            false,
-            true,
-            false,
-            Some(100),
-            UserId::new(42),
-        ));
-    }
-
-    #[test]
-    fn announce_bot_readable_without_metadata_is_dropped() {
-        assert!(should_drop_unauthorized_voice_announcement(
-            false,
-            false,
-            true,
-            false,
-            Some(100),
-            UserId::new(100),
-        ));
-    }
-
-    #[test]
-    fn stored_announcement_without_metadata_is_dropped() {
-        assert!(should_drop_unauthorized_voice_announcement(
-            true,
-            false,
-            false,
-            false,
-            None,
-            UserId::new(42),
-        ));
-    }
-
-    #[test]
-    fn resolved_announcement_is_not_dropped() {
-        assert!(!should_drop_unauthorized_voice_announcement(
-            true,
-            true,
-            true,
-            true,
-            Some(100),
-            UserId::new(100),
-        ));
-    }
 }
 
 #[cfg(test)]

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -124,6 +124,23 @@ pub(crate) struct IntakeRequest {
     pub turn_kind: TurnKind,
 }
 
+fn should_drop_unauthorized_voice_announcement(
+    has_stored_voice_announcement: bool,
+    has_legacy_voice_announcement: bool,
+    is_readable_voice_announcement: bool,
+    voice_announcement_resolved: bool,
+    announce_bot_id: Option<u64>,
+    request_owner: UserId,
+) -> bool {
+    if voice_announcement_resolved {
+        return false;
+    }
+
+    has_stored_voice_announcement
+        || (announce_bot_id == Some(request_owner.get())
+            && (has_legacy_voice_announcement || is_readable_voice_announcement))
+}
+
 /// Worker-callable entry point for executing an intake turn. Phase 2-pre.3
 /// of intake-node-routing: this is the public surface a worker node will
 /// invoke after claiming an `intake_outbox` row from its target queue. Pass
@@ -426,18 +443,32 @@ pub(in crate::services::discord) async fn handle_text_message(
     } else {
         None
     };
-    if has_stored_voice_announcement && announce_bot_id.is_none() {
+    let drop_unauthorized_voice_announcement = should_drop_unauthorized_voice_announcement(
+        has_stored_voice_announcement,
+        has_legacy_voice_announcement,
+        is_readable_voice_announcement,
+        voice_announcement.is_some(),
+        announce_bot_id,
+        request_owner,
+    );
+
+    if drop_unauthorized_voice_announcement
+        && has_stored_voice_announcement
+        && announce_bot_id.is_none()
+    {
         tracing::warn!(
             channel_id = channel_id.get(),
             message_id = user_msg_id.get(),
             author_id = request_owner.get(),
             "dropping stored voice transcript announcement because announce bot user id is unavailable"
         );
-    } else if (has_stored_voice_announcement
-        || has_legacy_voice_announcement
-        || is_readable_voice_announcement)
-        && voice_announcement.is_none()
-    {
+        // The message is an announce-bot voice transcript but we cannot
+        // authorize it. Do not fall through to generic text handling, or every
+        // voice-enabled agent that observes the announce message in the shared
+        // voice channel answers it (multi-agent reply storm). Only the owning
+        // agent, which successfully claims the durable metadata, should reply.
+        return Ok(());
+    } else if drop_unauthorized_voice_announcement {
         tracing::warn!(
             channel_id = channel_id.get(),
             message_id = user_msg_id.get(),
@@ -445,6 +476,11 @@ pub(in crate::services::discord) async fn handle_text_message(
             announce_bot_id = ?announce_bot_id,
             "ignoring voice transcript announcement without authorized durable metadata"
         );
+        // Same scoping guard: an unclaimed voice transcript announcement must
+        // not be answered by non-owning agents. The owning agent claims the
+        // durable metadata (`voice_announcement.is_some()`) and proceeds; all
+        // others stop here instead of emitting a generic chat reply.
+        return Ok(());
     }
     let is_voice_announcement = voice_announcement.is_some();
     let voice_prompt_text = voice_announcement.as_ref().map(|announcement| {
@@ -3766,6 +3802,60 @@ pub(in crate::services::discord) async fn handle_text_message(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod unauthorized_voice_announcement_scope_tests {
+    use super::*;
+
+    #[test]
+    fn human_readable_voice_shape_is_not_dropped() {
+        assert!(!should_drop_unauthorized_voice_announcement(
+            false,
+            false,
+            true,
+            false,
+            Some(100),
+            UserId::new(42),
+        ));
+    }
+
+    #[test]
+    fn announce_bot_readable_without_metadata_is_dropped() {
+        assert!(should_drop_unauthorized_voice_announcement(
+            false,
+            false,
+            true,
+            false,
+            Some(100),
+            UserId::new(100),
+        ));
+    }
+
+    #[test]
+    fn stored_announcement_without_metadata_is_dropped() {
+        assert!(should_drop_unauthorized_voice_announcement(
+            true,
+            false,
+            false,
+            false,
+            None,
+            UserId::new(42),
+        ));
+    }
+
+    #[test]
+    fn resolved_announcement_is_not_dropped() {
+        assert!(!should_drop_unauthorized_voice_announcement(
+            true,
+            true,
+            true,
+            true,
+            Some(100),
+            UserId::new(100),
+        ));
+    }
+}
+
 #[cfg(test)]
 mod voice_route_tests {
     use super::*;

--- a/src/services/discord/router/message_handler/voice_announcement_scope.rs
+++ b/src/services/discord/router/message_handler/voice_announcement_scope.rs
@@ -1,0 +1,125 @@
+//! EPIC #3464 — scope unauthorized voice-transcript announcements to the owning
+//! agent. Extracted from the LoC-frozen `intake_turn.rs` so the decision and the
+//! one-shot drop warn are unit-testable in isolation and the frozen file only
+//! carries a single call site.
+
+use super::*;
+
+/// Pure decision: should an inbound voice-transcript announcement be DROPPED
+/// (not answered) by this agent? Only the owning agent — which resolved the
+/// durable metadata (`voice_announcement_resolved`) — replies; everyone else
+/// must stop, or the shared voice channel gets a multi-agent reply storm.
+pub(super) fn should_drop_unauthorized_voice_announcement(
+    has_stored_voice_announcement: bool,
+    has_legacy_voice_announcement: bool,
+    is_readable_voice_announcement: bool,
+    voice_announcement_resolved: bool,
+    announce_bot_id: Option<u64>,
+    request_owner: UserId,
+) -> bool {
+    if voice_announcement_resolved {
+        return false;
+    }
+
+    has_stored_voice_announcement
+        || (announce_bot_id == Some(request_owner.get())
+            && (has_legacy_voice_announcement || is_readable_voice_announcement))
+}
+
+/// Intake scoping guard: returns `true` (the caller must `return Ok(())`) when
+/// this is an unauthorized voice announcement a non-owning agent must not answer,
+/// emitting the one-shot observability warn. Returns `false` for the owning agent
+/// (resolved durable metadata) and for non-announcements, which proceed normally.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn drop_unauthorized_voice_announcement(
+    has_stored_voice_announcement: bool,
+    has_legacy_voice_announcement: bool,
+    is_readable_voice_announcement: bool,
+    voice_announcement_resolved: bool,
+    announce_bot_id: Option<u64>,
+    request_owner: UserId,
+    channel_id: ChannelId,
+    user_msg_id: MessageId,
+) -> bool {
+    if !should_drop_unauthorized_voice_announcement(
+        has_stored_voice_announcement,
+        has_legacy_voice_announcement,
+        is_readable_voice_announcement,
+        voice_announcement_resolved,
+        announce_bot_id,
+        request_owner,
+    ) {
+        return false;
+    }
+
+    if has_stored_voice_announcement && announce_bot_id.is_none() {
+        tracing::warn!(
+            channel_id = channel_id.get(),
+            message_id = user_msg_id.get(),
+            author_id = request_owner.get(),
+            "dropping stored voice transcript announcement because announce bot user id is unavailable"
+        );
+    } else {
+        tracing::warn!(
+            channel_id = channel_id.get(),
+            message_id = user_msg_id.get(),
+            author_id = request_owner.get(),
+            announce_bot_id = ?announce_bot_id,
+            "ignoring voice transcript announcement without authorized durable metadata"
+        );
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_readable_voice_shape_is_not_dropped() {
+        assert!(!should_drop_unauthorized_voice_announcement(
+            false,
+            false,
+            true,
+            false,
+            Some(100),
+            UserId::new(42),
+        ));
+    }
+
+    #[test]
+    fn announce_bot_readable_without_metadata_is_dropped() {
+        assert!(should_drop_unauthorized_voice_announcement(
+            false,
+            false,
+            true,
+            false,
+            Some(100),
+            UserId::new(100),
+        ));
+    }
+
+    #[test]
+    fn stored_announcement_without_metadata_is_dropped() {
+        assert!(should_drop_unauthorized_voice_announcement(
+            true,
+            false,
+            false,
+            false,
+            None,
+            UserId::new(42),
+        ));
+    }
+
+    #[test]
+    fn resolved_announcement_is_not_dropped() {
+        assert!(!should_drop_unauthorized_voice_announcement(
+            true,
+            true,
+            true,
+            true,
+            Some(100),
+            UserId::new(100),
+        ));
+    }
+}


### PR DESCRIPTION
Curated upstream contribution from the kunkunGames/AgentDesk fork — rebased onto current main and re-authored against upstream's in-flight #3089 turn-output-controller refactor where needed. Verified locally (cargo check / targeted tests).

Commits (1):
- fix(voice): scope voice announcement to owning agent

🤖 Generated with Claude Code