### PR TITLE
fix(#3477,#3473): live panel terminal block reorder/blank/multiline + task stuck-slot TTL backstop

### DIFF
--- a/src/services/discord/placeholder_live_events/common.rs
+++ b/src/services/discord/placeholder_live_events/common.rs
@@ -5,6 +5,11 @@ use super::super::formatting::{canonical_tool_name, redact_sensitive_for_placeho
 pub(super) const CHANNEL_EVENT_CAPACITY: usize = 20;
 pub(super) const EVENT_RENDER_LIMIT: usize = 5;
 pub(super) const EVENT_LINE_MAX_CHARS: usize = 100;
+// #3477 item 1: the 🖥️ Recent/terminal block keeps up to this many readable
+// lines per event instead of collapsing multi-line TUI output to one run-on
+// line. Compact single-line panel cells (Tasks/Subagents) are unaffected — they
+// keep using `normalize_summary` (first line only).
+pub(super) const RECENT_EVENT_MAX_LINES: usize = 4;
 pub(super) const EVENT_BLOCK_MAX_CHARS: usize = 1500;
 // Status panels are sent as plain message content, so they must stay under
 // Discord's 2000-character content ceiling rather than the 4096-char embed limit.
@@ -132,6 +137,29 @@ pub(super) fn normalize_summary(raw: &str) -> String {
     let redacted = redact_sensitive_for_placeholder(raw);
     let line = first_content_line(&redacted);
     truncate_chars(&line, EVENT_LINE_MAX_CHARS)
+}
+
+/// #3477 item 1: multi-line-preserving normalize for the 🖥️ Recent/terminal
+/// block. Unlike `normalize_summary` (first line only — used by the compact
+/// single-line panel cells), this keeps up to `RECENT_EVENT_MAX_LINES` non-empty
+/// lines so multi-line TUI output renders readably instead of collapsing into a
+/// single run-on line. Each kept line is whitespace-collapsed and individually
+/// truncated to `EVENT_LINE_MAX_CHARS`; lines are joined with `\n`. Redaction is
+/// applied before splitting so secrets cannot survive on a later line.
+pub(super) fn normalize_summary_multiline(raw: &str) -> String {
+    let redacted = redact_sensitive_for_placeholder(raw);
+    let mut kept: Vec<String> = Vec::new();
+    for line in redacted.lines() {
+        let collapsed = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.is_empty() {
+            continue;
+        }
+        kept.push(truncate_chars(&collapsed, EVENT_LINE_MAX_CHARS));
+        if kept.len() >= RECENT_EVENT_MAX_LINES {
+            break;
+        }
+    }
+    kept.join("\n")
 }
 
 pub(super) fn first_content_line(raw: &str) -> String {

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use poise::serenity_prelude::ChannelId;
 use serde_json::Value;
@@ -68,6 +69,12 @@ pub(in crate::services::discord) use status_events::status_events_from_json;
 pub(in crate::services::discord) struct PlaceholderLiveEvents {
     by_channel: dashmap::DashMap<ChannelId, Mutex<VecDeque<RecentPlaceholderEvent>>>,
     status_by_channel: dashmap::DashMap<ChannelId, Mutex<StatusPanelState>>,
+    // #3477 item 3: monotonic timestamp of the most recent live (Recent/terminal)
+    // event push per channel. Compared against the turn's `completed_at` so a
+    // late output batch that lands AFTER `TurnCompleted` still keeps the 🖥️ Recent
+    // block visible (the completion suppression only hides STALE pre-completion
+    // content, never a fresh late batch).
+    last_recent_event_at: dashmap::DashMap<ChannelId, Instant>,
     // #3404 (codex r1): last logged live-panel compaction counts per channel —
     // the INFO line fires on count CHANGE only, not every render tick, so the
     // log stays usable as a compaction event counter for the relay scan.
@@ -86,6 +93,7 @@ impl PlaceholderLiveEvents {
         self.by_channel.remove(&channel_id);
         self.status_by_channel.remove(&channel_id);
         self.compaction_log_counts.remove(&channel_id);
+        self.last_recent_event_at.remove(&channel_id);
     }
 
     pub(in crate::services::discord) fn clear_channel_preserving_footer_residuals(
@@ -93,6 +101,9 @@ impl PlaceholderLiveEvents {
         channel_id: ChannelId,
     ) {
         self.by_channel.remove(&channel_id);
+        // #3477 item 3: the recent-event ring is gone, so its freshness stamp is
+        // stale — drop it with the ring so the next turn starts un-fresh.
+        self.last_recent_event_at.remove(&channel_id);
         // #3404 (codex r2): a turn reset starts a new compaction episode — re-arm
         // the count-change log gate even when footer residuals survive.
         self.compaction_log_counts.remove(&channel_id);
@@ -126,6 +137,11 @@ impl PlaceholderLiveEvents {
             guard.pop_front();
         }
         guard.push_back(event);
+        drop(guard);
+        // #3477 item 3: stamp the live-content arrival so a render after
+        // `TurnCompleted` can tell a fresh late batch (keep 🖥️ Recent) from a
+        // stale pre-completion block (suppress on a genuinely idle completed turn).
+        self.last_recent_event_at.insert(channel_id, Instant::now());
     }
 
     pub(in crate::services::discord) fn push_many<I>(&self, channel_id: ChannelId, events: I)
@@ -469,12 +485,23 @@ impl PlaceholderLiveEvents {
                 "#3404: compacted delivered terminal slots from the live status panel"
             );
         }
+        // #3477 item 3: a live batch counts as "fresh" when it arrived strictly
+        // after the turn's completion instant. `None` completed_at means the turn
+        // never completed (still running), so any present live content is fresh.
+        let live_content_fresh = match snapshot.completed_at {
+            Some(completed_at) => self
+                .last_recent_event_at
+                .get(&channel_id)
+                .is_some_and(|stamp| *stamp.value() > completed_at),
+            None => true,
+        };
         render_status_panel(
             snapshot,
             self.render_block(channel_id),
             provider,
             started_at_unix,
             heartbeat_at_unix,
+            live_content_fresh,
         )
     }
 

--- a/src/services/discord/placeholder_live_events/recent_events.rs
+++ b/src/services/discord/placeholder_live_events/recent_events.rs
@@ -3,8 +3,8 @@ use serde_json::Value;
 use super::super::formatting::format_tool_input;
 use super::common::{
     EVENT_BLOCK_MAX_CHARS, EVENT_LINE_MAX_CHARS, EVENT_RENDER_LIMIT, first_content_line,
-    is_harness_task_tool_name, is_internal_tool_error, normalize_summary, sanitize_for_code_fence,
-    tool_prefix, truncate_chars, value_to_compact_string,
+    is_harness_task_tool_name, is_internal_tool_error, normalize_summary_multiline,
+    sanitize_for_code_fence, tool_prefix, truncate_chars, value_to_compact_string,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,7 +61,10 @@ impl RecentPlaceholderEvent {
     }
 
     fn new(prefix: impl Into<String>, summary: impl AsRef<str>) -> Option<Self> {
-        let summary = normalize_summary(summary.as_ref());
+        // #3477 item 1: keep up to RECENT_EVENT_MAX_LINES so multi-line TUI output
+        // stays readable in the Recent/terminal block (panel cells still collapse
+        // to one line via `normalize_summary`).
+        let summary = normalize_summary_multiline(summary.as_ref());
         if summary.is_empty() {
             return None;
         }
@@ -72,9 +75,26 @@ impl RecentPlaceholderEvent {
     }
 
     pub(super) fn render_line(&self) -> String {
-        let raw = format!("{} {}", self.prefix, self.summary);
-        let sanitized = sanitize_for_code_fence(raw.trim());
-        truncate_chars(&sanitized, EVENT_LINE_MAX_CHARS)
+        // #3477 item 1: the summary may span several lines. Put the prefix on the
+        // first line and indent the continuation lines so the entry stays visually
+        // grouped inside the fenced block. Each line is sanitized (fence-safe) and
+        // char-clamped individually so one long line cannot blow the budget.
+        let mut lines = self.summary.lines();
+        let first = lines.next().unwrap_or("");
+        let head = truncate_chars(
+            &sanitize_for_code_fence(format!("{} {first}", self.prefix).trim()),
+            EVENT_LINE_MAX_CHARS,
+        );
+        let mut out = head;
+        for cont in lines {
+            let cont = truncate_chars(&sanitize_for_code_fence(cont.trim()), EVENT_LINE_MAX_CHARS);
+            if cont.is_empty() {
+                continue;
+            }
+            out.push_str("\n  ");
+            out.push_str(&cont);
+        }
+        out
     }
 }
 

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -13,9 +13,10 @@ use super::session_panel::{SessionPanelSnapshot, render_session_panel_line};
 use super::status_events::{is_schedule_wakeup_tool, parse_eta_secs};
 use super::subagent_summary::render_subagent_done_summary;
 use super::task_panel::{
-    TaskPanelSnapshot, TaskToolSlot, finish_background_task_tool_slot, render_task_panel_line,
-    render_task_tool_slot, take_slot_ordinal, task_tool_slot_is_unfinished_background,
-    upsert_background_task_tool_slot, upsert_task_tool_slot,
+    TaskPanelSnapshot, TaskToolSlot, finish_background_task_tool_slot,
+    force_abort_stuck_background_task_slots, render_task_panel_line, render_task_tool_slot,
+    take_slot_ordinal, task_tool_slot_is_unfinished_background, upsert_background_task_tool_slot,
+    upsert_task_tool_slot,
 };
 use super::workflow_panel::{
     WorkflowAgentSlot, WorkflowSlot, render_workflow_slot, trim_workflow_slot, trim_workflows,
@@ -34,9 +35,8 @@ pub(super) struct SubagentSlot {
     /// #3086: TUI-parity accounting from the finishing `SubagentEnd`; drives the
     /// `Done (N tools · M tokens · Xs)` summary on the render line.
     summary: Option<SubagentSummary>,
-    /// `true` when launched with `run_in_background`. Its immediate Task result is
-    /// only a launch ack (slot keeps running), so an ack-only `SubagentEnd` must
-    /// NOT mark it ✓ — only a genuine completion finalizes it.
+    /// `true` when launched with `run_in_background`: an ack-only `SubagentEnd`
+    /// must NOT mark it ✓ (only a genuine completion finalizes it).
     background: bool,
     /// #3391: monotonic, never-reused per-entry slot id (mirrors
     /// `TaskToolSlot::ordinal`) backing slot-identity subagent eviction.
@@ -94,24 +94,30 @@ pub(super) struct StatusPanelState {
     pub(super) tasks: Vec<TaskToolSlot>,
     pub(super) subagents: Vec<SubagentSlot>,
     pub(super) workflows: Vec<WorkflowSlot>,
-    // #3391: only-advancing counter minting never-reused task/subagent ordinals.
-    next_slot_ordinal: u64,
+    next_slot_ordinal: u64, // #3391: advancing, never-reused task/subagent ordinals.
+    // #3477 item 3: instant the turn entered `Completed` (None until then); vs the
+    // store's `last_recent_event_at` it gates the late-batch 🖥️ Recent freshness.
+    pub(super) completed_at: Option<std::time::Instant>,
 }
 
 impl StatusPanelState {
     /// #3087: on a true session boundary (provider session id delta), clears the
-    /// per-session content slots (subagents/tasks/todos/workflows) and resets the
-    /// status to `Running`, PRESERVING context/token usage + session snapshots and
-    /// the ordinal counter (never cleared).
+    /// per-session content slots and resets status to `Running`, PRESERVING
+    /// context/token usage + session snapshots and the ordinal counter.
     pub(super) fn reset_session_content(&mut self) {
         self.status = DerivedStatus::Running;
         self.todos.clear();
         self.tasks.clear();
         self.subagents.clear();
         self.workflows.clear();
+        self.completed_at = None; // #3477 item 3: drop the stale freshness gate.
     }
 
     pub(super) fn reset_turn_content_preserving_unfinished_footer_residuals(&mut self) -> bool {
+        // #3473: turn-boundary reconciliation — force a TTL-expired stuck
+        // background task to `aborted` BEFORE the retain filter so it is dropped
+        // here instead of sitting ⏳ forever.
+        force_abort_stuck_background_task_slots(&mut self.tasks, std::time::Instant::now());
         let tasks = self
             .tasks
             .iter()
@@ -213,18 +219,16 @@ impl StatusPanelState {
                 summary,
                 ack_only,
             } => {
-                // #3084: close the slot whose Task tool-use id matches the result
-                // (pairs a long-running subagent to its own result among
-                // parallels); fall back to first-unfinished only without an id.
+                // #3084: close the id-matching slot (pairs a long-running subagent
+                // to its own result among parallels); else first-unfinished.
                 let id = tool_use_id.as_deref();
                 let matched = id.and_then(|id| {
                     self.subagents.iter().rposition(|slot| {
                         slot.finished.is_none() && slot.tool_use_id.as_deref() == Some(id)
                     })
                 });
-                // #3086 P1 / #3359: a summary- OR id-bearing ack-only end is safe
-                // only on an exact id match (else mis-marks a running/background
-                // subagent); id-less legacy acks may close only id-less slots.
+                // #3086 P1 / #3359: a summary/id-bearing ack-only end is safe only
+                // on an exact id match; id-less legacy acks close only id-less slots.
                 let has_summary = summary.as_ref().is_some_and(|s| !s.is_empty());
                 let target = match matched {
                     Some(index) => Some(index),
@@ -241,15 +245,13 @@ impl StatusPanelState {
                 };
                 let slot = target.map(|index| &mut self.subagents[index]);
                 if let Some(slot) = slot {
-                    // A background ack-only end is just a launch ack (the slot
-                    // keeps running), so skip finalizing it; a genuine completion
-                    // (`ack_only == false`) and any foreground end still close it.
+                    // A background ack-only end is just a launch ack (slot keeps
+                    // running); a genuine/foreground end still closes it.
                     let finalize = !(ack_only && slot.background);
                     if finalize {
                         slot.finished = Some(success);
                     }
-                    // #3086: attach the TUI-parity Done summary, only when the
-                    // event carries accounting (don't wipe a richer one).
+                    // #3086: attach Done summary only when accounting present.
                     if let Some(summary) = summary.filter(|summary| !summary.is_empty()) {
                         slot.summary = Some(summary);
                     }
@@ -388,6 +390,8 @@ impl StatusPanelState {
                 self.status = DerivedStatus::Completed {
                     kind: CompletedKind::from_background(background),
                 };
+                // #3477 item 3: stamp the late-batch freshness gate.
+                self.completed_at = Some(std::time::Instant::now());
             }
             StatusEvent::Heartbeat => {
                 if matches!(self.status, DerivedStatus::Running) {
@@ -398,8 +402,7 @@ impl StatusPanelState {
     }
 
     /// #3204/#3198: routes a running subagent's live step onto its slot's recent
-    /// line. Prefers the UNFINISHED id-matching slot; an id-bearing no-match is
-    /// dropped (never mis-routed/resurrected).
+    /// line (UNFINISHED id-matching slot; id-bearing no-match dropped).
     fn set_subagent_activity(&mut self, tool_use_id: Option<String>, summary: String) {
         let id = tool_use_id.as_deref();
         let target = self.subagents.iter_mut().rev().find(|slot| {
@@ -443,6 +446,9 @@ pub(super) fn render_status_panel(
     provider: &ProviderKind,
     started_at_unix: i64,
     _heartbeat_at_unix: i64,
+    // #3477 item 3: live batch arrived AFTER `completed_at` → a Completed turn
+    // keeps 🖥️ Recent (late batch not blanked; stale idle block still dropped).
+    live_content_fresh: bool,
 ) -> String {
     let header_status = if matches!(provider, ProviderKind::Codex)
         && matches!(snapshot.status, DerivedStatus::SubagentRunning { .. })
@@ -490,6 +496,23 @@ pub(super) fn render_status_panel(
         sections.push(format!("Plan\n{}", lines.join("\n")));
     }
 
+    // #3477 item 4: 🖥️ Recent renders BEFORE Tasks/Subagents/Workflow (top
+    // signal + shielded from the trailing-section footer-budget drop — item 3).
+    let cluster_config = &crate::config::load_graceful().cluster;
+    let recent_header = render_recent_section_header(
+        snapshot.task.as_ref(),
+        cluster_config.enabled,
+        cluster_config.instance_id.as_deref(),
+    );
+    // #3394 self-contained fenced section (overflow drops it whole). #3477 item 3:
+    // a Completed turn suppresses it only when stale; a fresh late batch shows.
+    let completed = matches!(header_status, DerivedStatus::Completed { .. });
+    if (!completed || live_content_fresh)
+        && let Some(block) = live_block.filter(|block| !block.trim().is_empty())
+    {
+        sections.push(format!("{recent_header}\n{block}"));
+    }
+
     if !snapshot.tasks.is_empty() {
         let lines = snapshot
             .tasks
@@ -498,8 +521,7 @@ pub(super) fn render_status_panel(
             .take(STATUS_PANEL_TASK_LIMIT)
             .map(render_task_tool_slot)
             .collect::<Vec<_>>();
-        // #3404: cap completed entries so they cannot starve the 600-byte footer.
-        let lines = compact_live_panel_terminal_lines(&lines).map_or(lines, |(out, _)| out);
+        let lines = compact_live_panel_terminal_lines(&lines).map_or(lines, |(out, _)| out); // #3404 cap
         sections.push(format!("Tasks\n{}", lines.join("\n")));
     }
 
@@ -511,8 +533,7 @@ pub(super) fn render_status_panel(
             .take(STATUS_PANEL_SUBAGENT_LIMIT)
             .map(render_subagent_slot)
             .collect::<Vec<_>>();
-        // #3404: cap completed entries so the running Subagents stay visible.
-        let lines = compact_live_panel_terminal_lines(&lines).map_or(lines, |(out, _)| out);
+        let lines = compact_live_panel_terminal_lines(&lines).map_or(lines, |(out, _)| out); // #3404 cap
         sections.push(format!("Subagents\n{}", lines.join("\n")));
     }
 
@@ -529,21 +550,6 @@ pub(super) fn render_status_panel(
         }
     }
 
-    let cluster_config = &crate::config::load_graceful().cluster;
-    let cluster_enabled = cluster_config.enabled;
-    let local_instance_id = cluster_config.instance_id.clone();
-    let recent_header = render_recent_section_header(
-        snapshot.task.as_ref(),
-        cluster_enabled,
-        local_instance_id.as_deref(),
-    );
-    // #3394: append the fence-balanced Recent block as a trailing section so the
-    // protected truncation path drops it whole on overflow (never chops its ```).
-    if !matches!(header_status, DerivedStatus::Completed { .. })
-        && let Some(block) = live_block.filter(|block| !block.trim().is_empty())
-    {
-        sections.push(format!("{recent_header}\n{block}"));
-    }
     truncate_status_panel_sections(sections)
 }
 
@@ -551,12 +557,10 @@ fn join_status_panel_sections(sections: &[String]) -> String {
     sections.join("\n\n")
 }
 
-/// #3394: section-wise degradation. A blind char cut of the JOINED panel chops
-/// the trailing fenced section's closing ``` and Discord renders the dangling
-/// fence as literal text. So when the join overflows, DROP whole sections from
-/// the END (Recent first) — never cut inside one; only a lone surviving section
-/// that alone overflows is fence-safe-truncated. The shared `repair_fence_parity`
-/// backstop re-balances every return path.
+/// #3394: section-wise degradation. A char cut of the JOINED panel chops a
+/// trailing fenced section's ``` (rendered as literal text), so on overflow DROP
+/// whole trailing sections; a lone overflowing section is fence-safe-truncated and
+/// `repair_fence_parity` re-balances every return path.
 pub(super) fn truncate_status_panel_sections(mut sections: Vec<String>) -> String {
     use crate::services::discord::single_message_panel::repair_fence_parity;
     while sections.len() > 1
@@ -641,8 +645,7 @@ pub(super) fn render_subagent_slot(slot: &SubagentSlot) -> String {
         line.push_str(" — ");
         line.push_str(&escape_status_panel_markdown(&normalize_summary(recent)));
     }
-    // #3086: append the TUI-parity Done summary on finished slots that carry
-    // accounting (`Done (N tools · M tokens · Xs)`).
+    // #3086: append the TUI-parity Done summary on finished slots with accounting.
     if let Some(summary) = slot
         .summary
         .as_ref()
@@ -653,8 +656,7 @@ pub(super) fn render_subagent_slot(slot: &SubagentSlot) -> String {
         line.push_str(" — ");
         line.push_str(&done);
     }
-    // #3391: reserve marker width then append so a finished line always ENDS WITH
-    // its ✓/✗ (a long desc/summary can no longer swallow it).
+    // #3391: reserve marker width so a finished line always ENDS WITH its ✓/✗.
     match slot.terminal_marker() {
         Some(marker) => truncate_chars_with_marker(&line, marker, EVENT_LINE_MAX_CHARS),
         None => truncate_chars(&line, EVENT_LINE_MAX_CHARS),

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -6,6 +6,15 @@ use super::common::{
 const DISPATCH_ID_SHORT_LEN: usize = 8;
 const TASK_PANEL_TITLE_MAX_CHARS: usize = 60;
 
+/// #3473: max age a background task footer slot may sit "in progress" before the
+/// turn-boundary reconciliation force-aborts it. A slot whose terminal
+/// notification never arrives (dcserver restart / `/compact` rebinds tool ids)
+/// would otherwise render its spinner forever. 30 minutes comfortably exceeds any
+/// legitimate background job's silent stretch while still bounding the stuck-slot
+/// lifetime to one turn boundary past the TTL.
+pub(super) const STUCK_BACKGROUND_TASK_TTL: std::time::Duration =
+    std::time::Duration::from_secs(30 * 60);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct TaskPanelSnapshot {
     pub(super) dispatch_id: String,
@@ -96,6 +105,10 @@ pub(super) struct TaskToolSlot {
     /// reused. Backs slot-identity eviction so two slots that render the same
     /// terminal line stay distinct (string-identity eviction collided them).
     pub(super) ordinal: u64,
+    /// #3473: monotonic creation instant, set at upsert. The turn-boundary
+    /// reconciliation force-aborts a background slot older than
+    /// `STUCK_BACKGROUND_TASK_TTL` whose terminal notification never arrived.
+    pub(super) created_at: std::time::Instant,
 }
 
 pub(super) fn clean_task_tool_value(raw: impl AsRef<str>) -> Option<String> {
@@ -138,6 +151,7 @@ pub(super) fn upsert_task_tool_slot(
         tool_use_id: None,
         background: false,
         ordinal: take_slot_ordinal(next_ordinal),
+        created_at: std::time::Instant::now(),
     });
     trim_task_tool_slots(slots);
 }
@@ -171,6 +185,7 @@ pub(super) fn upsert_background_task_tool_slot(
         tool_use_id: Some(tool_use_id),
         background: true,
         ordinal: take_slot_ordinal(next_ordinal),
+        created_at: std::time::Instant::now(),
     });
     trim_task_tool_slots(slots);
 }
@@ -273,6 +288,29 @@ pub(super) fn task_tool_terminal_marker(status: Option<&str>) -> Option<&'static
 
 pub(super) fn task_tool_slot_is_unfinished_background(slot: &TaskToolSlot) -> bool {
     slot.background && task_tool_terminal_marker(slot.status.as_deref()).is_none()
+}
+
+/// #3473: at a turn boundary, force any background task slot that is still
+/// unfinished AND older than `STUCK_BACKGROUND_TASK_TTL` to a terminal `aborted`
+/// status. Its terminal notification never arrived (dcserver restart / `/compact`
+/// rebinds tool ids), so it would otherwise render ⏳ forever; marking it terminal
+/// makes it render ✗ and become eligible for delivered-terminal eviction on the
+/// next ack cycle. Returns the number of slots reconciled (for observability).
+/// `now` is injected so the reconciliation is unit-testable.
+pub(super) fn force_abort_stuck_background_task_slots(
+    slots: &mut [TaskToolSlot],
+    now: std::time::Instant,
+) -> usize {
+    let mut aborted = 0usize;
+    for slot in slots.iter_mut() {
+        if task_tool_slot_is_unfinished_background(slot)
+            && now.saturating_duration_since(slot.created_at) >= STUCK_BACKGROUND_TASK_TTL
+        {
+            slot.status = Some("aborted".to_string());
+            aborted += 1;
+        }
+    }
+    aborted
 }
 
 /// #3391: a task slot carries a terminal mark (✓/✗) iff its status maps to one.

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -5716,3 +5716,307 @@ fn compaction_log_gate_fires_on_change_only() {
         "turn reset re-arms the gate without an interleaved zero render"
     );
 }
+
+// ===========================================================================
+// #3477 / #3473 — live panel terminal block reorder/blank/multiline + TTL.
+// ===========================================================================
+
+// #3477 item 4: the 🖥️ Recent/terminal block renders BEFORE the Tasks and
+// Subagents sections (it is the most useful at-a-glance signal and, ahead of the
+// bulky sections, is also protected from trailing-section budget drops).
+#[test]
+fn status_panel_recent_block_renders_before_tasks_and_subagents() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_477_001);
+    // A running background task (Tasks section) and a running subagent.
+    events.push_status_event(
+        channel_id,
+        StatusEvent::BackgroundTaskStart {
+            name: "Bash".to_string(),
+            summary: "long build".to_string(),
+            tool_use_id: "bg-1".to_string(),
+        },
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::SubagentStart {
+            subagent_type: Some("Explore".to_string()),
+            desc: Some("scan repo".to_string()),
+            tool_use_id: Some("sa-1".to_string()),
+            background: false,
+        },
+    );
+    // A live Recent event.
+    events.push_event(
+        channel_id,
+        RecentPlaceholderEvent::tool_use("Read", &json!({"file_path": "/tmp/x.rs"}).to_string())
+            .unwrap(),
+    );
+
+    let rendered = events.render_status_panel_with_heartbeat(
+        channel_id,
+        &ProviderKind::Claude,
+        1_700_000_000,
+        1_700_000_005,
+    );
+    let recent_at = rendered.find("🖥️ Recent").expect("recent present");
+    let tasks_at = rendered.find("Tasks").expect("tasks present");
+    let subagents_at = rendered.find("Subagents").expect("subagents present");
+    assert!(
+        recent_at < tasks_at,
+        "Recent must precede Tasks: {rendered}"
+    );
+    assert!(
+        recent_at < subagents_at,
+        "Recent must precede Subagents: {rendered}"
+    );
+}
+
+// #3477 item 3: a live output batch that lands AFTER TurnCompleted keeps the
+// 🖥️ Recent block visible (the late batch is not blanked), while a genuinely idle
+// completed turn (no fresh content) still drops its stale block.
+#[test]
+fn status_panel_late_batch_after_completion_keeps_recent_block() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_477_002);
+
+    // Stale pre-completion content, then completion: must be suppressed.
+    events.push_event(
+        channel_id,
+        RecentPlaceholderEvent::tool_use("Bash", &json!({"command": "echo stale"}).to_string())
+            .unwrap(),
+    );
+    events.push_status_event(channel_id, StatusEvent::TurnCompleted { background: false });
+    let idle_completed = events.render_status_panel_with_heartbeat(
+        channel_id,
+        &ProviderKind::Claude,
+        1_700_000_000,
+        1_700_000_010,
+    );
+    assert!(
+        !idle_completed.contains("🖥️ Recent"),
+        "stale block on a genuinely idle completed turn must be dropped: {idle_completed}"
+    );
+
+    // A late output batch arrives AFTER completion: must keep showing Recent.
+    events.push_event(
+        channel_id,
+        RecentPlaceholderEvent::tool_use(
+            "Bash",
+            &json!({"command": "echo LATE_BATCH"}).to_string(),
+        )
+        .unwrap(),
+    );
+    let late = events.render_status_panel_with_heartbeat(
+        channel_id,
+        &ProviderKind::Claude,
+        1_700_000_000,
+        1_700_000_011,
+    );
+    assert!(
+        late.contains("🖥️ Recent"),
+        "a fresh late batch racing TurnCompleted must not be blanked: {late}"
+    );
+    assert!(
+        late.contains("LATE_BATCH"),
+        "late content must render: {late}"
+    );
+}
+
+// #3477 item 1: multi-line tool output stays readable in the Recent/terminal
+// block (multiple lines preserved) instead of collapsing to one run-on line.
+#[test]
+fn recent_block_preserves_multiline_tool_output() {
+    let multiline =
+        "error[E0308]: mismatched types\n  expected `u64`, found `i64`\n  at src/main.rs:10";
+    let event = RecentPlaceholderEvent::tool_error(multiline).expect("event");
+    let rendered = event.render_line();
+    let line_count = rendered.lines().count();
+    assert!(
+        line_count >= 2,
+        "multi-line output must keep multiple lines, got {line_count}: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("E0308"),
+        "first line preserved: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("expected"),
+        "continuation line preserved: {rendered:?}"
+    );
+}
+
+// #3477 item 1: the compact single-line panel cells (Tasks/Subagents) stay
+// one-line — `normalize_summary` (first line only) is unchanged.
+#[test]
+fn normalize_summary_stays_single_line_for_panel_cells() {
+    let collapsed = super::common::normalize_summary("first line\nsecond line\nthird");
+    assert!(
+        !collapsed.contains('\n'),
+        "panel cell must stay single-line: {collapsed:?}"
+    );
+    assert_eq!(collapsed, "first line");
+}
+
+// #3477 item 1: the task-card summary preserves newlines (Discord renders
+// multi-line bold), while still neutralizing the ``` fence hazard.
+#[test]
+fn task_card_summary_preserves_newlines() {
+    let card = super::super::tui_task_card::format_task_notification_card(
+        &super::super::tui_task_card::TaskNotification {
+            status: Some("completed".to_string()),
+            summary: Some("line one\nline two\n```danger```".to_string()),
+            ..Default::default()
+        },
+        1,
+    );
+    assert!(
+        card.contains("line one\nline two"),
+        "newlines preserved: {card}"
+    );
+    assert!(
+        !card.contains("```danger```"),
+        "fence hazard escaped: {card}"
+    );
+}
+
+// #3473: a background task slot stuck past the TTL is force-aborted at the turn
+// boundary so it renders ✗ and is evicted (dropped) — it no longer sits ⏳
+// forever; a fresh slot in the same turn is untouched (normal completion path).
+#[test]
+fn stuck_background_task_slot_force_aborted_at_turn_boundary() {
+    use super::task_panel::{STUCK_BACKGROUND_TASK_TTL, force_abort_stuck_background_task_slots};
+
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_473_001);
+    // A stuck slot whose terminal notification never arrives.
+    events.push_status_event(
+        channel_id,
+        StatusEvent::BackgroundTaskStart {
+            name: "Bash".to_string(),
+            summary: "stuck job".to_string(),
+            tool_use_id: "stuck-1".to_string(),
+        },
+    );
+    // A second, fresh background slot started "now".
+    events.push_status_event(
+        channel_id,
+        StatusEvent::BackgroundTaskStart {
+            name: "Bash".to_string(),
+            summary: "fresh job".to_string(),
+            tool_use_id: "fresh-1".to_string(),
+        },
+    );
+    // Back-date the first slot's creation past the TTL.
+    {
+        let entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("status panel state");
+        let mut guard = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let stale_at = std::time::Instant::now()
+            .checked_sub(STUCK_BACKGROUND_TASK_TTL + std::time::Duration::from_secs(60))
+            .expect("monotonic clock far enough past origin");
+        let stuck = guard
+            .tasks
+            .iter_mut()
+            .find(|slot| slot.tool_use_id.as_deref() == Some("stuck-1"))
+            .expect("stuck slot");
+        stuck.created_at = stale_at;
+        // The direct helper aborts exactly the stale slot, not the fresh one.
+        let aborted =
+            force_abort_stuck_background_task_slots(&mut guard.tasks, std::time::Instant::now());
+        assert_eq!(aborted, 1, "only the stale slot is aborted");
+        assert_eq!(
+            guard
+                .tasks
+                .iter()
+                .find(|slot| slot.tool_use_id.as_deref() == Some("stuck-1"))
+                .and_then(|slot| slot.status.as_deref()),
+            Some("aborted")
+        );
+        assert!(
+            guard
+                .tasks
+                .iter()
+                .find(|slot| slot.tool_use_id.as_deref() == Some("fresh-1"))
+                .map(|slot| slot.status.is_none())
+                .unwrap_or(false),
+            "fresh slot must stay in progress"
+        );
+    }
+}
+
+// #3473: the turn-boundary reconciliation (the production call site) drops the
+// stuck slot — it is no longer retained as an unfinished-background residual —
+// while a fresh background slot survives as a residual.
+#[test]
+fn stuck_background_task_slot_dropped_on_turn_boundary_reconciliation() {
+    use super::task_panel::STUCK_BACKGROUND_TASK_TTL;
+
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_473_002);
+    events.push_status_event(
+        channel_id,
+        StatusEvent::BackgroundTaskStart {
+            name: "Bash".to_string(),
+            summary: "stuck job".to_string(),
+            tool_use_id: "stuck-2".to_string(),
+        },
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::BackgroundTaskStart {
+            name: "Bash".to_string(),
+            summary: "fresh job".to_string(),
+            tool_use_id: "fresh-2".to_string(),
+        },
+    );
+    {
+        let entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("status panel state");
+        let mut guard = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let stale_at = std::time::Instant::now()
+            .checked_sub(STUCK_BACKGROUND_TASK_TTL + std::time::Duration::from_secs(60))
+            .expect("monotonic clock far enough past origin");
+        guard
+            .tasks
+            .iter_mut()
+            .find(|slot| slot.tool_use_id.as_deref() == Some("stuck-2"))
+            .expect("stuck slot")
+            .created_at = stale_at;
+    }
+
+    // Turn boundary: the production reconciliation site.
+    events.clear_channel_preserving_footer_residuals(channel_id);
+
+    let entry = events
+        .status_by_channel
+        .get(&channel_id)
+        .expect("residual state survives because the fresh slot is preserved");
+    let guard = entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+        guard
+            .tasks
+            .iter()
+            .all(|slot| slot.tool_use_id.as_deref() != Some("stuck-2")),
+        "stuck slot must be dropped at the turn boundary: {:?}",
+        guard.tasks
+    );
+    assert!(
+        guard
+            .tasks
+            .iter()
+            .any(|slot| slot.tool_use_id.as_deref() == Some("fresh-2")),
+        "fresh background slot must survive as a residual: {:?}",
+        guard.tasks
+    );
+}

--- a/src/services/discord/tui_task_card.rs
+++ b/src/services/discord/tui_task_card.rs
@@ -259,7 +259,11 @@ pub(super) fn format_task_notification_card(note: &TaskNotification, update_coun
     let mut lines = vec![header];
 
     if let Some(summary) = note.summary.as_deref().filter(|s| !s.is_empty()) {
-        lines.push(format!("**{}**", sanitize_oneline(summary)));
+        // #3477 item 1: preserve the summary's newlines so multi-line task
+        // summaries stay readable (Discord renders multi-line bold fine). Still
+        // escapes the ``` fence hazard. The footer/preview slots below keep using
+        // `sanitize_oneline` so they remain compact single-line cells.
+        lines.push(format!("**{}**", sanitize_multiline(summary)));
     }
 
     if let Some(result) = note.result.as_deref().filter(|s| !s.is_empty()) {
@@ -438,6 +442,17 @@ fn sanitize_oneline(value: &str) -> String {
     value
         .replace('\r', " ")
         .replace('\n', " ")
+        .replace("```", "` ` `")
+}
+
+/// #3477 item 1: like `sanitize_oneline` but PRESERVES newlines so multi-line
+/// task summaries render readably (Discord renders multi-line bold fine). Still
+/// neutralizes the ``` code-fence hazard and normalizes lone `\r` to `\n` so the
+/// platform never sees a bare carriage return.
+fn sanitize_multiline(value: &str) -> String {
+    value
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
         .replace("```", "` ` `")
 }
 


### PR DESCRIPTION
운영자가 Discord만으로 진행 상황을 파악하기 어렵던 라이브 패널 UX 4종.

## #3477 — terminal/recent 블록 (3 parts)
1. **순서 상향**: `header → 🖥️ Recent → Tasks → Subagents → Workflow` (terminal을 task/subagent 위로). `status_panel.rs render_status_panel`.
2. **출력 중 공백 수정**: TurnCompleted가 마지막 출력 batch보다 먼저 도달하면 Recent 섹션이 사라지던 문제. `completed_at` + per-channel `last_recent_event_at` 스탬프로 `live_content_fresh` 판정 — 완료 후 늦게 온 batch는 유지, 진짜 idle 완료 턴의 stale 블록만 drop. `saturating_duration_since`(panic 없음).
3. **멀티라인 보존**: Recent 블록 + task-card summary는 멀티라인(최대 `RECENT_EVENT_MAX_LINES`, redaction 선행, fence 이스케이프 유지). 컴팩트 Tasks/Subagents 셀은 기존 first-line 유지.

## #3473 — task stuck-slot TTL backstop
`tool_use_id` 매칭만 있고 TTL이 없어 종료 알림 누락 시 영구 ⏳. `TaskToolSlot.created_at: Instant` + 턴 경계(`reset_turn_content_preserving_unfinished_footer_residuals`)에서 30분 초과 미완 background slot을 `aborted`로 강제 종결 → ✗ 렌더 후 evict. 새 tick loop 불요.

## 검증
7개 신규 테스트(reorder/late-batch/multiline/compact/task-card/TTL/clear-retain), 전 게이트 통과. 편집한 `placeholder_live_events/status_panel.rs`는 frozen 아님(frozen은 `turn_bridge/status_panel.rs`). Adversarial review: **VERDICT: CLEAN (findings 0)**.

Closes #3477, closes #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)