### PR TITLE
feat(health): add stale active-session audit diagnostics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,6 +202,7 @@ src/
 │   │   │   ├── mod.rs
 │   │   │   ├── tuning_aggregate.rs
 │   │   │   └── verdict_route.rs
+│   │   ├── active_session_audit.rs
 │   │   ├── agents.rs
 │   │   ├── agents_crud.rs
 │   │   ├── agents_setup.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1282,7 +1282,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2320 lines).
+  - `src/config.rs` (2417 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1282,7 +1282,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2417 lines).
+  - `src/config.rs` (2340 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -729,3 +729,9 @@
   token-built Http fallback on standby nodes) are byte-identical and stay
   process-local. No new multinode ownership, singleton, or lease assumption
   is introduced.
+- Active-session audit: `active_session_audit` adds read-only health diagnostics
+  plus optional local repair-path metadata for stale running-session rows. It
+  does not move Discord gateway startup, worker ownership, durable queue claims,
+  or PG lease boundaries; each reported repair action still targets the existing
+  node-local/runtime owner. No new multinode ownership, singleton, or lease
+  assumption is introduced.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1353,6 +1353,23 @@ pub struct RuntimeSettingsConfig {
     /// prior Codex turn block the follow-up wait for the full configured duration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub followup_prompt_ready_timeout_secs: Option<u64>,
+    /// Master rollback flag for the read-only DB active-session mismatch audit
+    /// surfaced on `/api/health/detail` (`active_session_audit` block). When
+    /// unset it defaults to ON; `Some(false)` makes the audit report
+    /// `enabled:false` with empty candidates and skips the DB query entirely.
+    /// Read live via `config_live_reload::current()` so an `agentdesk.yaml` edit
+    /// applies on the next `/api/health/detail` call without a restart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_audit_enabled: Option<bool>,
+    /// Minimum seconds since `last_heartbeat` before a raw-active session can be
+    /// flagged by the active-session mismatch audit (post-restart/long-turn
+    /// grace). Unset (or `0`) falls back to the compiled-in 120s default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_audit_stale_secs: Option<u64>,
+    /// Hard cap on audit candidate rows AND the SQL `LIMIT`. Unset falls back to
+    /// the compiled-in 50 default; clamped to `1..=500` when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_audit_max_candidates: Option<u64>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub reset_overrides_on_restart: bool,
 }
@@ -1384,6 +1401,9 @@ impl RuntimeSettingsConfig {
             && self.github_repo_cache_sec.is_none()
             && self.rate_limit_stale_sec.is_none()
             && self.followup_prompt_ready_timeout_secs.is_none()
+            && self.active_session_audit_enabled.is_none()
+            && self.active_session_audit_stale_secs.is_none()
+            && self.active_session_audit_max_candidates.is_none()
             && !self.reset_overrides_on_restart
     }
 }

--- a/src/server/routes/active_session_audit.rs
+++ b/src/server/routes/active_session_audit.rs
@@ -216,23 +216,31 @@ fn recommend_repair_path(
     confidence: f64,
 ) -> RecommendedRepairPath {
     // Queued-but-not-started / low confidence must NOT be auto-recommended for a
-    // mutating repair (would risk corrupting queue state). `working` with no
-    // dispatch id is the queued-but-not-started shape here.
+    // mutating repair (would risk corrupting queue state).
     if confidence < HIGH_CONFIDENCE_THRESHOLD {
         return RecommendedRepairPath::None;
     }
-    // Raw says active but there is no orphan dispatch token → the mailbox/session
-    // row is the stale artifact; the existing stale-mailbox-repair clears it.
     if !row.active_dispatch_present() {
+        // Legacy `working` with no dispatch id is the queued-but-not-started
+        // shape: the turn was never actually dispatched, so a mutating repair
+        // (stale-mailbox clear) could wipe queue/session state for work that has
+        // not started. Route these to `none` even at high confidence.
+        if source == RawActiveSource::Working {
+            return RecommendedRepairPath::None;
+        }
+        // Otherwise raw is active (turn_active) with no orphan dispatch token →
+        // the mailbox/session row is the stale artifact; stale-mailbox-repair
+        // clears it.
         return RecommendedRepairPath::StaleMailbox;
     }
-    // A dispatch id is present but the provider runtime / live turn is missing
-    // (resolver says disconnected or not working) → relay recovery owns this.
-    if effective.status == crate::db::session_status::DISCONNECTED || !effective.is_working {
+    // A dispatch id is present but the resolver positively reports the provider
+    // runtime / live turn is GONE (disconnected) → relay recovery owns this.
+    if effective.status == crate::db::session_status::DISCONNECTED {
         return RecommendedRepairPath::RelayRecovery;
     }
-    // Liveness inconclusive but raw-active persists past grace → stall watchdog.
-    let _ = source;
+    // Dispatch id present, not disconnected, but liveness is inconclusive and the
+    // raw-active state has persisted past grace (the stalled-turn case) → the
+    // stall watchdog owns re-establishing or aborting the stuck turn.
     RecommendedRepairPath::StallWatchdog
 }
 
@@ -277,7 +285,10 @@ pub(super) fn classify_active_session_audit(
         let Some(source) = row.raw_active_source() else {
             continue;
         };
-        let effective = resolver.resolve(
+        // DB/heartbeat-only: this audit is an off-hot-path read on
+        // /api/health/detail and MUST NOT block the request on synchronous tmux
+        // probes (has_live_pane / pane readiness) for local session keys.
+        let effective = resolver.resolve_db_only(
             row.session_key.as_deref(),
             row.status.as_deref(),
             row.active_dispatch_id.as_deref(),
@@ -346,8 +357,13 @@ pub(super) fn classify_active_session_audit(
         .filter(|candidate| candidate.confidence >= HIGH_CONFIDENCE_THRESHOLD)
         .count() as u64;
     let candidate_count = candidates.len() as u64;
-    let truncated =
-        raw_matches_total > candidates.len() && raw_matches_total as u64 >= settings.max_candidates;
+    // `truncated` means the cap omitted raw active-like rows the classifier never
+    // examined: i.e. the pre-LIMIT raw-match count exceeds the rows actually
+    // fetched/scanned (`rows.len()`, capped at `max_candidates`). It is NOT a
+    // function of how many of those rows survived classification, so a fully
+    // candidate-producing capped batch correctly reports `truncated = true` and a
+    // sub-cap batch with resolver-filtered rows correctly reports `false`.
+    let truncated = raw_matches_total > rows.len();
 
     ActiveSessionAuditReport {
         enabled: true,
@@ -404,12 +420,130 @@ mod tests {
         );
         assert!(candidate.evidence["heartbeat_known"].as_bool().unwrap());
         assert!(candidate.stale_for_secs >= 800);
-        // Dispatch present + stale heartbeat + not working ⇒ relay_recovery.
+        // Dispatch present + stale heartbeat + not working, but the resolver does
+        // NOT positively report disconnected (raw status is turn_active, so the
+        // DB-only verdict is idle) ⇒ the stalled-turn case ⇒ stall_watchdog.
         assert_eq!(
             candidate.recommended_repair_path,
-            RecommendedRepairPath::RelayRecovery
+            RecommendedRepairPath::StallWatchdog
         );
         assert!(candidate.confidence >= HIGH_CONFIDENCE_THRESHOLD);
+    }
+
+    /// A dispatch-bearing row whose raw status is `disconnected` but still carries
+    /// an orphan dispatch token resolves to relay_recovery (the resolver
+    /// positively reports the runtime is gone). Guards the relay_recovery branch.
+    #[test]
+    fn active_session_audit_disconnected_with_dispatch_recommends_relay_recovery() {
+        let row = RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-disc".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some(crate::db::session_status::DISCONNECTED.to_string()),
+            active_dispatch_id: Some("dispatch-disc".to_string()),
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: Some("1490000000000000010".to_string()),
+        };
+        let effective = EffectiveSessionState {
+            status: crate::db::session_status::DISCONNECTED,
+            active_dispatch_id: None,
+            is_working: false,
+        };
+        // High confidence: stale (+0.20), not working (+0.20), dispatch present.
+        let confidence = confidence_score(true, true, true, false);
+        assert!(confidence >= HIGH_CONFIDENCE_THRESHOLD);
+        assert_eq!(
+            recommend_repair_path(
+                &row,
+                RawActiveSource::ActiveDispatchId,
+                &effective,
+                confidence
+            ),
+            RecommendedRepairPath::RelayRecovery
+        );
+    }
+
+    /// The stalled-turn case: a dispatch-bearing, high-confidence, not-working
+    /// candidate that is NOT disconnected reaches stall_watchdog (regression for
+    /// the previously-unreachable branch).
+    #[test]
+    fn active_session_audit_stalled_turn_recommends_stall_watchdog() {
+        let row = RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-stall".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: Some("dispatch-stall".to_string()),
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: Some("1490000000000000011".to_string()),
+        };
+        let effective = EffectiveSessionState {
+            status: crate::db::session_status::IDLE,
+            active_dispatch_id: None,
+            is_working: false,
+        };
+        let confidence = confidence_score(true, true, true, false);
+        assert!(confidence >= HIGH_CONFIDENCE_THRESHOLD);
+        assert_eq!(
+            recommend_repair_path(
+                &row,
+                RawActiveSource::ActiveDispatchId,
+                &effective,
+                confidence
+            ),
+            RecommendedRepairPath::StallWatchdog
+        );
+    }
+
+    /// Queued-but-not-started (`working` status, no dispatch id) at HIGH confidence
+    /// must map to `none`, never the mutating stale-mailbox path. Regression for
+    /// the queued-but-not-started shape (P2).
+    #[test]
+    fn active_session_audit_queued_high_confidence_maps_to_none() {
+        let row = RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-queued-hc".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("working".to_string()),
+            active_dispatch_id: None,
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: Some("1490000000000000012".to_string()),
+        };
+        let effective = EffectiveSessionState {
+            status: crate::db::session_status::IDLE,
+            active_dispatch_id: None,
+            is_working: false,
+        };
+        // stale (+0.20), not working (+0.20), missing dispatch (+0.20) ⇒ 1.0.
+        let confidence = confidence_score(true, true, true, true);
+        assert!(confidence >= HIGH_CONFIDENCE_THRESHOLD);
+        assert_eq!(
+            recommend_repair_path(&row, RawActiveSource::Working, &effective, confidence),
+            RecommendedRepairPath::None
+        );
+    }
+
+    /// A `turn_active` row with no dispatch id at high confidence is a genuine
+    /// stale mailbox artifact (distinct from the queued `working` shape) and maps
+    /// to stale_mailbox.
+    #[test]
+    fn active_session_audit_turn_active_no_dispatch_maps_to_stale_mailbox() {
+        let row = RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-sm".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: None,
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: Some("1490000000000000013".to_string()),
+        };
+        let effective = EffectiveSessionState {
+            status: crate::db::session_status::IDLE,
+            active_dispatch_id: None,
+            is_working: false,
+        };
+        let confidence = confidence_score(true, true, true, true);
+        assert!(confidence >= HIGH_CONFIDENCE_THRESHOLD);
+        assert_eq!(
+            recommend_repair_path(&row, RawActiveSource::TurnActive, &effective, confidence),
+            RecommendedRepairPath::StaleMailbox
+        );
     }
 
     /// A live, recent foreground turn must not be flagged. The resolver reports a

--- a/src/server/routes/active_session_audit.rs
+++ b/src/server/routes/active_session_audit.rs
@@ -271,8 +271,9 @@ fn confidence_score(
 /// A row becomes a candidate only when raw state is active-like AND the resolver
 /// verdict is NOT working. Rows still inside the grace window
 /// (`stale_for_secs < settings.stale_secs` with a KNOWN heartbeat) are excluded
-/// entirely (not surfaced as low-confidence). `raw_matches_total` is the count
-/// of raw active-like rows BEFORE the cap, used to compute `truncated`.
+/// entirely (not surfaced as low-confidence). `raw_matches_total` is the bounded
+/// raw active-like row count observed by the route layer (`cap + 1` sentinel at
+/// most), used only to compute `truncated`.
 pub(super) fn classify_active_session_audit(
     rows: &[RawSessionRow],
     resolver: &mut SessionActivityResolver,
@@ -358,11 +359,10 @@ pub(super) fn classify_active_session_audit(
         .count() as u64;
     let candidate_count = candidates.len() as u64;
     // `truncated` means the cap omitted raw active-like rows the classifier never
-    // examined: i.e. the pre-LIMIT raw-match count exceeds the rows actually
-    // fetched/scanned (`rows.len()`, capped at `max_candidates`). It is NOT a
-    // function of how many of those rows survived classification, so a fully
-    // candidate-producing capped batch correctly reports `truncated = true` and a
-    // sub-cap batch with resolver-filtered rows correctly reports `false`.
+    // examined. The route layer uses a `cap + 1` sentinel row rather than an
+    // uncapped total count. It is NOT a function of how many fetched rows survived
+    // classification, so a capped batch correctly reports `truncated = true` and
+    // a sub-cap batch with resolver-filtered rows correctly reports `false`.
     let truncated = raw_matches_total > rows.len();
 
     ActiveSessionAuditReport {

--- a/src/server/routes/active_session_audit.rs
+++ b/src/server/routes/active_session_audit.rs
@@ -17,6 +17,8 @@
 //! calls them): `stale_mailbox` → `/api/health/stale-mailbox-repair`,
 //! `relay_recovery` → `/api/health/relay-recovery`, `stall_watchdog` →
 //! `spawn_stall_watchdog`.
+//! `stale_mailbox` is recommended only for thread-backed rows because the
+//! existing repair handler intentionally matches `sessions.thread_channel_id`.
 
 use serde::Serialize;
 
@@ -90,6 +92,7 @@ pub struct RawSessionRow {
     pub active_dispatch_id: Option<String>,
     pub last_heartbeat: Option<String>,
     pub thread_channel_id: Option<String>,
+    pub channel_id: Option<String>,
 }
 
 impl RawSessionRow {
@@ -113,6 +116,26 @@ impl RawSessionRow {
             return Some(RawActiveSource::Working);
         }
         None
+    }
+
+    fn has_thread_channel(&self) -> bool {
+        self.thread_channel_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty())
+    }
+
+    fn audit_channel_id(&self) -> Option<String> {
+        self.thread_channel_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .or_else(|| {
+                self.channel_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+            })
+            .map(ToOwned::to_owned)
     }
 }
 
@@ -228,10 +251,14 @@ fn recommend_repair_path(
         if source == RawActiveSource::Working {
             return RecommendedRepairPath::None;
         }
-        // Otherwise raw is active (turn_active) with no orphan dispatch token →
-        // the mailbox/session row is the stale artifact; stale-mailbox-repair
-        // clears it.
-        return RecommendedRepairPath::StaleMailbox;
+        // Otherwise raw is active (turn_active) with no orphan dispatch token.
+        // Recommend stale-mailbox only for thread-backed rows: the existing
+        // repair path matches `sessions.thread_channel_id`, so recommending it
+        // for a channel_id-only session would be a no-op that keeps reappearing.
+        if row.has_thread_channel() {
+            return RecommendedRepairPath::StaleMailbox;
+        }
+        return RecommendedRepairPath::None;
     }
     // A dispatch id is present but the resolver positively reports the provider
     // runtime / live turn is GONE (disconnected) → relay recovery owns this.
@@ -338,11 +365,12 @@ pub(super) fn classify_active_session_audit(
                 .map(str::trim)
                 .is_some_and(|s| s.eq_ignore_ascii_case(LEGACY_WORKING)),
             "matched_active_dispatch_id": dispatch_present,
+            "thread_channel_id_present": row.has_thread_channel(),
         });
 
         candidates.push(ActiveSessionMismatchAuditCandidate {
             session_key: row.session_key.clone(),
-            channel_id: row.thread_channel_id.clone(),
+            channel_id: row.audit_channel_id(),
             provider: row.provider.clone(),
             raw_active_source: source,
             effective_state: effective.status.to_string(),
@@ -401,6 +429,7 @@ mod tests {
             active_dispatch_id: Some("dispatch-9".to_string()),
             last_heartbeat: Some(stale_ts(900)),
             thread_channel_id: Some("1490000000000000001".to_string()),
+            channel_id: None,
         }];
         let mut resolver = SessionActivityResolver::new();
         let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
@@ -442,6 +471,7 @@ mod tests {
             active_dispatch_id: Some("dispatch-disc".to_string()),
             last_heartbeat: Some(stale_ts(900)),
             thread_channel_id: Some("1490000000000000010".to_string()),
+            channel_id: None,
         };
         let effective = EffectiveSessionState {
             status: crate::db::session_status::DISCONNECTED,
@@ -474,6 +504,7 @@ mod tests {
             active_dispatch_id: Some("dispatch-stall".to_string()),
             last_heartbeat: Some(stale_ts(900)),
             thread_channel_id: Some("1490000000000000011".to_string()),
+            channel_id: None,
         };
         let effective = EffectiveSessionState {
             status: crate::db::session_status::IDLE,
@@ -505,6 +536,7 @@ mod tests {
             active_dispatch_id: None,
             last_heartbeat: Some(stale_ts(900)),
             thread_channel_id: Some("1490000000000000012".to_string()),
+            channel_id: None,
         };
         let effective = EffectiveSessionState {
             status: crate::db::session_status::IDLE,
@@ -532,6 +564,7 @@ mod tests {
             active_dispatch_id: None,
             last_heartbeat: Some(stale_ts(900)),
             thread_channel_id: Some("1490000000000000013".to_string()),
+            channel_id: None,
         };
         let effective = EffectiveSessionState {
             status: crate::db::session_status::IDLE,
@@ -543,6 +576,37 @@ mod tests {
         assert_eq!(
             recommend_repair_path(&row, RawActiveSource::TurnActive, &effective, confidence),
             RecommendedRepairPath::StaleMailbox
+        );
+    }
+
+    /// A non-thread fixed-channel session is still surfaced with its channel id,
+    /// but stale-mailbox is not recommended because that repair path only updates
+    /// rows by `thread_channel_id`.
+    #[test]
+    fn active_session_audit_channel_only_session_maps_to_none_not_stale_mailbox() {
+        let rows = vec![RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-channel-only".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: None,
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: None,
+            channel_id: Some("1490000000000000014".to_string()),
+        }];
+        let mut resolver = SessionActivityResolver::new();
+        let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
+        let report = classify_active_session_audit(&rows, &mut resolver, settings, 1, now());
+
+        assert_eq!(report.candidate_count, 1);
+        let candidate = &report.candidates[0];
+        assert_eq!(candidate.channel_id.as_deref(), Some("1490000000000000014"));
+        assert_eq!(
+            candidate.recommended_repair_path,
+            RecommendedRepairPath::None
+        );
+        assert_eq!(
+            candidate.evidence["thread_channel_id_present"].as_bool(),
+            Some(false)
         );
     }
 
@@ -559,6 +623,7 @@ mod tests {
             // Heartbeat within the remote grace ⇒ resolver says working.
             last_heartbeat: Some(stale_ts(5)),
             thread_channel_id: Some("1490000000000000002".to_string()),
+            channel_id: None,
         }];
         let mut resolver = SessionActivityResolver::new();
         let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
@@ -582,6 +647,7 @@ mod tests {
             active_dispatch_id: None,
             last_heartbeat: Some(stale_ts(100)),
             thread_channel_id: Some("1490000000000000003".to_string()),
+            channel_id: None,
         }];
         let mut resolver = SessionActivityResolver::new();
         // Audit grace of 600s: heartbeat 100s ago is inside grace ⇒ excluded.
@@ -610,6 +676,7 @@ mod tests {
             // a missing dispatch unless confidence is high.
             last_heartbeat: None,
             thread_channel_id: Some("1490000000000000004".to_string()),
+            channel_id: None,
         }];
         let mut resolver = SessionActivityResolver::new();
         let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
@@ -639,6 +706,7 @@ mod tests {
             active_dispatch_id: Some("d-1".to_string()),
             last_heartbeat: None,
             thread_channel_id: Some("1490000000000000009".to_string()),
+            channel_id: None,
         };
         // confidence = 0.40 + 0 (hb unknown) + 0.20 (not working) + 0 (dispatch
         // present) = 0.60 < 0.75 ⇒ none.
@@ -707,6 +775,7 @@ mod tests {
             active_dispatch_id: Some("d-dedup".to_string()),
             last_heartbeat: Some(stale_ts(900)),
             thread_channel_id: Some("1490000000000000005".to_string()),
+            channel_id: None,
         }];
         let mut resolver = SessionActivityResolver::new();
         // Cap of 1, and report raw_matches_total > returned ⇒ truncated.

--- a/src/server/routes/active_session_audit.rs
+++ b/src/server/routes/active_session_audit.rs
@@ -1,0 +1,600 @@
+//! Read-only DB active-session mismatch audit (P0).
+//!
+//! Ports Jinn's `gateway/status-reconciler.ts` confirmation pattern as a
+//! DETECT-ONLY audit: it classifies sessions whose raw DB/session state says
+//! "active" (`turn_active`, legacy `working`, or `active_dispatch_id IS NOT
+//! NULL`) but whose effective runtime evidence (from [`SessionActivityResolver`])
+//! says no live provider turn exists. The result is surfaced as the additive
+//! `active_session_audit` block on `/api/health/detail` only — never on the
+//! public `/api/health` response, and it NEVER mutates DB/session/runtime state.
+//!
+//! This module holds the pure classifier + output schema so it is unit-testable
+//! independently of the axum route and the database. The route layer
+//! ([`super::health_api`]) fetches the bounded candidate rows and the live
+//! config, then calls [`classify_active_session_audit`].
+//!
+//! Repair-path recommendations delegate to EXISTING mechanisms only (P0 never
+//! calls them): `stale_mailbox` → `/api/health/stale-mailbox-repair`,
+//! `relay_recovery` → `/api/health/relay-recovery`, `stall_watchdog` →
+//! `spawn_stall_watchdog`.
+
+use serde::Serialize;
+
+use crate::db::session_status::{LEGACY_WORKING, TURN_ACTIVE};
+use crate::services::session_activity::{EffectiveSessionState, SessionActivityResolver};
+
+/// Compiled-in defaults used when the matching `RuntimeSettingsConfig` override
+/// is unset/empty. `STALE_SECS` doubles as the post-restart/long-turn grace
+/// window (baseline aligned with the stall-watchdog positive-liveness budget).
+pub(super) const DEFAULT_STALE_SECS: u64 = 120;
+pub(super) const DEFAULT_MAX_CANDIDATES: u64 = 50;
+pub(super) const MIN_MAX_CANDIDATES: u64 = 1;
+pub(super) const MAX_MAX_CANDIDATES: u64 = 500;
+/// `high_confidence_count` counts candidates at or above this confidence.
+pub(super) const HIGH_CONFIDENCE_THRESHOLD: f64 = 0.75;
+
+/// Which raw DB signal selected the session as active-like. Stable reason code.
+/// Selection precedence when multiple match: `active_dispatch_id` > `turn_active`
+/// > `working` (the others are still recorded under `evidence`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RawActiveSource {
+    TurnActive,
+    Working,
+    ActiveDispatchId,
+}
+
+impl RawActiveSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RawActiveSource::TurnActive => "turn_active",
+            RawActiveSource::Working => "working",
+            RawActiveSource::ActiveDispatchId => "active_dispatch_id",
+        }
+    }
+}
+
+/// Existing repair mechanism the audit recommends an operator route the
+/// candidate to. P0 NEVER calls these; the audit is detect-only. Stable enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendedRepairPath {
+    None,
+    StaleMailbox,
+    RelayRecovery,
+    StallWatchdog,
+}
+
+impl RecommendedRepairPath {
+    /// Stable string contract (mirrors the `serde(rename_all = "snake_case")`
+    /// JSON form). Kept as the documented enum→string mapping and exercised by
+    /// the repair-mapping regression test.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecommendedRepairPath::None => "none",
+            RecommendedRepairPath::StaleMailbox => "stale_mailbox",
+            RecommendedRepairPath::RelayRecovery => "relay_recovery",
+            RecommendedRepairPath::StallWatchdog => "stall_watchdog",
+        }
+    }
+}
+
+/// One bounded `SELECT` row from `sessions`, already fetched by the route layer.
+/// All fields are read-only inputs to the pure classifier.
+#[derive(Debug, Clone, Default)]
+pub struct RawSessionRow {
+    pub session_key: Option<String>,
+    pub provider: Option<String>,
+    pub status: Option<String>,
+    pub active_dispatch_id: Option<String>,
+    pub last_heartbeat: Option<String>,
+    pub thread_channel_id: Option<String>,
+}
+
+impl RawSessionRow {
+    fn active_dispatch_present(&self) -> bool {
+        self.active_dispatch_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty())
+    }
+
+    /// Highest-precedence raw signal that made this row active-like, if any.
+    /// `None` means the row should not have been selected (defensive).
+    fn raw_active_source(&self) -> Option<RawActiveSource> {
+        if self.active_dispatch_present() {
+            return Some(RawActiveSource::ActiveDispatchId);
+        }
+        let status = self.status.as_deref().map(str::trim).unwrap_or("");
+        if status.eq_ignore_ascii_case(TURN_ACTIVE) {
+            return Some(RawActiveSource::TurnActive);
+        }
+        if status.eq_ignore_ascii_case(LEGACY_WORKING) {
+            return Some(RawActiveSource::Working);
+        }
+        None
+    }
+}
+
+/// Output schema — one element of `active_session_audit.candidates`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ActiveSessionMismatchAuditCandidate {
+    pub session_key: Option<String>,
+    pub channel_id: Option<String>,
+    pub provider: Option<String>,
+    pub raw_active_source: RawActiveSource,
+    pub effective_state: String,
+    pub stale_for_secs: i64,
+    pub evidence: serde_json::Value,
+    pub confidence: f64,
+    pub recommended_repair_path: RecommendedRepairPath,
+}
+
+/// Aggregate `active_session_audit` block placed on `/api/health/detail`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ActiveSessionAuditReport {
+    pub enabled: bool,
+    pub candidate_count: u64,
+    pub high_confidence_count: u64,
+    pub truncated: bool,
+    pub grace_secs: u64,
+    pub candidates: Vec<ActiveSessionMismatchAuditCandidate>,
+}
+
+impl ActiveSessionAuditReport {
+    /// The block reported when the feature is disabled by config (rollback).
+    pub fn disabled(grace_secs: u64) -> Self {
+        Self {
+            enabled: false,
+            candidate_count: 0,
+            high_confidence_count: 0,
+            truncated: false,
+            grace_secs,
+            candidates: Vec::new(),
+        }
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+    }
+}
+
+/// Resolved, None-safe audit settings derived from the live config snapshot.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ActiveSessionAuditSettings {
+    pub enabled: bool,
+    pub stale_secs: u64,
+    pub max_candidates: u64,
+}
+
+impl ActiveSessionAuditSettings {
+    /// Build from the optional `RuntimeSettingsConfig` overrides, applying the
+    /// compiled-in defaults and bounds. `enabled` defaults to ON when unset.
+    /// `stale_secs == Some(0)` is treated as unset (avoids a 0s grace footgun).
+    pub(super) fn from_overrides(
+        enabled: Option<bool>,
+        stale_secs: Option<u64>,
+        max_candidates: Option<u64>,
+    ) -> Self {
+        Self {
+            enabled: enabled.unwrap_or(true),
+            stale_secs: stale_secs
+                .filter(|secs| *secs > 0)
+                .unwrap_or(DEFAULT_STALE_SECS),
+            max_candidates: max_candidates
+                .filter(|cap| *cap > 0)
+                .unwrap_or(DEFAULT_MAX_CANDIDATES)
+                .clamp(MIN_MAX_CANDIDATES, MAX_MAX_CANDIDATES),
+        }
+    }
+}
+
+/// Seconds since `last_heartbeat`, or `None` when the heartbeat is unknown /
+/// unparseable. Mirrors the parse formats accepted by `SessionActivityResolver`.
+fn stale_for_secs(last_heartbeat: Option<&str>, now: chrono::DateTime<chrono::Utc>) -> Option<i64> {
+    let raw = last_heartbeat
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let parsed = chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .ok()
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S")
+                .ok()
+                .map(|value| {
+                    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(value, chrono::Utc)
+                })
+        })?;
+    Some((now - parsed).num_seconds().max(0))
+}
+
+/// Repair-path mapping (REQ-006). Delegates to EXISTING mechanisms only.
+fn recommend_repair_path(
+    row: &RawSessionRow,
+    source: RawActiveSource,
+    effective: &EffectiveSessionState,
+    confidence: f64,
+) -> RecommendedRepairPath {
+    // Queued-but-not-started / low confidence must NOT be auto-recommended for a
+    // mutating repair (would risk corrupting queue state). `working` with no
+    // dispatch id is the queued-but-not-started shape here.
+    if confidence < HIGH_CONFIDENCE_THRESHOLD {
+        return RecommendedRepairPath::None;
+    }
+    // Raw says active but there is no orphan dispatch token → the mailbox/session
+    // row is the stale artifact; the existing stale-mailbox-repair clears it.
+    if !row.active_dispatch_present() {
+        return RecommendedRepairPath::StaleMailbox;
+    }
+    // A dispatch id is present but the provider runtime / live turn is missing
+    // (resolver says disconnected or not working) → relay recovery owns this.
+    if effective.status == crate::db::session_status::DISCONNECTED || !effective.is_working {
+        return RecommendedRepairPath::RelayRecovery;
+    }
+    // Liveness inconclusive but raw-active persists past grace → stall watchdog.
+    let _ = source;
+    RecommendedRepairPath::StallWatchdog
+}
+
+/// Confidence from age + evidence only (observation memory skipped in P0).
+/// base 0.40; +0.20 each for: heartbeat known & stale past grace; resolver says
+/// NOT working; missing dispatch id while raw is active. Clamped to [0.0, 1.0].
+fn confidence_score(
+    heartbeat_known: bool,
+    stale_past_grace: bool,
+    effective_not_working: bool,
+    dispatch_missing_while_active: bool,
+) -> f64 {
+    let mut score = 0.40_f64;
+    if heartbeat_known && stale_past_grace {
+        score += 0.20;
+    }
+    if effective_not_working {
+        score += 0.20;
+    }
+    if dispatch_missing_while_active {
+        score += 0.20;
+    }
+    score.clamp(0.0, 1.0)
+}
+
+/// Pure classifier over already-fetched rows + the in-memory resolver verdict.
+///
+/// A row becomes a candidate only when raw state is active-like AND the resolver
+/// verdict is NOT working. Rows still inside the grace window
+/// (`stale_for_secs < settings.stale_secs` with a KNOWN heartbeat) are excluded
+/// entirely (not surfaced as low-confidence). `raw_matches_total` is the count
+/// of raw active-like rows BEFORE the cap, used to compute `truncated`.
+pub(super) fn classify_active_session_audit(
+    rows: &[RawSessionRow],
+    resolver: &mut SessionActivityResolver,
+    settings: ActiveSessionAuditSettings,
+    raw_matches_total: usize,
+    now: chrono::DateTime<chrono::Utc>,
+) -> ActiveSessionAuditReport {
+    let mut candidates = Vec::new();
+    for row in rows {
+        let Some(source) = row.raw_active_source() else {
+            continue;
+        };
+        let effective = resolver.resolve(
+            row.session_key.as_deref(),
+            row.status.as_deref(),
+            row.active_dispatch_id.as_deref(),
+            row.last_heartbeat.as_deref(),
+        );
+        // Only flag raw-active-but-effective-not-working.
+        if effective.is_working {
+            continue;
+        }
+
+        let stale_known = stale_for_secs(row.last_heartbeat.as_deref(), now);
+        let heartbeat_known = stale_known.is_some();
+        let stale_value = stale_known.unwrap_or(0);
+        let stale_past_grace = stale_value >= settings.stale_secs as i64;
+        // Grace: a KNOWN-recent heartbeat (within grace) suppresses the flag so a
+        // freshly (re)started long-running turn is not reported. An UNKNOWN
+        // heartbeat is allowed through (cannot prove it is fresh).
+        if heartbeat_known && !stale_past_grace {
+            continue;
+        }
+
+        let dispatch_present = row.active_dispatch_present();
+        let confidence = confidence_score(
+            heartbeat_known,
+            stale_past_grace,
+            !effective.is_working,
+            !dispatch_present,
+        );
+        let repair = recommend_repair_path(row, source, &effective, confidence);
+
+        let evidence = serde_json::json!({
+            "raw_status": row.status.as_deref().unwrap_or("").to_string(),
+            "raw_active_source": source.as_str(),
+            "active_dispatch_id_present": dispatch_present,
+            "effective_is_working": effective.is_working,
+            "heartbeat_known": heartbeat_known,
+            "heartbeat_recent": heartbeat_known && !stale_past_grace,
+            "matched_turn_active": row
+                .status
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|s| s.eq_ignore_ascii_case(TURN_ACTIVE)),
+            "matched_working": row
+                .status
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|s| s.eq_ignore_ascii_case(LEGACY_WORKING)),
+            "matched_active_dispatch_id": dispatch_present,
+        });
+
+        candidates.push(ActiveSessionMismatchAuditCandidate {
+            session_key: row.session_key.clone(),
+            channel_id: row.thread_channel_id.clone(),
+            provider: row.provider.clone(),
+            raw_active_source: source,
+            effective_state: effective.status.to_string(),
+            stale_for_secs: stale_value,
+            evidence,
+            confidence,
+            recommended_repair_path: repair,
+        });
+    }
+
+    let high_confidence_count = candidates
+        .iter()
+        .filter(|candidate| candidate.confidence >= HIGH_CONFIDENCE_THRESHOLD)
+        .count() as u64;
+    let candidate_count = candidates.len() as u64;
+    let truncated =
+        raw_matches_total > candidates.len() && raw_matches_total as u64 >= settings.max_candidates;
+
+    ActiveSessionAuditReport {
+        enabled: true,
+        candidate_count,
+        high_confidence_count,
+        truncated,
+        grace_secs: settings.stale_secs,
+        candidates,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+
+    fn stale_ts(secs_ago: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(secs_ago))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    }
+
+    /// A remote raw-active row with a long-stale heartbeat and no live turn is
+    /// flagged once, with evidence and no mutation. (TEST-001 / TEST-002)
+    #[test]
+    fn active_session_audit_flags_raw_active_effective_idle() {
+        // Remote host alias so the resolver uses heartbeat recency (no tmux probe).
+        let rows = vec![RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-1234".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: Some("dispatch-9".to_string()),
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: Some("1490000000000000001".to_string()),
+        }];
+        let mut resolver = SessionActivityResolver::new();
+        let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
+        let report = classify_active_session_audit(&rows, &mut resolver, settings, 1, now());
+
+        assert!(report.enabled);
+        assert_eq!(report.candidate_count, 1);
+        let candidate = &report.candidates[0];
+        assert_eq!(
+            candidate.raw_active_source,
+            RawActiveSource::ActiveDispatchId
+        );
+        assert!(
+            !candidate.evidence["effective_is_working"]
+                .as_bool()
+                .unwrap()
+        );
+        assert!(candidate.evidence["heartbeat_known"].as_bool().unwrap());
+        assert!(candidate.stale_for_secs >= 800);
+        // Dispatch present + stale heartbeat + not working ⇒ relay_recovery.
+        assert_eq!(
+            candidate.recommended_repair_path,
+            RecommendedRepairPath::RelayRecovery
+        );
+        assert!(candidate.confidence >= HIGH_CONFIDENCE_THRESHOLD);
+    }
+
+    /// A live, recent foreground turn must not be flagged. The resolver reports a
+    /// working turn for a recent-heartbeat remote session, so no candidate.
+    /// (TEST-005)
+    #[test]
+    fn active_session_audit_does_not_flag_live_turn() {
+        let rows = vec![RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-live".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: Some("dispatch-live".to_string()),
+            // Heartbeat within the remote grace ⇒ resolver says working.
+            last_heartbeat: Some(stale_ts(5)),
+            thread_channel_id: Some("1490000000000000002".to_string()),
+        }];
+        let mut resolver = SessionActivityResolver::new();
+        let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
+        let report = classify_active_session_audit(&rows, &mut resolver, settings, 1, now());
+
+        assert_eq!(report.candidate_count, 0);
+        assert!(report.candidates.is_empty());
+    }
+
+    /// A raw-active row whose heartbeat is within the configured grace window is
+    /// excluded entirely (not low-confidence). Forced by a long grace so the
+    /// resolver still says idle but the grace gate suppresses it. (TEST-005)
+    #[test]
+    fn active_session_audit_respects_grace_window() {
+        // No dispatch id + remote host with a heartbeat older than the remote
+        // resolver grace (so effective is idle) but younger than our audit grace.
+        let rows = vec![RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-grace".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: None,
+            last_heartbeat: Some(stale_ts(100)),
+            thread_channel_id: Some("1490000000000000003".to_string()),
+        }];
+        let mut resolver = SessionActivityResolver::new();
+        // Audit grace of 600s: heartbeat 100s ago is inside grace ⇒ excluded.
+        let settings = ActiveSessionAuditSettings::from_overrides(None, Some(600), None);
+        let report = classify_active_session_audit(&rows, &mut resolver, settings, 1, now());
+
+        assert_eq!(report.candidate_count, 0);
+        assert_eq!(report.grace_secs, 600);
+    }
+
+    /// Queued-but-not-started (legacy `working`, no dispatch id) past grace is a
+    /// low-confidence candidate that maps to `none` (never auto-repaired).
+    /// (TEST-005 / TEST-006)
+    #[test]
+    fn active_session_audit_queued_is_low_confidence_or_none() {
+        let rows = vec![RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-queued".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("working".to_string()),
+            active_dispatch_id: None,
+            // Unknown heartbeat ⇒ no +0.20 stale bump; resolver idle ⇒ +0.20;
+            // missing dispatch ⇒ +0.20 ⇒ 0.80, which is high. To assert the
+            // queued≠high path, use a known-recent-but-past-audit-grace shape is
+            // covered elsewhere; here unknown heartbeat with working maps to a
+            // candidate. Assert repair mapping never targets a mutating path for
+            // a missing dispatch unless confidence is high.
+            last_heartbeat: None,
+            thread_channel_id: Some("1490000000000000004".to_string()),
+        }];
+        let mut resolver = SessionActivityResolver::new();
+        let settings = ActiveSessionAuditSettings::from_overrides(None, None, None);
+        let report = classify_active_session_audit(&rows, &mut resolver, settings, 1, now());
+
+        assert_eq!(report.candidate_count, 1);
+        let candidate = &report.candidates[0];
+        // No dispatch id ⇒ never relay_recovery/stall_watchdog; either stale_mailbox
+        // (high confidence) or none (low confidence), never a queue-corrupting path.
+        assert!(matches!(
+            candidate.recommended_repair_path,
+            RecommendedRepairPath::StaleMailbox | RecommendedRepairPath::None
+        ));
+    }
+
+    /// A genuinely low-confidence row (resolver still working) yields `none`.
+    #[test]
+    fn active_session_audit_low_confidence_maps_to_none() {
+        // base 0.40 only: heartbeat unknown (no stale bump), dispatch present
+        // (no missing bump). Force not-working by a disconnected status so it is
+        // still a candidate but with confidence 0.60 (< 0.75 high threshold) when
+        // dispatch is present.
+        let row = RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-lc".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: Some("d-1".to_string()),
+            last_heartbeat: None,
+            thread_channel_id: Some("1490000000000000009".to_string()),
+        };
+        // confidence = 0.40 + 0 (hb unknown) + 0.20 (not working) + 0 (dispatch
+        // present) = 0.60 < 0.75 ⇒ none.
+        let effective = EffectiveSessionState {
+            status: crate::db::session_status::IDLE,
+            active_dispatch_id: None,
+            is_working: false,
+        };
+        let confidence = confidence_score(false, false, true, false);
+        assert!((confidence - 0.60).abs() < 1e-9);
+        assert_eq!(
+            recommend_repair_path(
+                &row,
+                RawActiveSource::ActiveDispatchId,
+                &effective,
+                confidence
+            ),
+            RecommendedRepairPath::None
+        );
+    }
+
+    /// Every repair enum maps only to an existing-mechanism string. (TEST-006)
+    #[test]
+    fn active_session_audit_repair_mapping_targets_existing_paths() {
+        assert_eq!(RecommendedRepairPath::None.as_str(), "none");
+        assert_eq!(
+            RecommendedRepairPath::StaleMailbox.as_str(),
+            "stale_mailbox"
+        );
+        assert_eq!(
+            RecommendedRepairPath::RelayRecovery.as_str(),
+            "relay_recovery"
+        );
+        assert_eq!(
+            RecommendedRepairPath::StallWatchdog.as_str(),
+            "stall_watchdog"
+        );
+    }
+
+    /// Disabling the audit yields an empty block and skips classification.
+    /// (rollback TEST)
+    #[test]
+    fn active_session_audit_disabled_emits_empty_block() {
+        let settings = ActiveSessionAuditSettings::from_overrides(Some(false), None, None);
+        assert!(!settings.enabled);
+        let report = ActiveSessionAuditReport::disabled(settings.stale_secs);
+        assert!(!report.enabled);
+        assert_eq!(report.candidate_count, 0);
+        assert!(report.candidates.is_empty());
+        let json = report.to_json();
+        assert_eq!(json["enabled"], serde_json::json!(false));
+        assert_eq!(json["candidate_count"], serde_json::json!(0));
+        assert!(json["candidates"].as_array().unwrap().is_empty());
+    }
+
+    /// `truncated` flips when raw matches exceed the cap. dedup/precedence:
+    /// a row matching multiple raw signals yields exactly one candidate row.
+    #[test]
+    fn active_session_audit_truncated_and_single_row_per_session() {
+        // Row matches BOTH turn_active AND active_dispatch_id; precedence picks
+        // active_dispatch_id and yields exactly one candidate.
+        let rows = vec![RawSessionRow {
+            session_key: Some("remote-host/farbox:codex-dedup".to_string()),
+            provider: Some("codex".to_string()),
+            status: Some("turn_active".to_string()),
+            active_dispatch_id: Some("d-dedup".to_string()),
+            last_heartbeat: Some(stale_ts(900)),
+            thread_channel_id: Some("1490000000000000005".to_string()),
+        }];
+        let mut resolver = SessionActivityResolver::new();
+        // Cap of 1, and report raw_matches_total > returned ⇒ truncated.
+        let settings = ActiveSessionAuditSettings::from_overrides(None, None, Some(1));
+        let report = classify_active_session_audit(&rows, &mut resolver, settings, 5, now());
+        assert_eq!(report.candidate_count, 1);
+        assert!(report.truncated);
+        assert_eq!(
+            report.candidates[0].raw_active_source,
+            RawActiveSource::ActiveDispatchId
+        );
+    }
+
+    /// Settings clamp the candidate cap to the documented bounds and treat
+    /// `stale_secs == 0` as unset.
+    #[test]
+    fn active_session_audit_settings_clamp_and_zero_handling() {
+        let s = ActiveSessionAuditSettings::from_overrides(None, Some(0), Some(99_999));
+        assert_eq!(s.stale_secs, DEFAULT_STALE_SECS);
+        assert_eq!(s.max_candidates, MAX_MAX_CANDIDATES);
+        let s2 = ActiveSessionAuditSettings::from_overrides(None, Some(300), Some(0));
+        assert_eq!(s2.stale_secs, 300);
+        assert_eq!(s2.max_candidates, DEFAULT_MAX_CANDIDATES);
+    }
+}

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -21,6 +21,18 @@ use crate::services::provider::ProviderKind;
 use super::AppState;
 
 const OUTBOX_AGE_DEGRADED_SECS: i64 = 60;
+const ACTIVE_SESSION_AUDIT_QUERY: &str =
+    "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat,
+                thread_channel_id, channel_id
+           FROM sessions
+          WHERE parent_session_id IS NULL
+            AND (NULLIF($2, '') IS NULL OR instance_id IS NULL OR instance_id = $2)
+            AND (
+                status IN ('turn_active', 'working')
+                OR COALESCE(btrim(active_dispatch_id), '') <> ''
+            )
+          ORDER BY last_heartbeat ASC NULLS FIRST, id ASC
+          LIMIT $1";
 
 struct DispatchOutboxStats {
     pending: i64,
@@ -721,8 +733,9 @@ async fn build_active_session_audit(state: &AppState) -> ActiveSessionAuditRepor
         return ActiveSessionAuditReport::disabled(settings.stale_secs);
     };
 
+    let local_instance_id = state.cluster_instance_id.as_deref();
     let (rows, raw_matches_total) =
-        load_active_session_audit_rows(pool, settings.max_candidates).await;
+        load_active_session_audit_rows(pool, settings.max_candidates, local_instance_id).await;
     let mut resolver = crate::services::session_activity::SessionActivityResolver::new();
     active_session_audit::classify_active_session_audit(
         &rows,
@@ -742,23 +755,18 @@ async fn build_active_session_audit(state: &AppState) -> ActiveSessionAuditRepor
 async fn load_active_session_audit_rows(
     pool: &PgPool,
     max_candidates: u64,
+    local_instance_id: Option<&str>,
 ) -> (Vec<RawSessionRow>, usize) {
     let capped = max_candidates.min(i64::MAX as u64) as usize;
     let limit = max_candidates.saturating_add(1).min(i64::MAX as u64) as i64;
+    let local_instance_id = local_instance_id.map(str::trim).unwrap_or("");
     // Surface the staleness-relevant rows FIRST so the LIMIT keeps the candidates
     // that matter: NULL/unknown heartbeats (can't be proven fresh) come first,
     // then the OLDEST heartbeats. Ordering newest-first would let stale/zombie
     // rows beyond the cap escape the audit entirely — the opposite of intent.
-    let query = sqlx::query(
-        "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat,
-                COALESCE(thread_channel_id, channel_id) AS audit_channel_id
-           FROM sessions
-          WHERE status IN ('turn_active', 'working')
-             OR COALESCE(btrim(active_dispatch_id), '') <> ''
-          ORDER BY last_heartbeat ASC NULLS FIRST, id ASC
-          LIMIT $1",
-    )
-    .bind(limit);
+    let query = sqlx::query(ACTIVE_SESSION_AUDIT_QUERY)
+        .bind(limit)
+        .bind(local_instance_id);
     let rows = match query.fetch_all(pool).await {
         Ok(rows) => rows,
         Err(error) => {
@@ -780,7 +788,8 @@ async fn load_active_session_audit_rows(
             status: row.try_get("status").ok(),
             active_dispatch_id: row.try_get("active_dispatch_id").ok(),
             last_heartbeat: pg_timestamp_to_rfc3339(row, "last_heartbeat"),
-            thread_channel_id: row.try_get("audit_channel_id").ok(),
+            thread_channel_id: row.try_get("thread_channel_id").ok(),
+            channel_id: row.try_get("channel_id").ok(),
         })
         .collect();
     (mapped, raw_matches_seen)
@@ -1627,8 +1636,8 @@ pub async fn senddm_handler(
 #[cfg(test)]
 mod tests {
     use super::{
-        RegistryPurgeDecision, discord_control_endpoints_allowed, public_health_json,
-        registry_purge_decision, stale_mailbox_repair_applied,
+        ACTIVE_SESSION_AUDIT_QUERY, RegistryPurgeDecision, discord_control_endpoints_allowed,
+        public_health_json, registry_purge_decision, stale_mailbox_repair_applied,
     };
     use axum::{
         body::Body,
@@ -1836,6 +1845,14 @@ mod tests {
         assert!(public.get("degraded_reasons").is_none());
         // TEST-004: the detail-only audit block is dropped from public health.
         assert!(public.get("active_session_audit").is_none());
+    }
+
+    #[test]
+    fn active_session_audit_query_filters_foreign_and_background_rows() {
+        assert!(ACTIVE_SESSION_AUDIT_QUERY.contains("parent_session_id IS NULL"));
+        assert!(ACTIVE_SESSION_AUDIT_QUERY.contains("instance_id IS NULL OR instance_id = $2"));
+        assert!(ACTIVE_SESSION_AUDIT_QUERY.contains("thread_channel_id, channel_id"));
+        assert!(!ACTIVE_SESSION_AUDIT_QUERY.contains("COALESCE(thread_channel_id, channel_id)"));
     }
 
     #[test]

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -11,6 +11,9 @@ use sqlx::{PgPool, Row, postgres::PgRow};
 use std::net::SocketAddr;
 
 use crate::db::session_status::is_active_status;
+use crate::server::routes::active_session_audit::{
+    self, ActiveSessionAuditReport, ActiveSessionAuditSettings, RawSessionRow,
+};
 use crate::services::discord::health;
 use crate::services::disk_monitor;
 use crate::services::provider::ProviderKind;
@@ -190,6 +193,11 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
             serde_json::to_value(discord_snapshot).unwrap_or_else(|_| serde_json::json!({}));
         if detailed {
             enrich_mailbox_session_state(&mut json, state).await;
+            // #stale-running-session-reconciler-audit: read-only DB active-session
+            // mismatch audit. Detail-only (never on public GET), additive block,
+            // no DB/session/runtime mutation. Runs AFTER mailbox enrichment so it
+            // is off the hot public health path (REQ-003/REQ-004).
+            json["active_session_audit"] = build_active_session_audit(state).await.to_json();
         }
         let mut degraded_reasons = json["degraded_reasons"]
             .as_array()
@@ -680,6 +688,105 @@ async fn enrich_mailbox_session_state(json: &mut serde_json::Value, state: &AppS
             mailbox["session_active_dispatch_id"] = serde_json::Value::Null;
         }
     }
+}
+
+/// Build the read-only `active_session_audit` block for `/api/health/detail`.
+///
+/// Reads audit settings live from `config_live_reload::current()` (hot-reload,
+/// no restart) with compiled-in fallbacks. When disabled by config it returns
+/// the empty `enabled:false` block WITHOUT issuing the DB query (rollback path).
+/// Otherwise it runs ONE bounded `SELECT` (`LIMIT` = max_candidates) against the
+/// existing `sessions` columns and classifies the rows with the pure
+/// [`active_session_audit`] classifier. No UPDATE/INSERT/DELETE, no tmux probe.
+async fn build_active_session_audit(state: &AppState) -> ActiveSessionAuditReport {
+    let runtime = crate::config_live_reload::current().map(|cfg| {
+        (
+            cfg.runtime.active_session_audit_enabled,
+            cfg.runtime.active_session_audit_stale_secs,
+            cfg.runtime.active_session_audit_max_candidates,
+        )
+    });
+    let (enabled_override, stale_override, cap_override) = runtime.unwrap_or((None, None, None));
+    let settings =
+        ActiveSessionAuditSettings::from_overrides(enabled_override, stale_override, cap_override);
+
+    if !settings.enabled {
+        return ActiveSessionAuditReport::disabled(settings.stale_secs);
+    }
+
+    let Some(pool) = state.pg_pool_ref() else {
+        return ActiveSessionAuditReport::disabled(settings.stale_secs);
+    };
+
+    let (rows, raw_matches_total) =
+        load_active_session_audit_rows(pool, settings.max_candidates).await;
+    let mut resolver = crate::services::session_activity::SessionActivityResolver::new();
+    active_session_audit::classify_active_session_audit(
+        &rows,
+        &mut resolver,
+        settings,
+        raw_matches_total,
+        chrono::Utc::now(),
+    )
+}
+
+/// One bounded `SELECT` for raw active-like sessions (`turn_active`, legacy
+/// `working`, OR a non-empty `active_dispatch_id`). Read-only. Returns the
+/// capped rows and the total raw-match count (capped at `LIMIT`, used only for
+/// the `truncated` flag). Duplicate rows are not possible because each row is a
+/// distinct `sessions` row; precedence dedup of the raw signal happens in the
+/// classifier.
+async fn load_active_session_audit_rows(
+    pool: &PgPool,
+    max_candidates: u64,
+) -> (Vec<RawSessionRow>, usize) {
+    let limit = max_candidates.min(i64::MAX as u64) as i64;
+    let query = sqlx::query(
+        "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat, thread_channel_id
+           FROM sessions
+          WHERE status IN ('turn_active', 'working')
+             OR COALESCE(btrim(active_dispatch_id), '') <> ''
+          ORDER BY last_heartbeat DESC NULLS LAST, id DESC
+          LIMIT $1",
+    )
+    .bind(limit);
+    let rows = match query.fetch_all(pool).await {
+        Ok(rows) => rows,
+        Err(error) => {
+            tracing::debug!(
+                event = "active_session_audit_query_failed",
+                error = %error,
+                "active-session audit query failed; emitting empty candidate set"
+            );
+            return (Vec::new(), 0);
+        }
+    };
+    let mapped: Vec<RawSessionRow> = rows
+        .iter()
+        .map(|row| RawSessionRow {
+            session_key: row.try_get("session_key").ok(),
+            provider: row.try_get("provider").ok(),
+            status: row.try_get("status").ok(),
+            active_dispatch_id: row.try_get("active_dispatch_id").ok(),
+            last_heartbeat: pg_timestamp_to_rfc3339(row, "last_heartbeat"),
+            thread_channel_id: row.try_get("thread_channel_id").ok(),
+        })
+        .collect();
+    let total = mapped.len();
+    (mapped, total)
+}
+
+/// Read a (possibly `timestamptz`/`timestamp`/`text`) heartbeat column into a
+/// string the audit classifier + `SessionActivityResolver` can parse. Falls back
+/// across representations so schema variance does not panic the read.
+fn pg_timestamp_to_rfc3339(row: &PgRow, column: &str) -> Option<String> {
+    if let Ok(Some(ts)) = row.try_get::<Option<chrono::DateTime<chrono::Utc>>, _>(column) {
+        return Some(ts.to_rfc3339());
+    }
+    if let Ok(Some(naive)) = row.try_get::<Option<chrono::NaiveDateTime>, _>(column) {
+        return Some(naive.format("%Y-%m-%d %H:%M:%S").to_string());
+    }
+    row.try_get::<Option<String>, _>(column).ok().flatten()
 }
 
 /// GET /api/health — public safe health summary.
@@ -1700,7 +1807,12 @@ mod tests {
             "providers": [{"name": "codex", "connected": true}],
             "mailboxes": [{"channel_id": 123, "has_cancel_token": true}],
             "config_audit": {"warnings": ["secret-ish path"]},
-            "degraded_reasons": ["provider:codex:pending_queue_depth:2"]
+            "degraded_reasons": ["provider:codex:pending_queue_depth:2"],
+            "active_session_audit": {
+                "enabled": true,
+                "candidate_count": 1,
+                "candidates": [{"session_key": "host/mini:codex-1", "confidence": 0.8}]
+            }
         }));
 
         assert_eq!(public["status"], "degraded");
@@ -1712,6 +1824,8 @@ mod tests {
         assert!(public.get("mailboxes").is_none());
         assert!(public.get("config_audit").is_none());
         assert!(public.get("degraded_reasons").is_none());
+        // TEST-004: the detail-only audit block is dropped from public health.
+        assert!(public.get("active_session_audit").is_none());
     }
 
     #[test]

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -731,16 +731,17 @@ async fn build_active_session_audit(state: &AppState) -> ActiveSessionAuditRepor
 }
 
 /// One bounded `SELECT` for raw active-like sessions (`turn_active`, legacy
-/// `working`, OR a non-empty `active_dispatch_id`). Read-only. Returns the
-/// capped rows and the total raw-match count (capped at `LIMIT`, used only for
-/// the `truncated` flag). Duplicate rows are not possible because each row is a
+/// `working`, OR a non-empty `active_dispatch_id`). Read-only. Fetches one
+/// sentinel row beyond the cap so `truncated` can be computed without an
+/// uncapped `COUNT(*)`. Duplicate rows are not possible because each row is a
 /// distinct `sessions` row; precedence dedup of the raw signal happens in the
 /// classifier.
 async fn load_active_session_audit_rows(
     pool: &PgPool,
     max_candidates: u64,
 ) -> (Vec<RawSessionRow>, usize) {
-    let limit = max_candidates.min(i64::MAX as u64) as i64;
+    let capped = max_candidates.min(i64::MAX as u64) as usize;
+    let limit = max_candidates.saturating_add(1).min(i64::MAX as u64) as i64;
     // Surface the staleness-relevant rows FIRST so the LIMIT keeps the candidates
     // that matter: NULL/unknown heartbeats (can't be proven fresh) come first,
     // then the OLDEST heartbeats. Ordering newest-first would let stale/zombie
@@ -765,8 +766,10 @@ async fn load_active_session_audit_rows(
             return (Vec::new(), 0);
         }
     };
+    let raw_matches_seen = rows.len();
     let mapped: Vec<RawSessionRow> = rows
         .iter()
+        .take(capped)
         .map(|row| RawSessionRow {
             session_key: row.try_get("session_key").ok(),
             provider: row.try_get("provider").ok(),
@@ -776,42 +779,7 @@ async fn load_active_session_audit_rows(
             thread_channel_id: row.try_get("thread_channel_id").ok(),
         })
         .collect();
-    // `truncated` must reflect the PRE-LIMIT raw-match count, not `mapped.len()`
-    // (which is capped at `LIMIT`). Compute it with a matching COUNT over the same
-    // predicate. If the returned rows are fewer than the cap, nothing was omitted
-    // and we can skip the extra round-trip; otherwise count the raw matches.
-    let raw_matches_total = if (mapped.len() as i64) < limit {
-        mapped.len()
-    } else {
-        count_active_session_audit_rows(pool)
-            .await
-            .unwrap_or(mapped.len())
-    };
-    (mapped, raw_matches_total)
-}
-
-/// Pre-LIMIT raw-match count over the same predicate as
-/// [`load_active_session_audit_rows`]. Read-only; used only to compute the
-/// `truncated` flag accurately when the capped query fills to `LIMIT`.
-async fn count_active_session_audit_rows(pool: &PgPool) -> Option<usize> {
-    let count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*)
-           FROM sessions
-          WHERE status IN ('turn_active', 'working')
-             OR COALESCE(btrim(active_dispatch_id), '') <> ''",
-    )
-    .fetch_one(pool)
-    .await
-    .map_err(|error| {
-        tracing::debug!(
-            event = "active_session_audit_count_failed",
-            error = %error,
-            "active-session audit count query failed; using capped row count"
-        );
-        error
-    })
-    .ok()?;
-    Some(count.max(0) as usize)
+    (mapped, raw_matches_seen)
 }
 
 /// Read a (possibly `timestamptz`/`timestamp`/`text`) heartbeat column into a

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -741,12 +741,16 @@ async fn load_active_session_audit_rows(
     max_candidates: u64,
 ) -> (Vec<RawSessionRow>, usize) {
     let limit = max_candidates.min(i64::MAX as u64) as i64;
+    // Surface the staleness-relevant rows FIRST so the LIMIT keeps the candidates
+    // that matter: NULL/unknown heartbeats (can't be proven fresh) come first,
+    // then the OLDEST heartbeats. Ordering newest-first would let stale/zombie
+    // rows beyond the cap escape the audit entirely — the opposite of intent.
     let query = sqlx::query(
         "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat, thread_channel_id
            FROM sessions
           WHERE status IN ('turn_active', 'working')
              OR COALESCE(btrim(active_dispatch_id), '') <> ''
-          ORDER BY last_heartbeat DESC NULLS LAST, id DESC
+          ORDER BY last_heartbeat ASC NULLS FIRST, id ASC
           LIMIT $1",
     )
     .bind(limit);
@@ -772,8 +776,42 @@ async fn load_active_session_audit_rows(
             thread_channel_id: row.try_get("thread_channel_id").ok(),
         })
         .collect();
-    let total = mapped.len();
-    (mapped, total)
+    // `truncated` must reflect the PRE-LIMIT raw-match count, not `mapped.len()`
+    // (which is capped at `LIMIT`). Compute it with a matching COUNT over the same
+    // predicate. If the returned rows are fewer than the cap, nothing was omitted
+    // and we can skip the extra round-trip; otherwise count the raw matches.
+    let raw_matches_total = if (mapped.len() as i64) < limit {
+        mapped.len()
+    } else {
+        count_active_session_audit_rows(pool)
+            .await
+            .unwrap_or(mapped.len())
+    };
+    (mapped, raw_matches_total)
+}
+
+/// Pre-LIMIT raw-match count over the same predicate as
+/// [`load_active_session_audit_rows`]. Read-only; used only to compute the
+/// `truncated` flag accurately when the capped query fills to `LIMIT`.
+async fn count_active_session_audit_rows(pool: &PgPool) -> Option<usize> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+           FROM sessions
+          WHERE status IN ('turn_active', 'working')
+             OR COALESCE(btrim(active_dispatch_id), '') <> ''",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(|error| {
+        tracing::debug!(
+            event = "active_session_audit_count_failed",
+            error = %error,
+            "active-session audit count query failed; using capped row count"
+        );
+        error
+    })
+    .ok()?;
+    Some(count.max(0) as usize)
 }
 
 /// Read a (possibly `timestamptz`/`timestamp`/`text`) heartbeat column into a

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -342,6 +342,9 @@ async fn health_response(state: &AppState, detailed: bool) -> Response {
         if let Some(report) = pipeline_override_report {
             json["pipeline_overrides"] = report;
         }
+        if detailed {
+            json["active_session_audit"] = build_active_session_audit(state).await.to_json();
+        }
         let json = if detailed {
             with_latest_startup_doctor(json, true)
         } else {
@@ -747,7 +750,8 @@ async fn load_active_session_audit_rows(
     // then the OLDEST heartbeats. Ordering newest-first would let stale/zombie
     // rows beyond the cap escape the audit entirely — the opposite of intent.
     let query = sqlx::query(
-        "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat, thread_channel_id
+        "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat,
+                COALESCE(thread_channel_id, channel_id) AS audit_channel_id
            FROM sessions
           WHERE status IN ('turn_active', 'working')
              OR COALESCE(btrim(active_dispatch_id), '') <> ''
@@ -776,7 +780,7 @@ async fn load_active_session_audit_rows(
             status: row.try_get("status").ok(),
             active_dispatch_id: row.try_get("active_dispatch_id").ok(),
             last_heartbeat: pg_timestamp_to_rfc3339(row, "last_heartbeat"),
-            thread_channel_id: row.try_get("thread_channel_id").ok(),
+            thread_channel_id: row.try_get("audit_channel_id").ok(),
         })
         .collect();
     (mapped, raw_matches_seen)

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod active_session_audit;
 pub mod agents;
 mod agents_crud;
 mod agents_setup;

--- a/src/services/session_activity.rs
+++ b/src/services/session_activity.rs
@@ -115,6 +115,40 @@ impl SessionActivityResolver {
         )
     }
 
+    /// DB/heartbeat-only liveness resolution that NEVER spawns a tmux probe.
+    ///
+    /// Used by the read-only active-session audit on `/api/health/detail`, which
+    /// is contractually an off-hot-path DB/evidence pass: it must not block the
+    /// request on synchronous tmux (`has_live_pane` / pane-readiness) probes for
+    /// local session keys. Every host (local or remote) is resolved via
+    /// heartbeat recency only, so an unknown/stale heartbeat reads as not-live.
+    pub fn resolve_db_only(
+        &mut self,
+        session_key: Option<&str>,
+        raw_status: Option<&str>,
+        active_dispatch_id: Option<&str>,
+        last_heartbeat: Option<&str>,
+    ) -> EffectiveSessionState {
+        let now = Utc::now();
+        // Empty alias set ⇒ no key is treated as local ⇒ the local-host branch
+        // (the only tmux-probing branch) is never taken; heartbeat recency is the
+        // sole liveness signal. The closures are unreachable but required by the
+        // shared signature.
+        let no_local_aliases: HashSet<String> = HashSet::new();
+        let mut never_live = |_tmux_name: &str| false;
+        let mut never_ready = |_tmux_name: &str| false;
+        resolve_effective_state_with(
+            &no_local_aliases,
+            session_key,
+            raw_status,
+            active_dispatch_id,
+            last_heartbeat,
+            now,
+            &mut never_live,
+            &mut never_ready,
+        )
+    }
+
     fn local_host_aliases(&mut self) -> &HashSet<String> {
         if self.local_host_aliases.is_none() {
             self.local_host_aliases = Some(load_local_host_aliases());
@@ -242,4 +276,65 @@ fn heartbeat_is_recent(last_heartbeat: Option<&str>, now: DateTime<Utc>) -> bool
     parsed
         .map(|value| (now - value).num_seconds() <= REMOTE_HEARTBEAT_GRACE_SECS)
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(secs_ago: i64) -> String {
+        (Utc::now() - chrono::Duration::seconds(secs_ago))
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    }
+
+    /// `resolve_db_only` must NOT take the local-host (tmux-probing) branch even
+    /// for a key whose host matches a local alias: it resolves via heartbeat
+    /// recency only, so a recent heartbeat reads as working without any tmux probe.
+    #[test]
+    fn resolve_db_only_uses_heartbeat_not_tmux_for_local_keys() {
+        let mut resolver = SessionActivityResolver::new();
+        // Force a local alias so `resolve` (the non-db path) would tmux-probe.
+        resolver.local_host_aliases = Some(HashSet::from(["localbox".to_string()]));
+
+        let recent = resolver.resolve_db_only(
+            Some("localbox:codex-chan-1"),
+            Some("turn_active"),
+            Some("dispatch-1"),
+            Some(&ts(5)),
+        );
+        assert!(
+            recent.is_working,
+            "recent heartbeat ⇒ working via heartbeat path, no tmux probe"
+        );
+
+        let stale = resolver.resolve_db_only(
+            Some("localbox:codex-chan-1"),
+            Some("turn_active"),
+            Some("dispatch-1"),
+            Some(&ts(900)),
+        );
+        assert!(
+            !stale.is_working,
+            "stale heartbeat ⇒ not working (db-only verdict)"
+        );
+
+        // Crucially, no tmux probe cache entry was ever populated.
+        assert!(resolver.tmux_live_cache.is_empty());
+        assert!(resolver.tmux_ready_cache.is_empty());
+    }
+
+    /// An unknown heartbeat in db-only mode reads as not-live (cannot prove fresh).
+    #[test]
+    fn resolve_db_only_unknown_heartbeat_is_not_working() {
+        let mut resolver = SessionActivityResolver::new();
+        let state = resolver.resolve_db_only(
+            Some("localbox:codex-chan-2"),
+            Some("turn_active"),
+            Some("dispatch-2"),
+            None,
+        );
+        assert!(!state.is_working);
+        assert!(resolver.tmux_live_cache.is_empty());
+    }
 }


### PR DESCRIPTION
## 목표
`/api/health/detail`의 read-only active-session audit가 stale foreground 세션을 안전하게 보여주되, 이 노드가 고칠 수 없거나 repair path가 실제로 처리하지 못하는 row를 잘못 추천하지 않도록 보강합니다.

## 쉬운 설명
상세 health 응답에서 active session mismatch를 계속 확인할 수 있습니다.
다만 다른 노드 소유 세션, background child 세션, fixed-channel 세션을 stale-mailbox repair 대상으로 잘못 안내하지 않습니다.
일반 channel-only 세션은 channel id는 표시하지만 no-op repair 추천은 하지 않습니다.

## 개선되는 것
### Fix 1
Before: standalone health detail launch mode에서 audit block이 누락될 수 있었습니다.
After: detail 응답은 Discord registry 유무와 무관하게 `active_session_audit` block을 포함합니다.

### Fix 2
Before: audit query가 `thread_channel_id`와 `channel_id`를 합쳐 classifier에 넘겨 stale-mailbox repair 가능 여부를 구분하지 못했습니다.
After: 두 값을 분리해 후보 `channel_id`는 유지하되, stale-mailbox repair 추천은 `thread_channel_id`가 있는 row로 제한합니다.

### Fix 3
Before: clustered DB의 foreign owner row나 background child row가 현재 노드의 repair 후보로 보일 수 있었습니다.
After: query가 `parent_session_id IS NULL`과 local/legacy owner 조건을 적용해 repair 불가능한 row를 audit 대상에서 제외합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| fixed-channel session | `channel_id`를 thread처럼 취급해 stale_mailbox 추천 가능 | `channel_id`는 표시하지만 repair path는 `none` |
| foreign owner session | 현재 노드 health에서 repair 추천 가능 | local instance 또는 legacy null owner만 조회 |
| background child session | parent 대기 중인 child row가 stale 후보 가능 | `parent_session_id IS NULL`로 제외 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| thread-backed stale session | 기존 stale_mailbox 추천 유지 | 기존 repair flow 유지 |
| dispatch id가 있는 stale session | relay_recovery/stall_watchdog 판단 유지 | 기존 classifier contract 유지 |
| audit disabled 또는 PG 없음 | disabled empty block 반환 | rollback path 유지 |

## 해결한 내용
- `src/server/routes/active_session_audit.rs`: `RawSessionRow`가 thread/channel id를 분리 보관하고, channel-only session에는 stale-mailbox repair를 추천하지 않도록 classifier를 보강했습니다.
- `src/server/routes/health_api.rs`: active-session audit SQL에 local owner/background-child filter를 추가하고, query contract regression test를 추가했습니다.

## 검증
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test --all-targets active_session_audit -- --skip _pg --skip pg_ --skip postgres` (15 passed)
- `cargo test --all-targets active_session_audit_query_filters_foreign_and_background_rows -- --skip _pg --skip pg_ --skip postgres` (1 passed)
- `cargo check --all-targets`
- `python3 scripts/check_agent_maintenance_docs.py --base-ref upstream/main`
- `./scripts/ci-script-checks.sh`
