### PR TITLE
fix(#3501): stamp PROVEN-delivered turn committed so restart does not re-relay it

### DIFF
--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -339,6 +339,20 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
                  (JSONL terminator on disk past turn start) — bridge finalizes instead of \
                  handing a finished turn to the watcher"
             );
+            // #3501: the body is PROVEN delivered (JSONL terminator on disk past
+            // turn start, already relayed), so STAMP the inflight delivered before
+            // returning. Otherwise it persists with response_sent_offset=0 +
+            // terminal_delivery_committed=false, and a later dcserver restart
+            // restores it as "undelivered" → the watcher RE-RELAYS the finished
+            // body at the next soft boundary (the #3501 re-relay). Mirrors the
+            // committed-delivery reconciliation in turn_bridge/mod.rs. Only this
+            // proven-COMPLETE branch is stamped; the still-streaming #3268 handoff
+            // below leaves the offset un-advanced, so a delegated turn's tail is
+            // never suppressed.
+            let delivered_len = inflight_state.full_response.len();
+            inflight_state.response_sent_offset = delivered_len;
+            inflight_state.terminal_delivery_committed = true;
+            let _ = save_inflight_state(inflight_state);
             return;
         }
         emit_post_gate_handoff_pending_response_visibility(


### PR DESCRIPTION
## Summary
Fixes #3501 — an OLD message re-relayed to Discord after a restart. The #3277 quiescence-timeout PROVEN-delivered finalize early-returned WITHOUT persisting delivery state: the inflight kept `response_sent_offset=0` + `terminal_delivery_committed=false` even though the body was already relayed (JSONL terminator on disk past turn start). A later dcserver restart restored that inflight, treated the whole body as undelivered, and the watcher RE-RELAYED it at the next soft boundary.

**Fix**: stamp the proven-complete branch (`watcher_handoff.rs`) with `response_sent_offset = full_response.len()` + `terminal_delivery_committed = true` before saving — mirroring the committed-delivery reconciliation in `turn_bridge/mod.rs`. Reached ONLY when `busy_turn_already_proven_delivered()` is true; the still-streaming #3268 handoff below is untouched, so a delegated turn's tail is never suppressed.

## Verification
- handoff (4) + tmux:: (244) + recovery tests pass; fmt/clippy clean; audit --check rc=0; ci-script-checks rc=0
- the downstream (offset=len → restored seed discarded → no re-relay) is existing tested behavior
- codex adversarial review in progress (case-B streaming-tail preservation is the key invariant)

Diagnosed via dcserver.stdout.log (11:41-11:46Z, ch 1480015244062490774). Severity: high (relay-integrity / duplicate delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)