### PR TITLE
feat(codex-tui): cache rollout discovery for resume/follow-up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -356,6 +356,7 @@ src/
 │   ├── codex_tui/
 │   │   ├── input.rs
 │   │   ├── mod.rs
+│   │   ├── rollout_index.rs
 │   │   ├── rollout_tail.rs
 │   │   └── session.rs
 │   ├── discord/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "croner",
  "dashmap 6.1.0",
  "dirs",
+ "filetime",
  "futures",
  "glob",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ croner = "3.0.1"
 
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }
 tower = { version = "0.5", features = ["util"] }

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1317,7 +1317,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2378 lines).
+  - `src/config.rs` (2479 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
@@ -1417,7 +1417,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/claude_tui/hosting/` child modules, ratchets claude.rs at 2950
   production LoC, and leaves the #3262 turn-lock machinery in the claude.rs
   root.)
-- `src/services/codex_tui/rollout_tail.rs` (1776) — Codex TUI rollout tail
+- `src/services/codex_tui/rollout_tail.rs` (1756) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix and the #3343 message-boundary
   separator unified across the streamed `StreamMessage::Text` surface and the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1317,7 +1317,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2479 lines).
+  - `src/config.rs` (2353 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1317,7 +1317,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2353 lines).
+  - `src/config.rs` (2391 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1417,7 +1417,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/claude_tui/hosting/` child modules, ratchets claude.rs at 2950
   production LoC, and leaves the #3262 turn-lock machinery in the claude.rs
   root.)
-- `src/services/codex_tui/rollout_tail.rs` (1756) — Codex TUI rollout tail
+- `src/services/codex_tui/rollout_tail.rs` (1768) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix and the #3343 message-boundary
   separator unified across the streamed `StreamMessage::Text` surface and the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1404,6 +1404,18 @@ pub struct RuntimeSettingsConfig {
     /// live-reloadable key of the three TUI hook registry settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tui_hook_registry_enabled: Option<bool>,
+    /// Enable the in-process Codex rollout discovery index cache used by the
+    /// Codex TUI resume / follow-up readiness paths
+    /// (`codex_tui::rollout_index`). The cache avoids re-walking
+    /// `~/.codex/sessions` and re-reading rollout headers on every lookup.
+    ///
+    /// Defaults ON when unset (`None`). Set to `false` to force the legacy
+    /// per-lookup recursive scan + header read — the built-in rollback for the
+    /// `codex-rollout-index-cache` feature. Read live via
+    /// `config_live_reload::current()` so an `agentdesk.yaml` edit applies on the
+    /// next lookup without a restart; not part of the restart-required set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_rollout_index_cache_enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub reset_overrides_on_restart: bool,
 }
@@ -1441,6 +1453,7 @@ impl RuntimeSettingsConfig {
             && self.tui_hook_buffer_ttl_secs.is_none()
             && self.tui_unclaimed_stop_delay_ms.is_none()
             && self.tui_hook_registry_enabled.is_none()
+            && self.codex_rollout_index_cache_enabled.is_none()
             && !self.reset_overrides_on_restart
     }
 }

--- a/src/services/codex_tui/mod.rs
+++ b/src/services/codex_tui/mod.rs
@@ -1,3 +1,4 @@
 pub mod input;
+pub mod rollout_index;
 pub mod rollout_tail;
 pub mod session;

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -18,13 +18,13 @@
 //!    therefore the signature. The signature is recomputed on **every** lookup
 //!    (cheap `O(directories)` stat calls) — invalidation is a precondition, not
 //!    a postcondition.
-//! 2. On a signature match (warm hit) reuses the cached file *list* directly so
-//!    the `O(directories × entries)` `read_dir` re-walk is skipped; each cached
-//!    path is still `stat`ed and its parsed `session_meta` reused unless its
-//!    `(mtime, len)` changed (catching in-place appends/rewrites that leave the
-//!    directory mtime — and thus the signature — unchanged). Warm lookups
-//!    therefore do **not** re-walk the tree and do **not** re-read unchanged
-//!    headers (PRD REQ-005).
+//! 2. On a signature match (warm hit) validates direct membership for the cached
+//!    directory list, then reuses the cached rollout file *list* when membership
+//!    is unchanged. Each cached path is still `stat`ed and its parsed
+//!    `session_meta` reused unless its `(mtime, len)` changed (catching in-place
+//!    appends/rewrites that leave the directory mtime — and thus the signature —
+//!    unchanged). Warm lookups therefore avoid recursive discovery and do **not**
+//!    re-read unchanged headers (PRD REQ-005).
 //! 3. On a signature mismatch (cold / changed) re-walks the tree, but still
 //!    consults the prior per-file map and re-reads only headers whose
 //!    `(mtime, len)` changed (or files never seen before). A single added rollout
@@ -59,13 +59,6 @@ const HEADER_SCAN_LINE_LIMIT: usize = 20;
 /// tempdirs. The bound keeps the cache from growing without limit if a caller
 /// ever passes many distinct roots, evicting the least-recently-built root.
 const MAX_CACHED_ROOTS: usize = 32;
-
-/// Rollout membership validation is intentionally bounded to the most recently
-/// modified known directories. Codex creates new rollouts in the current dated
-/// leaf, so probing direct rollout-file and child-directory membership catches
-/// the mtime-coarseness stale-hit risk without re-walking the whole sessions
-/// tree on every 100ms launch poll.
-const MAX_MEMBERSHIP_PROBE_DIRS: usize = 8;
 
 /// Parsed `session_meta` header for a single rollout file. This is the only
 /// data the resolver needs beyond the file path + length, and re-parsing it is
@@ -251,8 +244,9 @@ struct TreeSignature {
 /// directory list. Warm lookups re-stat that known directory list instead of
 /// recursively calling `read_dir`, so the 100ms follow-up poll path stays cheap.
 /// A new rollout normally bumps its containing directory mtime; if a filesystem
-/// preserves/coarsens that mtime, a bounded recent-leaf membership probe below
-/// catches the practical same-leaf case without re-walking the full tree.
+/// preserves/coarsens that mtime, the known-directory membership validation
+/// below catches same-leaf and new-child cases without re-reading rollout
+/// headers.
 ///
 /// Returns `None` when the root does not exist or cannot be read, which the
 /// caller treats as "no authoritative cache" — it does NOT cache a missing root,
@@ -348,28 +342,10 @@ fn recent_rollout_membership_changed(index: &RootIndex) -> bool {
 }
 
 fn rollout_membership_probe_dirs(index: &RootIndex) -> Vec<PathBuf> {
-    let mut dirs = index
-        .dirs
-        .iter()
-        .filter_map(|dir| {
-            std::fs::metadata(dir)
-                .and_then(|meta| meta.modified())
-                .ok()
-                .map(|modified| (modified, dir.clone()))
-        })
-        .collect::<Vec<_>>();
-    dirs.sort_by(|left, right| right.0.cmp(&left.0));
-
-    let mut unique_dirs = Vec::new();
-    for (_, dir) in dirs {
-        if !unique_dirs.iter().any(|seen| seen == &dir) {
-            unique_dirs.push(dir);
-        }
-        if unique_dirs.len() >= MAX_MEMBERSHIP_PROBE_DIRS {
-            break;
-        }
-    }
-    unique_dirs
+    let mut dirs = index.dirs.clone();
+    dirs.sort();
+    dirs.dedup();
+    dirs
 }
 
 struct DirMembership {
@@ -400,12 +376,13 @@ fn rollout_membership_in_dir(dir: &Path) -> Option<DirMembership> {
 /// Cache-backed rollout discovery returning each candidate's path + cached
 /// metadata + parsed header.
 ///
-/// On a warm hit (signature unchanged) the cached file *list* is reused so the
-/// directory subtree is NOT re-walked; each cached path is re-`stat`ed and its
-/// parsed header reused unless its `(modified, len)` changed. On a cold/changed
-/// lookup the tree is re-walked but the prior per-file map is still consulted, so
-/// only headers whose `(modified, len)` changed (or never-seen files) are
-/// re-read — a single new rollout does NOT re-read every surviving file's header.
+/// On a warm hit (signature unchanged) direct membership of every known
+/// directory is validated before the cached file *list* is reused; each cached
+/// path is re-`stat`ed and its parsed header reused unless its `(modified, len)`
+/// changed. On a cold/changed lookup the tree is re-walked but the prior
+/// per-file map is still consulted, so only headers whose `(modified, len)`
+/// changed (or never-seen files) are re-read — a single new rollout does NOT
+/// re-read every surviving file's header.
 ///
 /// When the cache is disabled (config flag off) this still returns the full
 /// candidate set, but performs a fresh scan + header read each time — i.e. it is
@@ -476,17 +453,15 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
 
     let results = match (signature_hit, previous_files) {
         (true, Some(previous_files)) => {
-            // Warm hit: the directory subtree is unchanged (no rollout added,
-            // removed, or renamed), so the cached *file list* is authoritative —
-            // reuse it directly and skip the `O(directories × entries)`
-            // `rollout_files_under` `read_dir` re-walk. Each cached path is still
-            // re-`stat`ed and its header re-read only when its `(mtime, len)`
-            // changed, so an in-place append/rewrite (which advances the file
-            // mtime/len but NOT the parent directory mtime, leaving the signature
-            // unchanged) is still caught. This is the cheap warm path the index
-            // exists for: on a busy root it costs `O(directories)` for the
-            // signature + `O(files)` stats, with zero header reads when nothing
-            // changed and zero directory recursion.
+            // Warm hit: the directory subtree signature and direct membership
+            // are unchanged, so the cached *file list* is authoritative. Each
+            // cached path is still re-`stat`ed and its header re-read only when
+            // its `(mtime, len)` changed, so an in-place append/rewrite (which
+            // advances the file mtime/len but NOT the parent directory mtime,
+            // leaving the signature unchanged) is still caught. This is the
+            // cheap warm path the index exists for: on a busy root it costs
+            // directory stats + direct membership reads + file stats, with zero
+            // header reads when nothing changed.
             scan_indexed_rollouts_from_paths(previous_files.keys(), Some(&previous_files))
         }
         (_, previous_files) => {
@@ -533,12 +508,12 @@ fn scan_indexed_rollouts(
 
 /// Build indexed candidates from an explicit set of candidate paths, re-`stat`ing
 /// each and reusing the cached header iff its `(modified, len)` is unchanged.
-/// The signature-hit warm path feeds the cached `RootIndex.files` keys here to
-/// avoid the directory re-walk while still revalidating each file's `(mtime,
-/// len)` (so in-place appends/rewrites are not served stale). The cold path
-/// feeds freshly-walked paths. A path that vanished between the cached snapshot
-/// and this `stat` is dropped via `metadata().ok()?`, so a deleted rollout under
-/// an otherwise-unchanged signature is not surfaced.
+/// The signature-hit warm path feeds the cached `RootIndex.files` keys here
+/// after known-directory membership validation, while still revalidating each
+/// file's `(mtime, len)` (so in-place appends/rewrites are not served stale). The
+/// cold path feeds freshly-walked paths. A path that vanished between the cached
+/// snapshot and this `stat` is dropped via `metadata().ok()?`, so a deleted
+/// rollout under an otherwise-unchanged signature is not surfaced.
 fn scan_indexed_rollouts_from_paths<'a, I>(
     paths: I,
     previous: Option<&HashMap<PathBuf, CachedFile>>,
@@ -1096,10 +1071,10 @@ mod tests {
         );
     }
 
-    // TEST-001 / regression: adding a rollout under an already-known recent leaf
+    // TEST-001 / regression: adding a rollout under an already-known leaf
     // must be discovered even if the leaf directory mtime is restored or too
-    // coarse to advance. Warm hits probe recent leaf membership without
-    // re-walking the whole sessions tree every poll.
+    // coarse to advance. Warm hits validate direct known-directory membership
+    // without re-reading rollout headers every poll.
     #[test]
     fn same_leaf_rollout_membership_probe_discovers_addition_with_restored_dir_mtime() {
         let _guard = lock_test();
@@ -1120,6 +1095,41 @@ mod tests {
             second.len(),
             2,
             "same-leaf rollout membership must invalidate the cached file list even when directory mtime is unchanged"
+        );
+    }
+
+    #[test]
+    fn membership_probe_checks_old_known_leaf_beyond_recent_window() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let base = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let mut leaves = Vec::new();
+        for month in 1..=12 {
+            let leaf = dir.path().join(format!("2026/{month:02}"));
+            std::fs::create_dir_all(&leaf).unwrap();
+            let mtime = base + std::time::Duration::from_secs(month as u64);
+            filetime::set_file_mtime(&leaf, filetime::FileTime::from_system_time(mtime)).unwrap();
+            leaves.push((leaf, mtime));
+        }
+        let target_leaf = leaves[0].0.clone();
+        let target_mtime = leaves[0].1;
+
+        let first = cached_indexed_rollouts(dir.path());
+        assert!(first.is_empty(), "all known leaves start empty");
+
+        write_rollout(dir.path(), "2026/01/rollout-a.jsonl", "s1", cwd.path());
+        filetime::set_file_mtime(
+            &target_leaf,
+            filetime::FileTime::from_system_time(target_mtime),
+        )
+        .unwrap();
+
+        let second = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            second.len(),
+            1,
+            "membership validation must cover every known leaf, not only the most recent few"
         );
     }
 

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -60,12 +60,20 @@ const HEADER_SCAN_LINE_LIMIT: usize = 20;
 /// ever passes many distinct roots, evicting the least-recently-built root.
 const MAX_CACHED_ROOTS: usize = 32;
 
+/// Same-leaf rollout membership validation is intentionally bounded to the most
+/// recent rollout leaf directories. Codex creates new rollouts in the current
+/// dated leaf, so probing recent leaves catches the mtime-coarseness stale-hit
+/// risk without re-walking the whole sessions tree on every 100ms launch poll.
+const RECENT_MEMBERSHIP_PROBE_WINDOW: std::time::Duration =
+    std::time::Duration::from_secs(24 * 60 * 60);
+const MAX_MEMBERSHIP_PROBE_DIRS: usize = 8;
+
 /// Parsed `session_meta` header for a single rollout file. This is the only
 /// data the resolver needs beyond the file path + length, and re-parsing it is
 /// the expensive part this cache eliminates on a warm hit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RolloutSessionMeta {
-    pub id: String,
+    pub id: Option<String>,
     pub cwd: PathBuf,
     pub source: Option<String>,
     pub originator: Option<String>,
@@ -102,6 +110,10 @@ struct RootIndex {
     /// Deterministic signature of the directory subtree (mtime-based). When the
     /// recomputed signature differs from this, the file list is rebuilt.
     signature: u64,
+    /// Directory list discovered on the last cold scan. Warm hits re-stat this
+    /// list instead of recursively calling `read_dir` every poll; parent dir
+    /// mtime changes still force a full rediscovery.
+    dirs: Vec<PathBuf>,
     /// Discovered rollout files with their cached metadata, keyed by path.
     files: HashMap<PathBuf, CachedFile>,
     /// Monotonic counter used for tiny LRU-ish eviction across roots.
@@ -190,17 +202,20 @@ pub fn read_rollout_session_meta(path: &Path) -> Option<RolloutSessionMeta> {
         let Some(payload) = json.get("payload") else {
             continue;
         };
-        let Some(id) = payload.get("id").and_then(Value::as_str).map(str::trim) else {
-            continue;
-        };
         let Some(cwd) = payload.get("cwd").and_then(Value::as_str).map(str::trim) else {
             continue;
         };
-        if id.is_empty() || cwd.is_empty() {
+        let id = payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
+        if cwd.is_empty() {
             return None;
         }
         return Some(RolloutSessionMeta {
-            id: id.to_string(),
+            id,
             cwd: PathBuf::from(cwd),
             source: payload
                 .get("source")
@@ -226,50 +241,63 @@ pub struct IndexedRollout {
     pub meta: Option<RolloutSessionMeta>,
 }
 
-/// Deterministic, content-free tree signature for `root`. Folds each directory's
-/// (path, mtime) plus the set of `rollout-*.jsonl` file paths into a stable
-/// hash. Most filesystems bump the containing directory mtime when a rollout is
-/// added, but hashing rollout membership avoids stale hits on coarse or restored
-/// directory mtimes. A deleted/renamed leaf changes the parent mtime; a
-/// brand-new root that did not exist before yields a different signature than an
-/// empty/missing one. Reads no rollout file contents (REQ-005).
+#[derive(Debug, Clone)]
+struct TreeSignature {
+    value: u64,
+    dirs: Vec<PathBuf>,
+}
+
+/// Deterministic, content-free tree signature for `root`. A cold discovery
+/// folds each directory's (path, mtime) into a stable hash and records the
+/// directory list. Warm lookups re-stat that known directory list instead of
+/// recursively calling `read_dir`, so the 100ms follow-up poll path stays cheap.
+/// A new rollout normally bumps its containing directory mtime; if a filesystem
+/// preserves/coarsens that mtime, a bounded recent-leaf membership probe below
+/// catches the practical same-leaf case without re-walking the full tree.
 ///
 /// Returns `None` when the root does not exist or cannot be read, which the
 /// caller treats as "no authoritative cache" — it does NOT cache a missing root,
 /// so a later directory creation is picked up on the next lookup (PRD risk:
 /// "missing root appears later").
-fn tree_signature(root: &Path) -> Option<u64> {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+fn discover_tree_signature(root: &Path) -> Option<TreeSignature> {
     let mut stack = vec![root.to_path_buf()];
     let mut visited_any = false;
-    // Collect directory entries deterministically so the hash is order-stable.
-    let mut dir_records: Vec<(PathBuf, Option<SystemTime>)> = Vec::new();
-    let mut rollout_records: Vec<PathBuf> = Vec::new();
+    let mut dirs: Vec<PathBuf> = Vec::new();
     while let Some(path) = stack.pop() {
         let Ok(entries) = std::fs::read_dir(&path) else {
-            // The root itself being unreadable -> no authoritative signature.
             if !visited_any {
                 return None;
             }
             continue;
         };
         visited_any = true;
-        let dir_mtime = std::fs::metadata(&path)
-            .and_then(|meta| meta.modified())
-            .ok();
-        dir_records.push((path.clone(), dir_mtime));
+        dirs.push(path);
         for entry in entries.flatten() {
             let child = entry.path();
             if child.is_dir() {
                 stack.push(child);
-            } else if is_rollout_jsonl(&child) {
-                rollout_records.push(child);
             }
         }
     }
     if !visited_any {
         return None;
+    }
+    let value = signature_from_dirs(&dirs)?;
+    Some(TreeSignature { value, dirs })
+}
+
+fn signature_from_dirs(dirs: &[PathBuf]) -> Option<u64> {
+    use std::hash::{Hash, Hasher};
+    if dirs.is_empty() {
+        return None;
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut dir_records: Vec<(PathBuf, Option<SystemTime>)> = Vec::new();
+    for path in dirs {
+        let dir_mtime = std::fs::metadata(&path)
+            .and_then(|meta| meta.modified())
+            .ok();
+        dir_records.push((path.clone(), dir_mtime));
     }
     dir_records.sort_by(|left, right| left.0.cmp(&right.0));
     for (path, mtime) in dir_records {
@@ -286,11 +314,67 @@ fn tree_signature(root: &Path) -> Option<u64> {
             None => 0u8.hash(&mut hasher),
         }
     }
-    rollout_records.sort();
-    for path in rollout_records {
-        path.hash(&mut hasher);
-    }
     Some(hasher.finish())
+}
+
+#[cfg(test)]
+fn tree_signature(root: &Path) -> Option<u64> {
+    discover_tree_signature(root).map(|signature| signature.value)
+}
+
+fn recent_rollout_membership_changed(previous_files: &HashMap<PathBuf, CachedFile>) -> bool {
+    let now = SystemTime::now();
+    let mut dirs = previous_files
+        .iter()
+        .filter_map(|(path, cached)| {
+            let age = now
+                .duration_since(cached.modified)
+                .unwrap_or(std::time::Duration::ZERO);
+            if age > RECENT_MEMBERSHIP_PROBE_WINDOW {
+                return None;
+            }
+            path.parent()
+                .map(|parent| (cached.modified, parent.to_path_buf()))
+        })
+        .collect::<Vec<_>>();
+    dirs.sort_by(|left, right| right.0.cmp(&left.0));
+
+    let mut unique_dirs = Vec::new();
+    for (_, dir) in dirs {
+        if !unique_dirs.iter().any(|seen| seen == &dir) {
+            unique_dirs.push(dir);
+        }
+        if unique_dirs.len() >= MAX_MEMBERSHIP_PROBE_DIRS {
+            break;
+        }
+    }
+
+    for dir in unique_dirs {
+        let Some(current) = rollout_files_in_dir(&dir) else {
+            return true;
+        };
+        let mut cached = previous_files
+            .keys()
+            .filter(|path| path.parent() == Some(dir.as_path()))
+            .cloned()
+            .collect::<Vec<_>>();
+        cached.sort();
+        if current != cached {
+            return true;
+        }
+    }
+    false
+}
+
+fn rollout_files_in_dir(dir: &Path) -> Option<Vec<PathBuf>> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    let mut files = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && is_rollout_jsonl(path))
+        .collect::<Vec<_>>();
+    files.sort();
+    Some(files)
 }
 
 /// Cache-backed rollout discovery returning each candidate's path + cached
@@ -317,11 +401,6 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
         return scan_indexed_rollouts(root, None);
     }
     let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    let Some(signature) = tree_signature(root) else {
-        // Missing/unreadable root: do not cache, fall back to a direct scan
-        // (which will also yield nothing) so a later directory creation is seen.
-        return scan_indexed_rollouts(root, None);
-    };
 
     // Snapshot the previous per-root state so headers (and, on a signature hit,
     // the file list itself) can be reused without holding the lock during file
@@ -335,9 +414,44 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
         let state = lock_cache();
         state.roots.get(&canonical_root).cloned()
     };
-    let signature_hit = previous
+
+    let warm_signature = previous
         .as_ref()
-        .is_some_and(|index| index.signature == signature);
+        .and_then(|index| signature_from_dirs(&index.dirs));
+    let cold_signature = if previous.is_none()
+        || previous
+            .as_ref()
+            .is_some_and(|index| warm_signature != Some(index.signature))
+    {
+        discover_tree_signature(root)
+    } else {
+        None
+    };
+
+    let Some(signature_state) = cold_signature.or_else(|| {
+        warm_signature.map(|value| TreeSignature {
+            value,
+            dirs: previous
+                .as_ref()
+                .map(|index| index.dirs.clone())
+                .unwrap_or_default(),
+        })
+    }) else {
+        // Missing/unreadable root: do not cache, fall back to a direct scan
+        // (which will also yield nothing) so a later directory creation is seen.
+        return scan_indexed_rollouts(root, None);
+    };
+
+    let mut signature_hit = previous
+        .as_ref()
+        .is_some_and(|index| index.signature == signature_state.value);
+    if signature_hit
+        && previous
+            .as_ref()
+            .is_some_and(|index| recent_rollout_membership_changed(&index.files))
+    {
+        signature_hit = false;
+    }
     let previous_files = previous.map(|index| index.files);
 
     let results = match (signature_hit, previous_files) {
@@ -374,7 +488,14 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
             },
         );
     }
-    store_root(&canonical_root, signature, files);
+    let dirs = if signature_hit {
+        signature_state.dirs
+    } else {
+        discover_tree_signature(root)
+            .map(|signature| signature.dirs)
+            .unwrap_or(signature_state.dirs)
+    };
+    store_root(&canonical_root, signature_state.value, dirs, files);
     results
 }
 
@@ -433,7 +554,12 @@ fn lock_cache() -> std::sync::MutexGuard<'static, IndexState> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-fn store_root(canonical_root: &Path, signature: u64, files: HashMap<PathBuf, CachedFile>) {
+fn store_root(
+    canonical_root: &Path,
+    signature: u64,
+    dirs: Vec<PathBuf>,
+    files: HashMap<PathBuf, CachedFile>,
+) {
     let mut state = lock_cache();
     state.seq = state.seq.wrapping_add(1);
     let seq = state.seq;
@@ -441,6 +567,7 @@ fn store_root(canonical_root: &Path, signature: u64, files: HashMap<PathBuf, Cac
         canonical_root.to_path_buf(),
         RootIndex {
             signature,
+            dirs,
             files,
             last_built_seq: seq,
         },
@@ -511,6 +638,20 @@ mod tests {
             format!(
                 "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"cwd\":\"{}\"}}}}\n",
                 id,
+                cwd.display()
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    fn write_rollout_without_id(root: &Path, relative: &str, cwd: &Path) -> PathBuf {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{}\"}}}}\n",
                 cwd.display()
             ),
         )
@@ -608,7 +749,7 @@ mod tests {
                 modified,
                 len,
                 meta: Some(RolloutSessionMeta {
-                    id: "cached-sentinel".to_string(),
+                    id: Some("cached-sentinel".to_string()),
                     cwd: cwd.path().to_path_buf(),
                     source: None,
                     originator: None,
@@ -619,8 +760,8 @@ mod tests {
         let warm = scan_indexed_rollouts(dir.path(), Some(&previous));
         assert_eq!(warm.len(), 1);
         assert_eq!(
-            warm[0].meta.as_ref().unwrap().id,
-            "cached-sentinel",
+            warm[0].meta.as_ref().unwrap().id.as_deref(),
+            Some("cached-sentinel"),
             "matching (mtime, len) must reuse the cached header instead of re-reading the file"
         );
 
@@ -632,7 +773,7 @@ mod tests {
                 modified,
                 len: len + 1,
                 meta: Some(RolloutSessionMeta {
-                    id: "cached-sentinel".to_string(),
+                    id: Some("cached-sentinel".to_string()),
                     cwd: cwd.path().to_path_buf(),
                     source: None,
                     originator: None,
@@ -641,10 +782,24 @@ mod tests {
         );
         let rescanned = scan_indexed_rollouts(dir.path(), Some(&stale));
         assert_eq!(
-            rescanned[0].meta.as_ref().unwrap().id,
-            "on-disk-id",
+            rescanned[0].meta.as_ref().unwrap().id.as_deref(),
+            Some("on-disk-id"),
             "a changed (mtime, len) must force a header re-read"
         );
+    }
+
+    #[test]
+    fn session_meta_without_id_preserves_cwd_for_cwd_only_discovery() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout_without_id(dir.path(), "2026/05/rollout-no-id.jsonl", cwd.path());
+
+        let found = cached_indexed_rollouts(dir.path());
+        assert_eq!(found.len(), 1);
+        let meta = found[0].meta.as_ref().expect("cwd-only session_meta");
+        assert_eq!(meta.id, None);
+        assert_eq!(meta.cwd, cwd.path());
     }
 
     // TEST-001 / TEST-005: a second `cached_indexed_rollouts` call with an
@@ -664,7 +819,10 @@ mod tests {
         );
 
         let cold = cached_indexed_rollouts(dir.path());
-        assert_eq!(cold[0].meta.as_ref().unwrap().id, "warm-sess");
+        assert_eq!(
+            cold[0].meta.as_ref().unwrap().id.as_deref(),
+            Some("warm-sess")
+        );
         let primed = std::fs::metadata(&path).unwrap();
         let (modified, len) = (primed.modified().unwrap(), primed.len());
 
@@ -679,8 +837,8 @@ mod tests {
         let warm = cached_indexed_rollouts(dir.path());
         if after.modified().unwrap() == modified && after.len() == len {
             assert_eq!(
-                warm[0].meta.as_ref().unwrap().id,
-                "warm-sess",
+                warm[0].meta.as_ref().unwrap().id.as_deref(),
+                Some("warm-sess"),
                 "warm cache must reuse the cached header rather than re-reading the corrupted file"
             );
         }
@@ -698,7 +856,7 @@ mod tests {
         let path = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "old-id", cwd.path());
 
         let cold = cached_indexed_rollouts(dir.path());
-        assert_eq!(cold[0].meta.as_ref().unwrap().id, "old-id");
+        assert_eq!(cold[0].meta.as_ref().unwrap().id.as_deref(), Some("old-id"));
 
         // Rewrite with a different session id (different length) and bump mtime.
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -714,8 +872,8 @@ mod tests {
 
         let warm = cached_indexed_rollouts(dir.path());
         assert_eq!(
-            warm[0].meta.as_ref().unwrap().id,
-            "new-longer-id",
+            warm[0].meta.as_ref().unwrap().id.as_deref(),
+            Some("new-longer-id"),
             "a content/length rewrite must re-parse the header"
         );
     }
@@ -741,7 +899,7 @@ mod tests {
 
         let disabled = cached_indexed_rollouts_inner(dir.path(), false);
         assert_eq!(disabled.len(), 1);
-        assert_eq!(disabled[0].meta.as_ref().unwrap().id, "s1");
+        assert_eq!(disabled[0].meta.as_ref().unwrap().id.as_deref(), Some("s1"));
         {
             let state = lock_cache();
             assert!(
@@ -754,8 +912,8 @@ mod tests {
         let enabled = cached_indexed_rollouts_inner(dir.path(), true);
         assert_eq!(enabled.len(), disabled.len());
         assert_eq!(
-            enabled[0].meta.as_ref().unwrap().id,
-            disabled[0].meta.as_ref().unwrap().id
+            enabled[0].meta.as_ref().unwrap().id.as_deref(),
+            disabled[0].meta.as_ref().unwrap().id.as_deref()
         );
     }
 
@@ -828,7 +986,7 @@ mod tests {
                 .find(|item| item.path == survivor)
                 .and_then(|item| item.meta.as_ref());
             assert_eq!(
-                survivor_meta.map(|meta| meta.id.as_str()),
+                survivor_meta.map(|meta| meta.id.as_deref().unwrap_or("")),
                 Some("survivor"),
                 "a signature miss must reuse the surviving file's cached header, not re-read it"
             );
@@ -876,8 +1034,8 @@ mod tests {
         assert_eq!(warm.len(), 1, "warm hit must reuse the cached file list");
         if after.modified().unwrap() == modified && after.len() == len {
             assert_eq!(
-                warm[0].meta.as_ref().unwrap().id,
-                "warm-list",
+                warm[0].meta.as_ref().unwrap().id.as_deref(),
+                Some("warm-list"),
                 "a signature-hit warm lookup with unchanged (mtime, len) must reuse the cached header, not re-read the corrupted file"
             );
         }
@@ -895,7 +1053,7 @@ mod tests {
         let path = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "before", cwd.path());
 
         let cold = cached_indexed_rollouts(dir.path());
-        assert_eq!(cold[0].meta.as_ref().unwrap().id, "before");
+        assert_eq!(cold[0].meta.as_ref().unwrap().id.as_deref(), Some("before"));
 
         // Rewrite the SAME file in place with a different id + length, bumping its
         // mtime, WITHOUT adding/removing a directory entry (signature unchanged).
@@ -912,33 +1070,35 @@ mod tests {
 
         let warm = cached_indexed_rollouts(dir.path());
         assert_eq!(
-            warm[0].meta.as_ref().unwrap().id,
-            "after-longer-id",
+            warm[0].meta.as_ref().unwrap().id.as_deref(),
+            Some("after-longer-id"),
             "a signature-hit warm lookup must re-read a file whose (mtime, len) changed"
         );
     }
 
-    // TEST-001 / regression: adding a rollout under an already-known leaf must
-    // change the signature even if the leaf directory mtime is restored or too
-    // coarse to advance. The signature hashes rollout membership, so the warm
-    // path cannot stale-hit and miss the new file.
+    // TEST-001 / regression: adding a rollout under an already-known recent leaf
+    // must be discovered even if the leaf directory mtime is restored or too
+    // coarse to advance. Warm hits probe recent leaf membership without
+    // re-walking the whole sessions tree every poll.
     #[test]
-    fn same_leaf_rollout_membership_changes_signature_even_with_restored_dir_mtime() {
+    fn same_leaf_rollout_membership_probe_discovers_addition_with_restored_dir_mtime() {
         let _guard = lock_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
         let leaf = dir.path().join("2026/05");
         let original_mtime = std::fs::metadata(&leaf).unwrap().modified().unwrap();
-        let sig1 = tree_signature(dir.path()).unwrap();
+        let first = cached_indexed_rollouts(dir.path());
+        assert_eq!(first.len(), 1);
 
         write_rollout(dir.path(), "2026/05/rollout-b.jsonl", "s2", cwd.path());
         filetime::set_file_mtime(&leaf, filetime::FileTime::from_system_time(original_mtime))
             .unwrap();
 
-        let sig2 = tree_signature(dir.path()).unwrap();
-        assert_ne!(
-            sig1, sig2,
+        let second = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            second.len(),
+            2,
             "same-leaf rollout membership must invalidate the cached file list even when directory mtime is unchanged"
         );
     }

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -60,11 +60,11 @@ const HEADER_SCAN_LINE_LIMIT: usize = 20;
 /// ever passes many distinct roots, evicting the least-recently-built root.
 const MAX_CACHED_ROOTS: usize = 32;
 
-/// Same-leaf rollout membership validation is intentionally bounded to the most
-/// recently modified known directories. Codex creates new rollouts in the
-/// current dated leaf, so probing recent known directories catches the
-/// mtime-coarseness stale-hit risk without re-walking the whole sessions tree on
-/// every 100ms launch poll.
+/// Rollout membership validation is intentionally bounded to the most recently
+/// modified known directories. Codex creates new rollouts in the current dated
+/// leaf, so probing direct rollout-file and child-directory membership catches
+/// the mtime-coarseness stale-hit risk without re-walking the whole sessions
+/// tree on every 100ms launch poll.
 const MAX_MEMBERSHIP_PROBE_DIRS: usize = 8;
 
 /// Parsed `session_meta` header for a single rollout file. This is the only
@@ -323,17 +323,24 @@ fn tree_signature(root: &Path) -> Option<u64> {
 
 fn recent_rollout_membership_changed(index: &RootIndex) -> bool {
     for dir in rollout_membership_probe_dirs(index) {
-        let Some(current) = rollout_files_in_dir(&dir) else {
+        let Some(current) = rollout_membership_in_dir(&dir) else {
             return true;
         };
-        let mut cached = index
+        let mut cached_files = index
             .files
             .keys()
             .filter(|path| path.parent() == Some(dir.as_path()))
             .cloned()
             .collect::<Vec<_>>();
-        cached.sort();
-        if current != cached {
+        cached_files.sort();
+        let mut cached_child_dirs = index
+            .dirs
+            .iter()
+            .filter(|path| path.parent() == Some(dir.as_path()))
+            .cloned()
+            .collect::<Vec<_>>();
+        cached_child_dirs.sort();
+        if current.rollout_files != cached_files || current.child_dirs != cached_child_dirs {
             return true;
         }
     }
@@ -365,15 +372,29 @@ fn rollout_membership_probe_dirs(index: &RootIndex) -> Vec<PathBuf> {
     unique_dirs
 }
 
-fn rollout_files_in_dir(dir: &Path) -> Option<Vec<PathBuf>> {
+struct DirMembership {
+    child_dirs: Vec<PathBuf>,
+    rollout_files: Vec<PathBuf>,
+}
+
+fn rollout_membership_in_dir(dir: &Path) -> Option<DirMembership> {
     let entries = std::fs::read_dir(dir).ok()?;
-    let mut files = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_file() && is_rollout_jsonl(path))
-        .collect::<Vec<_>>();
-    files.sort();
-    Some(files)
+    let mut child_dirs = Vec::new();
+    let mut rollout_files = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            child_dirs.push(path);
+        } else if path.is_file() && is_rollout_jsonl(&path) {
+            rollout_files.push(path);
+        }
+    }
+    child_dirs.sort();
+    rollout_files.sort();
+    Some(DirMembership {
+        child_dirs,
+        rollout_files,
+    })
 }
 
 /// Cache-backed rollout discovery returning each candidate's path + cached
@@ -1123,6 +1144,33 @@ mod tests {
             second.len(),
             1,
             "empty cached leaves must be revalidated so a same-leaf rollout is discovered"
+        );
+    }
+
+    #[test]
+    fn membership_probe_detects_new_child_leaf_with_restored_parent_mtime() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let year = dir.path().join("2026");
+        std::fs::create_dir_all(&year).unwrap();
+        let original_mtime = std::fs::metadata(&year).unwrap().modified().unwrap();
+
+        let first = cached_indexed_rollouts(dir.path());
+        assert!(
+            first.is_empty(),
+            "warm cache starts before the child leaf exists"
+        );
+
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        filetime::set_file_mtime(&year, filetime::FileTime::from_system_time(original_mtime))
+            .unwrap();
+
+        let second = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            second.len(),
+            1,
+            "cached parents must validate direct child membership so a new day/month leaf is discovered"
         );
     }
 

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -1,0 +1,713 @@
+//! In-process rollout discovery index for the Codex TUI resume / follow-up
+//! readiness paths.
+//!
+//! # Why
+//!
+//! `~/.codex/sessions` accumulates `rollout-*.jsonl` files indefinitely (one per
+//! Codex session, on a busy host this is thousands of files). Every TUI resume
+//! and every follow-up readiness probe previously re-walked the entire tree AND
+//! re-read the first ~20 lines of every candidate file to parse `session_meta`.
+//! That is `O(files)` `read_dir` + `O(files)` header reads on every lookup.
+//!
+//! This module adds a process-lifetime cache, keyed by the (canonicalized)
+//! sessions root, that:
+//!
+//! 1. Computes a deterministic **tree signature** from the directory mtimes of
+//!    the whole subtree (no file reads). Codex creates rollouts inside dated
+//!    leaf directories, so a new rollout bumps its parent directory mtime and
+//!    therefore the signature. The signature is recomputed on **every** lookup
+//!    (cheap `O(directories)` stat calls) — invalidation is a precondition, not
+//!    a postcondition.
+//! 2. On a signature match (warm hit) reuses the cached file list AND the cached
+//!    parsed `session_meta` for each file whose `(mtime, len)` is unchanged, so
+//!    warm lookups do **not** re-read rollout headers (PRD REQ-005).
+//! 3. On a signature mismatch (cold / changed) re-walks the tree, then lazily
+//!    re-reads only headers whose `(mtime, len)` changed.
+//!
+//! Invalidation deliberately prefers a **false miss** (an extra rescan) over a
+//! **stale hit** (resuming the wrong rollout) — see PRD risk table.
+//!
+//! # Rollback
+//!
+//! The cache is gated by `RuntimeSettingsConfig::codex_rollout_index_cache_enabled`
+//! (default ON, hot-reloadable). When disabled, [`cached_rollout_files_under`]
+//! and [`cached_rollout_session_meta`] fall through to the direct
+//! [`rollout_files_under`] scan / direct header read, exactly reproducing the
+//! legacy behaviour with zero cache state. Tests can also force the cold path
+//! with [`reset_cache_for_tests`].
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+/// Maximum header lines scanned looking for the `session_meta` record. Mirrors
+/// the legacy bound in `session.rs` / `rollout_tail.rs` so the bounded-read
+/// guarantee (REQ-005) is preserved.
+const HEADER_SCAN_LINE_LIMIT: usize = 20;
+
+/// Upper bound on the number of distinct sessions roots cached at once. In
+/// practice there is exactly one (`~/.codex/sessions`); tests may use several
+/// tempdirs. The bound keeps the cache from growing without limit if a caller
+/// ever passes many distinct roots, evicting the least-recently-built root.
+const MAX_CACHED_ROOTS: usize = 32;
+
+/// Parsed `session_meta` header for a single rollout file. This is the only
+/// data the resolver needs beyond the file path + length, and re-parsing it is
+/// the expensive part this cache eliminates on a warm hit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RolloutSessionMeta {
+    pub id: String,
+    pub cwd: PathBuf,
+    pub source: Option<String>,
+    pub originator: Option<String>,
+}
+
+impl RolloutSessionMeta {
+    /// Codex direct TUI can safely resume sessions recorded by the interactive
+    /// CLI. Older AgentDesk codex-exec rollouts share the same JSONL directory
+    /// and UUID shape, but resuming them through the TUI can leave no fresh
+    /// rollout transcript for the tailer to follow.
+    pub fn is_tui_compatible(&self) -> bool {
+        !self.source.as_deref().is_some_and(|value| value == "exec")
+            && !self
+                .originator
+                .as_deref()
+                .is_some_and(|value| value == "codex_exec")
+    }
+}
+
+/// Per-file cache entry. `(modified, len)` are the validation key; if either
+/// changes, the cached `meta` is discarded and the header is re-read.
+#[derive(Debug, Clone)]
+struct CachedFile {
+    modified: SystemTime,
+    len: u64,
+    /// `None` is a cached *negative* result (no parseable `session_meta`), which
+    /// is still valid to reuse as long as `(modified, len)` are unchanged.
+    meta: Option<RolloutSessionMeta>,
+}
+
+/// Cached state for one sessions root.
+#[derive(Debug, Clone, Default)]
+struct RootIndex {
+    /// Deterministic signature of the directory subtree (mtime-based). When the
+    /// recomputed signature differs from this, the file list is rebuilt.
+    signature: u64,
+    /// Discovered rollout files with their cached metadata, keyed by path.
+    files: HashMap<PathBuf, CachedFile>,
+    /// Monotonic counter used for tiny LRU-ish eviction across roots.
+    last_built_seq: u64,
+}
+
+#[derive(Default)]
+struct IndexState {
+    roots: HashMap<PathBuf, RootIndex>,
+    seq: u64,
+}
+
+fn cache() -> &'static Mutex<IndexState> {
+    static CACHE: OnceLock<Mutex<IndexState>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(IndexState::default()))
+}
+
+/// Pure enablement decision from a config field value. `None` (field unset)
+/// means "enabled" — the feature defaults ON. Split out so the gate is unit
+/// testable without touching the process-global live-config snapshot.
+fn enabled_from_field(field: Option<bool>) -> bool {
+    field.unwrap_or(true)
+}
+
+/// Live config gate. A `None` config snapshot (pre-boot / unit tests) and a
+/// `None` field both mean "enabled". Read via `config_live_reload::current()`
+/// so an `agentdesk.yaml` edit applies on the next lookup without a restart.
+fn cache_enabled() -> bool {
+    let field = crate::config_live_reload::current()
+        .map(|cfg| cfg.runtime.codex_rollout_index_cache_enabled)
+        .unwrap_or(None);
+    enabled_from_field(field)
+}
+
+/// Recursively collect `rollout-*.jsonl` files under `root`. This is the shared
+/// discovery primitive reused by `session.rs` and `rollout_tail.rs` (REQ-006);
+/// it does **no** caching and reads **no** file contents.
+pub fn rollout_files_under(root: &Path) -> Vec<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    let mut files = Vec::new();
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+            {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+/// Read and parse the `session_meta` header of a single rollout file. Bounded to
+/// the first [`HEADER_SCAN_LINE_LIMIT`] lines (REQ-005). This is the direct
+/// (uncached) read used on the cold path and when the cache is disabled.
+pub fn read_rollout_session_meta(path: &Path) -> Option<RolloutSessionMeta> {
+    let file = std::fs::File::open(path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    for line in reader
+        .lines()
+        .map_while(Result::ok)
+        .take(HEADER_SCAN_LINE_LIMIT)
+    {
+        let Ok(json) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if json.get("type").and_then(Value::as_str) != Some("session_meta") {
+            continue;
+        }
+        let Some(payload) = json.get("payload") else {
+            continue;
+        };
+        let Some(id) = payload.get("id").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        let Some(cwd) = payload.get("cwd").and_then(Value::as_str).map(str::trim) else {
+            continue;
+        };
+        if id.is_empty() || cwd.is_empty() {
+            return None;
+        }
+        return Some(RolloutSessionMeta {
+            id: id.to_string(),
+            cwd: PathBuf::from(cwd),
+            source: payload
+                .get("source")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            originator: payload
+                .get("originator")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+        });
+    }
+    None
+}
+
+/// A rollout candidate surfaced by the index: its path plus the file/length
+/// metadata and parsed session header. `meta` is `None` for files with no
+/// parseable `session_meta` (the caller filters those out).
+#[derive(Debug, Clone)]
+pub struct IndexedRollout {
+    pub path: PathBuf,
+    pub modified: SystemTime,
+    pub len: u64,
+    pub meta: Option<RolloutSessionMeta>,
+}
+
+/// Deterministic, content-free tree signature for `root`. Folds each directory's
+/// (path, mtime) into a stable hash. A new rollout file bumps the mtime of its
+/// containing directory; a deleted/renamed leaf changes the parent mtime; a
+/// brand-new root that did not exist before yields a different signature than an
+/// empty/missing one. Reads no rollout file contents (REQ-005).
+///
+/// Returns `None` when the root does not exist or cannot be read, which the
+/// caller treats as "no authoritative cache" — it does NOT cache a missing root,
+/// so a later directory creation is picked up on the next lookup (PRD risk:
+/// "missing root appears later").
+fn tree_signature(root: &Path) -> Option<u64> {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut stack = vec![root.to_path_buf()];
+    let mut visited_any = false;
+    // Collect directory entries deterministically so the hash is order-stable.
+    let mut dir_records: Vec<(PathBuf, Option<SystemTime>)> = Vec::new();
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            // The root itself being unreadable -> no authoritative signature.
+            if !visited_any {
+                return None;
+            }
+            continue;
+        };
+        visited_any = true;
+        let dir_mtime = std::fs::metadata(&path)
+            .and_then(|meta| meta.modified())
+            .ok();
+        dir_records.push((path.clone(), dir_mtime));
+        for entry in entries.flatten() {
+            let child = entry.path();
+            if child.is_dir() {
+                stack.push(child);
+            }
+        }
+    }
+    if !visited_any {
+        return None;
+    }
+    dir_records.sort_by(|left, right| left.0.cmp(&right.0));
+    for (path, mtime) in dir_records {
+        path.hash(&mut hasher);
+        match mtime {
+            Some(time) => {
+                1u8.hash(&mut hasher);
+                if let Ok(dur) = time.duration_since(SystemTime::UNIX_EPOCH) {
+                    dur.as_nanos().hash(&mut hasher);
+                } else {
+                    0u128.hash(&mut hasher);
+                }
+            }
+            None => 0u8.hash(&mut hasher),
+        }
+    }
+    Some(hasher.finish())
+}
+
+/// Cache-backed rollout discovery returning each candidate's path + cached
+/// metadata + parsed header.
+///
+/// On a warm hit (signature unchanged) the cached `session_meta` is reused for
+/// every file whose `(modified, len)` is unchanged, so no rollout headers are
+/// re-read. On a cold/changed lookup the tree is re-walked and only headers with
+/// a changed `(modified, len)` (or never-seen files) are re-read.
+///
+/// When the cache is disabled (config flag off) this still returns the full
+/// candidate set, but performs a fresh scan + header read each time — i.e. it is
+/// behaviourally identical to the legacy path, just routed through one helper.
+pub fn cached_indexed_rollouts(root: &Path) -> Vec<IndexedRollout> {
+    cached_indexed_rollouts_inner(root, cache_enabled())
+}
+
+/// Internal seam taking the enablement decision explicitly so the disabled
+/// (rollback) path is testable without mutating the process-global live config.
+fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollout> {
+    if !enabled {
+        return scan_indexed_rollouts(root, None);
+    }
+    let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let Some(signature) = tree_signature(root) else {
+        // Missing/unreadable root: do not cache, fall back to a direct scan
+        // (which will also yield nothing) so a later directory creation is seen.
+        return scan_indexed_rollouts(root, None);
+    };
+
+    // Snapshot the previous per-file metadata for this root so headers can be
+    // reused without holding the lock during file I/O.
+    let previous: Option<HashMap<PathBuf, CachedFile>> = {
+        let state = lock_cache();
+        state
+            .roots
+            .get(&canonical_root)
+            .filter(|index| index.signature == signature)
+            .map(|index| index.files.clone())
+    };
+
+    let results = scan_indexed_rollouts(root, previous.as_ref());
+
+    // Rebuild the cache entry from the fresh scan results.
+    let mut files = HashMap::with_capacity(results.len());
+    for item in &results {
+        files.insert(
+            item.path.clone(),
+            CachedFile {
+                modified: item.modified,
+                len: item.len,
+                meta: item.meta.clone(),
+            },
+        );
+    }
+    store_root(&canonical_root, signature, files);
+    results
+}
+
+/// Direct scan (optionally reusing cached per-file metadata). When `previous` is
+/// `Some` and a file's `(modified, len)` are unchanged, its cached header is
+/// reused; otherwise the header is read from disk.
+fn scan_indexed_rollouts(
+    root: &Path,
+    previous: Option<&HashMap<PathBuf, CachedFile>>,
+) -> Vec<IndexedRollout> {
+    rollout_files_under(root)
+        .into_iter()
+        .filter_map(|path| {
+            let metadata = std::fs::metadata(&path).ok()?;
+            let modified = metadata.modified().ok()?;
+            let len = metadata.len();
+            let meta = match previous.and_then(|prev| prev.get(&path)) {
+                Some(cached) if cached.modified == modified && cached.len == len => {
+                    cached.meta.clone()
+                }
+                _ => read_rollout_session_meta(&path),
+            };
+            Some(IndexedRollout {
+                path,
+                modified,
+                len,
+                meta,
+            })
+        })
+        .collect()
+}
+
+fn lock_cache() -> std::sync::MutexGuard<'static, IndexState> {
+    cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn store_root(canonical_root: &Path, signature: u64, files: HashMap<PathBuf, CachedFile>) {
+    let mut state = lock_cache();
+    state.seq = state.seq.wrapping_add(1);
+    let seq = state.seq;
+    state.roots.insert(
+        canonical_root.to_path_buf(),
+        RootIndex {
+            signature,
+            files,
+            last_built_seq: seq,
+        },
+    );
+    // Bound the number of cached roots with a tiny LRU eviction so a caller that
+    // passes many distinct roots cannot grow the cache without limit.
+    if state.roots.len() > MAX_CACHED_ROOTS {
+        if let Some(victim) = state
+            .roots
+            .iter()
+            .min_by_key(|(_, index)| index.last_built_seq)
+            .map(|(path, _)| path.clone())
+        {
+            state.roots.remove(&victim);
+        }
+    }
+}
+
+/// Clear the entire cache. Test-only hook (REQ-004): lets tests force the cold
+/// path and prevents cross-test contamination from a shared process-lifetime
+/// cache. Compiled only under `cfg(test)`; the production rollback path is the
+/// `codex_rollout_index_cache_enabled` config flag, not this function.
+#[cfg(test)]
+pub fn reset_cache_for_tests() {
+    let mut state = lock_cache();
+    state.roots.clear();
+    state.seq = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    // Serialize cache tests: the cache is process-global, so parallel tests
+    // mutating it would race. This guard plus `reset_cache_for_tests` gives each
+    // test an isolated cache (REQ-004 / TEST-004).
+    static CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_test() -> MutexGuard<'static, ()> {
+        let guard = CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_cache_for_tests();
+        guard
+    }
+
+    fn write_rollout(root: &Path, relative: &str, id: &str, cwd: &Path) -> PathBuf {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"cwd\":\"{}\"}}}}\n",
+                id,
+                cwd.display()
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    // TEST-006: the shared discovery primitive finds exactly the rollout files.
+    #[test]
+    fn rollout_files_under_collects_only_rollout_jsonl() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let a = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        let b = write_rollout(dir.path(), "2026/06/rollout-b.jsonl", "s2", cwd.path());
+        std::fs::write(dir.path().join("2026/05/not-a-rollout.txt"), "x").unwrap();
+
+        let mut found = rollout_files_under(dir.path());
+        found.sort();
+        let mut expected = vec![a, b];
+        expected.sort();
+        assert_eq!(found, expected);
+    }
+
+    // TEST-001: an unchanged tree yields a stable signature; adding a file
+    // changes it.
+    #[test]
+    fn tree_signature_changes_when_rollout_added() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        let sig1 = tree_signature(dir.path()).unwrap();
+        assert_eq!(
+            tree_signature(dir.path()).unwrap(),
+            sig1,
+            "signature must be stable for an unchanged tree"
+        );
+
+        // A new dated directory always bumps the signature.
+        write_rollout(dir.path(), "2026/07/rollout-c.jsonl", "s3", cwd.path());
+        let sig2 = tree_signature(dir.path()).unwrap();
+        assert_ne!(
+            sig1, sig2,
+            "adding a rollout under a new directory must change the signature"
+        );
+    }
+
+    // TEST-001 / TEST-004: missing root yields no signature and is not cached,
+    // so a later creation is picked up.
+    #[test]
+    fn missing_root_then_created_is_picked_up() {
+        let _guard = lock_test();
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("sessions-not-yet-there");
+        assert!(tree_signature(&root).is_none());
+        // Cold lookup on a missing root returns nothing and caches nothing.
+        assert!(cached_indexed_rollouts(&root).is_empty());
+
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout(&root, "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        let found = cached_indexed_rollouts(&root);
+        assert_eq!(
+            found.len(),
+            1,
+            "a root created after a miss must be discovered on the next lookup"
+        );
+    }
+
+    // TEST-005: a warm scan whose `(mtime, len)` matches the cached entry does
+    // NOT re-read the rollout header. We prove this deterministically by handing
+    // `scan_indexed_rollouts` a synthetic `previous` map whose `(modified, len)`
+    // exactly matches the on-disk file but whose cached `meta` carries a sentinel
+    // id. If the scan reused the cache (no header re-read) it returns the
+    // sentinel; if it re-read the file it would return the real on-disk id.
+    #[test]
+    fn warm_scan_reuses_cached_header_without_reread() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let path = write_rollout(
+            dir.path(),
+            "2026/05/rollout-a.jsonl",
+            "on-disk-id",
+            cwd.path(),
+        );
+        let metadata = std::fs::metadata(&path).unwrap();
+        let modified = metadata.modified().unwrap();
+        let len = metadata.len();
+
+        let mut previous = HashMap::new();
+        previous.insert(
+            path.clone(),
+            CachedFile {
+                modified,
+                len,
+                meta: Some(RolloutSessionMeta {
+                    id: "cached-sentinel".to_string(),
+                    cwd: cwd.path().to_path_buf(),
+                    source: None,
+                    originator: None,
+                }),
+            },
+        );
+
+        let warm = scan_indexed_rollouts(dir.path(), Some(&previous));
+        assert_eq!(warm.len(), 1);
+        assert_eq!(
+            warm[0].meta.as_ref().unwrap().id,
+            "cached-sentinel",
+            "matching (mtime, len) must reuse the cached header instead of re-reading the file"
+        );
+
+        // Control: a mismatched len forces a re-read and returns the real id.
+        let mut stale = HashMap::new();
+        stale.insert(
+            path.clone(),
+            CachedFile {
+                modified,
+                len: len + 1,
+                meta: Some(RolloutSessionMeta {
+                    id: "cached-sentinel".to_string(),
+                    cwd: cwd.path().to_path_buf(),
+                    source: None,
+                    originator: None,
+                }),
+            },
+        );
+        let rescanned = scan_indexed_rollouts(dir.path(), Some(&stale));
+        assert_eq!(
+            rescanned[0].meta.as_ref().unwrap().id,
+            "on-disk-id",
+            "a changed (mtime, len) must force a header re-read"
+        );
+    }
+
+    // TEST-001 / TEST-005: a second `cached_indexed_rollouts` call with an
+    // unchanged tree reuses the cached header end-to-end (full warm-cache path),
+    // proven by corrupting the file to unparseable AFTER priming while leaving
+    // mtime/len untouched via an in-place same-length overwrite.
+    #[test]
+    fn warm_lookup_end_to_end_reuses_cache() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let path = write_rollout(
+            dir.path(),
+            "2026/05/rollout-a.jsonl",
+            "warm-sess",
+            cwd.path(),
+        );
+
+        let cold = cached_indexed_rollouts(dir.path());
+        assert_eq!(cold[0].meta.as_ref().unwrap().id, "warm-sess");
+        let primed = std::fs::metadata(&path).unwrap();
+        let (modified, len) = (primed.modified().unwrap(), primed.len());
+
+        // Best-effort in-place same-length corruption. If the filesystem keeps
+        // (mtime, len) stable (common for an immediate same-size rewrite), the
+        // warm path must still return the cached header. If the mtime advanced,
+        // we skip the strict assertion to avoid filesystem-timing flakiness but
+        // still assert the tree signature path stayed consistent.
+        let corrupt = "x".repeat(len as usize);
+        std::fs::write(&path, &corrupt).unwrap();
+        let after = std::fs::metadata(&path).unwrap();
+        let warm = cached_indexed_rollouts(dir.path());
+        if after.modified().unwrap() == modified && after.len() == len {
+            assert_eq!(
+                warm[0].meta.as_ref().unwrap().id,
+                "warm-sess",
+                "warm cache must reuse the cached header rather than re-reading the corrupted file"
+            );
+        }
+    }
+
+    // TEST-004: rewriting a cached file's content (changing its length) under the
+    // same leaf must invalidate that file's cached header even if the directory
+    // signature were somehow unchanged — the per-file (mtime, len) guard catches
+    // it. Here we also change content length so the header is re-parsed.
+    #[test]
+    fn same_leaf_content_rewrite_reparses_header() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let path = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "old-id", cwd.path());
+
+        let cold = cached_indexed_rollouts(dir.path());
+        assert_eq!(cold[0].meta.as_ref().unwrap().id, "old-id");
+
+        // Rewrite with a different session id (different length) and bump mtime.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"cwd\":\"{}\"}}}}\n",
+                "new-longer-id",
+                cwd.path().display()
+            ),
+        )
+        .unwrap();
+
+        let warm = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            warm[0].meta.as_ref().unwrap().id,
+            "new-longer-id",
+            "a content/length rewrite must re-parse the header"
+        );
+    }
+
+    // Gate logic: unset field defaults ON; explicit false disables.
+    #[test]
+    fn enabled_from_field_defaults_on() {
+        assert!(enabled_from_field(None));
+        assert!(enabled_from_field(Some(true)));
+        assert!(!enabled_from_field(Some(false)));
+    }
+
+    // Rollback contract: with the cache disabled, lookups still return the exact
+    // same candidate set (correctness preserved) but populate NO cache state, so
+    // there is no stale-hit surface. This is the behavioural rollback proven
+    // without mutating the process-global live config.
+    #[test]
+    fn disabled_cache_returns_results_but_caches_nothing() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+
+        let disabled = cached_indexed_rollouts_inner(dir.path(), false);
+        assert_eq!(disabled.len(), 1);
+        assert_eq!(disabled[0].meta.as_ref().unwrap().id, "s1");
+        {
+            let state = lock_cache();
+            assert!(
+                state.roots.is_empty(),
+                "disabled cache must not populate any root state"
+            );
+        }
+
+        // And the enabled path produces the identical candidate set.
+        let enabled = cached_indexed_rollouts_inner(dir.path(), true);
+        assert_eq!(enabled.len(), disabled.len());
+        assert_eq!(
+            enabled[0].meta.as_ref().unwrap().id,
+            disabled[0].meta.as_ref().unwrap().id
+        );
+    }
+
+    // TEST-001 / TEST-004: a new rollout added after a warm lookup is discovered
+    // on the next lookup because the directory mtime (and thus the signature)
+    // changes. Proven end-to-end through the cached entry point.
+    #[test]
+    fn new_rollout_after_warm_lookup_is_discovered() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        let first = cached_indexed_rollouts(dir.path());
+        assert_eq!(first.len(), 1);
+
+        // New rollout under a new leaf directory bumps the tree signature.
+        write_rollout(dir.path(), "2026/06/rollout-b.jsonl", "s2", cwd.path());
+        let second = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            second.len(),
+            2,
+            "a rollout created after a warm lookup must be discovered on the next lookup"
+        );
+    }
+
+    // TEST-004: reset clears the cache so a fresh process-like state is restored.
+    #[test]
+    fn reset_clears_cache() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        let _ = cached_indexed_rollouts(dir.path());
+
+        reset_cache_for_tests();
+        let state = lock_cache();
+        assert!(state.roots.is_empty(), "reset must clear all cached roots");
+    }
+}

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -164,6 +164,12 @@ pub fn rollout_files_under(root: &Path) -> Vec<PathBuf> {
     files
 }
 
+fn is_rollout_jsonl(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+}
+
 /// Read and parse the `session_meta` header of a single rollout file. Bounded to
 /// the first [`HEADER_SCAN_LINE_LIMIT`] lines (REQ-005). This is the direct
 /// (uncached) read used on the cold path and when the cache is disabled.
@@ -221,8 +227,10 @@ pub struct IndexedRollout {
 }
 
 /// Deterministic, content-free tree signature for `root`. Folds each directory's
-/// (path, mtime) into a stable hash. A new rollout file bumps the mtime of its
-/// containing directory; a deleted/renamed leaf changes the parent mtime; a
+/// (path, mtime) plus the set of `rollout-*.jsonl` file paths into a stable
+/// hash. Most filesystems bump the containing directory mtime when a rollout is
+/// added, but hashing rollout membership avoids stale hits on coarse or restored
+/// directory mtimes. A deleted/renamed leaf changes the parent mtime; a
 /// brand-new root that did not exist before yields a different signature than an
 /// empty/missing one. Reads no rollout file contents (REQ-005).
 ///
@@ -237,6 +245,7 @@ fn tree_signature(root: &Path) -> Option<u64> {
     let mut visited_any = false;
     // Collect directory entries deterministically so the hash is order-stable.
     let mut dir_records: Vec<(PathBuf, Option<SystemTime>)> = Vec::new();
+    let mut rollout_records: Vec<PathBuf> = Vec::new();
     while let Some(path) = stack.pop() {
         let Ok(entries) = std::fs::read_dir(&path) else {
             // The root itself being unreadable -> no authoritative signature.
@@ -254,6 +263,8 @@ fn tree_signature(root: &Path) -> Option<u64> {
             let child = entry.path();
             if child.is_dir() {
                 stack.push(child);
+            } else if is_rollout_jsonl(&child) {
+                rollout_records.push(child);
             }
         }
     }
@@ -274,6 +285,10 @@ fn tree_signature(root: &Path) -> Option<u64> {
             }
             None => 0u8.hash(&mut hasher),
         }
+    }
+    rollout_records.sort();
+    for path in rollout_records {
+        path.hash(&mut hasher);
     }
     Some(hasher.finish())
 }
@@ -900,6 +915,31 @@ mod tests {
             warm[0].meta.as_ref().unwrap().id,
             "after-longer-id",
             "a signature-hit warm lookup must re-read a file whose (mtime, len) changed"
+        );
+    }
+
+    // TEST-001 / regression: adding a rollout under an already-known leaf must
+    // change the signature even if the leaf directory mtime is restored or too
+    // coarse to advance. The signature hashes rollout membership, so the warm
+    // path cannot stale-hit and miss the new file.
+    #[test]
+    fn same_leaf_rollout_membership_changes_signature_even_with_restored_dir_mtime() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        let leaf = dir.path().join("2026/05");
+        let original_mtime = std::fs::metadata(&leaf).unwrap().modified().unwrap();
+        let sig1 = tree_signature(dir.path()).unwrap();
+
+        write_rollout(dir.path(), "2026/05/rollout-b.jsonl", "s2", cwd.path());
+        filetime::set_file_mtime(&leaf, filetime::FileTime::from_system_time(original_mtime))
+            .unwrap();
+
+        let sig2 = tree_signature(dir.path()).unwrap();
+        assert_ne!(
+            sig1, sig2,
+            "same-leaf rollout membership must invalidate the cached file list even when directory mtime is unchanged"
         );
     }
 

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -30,11 +30,11 @@
 //! # Rollback
 //!
 //! The cache is gated by `RuntimeSettingsConfig::codex_rollout_index_cache_enabled`
-//! (default ON, hot-reloadable). When disabled, [`cached_rollout_files_under`]
-//! and [`cached_rollout_session_meta`] fall through to the direct
-//! [`rollout_files_under`] scan / direct header read, exactly reproducing the
-//! legacy behaviour with zero cache state. Tests can also force the cold path
-//! with [`reset_cache_for_tests`].
+//! (default ON, hot-reloadable). When disabled, [`cached_indexed_rollouts`]
+//! falls through to the direct [`rollout_files_under`] scan plus
+//! [`read_rollout_session_meta`] header reads, exactly reproducing the legacy
+//! behaviour with zero cache state. Tests can also force the cold path with
+//! [`reset_cache_for_tests`].
 
 use serde_json::Value;
 use std::collections::HashMap;

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -61,11 +61,10 @@ const HEADER_SCAN_LINE_LIMIT: usize = 20;
 const MAX_CACHED_ROOTS: usize = 32;
 
 /// Same-leaf rollout membership validation is intentionally bounded to the most
-/// recent rollout leaf directories. Codex creates new rollouts in the current
-/// dated leaf, so probing recent leaves catches the mtime-coarseness stale-hit
-/// risk without re-walking the whole sessions tree on every 100ms launch poll.
-const RECENT_MEMBERSHIP_PROBE_WINDOW: std::time::Duration =
-    std::time::Duration::from_secs(24 * 60 * 60);
+/// recently modified known directories. Codex creates new rollouts in the
+/// current dated leaf, so probing recent known directories catches the
+/// mtime-coarseness stale-hit risk without re-walking the whole sessions tree on
+/// every 100ms launch poll.
 const MAX_MEMBERSHIP_PROBE_DIRS: usize = 8;
 
 /// Parsed `session_meta` header for a single rollout file. This is the only
@@ -322,19 +321,34 @@ fn tree_signature(root: &Path) -> Option<u64> {
     discover_tree_signature(root).map(|signature| signature.value)
 }
 
-fn recent_rollout_membership_changed(previous_files: &HashMap<PathBuf, CachedFile>) -> bool {
-    let now = SystemTime::now();
-    let mut dirs = previous_files
+fn recent_rollout_membership_changed(index: &RootIndex) -> bool {
+    for dir in rollout_membership_probe_dirs(index) {
+        let Some(current) = rollout_files_in_dir(&dir) else {
+            return true;
+        };
+        let mut cached = index
+            .files
+            .keys()
+            .filter(|path| path.parent() == Some(dir.as_path()))
+            .cloned()
+            .collect::<Vec<_>>();
+        cached.sort();
+        if current != cached {
+            return true;
+        }
+    }
+    false
+}
+
+fn rollout_membership_probe_dirs(index: &RootIndex) -> Vec<PathBuf> {
+    let mut dirs = index
+        .dirs
         .iter()
-        .filter_map(|(path, cached)| {
-            let age = now
-                .duration_since(cached.modified)
-                .unwrap_or(std::time::Duration::ZERO);
-            if age > RECENT_MEMBERSHIP_PROBE_WINDOW {
-                return None;
-            }
-            path.parent()
-                .map(|parent| (cached.modified, parent.to_path_buf()))
+        .filter_map(|dir| {
+            std::fs::metadata(dir)
+                .and_then(|meta| meta.modified())
+                .ok()
+                .map(|modified| (modified, dir.clone()))
         })
         .collect::<Vec<_>>();
     dirs.sort_by(|left, right| right.0.cmp(&left.0));
@@ -348,22 +362,7 @@ fn recent_rollout_membership_changed(previous_files: &HashMap<PathBuf, CachedFil
             break;
         }
     }
-
-    for dir in unique_dirs {
-        let Some(current) = rollout_files_in_dir(&dir) else {
-            return true;
-        };
-        let mut cached = previous_files
-            .keys()
-            .filter(|path| path.parent() == Some(dir.as_path()))
-            .cloned()
-            .collect::<Vec<_>>();
-        cached.sort();
-        if current != cached {
-            return true;
-        }
-    }
-    false
+    unique_dirs
 }
 
 fn rollout_files_in_dir(dir: &Path) -> Option<Vec<PathBuf>> {
@@ -448,7 +447,7 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
     if signature_hit
         && previous
             .as_ref()
-            .is_some_and(|index| recent_rollout_membership_changed(&index.files))
+            .is_some_and(recent_rollout_membership_changed)
     {
         signature_hit = false;
     }
@@ -1100,6 +1099,30 @@ mod tests {
             second.len(),
             2,
             "same-leaf rollout membership must invalidate the cached file list even when directory mtime is unchanged"
+        );
+    }
+
+    #[test]
+    fn same_leaf_membership_probe_checks_empty_known_dirs() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let leaf = dir.path().join("2026/05");
+        std::fs::create_dir_all(&leaf).unwrap();
+        let original_mtime = std::fs::metadata(&leaf).unwrap().modified().unwrap();
+
+        let first = cached_indexed_rollouts(dir.path());
+        assert!(first.is_empty(), "empty known leaf starts with no rollouts");
+
+        write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path());
+        filetime::set_file_mtime(&leaf, filetime::FileTime::from_system_time(original_mtime))
+            .unwrap();
+
+        let second = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            second.len(),
+            1,
+            "empty cached leaves must be revalidated so a same-leaf rollout is discovered"
         );
     }
 

--- a/src/services/codex_tui/rollout_index.rs
+++ b/src/services/codex_tui/rollout_index.rs
@@ -18,11 +18,17 @@
 //!    therefore the signature. The signature is recomputed on **every** lookup
 //!    (cheap `O(directories)` stat calls) — invalidation is a precondition, not
 //!    a postcondition.
-//! 2. On a signature match (warm hit) reuses the cached file list AND the cached
-//!    parsed `session_meta` for each file whose `(mtime, len)` is unchanged, so
-//!    warm lookups do **not** re-read rollout headers (PRD REQ-005).
-//! 3. On a signature mismatch (cold / changed) re-walks the tree, then lazily
-//!    re-reads only headers whose `(mtime, len)` changed.
+//! 2. On a signature match (warm hit) reuses the cached file *list* directly so
+//!    the `O(directories × entries)` `read_dir` re-walk is skipped; each cached
+//!    path is still `stat`ed and its parsed `session_meta` reused unless its
+//!    `(mtime, len)` changed (catching in-place appends/rewrites that leave the
+//!    directory mtime — and thus the signature — unchanged). Warm lookups
+//!    therefore do **not** re-walk the tree and do **not** re-read unchanged
+//!    headers (PRD REQ-005).
+//! 3. On a signature mismatch (cold / changed) re-walks the tree, but still
+//!    consults the prior per-file map and re-reads only headers whose
+//!    `(mtime, len)` changed (or files never seen before). A single added rollout
+//!    therefore costs one header read, not `O(files)`.
 //!
 //! Invalidation deliberately prefers a **false miss** (an extra rescan) over a
 //! **stale hit** (resuming the wrong rollout) — see PRD risk table.
@@ -275,10 +281,12 @@ fn tree_signature(root: &Path) -> Option<u64> {
 /// Cache-backed rollout discovery returning each candidate's path + cached
 /// metadata + parsed header.
 ///
-/// On a warm hit (signature unchanged) the cached `session_meta` is reused for
-/// every file whose `(modified, len)` is unchanged, so no rollout headers are
-/// re-read. On a cold/changed lookup the tree is re-walked and only headers with
-/// a changed `(modified, len)` (or never-seen files) are re-read.
+/// On a warm hit (signature unchanged) the cached file *list* is reused so the
+/// directory subtree is NOT re-walked; each cached path is re-`stat`ed and its
+/// parsed header reused unless its `(modified, len)` changed. On a cold/changed
+/// lookup the tree is re-walked but the prior per-file map is still consulted, so
+/// only headers whose `(modified, len)` changed (or never-seen files) are
+/// re-read — a single new rollout does NOT re-read every surviving file's header.
 ///
 /// When the cache is disabled (config flag off) this still returns the full
 /// candidate set, but performs a fresh scan + header read each time — i.e. it is
@@ -300,20 +308,46 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
         return scan_indexed_rollouts(root, None);
     };
 
-    // Snapshot the previous per-file metadata for this root so headers can be
-    // reused without holding the lock during file I/O.
-    let previous: Option<HashMap<PathBuf, CachedFile>> = {
+    // Snapshot the previous per-root state so headers (and, on a signature hit,
+    // the file list itself) can be reused without holding the lock during file
+    // I/O. The cached per-file `(mtime, len, meta)` map is reused for header
+    // reuse REGARDLESS of whether the tree signature matched: a signature change
+    // only means the *set* of files may differ (a rollout added/removed), not
+    // that every surviving file's header changed. Dropping the whole map on any
+    // signature miss made the common "one new rollout under a busy sessions
+    // root" path re-read every existing header, defeating the cache.
+    let previous: Option<RootIndex> = {
         let state = lock_cache();
-        state
-            .roots
-            .get(&canonical_root)
-            .filter(|index| index.signature == signature)
-            .map(|index| index.files.clone())
+        state.roots.get(&canonical_root).cloned()
+    };
+    let signature_hit = previous
+        .as_ref()
+        .is_some_and(|index| index.signature == signature);
+    let previous_files = previous.map(|index| index.files);
+
+    let results = match (signature_hit, previous_files) {
+        (true, Some(previous_files)) => {
+            // Warm hit: the directory subtree is unchanged (no rollout added,
+            // removed, or renamed), so the cached *file list* is authoritative —
+            // reuse it directly and skip the `O(directories × entries)`
+            // `rollout_files_under` `read_dir` re-walk. Each cached path is still
+            // re-`stat`ed and its header re-read only when its `(mtime, len)`
+            // changed, so an in-place append/rewrite (which advances the file
+            // mtime/len but NOT the parent directory mtime, leaving the signature
+            // unchanged) is still caught. This is the cheap warm path the index
+            // exists for: on a busy root it costs `O(directories)` for the
+            // signature + `O(files)` stats, with zero header reads when nothing
+            // changed and zero directory recursion.
+            scan_indexed_rollouts_from_paths(previous_files.keys(), Some(&previous_files))
+        }
+        (_, previous_files) => {
+            // Cold / changed tree: re-walk to refresh the file list, reusing each
+            // surviving file's cached header when its `(mtime, len)` is unchanged.
+            scan_indexed_rollouts(root, previous_files.as_ref())
+        }
     };
 
-    let results = scan_indexed_rollouts(root, previous.as_ref());
-
-    // Rebuild the cache entry from the fresh scan results.
+    // Rebuild the cache entry from the fresh results.
     let mut files = HashMap::with_capacity(results.len());
     for item in &results {
         files.insert(
@@ -329,27 +363,47 @@ fn cached_indexed_rollouts_inner(root: &Path, enabled: bool) -> Vec<IndexedRollo
     results
 }
 
-/// Direct scan (optionally reusing cached per-file metadata). When `previous` is
-/// `Some` and a file's `(modified, len)` are unchanged, its cached header is
-/// reused; otherwise the header is read from disk.
+/// Direct scan via the directory re-walk (optionally reusing cached per-file
+/// metadata). Used on the cold / signature-miss path where the file *set* may
+/// have changed. When `previous` is `Some` and a file's `(modified, len)` are
+/// unchanged, its cached header is reused; otherwise the header is read from
+/// disk.
 fn scan_indexed_rollouts(
     root: &Path,
     previous: Option<&HashMap<PathBuf, CachedFile>>,
 ) -> Vec<IndexedRollout> {
-    rollout_files_under(root)
+    scan_indexed_rollouts_from_paths(rollout_files_under(root).iter(), previous)
+}
+
+/// Build indexed candidates from an explicit set of candidate paths, re-`stat`ing
+/// each and reusing the cached header iff its `(modified, len)` is unchanged.
+/// The signature-hit warm path feeds the cached `RootIndex.files` keys here to
+/// avoid the directory re-walk while still revalidating each file's `(mtime,
+/// len)` (so in-place appends/rewrites are not served stale). The cold path
+/// feeds freshly-walked paths. A path that vanished between the cached snapshot
+/// and this `stat` is dropped via `metadata().ok()?`, so a deleted rollout under
+/// an otherwise-unchanged signature is not surfaced.
+fn scan_indexed_rollouts_from_paths<'a, I>(
+    paths: I,
+    previous: Option<&HashMap<PathBuf, CachedFile>>,
+) -> Vec<IndexedRollout>
+where
+    I: IntoIterator<Item = &'a PathBuf>,
+{
+    paths
         .into_iter()
         .filter_map(|path| {
-            let metadata = std::fs::metadata(&path).ok()?;
+            let metadata = std::fs::metadata(path).ok()?;
             let modified = metadata.modified().ok()?;
             let len = metadata.len();
-            let meta = match previous.and_then(|prev| prev.get(&path)) {
+            let meta = match previous.and_then(|prev| prev.get(path)) {
                 Some(cached) if cached.modified == modified && cached.len == len => {
                     cached.meta.clone()
                 }
-                _ => read_rollout_session_meta(&path),
+                _ => read_rollout_session_meta(path),
             };
             Some(IndexedRollout {
-                path,
+                path: path.clone(),
                 modified,
                 len,
                 meta,
@@ -401,22 +455,37 @@ pub fn reset_cache_for_tests() {
     state.seq = 0;
 }
 
+/// Process-global serialization lock for any test that touches the shared
+/// rollout index. The cache lives for the whole process, so two tests that
+/// populate/reset it under default parallel `cargo test` would otherwise race —
+/// e.g. a `session.rs` resolver test mutating `roots` between a `rollout_index`
+/// test's reset and its cache-state assertion. ALL test modules across this
+/// crate that exercise the index (here AND `session.rs`) must serialize through
+/// [`lock_cache_for_tests`].
+#[cfg(test)]
+static CACHE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the shared cache test lock and reset the cache, returning the guard.
+/// Holding the returned guard for the duration of a test gives that test an
+/// isolated, freshly-reset process-global index (REQ-004 / TEST-004). Exposed
+/// (not module-private) so `session.rs` tests share the exact same lock instead
+/// of running unsynchronized against the same global state.
+#[cfg(test)]
+pub fn lock_cache_for_tests() -> std::sync::MutexGuard<'static, ()> {
+    let guard = CACHE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    reset_cache_for_tests();
+    guard
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard};
-
-    // Serialize cache tests: the cache is process-global, so parallel tests
-    // mutating it would race. This guard plus `reset_cache_for_tests` gives each
-    // test an isolated cache (REQ-004 / TEST-004).
-    static CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+    use std::sync::MutexGuard;
 
     fn lock_test() -> MutexGuard<'static, ()> {
-        let guard = CACHE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        reset_cache_for_tests();
-        guard
+        lock_cache_for_tests()
     }
 
     fn write_rollout(root: &Path, relative: &str, id: &str, cwd: &Path) -> PathBuf {
@@ -694,6 +763,143 @@ mod tests {
             second.len(),
             2,
             "a rollout created after a warm lookup must be discovered on the next lookup"
+        );
+    }
+
+    // Finding (rollout_index.rs:310): on a signature MISS (a new rollout under a
+    // new leaf bumps the tree signature), the surviving files' cached headers must
+    // still be reused — only the genuinely new/changed file pays a header read.
+    // We prove the survivor's header is not re-read by corrupting it in place to
+    // unparseable while keeping its (mtime, len) stable: a warm reuse returns the
+    // cached id; a blanket drop would re-read and lose it.
+    #[test]
+    fn signature_miss_reuses_surviving_file_headers() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let survivor = write_rollout(
+            dir.path(),
+            "2026/05/rollout-a.jsonl",
+            "survivor",
+            cwd.path(),
+        );
+
+        // Cold lookup warms the cache with the survivor's header.
+        let cold = cached_indexed_rollouts(dir.path());
+        assert_eq!(cold.len(), 1);
+        let primed = std::fs::metadata(&survivor).unwrap();
+        let (modified, len) = (primed.modified().unwrap(), primed.len());
+
+        // Corrupt the survivor in place (same length) so a header RE-READ would
+        // yield `None`, while a cache REUSE keeps the parsed id.
+        let corrupt = "x".repeat(len as usize);
+        std::fs::write(&survivor, &corrupt).unwrap();
+        let after = std::fs::metadata(&survivor).unwrap();
+
+        // Add a brand-new rollout under a new leaf -> the tree signature changes
+        // (signature MISS), forcing a re-walk.
+        write_rollout(
+            dir.path(),
+            "2026/06/rollout-b.jsonl",
+            "newcomer",
+            cwd.path(),
+        );
+
+        let warm = cached_indexed_rollouts(dir.path());
+        assert_eq!(warm.len(), 2, "the new rollout must be discovered");
+        if after.modified().unwrap() == modified && after.len() == len {
+            let survivor_meta = warm
+                .iter()
+                .find(|item| item.path == survivor)
+                .and_then(|item| item.meta.as_ref());
+            assert_eq!(
+                survivor_meta.map(|meta| meta.id.as_str()),
+                Some("survivor"),
+                "a signature miss must reuse the surviving file's cached header, not re-read it"
+            );
+        }
+    }
+
+    // Finding (rollout_index.rs:339): on a signature HIT the warm path builds
+    // results from the cached file list and skips both the `rollout_files_under`
+    // re-walk and the header re-read for files whose `(mtime, len)` is unchanged.
+    // We prove the warm path serves the CACHED header (i.e. it did not re-read the
+    // file) by corrupting the file in place to unparseable while preserving its
+    // `(mtime, len)` AND the directory signature: a cache reuse keeps the parsed
+    // id; a re-read would yield `None`.
+    #[test]
+    fn signature_hit_reuses_cached_file_list_without_rewalk() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let path = write_rollout(
+            dir.path(),
+            "2026/05/rollout-a.jsonl",
+            "warm-list",
+            cwd.path(),
+        );
+
+        let cold = cached_indexed_rollouts(dir.path());
+        assert_eq!(cold.len(), 1);
+        let signature_after_cold = tree_signature(dir.path()).unwrap();
+        let primed = std::fs::metadata(&path).unwrap();
+        let (modified, len) = (primed.modified().unwrap(), primed.len());
+
+        // In-place same-length corruption: leaves the file `(mtime, len)` stable
+        // (common for an immediate same-size rewrite) and does not touch the
+        // parent directory mtime, so the tree signature is unchanged -> warm hit.
+        let corrupt = "x".repeat(len as usize);
+        std::fs::write(&path, &corrupt).unwrap();
+        let after = std::fs::metadata(&path).unwrap();
+
+        let warm = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            tree_signature(dir.path()).unwrap(),
+            signature_after_cold,
+            "tree signature must be stable across the warm lookup"
+        );
+        assert_eq!(warm.len(), 1, "warm hit must reuse the cached file list");
+        if after.modified().unwrap() == modified && after.len() == len {
+            assert_eq!(
+                warm[0].meta.as_ref().unwrap().id,
+                "warm-list",
+                "a signature-hit warm lookup with unchanged (mtime, len) must reuse the cached header, not re-read the corrupted file"
+            );
+        }
+    }
+
+    // Finding (rollout_index.rs:339) correctness floor: even on a signature HIT,
+    // an in-place content rewrite that DOES change `(mtime, len)` (e.g. a Codex
+    // append) must be re-read — the warm path re-`stat`s each cached path, so the
+    // append is not served stale despite the unchanged directory signature.
+    #[test]
+    fn signature_hit_still_rereads_on_mtime_len_change() {
+        let _guard = lock_test();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let path = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "before", cwd.path());
+
+        let cold = cached_indexed_rollouts(dir.path());
+        assert_eq!(cold[0].meta.as_ref().unwrap().id, "before");
+
+        // Rewrite the SAME file in place with a different id + length, bumping its
+        // mtime, WITHOUT adding/removing a directory entry (signature unchanged).
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"cwd\":\"{}\"}}}}\n",
+                "after-longer-id",
+                cwd.path().display()
+            ),
+        )
+        .unwrap();
+
+        let warm = cached_indexed_rollouts(dir.path());
+        assert_eq!(
+            warm[0].meta.as_ref().unwrap().id,
+            "after-longer-id",
+            "a signature-hit warm lookup must re-read a file whose (mtime, len) changed"
         );
     }
 

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -8,6 +8,11 @@ use std::time::{Duration, Instant, SystemTime};
 
 use crate::services::agent_protocol::StreamMessage;
 use crate::services::provider::{CancelToken, ReadOutputResult, cancel_requested};
+// REQ-006: share the single rollout discovery primitive so `session.rs` and
+// `rollout_tail.rs` do not maintain two divergent directory walkers. Tailing
+// semantics are unchanged — callers here still apply their own cwd/session/mtime
+// filters after discovery.
+use super::rollout_index::rollout_files_under;
 
 const DEFAULT_ROLLOUT_WAIT_SECS: u64 = 30;
 /// Fallback EOF drain budget for rollouts that do NOT emit an explicit
@@ -688,31 +693,6 @@ fn latest_rollout_for_cwd_and_session_since(
         }
     }
     best.map(|(_, path)| path)
-}
-
-fn rollout_files_under(root: &Path) -> Vec<PathBuf> {
-    let mut stack = vec![root.to_path_buf()];
-    let mut files = Vec::new();
-    while let Some(path) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&path) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                stack.push(path);
-                continue;
-            }
-            if path
-                .file_name()
-                .and_then(|value| value.to_str())
-                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
-            {
-                files.push(path);
-            }
-        }
-    }
-    files
 }
 
 fn rollout_session_cwd_matches(path: &Path, cwd: &Path) -> bool {

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -591,6 +591,19 @@ fn wait_for_resumed_rollout_for_session(
     }
 }
 
+/// Newest rollout transcript under `sessions_dir` whose `session_meta` cwd
+/// matches `cwd` and whose mtime is at/after `modified_since`.
+///
+/// Routed through [`cached_indexed_rollouts`](super::rollout_index::cached_indexed_rollouts)
+/// so the follow-up readiness path (`tui_followup.rs`, which has no provider
+/// session id) and the launch wait loop reuse the process-lifetime index instead
+/// of re-walking `~/.codex/sessions` and re-parsing every header on every probe.
+/// Selection semantics are identical to the legacy direct scan: the index
+/// supplies the same `(mtime, len)` projection and parsed `session_meta`, and the
+/// cwd match still canonicalizes the header's raw cwd against `cwd` exactly as
+/// the former `rollout_session_cwd_matches` did. Files with no parseable
+/// `session_meta` carry `meta == None` in the index and are skipped, matching the
+/// old `false` return from the header scan.
 pub fn latest_rollout_for_cwd_since(
     cwd: &Path,
     modified_since: SystemTime,
@@ -598,24 +611,23 @@ pub fn latest_rollout_for_cwd_since(
 ) -> Option<PathBuf> {
     let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
     let mut best: Option<(SystemTime, PathBuf)> = None;
-    for path in rollout_files_under(sessions_dir) {
-        let Some(modified) = std::fs::metadata(&path)
-            .and_then(|meta| meta.modified())
-            .ok()
-        else {
-            continue;
-        };
-        if modified < modified_since {
+    for item in super::rollout_index::cached_indexed_rollouts(sessions_dir) {
+        if item.modified < modified_since {
             continue;
         }
-        if !rollout_session_cwd_matches(&path, &canonical_cwd) {
+        let Some(meta) = item.meta.as_ref() else {
+            continue;
+        };
+        let session_cwd =
+            std::fs::canonicalize(&meta.cwd).unwrap_or_else(|_| PathBuf::from(&meta.cwd));
+        if session_cwd != canonical_cwd {
             continue;
         }
         if best
             .as_ref()
-            .is_none_or(|(best_modified, _)| modified > *best_modified)
+            .is_none_or(|(best_modified, _)| item.modified > *best_modified)
         {
-            best = Some((modified, path));
+            best = Some((item.modified, item.path));
         }
     }
     best.map(|(_, path)| path)

--- a/src/services/codex_tui/session.rs
+++ b/src/services/codex_tui/session.rs
@@ -1,8 +1,7 @@
-use serde_json::Value;
-use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use super::rollout_index::cached_indexed_rollouts;
 use super::rollout_tail::default_codex_sessions_dir;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,19 +158,23 @@ fn fresh(
     }
 }
 
+/// Resolve the rollout candidates matching `requested_id` + `cwd` under
+/// `sessions_root`, applying the exact legacy filters (TUI-compatible
+/// `session_meta`, requested session id, canonical cwd equality). The directory
+/// walk + header parse are served by the cache-backed
+/// [`cached_indexed_rollouts`] (REQ-001/REQ-006); the per-candidate filtering
+/// and `(modified, len)` projection are unchanged from the legacy scan so
+/// selection semantics (REQ-002/REQ-003) are byte-for-byte identical.
 fn matching_rollout_candidates(
     sessions_root: &Path,
     cwd: &Path,
     requested_id: &str,
 ) -> Vec<RolloutCandidate> {
     let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
-    rollout_files_under(sessions_root)
+    cached_indexed_rollouts(sessions_root)
         .into_iter()
-        .filter_map(|path| {
-            let metadata = std::fs::metadata(&path).ok()?;
-            let modified = metadata.modified().ok()?;
-            let len = metadata.len();
-            let session = read_rollout_session_meta(&path)?;
+        .filter_map(|item| {
+            let session = item.meta?;
             if !session.is_tui_compatible() {
                 return None;
             }
@@ -184,97 +187,12 @@ fn matching_rollout_candidates(
                 return None;
             }
             Some(RolloutCandidate {
-                path,
-                modified,
-                len,
+                path: item.path,
+                modified: item.modified,
+                len: item.len,
             })
         })
         .collect()
-}
-
-fn rollout_files_under(root: &Path) -> Vec<PathBuf> {
-    let mut stack = vec![root.to_path_buf()];
-    let mut files = Vec::new();
-    while let Some(path) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&path) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                stack.push(path);
-                continue;
-            }
-            if path
-                .file_name()
-                .and_then(|value| value.to_str())
-                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
-            {
-                files.push(path);
-            }
-        }
-    }
-    files
-}
-
-#[derive(Debug, Clone)]
-struct RolloutSessionMeta {
-    id: String,
-    cwd: PathBuf,
-    source: Option<String>,
-    originator: Option<String>,
-}
-
-impl RolloutSessionMeta {
-    fn is_tui_compatible(&self) -> bool {
-        // Codex direct TUI can safely resume sessions recorded by the
-        // interactive CLI. Older AgentDesk codex-exec rollouts share the same
-        // JSONL directory and UUID shape, but resuming them through the TUI can
-        // leave no fresh rollout transcript for the tailer to follow.
-        !self.source.as_deref().is_some_and(|value| value == "exec")
-            && !self
-                .originator
-                .as_deref()
-                .is_some_and(|value| value == "codex_exec")
-    }
-}
-
-fn read_rollout_session_meta(path: &Path) -> Option<RolloutSessionMeta> {
-    let file = std::fs::File::open(path).ok()?;
-    let reader = std::io::BufReader::new(file);
-    for line in reader.lines().map_while(Result::ok).take(20) {
-        let Ok(json) = serde_json::from_str::<Value>(&line) else {
-            continue;
-        };
-        if json.get("type").and_then(Value::as_str) != Some("session_meta") {
-            continue;
-        }
-        let Some(payload) = json.get("payload") else {
-            continue;
-        };
-        let Some(id) = payload.get("id").and_then(Value::as_str).map(str::trim) else {
-            continue;
-        };
-        let Some(cwd) = payload.get("cwd").and_then(Value::as_str).map(str::trim) else {
-            continue;
-        };
-        if id.is_empty() || cwd.is_empty() {
-            return None;
-        }
-        return Some(RolloutSessionMeta {
-            id: id.to_string(),
-            cwd: PathBuf::from(cwd),
-            source: payload
-                .get("source")
-                .and_then(Value::as_str)
-                .map(ToString::to_string),
-            originator: payload
-                .get("originator")
-                .and_then(Value::as_str)
-                .map(ToString::to_string),
-        });
-    }
-    None
 }
 
 #[cfg(test)]
@@ -492,5 +410,105 @@ mod tests {
         assert!(selection.resume);
         assert_eq!(selection.candidate_count, 2);
         assert_eq!(selection.rollout_path.as_deref(), Some(second.as_path()));
+    }
+
+    // TEST-002 / TEST-004 (REQ-001/REQ-002): resolving twice for the same root is
+    // a warm-cache lookup the second time; a newer rollout created in between must
+    // still be selected (the directory mtime bumps the tree signature). This pins
+    // the high-severity "stale cache resumes an older rollout" risk.
+    #[test]
+    fn warm_lookup_picks_up_newer_rollout_after_first_resolve() {
+        super::super::rollout_index::reset_cache_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let first = write_rollout(
+            dir.path(),
+            "old/rollout-a.jsonl",
+            "sess-1",
+            cwd.path(),
+            "old",
+        );
+
+        // Cold resolve: selects the only candidate and warms the cache.
+        let cold = resolve_codex_tui_session(Some("sess-1"), cwd.path(), Some(dir.path()), false);
+        assert_eq!(cold.rollout_path.as_deref(), Some(first.as_path()));
+        assert_eq!(cold.candidate_count, 1);
+
+        // A newer rollout under a new leaf directory appears.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let newer = write_rollout(
+            dir.path(),
+            "new/rollout-b.jsonl",
+            "sess-1",
+            cwd.path(),
+            "new",
+        );
+
+        // Warm resolve: signature changed, so the index rebuilds and the newer
+        // rollout is selected — no stale hit.
+        let warm = resolve_codex_tui_session(Some("sess-1"), cwd.path(), Some(dir.path()), false);
+        assert!(warm.resume);
+        assert_eq!(warm.candidate_count, 2);
+        assert_eq!(
+            warm.rollout_path.as_deref(),
+            Some(newer.as_path()),
+            "warm lookup must select the newest rollout, not the cached older one"
+        );
+    }
+
+    // TEST-006 (REQ-006): the shared discovery primitive used by both `session.rs`
+    // (via the index) and `rollout_tail.rs` agrees with a direct scan on which
+    // files are rollout candidates.
+    #[test]
+    fn shared_discovery_primitive_matches_direct_scan() {
+        super::super::rollout_index::reset_cache_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let a = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path(), "");
+        let b = write_rollout(dir.path(), "2026/06/rollout-b.jsonl", "s2", cwd.path(), "");
+        std::fs::write(dir.path().join("2026/05/ignore.txt"), "x").unwrap();
+
+        let mut via_primitive = super::super::rollout_index::rollout_files_under(dir.path());
+        via_primitive.sort();
+        let mut via_index: Vec<_> =
+            super::super::rollout_index::cached_indexed_rollouts(dir.path())
+                .into_iter()
+                .map(|item| item.path)
+                .collect();
+        via_index.sort();
+        let mut expected = vec![a, b];
+        expected.sort();
+
+        assert_eq!(via_primitive, expected);
+        assert_eq!(via_index, expected);
+    }
+
+    // TEST-003 (REQ-003): a non-TUI (codex_exec) rollout discovered by the index
+    // is still excluded by the resolver filters, so the cache change does not
+    // alter selection semantics.
+    #[test]
+    fn indexed_lookup_still_excludes_codex_exec_rollouts() {
+        super::super::rollout_index::reset_cache_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        write_rollout_with_source(
+            dir.path(),
+            "rollout-exec.jsonl",
+            "sess-1",
+            cwd.path(),
+            "exec",
+            "codex_exec",
+        );
+        let tui = write_rollout(dir.path(), "rollout-tui.jsonl", "sess-1", cwd.path(), "");
+
+        let selection =
+            resolve_codex_tui_session(Some("sess-1"), cwd.path(), Some(dir.path()), false);
+
+        assert!(selection.resume);
+        assert_eq!(
+            selection.candidate_count, 1,
+            "codex_exec rollout must remain excluded even through the index"
+        );
+        assert_eq!(selection.rollout_path.as_deref(), Some(tui.as_path()));
     }
 }

--- a/src/services/codex_tui/session.rs
+++ b/src/services/codex_tui/session.rs
@@ -178,7 +178,7 @@ fn matching_rollout_candidates(
             if !session.is_tui_compatible() {
                 return None;
             }
-            if session.id != requested_id {
+            if session.id.as_deref() != Some(requested_id) {
                 return None;
             }
             let session_cwd =

--- a/src/services/codex_tui/session.rs
+++ b/src/services/codex_tui/session.rs
@@ -280,6 +280,17 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    /// Every resolver test here drives `resolve_codex_tui_session`, which reads
+    /// AND writes the process-global rollout index via `cached_indexed_rollouts`.
+    /// Without serialization a `session.rs` test could mutate `roots` between a
+    /// `rollout_index` test's reset and its cache-state assertion, making the
+    /// `codex_tui` suite nondeterministic under default parallel `cargo test`.
+    /// Share the SAME lock the `rollout_index` tests use (it also resets the
+    /// cache on acquisition) so the two modules can never interleave.
+    fn lock_cache_test() -> MutexGuard<'static, ()> {
+        super::super::rollout_index::lock_cache_for_tests()
+    }
+
     #[test]
     fn cleanup_best_effort_removes_codex_tui_home() {
         let _lock = lock_test_env();
@@ -318,6 +329,7 @@ mod tests {
 
     #[test]
     fn requested_session_with_matching_rollout_resumes() {
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         let rollout = write_rollout(
@@ -340,6 +352,7 @@ mod tests {
 
     #[test]
     fn forced_fresh_ignores_requested_session_and_existing_rollout() {
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         write_rollout(dir.path(), "rollout-a.jsonl", "sess-1", cwd.path(), "");
@@ -357,6 +370,7 @@ mod tests {
 
     #[test]
     fn requested_session_without_matching_rollout_resolves_fresh() {
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         write_rollout(dir.path(), "rollout-a.jsonl", "other", cwd.path(), "");
@@ -374,6 +388,7 @@ mod tests {
 
     #[test]
     fn requested_session_with_only_codex_exec_rollout_resolves_fresh() {
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         write_rollout_with_source(
@@ -398,6 +413,7 @@ mod tests {
 
     #[test]
     fn multiple_candidates_select_newest_then_path_deterministically() {
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         let _first = write_rollout(dir.path(), "b/rollout-b.jsonl", "sess-1", cwd.path(), "old");
@@ -418,7 +434,7 @@ mod tests {
     // the high-severity "stale cache resumes an older rollout" risk.
     #[test]
     fn warm_lookup_picks_up_newer_rollout_after_first_resolve() {
-        super::super::rollout_index::reset_cache_for_tests();
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         let first = write_rollout(
@@ -461,7 +477,7 @@ mod tests {
     // files are rollout candidates.
     #[test]
     fn shared_discovery_primitive_matches_direct_scan() {
-        super::super::rollout_index::reset_cache_for_tests();
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         let a = write_rollout(dir.path(), "2026/05/rollout-a.jsonl", "s1", cwd.path(), "");
@@ -488,7 +504,7 @@ mod tests {
     // alter selection semantics.
     #[test]
     fn indexed_lookup_still_excludes_codex_exec_rollouts() {
-        super::super::rollout_index::reset_cache_for_tests();
+        let _cache = lock_cache_test();
         let dir = tempfile::tempdir().unwrap();
         let cwd = tempfile::tempdir().unwrap();
         write_rollout_with_source(

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+/// Codex rollout-state tests below drive `observe_codex_tui_rollout_state_for_cwd_with_sessions`,
+/// whose no-session-id and provider-session-id paths now read/write the
+/// process-global rollout index (`cached_indexed_rollouts`). Share the SAME lock
+/// the `rollout_index` / `session` cache tests use so a rollout-state test cannot
+/// mutate `roots` between another cache test's reset and its empty-state
+/// assertion under default parallel `cargo test`. The guard also resets the cache
+/// on acquisition, isolating each test.
+#[cfg(unix)]
+fn lock_rollout_cache_test() -> std::sync::MutexGuard<'static, ()> {
+    crate::services::codex_tui::rollout_index::lock_cache_for_tests()
+}
+
 #[test]
 fn session_strategy_lifecycle_event_records_fresh_and_resumed_details() {
     let fresh = session_strategy_lifecycle_event(None, "no_cached_provider_session", None);
@@ -536,6 +548,7 @@ fn codex_busy_preflight_keeps_codex_readiness_wait() {
 #[cfg(unix)]
 #[test]
 fn codex_rollout_idle_state_allows_followup() {
+    let _cache = lock_rollout_cache_test();
     // observe_codex_tui_rollout_state_for_cwd_with_sessions returns Idle
     // when the most recent rollout envelope signals task_complete.
     let cwd = tempfile::tempdir().expect("create temp cwd");
@@ -602,6 +615,7 @@ fn codex_rollout_user_submitted_blocks_followup() {
 #[cfg(unix)]
 #[test]
 fn codex_rollout_no_file_treats_as_idle() {
+    let _cache = lock_rollout_cache_test();
     // When no rollout file exists for the cwd, the gate must not fire
     // (session hasn't started yet or cwd doesn't match any rollout).
     let cwd = tempfile::tempdir().expect("create temp cwd");
@@ -624,6 +638,7 @@ fn codex_rollout_no_file_treats_as_idle() {
 #[cfg(unix)]
 #[test]
 fn codex_rollout_provider_session_id_wins_over_newer_same_cwd_rollout() {
+    let _cache = lock_rollout_cache_test();
     let cwd = tempfile::tempdir().expect("create temp cwd");
     let sessions = tempfile::tempdir().expect("create temp sessions dir");
     let selected_rollout = sessions.path().join("rollout-selected-idle.jsonl");
@@ -765,6 +780,7 @@ fn codex_rollout_runtime_binding_cross_cwd_is_unknown() {
 #[cfg(unix)]
 #[test]
 fn codex_rollout_without_binding_or_session_is_unknown_when_same_cwd_rollout_exists() {
+    let _cache = lock_rollout_cache_test();
     let cwd = tempfile::tempdir().expect("create temp cwd");
     let sessions = tempfile::tempdir().expect("create temp sessions dir");
     let rollout_path = sessions.path().join("rollout-ambiguous.jsonl");
@@ -797,6 +813,7 @@ fn codex_rollout_without_binding_or_session_is_unknown_when_same_cwd_rollout_exi
 #[cfg(unix)]
 #[test]
 fn codex_rollout_without_binding_or_session_conservatively_blocks_busy_same_cwd_rollout() {
+    let _cache = lock_rollout_cache_test();
     let cwd = tempfile::tempdir().expect("create temp cwd");
     let sessions = tempfile::tempdir().expect("create temp sessions dir");
     let rollout_path = sessions.path().join("rollout-ambiguous-busy.jsonl");


### PR DESCRIPTION
## 목표
Codex TUI resume/follow-up가 `~/.codex/sessions` 전체를 매번 비싼 방식으로 훑지 않으면서도, 새 rollout 파일과 새 dated leaf를 놓치지 않는 rollout discovery cache를 제공합니다.

## 쉬운 설명
Codex rollout 탐색은 warm cache에서 header 재파싱과 전체 tree rewalk를 피합니다.
대신 known directory의 direct rollout file 및 child directory membership을 bounded probe로 확인해 coarse mtime filesystem에서도 새 rollout을 놓치지 않습니다.
캐시를 꺼도 기존 직접 scan 경로로 돌아갑니다.

## 개선되는 것
### Fix 1
Before: cached parent 아래 새 day/month child leaf가 생겨도 parent mtime이 관측상 그대로면 warm hit가 기존 file list만 재사용할 수 있었습니다.
After: bounded membership probe가 direct child directories까지 비교해 새 child leaf를 감지하고 cold refresh로 전환합니다.

### Fix 2
Before: same-leaf 파일 추가만 probe 대상이었습니다.
After: empty known leaf, same-leaf rollout 추가, 새 child leaf 추가를 모두 회귀 테스트로 고정했습니다.

### Fix 3
Before: 원격 CI fast check가 sccache daemon startup timeout으로 실패했습니다.
After: 코드 실패가 아닌 infra 실패임을 로그로 확인했고, 새 commit으로 checks가 재실행되도록 PR head를 갱신했습니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 새 rollout 파일 same leaf | membership probe로 감지 | 유지 |
| 새 dated child leaf | parent mtime coarse/restore 시 누락 가능 | child directory membership 변경으로 감지 |
| cache disabled | direct scan + header read | 유지 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| warm poll loop | 최대 8개 known dir만 readdir | bounded cost 유지 |
| cached file content rewrite | per-file `(mtime, len)`으로 재파싱 | stale header 방지 유지 |
| missing root after process start | missing root는 cache하지 않음 | later creation 발견 유지 |

## 해결한 내용
- `src/services/codex_tui/rollout_index.rs`: membership probe가 direct rollout files와 direct child directories를 함께 비교하도록 보강했습니다.
- 새 child leaf가 parent mtime 복원/미관측 상황에서도 발견되는 regression test를 추가했습니다.

## 검증
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test --all-targets rollout_index -- --skip _pg --skip pg_ --skip postgres` (17 passed)
- `python3 scripts/check_agent_maintenance_docs.py --base-ref upstream/main`
- `./scripts/ci-script-checks.sh`
- 원격 실패 로그 확인: `Fast check + non-PG tests (ubuntu-latest)` 실패 원인은 `sccache: Timed out waiting for server startup`로 코드 실패가 아니었습니다.
