### PR TITLE
refactor(#3479): extract panel-lifecycle rendering from turn_bridge/mod.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -552,6 +552,7 @@ src/
 │   │   │   ├── memory_lifecycle.rs
 │   │   │   ├── mod.rs
 │   │   │   ├── output_lifecycle.rs
+│   │   │   ├── panel_lifecycle.rs
 │   │   │   ├── recall_feedback.rs
 │   │   │   ├── recovery_text.rs
 │   │   │   ├── retry_state.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -930,9 +930,11 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6448 prod lines; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6239 prod lines; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
-    turn loop. Registered giant-file (#3038 decompose target — see
+    turn loop. #3479 extracted the task/session-panel line rendering +
+    active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.
+    Registered giant-file (#3038 decompose target — see
     `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).
     It surfaced as a giant only after #3028 fixed the prod/test splitter: an
     unterminated char-literal scan on a Rust lifetime (`&'a self`) inside the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -114,7 +114,7 @@
 # spawn_watcher_orphan_spinner_cleanup_retry) into
 # `turn_bridge/watcher_orphan_cleanup.rs` (both re-exported, call sites
 # byte-identical). Locks in the shrink win (ratchet down only).
-"src/services/discord/turn_bridge/mod.rs" = 6448
+"src/services/discord/turn_bridge/mod.rs" = 6239
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -4,6 +4,7 @@ mod context_window;
 mod headless_delivery;
 mod memory_lifecycle;
 mod output_lifecycle;
+mod panel_lifecycle;
 mod recall_feedback;
 mod recovery_text;
 mod retry_state;
@@ -41,6 +42,10 @@ use crate::services::observability::session_inventory::{
 };
 use crate::services::provider::cancel_requested;
 use output_lifecycle::{BridgeOutputOwner, classify_bridge_output_owner};
+use panel_lifecycle::{
+    child_progress_line, ensure_active_placeholder_card, first_request_line,
+    refresh_session_panel_line_from_lifecycle, refresh_task_panel_line_from_dispatch,
+};
 use std::collections::VecDeque;
 
 // Re-exports for pub(super) items used by sibling modules in the discord package
@@ -209,220 +214,6 @@ fn sync_inflight_restart_mode_from_cancel(
         None => inflight_state.clear_restart_mode(),
     }
     true
-}
-
-fn first_request_line(user_text: &str) -> Option<String> {
-    user_text
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(str::to_string)
-}
-
-async fn child_progress_line(
-    pg_pool: Option<&sqlx::PgPool>,
-    parent_session_key: Option<&str>,
-) -> Option<String> {
-    let (Some(pg_pool), Some(parent_session_key)) = (pg_pool, parent_session_key) else {
-        return None;
-    };
-    match load_child_inventory_by_parent_key_pg(pg_pool, parent_session_key).await {
-        Ok(summary) => format_child_inventory_progress(&summary, chrono::Utc::now()),
-        Err(error) => {
-            tracing::warn!(
-                "Failed to load background child inventory for {}: {}",
-                parent_session_key,
-                error
-            );
-            None
-        }
-    }
-}
-
-async fn refresh_session_panel_line_from_lifecycle(
-    shared: &SharedData,
-    channel_id: ChannelId,
-    turn_id: &str,
-    tmux_session_name: Option<&str>,
-) -> bool {
-    let Some(pg_pool) = shared.pg_pool.as_ref() else {
-        return false;
-    };
-    // `session_panel_instance_key` lives in the unix-only `tmux` module; on
-    // non-unix targets there is no tmux session, so the instance key is None.
-    #[cfg(unix)]
-    let session_instance_key = tmux_session_name
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-        .and_then(super::tmux::session_panel_instance_key);
-    #[cfg(not(unix))]
-    let session_instance_key = {
-        let _ = tmux_session_name;
-        Option::<String>::None
-    };
-    let channel_id_text = channel_id.get().to_string();
-    match crate::services::observability::turn_lifecycle::load_latest_session_lifecycle_event(
-        pg_pool,
-        &channel_id_text,
-        turn_id,
-    )
-    .await
-    {
-        Ok(Some(event)) => shared
-            .ui
-            .placeholder_live_events
-            .set_session_panel_lifecycle_event(
-                channel_id,
-                session_instance_key.as_deref(),
-                &event.kind,
-                &event.details_json,
-            ),
-        Ok(None) => shared
-            .ui
-            .placeholder_live_events
-            .clear_session_panel(channel_id),
-        Err(error) => {
-            tracing::debug!(
-                "[turn_bridge] failed to load session lifecycle line for turn {} in channel {}: {}",
-                turn_id,
-                channel_id,
-                error
-            );
-            false
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TaskPanelDispatchMetadata {
-    card_id: Option<String>,
-    dispatch_type: Option<String>,
-    claim_owner: Option<String>,
-    card_title: Option<String>,
-    dispatch_title: Option<String>,
-    github_issue_number: Option<i64>,
-}
-
-async fn load_task_panel_dispatch_metadata(
-    pg_pool: Option<&sqlx::PgPool>,
-    dispatch_id: &str,
-) -> Result<Option<TaskPanelDispatchMetadata>, String> {
-    let Some(pg_pool) = pg_pool else {
-        return Ok(None);
-    };
-    let row = sqlx::query(
-        "SELECT td.kanban_card_id,
-                td.dispatch_type,
-                td.title AS dispatch_title,
-                kc.title AS card_title,
-                kc.github_issue_number,
-                dox.claim_owner
-         FROM task_dispatches td
-         LEFT JOIN kanban_cards kc ON kc.id = td.kanban_card_id
-         LEFT JOIN dispatch_outbox dox ON dox.dispatch_id = td.id
-         WHERE td.id = $1
-         ORDER BY dox.created_at DESC NULLS LAST
-         LIMIT 1",
-    )
-    .bind(dispatch_id)
-    .fetch_optional(pg_pool)
-    .await
-    .map_err(|error| format!("load task panel dispatch metadata for {dispatch_id}: {error}"))?;
-
-    row.map(|row| {
-        Ok::<TaskPanelDispatchMetadata, String>(TaskPanelDispatchMetadata {
-            card_id: row
-                .try_get("kanban_card_id")
-                .map_err(|error| format!("decode task panel card_id for {dispatch_id}: {error}"))?,
-            dispatch_type: row.try_get("dispatch_type").map_err(|error| {
-                format!("decode task panel dispatch_type for {dispatch_id}: {error}")
-            })?,
-            claim_owner: row.try_get("claim_owner").map_err(|error| {
-                format!("decode task panel claim_owner for {dispatch_id}: {error}")
-            })?,
-            card_title: row.try_get("card_title").map_err(|error| {
-                format!("decode task panel card_title for {dispatch_id}: {error}")
-            })?,
-            dispatch_title: row.try_get("dispatch_title").map_err(|error| {
-                format!("decode task panel dispatch_title for {dispatch_id}: {error}")
-            })?,
-            github_issue_number: row.try_get("github_issue_number").map_err(|error| {
-                format!("decode task panel github_issue_number for {dispatch_id}: {error}")
-            })?,
-        })
-    })
-    .transpose()
-}
-
-async fn refresh_task_panel_line_from_dispatch(
-    shared: &SharedData,
-    channel_id: ChannelId,
-    dispatch_id: &str,
-) -> bool {
-    let dispatch_id = dispatch_id.trim();
-    if dispatch_id.is_empty() {
-        return false;
-    }
-    let metadata =
-        match load_task_panel_dispatch_metadata(shared.pg_pool.as_ref(), dispatch_id).await {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                tracing::debug!(
-                    "[turn_bridge] failed to load task line for dispatch {} in channel {}: {}",
-                    dispatch_id,
-                    channel_id,
-                    error
-                );
-                None
-            }
-        };
-    shared.ui.placeholder_live_events.set_task_panel_info(
-        channel_id,
-        crate::services::discord::placeholder_live_events::TaskPanelInfo {
-            dispatch_id,
-            card_id: metadata.as_ref().and_then(|value| value.card_id.as_deref()),
-            dispatch_type: metadata
-                .as_ref()
-                .and_then(|value| value.dispatch_type.as_deref()),
-            owner_instance_id: metadata
-                .as_ref()
-                .and_then(|value| value.claim_owner.as_deref()),
-            card_title: metadata
-                .as_ref()
-                .and_then(|value| value.card_title.as_deref()),
-            dispatch_title: metadata
-                .as_ref()
-                .and_then(|value| value.dispatch_title.as_deref()),
-            github_issue_number: metadata
-                .as_ref()
-                .and_then(|value| value.github_issue_number),
-        },
-    )
-}
-
-async fn ensure_active_placeholder_card<G: TurnGateway + ?Sized>(
-    shared: &SharedData,
-    gateway: &G,
-    key: super::placeholder_controller::PlaceholderKey,
-    input: super::placeholder_controller::PlaceholderActiveInput,
-) -> super::placeholder_controller::PlaceholderControllerOutcome {
-    if shared.ui.placeholder_live_events_enabled
-        && let Some(block) = shared
-            .ui
-            .placeholder_live_events
-            .render_block(key.channel_id)
-    {
-        return shared
-            .ui
-            .placeholder_controller
-            .ensure_active_with_live_events(gateway, key, input, block)
-            .await;
-    }
-    shared
-        .ui
-        .placeholder_controller
-        .ensure_active(gateway, key, input)
-        .await
 }
 
 fn record_placeholder_live_event(

--- a/src/services/discord/turn_bridge/panel_lifecycle.rs
+++ b/src/services/discord/turn_bridge/panel_lifecycle.rs
@@ -1,0 +1,219 @@
+//! #3479 task/session-panel line rendering + active-placeholder-card helpers,
+//! moved verbatim out of turn_bridge/mod.rs (Option A giant-file reduction;
+//! behavior-preserving — only visibility prefixes and `super::` depth adjusted).
+
+use super::*;
+
+pub(super) fn first_request_line(user_text: &str) -> Option<String> {
+    user_text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
+pub(super) async fn child_progress_line(
+    pg_pool: Option<&sqlx::PgPool>,
+    parent_session_key: Option<&str>,
+) -> Option<String> {
+    let (Some(pg_pool), Some(parent_session_key)) = (pg_pool, parent_session_key) else {
+        return None;
+    };
+    match load_child_inventory_by_parent_key_pg(pg_pool, parent_session_key).await {
+        Ok(summary) => format_child_inventory_progress(&summary, chrono::Utc::now()),
+        Err(error) => {
+            tracing::warn!(
+                "Failed to load background child inventory for {}: {}",
+                parent_session_key,
+                error
+            );
+            None
+        }
+    }
+}
+
+pub(super) async fn refresh_session_panel_line_from_lifecycle(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    turn_id: &str,
+    tmux_session_name: Option<&str>,
+) -> bool {
+    let Some(pg_pool) = shared.pg_pool.as_ref() else {
+        return false;
+    };
+    // `session_panel_instance_key` lives in the unix-only `tmux` module; on
+    // non-unix targets there is no tmux session, so the instance key is None.
+    #[cfg(unix)]
+    let session_instance_key = tmux_session_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .and_then(super::super::tmux::session_panel_instance_key);
+    #[cfg(not(unix))]
+    let session_instance_key = {
+        let _ = tmux_session_name;
+        Option::<String>::None
+    };
+    let channel_id_text = channel_id.get().to_string();
+    match crate::services::observability::turn_lifecycle::load_latest_session_lifecycle_event(
+        pg_pool,
+        &channel_id_text,
+        turn_id,
+    )
+    .await
+    {
+        Ok(Some(event)) => shared
+            .ui
+            .placeholder_live_events
+            .set_session_panel_lifecycle_event(
+                channel_id,
+                session_instance_key.as_deref(),
+                &event.kind,
+                &event.details_json,
+            ),
+        Ok(None) => shared
+            .ui
+            .placeholder_live_events
+            .clear_session_panel(channel_id),
+        Err(error) => {
+            tracing::debug!(
+                "[turn_bridge] failed to load session lifecycle line for turn {} in channel {}: {}",
+                turn_id,
+                channel_id,
+                error
+            );
+            false
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TaskPanelDispatchMetadata {
+    card_id: Option<String>,
+    dispatch_type: Option<String>,
+    claim_owner: Option<String>,
+    card_title: Option<String>,
+    dispatch_title: Option<String>,
+    github_issue_number: Option<i64>,
+}
+
+async fn load_task_panel_dispatch_metadata(
+    pg_pool: Option<&sqlx::PgPool>,
+    dispatch_id: &str,
+) -> Result<Option<TaskPanelDispatchMetadata>, String> {
+    let Some(pg_pool) = pg_pool else {
+        return Ok(None);
+    };
+    let row = sqlx::query(
+        "SELECT td.kanban_card_id,
+                td.dispatch_type,
+                td.title AS dispatch_title,
+                kc.title AS card_title,
+                kc.github_issue_number,
+                dox.claim_owner
+         FROM task_dispatches td
+         LEFT JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+         LEFT JOIN dispatch_outbox dox ON dox.dispatch_id = td.id
+         WHERE td.id = $1
+         ORDER BY dox.created_at DESC NULLS LAST
+         LIMIT 1",
+    )
+    .bind(dispatch_id)
+    .fetch_optional(pg_pool)
+    .await
+    .map_err(|error| format!("load task panel dispatch metadata for {dispatch_id}: {error}"))?;
+
+    row.map(|row| {
+        Ok::<TaskPanelDispatchMetadata, String>(TaskPanelDispatchMetadata {
+            card_id: row
+                .try_get("kanban_card_id")
+                .map_err(|error| format!("decode task panel card_id for {dispatch_id}: {error}"))?,
+            dispatch_type: row.try_get("dispatch_type").map_err(|error| {
+                format!("decode task panel dispatch_type for {dispatch_id}: {error}")
+            })?,
+            claim_owner: row.try_get("claim_owner").map_err(|error| {
+                format!("decode task panel claim_owner for {dispatch_id}: {error}")
+            })?,
+            card_title: row.try_get("card_title").map_err(|error| {
+                format!("decode task panel card_title for {dispatch_id}: {error}")
+            })?,
+            dispatch_title: row.try_get("dispatch_title").map_err(|error| {
+                format!("decode task panel dispatch_title for {dispatch_id}: {error}")
+            })?,
+            github_issue_number: row.try_get("github_issue_number").map_err(|error| {
+                format!("decode task panel github_issue_number for {dispatch_id}: {error}")
+            })?,
+        })
+    })
+    .transpose()
+}
+
+pub(super) async fn refresh_task_panel_line_from_dispatch(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    dispatch_id: &str,
+) -> bool {
+    let dispatch_id = dispatch_id.trim();
+    if dispatch_id.is_empty() {
+        return false;
+    }
+    let metadata =
+        match load_task_panel_dispatch_metadata(shared.pg_pool.as_ref(), dispatch_id).await {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::debug!(
+                    "[turn_bridge] failed to load task line for dispatch {} in channel {}: {}",
+                    dispatch_id,
+                    channel_id,
+                    error
+                );
+                None
+            }
+        };
+    shared.ui.placeholder_live_events.set_task_panel_info(
+        channel_id,
+        crate::services::discord::placeholder_live_events::TaskPanelInfo {
+            dispatch_id,
+            card_id: metadata.as_ref().and_then(|value| value.card_id.as_deref()),
+            dispatch_type: metadata
+                .as_ref()
+                .and_then(|value| value.dispatch_type.as_deref()),
+            owner_instance_id: metadata
+                .as_ref()
+                .and_then(|value| value.claim_owner.as_deref()),
+            card_title: metadata
+                .as_ref()
+                .and_then(|value| value.card_title.as_deref()),
+            dispatch_title: metadata
+                .as_ref()
+                .and_then(|value| value.dispatch_title.as_deref()),
+            github_issue_number: metadata
+                .as_ref()
+                .and_then(|value| value.github_issue_number),
+        },
+    )
+}
+
+pub(super) async fn ensure_active_placeholder_card<G: TurnGateway + ?Sized>(
+    shared: &SharedData,
+    gateway: &G,
+    key: super::super::placeholder_controller::PlaceholderKey,
+    input: super::super::placeholder_controller::PlaceholderActiveInput,
+) -> super::super::placeholder_controller::PlaceholderControllerOutcome {
+    if shared.ui.placeholder_live_events_enabled
+        && let Some(block) = shared
+            .ui
+            .placeholder_live_events
+            .render_block(key.channel_id)
+    {
+        return shared
+            .ui
+            .placeholder_controller
+            .ensure_active_with_live_events(gateway, key, input, block)
+            .await;
+    }
+    shared
+        .ui
+        .placeholder_controller
+        .ensure_active(gateway, key, input)
+        .await
+}


### PR DESCRIPTION
## #3479 giant-file reduction (Option A — safe verbatim extraction)

`turn_bridge/mod.rs` was the 2nd-largest giant (6448 prod LoC). `tmux_watcher.rs` (the most incident-prone) is already extraction-saturated (one ~6700-line loop), so per the agreed Option-A path this targets the next giant with cohesive headroom.

### What moved (verbatim, behavior-preserving)
A cohesive task/session-panel rendering cluster → new leaf `turn_bridge/panel_lifecycle.rs` (`use super::*;`):
- `first_request_line`, `child_progress_line`, `refresh_session_panel_line_from_lifecycle`, `refresh_task_panel_line_from_dispatch`, `ensure_active_placeholder_card` → `pub(super)`
- `TaskPanelDispatchMetadata` (struct) + `load_task_panel_dispatch_metadata` → private to the leaf (only used within it)

Only visibility prefixes and `super::tmux` / `super::placeholder_controller` → `super::super::…` depth were adjusted. Logic is byte-identical. All callers are mod.rs-internal (cross-file hits in tmux_watcher.rs / orphan_status_panel_cleanup.rs were verified to be comments).

### Result
- `turn_bridge/mod.rs`: **6448 → 6239 prod LoC** (−209); giant ratchet lowered to 6239 to lock the win.
- `panel_lifecycle.rs`: ~219 lines (<1000, not a giant — no registry entry).

### Verification
- `cargo check` / `cargo test services::discord::turn_bridge` green; `cargo fmt --check`, `audit_maintainability.py --check`, `ci-script-checks.sh`, `generate_inventory_docs.py` all RC=0 (inventory unchanged).
- codex adversarial review: **CLEAN** (r1 flagged only a stale change-surfaces.md count, fixed → 6239; r2 CLEAN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)