### PR TITLE
ci: run large-file guard unconditionally

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -693,7 +693,6 @@ jobs:
           fetch-depth: 0
 
       - name: Large file guard
-        if: ${{ needs.changes.outputs.ci_relax_safe == 'true' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 목표

PR CI에서 Large file guard가 조건부로 빠지지 않고 항상 실행되도록 workflow 조건을 단순화합니다. 대형 파일 회귀를 PR 단계에서 안정적으로 잡는 것이 목표입니다.

## 쉬운 설명

큰 파일 방지 검사는 PR마다 항상 돌아야 합니다. 기존 workflow 조건 때문에 특정 상황에서 guard가 건너뛰어질 수 있었습니다. 이제 CI가 이 검사를 무조건 실행합니다.

## 개선되는 것

### Fix 1
`.github/workflows/ci-pr.yml`에서 Large file guard 단계의 조건부 실행 제한을 제거했습니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 일반 PR CI | 조건에 따라 guard skip 가능 | guard 항상 실행 |
| 큰 파일 회귀 | 일부 경로에서 늦게 발견 가능 | PR CI에서 즉시 감지 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| guard 대상 파일 없음 | 빠르게 통과 | CI 비용 영향 작음 |
| 대형 파일 추가 | guard 실패 | 의도한 차단 |
| workflow 이벤트 차이 | 조건 제거로 동일 실행 | 회귀 감지 일관성 증가 |

## 해결한 내용

- `.github/workflows/ci-pr.yml`: Large file guard 단계의 조건부 skip 조건 제거

## 검증

- `./scripts/ci-script-checks.sh`: 통과

## Analyzer Hygiene

- WorkFingerprint: this PR branch contains only the commits and files described in the PR body.
- duplicate/overlap check: scope was compared against sibling upstream-pr branches before creation; no duplicate PR scope is intentionally included.
- verification: see `## 검증` above for commands and results actually run; remote CI status is tracked separately by GitHub checks.
- skipped checks: checks not listed in `## 검증` were not run locally; CI path filters may also skip unrelated jobs.
- risk assessment: risk is limited to the touched files and behavior described above.
- rollback notes: revert this PR branch to restore the previous behavior.

## 서브에이전트 적대적 검증
- 결과: large-file guard unconditional 실행 PR은 추가 코드 결함 없이 CI 경로 의도와 일치함.
- 추가 조치: 없음.
- 추가 검증: live CI에서 Script checks / Lint / Fast checks / PostgreSQL tests 성공 확인.
