### PR TITLE
fix(#3431): restore codex agent_message paragraph separator in relayed body

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1037,7 +1037,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   support extracted from the route layer; split before adding non-bugfix
   behavior.
 - `src/services/claude.rs` (2948), `src/services/gemini.rs` (1358),
-  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3002),
+  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -2943,13 +2943,21 @@ fn handle_codex_json_line(
                     "agent_message" => {
                         let text = item.get("text").and_then(|v| v.as_str()).unwrap_or("");
                         if !text.is_empty() {
-                            if !final_text.is_empty() {
+                            // #3431: each codex `agent_message` is a COMPLETE block
+                            // (item.completed, never a mid-token delta), so a second+
+                            // message must carry the SAME `\n\n` paragraph separator
+                            // that `final_text` uses — otherwise the bridge consumer
+                            // (`full_response.push_str`) butts two messages together
+                            // (`완료했습니다.#3089`). Mirror the separator into the
+                            // streamed `Text` so the relayed body matches `final_text`.
+                            let separated = if final_text.is_empty() {
+                                text.to_string()
+                            } else {
                                 final_text.push_str("\n\n");
-                            }
+                                format!("\n\n{text}")
+                            };
                             final_text.push_str(text);
-                            let _ = sender.send(StreamMessage::Text {
-                                content: text.to_string(),
-                            });
+                            let _ = sender.send(StreamMessage::Text { content: separated });
                         }
                     }
                     "command_execution" => {
@@ -3656,5 +3664,57 @@ mod remote_dispatch_gate_tests {
             "expected policy refusal, got: {err}"
         );
         assert!(err.contains("#2193"), "refusal must cite the issue: {err}");
+    }
+}
+
+#[cfg(test)]
+mod relay_separator_tests {
+    use super::handle_codex_json_line;
+    use crate::services::agent_protocol::StreamMessage;
+
+    fn agent_message_line(text: &str) -> String {
+        format!(r#"{{"type":"item.completed","item":{{"type":"agent_message","text":"{text}"}}}}"#)
+    }
+
+    #[test]
+    fn codex_second_agent_message_carries_paragraph_separator_3431() {
+        // #3431: the bridge accumulates streamed `Text` via `push_str` with NO
+        // separator, so a 2nd+ codex agent_message must itself carry the `\n\n`
+        // paragraph separator that `final_text` uses — otherwise two complete
+        // messages butt together in the relayed body (`완료했습니다.#3089`). The
+        // FIRST message emits raw text (no leading separator); the SECOND carries
+        // a `\n\n` prefix. `final_text` keeps its own joined form unchanged.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut thread_id = None;
+        let mut final_text = String::new();
+        let started = std::time::Instant::now();
+
+        handle_codex_json_line(
+            &agent_message_line("first"),
+            &tx,
+            &mut thread_id,
+            &mut final_text,
+            started,
+        )
+        .unwrap();
+        handle_codex_json_line(
+            &agent_message_line("second"),
+            &tx,
+            &mut thread_id,
+            &mut final_text,
+            started,
+        )
+        .unwrap();
+        drop(tx);
+
+        let texts: Vec<String> = rx
+            .iter()
+            .filter_map(|m| match m {
+                StreamMessage::Text { content } => Some(content),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(texts, vec!["first".to_string(), "\n\nsecond".to_string()]);
+        assert_eq!(final_text, "first\n\nsecond");
     }
 }


### PR DESCRIPTION
## #3431 — codex agent_message paragraph separator in the relayed body

`handle_codex_json_line` joins consecutive `agent_message`s with `\n\n` in its `final_text` accumulator, but the `StreamMessage::Text` sent to the bridge carried RAW text with no separator. The bridge accumulates via `full_response.push_str` (no separator), so two complete codex messages butted together (`완료했습니다.#3089`). Fix mirrors the `\n\n` into the streamed `Text` for the 2nd+ message only (codex.rs ~2943). First message + `final_text` byte-identical.

**Safety (codex-only):** codex `agent_message` is emitted only on `item.completed` (COMPLETE block, never a token delta) — prepending `\n\n` between complete messages cannot split a word. Deliberately NOT applied at the shared `full_response.push_str` layer (also serves opencode/watcher `content_block_delta` token deltas — would corrupt mid-word). Delta paths untouched.

**Deferred:** claude producer separator (invasive); opencode/watcher delta backends (unsafe at producer); Finding 2 over-spacing (already handled by `format_for_discord`).

Test: `relay_separator_tests::codex_second_agent_message_carries_paragraph_separator_3431` (mutation-sensitive). codex adversarial review: VERDICT CLEAN.

## Note on scope (rebased)
This branch originally also carried a cross-OS cfg-gate for two latent unix-only `tmux` call sites (`delivery_record.rs`, `tui_prompt_relay.rs`) that the windows lane exposed. While in review, `main` independently landed the equivalent fixes — `c4ad58e90 fix(windows): cfg-gate tmux call sites` and `7e1b46410 fix(windows): ignore unix-only git-worktree path tests`. So this branch was **rebased onto current main and the now-redundant cross-OS commit dropped**; it carries only the #3431 codex separator. The windows-lane gap is documented in #3470 (now largely resolved by those two main commits).

## Verification
- relay_separator 1 passed; audit --check exit 0; ci-script-checks exit 0 (await_holding_lock 34; freshness LoC gate green — the lone soft freshness warning is a pre-existing `discord-outbound-migration.md` header staleness from a main commit, non-fatal under `--warning-only`)
- change-surfaces.md codex.rs freeze entry synced 3002→3011
- rebased onto current main (7e1b46410); diff = codex.rs + change-surfaces.md only

Closes #3431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>