### PR TITLE
fix(#3521): keep TUI turn/footer alive while a background agent is pending

### DIFF
--- a/src/services/discord/tmux_watcher/completion_gate.rs
+++ b/src/services/discord/tmux_watcher/completion_gate.rs
@@ -240,12 +240,24 @@ pub(in crate::services::discord) async fn run_tui_completion_gate(
                 let tmux_session_name = tmux_session_name.to_string();
                 let inflight = inflight.clone();
                 move || {
-                    matched_session_structured_ready_for_input(
+                    let jsonl_ready = matched_session_structured_ready_for_input(
                         &provider,
                         inflight.as_ref(),
                         &tmux_session_name,
                     )
-                    .is_some_and(crate::services::tui_turn_state::TuiReadyState::is_ready)
+                    .is_some_and(crate::services::tui_turn_state::TuiReadyState::is_ready);
+                    // #3521: a detached background agent leaves the foreground JSONL idle while
+                    // it keeps running; hold the turn (and its live footer panel) open until the
+                    // pane no longer shows the `Waiting for N background agent` chrome — otherwise
+                    // the turn finalizes and the panel vanishes mid-run. Capture failure => not
+                    // pending => complete normally (no stuck turn; STALL-WATCHDOG backstops a
+                    // forever-pending agent, completion-footer TTL caps animation at ~1h).
+                    jsonl_ready
+                        && !crate::services::platform::tmux::capture_pane(&tmux_session_name, 0)
+                            .map(|pane| {
+                                crate::services::tmux_common::tmux_capture_indicates_claude_tui_background_agent_pending(&pane)
+                            })
+                            .unwrap_or(false)
                 }
             }),
         )

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -214,6 +214,31 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     }) || tmux_recent_lines_show_claude_tui_active_work(recent)
 }
 
+/// #3521: `true` when the Claude TUI pane shows a BACKGROUND AGENT still pending — the
+/// `✻ Waiting for N background agent(s) to finish` footer, or a fresh `Backgrounded agent`
+/// spawn line. Distinct from `tmux_capture_indicates_claude_tui_busy`: a detached background
+/// agent leaves the FOREGROUND turn JSONL-idle (no `esc to interrupt`, no spinner) while it
+/// keeps running, so the completion gate must treat this as not-yet-idle to keep the live
+/// footer/turn alive — otherwise the turn finalizes and the panel vanishes mid-run (#3521).
+/// Markers are TUI chrome (`waiting for` + `background agent`, or `backgrounded agent`),
+/// anchored tightly so assistant body text that merely mentions a "background agent" (e.g.
+/// the voice handoff line) does NOT trip a false keep-alive.
+pub(crate) fn tmux_capture_indicates_claude_tui_background_agent_pending(capture: &str) -> bool {
+    let non_empty = capture
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>();
+    if non_empty.is_empty() {
+        return false;
+    }
+    let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
+    non_empty[start..].iter().any(|line| {
+        let lower = line.to_ascii_lowercase();
+        (lower.contains("waiting for") && lower.contains("background agent"))
+            || lower.contains("backgrounded agent")
+    })
+}
+
 /// `true` when `line` is a Claude TUI spinner progress footer: a leading spinner
 /// glyph (the rotating set the TUI cycles through) directly followed by a work
 /// verb. Anchoring the verb to the spinner glyph is what distinguishes the TUI
@@ -1351,6 +1376,26 @@ another line of prior output";
         assert!(!tmux_capture_indicates_claude_tui_busy(capture));
         assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
             capture
+        ));
+    }
+
+    #[test]
+    fn background_agent_pending_detects_chrome_not_body_text() {
+        // #3521: the `✻ Waiting for N background agent to finish` footer and the
+        // `Backgrounded agent` spawn line ARE detected (keep the turn/footer alive);
+        // foreground-idle panes and assistant prose merely mentioning a background
+        // agent are NOT (no false keep-alive → no stuck turn).
+        assert!(tmux_capture_indicates_claude_tui_background_agent_pending(
+            "⏺ reading docs\n✻ Waiting for 1 background agent to finish\n❯ "
+        ));
+        assert!(tmux_capture_indicates_claude_tui_background_agent_pending(
+            "⏺ Agent(read story)\n  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)\n❯ "
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_background_agent_pending(
+            "⏺ done.\n❯ \n  🤖 Opus"
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_background_agent_pending(
+            "I will hand that to the background agent.\n❯ "
         ));
     }
 


### PR DESCRIPTION
Fixes #3521 — the live footer/Subagents panel vanishes during a Claude Code background-agent run (result then arrives minutes late via idle relay).

## Root cause
A background agent (`✻ Waiting for N background agent to finish` / `Backgrounded agent`) leaves the FOREGROUND turn JSONL-idle while it runs. `run_tui_completion_gate` read JSONL-only → ConfirmedIdle → finalized the turn → panel gone for the whole run.

## Fix
- `tmux_common.rs`: `tmux_capture_indicates_claude_tui_background_agent_pending` (tight TUI-chrome markers; body-text mentioning a background agent does not trip it — unit test).
- `completion_gate.rs`: gate idle = `jsonl_ready && !pane_shows_background_agent_pending`. Capture failure ⇒ not pending ⇒ complete normally (no stuck turn); STALL-WATCHDOG + completion-footer TTL (~1h) backstop a forever-pending agent.

- cargo check rc0, new test passes, audit --check rc0, ci-script rc0.
- Note: 2 pre-existing `idle_suggestion` sentinel-test failures also fail on clean main (verified via stash) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)