### PR TITLE
fix(#3534): gate post-terminal continuation flush on new output to stop turn-straddle duplicate relay

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -155,7 +155,11 @@
     through `shared.ui`; +8 from #3533 ActiveBridgeTurnGuard restart-boundary
     preserve fix (no SUPPRESSED_INTERNAL_LABEL on an already-delivered duplicate);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (6922 production lines after the #3479
+  - `src/services/discord/tmux_watcher.rs` (6923 production lines; +1 from #3534
+    gating the post-terminal-success continuation flush on
+    `new_output_observed` (`current_offset > data_start_offset`) so a zero-width
+    re-entry never re-relays an already-delivered carried body as a NEW message;
+    was 6922 after the #3479
     SPC-shadow removal deleted the dead `StatusPanelController` watcher
     shadow-parity calls — 2x `shadow_adopt_liveness_reacquired_panel` +
     `assert_watcher_create_parity`; legacy reacquire/create/edit IO unchanged —

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -67,7 +67,7 @@
 # #3479 SPC-shadow removal: lowered 6939 -> 6922 (deleted the dead StatusPanelController
 # shadow-parity calls — 2x shadow_adopt_liveness_reacquired_panel + assert_watcher_create_parity;
 # legacy reacquire/create/edit IO unchanged).
-"src/services/discord/tmux_watcher.rs" = 6922
+"src/services/discord/tmux_watcher.rs" = 6923
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1187,6 +1187,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             should_flush_post_terminal_success_continuation(
                 turn_result_relayed,
                 found_result,
+                current_offset > data_start_offset,
                 &full_response,
             );
         if post_terminal_success_continuation_flush {

--- a/src/services/discord/watchers/lifecycle_decision.rs
+++ b/src/services/discord/watchers/lifecycle_decision.rs
@@ -163,12 +163,24 @@ pub(super) fn missing_inflight_fallback_observation(
     }
 }
 
+/// #3534: only flush a post-terminal-success continuation when genuinely-new
+/// bytes arrived this read batch (`new_output_observed` = `current_offset >
+/// data_start_offset`). A zero-width re-entry re-parses the carried `all_data`
+/// into a `full_response` that was ALREADY delivered on the prior (advancing)
+/// pass; flushing it re-posts the prior turn's answer as a NEW Discord message
+/// (the #3268-handoff duplicate-relay regression, where `response_sent_offset`
+/// re-seeds to 0 so the whole carried body looks unsent). The legitimate #1137
+/// trailing-output case always advances the offset, so it still flushes.
 pub(super) fn should_flush_post_terminal_success_continuation(
     terminal_success_seen: bool,
     found_result: bool,
+    new_output_observed: bool,
     full_response: &str,
 ) -> bool {
-    terminal_success_seen && !found_result && !full_response.trim().is_empty()
+    terminal_success_seen
+        && !found_result
+        && new_output_observed
+        && !full_response.trim().is_empty()
 }
 
 pub(super) fn should_resume_watcher_after_turn(
@@ -250,5 +262,49 @@ mod tests {
         assert!(!should_resume_watcher_after_turn(true, false, false));
         assert!(!should_resume_watcher_after_turn(false, true, true));
         assert!(should_resume_watcher_after_turn(false, true, false));
+    }
+
+    #[test]
+    fn continuation_flush_suppressed_for_zero_width_carried_response() {
+        // #3534 THE BUG: terminal success already relayed, this iteration found
+        // no fresh result, the carried full_response is non-empty BUT no new
+        // bytes arrived this batch (current_offset == data_start_offset). The
+        // body was already delivered on the prior advancing pass — must NOT
+        // re-flush it as a new Discord message.
+        assert!(!should_flush_post_terminal_success_continuation(
+            /* terminal_success_seen */ true,
+            /* found_result */ false,
+            /* new_output_observed */ false,
+            /* full_response */ "already-delivered multi-part answer",
+        ));
+    }
+
+    #[test]
+    fn continuation_flush_fires_for_genuine_trailing_output() {
+        // #1137 regression guard: codex/claude emitting trailing output AFTER
+        // terminal-success advances the offset, so new_output_observed is true
+        // — the continuation flush MUST still fire.
+        assert!(should_flush_post_terminal_success_continuation(
+            true,
+            false,
+            true,
+            "trailing post-terminal output",
+        ));
+    }
+
+    #[test]
+    fn continuation_flush_requires_all_preconditions() {
+        // No terminal success yet -> no flush, even with new output.
+        assert!(!should_flush_post_terminal_success_continuation(
+            false, false, true, "body"
+        ));
+        // Already found this iteration's result -> no flush.
+        assert!(!should_flush_post_terminal_success_continuation(
+            true, true, true, "body"
+        ));
+        // Blank body -> no flush even with new output observed.
+        assert!(!should_flush_post_terminal_success_continuation(
+            true, false, true, "   "
+        ));
     }
 }


### PR DESCRIPTION
Fixes #3534. (Rebased onto main after #3533 merge; supersedes #3536 which auto-closed when its branch was deleted.)

The post-terminal-success continuation flush re-relayed a prior turn's already-delivered body as a NEW Discord message across the #3268 quiescence-timeout handoff (user saw the same answer twice; msgs ...342/...784 re-posted as ...577/...582). A second recurrence was observed at 22:41:16 UTC (zero-width offset 16786931->16786931).

Root cause: `should_flush_post_terminal_success_continuation` fired on a zero-width re-entry (`current_offset == data_start_offset`, no new bytes) because it only checked `!full_response.trim().is_empty()`; the carried `all_data` re-parsed into a `full_response` that `response_sent_offset` (re-seeded to 0) treated as fully unsent. The #3520 delivered-frontier guard didn't catch it (durable frontier END 20882073 lagged the edit-path-delivered 21076832).

Fix: gate the flush on `new_output_observed = current_offset > data_start_offset`. #1137 trailing-output always advances the offset (still flushes); the zero-width re-entry is suppressed and a non-result iteration hits the #3419 `continue` before the relay block (no dup, no delayed dup). Live logs: 14 zero-width (bug) vs 47 advancing (legit).

- lifecycle_decision.rs: +`new_output_observed` param; 3 new unit tests.
- tmux_watcher.rs: single call site passes `current_offset > data_start_offset` (+1 prod LoC).
- ratchet: tmux_watcher.rs 6922 -> 6923 in baseline.toml + change-surfaces.md.

Verification: audit --check (RC0), agent-maintenance freshness pass, fmt --check clean, continuation_flush + lifecycle_decision tests pass. codex adversarial review: VERDICT CLEAN. (Local full-suite parallel flakes reproduce on clean origin/main and pass in CI's isolated runs — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)