### PR TITLE
refactor(#3479): extract orphan status-panel cleanup from tmux_watcher.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -503,6 +503,7 @@ src/
 │   │   │   ├── completion_gate.rs
 │   │   │   ├── completion_gate_tests.rs
 │   │   │   ├── liveness.rs
+│   │   │   ├── orphan_status_panel_cleanup.rs
 │   │   │   ├── panel_decisions.rs
 │   │   │   ├── placeholder_reclaim.rs
 │   │   │   ├── prompt_observe.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -153,9 +153,14 @@
     (retained for a later phase, not the live watcher path after the R2 revert);
     -1 from #3038 S4 after routing the placeholder/status-panel cluster
     through `shared.ui`; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7241 production lines after #3479
-    Phase-1 rank-2; was 7485 after #3479 Phase-1 rank-1 and 8122 after #3038
-    tmux_watcher S1 moved top-level decision
+  - `src/services/discord/tmux_watcher.rs` (7022 production lines after #3479
+    item-2 moved the orphan status-panel cleanup cluster
+    (`cleanup_orphan_external_input_status_panel`,
+    `complete_watcher_status_panel_v2`,
+    `refresh_watcher_session_panel_from_lifecycle`) verbatim into the
+    `tmux_watcher/` child module `orphan_status_panel_cleanup.rs` (~210);
+    was 7241 after #3479 Phase-1 rank-2, 7485 after #3479 Phase-1 rank-1 and
+    8122 after #3038 tmux_watcher S1 moved top-level decision
     clusters A/B/C/E/F/I/J/K
     into `tmux_watcher/` child modules: `liveness.rs` (301),
     `panel_decisions.rs` (372), `prompt_observe.rs` (109),

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -64,7 +64,7 @@
 # clusters in the root) deliberately STAYS here; moved unit tests live in sibling
 # utf8_chunk_decoder_tests.rs / terminal_readiness_tests.rs (excluded from the
 # production splitter).
-"src/services/discord/tmux_watcher.rs" = 7241
+"src/services/discord/tmux_watcher.rs" = 7022
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -44,6 +44,18 @@ mod single_message_footer;
 #[path = "tmux_watcher/terminal_send.rs"]
 mod terminal_send;
 
+// #3479 item-2: the watcher-direct orphan status-panel cleanup/completion/refresh
+// cluster extracted to a sibling submodule (pure move, zero logic change). Items
+// are `pub(super)` there and re-imported below so the watcher loop's call sites —
+// and the sibling `single_message_footer.rs` completion call — stay byte-identical.
+#[path = "tmux_watcher/orphan_status_panel_cleanup.rs"]
+mod orphan_status_panel_cleanup;
+
+use self::orphan_status_panel_cleanup::{
+    cleanup_orphan_external_input_status_panel, complete_watcher_status_panel_v2,
+    refresh_watcher_session_panel_from_lifecycle,
+};
+
 // #3479 Phase-1 rank-1: the supervisor relay-forward + session-bound terminal ACK
 // cluster extracted to sibling submodules (pure move, zero logic change). Split
 // into two cohesive files only to keep each within the tmux_watcher/** namespace
@@ -270,237 +282,6 @@ async fn persist_watcher_provider_session_id(
         tmux_session_name,
         channel_id.get()
     );
-}
-
-/// #3003 (codex P2 r3): delete a watcher-created TUI-direct status panel that
-/// will never reach terminal completion — the turn was stopped or returned to
-/// idle with no committed response, so `complete_watcher_status_panel_v2` never
-/// runs and the panel would stay stuck at "계속 처리 중".
-///
-/// Ownership is decided by `turn_is_external_input` — a flag cached *while the
-/// inflight row was still present* — rather than reloading inflight here (codex
-/// P2 r4): a stopped/cancelled TUI-direct turn has already cleared its inflight,
-/// so a fresh read would miss the very panel this reclaim was added for. A
-/// bridge-owned panel never sets the flag, so it is never touched.
-///
-/// Deletion routes through `delete_nonterminal_placeholder` so the in-memory and
-/// persisted ids are dropped only on a committed delete (codex P3 r4) — a
-/// transient Discord error leaves the ids intact for a later retry. The
-/// persisted `status_message_id` is cleared only when it still points at this
-/// exact panel, so a newer turn's panel is never clobbered.
-///
-/// Returns `false` only when a delete was attempted and did not commit, so the
-/// caller can defer finalization/inflight-clearing and let a later iteration
-/// retry (codex P2 r5); `true` means nothing to clean or the delete committed.
-async fn cleanup_orphan_external_input_status_panel(
-    http: &Arc<serenity::Http>,
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    status_panel_msg_id: &mut Option<serenity::MessageId>,
-    provider: &ProviderKind,
-    tmux_session_name: &str,
-    turn_is_external_input: bool,
-) -> bool {
-    if !watcher_separate_status_panel_enabled(shared.ui.status_panel_v2_enabled) {
-        *status_panel_msg_id = None;
-        return true;
-    }
-    if !turn_is_external_input {
-        return true;
-    }
-    let Some(panel_msg_id) = *status_panel_msg_id else {
-        return true;
-    };
-    // EPIC #3078 PR-4 — SHADOW parity: the controller's chosen reclaim target
-    // must equal `panel_msg_id`; legacy deletes + clears the real id below.
-    crate::services::discord::watcher_panel_parity::assert_watcher_reclaim_parity(
-        shared,
-        channel_id,
-        provider,
-        panel_msg_id,
-    )
-    .await;
-    let outcome = delete_nonterminal_placeholder(
-        http,
-        channel_id,
-        shared,
-        provider,
-        tmux_session_name,
-        panel_msg_id,
-        "watcher_orphan_external_input_status_panel_cleanup",
-    )
-    .await;
-    if !outcome.is_committed() && !outcome.is_permanent_failure() {
-        // #3003 (codex P2 r10/r11/r13): the inline delete failed transiently. The
-        // local id is kept for an in-turn retry, but a stopped/cancelled turn may
-        // clear its inflight before any retry runs, leaving no per-turn handle.
-        // Record the panel in the durable store so the sweeper drain reclaims it
-        // independent of inflight lifecycle.
-        enqueue_watcher_status_panel_orphan(shared.as_ref(), provider, channel_id, panel_msg_id);
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ watcher: orphan status-panel-v2 delete did not commit for channel {} panel_msg {}; kept local id + enqueued durable retry",
-            channel_id.get(),
-            panel_msg_id.get()
-        );
-        return false;
-    }
-    // Committed (succeeded / already-gone) OR a permanent failure (403/410): neither
-    // is retried, so treat a permanent failure as terminal and clear the handle
-    // (codex P2 r16) rather than wedge finalization forever. Drop the durable record
-    // too, since the drain would also give up on the same permanent error.
-    if !outcome.is_committed() {
-        crate::services::discord::status_panel_orphan_store::remove(
-            provider,
-            &shared.token_hash,
-            channel_id.get(),
-            panel_msg_id.get(),
-        );
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ watcher: orphan status-panel-v2 delete permanently failed for channel {} panel_msg {}; giving up (treated as committed)",
-            channel_id.get(),
-            panel_msg_id.get()
-        );
-    }
-    *status_panel_msg_id = None;
-    // #3077: compare-and-clear under the inflight flock so a newer turn that
-    // rebound this panel between our load and our clear is never wiped. The
-    // tmux-session guard preserves the prior precondition (only clear our own
-    // TUI-direct turn's row).
-    let _ = crate::services::discord::inflight::clear_status_panel_if_current(
-        provider,
-        channel_id.get(),
-        panel_msg_id.get(),
-        &crate::services::discord::inflight::StatusPanelClearGuard {
-            require_tmux_session_name: Some(tmux_session_name.to_string()),
-            ..Default::default()
-        },
-    );
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!(
-        "  [{ts}] 🧹 watcher: cleaned orphan status-panel-v2 for TUI-direct turn (channel {}, tmux={}, panel_msg={})",
-        channel_id.get(),
-        tmux_session_name,
-        panel_msg_id.get()
-    );
-    true
-}
-
-/// Returns whether the completion edit/send committed. `false` means the final
-/// panel edit hit a transient Discord error and the panel is still showing the
-/// processing state — the caller must preserve a retry handle (enqueue the panel
-/// for the durable drain) before clearing the inflight, or the panel orphans
-/// (codex P2 r20).
-async fn complete_watcher_status_panel_v2(
-    http: &serenity::Http,
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    status_panel_msg_id: Option<serenity::MessageId>,
-    provider: &ProviderKind,
-    started_at_unix: i64,
-    last_status_panel_text: &mut String,
-    background: bool,
-    expected_user_msg_id: Option<u64>,
-) -> bool {
-    // #2427 D wire (Codex round 2 HIGH-1): explicit-signal inflight cleanup
-    // is intentionally NOT emitted from the watcher path. The watcher is
-    // not turn-scoped, so any user_msg_id read here would be the *current*
-    // on-disk value (possibly the next turn's). The committed-output path
-    // at L~2996 already performs the unconditional `clear_inflight_state`
-    // for the turn the watcher actually finished. Recovery-driven
-    // TurnCompleted still emits the guarded signal (see recovery_engine.rs)
-    // because its state snapshot is pinned at recovery entry.
-    if !watcher_should_complete_separate_status_panel(shared.ui.status_panel_v2_enabled) {
-        return true;
-    }
-    // EPIC #3078: completion parity is DEFERRED to the controller execute-cutover
-    // PR. A faithful check must replicate the SendFallback path (legacy completes
-    // with a concrete id when `status_panel_msg_id` is None, turn_bridge/mod.rs),
-    // which requires the controller to independently compute the completion id
-    // from raw inputs — not the resolved output. PR-4 ships only the faithful
-    // RECLAIM shadow-parity (see cleanup_orphan_external_input_status_panel).
-    crate::services::discord::turn_bridge::complete_status_panel_v2_with_http(
-        shared,
-        http,
-        channel_id,
-        status_panel_msg_id,
-        provider,
-        started_at_unix,
-        last_status_panel_text,
-        background,
-        "tmux_watcher",
-        expected_user_msg_id,
-    )
-    .await
-}
-
-/// #3055 — the per-channel session lifecycle panel snapshot (`🆕 새 세션 시작`,
-/// `기존 세션 복원`, …) is set by the bridge's
-/// `refresh_session_panel_line_from_lifecycle` and is keyed only by channel,
-/// not by turn. The bridge re-derives it from the *current* turn's lifecycle
-/// row on every status tick (and clears it when the current turn has no
-/// session lifecycle event). The watcher-direct render/completion paths never
-/// performed that refresh, so a watcher-direct TUI turn would reuse a stale
-/// snapshot left behind by a prior turn's `session_fresh`/`session_resumed`
-/// event (e.g. a `(최근 대화 N개…)` recovery line from an earlier
-/// recovery/new-session turn).
-///
-/// Mirror the bridge behaviour for the watcher: load the latest session
-/// lifecycle event for *this* watcher turn and set the panel from it, or clear
-/// the panel when the current turn has no such event. Watcher-direct TUI turns
-/// carry `user_msg_id == 0` (no anchored Discord message) so they key onto the
-/// invariant-guarded `discord:<channel>:0` turn id, which by construction has
-/// no session lifecycle row — the panel is therefore cleared and the stale
-/// line is never reused.
-async fn refresh_watcher_session_panel_from_lifecycle(
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    user_msg_id: u64,
-    tmux_session_name: &str,
-) {
-    if !shared.ui.status_panel_v2_enabled {
-        return;
-    }
-    let Some(pg_pool) = shared.pg_pool.as_ref() else {
-        return;
-    };
-    let turn_id = format!("discord:{}:{}", channel_id.get(), user_msg_id);
-    let session_instance_key = session_panel_instance_key(tmux_session_name);
-    let channel_id_text = channel_id.get().to_string();
-    match crate::services::observability::turn_lifecycle::load_latest_session_lifecycle_event(
-        pg_pool,
-        &channel_id_text,
-        &turn_id,
-    )
-    .await
-    {
-        Ok(Some(event)) => {
-            shared
-                .ui
-                .placeholder_live_events
-                .set_session_panel_lifecycle_event(
-                    channel_id,
-                    session_instance_key.as_deref(),
-                    &event.kind,
-                    &event.details_json,
-                );
-        }
-        Ok(None) => {
-            shared
-                .ui
-                .placeholder_live_events
-                .clear_session_panel(channel_id);
-        }
-        Err(error) => {
-            tracing::debug!(
-                "[tmux_watcher] failed to load session lifecycle line for turn {} in channel {}: {}",
-                turn_id,
-                channel_id,
-                error
-            );
-        }
-    }
 }
 
 pub(in crate::services::discord) async fn tmux_output_watcher(

--- a/src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs
+++ b/src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs
@@ -1,0 +1,240 @@
+//! #3479 item-2: orphan status-panel cleanup cluster for the tmux watcher.
+//!
+//! Verbatim extraction (zero logic change) of the watcher-direct status-panel
+//! cleanup/completion/refresh helpers from `tmux_watcher.rs`. Items are
+//! `pub(super)` here and re-imported by the parent so the watcher loop's call
+//! sites — and the sibling `single_message_footer.rs` completion call — stay
+//! byte-identical.
+
+use super::*;
+
+/// #3003 (codex P2 r3): delete a watcher-created TUI-direct status panel that
+/// will never reach terminal completion — the turn was stopped or returned to
+/// idle with no committed response, so `complete_watcher_status_panel_v2` never
+/// runs and the panel would stay stuck at "계속 처리 중".
+///
+/// Ownership is decided by `turn_is_external_input` — a flag cached *while the
+/// inflight row was still present* — rather than reloading inflight here (codex
+/// P2 r4): a stopped/cancelled TUI-direct turn has already cleared its inflight,
+/// so a fresh read would miss the very panel this reclaim was added for. A
+/// bridge-owned panel never sets the flag, so it is never touched.
+///
+/// Deletion routes through `delete_nonterminal_placeholder` so the in-memory and
+/// persisted ids are dropped only on a committed delete (codex P3 r4) — a
+/// transient Discord error leaves the ids intact for a later retry. The
+/// persisted `status_message_id` is cleared only when it still points at this
+/// exact panel, so a newer turn's panel is never clobbered.
+///
+/// Returns `false` only when a delete was attempted and did not commit, so the
+/// caller can defer finalization/inflight-clearing and let a later iteration
+/// retry (codex P2 r5); `true` means nothing to clean or the delete committed.
+pub(super) async fn cleanup_orphan_external_input_status_panel(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    status_panel_msg_id: &mut Option<serenity::MessageId>,
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+    turn_is_external_input: bool,
+) -> bool {
+    if !watcher_separate_status_panel_enabled(shared.ui.status_panel_v2_enabled) {
+        *status_panel_msg_id = None;
+        return true;
+    }
+    if !turn_is_external_input {
+        return true;
+    }
+    let Some(panel_msg_id) = *status_panel_msg_id else {
+        return true;
+    };
+    // EPIC #3078 PR-4 — SHADOW parity: the controller's chosen reclaim target
+    // must equal `panel_msg_id`; legacy deletes + clears the real id below.
+    crate::services::discord::watcher_panel_parity::assert_watcher_reclaim_parity(
+        shared,
+        channel_id,
+        provider,
+        panel_msg_id,
+    )
+    .await;
+    let outcome = delete_nonterminal_placeholder(
+        http,
+        channel_id,
+        shared,
+        provider,
+        tmux_session_name,
+        panel_msg_id,
+        "watcher_orphan_external_input_status_panel_cleanup",
+    )
+    .await;
+    if !outcome.is_committed() && !outcome.is_permanent_failure() {
+        // #3003 (codex P2 r10/r11/r13): the inline delete failed transiently. The
+        // local id is kept for an in-turn retry, but a stopped/cancelled turn may
+        // clear its inflight before any retry runs, leaving no per-turn handle.
+        // Record the panel in the durable store so the sweeper drain reclaims it
+        // independent of inflight lifecycle.
+        enqueue_watcher_status_panel_orphan(shared.as_ref(), provider, channel_id, panel_msg_id);
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ watcher: orphan status-panel-v2 delete did not commit for channel {} panel_msg {}; kept local id + enqueued durable retry",
+            channel_id.get(),
+            panel_msg_id.get()
+        );
+        return false;
+    }
+    // Committed (succeeded / already-gone) OR a permanent failure (403/410): neither
+    // is retried, so treat a permanent failure as terminal and clear the handle
+    // (codex P2 r16) rather than wedge finalization forever. Drop the durable record
+    // too, since the drain would also give up on the same permanent error.
+    if !outcome.is_committed() {
+        crate::services::discord::status_panel_orphan_store::remove(
+            provider,
+            &shared.token_hash,
+            channel_id.get(),
+            panel_msg_id.get(),
+        );
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ watcher: orphan status-panel-v2 delete permanently failed for channel {} panel_msg {}; giving up (treated as committed)",
+            channel_id.get(),
+            panel_msg_id.get()
+        );
+    }
+    *status_panel_msg_id = None;
+    // #3077: compare-and-clear under the inflight flock so a newer turn that
+    // rebound this panel between our load and our clear is never wiped. The
+    // tmux-session guard preserves the prior precondition (only clear our own
+    // TUI-direct turn's row).
+    let _ = crate::services::discord::inflight::clear_status_panel_if_current(
+        provider,
+        channel_id.get(),
+        panel_msg_id.get(),
+        &crate::services::discord::inflight::StatusPanelClearGuard {
+            require_tmux_session_name: Some(tmux_session_name.to_string()),
+            ..Default::default()
+        },
+    );
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::info!(
+        "  [{ts}] 🧹 watcher: cleaned orphan status-panel-v2 for TUI-direct turn (channel {}, tmux={}, panel_msg={})",
+        channel_id.get(),
+        tmux_session_name,
+        panel_msg_id.get()
+    );
+    true
+}
+
+/// Returns whether the completion edit/send committed. `false` means the final
+/// panel edit hit a transient Discord error and the panel is still showing the
+/// processing state — the caller must preserve a retry handle (enqueue the panel
+/// for the durable drain) before clearing the inflight, or the panel orphans
+/// (codex P2 r20).
+pub(super) async fn complete_watcher_status_panel_v2(
+    http: &serenity::Http,
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    status_panel_msg_id: Option<serenity::MessageId>,
+    provider: &ProviderKind,
+    started_at_unix: i64,
+    last_status_panel_text: &mut String,
+    background: bool,
+    expected_user_msg_id: Option<u64>,
+) -> bool {
+    // #2427 D wire (Codex round 2 HIGH-1): explicit-signal inflight cleanup
+    // is intentionally NOT emitted from the watcher path. The watcher is
+    // not turn-scoped, so any user_msg_id read here would be the *current*
+    // on-disk value (possibly the next turn's). The committed-output path
+    // at L~2996 already performs the unconditional `clear_inflight_state`
+    // for the turn the watcher actually finished. Recovery-driven
+    // TurnCompleted still emits the guarded signal (see recovery_engine.rs)
+    // because its state snapshot is pinned at recovery entry.
+    if !watcher_should_complete_separate_status_panel(shared.ui.status_panel_v2_enabled) {
+        return true;
+    }
+    // EPIC #3078: completion parity is DEFERRED to the controller execute-cutover
+    // PR. A faithful check must replicate the SendFallback path (legacy completes
+    // with a concrete id when `status_panel_msg_id` is None, turn_bridge/mod.rs),
+    // which requires the controller to independently compute the completion id
+    // from raw inputs — not the resolved output. PR-4 ships only the faithful
+    // RECLAIM shadow-parity (see cleanup_orphan_external_input_status_panel).
+    crate::services::discord::turn_bridge::complete_status_panel_v2_with_http(
+        shared,
+        http,
+        channel_id,
+        status_panel_msg_id,
+        provider,
+        started_at_unix,
+        last_status_panel_text,
+        background,
+        "tmux_watcher",
+        expected_user_msg_id,
+    )
+    .await
+}
+
+/// #3055 — the per-channel session lifecycle panel snapshot (`🆕 새 세션 시작`,
+/// `기존 세션 복원`, …) is set by the bridge's
+/// `refresh_session_panel_line_from_lifecycle` and is keyed only by channel,
+/// not by turn. The bridge re-derives it from the *current* turn's lifecycle
+/// row on every status tick (and clears it when the current turn has no
+/// session lifecycle event). The watcher-direct render/completion paths never
+/// performed that refresh, so a watcher-direct TUI turn would reuse a stale
+/// snapshot left behind by a prior turn's `session_fresh`/`session_resumed`
+/// event (e.g. a `(최근 대화 N개…)` recovery line from an earlier
+/// recovery/new-session turn).
+///
+/// Mirror the bridge behaviour for the watcher: load the latest session
+/// lifecycle event for *this* watcher turn and set the panel from it, or clear
+/// the panel when the current turn has no such event. Watcher-direct TUI turns
+/// carry `user_msg_id == 0` (no anchored Discord message) so they key onto the
+/// invariant-guarded `discord:<channel>:0` turn id, which by construction has
+/// no session lifecycle row — the panel is therefore cleared and the stale
+/// line is never reused.
+pub(super) async fn refresh_watcher_session_panel_from_lifecycle(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    user_msg_id: u64,
+    tmux_session_name: &str,
+) {
+    if !shared.ui.status_panel_v2_enabled {
+        return;
+    }
+    let Some(pg_pool) = shared.pg_pool.as_ref() else {
+        return;
+    };
+    let turn_id = format!("discord:{}:{}", channel_id.get(), user_msg_id);
+    let session_instance_key = session_panel_instance_key(tmux_session_name);
+    let channel_id_text = channel_id.get().to_string();
+    match crate::services::observability::turn_lifecycle::load_latest_session_lifecycle_event(
+        pg_pool,
+        &channel_id_text,
+        &turn_id,
+    )
+    .await
+    {
+        Ok(Some(event)) => {
+            shared
+                .ui
+                .placeholder_live_events
+                .set_session_panel_lifecycle_event(
+                    channel_id,
+                    session_instance_key.as_deref(),
+                    &event.kind,
+                    &event.details_json,
+                );
+        }
+        Ok(None) => {
+            shared
+                .ui
+                .placeholder_live_events
+                .clear_session_panel(channel_id);
+        }
+        Err(error) => {
+            tracing::debug!(
+                "[tmux_watcher] failed to load session lifecycle line for turn {} in channel {}: {}",
+                turn_id,
+                channel_id,
+                error
+            );
+        }
+    }
+}


### PR DESCRIPTION
Part of #3479 item-2 (giant-file decomposition). Behavior-preserving verbatim move.

Moves 3 async fns (cleanup_orphan_external_input_status_panel, complete_watcher_status_panel_v2, refresh_watcher_session_panel_from_lifecycle) out of `src/services/discord/tmux_watcher.rs` into the existing sibling submodule dir as `tmux_watcher/orphan_status_panel_cleanup.rs`.

- tmux_watcher.rs: 7241 → 7022 prod LoC (ratchet lowered). new file 240 LoC.
- byte-identical bodies (only `pub(super)` prefix). No `super::` re-depth needed (all refs are crate:: or resolve via `use super::*`). cross-sibling caller in single_message_footer.rs resolves unchanged.
- Gates: build/fmt/clippy clean (7 known sqlite warnings), tmux tests 263/263, audit rc 0, ci-script rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)