### PR TITLE
docs(#3479): refresh stale StatusPanelController DORMANT module doc

### DIFF
--- a/src/services/discord/status_panel_controller.rs
+++ b/src/services/discord/status_panel_controller.rs
@@ -1,4 +1,4 @@
-//! EPIC #3078 — single-authority `StatusPanelController` (PR-1, DORMANT).
+//! EPIC #3078 (CLOSED — superseded by #3089 M1) — `StatusPanelController` substrate.
 //!
 //! Today the user-visible status panel message id
 //! (`InflightTurnState.status_message_id`) has NO single writer: five actors
@@ -26,16 +26,15 @@
 //! the controller is the single writer. `PanelPhase` gives exactly-once
 //! finalize/reclaim (mutually idempotent), mirroring the finalizer's `Phase`.
 //!
-//! ## DORMANT (PR-1)
+//! ## Status: substrate + shadow parity only — #3078 CLOSED, superseded by #3089 M1
 //!
-//! This PR ships the substrate ONLY: the full API surface, the ledger, and the
-//! actor loop, spawned next to the finalizer. NO call site routes through it
-//! yet (turn_bridge / tmux_watcher / recovery / sweeper are untouched), so
-//! there is ZERO behaviour change. The spawn is gated on
-//! `status_panel_v2_enabled`: when v2 is off the actor task is not spawned and
-//! the controller stays inert, mirroring the existing v2 short-circuits.
-//! Later PRs (#3078 staged plan) route each actor through `ensure_created` /
-//! `stream_update` / `finalize` / `reclaim` / `clear_if_current`.
+//! PR-1 shipped the substrate (API, ledger, actor loop, gated on
+//! `status_panel_v2_enabled`); PR-2..6 wired only the read-side parity and
+//! ledger-seed methods into the five legacy actors as v2-gated fire-and-forget
+//! SHADOW calls — legacy still owns all Discord IO + `status_message_id` writes
+//! (the five parity-mismatch log targets are silent in prod). The MUTATING
+//! methods and `PanelSink` stay DORMANT: cutover frozen 2026-06-12, #3078 closed
+//! 2026-06-15 superseded by #3089 M1 (single-message footer) — "one owner" met.
 
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
Part of #3479 item 1 follow-up (the stale `//! DORMANT (PR-1)` doc flagged when #3078 was closed).

#3078 is closed as superseded by #3089 M1 (single-message footer consolidation, live). The module header said "PR-1, DORMANT / NO call site routes through it yet (turn_bridge / tmux_watcher / recovery / sweeper are untouched), so ZERO behaviour change" — stale, because PR-2..6 since wired read-side parity + ledger-seed shadow calls into the five legacy actors, and the cutover is now permanently not pursued.

Updated the header line + the DORMANT block to the terminal reality:
- substrate (PR-1) + read-side shadow parity / ledger-seed (PR-2..6) wired, v2-gated, fire-and-forget; legacy still owns all Discord IO + `status_message_id` writes; the five parity-mismatch log targets are silent in prod.
- the mutating lifecycle methods + `PanelSink` IO trait stay DORMANT by design; cutover frozen 2026-06-12, #3078 closed 2026-06-15, superseded by #3089 M1.

Doc-only (`//!` module comment); binary-unaffected. Net -1 line — `status_panel_controller.rs` stays under the 1000-prod-line giant threshold (not registered as a giant).

## Gates
- `cargo fmt --check`: clean
- `bash scripts/ci-script-checks.sh`: rc 0 (only the known soft `discord-outbound-migration.md` freshness warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)