### PR TITLE
refactor(#3479): extract idle-tail offset-resolution cluster from tui_prompt_relay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -534,6 +534,7 @@ src/
 │   │   │   └── store.rs
 │   │   ├── tui_prompt_relay/
 │   │   │   ├── anchor_completion.rs
+│   │   │   ├── idle_offset_resolution.rs
 │   │   │   ├── idle_transcript_scan.rs
 │   │   │   ├── injected_prompt_policy.rs
 │   │   │   ├── launch_script.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -507,7 +507,7 @@
     Moved unit tests live in sibling `utf8_chunk_decoder_tests.rs` /
     `terminal_readiness_tests.rs`; both child modules sit under the
     `tmux_watcher/**` 700-line namespace cap.
-  - `src/services/discord/tui_prompt_relay.rs` (4376 production lines; #3296
+  - `src/services/discord/tui_prompt_relay.rs` (4301 production lines; #3296
     codex r1+r2: the ABORT cleanup hook pins the foreign prior inflight's
     identity — the live row at the record instant, or the worker's LAST-VIEW
     identity when that row just vanished — and persists the marker via
@@ -775,6 +775,20 @@
     byte-identical call sites, while the module-internal
     `parse_claude_tui_launch_script_content` + `shell_words_from_line` stay private;
     below the giant-file threshold).
+  - `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` (100 prod
+    lines; #3479: the idle-tail transcript start-offset resolution helpers — the
+    #3154 timestamp-anchor choke point `resolve_idle_tail_start_offset`, the
+    `claude_idle_response_start_offset_after_timestamp` timestamp scan, the
+    stale-high `normalize_transcript_fallback_offset` guard, and the #3183
+    `clamp_idle_tail_start_offset_to_committed` committed-offset clamp — extracted
+    verbatim from `tui_prompt_relay.rs` (all `#[cfg(unix)]`). Deps reached via
+    `use super::*;`; `resolve_idle_tail_start_offset` +
+    `clamp_idle_tail_start_offset_to_committed` are `pub(super)` re-imported by the
+    parent's prod call sites, `claude_idle_response_start_offset_after_timestamp`
+    is `pub(super)` re-imported only under `#[cfg(all(unix, test))]` (its prod
+    callers are now child-internal), and the module-internal
+    `normalize_transcript_fallback_offset` stays private; below the giant-file
+    threshold).
   - `src/services/discord/idle_recap.rs` (idle-recap card compose/post/clear
     surface; #3479 dropped it below the giant-file threshold by extracting the
     scrollback/summarizer and token-context-display clusters into the two

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -177,7 +177,7 @@
 # verbatim to `tui_prompt_relay/launch_script.rs` (107 prod LoC, below the giant
 # threshold), reached via re-import so the call sites stay byte-identical. Lowers
 # the frozen baseline 4458 -> 4376 (-82). Locks in the shrink win (zero logic change).
-"src/services/discord/tui_prompt_relay.rs" = 4376
+"src/services/discord/tui_prompt_relay.rs" = 4301
 # #3038: lowered 4728 -> 4657 (-71) as `SensitivityState` (definition + impl)
 # moved to the `voice_sensitivity` sibling module. Locks in the shrink win.
 # #3038 VoiceBargeInRuntime S1: lowered 4657 -> 4350 (-307) as the STT

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -104,6 +104,26 @@ mod launch_script;
 #[cfg(unix)]
 use self::launch_script::parse_claude_tui_launch_script;
 
+// #3479: the idle-tail transcript start-offset resolution cluster (the #3154
+// timestamp-anchor choke point, its timestamp scan + stale-high fallback guard,
+// and the #3183 committed-offset clamp) moved verbatim to a capped sibling
+// module. Every item is unix-only, so the module decl and the re-imports are
+// `#[cfg(unix)]`-gated. Only `resolve_idle_tail_start_offset` and
+// `clamp_idle_tail_start_offset_to_committed` are reached from this parent's prod
+// call sites; `claude_idle_response_start_offset_after_timestamp` is referenced
+// only by the unit tests (its prod callers are now internal to the child), so it
+// is re-imported under `#[cfg(all(unix, test))]` to keep the non-test lib build
+// free of unused-import warnings. `normalize_transcript_fallback_offset` is fully
+// internal to the child and is not re-imported.
+#[cfg(unix)]
+mod idle_offset_resolution;
+#[cfg(all(unix, test))]
+use self::idle_offset_resolution::claude_idle_response_start_offset_after_timestamp;
+#[cfg(unix)]
+use self::idle_offset_resolution::{
+    clamp_idle_tail_start_offset_to_committed, resolve_idle_tail_start_offset,
+};
+
 const SSH_DIRECT_PROMPT_PREVIEW_LIMIT: usize = 1500;
 const CODEX_IDLE_ROLLOUT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL: Duration = Duration::from_secs(5);
@@ -2329,101 +2349,6 @@ where
             return true;
         }
     }
-}
-
-/// #3154 P1 (timestamp-anchor output loss): single choke point that resolves the
-/// idle-tail start offset.
-///
-/// When `explicit_start_offset` is `Some` (the deferred-BridgeAdapter worker path),
-/// the tail anchors DIRECTLY to that transcript byte offset — the claim's post-drain
-/// EOF `turn_start_offset`, the authoritative byte boundary for this synthetic turn —
-/// and the `observed_at` timestamp scan is BYPASSED. The worker synthesizes
-/// `observed_at = Utc::now()` only AFTER the deferred-claim wait, so every byte
-/// written to the transcript during that wait predates it; a timestamp scan would
-/// find no boundary line and SKIP those bytes (uncapped output loss). The explicit
-/// EOF offset includes every byte of this turn (no skip) and never precedes the
-/// prior bytes (no prior-turn re-relay). `normalize_transcript_fallback_offset`
-/// guards a stale-high offset (past EOF → 0); the committed-offset clamp in
-/// `spawn_claude_idle_response_tail_once` still dedupes against watcher delivery.
-///
-/// When `explicit_start_offset` is `None` (inline / non-deferred path), the original
-/// `observed_at` timestamp-scan anchoring is preserved unchanged.
-#[cfg(unix)]
-fn resolve_idle_tail_start_offset(
-    transcript_path: &Path,
-    explicit_start_offset: Option<u64>,
-    observed_at: chrono::DateTime<chrono::Utc>,
-    fallback_offset: u64,
-) -> u64 {
-    match explicit_start_offset {
-        Some(offset) => normalize_transcript_fallback_offset(transcript_path, offset),
-        None => claude_idle_response_start_offset_after_timestamp(
-            transcript_path,
-            observed_at,
-            fallback_offset,
-        ),
-    }
-}
-
-#[cfg(unix)]
-fn claude_idle_response_start_offset_after_timestamp(
-    transcript_path: &Path,
-    turn_started_at: chrono::DateTime<chrono::Utc>,
-    fallback_offset: u64,
-) -> u64 {
-    match crate::services::claude_tui::transcript_tail::claude_transcript_timestamp_at_or_after(
-        transcript_path,
-        turn_started_at,
-    ) {
-        Ok(Some(offset)) => offset,
-        Ok(None) => normalize_transcript_fallback_offset(transcript_path, fallback_offset),
-        Err(error) => {
-            tracing::debug!(
-                transcript_path = %transcript_path.display(),
-                error = %error,
-                fallback_offset,
-                "Claude idle transcript timestamp scan failed; using fallback offset"
-            );
-            normalize_transcript_fallback_offset(transcript_path, fallback_offset)
-        }
-    }
-}
-
-#[cfg(unix)]
-fn normalize_transcript_fallback_offset(transcript_path: &Path, fallback_offset: u64) -> u64 {
-    match std::fs::metadata(transcript_path).map(|metadata| metadata.len()) {
-        Ok(file_len) if fallback_offset > file_len => 0,
-        _ => fallback_offset,
-    }
-}
-
-/// #3183: clamp the idle-tail start offset to at least the watcher's committed
-/// delivery offset.
-///
-/// The idle-tail start offset is derived purely from the prompt timestamp (or
-/// the just-scanned prompt's `line_end_offset`), so it does NOT account for what
-/// the tmux watcher already delivered for this turn. When the watcher relayed a
-/// terminal response and THEN the idle tail spawns (e.g. an owner-arbitration /
-/// watcher-registration race lets the tail through before the
-/// `watcher_covers_current_transcript` suppression observes it), the tail
-/// re-relays the SAME byte range — the duplicate message in #3183.
-///
-/// `committed_relay_offset` is the single authoritative "JSONL byte offset
-/// (exclusive) past which the watcher has confirmed delivery" (#3017), in the
-/// SAME transcript-byte space as `start_offset`. Clamping
-/// `start_offset = max(start_offset, committed)` means the tail only ever scans
-/// output the watcher has NOT delivered:
-///   - watcher delivered up to X  → tail starts at >= X (no duplicate; if the
-///     watcher covered the whole turn the tail finds nothing to relay).
-///   - watcher stopped / not covering (the #3176 outage case) → `committed` is
-///     0 or below the timestamp offset, so the clamp is a no-op and the tail
-///     still relays from the timestamp offset (no relay-loss regression).
-///
-/// Returns the clamped offset; `committed == 0` (no confirmed delivery this
-/// process lifetime) leaves `start_offset` untouched.
-#[cfg(unix)]
-fn clamp_idle_tail_start_offset_to_committed(start_offset: u64, committed_offset: u64) -> u64 {
-    start_offset.max(committed_offset)
 }
 
 #[cfg(unix)]

--- a/src/services/discord/tui_prompt_relay/idle_offset_resolution.rs
+++ b/src/services/discord/tui_prompt_relay/idle_offset_resolution.rs
@@ -1,0 +1,100 @@
+//! #3479: idle-tail transcript start-offset resolution helpers, moved verbatim
+//! out of tui_prompt_relay.rs (behavior-preserving — only visibility prefixes
+//! adjusted and the shared `#[cfg(unix)]` lifted from each fn to the parent's
+//! `mod`/`use` decls). Every dependency is reached via `use super::*;`.
+
+use super::*;
+
+/// #3154 P1 (timestamp-anchor output loss): single choke point that resolves the
+/// idle-tail start offset.
+///
+/// When `explicit_start_offset` is `Some` (the deferred-BridgeAdapter worker path),
+/// the tail anchors DIRECTLY to that transcript byte offset — the claim's post-drain
+/// EOF `turn_start_offset`, the authoritative byte boundary for this synthetic turn —
+/// and the `observed_at` timestamp scan is BYPASSED. The worker synthesizes
+/// `observed_at = Utc::now()` only AFTER the deferred-claim wait, so every byte
+/// written to the transcript during that wait predates it; a timestamp scan would
+/// find no boundary line and SKIP those bytes (uncapped output loss). The explicit
+/// EOF offset includes every byte of this turn (no skip) and never precedes the
+/// prior bytes (no prior-turn re-relay). `normalize_transcript_fallback_offset`
+/// guards a stale-high offset (past EOF → 0); the committed-offset clamp in
+/// `spawn_claude_idle_response_tail_once` still dedupes against watcher delivery.
+///
+/// When `explicit_start_offset` is `None` (inline / non-deferred path), the original
+/// `observed_at` timestamp-scan anchoring is preserved unchanged.
+pub(super) fn resolve_idle_tail_start_offset(
+    transcript_path: &Path,
+    explicit_start_offset: Option<u64>,
+    observed_at: chrono::DateTime<chrono::Utc>,
+    fallback_offset: u64,
+) -> u64 {
+    match explicit_start_offset {
+        Some(offset) => normalize_transcript_fallback_offset(transcript_path, offset),
+        None => claude_idle_response_start_offset_after_timestamp(
+            transcript_path,
+            observed_at,
+            fallback_offset,
+        ),
+    }
+}
+
+pub(super) fn claude_idle_response_start_offset_after_timestamp(
+    transcript_path: &Path,
+    turn_started_at: chrono::DateTime<chrono::Utc>,
+    fallback_offset: u64,
+) -> u64 {
+    match crate::services::claude_tui::transcript_tail::claude_transcript_timestamp_at_or_after(
+        transcript_path,
+        turn_started_at,
+    ) {
+        Ok(Some(offset)) => offset,
+        Ok(None) => normalize_transcript_fallback_offset(transcript_path, fallback_offset),
+        Err(error) => {
+            tracing::debug!(
+                transcript_path = %transcript_path.display(),
+                error = %error,
+                fallback_offset,
+                "Claude idle transcript timestamp scan failed; using fallback offset"
+            );
+            normalize_transcript_fallback_offset(transcript_path, fallback_offset)
+        }
+    }
+}
+
+fn normalize_transcript_fallback_offset(transcript_path: &Path, fallback_offset: u64) -> u64 {
+    match std::fs::metadata(transcript_path).map(|metadata| metadata.len()) {
+        Ok(file_len) if fallback_offset > file_len => 0,
+        _ => fallback_offset,
+    }
+}
+
+/// #3183: clamp the idle-tail start offset to at least the watcher's committed
+/// delivery offset.
+///
+/// The idle-tail start offset is derived purely from the prompt timestamp (or
+/// the just-scanned prompt's `line_end_offset`), so it does NOT account for what
+/// the tmux watcher already delivered for this turn. When the watcher relayed a
+/// terminal response and THEN the idle tail spawns (e.g. an owner-arbitration /
+/// watcher-registration race lets the tail through before the
+/// `watcher_covers_current_transcript` suppression observes it), the tail
+/// re-relays the SAME byte range — the duplicate message in #3183.
+///
+/// `committed_relay_offset` is the single authoritative "JSONL byte offset
+/// (exclusive) past which the watcher has confirmed delivery" (#3017), in the
+/// SAME transcript-byte space as `start_offset`. Clamping
+/// `start_offset = max(start_offset, committed)` means the tail only ever scans
+/// output the watcher has NOT delivered:
+///   - watcher delivered up to X  → tail starts at >= X (no duplicate; if the
+///     watcher covered the whole turn the tail finds nothing to relay).
+///   - watcher stopped / not covering (the #3176 outage case) → `committed` is
+///     0 or below the timestamp offset, so the clamp is a no-op and the tail
+///     still relays from the timestamp offset (no relay-loss regression).
+///
+/// Returns the clamped offset; `committed == 0` (no confirmed delivery this
+/// process lifetime) leaves `start_offset` untouched.
+pub(super) fn clamp_idle_tail_start_offset_to_committed(
+    start_offset: u64,
+    committed_offset: u64,
+) -> u64 {
+    start_offset.max(committed_offset)
+}


### PR DESCRIPTION
## What
Behavior-preserving extraction of the idle-tail transcript **start-offset resolution** cluster (4 `#[cfg(unix)]` fns) out of the giant `src/services/discord/tui_prompt_relay.rs` into a new sibling leaf submodule `tui_prompt_relay/idle_offset_resolution.rs`.

Moved (bodies byte-identical; per-fn `#[cfg(unix)]` lifted to the parent's gated `mod`/`use`):
- `resolve_idle_tail_start_offset` (#3154 timestamp-anchor choke point)
- `claude_idle_response_start_offset_after_timestamp` (timestamp scan)
- `normalize_transcript_fallback_offset` (stale-high → 0 guard)
- `clamp_idle_tail_start_offset_to_committed` (#3183 committed-offset clamp)

## Why
Continues the #3479 giant-file decomposition. Root keeps byte-identical call sites via re-import.

## Notes
- All 4 were `#[cfg(unix)]`; the parent gates `mod`/`use` on `#[cfg(unix)]` (matching the `launch_script` precedent), so per-fn cfg is dropped inside the child.
- `resolve_idle_tail_start_offset` + `clamp_idle_tail_start_offset_to_committed` are `pub(super)` re-imported by the parent's prod call sites.
- `claude_idle_response_start_offset_after_timestamp` is re-imported only under `#[cfg(all(unix, test))]` — its prod callers are now child-internal, so an unconditional import would be unused in non-test builds (mirrors the `rehydration` precedent).
- `normalize_transcript_fallback_offset` is fully child-internal → stays private.
- `tui_prompt_relay.rs` 4376 → **4301** prod LoC. Giant baseline + `change-surfaces.md` freeze synced to 4301; new child = 100 prod lines (below the 700-line cap).

## Verification
- `cargo check --lib` (non-test) → no unused-import warning
- `cargo test --lib services::discord::tui_prompt_relay` → 123 passed / 0 failed
- `python3 scripts/audit_maintainability.py --check` → RC 0, no findings
- `bash scripts/ci-script-checks.sh` → agent-maintenance freshness check passed
- `cargo fmt --check` → clean
- codex adversarial review → VERDICT: CLEAN (r1, bodies verified byte-identical vs HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)