### PR TITLE
fix(#3533): ABTG preserves already-delivered body instead of SUPPRESSED_INTERNAL_LABEL on restart-straddle

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -135,7 +135,7 @@
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
     construction from the watcher-spawn handle).
-  - `src/services/discord/tmux.rs` (2049 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2057 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
     status/footer stripping in the placeholder suppression decisions;
@@ -152,7 +152,9 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     -1 from #3038 S4 after routing the placeholder/status-panel cluster
-    through `shared.ui`; still giant-file territory).
+    through `shared.ui`; +8 from #3533 ActiveBridgeTurnGuard restart-boundary
+    preserve fix (no SUPPRESSED_INTERNAL_LABEL on an already-delivered duplicate);
+    still giant-file territory).
   - `src/services/discord/tmux_watcher.rs` (6922 production lines after the #3479
     SPC-shadow removal deleted the dead `StatusPanelController` watcher
     shadow-parity calls — 2x `shadow_adopt_liveness_reacquired_panel` +

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -309,7 +309,7 @@
 # notify-outbox subsystem — build/enqueue/reconcile/parse/rollback).
 # suppressed-label noise, user report 2026-06-12: +38 for provider-aware
 # status/footer stripping in the placeholder suppression decisions.
-"src/services/discord/tmux.rs" = 2049
+"src/services/discord/tmux.rs" = 2057
 # completion_guard.rs decomposed in #3479 (1834 -> 872 prod LoC); dropped below
 # the giant threshold, so its ratchet baseline is retired (no longer tracked).
 # #3034 batch-8: lowered 1781 -> 1753 (deleted the dead `assistant_turns` turn-cap

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -686,9 +686,17 @@ fn decide_placeholder_suppression(
             ) {
                 SuppressedPlaceholderAction::None => PlaceholderSuppressDecision::None,
                 SuppressedPlaceholderAction::Delete => PlaceholderSuppressDecision::Delete,
-                SuppressedPlaceholderAction::Edit(content) => {
-                    PlaceholderSuppressDecision::Edit(content)
-                }
+                // #3533: this duplicate-relay guard fires because a bridge turn
+                // already owns delivery, so an exposed body was/will be delivered by
+                // it — preserve it (strip the live spinner) instead of stamping
+                // SUPPRESSED_INTERNAL_LABEL (wrong on the restart-straddling turn).
+                SuppressedPlaceholderAction::Edit(_) => PlaceholderSuppressDecision::Preserve {
+                    reason: "active-bridge-duplicate-delivered",
+                    cleaned_body: strip_placeholder_indicators_for_preserve(
+                        ctx.last_edit_text,
+                        ctx.provider,
+                    ),
+                },
             }
         }
         PlaceholderSuppressOrigin::TaskNotificationTerminal => {
@@ -1214,6 +1222,69 @@ mod placeholder_suppression_tests {
                 TEST_SESSION
             ),
             SuppressedPlaceholderAction::Edit(SUPPRESSED_RESTART_LABEL.to_string())
+        );
+    }
+
+    fn active_bridge_ctx<'a>(
+        placeholder: &'a str,
+        response_sent_offset: usize,
+        reattach_offset_match: bool,
+    ) -> PlaceholderSuppressContext<'a> {
+        PlaceholderSuppressContext {
+            origin: PlaceholderSuppressOrigin::ActiveBridgeTurnGuard,
+            provider: &ProviderKind::Claude,
+            placeholder_msg_id: Some(MessageId::new(1)),
+            response_sent_offset,
+            last_edit_text: placeholder,
+            inflight_state: None,
+            has_active_turn: false,
+            tmux_session_name: TEST_SESSION,
+            task_notification_kind: None,
+            reattach_offset_match,
+        }
+    }
+
+    #[test]
+    fn active_bridge_exposed_body_preserves_instead_of_internal_label() {
+        // #3533: a duplicate-relay guard on an already-exposed body (e.g. the
+        // in-flight turn that straddled a dcserver restart, reattach NOT matched)
+        // must PRESERVE the delivered body, never stamp SUPPRESSED_INTERNAL_LABEL.
+        let placeholder = body_with_footer("visible assistant body");
+        let ctx = active_bridge_ctx(&placeholder, 0, false);
+
+        let PlaceholderSuppressDecision::Preserve {
+            reason,
+            cleaned_body,
+        } = decide_placeholder_suppression(&ctx)
+        else {
+            panic!("active bridge duplicate of an exposed body should preserve, not label");
+        };
+        assert_eq!(reason, "active-bridge-duplicate-delivered");
+        assert_eq!(cleaned_body, "visible assistant body");
+        assert!(!cleaned_body.contains(SUPPRESSED_INTERNAL_LABEL));
+        assert!(!cleaned_body.contains("진행 중 — Claude"));
+    }
+
+    #[test]
+    fn active_bridge_offset_exposed_empty_text_preserves() {
+        // response_sent_offset > 0 (already-delivered bytes) with no residual text
+        // is the bare restart-boundary signal — still preserve, never label.
+        let ctx = active_bridge_ctx("", 1, false);
+        assert!(matches!(
+            decide_placeholder_suppression(&ctx),
+            PlaceholderSuppressDecision::Preserve { .. }
+        ));
+    }
+
+    #[test]
+    fn active_bridge_unexposed_placeholder_still_deletes() {
+        // No body and no sent offset → nothing to preserve; deleting the bare
+        // spinner placeholder is unchanged behavior.
+        let placeholder = footer_only_placeholder();
+        let ctx = active_bridge_ctx(&placeholder, 0, false);
+        assert_eq!(
+            decide_placeholder_suppression(&ctx),
+            PlaceholderSuppressDecision::Delete
         );
     }
 }


### PR DESCRIPTION
Fixes #3533.

ActiveBridgeTurnGuard (a duplicate-relay guard) stamped SUPPRESSED_INTERNAL_LABEL onto an already-delivered body on a restart-straddling turn. Now the ABTG Edit case Preserves the cleaned (spinner-stripped) body since the owning bridge turn delivers it.

- decide_placeholder_suppression ABTG arm: Edit(_) -> Preserve {reason: active-bridge-duplicate-delivered}; reattach early-return + None/Delete unchanged; shared suppressed_placeholder_action untouched (TaskNotificationTerminal/OrphanRestart unaffected).
- 3 new unit tests.
- ratchet: tmux.rs 2049 -> 2057 (+8 prod) in baseline.toml + change-surfaces.md.

Verification: cargo fmt --check, audit --check (count 0), agent-maintenance freshness pass, full lib test 3686 passed/0 failed. codex adversarial review: VERDICT CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)