### PR TITLE
refactor(#3479): extract dispatch-policy cluster from discord/mod.rs to dispatch_policy.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -573,6 +573,7 @@ src/
 │   │   ├── answer_flush_barrier.rs
 │   │   ├── catch_up.rs
 │   │   ├── discord_io.rs
+│   │   ├── dispatch_policy.rs
 │   │   ├── formatting.rs
 │   │   ├── gateway.rs
 │   │   ├── health.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1233,8 +1233,10 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
 - `src/services/platform/binary_resolver.rs` (1221).
-- `src/services/discord/mod.rs` (now 4243 prod LoC after #3479 item-2 extracted
-  the catch-up subsystem verbatim to `discord/catch_up.rs`; 4965; +34 from #3019 added the
+- `src/services/discord/mod.rs` (now 4074 prod LoC after #3479 item-2 extracted
+  the dispatch-policy cluster verbatim to `discord/dispatch_policy.rs` (-169) on
+  top of the earlier catch-up subsystem extraction to `discord/catch_up.rs`;
+  4965; +34 from #3019 added the
   single-authority `increment_global_active` helper + doc mirroring the
   existing decrement helper — offset by removing 6 inline raw `fetch_add`
   blocks across the relay turn-start sites that now route through it; +12 from

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -143,7 +143,11 @@
 # (restart-gap message recovery — classify/scan/enqueue + its tests) moved
 # verbatim to the capped sibling `catch_up.rs`, lowering the frozen baseline
 # 4979 -> 4243 (-736). Locks in the shrink win (#3028 ratchet down only).
-"src/services/discord/mod.rs" = 4243
+# #3479: the dispatch-policy cluster (monitor-auto-turn origin marker codec,
+# stale-dispatch turn gating + its tests, allowed-turn-sender / bot-user-id
+# resolvers, phase2 recovery predicate) moved verbatim to the capped sibling
+# `dispatch_policy.rs`, lowering the frozen baseline 4243 -> 4074 (-169).
+"src/services/discord/mod.rs" = 4074
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).

--- a/src/services/discord/dispatch_policy.rs
+++ b/src/services/discord/dispatch_policy.rs
@@ -1,0 +1,222 @@
+use std::borrow::Cow;
+use std::sync::OnceLock;
+
+use super::ChannelId;
+use super::QueueExitKind;
+use super::SharedData;
+use super::parse_dispatch_id;
+
+const MONITOR_AUTO_TURN_ORIGIN_LITERAL: &str = "[origin=monitor_auto_turn]";
+
+fn hidden_monitor_auto_turn_origin_marker() -> &'static str {
+    static MARKER: OnceLock<String> = OnceLock::new();
+    MARKER.get_or_init(|| {
+        MONITOR_AUTO_TURN_ORIGIN_LITERAL
+            .bytes()
+            .flat_map(|byte| {
+                (0..8).rev().map(move |shift| {
+                    if (byte >> shift) & 1 == 1 {
+                        '\u{200C}'
+                    } else {
+                        '\u{200B}'
+                    }
+                })
+            })
+            .collect()
+    })
+}
+
+pub(in crate::services::discord) fn prepend_monitor_auto_turn_origin(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("{}{}", hidden_monitor_auto_turn_origin_marker(), trimmed)
+    }
+}
+
+pub(in crate::services::discord) fn strip_monitor_auto_turn_origin<'a>(
+    text: &'a str,
+) -> (Cow<'a, str>, bool) {
+    if let Some(rest) = text.strip_prefix(hidden_monitor_auto_turn_origin_marker()) {
+        return (Cow::Borrowed(rest), true);
+    }
+
+    if let Some(rest) = text.strip_prefix(MONITOR_AUTO_TURN_ORIGIN_LITERAL) {
+        return (Cow::Owned(rest.trim_start().to_string()), true);
+    }
+
+    (Cow::Borrowed(text), false)
+}
+
+pub(super) fn session_retry_context_key(channel_id: ChannelId) -> String {
+    format!("session_retry_context:{}", channel_id.get())
+}
+
+pub(super) fn should_process_allowed_bot_turn_text(text: &str) -> bool {
+    let (sanitized, has_monitor_origin) = strip_monitor_auto_turn_origin(text);
+    has_monitor_origin || sanitized.trim_start().starts_with("DISPATCH:")
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) struct StaleDispatchTurn {
+    pub(in crate::services::discord) dispatch_id: String,
+    pub(in crate::services::discord) status: String,
+    pub(in crate::services::discord) queue_exit_kind: QueueExitKind,
+}
+
+fn dispatch_status_allows_turn(status: &str) -> bool {
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "pending" | "dispatched" | "in_progress"
+    )
+}
+
+fn stale_dispatch_queue_exit_kind(
+    status: Option<&str>,
+    result: Option<&str>,
+) -> Option<QueueExitKind> {
+    let Some(status) = status.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Some(QueueExitKind::Superseded);
+    };
+    if dispatch_status_allows_turn(status) {
+        return None;
+    }
+    let normalized_status = status.to_ascii_lowercase();
+    let result_says_superseded = result
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|value| value.contains("superseded"));
+    if normalized_status == "superseded" || result_says_superseded {
+        Some(QueueExitKind::Superseded)
+    } else {
+        Some(QueueExitKind::Cancelled)
+    }
+}
+
+pub(in crate::services::discord) async fn stale_dispatch_turn_for_text(
+    pg_pool: Option<&sqlx::PgPool>,
+    text: &str,
+) -> Option<StaleDispatchTurn> {
+    let dispatch_id = parse_dispatch_id(text)?;
+    let Some(pool) = pg_pool else {
+        return None;
+    };
+    let row = match sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT status, result::TEXT AS result
+           FROM task_dispatches
+          WHERE id = $1",
+    )
+    .bind(&dispatch_id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(row) => row,
+        Err(error) => {
+            tracing::warn!(
+                dispatch_id = %dispatch_id,
+                error = %error,
+                "failed to validate dispatch turn status; allowing message to proceed"
+            );
+            return None;
+        }
+    };
+    match row {
+        Some((status, result)) => stale_dispatch_queue_exit_kind(Some(&status), result.as_deref())
+            .map(|queue_exit_kind| StaleDispatchTurn {
+                dispatch_id,
+                status,
+                queue_exit_kind,
+            }),
+        None => Some(StaleDispatchTurn {
+            dispatch_id,
+            status: "missing".to_string(),
+            queue_exit_kind: QueueExitKind::Superseded,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod dispatch_turn_gate_tests {
+    use super::{QueueExitKind, dispatch_status_allows_turn, stale_dispatch_queue_exit_kind};
+
+    #[test]
+    fn dispatch_turn_status_allows_only_live_statuses() {
+        for status in ["pending", "dispatched", "in_progress", " DISPATCHED "] {
+            assert!(dispatch_status_allows_turn(status));
+        }
+        for status in [
+            "cancelled",
+            "completed",
+            "failed",
+            "superseded",
+            "",
+            "missing",
+        ] {
+            assert!(!dispatch_status_allows_turn(status));
+        }
+    }
+
+    #[test]
+    fn stale_dispatch_queue_exit_kind_classifies_terminal_statuses() {
+        assert_eq!(stale_dispatch_queue_exit_kind(Some("pending"), None), None);
+        assert_eq!(
+            stale_dispatch_queue_exit_kind(
+                Some("cancelled"),
+                Some("Cancelled: superseded by rereview")
+            ),
+            Some(QueueExitKind::Superseded)
+        );
+        assert_eq!(
+            stale_dispatch_queue_exit_kind(Some("failed"), Some("tmux session died")),
+            Some(QueueExitKind::Cancelled)
+        );
+        assert_eq!(
+            stale_dispatch_queue_exit_kind(None, None),
+            Some(QueueExitKind::Superseded)
+        );
+    }
+}
+
+pub(in crate::services::discord) async fn resolve_announce_bot_user_id(
+    shared: &SharedData,
+) -> Option<u64> {
+    let registry = shared.health_registry()?;
+    registry.utility_bot_user_id("announce").await
+}
+
+/// Cached lookup for the notify bot's Discord user id. Used by the message
+/// router to classify incoming messages as `BackgroundTrigger` turns —
+/// see `TurnKind` in `router/message_handler.rs` and the race-handler
+/// preservation rule from #796.
+pub(in crate::services::discord) async fn resolve_notify_bot_user_id(
+    shared: &SharedData,
+) -> Option<u64> {
+    let registry = shared.health_registry()?;
+    registry.utility_bot_user_id("notify").await
+}
+
+pub(in crate::services::discord) fn is_allowed_turn_sender(
+    allowed_bot_ids: &[u64],
+    author_id: u64,
+    author_is_bot: bool,
+    text: &str,
+) -> bool {
+    if allowed_bot_ids.contains(&author_id) {
+        return should_process_allowed_bot_turn_text(text);
+    }
+    !author_is_bot
+}
+
+pub(in crate::services::discord) fn should_phase2_recover_message(
+    message_id: u64,
+    checkpoint: Option<u64>,
+    existing_ids: &std::collections::HashSet<u64>,
+) -> bool {
+    if existing_ids.contains(&message_id) {
+        return false;
+    }
+    if checkpoint.is_some_and(|saved| message_id <= saved) {
+        return false;
+    }
+    true
+}

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -7,6 +7,7 @@ mod answer_flush_barrier;
 mod catch_up;
 mod commands;
 mod discord_io;
+mod dispatch_policy;
 pub(crate) mod formatting;
 mod gateway;
 pub(crate) mod health;
@@ -145,12 +146,10 @@ pub(in crate::services) use shared_state::RestartLifecycle;
 pub(crate) use router::{IntakeRequest, TurnKind, execute_intake_turn_core};
 pub(crate) use turn_bridge::TmuxCleanupPolicy;
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
@@ -215,6 +214,11 @@ pub use discord_io::{
     retry_failed_dm_notifications, send_file_to_channel, send_message_to_channel,
     send_message_to_user,
 };
+pub(in crate::services::discord) use dispatch_policy::{
+    is_allowed_turn_sender, prepend_monitor_auto_turn_origin, resolve_announce_bot_user_id,
+    resolve_notify_bot_user_id, session_retry_context_key, should_phase2_recover_message,
+    stale_dispatch_turn_for_text, strip_monitor_auto_turn_origin,
+};
 pub(crate) use inflight::latest_request_owner_user_id_for_channel;
 pub use settings::{
     load_discord_bot_launch_configs, resolve_discord_bot_provider, resolve_discord_token_by_hash,
@@ -254,220 +258,6 @@ const SESSION_RECOVERY_CONTEXT_MESSAGES: usize = 10;
 const DEAD_SESSION_REAP_INTERVAL: Duration = Duration::from_secs(60); // 1 minute
 const RESTART_REPORT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const DEFERRED_RESTART_POLL_INTERVAL: Duration = Duration::from_secs(10);
-const MONITOR_AUTO_TURN_ORIGIN_LITERAL: &str = "[origin=monitor_auto_turn]";
-
-fn hidden_monitor_auto_turn_origin_marker() -> &'static str {
-    static MARKER: OnceLock<String> = OnceLock::new();
-    MARKER.get_or_init(|| {
-        MONITOR_AUTO_TURN_ORIGIN_LITERAL
-            .bytes()
-            .flat_map(|byte| {
-                (0..8).rev().map(move |shift| {
-                    if (byte >> shift) & 1 == 1 {
-                        '\u{200C}'
-                    } else {
-                        '\u{200B}'
-                    }
-                })
-            })
-            .collect()
-    })
-}
-
-pub(in crate::services::discord) fn prepend_monitor_auto_turn_origin(text: &str) -> String {
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        String::new()
-    } else {
-        format!("{}{}", hidden_monitor_auto_turn_origin_marker(), trimmed)
-    }
-}
-
-pub(in crate::services::discord) fn strip_monitor_auto_turn_origin<'a>(
-    text: &'a str,
-) -> (Cow<'a, str>, bool) {
-    if let Some(rest) = text.strip_prefix(hidden_monitor_auto_turn_origin_marker()) {
-        return (Cow::Borrowed(rest), true);
-    }
-
-    if let Some(rest) = text.strip_prefix(MONITOR_AUTO_TURN_ORIGIN_LITERAL) {
-        return (Cow::Owned(rest.trim_start().to_string()), true);
-    }
-
-    (Cow::Borrowed(text), false)
-}
-
-pub(super) fn session_retry_context_key(channel_id: ChannelId) -> String {
-    format!("session_retry_context:{}", channel_id.get())
-}
-
-pub(super) fn should_process_allowed_bot_turn_text(text: &str) -> bool {
-    let (sanitized, has_monitor_origin) = strip_monitor_auto_turn_origin(text);
-    has_monitor_origin || sanitized.trim_start().starts_with("DISPATCH:")
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(in crate::services::discord) struct StaleDispatchTurn {
-    pub(in crate::services::discord) dispatch_id: String,
-    pub(in crate::services::discord) status: String,
-    pub(in crate::services::discord) queue_exit_kind: QueueExitKind,
-}
-
-fn dispatch_status_allows_turn(status: &str) -> bool {
-    matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "pending" | "dispatched" | "in_progress"
-    )
-}
-
-fn stale_dispatch_queue_exit_kind(
-    status: Option<&str>,
-    result: Option<&str>,
-) -> Option<QueueExitKind> {
-    let Some(status) = status.map(str::trim).filter(|value| !value.is_empty()) else {
-        return Some(QueueExitKind::Superseded);
-    };
-    if dispatch_status_allows_turn(status) {
-        return None;
-    }
-    let normalized_status = status.to_ascii_lowercase();
-    let result_says_superseded = result
-        .map(str::to_ascii_lowercase)
-        .is_some_and(|value| value.contains("superseded"));
-    if normalized_status == "superseded" || result_says_superseded {
-        Some(QueueExitKind::Superseded)
-    } else {
-        Some(QueueExitKind::Cancelled)
-    }
-}
-
-pub(in crate::services::discord) async fn stale_dispatch_turn_for_text(
-    pg_pool: Option<&sqlx::PgPool>,
-    text: &str,
-) -> Option<StaleDispatchTurn> {
-    let dispatch_id = parse_dispatch_id(text)?;
-    let Some(pool) = pg_pool else {
-        return None;
-    };
-    let row = match sqlx::query_as::<_, (String, Option<String>)>(
-        "SELECT status, result::TEXT AS result
-           FROM task_dispatches
-          WHERE id = $1",
-    )
-    .bind(&dispatch_id)
-    .fetch_optional(pool)
-    .await
-    {
-        Ok(row) => row,
-        Err(error) => {
-            tracing::warn!(
-                dispatch_id = %dispatch_id,
-                error = %error,
-                "failed to validate dispatch turn status; allowing message to proceed"
-            );
-            return None;
-        }
-    };
-    match row {
-        Some((status, result)) => stale_dispatch_queue_exit_kind(Some(&status), result.as_deref())
-            .map(|queue_exit_kind| StaleDispatchTurn {
-                dispatch_id,
-                status,
-                queue_exit_kind,
-            }),
-        None => Some(StaleDispatchTurn {
-            dispatch_id,
-            status: "missing".to_string(),
-            queue_exit_kind: QueueExitKind::Superseded,
-        }),
-    }
-}
-
-#[cfg(test)]
-mod dispatch_turn_gate_tests {
-    use super::{QueueExitKind, dispatch_status_allows_turn, stale_dispatch_queue_exit_kind};
-
-    #[test]
-    fn dispatch_turn_status_allows_only_live_statuses() {
-        for status in ["pending", "dispatched", "in_progress", " DISPATCHED "] {
-            assert!(dispatch_status_allows_turn(status));
-        }
-        for status in [
-            "cancelled",
-            "completed",
-            "failed",
-            "superseded",
-            "",
-            "missing",
-        ] {
-            assert!(!dispatch_status_allows_turn(status));
-        }
-    }
-
-    #[test]
-    fn stale_dispatch_queue_exit_kind_classifies_terminal_statuses() {
-        assert_eq!(stale_dispatch_queue_exit_kind(Some("pending"), None), None);
-        assert_eq!(
-            stale_dispatch_queue_exit_kind(
-                Some("cancelled"),
-                Some("Cancelled: superseded by rereview")
-            ),
-            Some(QueueExitKind::Superseded)
-        );
-        assert_eq!(
-            stale_dispatch_queue_exit_kind(Some("failed"), Some("tmux session died")),
-            Some(QueueExitKind::Cancelled)
-        );
-        assert_eq!(
-            stale_dispatch_queue_exit_kind(None, None),
-            Some(QueueExitKind::Superseded)
-        );
-    }
-}
-
-pub(in crate::services::discord) async fn resolve_announce_bot_user_id(
-    shared: &SharedData,
-) -> Option<u64> {
-    let registry = shared.health_registry()?;
-    registry.utility_bot_user_id("announce").await
-}
-
-/// Cached lookup for the notify bot's Discord user id. Used by the message
-/// router to classify incoming messages as `BackgroundTrigger` turns —
-/// see `TurnKind` in `router/message_handler.rs` and the race-handler
-/// preservation rule from #796.
-pub(in crate::services::discord) async fn resolve_notify_bot_user_id(
-    shared: &SharedData,
-) -> Option<u64> {
-    let registry = shared.health_registry()?;
-    registry.utility_bot_user_id("notify").await
-}
-
-pub(in crate::services::discord) fn is_allowed_turn_sender(
-    allowed_bot_ids: &[u64],
-    author_id: u64,
-    author_is_bot: bool,
-    text: &str,
-) -> bool {
-    if allowed_bot_ids.contains(&author_id) {
-        return should_process_allowed_bot_turn_text(text);
-    }
-    !author_is_bot
-}
-
-pub(in crate::services::discord) fn should_phase2_recover_message(
-    message_id: u64,
-    checkpoint: Option<u64>,
-    existing_ids: &std::collections::HashSet<u64>,
-) -> bool {
-    if existing_ids.contains(&message_id) {
-        return false;
-    }
-    if checkpoint.is_some_and(|saved| message_id <= saved) {
-        return false;
-    }
-    true
-}
 
 pub(in crate::services::discord) fn queued_message_ids(
     snapshot: &ChannelMailboxSnapshot,


### PR DESCRIPTION
Part of #3479 item-2 (giant-file decomposition). Behavior-preserving verbatim move.

Moves the dispatch-policy cluster (14 symbols: StaleDispatchTurn, is_allowed_turn_sender, stale_dispatch_turn_for_text, monitor-auto-turn origin helpers, bot-id resolvers, etc.) out of `src/services/discord/mod.rs` into new `src/services/discord/dispatch_policy.rs`.

- discord/mod.rs: 4243 → 4074 prod LoC (ratchet lowered). new dispatch_policy.rs 181 prod LoC.
- moved cluster byte-for-byte identical to origin/main. Re-export 8 externally-referenced symbols via `pub(in crate::services::discord) use`.
- Gates: build/fmt/clippy clean (7 known sqlite warnings), dispatch_policy tests 2/2, audit rc 0, ci-script rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)