### PR TITLE
refactor(#3479): extract task-notification lifecycle from turn_bridge/mod.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -546,6 +546,7 @@ src/
 │   │   │   ├── status_panel.rs
 │   │   │   ├── status_panel_tests.rs
 │   │   │   ├── streaming_edit_text.rs
+│   │   │   ├── task_notification_lifecycle.rs
 │   │   │   ├── terminal_controller_cutover.rs
 │   │   │   ├── terminal_delivery.rs
 │   │   │   ├── tmux_runtime.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -883,7 +883,7 @@
     stop-token/tmux binding runtime + PID-exit observation helper (#2426),
     split before adding non-bugfix behavior. #3169: added the
     claude-anonymous-teardown SIGINT suppression guard (death #3)).
-  - `src/services/discord/turn_bridge/mod.rs` (6535 prod lines; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6448 prod lines; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. Registered giant-file (#3038 decompose target — see
     `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -114,7 +114,7 @@
 # spawn_watcher_orphan_spinner_cleanup_retry) into
 # `turn_bridge/watcher_orphan_cleanup.rs` (both re-exported, call sites
 # byte-identical). Locks in the shrink win (ratchet down only).
-"src/services/discord/turn_bridge/mod.rs" = 6535
+"src/services/discord/turn_bridge/mod.rs" = 6448
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -12,6 +12,7 @@ mod skill_usage;
 mod stale_resume;
 mod status_panel;
 mod streaming_edit_text;
+mod task_notification_lifecycle;
 mod terminal_controller_cutover;
 mod terminal_delivery;
 mod tmux_runtime;
@@ -66,6 +67,11 @@ pub(in crate::services::discord) use status_panel::{
 pub(super) use streaming_edit_text::{
     bridge_pre_submission_tui_prompt_error, bridge_tui_transport_error_should_skip_quiescence,
     build_turn_bridge_streaming_edit_text,
+};
+pub(super) use task_notification_lifecycle::{
+    close_all_tracked_background_children, close_next_tracked_background_child,
+    merge_task_notification_kind, release_task_notification_kind,
+    task_notification_closes_background_child,
 };
 pub(crate) use tmux_runtime::TmuxCleanupPolicy;
 pub(super) use tmux_runtime::bind_cancel_token_tmux_runtime;
@@ -203,56 +209,6 @@ fn sync_inflight_restart_mode_from_cancel(
         None => inflight_state.clear_restart_mode(),
     }
     true
-}
-
-fn merge_task_notification_kind(
-    current: Option<TaskNotificationKind>,
-    new_kind: TaskNotificationKind,
-) -> Option<TaskNotificationKind> {
-    let priority = |kind: TaskNotificationKind| match kind {
-        TaskNotificationKind::Subagent => 0,
-        TaskNotificationKind::Background => 1,
-        TaskNotificationKind::MonitorAutoTurn => 2,
-    };
-
-    match current {
-        Some(existing) if priority(existing) >= priority(new_kind) => Some(existing),
-        _ => Some(new_kind),
-    }
-}
-
-fn release_task_notification_kind(
-    current: Option<TaskNotificationKind>,
-    closed_kind: TaskNotificationKind,
-) -> Option<TaskNotificationKind> {
-    match current {
-        Some(existing) if existing == closed_kind => None,
-        other => other,
-    }
-}
-
-async fn close_next_tracked_background_child(
-    pg_pool: Option<&sqlx::PgPool>,
-    child_session_ids: &mut Vec<i64>,
-    status: &str,
-    reason: &str,
-) {
-    let Some(pg_pool) = pg_pool else {
-        return;
-    };
-    if child_session_ids.is_empty() {
-        return;
-    }
-    let child_session_id = child_session_ids.remove(0);
-    match close_background_child_pg(pg_pool, child_session_id, status).await {
-        Ok(_) => {}
-        Err(error) => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
-                "  [{ts}] ⚠ Failed to close background child session {child_session_id} after {reason}: {error}"
-            );
-        }
-    }
 }
 
 fn first_request_line(user_text: &str) -> Option<String> {
@@ -441,37 +397,6 @@ async fn refresh_task_panel_line_from_dispatch(
                 .as_ref()
                 .and_then(|value| value.github_issue_number),
         },
-    )
-}
-
-async fn close_all_tracked_background_children(
-    pg_pool: Option<&sqlx::PgPool>,
-    child_session_ids: &mut Vec<i64>,
-    status: &str,
-    reason: &str,
-) {
-    while !child_session_ids.is_empty() {
-        close_next_tracked_background_child(pg_pool, child_session_ids, status, reason).await;
-    }
-}
-
-fn task_notification_closes_background_child(kind: TaskNotificationKind, status: &str) -> bool {
-    if !matches!(
-        kind,
-        TaskNotificationKind::Background | TaskNotificationKind::Subagent
-    ) {
-        return false;
-    }
-    matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "completed"
-            | "done"
-            | "finished"
-            | "aborted"
-            | "cancelled"
-            | "canceled"
-            | "failed"
-            | "error"
     )
 }
 
@@ -6943,133 +6868,4 @@ pub(super) fn spawn_turn_bridge(
 
         // completion_tx is sent automatically by CompletionGuard on drop
     }.instrument(bridge_span));
-}
-
-/// codex P2 followup (#1670): unit-level coverage of the
-/// "preserve task_notification_kind while other children remain" rule.
-/// This mirrors the production logic at the
-/// `task_notification_closes_background_child` arm in
-/// `StreamMessage::TaskNotification` (search: `codex P2 followup`).
-///
-/// The existing exhaustive-status coverage lives in
-/// `tests::task_notification_kind_resets_after_terminal_status` but that
-/// module is feature-gated on `legacy-sqlite-tests`; this lighter copy is
-/// added in the non-gated mod so the regression is observable in normal
-/// `cargo test` runs.
-#[cfg(test)]
-mod task_notification_kind_lifecycle_tests {
-    use super::{
-        TaskNotificationKind, merge_task_notification_kind, release_task_notification_kind,
-        task_notification_closes_background_child,
-    };
-
-    #[test]
-    fn kind_persists_while_other_children_remain() {
-        let mut child_ids: Vec<i64> = vec![100, 101];
-        let mut kind: Option<TaskNotificationKind> = None;
-        kind = merge_task_notification_kind(kind, TaskNotificationKind::Subagent);
-
-        let new_kind = TaskNotificationKind::Subagent;
-        let status = "completed";
-        kind = merge_task_notification_kind(kind, new_kind);
-        if task_notification_closes_background_child(new_kind, status) {
-            // Mirror the single-pop behavior of
-            // `close_next_tracked_background_child` at the call site.
-            let _ = child_ids.remove(0);
-            if child_ids.is_empty() {
-                kind = release_task_notification_kind(kind, new_kind);
-            }
-        }
-
-        assert_eq!(child_ids, vec![101]);
-        assert_eq!(
-            kind,
-            Some(TaskNotificationKind::Subagent),
-            "#1670 P2: kind must persist while other tracked children remain"
-        );
-
-        // Second terminal closes the queue, kind releases.
-        let new_kind = TaskNotificationKind::Subagent;
-        let status = "completed";
-        kind = merge_task_notification_kind(kind, new_kind);
-        if task_notification_closes_background_child(new_kind, status) {
-            let _ = child_ids.remove(0);
-            if child_ids.is_empty() {
-                kind = release_task_notification_kind(kind, new_kind);
-            }
-        }
-        assert!(child_ids.is_empty());
-        assert_eq!(
-            kind, None,
-            "#1670 P2: kind must release once the last child closes"
-        );
-    }
-
-    #[test]
-    fn kind_releases_immediately_when_queue_was_already_singleton() {
-        let mut child_ids: Vec<i64> = vec![42];
-        let mut kind: Option<TaskNotificationKind> = Some(TaskNotificationKind::Background);
-
-        let new_kind = TaskNotificationKind::Background;
-        let status = "aborted";
-        kind = merge_task_notification_kind(kind, new_kind);
-        if task_notification_closes_background_child(new_kind, status) {
-            let _ = child_ids.remove(0);
-            if child_ids.is_empty() {
-                kind = release_task_notification_kind(kind, new_kind);
-            }
-        }
-
-        assert!(child_ids.is_empty());
-        assert_eq!(
-            kind, None,
-            "#1670 P2: with a single tracked child, terminal status must release the kind"
-        );
-    }
-
-    #[test]
-    fn non_terminal_status_keeps_kind_and_does_not_pop() {
-        let mut child_ids: Vec<i64> = vec![1, 2];
-        let mut kind: Option<TaskNotificationKind> = None;
-        kind = merge_task_notification_kind(kind, TaskNotificationKind::Subagent);
-
-        let new_kind = TaskNotificationKind::Subagent;
-        let status = "started";
-        kind = merge_task_notification_kind(kind, new_kind);
-        if task_notification_closes_background_child(new_kind, status) {
-            let _ = child_ids.remove(0);
-            if child_ids.is_empty() {
-                kind = release_task_notification_kind(kind, new_kind);
-            }
-        }
-
-        assert_eq!(child_ids, vec![1, 2], "non-terminal must not pop");
-        assert_eq!(
-            kind,
-            Some(TaskNotificationKind::Subagent),
-            "non-terminal must keep kind"
-        );
-    }
-
-    #[test]
-    fn lower_priority_child_close_preserves_higher_priority_kind() {
-        let mut child_ids: Vec<i64> = vec![7];
-        let mut kind: Option<TaskNotificationKind> = Some(TaskNotificationKind::MonitorAutoTurn);
-
-        let new_kind = TaskNotificationKind::Subagent;
-        kind = merge_task_notification_kind(kind, new_kind);
-        if task_notification_closes_background_child(new_kind, "completed") {
-            let _ = child_ids.remove(0);
-            if child_ids.is_empty() {
-                kind = release_task_notification_kind(kind, new_kind);
-            }
-        }
-
-        assert!(child_ids.is_empty());
-        assert_eq!(
-            kind,
-            Some(TaskNotificationKind::MonitorAutoTurn),
-            "#1683: lower-priority child terminal notification must not clear a higher-priority active kind"
-        );
-    }
 }

--- a/src/services/discord/turn_bridge/task_notification_lifecycle.rs
+++ b/src/services/discord/turn_bridge/task_notification_lifecycle.rs
@@ -1,0 +1,222 @@
+//! Task-notification kind lifecycle + tracked background-child close helpers.
+//!
+//! #3479 extraction: the byte-identical helpers that maintain the active
+//! `TaskNotificationKind` priority (merge/release) and drain the tracked
+//! background-child session queue on terminal task notifications. Moved
+//! verbatim from `turn_bridge/mod.rs` and re-exported there so call sites
+//! stay identical.
+
+use super::*;
+
+pub(in crate::services::discord) fn merge_task_notification_kind(
+    current: Option<TaskNotificationKind>,
+    new_kind: TaskNotificationKind,
+) -> Option<TaskNotificationKind> {
+    let priority = |kind: TaskNotificationKind| match kind {
+        TaskNotificationKind::Subagent => 0,
+        TaskNotificationKind::Background => 1,
+        TaskNotificationKind::MonitorAutoTurn => 2,
+    };
+
+    match current {
+        Some(existing) if priority(existing) >= priority(new_kind) => Some(existing),
+        _ => Some(new_kind),
+    }
+}
+
+pub(in crate::services::discord) fn release_task_notification_kind(
+    current: Option<TaskNotificationKind>,
+    closed_kind: TaskNotificationKind,
+) -> Option<TaskNotificationKind> {
+    match current {
+        Some(existing) if existing == closed_kind => None,
+        other => other,
+    }
+}
+
+pub(in crate::services::discord) async fn close_next_tracked_background_child(
+    pg_pool: Option<&sqlx::PgPool>,
+    child_session_ids: &mut Vec<i64>,
+    status: &str,
+    reason: &str,
+) {
+    let Some(pg_pool) = pg_pool else {
+        return;
+    };
+    if child_session_ids.is_empty() {
+        return;
+    }
+    let child_session_id = child_session_ids.remove(0);
+    match close_background_child_pg(pg_pool, child_session_id, status).await {
+        Ok(_) => {}
+        Err(error) => {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] ⚠ Failed to close background child session {child_session_id} after {reason}: {error}"
+            );
+        }
+    }
+}
+
+pub(in crate::services::discord) async fn close_all_tracked_background_children(
+    pg_pool: Option<&sqlx::PgPool>,
+    child_session_ids: &mut Vec<i64>,
+    status: &str,
+    reason: &str,
+) {
+    while !child_session_ids.is_empty() {
+        close_next_tracked_background_child(pg_pool, child_session_ids, status, reason).await;
+    }
+}
+
+pub(in crate::services::discord) fn task_notification_closes_background_child(
+    kind: TaskNotificationKind,
+    status: &str,
+) -> bool {
+    if !matches!(
+        kind,
+        TaskNotificationKind::Background | TaskNotificationKind::Subagent
+    ) {
+        return false;
+    }
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "completed"
+            | "done"
+            | "finished"
+            | "aborted"
+            | "cancelled"
+            | "canceled"
+            | "failed"
+            | "error"
+    )
+}
+
+/// codex P2 followup (#1670): unit-level coverage of the
+/// "preserve task_notification_kind while other children remain" rule.
+/// This mirrors the production logic at the
+/// `task_notification_closes_background_child` arm in
+/// `StreamMessage::TaskNotification` (search: `codex P2 followup`).
+///
+/// The existing exhaustive-status coverage lives in
+/// `tests::task_notification_kind_resets_after_terminal_status` but that
+/// module is feature-gated on `legacy-sqlite-tests`; this lighter copy is
+/// added in the non-gated mod so the regression is observable in normal
+/// `cargo test` runs.
+#[cfg(test)]
+mod task_notification_kind_lifecycle_tests {
+    use super::{
+        TaskNotificationKind, merge_task_notification_kind, release_task_notification_kind,
+        task_notification_closes_background_child,
+    };
+
+    #[test]
+    fn kind_persists_while_other_children_remain() {
+        let mut child_ids: Vec<i64> = vec![100, 101];
+        let mut kind: Option<TaskNotificationKind> = None;
+        kind = merge_task_notification_kind(kind, TaskNotificationKind::Subagent);
+
+        let new_kind = TaskNotificationKind::Subagent;
+        let status = "completed";
+        kind = merge_task_notification_kind(kind, new_kind);
+        if task_notification_closes_background_child(new_kind, status) {
+            // Mirror the single-pop behavior of
+            // `close_next_tracked_background_child` at the call site.
+            let _ = child_ids.remove(0);
+            if child_ids.is_empty() {
+                kind = release_task_notification_kind(kind, new_kind);
+            }
+        }
+
+        assert_eq!(child_ids, vec![101]);
+        assert_eq!(
+            kind,
+            Some(TaskNotificationKind::Subagent),
+            "#1670 P2: kind must persist while other tracked children remain"
+        );
+
+        // Second terminal closes the queue, kind releases.
+        let new_kind = TaskNotificationKind::Subagent;
+        let status = "completed";
+        kind = merge_task_notification_kind(kind, new_kind);
+        if task_notification_closes_background_child(new_kind, status) {
+            let _ = child_ids.remove(0);
+            if child_ids.is_empty() {
+                kind = release_task_notification_kind(kind, new_kind);
+            }
+        }
+        assert!(child_ids.is_empty());
+        assert_eq!(
+            kind, None,
+            "#1670 P2: kind must release once the last child closes"
+        );
+    }
+
+    #[test]
+    fn kind_releases_immediately_when_queue_was_already_singleton() {
+        let mut child_ids: Vec<i64> = vec![42];
+        let mut kind: Option<TaskNotificationKind> = Some(TaskNotificationKind::Background);
+
+        let new_kind = TaskNotificationKind::Background;
+        let status = "aborted";
+        kind = merge_task_notification_kind(kind, new_kind);
+        if task_notification_closes_background_child(new_kind, status) {
+            let _ = child_ids.remove(0);
+            if child_ids.is_empty() {
+                kind = release_task_notification_kind(kind, new_kind);
+            }
+        }
+
+        assert!(child_ids.is_empty());
+        assert_eq!(
+            kind, None,
+            "#1670 P2: with a single tracked child, terminal status must release the kind"
+        );
+    }
+
+    #[test]
+    fn non_terminal_status_keeps_kind_and_does_not_pop() {
+        let mut child_ids: Vec<i64> = vec![1, 2];
+        let mut kind: Option<TaskNotificationKind> = None;
+        kind = merge_task_notification_kind(kind, TaskNotificationKind::Subagent);
+
+        let new_kind = TaskNotificationKind::Subagent;
+        let status = "started";
+        kind = merge_task_notification_kind(kind, new_kind);
+        if task_notification_closes_background_child(new_kind, status) {
+            let _ = child_ids.remove(0);
+            if child_ids.is_empty() {
+                kind = release_task_notification_kind(kind, new_kind);
+            }
+        }
+
+        assert_eq!(child_ids, vec![1, 2], "non-terminal must not pop");
+        assert_eq!(
+            kind,
+            Some(TaskNotificationKind::Subagent),
+            "non-terminal must keep kind"
+        );
+    }
+
+    #[test]
+    fn lower_priority_child_close_preserves_higher_priority_kind() {
+        let mut child_ids: Vec<i64> = vec![7];
+        let mut kind: Option<TaskNotificationKind> = Some(TaskNotificationKind::MonitorAutoTurn);
+
+        let new_kind = TaskNotificationKind::Subagent;
+        kind = merge_task_notification_kind(kind, new_kind);
+        if task_notification_closes_background_child(new_kind, "completed") {
+            let _ = child_ids.remove(0);
+            if child_ids.is_empty() {
+                kind = release_task_notification_kind(kind, new_kind);
+            }
+        }
+
+        assert!(child_ids.is_empty());
+        assert_eq!(
+            kind,
+            Some(TaskNotificationKind::MonitorAutoTurn),
+            "#1683: lower-priority child terminal notification must not clear a higher-priority active kind"
+        );
+    }
+}


### PR DESCRIPTION
Part of #3479 item-2 (giant-file decomposition). Behavior-preserving verbatim move.

Moves 5 task-notification lifecycle fns (merge/release_task_notification_kind, close_next/all_tracked_background_children, task_notification_closes_background_child) + tests out of `turn_bridge/mod.rs` into sibling `turn_bridge/task_notification_lifecycle.rs`.
- turn_bridge/mod.rs 6535→6448 prod LoC (ratchet lowered). new file 105 prod/117 test.
- fns pub(in crate::services::discord) (needed for re-export; pub(super) hit E0364), `pub(super) use` re-export scopes effective visibility to turn_bridge subtree (all callers). No super:: re-depth needed (bare refs via `use super::*`). Verbatim.
- Gates: build/fmt/clippy clean (7 known sqlite warnings), turn_bridge tests 181/181, audit rc 0, ci rc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)