### PR TITLE
fix(#3527): suppress re-observed Discord-relay [User:] lines from SSH-direct observation

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -810,9 +810,14 @@
     nested `usage` on the success result frame so watcher-owned codex turns
     persist token telemetry — never the session-cumulative
     `info.total_token_usage`).
-  - `src/services/tui_prompt_dedupe.rs` (1356 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1393 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
-    outside an extraction plan; +88 from #3041 P1-4 codex: a per-record
+    outside an extraction plan; +37 from #3527: `is_discord_relayed_user_prompt`
+    skips re-observed `[User: … (ID: …)]` Discord-relay lines (whole-string scan —
+    context like `[External Recall]` may precede the marker and the legacy pane
+    observer collapses blocks mid-line) in the observation candidate filter so a
+    quiescence-timeout re-observation never mints a spurious synthetic turn (notice
+    + orphan panel); +88 from #3041 P1-4 codex: a per-record
     `generation: u64` nonce on `ExternalInputRelayLease` (process-global
     `AtomicU64`, stamped in `record_external_input_turn_lease` which now returns
     the recorded lease) plus the `clear_external_input_relay_lease_if_generation_matches`

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -759,7 +759,14 @@ fn observe_prompt_candidates_by_tmux_inner(
     let mut candidates = Vec::new();
     for prompt in prompts {
         let prompt = prompt.trim();
-        if prompt.is_empty() || is_synthetic_tui_user_prompt(prompt) {
+        // #3527: skip AgentDesk's own `[User: … (ID: …)]` Discord-relay lines so a
+        // re-observation (after the discord-originated ledger entry was consumed)
+        // never publishes a spurious SSH-direct turn. Treated like other synthetic
+        // prompts → candidates stay empty → `PromptObservation::Ignored`.
+        if prompt.is_empty()
+            || is_synthetic_tui_user_prompt(prompt)
+            || is_discord_relayed_user_prompt(prompt)
+        {
             continue;
         }
         if !candidates
@@ -1121,6 +1128,36 @@ fn is_synthetic_tui_user_prompt(prompt: &str) -> bool {
     prompt.starts_with("[Shared Agent Knowledge]\n")
         || prompt.starts_with("[Proactive Memory Guidance]\n")
         || prompt == "No response requested."
+}
+
+/// #3527: `[User: <author> (ID: <digits>)] …` is AgentDesk's OWN Discord→TUI
+/// relay format (`discord/router/response_format.rs`), never an external SSH/cron
+/// injection — so the observer must not mint a synthetic turn for a re-observed
+/// one (the discord-originated ledger only suppresses the first, consumed/
+/// TTL-bounded sighting; a quiescence-timeout re-observation slips through).
+///
+/// The marker can be PRECEDED by prepended context (`[External Recall]`, reply/
+/// upload context, …) AND can be collapsed mid-line: the legacy pane observer
+/// (`tmux_watcher/prompt_observe.rs`) submits `join("")` / `join(" ")` /
+/// `join("\n")` variants of one block, so a line-anchored check would miss the
+/// collapsed ones (codex #3527). Scan the WHOLE string: find `[User: `, then any
+/// following `(ID: <digits>)]` (author may itself contain parens).
+fn is_discord_relayed_user_prompt(prompt: &str) -> bool {
+    let Some(user_at) = prompt.find("[User: ") else {
+        return false;
+    };
+    let mut tail = &prompt[user_at + "[User: ".len()..];
+    while let Some(id_at) = tail.find("(ID: ") {
+        let after_id = &tail[id_at + "(ID: ".len()..];
+        if let Some(close) = after_id.find(")]") {
+            let digits = &after_id[..close];
+            if !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()) {
+                return true;
+            }
+        }
+        tail = &tail[id_at + "(ID: ".len()..];
+    }
+    false
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2083,6 +2120,78 @@ mod tests {
         assert!(
             !external_input_relay_lease_present("claude", "tmux-c", 42),
             "a candidate matching a Discord-origin prompt must not create an ExternalInput lease"
+        );
+    }
+
+    #[test]
+    fn discord_relayed_user_prompt_format_is_recognized_3527() {
+        // AgentDesk's own `[User: <author> (ID: <digits>)]` relay lines — author
+        // may contain parens; prefix may be followed by a newline (multi-line).
+        assert!(is_discord_relayed_user_prompt(
+            "[User: 0hbujang (ID: 343742347365974026)] A부턱ㄱ"
+        ));
+        assert!(is_discord_relayed_user_prompt(
+            "[User: Alice (ops) team (ID: 77)] deploy it"
+        ));
+        assert!(is_discord_relayed_user_prompt(
+            "[User: Bob (ID: 5)]\nmultiline\nbody"
+        ));
+        // genuine external / cron / SSH injections carry no `[User: (ID:)]` prefix
+        assert!(!is_discord_relayed_user_prompt(
+            "/relay-scan — supervise relays"
+        ));
+        assert!(!is_discord_relayed_user_prompt(
+            "just typed directly via ssh"
+        ));
+        assert!(!is_discord_relayed_user_prompt("[User: no id here] text"));
+        assert!(!is_discord_relayed_user_prompt(
+            "[User: x (ID: abc)] non-numeric"
+        ));
+        assert!(!is_discord_relayed_user_prompt(""));
+        // codex #3527: the `[User:]` chunk may be PRECEDED by prepended context
+        // ([External Recall], reply/upload context, Codex reuse wrappers) — the
+        // marker is not necessarily on the first line, so every line is scanned.
+        assert!(is_discord_relayed_user_prompt(
+            "[External Recall]\n- prior context\n\n[User: Alice (ID: 77)] deploy it"
+        ));
+        assert!(is_discord_relayed_user_prompt(
+            "[Reply context] ...\n[User: 0hbujang (ID: 343742347365974026)] hi"
+        ));
+        // codex #3527 r2: the legacy pane observer submits join("")/join(" ")
+        // collapsed variants of one block, so the marker can be MID-LINE — the
+        // whole-string scan must catch those too, not just the newline variant.
+        assert!(is_discord_relayed_user_prompt(
+            "[External Recall]- prior context[User: Alice (ID: 77)] deploy it"
+        ));
+        assert!(is_discord_relayed_user_prompt(
+            "[External Recall] - prior context  [User: Alice (ID: 77)] deploy it"
+        ));
+        // author containing parens, collapsed mid-line
+        assert!(is_discord_relayed_user_prompt(
+            "ctx [User: Alice (ops) team (ID: 77)] deploy it"
+        ));
+    }
+
+    #[test]
+    fn observe_skips_discord_relayed_user_line_without_ledger_3527() {
+        // #3527: a re-observed `[User:]` relay line WITHOUT a discord-originated
+        // ledger entry (simulating a quiescence-timeout re-observation after the
+        // entry was consumed/expired) must NOT publish an SSH-direct turn and must
+        // not record an ExternalInput lease — otherwise it posts a spurious 직접
+        // 주입 notice + orphan placeholder panel.
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        assert_eq!(
+            observe_prompt_by_tmux(
+                "claude",
+                "tmux-3527",
+                "[User: 0hbujang (ID: 343742347365974026)] A부턱ㄱ"
+            ),
+            PromptObservation::Ignored
+        );
+        assert!(
+            !external_input_relay_lease_present("claude", "tmux-3527", 42),
+            "a [User:] relay re-observation must not create an ExternalInput lease (#3527)"
         );
     }
 


### PR DESCRIPTION
Fixes #3527.

## Problem (user-reported, live)

On a long subagent-heavy Claude-TUI turn the pane stays busy, so the #2161 quiescence gate repeatedly times out and the turn is not finalized. The `tui_prompt_relay` observer then re-reads the pane, sees the already-processed `[User: <author> (ID: <digits>)] …` line (AgentDesk's OWN Discord→TUI relay format from `router/response_format.rs`), and — because the discord-originated ledger only suppresses the **first**, consumed/TTL-bounded sighting — publishes it as a fresh SSH-direct observation. That mints:
1. a spurious `터미널에 직접 주입된 입력` 알림봇 notice (looks like the user's input was re-relayed), and
2. an orphan TUI-direct placeholder panel that flickers (long/short) before `placeholder_reclaim` cleans it.

Both symptoms are the **same root cause** (one spurious synthetic inflight). Recurs ~3–10×/35min on long turns. No message loss, no re-execution, not relay-death — but spurious + confusing. Residual after #3459/#3268/#2161 (all CLOSED+deployed).

## Fix

Add `is_discord_relayed_user_prompt` and skip such lines in the shared observation candidate chokepoint `observe_prompt_candidates_by_tmux_inner` (every `observe_prompt_*` path funnels through it) → candidates stay empty → `PromptObservation::Ignored` (no lease, no SSH-direct publish, no notice, no panel).

- **Ledger-independent** (format-based): robust across re-observations after the ledger entry was consumed/expired.
- **Whole-string scan**: the marker may be preceded by prepended context (`[External Recall]`, reply/upload) and the legacy pane observer collapses blocks mid-line via `join("")`/`join(" ")` — so it finds the first `[User: ` then any following `(ID: <digits>)]` (author may itself contain parens).
- **Cron/SSH preserved**: genuine external injections carry no `[User:]` prefix.
- **Behavior-neutral**: downstream `should_tail_response` treats `Ignored` == `SuppressedDiscordDuplicate`.

## codex adversarial review
- r1: caught prepended-context (first-line-only) under-suppression → scan all.
- r2: caught collapsed mid-line variants → whole-string scan.
- r3: **VERDICT: CLEAN** (under/over-suppression, UTF-8 slice safety, chokepoint completeness, first-time-relay non-breakage all verified).

## Tests / gates
48 `tui_prompt_dedupe` tests pass (covers newline / join("") / join(" ") / author-parens / `[Reply context]` / negatives). `audit --check`, `ci-script-checks` (freshness freeze synced to 1393), `fmt --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)