### PR TITLE
refactor(#3479): extract analytics+transcript cluster from recovery_engine

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -451,6 +451,7 @@ src/
 │   │   │   ├── mod.rs
 │   │   │   └── section_dedupe.rs
 │   │   ├── recovery_engine/
+│   │   │   ├── analytics_transcript.rs
 │   │   │   ├── jsonl_extract.rs
 │   │   │   ├── output_path_detect.rs
 │   │   │   ├── phase_policy.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -836,7 +836,12 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3424 lines; #3479 item-2 extracted
+  - `src/services/discord/recovery_engine.rs` (3330 lines; #3479 extracted the
+    recovered-turn analytics + transcript-persistence cluster
+    (`extract_turn_analytics_from_output` wrapper, `recovered_turn_duration_ms`,
+    `lookup_turn_finished_dispatch_kind`, `recovered_transcript_turn_id`,
+    `persist_recovered_transcript`) into the leaf `recovery_engine/analytics_transcript.rs`,
+    re-imported byte-identical; earlier #3479 item-2 extracted
     the inflight-state derivation helper cluster (handoff message, ready-for-input
     probes, worktree path/branch/info derivation, spawn-cwd) into the
     sub-1000-prod-LoC leaf module `recovery_engine/state_extractors.rs` (~150) —

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -224,7 +224,7 @@
 # probes, worktree path/branch/info derivation, spawn-cwd — into the leaf module
 # recovery_engine/state_extractors.rs; zero logic change, `save_missing_session_handoff`
 # re-exported and root-called helpers re-imported byte-identical).
-"src/services/discord/recovery_engine.rs" = 3424
+"src/services/discord/recovery_engine.rs" = 3330
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -42,6 +42,8 @@ mod terminal_watcher;
 // #3479 item-2: behavior-preserving extraction of the inflight-state derivation
 // helper cluster (handoff message, ready-for-input probes, worktree info /
 // spawn-cwd derivation) into a leaf module.
+#[path = "recovery_engine/analytics_transcript.rs"]
+mod analytics_transcript;
 #[path = "recovery_engine/state_extractors.rs"]
 mod state_extractors;
 
@@ -85,6 +87,15 @@ use self::state_extractors::{
 // `recovery_engine::save_missing_session_handoff` path stays valid for the
 // `recovery_paths::restart` external caller.
 pub(super) use self::state_extractors::save_missing_session_handoff;
+// #3479: re-import the analytics + transcript helpers so root call sites stay
+// byte-identical. `recovered_transcript_turn_id` is gated on cfg(test) — the root
+// reaches it only from its unit test (prod calls it inside analytics_transcript).
+#[cfg(test)]
+use self::analytics_transcript::recovered_transcript_turn_id;
+use self::analytics_transcript::{
+    extract_turn_analytics_from_output, lookup_turn_finished_dispatch_kind,
+    persist_recovered_transcript, recovered_turn_duration_ms,
+};
 
 #[cfg(not(unix))]
 fn tmux_session_has_live_pane(_name: &str) -> bool {
@@ -1280,111 +1291,6 @@ fn detect_live_tmux_output_path(
     };
     let candidates = parse_lsof_output_candidates(&stdout);
     detect_rebind_output_path_from_candidates(fallback_path, candidates)
-}
-
-fn extract_turn_analytics_from_output(
-    output_path: &str,
-    start_offset: u64,
-) -> (Option<String>, Option<TurnTokenUsage>) {
-    crate::services::session_backend::extract_turn_analytics_from_output(output_path, start_offset)
-}
-
-fn recovered_turn_duration_ms(started_at: Option<&str>) -> Option<i64> {
-    let started_at = started_at?.trim();
-    if started_at.is_empty() {
-        return None;
-    }
-    let parsed = chrono::NaiveDateTime::parse_from_str(started_at, "%Y-%m-%d %H:%M:%S").ok()?;
-    let elapsed = chrono::Local::now().naive_local() - parsed;
-    Some(elapsed.num_milliseconds().max(0))
-}
-
-async fn lookup_turn_finished_dispatch_kind(dispatch_id: Option<&str>) -> Option<String> {
-    let dispatch_id = dispatch_id?;
-    let body = super::internal_api::lookup_dispatch_info(dispatch_id)
-        .await
-        .ok()?;
-    super::turn_bridge::classify_turn_finished_dispatch_kind(
-        body.get("dispatch_context")
-            .and_then(|value| value.as_str()),
-        body.get("dispatch_type").and_then(|value| value.as_str()),
-    )
-    .map(str::to_string)
-}
-
-/// Build the transcript turn id for a recovered turn. A message-less recovery
-/// turn (`user_msg_id == 0`, e.g. TUI-direct) must NOT key on `discord:<ch>:0`
-/// (collides across every such turn → overwrite, Codex P2 r2) NOR purely on the
-/// session (repeated message-less turns upsert-overwrite, Codex P2 r3): instead
-/// append a PER-TURN discriminator — the JSONL start offset, falling back to the
-/// `started_at` timestamp when no offset is recorded.
-fn recovered_transcript_turn_id(
-    channel_id: u64,
-    user_msg_id: u64,
-    session_key: Option<&str>,
-    turn_start_offset: Option<u64>,
-    started_at: &str,
-) -> String {
-    if user_msg_id != 0 {
-        return format!("discord:{channel_id}:{user_msg_id}");
-    }
-    // Per-turn discriminator: stable for THIS turn, distinct across turns.
-    let turn_discriminator = match turn_start_offset {
-        Some(offset) => format!("off{offset}"),
-        None => format!("at{}", started_at.replace([' ', ':'], "-")),
-    };
-    match session_key {
-        Some(key) => format!("discord:{channel_id}:session:{key}:{turn_discriminator}"),
-        None => format!("discord:{channel_id}:recovery:{turn_discriminator}"),
-    }
-}
-
-async fn persist_recovered_transcript(
-    db: Option<&crate::db::Db>,
-    pg_pool: Option<&sqlx::PgPool>,
-    provider: &ProviderKind,
-    state: &inflight::InflightTurnState,
-    dispatch_id: Option<&str>,
-    assistant_message: &str,
-) -> bool {
-    let assistant_message = assistant_message.trim();
-    if assistant_message.is_empty() {
-        return false;
-    }
-
-    let turn_id = recovered_transcript_turn_id(
-        state.channel_id,
-        state.user_msg_id,
-        state.session_key.as_deref(),
-        state.turn_start_offset,
-        &state.started_at,
-    );
-    let channel_id_text = state.channel_id.to_string();
-    match crate::db::session_transcripts::persist_turn_db(
-        db,
-        pg_pool,
-        crate::db::session_transcripts::PersistSessionTranscript {
-            turn_id: &turn_id,
-            session_key: state.session_key.as_deref(),
-            channel_id: Some(channel_id_text.as_str()),
-            agent_id: None,
-            provider: Some(provider.as_str()),
-            dispatch_id,
-            user_message: &state.user_text,
-            assistant_message,
-            events: &[],
-            duration_ms: None,
-        },
-    )
-    .await
-    {
-        Ok(_) => true,
-        Err(e) => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!("  [{ts}] ⚠ recovery: failed to persist session transcript: {e}");
-            false
-        }
-    }
 }
 
 pub(super) async fn restore_inflight_turns(

--- a/src/services/discord/recovery_engine/analytics_transcript.rs
+++ b/src/services/discord/recovery_engine/analytics_transcript.rs
@@ -1,0 +1,112 @@
+//! #3479 recovered-turn analytics + transcript-persistence helpers, moved
+//! verbatim out of recovery_engine.rs (behavior-preserving — only visibility
+//! prefixes and `super::` depth adjusted).
+
+use super::*;
+
+pub(super) fn extract_turn_analytics_from_output(
+    output_path: &str,
+    start_offset: u64,
+) -> (Option<String>, Option<TurnTokenUsage>) {
+    crate::services::session_backend::extract_turn_analytics_from_output(output_path, start_offset)
+}
+
+pub(super) fn recovered_turn_duration_ms(started_at: Option<&str>) -> Option<i64> {
+    let started_at = started_at?.trim();
+    if started_at.is_empty() {
+        return None;
+    }
+    let parsed = chrono::NaiveDateTime::parse_from_str(started_at, "%Y-%m-%d %H:%M:%S").ok()?;
+    let elapsed = chrono::Local::now().naive_local() - parsed;
+    Some(elapsed.num_milliseconds().max(0))
+}
+
+pub(super) async fn lookup_turn_finished_dispatch_kind(
+    dispatch_id: Option<&str>,
+) -> Option<String> {
+    let dispatch_id = dispatch_id?;
+    let body = super::super::internal_api::lookup_dispatch_info(dispatch_id)
+        .await
+        .ok()?;
+    super::super::turn_bridge::classify_turn_finished_dispatch_kind(
+        body.get("dispatch_context")
+            .and_then(|value| value.as_str()),
+        body.get("dispatch_type").and_then(|value| value.as_str()),
+    )
+    .map(str::to_string)
+}
+
+/// Build the transcript turn id for a recovered turn. A message-less recovery
+/// turn (`user_msg_id == 0`, e.g. TUI-direct) must NOT key on `discord:<ch>:0`
+/// (collides across every such turn → overwrite, Codex P2 r2) NOR purely on the
+/// session (repeated message-less turns upsert-overwrite, Codex P2 r3): instead
+/// append a PER-TURN discriminator — the JSONL start offset, falling back to the
+/// `started_at` timestamp when no offset is recorded.
+pub(super) fn recovered_transcript_turn_id(
+    channel_id: u64,
+    user_msg_id: u64,
+    session_key: Option<&str>,
+    turn_start_offset: Option<u64>,
+    started_at: &str,
+) -> String {
+    if user_msg_id != 0 {
+        return format!("discord:{channel_id}:{user_msg_id}");
+    }
+    // Per-turn discriminator: stable for THIS turn, distinct across turns.
+    let turn_discriminator = match turn_start_offset {
+        Some(offset) => format!("off{offset}"),
+        None => format!("at{}", started_at.replace([' ', ':'], "-")),
+    };
+    match session_key {
+        Some(key) => format!("discord:{channel_id}:session:{key}:{turn_discriminator}"),
+        None => format!("discord:{channel_id}:recovery:{turn_discriminator}"),
+    }
+}
+
+pub(super) async fn persist_recovered_transcript(
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    provider: &ProviderKind,
+    state: &inflight::InflightTurnState,
+    dispatch_id: Option<&str>,
+    assistant_message: &str,
+) -> bool {
+    let assistant_message = assistant_message.trim();
+    if assistant_message.is_empty() {
+        return false;
+    }
+
+    let turn_id = recovered_transcript_turn_id(
+        state.channel_id,
+        state.user_msg_id,
+        state.session_key.as_deref(),
+        state.turn_start_offset,
+        &state.started_at,
+    );
+    let channel_id_text = state.channel_id.to_string();
+    match crate::db::session_transcripts::persist_turn_db(
+        db,
+        pg_pool,
+        crate::db::session_transcripts::PersistSessionTranscript {
+            turn_id: &turn_id,
+            session_key: state.session_key.as_deref(),
+            channel_id: Some(channel_id_text.as_str()),
+            agent_id: None,
+            provider: Some(provider.as_str()),
+            dispatch_id,
+            user_message: &state.user_text,
+            assistant_message,
+            events: &[],
+            duration_ms: None,
+        },
+    )
+    .await
+    {
+        Ok(_) => true,
+        Err(e) => {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!("  [{ts}] ⚠ recovery: failed to persist session transcript: {e}");
+            false
+        }
+    }
+}


### PR DESCRIPTION
## What
Behavior-preserving extraction of the recovered-turn **analytics + transcript-persistence** helper cluster (5 fns) out of the giant `src/services/discord/recovery_engine.rs` into a new leaf submodule `recovery_engine/analytics_transcript.rs`.

Moved (verbatim bodies; only `pub(super)` visibility + `super::super::` path depth adjusted):
- `extract_turn_analytics_from_output`
- `recovered_turn_duration_ms`
- `lookup_turn_finished_dispatch_kind`
- `recovered_transcript_turn_id`
- `persist_recovered_transcript`

## Why
Continues the #3479 giant-file decomposition. Root keeps byte-identical call sites via re-import.

## Notes
- `recovered_transcript_turn_id` is `#[cfg(test)]`-gated in the root re-import: the root reaches it only from its unit test (production calls it internally inside `analytics_transcript`), so an unconditional import would be unused in non-test builds (codex r1 finding, fixed).
- `recovery_engine.rs` 3424 → **3330** prod LoC. Giant baseline (`scripts/audit_maintainability_giant_baseline.toml`) + `change-surfaces.md` freeze both synced to 3330.

## Verification
- `cargo test --lib services::discord::recovery_engine` → 33 passed / 0 failed
- `cargo check --lib` (non-test) → no unused-import warning
- `python3 scripts/audit_maintainability.py --check` → 0 findings
- `bash scripts/ci-script-checks.sh` → agent-maintenance freshness check passed
- `cargo fmt --check` → clean
- codex adversarial review → VERDICT: CLEAN (r2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)