### PR TITLE
refactor(#3078): PR-6 seed liveness-reacquired watcher panel into controller ledger

### DIFF
--- a/src/services/discord/status_panel_controller.rs
+++ b/src/services/discord/status_panel_controller.rs
@@ -269,6 +269,21 @@ enum PanelMsg {
         owner: PanelOwnerKind,
         msg_id: Option<MessageId>,
     },
+    /// EPIC #3078 PR-6 — seed/refresh the LIVE panel id for a turn whose ledger
+    /// key is REUSED across re-acquisitions (the watcher liveness self-heal mints
+    /// a synthetic `user_msg_id == 0` channel-only key). Unlike `AdoptRecovered`
+    /// (first-id-wins, for unique per-turn keys), this OVERWRITES a non-terminal
+    /// entry's `msg_id` so the ledger tracks the LATEST live panel — otherwise a
+    /// second same-generation reacquire (panel B) would leave the ledger pinned to
+    /// the earlier panel A (no controller finalize/reclaim is dispatched in the
+    /// shadow phase to terminalize it between turns). Terminal entries are never
+    /// resurrected; ledger-only (no durable write / no IO).
+    SeedLivePanel {
+        key: TurnKey,
+        provider: ProviderKind,
+        owner: PanelOwnerKind,
+        msg_id: Option<MessageId>,
+    },
 }
 
 /// The per-runtime actor, held as `Arc<StatusPanelController>` on `SharedData`.
@@ -455,6 +470,27 @@ impl StatusPanelController {
         msg_id: Option<MessageId>,
     ) {
         let _ = self.tx.send(PanelMsg::AdoptRecovered {
+            key,
+            provider,
+            owner,
+            msg_id,
+        });
+    }
+
+    /// EPIC #3078 PR-6 — seed/refresh the LIVE panel id for a turn whose ledger
+    /// key is REUSED across re-acquisitions (the watcher liveness self-heal's
+    /// synthetic `user_msg_id == 0` channel-only key). Unlike [`Self::adopt_recovered`]
+    /// (first-id-wins), this OVERWRITES a non-terminal entry's id so the ledger
+    /// tracks the LATEST live panel. Non-resurrecting (terminal entries untouched);
+    /// fire-and-forget, ledger-only. Observe with [`Self::current_panel`].
+    pub(in crate::services::discord) fn seed_live_panel(
+        &self,
+        key: TurnKey,
+        provider: ProviderKind,
+        owner: PanelOwnerKind,
+        msg_id: Option<MessageId>,
+    ) {
+        let _ = self.tx.send(PanelMsg::SeedLivePanel {
             key,
             provider,
             owner,
@@ -714,6 +750,14 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<PanelMsg>) {
             } => {
                 adopt_recovered(&mut ledger, key, provider, owner, msg_id);
             }
+            PanelMsg::SeedLivePanel {
+                key,
+                provider,
+                owner,
+                msg_id,
+            } => {
+                seed_live_panel(&mut ledger, key, provider, owner, msg_id);
+            }
         }
     }
 }
@@ -748,6 +792,46 @@ fn adopt_recovered(
     entry.provider = provider;
     if entry.msg_id.is_none() {
         entry.msg_id = msg_id;
+    }
+    if entry.phase == PanelPhase::NotCreated {
+        entry.phase = PanelPhase::Live;
+    }
+}
+
+/// EPIC #3078 PR-6 — seed/refresh the LIVE panel for a turn whose ledger key is
+/// REUSED across re-acquisitions (the watcher liveness self-heal mints a synthetic
+/// `user_msg_id == 0` channel-only key, collapsed onto the channel's single live
+/// entry). Mirrors [`adopt_recovered`] EXCEPT it OVERWRITES a non-terminal entry's
+/// `msg_id` with the supplied id: the latest liveness panel is authoritative for
+/// the live channel, so a second same-generation reacquire (panel B) must not
+/// leave the ledger pinned to an earlier panel A (no controller finalize/reclaim
+/// runs in the shadow phase to terminalize it between turns). Terminal entries are
+/// never resurrected; ledger-only (no durable write / no Discord IO).
+fn seed_live_panel(
+    ledger: &mut HashMap<LedgerKey, PanelEntry>,
+    key: TurnKey,
+    provider: ProviderKind,
+    owner: PanelOwnerKind,
+    msg_id: Option<MessageId>,
+) {
+    let lk = resolve_key(ledger, key);
+    let entry = ledger.entry(lk).or_insert_with(|| PanelEntry {
+        msg_id,
+        owner,
+        provider: provider.clone(),
+        phase: PanelPhase::Live,
+        last_text: None,
+    });
+    if entry.phase.is_terminal() {
+        // Never reopen a finalized/reclaimed panel.
+        return;
+    }
+    entry.owner = owner;
+    entry.provider = provider;
+    if let Some(id) = msg_id {
+        // Overwrite (latest live panel wins) — the reused-key fix vs the
+        // first-id-wins `adopt_recovered`.
+        entry.msg_id = Some(id);
     }
     if entry.phase == PanelPhase::NotCreated {
         entry.phase = PanelPhase::Live;

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2072,18 +2072,14 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             } else {
                 false
             };
-        // #3107: lazy pane-busy probe — only capture the pane when the cheap
-        // (terminal + no-inflight) prefix is already true and we are about to
-        // suppress, mirroring the SSH-direct / external-lease computations
-        // above. Keeps the `tmux capture-pane` subprocess off the hot path.
+        // #3107: lazy pane-busy probe — capture the pane only when the cheap
+        // (terminal + no-inflight) prefix already holds (keeps `tmux capture-pane` off the hot path).
         let post_terminal_pane_actively_streaming = turn_result_relayed
             && post_terminal_inflight_missing
             && watcher_pane_actively_streaming(&tmux_session_name);
         if post_terminal_pane_actively_streaming {
-            // Self-heal: a live turn lost its inflight and kept producing
-            // post-terminal output. Re-establish a watcher-owned inflight so
-            // the continuation relays and the terminal ack has a target.
-            // Reuse the restored turn's persisted message ids when present.
+            // Self-heal: a live turn lost its inflight but kept streaming post-terminal;
+            // re-establish a watcher-owned inflight (reusing the restored turn's persisted ids).
             let restored_panel = restored_turn
                 .as_ref()
                 .and_then(|turn| turn.status_message_id);
@@ -2099,6 +2095,14 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 restored_panel,
                 restored_placeholder,
                 restored_injected_prompt_message_id,
+            );
+            // #3078 PR-6: ledger-seed the liveness-reacquired watcher panel.
+            crate::services::discord::watcher_panel_parity::shadow_adopt_liveness_reacquired_panel(
+                &shared,
+                channel_id,
+                &watcher_provider,
+                restored_panel,
+                reacquired,
             );
             if reacquired && !active_stream_inflight_reacquire_logged {
                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -3170,17 +3174,13 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             channel_id.get(),
                         )
                         .is_none();
-                    // #3107: only pay for the pane-capture probe when we are
-                    // already about to suppress (inflight is missing) — the
-                    // expensive signal stays off the hot path, mirroring the
-                    // lazy SSH-direct computation in the post-terminal guard.
+                    // #3107: lazy pane-capture probe — only when inflight is
+                    // missing (expensive signal stays off the hot path).
                     let pane_actively_streaming_for_streaming = inflight_missing_for_streaming
                         && watcher_pane_actively_streaming(&tmux_session_name);
                     if inflight_missing_for_streaming && pane_actively_streaming_for_streaming {
-                        // #3107 self-heal: the pane is live but inflight was
-                        // cleared mid-turn — re-establish a watcher-owned
-                        // inflight so this and subsequent edits relay and the
-                        // terminal ack has a target. Idempotent + 1-shot log.
+                        // #3107 self-heal: pane live but inflight cleared mid-turn —
+                        // re-establish a watcher-owned inflight (idempotent + 1-shot log).
                         let reacquired = reacquire_watcher_inflight_for_active_stream(
                             &watcher_provider,
                             channel_id,
@@ -3190,13 +3190,13 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             status_panel_msg_id,
                             placeholder_msg_id,
                             // #3107 (P2#3, F3): thread the #3099 hourglass anchor
-                            // captured up front (before `restored_turn` was consumed by
-                            // the streaming `.take()`). Previously hardcoded `None`, so a
-                            // hourglass-anchored turn losing its inflight MID-STREAM was
-                            // re-acquired WITHOUT the pinned id — orphaning the `⏳` (the
-                            // `⏳ → ✅` cleanup lost its anchor). Preserving it keeps the
-                            // re-acquired streaming inflight pointing at the ⏳ message.
+                            // (captured before `restored_turn` was `.take()`n) so a
+                            // mid-stream inflight loss keeps the `⏳ → ✅` cleanup anchor.
                             restored_injected_prompt_message_id,
+                        );
+                        // #3078 PR-6: ledger-seed the liveness-reacquired watcher panel.
+                        crate::services::discord::watcher_panel_parity::shadow_adopt_liveness_reacquired_panel(
+                            &shared, channel_id, &watcher_provider, status_panel_msg_id, reacquired,
                         );
                         if reacquired && !active_stream_inflight_reacquire_logged {
                             let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/watcher_panel_parity.rs
+++ b/src/services/discord/watcher_panel_parity.rs
@@ -131,6 +131,77 @@ pub(in crate::services::discord) async fn assert_watcher_reclaim_parity(
     );
 }
 
+/// EPIC #3078 PR-6 — SHADOW-seed the status panel the watcher liveness self-heal
+/// (`reacquire_watcher_inflight_for_active_stream`) re-binds onto its freshly
+/// minted synthetic (`user_msg_id == 0`) watcher-owned inflight, into the
+/// [`StatusPanelController`](super::status_panel_controller) ledger.
+///
+/// SUBSTRATE, not a decision-parity: the re-acquire merely *reuses* the persisted
+/// `status_message_id`, so re-deriving "which id" here would be the tautology the
+/// PR-4 codex P2 finding warned against (echoing an already-resolved id). PR-6
+/// instead SEEDS the ledger so a LATER faithful parity / execute-cutover can
+/// observe the liveness-recovered panel — mirroring the PR-5 bridge ledger seed.
+///
+/// Uses `seed_live_panel` (NOT `adopt_recovered`): the watcher synthetic key is
+/// REUSED across re-acquisitions, so the seed must OVERWRITE a stale earlier panel
+/// id rather than first-id-wins — otherwise a second same-generation reacquire
+/// would leave the ledger pinned to the prior panel (no controller finalize runs
+/// in the shadow phase to terminalize it between turns).
+///
+/// Zero behaviour change:
+/// - gated on `reacquired`: only the synthetic save that actually WON the
+///   `save_inflight_state_if_absent` race owns the panel; a lost race (a
+///   concurrent intake inflight) must NOT seed a Watcher-owned ledger entry the
+///   watcher does not own.
+/// - v2-gated: the controller actor is spawned but the flag is off, so we skip the
+///   send entirely (mirrors `assert_watcher_reclaim_parity`).
+/// - ledger-only: `seed_live_panel` is fire-and-forget (no Discord IO, no persist;
+///   the PR-1 durable-mirror sink is still dormant), so the legacy liveness path
+///   is byte-for-byte unchanged.
+pub(in crate::services::discord) fn shadow_adopt_liveness_reacquired_panel(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    provider: &ProviderKind,
+    panel_msg_id: Option<MessageId>,
+    reacquired: bool,
+) {
+    seed_liveness_panel_into_ledger(
+        &shared.status_panel_controller,
+        shared.ui.status_panel_v2_enabled,
+        channel_id,
+        provider,
+        panel_msg_id,
+        reacquired,
+    );
+}
+
+/// Testable seam for [`shadow_adopt_liveness_reacquired_panel`]: the full
+/// gate-then-seed logic against an explicit controller + v2 flag (so a directly
+/// spawned v2-on controller can exercise the seed path that a v2-off test
+/// `SharedData` cannot reach). All three gates live here, so a unit test that
+/// removes the seed call fails the positive case.
+fn seed_liveness_panel_into_ledger(
+    controller: &super::status_panel_controller::StatusPanelController,
+    status_panel_v2_enabled: bool,
+    channel_id: ChannelId,
+    provider: &ProviderKind,
+    panel_msg_id: Option<MessageId>,
+    reacquired: bool,
+) {
+    if !reacquired || !status_panel_v2_enabled {
+        return;
+    }
+    let Some(panel) = panel_msg_id else {
+        return;
+    };
+    controller.seed_live_panel(
+        watcher_turn_key(channel_id, 0),
+        provider.clone(),
+        super::status_panel_controller::PanelOwnerKind::Watcher,
+        Some(panel),
+    );
+}
+
 /// EPIC #3078 — the legacy watcher CREATE/ADOPT decision, re-derived from the
 /// SAME RAW inputs the `tmux_watcher.rs` ~7213 branch reads, as the parity
 /// reference. Mirrors that branch order exactly: a persisted (restart-safe) id
@@ -326,5 +397,105 @@ mod tests {
         let shape: WatcherCreateShape = (5099, (None, true, false), (None, false, true));
         assert!(super::WATCHER_CREATE_WARNED.should_warn(shape));
         assert!(!super::WATCHER_CREATE_WARNED.should_warn(shape));
+    }
+
+    /// PR-6 liveness seed, v2-off: the public SharedData wrapper must short-circuit
+    /// BEFORE the controller send even when `reacquired == true` and a panel id is
+    /// present. The default test SharedData has v2 off; completing without panic
+    /// proves the wrapper threads the flag (the seed is purely additive, so
+    /// off == inert).
+    #[tokio::test(flavor = "current_thread")]
+    async fn liveness_seed_v2_off_wrapper_is_inert() {
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+        assert!(!shared.ui.status_panel_v2_enabled);
+        shadow_adopt_liveness_reacquired_panel(
+            &shared,
+            ChannelId::new(4006),
+            &ProviderKind::Claude,
+            Some(MessageId::new(8006)),
+            true,
+        );
+    }
+
+    /// PR-6 liveness seed mechanism (POSITIVE, v2-on): the full helper seam against
+    /// a spawned controller seeds the reacquired watcher panel under the channel-
+    /// only synthetic key, and `current_panel` reads it back. Removing the seed
+    /// call from `seed_liveness_panel_into_ledger` fails this assertion.
+    #[tokio::test(flavor = "current_thread")]
+    async fn liveness_seed_writes_watcher_panel_into_ledger() {
+        let ctl = StatusPanelController::spawn(true);
+        let channel = ChannelId::new(4007);
+        let panel = MessageId::new(7007);
+        seed_liveness_panel_into_ledger(
+            &ctl,
+            true,
+            channel,
+            &ProviderKind::Claude,
+            Some(panel),
+            true,
+        );
+        assert_eq!(
+            ctl.current_panel(watcher_turn_key(channel, 0)).await,
+            Some(panel),
+            "liveness-reacquired watcher panel must seed the controller ledger"
+        );
+    }
+
+    /// PR-6 reused-key OVERWRITE (the Finding-1 fix): a second same-generation
+    /// liveness seed with a DIFFERENT panel must win — `seed_live_panel` overwrites
+    /// the non-terminal entry rather than first-id-wins, so the ledger tracks the
+    /// LATEST liveness panel, never a stale earlier one.
+    #[tokio::test(flavor = "current_thread")]
+    async fn liveness_seed_overwrites_stale_reused_key() {
+        let ctl = StatusPanelController::spawn(true);
+        let channel = ChannelId::new(4008);
+        let panel_a = MessageId::new(7008);
+        let panel_b = MessageId::new(7009);
+        seed_liveness_panel_into_ledger(
+            &ctl,
+            true,
+            channel,
+            &ProviderKind::Claude,
+            Some(panel_a),
+            true,
+        );
+        seed_liveness_panel_into_ledger(
+            &ctl,
+            true,
+            channel,
+            &ProviderKind::Claude,
+            Some(panel_b),
+            true,
+        );
+        assert_eq!(
+            ctl.current_panel(watcher_turn_key(channel, 0)).await,
+            Some(panel_b),
+            "the latest liveness panel must overwrite the stale earlier one"
+        );
+    }
+
+    /// PR-6 gates at the seam (v2-on controller, so a leaked send would be
+    /// observable): `reacquired == false` and `panel == None` each short-circuit
+    /// before the seed — the ledger stays empty.
+    #[tokio::test(flavor = "current_thread")]
+    async fn liveness_seed_reacquired_and_none_gates_are_inert() {
+        let ctl = StatusPanelController::spawn(true);
+        let channel = ChannelId::new(4009);
+        // reacquired == false: a lost save race must not seed.
+        seed_liveness_panel_into_ledger(
+            &ctl,
+            true,
+            channel,
+            &ProviderKind::Claude,
+            Some(MessageId::new(7010)),
+            false,
+        );
+        // panel == None: nothing to seed.
+        seed_liveness_panel_into_ledger(&ctl, true, channel, &ProviderKind::Claude, None, true);
+        assert_eq!(
+            ctl.current_panel(watcher_turn_key(channel, 0)).await,
+            None,
+            "neither a lost reacquire race nor a missing panel may seed the ledger"
+        );
     }
 }


### PR DESCRIPTION
## EPIC #3078 — PR-6: seed the liveness-reacquired watcher status panel into the controller ledger

Continues the staged shadow rollout (PR-1 substrate, PR-2 recovery, PR-3 sweeper, PR-4 watcher reclaim, PR-5 bridge ledger seed). The **watcher liveness self-heal** path now feeds its panel id into the `StatusPanelController` ledger.

### What it does
The watcher liveness self-heal (`reacquire_watcher_inflight_for_active_stream`) re-establishes a synthetic (`user_msg_id == 0`) watcher-owned inflight when the pane is actively streaming but inflight was cleared, preserving the still-present status panel id into `state.status_message_id`. PR-6 adds a hook at **both** self-heal call sites that seeds that panel id into the controller ledger.

**Substrate, not a decision-parity** — the re-acquire merely *reuses* the persisted id, so re-deriving "which id" would be the tautology the PR-4 codex P2 finding warned against. Mirrors PR-5's bridge ledger seed.

### Reused-key correctness (codex PR-6 Finding 1)
The watcher synthetic key `(channel, 0, gen)` is **reused** across re-acquisitions, so the seed uses a new `StatusPanelController::seed_live_panel` that **overwrites** a non-terminal entry's `msg_id` (latest live panel wins) instead of `adopt_recovered`'s first-id-wins — otherwise a second same-generation reacquire (panel B) would leave the ledger pinned to the stale earlier panel A (no controller finalize/reclaim is dispatched in the shadow phase to terminalize it between turns). Terminal entries are never resurrected; ledger-only (no durable write / no IO). `adopt_recovered` is left unchanged (still correct for the bridge/recovery unique-per-turn keys).

### Zero behaviour change
- gated on `reacquired`: only the synthetic save that **won** the `save_inflight_state_if_absent` race owns the panel; a lost race (concurrent intake) must not seed a Watcher-owned ledger entry it doesn't own.
- v2-gated; ledger-only fire-and-forget seed (no Discord IO, no persist; the PR-1 durable-mirror sink is still dormant) — legacy path byte-identical.
- the overwrite cannot race a genuinely live bridge turn (both hooks are inside `inflight_missing` gates); landing on a stale-Live entry of another owner only re-points the **read-only shadow** ledger, not runtime state.

### Files
- `status_panel_controller.rs` (uncapped): `PanelMsg::SeedLivePanel` + actor arm + module-fn `seed_live_panel` (overwrite) + public method.
- `watcher_panel_parity.rs` (not frozen): wrapper `shadow_adopt_liveness_reacquired_panel` + testable seam `seed_liveness_panel_into_ledger` + 4 tests.
- `tmux_watcher.rs` (FROZEN 8223): two call-site hooks; net LoC 0 (offset by compressing four verbose #3107 self-heal comments, # tags preserved) — ratchet holds. No new direct send (watcher uses outbound — no allowlist change).

### Tests (codex PR-6 Finding 2 — testable seam)
`liveness_seed_writes_watcher_panel_into_ledger` (positive), `liveness_seed_overwrites_stale_reused_key` (Finding-1 overwrite), `liveness_seed_v2_off_wrapper_is_inert`, `liveness_seed_reacquired_and_none_gates_are_inert`.

### Review
codex adversarial review (2 rounds): first round CHANGES_REQUESTED (first-id-wins stale ledger + test bypass); both addressed → **VERDICT: CLEAN**. Mutation-verified: no-op seam → 2 tests fail; first-id-wins revert → overwrite test fails (ledger stuck on panel A).

Closes part of #3078.
