### PR TITLE
refactor(#3479): extract response-delivery helpers from turn_bridge/mod.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -557,6 +557,7 @@ src/
 │   │   │   ├── panel_lifecycle.rs
 │   │   │   ├── recall_feedback.rs
 │   │   │   ├── recovery_text.rs
+│   │   │   ├── response_delivery.rs
 │   │   │   ├── retry_state.rs
 │   │   │   ├── single_message_footer.rs
 │   │   │   ├── skill_usage.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -954,7 +954,7 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6239 prod lines; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6189 prod lines; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.
@@ -1003,6 +1003,14 @@
     `spawn_watcher_orphan_spinner_cleanup_retry` + their tests. The retry-spawn
     routes through `task_supervisor`/`placeholder_cleanup` and takes all deps by
     value; not a giant-file).
+  - `src/services/discord/turn_bridge/response_delivery.rs` (74 prod lines; pure
+    response-delivery + transcript-event helpers extracted verbatim from `mod.rs`
+    by #3479: `push_transcript_event`, `response_portion_after_offset`,
+    `terminal_delivery_response_after_offset`,
+    `done_result_requires_full_terminal_replay`. All `pub(super)` and re-imported
+    so the parent call sites + inline tests stay byte-identical; the two
+    discord-level `super::` refs (`response_sanitizer`, `DISCORD_MSG_LIMIT`)
+    deepened to `super::super::`; no IO/async; not a giant-file).
   - `src/services/discord/turn_bridge/completion_guard.rs` (872 prod lines; no
     longer a giant-file after #3479 verbatim-extracted two leaf child modules
     under `completion_guard/` (1834 -> 872 prod). It now holds the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -114,7 +114,7 @@
 # spawn_watcher_orphan_spinner_cleanup_retry) into
 # `turn_bridge/watcher_orphan_cleanup.rs` (both re-exported, call sites
 # byte-identical). Locks in the shrink win (ratchet down only).
-"src/services/discord/turn_bridge/mod.rs" = 6239
+"src/services/discord/turn_bridge/mod.rs" = 6189
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -21,6 +21,18 @@ mod turn_analytics;
 mod voice_completion;
 mod watcher_handoff;
 mod watcher_orphan_cleanup;
+// #3479: the pure response-delivery + transcript-event helpers (the transcript
+// event-recording filter, the response-after-offset slice, the terminal delivery
+// sanitization+fallback builder, and the full-terminal-replay predicate) moved
+// verbatim to a capped sibling module. All four are `pub(super)` and re-imported
+// below so this parent's call sites (and the inline test modules) stay
+// byte-identical; deps are reached via `use super::*;` (the two discord-level
+// `super::` refs become `super::super::` from the child).
+mod response_delivery;
+use response_delivery::{
+    done_result_requires_full_terminal_replay, push_transcript_event,
+    response_portion_after_offset, terminal_delivery_response_after_offset,
+};
 
 use super::gateway::TurnGateway;
 use super::restart_report::{RestartCompletionReport, clear_restart_report, save_restart_report};
@@ -472,68 +484,6 @@ mod ready_drain_unit_tests {
 
         assert!(matches!(received, StreamMessage::TmuxReady { .. }));
     }
-}
-
-fn push_transcript_event(events: &mut Vec<SessionTranscriptEvent>, event: SessionTranscriptEvent) {
-    let has_payload = !event.content.trim().is_empty()
-        || event
-            .summary
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty())
-        || event
-            .tool_name
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty());
-    if has_payload
-        || matches!(
-            event.kind,
-            SessionTranscriptEventKind::Thinking
-                | SessionTranscriptEventKind::Result
-                | SessionTranscriptEventKind::Error
-                | SessionTranscriptEventKind::Task
-                | SessionTranscriptEventKind::System
-        )
-    {
-        events.push(event);
-    }
-}
-
-fn response_portion_after_offset(full_response: &str, response_sent_offset: usize) -> &str {
-    full_response.get(response_sent_offset..).unwrap_or("")
-}
-
-fn terminal_delivery_response_after_offset(
-    full_response: &str,
-    response_sent_offset: usize,
-    empty_response_notice: Option<&str>,
-) -> String {
-    let raw_response =
-        response_portion_after_offset(full_response, response_sent_offset).to_string();
-    let stripped_response =
-        super::response_sanitizer::strip_leading_tui_response_chrome(&raw_response);
-    if !raw_response.trim().is_empty() && stripped_response.trim().is_empty() {
-        return String::new();
-    }
-    let mut delivery_response = stripped_response;
-    if delivery_response.trim().is_empty()
-        && let Some(notice) = empty_response_notice
-    {
-        delivery_response = notice.to_string();
-    }
-    delivery_response
-}
-
-fn done_result_requires_full_terminal_replay(
-    full_response: &str,
-    result: &str,
-    response_sent_offset: usize,
-    streamed_assistant_text_this_turn: bool,
-) -> bool {
-    response_sent_offset > 0
-        && streamed_assistant_text_this_turn
-        && result.len() > super::DISCORD_MSG_LIMIT
-        && !result.trim().is_empty()
-        && full_response.trim() == result.trim()
 }
 
 #[cfg(test)]

--- a/src/services/discord/turn_bridge/response_delivery.rs
+++ b/src/services/discord/turn_bridge/response_delivery.rs
@@ -1,0 +1,74 @@
+//! #3479: pure response-delivery + transcript-event helpers, moved verbatim out
+//! of turn_bridge/mod.rs (behavior-preserving — only visibility prefixes set to
+//! `pub(super)` and the two `super::` discord-level refs deepened to
+//! `super::super::` from the child). All deps reached via `use super::*;`.
+
+use super::*;
+
+pub(super) fn push_transcript_event(
+    events: &mut Vec<SessionTranscriptEvent>,
+    event: SessionTranscriptEvent,
+) {
+    let has_payload = !event.content.trim().is_empty()
+        || event
+            .summary
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+        || event
+            .tool_name
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+    if has_payload
+        || matches!(
+            event.kind,
+            SessionTranscriptEventKind::Thinking
+                | SessionTranscriptEventKind::Result
+                | SessionTranscriptEventKind::Error
+                | SessionTranscriptEventKind::Task
+                | SessionTranscriptEventKind::System
+        )
+    {
+        events.push(event);
+    }
+}
+
+pub(super) fn response_portion_after_offset(
+    full_response: &str,
+    response_sent_offset: usize,
+) -> &str {
+    full_response.get(response_sent_offset..).unwrap_or("")
+}
+
+pub(super) fn terminal_delivery_response_after_offset(
+    full_response: &str,
+    response_sent_offset: usize,
+    empty_response_notice: Option<&str>,
+) -> String {
+    let raw_response =
+        response_portion_after_offset(full_response, response_sent_offset).to_string();
+    let stripped_response =
+        super::super::response_sanitizer::strip_leading_tui_response_chrome(&raw_response);
+    if !raw_response.trim().is_empty() && stripped_response.trim().is_empty() {
+        return String::new();
+    }
+    let mut delivery_response = stripped_response;
+    if delivery_response.trim().is_empty()
+        && let Some(notice) = empty_response_notice
+    {
+        delivery_response = notice.to_string();
+    }
+    delivery_response
+}
+
+pub(super) fn done_result_requires_full_terminal_replay(
+    full_response: &str,
+    result: &str,
+    response_sent_offset: usize,
+    streamed_assistant_text_this_turn: bool,
+) -> bool {
+    response_sent_offset > 0
+        && streamed_assistant_text_this_turn
+        && result.len() > super::super::DISCORD_MSG_LIMIT
+        && !result.trim().is_empty()
+        && full_response.trim() == result.trim()
+}


### PR DESCRIPTION
## What
Behavior-preserving extraction of 4 pure response-delivery + transcript-event helpers out of the giant `src/services/discord/turn_bridge/mod.rs` into a new sibling leaf submodule `turn_bridge/response_delivery.rs`.

Moved (bodies byte-identical):
- `push_transcript_event` (transcript event-recording filter)
- `response_portion_after_offset` (response-after-offset slice)
- `terminal_delivery_response_after_offset` (delivery sanitization + empty fallback)
- `done_result_requires_full_terminal_replay` (full-terminal-replay predicate)

## Why
Continues the #3479 giant-file decomposition (largest tractable giant). Root keeps byte-identical call sites + inline-test references via re-import.

## Notes
- All 4 → `pub(super)`, re-imported by the parent.
- Two discord-level `super::` refs deepened to `super::super::` from the child: `response_sanitizer::strip_leading_tui_response_chrome` and `DISCORD_MSG_LIMIT`. Other deps (`SessionTranscriptEvent`/`SessionTranscriptEventKind`) reached via `use super::*;`.
- `turn_bridge`'s `push_transcript_event` is distinct from the same-named `pub(super)` fn in `watchers/lifecycle.rs` — that one is scoped to the `watchers` module and not visible to this sibling, so the re-import is unambiguous (verified). The `health/recovery.rs` mention of `terminal_delivery_response_after_offset` is a code comment, not a call.
- `turn_bridge/mod.rs` 6239 → **6189** prod LoC. Giant baseline + `change-surfaces.md` freeze synced to 6189; new child = 74 prod lines (below the 700-line cap).

## Verification
- `cargo check --lib` (non-test) → no unused-import warning
- `cargo test --lib services::discord::turn_bridge` → 181 passed / 0 failed
- `python3 scripts/audit_maintainability.py --check` → RC 0, mod.rs not flagged
- `bash scripts/ci-script-checks.sh` → agent-maintenance freshness check passed
- `cargo fmt --check` → clean
- codex adversarial review → VERDICT: CLEAN (r1; bodies verified byte-identical, super::super paths + name-collision isolation confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)