### PR TITLE
refactor(#3479): extract provider-session persistence from tmux_watcher.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -508,6 +508,7 @@ src/
 │   │   │   ├── panel_decisions.rs
 │   │   │   ├── placeholder_reclaim.rs
 │   │   │   ├── prompt_observe.rs
+│   │   │   ├── provider_session_persistence.rs
 │   │   │   ├── session_bound_ack.rs
 │   │   │   ├── session_bound_ack_tests.rs
 │   │   │   ├── single_message_footer.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -153,8 +153,12 @@
     (retained for a later phase, not the live watcher path after the R2 revert);
     -1 from #3038 S4 after routing the placeholder/status-panel cluster
     through `shared.ui`; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7022 production lines after #3479
-    item-2 moved the orphan status-panel cleanup cluster
+  - `src/services/discord/tmux_watcher.rs` (6939 production lines after #3479
+    item-2 moved the provider-session persistence cluster
+    (`resolve_persistable_provider_session_id`,
+    `persist_watcher_provider_session_id`) verbatim into the `tmux_watcher/`
+    child module `provider_session_persistence.rs` (~101);
+    was 7022 after #3479 item-2 moved the orphan status-panel cleanup cluster
     (`cleanup_orphan_external_input_status_panel`,
     `complete_watcher_status_panel_v2`,
     `refresh_watcher_session_panel_from_lifecycle`) verbatim into the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -64,7 +64,7 @@
 # clusters in the root) deliberately STAYS here; moved unit tests live in sibling
 # utf8_chunk_decoder_tests.rs / terminal_readiness_tests.rs (excluded from the
 # production splitter).
-"src/services/discord/tmux_watcher.rs" = 7022
+"src/services/discord/tmux_watcher.rs" = 6939
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -56,6 +56,15 @@ use self::orphan_status_panel_cleanup::{
     refresh_watcher_session_panel_from_lifecycle,
 };
 
+// #3479 item-2: provider-session selector resolution + persistence cluster
+// extracted to a sibling submodule (pure move, zero logic change). Items are
+// `pub(super)` there and re-imported here so the watcher loop's call sites stay
+// byte-identical.
+#[path = "tmux_watcher/provider_session_persistence.rs"]
+mod provider_session_persistence;
+
+use self::provider_session_persistence::persist_watcher_provider_session_id;
+
 // #3479 Phase-1 rank-1: the supervisor relay-forward + session-bound terminal ACK
 // cluster extracted to sibling submodules (pure move, zero logic change). Split
 // into two cohesive files only to keep each within the tmux_watcher/** namespace
@@ -190,98 +199,6 @@ async fn commit_watcher_direct_terminal_session_idle(
         "watcher-direct terminal response committed session idle"
     );
     true
-}
-
-/// Resolve the provider session selector to durably persist at turn end.
-///
-/// #3095: a TUI resume turn frequently does NOT re-emit the provider session id
-/// in its pane output, so `observed_session_id` (`state.last_session_id`) is
-/// `None` on most committed turns even though resume is working off the durable
-/// in-memory selector. Falling back to the cached `session.session_id` keeps the
-/// DB selector in sync on every committed turn so resume survives an in-memory
-/// cache loss (idle-expiry / dcserver restart). The fallback is guarded against
-/// empty values so a stale/blank selector never overwrites a good DB row.
-fn resolve_persistable_provider_session_id(
-    observed_session_id: Option<&str>,
-    cached_session_id: Option<&str>,
-) -> Option<String> {
-    let nonempty = |value: Option<&str>| {
-        value
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    };
-    nonempty(observed_session_id).or_else(|| nonempty(cached_session_id))
-}
-
-async fn persist_watcher_provider_session_id(
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    provider: &ProviderKind,
-    tmux_session_name: &str,
-    session_id: Option<&str>,
-) {
-    // #3095: when the TUI did not re-emit a session id this turn, fall back to
-    // the durable in-memory selector so the DB row is refreshed on every
-    // committed turn — not only on the rare turns that print the id.
-    let session_id = {
-        let mut data = shared.core.lock().await;
-        let session = data.sessions.get_mut(&channel_id).filter(|s| !s.cleared);
-        let cached_session_id = session.as_ref().and_then(|s| s.session_id.clone());
-        let Some(session_id) =
-            resolve_persistable_provider_session_id(session_id, cached_session_id.as_deref())
-        else {
-            return;
-        };
-        if let Some(session) = session {
-            session.restore_provider_session(Some(session_id.clone()));
-        }
-        session_id
-    };
-
-    let session_key = crate::services::discord::adk_session::build_namespaced_session_key(
-        &shared.token_hash,
-        provider,
-        tmux_session_name,
-    );
-    crate::services::discord::adk_session::save_provider_session_id(
-        &session_key,
-        &session_id,
-        Some(&session_id),
-        provider,
-        channel_id,
-        shared.api_port,
-    )
-    .await;
-
-    // #3053: persisting a provider selector is live runtime activity — emit an
-    // auditable heartbeat touch so idle-kill's COALESCE(last_heartbeat,
-    // created_at) row is refreshed and the candidate-key match is logged.
-    // (hook_session already sets last_heartbeat; this adds the audit trail and
-    // covers any divergent/legacy session_key the upsert did not reach.)
-    touch_session_activity(
-        None::<&crate::db::Db>,
-        shared.pg_pool.as_ref(),
-        &shared.token_hash,
-        provider,
-        tmux_session_name,
-        crate::services::discord::adk_session::parse_thread_channel_id_from_name(
-            &crate::services::provider::parse_provider_and_channel_from_tmux_name(
-                tmux_session_name,
-            )
-            .map(|(_, channel)| channel)
-            .unwrap_or_default(),
-        ),
-        "provider_selector_persisted",
-        "tmux_watcher.rs:persist_provider_session_selector",
-    );
-
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    tracing::info!(
-        "  [{ts}] 👁 watcher persisted provider session selector for {} channel {}",
-        tmux_session_name,
-        channel_id.get()
-    );
 }
 
 pub(in crate::services::discord) async fn tmux_output_watcher(
@@ -7027,9 +6944,9 @@ mod tests {
         build_watcher_streaming_edit_text,
         discard_restored_response_seed_before_no_inflight_terminal_relay,
         legacy_wrapper_prompt_candidates_from_pane, mark_watcher_terminal_delivery_committed,
-        reacquire_watcher_inflight_for_active_stream, resolve_persistable_provider_session_id,
-        should_probe_tmux_liveness, terminal_relay_decision,
-        watcher_batch_contains_assistant_event, watcher_batch_contains_relayable_response,
+        reacquire_watcher_inflight_for_active_stream, should_probe_tmux_liveness,
+        terminal_relay_decision, watcher_batch_contains_assistant_event,
+        watcher_batch_contains_relayable_response,
         watcher_fallback_edit_failure_can_delete_original_placeholder,
         watcher_fresh_idle_finalize_decision, watcher_inflight_absence_is_abandonment,
         watcher_output_progressed_recently, watcher_should_clear_stale_terminal_message_ids,
@@ -7068,48 +6985,6 @@ mod tests {
                 None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
             }
         }
-    }
-
-    // #3095: a freshly observed TUI session id always wins so the DB tracks the
-    // newest selector.
-    #[test]
-    fn persistable_provider_session_prefers_freshly_observed_id() {
-        assert_eq!(
-            resolve_persistable_provider_session_id(Some("fresh-sid"), Some("cached-sid")),
-            Some("fresh-sid".to_string())
-        );
-    }
-
-    // #3095 core fix: a resume turn whose TUI output did NOT re-emit a session id
-    // must still persist the durable in-memory selector so the DB row is kept in
-    // sync and resume survives idle-expiry / dcserver restart.
-    #[test]
-    fn persistable_provider_session_falls_back_to_cached_selector_on_resume_turn() {
-        assert_eq!(
-            resolve_persistable_provider_session_id(None, Some("cached-sid")),
-            Some("cached-sid".to_string())
-        );
-    }
-
-    // #3095 guard: never overwrite a good DB row with an empty/blank selector —
-    // neither the observed nor the cached value is usable, so persist is skipped.
-    #[test]
-    fn persistable_provider_session_skips_when_no_usable_selector() {
-        assert_eq!(
-            resolve_persistable_provider_session_id(None, None),
-            None,
-            "no selector available -> skip persist"
-        );
-        assert_eq!(
-            resolve_persistable_provider_session_id(Some("   "), Some("")),
-            None,
-            "blank observed + empty cached -> skip persist"
-        );
-        assert_eq!(
-            resolve_persistable_provider_session_id(Some(""), Some("cached-sid")),
-            Some("cached-sid".to_string()),
-            "blank observed must fall through to the usable cached selector"
-        );
     }
 
     #[test]

--- a/src/services/discord/tmux_watcher/provider_session_persistence.rs
+++ b/src/services/discord/tmux_watcher/provider_session_persistence.rs
@@ -1,0 +1,147 @@
+//! #3479 item-2: provider-session persistence helpers for the tmux watcher.
+//!
+//! Verbatim extraction (zero logic change) of the watcher provider-session
+//! selector resolution/persistence helpers from `tmux_watcher.rs`. Items are
+//! `pub(super)` here and re-imported by the parent so the watcher loop's call
+//! sites stay byte-identical.
+
+use super::*;
+
+/// Resolve the provider session selector to durably persist at turn end.
+///
+/// #3095: a TUI resume turn frequently does NOT re-emit the provider session id
+/// in its pane output, so `observed_session_id` (`state.last_session_id`) is
+/// `None` on most committed turns even though resume is working off the durable
+/// in-memory selector. Falling back to the cached `session.session_id` keeps the
+/// DB selector in sync on every committed turn so resume survives an in-memory
+/// cache loss (idle-expiry / dcserver restart). The fallback is guarded against
+/// empty values so a stale/blank selector never overwrites a good DB row.
+pub(super) fn resolve_persistable_provider_session_id(
+    observed_session_id: Option<&str>,
+    cached_session_id: Option<&str>,
+) -> Option<String> {
+    let nonempty = |value: Option<&str>| {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    nonempty(observed_session_id).or_else(|| nonempty(cached_session_id))
+}
+
+pub(super) async fn persist_watcher_provider_session_id(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+    session_id: Option<&str>,
+) {
+    // #3095: when the TUI did not re-emit a session id this turn, fall back to
+    // the durable in-memory selector so the DB row is refreshed on every
+    // committed turn — not only on the rare turns that print the id.
+    let session_id = {
+        let mut data = shared.core.lock().await;
+        let session = data.sessions.get_mut(&channel_id).filter(|s| !s.cleared);
+        let cached_session_id = session.as_ref().and_then(|s| s.session_id.clone());
+        let Some(session_id) =
+            resolve_persistable_provider_session_id(session_id, cached_session_id.as_deref())
+        else {
+            return;
+        };
+        if let Some(session) = session {
+            session.restore_provider_session(Some(session_id.clone()));
+        }
+        session_id
+    };
+
+    let session_key = crate::services::discord::adk_session::build_namespaced_session_key(
+        &shared.token_hash,
+        provider,
+        tmux_session_name,
+    );
+    crate::services::discord::adk_session::save_provider_session_id(
+        &session_key,
+        &session_id,
+        Some(&session_id),
+        provider,
+        channel_id,
+        shared.api_port,
+    )
+    .await;
+
+    // #3053: persisting a provider selector is live runtime activity — emit an
+    // auditable heartbeat touch so idle-kill's COALESCE(last_heartbeat,
+    // created_at) row is refreshed and the candidate-key match is logged.
+    // (hook_session already sets last_heartbeat; this adds the audit trail and
+    // covers any divergent/legacy session_key the upsert did not reach.)
+    touch_session_activity(
+        None::<&crate::db::Db>,
+        shared.pg_pool.as_ref(),
+        &shared.token_hash,
+        provider,
+        tmux_session_name,
+        crate::services::discord::adk_session::parse_thread_channel_id_from_name(
+            &crate::services::provider::parse_provider_and_channel_from_tmux_name(
+                tmux_session_name,
+            )
+            .map(|(_, channel)| channel)
+            .unwrap_or_default(),
+        ),
+        "provider_selector_persisted",
+        "tmux_watcher.rs:persist_provider_session_selector",
+    );
+
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::info!(
+        "  [{ts}] 👁 watcher persisted provider session selector for {} channel {}",
+        tmux_session_name,
+        channel_id.get()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_persistable_provider_session_id;
+
+    // #3095: a freshly observed TUI session id always wins so the DB tracks the
+    // newest selector.
+    #[test]
+    fn persistable_provider_session_prefers_freshly_observed_id() {
+        assert_eq!(
+            resolve_persistable_provider_session_id(Some("fresh-sid"), Some("cached-sid")),
+            Some("fresh-sid".to_string())
+        );
+    }
+
+    // #3095 core fix: a resume turn whose TUI output did NOT re-emit a session id
+    // must still persist the durable in-memory selector so the DB row is kept in
+    // sync and resume survives idle-expiry / dcserver restart.
+    #[test]
+    fn persistable_provider_session_falls_back_to_cached_selector_on_resume_turn() {
+        assert_eq!(
+            resolve_persistable_provider_session_id(None, Some("cached-sid")),
+            Some("cached-sid".to_string())
+        );
+    }
+
+    // #3095 guard: never overwrite a good DB row with an empty/blank selector —
+    // neither the observed nor the cached value is usable, so persist is skipped.
+    #[test]
+    fn persistable_provider_session_skips_when_no_usable_selector() {
+        assert_eq!(
+            resolve_persistable_provider_session_id(None, None),
+            None,
+            "no selector available -> skip persist"
+        );
+        assert_eq!(
+            resolve_persistable_provider_session_id(Some("   "), Some("")),
+            None,
+            "blank observed + empty cached -> skip persist"
+        );
+        assert_eq!(
+            resolve_persistable_provider_session_id(Some(""), Some("cached-sid")),
+            Some("cached-sid".to_string()),
+            "blank observed must fall through to the usable cached selector"
+        );
+    }
+}


### PR DESCRIPTION
Part of #3479 item-2 (giant-file decomposition). Behavior-preserving verbatim move.

Moves resolve_persistable_provider_session_id + persist_watcher_provider_session_id (+ 3 tests) out of `tmux_watcher.rs` into sibling `tmux_watcher/provider_session_persistence.rs`.
- tmux_watcher.rs 7022→6939 prod LoC (ratchet lowered). new file 101 prod/46 test.
- both pub(super); only persist_* imported into parent (resolve_* now child-internal). Verbatim, no logic change.
- Gates: build/fmt/clippy clean (7 known sqlite warnings), tmux tests 263/263, audit rc 0, ci rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)