### PR TITLE
refactor(#3479): extract launch parsing from tui_prompt_relay.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -529,6 +529,7 @@ src/
 │   │   │   ├── anchor_completion.rs
 │   │   │   ├── idle_transcript_scan.rs
 │   │   │   ├── injected_prompt_policy.rs
+│   │   │   ├── launch_script.rs
 │   │   │   └── rehydration.rs
 │   │   ├── turn_bridge/
 │   │   │   ├── cancel_finalize_policy.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -507,7 +507,7 @@
     Moved unit tests live in sibling `utf8_chunk_decoder_tests.rs` /
     `terminal_readiness_tests.rs`; both child modules sit under the
     `tmux_watcher/**` 700-line namespace cap.
-  - `src/services/discord/tui_prompt_relay.rs` (4458 production lines; #3296
+  - `src/services/discord/tui_prompt_relay.rs` (4376 production lines; #3296
     codex r1+r2: the ABORT cleanup hook pins the foreign prior inflight's
     identity — the live row at the record instant, or the worker's LAST-VIEW
     identity when that row just vanished — and persists the marker via
@@ -721,9 +721,10 @@
     moved to `tui_prompt_relay/rehydration.rs` (deps reached via `use super::*;`,
     names re-imported so the call sites + tests stay byte-identical). The sibling
     helpers shared with non-rehydration code (`claude_tui_runtime_binding_matches_launch`,
-    `resolve_rehydrated_claude_tmux_channel_id`, `parse_claude_tui_launch_script`,
-    `claude_tui_rehydrate_start_offset`, the `ClaudeTuiLaunchInfo` struct, the
-    `DEAD_ORPHANED_PANE_PROBE_*` consts) STAY in this root. Frozen baseline 5142 ->
+    `resolve_rehydrated_claude_tmux_channel_id`, `claude_tui_rehydrate_start_offset`, the
+    `DEAD_ORPHANED_PANE_PROBE_*` consts) STAY in this root (`parse_claude_tui_launch_script`
+    + the `ClaudeTuiLaunchInfo` struct later moved to `tui_prompt_relay/launch_script.rs`
+    in #3479 launch-script, see below). Frozen baseline 5142 ->
     4630 (-512, locks in the shrink; zero logic change). #3479 item-2
     (behavior-preserving extraction): the live-relay TUI-direct prompt anchor
     COMPLETION lifecycle (`⏳ → ✅`) cluster — `should_complete_tui_direct_anchor_lifecycle`,
@@ -762,6 +763,18 @@
     the three externally-called helpers are `pub(in crate::services::discord)` and
     re-exported by the parent, the relay-internal drain decision/enum stay
     `pub(super)`; below the giant-file threshold).
+  - `src/services/discord/tui_prompt_relay/launch_script.rs` (107 prod lines;
+    #3479 launch-script: the Claude TUI launch-*script* parsing helpers — the
+    parsed `ClaudeTuiLaunchInfo` record, `parse_claude_tui_launch_script` +
+    `parse_claude_tui_launch_script_content`, and the minimal single-quote
+    `shell_words_from_line` shell-word splitter — extracted verbatim from
+    `tui_prompt_relay.rs` (all `#[cfg(unix)]`). Deps reached via `use super::*;`;
+    `parse_claude_tui_launch_script` + the `ClaudeTuiLaunchInfo` record are `pub(super)`
+    and `parse_claude_tui_launch_script` is re-imported by the parent so the
+    `claude_tui_launch_context` caller and the sibling `rehydration` module keep
+    byte-identical call sites, while the module-internal
+    `parse_claude_tui_launch_script_content` + `shell_words_from_line` stay private;
+    below the giant-file threshold).
   - `src/services/discord/idle_recap.rs` (1319 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -171,7 +171,13 @@
 # the giant threshold), reached via re-import so the call sites stay
 # byte-identical. Lowers the frozen baseline 4630 -> 4458 (-172). Locks in the
 # shrink win (zero logic change).
-"src/services/discord/tui_prompt_relay.rs" = 4458
+# #3479 launch-script (behavior-preserving extraction): the Claude TUI
+# launch-*script* parsing cluster (`ClaudeTuiLaunchInfo`, `parse_claude_tui_launch_script`
+# + `_content`, and the `shell_words_from_line` single-quote splitter) moved
+# verbatim to `tui_prompt_relay/launch_script.rs` (107 prod LoC, below the giant
+# threshold), reached via re-import so the call sites stay byte-identical. Lowers
+# the frozen baseline 4458 -> 4376 (-82). Locks in the shrink win (zero logic change).
+"src/services/discord/tui_prompt_relay.rs" = 4376
 # #3038: lowered 4728 -> 4657 (-71) as `SensitivityState` (definition + impl)
 # moved to the `voice_sensitivity` sibling module. Locks in the shrink win.
 # #3038 VoiceBargeInRuntime S1: lowered 4657 -> 4350 (-307) as the STT

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -91,6 +91,19 @@ pub(in crate::services::discord) use self::anchor_completion::{
     should_complete_tui_direct_anchor_lifecycle,
 };
 
+// #3479: the Claude TUI launch-*script* parsing cluster (`ClaudeTuiLaunchInfo`,
+// the file/content parsers, and the single-quote shell-word splitter) moved
+// verbatim to a capped sibling module. Every item is unix-only, so the module
+// decl and the re-import are `#[cfg(unix)]`-gated. Only
+// `parse_claude_tui_launch_script` is reached from outside the child (the parent
+// `claude_tui_launch_context` caller and, via this parent's `use super::*;`
+// glob, the sibling `rehydration` module), so it alone is re-imported here to
+// keep those call sites byte-identical.
+#[cfg(unix)]
+mod launch_script;
+#[cfg(unix)]
+use self::launch_script::parse_claude_tui_launch_script;
+
 const SSH_DIRECT_PROMPT_PREVIEW_LIMIT: usize = 1500;
 const CODEX_IDLE_ROLLOUT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL: Duration = Duration::from_secs(5);
@@ -3080,101 +3093,6 @@ fn advance_claude_tmux_runtime_binding_offset(
         transcript_path.to_str().unwrap_or_default(),
         offset,
     )
-}
-
-#[cfg(unix)]
-#[derive(Debug, PartialEq, Eq)]
-struct ClaudeTuiLaunchInfo {
-    working_dir: PathBuf,
-    session_id: String,
-}
-
-#[cfg(unix)]
-fn parse_claude_tui_launch_script(path: &Path) -> Result<ClaudeTuiLaunchInfo, String> {
-    let script = std::fs::read_to_string(path)
-        .map_err(|error| format!("read Claude TUI launch script {}: {error}", path.display()))?;
-    parse_claude_tui_launch_script_content(&script)
-        .ok_or_else(|| format!("parse Claude TUI launch script {}", path.display()))
-}
-
-#[cfg(unix)]
-fn parse_claude_tui_launch_script_content(script: &str) -> Option<ClaudeTuiLaunchInfo> {
-    let mut working_dir: Option<PathBuf> = None;
-    let mut session_id: Option<String> = None;
-    for line in script.lines() {
-        let words = shell_words_from_line(line.trim());
-        if words.first().is_some_and(|word| word == "cd") {
-            if let Some(dir) = words.get(1).filter(|value| !value.trim().is_empty()) {
-                working_dir = Some(PathBuf::from(dir));
-            }
-            continue;
-        }
-        if !words.first().is_some_and(|word| word == "exec") {
-            continue;
-        }
-        for pair in words.windows(2) {
-            if matches!(pair[0].as_str(), "--session-id" | "--resume") && !pair[1].trim().is_empty()
-            {
-                session_id = Some(pair[1].clone());
-                break;
-            }
-        }
-    }
-    Some(ClaudeTuiLaunchInfo {
-        working_dir: working_dir?,
-        session_id: session_id?,
-    })
-}
-
-#[cfg(unix)]
-fn shell_words_from_line(line: &str) -> Vec<String> {
-    let mut words = Vec::new();
-    let mut current = String::new();
-    let mut saw_word = false;
-    let mut in_single = false;
-    let mut chars = line.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if in_single {
-            if ch == '\'' {
-                in_single = false;
-            } else {
-                current.push(ch);
-            }
-            saw_word = true;
-            continue;
-        }
-
-        if ch.is_whitespace() {
-            if saw_word {
-                words.push(std::mem::take(&mut current));
-                saw_word = false;
-            }
-            continue;
-        }
-
-        match ch {
-            '\'' => {
-                in_single = true;
-                saw_word = true;
-            }
-            '\\' => {
-                if let Some(next) = chars.next() {
-                    current.push(next);
-                    saw_word = true;
-                }
-            }
-            _ => {
-                current.push(ch);
-                saw_word = true;
-            }
-        }
-    }
-
-    if saw_word {
-        words.push(current);
-    }
-    words
 }
 
 #[cfg(unix)]
@@ -6930,24 +6848,6 @@ mod tests {
         assert!(
             gateway.can_chain_locally(),
             "bridge adapter still owns Discord delivery for the already-submitted turn"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn parses_claude_tui_launch_script_content() {
-        let script = concat!(
-            "#!/bin/bash\n",
-            "cd '/tmp/project'\\''s dir'\n",
-            "exec '/usr/local/bin/claude' '--dangerously-skip-permissions' '--session-id' '01234567-89ab-cdef-0123-456789abcdef' '--settings' '/tmp/settings.json'\n",
-        );
-
-        assert_eq!(
-            parse_claude_tui_launch_script_content(script),
-            Some(ClaudeTuiLaunchInfo {
-                working_dir: PathBuf::from("/tmp/project's dir"),
-                session_id: "01234567-89ab-cdef-0123-456789abcdef".to_string(),
-            })
         );
     }
 

--- a/src/services/discord/tui_prompt_relay/launch_script.rs
+++ b/src/services/discord/tui_prompt_relay/launch_script.rs
@@ -1,0 +1,129 @@
+//! #3479: Claude TUI launch-*script* parsing helpers.
+//!
+//! Behavior-preserving extraction of the launch-script parsing cluster from the
+//! `tui_prompt_relay` parent module: the parsed `ClaudeTuiLaunchInfo` record, the
+//! file/content parsers, and the minimal single-quote shell-word splitter. The
+//! bodies stay byte-identical; every dependency is reached via `use super::*;`.
+//! `parse_claude_tui_launch_script` is re-imported by the parent so the
+//! `claude_tui_launch_context` caller and the sibling `rehydration` module (via
+//! the parent's glob) keep byte-identical call sites.
+
+use super::*;
+
+#[cfg(unix)]
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ClaudeTuiLaunchInfo {
+    pub(super) working_dir: PathBuf,
+    pub(super) session_id: String,
+}
+
+#[cfg(unix)]
+pub(super) fn parse_claude_tui_launch_script(path: &Path) -> Result<ClaudeTuiLaunchInfo, String> {
+    let script = std::fs::read_to_string(path)
+        .map_err(|error| format!("read Claude TUI launch script {}: {error}", path.display()))?;
+    parse_claude_tui_launch_script_content(&script)
+        .ok_or_else(|| format!("parse Claude TUI launch script {}", path.display()))
+}
+
+#[cfg(unix)]
+fn parse_claude_tui_launch_script_content(script: &str) -> Option<ClaudeTuiLaunchInfo> {
+    let mut working_dir: Option<PathBuf> = None;
+    let mut session_id: Option<String> = None;
+    for line in script.lines() {
+        let words = shell_words_from_line(line.trim());
+        if words.first().is_some_and(|word| word == "cd") {
+            if let Some(dir) = words.get(1).filter(|value| !value.trim().is_empty()) {
+                working_dir = Some(PathBuf::from(dir));
+            }
+            continue;
+        }
+        if !words.first().is_some_and(|word| word == "exec") {
+            continue;
+        }
+        for pair in words.windows(2) {
+            if matches!(pair[0].as_str(), "--session-id" | "--resume") && !pair[1].trim().is_empty()
+            {
+                session_id = Some(pair[1].clone());
+                break;
+            }
+        }
+    }
+    Some(ClaudeTuiLaunchInfo {
+        working_dir: working_dir?,
+        session_id: session_id?,
+    })
+}
+
+#[cfg(unix)]
+fn shell_words_from_line(line: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut saw_word = false;
+    let mut in_single = false;
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            } else {
+                current.push(ch);
+            }
+            saw_word = true;
+            continue;
+        }
+
+        if ch.is_whitespace() {
+            if saw_word {
+                words.push(std::mem::take(&mut current));
+                saw_word = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' => {
+                in_single = true;
+                saw_word = true;
+            }
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                    saw_word = true;
+                }
+            }
+            _ => {
+                current.push(ch);
+                saw_word = true;
+            }
+        }
+    }
+
+    if saw_word {
+        words.push(current);
+    }
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_claude_tui_launch_script_content() {
+        let script = concat!(
+            "#!/bin/bash\n",
+            "cd '/tmp/project'\\''s dir'\n",
+            "exec '/usr/local/bin/claude' '--dangerously-skip-permissions' '--session-id' '01234567-89ab-cdef-0123-456789abcdef' '--settings' '/tmp/settings.json'\n",
+        );
+
+        assert_eq!(
+            parse_claude_tui_launch_script_content(script),
+            Some(ClaudeTuiLaunchInfo {
+                working_dir: PathBuf::from("/tmp/project's dir"),
+                session_id: "01234567-89ab-cdef-0123-456789abcdef".to_string(),
+            })
+        );
+    }
+}


### PR DESCRIPTION
Behavior-preserving verbatim extraction (#3479 giant-file decomposition).

Moves the claude TUI launch-script parsing cluster (`ClaudeTuiLaunchInfo` + 3 fns + test, 107 prod LoC) from `tui_prompt_relay.rs` into new sibling submodule `tui_prompt_relay/launch_script.rs`. Visibility/path/wiring only — no logic change.

- baseline: tui_prompt_relay.rs 4458 → 4376
- cargo check rc0, focused test passed, audit --check rc0, ci-script-checks rc0

🤖 Generated with [Claude Code](https://claude.com/claude-code)