### PR TITLE
refactor(#3078): PR-5 shadow-register bridge status panel into controller ledger

### DIFF
--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -59,7 +59,10 @@ direct_discord_sends = [
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9b9526b38f0691a8",
   # #3089 S2: existing status-panel-v2 response-placeholder send moved out of
   # turn_bridge/mod.rs into the bridge footer helper while preserving behavior.
-  "src/services/discord/turn_bridge/single_message_footer.rs#direct_discord_sends:d2d9f46d97bfa069",
+  # #3078 PR-5: re-fingerprinted (same `gateway.send_message` placeholder call;
+  # context hash shifted only by the added `shared`/`provider` params + the new
+  # `shadow_register_bridge_panel` helper above it — no new direct send).
+  "src/services/discord/turn_bridge/single_message_footer.rs#direct_discord_sends:28b96a6bc14411ce",
   # #3038 turn_bridge S1: status-panel completion direct gateway calls moved
   # verbatim from turn_bridge/mod.rs to turn_bridge/status_panel.rs.
   "src/services/discord/turn_bridge/status_panel.rs#direct_discord_sends:8806b21b9432ae8a",

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -2495,6 +2495,8 @@ pub(super) fn spawn_turn_bridge(
             response_sent_offset,
             &full_response,
             &mut status_panel_dirty,
+            &shared_owned,
+            &provider,
         )
         .await;
 

--- a/src/services/discord/turn_bridge/single_message_footer.rs
+++ b/src/services/discord/turn_bridge/single_message_footer.rs
@@ -53,6 +53,36 @@ pub(super) fn bridge_should_complete_separate_status_panel(status_panel_v2_enabl
     bridge_separate_status_panel_enabled(status_panel_v2_enabled)
 }
 
+/// EPIC #3078 PR-5 — SHADOW-register a freshly bound bridge status panel into the
+/// [`StatusPanelController`](crate::services::discord::status_panel_controller)
+/// ledger so a later faithful parity check (and the eventual execute-cutover) can
+/// observe the bridge's panel id for this turn. v2-gated (the controller actor is
+/// only spawned when status-panel-v2 is on); ledger-only — PR-1 left the durable-
+/// mirror sink dormant, so this does NOT touch inflight persistence or any Discord
+/// IO and the legacy bridge path is byte-for-byte unchanged.
+pub(super) fn shadow_register_bridge_panel(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    user_msg_id: u64,
+    panel_id: MessageId,
+    provider: &crate::services::provider::ProviderKind,
+) {
+    if !shared.ui.status_panel_v2_enabled {
+        return;
+    }
+    let key = crate::services::discord::turn_finalizer::TurnKey::new(
+        channel_id,
+        user_msg_id,
+        crate::services::discord::runtime_store::load_generation(),
+    );
+    shared.status_panel_controller.adopt_recovered(
+        key,
+        provider.clone(),
+        crate::services::discord::status_panel_controller::PanelOwnerKind::Bridge,
+        Some(panel_id),
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn maybe_create_bridge_separate_status_panel_response<G: TurnGateway + ?Sized>(
     single_message_panel_footer_mode: bool,
@@ -68,6 +98,8 @@ pub(super) async fn maybe_create_bridge_separate_status_panel_response<G: TurnGa
     response_sent_offset: usize,
     full_response: &str,
     status_panel_dirty: &mut bool,
+    shared: &Arc<SharedData>,
+    provider: &crate::services::provider::ProviderKind,
 ) {
     if !bridge_should_create_separate_status_panel(
         single_message_panel_footer_mode,
@@ -90,6 +122,14 @@ pub(super) async fn maybe_create_bridge_separate_status_panel_response<G: TurnGa
             } else {
                 *status_panel_msg_id = Some(*current_msg_id);
                 inflight_state.status_message_id = Some(current_msg_id.get());
+                // #3078 PR-5: mirror the bound panel id into the controller ledger.
+                shadow_register_bridge_panel(
+                    shared,
+                    channel_id,
+                    inflight_state.user_msg_id,
+                    *current_msg_id,
+                    provider,
+                );
             }
             *current_msg_id = response_msg_id;
             *bridge_created_response_placeholder_msg_id = Some(response_msg_id);
@@ -463,5 +503,47 @@ mod tests {
 
         assert!(rendered.len() <= DISCORD_MSG_LIMIT);
         assert!(rendered.contains("\n\n"));
+    }
+
+    /// #3078 PR-5: with status-panel-v2 OFF the shadow registration is inert — it
+    /// returns before any controller interaction (the actor is not spawned), so the
+    /// legacy bridge path is untouched and nothing panics/hangs.
+    #[test]
+    fn shadow_register_bridge_panel_v2_off_is_inert() {
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        assert!(!shared.ui.status_panel_v2_enabled);
+        shadow_register_bridge_panel(
+            &shared,
+            ChannelId::new(30_785_001),
+            42,
+            MessageId::new(9001),
+            &ProviderKind::Claude,
+        );
+    }
+
+    /// #3078 PR-5: the ledger path the shadow registration drives — adopting a
+    /// bridge-created panel id makes the controller report it as the turn's current
+    /// panel, so a later faithful parity / execute-cutover can observe it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn controller_adopt_seeds_bridge_panel_into_ledger() {
+        use crate::services::discord::status_panel_controller::{
+            PanelOwnerKind, StatusPanelController,
+        };
+        use crate::services::discord::turn_finalizer::TurnKey;
+
+        let ctl = StatusPanelController::spawn(true);
+        let key = TurnKey::new(ChannelId::new(30_785_002), 42, 0);
+        let panel = MessageId::new(9002);
+        ctl.adopt_recovered(
+            key,
+            ProviderKind::Claude,
+            PanelOwnerKind::Bridge,
+            Some(panel),
+        );
+        assert_eq!(
+            ctl.current_panel(key).await,
+            Some(panel),
+            "controller ledger must reflect the bridge-adopted panel id"
+        );
     }
 }


### PR DESCRIPTION
## EPIC #3078 — PR-5: shadow-register bridge status panel into the controller ledger

Part of the staged shadow rollout that routes status-panel lifecycle through `StatusPanelController` (PR-1 substrate, PR-2 recovery, PR-3 sweeper, PR-4 watcher). This slice feeds the **bridge** path's panel id into the controller ledger so a later faithful parity / execute-cutover can observe it.

### What it does
When the bridge binds a freshly-created footer status panel (`maybe_create_bridge_separate_status_panel_response`, the `else` bind branch), it now also calls a new `shadow_register_bridge_panel` helper that `adopt_recovered`s the bound panel id into the controller ledger.

This is **substrate population, not a decision-parity assert** — the turn-start reuse decision (`status_panel_message_id_for_turn`) is a pure function of the persisted id, so a naive parity there would be tautological (the PR-4 codex P2 lesson). PR-5 instead seeds the ledger; faithful parity/cutover comes in later slices.

### Zero behaviour change
- **v2-gated**: helper returns immediately when `!status_panel_v2_enabled` (controller actor not even spawned when v2 off).
- **ledger-only**: `adopt_recovered` is fire-and-forget (`tx.send`, no await); PR-1 left the durable-mirror `PanelSink` dormant, so it does NOT write inflight `status_message_id`, does NOT persist, does NOT do Discord IO.
- **legacy path byte-identical**: the helper call is purely additive between the bind and the `*current_msg_id` reassignment.

### Correctness
- Adopts the OLD `*current_msg_id` (the panel id) BEFORE it is reassigned to `response_msg_id`.
- `TurnKey(channel_id, inflight_state.user_msg_id, load_generation())`, owner `PanelOwnerKind::Bridge`, `msg_id: Some(panel_id)`.
- Hook fires ONLY in the real bind branch (not the synthetic-headless clear branch).

### Files
- `single_message_footer.rs` (NOT frozen): helper + hook + 2 tests (`shadow_register_bridge_panel_v2_off_is_inert`, `controller_adopt_seeds_bridge_panel_into_ledger`).
- `turn_bridge/mod.rs` (FROZEN 6778): +2 arg lines at the existing call site only — ratchet holds (production LoC == 6778).
- `audit_allowlist.toml`: re-fingerprint of the SAME pre-existing `gateway.send_message` placeholder call whose `direct_discord_sends` context hash shifted only from the added `shared`/`provider` params + the helper above it (`d2d9f46d97bfa069` → `28b96a6bc14411ce`). No new direct send; flip-back-to-old-hash fails the gate.

### Review
codex adversarial review: **VERDICT: CLEAN** (Findings: None). Verified zero-behaviour-change, adopt correctness, hook-in-bind-branch-only, no-new-send + allowlist faithful + flip-back fails, frozen ratchet held, all gates green, mutation flip-back checked.

Closes part of #3078.
