### PR TITLE
refactor(#3479): extract DispatchRoutingState capability handle from SharedData god-object

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -919,7 +919,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2634 lines; health recovery
+  - `src/services/discord/health/recovery.rs` (2637 lines; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the
@@ -933,7 +933,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3671 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3672 lines; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;
@@ -1414,7 +1414,11 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
 - `src/services/platform/binary_resolver.rs` (1221).
-- `src/services/discord/mod.rs` (now 4074 prod LoC after #3479 item-2 extracted
+- `src/services/discord/mod.rs` (now 4056 prod LoC after #3479 item-3 extracted
+  the dispatch intake/routing cluster (`intake_dedup` + `dispatch_thread_parents`
+  + `dispatch_role_overrides`) verbatim to `discord/shared_state.rs` as
+  `DispatchRoutingState` (-18; call sites use `shared.dispatch.<field>`); 4074
+  after #3479 item-2 extracted
   the dispatch-policy cluster verbatim to `discord/dispatch_policy.rs` (-169) on
   top of the earlier catch-up subsystem extraction to `discord/catch_up.rs`;
   4965; +34 from #3019 added the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -150,7 +150,7 @@
 # stale-dispatch turn gating + its tests, allowed-turn-sender / bot-user-id
 # resolvers, phase2 recovery predicate) moved verbatim to the capped sibling
 # `dispatch_policy.rs`, lowering the frozen baseline 4243 -> 4074 (-169).
-"src/services/discord/mod.rs" = 4074
+"src/services/discord/mod.rs" = 4056
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).
@@ -238,7 +238,7 @@
 # FIX #6 (Codex P2): +6 (3771 -> 3777) for the `set_followup_requeue_context`
 # call that persists the originating Intervention's reply/upload/voice context on
 # the follow-up inflight row so a PRE-submit busy-timeout requeue can rebuild it.
-"src/services/discord/router/message_handler/intake_turn.rs" = 3671
+"src/services/discord/router/message_handler/intake_turn.rs" = 3672
 "src/services/discord/meeting_orchestrator.rs" = 3227
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered
@@ -259,7 +259,7 @@
 # `handle_event` (mirrors the model-picker / idle-recap arms — the dispatch can
 # only live in the root event handler). The cancel handler body itself lives in
 # the non-giant `steering.rs`, not here. Combined with #3446: 2969 -> 2975.
-"src/services/discord/router/intake_gate.rs" = 2975
+"src/services/discord/router/intake_gate.rs" = 2977
 "src/services/discord/formatting.rs" = 2802
 # #3038 run_bot S0/S1: lowered 2802 -> 1918 by adding characterization tests and
 # moving restored_state, queued_placeholders, startup_doctor, orphan_recovery,

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -109,7 +109,8 @@ fn resolve_dispatch_role_model(
     channel_id: serenity::ChannelId,
 ) -> Option<String> {
     let override_channel = shared
-        .dispatch_role_overrides
+        .dispatch
+        .role_overrides
         .get(&channel_id)
         .map(|value| *value)?;
     resolve_role_binding(override_channel, None).and_then(|binding| binding.model)
@@ -129,7 +130,8 @@ pub(in crate::services::discord) async fn effective_provider_for_channel(
     };
     let channel_name = session_channel_name.as_deref().or(channel_name_hint);
     shared
-        .dispatch_role_overrides
+        .dispatch
+        .role_overrides
         .get(&channel_id)
         .map(|value| *value)
         .and_then(|override_channel| resolve_role_binding(override_channel, None))

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -373,7 +373,7 @@ pub(in crate::services::discord) async fn clear_channel_session_state(
         }
     }
 
-    shared.dispatch_role_overrides.remove(&channel_id);
+    shared.dispatch.role_overrides.remove(&channel_id);
 
     clear_fast_mode_reset_pending_for_channel(shared, channel_id);
     clear_codex_goals_reset_pending_for_channel(shared, channel_id);

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -456,7 +456,8 @@ async fn hydrate_pending_queue_from_disk(
         discord::mailbox_hydrate_pending_queue_from_disk(shared, provider, channel_id).await;
     if let Some(alt_channel_id) = result.restored_override {
         shared
-            .dispatch_role_overrides
+            .dispatch
+            .role_overrides
             .insert(channel_id, alt_channel_id);
     }
     result
@@ -605,13 +606,14 @@ async fn apply_runtime_hard_stop_cleanup(
 
     discord::clear_watchdog_deadline_override(channel_id.get()).await;
     shared
-        .dispatch_thread_parents
+        .dispatch
+        .thread_parents
         .retain(|_, thread| *thread != channel_id);
     shared.restart.recovering_channels.remove(&channel_id);
     shared.turn_start_times.remove(&channel_id);
 
     if !finish.has_pending {
-        shared.dispatch_role_overrides.remove(&channel_id);
+        shared.dispatch.role_overrides.remove(&channel_id);
     }
 
     if stop_watcher && let Some((_, watcher)) = shared.tmux_watchers.remove(&channel_id) {
@@ -1864,7 +1866,8 @@ pub(crate) async fn run_stall_watchdog_pass(
         )
         .await;
         shared
-            .dispatch_thread_parents
+            .dispatch
+            .thread_parents
             .retain(|_, thread_id| *thread_id != channel_id);
         if let Some(user_msg_id) = pending_hourglass_user_msg_id
             && let Ok(http) = super::resolve_bot_http(registry, provider.as_str()).await

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -228,11 +228,13 @@ async fn relay_thread_proof_for_channel(
     current_channel_has_live_evidence: bool,
 ) -> RelayThreadProofSnapshot {
     let thread_channel_id = shared
-        .dispatch_thread_parents
+        .dispatch
+        .thread_parents
         .get(&channel_id)
         .map(|entry| entry.value().get());
     let parent_channel_id = shared
-        .dispatch_thread_parents
+        .dispatch
+        .thread_parents
         .iter()
         .find_map(|entry| (*entry.value() == channel_id).then_some(entry.key().get()));
 
@@ -429,9 +431,10 @@ async fn watcher_state_snapshot_for_shared(
         .tmux_session
         .as_deref()
         .or(mailbox_cancel_tmux_session.as_deref());
-    let has_thread_proof = shared.dispatch_thread_parents.contains_key(&channel)
+    let has_thread_proof = shared.dispatch.thread_parents.contains_key(&channel)
         || shared
-            .dispatch_thread_parents
+            .dispatch
+            .thread_parents
             .iter()
             .any(|entry| *entry.value() == channel);
     if !session.attached

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -132,6 +132,9 @@ pub(in crate::services::discord) use shared_state::RuntimeHttpCache;
 // #3038 S2: the cluster-D members were `pub(super)` on `SharedData` (visible up
 // to `crate::services`), so the group type is re-exported with that same scope.
 pub(in crate::services) use shared_state::SessionOverrideState;
+// #3479 Item 3: the cluster members were `pub(super)` on `SharedData` (visible
+// up to `crate::services`), so the group type is re-exported with that scope.
+pub(in crate::services) use shared_state::DispatchRoutingState;
 // #3038 S3: same scope rationale as S2 — the cluster-E members were
 // `pub(super)` on `SharedData` (visible up to `crate::services`).
 pub(in crate::services) use shared_state::RestartLifecycle;
@@ -1883,16 +1886,11 @@ pub(crate) struct SharedData {
     /// side-effects) as an atomic, exactly-once unit. Bridge/watcher terminals
     /// submit terminal events here instead of finalizing inline.
     pub(in crate::services::discord) turn_finalizer: Arc<turn_finalizer::TurnFinalizer>,
-    /// Intake-level dedup cache: prevents the same message from starting two turns
-    /// when duplicate bot dispatches arrive nearly simultaneously.
-    /// Key: dedup key (dispatch_id or channel+author+text hash).
-    /// Value: (first-seen Instant, was_thread_context).
-    pub(super) intake_dedup: dashmap::DashMap<String, (std::time::Instant, bool)>,
-    /// Maps parent channel → active dispatch thread channel.
-    /// When a dispatch creates a thread, the parent is recorded here so that
-    /// subsequent bot messages to the parent are queued instead of starting
-    /// a parallel turn.  Cleared when the dispatch thread turn completes.
-    pub(super) dispatch_thread_parents: dashmap::DashMap<ChannelId, ChannelId>,
+    /// #3479 Item 3 — dispatch intake/routing state: the intake dedup cache, the
+    /// parent→dispatch-thread map, and the per-thread role/model override map.
+    /// Field declarations and docs live on `shared_state::DispatchRoutingState`;
+    /// call sites access the members via `shared.dispatch.<original field name>`.
+    pub(super) dispatch: DispatchRoutingState,
     /// Runtime bridge from songbird receive events and STT transcript sidecars
     /// into live playback cuts, explicit-stop cancellation, and deferred prompts.
     pub(in crate::services::discord) voice_barge_in: Arc<voice_barge_in::VoiceBargeInRuntime>,
@@ -1912,12 +1910,6 @@ pub(crate) struct SharedData {
     /// `shared_state::SessionOverrideState`; call sites access the members via
     /// `shared.overrides.<original field name>`.
     pub(super) overrides: SessionOverrideState,
-    /// Per-thread role/model override for cross-channel dispatch reuse.
-    /// When a review dispatch reuses an implementation thread, this maps
-    /// thread_channel_id → alt_channel_id so role_binding and model_for_turn
-    /// resolve from the counter-model channel instead of the thread's parent.
-    /// Cleared when the turn completes.
-    pub(super) dispatch_role_overrides: dashmap::DashMap<ChannelId, ChannelId>,
     /// Per-channel last processed message ID — used for startup catch-up polling.
     pub(super) last_message_ids: dashmap::DashMap<ChannelId, u64>,
     /// Channels where catch-up stopped because the intervention queue was at
@@ -2195,8 +2187,11 @@ pub(super) fn make_shared_data_for_tests_with_storage(
             shutdown_counted: std::sync::atomic::AtomicBool::new(false),
         },
         turn_finalizer: turn_finalizer::TurnFinalizer::spawn(),
-        intake_dedup: dashmap::DashMap::new(),
-        dispatch_thread_parents: dashmap::DashMap::new(),
+        dispatch: DispatchRoutingState {
+            intake_dedup: dashmap::DashMap::new(),
+            thread_parents: dashmap::DashMap::new(),
+            role_overrides: dashmap::DashMap::new(),
+        },
         voice_barge_in: Arc::new(voice_barge_in::VoiceBargeInRuntime::disabled()),
         voice_pairings: Arc::new(voice_routing::VoiceChannelPairingStore::load_default()),
         bot_connected: std::sync::atomic::AtomicBool::new(false),
@@ -2211,7 +2206,6 @@ pub(super) fn make_shared_data_for_tests_with_storage(
             session_reset_pending: dashmap::DashSet::new(),
             model_picker_pending: dashmap::DashMap::new(),
         },
-        dispatch_role_overrides: dashmap::DashMap::new(),
         last_message_ids: dashmap::DashMap::new(),
         catch_up_retry_pending: dashmap::DashMap::new(),
         turn_start_times: dashmap::DashMap::new(),
@@ -2240,7 +2234,8 @@ fn queue_persistence_context(
         provider,
         &shared.token_hash,
         shared
-            .dispatch_role_overrides
+            .dispatch
+            .role_overrides
             .get(&channel_id)
             .map(|override_id| override_id.value().get()),
     )
@@ -3436,7 +3431,7 @@ async fn mailbox_restart_drain_all(
         .restart_drain_all(
             provider,
             &shared.token_hash,
-            &shared.dispatch_role_overrides,
+            &shared.dispatch.role_overrides,
         )
         .await;
     for failure in &result.persistence_errors {

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -651,13 +651,14 @@ async fn apply_relay_recovery_decision(
     match decision.action {
         RelayRecoveryActionKind::ClearStaleThreadProof => {
             let channel = ChannelId::new(decision.channel_id);
-            let before = shared.dispatch_thread_parents.len();
+            let before = shared.dispatch.thread_parents.len();
             shared
-                .dispatch_thread_parents
+                .dispatch
+                .thread_parents
                 .retain(|parent, thread| *parent != channel && *thread != channel);
             RelayRecoveryApplyResult {
                 status: "applied",
-                removed_thread_proofs: before.saturating_sub(shared.dispatch_thread_parents.len()),
+                removed_thread_proofs: before.saturating_sub(shared.dispatch.thread_parents.len()),
                 removed_mailbox_token: false,
                 post_mailbox_has_cancel_token: None,
                 post_mailbox_queue_depth: None,
@@ -717,12 +718,13 @@ async fn apply_relay_recovery_decision(
                 }
                 super::clear_watchdog_deadline_override(channel.get()).await;
                 shared
-                    .dispatch_thread_parents
+                    .dispatch
+                    .thread_parents
                     .retain(|_, thread| *thread != channel);
                 shared.restart.recovering_channels.remove(&channel);
                 shared.turn_start_times.remove(&channel);
                 if !finish.has_pending {
-                    shared.dispatch_role_overrides.remove(&channel);
+                    shared.dispatch.role_overrides.remove(&channel);
                 }
                 if let Some((_, watcher)) = shared.tmux_watchers.remove(&channel) {
                     watcher.cancel.store(true, Ordering::Relaxed);
@@ -1410,7 +1412,7 @@ mod tests {
         let (registry, shared) = registry_with_shared(provider.clone()).await;
         let parent = ChannelId::new(3_360_003);
         let thread = ChannelId::new(3_360_004);
-        shared.dispatch_thread_parents.insert(parent, thread);
+        shared.dispatch.thread_parents.insert(parent, thread);
 
         let response = auto_apply_relay_recovery_for_shared(
             &registry,
@@ -1433,7 +1435,7 @@ mod tests {
             Some("auto_heal_action_not_allowed")
         );
         assert!(
-            shared.dispatch_thread_parents.contains_key(&parent),
+            shared.dispatch.thread_parents.contains_key(&parent),
             "auto orphan cleanup must not apply other recovery action kinds"
         );
     }

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -561,7 +561,7 @@ pub(super) async fn thread_guard_force_clean_stale_thread(
         "  [{ts}] 🔓 THREAD-GUARD: stale inflight detected for thread {}, cleaning up and proceeding",
         thread_id
     );
-    shared.dispatch_thread_parents.remove(&parent_channel_id);
+    shared.dispatch.thread_parents.remove(&parent_channel_id);
     super::super::inflight::delete_inflight_state_file(provider, thread_id.get());
     let cleared = mailbox_clear_channel(shared, provider, thread_id).await;
     super::super::stall_recovery::finalize_orphaned_clear(
@@ -621,10 +621,11 @@ async fn release_queue_blocked_stale_active_turn(
         "1456_queue_blocked_stale_proof",
     );
     shared
-        .dispatch_thread_parents
+        .dispatch
+        .thread_parents
         .retain(|_, thread_id| *thread_id != channel_id);
     if !finish.has_pending {
-        shared.dispatch_role_overrides.remove(&channel_id);
+        shared.dispatch.role_overrides.remove(&channel_id);
     }
     true
 }
@@ -1721,7 +1722,7 @@ pub(in crate::services::discord) async fn handle_event(
                             )
                             .is_ok()
                     {
-                        data.shared.intake_dedup.retain(|k, v| {
+                        data.shared.dispatch.intake_dedup.retain(|k, v| {
                             if k.starts_with("mid:") {
                                 now.duration_since(v.0) < MSG_DEDUP_TTL
                             } else {
@@ -1747,7 +1748,7 @@ pub(in crate::services::discord) async fn handle_event(
                 // `is_allowed_bot`. We trust the mailbox as the source
                 // of truth.
                 let mut thread_promotion_blocked = false;
-                let is_dup = match data.shared.intake_dedup.entry(key.clone()) {
+                let is_dup = match data.shared.dispatch.intake_dedup.entry(key.clone()) {
                     dashmap::mapref::entry::Entry::Occupied(mut e) => {
                         let (ts, was_thread) = *e.get();
                         if now.duration_since(ts) >= MSG_DEDUP_TTL {
@@ -2223,7 +2224,7 @@ pub(in crate::services::discord) async fn handle_event(
                 // Lazy cleanup: remove expired bot-specific entries.
                 // Skip mid:* entries — they use a longer TTL and are cleaned
                 // separately in the universal dedup section above.
-                data.shared.intake_dedup.retain(|k, v| {
+                data.shared.dispatch.intake_dedup.retain(|k, v| {
                     if k.starts_with("mid:") {
                         true // preserved; cleaned by universal dedup cleanup
                     } else {
@@ -2233,7 +2234,8 @@ pub(in crate::services::discord) async fn handle_event(
 
                 // Atomic check+insert via entry() — holds shard lock so two
                 // simultaneous arrivals cannot both see a miss.
-                let is_duplicate = match data.shared.intake_dedup.entry(dedup_key.clone()) {
+                let is_duplicate = match data.shared.dispatch.intake_dedup.entry(dedup_key.clone())
+                {
                     dashmap::mapref::entry::Entry::Occupied(e) => {
                         now.duration_since(e.get().0) < INTAKE_DEDUP_TTL
                     }
@@ -2275,7 +2277,8 @@ pub(in crate::services::discord) async fn handle_event(
                 // RwLock. The narrow scope below releases the ref at the `}`.
                 let thread_id_opt = {
                     data.shared
-                        .dispatch_thread_parents
+                        .dispatch
+                        .thread_parents
                         .get(&channel_id)
                         .map(|entry| *entry.value())
                 };
@@ -2370,7 +2373,7 @@ pub(in crate::services::discord) async fn handle_event(
                         }
                     } else {
                         // Thread turn finished — clean up stale mapping
-                        data.shared.dispatch_thread_parents.remove(&channel_id);
+                        data.shared.dispatch.thread_parents.remove(&channel_id);
                     }
                 }
             }

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -618,7 +618,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                         // dispatch_thread_parents hasn't been populated yet).
                         let (wt_info, provider_isolation_applied) = {
                             let is_thread =
-                                shared.dispatch_thread_parents.contains_key(&channel_id)
+                                shared.dispatch.thread_parents.contains_key(&channel_id)
                                     || super::super::super::resolve_thread_parent(http, channel_id)
                                         .await
                                         .is_some();
@@ -912,7 +912,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                             "  [{ts}] 🔄 Review dispatch in reused thread: overriding role to alt channel {}",
                             alt_ch
                         );
-                        shared.dispatch_role_overrides.insert(channel_id, alt_ch);
+                        shared.dispatch.role_overrides.insert(channel_id, alt_ch);
                     }
                 }
                 channel_id
@@ -947,7 +947,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                                 cache,
                             )
                             .await;
-                        shared.dispatch_thread_parents.insert(channel_id, tid);
+                        shared.dispatch.thread_parents.insert(channel_id, tid);
                         // For review dispatches reusing an implementation thread,
                         // override role/model to use the counter-model channel.
                         if is_counter_model_dispatch {
@@ -957,7 +957,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                                     "  [{ts}] 🔄 Review dispatch reusing thread: overriding role to alt channel {}",
                                     alt_ch
                                 );
-                                shared.dispatch_role_overrides.insert(tid, alt_ch);
+                                shared.dispatch.role_overrides.insert(tid, alt_ch);
                             }
                         }
                         Some(tid)
@@ -1013,7 +1013,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                                     cache,
                                 )
                                 .await;
-                            shared.dispatch_thread_parents.insert(channel_id, thread.id);
+                            shared.dispatch.thread_parents.insert(channel_id, thread.id);
                             super::super::link_dispatch_thread(
                                 shared.api_port,
                                 did,
@@ -1175,7 +1175,7 @@ pub(in crate::services::discord) async fn handle_text_message(
     let role_binding = {
         // For cross-channel dispatch reuse (e.g. review in implementation thread),
         // resolve role from the override channel instead of the thread's parent.
-        if let Some(override_ch) = shared.dispatch_role_overrides.get(&channel_id) {
+        if let Some(override_ch) = shared.dispatch.role_overrides.get(&channel_id) {
             let alt_ch = *override_ch;
             resolve_role_binding(alt_ch, None)
         } else {
@@ -1195,7 +1195,7 @@ pub(in crate::services::discord) async fn handle_text_message(
 
     // For cross-channel dispatch reuse, override the provider so the turn
     // executes via the counter-model CLI (e.g. Codex reviews Claude's work).
-    let provider = if shared.dispatch_role_overrides.contains_key(&channel_id) {
+    let provider = if shared.dispatch.role_overrides.contains_key(&channel_id) {
         role_binding
             .as_ref()
             .and_then(|rb| rb.provider.clone())
@@ -2815,7 +2815,8 @@ pub(in crate::services::discord) async fn handle_text_message(
         .and_then(super::super::super::adk_session::parse_thread_channel_id_from_name)
         .or_else(|| {
             shared
-                .dispatch_thread_parents
+                .dispatch
+                .thread_parents
                 .contains_key(&channel_id)
                 .then_some(channel_id.get())
         });

--- a/src/services/discord/runtime_bootstrap/recovery_flush.rs
+++ b/src/services/discord/runtime_bootstrap/recovery_flush.rs
@@ -65,7 +65,8 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                     continue;
                 }
                 shared_for_tmux2
-                    .dispatch_role_overrides
+                    .dispatch
+                    .role_overrides
                     .insert(*thread_channel_id, *alt_channel_id);
             }
             if !restored_overrides.is_empty() {

--- a/src/services/discord/runtime_bootstrap/shared_data.rs
+++ b/src/services/discord/runtime_bootstrap/shared_data.rs
@@ -103,8 +103,15 @@ pub(super) fn run_bot_build_shared_data(
             shutdown_counted: std::sync::atomic::AtomicBool::new(false),
         },
         turn_finalizer: crate::services::discord::turn_finalizer::TurnFinalizer::spawn(),
-        intake_dedup: dashmap::DashMap::new(),
-        dispatch_thread_parents: dashmap::DashMap::new(),
+        // #3479 Item 3: dispatch intake/routing cluster. All three members are
+        // side-effect-free `DashMap::new()` inits, so grouping them at this
+        // first-member position (dispatch_role_overrides moved up from below)
+        // preserves the evaluation order of every side-effecting initializer.
+        dispatch: DispatchRoutingState {
+            intake_dedup: dashmap::DashMap::new(),
+            thread_parents: dashmap::DashMap::new(),
+            role_overrides: dashmap::DashMap::new(),
+        },
         bot_connected: std::sync::atomic::AtomicBool::new(false),
         last_turn_at: std::sync::Mutex::new(None),
         // #3038 S2: wrapped verbatim at the first-member position (evaluation-order preserved).
@@ -152,7 +159,6 @@ pub(super) fn run_bot_build_shared_data(
             ),
             model_picker_pending: dashmap::DashMap::new(),
         },
-        dispatch_role_overrides: dashmap::DashMap::new(),
         voice_barge_in: voice_barge_in.clone(),
         voice_pairings: Arc::new(voice_routing::VoiceChannelPairingStore::load_default()),
         last_message_ids: dashmap::DashMap::new(),

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -408,6 +408,33 @@ pub(in crate::services) struct SessionOverrideState {
         dashmap::DashMap<MessageId, ModelPickerPendingState>,
 }
 
+/// #3479 Item 3 — dispatch intake/routing state.
+///
+/// Groups the three cohesive per-dispatch routing maps that together decide
+/// whether an incoming bot message starts a new turn, is deduped, or is routed
+/// into an existing dispatch thread / counter-model channel. Field declarations,
+/// docs, and types moved verbatim from `discord/mod.rs`; the members keep their
+/// original `pub(super)` (== `pub(in crate::services)`) visibility, and call
+/// sites use `shared.dispatch.<original field name>`.
+pub(in crate::services) struct DispatchRoutingState {
+    /// Intake-level dedup cache: prevents the same message from starting two turns
+    /// when duplicate bot dispatches arrive nearly simultaneously.
+    /// Key: dedup key (dispatch_id or channel+author+text hash).
+    /// Value: (first-seen Instant, was_thread_context).
+    pub(in crate::services) intake_dedup: dashmap::DashMap<String, (std::time::Instant, bool)>,
+    /// Maps parent channel → active dispatch thread channel.
+    /// When a dispatch creates a thread, the parent is recorded here so that
+    /// subsequent bot messages to the parent are queued instead of starting
+    /// a parallel turn.  Cleared when the dispatch thread turn completes.
+    pub(in crate::services) thread_parents: dashmap::DashMap<ChannelId, ChannelId>,
+    /// Per-thread role/model override for cross-channel dispatch reuse.
+    /// When a review dispatch reuses an implementation thread, this maps
+    /// thread_channel_id → alt_channel_id so role_binding and model_for_turn
+    /// resolve from the counter-model channel instead of the thread's parent.
+    /// Cleared when the turn completes.
+    pub(in crate::services) role_overrides: dashmap::DashMap<ChannelId, ChannelId>,
+}
+
 // #3038 cluster D — free-function helpers that exclusively own
 // [`SessionOverrideState`]. Moved verbatim from `commands/config.rs` (which
 // re-exports them so every `super::config::*` importer and unqualified call

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -1086,7 +1086,8 @@ async fn do_finalize(
         //     Moved here so they cannot diverge between the routed paths.
         super::clear_watchdog_deadline_override(channel_id.get()).await;
         shared
-            .dispatch_thread_parents
+            .dispatch
+            .thread_parents
             .retain(|_, thread| *thread != channel_id);
 
         let voice_deferred_enqueued = if ctx.drain_voice {
@@ -1099,7 +1100,7 @@ async fn do_finalize(
         };
         let has_pending_after_voice = finish.has_pending || voice_deferred_enqueued;
         if !has_pending_after_voice {
-            shared.dispatch_role_overrides.remove(&channel_id);
+            shared.dispatch.role_overrides.remove(&channel_id);
         }
 
         // (E) optional deferred queue kickoff (watcher path), gated exactly as
@@ -2260,8 +2261,8 @@ mod tests {
             //   * dispatch_role_overrides is keyed BY `ch`.
             let thread_ch = ChannelId::new(1314);
             let override_ch = ChannelId::new(1315);
-            shared.dispatch_thread_parents.insert(thread_ch, ch);
-            shared.dispatch_role_overrides.insert(ch, override_ch);
+            shared.dispatch.thread_parents.insert(thread_ch, ch);
+            shared.dispatch.role_overrides.insert(ch, override_ch);
 
             let fin = TurnFinalizer::spawn();
             // A STALE terminal for turn-1 (its real id) arrives. The finalizer
@@ -2324,14 +2325,16 @@ mod tests {
             // side-effects, not corrupt the newer turn's routing/watchdog metadata.
             assert!(
                 shared
-                    .dispatch_thread_parents
+                    .dispatch
+                    .thread_parents
                     .get(&thread_ch)
                     .is_some_and(|v| *v == ch),
                 "stale terminal must NOT drop turn-2's dispatch_thread_parents entry"
             );
             assert!(
                 shared
-                    .dispatch_role_overrides
+                    .dispatch
+                    .role_overrides
                     .get(&ch)
                     .is_some_and(|v| *v == override_ch),
                 "stale terminal must NOT drop turn-2's dispatch_role_overrides entry"

--- a/src/services/discord/turn_finalizer/cleanup.rs
+++ b/src/services/discord/turn_finalizer/cleanup.rs
@@ -215,10 +215,11 @@ pub(super) async fn already_finalized_active_state(
     super::super::saturating_decrement_global_active(shared);
     super::super::clear_watchdog_deadline_override(key.channel_id.get()).await;
     shared
-        .dispatch_thread_parents
+        .dispatch
+        .thread_parents
         .retain(|_, thread| *thread != key.channel_id);
     if !finish.has_pending {
-        shared.dispatch_role_overrides.remove(&key.channel_id);
+        shared.dispatch.role_overrides.remove(&key.channel_id);
     }
 }
 

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -2986,8 +2986,11 @@ mod tests {
                 shutdown_counted: std::sync::atomic::AtomicBool::new(false),
             },
             turn_finalizer: super::super::turn_finalizer::TurnFinalizer::spawn(),
-            intake_dedup: dashmap::DashMap::new(),
-            dispatch_thread_parents: dashmap::DashMap::new(),
+            dispatch: super::super::DispatchRoutingState {
+                intake_dedup: dashmap::DashMap::new(),
+                thread_parents: dashmap::DashMap::new(),
+                role_overrides: dashmap::DashMap::new(),
+            },
             voice_barge_in: Arc::new(VoiceBargeInRuntime::disabled()),
             voice_pairings: Arc::new(
                 super::super::voice_routing::VoiceChannelPairingStore::load_default(),
@@ -3004,7 +3007,6 @@ mod tests {
                 session_reset_pending: dashmap::DashSet::new(),
                 model_picker_pending: dashmap::DashMap::new(),
             },
-            dispatch_role_overrides: dashmap::DashMap::new(),
             last_message_ids: dashmap::DashMap::new(),
             catch_up_retry_pending: dashmap::DashMap::new(),
             turn_start_times: dashmap::DashMap::new(),


### PR DESCRIPTION
Part of #3479 (Item 3 — SharedData god-object capability extraction). First PR.

Groups the three cohesive per-dispatch routing maps (`intake_dedup`, `dispatch_thread_parents`, `dispatch_role_overrides`) into a `DispatchRoutingState` sub-struct in `discord/shared_state.rs`, following the existing #3038 cluster pattern. SharedData struct: 33 → 31 fields.

- The two stuttering field names drop the redundant `dispatch_` prefix inside the sub-struct (`thread_parents`, `role_overrides`; `intake_dedup` kept). Call sites use `shared.dispatch.<field>`; the same-length path for the renamed pair avoids consumer line-wrap inflation.
- All three construction sites updated (`run_bot_build_shared_data` + `make_shared_data_for_tests` + the voice_barge_in test helper); all `DashMap::new()`, side-effect-free, init order preserved. The unrelated `turn_orchestrator.rs` `dispatch_role_overrides` fn parameter is untouched.
- Ratchet: `discord/mod.rs` 4074 → 4056 (god-object -18); irreducible `.dispatch.` nesting adds intake_turn +1, intake_gate +2, health/recovery +3 (synced in baseline.toml + change-surfaces.md).

Verification: audit --check RC0, agent-maintenance freshness pass, fmt --check clean, full lib test 3688 passed (the lone failure is the pre-existing `tui_direct_pending_start::successful_watcher_owned_claim_records_own_identity_marker` parallel-isolation flake that also reproduces on clean origin/main and passes in CI). codex adversarial review: VERDICT CLEAN (no orphan flat access, no stutter, turn_orchestrator param intact).

Follow-up PRs will cluster the remaining loose SharedData fields (catch-up polling, per-channel metrics/roster) by the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)