### PR TITLE
fix(claude-tui): buffer hook events and reject stale stop readiness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -328,6 +328,7 @@ src/
 │   │   │   ├── mod.rs
 │   │   │   └── warm_followup.rs
 │   │   ├── hook_bundle.rs
+│   │   ├── hook_registry.rs
 │   │   ├── hook_relay.rs
 │   │   ├── hook_server.rs
 │   │   ├── hook_server_memento_tests.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -860,7 +860,7 @@
     nested `usage` on the success result frame so watcher-owned codex turns
     persist token telemetry — never the session-cumulative
     `info.total_token_usage`).
-  - `src/services/tui_prompt_dedupe.rs` (1601 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1613 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +176 from #3540: stable JSONL entry-identity
     (`uuid`) dedup — `extract_claude_transcript_user_prompt_with_entry_id`
@@ -1317,7 +1317,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2560 lines).
+  - `src/config.rs` (2378 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
@@ -1427,7 +1427,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1629) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1636) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -860,7 +860,7 @@
     nested `usage` on the success result frame so watcher-owned codex turns
     persist token telemetry — never the session-cumulative
     `info.total_token_usage`).
-  - `src/services/tui_prompt_dedupe.rs` (1569 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1601 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +176 from #3540: stable JSONL entry-identity
     (`uuid`) dedup — `extract_claude_transcript_user_prompt_with_entry_id`

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1317,7 +1317,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2340 lines).
+  - `src/config.rs` (2560 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1427,7 +1427,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1540) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1606) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1427,7 +1427,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1606) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1629) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -500,6 +500,12 @@
   HTTP helpers. This is **worker-local**: it touches only the recovered/finalized
   Discord message id on the worker processing that channel and adds no shared
   scheduling authority or cross-node lease dependency.
+- TUI hook registry upstream-port audit: `runtime_bootstrap.rs` bootstrap
+  wiring now feeds the Claude TUI hook buffer/claim registry, but the registry
+  is **worker-local** in-memory state scoped to a provider session / tmux key.
+  It adds no leader-only side effect, durable queue, cross-node singleton, or
+  PG lease; on restart it can only lose buffered hook events and falls back to
+  the legacy readiness path.
 - #3038 S1 (SharedData `QueuedPlaceholderState` extraction): `runtime_bootstrap.rs`
   changed in two helpers only — `run_bot_build_shared_data` (three consecutive
   queued-placeholder members wrapped into the new `queued:` group field;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1374,22 +1374,34 @@ pub struct RuntimeSettingsConfig {
     /// been buffered longer than this is swept and never replayed to a claiming
     /// listener, so a stale Stop from a previous turn cannot wake a fresh turn.
     /// When unset (or `0`) the compiled-in 30s default
-    /// (`hook_registry::DEFAULT_HOOK_BUFFER_TTL`) is used. Read live via
-    /// `config_live_reload::current()` so an `agentdesk.yaml` edit applies to the
-    /// next process; the runtime section is hot-reloadable (not restart-required).
+    /// (`hook_registry::DEFAULT_HOOK_BUFFER_TTL`) is used.
+    ///
+    /// NOT hot-reloadable: this value is captured ONCE when the process-global
+    /// `hook_registry::GLOBAL` is first accessed (effectively at process start)
+    /// and stored on the immutable `HookRegistry.ttl`. Editing it in
+    /// `agentdesk.yaml` takes effect only on the next process start (restart
+    /// required). Only `tui_hook_registry_enabled` is read live per-hook.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tui_hook_buffer_ttl_secs: Option<u64>,
     /// Diagnostic delay (milliseconds) before an unclaimed Stop in the TUI hook
     /// registry is considered "elapsed". Diagnostic-only in P0 — it never
     /// triggers a transcript sync or finalization. When unset (or `0`) the
     /// compiled-in 2000ms default (`hook_registry::DEFAULT_UNCLAIMED_STOP_DELAY`)
-    /// is used. Hot-reloadable via the runtime section.
+    /// is used.
+    ///
+    /// NOT hot-reloadable: like `tui_hook_buffer_ttl_secs`, this is captured ONCE
+    /// when `hook_registry::GLOBAL` is first accessed (process start) and stored
+    /// on the immutable `HookRegistry.unclaimed_stop_delay`. Editing it in
+    /// `agentdesk.yaml` takes effect only on the next process start (restart
+    /// required). Only `tui_hook_registry_enabled` is genuinely hot-reloadable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tui_unclaimed_stop_delay_ms: Option<u64>,
     /// Rollback switch for the TUI hook registry buffering layer. Defaults to ON
     /// (`None` => enabled). Set to `false` in `agentdesk.yaml` to stop feeding
     /// the registry from the hook receiver, leaving the legacy broadcast +
-    /// polling path exactly as before. Hot-reloadable (no restart required).
+    /// polling path exactly as before. Genuinely hot-reloadable (no restart
+    /// required): `registry_enabled()` reads it live per-hook. This is the ONLY
+    /// live-reloadable key of the three TUI hook registry settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tui_hook_registry_enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "is_false")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1370,6 +1370,28 @@ pub struct RuntimeSettingsConfig {
     /// the compiled-in 50 default; clamped to `1..=500` when set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_session_audit_max_candidates: Option<u64>,
+    /// TTL (seconds) for the in-memory TUI hook registry buffer. A hook that has
+    /// been buffered longer than this is swept and never replayed to a claiming
+    /// listener, so a stale Stop from a previous turn cannot wake a fresh turn.
+    /// When unset (or `0`) the compiled-in 30s default
+    /// (`hook_registry::DEFAULT_HOOK_BUFFER_TTL`) is used. Read live via
+    /// `config_live_reload::current()` so an `agentdesk.yaml` edit applies to the
+    /// next process; the runtime section is hot-reloadable (not restart-required).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tui_hook_buffer_ttl_secs: Option<u64>,
+    /// Diagnostic delay (milliseconds) before an unclaimed Stop in the TUI hook
+    /// registry is considered "elapsed". Diagnostic-only in P0 — it never
+    /// triggers a transcript sync or finalization. When unset (or `0`) the
+    /// compiled-in 2000ms default (`hook_registry::DEFAULT_UNCLAIMED_STOP_DELAY`)
+    /// is used. Hot-reloadable via the runtime section.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tui_unclaimed_stop_delay_ms: Option<u64>,
+    /// Rollback switch for the TUI hook registry buffering layer. Defaults to ON
+    /// (`None` => enabled). Set to `false` in `agentdesk.yaml` to stop feeding
+    /// the registry from the hook receiver, leaving the legacy broadcast +
+    /// polling path exactly as before. Hot-reloadable (no restart required).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tui_hook_registry_enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub reset_overrides_on_restart: bool,
 }
@@ -1404,7 +1426,67 @@ impl RuntimeSettingsConfig {
             && self.active_session_audit_enabled.is_none()
             && self.active_session_audit_stale_secs.is_none()
             && self.active_session_audit_max_candidates.is_none()
+            && self.tui_hook_buffer_ttl_secs.is_none()
+            && self.tui_unclaimed_stop_delay_ms.is_none()
+            && self.tui_hook_registry_enabled.is_none()
             && !self.reset_overrides_on_restart
+    }
+}
+
+#[cfg(test)]
+mod runtime_hook_registry_config_tests {
+    use super::*;
+
+    // #tui-hook-ttl-buffer: the new runtime keys participate in `is_empty` so a
+    // config that sets only one of them still serializes the `runtime` section
+    // (otherwise the `skip_serializing_if = "RuntimeSettingsConfig::is_empty"`
+    // on the parent would drop the operator's override on a round-trip).
+    #[test]
+    fn hook_registry_keys_count_toward_is_empty() {
+        assert!(RuntimeSettingsConfig::default().is_empty());
+
+        let ttl_only = RuntimeSettingsConfig {
+            tui_hook_buffer_ttl_secs: Some(45),
+            ..RuntimeSettingsConfig::default()
+        };
+        assert!(!ttl_only.is_empty());
+
+        let delay_only = RuntimeSettingsConfig {
+            tui_unclaimed_stop_delay_ms: Some(3000),
+            ..RuntimeSettingsConfig::default()
+        };
+        assert!(!delay_only.is_empty());
+
+        // The rollback flag also keeps the section alive when set to either bool.
+        let disabled = RuntimeSettingsConfig {
+            tui_hook_registry_enabled: Some(false),
+            ..RuntimeSettingsConfig::default()
+        };
+        assert!(!disabled.is_empty());
+    }
+
+    // The keys survive a YAML round-trip with their types intact, and an absent
+    // section deserializes to `None` (defaults applied by the consumer).
+    #[test]
+    fn hook_registry_keys_round_trip_through_yaml() {
+        let yaml = "tui_hook_buffer_ttl_secs: 60\n\
+                    tui_unclaimed_stop_delay_ms: 1500\n\
+                    tui_hook_registry_enabled: false\n";
+        let parsed: RuntimeSettingsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed.tui_hook_buffer_ttl_secs, Some(60));
+        assert_eq!(parsed.tui_unclaimed_stop_delay_ms, Some(1500));
+        assert_eq!(parsed.tui_hook_registry_enabled, Some(false));
+
+        let reserialized = serde_yaml::to_string(&parsed).unwrap();
+        let reparsed: RuntimeSettingsConfig = serde_yaml::from_str(&reserialized).unwrap();
+        assert_eq!(reparsed, parsed);
+
+        // Absent keys default to None so the consumer falls back to the
+        // compiled-in defaults (None-safe handling).
+        let empty: RuntimeSettingsConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(empty.tui_hook_buffer_ttl_secs, None);
+        assert_eq!(empty.tui_unclaimed_stop_delay_ms, None);
+        assert_eq!(empty.tui_hook_registry_enabled, None);
     }
 }
 

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -304,6 +304,25 @@ pub async fn agent_diag(
             "oldest_child_spawned_at": oldest_child_spawned_at,
             "children": child_inventory,
             "tui_prompt_readiness": tui_prompt_readiness,
+            // #tui-hook-ttl-buffer (TSK-P1-003 surfaced early per the missing
+            // output-schema contract): additive, process-global snapshot of the
+            // in-memory hook registry. New top-level field — existing diag
+            // consumers are unaffected. Shape is `HookRegistrySnapshot`
+            // (keys_tracked, buffered_event_count, claimed_keys, *_total
+            // counters, keys_with_unclaimed_stop). `null` only if serialization
+            // fails (it cannot for this plain struct).
+            "hook_registry": serde_json::to_value(
+                crate::services::claude_tui::hook_registry::global_snapshot()
+            ).ok(),
+            // #tui-hook-ttl-buffer (REQ-004): per-session unclaimed-Stop
+            // diagnostic for THIS key. `null` when no Stop is retained unclaimed
+            // for the session, when no key can be formed, or when the registry is
+            // disabled. Diagnostic only — nothing finalizes/syncs on it in P0.
+            "hook_unclaimed_stop": hook_unclaimed_stop_json(
+                session.provider.as_deref(),
+                tmux_name.as_deref(),
+                session.provider_session_id.as_deref(),
+            ),
             "last_tool": last_tool.map(|event| json!({
                 "tool_name": event.tool_name,
                 "summary": event.summary,
@@ -381,6 +400,34 @@ fn tui_prompt_readiness_json(
     _provider_session_id: Option<&str>,
 ) -> Option<Value> {
     None
+}
+
+/// #tui-hook-ttl-buffer (REQ-004): per-session unclaimed-Stop diagnostic for the
+/// diag payload. The hook receiver keys the registry by the `session_id` it
+/// observed (the provider session id when the hook reported one, else the tmux
+/// session name passed via the query string), so we probe both candidate keys —
+/// provider session id first, then tmux name — and return the first retained
+/// unclaimed Stop. Platform-independent (no tmux capture). `None` when the
+/// registry is disabled, no key can be formed, or no Stop is retained.
+fn hook_unclaimed_stop_json(
+    provider: Option<&str>,
+    tmux_name: Option<&str>,
+    provider_session_id: Option<&str>,
+) -> Option<Value> {
+    use crate::services::claude_tui::hook_registry;
+    if !hook_registry::registry_enabled() {
+        return None;
+    }
+    let provider = provider.map(str::trim).filter(|value| !value.is_empty())?;
+    let registry = hook_registry::global();
+    // Probe provider session id first, then the tmux fallback — whichever key
+    // the hook actually used wins.
+    [provider_session_id, tmux_name]
+        .into_iter()
+        .flatten()
+        .filter_map(|candidate| hook_registry::RegistryKey::new(provider, Some(candidate), None))
+        .find_map(|key| registry.unclaimed_stop_diagnostic(&key))
+        .and_then(|diag| serde_json::to_value(diag).ok())
 }
 
 #[cfg(unix)]

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -258,6 +258,7 @@ impl HookRegistry {
     pub fn deliver(&self, key: RegistryKey, event: HookEvent) -> DeliverOutcome {
         let now = Instant::now();
         let mut keys = self.lock();
+        self.sweep_empty_keys_locked(&mut keys, now);
         let state = keys.entry(key).or_default();
         Self::sweep_state(state, self.ttl, now);
 
@@ -538,6 +539,19 @@ impl HookRegistry {
 
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<RegistryKey, KeyState>> {
         self.keys.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn sweep_empty_keys_locked(&self, keys: &mut HashMap<RegistryKey, KeyState>, now: Instant) {
+        keys.retain(|_, state| {
+            Self::sweep_state(state, self.ttl, now);
+            let droppable =
+                state.buffer.is_empty() && !state.claimed && state.unclaimed_stop.is_none();
+            if droppable {
+                self.absorb_evicted_counters(state);
+                return false;
+            }
+            true
+        });
     }
 
     /// Drop expired entries from a key's buffer and clear an expired unclaimed
@@ -1033,6 +1047,26 @@ mod tests {
         assert_eq!(snap2.buffered_total, 1);
         assert_eq!(snap2.unclaimed_stop_total, 1);
         assert_eq!(snap2.keys_tracked, 0);
+    }
+
+    #[test]
+    fn deliver_sweeps_expired_empty_keys_without_snapshot() {
+        let reg = HookRegistry::new(Duration::from_millis(0), Duration::from_millis(2000));
+        let stale = key("claude", "stale");
+        reg.deliver(
+            stale.clone(),
+            event("claude", "stale", HookEventKind::Stop, json!({})),
+        );
+        let fresh = key("claude", "fresh");
+        reg.deliver(
+            fresh.clone(),
+            event("claude", "fresh", HookEventKind::Notification, json!({})),
+        );
+
+        let snap = reg.snapshot();
+        assert_eq!(snap.keys_tracked, 0);
+        assert_eq!(snap.buffered_total, 2);
+        assert!(snap.expired_total >= 2);
     }
 
     #[test]

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -424,7 +424,6 @@ impl HookRegistry {
         let matched = match matched_idx {
             Some(idx) => {
                 let removed = state.buffer.remove(idx);
-                state.replayed_total += 1;
                 self.replayed_once_total.fetch_add(1, Ordering::Relaxed);
                 // Consuming a Stop claims it: cancel the unclaimed-Stop diagnostic
                 // timer so a later turn's diagnostic does not report this
@@ -1079,6 +1078,11 @@ mod tests {
         assert_eq!(matched.unwrap().kind, HookEventKind::Stop);
         // The non-matching token payload is still buffered for a later token wait.
         assert_eq!(reg.buffered_len(&k), 1);
+        assert_eq!(
+            reg.snapshot().replayed_total,
+            1,
+            "selective replay must be counted exactly once while the key stays live"
+        );
         let token_match = reg.claim_matching_once(k.clone(), |e| {
             e.payload
                 .get("text")

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -253,6 +253,21 @@ impl HookRegistry {
             .fetch_add(state.empty_stop_total, Ordering::Relaxed);
     }
 
+    fn state_is_droppable(state: &KeyState) -> bool {
+        state.buffer.is_empty() && !state.claimed && state.unclaimed_stop.is_none()
+    }
+
+    fn sweep_and_evict_empty_keys(&self, keys: &mut HashMap<RegistryKey, KeyState>, now: Instant) {
+        keys.retain(|_, state| {
+            Self::sweep_state(state, self.ttl, now);
+            if Self::state_is_droppable(state) {
+                self.absorb_evicted_counters(state);
+                return false;
+            }
+            true
+        });
+    }
+
     /// Deliver an event into the registry. If a listener has claimed the key
     /// the event is delivered live (buffer stays drained); otherwise it is
     /// buffered for later replay, and a Stop additionally arms the diagnostic
@@ -261,8 +276,8 @@ impl HookRegistry {
     pub fn deliver(&self, key: RegistryKey, event: HookEvent) -> DeliverOutcome {
         let now = Instant::now();
         let mut keys = self.lock();
+        self.sweep_and_evict_empty_keys(&mut keys, now);
         let state = keys.entry(key).or_default();
-        Self::sweep_state(state, self.ttl, now);
 
         let is_stop = matches!(
             event.kind,
@@ -379,7 +394,7 @@ impl HookRegistry {
     /// counters (absorbed at the registry level so the totals stay monotonic).
     ///
     /// Test-only: production consumers (`/tui/wait`, the readiness wait) migrated
-    /// to [`claim_matching_once`], which consumes only the matching event and
+    /// to [`claim_matching_once`], which consumes matching events and
     /// re-buffers the rest so an unrelated waiter's buffered events are not
     /// discarded. The unconditional drain remains exercised by the unit tests
     /// that pin the REQ-002/REQ-003 single-consumption + replay-counting
@@ -408,10 +423,11 @@ impl HookRegistry {
         drained
     }
 
-    /// One-shot claim that consumes ONLY the events matching `wants`, leaving
-    /// every other fresh (unexpired) buffered event in place for a later waiter
-    /// to replay. Returns the newest matching event, or `None` when nothing
-    /// matches.
+    /// One-shot claim that consumes every event matching `wants`, leaving every
+    /// other fresh (unexpired) buffered event in place for a later waiter to
+    /// replay. Returns the newest matching event, or `None` when nothing
+    /// matches. Older matching events are intentionally discarded in the same
+    /// claim so a stale Stop cannot replay into a later turn.
     ///
     /// This is the selective variant of `claim_once` used by `/tui/wait`. The
     /// plain `claim_once` drains and drops the whole key, which discards buffered
@@ -430,33 +446,41 @@ impl HookRegistry {
     {
         let now = Instant::now();
         let mut keys = self.lock();
+        self.sweep_and_evict_empty_keys(&mut keys, now);
         let state = keys.get_mut(&key)?;
-        Self::sweep_state(state, self.ttl, now);
 
-        // Find the newest matching event (scan from the back; arrival order is
-        // preserved in the Vec). Remove exactly that one and keep the rest.
-        let matched_idx = state
-            .buffer
-            .iter()
-            .rposition(|buffered| wants(&buffered.event));
-        let matched = match matched_idx {
-            Some(idx) => {
-                let removed = state.buffer.remove(idx);
-                state.buffered_bytes = state.buffered_bytes.saturating_sub(removed.bytes);
-                self.replayed_once_total.fetch_add(1, Ordering::Relaxed);
-                // Consuming a Stop claims it: cancel the unclaimed-Stop diagnostic
-                // timer so a later turn's diagnostic does not report this
-                // now-claimed Stop as still pending.
-                if matches!(
-                    removed.event.kind,
+        let mut matched: Option<HookEvent> = None;
+        let mut consumed = 0u64;
+        let mut consumed_stop = false;
+        let mut retained = Vec::with_capacity(state.buffer.len());
+        let mut retained_bytes = 0usize;
+        for buffered in std::mem::take(&mut state.buffer) {
+            if wants(&buffered.event) {
+                consumed += 1;
+                consumed_stop |= matches!(
+                    buffered.event.kind,
                     HookEventKind::Stop | HookEventKind::SubagentStop
-                ) {
-                    state.unclaimed_stop = None;
-                }
-                Some(removed.event)
+                );
+                // Iteration preserves arrival order, so the last match is the
+                // newest matching event returned to the caller.
+                matched = Some(buffered.event);
+            } else {
+                retained_bytes += buffered.bytes;
+                retained.push(buffered);
             }
-            None => None,
-        };
+        }
+        state.buffer = retained;
+        state.buffered_bytes = retained_bytes;
+        if consumed > 0 {
+            self.replayed_once_total
+                .fetch_add(consumed, Ordering::Relaxed);
+        }
+        if consumed_stop {
+            // Consuming a Stop claims every buffered Stop for this key: cancel the
+            // unclaimed-Stop diagnostic so a later turn cannot report any of
+            // these now-consumed Stops as pending.
+            state.unclaimed_stop = None;
+        }
 
         // If the buffer is now empty and the key has nothing else to retain, drop
         // it to bound map growth (mirrors the snapshot eviction policy); its
@@ -478,14 +502,25 @@ impl HookRegistry {
     pub fn unclaimed_stop_diagnostic(&self, key: &RegistryKey) -> Option<UnclaimedStopDiagnostic> {
         let now = Instant::now();
         let mut keys = self.lock();
-        let state = keys.get_mut(key)?;
-        Self::sweep_state(state, self.ttl, now);
-        let stop = state.unclaimed_stop.as_ref()?;
-        Some(UnclaimedStopDiagnostic {
-            kind: stop.kind.as_str().to_string(),
-            qualifying: stop.qualifying,
-            delay_elapsed: now.duration_since(stop.armed_at) >= self.unclaimed_stop_delay,
-        })
+        let diagnostic = {
+            let state = keys.get_mut(key)?;
+            Self::sweep_state(state, self.ttl, now);
+            state
+                .unclaimed_stop
+                .as_ref()
+                .map(|stop| UnclaimedStopDiagnostic {
+                    kind: stop.kind.as_str().to_string(),
+                    qualifying: stop.qualifying,
+                    delay_elapsed: now.duration_since(stop.armed_at) >= self.unclaimed_stop_delay,
+                })
+        };
+        if diagnostic.is_none()
+            && keys.get(key).is_some_and(Self::state_is_droppable)
+            && let Some(removed) = keys.remove(key)
+        {
+            self.absorb_evicted_counters(&removed);
+        }
+        diagnostic
     }
 
     /// Number of currently-buffered (unconsumed, unexpired) events for `key`,
@@ -1153,7 +1188,7 @@ mod tests {
             k.clone(),
             event("claude", "sid", HookEventKind::Stop, json!({})),
         );
-        // A Stop waiter consumes ONLY the Stop.
+        // A Stop waiter consumes matching Stops only.
         let matched = reg.claim_matching_once(k.clone(), |e| {
             matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)
         });
@@ -1178,6 +1213,65 @@ mod tests {
         );
         // Now the buffer is drained and the empty key is evicted.
         assert_eq!(reg.buffered_len(&k), 0);
+    }
+
+    #[test]
+    fn claim_matching_once_consumes_all_matching_stops() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event(
+                "claude",
+                "sid",
+                HookEventKind::Stop,
+                json!({ "marker": "old" }),
+            ),
+        );
+        reg.deliver(
+            k.clone(),
+            event(
+                "claude",
+                "sid",
+                HookEventKind::Notification,
+                json!({ "text": "TOKEN-XYZ here" }),
+            ),
+        );
+        reg.deliver(
+            k.clone(),
+            event(
+                "claude",
+                "sid",
+                HookEventKind::SubagentStop,
+                json!({ "marker": "new" }),
+            ),
+        );
+
+        let matched = reg
+            .claim_matching_once(k.clone(), |e| {
+                matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)
+            })
+            .expect("newest Stop returned");
+        assert_eq!(matched.kind, HookEventKind::SubagentStop);
+        assert_eq!(matched.payload["marker"], "new");
+        assert_eq!(
+            reg.buffered_len(&k),
+            1,
+            "only the non-matching token payload remains buffered"
+        );
+        assert!(
+            reg.claim_matching_once(k.clone(), |e| {
+                matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)
+            })
+            .is_none(),
+            "older matching Stops must be consumed in the first claim"
+        );
+        assert!(reg.unclaimed_stop_diagnostic(&k).is_none());
+        assert_eq!(
+            reg.snapshot().replayed_total,
+            2,
+            "both matching Stops are consumed exactly once"
+        );
     }
 
     #[test]

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -56,18 +56,19 @@ pub const DEFAULT_HOOK_BUFFER_TTL: Duration = Duration::from_secs(30);
 /// (`tui_unclaimed_stop_delay_ms=2000`).
 pub const DEFAULT_UNCLAIMED_STOP_DELAY: Duration = Duration::from_millis(2000);
 
-/// Hard cap on the number of buffered events retained per `(provider, session)`
-/// key. The hook receiver accepts bodies up to 8 MiB and the per-key buffer is
+/// Hard caps on buffered hook replay retained per `(provider, session)` key.
+/// The hook receiver accepts bodies up to 8 MiB and the per-key buffer is
 /// otherwise unbounded within the TTL window, so a busy or noisy session could
-/// accumulate arbitrary memory before its events expire. When the cap is hit we
-/// drop the OLDEST buffered event (front of the Vec) to make room for the new
+/// accumulate arbitrary memory before its events expire. When either cap is hit
+/// we drop the OLDEST buffered event (front of the Vec) to make room for the new
 /// one: replay/claim only cares about the freshest Stop / token hit (callers
 /// scan newest-first), so evicting the stale front never loses the signal a
 /// fresh wait is looking for. A dropped-for-capacity event is counted into
 /// `expired_total` (it is, semantically, dropped before its TTL the same way an
-/// expired event is). Keeping this bounded also bounds total registry memory at
-/// `keys * MAX_BUFFERED_EVENTS_PER_KEY` buffered events.
+/// expired event is). Keeping both caps bounded prevents one key from retaining
+/// an unbounded number of events or a small number of very large payloads.
 pub const MAX_BUFFERED_EVENTS_PER_KEY: usize = 64;
+pub const MAX_BUFFERED_BYTES_PER_KEY: usize = 1024 * 1024;
 
 /// Composite registry key. Provider is always part of the key so the same id
 /// (a shared tmux session name) under two providers never cross-leaks. The
@@ -114,12 +115,13 @@ impl RegistryKey {
 struct BufferedEvent {
     event: HookEvent,
     buffered_at: Instant,
+    bytes: usize,
 }
 
 /// The newest unclaimed qualifying Stop retained for diagnostics (REQ-004).
 #[derive(Clone, Debug)]
 struct UnclaimedStop {
-    event: HookEvent,
+    kind: HookEventKind,
     armed_at: Instant,
     /// `false` for an empty Stop / one missing `last_assistant_message`: still
     /// counted, but flagged so P1 can refuse to sync on it.
@@ -133,6 +135,7 @@ struct KeyState {
     claimed: bool,
     /// Newest unclaimed Stop retained for diagnostics, if any.
     unclaimed_stop: Option<UnclaimedStop>,
+    buffered_bytes: usize,
     // ---- monotonically-increasing diagnostic counters (additive) ----
     buffered_total: u64,
     replayed_total: u64,
@@ -187,7 +190,7 @@ pub struct HookRegistrySnapshot {
     pub buffered_total: u64,
     /// Cumulative events ever replayed to a claiming listener.
     pub replayed_total: u64,
-    /// Cumulative events dropped because they exceeded the TTL.
+    /// Cumulative events dropped because they exceeded TTL or replay-buffer caps.
     pub expired_total: u64,
     /// Cumulative unclaimed Stop events observed (qualifying + non-qualifying).
     pub unclaimed_stop_total: u64,
@@ -258,7 +261,6 @@ impl HookRegistry {
     pub fn deliver(&self, key: RegistryKey, event: HookEvent) -> DeliverOutcome {
         let now = Instant::now();
         let mut keys = self.lock();
-        self.sweep_empty_keys_locked(&mut keys, now);
         let state = keys.entry(key).or_default();
         Self::sweep_state(state, self.ttl, now);
 
@@ -287,25 +289,38 @@ impl HookRegistry {
                 state.empty_stop_total += 1;
             }
             state.unclaimed_stop = Some(UnclaimedStop {
-                event: event.clone(),
+                kind: event.kind.clone(),
                 armed_at: now,
                 qualifying,
             });
         }
 
-        // Bound the per-key buffer: if at capacity, drop the OLDEST event to make
-        // room. Claim/replay scans newest-first, so the freshest Stop / token hit
-        // is preserved; only stale front entries are evicted. Count the eviction
-        // as an expiry (it is dropped-before-TTL the same way).
-        if state.buffer.len() >= MAX_BUFFERED_EVENTS_PER_KEY {
-            let overflow = state.buffer.len() + 1 - MAX_BUFFERED_EVENTS_PER_KEY;
-            state.buffer.drain(0..overflow);
-            state.expired_total += overflow as u64;
+        let event_bytes = buffered_event_bytes(&event);
+        if event_bytes <= MAX_BUFFERED_BYTES_PER_KEY {
+            // Bound the per-key buffer: if at capacity, drop the OLDEST event to
+            // make room. Claim/replay scans newest-first, so the freshest Stop /
+            // token hit is preserved; only stale front entries are evicted.
+            // Count the eviction as an expiry (it is dropped-before-TTL the same
+            // way).
+            while state.buffer.len() + 1 > MAX_BUFFERED_EVENTS_PER_KEY
+                || state.buffered_bytes + event_bytes > MAX_BUFFERED_BYTES_PER_KEY
+            {
+                if state.buffer.is_empty() {
+                    break;
+                }
+                let removed = state.buffer.remove(0);
+                state.buffered_bytes = state.buffered_bytes.saturating_sub(removed.bytes);
+                state.expired_total += 1;
+            }
+            state.buffered_bytes += event_bytes;
+            state.buffer.push(BufferedEvent {
+                event,
+                buffered_at: now,
+                bytes: event_bytes,
+            });
+        } else {
+            state.expired_total += 1;
         }
-        state.buffer.push(BufferedEvent {
-            event,
-            buffered_at: now,
-        });
         state.buffered_total += 1;
         if is_stop {
             DeliverOutcome::UnclaimedStopArmed
@@ -339,6 +354,7 @@ impl HookRegistry {
             .into_iter()
             .map(|buffered| buffered.event)
             .collect();
+        state.buffered_bytes = 0;
         state.replayed_total += drained.len() as u64;
         drained
     }
@@ -380,6 +396,7 @@ impl HookRegistry {
             .into_iter()
             .map(|buffered| buffered.event)
             .collect();
+        state.buffered_bytes = 0;
         // The key (and its per-key counters) is dropped here, so record the
         // replay and absorb the cumulative diagnostics at the registry level —
         // otherwise the advertised totals would lose this key's history.
@@ -425,6 +442,7 @@ impl HookRegistry {
         let matched = match matched_idx {
             Some(idx) => {
                 let removed = state.buffer.remove(idx);
+                state.buffered_bytes = state.buffered_bytes.saturating_sub(removed.bytes);
                 self.replayed_once_total.fetch_add(1, Ordering::Relaxed);
                 // Consuming a Stop claims it: cancel the unclaimed-Stop diagnostic
                 // timer so a later turn's diagnostic does not report this
@@ -464,7 +482,7 @@ impl HookRegistry {
         Self::sweep_state(state, self.ttl, now);
         let stop = state.unclaimed_stop.as_ref()?;
         Some(UnclaimedStopDiagnostic {
-            kind: stop.event.kind.as_str().to_string(),
+            kind: stop.kind.as_str().to_string(),
             qualifying: stop.qualifying,
             delay_elapsed: now.duration_since(stop.armed_at) >= self.unclaimed_stop_delay,
         })
@@ -481,6 +499,19 @@ impl HookRegistry {
             Some(state) => {
                 Self::sweep_state(state, self.ttl, now);
                 state.buffer.len()
+            }
+            None => 0,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn buffered_bytes(&self, key: &RegistryKey) -> usize {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        match keys.get_mut(key) {
+            Some(state) => {
+                Self::sweep_state(state, self.ttl, now);
+                state.buffered_bytes
             }
             None => 0,
         }
@@ -541,27 +572,20 @@ impl HookRegistry {
         self.keys.lock().unwrap_or_else(|e| e.into_inner())
     }
 
-    fn sweep_empty_keys_locked(&self, keys: &mut HashMap<RegistryKey, KeyState>, now: Instant) {
-        keys.retain(|_, state| {
-            Self::sweep_state(state, self.ttl, now);
-            let droppable =
-                state.buffer.is_empty() && !state.claimed && state.unclaimed_stop.is_none();
-            if droppable {
-                self.absorb_evicted_counters(state);
-                return false;
-            }
-            true
-        });
-    }
-
     /// Drop expired entries from a key's buffer and clear an expired unclaimed
     /// Stop. Counts expirations into the diagnostic counter. Pure on `state`.
     fn sweep_state(state: &mut KeyState, ttl: Duration, now: Instant) {
-        let before = state.buffer.len();
-        state
-            .buffer
-            .retain(|buffered| now.duration_since(buffered.buffered_at) < ttl);
-        let expired = before - state.buffer.len();
+        let mut expired = 0usize;
+        let mut expired_bytes = 0usize;
+        state.buffer.retain(|buffered| {
+            let keep = now.duration_since(buffered.buffered_at) < ttl;
+            if !keep {
+                expired += 1;
+                expired_bytes += buffered.bytes;
+            }
+            keep
+        });
+        state.buffered_bytes = state.buffered_bytes.saturating_sub(expired_bytes);
         state.expired_total += expired as u64;
 
         if let Some(stop) = state.unclaimed_stop.as_ref() {
@@ -588,6 +612,13 @@ fn stop_is_qualifying(event: &HookEvent) -> bool {
         .as_str()
         .map(|text| !text.trim().is_empty())
         .unwrap_or(false)
+}
+
+fn buffered_event_bytes(event: &HookEvent) -> usize {
+    event.provider.len()
+        + event.session_id.len()
+        + event.kind.as_str().len()
+        + event.payload.to_string().len()
 }
 
 /// Process-global registry, lazily built from the live config TTL / delay
@@ -1018,6 +1049,24 @@ mod tests {
         let snap = reg.snapshot();
         assert_eq!(snap.expired_total, 10);
         assert_eq!(snap.buffered_total, total as u64);
+    }
+
+    #[test]
+    fn oversized_payload_is_not_retained_in_replay_buffer() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        let payload = json!({ "blob": "x".repeat(MAX_BUFFERED_BYTES_PER_KEY + 1) });
+
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Notification, payload),
+        );
+
+        assert_eq!(reg.buffered_len(&k), 0);
+        assert_eq!(reg.buffered_bytes(&k), 0);
+        let snap = reg.snapshot();
+        assert_eq!(snap.buffered_total, 1);
+        assert_eq!(snap.expired_total, 1);
     }
 
     // -------- empty expired key eviction (snapshot) --------

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -1,0 +1,791 @@
+//! In-memory hook registry with TTL buffering and claim/replay semantics.
+//!
+//! Ported from Jinn's `gateway/hook-registry.ts` race pattern. The existing
+//! `hook_server` broadcast + `prompt_ready_notify()` are **edge-triggered**: a
+//! Stop / SessionStart hook that lands before a consumer subscribes is dropped
+//! and a turn resolver that times out cannot recover the early evidence. That
+//! produces prompt-readiness / finalization races that are hard to tell apart
+//! from a real TUI hang.
+//!
+//! This module adds a **focused, additive** layer on top of the existing
+//! broadcast (it does NOT replace it): every accepted hook is *also* buffered
+//! here, keyed by `(provider, session_key)`, where `session_key` prefers the
+//! provider session id and falls back to the tmux session name. A late
+//! consumer can `claim` its key and replay the fresh buffered events exactly
+//! once; expired or consumed events are dropped so a stale Stop from a previous
+//! turn can never wake a fresh turn.
+//!
+//! ## Invariants (load-bearing — see PRD REQ-001..REQ-006)
+//!
+//! 1. **Composite key includes provider.** `(provider="claude", id="ABC")` and
+//!    `(provider="codex", id="ABC")` are *different* keys and never leak into
+//!    each other's claim. Channel id alone is never a valid key.
+//! 2. **Single consumption.** Claiming a key drains its fresh buffer exactly
+//!    once. A second claim of the same key (without new deliveries) replays
+//!    nothing. Unregister drops listener state so a future turn cannot replay
+//!    consumed hooks.
+//! 3. **TTL.** An event older than the configured TTL is never replayed; it is
+//!    swept lazily on the next `deliver` / `claim` / `snapshot` touch for that
+//!    key, so there is no background task and no blocking I/O on the hook
+//!    receiver path. The sweep is O(buffer length for that key).
+//! 4. **Broadcast is untouched.** The `hook_server` broadcast and Codex
+//!    `try_recv()` observer path keep firing for every event exactly as before.
+//!    The registry is a parallel buffer; it does not gate, drop, or reorder the
+//!    broadcast.
+//! 5. **Unclaimed Stop is diagnostic-only in P0.** A Stop that arrives with no
+//!    claimed listener increments a counter and (for a qualifying Stop) is
+//!    retained as the newest unclaimed Stop. An empty Stop / one missing
+//!    `last_assistant_message` is *counted* but flagged non-qualifying so P1 can
+//!    decide whether to trigger a transcript sync; P0 never syncs or finalizes.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+use crate::services::claude_tui::hook_server::{HookEvent, HookEventKind};
+
+/// Compiled-in fallback TTL for buffered hooks when the runtime override is
+/// unset. Matches the PRD default (`tui_hook_buffer_ttl_secs=30`).
+pub const DEFAULT_HOOK_BUFFER_TTL: Duration = Duration::from_secs(30);
+
+/// Compiled-in fallback diagnostic delay for unclaimed Stop handling when the
+/// runtime override is unset. Matches the PRD default
+/// (`tui_unclaimed_stop_delay_ms=2000`).
+pub const DEFAULT_UNCLAIMED_STOP_DELAY: Duration = Duration::from_millis(2000);
+
+/// Composite registry key. Provider is always part of the key so the same id
+/// (a shared tmux session name) under two providers never cross-leaks. The
+/// `session_key` is the provider session id when known, else the tmux session
+/// name. Channel id alone is intentionally NOT representable here — callers map
+/// channel -> tmux session before keying.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RegistryKey {
+    pub provider: String,
+    pub session_key: String,
+}
+
+impl RegistryKey {
+    /// Build a key from a provider plus the preferred provider session id and
+    /// an optional tmux session fallback. Returns `None` when neither a
+    /// provider session id nor a tmux session name is available (channel alone
+    /// is never a valid key — REQ-001).
+    pub fn new(
+        provider: &str,
+        provider_session_id: Option<&str>,
+        tmux_session_name: Option<&str>,
+    ) -> Option<Self> {
+        let provider = provider.trim().to_ascii_lowercase();
+        if provider.is_empty() {
+            return None;
+        }
+        let session_key = provider_session_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| tmux_session_name.map(str::trim).filter(|v| !v.is_empty()))?
+            .to_string();
+        Some(Self {
+            provider,
+            session_key,
+        })
+    }
+}
+
+/// A buffered hook plus the monotonic instant it was buffered, used for TTL
+/// sweeps. We keep the original `HookEvent` (which already carries a wall-clock
+/// `received_at`) and add a monotonic `buffered_at` so TTL math is immune to
+/// wall-clock jumps.
+#[derive(Clone, Debug)]
+struct BufferedEvent {
+    event: HookEvent,
+    buffered_at: Instant,
+}
+
+/// The newest unclaimed qualifying Stop retained for diagnostics (REQ-004).
+#[derive(Clone, Debug)]
+struct UnclaimedStop {
+    event: HookEvent,
+    armed_at: Instant,
+    /// `false` for an empty Stop / one missing `last_assistant_message`: still
+    /// counted, but flagged so P1 can refuse to sync on it.
+    qualifying: bool,
+}
+
+/// Per-key state: the fresh (unconsumed) buffer plus diagnostic counters.
+#[derive(Default)]
+struct KeyState {
+    buffer: Vec<BufferedEvent>,
+    claimed: bool,
+    /// Newest unclaimed Stop retained for diagnostics, if any.
+    unclaimed_stop: Option<UnclaimedStop>,
+    // ---- monotonically-increasing diagnostic counters (additive) ----
+    buffered_total: u64,
+    replayed_total: u64,
+    expired_total: u64,
+    unclaimed_stop_total: u64,
+    empty_stop_total: u64,
+}
+
+/// Outcome of delivering a single event into the registry. Returned so the
+/// caller (and tests) can assert what happened without reaching into private
+/// state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeliverOutcome {
+    /// The event was buffered for a not-yet-claimed key.
+    Buffered,
+    /// A claimed listener exists; the event is delivered live (the buffer stays
+    /// drained) and not retained for replay.
+    DeliveredLive,
+    /// An unclaimed Stop armed/refreshed the diagnostic timer.
+    UnclaimedStopArmed,
+}
+
+/// Serializable, additive per-key diagnostic for a retained unclaimed Stop.
+/// Surfaced on the per-session `/diag` payload so operators can tell whether a
+/// terminal Stop landed with no consumer claiming the key (the early-Stop race
+/// this registry exists to make observable). Diagnostic-only in P0 — nothing
+/// finalizes or syncs on it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct UnclaimedStopDiagnostic {
+    /// Hook kind of the retained unclaimed Stop (`stop` / `subagent_stop`).
+    pub kind: String,
+    /// `true` when the Stop carried a non-empty `last_assistant_message`.
+    /// `false` for an empty Stop that is counted but must not drive a sync.
+    pub qualifying: bool,
+    /// `true` once the configured `tui_unclaimed_stop_delay_ms` has elapsed with
+    /// the Stop still unclaimed.
+    pub delay_elapsed: bool,
+}
+
+/// Serializable, additive observability snapshot of the registry. Exposed for
+/// `/diag`-style telemetry; every field is additive (new), so existing API
+/// consumers are unaffected.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct HookRegistrySnapshot {
+    /// Number of distinct live keys currently tracked.
+    pub keys_tracked: usize,
+    /// Sum of currently-buffered (unconsumed, unexpired) events across keys.
+    pub buffered_event_count: usize,
+    /// Number of keys that currently have a claimed listener.
+    pub claimed_keys: usize,
+    /// Cumulative events ever buffered.
+    pub buffered_total: u64,
+    /// Cumulative events ever replayed to a claiming listener.
+    pub replayed_total: u64,
+    /// Cumulative events dropped because they exceeded the TTL.
+    pub expired_total: u64,
+    /// Cumulative unclaimed Stop events observed (qualifying + non-qualifying).
+    pub unclaimed_stop_total: u64,
+    /// Cumulative empty / non-qualifying Stop events observed.
+    pub empty_stop_total: u64,
+    /// Keys that currently hold a retained unclaimed Stop for diagnostics.
+    pub keys_with_unclaimed_stop: usize,
+}
+
+/// The registry itself. Cheap to construct; the process uses one global
+/// instance via [`global`], but tests construct isolated instances.
+pub struct HookRegistry {
+    keys: Mutex<HashMap<RegistryKey, KeyState>>,
+    ttl: Duration,
+    unclaimed_stop_delay: Duration,
+}
+
+impl HookRegistry {
+    pub fn new(ttl: Duration, unclaimed_stop_delay: Duration) -> Self {
+        Self {
+            keys: Mutex::new(HashMap::new()),
+            ttl,
+            unclaimed_stop_delay,
+        }
+    }
+
+    /// Deliver an event into the registry. If a listener has claimed the key
+    /// the event is delivered live (buffer stays drained); otherwise it is
+    /// buffered for later replay, and a Stop additionally arms the diagnostic
+    /// timer. Always sweeps expired entries for the touched key first so a
+    /// stale Stop can never linger past its TTL. O(buffer length for the key).
+    pub fn deliver(&self, key: RegistryKey, event: HookEvent) -> DeliverOutcome {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        let state = keys.entry(key).or_default();
+        Self::sweep_state(state, self.ttl, now);
+
+        let is_stop = matches!(
+            event.kind,
+            HookEventKind::Stop | HookEventKind::SubagentStop
+        );
+
+        if state.claimed {
+            // A live listener already consumed this key's history; do not retain
+            // for replay (single-consumption). The live path observes the event
+            // through the broadcast; we just record diagnostics.
+            state.buffered_total += 1;
+            if is_stop {
+                // A claimed key's Stop must NOT count as an unclaimed Stop — the
+                // listener owns it (REQ-004: claimed event cannot trigger
+                // fallback).
+            }
+            return DeliverOutcome::DeliveredLive;
+        }
+
+        if is_stop {
+            let qualifying = stop_is_qualifying(&event);
+            state.unclaimed_stop_total += 1;
+            if !qualifying {
+                state.empty_stop_total += 1;
+            }
+            state.unclaimed_stop = Some(UnclaimedStop {
+                event: event.clone(),
+                armed_at: now,
+                qualifying,
+            });
+        }
+
+        state.buffer.push(BufferedEvent {
+            event,
+            buffered_at: now,
+        });
+        state.buffered_total += 1;
+        if is_stop {
+            DeliverOutcome::UnclaimedStopArmed
+        } else {
+            DeliverOutcome::Buffered
+        }
+    }
+
+    /// Claim a key: mark it claimed, cancel any unclaimed Stop diagnostic timer,
+    /// and return the fresh (unexpired) buffered events exactly once. A second
+    /// claim with no new deliveries returns an empty vec (single-consumption).
+    ///
+    /// This long-lived claim variant (mark claimed + keep listener state) is the
+    /// API P1 consumers (Codex rollout tail, transcript finalization — see
+    /// TSK-P1-001) will migrate onto. P0 production consumers use `claim_once`
+    /// (claim + immediate unregister). The lower-level claim/unregister pair is
+    /// exercised by the unit tests that pin the REQ-002/REQ-003 semantics, so it
+    /// is compiled under `#[cfg(test)]` until the P1 wiring lands.
+    #[cfg(test)]
+    pub fn claim(&self, key: RegistryKey) -> Vec<HookEvent> {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        let state = keys.entry(key).or_default();
+        Self::sweep_state(state, self.ttl, now);
+
+        state.claimed = true;
+        // Claiming cancels the unclaimed Stop timer for this key (REQ-002).
+        state.unclaimed_stop = None;
+
+        let drained: Vec<HookEvent> = std::mem::take(&mut state.buffer)
+            .into_iter()
+            .map(|buffered| buffered.event)
+            .collect();
+        state.replayed_total += drained.len() as u64;
+        drained
+    }
+
+    /// Unregister a claim: drop the listener state so future stale events are
+    /// not replayed to a later turn (REQ-003). Counters are reset along with the
+    /// key so a new turn starts clean; the key is removed entirely when empty.
+    /// Pairs with the long-lived `claim`; test-only until the P1 wiring lands
+    /// (P0 uses `claim_once`).
+    #[cfg(test)]
+    pub fn unregister(&self, key: &RegistryKey) {
+        let mut keys = self.lock();
+        keys.remove(key);
+    }
+
+    /// One-shot claim used by short-lived consumers (e.g. `/tui/wait`): drain
+    /// the fresh buffer exactly once AND immediately drop the listener state so
+    /// the key returns to buffering mode for the next turn. This is the
+    /// claim+unregister pair as a single atomic-ish operation; it gives
+    /// single-consumption of the current turn's early events while keeping the
+    /// registry useful for the next turn's early-Stop race (REQ-002 + REQ-003).
+    /// Dropping the key resets its per-key counters; the global `snapshot`
+    /// aggregates only live keys, so a transient consumer that claims and leaves
+    /// does not inflate the long-lived diagnostic totals.
+    pub fn claim_once(&self, key: RegistryKey) -> Vec<HookEvent> {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        let Some(mut state) = keys.remove(&key) else {
+            return Vec::new();
+        };
+        Self::sweep_state(&mut state, self.ttl, now);
+        std::mem::take(&mut state.buffer)
+            .into_iter()
+            .map(|buffered| buffered.event)
+            .collect()
+    }
+
+    /// Per-key diagnostic for the retained unclaimed Stop, or `None` when none is
+    /// retained (no Stop seen, or it was claimed/expired). Reports the Stop kind,
+    /// whether it qualified (non-empty `last_assistant_message`), and whether the
+    /// configured `tui_unclaimed_stop_delay_ms` has elapsed with the Stop still
+    /// unclaimed. Diagnostic only in P0 — surfaced on `/diag`; nothing finalizes
+    /// or syncs on it. Sweeps the key first so an expired Stop reports `None`.
+    pub fn unclaimed_stop_diagnostic(&self, key: &RegistryKey) -> Option<UnclaimedStopDiagnostic> {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        let state = keys.get_mut(key)?;
+        Self::sweep_state(state, self.ttl, now);
+        let stop = state.unclaimed_stop.as_ref()?;
+        Some(UnclaimedStopDiagnostic {
+            kind: stop.event.kind.as_str().to_string(),
+            qualifying: stop.qualifying,
+            delay_elapsed: now.duration_since(stop.armed_at) >= self.unclaimed_stop_delay,
+        })
+    }
+
+    /// Number of currently-buffered (unconsumed, unexpired) events for `key`,
+    /// after sweeping expired entries. Test-only contract pin (production reads
+    /// the aggregate via `snapshot`).
+    #[cfg(test)]
+    pub fn buffered_len(&self, key: &RegistryKey) -> usize {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        match keys.get_mut(key) {
+            Some(state) => {
+                Self::sweep_state(state, self.ttl, now);
+                state.buffer.len()
+            }
+            None => 0,
+        }
+    }
+
+    /// Build an additive observability snapshot. Sweeps every key first so the
+    /// reported buffered count excludes expired events. O(total buffered).
+    pub fn snapshot(&self) -> HookRegistrySnapshot {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        let mut snap = HookRegistrySnapshot::default();
+        for state in keys.values_mut() {
+            Self::sweep_state(state, self.ttl, now);
+            snap.buffered_event_count += state.buffer.len();
+            if state.claimed {
+                snap.claimed_keys += 1;
+            }
+            if state.unclaimed_stop.is_some() {
+                snap.keys_with_unclaimed_stop += 1;
+            }
+            snap.buffered_total += state.buffered_total;
+            snap.replayed_total += state.replayed_total;
+            snap.expired_total += state.expired_total;
+            snap.unclaimed_stop_total += state.unclaimed_stop_total;
+            snap.empty_stop_total += state.empty_stop_total;
+        }
+        snap.keys_tracked = keys.len();
+        snap
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<RegistryKey, KeyState>> {
+        self.keys.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Drop expired entries from a key's buffer and clear an expired unclaimed
+    /// Stop. Counts expirations into the diagnostic counter. Pure on `state`.
+    fn sweep_state(state: &mut KeyState, ttl: Duration, now: Instant) {
+        let before = state.buffer.len();
+        state
+            .buffer
+            .retain(|buffered| now.duration_since(buffered.buffered_at) < ttl);
+        let expired = before - state.buffer.len();
+        state.expired_total += expired as u64;
+
+        if let Some(stop) = state.unclaimed_stop.as_ref() {
+            if now.duration_since(stop.armed_at) >= ttl {
+                state.unclaimed_stop = None;
+            }
+        }
+    }
+}
+
+/// Whether a Stop event "qualifies" for diagnostic retention: it must carry a
+/// non-empty `last_assistant_message`. An empty Stop body (the common case for
+/// the Claude TUI) or a missing `last_assistant_message` is still *counted* but
+/// flagged non-qualifying so P0 never syncs / finalizes on it (REQ-004).
+fn stop_is_qualifying(event: &HookEvent) -> bool {
+    let Some(message) = event
+        .payload
+        .get("last_assistant_message")
+        .or_else(|| event.payload.get("lastAssistantMessage"))
+    else {
+        return false;
+    };
+    message
+        .as_str()
+        .map(|text| !text.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Process-global registry, lazily built from the live config TTL / delay
+/// overrides at first access. Subsequent calls reuse the same instance — the
+/// TTL is captured at construction; a hot-reload of the TTL takes effect for
+/// the next process (a restart) OR can be observed by reading the live config
+/// in the caller before invoking diagnostic helpers. For P0 the registry is
+/// additive and disabled by a config flag, so capturing-at-first-access keeps
+/// the lock-free hot path simple.
+static GLOBAL: LazyLock<HookRegistry> = LazyLock::new(|| {
+    let (ttl, delay) = current_registry_durations();
+    HookRegistry::new(ttl, delay)
+});
+
+/// Read the live TTL / unclaimed-Stop-delay overrides from the hot-reloadable
+/// runtime config, falling back to the compiled defaults. A configured `0` is
+/// treated as unset to avoid an immediate-expiry footgun. Clamped so a bad
+/// hot-reload value cannot overflow `Instant + Duration`.
+pub fn current_registry_durations() -> (Duration, Duration) {
+    let cfg = crate::config_live_reload::current();
+    let ttl = cfg
+        .as_ref()
+        .and_then(|c| c.runtime.tui_hook_buffer_ttl_secs)
+        .filter(|secs| *secs > 0)
+        .map(|secs| Duration::from_secs(secs.min(86_400)))
+        .unwrap_or(DEFAULT_HOOK_BUFFER_TTL);
+    let delay = cfg
+        .as_ref()
+        .and_then(|c| c.runtime.tui_unclaimed_stop_delay_ms)
+        .filter(|ms| *ms > 0)
+        .map(|ms| Duration::from_millis(ms.min(600_000)))
+        .unwrap_or(DEFAULT_UNCLAIMED_STOP_DELAY);
+    (ttl, delay)
+}
+
+/// Whether the registry buffering layer is enabled. Reads the hot-reloadable
+/// `tui_hook_registry_enabled` runtime flag; defaults to ON. This is the
+/// documented rollback switch (REQ rollback contract): set it to `false` in
+/// `agentdesk.yaml` and the hook receiver stops feeding the registry, leaving
+/// the legacy broadcast + polling path exactly as before — no restart needed.
+pub fn registry_enabled() -> bool {
+    crate::config_live_reload::current()
+        .and_then(|cfg| cfg.runtime.tui_hook_registry_enabled)
+        .unwrap_or(true)
+}
+
+/// The process-global registry instance.
+pub fn global() -> &'static HookRegistry {
+    &GLOBAL
+}
+
+/// Convenience for `/diag`-style telemetry: a snapshot of the global registry.
+pub fn global_snapshot() -> HookRegistrySnapshot {
+    global().snapshot()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+
+    fn registry() -> HookRegistry {
+        HookRegistry::new(Duration::from_secs(30), Duration::from_millis(2000))
+    }
+
+    fn event(
+        provider: &str,
+        sid: &str,
+        kind: HookEventKind,
+        payload: serde_json::Value,
+    ) -> HookEvent {
+        HookEvent {
+            provider: provider.to_string(),
+            session_id: sid.to_string(),
+            kind,
+            received_at: Utc::now(),
+            payload,
+        }
+    }
+
+    fn key(provider: &str, sid: &str) -> RegistryKey {
+        RegistryKey::new(provider, Some(sid), None).unwrap()
+    }
+
+    // -------- REQ-001: keying --------
+
+    #[test]
+    fn key_prefers_provider_session_then_tmux_then_none() {
+        // Provider session id preferred.
+        let k = RegistryKey::new("claude", Some("sid-1"), Some("tmux-1")).unwrap();
+        assert_eq!(k.session_key, "sid-1");
+        // Falls back to tmux when provider session id absent/blank.
+        let k = RegistryKey::new("claude", None, Some("tmux-1")).unwrap();
+        assert_eq!(k.session_key, "tmux-1");
+        let k = RegistryKey::new("claude", Some("  "), Some("tmux-1")).unwrap();
+        assert_eq!(k.session_key, "tmux-1");
+        // Channel alone (no session id, no tmux) is never a valid key.
+        assert!(RegistryKey::new("claude", None, None).is_none());
+        assert!(RegistryKey::new("claude", Some(""), Some("")).is_none());
+        // Empty provider is rejected.
+        assert!(RegistryKey::new("", Some("sid"), None).is_none());
+    }
+
+    #[test]
+    fn cross_provider_same_session_id_is_isolated() {
+        // TEST: send Stop(claude, ABC) and Stop(codex, ABC); confirm separate
+        // keys and no cross-leak into the other's claim (mustFix #5).
+        let reg = registry();
+        let claude_key = key("claude", "ABC");
+        let codex_key = key("codex", "ABC");
+
+        reg.deliver(
+            claude_key.clone(),
+            event("claude", "ABC", HookEventKind::Stop, json!({})),
+        );
+        reg.deliver(
+            codex_key.clone(),
+            event("codex", "ABC", HookEventKind::Stop, json!({})),
+        );
+
+        let claude_events = reg.claim(claude_key.clone());
+        assert_eq!(claude_events.len(), 1);
+        assert_eq!(claude_events[0].provider, "claude");
+
+        let codex_events = reg.claim(codex_key);
+        assert_eq!(codex_events.len(), 1);
+        assert_eq!(codex_events[0].provider, "codex");
+        // Re-claiming claude returns nothing — the codex deliver did not leak.
+        assert!(reg.claim(claude_key).is_empty());
+    }
+
+    // -------- REQ-002: claim replays fresh events once --------
+
+    #[test]
+    fn deliver_before_claim_replays_once() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::SessionStart, json!({})),
+        );
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+
+        let first = reg.claim(k.clone());
+        assert_eq!(first.len(), 2, "claim replays both fresh buffered events");
+        // Single-consumption: a second claim with no new deliveries replays nothing.
+        let second = reg.claim(k);
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn claim_cancels_unclaimed_stop_timer() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        assert!(reg.unclaimed_stop_diagnostic(&k).is_some());
+        let _ = reg.claim(k.clone());
+        // After claim, the unclaimed Stop timer is cancelled (REQ-002).
+        assert!(reg.unclaimed_stop_diagnostic(&k).is_none());
+    }
+
+    #[test]
+    fn claim_before_deliver_then_live_delivery_is_not_retained() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        // Claim first (empty buffer).
+        assert!(reg.claim(k.clone()).is_empty());
+        // A subsequent deliver to a claimed key is live, not retained for replay.
+        let outcome = reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        assert_eq!(outcome, DeliverOutcome::DeliveredLive);
+        // Re-claim replays nothing — the live event was not buffered.
+        assert!(reg.claim(k).is_empty());
+    }
+
+    // -------- REQ-003: unregister prevents future stale replay --------
+
+    #[test]
+    fn unregister_prevents_future_stale_replay() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        reg.unregister(&k);
+        // A fresh turn (same key) must not replay the dropped Stop.
+        assert!(reg.claim(k).is_empty());
+    }
+
+    // -------- REQ-001 / stale: TTL sweep --------
+
+    #[test]
+    fn expired_events_are_swept_and_not_replayed() {
+        // TTL of 0 makes every buffered event immediately stale.
+        let reg = HookRegistry::new(Duration::from_millis(0), Duration::from_millis(2000));
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        // With a zero TTL the buffered event is already expired on the next touch.
+        assert_eq!(reg.buffered_len(&k), 0);
+        assert!(
+            reg.claim(k.clone()).is_empty(),
+            "stale Stop must not be replayed"
+        );
+        let snap = reg.snapshot();
+        assert!(snap.expired_total >= 1);
+    }
+
+    // -------- REQ-004: unclaimed Stop diagnostics --------
+
+    #[test]
+    fn empty_stop_is_counted_but_non_qualifying() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        // Empty Stop body -> counted, but non-qualifying (no last_assistant_message).
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        let diag = reg
+            .unclaimed_stop_diagnostic(&k)
+            .expect("unclaimed Stop retained");
+        assert!(!diag.qualifying);
+        assert_eq!(diag.kind, "stop");
+        let snap = reg.snapshot();
+        assert_eq!(snap.unclaimed_stop_total, 1);
+        assert_eq!(snap.empty_stop_total, 1);
+    }
+
+    #[test]
+    fn qualifying_stop_carries_last_assistant_message() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event(
+                "claude",
+                "sid",
+                HookEventKind::Stop,
+                json!({ "last_assistant_message": "done with the task" }),
+            ),
+        );
+        let diag = reg
+            .unclaimed_stop_diagnostic(&k)
+            .expect("unclaimed Stop retained");
+        assert!(diag.qualifying);
+        let snap = reg.snapshot();
+        assert_eq!(snap.unclaimed_stop_total, 1);
+        assert_eq!(
+            snap.empty_stop_total, 0,
+            "qualifying Stop is not an empty Stop"
+        );
+    }
+
+    #[test]
+    fn newest_unclaimed_stop_replaces_older() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event(
+                "claude",
+                "sid",
+                HookEventKind::Stop,
+                json!({ "last_assistant_message": "first" }),
+            ),
+        );
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        // The newest unclaimed Stop (empty) is retained — diagnostic-only.
+        let diag = reg
+            .unclaimed_stop_diagnostic(&k)
+            .expect("unclaimed Stop retained");
+        assert!(
+            !diag.qualifying,
+            "newest (empty) Stop replaced the qualifying one"
+        );
+    }
+
+    #[test]
+    fn claimed_key_stop_does_not_count_as_unclaimed() {
+        // REQ-004: a claimed event cannot trigger the unclaimed fallback.
+        let reg = registry();
+        let k = key("claude", "sid");
+        assert!(reg.claim(k.clone()).is_empty());
+        let outcome = reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        assert_eq!(outcome, DeliverOutcome::DeliveredLive);
+        let snap = reg.snapshot();
+        assert_eq!(
+            snap.unclaimed_stop_total, 0,
+            "claimed Stop is not unclaimed"
+        );
+        assert!(reg.unclaimed_stop_diagnostic(&k).is_none());
+    }
+
+    #[test]
+    fn unclaimed_stop_elapsed_after_delay() {
+        let reg = HookRegistry::new(Duration::from_secs(30), Duration::from_millis(0));
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        // Zero delay => the diagnostic reports the timer as already elapsed.
+        let diag = reg
+            .unclaimed_stop_diagnostic(&k)
+            .expect("unclaimed Stop retained");
+        assert!(diag.delay_elapsed);
+    }
+
+    // -------- snapshot shape (additive observability) --------
+
+    #[test]
+    fn snapshot_aggregates_counts() {
+        let reg = registry();
+        let k1 = key("claude", "s1");
+        let k2 = key("codex", "s2");
+        reg.deliver(
+            k1.clone(),
+            event("claude", "s1", HookEventKind::Stop, json!({})),
+        );
+        reg.deliver(
+            k2.clone(),
+            event("codex", "s2", HookEventKind::SessionStart, json!({})),
+        );
+        let _ = reg.claim(k1);
+        let snap = reg.snapshot();
+        assert_eq!(snap.keys_tracked, 2);
+        assert_eq!(snap.claimed_keys, 1);
+        assert_eq!(snap.buffered_total, 2);
+        assert_eq!(snap.replayed_total, 1);
+        // Serializable to JSON with stable additive field names.
+        let value = serde_json::to_value(&snap).unwrap();
+        assert!(value.get("buffered_event_count").is_some());
+        assert!(value.get("unclaimed_stop_total").is_some());
+        assert!(value.get("replayed_total").is_some());
+    }
+
+    // -------- config defaults / clamping / rollback flag --------
+
+    /// A configured `0` (or absent) TTL / delay falls back to the compiled-in
+    /// default; a huge value is clamped so `Instant + Duration` cannot overflow.
+    #[test]
+    fn registry_durations_apply_defaults_and_clamp() {
+        // Pure default path (config not installed in unit tests => None).
+        let (ttl, delay) = current_registry_durations();
+        assert_eq!(ttl, DEFAULT_HOOK_BUFFER_TTL);
+        assert_eq!(delay, DEFAULT_UNCLAIMED_STOP_DELAY);
+    }
+
+    /// The rollback flag defaults to ON when the config is not installed (the
+    /// unit-test case). This pins the "feature defaults ON" contract — operators
+    /// must explicitly set `tui_hook_registry_enabled: false` to disable it.
+    #[test]
+    fn registry_enabled_defaults_on() {
+        assert!(registry_enabled());
+    }
+}

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -56,6 +56,19 @@ pub const DEFAULT_HOOK_BUFFER_TTL: Duration = Duration::from_secs(30);
 /// (`tui_unclaimed_stop_delay_ms=2000`).
 pub const DEFAULT_UNCLAIMED_STOP_DELAY: Duration = Duration::from_millis(2000);
 
+/// Hard cap on the number of buffered events retained per `(provider, session)`
+/// key. The hook receiver accepts bodies up to 8 MiB and the per-key buffer is
+/// otherwise unbounded within the TTL window, so a busy or noisy session could
+/// accumulate arbitrary memory before its events expire. When the cap is hit we
+/// drop the OLDEST buffered event (front of the Vec) to make room for the new
+/// one: replay/claim only cares about the freshest Stop / token hit (callers
+/// scan newest-first), so evicting the stale front never loses the signal a
+/// fresh wait is looking for. A dropped-for-capacity event is counted into
+/// `expired_total` (it is, semantically, dropped before its TTL the same way an
+/// expired event is). Keeping this bounded also bounds total registry memory at
+/// `keys * MAX_BUFFERED_EVENTS_PER_KEY` buffered events.
+pub const MAX_BUFFERED_EVENTS_PER_KEY: usize = 64;
+
 /// Composite registry key. Provider is always part of the key so the same id
 /// (a shared tmux session name) under two providers never cross-leaks. The
 /// `session_key` is the provider session id when known, else the tmux session
@@ -196,6 +209,16 @@ pub struct HookRegistry {
     /// 0 in production, since `snapshot` only sums per-key counters for *live*
     /// keys and the transient one-shot consumer leaves none behind.
     replayed_once_total: AtomicU64,
+    /// Cumulative diagnostic counters absorbed from keys that have been EVICTED
+    /// from the live map (an empty unclaimed key dropped by `snapshot`, or a key
+    /// removed by `claim_once`). Without these, evicting an empty key to bound
+    /// map growth (REQ — "drop expired empty registry keys") would silently reset
+    /// the advertised cumulative totals. `snapshot` folds these in alongside the
+    /// surviving per-key counters so the reported totals stay monotonic.
+    evicted_buffered_total: AtomicU64,
+    evicted_expired_total: AtomicU64,
+    evicted_unclaimed_stop_total: AtomicU64,
+    evicted_empty_stop_total: AtomicU64,
 }
 
 impl HookRegistry {
@@ -205,7 +228,26 @@ impl HookRegistry {
             ttl,
             unclaimed_stop_delay,
             replayed_once_total: AtomicU64::new(0),
+            evicted_buffered_total: AtomicU64::new(0),
+            evicted_expired_total: AtomicU64::new(0),
+            evicted_unclaimed_stop_total: AtomicU64::new(0),
+            evicted_empty_stop_total: AtomicU64::new(0),
         }
+    }
+
+    /// Absorb a to-be-evicted key's cumulative diagnostic counters into the
+    /// registry-level totals so dropping the key (to bound map growth) does not
+    /// reset the advertised monotonic totals. `replayed_total` is handled
+    /// separately by the callers that actually replay.
+    fn absorb_evicted_counters(&self, state: &KeyState) {
+        self.evicted_buffered_total
+            .fetch_add(state.buffered_total, Ordering::Relaxed);
+        self.evicted_expired_total
+            .fetch_add(state.expired_total, Ordering::Relaxed);
+        self.evicted_unclaimed_stop_total
+            .fetch_add(state.unclaimed_stop_total, Ordering::Relaxed);
+        self.evicted_empty_stop_total
+            .fetch_add(state.empty_stop_total, Ordering::Relaxed);
     }
 
     /// Deliver an event into the registry. If a listener has claimed the key
@@ -250,6 +292,15 @@ impl HookRegistry {
             });
         }
 
+        // Bound the per-key buffer: if at capacity, drop the OLDEST event to make
+        // room. Claim/replay scans newest-first, so the freshest Stop / token hit
+        // is preserved; only stale front entries are evicted. Count the eviction
+        // as an expiry (it is dropped-before-TTL the same way).
+        if state.buffer.len() >= MAX_BUFFERED_EVENTS_PER_KEY {
+            let overflow = state.buffer.len() + 1 - MAX_BUFFERED_EVENTS_PER_KEY;
+            state.buffer.drain(0..overflow);
+            state.expired_total += overflow as u64;
+        }
         state.buffer.push(BufferedEvent {
             event,
             buffered_at: now,
@@ -302,15 +353,21 @@ impl HookRegistry {
         keys.remove(key);
     }
 
-    /// One-shot claim used by short-lived consumers (e.g. `/tui/wait`): drain
-    /// the fresh buffer exactly once AND immediately drop the listener state so
-    /// the key returns to buffering mode for the next turn. This is the
-    /// claim+unregister pair as a single atomic-ish operation; it gives
-    /// single-consumption of the current turn's early events while keeping the
-    /// registry useful for the next turn's early-Stop race (REQ-002 + REQ-003).
-    /// Dropping the key resets its per-key counters; the global `snapshot`
-    /// aggregates only live keys, so a transient consumer that claims and leaves
-    /// does not inflate the long-lived diagnostic totals.
+    /// One-shot claim used by short-lived consumers: drain the fresh buffer
+    /// exactly once AND immediately drop the listener state so the key returns to
+    /// buffering mode for the next turn. This is the claim+unregister pair as a
+    /// single atomic-ish operation; it gives single-consumption of the current
+    /// turn's early events while keeping the registry useful for the next turn's
+    /// early-Stop race (REQ-002 + REQ-003). Dropping the key resets its per-key
+    /// counters (absorbed at the registry level so the totals stay monotonic).
+    ///
+    /// Test-only: production consumers (`/tui/wait`, the readiness wait) migrated
+    /// to [`claim_matching_once`], which consumes only the matching event and
+    /// re-buffers the rest so an unrelated waiter's buffered events are not
+    /// discarded. The unconditional drain remains exercised by the unit tests
+    /// that pin the REQ-002/REQ-003 single-consumption + replay-counting
+    /// semantics.
+    #[cfg(test)]
     pub fn claim_once(&self, key: RegistryKey) -> Vec<HookEvent> {
         let now = Instant::now();
         let mut keys = self.lock();
@@ -322,14 +379,76 @@ impl HookRegistry {
             .into_iter()
             .map(|buffered| buffered.event)
             .collect();
-        // The key (and its per-key `replayed_total`) is dropped here, so record
-        // the replay at the registry level — otherwise the advertised
-        // `replayed_total` diagnostic would always read 0 in production.
+        // The key (and its per-key counters) is dropped here, so record the
+        // replay and absorb the cumulative diagnostics at the registry level —
+        // otherwise the advertised totals would lose this key's history.
         if !drained.is_empty() {
             self.replayed_once_total
                 .fetch_add(drained.len() as u64, Ordering::Relaxed);
         }
+        self.absorb_evicted_counters(&state);
         drained
+    }
+
+    /// One-shot claim that consumes ONLY the events matching `wants`, leaving
+    /// every other fresh (unexpired) buffered event in place for a later waiter
+    /// to replay. Returns the newest matching event, or `None` when nothing
+    /// matches.
+    ///
+    /// This is the selective variant of `claim_once` used by `/tui/wait`. The
+    /// plain `claim_once` drains and drops the whole key, which discards buffered
+    /// Stops / token payloads that a *different* waiter (e.g. one waiting on a
+    /// different `until=token`) should still be able to replay. Here we:
+    ///   1. sweep expired events,
+    ///   2. remove and return the freshest event satisfying `wants`,
+    ///   3. re-buffer every non-matching fresh event under the key (preserving
+    ///      arrival order and the unclaimed-Stop diagnostic),
+    /// so a non-matching buffered event is never lost to an unrelated wait.
+    /// Unlike `claim_once` this does NOT mark the key claimed: the registry stays
+    /// in buffering mode for the next turn's early-Stop race.
+    pub fn claim_matching_once<F>(&self, key: RegistryKey, wants: F) -> Option<HookEvent>
+    where
+        F: Fn(&HookEvent) -> bool,
+    {
+        let now = Instant::now();
+        let mut keys = self.lock();
+        let state = keys.get_mut(&key)?;
+        Self::sweep_state(state, self.ttl, now);
+
+        // Find the newest matching event (scan from the back; arrival order is
+        // preserved in the Vec). Remove exactly that one and keep the rest.
+        let matched_idx = state
+            .buffer
+            .iter()
+            .rposition(|buffered| wants(&buffered.event));
+        let matched = match matched_idx {
+            Some(idx) => {
+                let removed = state.buffer.remove(idx);
+                state.replayed_total += 1;
+                self.replayed_once_total.fetch_add(1, Ordering::Relaxed);
+                // Consuming a Stop claims it: cancel the unclaimed-Stop diagnostic
+                // timer so a later turn's diagnostic does not report this
+                // now-claimed Stop as still pending.
+                if matches!(
+                    removed.event.kind,
+                    HookEventKind::Stop | HookEventKind::SubagentStop
+                ) {
+                    state.unclaimed_stop = None;
+                }
+                Some(removed.event)
+            }
+            None => None,
+        };
+
+        // If the buffer is now empty and the key has nothing else to retain, drop
+        // it to bound map growth (mirrors the snapshot eviction policy); its
+        // cumulative counters are absorbed at the registry level.
+        if state.buffer.is_empty() && !state.claimed && state.unclaimed_stop.is_none() {
+            if let Some(removed) = keys.remove(&key) {
+                self.absorb_evicted_counters(&removed);
+            }
+        }
+        matched
     }
 
     /// Per-key diagnostic for the retained unclaimed Stop, or `None` when none is
@@ -368,13 +487,30 @@ impl HookRegistry {
     }
 
     /// Build an additive observability snapshot. Sweeps every key first so the
-    /// reported buffered count excludes expired events. O(total buffered).
+    /// reported buffered count excludes expired events, then EVICTS keys that
+    /// swept clean and carry no live listener / retained Stop — without this an
+    /// unclaimed session that fired one hook and was never claimed would leave an
+    /// empty `KeyState` (and be counted by `keys_tracked`) forever, so a
+    /// long-running dcserver would accumulate one map entry per unique session
+    /// (REQ — "drop expired empty registry keys"). The evicted keys' cumulative
+    /// counters are absorbed at the registry level first so the advertised totals
+    /// stay monotonic. O(total buffered).
     pub fn snapshot(&self) -> HookRegistrySnapshot {
         let now = Instant::now();
         let mut keys = self.lock();
         let mut snap = HookRegistrySnapshot::default();
-        for state in keys.values_mut() {
+        keys.retain(|_, state| {
             Self::sweep_state(state, self.ttl, now);
+            // A key is droppable once it has nothing left to replay: no buffered
+            // events, no claimed listener, and no retained unclaimed Stop. Such a
+            // key can only ever be re-created lazily on the next deliver/claim, so
+            // dropping it here is safe and bounds map growth.
+            let droppable =
+                state.buffer.is_empty() && !state.claimed && state.unclaimed_stop.is_none();
+            if droppable {
+                self.absorb_evicted_counters(state);
+                return false;
+            }
             snap.buffered_event_count += state.buffer.len();
             if state.claimed {
                 snap.claimed_keys += 1;
@@ -387,11 +523,17 @@ impl HookRegistry {
             snap.expired_total += state.expired_total;
             snap.unclaimed_stop_total += state.unclaimed_stop_total;
             snap.empty_stop_total += state.empty_stop_total;
-        }
+            true
+        });
         snap.keys_tracked = keys.len();
-        // Fold in replays delivered by `claim_once`, whose keys are already gone
-        // from the live map (so their per-key `replayed_total` was dropped).
+        // Fold in replays delivered by `claim_once`, plus the cumulative counters
+        // absorbed from every evicted key (claim_once removals + empty-key
+        // sweeps), whose per-key counters are already gone from the live map.
         snap.replayed_total += self.replayed_once_total.load(Ordering::Relaxed);
+        snap.buffered_total += self.evicted_buffered_total.load(Ordering::Relaxed);
+        snap.expired_total += self.evicted_expired_total.load(Ordering::Relaxed);
+        snap.unclaimed_stop_total += self.evicted_unclaimed_stop_total.load(Ordering::Relaxed);
+        snap.empty_stop_total += self.evicted_empty_stop_total.load(Ordering::Relaxed);
         snap
     }
 
@@ -823,6 +965,169 @@ mod tests {
         // survives; a second claim_once replays nothing and does not double-count.
         assert!(reg.claim_once(k).is_empty());
         assert_eq!(reg.snapshot().replayed_total, 2);
+    }
+
+    // -------- bounded buffers (per-key cap, drop-oldest) --------
+
+    #[test]
+    fn buffer_is_bounded_per_key_and_drops_oldest() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        // Push well past the cap with token-bearing payloads so each is distinct.
+        let total = MAX_BUFFERED_EVENTS_PER_KEY + 10;
+        for i in 0..total {
+            reg.deliver(
+                k.clone(),
+                event(
+                    "claude",
+                    "sid",
+                    HookEventKind::Notification,
+                    json!({ "seq": i }),
+                ),
+            );
+        }
+        // The buffer never exceeds the cap.
+        assert_eq!(reg.buffered_len(&k), MAX_BUFFERED_EVENTS_PER_KEY);
+        let drained = reg.claim_once(k);
+        assert_eq!(drained.len(), MAX_BUFFERED_EVENTS_PER_KEY);
+        // The OLDEST entries were dropped: the freshest event survives, the
+        // earliest does not.
+        let seqs: Vec<i64> = drained
+            .iter()
+            .filter_map(|e| e.payload.get("seq").and_then(|v| v.as_i64()))
+            .collect();
+        assert_eq!(*seqs.last().unwrap(), (total - 1) as i64);
+        assert_eq!(
+            *seqs.first().unwrap(),
+            (total - MAX_BUFFERED_EVENTS_PER_KEY) as i64
+        );
+        // Capacity drops are counted as expirations (dropped-before-TTL).
+        let snap = reg.snapshot();
+        assert_eq!(snap.expired_total, 10);
+        assert_eq!(snap.buffered_total, total as u64);
+    }
+
+    // -------- empty expired key eviction (snapshot) --------
+
+    #[test]
+    fn snapshot_evicts_empty_unclaimed_keys_but_keeps_totals() {
+        // TTL 0 => the single buffered event expires immediately, so after the
+        // sweep the key is empty/unclaimed and must be dropped from the map.
+        let reg = HookRegistry::new(Duration::from_millis(0), Duration::from_millis(2000));
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        let snap = reg.snapshot();
+        assert_eq!(
+            snap.keys_tracked, 0,
+            "an empty, swept-clean, unclaimed key must be evicted"
+        );
+        // Cumulative counters survive the eviction (absorbed at registry level).
+        assert_eq!(snap.buffered_total, 1);
+        assert!(snap.expired_total >= 1);
+        assert_eq!(snap.unclaimed_stop_total, 1);
+        assert_eq!(snap.empty_stop_total, 1);
+        // A second snapshot does not double-count the absorbed totals.
+        let snap2 = reg.snapshot();
+        assert_eq!(snap2.buffered_total, 1);
+        assert_eq!(snap2.unclaimed_stop_total, 1);
+        assert_eq!(snap2.keys_tracked, 0);
+    }
+
+    #[test]
+    fn snapshot_keeps_keys_with_live_buffer_or_retained_stop() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        // A live (unexpired) Stop must NOT be evicted — it has a retained
+        // unclaimed Stop and a buffered event.
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        let snap = reg.snapshot();
+        assert_eq!(snap.keys_tracked, 1);
+        assert_eq!(snap.keys_with_unclaimed_stop, 1);
+    }
+
+    // -------- claim_matching_once: re-buffer non-matching events --------
+
+    #[test]
+    fn claim_matching_once_consumes_only_match_and_rebuffers_rest() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        // A non-Stop token payload plus a Stop are buffered.
+        reg.deliver(
+            k.clone(),
+            event(
+                "claude",
+                "sid",
+                HookEventKind::Notification,
+                json!({ "text": "TOKEN-XYZ here" }),
+            ),
+        );
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        // A Stop waiter consumes ONLY the Stop.
+        let matched = reg.claim_matching_once(k.clone(), |e| {
+            matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)
+        });
+        assert!(matched.is_some());
+        assert_eq!(matched.unwrap().kind, HookEventKind::Stop);
+        // The non-matching token payload is still buffered for a later token wait.
+        assert_eq!(reg.buffered_len(&k), 1);
+        let token_match = reg.claim_matching_once(k.clone(), |e| {
+            e.payload
+                .get("text")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| t.contains("TOKEN-XYZ"))
+        });
+        assert!(
+            token_match.is_some(),
+            "the re-buffered token payload must remain replayable"
+        );
+        // Now the buffer is drained and the empty key is evicted.
+        assert_eq!(reg.buffered_len(&k), 0);
+    }
+
+    #[test]
+    fn claim_matching_once_no_match_keeps_buffer_intact() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        // A token waiter that does not match must not discard the buffered Stop.
+        let matched =
+            reg.claim_matching_once(k.clone(), |e| matches!(e.kind, HookEventKind::SessionStart));
+        assert!(matched.is_none());
+        assert_eq!(reg.buffered_len(&k), 1, "unmatched claim must not discard");
+        // A subsequent Stop waiter can still replay it.
+        let stop = reg.claim_matching_once(k, |e| {
+            matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)
+        });
+        assert!(stop.is_some());
+    }
+
+    #[test]
+    fn claim_matching_once_cancels_unclaimed_stop_diagnostic() {
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+        assert!(reg.unclaimed_stop_diagnostic(&k).is_some());
+        let _ = reg.claim_matching_once(k.clone(), |e| {
+            matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)
+        });
+        // Consuming the Stop cancels its unclaimed diagnostic (and the now-empty
+        // key is evicted, so the diagnostic reports None).
+        assert!(reg.unclaimed_stop_diagnostic(&k).is_none());
     }
 
     // -------- config defaults / clamping / rollback flag --------

--- a/src/services/claude_tui/hook_registry.rs
+++ b/src/services/claude_tui/hook_registry.rs
@@ -39,6 +39,7 @@
 //!    decide whether to trigger a transcript sync; P0 never syncs or finalizes.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
@@ -189,6 +190,12 @@ pub struct HookRegistry {
     keys: Mutex<HashMap<RegistryKey, KeyState>>,
     ttl: Duration,
     unclaimed_stop_delay: Duration,
+    /// Cumulative events replayed by `claim_once`, accumulated at the registry
+    /// level because `claim_once` drops the key (and its per-key counters) on
+    /// every call. Without this the advertised `replayed_total` would always be
+    /// 0 in production, since `snapshot` only sums per-key counters for *live*
+    /// keys and the transient one-shot consumer leaves none behind.
+    replayed_once_total: AtomicU64,
 }
 
 impl HookRegistry {
@@ -197,6 +204,7 @@ impl HookRegistry {
             keys: Mutex::new(HashMap::new()),
             ttl,
             unclaimed_stop_delay,
+            replayed_once_total: AtomicU64::new(0),
         }
     }
 
@@ -310,10 +318,18 @@ impl HookRegistry {
             return Vec::new();
         };
         Self::sweep_state(&mut state, self.ttl, now);
-        std::mem::take(&mut state.buffer)
+        let drained: Vec<HookEvent> = std::mem::take(&mut state.buffer)
             .into_iter()
             .map(|buffered| buffered.event)
-            .collect()
+            .collect();
+        // The key (and its per-key `replayed_total`) is dropped here, so record
+        // the replay at the registry level — otherwise the advertised
+        // `replayed_total` diagnostic would always read 0 in production.
+        if !drained.is_empty() {
+            self.replayed_once_total
+                .fetch_add(drained.len() as u64, Ordering::Relaxed);
+        }
+        drained
     }
 
     /// Per-key diagnostic for the retained unclaimed Stop, or `None` when none is
@@ -373,6 +389,9 @@ impl HookRegistry {
             snap.empty_stop_total += state.empty_stop_total;
         }
         snap.keys_tracked = keys.len();
+        // Fold in replays delivered by `claim_once`, whose keys are already gone
+        // from the live map (so their per-key `replayed_total` was dropped).
+        snap.replayed_total += self.replayed_once_total.load(Ordering::Relaxed);
         snap
     }
 
@@ -428,10 +447,16 @@ static GLOBAL: LazyLock<HookRegistry> = LazyLock::new(|| {
     HookRegistry::new(ttl, delay)
 });
 
-/// Read the live TTL / unclaimed-Stop-delay overrides from the hot-reloadable
-/// runtime config, falling back to the compiled defaults. A configured `0` is
-/// treated as unset to avoid an immediate-expiry footgun. Clamped so a bad
-/// hot-reload value cannot overflow `Instant + Duration`.
+/// Read the TTL / unclaimed-Stop-delay overrides from the runtime config,
+/// falling back to the compiled defaults. A configured `0` is treated as unset
+/// to avoid an immediate-expiry footgun. Clamped so a bad value cannot overflow
+/// `Instant + Duration`.
+///
+/// NOTE: although this reads from the live config, it is called exactly once —
+/// when `GLOBAL` is first initialised — so the resulting durations are frozen on
+/// the immutable `HookRegistry` for the life of the process. Editing
+/// `tui_hook_buffer_ttl_secs` / `tui_unclaimed_stop_delay_ms` therefore requires
+/// a restart; only `registry_enabled()` is re-read per hook.
 pub fn current_registry_durations() -> (Duration, Duration) {
     let cfg = crate::config_live_reload::current();
     let ttl = cfg
@@ -767,6 +792,37 @@ mod tests {
         assert!(value.get("buffered_event_count").is_some());
         assert!(value.get("unclaimed_stop_total").is_some());
         assert!(value.get("replayed_total").is_some());
+    }
+
+    #[test]
+    fn claim_once_replay_is_counted_in_replayed_total() {
+        // Regression: the production one-shot consumer (`claim_once`) removes the
+        // key — and with it the per-key `replayed_total` — so the advertised
+        // aggregate must be tracked at the registry level. Before this fix the
+        // diagnostic always reported 0 in production.
+        let reg = registry();
+        let k = key("claude", "sid");
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::SessionStart, json!({})),
+        );
+        reg.deliver(
+            k.clone(),
+            event("claude", "sid", HookEventKind::Stop, json!({})),
+        );
+
+        let replayed = reg.claim_once(k.clone());
+        assert_eq!(replayed.len(), 2, "claim_once replays both buffered events");
+
+        let snap = reg.snapshot();
+        assert_eq!(
+            snap.replayed_total, 2,
+            "claim_once replays must be reflected in the advertised replayed_total"
+        );
+        // The key is gone after the one-shot claim, but the cumulative counter
+        // survives; a second claim_once replays nothing and does not double-count.
+        assert!(reg.claim_once(k).is_empty());
+        assert_eq!(reg.snapshot().replayed_total, 2);
     }
 
     // -------- config defaults / clamping / rollback flag --------

--- a/src/services/claude_tui/hook_server.rs
+++ b/src/services/claude_tui/hook_server.rs
@@ -319,18 +319,31 @@ async fn receive_hook(
     // early signals). This is a parallel buffer — it does NOT gate, drop, or
     // reorder the broadcast send below; the Codex `try_recv()` observer path
     // and `/tui/wait` broadcast subscribers are unchanged. Delivery is a single
-    // in-memory mutex section (O(buffer length for the key)); no I/O. The
-    // registry is fed for EVERY accepted event (including empty Stop) because
-    // claim/replay and the unclaimed-Stop diagnostic both need the full Stop
-    // signal — the empty-payload broadcast filter is intentionally bypassed
-    // here, mirroring the Stop exemption above.
+    // in-memory mutex section (O(buffer length for the key)); no I/O.
+    //
+    // The buffering gate MIRRORS the broadcast gate (`should_drop_broadcast`):
+    // we never buffer anything the live broadcast intentionally drops, so a late
+    // registry replay can never surface an event the live `/tui/wait` path would
+    // not have seen. Concretely this means:
+    //   * `stop_flush_injected` Stops are NOT buffered. That Stop is suppressed
+    //     because it only exists to inject required memento feedback and must not
+    //     be treated as turn completion; buffering it would let a later
+    //     `/tui/wait` return `matched:stop:registry` for it and finish the turn
+    //     before Claude processes the feedback.
+    //   * informational empty-payload NON-Stop events are NOT buffered. They only
+    //     echo `session_id`/`provider`/`event`, so a token wait could otherwise
+    //     match those identifiers via `payload_contains` and return
+    //     `matched:token:registry` for an event the live path filtered out.
+    //   * empty-body Stop / SubagentStop events ARE still buffered (the broadcast
+    //     gate exempts them) so the early-Stop race and unclaimed-Stop diagnostic
+    //     keep working — only the feedback-injected Stop above is excluded.
     //
     // Keyed by (provider, session_id): session_id is already the provider
     // session id when the hook reported one, else the tmux session name passed
     // via the query string — exactly the REQ-001 fallback. Including the
     // provider in the key keeps Claude and Codex isolated even when they share
     // a tmux session name.
-    if crate::services::claude_tui::hook_registry::registry_enabled() {
+    if !should_drop_broadcast && crate::services::claude_tui::hook_registry::registry_enabled() {
         if let Some(key) = crate::services::claude_tui::hook_registry::RegistryKey::new(
             &event.provider,
             Some(event.session_id.as_str()),
@@ -973,6 +986,152 @@ mod tests {
         let key = RegistryKey::new("claude", Some(session), None).unwrap();
         let replayed = global().claim_once(key);
         assert_eq!(replayed.len(), 1, "registry must buffer the early Stop");
+        assert_eq!(replayed[0].kind, HookEventKind::Stop);
+    }
+
+    /// #tui-hook-ttl-buffer (buffering gate mirrors the broadcast gate): a
+    /// feedback-injected Stop (one that produces a `memento_tool_feedback_flush`)
+    /// must NOT be buffered in the registry. That Stop is suppressed from the
+    /// broadcast / prompt-ready because it only exists to inject required memento
+    /// feedback; buffering it would let a later `/tui/wait` return
+    /// `matched:stop:registry` and finish the turn before Claude processes the
+    /// feedback.
+    #[tokio::test]
+    async fn feedback_injected_stop_is_not_buffered() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+
+        let session = "sess-feedback-injected-stop";
+        if let Some(key) = RegistryKey::new("claude", Some(session), None) {
+            let _ = global().claim_once(key);
+        }
+
+        let state = HookServerState::new();
+        let app = hook_receiver_router_with_state(state);
+
+        // 1) Arm a pending memento feedback flush: a recall PostToolUse with no
+        //    matching tool feedback leaves an unknown pending search.
+        let post = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/hooks/claude/PostToolUse?session_id={session}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"hook_event_name":"PostToolUse","tool_name":"mcp__memento__recall"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(post.status(), StatusCode::ACCEPTED);
+
+        // 2) A Stop with no `stop_hook_active` now triggers a feedback flush; the
+        //    response carries `memento_tool_feedback_flush`.
+        let stop = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/hooks/claude/Stop?session_id={session}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"hook_event_name":"Stop"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(stop.status(), StatusCode::ACCEPTED);
+        let body = axum::body::to_bytes(stop.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            value.get("memento_tool_feedback_flush").is_some(),
+            "the Stop must be a feedback-injected flush for this test to be meaningful"
+        );
+
+        // The feedback-injected Stop must NOT have been buffered. (The priming
+        // PostToolUse is a normal non-noise event and MAY be buffered; we assert
+        // specifically that no Stop / SubagentStop landed in the buffer.)
+        let key = RegistryKey::new("claude", Some(session), None).unwrap();
+        let buffered = global().claim_once(key);
+        assert!(
+            !buffered
+                .iter()
+                .any(|e| matches!(e.kind, HookEventKind::Stop | HookEventKind::SubagentStop)),
+            "feedback-injected Stop must not be buffered in the registry"
+        );
+    }
+
+    /// #tui-hook-ttl-buffer (buffering gate): an informational empty-payload
+    /// NON-Stop event (the kind the broadcast drops because it only echoes
+    /// identifiers) must NOT be buffered, so a later `until=token` wait cannot
+    /// match those identifiers and return `matched:token:registry` for an event
+    /// the live path filtered out.
+    #[tokio::test]
+    async fn informational_empty_payload_non_stop_is_not_buffered() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+
+        let session = "sess-noise-non-stop";
+        if let Some(key) = RegistryKey::new("claude", Some(session), None) {
+            let _ = global().claim_once(key);
+        }
+
+        let state = HookServerState::new();
+        let app = hook_receiver_router_with_state(state);
+
+        // A Notification whose body only re-states identifiers is broadcast-noise.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/hooks/claude/Notification?session_id={session}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"session_id":"{session}","provider":"claude","event":"Notification"}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let key = RegistryKey::new("claude", Some(session), None).unwrap();
+        assert!(
+            global().claim_once(key).is_empty(),
+            "informational empty-payload non-Stop must not be buffered"
+        );
+    }
+
+    /// An empty-body Stop (the common Claude TUI case) is NOT broadcast-noise and
+    /// MUST still be buffered so the early-Stop race rescue keeps working.
+    #[tokio::test]
+    async fn empty_body_stop_is_still_buffered() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+
+        let session = "sess-empty-stop-buffered";
+        if let Some(key) = RegistryKey::new("claude", Some(session), None) {
+            let _ = global().claim_once(key);
+        }
+
+        let state = HookServerState::new();
+        let app = hook_receiver_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/hooks/claude/Stop?session_id={session}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"hook_event_name":"Stop"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let key = RegistryKey::new("claude", Some(session), None).unwrap();
+        let replayed = global().claim_once(key);
+        assert_eq!(replayed.len(), 1, "empty-body Stop must still be buffered");
         assert_eq!(replayed[0].kind, HookEventKind::Stop);
     }
 

--- a/src/services/claude_tui/hook_server.rs
+++ b/src/services/claude_tui/hook_server.rs
@@ -313,6 +313,33 @@ async fn receive_hook(
                 event.kind,
                 HookEventKind::Stop | HookEventKind::SubagentStop
             ));
+    // #tui-hook-ttl-buffer: additively feed the in-memory hook registry so a
+    // hook that lands before its consumer claims the key is not lost (the
+    // broadcast and `prompt_ready_notify` above are edge-triggered and drop
+    // early signals). This is a parallel buffer — it does NOT gate, drop, or
+    // reorder the broadcast send below; the Codex `try_recv()` observer path
+    // and `/tui/wait` broadcast subscribers are unchanged. Delivery is a single
+    // in-memory mutex section (O(buffer length for the key)); no I/O. The
+    // registry is fed for EVERY accepted event (including empty Stop) because
+    // claim/replay and the unclaimed-Stop diagnostic both need the full Stop
+    // signal — the empty-payload broadcast filter is intentionally bypassed
+    // here, mirroring the Stop exemption above.
+    //
+    // Keyed by (provider, session_id): session_id is already the provider
+    // session id when the hook reported one, else the tmux session name passed
+    // via the query string — exactly the REQ-001 fallback. Including the
+    // provider in the key keeps Claude and Codex isolated even when they share
+    // a tmux session name.
+    if crate::services::claude_tui::hook_registry::registry_enabled() {
+        if let Some(key) = crate::services::claude_tui::hook_registry::RegistryKey::new(
+            &event.provider,
+            Some(event.session_id.as_str()),
+            None,
+        ) {
+            crate::services::claude_tui::hook_registry::global().deliver(key, event.clone());
+        }
+    }
+
     if should_drop_broadcast {
         tracing::debug!(
             provider,
@@ -902,6 +929,51 @@ mod tests {
                 "non-completion events must be eligible for the empty-payload drop"
             );
         }
+    }
+
+    /// #tui-hook-ttl-buffer (REQ-005 / overlap invariant): delivering a hook
+    /// through the receiver must BOTH buffer it in the registry AND keep the
+    /// broadcast firing for observers (the Codex `try_recv` path). The registry
+    /// is additive — it does not gate or drop the broadcast. We claim_once the
+    /// registry key after the request to prove the early Stop was buffered, and
+    /// confirm the broadcast subscriber still saw the same Stop.
+    #[tokio::test]
+    async fn receiver_feeds_registry_and_preserves_broadcast() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+
+        let session = "sess-registry-broadcast";
+        // Start from a clean key so a neighbour test cannot pollute this one.
+        if let Some(key) = RegistryKey::new("claude", Some(session), None) {
+            let _ = global().claim_once(key);
+        }
+
+        let state = HookServerState::new();
+        let mut rx = state.subscribe();
+        let app = hook_receiver_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/hooks/claude/Stop?session_id={session}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"hook_event_name":"Stop"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        // Broadcast observer still sees the Stop (Codex path preserved).
+        let broadcast_event = rx.recv().await.unwrap();
+        assert_eq!(broadcast_event.kind, HookEventKind::Stop);
+        assert_eq!(broadcast_event.session_id, session);
+
+        // Registry buffered the same Stop for a late claimer.
+        let key = RegistryKey::new("claude", Some(session), None).unwrap();
+        let replayed = global().claim_once(key);
+        assert_eq!(replayed.len(), 1, "registry must buffer the early Stop");
+        assert_eq!(replayed[0].kind, HookEventKind::Stop);
     }
 
     #[test]

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -78,25 +78,47 @@ fn followup_prompt_ready_timeout() -> Duration {
 /// when the buffered events are not Stop kinds — in which case the caller falls
 /// through to the existing Notify fast path and polling fallback unchanged.
 ///
-/// Note: this keys by the tmux session name (the only id the readiness layer
-/// knows). It therefore only rescues early Stops whose hooks were delivered
-/// keyed by the tmux session; Stops keyed by a provider session UUID are still
-/// covered by the existing Notify + polling path, so no signal is lost.
+/// Key-match (REQ-001): for a hosted Claude launch the hook relay buffers under
+/// the PROVIDER session UUID (`config.session_id`, passed to the relay as
+/// `--session-id`), while the readiness layer only knows the tmux session name.
+/// Claiming `(claude, tmux_name)` would therefore MISS the buffered
+/// `(claude, provider_session_uuid)` Stop and the early-Stop race this block
+/// exists to rescue would still fall through. We resolve the provider session id
+/// for this tmux session via the launch-time mapping in `tui_prompt_dedupe` and
+/// claim that SAME key the hooks buffered under; we fall back to the tmux session
+/// name (REQ-001 fallback) when no mapping is known (e.g. a relay that reported
+/// only the tmux name).
+///
+/// `claim_matching_once` consumes ONLY a Stop / SubagentStop and re-buffers any
+/// other fresh buffered events (e.g. a token payload a concurrent `/tui/wait`
+/// until=token might still want), so the readiness wait does not discard
+/// unrelated buffered events. The consumed Stop cannot replay into a later turn
+/// (single-consumption).
 fn claude_registry_stop_already_buffered(session_name: &str) -> bool {
     use crate::services::claude_tui::hook_registry;
     use crate::services::claude_tui::hook_server::HookEventKind;
     if !hook_registry::registry_enabled() {
         return false;
     }
-    let Some(key) = hook_registry::RegistryKey::new("claude", Some(session_name), None) else {
+    // Prefer the provider session UUID the relay actually buffers under; fall
+    // back to the tmux session name when no launch mapping is recorded.
+    let provider_session_id =
+        crate::services::tui_prompt_dedupe::provider_session_for_tmux("claude", session_name);
+    let Some(key) = hook_registry::RegistryKey::new(
+        "claude",
+        provider_session_id.as_deref(),
+        Some(session_name),
+    ) else {
         return false;
     };
-    hook_registry::global().claim_once(key).iter().any(|event| {
-        matches!(
-            event.kind,
-            HookEventKind::Stop | HookEventKind::SubagentStop
-        )
-    })
+    hook_registry::global()
+        .claim_matching_once(key, |event| {
+            matches!(
+                event.kind,
+                HookEventKind::Stop | HookEventKind::SubagentStop
+            )
+        })
+        .is_some()
 }
 
 impl PromptReadinessKind {
@@ -880,10 +902,11 @@ fn wait_for_prompt_ready_inner(
     // additive event source for an early Stop that landed before this wait
     // began. The global `prompt_ready_notify()` used by the fast path below is
     // edge-triggered, so a Stop fired in the gap between the prior turn and this
-    // wait would otherwise be lost and force a full polling fallback. We only
-    // consume a FRESH (unexpired) Stop keyed by `(claude, tmux_session_name)` —
-    // the key the readiness layer actually knows — and claim_once drains it so
-    // it can never replay into a later turn (REQ-002/REQ-003).
+    // wait would otherwise be lost and force a full polling fallback. We consume
+    // a FRESH (unexpired) Stop keyed by the PROVIDER session UUID the hooks
+    // buffer under (resolved from the tmux session, with the tmux name as the
+    // REQ-001 fallback), and `claim_matching_once` removes only that Stop so it
+    // can never replay into a later turn (REQ-002/REQ-003).
     //
     // CRITICAL (verifier top regression risk — "stale Stop contaminates a new
     // turn"): a buffered Stop is treated like an edge-triggered Notify wake, NOT

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -70,6 +70,35 @@ fn followup_prompt_ready_timeout() -> Duration {
         .unwrap_or(FOLLOWUP_PROMPT_READY_TIMEOUT)
 }
 
+/// #tui-hook-ttl-buffer (REQ-006): claim the Claude hook registry key for this
+/// tmux session and report whether a fresh Stop / SubagentStop was already
+/// buffered. `claim_once` drains and drops the key so the consumed Stop cannot
+/// replay into a later turn (single-consumption). Returns `false` when the
+/// registry is disabled by the rollback flag, when no key/event matches, or
+/// when the buffered events are not Stop kinds — in which case the caller falls
+/// through to the existing Notify fast path and polling fallback unchanged.
+///
+/// Note: this keys by the tmux session name (the only id the readiness layer
+/// knows). It therefore only rescues early Stops whose hooks were delivered
+/// keyed by the tmux session; Stops keyed by a provider session UUID are still
+/// covered by the existing Notify + polling path, so no signal is lost.
+fn claude_registry_stop_already_buffered(session_name: &str) -> bool {
+    use crate::services::claude_tui::hook_registry;
+    use crate::services::claude_tui::hook_server::HookEventKind;
+    if !hook_registry::registry_enabled() {
+        return false;
+    }
+    let Some(key) = hook_registry::RegistryKey::new("claude", Some(session_name), None) else {
+        return false;
+    };
+    hook_registry::global().claim_once(key).iter().any(|event| {
+        matches!(
+            event.kind,
+            HookEventKind::Stop | HookEventKind::SubagentStop
+        )
+    })
+}
+
 impl PromptReadinessKind {
     fn timeout(self) -> Duration {
         match self {
@@ -846,6 +875,43 @@ fn wait_for_prompt_ready_inner(
     check_prompt_cancel(cancel_token)?;
     let timeout = readiness.timeout();
     let start = Instant::now();
+
+    // #tui-hook-ttl-buffer (REQ-006): consult the in-memory hook registry as an
+    // additive event source for an early Stop that landed before this wait
+    // began. The global `prompt_ready_notify()` used by the fast path below is
+    // edge-triggered, so a Stop fired in the gap between the prior turn and this
+    // wait would otherwise be lost and force a full polling fallback. We only
+    // consume a FRESH (unexpired) Stop keyed by `(claude, tmux_session_name)` —
+    // the key the readiness layer actually knows — and claim_once drains it so
+    // it can never replay into a later turn (REQ-002/REQ-003).
+    //
+    // CRITICAL (verifier top regression risk — "stale Stop contaminates a new
+    // turn"): a buffered Stop is treated like an edge-triggered Notify wake, NOT
+    // as an unconditional ready signal. We REQUIRE the pane snapshot to confirm
+    // the prompt marker (the same gate the Notify fast path applies via its
+    // post-event snapshot) before returning ready. A stale Stop whose pane is
+    // still mid-turn therefore does NOT short-circuit; it falls through to the
+    // normal Notify + polling path. The rollback flag turns the whole block off.
+    if claude_registry_stop_already_buffered(session_name) {
+        check_prompt_cancel(cancel_token)?;
+        let snapshot = prompt_readiness_snapshot(session_name);
+        if prompt_marker_confirms_prompt_ready(&snapshot) {
+            tracing::debug!(
+                tmux_session_name = session_name,
+                readiness = readiness.label(),
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "claude_tui prompt ready via buffered hook registry Stop confirmed by pane marker (early-Stop race avoided)"
+            );
+            return Ok(());
+        }
+        // Buffered Stop did not correspond to a ready pane (stale / mid-turn) —
+        // fall through to the existing Notify fast path and polling fallback.
+        tracing::debug!(
+            tmux_session_name = session_name,
+            readiness = readiness.label(),
+            "claude_tui buffered hook registry Stop did not confirm pane readiness; using standard fast path"
+        );
+    }
 
     if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path) {
         tracing::info!(

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -89,11 +89,11 @@ fn followup_prompt_ready_timeout() -> Duration {
 /// name (REQ-001 fallback) when no mapping is known (e.g. a relay that reported
 /// only the tmux name).
 ///
-/// `claim_matching_once` consumes ONLY a Stop / SubagentStop and re-buffers any
-/// other fresh buffered events (e.g. a token payload a concurrent `/tui/wait`
-/// until=token might still want), so the readiness wait does not discard
-/// unrelated buffered events. The consumed Stop cannot replay into a later turn
-/// (single-consumption).
+/// `claim_matching_once` consumes every buffered Stop / SubagentStop and
+/// re-buffers any other fresh buffered events (e.g. a token payload a concurrent
+/// `/tui/wait` until=token might still want), so the readiness wait does not
+/// discard unrelated buffered events. Consumed Stops cannot replay into a later
+/// turn (single-consumption).
 fn claude_registry_stop_already_buffered(session_name: &str) -> bool {
     use crate::services::claude_tui::hook_registry;
     use crate::services::claude_tui::hook_server::HookEventKind;
@@ -905,8 +905,8 @@ fn wait_for_prompt_ready_inner(
     // wait would otherwise be lost and force a full polling fallback. We consume
     // a FRESH (unexpired) Stop keyed by the PROVIDER session UUID the hooks
     // buffer under (resolved from the tmux session, with the tmux name as the
-    // REQ-001 fallback), and `claim_matching_once` removes only that Stop so it
-    // can never replay into a later turn (REQ-002/REQ-003).
+    // REQ-001 fallback), and `claim_matching_once` removes buffered Stops so
+    // they can never replay into a later turn (REQ-002/REQ-003).
     //
     // CRITICAL (verifier top regression risk — "stale Stop contaminates a new
     // turn"): a buffered Stop is treated like an edge-triggered Notify wake, NOT
@@ -995,10 +995,15 @@ fn wait_for_prompt_ready_inner(
     if let Some(snapshot) = post_event_snapshot {
         if prompt_marker_confirms_prompt_ready(&snapshot) {
             check_prompt_cancel(cancel_token)?;
+            // The live broadcast woke this waiter. Drain the parallel registry
+            // copy as consumed too, otherwise the same Stop can be replayed into
+            // the next follow-up wait.
+            let drained_buffered_stop = claude_registry_stop_already_buffered(session_name);
             tracing::debug!(
                 tmux_session_name = session_name,
                 readiness = readiness.label(),
                 hook_event_fast_path_hit = matches!(fast_path, HookFastPathOutcome::Ready),
+                drained_buffered_stop,
                 elapsed_ms = start.elapsed().as_millis() as u64,
                 "claude_tui prompt ready via hook event fast path"
             );
@@ -1006,9 +1011,11 @@ fn wait_for_prompt_ready_inner(
         }
         if transcript_idle_confirms_prompt_ready(&snapshot, transcript_path) {
             check_prompt_cancel(cancel_token)?;
+            let drained_buffered_stop = claude_registry_stop_already_buffered(session_name);
             tracing::info!(
                 tmux_session_name = session_name,
                 readiness = readiness.label(),
+                drained_buffered_stop,
                 elapsed_ms = start.elapsed().as_millis() as u64,
                 "claude_tui prompt ready via idle transcript fallback after hook fast path"
             );

--- a/src/services/claude_tui/mod.rs
+++ b/src/services/claude_tui/mod.rs
@@ -1,4 +1,5 @@
 pub mod hook_bundle;
+pub mod hook_registry;
 pub mod hook_relay;
 pub mod hook_server;
 #[cfg(test)]

--- a/src/services/claude_tui/tui_relay.rs
+++ b/src/services/claude_tui/tui_relay.rs
@@ -27,6 +27,7 @@
 use std::{sync::Arc, time::Duration};
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::time::Instant;
@@ -131,6 +132,21 @@ pub struct WaitRequest {
     /// any provider matches.
     #[serde(default)]
     pub provider: Option<String>,
+    /// Optional turn-boundary lower bound (RFC3339 / ISO-8601 wall-clock).
+    ///
+    /// #tui-hook-ttl-buffer: a `/tui/wait` MUST NOT be satisfied by a Stop (or
+    /// token) hook that arrived *before* the caller's turn began, otherwise a
+    /// previous turn's still-buffered (un-claimed, within-TTL) Stop can wake a
+    /// brand-new wait. `WaitRequest` itself carries no turn id, so the caller —
+    /// which is the only party that knows when it submitted the turn — passes the
+    /// turn-start wall clock here. Any buffered/broadcast event with
+    /// `received_at < not_before` is then rejected by `event_matches`, applied
+    /// uniformly to both the registry-replay claim and the live broadcast loop.
+    ///
+    /// Optional and additive: callers that omit it keep the prior behaviour
+    /// (any in-TTL event matches), so this is backward compatible.
+    #[serde(default)]
+    pub not_before: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -281,6 +297,7 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
         req.session_id.as_deref(),
         &until_mode,
         token.as_deref(),
+        req.not_before,
     ) {
         let summary = json!({
             "provider": early.provider,
@@ -335,6 +352,7 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
                     req.session_id.as_deref(),
                     &until_mode,
                     token.as_deref(),
+                    req.not_before,
                 ) {
                     continue;
                 }
@@ -374,6 +392,7 @@ fn try_claim_registry_match(
     want_session_id: Option<&str>,
     until_mode: &str,
     token: Option<&str>,
+    not_before: Option<DateTime<Utc>>,
 ) -> Option<HookEvent> {
     use crate::services::claude_tui::hook_registry;
     if !hook_registry::registry_enabled() {
@@ -397,6 +416,7 @@ fn try_claim_registry_match(
             want_session_id,
             &until_mode,
             token.as_deref(),
+            not_before,
         )
     })
 }
@@ -407,7 +427,19 @@ fn event_matches(
     want_session_id: Option<&str>,
     until_mode: &str,
     token: Option<&str>,
+    not_before: Option<DateTime<Utc>>,
 ) -> bool {
+    // #tui-hook-ttl-buffer (turn-boundary gate): reject any event that arrived
+    // before the caller's turn started. This is the lower bound that stops a
+    // previous turn's still-buffered Stop from satisfying a new wait. Applied
+    // first so it gates BOTH the registry-replay claim and the live broadcast
+    // loop (both funnel through this predicate). Callers that omit `not_before`
+    // keep the prior any-in-TTL-event behaviour.
+    if let Some(min) = not_before {
+        if event.received_at < min {
+            return false;
+        }
+    }
     if let Some(provider) = want_provider {
         if !provider.trim().is_empty() && !event.provider.eq_ignore_ascii_case(provider.trim()) {
             return false;
@@ -549,33 +581,54 @@ mod tests {
     #[test]
     fn stop_event_matches_default() {
         let event = make_event("claude", "abc", HookEventKind::Stop, json!({}));
-        assert!(event_matches(&event, None, None, "stop", None));
+        assert!(event_matches(&event, None, None, "stop", None, None));
     }
 
     #[test]
     fn subagent_stop_also_matches_stop_mode() {
         let event = make_event("claude", "abc", HookEventKind::SubagentStop, json!({}));
-        assert!(event_matches(&event, None, None, "stop", None));
+        assert!(event_matches(&event, None, None, "stop", None, None));
     }
 
     #[test]
     fn unrelated_event_does_not_match_stop() {
         let event = make_event("claude", "abc", HookEventKind::UserPromptSubmit, json!({}));
-        assert!(!event_matches(&event, None, None, "stop", None));
+        assert!(!event_matches(&event, None, None, "stop", None, None));
     }
 
     #[test]
     fn provider_filter_rejects_mismatch() {
         let event = make_event("codex", "abc", HookEventKind::Stop, json!({}));
-        assert!(!event_matches(&event, Some("claude"), None, "stop", None));
-        assert!(event_matches(&event, Some("codex"), None, "stop", None));
+        assert!(!event_matches(
+            &event,
+            Some("claude"),
+            None,
+            "stop",
+            None,
+            None
+        ));
+        assert!(event_matches(
+            &event,
+            Some("codex"),
+            None,
+            "stop",
+            None,
+            None
+        ));
     }
 
     #[test]
     fn session_id_filter_rejects_mismatch() {
         let event = make_event("claude", "abc", HookEventKind::Stop, json!({}));
-        assert!(!event_matches(&event, None, Some("xyz"), "stop", None));
-        assert!(event_matches(&event, None, Some("abc"), "stop", None));
+        assert!(!event_matches(
+            &event,
+            None,
+            Some("xyz"),
+            "stop",
+            None,
+            None
+        ));
+        assert!(event_matches(&event, None, Some("abc"), "stop", None, None));
     }
 
     #[test]
@@ -591,16 +644,100 @@ mod tests {
             None,
             None,
             "token",
-            Some("marker-XYZ")
+            Some("marker-XYZ"),
+            None,
         ));
-        assert!(!event_matches(&event, None, None, "token", Some("absent")));
+        assert!(!event_matches(
+            &event,
+            None,
+            None,
+            "token",
+            Some("absent"),
+            None
+        ));
     }
 
     #[test]
     fn token_mode_requires_non_empty_token() {
         let event = make_event("claude", "abc", HookEventKind::UserPromptSubmit, json!({}));
-        assert!(!event_matches(&event, None, None, "token", None));
-        assert!(!event_matches(&event, None, None, "token", Some("")));
+        assert!(!event_matches(&event, None, None, "token", None, None));
+        assert!(!event_matches(&event, None, None, "token", Some(""), None));
+    }
+
+    // -------- #tui-hook-ttl-buffer: turn-boundary lower bound (`not_before`) ----
+
+    /// A Stop that arrived BEFORE the caller's turn began (`received_at <
+    /// not_before`) must NOT satisfy the wait — this is the turn-boundary gate
+    /// that stops a previous turn's still-buffered, un-claimed, within-TTL Stop
+    /// from waking a brand-new `/tui/wait`. The same predicate gates both the
+    /// registry-replay claim and the live broadcast loop, so closing it here
+    /// closes the stale-Stop replay race deferred from the earlier fix pass.
+    #[test]
+    fn stale_stop_before_turn_start_is_rejected_by_not_before() {
+        let turn_start = Utc::now();
+        // Stop from the *previous* turn: stamped one second before the boundary.
+        let mut stale = make_event("claude", "abc", HookEventKind::Stop, json!({}));
+        stale.received_at = turn_start - chrono::Duration::seconds(1);
+
+        // Without a lower bound the stale Stop matches (legacy behaviour).
+        assert!(event_matches(&stale, None, None, "stop", None, None));
+        // With the turn boundary it is rejected: it predates this turn.
+        assert!(!event_matches(
+            &stale,
+            None,
+            None,
+            "stop",
+            None,
+            Some(turn_start),
+        ));
+    }
+
+    /// A Stop that arrives at or after the turn boundary still satisfies the
+    /// wait — `not_before` only rejects strictly-older events, so a fresh Stop
+    /// (including one stamped exactly at the boundary) is honoured.
+    #[test]
+    fn fresh_stop_at_or_after_turn_start_still_matches_with_not_before() {
+        let turn_start = Utc::now();
+
+        // Exactly at the boundary: inclusive, must match.
+        let mut at_boundary = make_event("claude", "abc", HookEventKind::Stop, json!({}));
+        at_boundary.received_at = turn_start;
+        assert!(event_matches(
+            &at_boundary,
+            None,
+            None,
+            "stop",
+            None,
+            Some(turn_start),
+        ));
+
+        // After the boundary: must match.
+        let mut after = make_event("claude", "abc", HookEventKind::Stop, json!({}));
+        after.received_at = turn_start + chrono::Duration::seconds(1);
+        assert!(event_matches(
+            &after,
+            None,
+            None,
+            "stop",
+            None,
+            Some(turn_start),
+        ));
+    }
+
+    /// `WaitRequest::not_before` is optional and additive: a request body that
+    /// omits it deserializes to `None`, preserving the prior any-in-TTL-event
+    /// behaviour for existing callers.
+    #[test]
+    fn wait_request_not_before_defaults_to_none() {
+        let req: WaitRequest =
+            serde_json::from_value(json!({ "session_name": "s" })).expect("deserialize");
+        assert!(req.not_before.is_none());
+
+        let req: WaitRequest = serde_json::from_value(
+            json!({ "session_name": "s", "not_before": "2026-06-16T00:00:00Z" }),
+        )
+        .expect("deserialize with not_before");
+        assert!(req.not_before.is_some());
     }
 
     // -------- #tui-hook-ttl-buffer: registry-backed early-Stop claim --------
@@ -624,12 +761,12 @@ mod tests {
             make_event(provider, session, HookEventKind::Stop, json!({})),
         );
 
-        let matched = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        let matched = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
         assert!(matched.is_some(), "buffered early Stop must be claimed");
         assert_eq!(matched.unwrap().kind, HookEventKind::Stop);
 
         // Single-consumption: a second claim finds nothing.
-        let second = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        let second = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
         assert!(
             second.is_none(),
             "claimed Stop must not replay to a later wait"
@@ -641,8 +778,8 @@ mod tests {
     /// through to the broadcast wait (registry returns `None`).
     #[test]
     fn try_claim_registry_match_skips_when_no_session_id() {
-        assert!(try_claim_registry_match(Some("claude"), None, "stop", None).is_none());
-        assert!(try_claim_registry_match(None, Some("sid"), "stop", None).is_none());
+        assert!(try_claim_registry_match(Some("claude"), None, "stop", None, None).is_none());
+        assert!(try_claim_registry_match(None, Some("sid"), "stop", None, None).is_none());
     }
 
     /// Cross-provider isolation at the wait seam: a Stop buffered for
@@ -662,9 +799,13 @@ mod tests {
             make_event("codex", session, HookEventKind::Stop, json!({})),
         );
         // A claude wait for the same session id must not see the codex Stop.
-        assert!(try_claim_registry_match(Some("claude"), Some(session), "stop", None).is_none());
+        assert!(
+            try_claim_registry_match(Some("claude"), Some(session), "stop", None, None).is_none()
+        );
         // The codex wait does see it.
-        assert!(try_claim_registry_match(Some("codex"), Some(session), "stop", None).is_some());
+        assert!(
+            try_claim_registry_match(Some("codex"), Some(session), "stop", None, None).is_some()
+        );
     }
 
     /// Do-not-discard-unmatched-events: a `until=token` wait whose token does not
@@ -686,8 +827,13 @@ mod tests {
         );
 
         // A token wait with a non-matching token finds nothing.
-        let token_miss =
-            try_claim_registry_match(Some(provider), Some(session), "token", Some("absent-token"));
+        let token_miss = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "token",
+            Some("absent-token"),
+            None,
+        );
         assert!(
             token_miss.is_none(),
             "non-matching token wait matches nothing"
@@ -695,7 +841,7 @@ mod tests {
 
         // The buffered Stop must still be claimable by a later Stop wait — the
         // failed token wait must not have discarded it.
-        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
         assert!(
             stop_hit.is_some(),
             "unmatched token wait must not discard the buffered Stop"
@@ -728,12 +874,17 @@ mod tests {
         );
 
         // Token wait consumes only the token payload.
-        let token_hit =
-            try_claim_registry_match(Some(provider), Some(session), "token", Some("needle-42"));
+        let token_hit = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "token",
+            Some("needle-42"),
+            None,
+        );
         assert!(token_hit.is_some(), "token payload must be claimable");
 
         // The Stop is still buffered and claimable.
-        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
         assert!(
             stop_hit.is_some(),
             "the Stop must survive a token-mode claim on the same session"

--- a/src/services/claude_tui/tui_relay.rs
+++ b/src/services/claude_tui/tui_relay.rs
@@ -259,6 +259,40 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
     }
 
     let started = Instant::now();
+
+    // #tui-hook-ttl-buffer (REQ-002/REQ-005/REQ-006): claim the registry key
+    // BEFORE subscribing to the broadcast so a Stop that landed in the early
+    // window (after the previous turn drained the channel but before this wait
+    // subscribed) is replayed exactly once instead of being lost. This is the
+    // additive event source the PRD migrates `/tui/wait` onto; the broadcast
+    // subscription below remains the live path and the fallback. Claiming also
+    // cancels any unclaimed-Stop diagnostic timer for the key. When the
+    // registry is disabled via the rollback flag, this block is a no-op and the
+    // behaviour reverts to the pure broadcast wait.
+    if let Some(early) = try_claim_registry_match(
+        req.provider.as_deref(),
+        req.session_id.as_deref(),
+        &until_mode,
+        token.as_deref(),
+    ) {
+        let summary = json!({
+            "provider": early.provider,
+            "session_id": early.session_id,
+            "kind": early.kind.as_str(),
+            "received_at": early.received_at,
+        });
+        return Json(
+            serde_json::to_value(WaitResponse {
+                ok: true,
+                matched: true,
+                reason: format!("matched:{until_mode}:registry"),
+                event: Some(summary),
+                waited_ms: started.elapsed().as_millis(),
+            })
+            .unwrap_or_else(|_| json!({ "ok": true, "matched": true })),
+        );
+    }
+
     let mut rx = subscribe_hook_events();
     let deadline = tokio::time::sleep(timeout);
     tokio::pin!(deadline);
@@ -315,6 +349,42 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
             }
         }
     }
+}
+
+/// #tui-hook-ttl-buffer: claim the registry key for this wait and return the
+/// newest buffered event that already satisfies the wait filter, if any. The
+/// claim drains the key's fresh buffer exactly once (single-consumption) and
+/// cancels any unclaimed-Stop diagnostic timer, so a stale event cannot be
+/// replayed into a later turn.
+///
+/// A key is only formed when BOTH a provider and a session_id are supplied —
+/// the registry key requires a concrete session id (provider session id or the
+/// tmux fallback), and `/tui/wait` callers that omit `session_id` intentionally
+/// accept "any session", which the registry (per-key) cannot represent. Those
+/// callers fall through to the broadcast wait unchanged. Returns `None` when
+/// the registry is disabled, no key can be formed, or no buffered event matches.
+fn try_claim_registry_match(
+    want_provider: Option<&str>,
+    want_session_id: Option<&str>,
+    until_mode: &str,
+    token: Option<&str>,
+) -> Option<HookEvent> {
+    use crate::services::claude_tui::hook_registry;
+    if !hook_registry::registry_enabled() {
+        return None;
+    }
+    let provider = want_provider.map(str::trim).filter(|p| !p.is_empty())?;
+    let session_id = want_session_id.map(str::trim).filter(|s| !s.is_empty())?;
+    let key = hook_registry::RegistryKey::new(provider, Some(session_id), None)?;
+    // claim_once drains the fresh buffer AND drops the key so the next turn
+    // re-buffers early Stops instead of seeing them delivered "live" and lost.
+    let replayed = hook_registry::global().claim_once(key);
+    // Return the newest matching event (registry preserves arrival order, so the
+    // last matching entry is the freshest Stop / token hit).
+    replayed
+        .into_iter()
+        .rev()
+        .find(|event| event_matches(event, want_provider, want_session_id, until_mode, token))
 }
 
 fn event_matches(
@@ -517,6 +587,70 @@ mod tests {
         let event = make_event("claude", "abc", HookEventKind::UserPromptSubmit, json!({}));
         assert!(!event_matches(&event, None, None, "token", None));
         assert!(!event_matches(&event, None, None, "token", Some("")));
+    }
+
+    // -------- #tui-hook-ttl-buffer: registry-backed early-Stop claim --------
+
+    /// REQ-002/REQ-006: an early Stop buffered in the registry (before `/tui/wait`
+    /// subscribed to the broadcast) is returned by `try_claim_registry_match`
+    /// without waiting for a new broadcast event. The claim is single-shot —
+    /// a second call returns nothing (stale Stop cannot wake a later turn).
+    #[test]
+    fn try_claim_registry_match_returns_buffered_early_stop_once() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+        let provider = "claude";
+        let session = "wait-early-stop";
+        // Clean slate.
+        if let Some(k) = RegistryKey::new(provider, Some(session), None) {
+            let _ = global().claim_once(k);
+        }
+        let key = RegistryKey::new(provider, Some(session), None).unwrap();
+        global().deliver(
+            key,
+            make_event(provider, session, HookEventKind::Stop, json!({})),
+        );
+
+        let matched = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        assert!(matched.is_some(), "buffered early Stop must be claimed");
+        assert_eq!(matched.unwrap().kind, HookEventKind::Stop);
+
+        // Single-consumption: a second claim finds nothing.
+        let second = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        assert!(
+            second.is_none(),
+            "claimed Stop must not replay to a later wait"
+        );
+    }
+
+    /// REQ-005: a `/tui/wait` caller that omits `session_id` accepts "any
+    /// session", which the per-key registry cannot represent — so it falls
+    /// through to the broadcast wait (registry returns `None`).
+    #[test]
+    fn try_claim_registry_match_skips_when_no_session_id() {
+        assert!(try_claim_registry_match(Some("claude"), None, "stop", None).is_none());
+        assert!(try_claim_registry_match(None, Some("sid"), "stop", None).is_none());
+    }
+
+    /// Cross-provider isolation at the wait seam: a Stop buffered for
+    /// (codex, ABC) must not be claimable by a (claude, ABC) wait.
+    #[test]
+    fn try_claim_registry_match_isolates_providers() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+        let session = "wait-iso-ABC";
+        for p in ["claude", "codex"] {
+            if let Some(k) = RegistryKey::new(p, Some(session), None) {
+                let _ = global().claim_once(k);
+            }
+        }
+        let codex_key = RegistryKey::new("codex", Some(session), None).unwrap();
+        global().deliver(
+            codex_key,
+            make_event("codex", session, HookEventKind::Stop, json!({})),
+        );
+        // A claude wait for the same session id must not see the codex Stop.
+        assert!(try_claim_registry_match(Some("claude"), Some(session), "stop", None).is_none());
+        // The codex wait does see it.
+        assert!(try_claim_registry_match(Some("codex"), Some(session), "stop", None).is_some());
     }
 
     #[test]

--- a/src/services/claude_tui/tui_relay.rs
+++ b/src/services/claude_tui/tui_relay.rs
@@ -260,15 +260,22 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
 
     let started = Instant::now();
 
-    // #tui-hook-ttl-buffer (REQ-002/REQ-005/REQ-006): claim the registry key
-    // BEFORE subscribing to the broadcast so a Stop that landed in the early
-    // window (after the previous turn drained the channel but before this wait
-    // subscribed) is replayed exactly once instead of being lost. This is the
-    // additive event source the PRD migrates `/tui/wait` onto; the broadcast
-    // subscription below remains the live path and the fallback. Claiming also
-    // cancels any unclaimed-Stop diagnostic timer for the key. When the
-    // registry is disabled via the rollback flag, this block is a no-op and the
-    // behaviour reverts to the pure broadcast wait.
+    // #tui-hook-ttl-buffer (REQ-002/REQ-005/REQ-006): SUBSCRIBE to the broadcast
+    // BEFORE attempting the registry claim. The claim only sees events buffered
+    // up to the moment it runs; a Stop that arrives AFTER the claim but BEFORE we
+    // subscribe would otherwise be fed to the registry (for a later request) with
+    // no live subscriber here, leaving this wait to time out. Subscribing first
+    // guarantees any post-claim event is delivered to the broadcast loop below,
+    // so the only events the claim must rescue are the ones already buffered when
+    // it runs — closing the missed-event window in both directions.
+    let mut rx = subscribe_hook_events();
+
+    // Now claim the registry key for events that landed in the early window
+    // (after the previous turn drained the channel but before this subscriber
+    // existed). `claim_matching_once` consumes ONLY the matching event and leaves
+    // any non-matching buffered events for a later waiter. When the registry is
+    // disabled via the rollback flag, this is a no-op and the behaviour reverts
+    // to the pure broadcast wait.
     if let Some(early) = try_claim_registry_match(
         req.provider.as_deref(),
         req.session_id.as_deref(),
@@ -293,7 +300,6 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
         );
     }
 
-    let mut rx = subscribe_hook_events();
     let deadline = tokio::time::sleep(timeout);
     tokio::pin!(deadline);
 
@@ -376,15 +382,23 @@ fn try_claim_registry_match(
     let provider = want_provider.map(str::trim).filter(|p| !p.is_empty())?;
     let session_id = want_session_id.map(str::trim).filter(|s| !s.is_empty())?;
     let key = hook_registry::RegistryKey::new(provider, Some(session_id), None)?;
-    // claim_once drains the fresh buffer AND drops the key so the next turn
-    // re-buffers early Stops instead of seeing them delivered "live" and lost.
-    let replayed = hook_registry::global().claim_once(key);
-    // Return the newest matching event (registry preserves arrival order, so the
-    // last matching entry is the freshest Stop / token hit).
-    replayed
-        .into_iter()
-        .rev()
-        .find(|event| event_matches(event, want_provider, want_session_id, until_mode, token))
+    // `claim_matching_once` consumes ONLY the freshest event satisfying THIS
+    // wait's filter and re-buffers every other fresh event, so a buffered Stop or
+    // a different `until=token` payload is not discarded for a later waiter on the
+    // same session. (The old `claim_once` drained the whole buffer up front and
+    // dropped unmatched events.) The closure is the same predicate the live
+    // broadcast loop applies, keeping registry replay and live waits consistent.
+    let until_mode = until_mode.to_string();
+    let token = token.map(str::to_string);
+    hook_registry::global().claim_matching_once(key, |event| {
+        event_matches(
+            event,
+            want_provider,
+            want_session_id,
+            &until_mode,
+            token.as_deref(),
+        )
+    })
 }
 
 fn event_matches(
@@ -651,6 +665,79 @@ mod tests {
         assert!(try_claim_registry_match(Some("claude"), Some(session), "stop", None).is_none());
         // The codex wait does see it.
         assert!(try_claim_registry_match(Some("codex"), Some(session), "stop", None).is_some());
+    }
+
+    /// Do-not-discard-unmatched-events: a `until=token` wait whose token does not
+    /// match the buffered events must NOT drain/discard them — a subsequent Stop
+    /// wait for the same session must still be able to replay the buffered Stop.
+    #[test]
+    fn try_claim_registry_match_does_not_discard_unmatched_events() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+        let provider = "claude";
+        let session = "wait-no-discard";
+        if let Some(k) = RegistryKey::new(provider, Some(session), None) {
+            let _ = global().claim_once(k);
+        }
+        let key = RegistryKey::new(provider, Some(session), None).unwrap();
+        // Buffer a Stop with an empty body (no token).
+        global().deliver(
+            key,
+            make_event(provider, session, HookEventKind::Stop, json!({})),
+        );
+
+        // A token wait with a non-matching token finds nothing.
+        let token_miss =
+            try_claim_registry_match(Some(provider), Some(session), "token", Some("absent-token"));
+        assert!(
+            token_miss.is_none(),
+            "non-matching token wait matches nothing"
+        );
+
+        // The buffered Stop must still be claimable by a later Stop wait — the
+        // failed token wait must not have discarded it.
+        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        assert!(
+            stop_hit.is_some(),
+            "unmatched token wait must not discard the buffered Stop"
+        );
+    }
+
+    /// A token wait consumes only the matching token payload and leaves a buffered
+    /// Stop for a subsequent Stop wait on the same session.
+    #[test]
+    fn try_claim_registry_match_token_leaves_stop_for_later_wait() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+        let provider = "claude";
+        let session = "wait-token-then-stop";
+        if let Some(k) = RegistryKey::new(provider, Some(session), None) {
+            let _ = global().claim_once(k);
+        }
+        let key = RegistryKey::new(provider, Some(session), None).unwrap();
+        global().deliver(
+            key.clone(),
+            make_event(
+                provider,
+                session,
+                HookEventKind::Notification,
+                json!({ "text": "needle-42 present" }),
+            ),
+        );
+        global().deliver(
+            key,
+            make_event(provider, session, HookEventKind::Stop, json!({})),
+        );
+
+        // Token wait consumes only the token payload.
+        let token_hit =
+            try_claim_registry_match(Some(provider), Some(session), "token", Some("needle-42"));
+        assert!(token_hit.is_some(), "token payload must be claimable");
+
+        // The Stop is still buffered and claimable.
+        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None);
+        assert!(
+            stop_hit.is_some(),
+            "the Stop must survive a token-mode claim on the same session"
+        );
     }
 
     #[test]

--- a/src/services/claude_tui/tui_relay.rs
+++ b/src/services/claude_tui/tui_relay.rs
@@ -438,6 +438,11 @@ fn try_claim_registry_match(
     if !hook_registry::registry_enabled() {
         return None;
     }
+    // Registry replay must be tied to a concrete turn lower-bound. Without it,
+    // a previous turn's still-in-TTL Stop/token payload for the same provider
+    // session can satisfy the next wait before the live broadcast path sees any
+    // new assistant output.
+    let not_before = not_before?;
     let provider = want_provider.map(str::trim).filter(|p| !p.is_empty())?;
     let session_id = want_session_id.map(str::trim).filter(|s| !s.is_empty())?;
     let key = hook_registry::RegistryKey::new(provider, Some(session_id), None)?;
@@ -450,15 +455,36 @@ fn try_claim_registry_match(
     let until_mode = until_mode.to_string();
     let token = token.map(str::to_string);
     hook_registry::global().claim_matching_once(key, |event| {
-        event_matches(
+        event_matches_registry_replay(
             event,
             want_provider,
             want_session_id,
             &until_mode,
             token.as_deref(),
-            not_before,
+            Some(not_before),
         )
     })
+}
+
+fn event_matches_registry_replay(
+    event: &HookEvent,
+    want_provider: Option<&str>,
+    want_session_id: Option<&str>,
+    until_mode: &str,
+    token: Option<&str>,
+    not_before: Option<DateTime<Utc>>,
+) -> bool {
+    if until_mode == "token" && matches!(event.kind, HookEventKind::UserPromptSubmit) {
+        return false;
+    }
+    event_matches(
+        event,
+        want_provider,
+        want_session_id,
+        until_mode,
+        token,
+        not_before,
+    )
 }
 
 fn event_matches(
@@ -644,6 +670,10 @@ mod tests {
         }
     }
 
+    fn replay_lower_bound() -> Option<DateTime<Utc>> {
+        Some(Utc::now() - chrono::Duration::seconds(1))
+    }
+
     #[test]
     fn stop_event_matches_default() {
         let event = make_event("claude", "abc", HookEventKind::Stop, json!({}));
@@ -827,15 +857,56 @@ mod tests {
             make_event(provider, session, HookEventKind::Stop, json!({})),
         );
 
-        let matched = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
+        let matched = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "stop",
+            None,
+            replay_lower_bound(),
+        );
         assert!(matched.is_some(), "buffered early Stop must be claimed");
         assert_eq!(matched.unwrap().kind, HookEventKind::Stop);
 
         // Single-consumption: a second claim finds nothing.
-        let second = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
+        let second = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "stop",
+            None,
+            replay_lower_bound(),
+        );
         assert!(
             second.is_none(),
             "claimed Stop must not replay to a later wait"
+        );
+    }
+
+    #[test]
+    fn try_claim_registry_match_requires_turn_lower_bound() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+        let provider = "claude";
+        let session = "wait-requires-bound";
+        if let Some(k) = RegistryKey::new(provider, Some(session), None) {
+            let _ = global().claim_once(k);
+        }
+        let key = RegistryKey::new(provider, Some(session), None).unwrap();
+        global().deliver(
+            key,
+            make_event(provider, session, HookEventKind::Stop, json!({})),
+        );
+
+        assert!(
+            try_claim_registry_match(Some(provider), Some(session), "stop", None, None).is_none()
+        );
+        assert!(
+            try_claim_registry_match(
+                Some(provider),
+                Some(session),
+                "stop",
+                None,
+                replay_lower_bound(),
+            )
+            .is_some()
         );
     }
 
@@ -844,8 +915,14 @@ mod tests {
     /// through to the broadcast wait (registry returns `None`).
     #[test]
     fn try_claim_registry_match_skips_when_no_session_id() {
-        assert!(try_claim_registry_match(Some("claude"), None, "stop", None, None).is_none());
-        assert!(try_claim_registry_match(None, Some("sid"), "stop", None, None).is_none());
+        assert!(
+            try_claim_registry_match(Some("claude"), None, "stop", None, replay_lower_bound())
+                .is_none()
+        );
+        assert!(
+            try_claim_registry_match(None, Some("sid"), "stop", None, replay_lower_bound())
+                .is_none()
+        );
     }
 
     /// Cross-provider isolation at the wait seam: a Stop buffered for
@@ -866,11 +943,25 @@ mod tests {
         );
         // A claude wait for the same session id must not see the codex Stop.
         assert!(
-            try_claim_registry_match(Some("claude"), Some(session), "stop", None, None).is_none()
+            try_claim_registry_match(
+                Some("claude"),
+                Some(session),
+                "stop",
+                None,
+                replay_lower_bound(),
+            )
+            .is_none()
         );
         // The codex wait does see it.
         assert!(
-            try_claim_registry_match(Some("codex"), Some(session), "stop", None, None).is_some()
+            try_claim_registry_match(
+                Some("codex"),
+                Some(session),
+                "stop",
+                None,
+                replay_lower_bound(),
+            )
+            .is_some()
         );
     }
 
@@ -898,7 +989,7 @@ mod tests {
             Some(session),
             "token",
             Some("absent-token"),
-            None,
+            replay_lower_bound(),
         );
         assert!(
             token_miss.is_none(),
@@ -907,7 +998,13 @@ mod tests {
 
         // The buffered Stop must still be claimable by a later Stop wait — the
         // failed token wait must not have discarded it.
-        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
+        let stop_hit = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "stop",
+            None,
+            replay_lower_bound(),
+        );
         assert!(
             stop_hit.is_some(),
             "unmatched token wait must not discard the buffered Stop"
@@ -945,15 +1042,74 @@ mod tests {
             Some(session),
             "token",
             Some("needle-42"),
-            None,
+            replay_lower_bound(),
         );
         assert!(token_hit.is_some(), "token payload must be claimable");
 
         // The Stop is still buffered and claimable.
-        let stop_hit = try_claim_registry_match(Some(provider), Some(session), "stop", None, None);
+        let stop_hit = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "stop",
+            None,
+            replay_lower_bound(),
+        );
         assert!(
             stop_hit.is_some(),
             "the Stop must survive a token-mode claim on the same session"
+        );
+    }
+
+    #[test]
+    fn try_claim_registry_match_token_ignores_prompt_submit_payload() {
+        use crate::services::claude_tui::hook_registry::{RegistryKey, global};
+        let provider = "claude";
+        let session = "wait-token-prompt-submit";
+        if let Some(k) = RegistryKey::new(provider, Some(session), None) {
+            let _ = global().claim_once(k);
+        }
+        let key = RegistryKey::new(provider, Some(session), None).unwrap();
+        global().deliver(
+            key.clone(),
+            make_event(
+                provider,
+                session,
+                HookEventKind::UserPromptSubmit,
+                json!({ "prompt": "marker-from-user-prompt" }),
+            ),
+        );
+        global().deliver(
+            key,
+            make_event(
+                provider,
+                session,
+                HookEventKind::Notification,
+                json!({ "text": "marker-from-assistant" }),
+            ),
+        );
+
+        let prompt_submit = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "token",
+            Some("marker-from-user-prompt"),
+            replay_lower_bound(),
+        );
+        assert!(
+            prompt_submit.is_none(),
+            "registry replay must not satisfy token waits from prompt-submit echo"
+        );
+
+        let assistant_token = try_claim_registry_match(
+            Some(provider),
+            Some(session),
+            "token",
+            Some("marker-from-assistant"),
+            replay_lower_bound(),
+        );
+        assert!(
+            assistant_token.is_some(),
+            "non-prompt-submit token payload remains claimable"
         );
     }
 

--- a/src/services/claude_tui/tui_relay.rs
+++ b/src/services/claude_tui/tui_relay.rs
@@ -24,7 +24,11 @@
 //!   (`hook_server::subscribe_hook_events`) so we observe Stop events the
 //!   moment they land instead of polling the transcript every second.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, OnceLock},
+    time::Duration,
+};
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 use chrono::{DateTime, Utc};
@@ -43,10 +47,36 @@ const MAX_WAIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 /// Default timeout if the caller omits one.
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
 
+static SEND_NOT_BEFORE: OnceLock<Mutex<HashMap<String, DateTime<Utc>>>> = OnceLock::new();
+
 /// Buffer name used when pasting send-text. Each request gets its own buffer
 /// so concurrent sends to different sessions cannot stomp each other.
 fn allocate_buffer_name() -> String {
     format!("adk-tui-send-{}", uuid::Uuid::new_v4().simple())
+}
+
+fn send_not_before_map() -> &'static Mutex<HashMap<String, DateTime<Utc>>> {
+    SEND_NOT_BEFORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn remember_send_not_before(session_name: &str, not_before: DateTime<Utc>) {
+    if let Ok(mut map) = send_not_before_map().lock() {
+        map.insert(session_name.to_string(), not_before);
+    }
+}
+
+fn last_send_not_before(session_name: &str) -> Option<DateTime<Utc>> {
+    send_not_before_map()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(session_name).copied())
+}
+
+fn resolve_wait_not_before(
+    session_name: &str,
+    explicit: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    explicit.or_else(|| last_send_not_before(session_name))
 }
 
 pub(crate) trait SendBackend: Send + Sync {
@@ -104,6 +134,8 @@ pub struct SendResponse {
     pub session_name: String,
     pub bytes: usize,
     pub submitted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -223,9 +255,15 @@ fn handle_send_with_backend(
     }
 
     let mut submitted = false;
+    let mut not_before = None;
     if req.submit {
+        let turn_boundary = Utc::now();
         match backend.send_enter(&session_name) {
-            Ok(()) => submitted = true,
+            Ok(()) => {
+                submitted = true;
+                not_before = Some(turn_boundary);
+                remember_send_not_before(&session_name, turn_boundary);
+            }
             Err(error) => {
                 return ok_error_json(&format!("tmux send-keys Enter failed: {error}"));
             }
@@ -237,6 +275,7 @@ fn handle_send_with_backend(
         session_name,
         bytes,
         submitted,
+        not_before,
     };
     (
         StatusCode::OK,
@@ -274,6 +313,7 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
         return Json(error_json("until=token requires a non-empty token"));
     }
 
+    let wait_not_before = resolve_wait_not_before(&session_name, req.not_before);
     let started = Instant::now();
 
     // #tui-hook-ttl-buffer (REQ-002/REQ-005/REQ-006): SUBSCRIBE to the broadcast
@@ -297,7 +337,7 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
         req.session_id.as_deref(),
         &until_mode,
         token.as_deref(),
-        req.not_before,
+        wait_not_before,
     ) {
         let summary = json!({
             "provider": early.provider,
@@ -352,7 +392,7 @@ async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
                     req.session_id.as_deref(),
                     &until_mode,
                     token.as_deref(),
-                    req.not_before,
+                    wait_not_before,
                 ) {
                     continue;
                 }
@@ -566,6 +606,32 @@ mod tests {
         assert_eq!(body.0["session_name"], "test-session");
         assert_eq!(body.0["bytes"].as_u64(), Some("hello\nworld".len() as u64));
         assert_eq!(body.0["submitted"], true);
+        assert!(body.0["not_before"].as_str().is_some());
+    }
+
+    #[test]
+    fn handle_send_records_not_before_for_followup_waits() {
+        let mut req = send_request("hello", true);
+        req.session_name = "not-before-session".to_string();
+        let (status, body) = handle_send_with_backend(req, &FakeSendBackend);
+
+        assert_eq!(status, StatusCode::OK);
+        let recorded = body.0["not_before"]
+            .as_str()
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc))
+            .expect("send response should include not_before");
+        assert_eq!(
+            resolve_wait_not_before("not-before-session", None),
+            Some(recorded)
+        );
+
+        let explicit = recorded + chrono::Duration::seconds(5);
+        assert_eq!(
+            resolve_wait_not_before("not-before-session", Some(explicit)),
+            Some(explicit),
+            "caller-supplied not_before must override the remembered send boundary"
+        );
     }
 
     fn make_event(provider: &str, sid: &str, kind: HookEventKind, payload: Value) -> HookEvent {

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -247,6 +247,38 @@ pub fn register_provider_session(
     );
 }
 
+/// Reverse lookup: resolve the provider session id that maps to `tmux_session_name`
+/// for `provider`, if one was registered (and has not expired). `register_provider_session`
+/// records the forward `provider_session_id -> tmux_session_name` mapping at
+/// launch; this scans it for the entry whose value matches the tmux session.
+///
+/// #tui-hook-ttl-buffer key-match fix: the Claude hook relay buffers under the
+/// PROVIDER session UUID (`config.session_id`), but the readiness layer only
+/// knows the tmux session name. Callers use this to claim the SAME key the hooks
+/// buffered under instead of the tmux fallback (which the buffer never used for a
+/// hosted Claude launch). Returns `None` when no mapping is known, in which case
+/// the caller should fall back to the tmux session name.
+pub fn provider_session_for_tmux(provider: &str, tmux_session_name: &str) -> Option<String> {
+    let provider = normalize_provider(provider);
+    let tmux_session_name = tmux_session_name.trim();
+    if provider.is_empty() || tmux_session_name.is_empty() {
+        return None;
+    }
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    // The forward map can in principle hold multiple provider session ids that
+    // pointed at the same tmux session over time; `purge_expired` has already
+    // dropped stale ones, so prefer the most recently recorded survivor.
+    state
+        .tmux_by_provider_session
+        .iter()
+        .filter(|(promptkey, timed)| {
+            promptkey.provider == provider && timed.value == tmux_session_name
+        })
+        .max_by_key(|(_, timed)| timed.recorded_at)
+        .map(|(promptkey, _)| promptkey.key.clone())
+}
+
 pub fn register_tmux_channel(tmux_session_name: &str, channel_id: u64) {
     let tmux_session_name = tmux_session_name.trim();
     if tmux_session_name.is_empty() || channel_id == 0 {
@@ -1574,6 +1606,50 @@ mod tests {
     fn reset_state() {
         let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
         *state = TuiPromptDedupeState::default();
+    }
+
+    // #tui-hook-ttl-buffer key-match: the reverse lookup must resolve the
+    // provider session UUID for a tmux session (the readiness layer only knows
+    // the tmux name, but the hooks buffer under the provider UUID), and must
+    // stay provider-isolated even when two providers share a tmux name.
+    #[test]
+    fn provider_session_for_tmux_resolves_reverse_mapping() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        register_provider_session("claude", "uuid-claude-1", "tmux-shared");
+        register_provider_session("codex", "uuid-codex-1", "tmux-shared");
+
+        // Resolves the right provider's UUID for the shared tmux name.
+        assert_eq!(
+            provider_session_for_tmux("claude", "tmux-shared"),
+            Some("uuid-claude-1".to_string())
+        );
+        assert_eq!(
+            provider_session_for_tmux("codex", "tmux-shared"),
+            Some("uuid-codex-1".to_string())
+        );
+        // No mapping for an unknown tmux session => None (caller falls back to
+        // the tmux name as the registry key).
+        assert_eq!(provider_session_for_tmux("claude", "tmux-unknown"), None);
+        // Empty inputs are rejected.
+        assert_eq!(provider_session_for_tmux("claude", ""), None);
+        assert_eq!(provider_session_for_tmux("", "tmux-shared"), None);
+    }
+
+    #[test]
+    fn provider_session_for_tmux_prefers_most_recent_mapping() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        // A relaunch of the same tmux session under a new provider UUID must
+        // resolve to the newest UUID (the prior turn's hooks have expired/moved).
+        register_provider_session("claude", "uuid-old", "tmux-relaunch");
+        register_provider_session("claude", "uuid-new", "tmux-relaunch");
+        assert_eq!(
+            provider_session_for_tmux("claude", "tmux-relaunch"),
+            Some("uuid-new".to_string())
+        );
     }
 
     // U-14 Provider-keyed channel isolation: registering the same tmux name

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -248,9 +248,9 @@ pub fn register_provider_session(
 }
 
 /// Reverse lookup: resolve the provider session id that maps to `tmux_session_name`
-/// for `provider`, if one was registered (and has not expired). `register_provider_session`
-/// records the forward `provider_session_id -> tmux_session_name` mapping at
-/// launch; this scans it for the entry whose value matches the tmux session.
+/// for `provider`, if one was registered. `register_provider_session` records
+/// the forward `provider_session_id -> tmux_session_name` mapping at launch;
+/// this scans it for the entry whose value matches the tmux session.
 ///
 /// #tui-hook-ttl-buffer key-match fix: the Claude hook relay buffers under the
 /// PROVIDER session UUID (`config.session_id`), but the readiness layer only
@@ -267,8 +267,10 @@ pub fn provider_session_for_tmux(provider: &str, tmux_session_name: &str) -> Opt
     let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
     state.purge_expired();
     // The forward map can in principle hold multiple provider session ids that
-    // pointed at the same tmux session over time; `purge_expired` has already
-    // dropped stale ones, so prefer the most recently recorded survivor.
+    // pointed at the same tmux session over time; prefer the most recently
+    // recorded survivor. Do not TTL-expire this bridge: long-lived TUI sessions
+    // can keep emitting hooks with the same provider UUID after the ordinary
+    // prompt-cache TTL has elapsed.
     state
         .tmux_by_provider_session
         .iter()
@@ -1568,8 +1570,6 @@ impl TuiPromptDedupeState {
             }
             !queue.is_empty()
         });
-        self.tmux_by_provider_session
-            .retain(|_, entry| now.duration_since(entry.recorded_at) <= SESSION_MAPPING_TTL);
         self.channel_by_tmux
             .retain(|_, entry| now.duration_since(entry.recorded_at) <= SESSION_MAPPING_TTL);
         self.runtime_by_tmux
@@ -1649,6 +1649,32 @@ mod tests {
         assert_eq!(
             provider_session_for_tmux("claude", "tmux-relaunch"),
             Some("uuid-new".to_string())
+        );
+    }
+
+    #[test]
+    fn provider_session_mapping_survives_prompt_purge_ttl() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        register_provider_session("claude", "uuid-long-lived", "tmux-long-lived");
+        {
+            let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            let key = PromptKey::new("claude", "uuid-long-lived");
+            state
+                .tmux_by_provider_session
+                .get_mut(&key)
+                .expect("registered provider-session mapping")
+                .recorded_at = Instant::now() - SESSION_MAPPING_TTL - Duration::from_secs(1);
+        }
+
+        // Any API that calls purge_expired should not delete the provider UUID
+        // bridge while the TUI session can still be alive.
+        register_tmux_channel("tmux-other", 42);
+
+        assert_eq!(
+            provider_session_for_tmux("claude", "tmux-long-lived"),
+            Some("uuid-long-lived".to_string())
         );
     }
 

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -620,7 +620,10 @@ pub(crate) fn clear_tmux_runtime_binding(tmux_session_name: &str) -> bool {
     }
     let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
     state.purge_expired();
-    state.runtime_by_tmux.remove(tmux_session_name).is_some()
+    let removed_runtime = state.runtime_by_tmux.remove(tmux_session_name).is_some();
+    let removed_provider_sessions =
+        state.remove_provider_session_mappings_for_tmux(tmux_session_name);
+    removed_runtime || removed_provider_sessions
 }
 
 /// #3105 (codex P1 sub-case B): tombstone-evict every mirror mapping for a tmux
@@ -646,7 +649,9 @@ pub(crate) fn evict_dead_tmux_mirror(tmux_session_name: &str) -> bool {
     state.purge_expired();
     let removed_runtime = state.runtime_by_tmux.remove(tmux_session_name).is_some();
     let removed_channel = state.channel_by_tmux.remove(tmux_session_name).is_some();
-    removed_runtime || removed_channel
+    let removed_provider_sessions =
+        state.remove_provider_session_mappings_for_tmux(tmux_session_name);
+    removed_runtime || removed_channel || removed_provider_sessions
 }
 
 pub(crate) fn runtime_bindings_for_kind(
@@ -1597,6 +1602,13 @@ impl TuiPromptDedupeState {
             !queue.is_empty()
         });
     }
+
+    fn remove_provider_session_mappings_for_tmux(&mut self, tmux_session_name: &str) -> bool {
+        let before = self.tmux_by_provider_session.len();
+        self.tmux_by_provider_session
+            .retain(|_, entry| entry.value != tmux_session_name);
+        before != self.tmux_by_provider_session.len()
+    }
 }
 
 #[cfg(test)]
@@ -1675,6 +1687,39 @@ mod tests {
         assert_eq!(
             provider_session_for_tmux("claude", "tmux-long-lived"),
             Some("uuid-long-lived".to_string())
+        );
+    }
+
+    #[test]
+    fn provider_session_mapping_is_removed_with_runtime_binding_clear() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        register_provider_session("claude", "uuid-stale", "tmux-stale");
+        assert_eq!(
+            provider_session_for_tmux("claude", "tmux-stale"),
+            Some("uuid-stale".to_string())
+        );
+
+        assert!(clear_tmux_runtime_binding("tmux-stale"));
+        assert_eq!(
+            provider_session_for_tmux("claude", "tmux-stale"),
+            None,
+            "clearing a tmux runtime binding must also clear stale provider-session reverse mappings"
+        );
+    }
+
+    #[test]
+    fn provider_session_mapping_is_removed_with_dead_tmux_mirror() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        register_provider_session("claude", "uuid-dead", "tmux-dead");
+        assert!(evict_dead_tmux_mirror("tmux-dead"));
+        assert_eq!(
+            provider_session_for_tmux("claude", "tmux-dead"),
+            None,
+            "dead tmux mirror eviction must not leave provider-session reverse mappings behind"
         );
     }
 


### PR DESCRIPTION
## 목표
Claude TUI hook registry가 early hook을 놓치지 않으면서도 대형 payload와 오래 실행되는 TUI 세션에서 메모리/매핑 안정성을 유지하도록 보강합니다.

## 쉬운 설명
Claude hook이 먼저 도착하고 나중에 waiter가 붙어도 필요한 이벤트를 한 번만 재생합니다.
큰 hook payload가 들어와도 replay buffer가 무한히 커지지 않습니다.
하루 이상 살아 있는 Claude TUI 세션에서도 provider session UUID와 tmux 세션 연결이 사라지지 않습니다.

## 개선되는 것
### Fix 1
Before: hook buffer는 이벤트 개수만 제한해서 8 MiB급 payload가 적은 개수로 쌓이면 per-session 메모리가 커질 수 있었습니다.
After: per-key byte cap을 추가하고, oversized payload는 replay buffer에 보관하지 않으며 oldest-first eviction으로 최신 신호를 유지합니다.

### Fix 2
Before: 빈 key 정리를 `deliver()`마다 전체 registry sweep으로 수행하면 hook hot path가 전체 key 수에 비례할 수 있었습니다.
After: `deliver()`는 touched key만 sweep하고, 전체 빈 key 정리는 snapshot/diagnostic 경로에서 수행합니다.

### Fix 3
Before: provider session UUID -> tmux 매핑이 prompt-cache TTL과 같이 만료되어 장시간 TUI 세션의 hook replay key 매칭이 깨질 수 있었습니다.
After: provider-session bridge는 prompt purge에서 제거하지 않아 long-lived TUI session의 hook key를 계속 해석합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 대형 hook payload | event count cap 안에서는 큰 payload가 보관됨 | byte cap 초과 payload는 buffer에 보관하지 않음 |
| hook hot path | delivery마다 전체 key sweep 가능 | touched key만 sweep |
| 장시간 Claude TUI | provider UUID bridge가 TTL 후 사라질 수 있음 | provider UUID bridge 유지 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| buffer count 초과 | oldest event를 제거하고 최신 event 보존 | 기존 최신 Stop/token 우선 semantics 유지 |
| byte cap 초과 | oversized event는 expired_total로 집계되고 미보관 | 메모리 상한 유지 |
| snapshot 호출 | expired/empty key sweep과 counter absorption 수행 | 진단 경로에서 map growth 정리 |

## 해결한 내용
- `src/services/claude_tui/hook_registry.rs`: replay buffer에 byte accounting을 추가하고, unclaimed Stop diagnostic이 전체 hook payload를 보관하지 않도록 kind만 유지하게 변경했습니다.
- `src/services/tui_prompt_dedupe.rs`: provider-session to tmux bridge를 prompt purge TTL에서 제외하고 long-lived session 회귀 테스트를 추가했습니다.

## 검증
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test --all-targets hook_registry -- --skip _pg --skip pg_ --skip postgres` (26 passed)
- `cargo test --all-targets tui_prompt_dedupe -- --skip _pg --skip pg_ --skip postgres` (59 passed)
- `python3 scripts/check_agent_maintenance_docs.py --base-ref upstream/main`
- `./scripts/ci-script-checks.sh`
