### PR TITLE
refactor(#3479): extract turn_bridge streaming-edit-text + watcher-orphan-cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -530,13 +530,15 @@ src/
 │   │   │   ├── stale_resume.rs
 │   │   │   ├── status_panel.rs
 │   │   │   ├── status_panel_tests.rs
+│   │   │   ├── streaming_edit_text.rs
 │   │   │   ├── terminal_controller_cutover.rs
 │   │   │   ├── terminal_delivery.rs
 │   │   │   ├── tmux_runtime.rs
 │   │   │   ├── turn_analytics.rs
 │   │   │   ├── voice_completion.rs
 │   │   │   ├── voice_completion_tests.rs
-│   │   │   └── watcher_handoff.rs
+│   │   │   ├── watcher_handoff.rs
+│   │   │   └── watcher_orphan_cleanup.rs
 │   │   ├── turn_finalizer/
 │   │   │   └── cleanup.rs
 │   │   ├── voice_barge_in/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -801,7 +801,7 @@
     stop-token/tmux binding runtime + PID-exit observation helper (#2426),
     split before adding non-bugfix behavior. #3169: added the
     claude-anonymous-teardown SIGINT suppression guard (death #3)).
-  - `src/services/discord/turn_bridge/mod.rs` (6702 prod lines; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6535 prod lines; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. Registered giant-file (#3038 decompose target — see
     `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).
@@ -819,6 +819,11 @@
     #3479 Phase-1 rank-3 lowered the root 6811 -> 6702 by moving the pure,
     unit-tested cancel/finalize decision helpers into the sibling
     `cancel_finalize_policy.rs` (re-exported, call sites byte-identical).
+    #3479 Phase-1 rank-4 lowered the root 6702 -> 6535 by moving the pure
+    streaming-edit-text + pre-submission/transport TUI prompt-error classifiers
+    into `streaming_edit_text.rs` and the watcher-orphan spinner-cleanup
+    decision + retry-spawn helpers into `watcher_orphan_cleanup.rs` (both
+    re-exported, call sites byte-identical).
     Hotfile — bugfix only outside the #3038 decompose plan).
   - `src/services/discord/turn_bridge/cancel_finalize_policy.rs` (131 prod
     lines; pure cancel/finalize-policy decisions extracted from `mod.rs` by
@@ -827,6 +832,22 @@
     `should_suppress_headless_delivery_for_cancel`,
     `should_record_final_turn_transcript`, `resolve_bridge_owner_channel` +
     their tests. No IO/async; not a giant-file).
+  - `src/services/discord/turn_bridge/streaming_edit_text.rs` (88 prod lines;
+    pure streaming-edit text + pre-submission/transport TUI prompt-error
+    classifiers extracted from `mod.rs` by #3479 rank-4:
+    `build_turn_bridge_streaming_edit_text`,
+    `bridge_pre_submission_tui_prompt_error`,
+    `bridge_tui_transport_error_should_skip_quiescence` + their tests. No
+    IO/async; not a giant-file).
+  - `src/services/discord/turn_bridge/watcher_orphan_cleanup.rs` (119 prod
+    lines; watcher-orphan spinner-cleanup decision + retry-spawn helpers
+    extracted from `mod.rs` by #3479 rank-4:
+    `should_delete_bridge_created_watcher_orphan_response`,
+    `should_retry_watcher_orphan_spinner_cleanup`,
+    `record_watcher_orphan_spinner_cleanup`,
+    `spawn_watcher_orphan_spinner_cleanup_retry` + their tests. The retry-spawn
+    routes through `task_supervisor`/`placeholder_cleanup` and takes all deps by
+    value; not a giant-file).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1834 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1545 lines).
   - `src/services/discord/turn_bridge/terminal_delivery.rs` (604 prod lines;

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -89,7 +89,17 @@
 # resolve_bridge_owner_channel) + their tests into the new sibling
 # `turn_bridge/cancel_finalize_policy.rs` (re-exported, so call sites stay
 # byte-identical). Locks in the shrink win (ratchet down only).
-"src/services/discord/turn_bridge/mod.rs" = 6702
+# #3479 Phase-1 rank-4: lowered 6702 -> 6535 (-167) by moving the pure
+# streaming-edit-text + pre-submission/transport TUI prompt-error classifiers
+# (build_turn_bridge_streaming_edit_text, bridge_pre_submission_tui_prompt_error,
+# bridge_tui_transport_error_should_skip_quiescence) into the new sibling
+# `turn_bridge/streaming_edit_text.rs`, and the watcher-orphan spinner-cleanup
+# decision + retry-spawn helpers (should_delete_bridge_created_watcher_orphan_response,
+# should_retry_watcher_orphan_spinner_cleanup, record_watcher_orphan_spinner_cleanup,
+# spawn_watcher_orphan_spinner_cleanup_retry) into
+# `turn_bridge/watcher_orphan_cleanup.rs` (both re-exported, call sites
+# byte-identical). Locks in the shrink win (ratchet down only).
+"src/services/discord/turn_bridge/mod.rs" = 6535
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -11,12 +11,14 @@ mod single_message_footer;
 mod skill_usage;
 mod stale_resume;
 mod status_panel;
+mod streaming_edit_text;
 mod terminal_controller_cutover;
 mod terminal_delivery;
 mod tmux_runtime;
 mod turn_analytics;
 mod voice_completion;
 mod watcher_handoff;
+mod watcher_orphan_cleanup;
 
 use super::gateway::TurnGateway;
 use super::restart_report::{RestartCompletionReport, clear_restart_report, save_restart_report};
@@ -61,6 +63,10 @@ pub(super) use stale_resume::result_event_has_stale_resume_error;
 pub(in crate::services::discord) use status_panel::{
     complete_status_panel_v2_with_http, normalize_status_panel_message_id,
 };
+pub(super) use streaming_edit_text::{
+    bridge_pre_submission_tui_prompt_error, bridge_tui_transport_error_should_skip_quiescence,
+    build_turn_bridge_streaming_edit_text,
+};
 pub(crate) use tmux_runtime::TmuxCleanupPolicy;
 pub(super) use tmux_runtime::bind_cancel_token_tmux_runtime;
 pub(super) use tmux_runtime::cancel_active_token;
@@ -68,6 +74,10 @@ pub(super) use tmux_runtime::cancel_token_has_tmux_session;
 pub(super) use tmux_runtime::handoff_interrupted_message;
 pub(super) use tmux_runtime::stale_inflight_message;
 pub(super) use tmux_runtime::stop_active_turn;
+pub(super) use watcher_orphan_cleanup::{
+    record_watcher_orphan_spinner_cleanup, should_delete_bridge_created_watcher_orphan_response,
+    should_retry_watcher_orphan_spinner_cleanup, spawn_watcher_orphan_spinner_cleanup_retry,
+};
 
 /// #2452 H6 graduation: schedule the history-aware auto-retry via the
 /// gateway's `_with_completion` variant, then release the
@@ -908,172 +918,15 @@ mod sentinel_overwrite_clamp_tests {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WatcherHandoffClaimOutcome {
+pub(super) enum WatcherHandoffClaimOutcome {
     None,
     ReusedExisting,
     Spawned,
 }
 
-fn should_delete_bridge_created_watcher_orphan_response(
-    status_panel_v2_enabled: bool,
-    watcher_handoff_claim_outcome: WatcherHandoffClaimOutcome,
-    bridge_created_response_placeholder_msg_id: Option<MessageId>,
-    current_msg_id: MessageId,
-) -> bool {
-    status_panel_v2_enabled
-        && watcher_handoff_claim_outcome == WatcherHandoffClaimOutcome::ReusedExisting
-        && bridge_created_response_placeholder_msg_id == Some(current_msg_id)
-}
-
-fn should_retry_watcher_orphan_spinner_cleanup(
-    outcome: &super::placeholder_cleanup::PlaceholderCleanupOutcome,
-) -> bool {
-    matches!(
-        outcome,
-        super::placeholder_cleanup::PlaceholderCleanupOutcome::Failed {
-            class: super::placeholder_cleanup::PlaceholderCleanupFailureClass::LifecycleFailure,
-            ..
-        }
-    )
-}
-
-fn record_watcher_orphan_spinner_cleanup(
-    shared: &SharedData,
-    provider: &ProviderKind,
-    channel_id: ChannelId,
-    message_id: MessageId,
-    tmux_session_name: Option<&str>,
-    outcome: super::placeholder_cleanup::PlaceholderCleanupOutcome,
-    source: &'static str,
-) {
-    if let super::placeholder_cleanup::PlaceholderCleanupOutcome::Failed { class, detail } =
-        &outcome
-    {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ watcher orphan spinner cleanup failed ({}) for channel {} msg {}: {}",
-            class.as_str(),
-            channel_id.get(),
-            message_id.get(),
-            detail
-        );
-    }
-    shared
-        .ui
-        .placeholder_cleanup
-        .record(super::placeholder_cleanup::PlaceholderCleanupRecord {
-            provider: provider.clone(),
-            channel_id,
-            message_id,
-            tmux_session_name: tmux_session_name.map(str::to_string),
-            operation: super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal,
-            outcome,
-            source,
-        });
-}
-
-fn spawn_watcher_orphan_spinner_cleanup_retry(
-    shared: Arc<SharedData>,
-    provider: ProviderKind,
-    gateway: Arc<dyn TurnGateway>,
-    channel_id: ChannelId,
-    message_id: MessageId,
-    tmux_session_name: Option<String>,
-) {
-    const RETRY_DELAYS: &[std::time::Duration] = &[
-        std::time::Duration::from_secs(2),
-        std::time::Duration::from_secs(5),
-        std::time::Duration::from_secs(15),
-    ];
-
-    super::task_supervisor::spawn_observed("watcher_orphan_spinner_cleanup_retry", async move {
-        for (attempt, delay) in RETRY_DELAYS.iter().enumerate() {
-            tokio::time::sleep(*delay).await;
-            let outcome = match gateway.delete_message(channel_id, message_id).await {
-                Ok(()) => super::placeholder_cleanup::PlaceholderCleanupOutcome::Succeeded,
-                Err(error) => super::placeholder_cleanup::classify_delete_error(&error),
-            };
-            let committed = outcome.is_committed();
-            let should_retry = should_retry_watcher_orphan_spinner_cleanup(&outcome);
-            record_watcher_orphan_spinner_cleanup(
-                shared.as_ref(),
-                &provider,
-                channel_id,
-                message_id,
-                tmux_session_name.as_deref(),
-                outcome,
-                "turn_bridge_watcher_orphan_spinner_cleanup_retry",
-            );
-            if committed || !should_retry {
-                return;
-            }
-            if attempt + 1 == RETRY_DELAYS.len() {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
-                    "  [{ts}] ⚠ watcher orphan spinner cleanup exhausted retries for channel {} msg {}",
-                    channel_id.get(),
-                    message_id.get()
-                );
-            }
-        }
-    });
-}
-
-fn build_turn_bridge_streaming_edit_text(
-    status_panel_v2_enabled: bool,
-    current_portion: &str,
-    status_block: &str,
-    provider: &ProviderKind,
-) -> String {
-    if status_panel_v2_enabled {
-        super::formatting::build_status_panel_streaming_edit_text(
-            current_portion,
-            status_block,
-            provider,
-        )
-    } else {
-        super::formatting::build_streaming_placeholder_text(current_portion, status_block)
-    }
-}
-
 #[cfg(test)]
 mod streaming_edit_text_tests {
     use super::*;
-
-    #[test]
-    fn status_panel_v2_streaming_edit_moves_processing_footer_to_response_message() {
-        let rendered = build_turn_bridge_streaming_edit_text(
-            true,
-            "E2E-CODEX-1-OK\n- Working on the backend now",
-            "⠙ 계속 처리 중",
-            &ProviderKind::Codex,
-        );
-
-        assert_eq!(
-            rendered,
-            "E2E-CODEX-1-OK\n- Working on the backend now\n\n⠙ 계속 처리 중"
-        );
-    }
-
-    #[test]
-    fn legacy_streaming_edit_keeps_processing_footer() {
-        let rendered = build_turn_bridge_streaming_edit_text(
-            false,
-            "Partial answer",
-            "⠙ 계속 처리 중",
-            &ProviderKind::Codex,
-        );
-
-        assert_eq!(rendered, "Partial answer\n\n⠙ 계속 처리 중");
-    }
-
-    #[test]
-    fn status_panel_v2_empty_streaming_edit_keeps_placeholder() {
-        let rendered =
-            build_turn_bridge_streaming_edit_text(true, "", "⠙ 계속 처리 중", &ProviderKind::Codex);
-
-        assert_eq!(rendered, "⠙ 계속 처리 중");
-    }
 
     #[test]
     fn empty_response_notice_is_delivery_only_not_history_payload() {
@@ -1083,178 +936,6 @@ mod streaming_edit_text_tests {
 
         assert_eq!(rendered, "(No response)");
         assert!(full_response.is_empty());
-    }
-
-    #[test]
-    fn watcher_reuse_deletes_only_bridge_created_response_placeholder() {
-        let bridge_placeholder = MessageId::new(20);
-
-        assert!(should_delete_bridge_created_watcher_orphan_response(
-            true,
-            WatcherHandoffClaimOutcome::ReusedExisting,
-            Some(bridge_placeholder),
-            bridge_placeholder,
-        ));
-        assert!(!should_delete_bridge_created_watcher_orphan_response(
-            true,
-            WatcherHandoffClaimOutcome::Spawned,
-            Some(bridge_placeholder),
-            bridge_placeholder,
-        ));
-        assert!(!should_delete_bridge_created_watcher_orphan_response(
-            true,
-            WatcherHandoffClaimOutcome::ReusedExisting,
-            Some(bridge_placeholder),
-            MessageId::new(10),
-        ));
-        assert!(!should_delete_bridge_created_watcher_orphan_response(
-            false,
-            WatcherHandoffClaimOutcome::ReusedExisting,
-            Some(bridge_placeholder),
-            bridge_placeholder,
-        ));
-        assert!(!should_delete_bridge_created_watcher_orphan_response(
-            true,
-            WatcherHandoffClaimOutcome::None,
-            Some(bridge_placeholder),
-            bridge_placeholder,
-        ));
-    }
-
-    #[test]
-    fn watcher_orphan_spinner_cleanup_retries_only_lifecycle_failures() {
-        use super::super::placeholder_cleanup::{
-            PlaceholderCleanupFailureClass, PlaceholderCleanupOutcome,
-        };
-
-        assert!(should_retry_watcher_orphan_spinner_cleanup(
-            &PlaceholderCleanupOutcome::Failed {
-                class: PlaceholderCleanupFailureClass::LifecycleFailure,
-                detail: "HTTP 500".to_string(),
-            }
-        ));
-        assert!(!should_retry_watcher_orphan_spinner_cleanup(
-            &PlaceholderCleanupOutcome::Failed {
-                class: PlaceholderCleanupFailureClass::PermissionOrRoutingDiagnostic,
-                detail: "HTTP 403".to_string(),
-            }
-        ));
-        assert!(!should_retry_watcher_orphan_spinner_cleanup(
-            &PlaceholderCleanupOutcome::Succeeded
-        ));
-        assert!(!should_retry_watcher_orphan_spinner_cleanup(
-            &PlaceholderCleanupOutcome::AlreadyGone
-        ));
-    }
-}
-
-fn bridge_pre_submission_tui_prompt_error(provider: &ProviderKind, full_response: &str) -> bool {
-    let Some(error_text) = full_response
-        .trim_start()
-        .strip_prefix("Error:")
-        .map(str::trim_start)
-    else {
-        return false;
-    };
-    match provider {
-        ProviderKind::Claude => {
-            crate::services::claude_tui::input::is_prompt_ready_timeout_error(error_text)
-        }
-        ProviderKind::Codex => {
-            crate::services::codex_tui::input::is_prompt_ready_timeout_error(error_text)
-        }
-        _ => false,
-    }
-}
-
-fn bridge_tui_transport_error_should_skip_quiescence(
-    provider: &ProviderKind,
-    runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
-    full_response: &str,
-) -> bool {
-    let Some(error_text) = full_response
-        .trim_start()
-        .strip_prefix("Error:")
-        .map(str::trim_start)
-    else {
-        return false;
-    };
-
-    match (provider, runtime_kind) {
-        (
-            ProviderKind::Claude,
-            Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui),
-        ) => {
-            bridge_pre_submission_tui_prompt_error(provider, full_response)
-                || error_text == "Timeout waiting for output file"
-                || error_text.starts_with("timeout waiting for claude tui transcript file")
-                || error_text.contains("claude tui session died")
-        }
-        (
-            ProviderKind::Codex,
-            Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui),
-        ) => {
-            bridge_pre_submission_tui_prompt_error(provider, full_response)
-                || error_text == "Timeout waiting for output file"
-                || error_text.contains("codex tui session died")
-        }
-        _ => false,
-    }
-}
-
-#[cfg(test)]
-mod pre_submission_tui_prompt_error_tests {
-    use super::*;
-
-    #[test]
-    fn classifier_matches_wrapped_readiness_errors() {
-        assert!(bridge_pre_submission_tui_prompt_error(
-            &ProviderKind::Claude,
-            "Error: timeout waiting for claude tui follow-up prompt input readiness after 45s; reason=prompt_marker_not_detected; previous_tui_turn_still_running=true; capture_available=true",
-        ));
-        assert!(bridge_pre_submission_tui_prompt_error(
-            &ProviderKind::Codex,
-            "Error: timeout waiting for codex tui follow-up prompt input readiness after 45s; reason=composer_not_detected; previous_tui_turn_still_running=true; capture_available=true",
-        ));
-        assert!(!bridge_pre_submission_tui_prompt_error(
-            &ProviderKind::Claude,
-            "Error: claude tui session died during follow-up output reading",
-        ));
-        assert!(!bridge_pre_submission_tui_prompt_error(
-            &ProviderKind::Claude,
-            "timeout waiting for claude tui follow-up prompt input readiness after 45s",
-        ));
-    }
-
-    #[test]
-    fn tui_transport_errors_skip_quiescence_only_for_matching_tui_runtime() {
-        use crate::services::agent_protocol::RuntimeHandoffKind;
-
-        assert!(bridge_tui_transport_error_should_skip_quiescence(
-            &ProviderKind::Claude,
-            Some(RuntimeHandoffKind::ClaudeTui),
-            "Error: Timeout waiting for output file",
-        ));
-        assert!(bridge_tui_transport_error_should_skip_quiescence(
-            &ProviderKind::Claude,
-            Some(RuntimeHandoffKind::ClaudeTui),
-            "Error: timeout waiting for claude tui transcript file after 120s; capture_available=true; prompt_marker_detected=true; prompt_draft_detected=false",
-        ));
-        assert!(bridge_tui_transport_error_should_skip_quiescence(
-            &ProviderKind::Codex,
-            Some(RuntimeHandoffKind::CodexTui),
-            "Error: timeout waiting for codex tui follow-up prompt input readiness after 45s; reason=composer_not_detected; previous_tui_turn_still_running=true; capture_available=true",
-        ));
-        assert!(!bridge_tui_transport_error_should_skip_quiescence(
-            &ProviderKind::Claude,
-            Some(RuntimeHandoffKind::LegacyTmuxWrapper),
-            "Error: Timeout waiting for output file",
-        ));
-        assert!(!bridge_tui_transport_error_should_skip_quiescence(
-            &ProviderKind::Claude,
-            Some(RuntimeHandoffKind::ClaudeTui),
-            "Error: upstream API returned 500",
-        ));
     }
 }
 

--- a/src/services/discord/turn_bridge/streaming_edit_text.rs
+++ b/src/services/discord/turn_bridge/streaming_edit_text.rs
@@ -1,0 +1,182 @@
+//! Pure streaming-edit text + pre-submission TUI prompt-error classifiers for
+//! the turn bridge.
+//!
+//! #3479 Phase-1 rank-4 extraction: byte-identical value-in/value-out helpers
+//! the relay streaming path and quiescence-gate consult — the status-panel vs
+//! legacy streaming-edit body composer, and the pre-submission / transport
+//! TUI prompt-error predicates that decide whether to re-queue a follow-up or
+//! skip the quiescence gate. None touch `shared`/`http`/async IO; each is
+//! unit-tested. Moved verbatim from `turn_bridge/mod.rs` and re-exported there
+//! so call sites stay identical.
+
+use super::*;
+
+pub(in crate::services::discord) fn build_turn_bridge_streaming_edit_text(
+    status_panel_v2_enabled: bool,
+    current_portion: &str,
+    status_block: &str,
+    provider: &ProviderKind,
+) -> String {
+    if status_panel_v2_enabled {
+        super::formatting::build_status_panel_streaming_edit_text(
+            current_portion,
+            status_block,
+            provider,
+        )
+    } else {
+        super::formatting::build_streaming_placeholder_text(current_portion, status_block)
+    }
+}
+
+pub(in crate::services::discord) fn bridge_pre_submission_tui_prompt_error(
+    provider: &ProviderKind,
+    full_response: &str,
+) -> bool {
+    let Some(error_text) = full_response
+        .trim_start()
+        .strip_prefix("Error:")
+        .map(str::trim_start)
+    else {
+        return false;
+    };
+    match provider {
+        ProviderKind::Claude => {
+            crate::services::claude_tui::input::is_prompt_ready_timeout_error(error_text)
+        }
+        ProviderKind::Codex => {
+            crate::services::codex_tui::input::is_prompt_ready_timeout_error(error_text)
+        }
+        _ => false,
+    }
+}
+
+pub(in crate::services::discord) fn bridge_tui_transport_error_should_skip_quiescence(
+    provider: &ProviderKind,
+    runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
+    full_response: &str,
+) -> bool {
+    let Some(error_text) = full_response
+        .trim_start()
+        .strip_prefix("Error:")
+        .map(str::trim_start)
+    else {
+        return false;
+    };
+
+    match (provider, runtime_kind) {
+        (
+            ProviderKind::Claude,
+            Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui),
+        ) => {
+            bridge_pre_submission_tui_prompt_error(provider, full_response)
+                || error_text == "Timeout waiting for output file"
+                || error_text.starts_with("timeout waiting for claude tui transcript file")
+                || error_text.contains("claude tui session died")
+        }
+        (
+            ProviderKind::Codex,
+            Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui),
+        ) => {
+            bridge_pre_submission_tui_prompt_error(provider, full_response)
+                || error_text == "Timeout waiting for output file"
+                || error_text.contains("codex tui session died")
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod streaming_edit_text_tests {
+    use super::*;
+
+    #[test]
+    fn status_panel_v2_streaming_edit_moves_processing_footer_to_response_message() {
+        let rendered = build_turn_bridge_streaming_edit_text(
+            true,
+            "E2E-CODEX-1-OK\n- Working on the backend now",
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+
+        assert_eq!(
+            rendered,
+            "E2E-CODEX-1-OK\n- Working on the backend now\n\n⠙ 계속 처리 중"
+        );
+    }
+
+    #[test]
+    fn legacy_streaming_edit_keeps_processing_footer() {
+        let rendered = build_turn_bridge_streaming_edit_text(
+            false,
+            "Partial answer",
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+
+        assert_eq!(rendered, "Partial answer\n\n⠙ 계속 처리 중");
+    }
+
+    #[test]
+    fn status_panel_v2_empty_streaming_edit_keeps_placeholder() {
+        let rendered =
+            build_turn_bridge_streaming_edit_text(true, "", "⠙ 계속 처리 중", &ProviderKind::Codex);
+
+        assert_eq!(rendered, "⠙ 계속 처리 중");
+    }
+}
+
+#[cfg(test)]
+mod pre_submission_tui_prompt_error_tests {
+    use super::*;
+
+    #[test]
+    fn classifier_matches_wrapped_readiness_errors() {
+        assert!(bridge_pre_submission_tui_prompt_error(
+            &ProviderKind::Claude,
+            "Error: timeout waiting for claude tui follow-up prompt input readiness after 45s; reason=prompt_marker_not_detected; previous_tui_turn_still_running=true; capture_available=true",
+        ));
+        assert!(bridge_pre_submission_tui_prompt_error(
+            &ProviderKind::Codex,
+            "Error: timeout waiting for codex tui follow-up prompt input readiness after 45s; reason=composer_not_detected; previous_tui_turn_still_running=true; capture_available=true",
+        ));
+        assert!(!bridge_pre_submission_tui_prompt_error(
+            &ProviderKind::Claude,
+            "Error: claude tui session died during follow-up output reading",
+        ));
+        assert!(!bridge_pre_submission_tui_prompt_error(
+            &ProviderKind::Claude,
+            "timeout waiting for claude tui follow-up prompt input readiness after 45s",
+        ));
+    }
+
+    #[test]
+    fn tui_transport_errors_skip_quiescence_only_for_matching_tui_runtime() {
+        use crate::services::agent_protocol::RuntimeHandoffKind;
+
+        assert!(bridge_tui_transport_error_should_skip_quiescence(
+            &ProviderKind::Claude,
+            Some(RuntimeHandoffKind::ClaudeTui),
+            "Error: Timeout waiting for output file",
+        ));
+        assert!(bridge_tui_transport_error_should_skip_quiescence(
+            &ProviderKind::Claude,
+            Some(RuntimeHandoffKind::ClaudeTui),
+            "Error: timeout waiting for claude tui transcript file after 120s; capture_available=true; prompt_marker_detected=true; prompt_draft_detected=false",
+        ));
+        assert!(bridge_tui_transport_error_should_skip_quiescence(
+            &ProviderKind::Codex,
+            Some(RuntimeHandoffKind::CodexTui),
+            "Error: timeout waiting for codex tui follow-up prompt input readiness after 45s; reason=composer_not_detected; previous_tui_turn_still_running=true; capture_available=true",
+        ));
+        assert!(!bridge_tui_transport_error_should_skip_quiescence(
+            &ProviderKind::Claude,
+            Some(RuntimeHandoffKind::LegacyTmuxWrapper),
+            "Error: Timeout waiting for output file",
+        ));
+        assert!(!bridge_tui_transport_error_should_skip_quiescence(
+            &ProviderKind::Claude,
+            Some(RuntimeHandoffKind::ClaudeTui),
+            "Error: upstream API returned 500",
+        ));
+    }
+}

--- a/src/services/discord/turn_bridge/watcher_orphan_cleanup.rs
+++ b/src/services/discord/turn_bridge/watcher_orphan_cleanup.rs
@@ -1,0 +1,185 @@
+//! Watcher-orphan spinner-card cleanup decision + retry-spawn helpers for the
+//! turn bridge.
+//!
+//! #3479 Phase-1 rank-4 extraction: byte-identical helpers the bridge consults
+//! when a reused tmux watcher leaves the bridge-created response placeholder
+//! orphaned — the delete-eligibility predicate, the lifecycle-failure retry
+//! predicate, the cleanup-outcome recorder, and the bounded retry-spawn. The
+//! retry-spawn takes every dependency by value (no ambient `shared`/`http`
+//! capture) and routes through `super::task_supervisor` /
+//! `super::placeholder_cleanup`, so it moves as a free fn. Moved verbatim from
+//! `turn_bridge/mod.rs` and re-exported there so call sites stay identical.
+
+use super::*;
+
+pub(in crate::services::discord) fn should_delete_bridge_created_watcher_orphan_response(
+    status_panel_v2_enabled: bool,
+    watcher_handoff_claim_outcome: WatcherHandoffClaimOutcome,
+    bridge_created_response_placeholder_msg_id: Option<MessageId>,
+    current_msg_id: MessageId,
+) -> bool {
+    status_panel_v2_enabled
+        && watcher_handoff_claim_outcome == WatcherHandoffClaimOutcome::ReusedExisting
+        && bridge_created_response_placeholder_msg_id == Some(current_msg_id)
+}
+
+pub(in crate::services::discord) fn should_retry_watcher_orphan_spinner_cleanup(
+    outcome: &super::placeholder_cleanup::PlaceholderCleanupOutcome,
+) -> bool {
+    matches!(
+        outcome,
+        super::placeholder_cleanup::PlaceholderCleanupOutcome::Failed {
+            class: super::placeholder_cleanup::PlaceholderCleanupFailureClass::LifecycleFailure,
+            ..
+        }
+    )
+}
+
+pub(in crate::services::discord) fn record_watcher_orphan_spinner_cleanup(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    message_id: MessageId,
+    tmux_session_name: Option<&str>,
+    outcome: super::placeholder_cleanup::PlaceholderCleanupOutcome,
+    source: &'static str,
+) {
+    if let super::placeholder_cleanup::PlaceholderCleanupOutcome::Failed { class, detail } =
+        &outcome
+    {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ watcher orphan spinner cleanup failed ({}) for channel {} msg {}: {}",
+            class.as_str(),
+            channel_id.get(),
+            message_id.get(),
+            detail
+        );
+    }
+    shared
+        .ui
+        .placeholder_cleanup
+        .record(super::placeholder_cleanup::PlaceholderCleanupRecord {
+            provider: provider.clone(),
+            channel_id,
+            message_id,
+            tmux_session_name: tmux_session_name.map(str::to_string),
+            operation: super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal,
+            outcome,
+            source,
+        });
+}
+
+pub(in crate::services::discord) fn spawn_watcher_orphan_spinner_cleanup_retry(
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+    gateway: Arc<dyn TurnGateway>,
+    channel_id: ChannelId,
+    message_id: MessageId,
+    tmux_session_name: Option<String>,
+) {
+    const RETRY_DELAYS: &[std::time::Duration] = &[
+        std::time::Duration::from_secs(2),
+        std::time::Duration::from_secs(5),
+        std::time::Duration::from_secs(15),
+    ];
+
+    super::task_supervisor::spawn_observed("watcher_orphan_spinner_cleanup_retry", async move {
+        for (attempt, delay) in RETRY_DELAYS.iter().enumerate() {
+            tokio::time::sleep(*delay).await;
+            let outcome = match gateway.delete_message(channel_id, message_id).await {
+                Ok(()) => super::placeholder_cleanup::PlaceholderCleanupOutcome::Succeeded,
+                Err(error) => super::placeholder_cleanup::classify_delete_error(&error),
+            };
+            let committed = outcome.is_committed();
+            let should_retry = should_retry_watcher_orphan_spinner_cleanup(&outcome);
+            record_watcher_orphan_spinner_cleanup(
+                shared.as_ref(),
+                &provider,
+                channel_id,
+                message_id,
+                tmux_session_name.as_deref(),
+                outcome,
+                "turn_bridge_watcher_orphan_spinner_cleanup_retry",
+            );
+            if committed || !should_retry {
+                return;
+            }
+            if attempt + 1 == RETRY_DELAYS.len() {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    "  [{ts}] ⚠ watcher orphan spinner cleanup exhausted retries for channel {} msg {}",
+                    channel_id.get(),
+                    message_id.get()
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod watcher_orphan_cleanup_tests {
+    use super::*;
+
+    #[test]
+    fn watcher_reuse_deletes_only_bridge_created_response_placeholder() {
+        let bridge_placeholder = MessageId::new(20);
+
+        assert!(should_delete_bridge_created_watcher_orphan_response(
+            true,
+            WatcherHandoffClaimOutcome::ReusedExisting,
+            Some(bridge_placeholder),
+            bridge_placeholder,
+        ));
+        assert!(!should_delete_bridge_created_watcher_orphan_response(
+            true,
+            WatcherHandoffClaimOutcome::Spawned,
+            Some(bridge_placeholder),
+            bridge_placeholder,
+        ));
+        assert!(!should_delete_bridge_created_watcher_orphan_response(
+            true,
+            WatcherHandoffClaimOutcome::ReusedExisting,
+            Some(bridge_placeholder),
+            MessageId::new(10),
+        ));
+        assert!(!should_delete_bridge_created_watcher_orphan_response(
+            false,
+            WatcherHandoffClaimOutcome::ReusedExisting,
+            Some(bridge_placeholder),
+            bridge_placeholder,
+        ));
+        assert!(!should_delete_bridge_created_watcher_orphan_response(
+            true,
+            WatcherHandoffClaimOutcome::None,
+            Some(bridge_placeholder),
+            bridge_placeholder,
+        ));
+    }
+
+    #[test]
+    fn watcher_orphan_spinner_cleanup_retries_only_lifecycle_failures() {
+        use super::super::placeholder_cleanup::{
+            PlaceholderCleanupFailureClass, PlaceholderCleanupOutcome,
+        };
+
+        assert!(should_retry_watcher_orphan_spinner_cleanup(
+            &PlaceholderCleanupOutcome::Failed {
+                class: PlaceholderCleanupFailureClass::LifecycleFailure,
+                detail: "HTTP 500".to_string(),
+            }
+        ));
+        assert!(!should_retry_watcher_orphan_spinner_cleanup(
+            &PlaceholderCleanupOutcome::Failed {
+                class: PlaceholderCleanupFailureClass::PermissionOrRoutingDiagnostic,
+                detail: "HTTP 403".to_string(),
+            }
+        ));
+        assert!(!should_retry_watcher_orphan_spinner_cleanup(
+            &PlaceholderCleanupOutcome::Succeeded
+        ));
+        assert!(!should_retry_watcher_orphan_spinner_cleanup(
+            &PlaceholderCleanupOutcome::AlreadyGone
+        ));
+    }
+}


### PR DESCRIPTION
Phase-1 rank-4 of #3479 (builds on rank-3). Pure behavior-preserving move: streaming-edit/TUI-error helpers → `turn_bridge/streaming_edit_text.rs` (88 LoC) and watcher-orphan spinner cleanup → `turn_bridge/watcher_orphan_cleanup.rs` (119 LoC). Frozen baseline 6702 -> 6535 prod LoC (-167). Zero logic change (bodies byte-identical). Adversarial review: VERDICT CLEAN. Gates green; 181 tests.

Part of #3479

🤖 Generated with [Claude Code](https://claude.com/claude-code)