### PR TITLE
refactor(#3479): extract PolicyRuntime capability from SharedData

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -119,6 +119,7 @@ pub(crate) use session_relay_sink::run_session_bound_discord_relay_supervisor;
 // #3038 S4: re-export the live-placeholder cluster type so `SharedData`
 // declarations/constructors keep the S1/S2/S3 unqualified surface.
 pub(in crate::services::discord) use shared_state::PlaceholderState;
+pub(in crate::services::discord) use shared_state::PolicyRuntime;
 pub(in crate::services::discord) use shared_state::QueuedPlaceholderState;
 pub(in crate::services::discord) use shared_state::RuntimeHttpCache;
 // #3038 S2: the cluster-D members were `pub(super)` on `SharedData` (visible up
@@ -2305,8 +2306,7 @@ pub(crate) struct SharedData {
     pub(super) api_port: u16,
     /// Shared PostgreSQL pool for PG-backed route and runtime helpers.
     pub(super) pg_pool: Option<sqlx::PgPool>,
-    /// Shared policy engine for direct dispatch finalization.
-    pub(super) engine: Option<crate::engine::PolicyEngine>,
+    pub(in crate::services::discord) policy: PolicyRuntime,
     /// Weak reference to the process-wide health registry so turn handlers can
     /// reach dedicated Discord bot HTTP clients without creating an Arc cycle.
     pub(super) health_registry: std::sync::Weak<health::HealthRegistry>,
@@ -2584,7 +2584,7 @@ pub(super) fn make_shared_data_for_tests_with_storage(
         provider: ProviderKind::Claude,
         api_port: 9,
         pg_pool,
-        engine: None,
+        policy: PolicyRuntime { engine: None },
         health_registry: std::sync::Weak::new(),
         known_slash_commands: tokio::sync::OnceCell::new(),
         inflight_signals: tokio::sync::broadcast::channel(256).0,

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1981,7 +1981,7 @@ pub(super) async fn restore_inflight_turns(
                         tracing::warn!(
                             "  [{ts}] ⚠ recovery: refusing to complete work dispatch {did} without assistant response"
                         );
-                    } else if let Some(engine) = &shared.engine {
+                    } else if let Some(engine) = &shared.policy.engine {
                         // #143: Use finalize_dispatch directly with retry.
                         for attempt in 1..=3u8 {
                             match crate::dispatch::finalize_dispatch_with_backends(
@@ -2605,7 +2605,7 @@ pub(super) async fn restore_inflight_turns(
                             tracing::warn!(
                                 "  [{ts}] ⚠ recovery: refusing to complete work dispatch {did} without assistant response"
                             );
-                        } else if let Some(engine) = &shared.engine {
+                        } else if let Some(engine) = &shared.policy.engine {
                             for attempt in 1..=3u8 {
                                 match crate::dispatch::finalize_dispatch_with_backends(
                                     None::<&crate::db::Db>,
@@ -2863,7 +2863,7 @@ pub(super) async fn restore_inflight_turns(
                             tracing::warn!(
                                 "  [{ts}] ⚠ recovery: refusing to complete work dispatch {did} without assistant response"
                             );
-                        } else if let Some(engine) = &shared.engine {
+                        } else if let Some(engine) = &shared.policy.engine {
                             for attempt in 1..=3u8 {
                                 match crate::dispatch::finalize_dispatch_with_backends(
                                     None::<&crate::db::Db>,

--- a/src/services/discord/runtime_bootstrap/shared_data.rs
+++ b/src/services/discord/runtime_bootstrap/shared_data.rs
@@ -172,7 +172,7 @@ pub(super) fn run_bot_build_shared_data(
         provider: provider.clone(),
         api_port,
         pg_pool,
-        engine,
+        policy: PolicyRuntime { engine },
         health_registry: Arc::downgrade(health_registry),
         known_slash_commands: tokio::sync::OnceCell::new(),
         // #2448: capacity 256 gives ~hundreds of in-flight turns headroom

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -69,6 +69,17 @@ pub(in crate::services::discord) struct RuntimeHttpCache {
     pub(in crate::services::discord) cached_bot_token: tokio::sync::OnceCell<String>,
 }
 
+/// #3479 cluster — policy runtime capability.
+///
+/// Groups the shared policy engine used by direct-dispatch finalization. The
+/// field, doc, and type moved verbatim from `discord/mod.rs`; direct readers
+/// all stay inside `discord` (`recovery_engine` +
+/// `turn_bridge::completion_guard`) and reach it via `shared.policy.engine`.
+pub(in crate::services::discord) struct PolicyRuntime {
+    /// Shared policy engine for direct dispatch finalization.
+    pub(in crate::services::discord) engine: Option<crate::engine::PolicyEngine>,
+}
+
 impl SharedData {
     /// Phase 5.2 of intake-node-routing (issue #2009): return an `Arc<Http>`
     /// that the response path (tmux watcher, placeholder updates, message

--- a/src/services/discord/turn_bridge/completion_guard.rs
+++ b/src/services/discord/turn_bridge/completion_guard.rs
@@ -1550,7 +1550,7 @@ pub(super) async fn complete_work_dispatch_on_turn_end(
     let tracked_changes = tracked_change_summary(adk_cwd);
 
     // Direct finalize_dispatch with retry — single completion authority (#143)
-    if let Some(engine) = &shared.engine {
+    if let Some(engine) = &shared.policy.engine {
         if explicit_work_outcome == Some("noop") {
             if let Some(ref changes) = tracked_changes {
                 let reason = format!(

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -3019,7 +3019,7 @@ mod tests {
             provider: ProviderKind::Claude,
             api_port: 9,
             pg_pool,
-            engine: None,
+            policy: super::super::PolicyRuntime { engine: None },
             health_registry: std::sync::Weak::new(),
             known_slash_commands: tokio::sync::OnceCell::new(),
             inflight_signals: tokio::sync::broadcast::channel(256).0,


### PR DESCRIPTION
## Summary
First SharedData god-object **capability extraction** (pilot) for the #3479 maintainability sweep. Groups the shared `engine: Option<PolicyEngine>` field into a dedicated `PolicyRuntime` sub-struct in `shared_state.rs`, mirroring the existing #3038 cluster pattern (ui/queued/restart/overrides/http).

- `SharedData` now composes `policy: PolicyRuntime`; the 4 read-only consumers (recovery_engine ×3, turn_bridge::completion_guard ×1) reach the engine via `shared.policy.engine`.
- Pure field-nesting move — **zero behaviour change**. Visibility is *narrowed* (engine field now `pub(in crate::services::discord)`, was `pub(super)`).
- Frozen `mod.rs` stays **net-neutral** on production LoC (re-export +1 / removed field-doc −1).

## Verification
- fmt / clippy (`--all-targets`) clean (only known legacy-sqlite warnings)
- targeted tests: recovery_engine 33, voice_barge_in 52, turn_bridge 181, runtime_bootstrap 14 — all pass
- `audit_maintainability.py --check` rc=0 (ratchet holds), `ci-script-checks.sh` rc=0
- codex adversarial review: **VERDICT: CLEAN** (no findings; completeness sweep confirms no missed consumer, semantics identical, visibility not widened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)