### PR TITLE
fix(#3524): restore idle/draft detection for finished 0-tool TUI turns

### DIFF
--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -49,6 +49,13 @@ fn tmux_lines_after_claude_prompt_show_completed_history(lines: &[&str]) -> bool
 }
 
 fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) -> bool {
+    // POST-FINISH idle ghost chrome ONLY (see
+    // `tmux_capture_indicates_claude_tui_actively_streaming`). A `Tools: 0 done`
+    // footer is deliberately NOT treated as busy here: a turn that finished having
+    // run zero tools also prints it, and suppressing that broke idle/draft
+    // detection for 0-tool turns (#3524). The freshly-submitted-vs-idle guard
+    // (a just-submitted prompt must not read as READY) lives in the
+    // `ready_for_input` caller via `..._show_freshly_submitted_footer` (#3463).
     let busy = lines.iter().any(|line| {
         let trimmed = trim_prompt_line(line);
         let lower = trimmed.to_ascii_lowercase();
@@ -56,12 +63,6 @@ fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) ->
             || lower.contains("processing")
             || lower.contains("thinking")
             || lower.contains("running")
-            // `Tools: 0 done` is a freshly-submitted, still-starting turn (no tools
-            // run yet), NOT idle chrome. Without this, a just-submitted prompt
-            // followed by a separator + the `bypass permissions` banner would
-            // satisfy `idle_footer` (via the banner) and read as ready, letting a
-            // follow-up inject into a turn that has not produced output yet (#3463).
-            || trimmed.contains("Tools: 0 done")
     });
     if busy {
         return false;
@@ -89,6 +90,18 @@ fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) ->
     separator && idle_footer
 }
 
+/// #3463/#3524: a just-submitted prompt's footer shows `Tools: 0 done` (no tools
+/// run yet) while output has not begun. For READINESS this is a RUNNING signal —
+/// a follow-up must not inject into it — but it is NOT a post-finish idle signal
+/// (a turn that finished having run zero tools also prints `Tools: 0 done`), so
+/// this guard lives only in the `ready_for_input` caller, never in the shared
+/// idle-suggestion chrome detector (which by design reports post-finish ghost).
+fn tmux_lines_after_claude_prompt_show_freshly_submitted_footer(lines: &[&str]) -> bool {
+    lines
+        .iter()
+        .any(|line| trim_prompt_line(line).contains("Tools: 0 done"))
+}
+
 pub(crate) fn tmux_capture_indicates_claude_tui_ready_for_input(capture: &str) -> bool {
     let non_empty = capture
         .lines()
@@ -111,6 +124,29 @@ pub(crate) fn tmux_capture_indicates_claude_tui_ready_for_input(capture: &str) -
         .any(|l| tmux_line_is_claude_tui_ready_prompt(l))
     {
         return true;
+    }
+
+    // #3463/#3524: if the BOTTOM-most prompt is a just-submitted, still-running
+    // turn (footer shows `Tools: 0 done` with no produced output after it), the
+    // pane is NOT ready — even when an older completed prompt sits higher in the
+    // scrollback. Checked GLOBALLY on the latest prompt so the `.any` scan below
+    // cannot flip readiness via an earlier historical prompt whose own
+    // `after_prompt` happens to contain completed output (codex #3524). A
+    // bypass-permissions banner alone would otherwise satisfy idle chrome and let
+    // a follow-up inject into a turn that has not produced output (#3463).
+    // Empty-composer ready panes are already returned above; a finished 0-tool
+    // turn (idle suggestion) is intentionally not-ready here but is still
+    // reported by `tmux_capture_indicates_claude_tui_idle_suggestion`.
+    if let Some(last_prompt_idx) = recent_forward
+        .iter()
+        .rposition(|line| trim_prompt_line(line).starts_with(CLAUDE_TUI_PROMPT_MARKER))
+    {
+        let tail = &recent_forward[last_prompt_idx + 1..];
+        if tmux_lines_after_claude_prompt_show_freshly_submitted_footer(tail)
+            && !tmux_lines_after_claude_prompt_show_completed_history(tail)
+        {
+            return false;
+        }
     }
 
     recent_forward
@@ -1204,6 +1240,52 @@ assistant output
   CLAUDE.md: 1, MCP: 2 │ Tools: 0 done";
 
         assert!(tmux_capture_indicates_claude_tui_prompt_draft(capture));
+        assert!(!tmux_capture_indicates_claude_tui_ready_for_input(capture));
+    }
+
+    #[test]
+    fn ready_for_input_rejects_freshly_submitted_prompt_with_bypass_banner() {
+        // #3463/#3524: the banner-present companion to
+        // `claude_prompt_draft_detector_treats_running_submitted_prompt_as_not_ready`.
+        // A just-submitted prompt (footer `Tools: 0 done`, no output produced
+        // yet) renders the `bypass permissions` banner, which on its own
+        // satisfies idle chrome. It must STILL NOT read as ready-for-input —
+        // otherwise a follow-up injects into a turn that has not produced output.
+        // This is what keeps #3524's idle-suggestion relaxation from regressing
+        // #3463; the freshly-submitted guard lives in `ready_for_input`, so a
+        // finished 0-tool turn (see `claude_idle_suggestion_prompt_is_not_prompt_draft`)
+        // is still reported as idle while this running one is not ready.
+        let capture = "\
+⏺ previous response
+✻ Brewed for 2s
+─────────────────────────────────────────────────────────────────────────────
+❯ direct prompt that has just been submitted
+─────────────────────────────────────────────────────────────────────────────
+  🤖 Opus(H) │ ██░░░░░░░░ │ 24%
+  CLAUDE.md: 1, MCP: 2 │ Tools: 0 done
+  ⏵⏵ bypass permissions on";
+
+        assert!(!tmux_capture_indicates_claude_tui_ready_for_input(capture));
+    }
+
+    #[test]
+    fn ready_for_input_rejects_fresh_submit_below_older_completed_prompt() {
+        // codex #3524: the `.any` readiness scan must NOT let an OLDER historical
+        // prompt — whose own `after_prompt` contains completed output — flip
+        // readiness to true while the BOTTOM-most prompt is a just-submitted,
+        // still-running turn (`Tools: 0 done`, no output). Otherwise the #3463
+        // follow-up-injection race returns for multi-prompt panes.
+        let capture = "\
+❯ previous prompt
+⏺ previous response
+✻ Brewed for 2s
+─────────────────────────────────────────────────────────────────────────────
+❯ direct prompt that has just been submitted
+─────────────────────────────────────────────────────────────────────────────
+  🤖 Opus(H) │ ██░░░░░░░░ │ 24%
+  CLAUDE.md: 1, MCP: 2 │ Tools: 0 done
+  ⏵⏵ bypass permissions on";
+
         assert!(!tmux_capture_indicates_claude_tui_ready_for_input(capture));
     }
 


### PR DESCRIPTION
## Problem (#3524 — regression from #3463)

#3463 added `|| trimmed.contains("Tools: 0 done")` to the `busy` check inside the **shared** `tmux_lines_after_claude_prompt_show_idle_suggestion_chrome`. Intent: a freshly-submitted prompt (footer `Tools: 0 done`, no output yet) must not read as ready (else a follow-up injects into a turn that hasn't produced output).

But that guard is too broad: a turn that **finished having run zero tools** also prints `Tools: 0 done`. The shared helper is also consumed by `idle_suggestion` and the draft detector, so finished-0-tool panes stopped being recognized as post-finish idle ghost — a leftover `❯ …` suggestion was misclassified as an editable composer draft. Two sentinel tests began failing:
- `claude_idle_suggestion_prompt_is_not_prompt_draft`
- `actively_streaming_rejects_idle_suggestion_chrome`

In `after_prompt` a finished-0-tool pane and a freshly-submitted pane are byte-identical, so no change to the shared helper alone can distinguish them.

## Fix (relocate the guard to the readiness caller)

- Remove `Tools: 0 done` from the shared `idle_suggestion_chrome` busy check — it again reports post-finish idle chrome for 0-tool turns.
- Add `tmux_lines_after_claude_prompt_show_freshly_submitted_footer`.
- In `ready_for_input` ONLY, add a **global** pre-check on the **bottom-most** prompt's footer: if it is a freshly-submitted footer (`Tools: 0 done`, no completed output after it) → not ready. This preserves the #3463 anti-injection guard for the readiness path while letting idle/draft detection treat finished-0-tool panes correctly.

## codex adversarial review
- r1 caught a real `.any()` bypass (an older completed prompt could flip readiness to true while the bottom prompt was a fresh-submit). Fixed by making the guard a global pre-check on the latest prompt.
- r2: **VERDICT: CLEAN**.

## Tests
Restores the 2 regressed sentinel tests; adds 2 regression locks:
- `ready_for_input_rejects_freshly_submitted_prompt_with_bypass_banner`
- `ready_for_input_rejects_fresh_submit_below_older_completed_prompt`

All 38 `tmux_common` sentinel tests pass; `audit --check`, `ci-script-checks`, `fmt --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)