### PR TITLE
feat(opencode): reuse warm serve process with safe diagnostics

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2620), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2624), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2545), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2555), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,7 +12,7 @@
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
-> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2717 prod
+> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2733 prod
 > lines); no new logic added to either giant file, the line deltas are
 > bugfix-only. On top of #3358 round 2 — synthetic-inflight carry-forward now
 > gated on same-generation evidence: `tmux.rs` re-exports the new
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2717), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2733), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2555), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2620), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2113), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2229), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2501), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2545), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,7 +12,7 @@
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
-> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2689 prod
+> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2717 prod
 > lines); no new logic added to either giant file, the line deltas are
 > bugfix-only. On top of #3358 round 2 — synthetic-inflight carry-forward now
 > gated on same-generation evidence: `tmux.rs` re-exports the new
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2689), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2717), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,7 +12,7 @@
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
-> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2733 prod
+> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2760 prod
 > lines); no new logic added to either giant file, the line deltas are
 > bugfix-only. On top of #3358 round 2 — synthetic-inflight carry-forward now
 > gated on same-generation evidence: `tmux.rs` re-exports the new
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2733), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2760), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,7 +12,7 @@
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
-> OpenCode poisoned-lock recovery (`src/services/opencode.rs` now 1886 prod
+> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2113 prod
 > lines); no new logic added to either giant file, the line deltas are
 > bugfix-only. On top of #3358 round 2 — synthetic-inflight carry-forward now
 > gated on same-generation evidence: `tmux.rs` re-exports the new
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (1886), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2113), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2341), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2501), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2273), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2341), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -12,7 +12,7 @@
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
-> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2113 prod
+> OpenCode warm-server reuse/cancel recovery (`src/services/opencode.rs` now 2689 prod
 > lines); no new logic added to either giant file, the line deltas are
 > bugfix-only. On top of #3358 round 2 — synthetic-inflight carry-forward now
 > gated on same-generation evidence: `tmux.rs` re-exports the new
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2624), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2689), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1398,7 +1398,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
-  `src/services/opencode.rs` (2229), `src/services/provider.rs` (1818) —
+  `src/services/opencode.rs` (2273), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -776,3 +776,11 @@
   or PG lease boundaries; each reported repair action still targets the existing
   node-local/runtime owner. No new multinode ownership, singleton, or lease
   assumption is introduced.
+- #3543 follow-up (OpenCode warm-server race/timeout hardening):
+  `opencode.rs` now marks a warm server as retiring before the exclusive
+  hard-kill fallback and rejects new leases on retiring servers; pre-SSE
+  `/session` and `/prompt_async` REST calls use bounded request timeouts.
+  This remains a worker-local provider process pool on the node that owns the
+  OpenCode turn. It adds no durable queue, cross-node read, leader-only side
+  effect, or PG lease assumption, so multinode ownership semantics are
+  unchanged.

--- a/src/cli/doctor/health.rs
+++ b/src/cli/doctor/health.rs
@@ -96,6 +96,28 @@ pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
             summary: format!("provider {provider} is recovering {count} channel(s)"),
             next_step: "wait for recovery or inspect stale recovery markers".to_string(),
         },
+        ["opencode_warm_server", "suspicious_active_leak", count] => ClassifiedReason {
+            raw: raw.to_string(),
+            subsystem: "provider_runtime",
+            severity: Severity::Warning,
+            fix_safety: FixSafety::ReadOnly,
+            security_exposure: SecurityExposure::OperationalMetadata,
+            summary: format!(
+                "{count} resident OpenCode warm server(s) show suspicious active-session evidence"
+            ),
+            next_step: "inspect opencode.warm_servers[] in /api/health/detail; this is evidence-only, no repair runs in P0".to_string(),
+        },
+        ["opencode_warm_server", "stopped_resident", count] => ClassifiedReason {
+            raw: raw.to_string(),
+            subsystem: "provider_runtime",
+            severity: Severity::Warning,
+            fix_safety: FixSafety::ReadOnly,
+            security_exposure: SecurityExposure::OperationalMetadata,
+            summary: format!(
+                "{count} resident OpenCode warm server(s) have a stopped process and will be evicted on next reuse"
+            ),
+            next_step: "inspect opencode.warm_servers[] running/pid fields in /api/health/detail".to_string(),
+        },
         ["dispatch_outbox_oldest_pending_age", age] => ClassifiedReason {
             raw: raw.to_string(),
             subsystem: "dispatch_outbox",
@@ -228,6 +250,7 @@ pub(crate) fn is_loopback_base_url(base: &str) -> bool {
 
 #[cfg(test)]
 mod health_classification_tests {
+    use super::super::contract::{FixSafety, Severity};
     use super::{LATEST_STARTUP_DOCTOR_ENDPOINT, classify_degraded_reason};
 
     #[test]
@@ -254,6 +277,26 @@ mod health_classification_tests {
 
         let reason_invalid = classify_degraded_reason("disk_low_free_bytes:invalid");
         assert_eq!(reason_invalid.summary, "disk has low free bytes: invalid");
+    }
+
+    /// [TEST-004] resident warm-pool reason codes classify to provider_runtime
+    /// (Warning/ReadOnly) and are NOT the generic catch-all, and are distinct
+    /// from the fresh-serve probe check.
+    #[test]
+    fn opencode_warm_server_reason_codes_classify_without_serve_overlap() {
+        let leak = classify_degraded_reason("opencode_warm_server:suspicious_active_leak:2");
+        assert_eq!(leak.subsystem, "provider_runtime");
+        assert_eq!(leak.severity, Severity::Warning);
+        assert_eq!(leak.fix_safety, FixSafety::ReadOnly);
+        assert!(leak.summary.contains('2'));
+        // Not the generic catch-all (which echoes the raw string as summary).
+        assert_ne!(leak.summary, leak.raw);
+
+        let stopped = classify_degraded_reason("opencode_warm_server:stopped_resident:1");
+        assert_eq!(stopped.subsystem, "provider_runtime");
+        assert_eq!(stopped.severity, Severity::Warning);
+        assert_eq!(stopped.fix_safety, FixSafety::ReadOnly);
+        assert_ne!(stopped.summary, stopped.raw);
     }
 
     #[test]

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -375,9 +375,18 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
         };
         let health_status =
             serde_json::to_value(health_state).unwrap_or_else(|_| serde_json::json!("unhealthy"));
-        // `ok`/`fully_recovered` track full health: a degraded warm pool keeps
-        // the server HTTP-ready but is not "ok".
+        // `ok` tracks full health: a degraded warm pool keeps the server
+        // HTTP-ready but is not "ok".
         let healthy = health_state == health::HealthStatus::Healthy;
+        // `fully_recovered` tracks the startup/recovery (server_up) axis, NOT
+        // live runtime degradation — mirroring `compute_fully_recovered` in the
+        // registry branch, whose doc explicitly excludes warm-pool health. A
+        // degraded warm pool must not flip `fully_recovered` to false here, or
+        // the standalone branch would be asymmetric with the registry branch
+        // (where warm-pool reasons never touch `fully_recovered`). In
+        // standalone mode the only non-warm-pool degradation is
+        // `db_unavailable`, so the recovery axis is exactly `server_up`.
+        let fully_recovered = server_up;
         let mut json = serde_json::json!({
             "status": health_status,
             "ok": healthy,
@@ -385,7 +394,7 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
             "db": server_up,
             "dashboard": dashboard_ok,
             "server_up": server_up,
-            "fully_recovered": healthy,
+            "fully_recovered": fully_recovered,
             "deferred_hooks": 0,
             "outbox_age": outbox_age,
             "queue_depth": 0,

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -258,6 +258,14 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
             )));
         }
 
+        // Resident OpenCode warm-pool diagnostics (additive, read-only). The
+        // reasons worsen status to Degraded only; the per-server array is
+        // detailed-only and the count summary is public-safe.
+        for reason in opencode_warm_pool_degraded_reasons() {
+            status = status.worsen(health::HealthStatus::Degraded);
+            degraded_reasons.push(reason);
+        }
+
         // Startup doctor warnings are boot/recovery diagnostics, not proof
         // that the current runtime is unhealthy. Keep them on a separate
         // startup axis so deploy/restart gates that read runtime health do
@@ -304,6 +312,9 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
         }
         if let Some(report) = pipeline_override_report.clone() {
             json["pipeline_overrides"] = report;
+        }
+        if let Some(opencode_block) = opencode_warm_pool_json(detailed) {
+            json["opencode"] = opencode_block;
         }
 
         // feature: rate-limit-aware-dispatch-gate (REQ-004). Aggregate,
@@ -372,6 +383,9 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
         }
         if detailed {
             json["active_session_audit"] = build_active_session_audit(state).await.to_json();
+        }
+        if let Some(opencode_block) = opencode_warm_pool_json(detailed) {
+            json["opencode"] = opencode_block;
         }
         let json = if detailed {
             with_latest_startup_doctor(json, true)
@@ -503,6 +517,17 @@ fn public_health_json(json: serde_json::Value) -> serde_json::Value {
     let startup_status = json.get("startup_status").cloned();
     let startup_degraded = json.get("startup_degraded").cloned();
     let startup_degraded_reasons = json.get("startup_degraded_reasons").cloned();
+    // Public OpenCode summary is count-only and never includes the per-server
+    // `warm_servers` array, pids, ports, or startup tails (spec C-3). The
+    // upstream `opencode_warm_pool_json(false)` already produced a count-only
+    // object for the public path; defensively strip `warm_servers` if present.
+    let opencode_public = json.get("opencode").map(|block| {
+        serde_json::json!({
+            "warm_server_count": block.get("warm_server_count").cloned().unwrap_or(serde_json::json!(0)),
+            "warm_server_active_sessions": block.get("warm_server_active_sessions").cloned().unwrap_or(serde_json::json!(0)),
+            "warm_server_suspicious_count": block.get("warm_server_suspicious_count").cloned().unwrap_or(serde_json::json!(0)),
+        })
+    });
     let degraded = status.as_str().is_some_and(|status| status != "healthy");
     let mut public = serde_json::json!({
         "ok": !degraded,
@@ -523,6 +548,9 @@ fn public_health_json(json: serde_json::Value) -> serde_json::Value {
     }
     if let Some(startup_degraded_reasons) = startup_degraded_reasons {
         public["startup_degraded_reasons"] = startup_degraded_reasons;
+    }
+    if let Some(opencode_public) = opencode_public {
+        public["opencode"] = opencode_public;
     }
     public
 }
@@ -846,6 +874,60 @@ fn pg_timestamp_to_rfc3339(row: &PgRow, column: &str) -> Option<String> {
         return Some(naive.format("%Y-%m-%d %H:%M:%S").to_string());
     }
     row.try_get::<Option<String>, _>(column).ok().flatten()
+}
+
+/// Build the additive `opencode` warm-pool diagnostics block.
+///
+/// `detailed=true` (authenticated/local) includes the full redacted per-server
+/// snapshot array; public callers get count-only aggregates. Returns `None`
+/// when no resident warm servers exist so the field is omitted entirely
+/// (cold-start safe — spec C-6/C-7). Snapshot collection performs no network
+/// probes and copies pool data under short locks (REQ-002).
+fn opencode_warm_pool_json(detailed: bool) -> Option<serde_json::Value> {
+    let snapshots = crate::services::opencode::warm_server_snapshots();
+    if snapshots.is_empty() {
+        return None;
+    }
+    let count = snapshots.len() as u64;
+    let active_sessions: u64 = snapshots.iter().map(|s| s.active_sessions as u64).sum();
+    let suspicious_count = snapshots
+        .iter()
+        .filter(|s| s.suspicious_active_leak)
+        .count() as u64;
+    let mut block = serde_json::json!({
+        "warm_server_count": count,
+        "warm_server_active_sessions": active_sessions,
+        "warm_server_suspicious_count": suspicious_count,
+    });
+    if detailed {
+        block["warm_servers"] =
+            serde_json::to_value(&snapshots).unwrap_or_else(|_| serde_json::json!([]));
+    }
+    Some(block)
+}
+
+/// Additive `degraded_reasons` for the resident warm pool (REQ-004). These are
+/// classified by the existing `classify_degraded_reason` table and are distinct
+/// from the fresh-serve / MCP doctor checks.
+fn opencode_warm_pool_degraded_reasons() -> Vec<serde_json::Value> {
+    let snapshots = crate::services::opencode::warm_server_snapshots();
+    let mut reasons = Vec::new();
+    let suspicious = snapshots
+        .iter()
+        .filter(|s| s.suspicious_active_leak)
+        .count();
+    if suspicious > 0 {
+        reasons.push(serde_json::json!(format!(
+            "opencode_warm_server:suspicious_active_leak:{suspicious}"
+        )));
+    }
+    let stopped = snapshots.iter().filter(|s| !s.running).count();
+    if stopped > 0 {
+        reasons.push(serde_json::json!(format!(
+            "opencode_warm_server:stopped_resident:{stopped}"
+        )));
+    }
+    reasons
 }
 
 /// GET /api/health — public safe health summary.
@@ -1893,6 +1975,40 @@ mod tests {
         assert!(ACTIVE_SESSION_AUDIT_QUERY.contains("instance_id IS NULL OR instance_id = $2"));
         assert!(ACTIVE_SESSION_AUDIT_QUERY.contains("thread_channel_id, channel_id"));
         assert!(!ACTIVE_SESSION_AUDIT_QUERY.contains("COALESCE(thread_channel_id, channel_id)"));
+    }
+
+    /// [TEST-003] public health omits the per-server OpenCode warm_servers
+    /// array but may keep the count-only summary; no pid/port/tail leaks.
+    #[test]
+    fn public_health_json_omits_opencode_warm_server_array() {
+        let public = public_health_json(json!({
+            "status": "healthy",
+            "version": "0.1.2",
+            "db": true,
+            "dashboard": true,
+            "opencode": {
+                "warm_server_count": 2,
+                "warm_server_active_sessions": 3,
+                "warm_server_suspicious_count": 1,
+                "warm_servers": [
+                    {"pid": 12345, "port": 54321, "key_hash": "abcdef0123456789",
+                     "startup_output_tail": "secret leak", "base_url": "http://127.0.0.1:54321"}
+                ]
+            }
+        }));
+
+        let opencode = public.get("opencode").expect("opencode summary present");
+        assert_eq!(opencode["warm_server_count"], 2);
+        assert_eq!(opencode["warm_server_active_sessions"], 3);
+        assert_eq!(opencode["warm_server_suspicious_count"], 1);
+        // The per-server array and all sensitive fields are gone.
+        assert!(opencode.get("warm_servers").is_none());
+        let text = public.to_string();
+        assert!(!text.contains("12345"));
+        assert!(!text.contains("54321"));
+        assert!(!text.contains("startup_output_tail"));
+        assert!(!text.contains("base_url"));
+        assert!(!text.contains("abcdef0123456789"));
     }
 
     #[test]

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -346,25 +346,52 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
         (http_status, Json(json)).into_response()
     } else {
         // Standalone mode — no Discord providers
-        let status = if server_up {
+        let mut health_state = if server_up {
+            health::HealthStatus::Healthy
+        } else {
+            health::HealthStatus::Unhealthy
+        };
+        let mut degraded_reasons: Vec<serde_json::Value> = Vec::new();
+        if !server_up {
+            degraded_reasons.push(serde_json::json!("db_unavailable"));
+        }
+
+        // Resident OpenCode warm-pool diagnostics (additive, read-only). Mirror
+        // the registry branch above so a stopped or suspicious resident server
+        // degrades standalone health too — otherwise top-level `/api/health`
+        // and `/api/health/detail` could keep reporting `status: healthy` /
+        // `ok: true` while a bad warm server is surfaced under `opencode`.
+        // Per spec C-8 the `stopped_resident` reason is intentional worsening
+        // and is kept consistent with the registry branch.
+        for reason in opencode_warm_pool_degraded_reasons() {
+            health_state = health_state.worsen(health::HealthStatus::Degraded);
+            degraded_reasons.push(reason);
+        }
+
+        let status = if health_state.is_http_ready() {
             StatusCode::OK
         } else {
             StatusCode::SERVICE_UNAVAILABLE
         };
-        let health_status = if server_up { "healthy" } else { "unhealthy" };
+        let health_status =
+            serde_json::to_value(health_state).unwrap_or_else(|_| serde_json::json!("unhealthy"));
+        // `ok`/`fully_recovered` track full health: a degraded warm pool keeps
+        // the server HTTP-ready but is not "ok".
+        let healthy = health_state == health::HealthStatus::Healthy;
         let mut json = serde_json::json!({
             "status": health_status,
-            "ok": server_up,
+            "ok": healthy,
             "version": env!("CARGO_PKG_VERSION"),
             "db": server_up,
             "dashboard": dashboard_ok,
             "server_up": server_up,
-            "fully_recovered": server_up,
+            "fully_recovered": healthy,
             "deferred_hooks": 0,
             "outbox_age": outbox_age,
             "queue_depth": 0,
             "watcher_count": 0,
-            "recovery_duration": 0.0
+            "recovery_duration": 0.0,
+            "degraded_reasons": serde_json::Value::Array(degraded_reasons),
         });
         if let Some(snapshot) = disk_snapshot {
             json["disk_free_bytes"] = serde_json::json!(snapshot.free_bytes);
@@ -2009,6 +2036,25 @@ mod tests {
         assert!(!text.contains("startup_output_tail"));
         assert!(!text.contains("base_url"));
         assert!(!text.contains("abcdef0123456789"));
+    }
+
+    /// The standalone (no-HealthRegistry) branch now mirrors the registry
+    /// branch: when `opencode_warm_pool_degraded_reasons()` reports a bad warm
+    /// server it sets `status: "degraded"`, which the public projection turns
+    /// into `ok: false` / `degraded: true` instead of leaving health "healthy".
+    #[test]
+    fn public_health_json_degraded_status_reports_not_ok() {
+        let public = public_health_json(json!({
+            "status": "degraded",
+            "version": "0.1.2",
+            "db": true,
+            "dashboard": true,
+            "server_up": true,
+            "degraded_reasons": ["opencode_warm_server:stopped_resident:1"],
+        }));
+        assert_eq!(public["status"], json!("degraded"));
+        assert_eq!(public["ok"], json!(false));
+        assert_eq!(public["degraded"], json!(true));
     }
 
     #[test]

--- a/src/services/discord/runtime_bootstrap/shutdown.rs
+++ b/src/services/discord/runtime_bootstrap/shutdown.rs
@@ -206,6 +206,4 @@ pub(super) async fn run_bot_run_gateway_backend(
         handle.abort();
         let _ = handle.await;
     }
-
-    crate::services::opencode::shutdown_warm_servers();
 }

--- a/src/services/discord/runtime_bootstrap/shutdown.rs
+++ b/src/services/discord/runtime_bootstrap/shutdown.rs
@@ -118,6 +118,8 @@ pub(super) fn run_bot_spawn_sigterm_handler(
                     }
                 }
 
+                crate::services::opencode::shutdown_warm_servers();
+
                 // Wait for all providers to finish saving before exiting.
                 // CAS guard: skip if this provider already decremented via deferred restart path.
                 if shared_for_signal
@@ -204,4 +206,6 @@ pub(super) async fn run_bot_run_gateway_backend(
         handle.abort();
         let _ = handle.await;
     }
+
+    crate::services::opencode::shutdown_warm_servers();
 }

--- a/src/services/onboarding/provider.rs
+++ b/src/services/onboarding/provider.rs
@@ -12,6 +12,9 @@ use serde_json::json;
 use crate::services::provider::ProviderKind;
 use crate::services::provider_exec;
 
+const DEFAULT_PROMPT_GENERATION_TIMEOUT_SECS: u64 = 30;
+const OPENCODE_PROMPT_GENERATION_TIMEOUT_SECS: u64 = 90;
+
 // ── Provider Check ──────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -136,13 +139,19 @@ pub async fn generate_prompt(body: GeneratePromptBody) -> (StatusCode, Json<serd
         body.name, body.description
     );
 
-    let result = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        provider_exec::execute_simple(provider, instruction),
+    let timeout_secs = match provider {
+        ProviderKind::OpenCode => OPENCODE_PROMPT_GENERATION_TIMEOUT_SECS,
+        _ => DEFAULT_PROMPT_GENERATION_TIMEOUT_SECS,
+    };
+    let result = provider_exec::execute_simple_with_timeout(
+        provider,
+        instruction,
+        std::time::Duration::from_secs(timeout_secs),
+        "onboarding prompt generation".to_string(),
     )
     .await;
 
-    if let Ok(Ok(text)) = result {
+    if let Ok(text) = result {
         if !text.trim().is_empty() {
             return (
                 StatusCode::OK,

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -765,6 +765,14 @@ fn idle_disposal_delay_for_idle_duration(idle_for: Duration) -> Duration {
     WARM_SERVER_IDLE_TTL.saturating_sub(idle_for)
 }
 
+fn min_idle_disposal_delay(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(delay), None) | (None, Some(delay)) => Some(delay),
+        (None, None) => None,
+    }
+}
+
 fn evict_warm_server_from_pool(server: &Arc<OpenCodeWarmServer>) {
     let mut pool = opencode_server_pool().lock().unwrap_or_else(|e| {
         tracing::warn!("Recovered poisoned lock for OpenCode server pool");
@@ -826,7 +834,14 @@ fn schedule_idle_disposal_after(delay: Duration) {
         let next_delay = next_idle_disposal_delay(&pool);
         drop(pool);
         IDLE_DISPOSAL_SCHEDULED.store(false, Ordering::SeqCst);
-        if let Some(delay) = next_delay {
+        let rechecked_delay = {
+            let pool = opencode_server_pool().lock().unwrap_or_else(|e| {
+                tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+                e.into_inner()
+            });
+            next_idle_disposal_delay(&pool)
+        };
+        if let Some(delay) = min_idle_disposal_delay(next_delay, rechecked_delay) {
             schedule_idle_disposal_after(delay);
         }
     });
@@ -1158,6 +1173,7 @@ fn run_session(
 
     // 4. Connect SSE stream first, then send prompt
     let sse_agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(2))
         .timeout_read(SSE_READ_TIMEOUT)
         .build();
 
@@ -2788,6 +2804,27 @@ mod tests {
             idle_disposal_delay_for_idle_duration(WARM_SERVER_IDLE_TTL + Duration::from_secs(1)),
             Duration::ZERO
         );
+    }
+
+    #[test]
+    fn idle_disposal_reschedule_uses_rechecked_soonest_delay() {
+        assert_eq!(
+            min_idle_disposal_delay(None, Some(Duration::from_secs(1))),
+            Some(Duration::from_secs(1))
+        );
+        assert_eq!(
+            min_idle_disposal_delay(Some(Duration::from_secs(30)), Some(Duration::from_secs(5))),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            min_idle_disposal_delay(Some(Duration::from_secs(5)), Some(Duration::from_secs(30))),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            min_idle_disposal_delay(Some(Duration::from_secs(5)), None),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(min_idle_disposal_delay(None, None), None);
     }
 
     #[test]

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -15,7 +15,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::services::agent_protocol::StreamMessage;
 use crate::services::process::{configure_child_process_group, kill_pid_tree};
@@ -29,6 +31,26 @@ const DISPOSE_TIMEOUT: Duration = Duration::from_secs(5);
 const MESSAGE_RECOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 const STARTUP_OUTPUT_LIMIT: usize = 8 * 1024;
 const WARM_SERVER_IDLE_TTL: Duration = Duration::from_secs(20 * 60);
+
+// ---------------------------------------------------------------------------
+// Resident warm-pool diagnostics (read-only, additive). See spec section C.
+// ---------------------------------------------------------------------------
+
+/// Max length of the redacted, detailed-only startup output tail exposed in
+/// `/api/health/detail`. The public payload never includes this field.
+const SNAPSHOT_STARTUP_TAIL_LIMIT: usize = 256;
+
+/// REQ-006: conservative active-session leak threshold. A real fan-out can keep
+/// several concurrent leases on one warm server, so we only treat an elevated
+/// lease count as *suspicious evidence* when the server is also dead or has been
+/// idle past [`SNAPSHOT_LEAK_IDLE_SECS`]. This is evidence-only and never
+/// mutates the pool (no kill, no `active_sessions` decrement).
+const SNAPSHOT_ACTIVE_LEAK_THRESHOLD: u32 = 8;
+
+/// REQ-006: a warm server with an elevated lease count is only flagged once it
+/// has also been idle this long (or has a dead process). Avoids flagging normal
+/// in-use multi-session reuse.
+const SNAPSHOT_LEAK_IDLE_SECS: u64 = 300;
 
 #[derive(Debug, Default)]
 struct OpenCodeStartupOutput {
@@ -140,6 +162,212 @@ impl OpenCodeWarmServer {
         });
         shutdown_server(&mut process, &self.base_url, &self.auth);
     }
+}
+
+/// Read-only, redacted diagnostic view of a resident warm `opencode serve`
+/// process. See spec section C-1 for the field contract. ADDITIVE only — never
+/// stores `auth` or `base_url`, so credentials cannot leak through this type.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct OpenCodeWarmServerHealth {
+    /// P0 snapshot never performs a network probe, so this is `false` unless a
+    /// deep doctor profile explicitly fills it in later.
+    pub probed: bool,
+    /// `None` when not probed; deep doctor MAY set `Some(bool)`.
+    pub ok: Option<bool>,
+}
+
+/// Redacted, read-only snapshot of one resident warm server (REQ-001).
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct OpenCodeWarmServerSnapshot {
+    /// `sha256(bin \0 working_dir)` truncated to 16 hex chars. Stable per key,
+    /// never reveals the path.
+    pub key_hash: String,
+    /// Binary file name only (e.g. `opencode`); never the full path.
+    pub bin_basename: String,
+    /// Working-dir last path component only; never the full path.
+    pub working_dir_basename: String,
+    /// OS pid of the resident child. Detailed/local callers only.
+    pub pid: u32,
+    /// Loopback port parsed from base_url. Detailed/local callers only.
+    pub port: Option<u32>,
+    /// Current lease count.
+    pub active_sessions: u32,
+    /// Seconds since `last_used`.
+    pub idle_secs: u64,
+    /// Alias of `idle_secs` for clients keying on "last used".
+    pub last_used_secs: u64,
+    /// Process still alive (`try_wait()==Ok(None)`).
+    pub running: bool,
+    /// Health probe state. Always `{probed:false, ok:null}` for the P0 snapshot.
+    pub health: OpenCodeWarmServerHealth,
+    /// `sha256` (16 hex chars) of the full retained startup output, or `None`.
+    pub startup_output_tail_hash: Option<String>,
+    /// DETAILED/local only: bounded + scrubbed tail of startup output. Callers
+    /// MUST strip this before serving the public payload.
+    pub startup_output_tail: Option<String>,
+    /// REQ-006 evidence-only flag; never triggers a mutation.
+    pub suspicious_active_leak: bool,
+}
+
+impl OpenCodeWarmServerSnapshot {
+    /// Public-safe subset (spec C-3): drops pid, port, basenames, key_hash, and
+    /// the startup tail. The public `/api/health` path uses aggregate counts
+    /// (see `opencode_warm_pool_json`) rather than per-server objects, so this
+    /// per-server projection is reserved for redaction tests and future use.
+    #[cfg(test)]
+    pub fn redacted_public(&self) -> serde_json::Value {
+        serde_json::json!({
+            "active_sessions": self.active_sessions,
+            "idle_secs": self.idle_secs,
+            "running": self.running,
+            "suspicious_active_leak": self.suspicious_active_leak,
+        })
+    }
+}
+
+fn sha256_hex16(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn basename_of(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| path.to_string())
+}
+
+fn port_from_base_url(base_url: &str) -> Option<u32> {
+    base_url
+        .rsplit(':')
+        .next()
+        .and_then(|tail| tail.split('/').next())
+        .and_then(|port| port.parse::<u32>().ok())
+}
+
+/// Scrub obvious credential material from a startup-output line before it is
+/// exposed in the DETAILED tail. Conservative: redacts the value portion of
+/// known secret-bearing tokens. The public payload never carries this tail at
+/// all, so this is defense-in-depth for the authenticated/local surface.
+fn scrub_startup_secrets(raw: &str) -> String {
+    let mut out: Vec<String> = Vec::new();
+    // When the previous token was an auth scheme marker (`Basic`/`Bearer`), the
+    // immediately following token is its opaque credential value and must be
+    // redacted too.
+    let mut redact_next = false;
+    for token in raw.split(' ') {
+        if redact_next {
+            out.push("[REDACTED]".to_string());
+            redact_next = false;
+            continue;
+        }
+        let lower = token.to_ascii_lowercase();
+        if let Some(eq) = token.find('=') {
+            let key_lower = token[..eq].to_ascii_lowercase();
+            if key_lower.contains("password")
+                || key_lower.contains("secret")
+                || key_lower.contains("token")
+                || key_lower.contains("auth")
+            {
+                out.push(format!("{}=[REDACTED]", &token[..eq]));
+                continue;
+            }
+        }
+        if lower == "basic" || lower == "bearer" {
+            // Keep the scheme marker for readability but redact its value next.
+            out.push(token.to_string());
+            redact_next = true;
+            continue;
+        }
+        out.push(token.to_string());
+    }
+    out.join(" ")
+}
+
+fn snapshot_startup_tail(
+    output: &Arc<Mutex<OpenCodeStartupOutput>>,
+) -> (Option<String>, Option<String>) {
+    let compact = summarize_startup_output(output);
+    if compact.is_empty() {
+        return (None, None);
+    }
+    let hash = sha256_hex16(&compact);
+    let scrubbed = scrub_startup_secrets(&compact);
+    // Take a bounded tail by char boundary.
+    let tail = if scrubbed.chars().count() > SNAPSHOT_STARTUP_TAIL_LIMIT {
+        let skip = scrubbed.chars().count() - SNAPSHOT_STARTUP_TAIL_LIMIT;
+        scrubbed.chars().skip(skip).collect::<String>()
+    } else {
+        scrubbed
+    };
+    (Some(hash), Some(tail))
+}
+
+fn compute_suspicious_active_leak(active_sessions: u32, idle_secs: u64, running: bool) -> bool {
+    if active_sessions <= SNAPSHOT_ACTIVE_LEAK_THRESHOLD {
+        return false;
+    }
+    !running || idle_secs >= SNAPSHOT_LEAK_IDLE_SECS
+}
+
+impl OpenCodeWarmServer {
+    /// Build a redacted snapshot of this resident server. Holds only this
+    /// server's per-field locks for single-field copies; performs NO network
+    /// I/O and NO `wait_for_health` (REQ-002, spec C-2/C-9). Caller must have
+    /// already released the pool lock.
+    fn snapshot(&self) -> OpenCodeWarmServerSnapshot {
+        let key_input = format!("{}\u{0}{}", self.key.bin, self.key.working_dir);
+        let key_hash = sha256_hex16(&key_input);
+        let running = self.is_running();
+        let pid = self.id();
+        let active_sessions = self.active_sessions.load(Ordering::SeqCst) as u32;
+        let idle_secs = self.idle_for().as_secs();
+        let (startup_output_tail_hash, startup_output_tail) =
+            snapshot_startup_tail(&self.startup_output);
+        let suspicious_active_leak =
+            compute_suspicious_active_leak(active_sessions, idle_secs, running);
+        OpenCodeWarmServerSnapshot {
+            key_hash,
+            bin_basename: basename_of(&self.key.bin),
+            working_dir_basename: basename_of(&self.key.working_dir),
+            pid,
+            port: port_from_base_url(&self.base_url),
+            active_sessions,
+            idle_secs,
+            last_used_secs: idle_secs,
+            running,
+            health: OpenCodeWarmServerHealth {
+                probed: false,
+                ok: None,
+            },
+            startup_output_tail_hash,
+            startup_output_tail,
+            suspicious_active_leak,
+        }
+    }
+}
+
+/// Collect redacted diagnostics for every resident warm server (REQ-001/002).
+///
+/// Clones the `Arc<OpenCodeWarmServer>` handles out of the pool under the pool
+/// lock, then RELEASES the pool lock before computing per-server snapshots, so
+/// the hot dispatch path is never blocked by snapshot work. No network probes.
+pub fn warm_server_snapshots() -> Vec<OpenCodeWarmServerSnapshot> {
+    let servers: Vec<Arc<OpenCodeWarmServer>> = {
+        let pool = opencode_server_pool().lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCode server pool (snapshot)");
+            e.into_inner()
+        });
+        pool.values().cloned().collect()
+    };
+    servers.iter().map(|server| server.snapshot()).collect()
 }
 
 struct OpenCodeWarmServerLease {
@@ -2301,5 +2529,147 @@ mod tests {
         assert_ne!(first_key, second_key);
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    // -----------------------------------------------------------------------
+    // Resident warm-pool diagnostics (REQ-001..REQ-006)
+    // -----------------------------------------------------------------------
+
+    fn fake_snapshot() -> OpenCodeWarmServerSnapshot {
+        let key_input = "/usr/local/bin/opencode\u{0}/Users/dev/projects/myapp";
+        OpenCodeWarmServerSnapshot {
+            key_hash: sha256_hex16(key_input),
+            bin_basename: basename_of("/usr/local/bin/opencode"),
+            working_dir_basename: basename_of("/Users/dev/projects/myapp"),
+            pid: 12345,
+            port: port_from_base_url("http://127.0.0.1:54321"),
+            active_sessions: 1,
+            idle_secs: 42,
+            last_used_secs: 42,
+            running: true,
+            health: OpenCodeWarmServerHealth {
+                probed: false,
+                ok: None,
+            },
+            startup_output_tail_hash: Some(sha256_hex16("stdout=server listening")),
+            startup_output_tail: Some("stdout=server listening".to_string()),
+            suspicious_active_leak: false,
+        }
+    }
+
+    /// [TEST-001] snapshot includes pid/active/idle/running/last_used and
+    /// redacts key fields; serialized JSON carries no auth/base_url.
+    #[test]
+    fn warm_server_snapshot_redacts_key_fields_and_reports_state() {
+        let snap = fake_snapshot();
+        assert_eq!(snap.pid, 12345);
+        assert_eq!(snap.active_sessions, 1);
+        assert_eq!(snap.idle_secs, 42);
+        assert_eq!(snap.last_used_secs, snap.idle_secs);
+        assert!(snap.running);
+        assert_eq!(snap.port, Some(54321));
+
+        // key_hash is exactly 16 lowercase hex chars and reveals no path.
+        assert_eq!(snap.key_hash.len(), 16);
+        assert!(snap.key_hash.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!snap.key_hash.contains('/'));
+
+        // Basenames carry no path separators / no full path.
+        assert_eq!(snap.bin_basename, "opencode");
+        assert_eq!(snap.working_dir_basename, "myapp");
+        assert!(!snap.working_dir_basename.contains('/'));
+
+        let json = serde_json::to_value(&snap).expect("serialize snapshot");
+        let text = json.to_string();
+        assert!(!text.contains("Authorization"));
+        assert!(!text.contains("Basic "));
+        assert!(!text.contains("base_url"));
+        assert!(!text.contains("/usr/local/bin"));
+        assert!(!text.contains("/Users/dev"));
+        // The serialized object must not have an `auth` field at all.
+        assert!(json.get("auth").is_none());
+    }
+
+    /// [TEST-002] default health probe is `probed=false` (no network I/O).
+    #[test]
+    fn warm_server_snapshot_default_health_is_unprobed() {
+        let snap = fake_snapshot();
+        assert!(!snap.health.probed);
+        assert_eq!(snap.health.ok, None);
+        let json = serde_json::to_value(&snap).expect("serialize");
+        assert_eq!(json["health"]["probed"], serde_json::json!(false));
+        assert_eq!(json["health"]["ok"], serde_json::Value::Null);
+    }
+
+    /// [TEST-005] secrets never appear in startup tail (scrub) and the tail is
+    /// bounded to <=256 chars.
+    #[test]
+    fn warm_server_snapshot_scrubs_secret_in_startup_tail() {
+        let raw = "stdout=starting OPENCODE_SERVER_PASSWORD=hunter2supersecret Authorization: Basic Zm9vOmJhcg==";
+        let scrubbed = scrub_startup_secrets(raw);
+        assert!(!scrubbed.contains("hunter2supersecret"));
+        assert!(!scrubbed.contains("Zm9vOmJhcg=="));
+        assert!(scrubbed.contains("OPENCODE_SERVER_PASSWORD=[REDACTED]"));
+
+        // Bounded tail: a very long output is truncated to <=256 chars.
+        let long = "x ".repeat(400);
+        let output = Arc::new(Mutex::new(OpenCodeStartupOutput {
+            stdout: long,
+            stderr: String::new(),
+        }));
+        let (hash, tail) = snapshot_startup_tail(&output);
+        assert!(hash.is_some());
+        let tail = tail.expect("tail");
+        assert!(tail.chars().count() <= SNAPSHOT_STARTUP_TAIL_LIMIT);
+    }
+
+    /// [TEST-006] empty pool is cold-start safe: returns empty, no panic.
+    #[test]
+    fn warm_server_snapshots_empty_pool_is_cold_start_safe() {
+        // The global pool starts empty in the unit-test process; even if other
+        // tests touched it, this asserts the collection never panics and the
+        // public redaction of an empty set is an empty Vec equivalent.
+        let snaps = warm_server_snapshots();
+        // Each snapshot, if any exist from other tests, must be well-formed.
+        for snap in &snaps {
+            assert_eq!(snap.key_hash.len(), 16);
+        }
+        // The redacted public subset of a fabricated server omits sensitive keys.
+        let pubv = fake_snapshot().redacted_public();
+        assert!(pubv.get("pid").is_none());
+        assert!(pubv.get("port").is_none());
+        assert!(pubv.get("key_hash").is_none());
+        assert!(pubv.get("startup_output_tail").is_none());
+    }
+
+    /// [TEST-007] REQ-006 leak detection is evidence-only and uses the
+    /// dead-or-idle conjunction.
+    #[test]
+    fn suspicious_active_leak_threshold_is_evidence_only() {
+        // At or below threshold: never suspicious regardless of state.
+        assert!(!compute_suspicious_active_leak(
+            SNAPSHOT_ACTIVE_LEAK_THRESHOLD,
+            10_000,
+            false
+        ));
+        // Above threshold but actively running and recently used: NOT flagged
+        // (normal in-use multi-session reuse).
+        assert!(!compute_suspicious_active_leak(
+            SNAPSHOT_ACTIVE_LEAK_THRESHOLD + 1,
+            0,
+            true
+        ));
+        // Above threshold AND process dead: flagged.
+        assert!(compute_suspicious_active_leak(
+            SNAPSHOT_ACTIVE_LEAK_THRESHOLD + 1,
+            0,
+            false
+        ));
+        // Above threshold AND idle past the window: flagged.
+        assert!(compute_suspicious_active_leak(
+            SNAPSHOT_ACTIVE_LEAK_THRESHOLD + 1,
+            SNAPSHOT_LEAK_IDLE_SECS,
+            true
+        ));
     }
 }

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 
 use crate::services::agent_protocol::StreamMessage;
 use crate::services::process::{configure_child_process_group, kill_pid_tree};
-use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
+use crate::services::provider::{CancelToken, ProviderKind, cancel_requested};
 use crate::services::remote::RemoteProfile;
 
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -361,6 +361,23 @@ fn compute_suspicious_active_leak(active_sessions: u32, _idle_secs: u64, running
     !running
 }
 
+/// Whether a warm `opencode serve` process may be hard-killed (process-tree
+/// SIGKILL) to satisfy a single turn's cancel/timeout. A warm server is shared
+/// across co-resident turns, so the kill is only safe when the requesting turn
+/// is the *sole* active session; otherwise the SIGKILL would tear the server
+/// out from under unrelated live SSE streams.
+///
+/// This predicate is the **only** guard protecting co-resident sessions: the
+/// shared server PID is intentionally never registered on a `CancelToken`
+/// (see `execute_command_streaming_inner`), because the generic kill sinks
+/// (`provider_exec` timeout, `cancel_active_token` teardown) fire
+/// unconditionally and a register-time `active_sessions <= 1` check is a TOCTOU
+/// — a second turn can attach right after registration. The in-stream cancel
+/// watchdog re-evaluates this predicate at kill time, which is race-safe.
+fn warm_server_hard_kill_allowed(active_sessions: usize) -> bool {
+    active_sessions <= 1
+}
+
 impl OpenCodeWarmServer {
     /// Build a redacted snapshot of this resident server. Holds only this
     /// server's per-field locks for single-field copies; performs NO network
@@ -613,30 +630,22 @@ fn execute_command_streaming_inner(
     })?;
 
     let server = acquire_warm_server(&bin, &resolution, working_dir)?;
-    // Register the warm server's PID on the caller's CancelToken so timeout
-    // callers (which only have `CancelToken.child_pid` to kill) can interrupt a
-    // turn that is blocked before `run_session` installs the SSE cancel
-    // watchdog. The watchdog itself prefers the shared-server Arc, but this
-    // keeps the historical PID-based cancel path working during startup.
-    //
-    // Crucially, only register the PID when this turn is the *sole* active
-    // session on the server. The generic provider_exec timeout path calls
-    // `kill_pid_tree(child_pid)` unconditionally on timeout, so registering a
-    // shared `opencode serve` PID would let a single turn's timeout kill the
-    // warm server out from under every other concurrent streaming turn —
-    // defeating the warm-pool's whole purpose. When the server is shared, leave
-    // `child_pid` unset: the in-stream cancel watchdog (which guards its
-    // hard-kill fallback on `active_sessions <= 1`) plus `abort_session` are the
-    // only mechanisms allowed to terminate the turn, and neither disturbs the
-    // co-resident sessions.
-    if server
-        .shared_server()
-        .active_sessions
-        .load(Ordering::SeqCst)
-        <= 1
-    {
-        register_child_pid(cancel_token, server.shared_server().id());
-    }
+    // The shared `opencode serve` PID is deliberately NOT registered on the
+    // caller's CancelToken. Every generic cancel/timeout sink kills
+    // `CancelToken.child_pid` *unconditionally* — the provider_exec timeout
+    // path (`kill_pid_tree(child_pid)`) and the Discord `cancel_active_token`
+    // teardown both fire without re-reading `active_sessions`. A register-time
+    // `active_sessions <= 1` guard does not make this safe: the count is only
+    // valid at registration, and a second co-resident turn can attach to the
+    // same warm server immediately afterward (active_sessions 1 -> 2). The
+    // first turn's later timeout/stop would then SIGKILL the shared server out
+    // from under the second turn's live SSE stream — a TOCTOU that defeats the
+    // warm pool's whole purpose. Closing it at the source (never handing the
+    // shared PID to an unconditional killer) is robust against every present
+    // and future kill sink. Cancellation is handled race-safely by the
+    // in-stream watchdog in `run_session` — which re-checks
+    // `active_sessions <= 1` at kill time (see `warm_server_hard_kill_allowed`)
+    // — plus cooperative `abort_session`; neither disturbs co-resident sessions.
     let result = run_session(
         prompt,
         system_prompt,
@@ -1497,13 +1506,14 @@ fn consume_sse(
                         if !stop.load(Ordering::Relaxed)
                             && let Some(server) = watchdog_server.as_ref()
                         {
-                            if server.active_sessions.load(Ordering::SeqCst) <= 1 {
+                            let active = server.active_sessions.load(Ordering::SeqCst);
+                            if warm_server_hard_kill_allowed(active) {
                                 kill_pid_tree(server.id());
                             } else {
                                 tracing::warn!(
                                     "Skipping OpenCode hard-kill cancel fallback for shared warm server {} with {} active sessions",
                                     server.base_url,
-                                    server.active_sessions.load(Ordering::SeqCst)
+                                    active
                                 );
                             }
                         }
@@ -2546,6 +2556,18 @@ fn send_error(sender: &Sender<StreamMessage>, message: String) -> Result<(), Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn warm_server_hard_kill_vetoed_when_co_resident() {
+        // Sole session (or under-counted) -> hard-kill permitted.
+        assert!(warm_server_hard_kill_allowed(0));
+        assert!(warm_server_hard_kill_allowed(1));
+        // Co-resident turns share the warm server -> hard-kill must be vetoed
+        // so a single turn's cancel/timeout cannot SIGKILL the shared
+        // `opencode serve` out from under another turn's live SSE stream.
+        assert!(!warm_server_hard_kill_allowed(2));
+        assert!(!warm_server_hard_kill_allowed(8));
+    }
 
     #[test]
     fn opencode_warm_server_key_canonicalizes_equivalent_working_dirs() {

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -1,12 +1,14 @@
 //! OpenCode provider backend — `opencode serve` HTTP/SSE integration.
 //!
-//! Architecture: spawns `opencode serve --hostname 127.0.0.1 --port <N>`, drives the
-//! HTTP REST + SSE API, and normalizes events to AgentDesk `StreamMessage`.
+//! Architecture: keeps a loopback `opencode serve` warm per workspace/runtime key,
+//! drives the HTTP REST + SSE API, and normalizes events to AgentDesk `StreamMessage`.
 
 use std::collections::{HashMap, HashSet, hash_map::Entry};
+use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -17,7 +19,7 @@ use serde_json::Value;
 
 use crate::services::agent_protocol::StreamMessage;
 use crate::services::process::{configure_child_process_group, kill_pid_tree};
-use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
+use crate::services::provider::{CancelToken, ProviderKind, cancel_requested};
 use crate::services::remote::RemoteProfile;
 
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -26,6 +28,7 @@ const SSE_READ_TIMEOUT: Duration = Duration::from_secs(120);
 const DISPOSE_TIMEOUT: Duration = Duration::from_secs(5);
 const MESSAGE_RECOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 const STARTUP_OUTPUT_LIMIT: usize = 8 * 1024;
+const WARM_SERVER_IDLE_TTL: Duration = Duration::from_secs(20 * 60);
 
 #[derive(Debug, Default)]
 struct OpenCodeStartupOutput {
@@ -47,6 +50,10 @@ impl OpenCodeServerProcess {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
+
+    fn is_running(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
 }
 
 /// Make sure the spawned `opencode serve` child is reaped even when the
@@ -62,6 +69,114 @@ impl Drop for OpenCodeServerProcess {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
+}
+
+#[derive(Clone, Debug, Eq)]
+struct OpenCodeServerKey {
+    bin: String,
+    working_dir: String,
+}
+
+impl PartialEq for OpenCodeServerKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.bin == other.bin && self.working_dir == other.working_dir
+    }
+}
+
+impl Hash for OpenCodeServerKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.bin.hash(state);
+        self.working_dir.hash(state);
+    }
+}
+
+struct OpenCodeWarmServer {
+    key: OpenCodeServerKey,
+    base_url: String,
+    auth: String,
+    startup_output: Arc<Mutex<OpenCodeStartupOutput>>,
+    process: Mutex<OpenCodeServerProcess>,
+    active_sessions: AtomicUsize,
+    last_used: Mutex<Instant>,
+}
+
+impl OpenCodeWarmServer {
+    fn id(&self) -> u32 {
+        let process = self.process.lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCodeWarmServer::process");
+            e.into_inner()
+        });
+        process.id()
+    }
+
+    fn is_running(&self) -> bool {
+        let mut process = self.process.lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCodeWarmServer::process");
+            e.into_inner()
+        });
+        process.is_running()
+    }
+
+    fn mark_used(&self) {
+        let mut last_used = self.last_used.lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCodeWarmServer::last_used");
+            e.into_inner()
+        });
+        *last_used = Instant::now();
+    }
+
+    fn idle_for(&self) -> Duration {
+        let last_used = self.last_used.lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCodeWarmServer::last_used");
+            e.into_inner()
+        });
+        Instant::now().saturating_duration_since(*last_used)
+    }
+
+    fn shutdown(&self) {
+        let mut process = self.process.lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCodeWarmServer::process");
+            e.into_inner()
+        });
+        shutdown_server(&mut process, &self.base_url, &self.auth);
+    }
+}
+
+struct OpenCodeWarmServerLease {
+    server: Arc<OpenCodeWarmServer>,
+}
+
+impl OpenCodeWarmServerLease {
+    fn base_url(&self) -> &str {
+        &self.server.base_url
+    }
+
+    fn auth(&self) -> &str {
+        &self.server.auth
+    }
+
+    fn startup_output(&self) -> Arc<Mutex<OpenCodeStartupOutput>> {
+        self.server.startup_output.clone()
+    }
+
+    fn shared_server(&self) -> Arc<OpenCodeWarmServer> {
+        self.server.clone()
+    }
+}
+
+impl Drop for OpenCodeWarmServerLease {
+    fn drop(&mut self) {
+        self.server.mark_used();
+        self.server.active_sessions.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+type OpenCodeServerPool = HashMap<OpenCodeServerKey, Arc<OpenCodeWarmServer>>;
+
+static OPENCODE_SERVER_POOL: OnceLock<Mutex<OpenCodeServerPool>> = OnceLock::new();
+
+fn opencode_server_pool() -> &'static Mutex<OpenCodeServerPool> {
+    OPENCODE_SERVER_POOL.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 // ---------------------------------------------------------------------------
@@ -216,27 +331,19 @@ fn execute_command_streaming_inner(
         "OpenCode CLI not found — install with: npm install -g opencode-ai".to_string()
     })?;
 
-    let port = allocate_port()?;
-    let password = generate_password();
-    let auth = build_auth_header(&password);
-    let base_url = format!("http://127.0.0.1:{port}");
-
-    let mut server = spawn_server(&bin, &resolution, port, &password, working_dir)?;
-    register_child_pid(cancel_token, server.id());
-
+    let server = acquire_warm_server(&bin, &resolution, working_dir)?;
     let result = run_session(
         prompt,
         system_prompt,
         allowed_tools,
         model_override.as_ref(),
-        &base_url,
-        &auth,
+        server.base_url(),
+        server.auth(),
         &sender,
         cancel_token,
-        Some(server.startup_output.clone()),
+        Some(server.startup_output()),
+        Some(server.shared_server()),
     );
-
-    shutdown_server(&mut server, &base_url, &auth);
 
     match result {
         Ok(()) => Ok(()),
@@ -247,6 +354,108 @@ fn execute_command_streaming_inner(
 // ---------------------------------------------------------------------------
 // Server lifecycle
 // ---------------------------------------------------------------------------
+
+fn pool_working_dir(working_dir: &str) -> String {
+    std::fs::canonicalize(working_dir)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| working_dir.to_string())
+}
+
+fn warm_server_key(bin: &str, working_dir: &str) -> OpenCodeServerKey {
+    OpenCodeServerKey {
+        bin: bin.to_string(),
+        working_dir: pool_working_dir(working_dir),
+    }
+}
+
+fn cleanup_idle_warm_servers(pool: &mut OpenCodeServerPool) {
+    let expired = pool
+        .iter()
+        .filter_map(|(key, server)| {
+            let active = server.active_sessions.load(Ordering::SeqCst);
+            (active == 0 && server.idle_for() >= WARM_SERVER_IDLE_TTL).then(|| key.clone())
+        })
+        .collect::<Vec<_>>();
+
+    for key in expired {
+        if let Some(server) = pool.remove(&key) {
+            tracing::info!(
+                "Disposing idle OpenCode warm server for {} after {}s",
+                key.working_dir,
+                WARM_SERVER_IDLE_TTL.as_secs()
+            );
+            server.shutdown();
+        }
+    }
+}
+
+fn acquire_warm_server(
+    bin: &str,
+    resolution: &crate::services::platform::BinaryResolution,
+    working_dir: &str,
+) -> Result<OpenCodeWarmServerLease, String> {
+    let key = warm_server_key(bin, working_dir);
+    let pool = opencode_server_pool();
+    let mut pool = pool.lock().unwrap_or_else(|e| {
+        tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+        e.into_inner()
+    });
+
+    cleanup_idle_warm_servers(&mut pool);
+
+    if let Some(server) = pool.get(&key).cloned() {
+        if server.is_running()
+            && wait_for_health(&server.base_url, &server.auth, Some(&server.startup_output)).is_ok()
+        {
+            server.active_sessions.fetch_add(1, Ordering::SeqCst);
+            server.mark_used();
+            tracing::debug!(
+                "Reusing OpenCode warm server {} for {}",
+                server.base_url,
+                key.working_dir
+            );
+            return Ok(OpenCodeWarmServerLease { server });
+        }
+
+        tracing::warn!(
+            "Evicting stale OpenCode warm server {} for {}",
+            server.base_url,
+            key.working_dir
+        );
+        pool.remove(&key);
+        server.shutdown();
+    }
+
+    let port = allocate_port()?;
+    let password = generate_password();
+    let auth = build_auth_header(&password);
+    let base_url = format!("http://127.0.0.1:{port}");
+    let server_process = spawn_server(bin, resolution, port, &password, working_dir)?;
+    let startup_output = server_process.startup_output.clone();
+
+    if let Err(error) = wait_for_health(&base_url, &auth, Some(&startup_output)) {
+        let mut server_process = server_process;
+        shutdown_server(&mut server_process, &base_url, &auth);
+        return Err(error);
+    }
+
+    let server = Arc::new(OpenCodeWarmServer {
+        key: key.clone(),
+        base_url,
+        auth,
+        startup_output,
+        process: Mutex::new(server_process),
+        active_sessions: AtomicUsize::new(1),
+        last_used: Mutex::new(Instant::now()),
+    });
+    tracing::info!(
+        "Started OpenCode warm server {} for {}",
+        server.base_url,
+        server.key.working_dir
+    );
+    pool.insert(key, server.clone());
+    Ok(OpenCodeWarmServerLease { server })
+}
 
 fn spawn_server(
     bin: &str,
@@ -376,6 +585,7 @@ fn run_session(
     sender: &Sender<StreamMessage>,
     cancel_token: Option<&CancelToken>,
     startup_output: Option<Arc<Mutex<OpenCodeStartupOutput>>>,
+    warm_server: Option<Arc<OpenCodeWarmServer>>,
 ) -> Result<(), String> {
     // 1. Wait for server to be ready
     wait_for_health(base_url, auth, startup_output.as_ref())?;
@@ -419,7 +629,15 @@ fn run_session(
     // 6. Read SSE stream
     let reader: BufReader<Box<dyn std::io::Read + Send>> =
         BufReader::new(Box::new(sse_response.into_reader()));
-    consume_sse(reader, &session_id, sender, cancel_token, base_url, auth)
+    consume_sse(
+        reader,
+        &session_id,
+        sender,
+        cancel_token,
+        base_url,
+        auth,
+        warm_server,
+    )
 }
 
 fn wait_for_health(
@@ -809,6 +1027,7 @@ fn consume_sse(
     cancel_token: Option<&CancelToken>,
     base_url: &str,
     auth: &str,
+    warm_server: Option<Arc<OpenCodeWarmServer>>,
 ) -> Result<(), String> {
     // Watchdog: when the caller's `CancelToken` fires while we're parked
     // inside `reader.lines()`, the in-loop poll wouldn't notice until the
@@ -832,6 +1051,7 @@ fn consume_sse(
             let watchdog_base_url = base_url.to_string();
             let watchdog_auth = auth.to_string();
             let watchdog_session_id = session_id.to_string();
+            let watchdog_server = warm_server.clone();
             scope.spawn(move || {
                 while !stop.load(Ordering::Relaxed) {
                     if cancel_requested(Some(cancel)) {
@@ -844,20 +1064,26 @@ fn consume_sse(
                         while Instant::now() < kill_deadline && !stop.load(Ordering::Relaxed) {
                             thread::sleep(Duration::from_millis(50));
                         }
-                        // Hard fallback: SSE loop still hasn't exited
-                        // (abort POST stalled, or server-side abort
-                        // didn't propagate). Kill the opencode server
-                        // process tree so the TCP socket drops and
-                        // `read_line` returns regardless of server
-                        // behaviour. PID is registered via
-                        // `register_child_pid` during server startup.
+                        // Hard fallback: if this warm server is not
+                        // shared by another active turn, kill the server
+                        // process tree so the SSE socket drops and
+                        // `read_line` returns. When multiple OpenCode
+                        // turns share the same warm server, killing the
+                        // server would interrupt unrelated sessions, so
+                        // skip the hard-kill fallback and let the bounded
+                        // read timeout surface the cancel/error instead.
                         if !stop.load(Ordering::Relaxed)
-                            && let Some(pid) = *cancel.child_pid.lock().unwrap_or_else(|e| {
-                                tracing::warn!("Recovered poisoned lock for CancelToken::child_pid in OpenCode watchdog");
-                                e.into_inner()
-                            })
+                            && let Some(server) = watchdog_server.as_ref()
                         {
-                            kill_pid_tree(pid);
+                            if server.active_sessions.load(Ordering::SeqCst) <= 1 {
+                                kill_pid_tree(server.id());
+                            } else {
+                                tracing::warn!(
+                                    "Skipping OpenCode hard-kill cancel fallback for shared warm server {} with {} active sessions",
+                                    server.base_url,
+                                    server.active_sessions.load(Ordering::SeqCst)
+                                );
+                            }
                         }
                         return;
                     }
@@ -1884,3 +2110,36 @@ fn send_error(sender: &Sender<StreamMessage>, message: String) -> Result<(), Str
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_warm_server_key_canonicalizes_equivalent_working_dirs() {
+        let cwd = std::env::current_dir().expect("current dir");
+        let key_from_dot = warm_server_key("opencode", ".");
+        let key_from_cwd = warm_server_key("opencode", &cwd.to_string_lossy());
+
+        assert_eq!(key_from_dot, key_from_cwd);
+    }
+
+    #[test]
+    fn opencode_warm_server_key_separates_working_dirs() {
+        let root = std::env::temp_dir().join(format!(
+            "agentdesk-opencode-key-test-{}",
+            std::process::id()
+        ));
+        let first = root.join("first");
+        let second = root.join("second");
+        std::fs::create_dir_all(&first).expect("create first temp dir");
+        std::fs::create_dir_all(&second).expect("create second temp dir");
+
+        let first_key = warm_server_key("opencode", &first.to_string_lossy());
+        let second_key = warm_server_key("opencode", &second.to_string_lossy());
+
+        assert_ne!(first_key, second_key);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -323,7 +323,11 @@ fn scrub_startup_secrets(raw: &str) -> String {
                     out.push(format!("{key}:"));
                     redact_next = true;
                 } else {
-                    // `token:abc` — value is inline.
+                    // `token:abc` — value is inline. If that inline value is
+                    // itself an auth scheme marker (e.g. `Authorization:Basic
+                    // <cred>`), the real credential is the *next* token, so keep
+                    // redacting forward instead of leaking it into the tail.
+                    redact_next = is_auth_scheme_marker(value);
                     out.push(format!("{key}:[REDACTED]"));
                 }
                 continue;
@@ -2809,6 +2813,22 @@ mod tests {
         assert!(!s.contains("hunter2"), "leaked inline colon value: {s}");
         assert!(s.contains("password:[REDACTED]"), "got: {s}");
         assert!(s.contains("ok"));
+
+        // Inline `auth:Scheme value` — when the inline value is itself a
+        // `Basic`/`Bearer` scheme marker, the real credential is the next token
+        // and must still be redacted (otherwise it leaks into the detail tail).
+        let s = scrub_startup_secrets("Authorization:Basic c2VjcmV0Y3JlZA== done");
+        assert!(
+            !s.contains("c2VjcmV0Y3JlZA=="),
+            "leaked inline-scheme credential: {s}"
+        );
+        assert!(s.contains("done"));
+        let s = scrub_startup_secrets("auth:Bearer tok_inlinecred tail");
+        assert!(
+            !s.contains("tok_inlinecred"),
+            "leaked inline bearer credential: {s}"
+        );
+        assert!(s.contains("tail"));
 
         // A non-secret colon token (e.g. a URL) is left intact.
         let s = scrub_startup_secrets("listening http://127.0.0.1:8080 ready");

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -1708,6 +1708,26 @@ fn consume_sse(
     })
 }
 
+/// Whether a line successfully read from the SSE socket proves the transport is
+/// still alive and must therefore refresh the `SSE_READ_TIMEOUT` idle deadline
+/// in [`consume_sse_inner`].
+///
+/// Intentionally `true` for EVERY line — keep-alive comments (`:` / `event:`),
+/// `data:` chunks, the blank dispatch delimiter, and frames addressed to OTHER
+/// co-resident sessions on the shared `/global/event` stream. The warm pool
+/// multiplexes many sessions over one `opencode serve` SSE stream, so liveness
+/// is a property of the TRANSPORT, not of this session's dispatched events.
+/// Tying the refresh to `process_sse_event` returning `Some(_)` (which is `None`
+/// for keep-alives and any non-matching `sessionID`) would let a long-running
+/// turn that legitimately emits no data for >120s be falsely declared idle and
+/// `abort_session`'d — killing the live server-side turn — whenever co-resident
+/// traffic keeps the socket busy. Restores the pre-warm-pool transport-idle
+/// semantics; guarded by `sse_idle_timer_refreshes_on_all_transport_lines`.
+#[inline]
+fn sse_line_is_transport_liveness(_line: &str) -> bool {
+    true
+}
+
 fn consume_sse_inner(
     reader: BufReader<Box<dyn std::io::Read + Send>>,
     session_id: &str,
@@ -1757,6 +1777,14 @@ fn consume_sse_inner(
             }
         };
 
+        // Transport-liveness: any line we manage to read refreshes the idle
+        // deadline, BEFORE the keep-alive / data / dispatch branches below.
+        // (See `sse_line_is_transport_liveness` for why this must not be gated
+        // on this session's dispatched events in the shared warm-pool stream.)
+        if sse_line_is_transport_liveness(&line) {
+            last_event = Instant::now();
+        }
+
         // Keep-alive comment
         if line.starts_with(':') || line.starts_with("event:") {
             continue;
@@ -1773,7 +1801,6 @@ fn consume_sse_inner(
             current_data.clear();
 
             if let Some(should_stop) = process_sse_event(&data, session_id, sender, &mut state) {
-                last_event = Instant::now();
                 if should_stop {
                     terminal_seen = true;
                     if !state.terminal_error {
@@ -3017,6 +3044,30 @@ mod tests {
             process_sse_event(&current.to_string(), "current-session", &tx, &mut state),
             Some(false)
         );
+    }
+
+    /// Regression guard for the warm-pool SSE idle-timeout: the 120s
+    /// `SSE_READ_TIMEOUT` deadline is a TRANSPORT-idle guard, so every line read
+    /// from the shared `/global/event` stream must refresh it — keep-alives,
+    /// `event:` framing, `data:` chunks, the blank dispatch delimiter, and
+    /// frames for OTHER co-resident sessions. Gating the refresh on this
+    /// session's dispatched events (the bug this fix reverts) false-aborted
+    /// long-running turns that emit no data for >120s while co-resident traffic
+    /// kept the socket alive.
+    #[test]
+    fn sse_idle_timer_refreshes_on_all_transport_lines() {
+        for line in [
+            ":heartbeat",
+            "event: message.updated",
+            "data: {\"type\":\"message.updated\",\"properties\":{\"sessionID\":\"other-session\"}}",
+            "",
+            "data: {\"type\":\"session.idle\"}",
+        ] {
+            assert!(
+                sse_line_is_transport_liveness(line),
+                "line must count as transport liveness for the SSE idle timer: {line:?}"
+            );
+        }
     }
 
     /// [TEST-006] empty pool is cold-start safe: returns empty, no panic.

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -754,6 +754,17 @@ fn cleanup_idle_warm_servers(pool: &mut OpenCodeServerPool) {
     }
 }
 
+fn next_idle_disposal_delay(pool: &OpenCodeServerPool) -> Option<Duration> {
+    pool.values()
+        .filter(|server| server.active_sessions.load(Ordering::SeqCst) == 0)
+        .map(|server| idle_disposal_delay_for_idle_duration(server.idle_for()))
+        .min()
+}
+
+fn idle_disposal_delay_for_idle_duration(idle_for: Duration) -> Duration {
+    WARM_SERVER_IDLE_TTL.saturating_sub(idle_for)
+}
+
 fn evict_warm_server_from_pool(server: &Arc<OpenCodeWarmServer>) {
     let mut pool = opencode_server_pool().lock().unwrap_or_else(|e| {
         tracing::warn!("Recovered poisoned lock for OpenCode server pool");
@@ -797,18 +808,27 @@ fn claim_idle_disposal_sweep(scheduled: &AtomicBool) -> bool {
 /// and `idle_for` under the pool lock, so a server that was re-acquired in
 /// the meantime is left untouched.
 fn schedule_idle_disposal() {
+    schedule_idle_disposal_after(WARM_SERVER_IDLE_TTL);
+}
+
+fn schedule_idle_disposal_after(delay: Duration) {
     if !claim_idle_disposal_sweep(&IDLE_DISPOSAL_SCHEDULED) {
         return;
     }
-    thread::spawn(|| {
-        thread::sleep(WARM_SERVER_IDLE_TTL);
+    thread::spawn(move || {
+        thread::sleep(delay);
         let pool = opencode_server_pool();
         let mut pool = pool.lock().unwrap_or_else(|e| {
             tracing::warn!("Recovered poisoned lock for OpenCode server pool");
             e.into_inner()
         });
         cleanup_idle_warm_servers(&mut pool);
+        let next_delay = next_idle_disposal_delay(&pool);
+        drop(pool);
         IDLE_DISPOSAL_SCHEDULED.store(false, Ordering::SeqCst);
+        if let Some(delay) = next_delay {
+            schedule_idle_disposal_after(delay);
+        }
     });
 }
 
@@ -1141,12 +1161,18 @@ fn run_session(
         .timeout_read(SSE_READ_TIMEOUT)
         .build();
 
-    let sse_response = sse_agent
+    let sse_response = match sse_agent
         .get(&format!("{base_url}/global/event"))
         .set("Authorization", auth)
         .set("Accept", "text/event-stream")
         .call()
-        .map_err(|e| format!("Failed to connect to OpenCode SSE stream: {e}"))?;
+    {
+        Ok(response) => response,
+        Err(error) => {
+            abort_session(base_url, auth, &session_id);
+            return Err(format!("Failed to connect to OpenCode SSE stream: {error}"));
+        }
+    };
 
     // 5. Send prompt (non-blocking — server processes it while we read SSE)
     if let Err(error) = send_prompt(
@@ -1765,6 +1791,7 @@ fn consume_sse_inner(
     if !terminal_seen {
         let result = state.accumulated_text.trim().to_string();
         if !result.is_empty() {
+            abort_session(base_url, auth, session_id);
             send_sse_done(sender, session_id, result);
             return Ok(());
         }
@@ -1784,6 +1811,7 @@ fn consume_sse_inner(
                 abort_session(base_url, auth, session_id);
                 return Err("OpenCode request cancelled".to_string());
             }
+            abort_session(base_url, auth, session_id);
             send_sse_done(sender, session_id, result);
             return Ok(());
         }
@@ -2744,6 +2772,22 @@ mod tests {
         assert!(!claim_idle_disposal_sweep(&scheduled));
         scheduled.store(false, Ordering::SeqCst);
         assert!(claim_idle_disposal_sweep(&scheduled));
+    }
+
+    #[test]
+    fn idle_disposal_delay_reschedules_until_ttl_elapsed() {
+        assert_eq!(
+            idle_disposal_delay_for_idle_duration(Duration::from_secs(0)),
+            WARM_SERVER_IDLE_TTL
+        );
+        assert_eq!(
+            idle_disposal_delay_for_idle_duration(WARM_SERVER_IDLE_TTL / 2),
+            WARM_SERVER_IDLE_TTL / 2
+        );
+        assert_eq!(
+            idle_disposal_delay_for_idle_duration(WARM_SERVER_IDLE_TTL + Duration::from_secs(1)),
+            Duration::ZERO
+        );
     }
 
     #[test]

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -29,6 +29,7 @@ const HEALTH_POLL_MS: u64 = 250;
 const SSE_READ_TIMEOUT: Duration = Duration::from_secs(120);
 const DISPOSE_TIMEOUT: Duration = Duration::from_secs(5);
 const MESSAGE_RECOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+const SESSION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const STARTUP_OUTPUT_LIMIT: usize = 8 * 1024;
 const WARM_SERVER_IDLE_TTL: Duration = Duration::from_secs(20 * 60);
 
@@ -118,6 +119,7 @@ struct OpenCodeWarmServer {
     startup_output: Arc<Mutex<OpenCodeStartupOutput>>,
     process: Mutex<OpenCodeServerProcess>,
     active_sessions: AtomicUsize,
+    retiring: AtomicBool,
     last_used: Mutex<Instant>,
 }
 
@@ -160,6 +162,18 @@ impl OpenCodeWarmServer {
             e.into_inner()
         });
         shutdown_server(&mut process, &self.base_url, &self.auth);
+    }
+
+    fn try_acquire_lease(&self) -> bool {
+        let acquired = try_acquire_warm_server_session(&self.active_sessions, &self.retiring);
+        if acquired {
+            self.mark_used();
+        }
+        acquired
+    }
+
+    fn try_begin_exclusive_hard_kill(&self) -> Result<(), usize> {
+        try_begin_exclusive_warm_server_hard_kill(&self.active_sessions, &self.retiring)
     }
 }
 
@@ -376,6 +390,38 @@ fn compute_suspicious_active_leak(active_sessions: u32, _idle_secs: u64, running
 /// watchdog re-evaluates this predicate at kill time, which is race-safe.
 fn warm_server_hard_kill_allowed(active_sessions: usize) -> bool {
     active_sessions <= 1
+}
+
+fn try_acquire_warm_server_session(active_sessions: &AtomicUsize, retiring: &AtomicBool) -> bool {
+    if retiring.load(Ordering::SeqCst) {
+        return false;
+    }
+    active_sessions.fetch_add(1, Ordering::SeqCst);
+    if retiring.load(Ordering::SeqCst) {
+        active_sessions.fetch_sub(1, Ordering::SeqCst);
+        return false;
+    }
+    true
+}
+
+fn try_begin_exclusive_warm_server_hard_kill(
+    active_sessions: &AtomicUsize,
+    retiring: &AtomicBool,
+) -> Result<(), usize> {
+    if retiring
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(active_sessions.load(Ordering::SeqCst));
+    }
+
+    let active = active_sessions.load(Ordering::SeqCst);
+    if warm_server_hard_kill_allowed(active) {
+        Ok(())
+    } else {
+        retiring.store(false, Ordering::SeqCst);
+        Err(active)
+    }
 }
 
 impl OpenCodeWarmServer {
@@ -774,9 +820,7 @@ fn acquire_warm_server(
             .get(&key)
             .is_some_and(|current| Arc::ptr_eq(current, &server));
 
-        if healthy && still_pooled {
-            server.active_sessions.fetch_add(1, Ordering::SeqCst);
-            server.mark_used();
+        if healthy && still_pooled && server.try_acquire_lease() {
             tracing::debug!(
                 "Reusing OpenCode warm server {} for {}",
                 server.base_url,
@@ -843,6 +887,7 @@ fn acquire_warm_server(
         startup_output,
         process: Mutex::new(server_process),
         active_sessions: AtomicUsize::new(1),
+        retiring: AtomicBool::new(false),
         last_used: Mutex::new(Instant::now()),
     });
     tracing::info!(
@@ -867,19 +912,28 @@ fn acquire_warm_server(
         e.into_inner()
     });
     match pool.entry(key) {
-        Entry::Occupied(existing) => {
+        Entry::Occupied(mut existing) => {
             // Another thread won the race. Reuse their server (taking a lease)
             // and discard ours to avoid leaking an orphaned `opencode serve`.
             let winner = existing.get().clone();
-            winner.active_sessions.fetch_add(1, Ordering::SeqCst);
-            winner.mark_used();
-            drop(pool);
-            tracing::info!(
-                "Discarding duplicate OpenCode warm server {} after losing startup race",
-                server.base_url
-            );
-            server.shutdown();
-            Ok(OpenCodeWarmServerLease { server: winner })
+            if winner.try_acquire_lease() {
+                drop(pool);
+                tracing::info!(
+                    "Discarding duplicate OpenCode warm server {} after losing startup race",
+                    server.base_url
+                );
+                server.shutdown();
+                Ok(OpenCodeWarmServerLease { server: winner })
+            } else {
+                existing.insert(server.clone());
+                drop(pool);
+                tracing::info!(
+                    "Replacing retiring OpenCode warm server with {} for {}",
+                    server.base_url,
+                    server.key.working_dir
+                );
+                Ok(OpenCodeWarmServerLease { server })
+            }
         }
         Entry::Vacant(slot) => {
             slot.insert(server.clone());
@@ -1105,7 +1159,9 @@ fn wait_for_health(
 }
 
 fn create_session(base_url: &str, auth: &str) -> Result<String, String> {
-    let response = ureq::post(&format!("{base_url}/session"))
+    let agent = session_request_agent();
+    let response = agent
+        .post(&format!("{base_url}/session"))
         .set("Authorization", auth)
         .set("Content-Type", "application/json")
         .send_json(serde_json::json!({}))
@@ -1134,7 +1190,9 @@ fn send_prompt(
 ) -> Result<(), String> {
     let body = build_prompt_body(prompt, system_prompt, allowed_tools, model);
 
-    let resp = ureq::post(&format!("{base_url}/session/{session_id}/prompt_async"))
+    let agent = session_request_agent();
+    let resp = agent
+        .post(&format!("{base_url}/session/{session_id}/prompt_async"))
         .set("Authorization", auth)
         .set("Content-Type", "application/json")
         .send_json(body)
@@ -1146,6 +1204,13 @@ fn send_prompt(
     } else {
         Err(format!("prompt_async returned unexpected status: {status}"))
     }
+}
+
+fn session_request_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(2))
+        .timeout(SESSION_REQUEST_TIMEOUT)
+        .build()
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -1506,10 +1571,10 @@ fn consume_sse(
                         if !stop.load(Ordering::Relaxed)
                             && let Some(server) = watchdog_server.as_ref()
                         {
-                            let active = server.active_sessions.load(Ordering::SeqCst);
-                            if warm_server_hard_kill_allowed(active) {
+                            if server.try_begin_exclusive_hard_kill().is_ok() {
                                 kill_pid_tree(server.id());
                             } else {
+                                let active = server.active_sessions.load(Ordering::SeqCst);
                                 tracing::warn!(
                                     "Skipping OpenCode hard-kill cancel fallback for shared warm server {} with {} active sessions",
                                     server.base_url,
@@ -2567,6 +2632,40 @@ mod tests {
         // `opencode serve` out from under another turn's live SSE stream.
         assert!(!warm_server_hard_kill_allowed(2));
         assert!(!warm_server_hard_kill_allowed(8));
+    }
+
+    #[test]
+    fn retiring_warm_server_rejects_new_lease_without_incrementing() {
+        let active = AtomicUsize::new(1);
+        let retiring = AtomicBool::new(true);
+
+        assert!(!try_acquire_warm_server_session(&active, &retiring));
+        assert_eq!(active.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn hard_kill_marks_retiring_only_for_exclusive_session() {
+        let active = AtomicUsize::new(1);
+        let retiring = AtomicBool::new(false);
+
+        assert!(try_begin_exclusive_warm_server_hard_kill(&active, &retiring).is_ok());
+        assert!(retiring.load(Ordering::SeqCst));
+        assert!(!try_acquire_warm_server_session(&active, &retiring));
+        assert_eq!(active.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn hard_kill_veto_clears_retiring_for_shared_session() {
+        let active = AtomicUsize::new(2);
+        let retiring = AtomicBool::new(false);
+
+        assert_eq!(
+            try_begin_exclusive_warm_server_hard_kill(&active, &retiring),
+            Err(2)
+        );
+        assert!(!retiring.load(Ordering::SeqCst));
+        assert!(try_acquire_warm_server_session(&active, &retiring));
+        assert_eq!(active.load(Ordering::SeqCst), 3);
     }
 
     #[test]

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 
 use crate::services::agent_protocol::StreamMessage;
 use crate::services::process::{configure_child_process_group, kill_pid_tree};
-use crate::services::provider::{CancelToken, ProviderKind, cancel_requested};
+use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
 use crate::services::remote::RemoteProfile;
 
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -167,7 +167,16 @@ impl OpenCodeWarmServerLease {
 impl Drop for OpenCodeWarmServerLease {
     fn drop(&mut self) {
         self.server.mark_used();
-        self.server.active_sessions.fetch_sub(1, Ordering::SeqCst);
+        // `fetch_sub` returns the *previous* value, so a result of `1` means
+        // this drop took `active_sessions` to `0` — i.e. the final lease was
+        // released. Without an `acquire_warm_server` call to drive
+        // `cleanup_idle_warm_servers`, an idle warm `opencode serve` process
+        // would otherwise stay resident indefinitely after `WARM_SERVER_IDLE_TTL`.
+        // Schedule a one-shot disposal sweep so the last turn's cleanup does
+        // not depend on a future acquire.
+        if self.server.active_sessions.fetch_sub(1, Ordering::SeqCst) == 1 {
+            schedule_idle_disposal();
+        }
     }
 }
 
@@ -332,6 +341,12 @@ fn execute_command_streaming_inner(
     })?;
 
     let server = acquire_warm_server(&bin, &resolution, working_dir)?;
+    // Register the warm server's PID on the caller's CancelToken so timeout
+    // callers (which only have `CancelToken.child_pid` to kill) can interrupt a
+    // turn that is blocked before `run_session` installs the SSE cancel
+    // watchdog. The watchdog itself prefers the shared-server Arc, but this
+    // keeps the historical PID-based cancel path working during startup.
+    register_child_pid(cancel_token, server.shared_server().id());
     let result = run_session(
         prompt,
         system_prompt,
@@ -389,6 +404,25 @@ fn cleanup_idle_warm_servers(pool: &mut OpenCodeServerPool) {
     }
 }
 
+/// Schedule a one-shot idle-disposal sweep `WARM_SERVER_IDLE_TTL` from now.
+///
+/// Called when the final lease on a warm server drops, so an idle
+/// `opencode serve` process is reclaimed even when no further
+/// `acquire_warm_server` ever runs. The sweep re-checks `active_sessions`
+/// and `idle_for` under the pool lock, so a server that was re-acquired in
+/// the meantime is left untouched.
+fn schedule_idle_disposal() {
+    thread::spawn(|| {
+        thread::sleep(WARM_SERVER_IDLE_TTL);
+        let pool = opencode_server_pool();
+        let mut pool = pool.lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+            e.into_inner()
+        });
+        cleanup_idle_warm_servers(&mut pool);
+    });
+}
+
 fn acquire_warm_server(
     bin: &str,
     resolution: &crate::services::platform::BinaryResolution,
@@ -403,10 +437,32 @@ fn acquire_warm_server(
 
     cleanup_idle_warm_servers(&mut pool);
 
+    // Whether the freshly spawned server (if we end up spawning one) should be
+    // published into the pool. It is set to `false` only when an existing
+    // unhealthy server still has active sessions: in that case we must not
+    // disturb the pooled entry, so this acquire gets a private, non-pooled
+    // server whose process is reclaimed via `Arc` drop once its lease ends.
+    let mut publish_spawn = true;
+
     if let Some(server) = pool.get(&key).cloned() {
-        if server.is_running()
-            && wait_for_health(&server.base_url, &server.auth, Some(&server.startup_output)).is_ok()
-        {
+        // Release the pool lock before probing health. `is_running` and
+        // `wait_for_health` can block for up to `HEALTH_TIMEOUT` (30s) on a
+        // wedged server; holding the global pool mutex across that window
+        // would stall every other OpenCode request — including unrelated
+        // working directories that could spawn their own server.
+        drop(pool);
+
+        let healthy = server.is_running()
+            && wait_for_health(&server.base_url, &server.auth, Some(&server.startup_output))
+                .is_ok();
+
+        // Re-acquire the pool lock to commit the reuse-or-evict decision.
+        let mut pool = opencode_server_pool().lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+            e.into_inner()
+        });
+
+        if healthy {
             server.active_sessions.fetch_add(1, Ordering::SeqCst);
             server.mark_used();
             tracing::debug!(
@@ -417,13 +473,39 @@ fn acquire_warm_server(
             return Ok(OpenCodeWarmServerLease { server });
         }
 
-        tracing::warn!(
-            "Evicting stale OpenCode warm server {} for {}",
-            server.base_url,
-            key.working_dir
-        );
-        pool.remove(&key);
-        server.shutdown();
+        // Unhealthy server. Only evict/shutdown when no other turn is using
+        // it; killing a server with active sessions would interrupt those
+        // in-flight turns as collateral damage.
+        if server.active_sessions.load(Ordering::SeqCst) == 0 {
+            // Confirm the pool still holds the same instance before removing,
+            // so we don't evict a replacement inserted while the lock was
+            // released.
+            if pool
+                .get(&key)
+                .is_some_and(|current| Arc::ptr_eq(current, &server))
+            {
+                pool.remove(&key);
+            }
+            tracing::warn!(
+                "Evicting stale OpenCode warm server {} for {}",
+                server.base_url,
+                key.working_dir
+            );
+            server.shutdown();
+        } else {
+            // Leave the active (but unhealthy) entry pooled and give this
+            // acquire a private server instead of publishing over it.
+            publish_spawn = false;
+            tracing::warn!(
+                "OpenCode warm server {} for {} failed health probe but has {} active sessions; spawning a private server for this turn instead of evicting",
+                server.base_url,
+                key.working_dir,
+                server.active_sessions.load(Ordering::SeqCst)
+            );
+        }
+        drop(pool);
+    } else {
+        drop(pool);
     }
 
     let port = allocate_port()?;
@@ -453,8 +535,42 @@ fn acquire_warm_server(
         server.base_url,
         server.key.working_dir
     );
-    pool.insert(key, server.clone());
-    Ok(OpenCodeWarmServerLease { server })
+
+    if !publish_spawn {
+        // The pooled entry is unhealthy but still serving other turns, so we
+        // intentionally do not register this server. Its process is reclaimed
+        // when the returned lease (and the cancel watchdog's clone) drop the
+        // last `Arc`, via `OpenCodeServerProcess::drop`.
+        return Ok(OpenCodeWarmServerLease { server });
+    }
+
+    // Re-acquire the pool lock to publish the freshly spawned server. The lock
+    // was released across `spawn_server`/`wait_for_health`, so another acquire
+    // may have raced us and already published a healthy server for this key.
+    let mut pool = opencode_server_pool().lock().unwrap_or_else(|e| {
+        tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+        e.into_inner()
+    });
+    match pool.entry(key) {
+        Entry::Occupied(existing) => {
+            // Another thread won the race. Reuse their server (taking a lease)
+            // and discard ours to avoid leaking an orphaned `opencode serve`.
+            let winner = existing.get().clone();
+            winner.active_sessions.fetch_add(1, Ordering::SeqCst);
+            winner.mark_used();
+            drop(pool);
+            tracing::info!(
+                "Discarding duplicate OpenCode warm server {} after losing startup race",
+                server.base_url
+            );
+            server.shutdown();
+            Ok(OpenCodeWarmServerLease { server: winner })
+        }
+        Entry::Vacant(slot) => {
+            slot.insert(server.clone());
+            Ok(OpenCodeWarmServerLease { server })
+        }
+    }
 }
 
 fn spawn_server(

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -346,7 +346,25 @@ fn execute_command_streaming_inner(
     // turn that is blocked before `run_session` installs the SSE cancel
     // watchdog. The watchdog itself prefers the shared-server Arc, but this
     // keeps the historical PID-based cancel path working during startup.
-    register_child_pid(cancel_token, server.shared_server().id());
+    //
+    // Crucially, only register the PID when this turn is the *sole* active
+    // session on the server. The generic provider_exec timeout path calls
+    // `kill_pid_tree(child_pid)` unconditionally on timeout, so registering a
+    // shared `opencode serve` PID would let a single turn's timeout kill the
+    // warm server out from under every other concurrent streaming turn —
+    // defeating the warm-pool's whole purpose. When the server is shared, leave
+    // `child_pid` unset: the in-stream cancel watchdog (which guards its
+    // hard-kill fallback on `active_sessions <= 1`) plus `abort_session` are the
+    // only mechanisms allowed to terminate the turn, and neither disturbs the
+    // co-resident sessions.
+    if server
+        .shared_server()
+        .active_sessions
+        .load(Ordering::SeqCst)
+        <= 1
+    {
+        register_child_pid(cancel_token, server.shared_server().id());
+    }
     let result = run_session(
         prompt,
         system_prompt,
@@ -462,7 +480,20 @@ fn acquire_warm_server(
             e.into_inner()
         });
 
-        if healthy {
+        // Only lease the probed server if the pool *still* holds this exact
+        // instance. The lock was released across the (up to 30s) health probe,
+        // so a racing acquire may have evicted/swapped/shutdown this entry in
+        // the gap; leasing it then would hand out a server whose process is
+        // being torn down (or a duplicate the pool no longer tracks), leaking
+        // the `opencode serve` child and skewing `active_sessions`. When the
+        // instance is no longer pooled, fall through to the spawn path below,
+        // whose `Entry` match safely re-resolves the current pooled server (or
+        // publishes a fresh one).
+        let still_pooled = pool
+            .get(&key)
+            .is_some_and(|current| Arc::ptr_eq(current, &server));
+
+        if healthy && still_pooled {
             server.active_sessions.fetch_add(1, Ordering::SeqCst);
             server.mark_used();
             tracing::debug!(
@@ -473,9 +504,12 @@ fn acquire_warm_server(
             return Ok(OpenCodeWarmServerLease { server });
         }
 
-        // Unhealthy server. Only evict/shutdown when no other turn is using
-        // it; killing a server with active sessions would interrupt those
-        // in-flight turns as collateral damage.
+        // Reached when the probed instance is unhealthy, or healthy but no
+        // longer the pooled entry (a racing acquire swapped in a replacement).
+        // Only evict/shutdown when no other turn is using it; killing a server
+        // with active sessions would interrupt those in-flight turns as
+        // collateral damage. The `Arc::ptr_eq` guard below ensures we never
+        // remove a replacement the pool now tracks.
         if server.active_sessions.load(Ordering::SeqCst) == 0 {
             // Confirm the pool still holds the same instance before removing,
             // so we don't evict a replacement inserted while the lock was
@@ -1255,6 +1289,11 @@ fn consume_sse_inner(
                 if is_cancelled(cancel_token) {
                     return Err("OpenCode request cancelled".to_string());
                 }
+                // Abnormal read error before a terminal event. Abort the
+                // server-side session so the async OpenCode turn does not keep
+                // running and mutating the (potentially warm-pooled, reused)
+                // workspace after we have given up on the stream.
+                abort_session(base_url, auth, session_id);
                 return Err(format!("OpenCode SSE stream read error: {e}"));
             }
         };
@@ -1336,6 +1375,11 @@ fn consume_sse_inner(
             abort_session(base_url, auth, session_id);
             return Err("OpenCode request cancelled".to_string());
         }
+        // Stream EOF with no terminal event, no recoverable text, and no
+        // cancel. The async session may still be live server-side; abort it so
+        // it cannot keep mutating a warm-pooled workspace that the next turn
+        // would reuse.
+        abort_session(base_url, auth, session_id);
         return Err("OpenCode stream ended without a terminal event".to_string());
     }
 

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -42,15 +42,14 @@ const SNAPSHOT_STARTUP_TAIL_LIMIT: usize = 256;
 
 /// REQ-006: conservative active-session leak threshold. A real fan-out can keep
 /// several concurrent leases on one warm server, so we only treat an elevated
-/// lease count as *suspicious evidence* when the server is also dead or has been
-/// idle past [`SNAPSHOT_LEAK_IDLE_SECS`]. This is evidence-only and never
-/// mutates the pool (no kill, no `active_sessions` decrement).
+/// lease count as *suspicious evidence* when the server's process is also dead —
+/// leases cannot legitimately be active on an `opencode serve` that has exited.
+/// We deliberately do NOT use an idle-window signal here: `idle_secs` is derived
+/// from `last_used`, which is not refreshed while sessions are streaming, so it
+/// would false-positive on a busy server fanning out long-running turns. This is
+/// evidence-only and never mutates the pool (no kill, no `active_sessions`
+/// decrement).
 const SNAPSHOT_ACTIVE_LEAK_THRESHOLD: u32 = 8;
-
-/// REQ-006: a warm server with an elevated lease count is only flagged once it
-/// has also been idle this long (or has a dead process). Avoids flagging normal
-/// in-use multi-session reuse.
-const SNAPSHOT_LEAK_IDLE_SECS: u64 = 300;
 
 #[derive(Debug, Default)]
 struct OpenCodeStartupOutput {
@@ -252,35 +251,72 @@ fn port_from_base_url(base_url: &str) -> Option<u32> {
         .and_then(|port| port.parse::<u32>().ok())
 }
 
+/// Whether a token key (the portion before a `=` or `:` delimiter) names a
+/// secret-bearing field whose value must be redacted.
+fn is_secret_key(key: &str) -> bool {
+    let key_lower = key.to_ascii_lowercase();
+    key_lower.contains("password")
+        || key_lower.contains("secret")
+        || key_lower.contains("token")
+        || key_lower.contains("auth")
+}
+
+fn is_auth_scheme_marker(token: &str) -> bool {
+    let lower = token.to_ascii_lowercase();
+    lower == "basic" || lower == "bearer"
+}
+
 /// Scrub obvious credential material from a startup-output line before it is
 /// exposed in the DETAILED tail. Conservative: redacts the value portion of
-/// known secret-bearing tokens. The public payload never carries this tail at
-/// all, so this is defense-in-depth for the authenticated/local surface.
+/// known secret-bearing tokens. Handles both `key=value` and colon-delimited
+/// (`key: value` / `key:value`) forms, plus bare `Basic`/`Bearer` schemes. The
+/// public payload never carries this tail at all, so this is defense-in-depth
+/// for the authenticated/local surface.
 fn scrub_startup_secrets(raw: &str) -> String {
     let mut out: Vec<String> = Vec::new();
-    // When the previous token was an auth scheme marker (`Basic`/`Bearer`), the
-    // immediately following token is its opaque credential value and must be
-    // redacted too.
+    // When the previous token requested redaction of the following value
+    // (`Basic`/`Bearer` scheme, or a secret key with the value in the next
+    // token such as `token: abc`), redact the next token. If that redacted
+    // token is itself a scheme marker (e.g. `auth: Bearer abc`), keep redacting
+    // so the scheme's opaque value does not leak.
     let mut redact_next = false;
     for token in raw.split(' ') {
         if redact_next {
+            // Carry the redaction forward when this value is a scheme marker so
+            // the *next* token (the actual credential) is also redacted.
+            redact_next = is_auth_scheme_marker(token);
             out.push("[REDACTED]".to_string());
-            redact_next = false;
             continue;
         }
-        let lower = token.to_ascii_lowercase();
+
+        // `key=value`
         if let Some(eq) = token.find('=') {
-            let key_lower = token[..eq].to_ascii_lowercase();
-            if key_lower.contains("password")
-                || key_lower.contains("secret")
-                || key_lower.contains("token")
-                || key_lower.contains("auth")
-            {
+            if is_secret_key(&token[..eq]) {
                 out.push(format!("{}=[REDACTED]", &token[..eq]));
                 continue;
             }
         }
-        if lower == "basic" || lower == "bearer" {
+
+        // `key:value` or `key:` (colon-delimited). Only treat a leading-key
+        // colon as a delimiter (skip URLs like `http://...` and bare schemes,
+        // which are handled below / never match `is_secret_key`).
+        if let Some(colon) = token.find(':') {
+            let key = &token[..colon];
+            if is_secret_key(key) {
+                let value = &token[colon + 1..];
+                if value.is_empty() {
+                    // `token:` — value is the next whitespace-separated token.
+                    out.push(format!("{key}:"));
+                    redact_next = true;
+                } else {
+                    // `token:abc` — value is inline.
+                    out.push(format!("{key}:[REDACTED]"));
+                }
+                continue;
+            }
+        }
+
+        if is_auth_scheme_marker(token) {
             // Keep the scheme marker for readability but redact its value next.
             out.push(token.to_string());
             redact_next = true;
@@ -310,11 +346,19 @@ fn snapshot_startup_tail(
     (Some(hash), Some(tail))
 }
 
-fn compute_suspicious_active_leak(active_sessions: u32, idle_secs: u64, running: bool) -> bool {
+fn compute_suspicious_active_leak(active_sessions: u32, _idle_secs: u64, running: bool) -> bool {
     if active_sessions <= SNAPSHOT_ACTIVE_LEAK_THRESHOLD {
         return false;
     }
-    !running || idle_secs >= SNAPSHOT_LEAK_IDLE_SECS
+    // `idle_secs` (derived from `last_used`) is only refreshed when a lease is
+    // acquired or dropped — NOT while active sessions are streaming. A busy
+    // server fanning out >8 long-running turns therefore looks "idle" even
+    // though it is legitimately working, so the idle window must NOT flag a
+    // server that is still running. An elevated lease count is only treated as a
+    // suspicious leak when the process is dead: leases cannot be making progress
+    // on an `opencode serve` that has exited, so a high count there is a genuine
+    // never-released-lease leak rather than normal in-use fan-out.
+    !running
 }
 
 impl OpenCodeWarmServer {
@@ -2623,6 +2667,33 @@ mod tests {
         assert!(tail.chars().count() <= SNAPSHOT_STARTUP_TAIL_LIMIT);
     }
 
+    /// Colon-delimited secret labels (`token: x`, `auth: Bearer x`, inline
+    /// `password:x`) must also be redacted, not just `key=value` forms.
+    #[test]
+    fn scrub_startup_secrets_redacts_colon_delimited_forms() {
+        // `token: value` — value is the next whitespace-separated token.
+        let s = scrub_startup_secrets("starting token: abc123secret done");
+        assert!(!s.contains("abc123secret"), "leaked colon-space token: {s}");
+        assert!(s.contains("token: [REDACTED]"), "got: {s}");
+        assert!(s.contains("done"));
+
+        // `auth: Bearer value` — both the scheme marker's value and the
+        // credential must be redacted, leaving no plaintext credential.
+        let s = scrub_startup_secrets("auth: Bearer xyzcredential rest");
+        assert!(!s.contains("xyzcredential"), "leaked bearer value: {s}");
+        assert!(s.contains("rest"));
+
+        // Inline `password:value` (no space).
+        let s = scrub_startup_secrets("password:hunter2 ok");
+        assert!(!s.contains("hunter2"), "leaked inline colon value: {s}");
+        assert!(s.contains("password:[REDACTED]"), "got: {s}");
+        assert!(s.contains("ok"));
+
+        // A non-secret colon token (e.g. a URL) is left intact.
+        let s = scrub_startup_secrets("listening http://127.0.0.1:8080 ready");
+        assert!(s.contains("http://127.0.0.1:8080"), "mangled url: {s}");
+    }
+
     /// [TEST-006] empty pool is cold-start safe: returns empty, no panic.
     #[test]
     fn warm_server_snapshots_empty_pool_is_cold_start_safe() {
@@ -2665,10 +2736,13 @@ mod tests {
             0,
             false
         ));
-        // Above threshold AND idle past the window: flagged.
-        assert!(compute_suspicious_active_leak(
+        // Above threshold, running, but stale `idle_secs` (large value): still
+        // NOT flagged. `idle_secs` is unreliable while sessions are active
+        // because `last_used` is not refreshed mid-stream, so a busy fan-out of
+        // long-running turns must not be reported as a leak.
+        assert!(!compute_suspicious_active_leak(
             SNAPSHOT_ACTIVE_LEAK_THRESHOLD + 1,
-            SNAPSHOT_LEAK_IDLE_SECS,
+            10_000,
             true
         ));
     }

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -522,6 +522,7 @@ impl Drop for OpenCodeWarmServerLease {
 type OpenCodeServerPool = HashMap<OpenCodeServerKey, Arc<OpenCodeWarmServer>>;
 
 static OPENCODE_SERVER_POOL: OnceLock<Mutex<OpenCodeServerPool>> = OnceLock::new();
+static IDLE_DISPOSAL_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 fn opencode_server_pool() -> &'static Mutex<OpenCodeServerPool> {
     OPENCODE_SERVER_POOL.get_or_init(|| Mutex::new(HashMap::new()))
@@ -753,6 +754,41 @@ fn cleanup_idle_warm_servers(pool: &mut OpenCodeServerPool) {
     }
 }
 
+fn evict_warm_server_from_pool(server: &Arc<OpenCodeWarmServer>) {
+    let mut pool = opencode_server_pool().lock().unwrap_or_else(|e| {
+        tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+        e.into_inner()
+    });
+    if pool
+        .get(&server.key)
+        .is_some_and(|current| Arc::ptr_eq(current, server))
+    {
+        pool.remove(&server.key);
+    }
+}
+
+/// Drain all resident warm servers. Called during AgentDesk shutdown so
+/// process-grouped `opencode serve` children do not survive a normal restart.
+pub fn shutdown_warm_servers() {
+    let servers = {
+        let mut pool = opencode_server_pool().lock().unwrap_or_else(|e| {
+            tracing::warn!("Recovered poisoned lock for OpenCode server pool");
+            e.into_inner()
+        });
+        pool.drain().map(|(_, server)| server).collect::<Vec<_>>()
+    };
+    for server in servers {
+        server.retiring.store(true, Ordering::SeqCst);
+        server.shutdown();
+    }
+}
+
+fn claim_idle_disposal_sweep(scheduled: &AtomicBool) -> bool {
+    scheduled
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+}
+
 /// Schedule a one-shot idle-disposal sweep `WARM_SERVER_IDLE_TTL` from now.
 ///
 /// Called when the final lease on a warm server drops, so an idle
@@ -761,6 +797,9 @@ fn cleanup_idle_warm_servers(pool: &mut OpenCodeServerPool) {
 /// and `idle_for` under the pool lock, so a server that was re-acquired in
 /// the meantime is left untouched.
 fn schedule_idle_disposal() {
+    if !claim_idle_disposal_sweep(&IDLE_DISPOSAL_SCHEDULED) {
+        return;
+    }
     thread::spawn(|| {
         thread::sleep(WARM_SERVER_IDLE_TTL);
         let pool = opencode_server_pool();
@@ -769,6 +808,7 @@ fn schedule_idle_disposal() {
             e.into_inner()
         });
         cleanup_idle_warm_servers(&mut pool);
+        IDLE_DISPOSAL_SCHEDULED.store(false, Ordering::SeqCst);
     });
 }
 
@@ -1084,13 +1124,17 @@ fn run_session(
     }
 
     // 2. Create session
-    let session_id = create_session(base_url, auth)?;
+    let session_id = create_session(base_url, auth, cancel_token)?;
 
     // 3. Announce session
     let _ = sender.send(StreamMessage::Init {
         session_id: session_id.clone(),
         raw_session_id: None,
     });
+    if is_cancelled(cancel_token) {
+        abort_session(base_url, auth, &session_id);
+        return Err("OpenCode request cancelled before prompt send".to_string());
+    }
 
     // 4. Connect SSE stream first, then send prompt
     let sse_agent = ureq::AgentBuilder::new()
@@ -1105,7 +1149,7 @@ fn run_session(
         .map_err(|e| format!("Failed to connect to OpenCode SSE stream: {e}"))?;
 
     // 5. Send prompt (non-blocking — server processes it while we read SSE)
-    send_prompt(
+    if let Err(error) = send_prompt(
         base_url,
         auth,
         &session_id,
@@ -1113,7 +1157,11 @@ fn run_session(
         system_prompt,
         allowed_tools,
         model,
-    )?;
+        cancel_token,
+    ) {
+        abort_session(base_url, auth, &session_id);
+        return Err(error);
+    }
 
     // 6. Read SSE stream
     let reader: BufReader<Box<dyn std::io::Read + Send>> =
@@ -1162,7 +1210,14 @@ fn wait_for_health(
     }
 }
 
-fn create_session(base_url: &str, auth: &str) -> Result<String, String> {
+fn create_session(
+    base_url: &str,
+    auth: &str,
+    cancel_token: Option<&CancelToken>,
+) -> Result<String, String> {
+    if is_cancelled(cancel_token) {
+        return Err("OpenCode request cancelled before session creation".to_string());
+    }
     let agent = session_request_agent();
     let response = agent
         .post(&format!("{base_url}/session"))
@@ -1174,6 +1229,9 @@ fn create_session(base_url: &str, auth: &str) -> Result<String, String> {
     let json: Value = response
         .into_json()
         .map_err(|e| format!("Failed to parse session response: {e}"))?;
+    if is_cancelled(cancel_token) {
+        return Err("OpenCode request cancelled after session creation".to_string());
+    }
 
     // Accept "id", "sessionID", or "session_id"
     ["id", "sessionID", "session_id"]
@@ -1191,7 +1249,11 @@ fn send_prompt(
     system_prompt: Option<&str>,
     allowed_tools: Option<&[String]>,
     model: Option<&OpenCodeModelRef>,
+    cancel_token: Option<&CancelToken>,
 ) -> Result<(), String> {
+    if is_cancelled(cancel_token) {
+        return Err("OpenCode request cancelled before prompt send".to_string());
+    }
     let body = build_prompt_body(prompt, system_prompt, allowed_tools, model);
 
     let agent = session_request_agent();
@@ -1203,6 +1265,9 @@ fn send_prompt(
         .map_err(|e| format!("Failed to send prompt to OpenCode: {e}"))?;
 
     let status = resp.status();
+    if is_cancelled(cancel_token) {
+        return Err("OpenCode request cancelled after prompt send".to_string());
+    }
     if status == 204 || (200..300).contains(&(status as u32)) {
         Ok(())
     } else {
@@ -1577,6 +1642,7 @@ fn consume_sse(
                         {
                             if server.try_begin_exclusive_hard_kill().is_ok() {
                                 kill_pid_tree(server.id());
+                                evict_warm_server_from_pool(server);
                             } else {
                                 let active = server.active_sessions.load(Ordering::SeqCst);
                                 tracing::warn!(
@@ -1649,8 +1715,6 @@ fn consume_sse_inner(
             }
         };
 
-        last_event = Instant::now();
-
         // Keep-alive comment
         if line.starts_with(':') || line.starts_with("event:") {
             continue;
@@ -1667,6 +1731,7 @@ fn consume_sse_inner(
             current_data.clear();
 
             if let Some(should_stop) = process_sse_event(&data, session_id, sender, &mut state) {
+                last_event = Instant::now();
                 if should_stop {
                     terminal_seen = true;
                     if !state.terminal_error {
@@ -2673,6 +2738,15 @@ mod tests {
     }
 
     #[test]
+    fn idle_disposal_sweep_claim_is_coalesced() {
+        let scheduled = AtomicBool::new(false);
+        assert!(claim_idle_disposal_sweep(&scheduled));
+        assert!(!claim_idle_disposal_sweep(&scheduled));
+        scheduled.store(false, Ordering::SeqCst);
+        assert!(claim_idle_disposal_sweep(&scheduled));
+    }
+
+    #[test]
     fn opencode_warm_server_key_canonicalizes_equivalent_working_dirs() {
         let cwd = std::env::current_dir().expect("current dir");
         let key_from_dot = warm_server_key("opencode", ".");
@@ -2833,6 +2907,35 @@ mod tests {
         // A non-secret colon token (e.g. a URL) is left intact.
         let s = scrub_startup_secrets("listening http://127.0.0.1:8080 ready");
         assert!(s.contains("http://127.0.0.1:8080"), "mangled url: {s}");
+    }
+
+    #[test]
+    fn process_sse_event_ignores_other_session_without_liveness_signal() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut state = SseMessageState::default();
+        let other = serde_json::json!({
+            "type": "message.updated",
+            "properties": {
+                "sessionID": "other-session",
+                "message": {"id": "m1", "role": "assistant"}
+            }
+        });
+        assert_eq!(
+            process_sse_event(&other.to_string(), "current-session", &tx, &mut state),
+            None
+        );
+
+        let current = serde_json::json!({
+            "type": "message.updated",
+            "properties": {
+                "sessionID": "current-session",
+                "message": {"id": "m2", "role": "assistant"}
+            }
+        });
+        assert_eq!(
+            process_sse_event(&current.to_string(), "current-session", &tx, &mut state),
+            Some(false)
+        );
     }
 
     /// [TEST-006] empty pool is cold-start safe: returns empty, no panic.

--- a/src/services/provider_exec.rs
+++ b/src/services/provider_exec.rs
@@ -1,8 +1,8 @@
 //! One-shot provider dispatch (#1100 boundary doc).
 //!
 //! This module is the single execution dispatch point for short-lived,
-//! prompt-in / text-out provider invocations: `execute_simple`,
-//! `execute_simple_with_timeout`, and `execute_structured`. It owns the
+//! prompt-in / text-out provider invocations: `execute_simple_with_timeout`
+//! and `execute_structured`. It owns the
 //! `ProviderKind` → provider-specific helper match, timeout/cancel wiring, and
 //! the small `collect_stream_result` helper.
 //!
@@ -30,12 +30,6 @@ use crate::services::process::kill_pid_tree;
 use crate::services::provider::{CancelToken, ProviderKind};
 use crate::services::provider_cli::ProviderExecutionContext;
 use crate::services::{claude, codex, gemini, opencode, qwen};
-
-pub async fn execute_simple(provider: ProviderKind, prompt: String) -> Result<String, String> {
-    tokio::task::spawn_blocking(move || execute_simple_blocking(provider, prompt, None, None))
-        .await
-        .map_err(|e| format!("Task join error: {}", e))?
-}
 
 pub async fn execute_simple_with_timeout(
     provider: ProviderKind,


### PR DESCRIPTION
## 목표
OpenCode provider가 매 turn마다 `opencode serve`를 새로 띄우는 대신 workspace별 warm serve process를 재사용하고, warm-pool 상태를 안전하게 진단/정리할 수 있게 합니다. 최신 `upstream/main` 위에서 OpenCode warm-server 관련 fork-only 커밋을 포트했습니다.

## 개선되는 것
- workspace key별 warm `opencode serve` process 재사용으로 cold-start 비용과 실패면을 줄입니다.
- shared warm-server PID를 per-turn cancel registry에 등록하지 않아 co-resident turn을 kill하지 않습니다.
- hard-kill fallback은 exclusive session일 때만 허용하고, hard-killed server는 pool에서 즉시 evict합니다.
- `/session`, SSE connect, `/prompt_async` pre-SSE 단계에 bounded request/cancel handling을 적용합니다.
- prompt/SSE setup/EOF failure 경로에서 server-side OpenCode session을 abort해 warm workspace mutation leak을 막습니다.
- shared `/global/event` stream에서는 현재 session으로 accepted된 이벤트만 liveness를 갱신합니다.
- idle disposal은 coalesced one-shot sweeper로 제한하고, TTL 미달 idle server가 남으면 재스케줄합니다.
- process-wide SIGTERM shutdown에서 warm pool을 drain하고, unrelated provider gateway exit에서는 global pool을 drain하지 않습니다.
- health/detail diagnostics는 secret-scrubbed snapshot과 count-only public surface로 제공합니다.

## 주요 파일
- `src/services/opencode.rs`: warm pool, lease/lock discipline, bounded pre-SSE requests, cancel/abort scoping, diagnostics, coalesced idle disposal
- `src/server/routes/health_api.rs`: OpenCode warm-server health/diagnostic surface
- `src/services/discord/runtime_bootstrap/shutdown.rs`: process-wide shutdown drain
- `docs/agent-maintenance/change-surfaces.md`: giant-file freeze counts

## 리뷰 반영
- inline `Authorization:Basic <cred>` / `auth:Bearer <cred>` startup tail redaction leak 수정
- prompt timeout/SSE setup failure/partial-text EOF/recovered EOF session abort 보강
- hard-kill cancel fallback 이후 pool residue 제거
- idle disposal missed wakeup 및 sweep flag race 보강
- SSE connect timeout 추가

## 검증
- `cargo fmt --all --check`
- `cargo test --all-targets opencode -- --skip _pg --skip pg_ --skip postgres` (20 passed)
- `python3 scripts/check_agent_maintenance_docs.py --base-ref upstream/main`
- `./scripts/ci-script-checks.sh`

## Analyzer Hygiene
- WorkFingerprint: this PR branch contains only the commits and files described above.
- verification: commands listed in `## 검증` were run locally on head `c35f5f5a6`.
- skipped checks: checks not listed above were not run locally; remote CI status is tracked separately by GitHub checks.
- rollback notes: revert this PR branch to restore the previous cold-start behavior.