### PR TITLE
fix(dashboard): improve emoji picker accessibility in agent modals

### DIFF
--- a/dashboard/src/components/agent-manager/AgentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/AgentFormModal.tsx
@@ -107,7 +107,7 @@ export default function AgentFormModal({
       <form
         role="dialog"
         aria-modal="true"
-        aria-label={isEdit ? tr("직원 정보 수정", "Edit Agent") : tr("신규 직원 채용", "Hire New Agent")}
+        aria-labelledby="agent-modal-title"
         onSubmit={handleSave}
         className="w-full self-start max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-1.5rem)] max-w-[calc(100vw-1.5rem)] overflow-x-hidden overflow-y-auto overscroll-contain rounded-[28px] border p-4 shadow-2xl animate-in fade-in zoom-in-95 duration-200 sm:my-auto sm:max-h-[90vh] sm:max-w-5xl sm:p-6"
         style={{
@@ -121,7 +121,7 @@ export default function AgentFormModal({
       >
         {/* Modal header */}
         <div className="flex items-center justify-between mb-5">
-          <h3 className="text-base font-bold" style={{ color: "var(--th-text-heading)" }}>
+          <h3 id="agent-modal-title" className="text-base font-bold" style={{ color: "var(--th-text-heading)" }}>
             {isEdit ? tr("직원 정보 수정", "Edit Agent") : tr("신규 직원 채용", "Hire New Agent")}
           </h3>
           <SurfaceActionButton onClick={onClose} tone="neutral" compact className="h-11 w-11" style={{ padding: 0 }} aria-label={tr("닫기", "Close")}>
@@ -319,6 +319,7 @@ export default function AgentFormModal({
                       ? t({ ko: `선택된 이모지: ${formValues.avatar_emoji}, 이모지 변경`, en: `Selected emoji: ${formValues.avatar_emoji}, change emoji` })
                       : t({ ko: "이모지 선택기 열기", en: "Open emoji picker" })
                   }
+                  dialogLabel={t({ ko: "이모지 선택", en: "Choose an emoji" })}
                 />
               </div>
               <div>

--- a/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
@@ -277,7 +277,7 @@ export default function DepartmentFormModal({
       <form
         role="dialog"
         aria-modal="true"
-        aria-label={isEdit ? tr("부서 정보 수정", "Edit Department") : tr("신규 부서 추가", "Add Department")}
+        aria-labelledby="dept-modal-title"
         className="w-full max-w-2xl max-h-full overflow-y-auto rounded-t-3xl p-5 shadow-2xl animate-in fade-in zoom-in-95 duration-200 sm:max-h-[85vh] sm:rounded-[28px] sm:p-6"
         style={{
           background:
@@ -288,8 +288,8 @@ export default function DepartmentFormModal({
       >
         {/* Header */}
         <div className="flex items-center justify-between mb-5">
-          <h3 className="text-base font-bold flex items-center gap-2" style={{ color: "var(--th-text-heading)" }}>
-            <span className="text-lg">{form.icon}</span>
+          <h3 id="dept-modal-title" className="text-base font-bold flex items-center gap-2" style={{ color: "var(--th-text-heading)" }}>
+            <span className="text-lg" aria-hidden="true">{form.icon}</span>
             {isEdit ? tr("부서 정보 수정", "Edit Department") : tr("신규 부서 추가", "Add Department")}
           </h3>
           <SurfaceActionButton
@@ -323,6 +323,7 @@ export default function DepartmentFormModal({
                         ? t({ ko: `선택된 아이콘: ${form.icon}, 아이콘 변경`, en: `Selected icon: ${form.icon}, change icon` })
                         : t({ ko: "아이콘 선택기 열기", en: "Open icon picker" })
                     }
+                    dialogLabel={t({ ko: "아이콘 선택", en: "Choose an icon" })}
                   />
                 </div>
                 <div className="flex-1">

--- a/dashboard/src/components/agent-manager/EmojiPicker.test.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.test.tsx
@@ -61,4 +61,26 @@ describe("EmojiPicker", () => {
     expect(dialog).not.toBeNull();
     expect(dialog?.getAttribute("aria-label")).toBe("Choose an emoji");
   });
+
+  it("returns focus to the trigger when dismissed by an outside click", async () => {
+    const target = await render(<EmojiPicker value="🤖" onChange={() => {}} />);
+    const button = target.querySelector("button") as HTMLButtonElement;
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(target.querySelector('div[role="dialog"]')).not.toBeNull();
+
+    await act(async () => {
+      outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    expect(target.querySelector('div[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(button);
+
+    outside.remove();
+  });
 });

--- a/dashboard/src/components/agent-manager/EmojiPicker.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.tsx
@@ -53,7 +53,10 @@ export default function EmojiPicker({
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
     };
     const keyHandler = (e: KeyboardEvent) => {
       if (e.key === "Escape") {

--- a/dashboard/src/components/agent-manager/EmojiPicker.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.tsx
@@ -37,14 +37,17 @@ export default function EmojiPicker({
   onChange,
   size = "md",
   "aria-label": ariaLabel,
+  dialogLabel,
 }: {
   value: string;
   onChange: (emoji: string) => void;
   size?: "sm" | "md";
   "aria-label"?: string;
+  dialogLabel?: string;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { t: tr } = useI18n();
 
   useEffect(() => {
@@ -52,8 +55,20 @@ export default function EmojiPicker({
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
     document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    document.addEventListener("keydown", keyHandler, true);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", keyHandler, true);
+    };
   }, [open]);
 
   const btnSize = size === "sm" ? "w-10 h-10 text-lg" : "w-14 h-10 text-xl";
@@ -62,11 +77,13 @@ export default function EmojiPicker({
   const handleEmojiSelect = (emoji: string) => {
     onChange(emoji);
     setOpen(false);
+    buttonRef.current?.focus();
   };
 
   return (
     <div className="relative" ref={ref}>
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen(!open)}
         className={`${btnSize} rounded-lg border flex items-center justify-center transition-all hover:scale-105 hover:shadow-md`}
@@ -85,7 +102,7 @@ export default function EmojiPicker({
       {open && (
         <div
           role="dialog"
-          aria-label={tr({ ko: "이모지 선택", en: "Choose an emoji" })}
+          aria-label={dialogLabel || tr({ ko: "이모지 선택", en: "Choose an emoji" })}
           className="absolute left-0 top-full z-[60] mt-1 overflow-hidden rounded-xl shadow-2xl"
           style={{
             background:


### PR DESCRIPTION
## 목표

Agent/Department 모달의 제목 연결과 이모지/아이콘 선택기 접근성을 보완합니다. 스크린리더 라벨, Escape 닫기, 선택 후 포커스 복귀가 자연스럽게 동작하는 상태가 목표입니다.

## 쉬운 설명

모달은 실제 제목 요소를 `aria-labelledby`로 참조합니다. 이모지 선택기는 열릴 때 명확한 dialog label을 갖고, Escape 또는 선택 후 버튼으로 포커스를 되돌립니다. 부서 아이콘은 제목에서 장식용으로 처리되어 중복 낭독을 줄입니다.

## 개선되는 것

### Fix 1
Agent/Department form dialog가 제목 텍스트와 직접 연결됩니다.

### Fix 2
EmojiPicker가 Escape 키를 처리하고 닫힌 뒤 trigger button에 포커스를 복귀합니다.

### Fix 3
선택기 dialog label을 호출 위치에서 agent/department 문맥에 맞게 지정할 수 있습니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 모달 제목 낭독 | aria-label 문자열만 사용 | 실제 제목 요소와 연결 |
| Escape로 선택기 닫기 | 포커스 복귀 불명확 | 버튼으로 포커스 복귀 |
| 부서 제목 아이콘 | 텍스트와 함께 낭독 가능 | 장식용 `aria-hidden` 처리 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 마우스로 외부 클릭 | 기존처럼 닫힘 | 동작 유지 |
| 이모지 선택 | 값 반영 후 버튼 포커스 | 키보드 흐름 개선 |
| dialogLabel 미전달 | 기본 이모지 label 사용 | 기존 사용처 호환 |

## 해결한 내용

- `AgentFormModal.tsx`: dialog title id 연결과 emoji picker label 전달
- `DepartmentFormModal.tsx`: dialog title id 연결, 장식 아이콘 숨김, icon picker label 전달
- `EmojiPicker.tsx`: trigger ref, Escape close, close-after-select focus 복귀, dialog label prop 추가

## 검증

- `npm --prefix dashboard test -- EmojiPicker`: 1 file / 2 tests passed
- `npm --prefix dashboard run build`: 통과

## WorkFingerprint

- files: `dashboard/src/components/agent-manager/{AgentFormModal.tsx,DepartmentFormModal.tsx,EmojiPicker.tsx}`
- duplicate/overlap check: fork-only dashboard accessibility 단일 커밋만 포함했습니다.

## skipped checks

- Rust 테스트는 실행하지 않았습니다. Dashboard TS/React 변경만 포함합니다.

## risk assessment

- 낮음. aria 속성과 focus handling만 바꾸며 picker value/state 계약은 유지합니다.

## rollback notes

- 문제가 있으면 이 PR 커밋을 revert하면 기존 모달/EmojiPicker 접근성 동작으로 돌아갑니다.

## Analyzer Hygiene

- WorkFingerprint: this PR branch contains only the commits and files described in the PR body.
- duplicate/overlap check: scope was compared against sibling upstream-pr branches before creation; no duplicate PR scope is intentionally included.
- verification: see `## 검증` above for commands and results actually run; remote CI status is tracked separately by GitHub checks.
- skipped checks: checks not listed in `## 검증` were not run locally; CI path filters may also skip unrelated jobs.
- risk assessment: risk is limited to the touched files and behavior described above.
- rollback notes: revert this PR branch to restore the previous behavior.

## 서브에이전트 적대적 검증
- 지적: EmojiPicker outside-click dismissal 후 trigger button으로 focus가 복귀하지 않음.
- 조치: outside mousedown close 경로에서 trigger focus restore를 수행하고 회귀 테스트를 추가함.
- 추가 검증: `npm --prefix dashboard exec -- vitest run src/components/agent-manager/EmojiPicker.test.tsx`; `npm --prefix dashboard run build`.
