### PR TITLE
fix(routines/discord): #3463 후속 — 라우틴 워크스페이스 해소 + 후속 재큐 컨텍스트 보존

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -742,7 +742,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3777 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3769 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -742,7 +742,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3758 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3777 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -756,7 +756,7 @@
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
     re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
     S4 mechanical placeholder/status-panel `.ui` rewiring).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1442 lines;
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1462 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).
   - `src/services/discord/meeting_orchestrator.rs` (3222 lines after #3034

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -140,7 +140,7 @@
 # FIX #6 (Codex P2): +6 (3771 -> 3777) for the `set_followup_requeue_context`
 # call that persists the originating Intervention's reply/upload/voice context on
 # the follow-up inflight row so a PRE-submit busy-timeout requeue can rebuild it.
-"src/services/discord/router/message_handler/intake_turn.rs" = 3777
+"src/services/discord/router/message_handler/intake_turn.rs" = 3769
 "src/services/discord/meeting_orchestrator.rs" = 3227
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -223,7 +223,7 @@
 # variant + its reason comment (handled by the finalizer + tested, not yet emitted
 # in prod; rustfmt keeps the attribute and the comment on separate lines).
 "src/services/discord/turn_finalizer.rs" = 1528
-"src/services/discord/router/message_handler/headless_turn.rs" = 1442
+"src/services/discord/router/message_handler/headless_turn.rs" = 1462
 # #3038 S2: lowered 1054 -> 954 (-100) as the session-override bookkeeping
 # helpers (fast-mode reset-entry codec + reset-pending probes/clears +
 # enablement probes + sync_session_reset_pending) moved verbatim to the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -137,7 +137,10 @@
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced
 # by lifting cluster C into `QueuedPlaceholderState`. Net program-wide: mod.rs -201.
-"src/services/discord/router/message_handler/intake_turn.rs" = 3771
+# FIX #6 (Codex P2): +6 (3771 -> 3777) for the `set_followup_requeue_context`
+# call that persists the originating Intervention's reply/upload/voice context on
+# the follow-up inflight row so a PRE-submit busy-timeout requeue can rebuild it.
+"src/services/discord/router/message_handler/intake_turn.rs" = 3777
 "src/services/discord/meeting_orchestrator.rs" = 3227
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered
@@ -184,7 +187,12 @@
 # #3351: +58 for `clear_current_msg_if_matches(_in_root)` — the relay-placeholder
 # compare-and-clear needs the file-private lock/load/persist internals, so it
 # lives here until the inflight split.
-"src/services/discord/inflight.rs" = 2523
+# FIX #6 (Codex P2): +62 (2523 -> 2585) for the five `#[serde(default)]`
+# follow-up requeue context fields on `InflightTurnState` (+ doc comments), the
+# v8->v9 version bump comment, the `set_followup_requeue_context` setter, and the
+# matching defaults in `InflightTurnState::new`, so a PRE-submit busy-timeout
+# requeue rebuilds the retry Intervention without losing reply/upload/voice data.
+"src/services/discord/inflight.rs" = 2585
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/src/services/discord/health/headless_turn.rs
+++ b/src/services/discord/health/headless_turn.rs
@@ -90,12 +90,14 @@ pub async fn start_reserved_headless_agent_turn(
         metadata,
         channel_name_hint,
         None,
+        None,
         reservation,
         expected_turn_id,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_reserved_headless_agent_turn_with_owner_channel(
     registry: &HealthRegistry,
     owner_channel_id: ChannelId,
@@ -105,6 +107,11 @@ pub async fn start_reserved_headless_agent_turn_with_owner_channel(
     source: Option<String>,
     metadata: Option<serde_json::Value>,
     channel_name_hint: Option<String>,
+    // #5: When set, this synthetic label drives the routine's DISTINCT tmux
+    // session while `channel_name_hint` carries the agent's REAL primary
+    // channel/alias so workspace resolution succeeds. Non-routine callers pass
+    // `None` for identical behavior.
+    tmux_session_label: Option<String>,
     reservation: HeadlessAgentTurnReservation,
 ) -> Result<router::HeadlessTurnStartOutcome, router::HeadlessTurnStartError> {
     if reservation.channel_id != turn_channel_id {
@@ -128,6 +135,7 @@ pub async fn start_reserved_headless_agent_turn_with_owner_channel(
         source,
         metadata,
         channel_name_hint,
+        tmux_session_label,
         Some(false),
         reservation,
         expected_turn_id,
@@ -179,6 +187,7 @@ pub async fn start_headless_agent_turn_in_dm(
         source,
         metadata,
         channel_name_hint,
+        None,
         Some(true),
         reservation,
         expected_turn_id,
@@ -251,6 +260,7 @@ pub async fn start_reserved_headless_agent_turn_in_dm(
         source,
         metadata,
         channel_name_hint,
+        None,
         Some(true),
         reservation,
         expected_turn_id,
@@ -258,6 +268,7 @@ pub async fn start_reserved_headless_agent_turn_in_dm(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_reserved_headless_agent_turn_with_shared(
     shared: Arc<SharedData>,
     channel_id: ChannelId,
@@ -266,6 +277,11 @@ async fn start_reserved_headless_agent_turn_with_shared(
     source: Option<String>,
     metadata: Option<serde_json::Value>,
     channel_name_hint: Option<String>,
+    // #5: synthetic tmux-session label for routine turns; forwarded to the
+    // router so the routine keeps a distinct tmux session while
+    // `channel_name_hint` stays the real channel for workspace resolution.
+    // `None` for non-routine callers.
+    tmux_session_label: Option<String>,
     is_dm_hint: Option<bool>,
     reservation: HeadlessAgentTurnReservation,
     expected_turn_id: String,
@@ -312,6 +328,7 @@ async fn start_reserved_headless_agent_turn_with_shared(
         source.as_deref(),
         metadata,
         channel_name_hint,
+        tmux_session_label,
         is_dm_hint,
         reservation.inner,
     )

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -27,7 +27,17 @@ use crate::services::provider::ProviderKind;
 // `input_fifo_path` alongside ClaudeTui plus the silent-skip recovery branch;
 // old binaries deserialize v8 rows via `#[serde(default)]` (compat window:
 // one release each direction).
-const INFLIGHT_STATE_VERSION: u32 = 8;
+//
+// FIX #6 (Codex P2): bump v8→v9. v9 persists the originating Intervention's
+// follow-up requeue context (`followup_reply_context`,
+// `followup_has_reply_boundary`, `followup_merge_consecutive`,
+// `followup_pending_uploads`, `followup_voice_announcement`) so a follow-up
+// that hit a PRE-submit busy-timeout with requeue enabled can rebuild the
+// retry Intervention faithfully instead of dropping its attachments / reply
+// context / voice metadata. All five fields are `#[serde(default)]`, so v8 rows
+// (and rows written by binaries that pre-date this field) still deserialize and
+// simply yield empty/None — no recovery regression, full compat each direction.
+const INFLIGHT_STATE_VERSION: u32 = 9;
 const INFLIGHT_MAX_AGE_SECS: u64 = 300; // 5 minutes
 const DRAIN_RESTART_MAX_AGE_SECS: u64 = 1800; // 30 minutes
 const HOT_SWAP_HANDOFF_MAX_AGE_SECS: u64 = 900; // 15 minutes
@@ -263,6 +273,31 @@ pub(super) struct InflightTurnState {
     /// `None` for turns with a real `user_msg_id` or legacy rows.
     #[serde(default)]
     pub injected_prompt_message_id: Option<u64>,
+    /// FIX #6 (Codex P2): originating `Intervention::reply_context` for this
+    /// follow-up turn, persisted so a PRE-submit busy-timeout requeue can
+    /// rebuild the retry Intervention without losing the quoted-reply context.
+    /// `#[serde(default)]` → `None` for legacy rows / non-follow-up paths.
+    #[serde(default)]
+    pub followup_reply_context: Option<String>,
+    /// FIX #6: originating `Intervention::has_reply_boundary`. Defaults to
+    /// `false` for legacy rows.
+    #[serde(default)]
+    pub followup_has_reply_boundary: bool,
+    /// FIX #6: originating `Intervention::merge_consecutive`. Defaults to
+    /// `false` for legacy rows.
+    #[serde(default)]
+    pub followup_merge_consecutive: bool,
+    /// FIX #6: originating `Intervention::pending_uploads` (attachment refs).
+    /// Empty for legacy rows / turns without uploads.
+    #[serde(default)]
+    pub followup_pending_uploads: Vec<String>,
+    /// FIX #6: originating `Intervention::voice_announcement` projection.
+    /// `VoiceTranscriptAnnouncement` is already serde-persisted in the durable
+    /// intervention queue, so it round-trips directly here. `None` for
+    /// non-voice turns / legacy rows.
+    #[serde(default)]
+    pub followup_voice_announcement:
+        Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
 }
 
 /// Origin of a turn whose state is captured in [`InflightTurnState`]. Pure
@@ -596,6 +631,11 @@ impl InflightTurnState {
             relay_owner_kind: RelayOwnerKind::None,
             turn_source: TurnSource::Managed,
             injected_prompt_message_id: None,
+            followup_reply_context: None,
+            followup_has_reply_boundary: false,
+            followup_merge_consecutive: false,
+            followup_pending_uploads: Vec::new(),
+            followup_voice_announcement: None,
         }
     }
 
@@ -664,6 +704,28 @@ impl InflightTurnState {
         self.worktree_path = worktree_path;
         self.worktree_branch = worktree_branch;
         self.base_commit = base_commit;
+    }
+
+    /// FIX #6 (Codex P2): record the originating `Intervention`'s follow-up
+    /// requeue context so a PRE-submit busy-timeout requeue
+    /// (`mailbox_requeue_inflight_for_followup_retry`) can faithfully rebuild
+    /// the retry Intervention (reply context / attachments / voice metadata)
+    /// instead of dropping it. Called at the follow-up turn-start construction
+    /// site; non-follow-up paths leave the defaults (empty/None), which is
+    /// correct.
+    pub(in crate::services::discord) fn set_followup_requeue_context(
+        &mut self,
+        reply_context: Option<String>,
+        has_reply_boundary: bool,
+        merge_consecutive: bool,
+        pending_uploads: Vec<String>,
+        voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
+    ) {
+        self.followup_reply_context = reply_context;
+        self.followup_has_reply_boundary = has_reply_boundary;
+        self.followup_merge_consecutive = merge_consecutive;
+        self.followup_pending_uploads = pending_uploads;
+        self.followup_voice_announcement = voice_announcement;
     }
 }
 
@@ -2841,6 +2903,81 @@ mod stall_recovery_tests {
         assert_eq!(loaded[0].current_msg_id, 99);
     }
 
+    /// FIX #6 (Codex P2): the follow-up requeue context must survive the
+    /// on-disk JSON round-trip, and rows written WITHOUT the fields (legacy
+    /// v8 / pre-field rows) must deserialize cleanly to empty/None so requeue
+    /// behaves exactly as before for them.
+    #[test]
+    fn followup_requeue_context_round_trips_and_defaults_when_absent() {
+        let temp = TempDir::new().unwrap();
+        let mut state = InflightTurnState::new(
+            ProviderKind::Claude,
+            42,
+            Some("adk-claude".to_string()),
+            7,
+            8,
+            99,
+            "hello".to_string(),
+            Some("session-1".to_string()),
+            Some("AgentDesk-claude-adk-claude".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        let announcement = crate::voice::prompt::VoiceTranscriptAnnouncement {
+            transcript: "전투 시스템 고쳐줘".to_string(),
+            user_id: "7".to_string(),
+            utterance_id: "utt-1".to_string(),
+            language: "ko".to_string(),
+            verbose_progress: false,
+            started_at: None,
+            completed_at: None,
+            samples_written: None,
+            control_channel_id: None,
+            stt_mode: None,
+            stt_latency_ms: None,
+        };
+        state.set_followup_requeue_context(
+            Some("quoted reply context".to_string()),
+            true,
+            true,
+            vec!["upload://a.png".to_string(), "upload://b.png".to_string()],
+            Some(announcement.clone()),
+        );
+
+        save_inflight_state_in_root(temp.path(), &state).expect("save inflight state");
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].followup_reply_context.as_deref(),
+            Some("quoted reply context")
+        );
+        assert!(loaded[0].followup_has_reply_boundary);
+        assert!(loaded[0].followup_merge_consecutive);
+        assert_eq!(
+            loaded[0].followup_pending_uploads,
+            vec!["upload://a.png".to_string(), "upload://b.png".to_string()]
+        );
+        assert_eq!(loaded[0].followup_voice_announcement, Some(announcement));
+
+        // A JSON row that omits the new fields entirely (legacy v8 / pre-field
+        // shape) must still deserialize, defaulting the follow-up context.
+        let mut value = serde_json::to_value(&state).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("followup_reply_context");
+        obj.remove("followup_has_reply_boundary");
+        obj.remove("followup_merge_consecutive");
+        obj.remove("followup_pending_uploads");
+        obj.remove("followup_voice_announcement");
+        let legacy: InflightTurnState =
+            serde_json::from_value(value).expect("legacy row must deserialize");
+        assert_eq!(legacy.followup_reply_context, None);
+        assert!(!legacy.followup_has_reply_boundary);
+        assert!(!legacy.followup_merge_consecutive);
+        assert!(legacy.followup_pending_uploads.is_empty());
+        assert_eq!(legacy.followup_voice_announcement, None);
+    }
+
     // ---- #3077: typed status-panel ownership write tests ----
 
     /// Seeds a single inflight row in `root` and returns it. `user_msg_id` /
@@ -3416,7 +3553,7 @@ mod stall_recovery_tests {
         let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].version, super::INFLIGHT_STATE_VERSION);
-        assert_eq!(loaded[0].version, 8);
+        assert_eq!(loaded[0].version, 9);
         assert_eq!(loaded[0].runtime_kind, Some(RuntimeHandoffKind::ClaudeTui));
         assert_eq!(
             loaded[0].input_fifo_path.as_deref(),

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -296,8 +296,7 @@ pub(super) struct InflightTurnState {
     /// intervention queue, so it round-trips directly here. `None` for
     /// non-voice turns / legacy rows.
     #[serde(default)]
-    pub followup_voice_announcement:
-        Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
+    pub followup_voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
 }
 
 /// Origin of a turn whose state is captured in [`InflightTurnState`]. Pure

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3627,27 +3627,32 @@ pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_
     shared: &SharedData,
     provider: &ProviderKind,
     channel_id: ChannelId,
-    request_owner_user_id: u64,
-    user_msg_id: u64,
-    user_text: &str,
+    inflight_state: &InflightTurnState,
 ) {
-    if user_msg_id == 0 || user_text.trim().is_empty() {
+    let request_owner_user_id = inflight_state.request_owner_user_id;
+    let user_msg_id = inflight_state.user_msg_id;
+    if user_msg_id == 0 || inflight_state.user_text.trim().is_empty() {
         return;
     }
     let message_id = MessageId::new(user_msg_id);
+    // FIX #6 (Codex P2): rebuild the retry Intervention from the persisted
+    // follow-up requeue context instead of hardcoding empty values, so a
+    // PRE-submit busy-timeout requeue preserves the originating turn's reply
+    // context, attachments, and voice metadata. Legacy rows (pre-v9) default
+    // these to None/empty/false, matching the previous behavior exactly.
     let intervention = Intervention {
         author_id: UserId::new(request_owner_user_id),
         author_is_bot: false,
         message_id,
         source_message_ids: vec![message_id],
-        text: user_text.to_string(),
+        text: inflight_state.user_text.clone(),
         mode: crate::services::turn_orchestrator::InterventionMode::Soft,
         created_at: std::time::Instant::now(),
-        reply_context: None,
-        has_reply_boundary: false,
-        merge_consecutive: false,
-        pending_uploads: Vec::new(),
-        voice_announcement: None,
+        reply_context: inflight_state.followup_reply_context.clone(),
+        has_reply_boundary: inflight_state.followup_has_reply_boundary,
+        merge_consecutive: inflight_state.followup_merge_consecutive,
+        pending_uploads: inflight_state.followup_pending_uploads.clone(),
+        voice_announcement: inflight_state.followup_voice_announcement.clone(),
     };
     let _ = mailbox_enqueue_intervention(shared, provider, channel_id, intervention).await;
 }

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -22,11 +22,13 @@ pub(in crate::services::discord) async fn start_headless_turn(
         metadata,
         channel_name_hint,
         None,
+        None,
         reserve_headless_turn(),
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::services::discord) async fn start_reserved_headless_turn(
     ctx: &serenity::Context,
     channel_id: ChannelId,
@@ -37,6 +39,9 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
     source: Option<&str>,
     metadata: Option<serde_json::Value>,
     channel_name_hint: Option<String>,
+    // #5: synthetic tmux-session label for routine turns (see
+    // `start_reserved_headless_turn_with_owner`); `None` for all other callers.
+    tmux_session_label: Option<String>,
     is_dm_hint: Option<bool>,
     reservation: HeadlessTurnReservation,
 ) -> Result<HeadlessTurnStartOutcome, HeadlessTurnStartError> {
@@ -51,6 +56,7 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
         source,
         metadata,
         channel_name_hint,
+        tmux_session_label,
         is_dm_hint,
         reservation,
     )
@@ -111,12 +117,14 @@ pub(in crate::services::discord) async fn start_voice_headless_turn(
         Some(crate::dispatch::Source::Voice.as_str()),
         metadata,
         channel_name_hint,
+        None,
         Some(false),
         reserve_headless_turn(),
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn start_reserved_headless_turn_with_owner(
     ctx: &serenity::Context,
     channel_id: ChannelId,
@@ -128,6 +136,13 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     source: Option<&str>,
     metadata: Option<serde_json::Value>,
     channel_name_hint: Option<String>,
+    // #5: When set, this synthetic label (e.g. a routine's distinct tmux session
+    // name) drives ONLY the tmux-session naming below, decoupled from
+    // `channel_name_hint`, which must stay the agent's REAL primary
+    // channel/alias so `resolve_workspace`/worktree isolation/dispatch/role and
+    // the routine-identity reset guard keep resolving against the real channel.
+    // Non-routine callers pass `None` and behave exactly as before.
+    tmux_session_label: Option<String>,
     is_dm_hint: Option<bool>,
     reservation: HeadlessTurnReservation,
 ) -> Result<HeadlessTurnStartOutcome, HeadlessTurnStartError> {
@@ -500,8 +515,13 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             .and_then(|session| session.channel_name.clone())
             .or_else(|| channel_name_hint.clone());
         let tmux_session_name = if provider.uses_managed_tmux_backend() {
-            channel_name
-                .as_ref()
+            // #5: Prefer the synthetic routine label (when supplied) so the
+            // routine keeps its DISTINCT tmux session (#3463: routine-name-first
+            // label avoids two routines on one agent colliding) while
+            // `channel_name` stays the REAL channel for workspace/dispatch/role.
+            tmux_session_label
+                .as_deref()
+                .or(channel_name.as_deref())
                 .map(|name| provider.build_tmux_session_name(name))
         } else {
             None

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -3444,6 +3444,17 @@ pub(in crate::services::discord) async fn handle_text_message(
             .unwrap_or((None, None, None))
     };
     inflight_state.set_worktree_context(worktree_path, worktree_branch, base_commit);
+    // FIX #6 (Codex P2): persist the originating Intervention's follow-up
+    // requeue context so a PRE-submit busy-timeout requeue
+    // (`mailbox_requeue_inflight_for_followup_retry`) can rebuild the retry
+    // Intervention without losing reply context / attachments / voice metadata.
+    inflight_state.set_followup_requeue_context(
+        reply_context.clone(),
+        has_reply_boundary,
+        merge_consecutive,
+        pending_uploads.clone(),
+        voice_announcement.clone(),
+    );
     inflight_state.logical_channel_id = Some(logical_channel_id);
     inflight_state.thread_id = thread_id;
     inflight_state.thread_title = thread_title;

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -6491,9 +6491,7 @@ pub(super) fn spawn_turn_bridge(
                             &shared_owned,
                             &provider,
                             channel_id,
-                            inflight_state.request_owner_user_id,
-                            inflight_state.user_msg_id,
-                            &inflight_state.user_text,
+                            &inflight_state,
                         )
                         .await;
                         tracing::info!(

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -1026,7 +1026,13 @@ impl RoutineAgentExecutor {
             )
             .await
         } else {
-            let channel_name_hint = Some(routine_agent_session_name(&claimed.name, agent_id));
+            // #5: Pass the agent's REAL primary channel/alias as the workspace
+            // hint so `resolve_workspace` resolves for alias/by-name routine
+            // agents, and carry the synthetic routine session name separately as
+            // the tmux-session label so the routine still gets its DISTINCT tmux
+            // session (#3463: routine-name-first avoids cross-routine collision).
+            let channel_name_hint = Some(primary_channel.clone());
+            let tmux_session_label = Some(routine_agent_session_name(&claimed.name, agent_id));
             start_reserved_headless_agent_turn_with_owner_channel(
                 registry,
                 channel_id,
@@ -1036,6 +1042,7 @@ impl RoutineAgentExecutor {
                 Some("routine".to_string()),
                 metadata,
                 channel_name_hint,
+                tmux_session_label,
                 reservation,
             )
             .await


### PR DESCRIPTION
## 목표
머지된 #3463의 본문에 후속으로 남겨둔 Codex P2 2건을 해결한다: (1) 라우틴 헤드리스 턴의 워크스페이스 해소가 synthetic tmux 세션명 때문에 실패하던 문제, (2) pre-submit busy-timeout 재큐 시 첨부/reply_context/voice 메타가 유실되던 문제.

## 쉬운 설명
라우틴 턴이 alias로 바인딩된 에이전트에서 "no workspace resolved"로 실패할 수 있던 것을, 실제 채널 별칭으로 워크스페이스를 해소하면서도 라우틴별 tmux 세션은 그대로 구분되게 고쳤다. 또 후속 입력이 제출 직전 타임아웃으로 재큐될 때(옵트인) 첨부파일·답글맥락·음성 메타가 사라지던 것을 그대로 보존하도록 했다.

## 개선되는 것
### Fix 5 — 라우틴 워크스페이스 해소 / tmux 세션 분리
- before: 라우틴 경로가 synthetic `routine <name> - <agent>`를 `channel_name_hint`로 넘겨 `resolve_workspace(channel_id, n)`의 by-name 해소를 가림 → alias-only 에이전트가 워크스페이스 미해소.
- after: `tmux_session_label: Option<String>` 파라미터를 라우틴 진입점에 추가해 tmux 세션 라벨과 워크스페이스 해소 힌트를 분리. 라우틴 호출자는 실제 `primary_channel`(별칭)을 `channel_name_hint`로, synthetic 세션명을 `tmux_session_label`로 전달. 비-라우틴 경로는 `None` → 동작 불변.

### Fix 6 — 후속 재큐 컨텍스트 보존
- before: `mailbox_requeue_inflight_for_followup_retry`가 `user_text`만으로 Intervention 재구성 (reply_context=None, pending_uploads=빈값, voice=None).
- after: `InflightTurnState`에 5개 필드(`#[serde(default)]`)를 추가해 follow-up 컨텍스트를 영속화하고, 재큐 시 reply_context/pending_uploads/voice_announcement/merge_consecutive/has_reply_boundary를 복원. `INFLIGHT_STATE_VERSION` 8→9.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| alias-only 라우틴 턴 | 워크스페이스 미해소 가능 | 실제 별칭으로 해소, tmux 세션은 여전히 라우틴별 구분 |
| 첨부 포함 후속이 busy-timeout 재큐 | 첨부/reply/voice 유실 | 영속 컨텍스트에서 복원 |
| 비-라우틴 헤드리스 턴 / 비-옵트인 | — | 동작 불변(라벨 None, 레거시 v8 row는 기본값) |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| 기존 on-disk inflight(v8) 복구 | 새 필드 부재 → serde 기본값, version 8<9이므로 silent-skip 안 됨 | 복구 회귀 없음 |
| 신→구 바이너리 롤백 | 구 바이너리가 v9 row의 미지 필드 무시 | 안전(재큐는 기존처럼 컨텍스트 없이 동작) |
| 같은 에이전트의 두 라우틴 | routine-이름-우선 라벨로 tmux 세션 구분 | #3463 비충돌 유지 |

## 해결한 내용
- `inflight.rs`: InflightTurnState에 followup_* 5필드(serde default), `::new` 기본값, 세터, version 8→9, 라운드트립 테스트 추가.
- `intake_turn.rs`: follow-up 턴 시작 시 컨텍스트 캡처.
- `mod.rs`: 재큐 시 영속 컨텍스트로 Intervention 복원.
- `turn_bridge/mod.rs`: 호출부가 `&inflight_state` 전달.
- `health/headless_turn.rs`, `router/message_handler/headless_turn.rs`: `tmux_session_label` 파라미터 스레딩 + tmux 네이밍 지점에서 라벨 우선/`channel_name` 폴백.
- `agent_executor.rs`: 라우틴 호출자가 real primary_channel + synthetic 라벨 분리 전달.
- `change-surfaces.md` freeze + giant baseline(headless_turn 1462 등) 동기화.

## 검증
- `cargo check --bin agentdesk` (공유 타깃) → exit 0 (두 수정 결합 상태).
- `python3.12 scripts/audit_maintainability.py --check` → exit 0, `check_agent_maintenance_docs.py --warning-only --line-count-gate` → exit 0.
- inflight serde 라운드트립 테스트 추가(신규 필드 보존 + 레거시 v8 기본값). 전체 매트릭스는 클라우드 CI에서 검증.

## 이슈 연결
- #3463 후속 (해당 PR 본문의 "비목표 / 후속" 2건 해소).
