### PR TITLE
refactor(#3479): extract terminal-success watcher helpers from recovery_engine.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -449,7 +449,8 @@ src/
 │   │   │   ├── jsonl_extract.rs
 │   │   │   ├── output_path_detect.rs
 │   │   │   ├── phase_policy.rs
-│   │   │   └── status_panel.rs
+│   │   │   ├── status_panel.rs
+│   │   │   └── terminal_watcher.rs
 │   │   ├── recovery_paths/
 │   │   │   ├── controller_cutover.rs
 │   │   │   ├── mod.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -767,7 +767,11 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3718 lines; #3479 r8 extracted the
+  - `src/services/discord/recovery_engine.rs` (3607 lines; #3479 item-2 extracted
+    the terminal-success watcher / recovery start-offset helper cluster into the
+    sub-1000-prod-LoC leaf module `recovery_engine/terminal_watcher.rs` (137) —
+    behaviour-preserving move, externally-called helpers re-imported byte-identical;
+    #3479 r8 extracted the
     pure output-path-detect, phase-policy, and jsonl-extract clusters into the
     sub-1000-prod-LoC leaf modules `recovery_engine/output_path_detect.rs` (177),
     `recovery_engine/phase_policy.rs` (120), and `recovery_engine/jsonl_extract.rs`

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -194,7 +194,11 @@
 # #3479 r8: lowered 4090 -> 3718 (behavior-preserving extraction of the pure
 # output-path-detect, phase-policy, and jsonl-extract clusters into leaf modules
 # under recovery_engine/; zero logic change, call sites re-imported byte-identical).
-"src/services/discord/recovery_engine.rs" = 3718
+# #3479 item-2: lowered 3718 -> 3607 (behavior-preserving extraction of the
+# terminal-success watcher / recovery start-offset helper cluster into the leaf
+# module recovery_engine/terminal_watcher.rs; zero logic change, externally-called
+# helpers re-imported byte-identical).
+"src/services/discord/recovery_engine.rs" = 3607
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -35,6 +35,10 @@ mod jsonl_extract;
 mod output_path_detect;
 #[path = "recovery_engine/phase_policy.rs"]
 mod phase_policy;
+// #3479 item-2: behavior-preserving extraction of the terminal-success watcher /
+// recovery start-offset helper cluster into a leaf module.
+#[path = "recovery_engine/terminal_watcher.rs"]
+mod terminal_watcher;
 
 // Re-import moved items so existing call sites stay byte-identical.
 use self::jsonl_extract::{extract_response_from_output, success_result_end_offset_after_offset};
@@ -54,6 +58,15 @@ use self::phase_policy::{
 // `recovery_engine::extract_response_from_output_pub` path stays valid for the
 // turn_bridge / tmux_restart_handoff external callers.
 pub(super) use self::jsonl_extract::extract_response_from_output_pub;
+// #3479 item-2: re-import the externally-called terminal-watcher helpers so the
+// existing call sites stay byte-identical. The remaining cluster members
+// (`terminal_success_watcher_stop_allowed`, `jsonl_tail_contains_terminal_end_sentinel`,
+// `TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD`) are only used inside the submodule and
+// stay private to it.
+use self::terminal_watcher::{
+    output_has_bytes_after_offset, recovery_watcher_start_offset,
+    terminal_success_output_drained_for_recovery,
+};
 
 #[cfg(not(unix))]
 fn tmux_session_has_live_pane(_name: &str) -> bool {
@@ -1554,130 +1567,6 @@ async fn persist_recovered_transcript(
             tracing::warn!("  [{ts}] ⚠ recovery: failed to persist session transcript: {e}");
             false
         }
-    }
-}
-
-fn output_has_bytes_after_offset(output_path: &str, start_offset: u64) -> bool {
-    std::fs::metadata(output_path)
-        .map(|meta| meta.len() > start_offset)
-        .unwrap_or(false)
-}
-
-const TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_secs(2);
-
-fn terminal_success_watcher_stop_allowed(
-    confirmed_end: u64,
-    tmux_tail_offset: u64,
-    quiet_for: std::time::Duration,
-) -> bool {
-    confirmed_end >= tmux_tail_offset && quiet_for >= TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD
-}
-
-async fn terminal_success_output_drained_for_recovery(
-    output_path: &str,
-    confirmed_end: u64,
-    tmux_session_name: Option<&str>,
-) -> bool {
-    let Ok(before_meta) = std::fs::metadata(output_path) else {
-        return false;
-    };
-    let tmux_alive = tmux_session_name
-        .map(crate::services::platform::tmux::has_session)
-        .unwrap_or(false);
-
-    if !tmux_alive {
-        return terminal_success_watcher_stop_allowed(
-            confirmed_end,
-            before_meta.len(),
-            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
-        );
-    }
-
-    if !terminal_success_watcher_stop_allowed(
-        confirmed_end,
-        before_meta.len(),
-        TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
-    ) {
-        return false;
-    }
-
-    // #2442 (H2) — fast-path: if the wrapper has already emitted the
-    // `terminal_end` JSONL sentinel, the pane is *definitively* done
-    // writing and we can graduate the 2s drain quiet-period immediately.
-    // The wrapper writes the sentinel as one of its very last actions
-    // before kill_child_tree/cleanup, so its presence is a strict superset
-    // of the quiet-period heuristic. We still keep the legacy 2s sleep as
-    // a fallback for SIGKILL paths that bypass the sentinel write.
-    if jsonl_tail_contains_terminal_end_sentinel(output_path) {
-        return terminal_success_watcher_stop_allowed(
-            confirmed_end,
-            before_meta.len(),
-            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
-        );
-    }
-
-    tokio::time::sleep(TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD).await;
-
-    let tail_after = std::fs::metadata(output_path)
-        .map(|meta| meta.len())
-        .unwrap_or(confirmed_end.saturating_add(1));
-    tail_after == confirmed_end
-        && terminal_success_watcher_stop_allowed(
-            confirmed_end,
-            tail_after,
-            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
-        )
-}
-
-/// #2442 — peek the JSONL tail (last ~4 KiB) for the wrapper's
-/// `terminal_end` sentinel. Reading the tail rather than the entire file
-/// keeps this O(1) regardless of jsonl size. False negatives (no sentinel
-/// detected when one is present) just fall back to the legacy 2s
-/// quiet-period sleep, so a partial-line edge case is harmless.
-fn jsonl_tail_contains_terminal_end_sentinel(output_path: &str) -> bool {
-    use std::io::{Read, Seek, SeekFrom};
-
-    const TAIL_WINDOW_BYTES: u64 = 4 * 1024;
-
-    let Ok(mut file) = std::fs::File::open(output_path) else {
-        return false;
-    };
-    let Ok(meta) = file.metadata() else {
-        return false;
-    };
-    let len = meta.len();
-    if len == 0 {
-        return false;
-    }
-    let start = len.saturating_sub(TAIL_WINDOW_BYTES);
-    if file.seek(SeekFrom::Start(start)).is_err() {
-        return false;
-    }
-    let mut buf = Vec::with_capacity(TAIL_WINDOW_BYTES as usize);
-    if file.read_to_end(&mut buf).is_err() {
-        return false;
-    }
-    // The sentinel is one JSONL line: {"type":"terminal_end",...}. We search the
-    // literal `"type":"terminal_end"` token because the wrapper writes JSON via
-    // `serde_json::Value::to_string()` (exact compact form); the contract lives in
-    // `tmux_common::emit_wrapper_sentinel` (pretty-printing would need a rework).
-    let needle = format!(
-        "\"type\":\"{}\"",
-        crate::services::tmux_common::WRAPPER_TERMINAL_END_EVENT
-    );
-    let haystack = String::from_utf8_lossy(&buf);
-    haystack.contains(&needle)
-}
-
-fn recovery_watcher_start_offset(output_path: &str, saved_last_offset: u64) -> (u64, u64, bool) {
-    let current_len = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
-    if current_len >= saved_last_offset {
-        (saved_last_offset, current_len, false)
-    } else {
-        // The output file was recreated or truncated while dcserver was down.
-        // Resume from the beginning of the new file so we do not skip the
-        // entire restarted session output.
-        (0, current_len, true)
     }
 }
 

--- a/src/services/discord/recovery_engine/terminal_watcher.rs
+++ b/src/services/discord/recovery_engine/terminal_watcher.rs
@@ -1,0 +1,137 @@
+//! Terminal-success watcher / recovery start-offset helpers (#3479 item-2 split).
+//!
+//! Behavior-preserving extraction from `recovery_engine.rs`: the helpers that
+//! decide when a terminal-success tmux pane has finished draining its JSONL
+//! output (so recovery may stop watching) and that compute the byte offset a
+//! restart-recovery watcher should resume reading from. They depend only on
+//! `std::fs`/`tokio::time` and the tmux `has_session` / `WRAPPER_TERMINAL_END_EVENT`
+//! contracts, so they live in this leaf module. The async drain driver and the
+//! offset helper are re-imported by the root module so existing call sites stay
+//! byte-identical.
+
+pub(super) fn output_has_bytes_after_offset(output_path: &str, start_offset: u64) -> bool {
+    std::fs::metadata(output_path)
+        .map(|meta| meta.len() > start_offset)
+        .unwrap_or(false)
+}
+
+const TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_secs(2);
+
+fn terminal_success_watcher_stop_allowed(
+    confirmed_end: u64,
+    tmux_tail_offset: u64,
+    quiet_for: std::time::Duration,
+) -> bool {
+    confirmed_end >= tmux_tail_offset && quiet_for >= TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD
+}
+
+pub(super) async fn terminal_success_output_drained_for_recovery(
+    output_path: &str,
+    confirmed_end: u64,
+    tmux_session_name: Option<&str>,
+) -> bool {
+    let Ok(before_meta) = std::fs::metadata(output_path) else {
+        return false;
+    };
+    let tmux_alive = tmux_session_name
+        .map(crate::services::platform::tmux::has_session)
+        .unwrap_or(false);
+
+    if !tmux_alive {
+        return terminal_success_watcher_stop_allowed(
+            confirmed_end,
+            before_meta.len(),
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+        );
+    }
+
+    if !terminal_success_watcher_stop_allowed(
+        confirmed_end,
+        before_meta.len(),
+        TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+    ) {
+        return false;
+    }
+
+    // #2442 (H2) — fast-path: if the wrapper has already emitted the
+    // `terminal_end` JSONL sentinel, the pane is *definitively* done
+    // writing and we can graduate the 2s drain quiet-period immediately.
+    // The wrapper writes the sentinel as one of its very last actions
+    // before kill_child_tree/cleanup, so its presence is a strict superset
+    // of the quiet-period heuristic. We still keep the legacy 2s sleep as
+    // a fallback for SIGKILL paths that bypass the sentinel write.
+    if jsonl_tail_contains_terminal_end_sentinel(output_path) {
+        return terminal_success_watcher_stop_allowed(
+            confirmed_end,
+            before_meta.len(),
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+        );
+    }
+
+    tokio::time::sleep(TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD).await;
+
+    let tail_after = std::fs::metadata(output_path)
+        .map(|meta| meta.len())
+        .unwrap_or(confirmed_end.saturating_add(1));
+    tail_after == confirmed_end
+        && terminal_success_watcher_stop_allowed(
+            confirmed_end,
+            tail_after,
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+        )
+}
+
+/// #2442 — peek the JSONL tail (last ~4 KiB) for the wrapper's
+/// `terminal_end` sentinel. Reading the tail rather than the entire file
+/// keeps this O(1) regardless of jsonl size. False negatives (no sentinel
+/// detected when one is present) just fall back to the legacy 2s
+/// quiet-period sleep, so a partial-line edge case is harmless.
+fn jsonl_tail_contains_terminal_end_sentinel(output_path: &str) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+
+    const TAIL_WINDOW_BYTES: u64 = 4 * 1024;
+
+    let Ok(mut file) = std::fs::File::open(output_path) else {
+        return false;
+    };
+    let Ok(meta) = file.metadata() else {
+        return false;
+    };
+    let len = meta.len();
+    if len == 0 {
+        return false;
+    }
+    let start = len.saturating_sub(TAIL_WINDOW_BYTES);
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return false;
+    }
+    let mut buf = Vec::with_capacity(TAIL_WINDOW_BYTES as usize);
+    if file.read_to_end(&mut buf).is_err() {
+        return false;
+    }
+    // The sentinel is one JSONL line: {"type":"terminal_end",...}. We search the
+    // literal `"type":"terminal_end"` token because the wrapper writes JSON via
+    // `serde_json::Value::to_string()` (exact compact form); the contract lives in
+    // `tmux_common::emit_wrapper_sentinel` (pretty-printing would need a rework).
+    let needle = format!(
+        "\"type\":\"{}\"",
+        crate::services::tmux_common::WRAPPER_TERMINAL_END_EVENT
+    );
+    let haystack = String::from_utf8_lossy(&buf);
+    haystack.contains(&needle)
+}
+
+pub(super) fn recovery_watcher_start_offset(
+    output_path: &str,
+    saved_last_offset: u64,
+) -> (u64, u64, bool) {
+    let current_len = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
+    if current_len >= saved_last_offset {
+        (saved_last_offset, current_len, false)
+    } else {
+        // The output file was recreated or truncated while dcserver was down.
+        // Resume from the beginning of the new file so we do not skip the
+        // entire restarted session output.
+        (0, current_len, true)
+    }
+}


### PR DESCRIPTION
Part of #3479 item-2 (giant-file decomposition). Behavior-preserving verbatim move.

Moves the terminal-success watcher / recovery start-offset helper cluster (6 symbols: `output_has_bytes_after_offset`, `terminal_success_watcher_stop_allowed`, `terminal_success_output_drained_for_recovery`, `jsonl_tail_contains_terminal_end_sentinel`, `recovery_watcher_start_offset`, `TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD`) out of `src/services/discord/recovery_engine.rs` into the existing sibling submodule dir as `recovery_engine/terminal_watcher.rs`.

- `recovery_engine.rs`: 3718 → 3607 production LoC (ratchet baseline lowered to 3607).
- new `terminal_watcher.rs`: 137 production LoC.
- 3 fns called externally promoted to `pub(super)` + re-imported; 3 internal helpers stay private.
- Normalized diff of the moved cluster vs origin/main is IDENTICAL (only visibility prefixes + 1 rustfmt signature wrap).

Gates: cargo build/fmt/clippy clean (only the 7 known legacy-sqlite warnings), `services::discord::recovery_engine` tests 33/33, `audit_maintainability.py --check` rc 0, `ci-script-checks.sh` rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)