### PR TITLE
fix(#3478): remove expired announce-authored issue-card transitional code (sunset 2026-06-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Policies hook into a 3-tier periodic tick system running on a dedicated OS threa
 Each bot identity has a distinct role so message intent stays unambiguous:
 
 - **`announce`** is the authoritative trigger source. It posts dispatch envelopes (`── implementation dispatch ──\nDISPATCH:<uuid>…`), PM/escalation cards, and agent-to-agent messages routed through `/api/discord/send`. Other agent bots accept its messages as turn triggers when its user id is listed under `auth.allowed_bot_ids`.
-- **`notify`** delivers informational notifications — issue announcement cards (`📋 새 이슈 #N`, `✅ #N 완료`) and system alerts. Its user id is intentionally omitted from `allowed_bot_ids`, so its posts never trigger an agent turn (the routing change landed in #1448 follow-up; the message router still suppresses pre-deploy `announce`-authored issue cards via `is_legacy_announce_issue_card` until the catch-up window expires on 2026-06-01).
+- **`notify`** delivers informational notifications — issue announcement cards (`📋 새 이슈 #N`, `✅ #N 완료`) and system alerts. Its user id is intentionally omitted from `allowed_bot_ids`, so its posts never trigger an agent turn (the routing change landed in #1448 follow-up).
 - **Per-provider bots** (`claude`, `codex`, optionally `gemini` / `opencode` / `qwen`) are the user-facing identities humans @-mention in agent channels. A user message in a channel mapped to one of these bots starts a turn for that provider. Each agent can be wired to multiple provider bots — see `agents[].channels` in `agentdesk.yaml` — letting Claude and Codex (or any combination) work side-by-side on the same agent role.
 
 ### Web Dashboard

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -433,48 +433,14 @@ pub(in crate::services::discord) async fn resolve_notify_bot_user_id(
 
 pub(in crate::services::discord) fn is_allowed_turn_sender(
     allowed_bot_ids: &[u64],
-    announce_bot_id: Option<u64>,
     author_id: u64,
     author_is_bot: bool,
     text: &str,
 ) -> bool {
-    if announce_bot_id.is_some_and(|id| id == author_id) {
-        // Issue announcements moved to notify-bot in the #1448 follow-up,
-        // so live announce-bot traffic is dispatch / PM-decision /
-        // escalation / generic routing — all of which trigger turns.
-        // The transitional block below catches catch-up replays of
-        // pre-deploy announce-authored issue cards (📋/✅) so they
-        // don't spawn spurious turns. Remove once existing announce-bot
-        // announcement messages have aged out of catch-up scan windows
-        // (safe sunset target: 2026-06-01).
-        return !is_legacy_announce_issue_card(text);
-    }
     if allowed_bot_ids.contains(&author_id) {
         return should_process_allowed_bot_turn_text(text);
     }
     !author_is_bot
-}
-
-/// TRANSITIONAL (#1448 follow-up — sunset 2026-06-01): suppresses
-/// pre-deploy announce-bot issue-announcement / completion cards that
-/// reappear during restart catch-up. Live traffic now routes through
-/// notify-bot, which never reaches the announce-bot branch above.
-fn is_legacy_announce_issue_card(text: &str) -> bool {
-    let head = text.trim_start();
-    if head.starts_with("📋 **새 이슈 #") {
-        return true;
-    }
-    if let Some(rest) = head.strip_prefix("✅ **#") {
-        let digits_end = rest
-            .char_indices()
-            .find(|(_, ch)| !ch.is_ascii_digit())
-            .map(|(idx, _)| idx)
-            .unwrap_or(rest.len());
-        if digits_end > 0 && rest[digits_end..].starts_with(" 완료** —") {
-            return true;
-        }
-    }
-    false
 }
 
 pub(in crate::services::discord) fn should_phase2_recover_message(
@@ -3924,7 +3890,6 @@ pub(in crate::services::discord) fn classify_catch_up_message(
     existing_ids: &std::collections::HashSet<u64>,
     max_age_secs: i64,
     allowed_bot_ids: &[u64],
-    announce_bot_id: Option<u64>,
 ) -> CatchUpClassification {
     if !msg.is_processable_kind {
         return CatchUpClassification::SystemKind;
@@ -3943,7 +3908,6 @@ pub(in crate::services::discord) fn classify_catch_up_message(
     }
     if !is_allowed_turn_sender(
         allowed_bot_ids,
-        announce_bot_id,
         msg.author_id,
         msg.author_is_bot,
         &msg.trimmed_text,
@@ -4102,8 +4066,6 @@ async fn catch_up_missed_messages_inner(
             let settings = shared.settings.read().await;
             settings.allowed_bot_ids.clone()
         };
-        let announce_bot_id = resolve_announce_bot_user_id(shared).await;
-
         let mut max_recovered_id: Option<u64> = None;
         let mut stats = CatchUpScanStats::default();
         stats.returned = messages.len();
@@ -4143,7 +4105,6 @@ async fn catch_up_missed_messages_inner(
                 &existing_ids,
                 max_age.as_secs() as i64,
                 &allowed_bot_ids,
-                announce_bot_id,
             );
             // Codex P2 round 2 on #1301: check the cap BEFORE recording the
             // recover, otherwise `stats.recovered` would tally a message we
@@ -4343,7 +4304,6 @@ async fn catch_up_missed_messages_inner(
             let mid = msg.id.get();
             if !is_allowed_turn_sender(
                 &allowed_bot_ids_phase2,
-                announce_bot_id_phase2,
                 msg.author.id.get(),
                 msg.author.bot,
                 text,
@@ -5367,11 +5327,11 @@ mod catch_up_recovery_tests {
         let existing = HashSet::new();
 
         assert_eq!(
-            classify_catch_up_message(&view, Some(current_bot_id), &existing, 300, &[], None),
+            classify_catch_up_message(&view, Some(current_bot_id), &existing, 300, &[]),
             CatchUpClassification::Recover
         );
         assert_eq!(
-            classify_catch_up_message(&view, Some(owner_user_id), &existing, 300, &[], None),
+            classify_catch_up_message(&view, Some(owner_user_id), &existing, 300, &[]),
             CatchUpClassification::SelfAuthored
         );
     }

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1999,7 +1999,6 @@ pub(in crate::services::discord) async fn handle_event(
             if is_allowed_bot_sender
                 && !super::super::is_allowed_turn_sender(
                     &settings_snapshot.allowed_bot_ids,
-                    announce_bot_id,
                     user_id.get(),
                     new_message.author.bot,
                     raw_text,

--- a/src/services/discord/runtime_bootstrap/recovery_flush.rs
+++ b/src/services/discord/runtime_bootstrap/recovery_flush.rs
@@ -55,8 +55,6 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                 let settings = shared_for_tmux2.settings.read().await;
                 settings.allowed_bot_ids.clone()
             };
-            let announce_bot_id_for_restore =
-                super::resolve_announce_bot_user_id(&shared_for_tmux2).await;
             // P1-1: Restore dispatch_role_overrides from queue snapshots
             for (thread_channel_id, alt_channel_id) in &restored_overrides {
                 if !matches!(
@@ -96,7 +94,6 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                     for item in items {
                         if !super::is_allowed_turn_sender(
                             &allowed_bot_ids_for_restore,
-                            announce_bot_id_for_restore,
                             item.author_id.get(),
                             item.author_is_bot,
                             &item.text,

--- a/src/services/issue_announcements.rs
+++ b/src/services/issue_announcements.rs
@@ -178,13 +178,19 @@ pub async fn complete_issue_announcement_pg(
     let title = event.title.as_deref().unwrap_or(&row.title);
     let content = render_completed_card(title, &row, &event);
     let log_key = format!("issue_announcement:{}:{}", event.repo, event.issue_number);
-    let edit_result = edit_announcement_with_legacy_fallback(
-        &row.channel_id,
-        &row.message_id,
-        &content,
-        &log_key,
-    )
-    .await;
+    let edit_result = match crate::credential::read_bot_token("notify") {
+        Some(token) => send_issue_announcement_message(
+            &token,
+            &row.channel_id,
+            Some(&row.message_id),
+            &content,
+            &log_key,
+            "completed",
+        )
+        .await
+        .map_err(|error| error.to_string()),
+        None => Err("no notify bot token configured".to_string()),
+    };
 
     match edit_result {
         Ok(_) => {
@@ -238,79 +244,6 @@ pub async fn complete_issue_announcement_pg(
             Err(error)
         }
     }
-}
-
-/// Edits an existing issue-announcement message, falling back to the
-/// legacy `announce` token when the message was authored by announce-bot
-/// before the #1448 follow-up moved announcements to `notify`.
-///
-/// Fallback triggers (the announce-only deployment shape is the legacy
-/// reality we have to support during the cutover window):
-/// - `notify` token is not configured (deployment hasn't seeded notify yet)
-/// - `notify` PATCH returns Discord 50005 (cross-bot edit on a message
-///   authored by announce-bot)
-/// - `notify` PATCH returns Discord 50001 or HTTP 403 (notify bot doesn't
-///   yet have access to the legacy announcement channel)
-///
-/// Once all legacy announce-authored rows have closed and notify-bot has
-/// permissions on every announcement channel, both this fallback and the
-/// matching `is_legacy_announce_issue_card` gate in `mod.rs` can be
-/// removed (sunset target 2026-06-01).
-async fn edit_announcement_with_legacy_fallback(
-    channel_id: &str,
-    message_id: &str,
-    content: &str,
-    log_key: &str,
-) -> Result<String, String> {
-    let notify_token = crate::credential::read_bot_token("notify");
-    if let Some(token) = notify_token.as_deref() {
-        match send_issue_announcement_message(
-            token,
-            channel_id,
-            Some(message_id),
-            content,
-            log_key,
-            "completed",
-        )
-        .await
-        {
-            Ok(id) => return Ok(id),
-            Err(error) if should_try_legacy_announce_fallback(&error) => {
-                tracing::info!(
-                    target: "issue_announcements",
-                    "{log_key}: notify edit failed with `{error}`, retrying with announce token"
-                );
-            }
-            Err(error) => return Err(error.to_string()),
-        }
-    }
-    let Some(announce_token) = crate::credential::read_bot_token("announce") else {
-        return Err(if notify_token.is_some() {
-            "notify edit failed and no announce bot token configured for legacy fallback"
-                .to_string()
-        } else {
-            "no notify or announce bot token configured".to_string()
-        });
-    };
-    send_issue_announcement_message(
-        &announce_token,
-        channel_id,
-        Some(message_id),
-        content,
-        log_key,
-        "completed-legacy-fallback",
-    )
-    .await
-    .map_err(|error| error.to_string())
-}
-
-/// Decides whether a notify-side PATCH failure should trigger the
-/// announce-token fallback. The classifier intentionally uses Discord's
-/// typed JSON error code plus HTTP status instead of matching localized or
-/// formatting-sensitive message text.
-fn should_try_legacy_announce_fallback(error: &IssueAnnouncementDeliveryError) -> bool {
-    matches!(error.discord_error_code, Some(50005 | 50001))
-        || error.http_status == Some(reqwest::StatusCode::FORBIDDEN)
 }
 
 async fn resolve_announcement_channel_pg(
@@ -540,39 +473,5 @@ mod tests {
 
         assert!(rendered.contains("✅ **#1331 완료** — Lifecycle"));
         assert!(rendered.contains("> 머지: PR #1410 https://github.com/owner/repo/pull/1410"));
-    }
-
-    #[test]
-    fn legacy_fallback_classifier_uses_typed_http_status_and_discord_code() {
-        let cross_bot = IssueAnnouncementDeliveryError {
-            detail: "cannot edit message".to_string(),
-            http_status: Some(reqwest::StatusCode::BAD_REQUEST),
-            discord_error_code: Some(50005),
-        };
-        assert!(should_try_legacy_announce_fallback(&cross_bot));
-
-        let missing_access = IssueAnnouncementDeliveryError {
-            detail: "missing access".to_string(),
-            http_status: Some(reqwest::StatusCode::BAD_REQUEST),
-            discord_error_code: Some(50001),
-        };
-        assert!(should_try_legacy_announce_fallback(&missing_access));
-
-        let forbidden = IssueAnnouncementDeliveryError {
-            detail: "localized forbidden text".to_string(),
-            http_status: Some(reqwest::StatusCode::FORBIDDEN),
-            discord_error_code: None,
-        };
-        assert!(should_try_legacy_announce_fallback(&forbidden));
-    }
-
-    #[test]
-    fn legacy_fallback_classifier_ignores_detail_text_without_typed_signal() {
-        let string_only = IssueAnnouncementDeliveryError {
-            detail: "Discord 50005 cannot edit a message authored by another user".to_string(),
-            http_status: Some(reqwest::StatusCode::BAD_REQUEST),
-            discord_error_code: None,
-        };
-        assert!(!should_try_legacy_announce_fallback(&string_only));
     }
 }


### PR DESCRIPTION
Removes transitional code past its sunset (2026-06-01; now 2026-06-15), which ran unconditionally with no date gate.

## Removed
- `discord/mod.rs`: `is_allowed_turn_sender` announce-bot early-return branch + `fn is_legacy_announce_issue_card`; propagated removal of the now-dead `announce_bot_id` param through `classify_catch_up_message`, `intake_gate.rs`, `recovery_flush.rs`.
- `issue_announcements.rs`: `edit_announcement_with_legacy_fallback` + `should_try_legacy_announce_fallback` (+ their classifier tests). The non-legacy edit/send path was INLINED at the call site so announcement delivery is unchanged (`Result<String,String>` contract preserved).
- `README.md`: catch-up-window/2026-06-01 note.

Net 5 files, +16/−161. Announce-bot messages now flow through the normal sender path. Adversarial review: **VERDICT: CLEAN**. Gates: build/clippy/fmt/ratchet(net-negative on frozen mod.rs)/ci-script + targeted tests pass.

Closes #3478

🤖 Generated with [Claude Code](https://claude.com/claude-code)