### PR TITLE
fix(db-ops): translate sqlite rowid inside quoted SQL

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -84,7 +84,7 @@
   pre-migration giant-file territory.
 - do_not_edit_without_migration_plan:
   - `src/engine/mod.rs` (1265 lines, giant-file).
-  - `src/engine/ops/db_ops.rs` (1111 lines, giant-file).
+  - `src/engine/ops/db_ops.rs` (1134 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
   - `src/pipeline.rs` (1314 lines, giant-file).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -84,7 +84,7 @@
   pre-migration giant-file territory.
 - do_not_edit_without_migration_plan:
   - `src/engine/mod.rs` (1265 lines, giant-file).
-  - `src/engine/ops/db_ops.rs` (1143 lines, giant-file).
+  - `src/engine/ops/db_ops.rs` (1202 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
   - `src/pipeline.rs` (1314 lines, giant-file).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -84,7 +84,7 @@
   pre-migration giant-file territory.
 - do_not_edit_without_migration_plan:
   - `src/engine/mod.rs` (1265 lines, giant-file).
-  - `src/engine/ops/db_ops.rs` (1134 lines, giant-file).
+  - `src/engine/ops/db_ops.rs` (1143 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
   - `src/pipeline.rs` (1314 lines, giant-file).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -84,7 +84,7 @@
   pre-migration giant-file territory.
 - do_not_edit_without_migration_plan:
   - `src/engine/mod.rs` (1265 lines, giant-file).
-  - `src/engine/ops/db_ops.rs` (1202 lines, giant-file).
+  - `src/engine/ops/db_ops.rs` (1244 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
   - `src/pipeline.rs` (1314 lines, giant-file).

--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -1,5 +1,7 @@
 # Discord Outbound Migration — Coverage Map (#1006 v3 / #1280 / #1436 / #1457)
 
+Last refreshed: 2026-06-16 (against `main` @ `8ec7336e32eb6ef89e1143fab2543f2fc644ebac`)
+
 > Implementation refresh for #1457 / #2368 / #2533 / #2535: v3 delivery now
 > covers dispatch outbox, review followups, issue announcements, monitoring
 > status, meeting notifications, short manual/DM notifications, gateway

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -58,6 +58,9 @@
 - 2026-06-17 audit note (#3548): PR analyzer hygiene guard work is confined to
   `scripts/analyze_prs.py`; gateway lease, startup order, worker ownership, and
   singleton assumptions are unchanged.
+- 2026-06-17 audit note (#3546): SQLite rowid compatibility work is confined to
+  `src/engine/ops/db_ops.rs`; gateway lease, startup order, worker ownership,
+  and singleton assumptions are unchanged.
 - invariants: `singleton_on_leader`,
   `heartbeat_capability_registry_routing`.
 - allowed_changes: `bugfix` only before #876/#877. New gateway, reconnect,

--- a/src/engine/ops/db_ops.rs
+++ b/src/engine/ops/db_ops.rs
@@ -542,6 +542,29 @@ fn translate_sqlite_rowid(sql: &str) -> String {
             continue;
         }
 
+        if ch == '"' && !in_single_quote {
+            result.push(ch);
+            idx += 1;
+
+            let start = idx;
+            while idx < chars.len() && chars[idx] != '"' {
+                idx += 1;
+            }
+
+            let token: String = chars[start..idx].iter().collect();
+            if token.eq_ignore_ascii_case("rowid") {
+                result.push_str("ctid");
+            } else {
+                result.push_str(&token);
+            }
+
+            if idx < chars.len() && chars[idx] == '"' {
+                result.push('"');
+                idx += 1;
+            }
+            continue;
+        }
+
         if !in_single_quote && (ch.is_ascii_alphabetic() || ch == '_') {
             let start = idx;
             idx += 1;
@@ -1232,13 +1255,13 @@ mod tests {
 
     #[test]
     fn prepare_policy_sql_for_pg_rewrites_rowid_tokens() {
-        let sql = "SELECT rowid, td.rowid, 'rowid' AS literal FROM task_dispatches td ORDER BY td.rowid DESC, rowid DESC";
+        let sql = "SELECT rowid, td.rowid, \"rowid\", 'rowid' AS literal FROM task_dispatches td ORDER BY td.rowid DESC, rowid DESC";
         let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid");
 
         assert!(
             prepared
                 .sql
-                .contains("SELECT ctid, td.ctid, 'rowid' AS literal")
+                .contains("SELECT ctid, td.ctid, \"ctid\", 'rowid' AS literal")
         );
         assert!(prepared.sql.contains("ORDER BY td.ctid DESC, ctid DESC"));
         assert!(prepared.params.is_empty());

--- a/src/engine/ops/db_ops.rs
+++ b/src/engine/ops/db_ops.rs
@@ -546,12 +546,21 @@ fn translate_sqlite_rowid(sql: &str) -> String {
             result.push(ch);
             idx += 1;
 
-            let start = idx;
-            while idx < chars.len() && chars[idx] != '"' {
+            let mut token = String::new();
+            while idx < chars.len() {
+                if chars[idx] == '"' {
+                    if idx + 1 < chars.len() && chars[idx + 1] == '"' {
+                        token.push('"');
+                        token.push('"');
+                        idx += 2;
+                        continue;
+                    }
+                    break;
+                }
+                token.push(chars[idx]);
                 idx += 1;
             }
 
-            let token: String = chars[start..idx].iter().collect();
             if token.eq_ignore_ascii_case("rowid") {
                 result.push_str("ctid");
             } else {
@@ -1265,6 +1274,14 @@ mod tests {
         );
         assert!(prepared.sql.contains("ORDER BY td.ctid DESC, ctid DESC"));
         assert!(prepared.params.is_empty());
+    }
+
+    #[test]
+    fn prepare_policy_sql_for_pg_preserves_escaped_quote_identifiers() {
+        let sql = r#"SELECT "rowid""suffix", "rowid" FROM task_dispatches"#;
+        let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid");
+
+        assert!(prepared.sql.contains(r#""rowid""suffix", "ctid""#));
     }
 
     #[test]

--- a/src/engine/ops/db_ops.rs
+++ b/src/engine/ops/db_ops.rs
@@ -518,6 +518,52 @@ fn strip_prefix_ci<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
     }
 }
 
+fn scan_double_quoted_identifier(sql: &str, start: usize) -> Option<(&str, String, usize)> {
+    let bytes = sql.as_bytes();
+    if bytes.get(start).copied() != Some(b'"') {
+        return None;
+    }
+
+    let mut idx = start + 1;
+    let mut ident = String::new();
+    while idx < bytes.len() {
+        if bytes[idx] == b'"' {
+            if bytes.get(idx + 1).copied() == Some(b'"') {
+                ident.push('"');
+                idx += 2;
+                continue;
+            }
+            let end = idx + 1;
+            return Some((&sql[start..end], ident, end));
+        }
+
+        let ch = sql[idx..].chars().next()?;
+        ident.push(ch);
+        idx += ch.len_utf8();
+    }
+
+    None
+}
+
+fn is_quoted_identifier_alias(sql: &str, quote_start: usize) -> bool {
+    previous_sql_word(sql, quote_start).is_some_and(|word| word.eq_ignore_ascii_case("as"))
+}
+
+fn previous_sql_word(sql: &str, before: usize) -> Option<&str> {
+    let bytes = sql.as_bytes();
+    let mut end = before.min(bytes.len());
+    while end > 0 && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+
+    let mut start = end;
+    while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
+        start -= 1;
+    }
+
+    (start < end).then_some(&sql[start..end])
+}
+
 fn translate_sqlite_rowid(sql: &str) -> String {
     let mut result = String::with_capacity(sql.len());
     let bytes = sql.as_bytes();
@@ -526,7 +572,6 @@ fn translate_sqlite_rowid(sql: &str) -> String {
     enum ScanState {
         Normal,
         SingleQuoted,
-        DoubleQuoted,
         LineComment,
         BlockComment { depth: usize },
         DollarQuoted { delimiter: String },
@@ -544,9 +589,19 @@ fn translate_sqlite_rowid(sql: &str) -> String {
                     continue;
                 }
                 if bytes[idx] == b'"' {
-                    result.push('"');
-                    state = ScanState::DoubleQuoted;
-                    idx += 1;
+                    if let Some((raw, ident, next_idx)) = scan_double_quoted_identifier(sql, idx) {
+                        if ident.eq_ignore_ascii_case("rowid")
+                            && !is_quoted_identifier_alias(sql, idx)
+                        {
+                            result.push_str("ctid");
+                        } else {
+                            result.push_str(raw);
+                        }
+                        idx = next_idx;
+                    } else {
+                        result.push('"');
+                        idx += 1;
+                    }
                     continue;
                 }
                 if sql[idx..].starts_with("--") {
@@ -600,19 +655,6 @@ fn translate_sqlite_rowid(sql: &str) -> String {
                     result.push('\'');
                     if bytes.get(idx + 1).copied() == Some(b'\'') {
                         result.push('\'');
-                        idx += 2;
-                    } else {
-                        idx += 1;
-                        state = ScanState::Normal;
-                    }
-                    continue;
-                }
-            }
-            ScanState::DoubleQuoted => {
-                if bytes[idx] == b'"' {
-                    result.push('"');
-                    if bytes.get(idx + 1).copied() == Some(b'"') {
-                        result.push('"');
                         idx += 2;
                     } else {
                         idx += 1;
@@ -1329,7 +1371,7 @@ mod tests {
         assert!(
             prepared
                 .sql
-                .contains("SELECT ctid, td.ctid, \"rowid\", 'rowid' AS literal")
+                .contains("SELECT ctid, td.ctid, ctid, 'rowid' AS literal")
         );
         assert!(prepared.sql.contains("ORDER BY td.ctid DESC, ctid DESC"));
         assert!(prepared.params.is_empty());
@@ -1340,7 +1382,7 @@ mod tests {
         let sql = r#"SELECT "rowid""suffix", "rowid" FROM task_dispatches"#;
         let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid");
 
-        assert!(prepared.sql.contains(r#""rowid""suffix", "rowid""#));
+        assert!(prepared.sql.contains(r#""rowid""suffix", ctid"#));
     }
 
     #[test]
@@ -1349,6 +1391,15 @@ mod tests {
         let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid alias");
 
         assert!(prepared.sql.contains(r#"1 AS "rowid", ctid"#));
+        assert!(prepared.sql.contains("ORDER BY ctid"));
+    }
+
+    #[test]
+    fn prepare_policy_sql_for_pg_rewrites_quoted_rowid_expressions() {
+        let sql = r#"SELECT td."rowid" FROM task_dispatches td ORDER BY "rowid""#;
+        let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render quoted rowid");
+
+        assert!(prepared.sql.contains("SELECT td.ctid"));
         assert!(prepared.sql.contains("ORDER BY ctid"));
     }
 

--- a/src/engine/ops/db_ops.rs
+++ b/src/engine/ops/db_ops.rs
@@ -519,89 +519,148 @@ fn strip_prefix_ci<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
 }
 
 fn translate_sqlite_rowid(sql: &str) -> String {
-    let chars: Vec<char> = sql.chars().collect();
     let mut result = String::with_capacity(sql.len());
+    let bytes = sql.as_bytes();
     let mut idx = 0usize;
-    let mut in_single_quote = false;
 
-    while idx < chars.len() {
-        let ch = chars[idx];
-        if ch == '\'' {
-            result.push(ch);
-            if in_single_quote {
-                if idx + 1 < chars.len() && chars[idx + 1] == '\'' {
+    enum ScanState {
+        Normal,
+        SingleQuoted,
+        DoubleQuoted,
+        LineComment,
+        BlockComment { depth: usize },
+        DollarQuoted { delimiter: String },
+    }
+
+    let mut state = ScanState::Normal;
+
+    while idx < bytes.len() {
+        match &mut state {
+            ScanState::Normal => {
+                if bytes[idx] == b'\'' {
                     result.push('\'');
+                    state = ScanState::SingleQuoted;
+                    idx += 1;
+                    continue;
+                }
+                if bytes[idx] == b'"' {
+                    result.push('"');
+                    state = ScanState::DoubleQuoted;
+                    idx += 1;
+                    continue;
+                }
+                if sql[idx..].starts_with("--") {
+                    result.push_str("--");
+                    idx += 2;
+                    state = ScanState::LineComment;
+                    continue;
+                }
+                if sql[idx..].starts_with("/*") {
+                    result.push_str("/*");
+                    idx += 2;
+                    state = ScanState::BlockComment { depth: 1 };
+                    continue;
+                }
+                if let Some(delimiter) = dollar_quote_delimiter(sql, idx) {
+                    result.push_str(&delimiter);
+                    idx += delimiter.len();
+                    state = ScanState::DollarQuoted { delimiter };
+                    continue;
+                }
+                if bytes[idx].is_ascii_alphabetic() || bytes[idx] == b'_' {
+                    let start = idx;
+                    idx += 1;
+                    while idx < bytes.len()
+                        && (bytes[idx].is_ascii_alphanumeric()
+                            || bytes[idx] == b'_'
+                            || bytes[idx] == b'.')
+                    {
+                        idx += 1;
+                    }
+
+                    let token = &sql[start..idx];
+                    if token.eq_ignore_ascii_case("rowid") {
+                        result.push_str("ctid");
+                        continue;
+                    }
+
+                    let lower = token.to_ascii_lowercase();
+                    if let Some(prefix) = lower.strip_suffix(".rowid") {
+                        result.push_str(&token[..prefix.len()]);
+                        result.push_str(".ctid");
+                        continue;
+                    }
+
+                    result.push_str(token);
+                    continue;
+                }
+            }
+            ScanState::SingleQuoted => {
+                if bytes[idx] == b'\'' {
+                    result.push('\'');
+                    if bytes.get(idx + 1).copied() == Some(b'\'') {
+                        result.push('\'');
+                        idx += 2;
+                    } else {
+                        idx += 1;
+                        state = ScanState::Normal;
+                    }
+                    continue;
+                }
+            }
+            ScanState::DoubleQuoted => {
+                if bytes[idx] == b'"' {
+                    result.push('"');
+                    if bytes.get(idx + 1).copied() == Some(b'"') {
+                        result.push('"');
+                        idx += 2;
+                    } else {
+                        idx += 1;
+                        state = ScanState::Normal;
+                    }
+                    continue;
+                }
+            }
+            ScanState::LineComment => {
+                if bytes[idx] == b'\n' {
+                    result.push('\n');
+                    idx += 1;
+                    state = ScanState::Normal;
+                    continue;
+                }
+            }
+            ScanState::BlockComment { depth } => {
+                if sql[idx..].starts_with("/*") {
+                    result.push_str("/*");
+                    *depth += 1;
                     idx += 2;
                     continue;
                 }
-                in_single_quote = false;
-            } else {
-                in_single_quote = true;
-            }
-            idx += 1;
-            continue;
-        }
-
-        if ch == '"' && !in_single_quote {
-            result.push(ch);
-            idx += 1;
-
-            let mut token = String::new();
-            while idx < chars.len() {
-                if chars[idx] == '"' {
-                    if idx + 1 < chars.len() && chars[idx + 1] == '"' {
-                        token.push('"');
-                        token.push('"');
-                        idx += 2;
-                        continue;
+                if sql[idx..].starts_with("*/") {
+                    result.push_str("*/");
+                    *depth = depth.saturating_sub(1);
+                    if *depth == 0 {
+                        state = ScanState::Normal;
                     }
-                    break;
+                    idx += 2;
+                    continue;
                 }
-                token.push(chars[idx]);
-                idx += 1;
             }
-
-            if token.eq_ignore_ascii_case("rowid") {
-                result.push_str("ctid");
-            } else {
-                result.push_str(&token);
+            ScanState::DollarQuoted { delimiter } => {
+                if sql[idx..].starts_with(delimiter.as_str()) {
+                    result.push_str(delimiter);
+                    idx += delimiter.len();
+                    state = ScanState::Normal;
+                    continue;
+                }
             }
+        };
 
-            if idx < chars.len() && chars[idx] == '"' {
-                result.push('"');
-                idx += 1;
-            }
-            continue;
-        }
-
-        if !in_single_quote && (ch.is_ascii_alphabetic() || ch == '_') {
-            let start = idx;
-            idx += 1;
-            while idx < chars.len()
-                && (chars[idx].is_ascii_alphanumeric() || chars[idx] == '_' || chars[idx] == '.')
-            {
-                idx += 1;
-            }
-
-            let token: String = chars[start..idx].iter().collect();
-            if token.eq_ignore_ascii_case("rowid") {
-                result.push_str("ctid");
-                continue;
-            }
-
-            let lower = token.to_ascii_lowercase();
-            if let Some(prefix) = lower.strip_suffix(".rowid") {
-                result.push_str(&token[..prefix.len()]);
-                result.push_str(".ctid");
-                continue;
-            }
-
-            result.push_str(&token);
-            continue;
-        }
-
+        let Some(ch) = sql[idx..].chars().next() else {
+            break;
+        };
         result.push(ch);
-        idx += 1;
+        idx += ch.len_utf8();
     }
 
     result
@@ -1270,7 +1329,7 @@ mod tests {
         assert!(
             prepared
                 .sql
-                .contains("SELECT ctid, td.ctid, \"ctid\", 'rowid' AS literal")
+                .contains("SELECT ctid, td.ctid, \"rowid\", 'rowid' AS literal")
         );
         assert!(prepared.sql.contains("ORDER BY td.ctid DESC, ctid DESC"));
         assert!(prepared.params.is_empty());
@@ -1281,7 +1340,36 @@ mod tests {
         let sql = r#"SELECT "rowid""suffix", "rowid" FROM task_dispatches"#;
         let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid");
 
-        assert!(prepared.sql.contains(r#""rowid""suffix", "ctid""#));
+        assert!(prepared.sql.contains(r#""rowid""suffix", "rowid""#));
+    }
+
+    #[test]
+    fn prepare_policy_sql_for_pg_preserves_quoted_rowid_alias() {
+        let sql = r#"SELECT 1 AS "rowid", rowid FROM task_dispatches ORDER BY rowid"#;
+        let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid alias");
+
+        assert!(prepared.sql.contains(r#"1 AS "rowid", ctid"#));
+        assert!(prepared.sql.contains("ORDER BY ctid"));
+    }
+
+    #[test]
+    fn prepare_policy_sql_for_pg_ignores_comment_quotes_while_rewriting_rowid() {
+        let sql = "SELECT id FROM task_dispatches -- \" explain\nORDER BY rowid";
+        let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render rowid after comment");
+
+        assert!(prepared.sql.contains("-- \" explain\nORDER BY ctid"));
+    }
+
+    #[test]
+    fn prepare_policy_sql_for_pg_skips_dollar_quoted_literals_for_rowid() {
+        let sql = r#"SELECT $$ {"rowid": 1} $$ AS payload, rowid FROM task_dispatches"#;
+        let prepared = prepare_policy_sql_for_pg(sql, &[]).expect("render dollar quote");
+
+        assert!(
+            prepared
+                .sql
+                .contains(r#"$$ {"rowid": 1} $$ AS payload, ctid"#)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 목표
SQLite 호환 정책 SQL을 Postgres로 변환할 때 SQLite `rowid` 표현식은 `ctid`로 바꾸되, 출력 alias/result label과 string/comment/dollar-quoted payload는 보존합니다.

## 핵심 동작
- bare `rowid` -> `ctid`
- qualified `td.rowid` -> `td.ctid`
- quoted expression `"rowid"` / `td."rowid"` -> `ctid` / `td.ctid`
- output alias `AS "rowid"`는 JSON/result shape 유지를 위해 보존
- single-quoted string, SQL comments, dollar-quoted literal 안의 `rowid` 텍스트는 보존

## 리뷰 반영
- double-quoted scanner가 escaped quote를 해석해 identifier text를 확인하도록 변경
- `AS "rowid"` alias context만 보존하고, `ORDER BY "rowid"` 및 `td."rowid"` 같은 표현식은 `ctid`로 번역
- comment quote와 dollar-quoted literal 경계는 기존 scanner state로 계속 보존
- 회귀 테스트 `prepare_policy_sql_for_pg_rewrites_quoted_rowid_expressions` 추가 및 기존 rowid tests 기대값 갱신

## 주요 파일
- `src/engine/ops/db_ops.rs`: rowid translation scanner 및 tests
- `docs/agent-maintenance/change-surfaces.md`: `db_ops.rs` production line count 동기화
- `docs/agent-maintenance/multinode-transition.md`: maintenance freshness audit note

## 검증
- `cargo fmt --all --check`
- `cargo test --all-targets prepare_policy_sql_for_pg` (12 passed)
- `cargo test --all-targets db_ops -- --skip _pg --skip pg_ --skip postgres` (2 passed; rowid tests intentionally skipped by `pg_` filter)
- `python3 scripts/check_agent_maintenance_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --base-ref upstream/main`
- `./scripts/ci-script-checks.sh`

## Analyzer Hygiene
- WorkFingerprint: this PR branch contains only the commits and files described above.
- verification: commands listed in `## 검증` were run locally on head `f582976f6`.
- skipped checks: checks not listed above were not run locally; remote CI status is tracked separately by GitHub checks.
- rollback notes: revert this PR branch to restore the previous rowid translation behavior.