### PR TITLE
fix(#3540): identity-dedup root prevention + no-evict recovery for phantom synthetic inflight queue stall (+ warm-followup strand)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -516,7 +516,7 @@
     Moved unit tests live in sibling `utf8_chunk_decoder_tests.rs` /
     `terminal_readiness_tests.rs`; both child modules sit under the
     `tmux_watcher/**` 700-line namespace cap.
-  - `src/services/discord/tui_prompt_relay.rs` (4301 production lines; #3296
+  - `src/services/discord/tui_prompt_relay.rs` (4310 production lines; #3296
     codex r1+r2: the ABORT cleanup hook pins the foreign prior inflight's
     identity — the live row at the record instant, or the worker's LAST-VIEW
     identity when that row just vanished — and persists the marker via
@@ -746,7 +746,22 @@
     `recovery_engine.rs`) are re-exported at `pub(in crate::services::discord)`;
     the relay-internal drain decision/enum are re-imported privately, so the call
     sites + tests stay byte-identical. Frozen baseline 4630 -> 4458 (-172, locks in
-    the shrink; zero logic change).
+    the shrink; zero logic change). +9 from #3540 root-prevention: the
+    idle-transcript scanner identity-dedup threading — the resolved `entry_id`
+    passed inline across the scan -> observe seam plus the `SuppressedReplayedEntry`
+    handling that stops the scanner re-claiming an already-processed prompt across a
+    watermark reset — is inline integration code on the scan/observe call path (not
+    a self-contained helper) and the sibling `idle_transcript_scan.rs` is itself
+    giant-capped, so the ratchet baseline was RAISED 4301 -> 4310 (a deliberate,
+    reviewable admission per the baseline header) rather than split.
+  - `src/services/discord/tui_direct_pending_start.rs` (1030 production lines;
+    the deferred TUI-direct synthetic turn-start path — the pending-start claim
+    queue, the no-evict promote of a stalled inflight, and the deferred-claim
+    owner handoff. #3540 added the B′ "no-evict promote" path (a stalled inflight
+    is safely promoted off the pending-start queue instead of evicted) plus its
+    regression tests, which pushed the production surface over the 1000-line
+    giant-file threshold, so this file is now a registered giant. Bugfix /
+    queue-safety only; split before adding new pending-start behavior).
   - `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` (318 prod
     lines; #3479 rank-5: pure injected-prompt classification + formatting policy
     extracted verbatim from `tui_prompt_relay.rs` — no `shared.`/`http.`/async-IO
@@ -833,9 +848,17 @@
     nested `usage` on the success result frame so watcher-owned codex turns
     persist token telemetry — never the session-cumulative
     `info.total_token_usage`).
-  - `src/services/tui_prompt_dedupe.rs` (1393 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1569 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
-    outside an extraction plan; +37 from #3527: `is_discord_relayed_user_prompt`
+    outside an extraction plan; +176 from #3540: stable JSONL entry-identity
+    (`uuid`) dedup — `extract_claude_transcript_user_prompt_with_entry_id`
+    returns `(prompt, Option<uuid>)`, a `relayed_entry_ids_by_tmux` ledger
+    (PROMPT_ANCHOR_TTL-purged, ring-capped) + `PromptObservation::SuppressedReplayedEntry`,
+    and `observe_prompt_by_tmux_with_entry_id_at` suppress an already-relayed entry
+    re-encountered after a relay-watermark reset / jsonl head rotation BY IDENTITY
+    (never by inflight/EOF observation), so the idle-transcript scanner cannot mint
+    a phantom synthetic inflight; a genuinely new prompt carries a new uuid and is
+    never suppressed (#3459/#3303 missed-prompt guard); +37 from #3527: `is_discord_relayed_user_prompt`
     skips re-observed `[User: … (ID: …)]` Discord-relay lines (whole-string scan —
     context like `[External Recall]` may precede the marker and the legacy pane
     observer collapses blocks mid-line) in the observation candidate filter so a

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -396,6 +396,35 @@
 
 ### Audited touches
 
+- #3540 phantom-synthetic-inflight fix: two worker-local, in-memory-state-only
+  touches with no multinode ownership/lease/singleton implications.
+  (A) `tui_prompt_dedupe.rs` gained a process-global `relayed_entry_ids_by_tmux`
+  ledger keyed on the Claude transcript `user` entry's stable `uuid`
+  (TTL-purged + ring-capped) and the `SuppressedReplayedEntry` observation, so
+  the idle-transcript scanner suppresses an already-relayed prompt re-encountered
+  after a relay-watermark reset / jsonl head rotation BY IDENTITY. This is the
+  same per-process dedupe state the relay already owns (it is NOT a routing
+  authority and is never read cross-node); the channel→tmux routing invariant is
+  untouched. (B) `tui_direct_pending_start.rs` adds a no-evict post-abort queue
+  promote: on the terminal backstop ABORT it kicks the EXISTING
+  `schedule_deferred_idle_queue_kickoff` once (after the pending record is
+  deleted) so a queued follow-up dispatches through the unchanged
+  `mailbox_try_start_turn_kinded` FSM — NO inflight is cleared/reset/deleted, so
+  the worst case is a normal merge with zero live-turn loss. The detached worker
+  remains per-`(provider, channel_id)` worker-local under the existing channel
+  lock; queue ownership, lease semantics, and singleton assumptions are
+  unchanged. (C) absorbed warm-followup strand fix in
+  `turn_bridge/watcher_handoff.rs`: the #3277 proven-delivered guard
+  (`busy_turn_already_proven_delivered`) now reads the transcript's on-disk EOF
+  (`std::fs::metadata(output_path).len()`) instead of the racy in-memory
+  `tmux_last_offset` to decide whether a quiescence-timeout turn already grew
+  its full response past `turn_start_offset`. Both `turn_start_offset` and
+  `tmux_last_offset` are seeded to the same per-turn `inflight_offset` (itself a
+  `std::fs::metadata().len()` of the same `output_path`), so the new EOF read is
+  in the SAME single-file byte-space — purely a worker-local disk read on the
+  bridge's own transcript path, with no node ownership, lease, or singleton
+  implication. A rotated/truncated transcript shrinks the EOF and the guard
+  conservatively fails open to the existing #3268 watcher handoff.
 - #3038 run_bot S5: the leader gateway runtime tail moved verbatim from
   `runtime_bootstrap.rs` into `runtime_bootstrap/gateway_runtime.rs`: restored
   generation/model/fast-mode logging, health registry registration,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -180,7 +180,7 @@
 # verbatim to `tui_prompt_relay/launch_script.rs` (107 prod LoC, below the giant
 # threshold), reached via re-import so the call sites stay byte-identical. Lowers
 # the frozen baseline 4458 -> 4376 (-82). Locks in the shrink win (zero logic change).
-"src/services/discord/tui_prompt_relay.rs" = 4301
+"src/services/discord/tui_prompt_relay.rs" = 4310
 # #3038: lowered 4728 -> 4657 (-71) as `SensitivityState` (definition + impl)
 # moved to the `voice_sensitivity` sibling module. Locks in the shrink win.
 # #3038 VoiceBargeInRuntime S1: lowered 4657 -> 4350 (-307) as the STT

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -347,3 +347,17 @@ file = "src/services/discord/turn_bridge/mod.rs"
 owner = "discord-relay"
 deadline = "2026-08-31"
 decompose_issue = "#3038"
+
+[[entry]]
+# Crossed the 1000-prod-LoC giant threshold in #3540: the durable pending
+# synthetic-turn-start worker (#3154) accreted the #3174/#3282/#3296/#3303/#3350
+# reconcile-marker chokepoints plus the #3540 no-evict post-abort queue promote.
+# The file is dominated by the worker FSM (`run_worker_inner`) and its
+# marker-recording guards; decomposition would lift the marker-record cluster
+# (`record_claim_marker_if_watcher_owned` + wrappers) and the durable
+# store/persistence helpers into siblings, leaving the worker loop in the root.
+# Tracked for splitting under the relay-decomposition program.
+file = "src/services/discord/tui_direct_pending_start.rs"
+owner = "discord-relay"
+deadline = "2026-08-31"
+decompose_issue = "#3540"

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -728,6 +728,22 @@ async fn run_worker_inner(
                     // pinning the last-view foreign identity (codex r2).
                     abort_cleanup_fn(&shared, &record, last_foreign_identity.clone()).await;
                     delete(&record);
+                    // #3540 (B′ — defense-in-depth, NO EVICT): the pending gate is
+                    // now released (`delete` above), but a follow-up the user sent
+                    // while this synthetic start was deferring is still parked in
+                    // the mailbox queue behind a QUEUE-ACK. If the FOREIGN inflight
+                    // we were deferring on is a phantom (#3540 root cause: a
+                    // watermark-reset re-claim whose commit will never arrive), the
+                    // queued follow-up would otherwise stay parked until the
+                    // ABORT_MARKER_TTL sweep. Kick the EXISTING mailbox dispatch
+                    // path once so the follow-up promotes promptly. This clears /
+                    // resets / deletes NO inflight — `kickoff_idle_queues` routes
+                    // through `mailbox_try_start_turn_kinded`, which (a) starts a
+                    // fresh turn if the slot is genuinely free, or (b) MERGES into a
+                    // still-live prior turn (worst case = normal merge, zero live
+                    // loss). The phantom row, if any, is reaped later by its own
+                    // commit/finalize or the bounded ⏳ sweep — never evicted here.
+                    promote_queued_follow_up_after_abort(&shared, &record);
                     return;
                 }
                 tracing::warn!(
@@ -929,6 +945,68 @@ fn record_deferred_claim_marker_if_watcher_owned(record: &TuiDirectPendingStart)
         &record.tmux_session_name,
     );
 }
+
+/// #3540 (B′): after the terminal backstop ABORT has run `abort_cleanup_fn` and
+/// `delete(&record)` (pending gate released), kick the EXISTING mailbox dispatch
+/// path ONCE so a follow-up parked behind a QUEUE-ACK promotes promptly instead
+/// of waiting out the bounded ⏳ sweep when the deferred-on FOREIGN inflight was
+/// a phantom.
+///
+/// NO-EVICT INVARIANT (load-bearing): this function does NOT clear / reset /
+/// `save_inflight(empty)` / delete ANY inflight row. It only schedules
+/// [`super::schedule_deferred_idle_queue_kickoff`], the same idempotent
+/// queued-dispatch entrypoint the post-turn / catch-up paths already use. That
+/// kickoff routes through `mailbox_try_start_turn_kinded`, which either starts a
+/// fresh turn (slot genuinely free) or MERGES the follow-up into a still-live
+/// prior turn — so even if the deferred-on row is in fact a live turn, the worst
+/// case is a normal merge with ZERO live-turn loss. The serialization is the
+/// channel lock the worker already holds (this runs before its `return`, under
+/// `_guard`); the kickoff's own work is detached, so no new lock-order risk.
+/// Fail-soft: an unparseable provider only warns — the ABORT path is otherwise
+/// unchanged (pre-#3540 behavior: the follow-up waits for the sweep).
+fn promote_queued_follow_up_after_abort(shared: &Arc<SharedData>, record: &TuiDirectPendingStart) {
+    let Some(provider) = crate::services::provider::ProviderKind::from_str(&record.provider) else {
+        tracing::warn!(
+            provider = %record.provider,
+            channel_id = record.channel_id,
+            anchor_message_id = record.anchor_message_id,
+            "tui_direct_pending_start: unparseable provider; skipping post-abort queue promote (fail-open — follow-up still drains via the bounded sweep) (#3540)"
+        );
+        return;
+    };
+    let channel_id = poise::serenity_prelude::ChannelId::new(record.channel_id);
+    tracing::info!(
+        provider = provider.as_str(),
+        channel_id = record.channel_id,
+        anchor_message_id = record.anchor_message_id,
+        "tui_direct_pending_start: post-abort queue promote — kicking the existing mailbox dispatch once so a queued follow-up is not parked until the ⏳ sweep; NO inflight is cleared/reset/deleted (#3540 B′)"
+    );
+    #[cfg(test)]
+    {
+        // Test seam: record that the promote fired exactly once without spawning
+        // the real detached kickoff task (which would leak past the test and, with
+        // a test `shared`, has no cached ctx/token to act on anyway). Production
+        // (below) takes the real path.
+        POST_ABORT_PROMOTE_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let _ = (shared, channel_id, &provider);
+        return;
+    }
+    #[cfg(not(test))]
+    super::schedule_deferred_idle_queue_kickoff(
+        shared.clone(),
+        provider,
+        channel_id,
+        "tui_direct_pending_start backstop abort follow-up promote (#3540)",
+    );
+}
+
+/// #3540 (B′) test seam: counts `promote_queued_follow_up_after_abort` firings so
+/// the ABORT-path regression test can assert it ran EXACTLY ONCE while the claim
+/// (inflight write) NEVER ran — proving the queue is promoted without evicting or
+/// clearing any inflight row.
+#[cfg(test)]
+static POST_ABORT_PROMOTE_CALLS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
 
 /// #3350 issue-3: the observer INLINE-claim wiring, separated so a unit test
 /// can pin it — `relay_observed_prompt` must record the #3303 DeferredClaim
@@ -1519,6 +1597,125 @@ mod tests {
         reset_present_for_tests();
     }
 
+    /// #3540 (B′ — NO-EVICT queue promote): after the terminal backstop ABORT
+    /// the worker must kick the EXISTING mailbox dispatch ONCE so a follow-up
+    /// parked behind a QUEUE-ACK promotes promptly — WITHOUT touching any
+    /// inflight. Proven by: (1) the claim (the ONLY inflight-write seam in the
+    /// worker) NEVER runs, so no row is created/cleared/reset/deleted; (2) the
+    /// promote seam fires EXACTLY ONCE; (3) it fires AFTER abort_cleanup +
+    /// record-delete (the pending gate is released first). This is the
+    /// defense-in-depth that breaks the phantom-inflight → infinite QUEUE-ACK
+    /// stall while structurally guaranteeing zero live-turn loss (worst case in
+    /// production is a normal merge inside `mailbox_try_start_turn_kinded`).
+    // Sync test + explicit block_on: the std-mutex test-env guards live only in
+    // this sync scope and never span an await, so no await_holding_lock allow is
+    // needed (#3034 ratchet stays frozen at its baseline).
+    #[test]
+    fn backstop_abort_promotes_queued_follow_up_without_evicting_inflight() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let _guard = worker_test_lock();
+        // Isolate the durable store root to a per-test temp dir (under the crate
+        // env lock) so this test's persist/delete never races other tests'
+        // store reads on the shared default root.
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        reset_present_for_tests();
+        POST_ABORT_PROMOTE_CALLS.store(0, Ordering::SeqCst);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .start_paused(true)
+            .build()
+            .expect("test runtime");
+        rt.block_on(async move {
+            let shared = super::super::make_shared_data_for_tests();
+
+            // FOREIGN prior inflight stays live across the WHOLE budget (the #3540
+            // phantom: a watermark-reset re-claim whose commit never arrives — but
+            // observationally indistinguishable from a slow live turn, so we must
+            // NOT evict it).
+            let view: ViewFn = Box::new(move |_shared, _record| {
+                Box::pin(async move {
+                    Some(PriorTurnObservation {
+                        view: PriorTurnView {
+                            inflight_present: true,
+                            inflight_is_own_anchor: false,
+                            mailbox_blocking_turn_present: true,
+                            mailbox_turn_is_own_anchor: false,
+                            runtime_binding_present: true,
+                        },
+                        foreign_inflight_identity: Some((
+                            1516634295270117460,
+                            "2026-06-17 11:43:13".to_string(),
+                        )),
+                    })
+                })
+            });
+
+            // The claim is the ONLY inflight-write seam in the worker; if the B′
+            // promote ever reached for an evict/clear it would have to go through a
+            // claim-like write. We assert it stays at zero — structural no-evict.
+            let claim_calls = Arc::new(AtomicU32::new(0));
+            let claim_calls_for_fn = claim_calls.clone();
+            let claim: ClaimFn = Box::new(move |_shared, _record| {
+                let calls = claim_calls_for_fn.clone();
+                Box::pin(async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    true
+                })
+            });
+
+            let rec = record("claude", 14, 140);
+            persist(&rec).unwrap();
+            assert!(pending_synthetic_start_present("claude", 14));
+
+            let (abort_cleanup, abort_cleanup_calls, _) = recording_abort_cleanup();
+            let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
+
+            for _ in 0..(PENDING_START_MAX_BACKSTOP_CYCLES + 1) {
+                tokio::time::advance(PENDING_START_BACKSTOP + PENDING_START_POLL * 2).await;
+                tokio::task::yield_now().await;
+            }
+            handle.await.unwrap();
+
+            assert_eq!(
+                claim_calls.load(Ordering::SeqCst),
+                0,
+                "#3540 B′: the claim (the worker's only inflight-write seam) must \
+             NEVER run on the ABORT path — the foreign/phantom row is left \
+             untouched (NO evict). RED if the promote path tries to overwrite/clear \
+             an inflight to make room for the follow-up."
+            );
+            assert_eq!(
+                abort_cleanup_calls.load(Ordering::SeqCst),
+                1,
+                "#3540 B′: the abort reconcile hook still runs exactly once (the \
+             #3282/#3296 marker), preserving the existing ⏳ reconcile path."
+            );
+            assert!(
+                !pending_synthetic_start_present("claude", 14),
+                "#3540 B′: the pending gate is released (record deleted) so the \
+             follow-up is no longer blocked by intake_gate."
+            );
+            assert_eq!(
+                POST_ABORT_PROMOTE_CALLS.load(Ordering::SeqCst),
+                1,
+                "#3540 B′: the post-abort queue promote must fire EXACTLY ONCE after \
+             the record is deleted, so a follow-up parked behind a QUEUE-ACK is \
+             dispatched promptly instead of waiting out the bounded ⏳ sweep. RED \
+             if the ABORT branch returns without kicking the mailbox dispatch."
+            );
+        });
+
+        POST_ABORT_PROMOTE_CALLS.store(0, Ordering::SeqCst);
+        reset_present_for_tests();
+    }
+
     /// P2-2 (b): the claim returns `false` (transient — another turn briefly
     /// owns the mailbox). The worker MUST retain the durable record (never lose a
     /// Discord-submitted prompt) and retry; once the claim later succeeds it
@@ -1923,6 +2120,13 @@ mod tests {
         use std::sync::atomic::Ordering;
 
         let _guard = worker_test_lock();
+        // The watcher-owned marker decision reads the PROCESS-GLOBAL dedupe lease
+        // (`record_lease` → `external_input_relay_lease`); hold `TEST_LOCK` so a
+        // concurrent dedupe-state test cannot wipe the lease mid-claim and turn
+        // the watcher-owned marker into a no-op (cross-lock race, #3540).
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -1994,6 +2198,11 @@ mod tests {
     #[test]
     fn bridge_owned_claim_records_no_marker() {
         let _guard = worker_test_lock();
+        // Holds the dedupe `TEST_LOCK` because this test seeds + reads the
+        // process-global relay lease (#3540 cross-lock race guard).
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -2036,6 +2245,11 @@ mod tests {
     #[test]
     fn reclaim_overwrites_stale_abort_marker_with_own_identity() {
         let _guard = worker_test_lock();
+        // Holds the dedupe `TEST_LOCK` because this test seeds + reads the
+        // process-global relay lease (#3540 cross-lock race guard).
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -2093,6 +2307,11 @@ mod tests {
     #[test]
     fn generalized_helper_skips_non_watcher_lease() {
         let _guard = worker_test_lock();
+        // Holds the dedupe `TEST_LOCK` because this test seeds + reads the
+        // process-global relay lease (#3540 cross-lock race guard).
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -2122,6 +2341,11 @@ mod tests {
     #[test]
     fn generalized_helper_records_marker_for_watcher_lease_and_own_row() {
         let _guard = worker_test_lock();
+        // Holds the dedupe `TEST_LOCK` because this test seeds + reads the
+        // process-global relay lease (#3540 cross-lock race guard).
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -2559,20 +2559,29 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
                     ClaudeIdleTranscriptScan::Prompt {
                         prompt,
                         line_end_offset,
+                        entry_id,
                         ..
                     } => {
                         let observed_at = chrono::Utc::now();
+                        // #3540: pass the entry's STABLE identity so an
+                        // already-relayed prompt re-encountered after a watermark
+                        // reset / jsonl head rotation is suppressed by identity
+                        // (`SuppressedReplayedEntry`) and never mints a phantom
+                        // synthetic inflight. `entry_id == None` falls back to the
+                        // content-keyed 30s recent-observed dedup (pre-#3540).
                         let observation =
-                            crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_at(
+                            crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
                                 ProviderKind::Claude.as_str(),
                                 &tmux_session_name,
                                 &prompt,
+                                entry_id.as_deref(),
                                 observed_at,
                             );
                         tracing::info!(
                             tmux_session_name = %tmux_session_name,
                             channel_id = channel_id.get(),
                             observation = ?observation,
+                            entry_id = entry_id.as_deref().unwrap_or(""),
                             "Claude idle transcript relay observed prompt"
                         );
                         advance_claude_tmux_runtime_binding_offset(
@@ -6942,6 +6951,7 @@ mod tests {
                 prompt: text,
                 line_end_offset,
                 prompt_start_offset,
+                ..
             } => {
                 assert_eq!(text, "after compact");
                 assert_eq!(line_end_offset, prompt.len() as u64);
@@ -7132,6 +7142,7 @@ mod tests {
                 prompt: "direct claude prompt".to_string(),
                 prompt_start_offset: before.len() as u64,
                 line_end_offset: (before.len() + prompt.len()) as u64,
+                entry_id: None,
             }
         );
         assert_eq!(
@@ -7162,6 +7173,7 @@ mod tests {
                 prompt: "real prompt".to_string(),
                 prompt_start_offset: (meta.len() + synthetic.len()) as u64,
                 line_end_offset: (meta.len() + synthetic.len() + prompt.len()) as u64,
+                entry_id: None,
             }
         );
     }
@@ -7202,6 +7214,7 @@ mod tests {
                 prompt: "old finished turn".to_string(),
                 prompt_start_offset: 0,
                 line_end_offset: old_prompt.len() as u64,
+                entry_id: None,
             }
         );
         // Last-prompt scan returns the just-typed prompt instead.
@@ -7211,6 +7224,7 @@ mod tests {
                 prompt: "just typed prompt".to_string(),
                 prompt_start_offset: (old_prompt.len() + old_answer.len()) as u64,
                 line_end_offset: (old_prompt.len() + old_answer.len() + new_prompt.len()) as u64,
+                entry_id: None,
             }
         );
     }
@@ -7253,6 +7267,7 @@ mod tests {
                 prompt: "complete prompt".to_string(),
                 prompt_start_offset: 0,
                 line_end_offset: prompt.len() as u64,
+                entry_id: None,
             }
         );
 
@@ -7267,8 +7282,114 @@ mod tests {
                 prompt: "next prompt".to_string(),
                 prompt_start_offset: prompt.len() as u64,
                 line_end_offset: (prompt.len() + next.len()) as u64,
+                entry_id: None,
             }
         );
+    }
+
+    /// #3540: the watermark-reset / jsonl-head-rotation re-scan must NOT mint a
+    /// phantom synthetic inflight. End-to-end at the scan→observe seam:
+    ///   1. scan a transcript whose `user` entry carries a stable `uuid`;
+    ///   2. feed (prompt, entry_id) to the relay observer → it relays
+    ///      (`PublishedSshDirect`) and records the uuid;
+    ///   3. simulate a head rotation: rewrite the transcript so the SAME entry
+    ///      survives at a SHIFTED offset (head clipped) — its uuid is unchanged;
+    ///   4. re-scan from offset 0 (watermark reset) and feed the same entry_id to
+    ///      the observer → it is suppressed by IDENTITY
+    ///      (`SuppressedReplayedEntry`), so the scanner's
+    ///      `claude_idle_prompt_observation_should_tail_response` is FALSE and no
+    ///      external-turn lease / synthetic claim is taken.
+    #[test]
+    fn watermark_reset_rescan_of_relayed_entry_does_not_resynthesize_turn() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let transcript = dir.path().join("transcript.jsonl");
+        let uuid = "1516634295270117460-uuid";
+        let head = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"earlier answer\"}]},\"sessionId\":\"s1\"}\n";
+        let prompt_line = format!(
+            "{{\"type\":\"user\",\"uuid\":\"{uuid}\",\"message\":{{\"role\":\"user\",\"content\":[{{\"type\":\"text\",\"text\":\"deploy to make=live\"}}]}},\"sessionId\":\"s1\"}}\n"
+        );
+        std::fs::write(&transcript, format!("{head}{prompt_line}")).expect("write transcript");
+
+        // ---- (1)/(2): first scan + observe → relays, records uuid. ----
+        let scan = scan_claude_idle_transcript_for_prompt(&transcript, 0).expect("first scan");
+        let (prompt, entry_id) = match scan {
+            ClaudeIdleTranscriptScan::Prompt {
+                prompt, entry_id, ..
+            } => (prompt, entry_id),
+            other => panic!("expected Prompt, got {other:?}"),
+        };
+        assert_eq!(prompt, "deploy to make=live");
+        assert_eq!(entry_id.as_deref(), Some(uuid));
+        let first = crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
+            ProviderKind::Claude.as_str(),
+            "tmux-3540",
+            &prompt,
+            entry_id.as_deref(),
+            chrono::Utc::now(),
+        );
+        assert_eq!(
+            first,
+            crate::services::tui_prompt_dedupe::PromptObservation::PublishedSshDirect,
+            "the freshly-typed prompt relays on first sighting"
+        );
+        assert!(
+            claude_idle_prompt_observation_should_tail_response(first),
+            "first sighting tails the response (mints the external turn)"
+        );
+
+        // ---- (3): head rotation — same entry survives at a SHIFTED offset. ----
+        let new_head = "{\"type\":\"system\",\"subtype\":\"init\",\"sessionId\":\"s1\"}\n{\"type\":\"system\",\"subtype\":\"compact\",\"sessionId\":\"s1\"}\n";
+        std::fs::write(&transcript, format!("{new_head}{prompt_line}"))
+            .expect("rewrite transcript (rotation)");
+
+        // ---- (4): watermark reset → re-scan from 0, same uuid → suppressed. ----
+        let rescan = scan_claude_idle_transcript_for_prompt(&transcript, 0).expect("re-scan");
+        let (re_prompt, re_entry_id) = match rescan {
+            ClaudeIdleTranscriptScan::Prompt {
+                prompt,
+                entry_id,
+                prompt_start_offset,
+                ..
+            } => {
+                assert_eq!(
+                    prompt_start_offset,
+                    new_head.len() as u64,
+                    "the surviving entry is at a SHIFTED offset after head rotation"
+                );
+                (prompt, entry_id)
+            }
+            other => panic!("expected Prompt, got {other:?}"),
+        };
+        assert_eq!(
+            re_entry_id.as_deref(),
+            Some(uuid),
+            "uuid survives the rotation"
+        );
+        let second = crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
+            ProviderKind::Claude.as_str(),
+            "tmux-3540",
+            &re_prompt,
+            re_entry_id.as_deref(),
+            chrono::Utc::now(),
+        );
+        assert_eq!(
+            second,
+            crate::services::tui_prompt_dedupe::PromptObservation::SuppressedReplayedEntry,
+            "#3540: the already-relayed entry re-encountered after a watermark \
+             reset / head rotation is suppressed by identity"
+        );
+        assert!(
+            !claude_idle_prompt_observation_should_tail_response(second),
+            "#3540 (the fix): a suppressed-replayed entry does NOT tail a \
+             response, so no external-turn lease / synthetic claim is taken — the \
+             phantom synthetic inflight is never created"
+        );
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
     }
 
     #[cfg(unix)]

--- a/src/services/discord/tui_prompt_relay/idle_transcript_scan.rs
+++ b/src/services/discord/tui_prompt_relay/idle_transcript_scan.rs
@@ -55,6 +55,13 @@ pub(super) enum ClaudeIdleTranscriptScan {
         prompt: String,
         prompt_start_offset: u64,
         line_end_offset: u64,
+        /// #3540: the scanned `user` entry's STABLE identity (`uuid`), when the
+        /// transcript provides one. Threaded into the dedupe layer so an
+        /// already-relayed entry re-encountered after a watermark reset / jsonl
+        /// head rotation is suppressed by identity (not by the 30s content
+        /// window), preventing a phantom synthetic inflight. `None` falls back to
+        /// the content-keyed recent-observed dedup (pre-#3540 behavior).
+        entry_id: Option<String>,
     },
 }
 
@@ -112,13 +119,16 @@ pub(super) fn scan_claude_idle_transcript_for_prompt(
             }
             continue;
         };
-        if let Some(prompt) =
-            crate::services::tui_prompt_dedupe::extract_claude_transcript_user_prompt(&json)
+        if let Some((prompt, entry_id)) =
+            crate::services::tui_prompt_dedupe::extract_claude_transcript_user_prompt_with_entry_id(
+                &json,
+            )
         {
             return Ok(ClaudeIdleTranscriptScan::Prompt {
                 prompt,
                 prompt_start_offset: line_start_offset,
                 line_end_offset: offset,
+                entry_id,
             });
         }
     }
@@ -216,13 +226,16 @@ pub(super) fn scan_claude_idle_transcript_for_last_prompt(
             }
             continue;
         };
-        if let Some(prompt) =
-            crate::services::tui_prompt_dedupe::extract_claude_transcript_user_prompt(&json)
+        if let Some((prompt, entry_id)) =
+            crate::services::tui_prompt_dedupe::extract_claude_transcript_user_prompt_with_entry_id(
+                &json,
+            )
         {
             last_prompt = Some(ClaudeIdleTranscriptScan::Prompt {
                 prompt,
                 prompt_start_offset: line_start_offset,
                 line_end_offset: offset,
+                entry_id,
             });
         }
     }

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -108,20 +108,39 @@ pub(super) fn genuinely_live_watcher_for_relay(
 /// turn, not merely be alive.
 ///
 /// True ONLY when the transcript completion signal is `Done` (terminator
-/// PROVEN on disk) AND the bridge's confirmed relay offset advanced past the
-/// turn's start offset (so the terminator belongs to THIS turn, not a stale
-/// one from before the turn's user line was appended). Everything else —
-/// `PausedLive`, `Unknown` (non-JSONL runtimes), or missing/unadvanced
-/// offsets — returns `false` and keeps the #3268 handoff byte-for-byte
-/// (fail-open). In the proven case the bridge finalizing is not premature:
-/// it is the CORRECT completion handling.
+/// PROVEN on disk) AND the transcript itself GREW past the turn's start offset
+/// (so the terminator + the response body belong to THIS turn, not a stale one
+/// from before the turn's user line was appended). Everything else —
+/// `PausedLive`, `Unknown` (non-JSONL runtimes), or a transcript that did not
+/// grow past the start offset — returns `false` and keeps the #3268 handoff
+/// byte-for-byte (fail-open). In the proven case the bridge finalizing is not
+/// premature: it is the CORRECT completion handling.
+///
+/// #3540 (warm-followup strand): the #3277 gate originally compared the racy
+/// `tmux_last_offset` against `turn_start_offset`. Both are seeded to the SAME
+/// `inflight_offset` at turn start (`InflightTurnState::new` ←
+/// `intake_turn.rs`'s `Some(inflight_offset)`), and a warm-followup turn only
+/// advances `tmux_last_offset` via the trailing `RuntimeReady{last_offset}`.
+/// When that ready signal misses the 250 ms drain window the offset stays at
+/// `inflight_offset`, so `last > start` is `false` even though the producer
+/// already wrote the WHOLE response (terminator + body) to the transcript →
+/// the gate fails open → the #3268 handoff strands the finished turn behind a
+/// "in progress" placeholder. The non-racy fact is on disk: the transcript
+/// EOF. `inflight_offset` IS that transcript file's byte length stat-ed at
+/// turn start (`std::fs::metadata(output_path).len()`), and `transcript_eof`
+/// here re-stats the SAME `output_path`, so both live in one byte-space.
+/// Comparing `transcript_eof > turn_start_offset` therefore asks the exact,
+/// non-racy question "did the producer append (and terminate) this turn's
+/// response past where the turn began?". A rotated/truncated transcript shrinks
+/// its EOF below `turn_start_offset`, so the comparison stays `false` and the
+/// handoff fails open (conservative: only an EOF that DEFINITELY grew proves
+/// delivery).
 pub(super) fn busy_turn_already_proven_delivered(
     signal: CompletionSignal,
-    tmux_last_offset: Option<u64>,
+    transcript_eof: Option<u64>,
     turn_start_offset: u64,
 ) -> bool {
-    signal == CompletionSignal::Done
-        && tmux_last_offset.is_some_and(|last| last > turn_start_offset)
+    signal == CompletionSignal::Done && transcript_eof.is_some_and(|eof| eof > turn_start_offset)
 }
 
 /// #3281: which empty-terminal-response visibility event (if any) applies to
@@ -308,14 +327,31 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
     ) && let Some(watcher) = shared_owned.tmux_watchers.get(&watcher_owner_channel_id)
     {
         // #3277 (Defect A): a turn whose JSONL terminator is ALREADY on disk
-        // (and whose relay offset advanced past the turn start) has nothing
-        // left for the watcher to relay — handing it off parks the watcher at
-        // EOF and strands the channel until the far-backstop. Keep the bridge
-        // finalize instead (the pre-#3268 path; correct, not premature, for a
+        // (and whose transcript grew past the turn start) has nothing left for
+        // the watcher to relay — handing it off parks the watcher at EOF and
+        // strands the channel until the far-backstop. Keep the bridge finalize
+        // instead (the pre-#3268 path; correct, not premature, for a
         // proven-complete turn). Read failures / Unknown / PausedLive /
         // missing offsets all fall through to the #3268 handoff (fail-open);
         // this gate-timeout path already spent 3s, so one transcript tail
         // read is negligible.
+        //
+        // #3540 (warm-followup strand): the growth check now uses the
+        // transcript's on-disk EOF, NOT the racy `tmux_last_offset`. A
+        // warm-followup turn whose trailing `RuntimeReady{last_offset}` missed
+        // the 250 ms drain window leaves `tmux_last_offset == turn_start_offset`
+        // even though the producer already wrote the whole response — the old
+        // `tmux_last_offset > start` comparison was `false` there and fell open
+        // to the handoff, stranding the finished turn. `turn_start_offset` is
+        // `output_path`'s byte length stat-ed at turn start, so re-stat the SAME
+        // `output_path` for a byte-space-matched EOF. A read failure → `None` →
+        // fall through to the #3268 handoff (fail-open, unchanged). A
+        // rotated/truncated transcript shrinks the EOF below the start offset,
+        // so `eof > start` stays `false` and the handoff still fails open.
+        let transcript_eof = inflight_state
+            .output_path
+            .as_deref()
+            .and_then(|path| std::fs::metadata(path).map(|m| m.len()).ok());
         if let (Some(output_path), Some(turn_start_offset)) = (
             inflight_state.output_path.as_deref(),
             inflight_state.turn_start_offset,
@@ -325,7 +361,7 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
                 inflight_state.runtime_kind,
                 std::path::Path::new(output_path),
             ),
-            tmux_last_offset,
+            transcript_eof,
             turn_start_offset,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -335,9 +371,11 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
                 watcher_owner_channel = watcher_owner_channel_id.get(),
                 turn_start_offset,
                 tmux_last_offset = tmux_last_offset.unwrap_or(0),
-                "  [{ts}] 👁 #3277: quiescence timeout but the turn is PROVEN delivered \
-                 (JSONL terminator on disk past turn start) — bridge finalizes instead of \
-                 handing a finished turn to the watcher"
+                transcript_eof = transcript_eof.unwrap_or(0),
+                "  [{ts}] 👁 #3277/#3540: quiescence timeout but the turn is PROVEN delivered \
+                 (JSONL terminator on disk + transcript grew past turn start) — bridge \
+                 finalizes instead of handing a finished turn to the watcher (warm-followup: \
+                 disk EOF, not racy tmux_last_offset)"
             );
             // #3501: the body is PROVEN delivered (JSONL terminator on disk past
             // turn start, already relayed), so STAMP the inflight delivered before
@@ -474,32 +512,54 @@ mod tests {
         assert_eq!(watcher_resume_seed_offset(376_405, Some(999_999)), 376_405);
     }
 
-    /// #3277 (Defect A) truth table: ONLY a `Done` signal with the relay offset
-    /// advanced PAST the turn start proves the turn delivered (and suppresses
-    /// the #3268 handoff). Every other combination fails open — the handoff to
-    /// a genuinely-live watcher proceeds exactly as before #3277.
+    /// #3277 (Defect A) + #3540 (warm-followup strand) truth table: ONLY a
+    /// `Done` signal whose TRANSCRIPT EOF grew PAST the turn start proves the
+    /// turn delivered (and suppresses the #3268 handoff). Every other
+    /// combination fails open — the handoff to a genuinely-live watcher proceeds
+    /// exactly as before #3277. #3540: the growth fact is read from the
+    /// transcript's on-disk EOF (`std::fs::metadata(output_path).len()`), NOT
+    /// the racy `tmux_last_offset`, so a warm-followup whose trailing
+    /// `RuntimeReady{last_offset}` was late still finalizes when the producer
+    /// already wrote the response.
     #[test]
     fn busy_turn_proven_delivered_truth_table() {
-        // Done + offset advanced past turn start → PROVEN: no handoff.
+        // Done + transcript EOF grew past turn start → PROVEN: no handoff.
         assert!(busy_turn_already_proven_delivered(
             CompletionSignal::Done,
             Some(37_154),
             17_737,
         ));
-        // Done but offset did NOT advance (== start): the terminator could be
-        // the PRIOR turn's — not proven, hand off (fail-open).
+        // #3540 warm-followup: the producer wrote the WHOLE response — the
+        // transcript EOF (929_166) grew well past `turn_start_offset` (886_134,
+        // the `inflight_offset` both `turn_start_offset` AND the racy
+        // `tmux_last_offset` were seeded to). Under the pre-#3540 gate the racy
+        // `tmux_last_offset` was still parked at 886_134 (its trailing
+        // `RuntimeReady` missed the 250 ms drain window) → `886_134 > 886_134`
+        // was `false` → fail-open → the #3268 handoff stranded the finished turn
+        // behind an "in progress" placeholder. Reading the non-racy disk EOF
+        // proves delivery → finalize, no handoff, no strand.
+        assert!(busy_turn_already_proven_delivered(
+            CompletionSignal::Done,
+            Some(929_166),
+            886_134,
+        ));
+        // Done but the transcript did NOT grow (EOF == start): the producer
+        // appended nothing past the turn start, so the terminator on disk is the
+        // PRIOR turn's — a genuinely unfinished turn. Not proven, hand off
+        // (fail-open) so the live watcher carries the still-streaming body.
         assert!(!busy_turn_already_proven_delivered(
             CompletionSignal::Done,
-            Some(17_737),
-            17_737,
+            Some(886_134),
+            886_134,
         ));
-        // Done but no confirmed offset at all → not proven.
+        // Done but the transcript could not be stat-ed (read failure → None) →
+        // not proven, fall through to the #3268 handoff (fail-open, unchanged).
         assert!(!busy_turn_already_proven_delivered(
             CompletionSignal::Done,
             None,
             17_737,
         ));
-        // Still live (no terminator) → never proven, regardless of offsets.
+        // Still live (no terminator) → never proven, regardless of the EOF.
         assert!(!busy_turn_already_proven_delivered(
             CompletionSignal::PausedLive,
             Some(37_154),
@@ -511,7 +571,10 @@ mod tests {
             Some(37_154),
             17_737,
         ));
-        // Done but offset BEHIND turn start (stale/rotated transcript) → not proven.
+        // Done but transcript EOF BEHIND turn start (rotated/truncated transcript
+        // shrank it below where the turn began) → not proven (conservative
+        // fail-open: only a transcript that DEFINITELY grew proves delivery, so a
+        // rotation that mixed byte-spaces can never spuriously finalize).
         assert!(!busy_turn_already_proven_delivered(
             CompletionSignal::Done,
             Some(100),
@@ -519,7 +582,7 @@ mod tests {
         ));
         // #3281 cold-start variant: /clear cold-start intake records
         // turn_start_offset = 0 (the transcript did not exist yet), so a Done
-        // terminator with ANY advanced relay offset is proven — the #3268
+        // terminator with ANY non-zero transcript EOF is proven — the #3268
         // handoff stays suppressed, `bridge_output_owner` stays `None`, and
         // the bridge delivers `full_response` directly.
         assert!(busy_turn_already_proven_delivered(

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -25,6 +25,12 @@ const EXTERNAL_INPUT_RELAY_LEASE_TTL: Duration = Duration::from_secs(10 * 60);
 // leaking onto a much-later same-key turn.
 const DEFERRED_ANCHOR_COMPLETION_TTL: Duration = Duration::from_secs(60);
 const OBSERVED_PROMPT_BUFFER: usize = 128;
+// #3540: per-`(provider, tmux)` ring cap on the relayed-entry-id ledger. A
+// single session rarely relays anywhere near this many DISTINCT user prompts
+// inside the 30min entry-id TTL; the cap is a belt-and-braces upper bound so a
+// pathological long-lived session cannot grow the set without limit (TTL purge
+// is the primary bound). Oldest entries are dropped first.
+const RELAYED_ENTRY_ID_RING_CAP: usize = 512;
 
 static STATE: LazyLock<Mutex<TuiPromptDedupeState>> =
     LazyLock::new(|| Mutex::new(TuiPromptDedupeState::default()));
@@ -183,6 +189,22 @@ struct TuiPromptDedupeState {
     // marker whose stored generation MATCHES the lease generation THIS relay
     // invocation recorded; a marker for a different turn is left untouched.
     deferred_anchor_completion_by_tmux: HashMap<PromptKey, TimedValue<u64>>,
+    // #3540: stable JSONL entry-identity (`uuid`) ledger of prompts THIS process
+    // has already relayed for a `(provider, tmux)` pair. The root-cause fix for
+    // the phantom synthetic inflight: when the relay watermark is reset to 0
+    // (jsonl head rotation / session restore), the idle-transcript scanner
+    // re-scans from offset 0 and re-encounters already-relayed prompts. The
+    // content-keyed `recent_observed_by_tmux` (30s TTL) lets a re-encounter that
+    // straddles that window slip through and mint a fresh — phantom — synthetic
+    // inflight whose commit will never arrive. This ledger keys on the entry's
+    // immutable `uuid`, which is preserved verbatim across head rotation (offset
+    // shifts, uuid does not), so an already-relayed entry is suppressed by
+    // IDENTITY regardless of the 30s window. A genuinely NEW prompt has a NEW
+    // uuid (issued by Claude Code at type time) so it can never collide here —
+    // no #3459/#3303 missed-prompt regression. TTL'd by `PROMPT_ANCHOR_TTL`
+    // (30min) — long enough to span the rotation+self-loop window, bounded so
+    // the set cannot grow without limit; additionally ring-capped per key.
+    relayed_entry_ids_by_tmux: HashMap<PromptKey, VecDeque<TimedValue<String>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -708,6 +730,31 @@ pub fn observe_prompt_by_tmux_at(
         provider,
         tmux_session_name,
         &[prompt.to_string()],
+        None,
+        PromptObservationEffect::NotifyAndLease,
+        observed_at,
+    )
+}
+
+/// #3540: same as [`observe_prompt_by_tmux_at`] but carries the prompt's stable
+/// JSONL entry identity (`uuid`). When `entry_id` is `Some` AND that uuid was
+/// already relayed for this `(provider, tmux)` pair the call returns
+/// [`PromptObservation::SuppressedReplayedEntry`] BEFORE any synthetic turn is
+/// minted — closing the watermark-reset / jsonl-head-rotation re-claim window
+/// that the 30s content dedup leaves open. `entry_id == None` falls back to the
+/// pre-#3540 content-keyed path (no behavior change).
+pub fn observe_prompt_by_tmux_with_entry_id_at(
+    provider: &str,
+    tmux_session_name: &str,
+    prompt: &str,
+    entry_id: Option<&str>,
+    observed_at: DateTime<Utc>,
+) -> PromptObservation {
+    observe_prompt_candidates_by_tmux_inner(
+        provider,
+        tmux_session_name,
+        &[prompt.to_string()],
+        entry_id,
         PromptObservationEffect::NotifyAndLease,
         observed_at,
     )
@@ -722,6 +769,7 @@ pub fn observe_prompt_candidates_by_tmux(
         provider,
         tmux_session_name,
         prompts,
+        None,
         PromptObservationEffect::NotifyAndLease,
         Utc::now(),
     )
@@ -736,6 +784,7 @@ pub(crate) fn observe_prompt_candidates_by_tmux_for_relay_lease(
         provider,
         tmux_session_name,
         prompts,
+        None,
         PromptObservationEffect::RelayLeaseOnly,
         Utc::now(),
     )
@@ -751,11 +800,13 @@ fn observe_prompt_candidates_by_tmux_inner(
     provider: &str,
     tmux_session_name: &str,
     prompts: &[String],
+    entry_id: Option<&str>,
     effect: PromptObservationEffect,
     observed_at: DateTime<Utc>,
 ) -> PromptObservation {
     let provider = normalize_provider(provider);
     let tmux_session_name = tmux_session_name.trim();
+    let entry_id = entry_id.map(str::trim).filter(|value| !value.is_empty());
     let mut candidates = Vec::new();
     for prompt in prompts {
         let prompt = prompt.trim();
@@ -779,6 +830,20 @@ fn observe_prompt_candidates_by_tmux_inner(
     if provider.is_empty() || tmux_session_name.is_empty() || candidates.is_empty() {
         return PromptObservation::Ignored;
     }
+    // #3540 (root cause): suppress by STABLE entry identity BEFORE any pending /
+    // recent / lease bookkeeping or synthetic-turn mint. If this JSONL entry
+    // `uuid` was already relayed for this `(provider, tmux)` pair it is a
+    // re-encounter from a watermark reset / jsonl head rotation, NOT a new
+    // submission — return early so the scanner never mints a phantom synthetic
+    // inflight. This check inspects ONLY the relayed-entry ledger; it never
+    // reads inflight / EOF / current_msg_id, so it cannot mis-handle a slow
+    // genuine turn. A genuinely new prompt has a fresh uuid (absent from the
+    // ledger) and is never suppressed here.
+    if let Some(entry_id) = entry_id {
+        if relayed_entry_id_already_seen(&provider, tmux_session_name, entry_id) {
+            return PromptObservation::SuppressedReplayedEntry;
+        }
+    }
     for prompt in &candidates {
         if take_matching_pending_prompt(&provider, tmux_session_name, prompt) {
             return PromptObservation::SuppressedDiscordDuplicate;
@@ -788,6 +853,14 @@ fn observe_prompt_candidates_by_tmux_inner(
         if take_or_record_recent_observed_prompt(&provider, tmux_session_name, prompt) {
             return PromptObservation::SuppressedRecentDuplicate;
         }
+    }
+    // #3540: this candidate cleared the pending + recent dedup, so it is about to
+    // be relayed for real — record its stable entry id NOW (not earlier, so a
+    // candidate that was dedup-suppressed above is never recorded as "relayed").
+    // A future watermark-reset re-encounter of this exact uuid is then
+    // suppressed at the identity check above.
+    if let Some(entry_id) = entry_id {
+        record_relayed_entry_id(&provider, tmux_session_name, entry_id);
     }
     record_external_input_relay_lease(&provider, tmux_session_name, None);
     if effect == PromptObservationEffect::RelayLeaseOnly {
@@ -1080,6 +1153,33 @@ pub fn extract_codex_rollout_user_prompt(json: &Value) -> Option<String> {
 }
 
 pub fn extract_claude_transcript_user_prompt(json: &Value) -> Option<String> {
+    extract_claude_transcript_user_prompt_with_entry_id(json).map(|(prompt, _)| prompt)
+}
+
+/// #3540: same extraction as [`extract_claude_transcript_user_prompt`], but also
+/// returns the JSONL entry's STABLE identity (`uuid`) when present.
+///
+/// Claude Code stamps every transcript `user` entry with a content-stable
+/// top-level `uuid` (measured: ~18k user uuids across ~3.8k transcript files
+/// with ZERO cross-file collisions — it is a genuine per-entry identity, not a
+/// timestamp derivative). The relay-watermark reset path (`/relay-scan`
+/// self-loop + jsonl head rotation) re-presents an already-relayed prompt at a
+/// shifted byte offset; the rotation is a `truncate_jsonl_head_safe` rename
+/// (head clipped, surviving bytes preserved verbatim), so the SAME logical
+/// prompt keeps its uuid even though its offset moved. The idle-transcript
+/// scanner threads this uuid into the dedupe layer so an already-relayed entry
+/// is suppressed by IDENTITY (see [`observe_prompt_candidates_by_tmux`]) without
+/// ever inspecting inflight / EOF / current_msg_id — sidestepping the
+/// observationally-indistinguishable phantom-vs-slow-live-turn problem entirely.
+///
+/// Defensive extraction: the uuid is read from the top-level object (where
+/// Claude Code places it for `user` entries) with a `message.uuid` fallback for
+/// forward/backward tolerance. A missing uuid yields `None`, in which case the
+/// scanner falls back to the existing content-keyed 30s recent-observed dedup —
+/// no regression, just the same window as before #3540.
+pub fn extract_claude_transcript_user_prompt_with_entry_id(
+    json: &Value,
+) -> Option<(String, Option<String>)> {
     if json.get("type").and_then(Value::as_str) != Some("user") {
         return None;
     }
@@ -1098,7 +1198,23 @@ pub fn extract_claude_transcript_user_prompt(json: &Value) -> Option<String> {
     {
         return None;
     }
-    reject_synthetic_tui_user_prompt(extract_message_content_text(message)?)
+    let prompt = reject_synthetic_tui_user_prompt(extract_message_content_text(message)?)?;
+    let entry_id = extract_claude_transcript_entry_id(json, message);
+    Some((prompt, entry_id))
+}
+
+/// #3540: pull the stable entry identity for a Claude transcript `user` entry.
+/// Prefers the top-level `uuid` (where Claude Code writes it), falls back to a
+/// `message.uuid` if a future format ever moves it. Returns a normalized,
+/// non-empty `String` or `None` (the scanner treats `None` as "no stable
+/// identity available — use the content-keyed fallback").
+fn extract_claude_transcript_entry_id(json: &Value, message: &Value) -> Option<String> {
+    json.get("uuid")
+        .and_then(Value::as_str)
+        .or_else(|| message.get("uuid").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 pub fn extract_qwen_jsonl_user_prompt(json: &Value) -> Option<String> {
@@ -1165,6 +1281,16 @@ pub enum PromptObservation {
     PublishedSshDirect,
     SuppressedDiscordDuplicate,
     SuppressedRecentDuplicate,
+    /// #3540: the observed prompt's stable JSONL entry `uuid` was ALREADY relayed
+    /// for this `(provider, tmux)` pair. Distinct from
+    /// [`Self::SuppressedRecentDuplicate`]: that is a content match bounded by the
+    /// 30s recent window, whereas this is an IDENTITY match bounded only by the
+    /// 30min entry-id TTL. The idle-transcript scanner treats it like the other
+    /// suppressions — `should_tail_response == false` — so a re-encountered
+    /// already-relayed entry (watermark reset / jsonl head rotation) never mints a
+    /// phantom synthetic inflight. A genuinely new prompt carries a new uuid and
+    /// is never returned here.
+    SuppressedReplayedEntry,
     Ignored,
 }
 
@@ -1216,6 +1342,44 @@ fn take_or_record_recent_observed_prompt(
     }
     state.record_recent_observed_prompt(provider, tmux_session_name, prompt);
     false
+}
+
+/// #3540: `true` iff `entry_id` is in the already-relayed ledger for this
+/// `(provider, tmux)` pair (and not yet purged). Read-only — recording happens
+/// separately in [`record_relayed_entry_id`] at the actual relay point.
+fn relayed_entry_id_already_seen(provider: &str, tmux_session_name: &str, entry_id: &str) -> bool {
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    state
+        .relayed_entry_ids_by_tmux
+        .get(&PromptKey::new(provider, tmux_session_name))
+        .is_some_and(|queue| queue.iter().any(|seen| seen.value == entry_id))
+}
+
+/// #3540: record `entry_id` as relayed for this `(provider, tmux)` pair. Called
+/// only at the actual relay point (after pending/recent dedup pass), so a
+/// dedup-suppressed candidate is never mis-recorded as relayed. Idempotent: a
+/// re-record of an id already present refreshes nothing and does not duplicate
+/// (the identity check would have short-circuited the caller anyway). Ring-capped
+/// per key at [`RELAYED_ENTRY_ID_RING_CAP`] (oldest dropped first); TTL-purged by
+/// `PROMPT_ANCHOR_TTL`.
+fn record_relayed_entry_id(provider: &str, tmux_session_name: &str, entry_id: &str) {
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    let queue = state
+        .relayed_entry_ids_by_tmux
+        .entry(PromptKey::new(provider, tmux_session_name))
+        .or_default();
+    if queue.iter().any(|seen| seen.value == entry_id) {
+        return;
+    }
+    queue.push_back(TimedValue {
+        value: entry_id.to_string(),
+        recorded_at: Instant::now(),
+    });
+    while queue.len() > RELAYED_ENTRY_ID_RING_CAP {
+        queue.pop_front();
+    }
 }
 
 pub(crate) fn prompts_match(expected: &str, observed: &str) -> bool {
@@ -1387,6 +1551,18 @@ impl TuiPromptDedupeState {
         });
         self.deferred_anchor_completion_by_tmux.retain(|_, entry| {
             now.duration_since(entry.recorded_at) <= DEFERRED_ANCHOR_COMPLETION_TTL
+        });
+        // #3540: relayed-entry-id ledger — purge ids older than PROMPT_ANCHOR_TTL
+        // (30min), long enough to span a watermark-reset / jsonl-rotation +
+        // self-loop window while bounding memory growth.
+        self.relayed_entry_ids_by_tmux.retain(|_, queue| {
+            while queue
+                .front()
+                .is_some_and(|entry| now.duration_since(entry.recorded_at) > PROMPT_ANCHOR_TTL)
+            {
+                queue.pop_front();
+            }
+            !queue.is_empty()
         });
     }
 }
@@ -2787,5 +2963,275 @@ mod tests {
         });
 
         assert_eq!(extract_qwen_jsonl_user_prompt(&json), None);
+    }
+
+    // ----------------------------------------------------------------------
+    // #3540: stable JSONL entry-id (uuid) dedup — root-cause prevention of the
+    // phantom synthetic inflight on watermark reset / jsonl head rotation.
+    // ----------------------------------------------------------------------
+
+    /// #3540: the SAME entry uuid observed twice (the watermark-reset re-scan)
+    /// publishes once and is then suppressed by IDENTITY — so the second sighting
+    /// never mints a synthetic turn. This is the bound the 30s content window
+    /// could not provide.
+    #[test]
+    fn replayed_entry_id_is_suppressed_on_second_observe() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let now = Utc::now();
+
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "deploy to make=live",
+                Some("uuid-A"),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect,
+            "first sighting of a fresh entry relays normally"
+        );
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "deploy to make=live",
+                Some("uuid-A"),
+                now,
+            ),
+            PromptObservation::SuppressedReplayedEntry,
+            "the SAME entry uuid re-encountered (watermark reset / head rotation) \
+             is suppressed by identity — no phantom synthetic inflight (#3540)"
+        );
+    }
+
+    /// #3540 regression guard (#3459/#3303): a genuinely NEW prompt carries a NEW
+    /// uuid (Claude Code issues one at type time), so it is NEVER suppressed by
+    /// the entry-id ledger — missed-prompt regression cannot recur.
+    #[test]
+    fn new_entry_id_is_never_suppressed() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let now = Utc::now();
+
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "first prompt",
+                Some("uuid-1"),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect
+        );
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "second prompt",
+                Some("uuid-2"),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect,
+            "a distinct entry uuid carrying distinct content is a distinct \
+             submission — always relayed (#3459/#3303 missed-prompt regression \
+             guard). The entry-id ledger only suppresses a RE-ENCOUNTER of the \
+             EXACT same uuid; a new uuid never collides."
+        );
+        // A THIRD distinct prompt under a THIRD uuid also relays — the ledger
+        // does not accumulate false suppressions across genuinely new prompts.
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "third prompt",
+                Some("uuid-3"),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect,
+            "each genuinely new prompt (new uuid + new content) keeps relaying"
+        );
+    }
+
+    /// #3540: `entry_id == None` (uuid missing / non-Claude provider) falls back
+    /// to the pre-#3540 content-keyed 30s recent-observed dedup — no behavior
+    /// change, no functional regression.
+    #[test]
+    fn missing_entry_id_falls_back_to_content_dedup() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let now = Utc::now();
+
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "no-uuid prompt",
+                None,
+                now,
+            ),
+            PromptObservation::PublishedSshDirect
+        );
+        // Same content again with no uuid → the content-keyed recent dedup
+        // suppresses it (the existing 30s path), NOT the entry-id path.
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "no-uuid prompt",
+                None,
+                now,
+            ),
+            PromptObservation::SuppressedRecentDuplicate,
+            "with no stable id the legacy content-keyed dedup still applies"
+        );
+    }
+
+    /// #3540: a candidate suppressed by the recent-duplicate path must NOT be
+    /// recorded in the entry-id ledger as 'relayed' — only an ACTUAL relay
+    /// records the id. (Recording on a dedup-suppressed sighting would be a
+    /// false 'seen', a subtle correctness bug.)
+    #[test]
+    fn dedup_suppressed_candidate_does_not_record_entry_id() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let now = Utc::now();
+
+        // A discord-originated pending prompt is queued first.
+        record_discord_originated_prompt("claude", "tmux-3540", "queued prompt");
+        // The transcript scanner then observes the SAME text (with a uuid) — it is
+        // suppressed as a Discord duplicate, NOT relayed-as-SSH-direct.
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "queued prompt",
+                Some("uuid-D"),
+                now,
+            ),
+            PromptObservation::SuppressedDiscordDuplicate
+        );
+        // Because that sighting was dedup-suppressed (not a real SSH-direct
+        // relay), its uuid was NOT recorded. A later genuine SSH-direct sighting
+        // of a DIFFERENT prompt under that same uuid would still relay — proving
+        // the ledger was not poisoned. (We assert the simpler invariant: the same
+        // uuid under fresh content publishes, i.e. is not falsely pre-suppressed.)
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "claude",
+                "tmux-3540",
+                "different fresh text",
+                Some("uuid-D"),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect,
+            "a uuid seen only on a dedup-suppressed sighting was not recorded as \
+             relayed, so it does not falsely suppress a later real relay (#3540)"
+        );
+    }
+
+    /// #3540: purge_expired drops entry ids older than PROMPT_ANCHOR_TTL so the
+    /// ledger cannot grow without bound; a re-encounter after purge relays again
+    /// (correct — the watermark-reset window is far shorter than the 30min TTL).
+    #[test]
+    fn relayed_entry_id_ledger_purges_after_ttl() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        record_relayed_entry_id("claude", "tmux-3540", "uuid-T");
+        assert!(relayed_entry_id_already_seen(
+            "claude",
+            "tmux-3540",
+            "uuid-T"
+        ));
+
+        // Force the recorded id to look older than the TTL, then purge.
+        {
+            let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            if let Some(queue) = state
+                .relayed_entry_ids_by_tmux
+                .get_mut(&PromptKey::new("claude", "tmux-3540"))
+            {
+                for entry in queue.iter_mut() {
+                    entry.recorded_at =
+                        Instant::now() - (PROMPT_ANCHOR_TTL + Duration::from_secs(1));
+                }
+            }
+            state.purge_expired();
+        }
+        assert!(
+            !relayed_entry_id_already_seen("claude", "tmux-3540", "uuid-T"),
+            "entry ids older than PROMPT_ANCHOR_TTL are purged (bounded growth)"
+        );
+    }
+
+    /// #3540: the ring cap bounds per-key growth even before the TTL fires —
+    /// the oldest id is evicted once the cap is exceeded.
+    #[test]
+    fn relayed_entry_id_ledger_is_ring_capped() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        record_relayed_entry_id("claude", "tmux-cap", "uuid-oldest");
+        for i in 0..RELAYED_ENTRY_ID_RING_CAP {
+            record_relayed_entry_id("claude", "tmux-cap", &format!("uuid-{i}"));
+        }
+        assert!(
+            !relayed_entry_id_already_seen("claude", "tmux-cap", "uuid-oldest"),
+            "the oldest id is dropped once the ring cap is exceeded"
+        );
+        assert!(
+            relayed_entry_id_already_seen(
+                "claude",
+                "tmux-cap",
+                &format!("uuid-{}", RELAYED_ENTRY_ID_RING_CAP - 1)
+            ),
+            "the newest ids remain"
+        );
+    }
+
+    /// #3540: head-rotation simulation — `extract_claude_transcript_user_prompt_with_entry_id`
+    /// returns the SAME top-level uuid regardless of where the entry sits, so a
+    /// surviving entry whose byte offset shifted after a head truncation is still
+    /// recognized by identity.
+    #[test]
+    fn extract_returns_stable_top_level_uuid() {
+        let json = serde_json::json!({
+            "type": "user",
+            "uuid": "6c532800-4c8c-4d1d-9e64-d308fab44a1e",
+            "message": {
+                "role": "user",
+                "content": [{ "type": "text", "text": "surviving prompt" }],
+            },
+            "sessionId": "sess-rot",
+        });
+        let (prompt, entry_id) =
+            extract_claude_transcript_user_prompt_with_entry_id(&json).expect("user prompt");
+        assert_eq!(prompt, "surviving prompt");
+        assert_eq!(
+            entry_id.as_deref(),
+            Some("6c532800-4c8c-4d1d-9e64-d308fab44a1e"),
+            "the stable top-level uuid is extracted; it survives head rotation \
+             (offset shifts, uuid does not) so identity dedup recognizes the \
+             re-encountered entry (#3540)"
+        );
+    }
+
+    /// #3540: a `user` entry with no uuid yields `(prompt, None)` — the scanner
+    /// then uses the content-keyed fallback (no panic, no regression).
+    #[test]
+    fn extract_yields_none_entry_id_when_uuid_absent() {
+        let json = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{ "type": "text", "text": "no uuid here" }],
+            },
+            "sessionId": "sess-x",
+        });
+        let (prompt, entry_id) =
+            extract_claude_transcript_user_prompt_with_entry_id(&json).expect("user prompt");
+        assert_eq!(prompt, "no uuid here");
+        assert_eq!(entry_id, None);
     }
 }


### PR DESCRIPTION
## #3540 — 팬텀 synthetic inflight 큐 무한정체 (근본예방 + 안전복구 + 인접 strand 흡수)

`/relay-scan` 셀프루프 + jsonl 로테이션이 relay watermark를 리셋한 직후, idle-transcript scanner가 **이미 relay한 과거 프롬프트를 새 제출로 오인** → commit이 영영 안 오는 팬텀 synthetic inflight 핀 → 후속 사용자 메시지가 QUEUE-ACK placeholder로 무한 정체(수동 복구 반복).

### (A) 근본예방 — stable identity dedup
- Claude transcript user 엔트리의 **top-level `uuid`**(로테이션 head-절단에도 불변)를 per-(provider,tmux) ledger에 기록. 이미 relay한 uuid면 `SuppressedReplayedEntry` → synthetic 턴 자체를 만들지 않음.
- inflight/EOF/current_msg_id를 **일절 관찰하지 않음** → "팬텀 ↔ thinking 중인 느린 실제 턴" 관찰 불가분 문제를 원천 우회.
- 새 프롬프트는 새 uuid라 절대 suppress 안 됨(#3459/#3303 missed-prompt 회귀 없음). 실측: real transcript user-uuid 6462개 중 distinct-text 충돌 0.
- ledger: TTL purge(30min) + ring-cap. uuid 누락/타 provider는 기존 content dedup으로 폴백.

### (B′) 안전복구 — no-evict promote (defense-in-depth)
- backstop ABORT 분기에서 abort_cleanup + pending-record delete 후, 기존 mailbox dispatch를 1회 kick해 큐 follow-up promote.
- **어떤 inflight도 evict/clear/reset/delete 안 함.** 최악 케이스 = follow-up이 진행 중 턴에 정상 merge(라이브 손실 0).

### (C) 인접 결함 흡수 — warm-followup strand (#3277 가드)
- `busy_turn_already_proven_delivered`가 `signal==Done && tmux_last_offset > turn_start_offset` 요구했으나, warm-followup은 둘을 동일 seed로 두고 후행 RuntimeReady가 250ms drain 창을 놓치면 `n>n=false` → fail-open → #3268 핸드오프 → 완료된 답변 strand.
- Fix: `signal==Done`일 때 비교 기준을 racy한 `tmux_last_offset` → **디스크 transcript EOF**(같은 output_path 재-stat, 동일 byte-space). `eof > start`만 delivery 증명, 로테이션/shrink/read-fail은 conservative fail-open. Done 요건 유지(PausedLive/Unknown 배제 보존).

### 불변식 / 검증
- 보존: #3154(라이브 미덮어쓰기 — 애초에 evict 안 함), #3296, #3277/#3268/#3460/#3281/#3501, #3459/#3303(missed-prompt). load-bearing event key 무변경.
- 게이트: cargo fmt/check/test green, agent-maintenance freshness pass.
- 테스트: watermark-reset 재스캔 미-resynthesize, replayed-uuid suppress, new-uuid 항상 통과, no-evict 가드, warm-followup proven truth-table 등.
- **교차모델 적대 리뷰**: 구현=Claude → 리뷰=codex(gpt-5.5, xhigh) **VERDICT: CLEAN (findings: none)**. (이전 evict 접근은 codex 3라운드 reject 후 전면 폐기, identity-dedup 무-evict 접근으로 재설계.)

처리: #3540
