### PR TITLE
fix(#3499): treat /model as local-only so it does not strand an inflight turn

### DIFF
--- a/src/services/discord/commands/tui_passthrough.rs
+++ b/src/services/discord/commands/tui_passthrough.rs
@@ -131,10 +131,27 @@ impl ClaudeSlashPassthrough {
 pub(in crate::services::discord) const LOCAL_ONLY_SLASH_COMMANDS: [&str; 4] =
     ["/effort", "/compact", "/cost", "/context"];
 
-/// #3305: whether `kind` (a canonical `slash_command_control_kind`, e.g. `/compact`)
-/// is a local-completing pass-through command — see [`LOCAL_ONLY_SLASH_COMMANDS`].
+/// #3500: local-completing slash commands that are NOT AgentDesk pass-throughs.
+/// These are Claude-NATIVE commands (e.g. `/model`) the idle relay only OBSERVES
+/// echoed in the pane transcript — they change local state and start NO model
+/// turn, so like [`LOCAL_ONLY_SLASH_COMMANDS`] they must SKIP the turn lifecycle.
+/// Otherwise the post-#3178 "SlashCommandControl == full active turn" rule mints a
+/// synthetic inflight that never finalizes (no model turn to complete it),
+/// stranding the mailbox so the next real message queues — the #3500 bug. They are
+/// intentionally absent from the [`ClaudeSlashPassthrough`] variant set (no
+/// pass-through handler), so they live here rather than in `LOCAL_ONLY_SLASH_COMMANDS`
+/// (which the `local_only_whitelist_matches_passthrough_command_set` anti-drift test
+/// pins to that variant set).
+pub(in crate::services::discord) const OBSERVATION_ONLY_LOCAL_SLASH_COMMANDS: [&str; 1] =
+    ["/model"];
+
+/// #3305/#3500: whether `kind` (a canonical `slash_command_control_kind`, e.g.
+/// `/compact`) is a local-completing command that SKIPS the turn lifecycle — either
+/// an AgentDesk pass-through ([`LOCAL_ONLY_SLASH_COMMANDS`]) or a Claude-native
+/// observation-only command ([`OBSERVATION_ONLY_LOCAL_SLASH_COMMANDS`]).
 pub(in crate::services::discord) fn is_local_only_slash_command_kind(kind: &str) -> bool {
     LOCAL_ONLY_SLASH_COMMANDS.contains(&kind)
+        || OBSERVATION_ONLY_LOCAL_SLASH_COMMANDS.contains(&kind)
 }
 
 fn ultracode_notice() -> &'static str {
@@ -374,6 +391,22 @@ mod tests {
             assert!(is_local_only_slash_command_kind(name));
         }
         assert!(!is_local_only_slash_command_kind("/loop"));
-        assert!(!is_local_only_slash_command_kind("/model"));
+        // #3500: `/model` is local-only (observation-only, Claude-native) but is
+        // intentionally NOT a pass-through variant, so it must stay OUT of
+        // LOCAL_ONLY_SLASH_COMMANDS (the variant-pinned set) — see the dedicated
+        // test below for its local-only behavior.
+        assert!(!LOCAL_ONLY_SLASH_COMMANDS.contains(&"/model"));
+    }
+
+    /// #3500: `/model` (Claude-native model change, no model turn) must be treated
+    /// as local-only so the idle relay SKIPS the turn lifecycle — otherwise it
+    /// strands a synthetic inflight that queues the next real message.
+    #[test]
+    fn model_command_is_observation_only_local() {
+        assert!(is_local_only_slash_command_kind("/model"));
+        assert!(OBSERVATION_ONLY_LOCAL_SLASH_COMMANDS.contains(&"/model"));
+        // Intentionally not a pass-through variant (no handler) → stays out of the
+        // variant-pinned LOCAL_ONLY_SLASH_COMMANDS set.
+        assert!(!LOCAL_ONLY_SLASH_COMMANDS.contains(&"/model"));
     }
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -5716,15 +5716,26 @@ mod tests {
         assert!(!is_local_only_slash_command_prompt(
             "/compactX do the thing"
         ));
-        // An UNLISTED command's wrapper — `/model` is a SlashCommandControl but is
-        // NOT on the allow-list, so lifecycle is preserved (fail-safe default).
+        // An UNLISTED command's wrapper — `/loop` is a SlashCommandControl but is
+        // NOT on the allow-list (it starts a model turn), so lifecycle is preserved
+        // (fail-safe default).
+        let loop_wrapper =
+            "<command-message>x</command-message>\n<command-name>/loop</command-name>";
+        assert!(matches!(
+            classify_injected_prompt(loop_wrapper),
+            InjectedPromptClass::SlashCommandControl
+        ));
+        assert!(!is_local_only_slash_command_prompt(loop_wrapper));
+        // #3500: `/model` IS a SlashCommandControl AND local-only (Claude-native,
+        // changes the model with no model turn) — lifecycle is SKIPPED so it does
+        // not strand a synthetic inflight that queues the next real message.
         let model_wrapper =
             "<command-message>x</command-message>\n<command-name>/model</command-name>";
         assert!(matches!(
             classify_injected_prompt(model_wrapper),
             InjectedPromptClass::SlashCommandControl
         ));
-        assert!(!is_local_only_slash_command_prompt(model_wrapper));
+        assert!(is_local_only_slash_command_prompt(model_wrapper));
     }
 
     // #3178: the machine slash-command control trigger now resolves to a stable


### PR DESCRIPTION
## Summary
Fixes #3499 — running `/model` in the TUI was treated as a full active turn, minting a synthetic inflight that never finalized (`/model` emits no model turn), so the mailbox stayed owned and the user's next message wrongly queued (`📬 메시지 대기 중 / 앞선 턴 진행 중`), with `last_offset_monotonic` invariant ERRORs + `claim_retry_exhausted` (#3268) as secondary symptoms.

**Root cause**: `/model` classifies as `SlashCommandControl` but was missing from the local-only allow-list, and since #3178 a non-local-only SlashCommandControl is a FULL active turn. This is exactly the failure #3305/#3308 fixed for `/effort /compact /cost /context` — `/model` was just left off.

**Fix**: add a new `OBSERVATION_ONLY_LOCAL_SLASH_COMMANDS = ["/model"]` set (Claude-native, not an AgentDesk pass-through variant) consulted by `is_local_only_slash_command_kind`, so `/model` takes the local-only branch (kind-only note, no anchor, no synthetic inflight). `LOCAL_ONLY_SLASH_COMMANDS` stays pinned to the `ClaudeSlashPassthrough` variant set (anti-drift test intact). The model change itself still applies to subsequent turns.

## Verification
- tui_passthrough tests (anti-drift + new `model_command_is_observation_only_local`) pass; tui_prompt_relay slash-command tests (111) pass
- fmt / clippy clean; audit_maintainability --check rc=0; ci-script-checks rc=0
- codex adversarial review in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)