### PR TITLE
fix(#3552): downgrade monotonic inflight invariants to WARN when #3416 enforce skips the backward write (remove ERROR log noise)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,7 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-15 (against `main` @ `9594a4d94`).
+> Last refreshed: 2026-06-17 (against #3552 watcher invariant-severity TOCTOU fix — removed the racy tmux pre-save `response_sent_offset_monotonic` emit; the lock-atomic inflight save-path is the single authoritative emitter).
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the
@@ -135,7 +135,7 @@
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
     construction from the watcher-spawn handle).
-  - `src/services/discord/tmux.rs` (2057 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2058 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
     status/footer stripping in the placeholder suppression decisions;
@@ -154,6 +154,18 @@
     -1 from #3038 S4 after routing the placeholder/status-panel cluster
     through `shared.ui`; +8 from #3533 ActiveBridgeTurnGuard restart-boundary
     preserve fix (no SUPPRESSED_INTERNAL_LABEL on an already-delivered duplicate);
+    +1 from #3552 codex r2 (2057 -> 2058): the watcher pre-save
+    `response_sent_offset_monotonic` severity emit added by #3552 codex r1 was
+    REMOVED as a TOCTOU-racy duplicate — it judged WARN/ERROR against an unlocked
+    `load_inflight_state` snapshot while the immediately-following
+    `save_inflight_state` re-judges the row under its own lock and emits at the
+    correct severity atomically with the skip/persist decision. The lock-atomic
+    inflight save-path is now the single authoritative emitter of this invariant
+    (`persist_watcher_stream_progress` always reaches that save), removing the
+    `record_watcher_invariant_with_severity` / `persist_watcher_response_sent_offset_severity`
+    helpers and the `persist_watcher_stream_progress_with_authority` test seam;
+    net +1 is the replacement doc-comment. The DEBUG-only
+    `debug_assert!(monotonic_offset)` tripwire stays;
     still giant-file territory).
   - `src/services/discord/tmux_watcher.rs` (6923 production lines; +1 from #3534
     gating the post-terminal-success continuation flush on

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -296,7 +296,18 @@
 # entry). Lowers 2585 -> 1980 (actual post-split prod LoC). The status-panel
 # guards stay in root: their compare-and-clear still needs the file-private
 # load/persist-under-lock internals, so they cannot move cleanly yet.
-"src/services/discord/inflight.rs" = 1980
+# #3552: +55 (1980 -> 2035) for the severity-aware invariant recorder
+# (`record_inflight_invariant_with_severity` + `offset_monotonic_invariant_severity`
+# pure helper + doc) on the save path. When the #3416 enforce guard will skip a
+# backward inflight write (offset preserved, zero data loss) the paired
+# offset-monotonic invariant is recorded at WARN instead of ERROR, killing the
+# duplicate ERROR-log noise; the ERROR severity is preserved for the persist path.
+# This save-path emit is the SINGLE lock-atomic authority for the
+# response_sent_offset_monotonic invariant (codex r2): it re-validates the row
+# under its own lock and emits at the correct severity atomically with the
+# skip/persist decision, so the tmux watcher pre-save emit was removed as a
+# race-prone duplicate (`offset_monotonic_invariant_severity` stays private).
+"src/services/discord/inflight.rs" = 2035
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).
@@ -309,7 +320,21 @@
 # notify-outbox subsystem — build/enqueue/reconcile/parse/rollback).
 # suppressed-label noise, user report 2026-06-12: +38 for provider-aware
 # status/footer stripping in the placeholder suppression decisions.
-"src/services/discord/tmux.rs" = 2057
+# #3552 (codex r2): +1 (2057 -> 2058) — the racy pre-save
+# `response_sent_offset_monotonic` severity emit added in #3552 codex r1 is
+# REMOVED. It computed WARN/ERROR against an unlocked `load_inflight_state`
+# snapshot, but the immediately-following `save_inflight_state` re-judges the row
+# under its own lock; a concurrent clear/fresh-row between them could make the
+# tmux emit WARN while the save actually persists a stale backward write (a
+# WARN-only-when-skipped breach hidden). `persist_watcher_stream_progress` always
+# reaches that save (no early return after the check), so the lock-atomic
+# save-path emit is the single authoritative source — the tmux emit was a pure
+# duplicate. Dropping it also removes `record_watcher_invariant_with_severity`,
+# `persist_watcher_response_sent_offset_severity`, and the
+# `persist_watcher_stream_progress_with_authority` test seam; net +1 vs base is a
+# replacement doc-comment explaining the delegation. The DEBUG-only
+# `debug_assert!(monotonic_offset)` tripwire stays (production no-op).
+"src/services/discord/tmux.rs" = 2058
 # completion_guard.rs decomposed in #3479 (1834 -> 872 prod LoC); dropped below
 # the giant threshold, so its ratchet baseline is retired (no longer tracked).
 # #3034 batch-8: lowered 1781 -> 1753 (deleted the dead `assistant_turns` turn-cap

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -40,6 +40,8 @@ use super::InflightRestartMode;
 use super::runtime_store::{atomic_write, discord_inflight_root};
 use crate::dispatch::Source;
 use crate::services::agent_protocol::{RuntimeHandoffKind, TaskNotificationKind};
+// #3552: short alias for the invariant-severity hint forwarded to observability.
+use crate::services::observability::InvariantSeverity as ObsSeverity;
 use crate::services::provider::ProviderKind;
 
 // #2235 (follow-up to #2213): bump v7→v8. v7 added `runtime_kind` without a
@@ -211,8 +213,44 @@ fn record_inflight_invariant(
     message: &'static str,
     details: serde_json::Value,
 ) -> bool {
+    record_inflight_invariant_with_severity(
+        condition,
+        state,
+        invariant,
+        code_location,
+        message,
+        details,
+        ObsSeverity::Error,
+    )
+}
+
+/// #3552 (pure, testable): the offset-monotonic invariants on the save path are
+/// paired with the #3416 enforce guard. When that guard will SKIP the backward
+/// write (`enforce_skips_backward_write`), the violation is already safely
+/// handled (offset preserved, zero data loss) → record at WARN so the paired
+/// `#3416 enforce` WARN is the only operator log and the duplicate ERROR noise
+/// (~17/day) disappears. Otherwise the backward write persists → ERROR (a
+/// genuine breach). The structured analytics event is identical either way.
+fn offset_monotonic_invariant_severity(enforce_skips_backward_write: bool) -> ObsSeverity {
+    if enforce_skips_backward_write {
+        ObsSeverity::Warn
+    } else {
+        ObsSeverity::Error
+    }
+}
+
+/// #3552: severity-aware variant of `record_inflight_invariant`.
+fn record_inflight_invariant_with_severity(
+    condition: bool,
+    state: &InflightTurnState,
+    invariant: &'static str,
+    code_location: &'static str,
+    message: &'static str,
+    details: serde_json::Value,
+    severity: ObsSeverity,
+) -> bool {
     let turn_id = turn_id_for_state(state);
-    crate::services::observability::record_invariant_check(
+    crate::services::observability::record_invariant_check_with_severity(
         condition,
         crate::services::observability::InvariantViolation {
             provider: Some(state.provider.as_str()),
@@ -225,6 +263,7 @@ fn record_inflight_invariant(
             message,
             details,
         },
+        severity,
     )
 }
 
@@ -272,7 +311,33 @@ fn validate_inflight_state_for_save(
         && existing.turn_start_offset == state.turn_start_offset;
     let monotonic_offset =
         !same_turn_identity || state.response_sent_offset >= existing.response_sent_offset;
-    record_inflight_invariant(
+    // I6 (last_offset_monotonic) — OBSERVE-ONLY on the bridge/watcher save
+    // path. A legit fresh-turn reset (different user_msg_id or
+    // turn_start_offset) lowers last_offset on purpose, so the check is gated
+    // by SAME turn identity; only a backward move within the same turn is a
+    // violation. We do not skip the write here (that would drop a legit fresh
+    // turn); the enforcing variant lives in the standby/refresh path.
+    let last_offset_monotonic = !same_turn_identity || state.last_offset >= existing.last_offset;
+
+    // #3552: when the #3416 enforce guard (below) will SKIP this backward write
+    // and preserve the offset (zero data loss), the offset-monotonic violation
+    // has already been safely handled — record it at WARN instead of ERROR so
+    // the paired `#3416 enforce` WARN is the only operator-facing log, killing
+    // the duplicate ERROR-log noise. When enforce is OFF the backward write
+    // actually persists below, so the violation stays ERROR (a genuine breach).
+    // Computed BEFORE the records so the severity is correct; the enforce branch
+    // itself (skip + return false) is unchanged.
+    use crate::services::discord::outbound::delivery_record as dr;
+    let authority = dr::delivery_record_authority_enabled();
+    let enforce_skips_backward_write = dr::authority_blocks_backward_inflight_write(
+        authority,
+        monotonic_offset,
+        last_offset_monotonic,
+    );
+    let offset_monotonic_severity =
+        offset_monotonic_invariant_severity(enforce_skips_backward_write);
+
+    record_inflight_invariant_with_severity(
         monotonic_offset,
         state,
         "response_sent_offset_monotonic",
@@ -284,20 +349,14 @@ fn validate_inflight_state_for_save(
             "same_turn_identity": same_turn_identity,
             "path": path.display().to_string(),
         }),
+        offset_monotonic_severity,
     );
     debug_assert!(
         monotonic_offset,
         "inflight response_sent_offset must not move backwards for the same turn identity"
     );
 
-    // I6 (last_offset_monotonic) — OBSERVE-ONLY on the bridge/watcher save
-    // path. A legit fresh-turn reset (different user_msg_id or
-    // turn_start_offset) lowers last_offset on purpose, so the check is gated
-    // by SAME turn identity; only a backward move within the same turn is a
-    // violation. We do not skip the write here (that would drop a legit fresh
-    // turn); the enforcing variant lives in the standby/refresh path.
-    let last_offset_monotonic = !same_turn_identity || state.last_offset >= existing.last_offset;
-    record_inflight_invariant(
+    record_inflight_invariant_with_severity(
         last_offset_monotonic,
         state,
         "last_offset_monotonic",
@@ -309,6 +368,7 @@ fn validate_inflight_state_for_save(
             "same_turn_identity": same_turn_identity,
             "path": path.display().to_string(),
         }),
+        offset_monotonic_severity,
     );
     debug_assert!(
         last_offset_monotonic,
@@ -334,14 +394,9 @@ fn validate_inflight_state_for_save(
 
     // #3416 (#3089 B3): observe→ENFORCE under the durable-authority flag (no-op
     // when OFF); see dr::authority_blocks_backward_inflight_write. The violation
-    // itself was already recorded by the monotonic record_inflight_invariant above.
-    use crate::services::discord::outbound::delivery_record as dr;
-    let authority = dr::delivery_record_authority_enabled();
-    if dr::authority_blocks_backward_inflight_write(
-        authority,
-        monotonic_offset,
-        last_offset_monotonic,
-    ) {
+    // itself was already recorded by the monotonic record_inflight_invariant
+    // above (downgraded to WARN for this skipped-write case — see #3552).
+    if enforce_skips_backward_write {
         tracing::warn!(
             "#3416 enforce: skipped backward inflight write at {}",
             path.display()
@@ -1989,6 +2044,7 @@ mod stall_recovery_tests {
         clear_inflight_state_if_matches_zero_owned_in_root, clear_status_panel_if_current_in_root,
         inflight_state_allows_idle_tmux_repair_state, inflight_state_is_stale, inflight_state_path,
         load_inflight_states_from_root, lock_inflight_state_path, normalize_response_sent_offset,
+        offset_monotonic_invariant_severity,
         refresh_inflight_last_offset_if_matches_identity_in_root,
         save_inflight_state_if_matches_identity_in_root, save_inflight_state_in_root,
         validate_inflight_state_for_save,
@@ -3652,6 +3708,22 @@ mod stall_recovery_tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].user_msg_id, 101);
         assert_eq!(loaded[0].last_offset, 10);
+    }
+
+    #[test]
+    fn offset_monotonic_severity_downgrades_only_when_enforce_skips() {
+        use crate::services::observability::InvariantSeverity;
+        // #3552: when the #3416 enforce guard will skip the backward write the
+        // violation is already handled → WARN (no ERROR noise). When it will NOT
+        // skip (enforce OFF → write persists) it stays ERROR (a genuine breach).
+        assert_eq!(
+            offset_monotonic_invariant_severity(true),
+            InvariantSeverity::Warn
+        );
+        assert_eq!(
+            offset_monotonic_invariant_severity(false),
+            InvariantSeverity::Error
+        );
     }
 
     #[test]

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2393,19 +2393,20 @@ fn persist_watcher_stream_progress(
     let normalized_response_sent_offset =
         normalize_response_sent_offset(full_response, response_sent_offset);
     let monotonic_offset = normalized_response_sent_offset >= inflight.response_sent_offset;
-    record_watcher_invariant(
-        monotonic_offset,
-        Some(provider),
-        channel_id,
-        "response_sent_offset_monotonic",
-        "src/services/discord/tmux.rs:persist_watcher_stream_progress",
-        "watcher response_sent_offset must not move backwards",
-        serde_json::json!({
-            "previous": inflight.response_sent_offset,
-            "next": normalized_response_sent_offset,
-            "tmux_session_name": tmux_session_name,
-        }),
-    );
+    // #3552 (codex r2): the `response_sent_offset_monotonic` invariant for this
+    // backward write is NOT emitted here. This load↔save is unlocked, so a
+    // severity computed against `inflight` (loaded above) can race a concurrent
+    // path that clears the row or stores a fresh-turn row B before the
+    // `save_inflight_state` below re-reads it under its lock — which would make
+    // this emit WARN ("#3416 will skip") while the save actually persists the
+    // stale write (WARN-only-when-skipped violation that hides a real breach).
+    // `save_inflight_state` re-validates the SAME row inside its lock and emits
+    // `response_sent_offset_monotonic` at the correct severity atomically with
+    // the skip/persist decision (WARN iff #3416 skips, ERROR iff it persists),
+    // and this function always reaches that save (no early return after this
+    // point), so the save path is the single authoritative emitter and the tmux
+    // pre-save emit would be a pure, race-prone duplicate. The DEBUG-only
+    // tripwire below stays as a local safety net (production no-op).
     debug_assert!(
         monotonic_offset,
         "watcher response_sent_offset must not move backwards"

--- a/src/services/observability/emit.rs
+++ b/src/services/observability/emit.rs
@@ -248,22 +248,58 @@ pub(super) fn emit_relay_root_cause_counter(provider: &str, channel_id: u64, cou
 }
 
 pub fn record_invariant_check(condition: bool, violation: InvariantViolation<'_>) -> bool {
+    record_invariant_check_with_severity(condition, violation, InvariantSeverity::Error)
+}
+
+/// #3552: severity for a recorded invariant violation. `Error` is the default
+/// (ERROR-level tracing log) used by every breach that actually persists bad
+/// state. `Warn` is used ONLY when a downstream guard has *already handled* the
+/// condition (e.g. the #3416 enforce path skips the backward inflight write and
+/// preserves the offset → zero data loss), so an ERROR is inappropriate noise.
+/// The structured `invariant_violation` analytics event (incl. `guard_fires`)
+/// is emitted identically in both cases — only the tracing log level changes —
+/// so dashboards/PG analytics keep full visibility while the operator-facing
+/// ERROR log stays clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvariantSeverity {
+    Error,
+    Warn,
+}
+
+pub fn record_invariant_check_with_severity(
+    condition: bool,
+    violation: InvariantViolation<'_>,
+    severity: InvariantSeverity,
+) -> bool {
     if condition {
         return true;
     }
 
     let invariant = normalize_string(violation.invariant).unwrap_or_else(|| "unknown".to_string());
-    tracing::error!(
-        invariant = %invariant,
-        provider = violation.provider.unwrap_or_default(),
-        channel_id = violation.channel_id.unwrap_or_default(),
-        dispatch_id = violation.dispatch_id.unwrap_or_default(),
-        session_key = violation.session_key.unwrap_or_default(),
-        turn_id = violation.turn_id.unwrap_or_default(),
-        code_location = violation.code_location,
-        "[invariant] {}",
-        violation.message
-    );
+    match severity {
+        InvariantSeverity::Error => tracing::error!(
+            invariant = %invariant,
+            provider = violation.provider.unwrap_or_default(),
+            channel_id = violation.channel_id.unwrap_or_default(),
+            dispatch_id = violation.dispatch_id.unwrap_or_default(),
+            session_key = violation.session_key.unwrap_or_default(),
+            turn_id = violation.turn_id.unwrap_or_default(),
+            code_location = violation.code_location,
+            "[invariant] {}",
+            violation.message
+        ),
+        InvariantSeverity::Warn => tracing::warn!(
+            invariant = %invariant,
+            provider = violation.provider.unwrap_or_default(),
+            channel_id = violation.channel_id.unwrap_or_default(),
+            dispatch_id = violation.dispatch_id.unwrap_or_default(),
+            session_key = violation.session_key.unwrap_or_default(),
+            turn_id = violation.turn_id.unwrap_or_default(),
+            code_location = violation.code_location,
+            "[invariant] {} (handled by downstream guard — downgraded to WARN)",
+            violation.message
+        ),
+    }
 
     emit_event(
         "invariant_violation",
@@ -710,6 +746,88 @@ mod tests {
         assert_eq!(quality.payload["dispatch_id"], "dispatch-quality");
         assert_eq!(quality.payload["source_event_id"], "turn-quality");
         assert_eq!(quality.payload["status"], "review_pass");
+    }
+
+    #[test]
+    fn warn_severity_invariant_still_emits_event_without_error_level() {
+        // #3552: a violation downgraded to WARN (because a downstream guard
+        // already handled it) must keep full structured-event visibility — the
+        // analytics `invariant_violation` event (incl. guard_fires) is identical
+        // to the ERROR case; only the tracing log LEVEL changes. The recorder
+        // still returns `false` (violation observed), so callers/debug_asserts
+        // behave exactly as before.
+        let _guard = super::super::test_runtime_lock();
+        super::super::reset_for_tests();
+
+        // Holds true regardless of severity → no event recorded.
+        assert!(record_invariant_check_with_severity(
+            true,
+            InvariantViolation {
+                provider: Some("Codex"),
+                channel_id: Some(7),
+                dispatch_id: None,
+                session_key: None,
+                turn_id: None,
+                invariant: "last_offset_monotonic",
+                code_location: "src/services/observability/emit.rs:test",
+                message: "should not fire",
+                details: json!({}),
+            },
+            InvariantSeverity::Warn,
+        ));
+
+        // Violation downgraded to WARN → returns false AND records the event.
+        assert!(!record_invariant_check_with_severity(
+            false,
+            InvariantViolation {
+                provider: Some("Codex"),
+                channel_id: Some(7),
+                dispatch_id: None,
+                session_key: None,
+                turn_id: None,
+                invariant: "last_offset_monotonic",
+                code_location: "src/services/observability/emit.rs:test",
+                message: "handled-by-guard violation",
+                details: json!({"downgraded": true}),
+            },
+            InvariantSeverity::Warn,
+        ));
+
+        // Isolation-robust: assert THIS test's specific WARN-downgraded event is
+        // present in the (shared, global) recent-events ring — filtered by a
+        // unique marker (`details.downgraded` + the verbatim message) — rather
+        // than demanding exactly one `invariant_violation` event ring-wide. Other
+        // tests that don't hold `test_runtime_lock()` can concurrently push their
+        // own `invariant_violation` events into the same global ring on a parallel
+        // (self-hosted) runner, which would otherwise inflate the count past 1.
+        // The analytics event is byte-for-byte identical across Error/Warn (only
+        // the tracing log LEVEL differs), so presence of this exact event — emitted
+        // despite the WARN downgrade — is what proves the test's intent.
+        let events = events::recent(50);
+        let downgraded_events: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event.event_type == "invariant_violation"
+                    && event.payload["message"] == "handled-by-guard violation"
+                    && event.payload["details"]["downgraded"] == json!(true)
+            })
+            .collect();
+        assert_eq!(
+            downgraded_events.len(),
+            1,
+            "WARN-downgraded violation must still emit exactly one analytics event for THIS test's \
+             unique marker (details.downgraded + message); other concurrent invariant_violation \
+             events in the shared ring are tolerated"
+        );
+        let downgraded_event = downgraded_events[0];
+        assert_eq!(
+            downgraded_event.payload["invariant"],
+            "last_offset_monotonic"
+        );
+        // The downgrade only changes the tracing log level; the structured event
+        // is emitted identically and carries the same provider/channel as ERROR.
+        assert_eq!(downgraded_event.provider.as_deref(), Some("codex"));
+        assert_eq!(downgraded_event.channel_id, Some(7));
     }
 
     #[test]

--- a/src/services/observability/mod.rs
+++ b/src/services/observability/mod.rs
@@ -38,10 +38,11 @@ mod worker;
 // or by downstream crates that ship outside the default build profile.
 #[allow(unused_imports)]
 pub use emit::{
-    emit_agent_quality_event, emit_dispatch_result, emit_guard_fired,
+    InvariantSeverity, emit_agent_quality_event, emit_dispatch_result, emit_guard_fired,
     emit_inflight_lifecycle_event, emit_intake_placeholder_post_failed, emit_recovery_fired,
     emit_relay_delivery, emit_turn_cancelled, emit_turn_finished_with_dispatch_kind,
     emit_turn_started, emit_watcher_replaced, record_invariant_check,
+    record_invariant_check_with_severity,
 };
 #[allow(unused_imports)]
 pub use queries::{


### PR DESCRIPTION
## #3552 — `#3416` 가드가 skip하는 backward inflight write를 monotonic invariant가 ERROR로 중복 emit하는 노이즈 제거

`#3416` enforce 가드가 안전하게 **skip하는**(offset 보존, 데이터 유실 0) backward inflight write 조건을 `last_offset_monotonic` / `response_sent_offset_monotonic` invariant가 **ERROR 레벨로 emit**해 로그 노이즈(~17건/일, monitor worktree 채널 등)를 만들었다. ERROR 카운트 인플레이션으로 진짜 ERROR가 묻히고 `/relay-scan` 감독이 매번 특수처리해야 했다.

### 변경
- **`emit.rs`**: `InvariantSeverity{Error,Warn}` enum + `record_invariant_check_with_severity`. 기존 `record_invariant_check`는 `Error`로 위임(byte-identical). **구조화 analytics 이벤트(`invariant_violation` + `invariant` 키 + guard_fires)는 동일** — 오직 tracing 로그 **LEVEL**만 달라짐.
- **`inflight.rs` save-path(`validate_inflight_state_for_save`)**: `#3416` enforce disposition(`authority_blocks_backward_inflight_write`)을 invariant 기록 **이전에** 계산해 severity로 전달. enforce가 backward write를 **skip할 것**이면 `last_offset_monotonic`/`response_sent_offset_monotonic`를 **WARN**으로, persist될 것(authority OFF)이면 **ERROR** 유지. 이 판정·emit·skip은 전부 `lock_inflight_state_path` lock 안에서 **atomic**. `inflight_tmux_one_to_one`/`response_sent_offset_in_bounds`는 ERROR 유지.
- **`tmux.rs`**: `persist_watcher_stream_progress`의 pre-save `response_sent_offset_monotonic` emit은 save-path emit과 **중복**이고 unlocked snapshot 기반이라 TOCTOU race(persist인데 WARN)를 유발했음 → **제거하고 lock-atomic save-path를 단일 권위 emit 소스로 위임**. backward write는 항상 save에 도달함을 검증. debug-only tripwire는 유지.

### 검증
- 보존: `#3416` enforce 동작(skip/return false/WARN), `#3306`, analytics 이벤트 schema/키, load-bearing event key. 로그 레벨만 변경.
- 게이트: cargo fmt/check/test(lib 3701 pass), audit_maintainability hard-gate 0(baseline 동기화), agent-maintenance freshness, await_holding_lock ratchet 34/34.
- **교차모델 적대 리뷰 codex(gpt-5.5 xhigh) 3라운드 → VERDICT: CLEAN**. (r1: tmux 누락, r2: tmux TOCTOU, r3: suppress+delegate CLEAN.)
- 수용 기준: enforce-ON same-turn backward write → ERROR 없음(`#3416` WARN + WARN invariant); enforce-OFF persist → ERROR 유지.

처리: #3552
