### PR TITLE
fix: centralize legacy-SQLite db selection for the heartbeat-audit fallback

### DIFF
--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -73,7 +73,8 @@ use self::watcher_lifecycle::*;
 pub(in crate::services::discord) use self::watcher_lifecycle::{
     claim_or_reuse_watcher, clear_recovery_handled_channels,
     fail_dispatch_for_ready_for_input_stall, refresh_session_heartbeat_from_tmux_output,
-    restore_tmux_watchers, session_belongs_to_current_runtime, store_recovery_handled_channels,
+    restore_tmux_watchers, session_belongs_to_current_runtime, sqlite_runtime_db,
+    store_recovery_handled_channels,
 };
 use super::watcher_lifecycle_decision::*;
 const READY_FOR_INPUT_IDLE_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1770,7 +1770,7 @@ fn maybe_refresh_active_turn_activity_heartbeat_at(
     };
     let thread_channel_id = active_turn_thread_channel_id(adk_session_name, inflight_state);
 
-    let legacy_db = None::<&crate::db::Db>;
+    let legacy_db = super::tmux::sqlite_runtime_db(shared);
 
     if super::tmux::refresh_session_heartbeat_from_tmux_output(
         legacy_db,

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -842,7 +842,9 @@ pub(super) fn recovery_handled_channel_key(channel_id: u64) -> String {
     format!("recovery_handled_channel:{channel_id}")
 }
 
-pub(super) fn sqlite_runtime_db(shared: &SharedData) -> Option<&crate::db::Db> {
+pub(in crate::services::discord) fn sqlite_runtime_db(
+    shared: &SharedData,
+) -> Option<&crate::db::Db> {
     if shared.pg_pool.is_some() {
         None
     } else {


### PR DESCRIPTION
Curated upstream contribution from the kunkunGames/AgentDesk fork — rebased onto current main and re-authored against upstream's in-flight #3089 turn-output-controller refactor where needed. Verified locally (cargo check / targeted tests).

Commits (1):
- Fix legacy sqlite audit for heartbeat fallback

🤖 Generated with Claude Code