### PR TITLE
refactor(#3479): group run_bot_build_shared_data args 20→6 param structs

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1106,7 +1106,7 @@
     `finalize_stale_streaming_footer` / `text_ends_with_streaming_footer` shared
     terminal-idle reconciliation helpers + their unit tests).
   - `src/services/discord/prompt_builder/` (directory, refactored).
-  - `src/services/discord/runtime_bootstrap.rs` (274 production lines after
+  - `src/services/discord/runtime_bootstrap.rs` (285 production lines after #3479 item-3 grouped the 20 builder args into 6 param structs; was 274 after
     #3038 run_bot S0/S5; characterization tests pin the startup-doctor barrier,
     restored settings filters, queued-placeholder filtering/deletion, and
     gateway intents, then the low-risk clusters moved verbatim into
@@ -1115,7 +1115,7 @@
     `session_gc.rs` (102 prod / 69 test), `framework_setup.rs` (287),
     `spawns.rs` (229), `recovery_flush.rs` (357), `voice.rs` (140),
     `gateway_lease.rs` (190), `shutdown.rs` (207), `intake.rs` (63),
-    `shared_data.rs` (176, the `run_bot_build_shared_data` builder plus its
+    `shared_data.rs` (236, the `run_bot_build_shared_data` builder + its 4 #3479 param structs plus its
     side-effect-order doc), and `gateway_runtime.rs` (147, the leader runtime
     tail from restored logging through backend event-loop entry).
     The namespace is capped at 700 prod lines per child module in

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -274,7 +274,7 @@
 # #3038 run_bot S5: lowered 369 -> 274 by moving the 120-line leader gateway
 # runtime tail into `runtime_bootstrap/gateway_runtime.rs`; all
 # `runtime_bootstrap/` child modules remain under the 700-line namespace cap.
-"src/services/discord/runtime_bootstrap.rs" = 274
+"src/services/discord/runtime_bootstrap.rs" = 285
 # #3034 batch-8: lowered 2655 -> 2645 (dead-code removal: `stop_provider_channel_runtime`).
 # #3293: lowered 2645 -> 2641 (mailbox probe routed through the non-creating
 # `health/mailbox.rs::peeked_provider_mailbox_state`).

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -27,7 +27,10 @@ pub(in crate::services::discord) use self::queued_placeholders::{
     delete_stale_queued_placeholder_cards, delete_stale_queued_placeholder_cards_with,
     filter_restored_queued_placeholders,
 };
-use self::shared_data::run_bot_build_shared_data;
+use self::shared_data::{
+    ProcessLifecycleCounters, RestoredSessionState, RuntimeServices, UiFeatureFlags,
+    run_bot_build_shared_data,
+};
 use self::shutdown::{run_bot_run_gateway_backend, run_bot_spawn_sigterm_handler};
 #[cfg(test)]
 use self::voice::voice_auto_join_provider_map;
@@ -162,25 +165,33 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
 
     let shared = run_bot_build_shared_data(
         bot_settings,
-        initial_skills,
         &provider,
-        &token_hash,
-        &voice_barge_in,
-        global_active,
-        global_finalizing,
-        &shutdown_remaining,
-        &health_registry,
-        pg_pool,
-        engine,
-        api_port,
-        placeholder_live_events_enabled,
-        status_panel_v2_enabled,
-        &restored_model_overrides,
-        &restored_fast_mode_channels,
-        &restored_fast_mode_reset_entries,
-        &restored_fast_mode_reset_channels,
-        &restored_codex_goals_channels,
-        &restored_codex_goals_reset_channels,
+        RuntimeServices {
+            initial_skills,
+            token_hash: token_hash.clone(),
+            api_port,
+            voice_barge_in: voice_barge_in.clone(),
+            health_registry: health_registry.clone(),
+            pg_pool,
+            engine,
+        },
+        ProcessLifecycleCounters {
+            global_active,
+            global_finalizing,
+            shutdown_remaining: shutdown_remaining.clone(),
+        },
+        UiFeatureFlags {
+            placeholder_live_events_enabled,
+            status_panel_v2_enabled,
+        },
+        RestoredSessionState {
+            model_overrides: &restored_model_overrides,
+            fast_mode_channels: &restored_fast_mode_channels,
+            fast_mode_reset_entries: &restored_fast_mode_reset_entries,
+            fast_mode_reset_channels: &restored_fast_mode_reset_channels,
+            codex_goals_channels: &restored_codex_goals_channels,
+            codex_goals_reset_channels: &restored_codex_goals_reset_channels,
+        },
     );
     super::tui_prompt_relay::spawn_tui_prompt_relay(shared.clone(), provider.clone());
 
@@ -728,25 +739,33 @@ mod restart_lifecycle_characterization_tests {
         let health_registry = Arc::new(health::HealthRegistry::new());
         run_bot_build_shared_data(
             DiscordBotSettings::default(),
-            Vec::new(),
             &ProviderKind::Claude,
-            "s3-restart-characterization-token-hash",
-            &voice,
-            Arc::new(AtomicUsize::new(0)),
-            Arc::new(AtomicUsize::new(0)),
-            shutdown_remaining,
-            &health_registry,
-            None,
-            None,
-            9,
-            false,
-            false,
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
+            RuntimeServices {
+                initial_skills: Vec::new(),
+                token_hash: "s3-restart-characterization-token-hash".to_string(),
+                api_port: 9,
+                voice_barge_in: voice,
+                health_registry,
+                pg_pool: None,
+                engine: None,
+            },
+            ProcessLifecycleCounters {
+                global_active: Arc::new(AtomicUsize::new(0)),
+                global_finalizing: Arc::new(AtomicUsize::new(0)),
+                shutdown_remaining: shutdown_remaining.clone(),
+            },
+            UiFeatureFlags {
+                placeholder_live_events_enabled: false,
+                status_panel_v2_enabled: false,
+            },
+            RestoredSessionState {
+                model_overrides: &[],
+                fast_mode_channels: &[],
+                fast_mode_reset_entries: &[],
+                fast_mode_reset_channels: &[],
+                codex_goals_channels: &[],
+                codex_goals_reset_channels: &[],
+            },
         )
     }
 

--- a/src/services/discord/runtime_bootstrap/shared_data.rs
+++ b/src/services/discord/runtime_bootstrap/shared_data.rs
@@ -1,36 +1,88 @@
 use super::*;
 
+/// #3479 Item 3: runtime services/handles/backends consumed by the SharedData
+/// builder. Groups seven former positional args; field names match the original
+/// argument names so the builder body is unchanged after destructuring.
+pub(super) struct RuntimeServices {
+    pub(super) initial_skills: Vec<(String, String)>,
+    pub(super) token_hash: String,
+    pub(super) api_port: u16,
+    pub(super) voice_barge_in: Arc<voice_barge_in::VoiceBargeInRuntime>,
+    pub(super) health_registry: Arc<health::HealthRegistry>,
+    pub(super) pg_pool: Option<sqlx::PgPool>,
+    pub(super) engine: Option<crate::engine::PolicyEngine>,
+}
+
+/// #3479 Item 3: process-wide lifecycle counters shared across all providers
+/// (injected so every provider's `SharedData` shares the same atomics).
+pub(super) struct ProcessLifecycleCounters {
+    pub(super) global_active: Arc<std::sync::atomic::AtomicUsize>,
+    pub(super) global_finalizing: Arc<std::sync::atomic::AtomicUsize>,
+    pub(super) shutdown_remaining: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+/// #3479 Item 3: UI feature gates for the live-placeholder / status-panel surface.
+pub(super) struct UiFeatureFlags {
+    pub(super) placeholder_live_events_enabled: bool,
+    pub(super) status_panel_v2_enabled: bool,
+}
+
+/// #3479 Item 3: session state restored from persisted bot settings. Borrowed
+/// because run_bot reuses these slices for logging + session-reset bootstrap
+/// after the builder returns.
+pub(super) struct RestoredSessionState<'a> {
+    pub(super) model_overrides: &'a [(ChannelId, String)],
+    pub(super) fast_mode_channels: &'a [ChannelId],
+    pub(super) fast_mode_reset_entries: &'a [String],
+    pub(super) fast_mode_reset_channels: &'a [ChannelId],
+    pub(super) codex_goals_channels: &'a [ChannelId],
+    pub(super) codex_goals_reset_channels: &'a [ChannelId],
+}
+
 /// Build all owned `SharedData` fields and wrap in an `Arc`. Side-effecting
 /// initializers (`TurnFinalizer::spawn`,
 /// `runtime_store::load_generation`, `load_queue_exit_placeholder_clears`,
 /// the `inflight_signals` broadcast channel) run here in the exact same order
-/// as the original inline struct literal. `bot_settings`, `initial_skills`,
-/// `global_active`, `global_finalizing`, `pg_pool`, and `engine` are consumed
-/// by move; the `restored_*` slices are borrowed (they are reused later in
-/// run_bot for logging and session-reset bootstrap).
-#[allow(clippy::too_many_arguments)]
+/// as the original inline struct literal. `bot_settings`, `services.initial_skills`,
+/// `counters.global_active`, `counters.global_finalizing`, `services.pg_pool`, and
+/// `services.engine` are consumed by move; the `restored.*` slices are borrowed
+/// (they are reused later in run_bot for logging and session-reset bootstrap).
 pub(super) fn run_bot_build_shared_data(
     bot_settings: DiscordBotSettings,
-    initial_skills: Vec<(String, String)>,
     provider: &ProviderKind,
-    token_hash: &str,
-    voice_barge_in: &Arc<voice_barge_in::VoiceBargeInRuntime>,
-    global_active: Arc<std::sync::atomic::AtomicUsize>,
-    global_finalizing: Arc<std::sync::atomic::AtomicUsize>,
-    shutdown_remaining: &Arc<std::sync::atomic::AtomicUsize>,
-    health_registry: &Arc<health::HealthRegistry>,
-    pg_pool: Option<sqlx::PgPool>,
-    engine: Option<crate::engine::PolicyEngine>,
-    api_port: u16,
-    placeholder_live_events_enabled: bool,
-    status_panel_v2_enabled: bool,
-    restored_model_overrides: &[(ChannelId, String)],
-    restored_fast_mode_channels: &[ChannelId],
-    restored_fast_mode_reset_entries: &[String],
-    restored_fast_mode_reset_channels: &[ChannelId],
-    restored_codex_goals_channels: &[ChannelId],
-    restored_codex_goals_reset_channels: &[ChannelId],
+    services: RuntimeServices,
+    counters: ProcessLifecycleCounters,
+    flags: UiFeatureFlags,
+    restored: RestoredSessionState<'_>,
 ) -> Arc<SharedData> {
+    // #3479 Item 3: destructure the grouped params back into the original
+    // variable names so the construction body below is byte-identical.
+    let RuntimeServices {
+        initial_skills,
+        token_hash,
+        api_port,
+        voice_barge_in,
+        health_registry,
+        pg_pool,
+        engine,
+    } = services;
+    let ProcessLifecycleCounters {
+        global_active,
+        global_finalizing,
+        shutdown_remaining,
+    } = counters;
+    let UiFeatureFlags {
+        placeholder_live_events_enabled,
+        status_panel_v2_enabled,
+    } = flags;
+    let RestoredSessionState {
+        model_overrides: restored_model_overrides,
+        fast_mode_channels: restored_fast_mode_channels,
+        fast_mode_reset_entries: restored_fast_mode_reset_entries,
+        fast_mode_reset_channels: restored_fast_mode_reset_channels,
+        codex_goals_channels: restored_codex_goals_channels,
+        codex_goals_reset_channels: restored_codex_goals_reset_channels,
+    } = restored;
     Arc::new(SharedData {
         core: Mutex::new(CoreState {
             sessions: HashMap::new(),
@@ -65,7 +117,7 @@ pub(super) fn run_bot_build_shared_data(
                 let map = dashmap::DashMap::new();
                 for (key, placeholder_msg_id) in
                     crate::services::discord::queued_placeholders_store::load_queue_exit_placeholder_clears(
-                        provider, token_hash,
+                        provider, &token_hash,
                     )
                 {
                     map.insert(key, placeholder_msg_id);
@@ -99,7 +151,7 @@ pub(super) fn run_bot_build_shared_data(
             recovery_duration_ms: std::sync::atomic::AtomicU64::new(0),
             global_active,
             global_finalizing,
-            shutdown_remaining: shutdown_remaining.clone(),
+            shutdown_remaining,
             shutdown_counted: std::sync::atomic::AtomicBool::new(false),
         },
         turn_finalizer: crate::services::discord::turn_finalizer::TurnFinalizer::spawn(),
@@ -159,7 +211,7 @@ pub(super) fn run_bot_build_shared_data(
             ),
             model_picker_pending: dashmap::DashMap::new(),
         },
-        voice_barge_in: voice_barge_in.clone(),
+        voice_barge_in,
         voice_pairings: Arc::new(voice_routing::VoiceChannelPairingStore::load_default()),
         last_message_ids: dashmap::DashMap::new(),
         catch_up_retry_pending: dashmap::DashMap::new(),
@@ -169,12 +221,12 @@ pub(super) fn run_bot_build_shared_data(
             cached_serenity_ctx: tokio::sync::OnceCell::new(),
             cached_bot_token: tokio::sync::OnceCell::new(),
         },
-        token_hash: token_hash.to_string(),
+        token_hash,
         provider: provider.clone(),
         api_port,
         pg_pool,
         policy: PolicyRuntime { engine },
-        health_registry: Arc::downgrade(health_registry),
+        health_registry: Arc::downgrade(&health_registry),
         known_slash_commands: tokio::sync::OnceCell::new(),
         // #2448: capacity 256 gives ~hundreds of in-flight turns headroom
         // before a slow listener triggers `RecvError::Lagged`. The standby


### PR DESCRIPTION
Part of #3479 (Item 3 — SharedData capability extraction). Addresses the cited `run_bot_build_shared_data` 20-args + `#[allow(clippy::too_many_arguments)]` smell.

Replaces the builder's 20 positional args with 6 cohesive param structs: `RuntimeServices`, `ProcessLifecycleCounters`, `UiFeatureFlags`, `RestoredSessionState<'a>`. A destructure preamble rebinds each field to its original variable name so the SharedData construction body is byte-identical except 4 owned/borrowed adjustments. `#[allow(too_many_arguments)]` removed.

Behavior-preserving: prod call site clones the 4 values run_bot reuses after the call (token_hash, voice_barge_in, health_registry, shutdown_remaining — formerly `&`-args; an attempted move was correctly rejected by the borrow checker, confirming they're used after) and moves the rest; struct-literal init order unchanged; restored_* still borrowed.

- ratchet: runtime_bootstrap.rs 274→285 (verbose struct-literal call sites) in baseline.toml + change-surfaces.md; shared_data.rs prose 176→236.

Verification: audit --check RC0, agent-maintenance freshness pass, clippy clean, fmt clean, full lib test 3688 passed (lone failure is the pre-existing `tui_direct_pending_start::successful_watcher_owned_claim_records_own_identity_marker` parallel-isolation flake, reproduces on clean origin/main, passes in CI). codex adversarial review: VERDICT CLEAN.

Closes the #3479 Item-3 actionable work (capability handles via #3038 ×5 + DispatchRoutingState #3538 + this builder-arg cleanup). Will close #3479 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)