### PR TITLE
chore(pr-analyzer): add risk rollback duplicate guard checks

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -55,6 +55,9 @@
 - 2026-06-12 audit note (#3089 S0): `runtime_bootstrap` only initializes the
   default-off `single_message_panel` flag for startup logging. Gateway lease,
   startup order, worker ownership, and singleton assumptions are unchanged.
+- 2026-06-17 audit note (#3548): PR analyzer hygiene guard work is confined to
+  `scripts/analyze_prs.py`; gateway lease, startup order, worker ownership, and
+  singleton assumptions are unchanged.
 - invariants: `singleton_on_leader`,
   `heartbeat_capability_registry_routing`.
 - allowed_changes: `bugfix` only before #876/#877. New gateway, reconnect,

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -37,6 +37,11 @@ def _meaningful_field_value(value):
     normalized = value.strip().strip("-–—").strip()
     return bool(normalized) and normalized.casefold() not in {"n/a", "none", "todo", "tbd", "na"}
 
+def _is_top_level_field_label(line):
+    if line[:1] in {" ", "\t"}:
+        return False
+    return re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", line.strip(), re.I)
+
 def has_non_empty_body_field(body, labels):
     for label in labels:
         pattern = re.compile(
@@ -55,7 +60,7 @@ def has_non_empty_body_field(body, labels):
                 # Next field label is a boundary whether or not it carries a
                 # value: an empty `- Risk:` must not borrow the value of a
                 # following populated field (e.g. `- Rollback notes: revert`).
-                if re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", stripped, re.I):
+                if _is_top_level_field_label(next_line):
                     break
                 if _meaningful_field_value(stripped):
                     return True

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -1,5 +1,6 @@
 import subprocess
 import json
+import re
 from datetime import datetime, timedelta, timezone
 
 def run(cmd):
@@ -32,6 +33,32 @@ def head_commit_timestamp(pr):
     if code != 0:
         return None
     return parse_github_timestamp(timestamp)
+
+def _meaningful_field_value(value):
+    normalized = value.strip().strip("-–—").strip()
+    return bool(normalized) and normalized not in {"n/a", "none", "todo", "tbd", "na"}
+
+def has_non_empty_body_field(body, labels):
+    for label in labels:
+        pattern = re.compile(
+            rf"(?im)^[ \t]*(?:[-*][ \t]*)?(?:#{{1,6}}[ \t]*)?{re.escape(label)}(?:[ \t]*:[ \t]*(.*)|[ \t]*)$"
+        )
+        for match in pattern.finditer(body):
+            if _meaningful_field_value(match.group(1) or ""):
+                return True
+
+            for next_line in body[match.end():].splitlines():
+                stripped = next_line.strip()
+                if not stripped:
+                    continue
+                if stripped.startswith("#"):
+                    break
+                if re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:\s*$", stripped, re.I):
+                    break
+                if _meaningful_field_value(stripped):
+                    return True
+                break
+    return False
 
 print("Fetching PRs...")
 prs_json, gh_code = run(f"gh pr list --repo {REPO} --state open --limit 50 --json number,title,headRefName,createdAt,headRefOid,body")
@@ -66,9 +93,9 @@ for pr in prs:
         print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
     if "skipped checks" not in body:
         print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
-    if "risk" not in body:
+    if not has_non_empty_body_field(body, ["risk", "risk assessment"]):
         print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")
-    if "rollback notes" not in body:
+    if not has_non_empty_body_field(body, ["rollback notes", "rollback"]):
         print("  [!] MISSING ROLLBACK NOTES: PR body fails to mention 'rollback notes'.")
 
     # 2026-05-13 lesson: treat low-signal or stale broad branches as queue debt

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -53,7 +53,10 @@ def has_non_empty_body_field(body, labels):
                     continue
                 if stripped.startswith("#"):
                     break
-                if re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:\s*$", stripped, re.I):
+                # Next field label is a boundary whether or not it carries a
+                # value: an empty `- Risk:` must not borrow the value of a
+                # following populated field (e.g. `- Rollback notes: revert`).
+                if re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", stripped, re.I):
                     break
                 if _meaningful_field_value(stripped):
                     return True

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -1,6 +1,7 @@
 import subprocess
 import json
 import re
+import sys
 from datetime import datetime, timedelta, timezone
 
 def run(cmd):
@@ -13,8 +14,6 @@ def _detect_repo():
     out, code = run("gh repo view --json nameWithOwner --jq .nameWithOwner")
     return out if code == 0 and out else "itismyfield/AgentDesk"
 
-REPO = _detect_repo()
-
 def parse_github_timestamp(value):
     if not value:
         return None
@@ -23,12 +22,12 @@ def parse_github_timestamp(value):
     except Exception:
         return None
 
-def head_commit_timestamp(pr):
+def head_commit_timestamp(pr, repo):
     head_oid = pr.get("headRefOid")
     if not head_oid:
         return None
     timestamp, code = run(
-        f"gh api repos/{REPO}/commits/{head_oid} --jq .commit.committer.date"
+        f"gh api repos/{repo}/commits/{head_oid} --jq .commit.committer.date"
     )
     if code != 0:
         return None
@@ -36,7 +35,7 @@ def head_commit_timestamp(pr):
 
 def _meaningful_field_value(value):
     normalized = value.strip().strip("-–—").strip()
-    return bool(normalized) and normalized not in {"n/a", "none", "todo", "tbd", "na"}
+    return bool(normalized) and normalized.casefold() not in {"n/a", "none", "todo", "tbd", "na"}
 
 def has_non_empty_body_field(body, labels):
     for label in labels:
@@ -63,73 +62,93 @@ def has_non_empty_body_field(body, labels):
                 break
     return False
 
-print("Fetching PRs...")
-prs_json, gh_code = run(f"gh pr list --repo {REPO} --state open --limit 50 --json number,title,headRefName,createdAt,headRefOid,body")
+def has_duplicate_guard_ack(body):
+    if re.search(r"(?im)^[ \t]*[-*][ \t]*\[[xX]\][ \t]*\*\*duplicate pr guard:\*\*", body):
+        return True
+    return has_non_empty_body_field(
+        body,
+        [
+            "duplicate pr guard",
+            "duplicate-pr guard",
+            "duplicate/overlap check",
+            "overlap check",
+        ],
+    )
 
-if gh_code != 0 or not prs_json:
-    print("Warning: `gh` CLI not available or failed. Skipping PR analysis.")
-    exit(0)
+def main():
+    repo = _detect_repo()
+    print("Fetching PRs...")
+    prs_json, gh_code = run(f"gh pr list --repo {repo} --state open --limit 50 --json number,title,headRefName,createdAt,headRefOid,body")
 
-try:
-    prs = json.loads(prs_json)
-except Exception as e:
-    print(f"Error parsing JSON: {e}")
-    print(prs_json)
-    exit(1)
+    if gh_code != 0 or not prs_json:
+        print("Warning: `gh` CLI not available or failed. Skipping PR analysis.")
+        return 0
 
-inventory_refresh_count = 0
-now = datetime.now(timezone.utc)
+    try:
+        prs = json.loads(prs_json)
+    except Exception as e:
+        print(f"Error parsing JSON: {e}")
+        print(prs_json)
+        return 1
 
-for pr in prs:
-    num = pr['number']
-    title = pr['title']
-    body = str(pr.get('body') or '').lower()
-    head_commit_at = head_commit_timestamp(pr)
-    print(f"\n# {num} - {title}")
+    inventory_refresh_count = 0
+    now = datetime.now(timezone.utc)
 
-    # Check PR hygiene requirements
-    if "workfingerprint" not in body:
-        print("  [!] MISSING FINGERPRINT: PR body lacks the required 'WorkFingerprint' section.")
-    if "duplicate" not in body and "overlap" not in body:
-        print("  [!] MISSING OVERLAP CHECK: PR body fails to explicitly mention a 'duplicate' or 'overlap' check.")
-    if "verification" not in body:
-        print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
-    if "skipped checks" not in body:
-        print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
-    if not has_non_empty_body_field(body, ["risk", "risk assessment"]):
-        print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")
-    if not has_non_empty_body_field(body, ["rollback notes", "rollback"]):
-        print("  [!] MISSING ROLLBACK NOTES: PR body fails to mention 'rollback notes'.")
+    for pr in prs:
+        num = pr['number']
+        title = pr['title']
+        body = str(pr.get('body') or '')
+        normalized_body = body.lower()
+        head_commit_at = head_commit_timestamp(pr, repo)
+        print(f"\n# {num} - {title}")
 
-    # 2026-05-13 lesson: treat low-signal or stale broad branches as queue debt
-    is_stale = head_commit_at is not None and (now - head_commit_at) > timedelta(days=14)
+        # Check PR hygiene requirements
+        if "workfingerprint" not in normalized_body:
+            print("  [!] MISSING FINGERPRINT: PR body lacks the required 'WorkFingerprint' section.")
+        if not has_duplicate_guard_ack(body):
+            print("  [!] MISSING OVERLAP CHECK: PR body lacks a completed duplicate/overlap guard acknowledgement.")
+        if "verification" not in normalized_body:
+            print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
+        if "skipped checks" not in normalized_body:
+            print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
+        if not has_non_empty_body_field(body, ["risk", "risk assessment"]):
+            print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")
+        if not has_non_empty_body_field(body, ["rollback notes", "rollback"]):
+            print("  [!] MISSING ROLLBACK NOTES: PR body fails to mention 'rollback notes'.")
 
-    # Get diff stat
-    stat, _ = run(f"gh pr diff {num} --repo {REPO} --stat")
-    print(f"Stat:\n{stat}")
+        # 2026-05-13 lesson: treat low-signal or stale broad branches as queue debt
+        is_stale = head_commit_at is not None and (now - head_commit_at) > timedelta(days=14)
 
-    if is_stale:
-        print(f"  [!] STALE BRANCH: Head commit is > 14 days old. Treat as queue debt. Close or recommend closing instead of salvaging in place.")
+        # Get diff stat
+        stat, _ = run(f"gh pr diff {num} --repo {repo} --stat")
+        print(f"Stat:\n{stat}")
 
-    # PR #214/#215 lesson: no-change PRs must have 0 changed files
-    if "no-change" in title.lower():
-        files_json, _ = run(f"gh pr view {num} --repo {REPO} --json files")
-        try:
-            files_data = json.loads(files_json)
-            if files_data.get("files") is not None:
-                if len(files_data["files"]) > 0:
-                    print(f"  [!] UNSAFE NO-CHANGE PR: Title claims no-change but modifies {len(files_data['files'])} files.")
-                else:
-                    print(f"  [i] EMPTY NO-CHANGE PR: No changed files. If no durable queue-hygiene artifact is changed, it is a close candidate (report only).")
-        except Exception:
-            pass
+        if is_stale:
+            print(f"  [!] STALE BRANCH: Head commit is > 14 days old. Treat as queue debt. Close or recommend closing instead of salvaging in place.")
 
-    # PR #199/#200/#201 lesson: check for multiple inventory refreshes
-    if "inventory" in title.lower() and "refresh" in title.lower():
-        inventory_refresh_count += 1
-        if "duplicate-pr guard" not in body and "duplicate pr guard" not in body:
-            print("  [!] MISSING DUPLICATE PR GUARD: Inventory refresh PR body fails to mention 'duplicate-pr guard'.")
+        # PR #214/#215 lesson: no-change PRs must have 0 changed files
+        if "no-change" in title.lower():
+            files_json, _ = run(f"gh pr view {num} --repo {repo} --json files")
+            try:
+                files_data = json.loads(files_json)
+                if files_data.get("files") is not None:
+                    if len(files_data["files"]) > 0:
+                        print(f"  [!] UNSAFE NO-CHANGE PR: Title claims no-change but modifies {len(files_data['files'])} files.")
+                    else:
+                        print(f"  [i] EMPTY NO-CHANGE PR: No changed files. If no durable queue-hygiene artifact is changed, it is a close candidate (report only).")
+            except Exception:
+                pass
 
-if inventory_refresh_count > 1:
-    print("\n[!] WARNING: Multiple open inventory refresh PRs detected. Ensure strict duplicate-PR guard is followed.")
-    exit(1)
+        # PR #199/#200/#201 lesson: check for multiple inventory refreshes
+        if "inventory" in title.lower() and "refresh" in title.lower():
+            inventory_refresh_count += 1
+            if not has_duplicate_guard_ack(body):
+                print("  [!] MISSING DUPLICATE PR GUARD: Inventory refresh PR body lacks a completed duplicate-pr guard acknowledgement.")
+
+    if inventory_refresh_count > 1:
+        print("\n[!] WARNING: Multiple open inventory refresh PRs detected. Ensure strict duplicate-PR guard is followed.")
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -66,6 +66,10 @@ for pr in prs:
         print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
     if "skipped checks" not in body:
         print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
+    if "risk" not in body:
+        print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")
+    if "rollback notes" not in body:
+        print("  [!] MISSING ROLLBACK NOTES: PR body fails to mention 'rollback notes'.")
 
     # 2026-05-13 lesson: treat low-signal or stale broad branches as queue debt
     is_stale = head_commit_at is not None and (now - head_commit_at) > timedelta(days=14)
@@ -93,6 +97,8 @@ for pr in prs:
     # PR #199/#200/#201 lesson: check for multiple inventory refreshes
     if "inventory" in title.lower() and "refresh" in title.lower():
         inventory_refresh_count += 1
+        if "duplicate-pr guard" not in body and "duplicate pr guard" not in body:
+            print("  [!] MISSING DUPLICATE PR GUARD: Inventory refresh PR body fails to mention 'duplicate-pr guard'.")
 
 if inventory_refresh_count > 1:
     print("\n[!] WARNING: Multiple open inventory refresh PRs detected. Ensure strict duplicate-PR guard is followed.")

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -78,7 +78,8 @@ echo "=== Portable deployable path lint ==="
 python3 scripts/check-portable-paths.py
 python3 -m unittest \
   tests.test_portable_path_lint \
-  tests.test_install_bootstrap_portable
+  tests.test_install_bootstrap_portable \
+  tests.test_analyze_prs
 
 echo "=== Generate inventory docs (also gates giant-file registry, #3036) ==="
 # The generator hard-fails (exit 2) on giant-file registry drift: unregistered

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -1,0 +1,62 @@
+import unittest
+
+from scripts.analyze_prs import has_duplicate_guard_ack, has_non_empty_body_field
+
+
+class PrAnalyzerBodyFieldTests(unittest.TestCase):
+    def test_blank_risk_does_not_borrow_populated_rollback(self):
+        body = "- Risk:\n- Rollback notes: revert this PR"
+
+        self.assertFalse(has_non_empty_body_field(body, ["risk", "risk assessment"]))
+        self.assertTrue(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
+
+    def test_template_placeholders_are_not_meaningful_fields(self):
+        body = """
+## WorkFingerprint
+
+- Risk:
+- Rollback notes:
+"""
+
+        self.assertFalse(has_non_empty_body_field(body, ["risk", "risk assessment"]))
+        self.assertFalse(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
+
+    def test_multiline_field_value_stops_at_next_field_label(self):
+        body = """
+- Risk:
+  Limited to analyzer reporting.
+- Rollback notes:
+  Revert the analyzer change.
+"""
+
+        self.assertTrue(has_non_empty_body_field(body, ["risk", "risk assessment"]))
+        self.assertTrue(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
+
+
+class PrAnalyzerDuplicateGuardTests(unittest.TestCase):
+    def test_unchecked_template_duplicate_guard_is_not_acknowledgement(self):
+        body = "- [ ] **Duplicate PR guard:** I have checked for overlapping open PRs."
+
+        self.assertFalse(has_duplicate_guard_ack(body))
+
+    def test_checked_template_duplicate_guard_is_acknowledgement(self):
+        body = "- [x] **Duplicate PR guard:** I have checked for overlapping open PRs."
+
+        self.assertTrue(has_duplicate_guard_ack(body))
+
+    def test_filled_duplicate_overlap_field_is_acknowledgement(self):
+        body = (
+            "- duplicate/overlap check: compared against sibling upstream-pr "
+            "branches; no overlapping scope found."
+        )
+
+        self.assertTrue(has_duplicate_guard_ack(body))
+
+    def test_blank_duplicate_field_does_not_borrow_next_value(self):
+        body = "- Duplicate PR guard:\n- Risk: limited to analyzer reporting"
+
+        self.assertFalse(has_duplicate_guard_ack(body))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -32,6 +32,17 @@ class PrAnalyzerBodyFieldTests(unittest.TestCase):
         self.assertTrue(has_non_empty_body_field(body, ["risk", "risk assessment"]))
         self.assertTrue(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
 
+    def test_indented_key_value_lines_count_as_field_content(self):
+        body = """
+- Risk:
+  - Impact: low
+- Rollback notes:
+  Command: git revert HEAD
+"""
+
+        self.assertTrue(has_non_empty_body_field(body, ["risk", "risk assessment"]))
+        self.assertTrue(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
+
 
 class PrAnalyzerDuplicateGuardTests(unittest.TestCase):
     def test_unchecked_template_duplicate_guard_is_not_acknowledgement(self):


### PR DESCRIPTION
## 목표
PR analyzer가 hygiene fields를 검사할 때 template placeholder와 실제 작성된 내용을 구분하고, multiline field content를 오탐 없이 인식하게 합니다.

## 리뷰 반영
- `Risk` / `Rollback notes` field는 label 존재가 아니라 meaningful value가 있어야 통과합니다.
- 다음 top-level field label은 값 borrowing boundary로 처리합니다.
- indented continuation line은 boundary가 아니라 field content로 처리합니다. 예: `- Risk:\n  - Impact: low`, `- Rollback notes:\n  Command: git revert ...`.
- duplicate/overlap guard도 unchecked template text가 아니라 checked/filled acknowledgement만 통과합니다.

## 주요 파일
- `scripts/analyze_prs.py`: top-level field boundary helper 및 multiline parser fix
- `tests/test_analyze_prs.py`: blank field, duplicate guard, indented key/value continuation regression tests
- `docs/agent-maintenance/multinode-transition.md`: maintenance freshness audit note

## 검증
- `python3 -m unittest tests/test_analyze_prs.py` (8 passed)
- `python3 scripts/check_agent_maintenance_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py --base-ref upstream/main`
- `cargo fmt --all --check`
- `./scripts/ci-script-checks.sh`

## Analyzer Hygiene
- WorkFingerprint: this PR branch contains only the commits and files described above.
- verification: commands listed in `## 검증` were run locally on head `73616641f`.
- skipped checks: checks not listed above were not run locally; remote CI status is tracked separately by GitHub checks.
- risk assessment: risk is limited to PR analyzer body parsing and warning output.
- rollback notes: revert this PR branch to restore the previous analyzer behavior.