### PR TITLE
fix(#3563): RoutineAction 'unsupported field lastResult' 역직렬화 오류 수정

### DIFF
--- a/src/services/routines/action.rs
+++ b/src/services/routines/action.rs
@@ -27,6 +27,7 @@ pub enum RoutineAction {
         prompt: String,
         dm_user_id: Option<String>,
         checkpoint: Option<Value>,
+        last_result: Option<String>,
         next_due_at: Option<DateTime<Utc>>,
     },
 }
@@ -131,6 +132,8 @@ pub fn validate_routine_action(value: Value) -> Result<RoutineAction> {
                     "dmUserId",
                     "dm_user_id",
                     "checkpoint",
+                    "lastResult",
+                    "last_result",
                     "nextDueAt",
                     "next_due_at",
                 ],
@@ -143,6 +146,7 @@ pub fn validate_routine_action(value: Value) -> Result<RoutineAction> {
                 prompt,
                 dm_user_id: optional_discord_snowflake_alias(obj, "dmUserId", "dm_user_id")?,
                 checkpoint: optional_value(obj, "checkpoint"),
+                last_result: optional_string_alias(obj, "lastResult", "last_result")?,
                 next_due_at: optional_datetime_alias(obj, "nextDueAt", "next_due_at")?,
             })
         }
@@ -290,11 +294,13 @@ mod tests {
                 prompt,
                 dm_user_id,
                 checkpoint,
+                last_result,
                 next_due_at,
             } => {
                 assert_eq!(prompt, "summarize current queue");
                 assert_eq!(dm_user_id, None);
                 assert_eq!(checkpoint, Some(json!({"cursor": 3})));
+                assert_eq!(last_result, None);
                 assert!(next_due_at.is_some());
             }
             other => panic!("unexpected action: {other:?}"),
@@ -302,6 +308,35 @@ mod tests {
 
         let err = RoutineAction::validate(json!({"action": "agent", "prompt": "   "})).unwrap_err();
         assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn validates_agent_action_with_last_result() {
+        // Regression for #3563: dispatch-label routines (e.g.
+        // dependency-update-watcher) return `{action:"agent", ...,
+        // lastResult:"...dispatched"}`. Both the camelCase and snake_case
+        // spellings must validate into RoutineAction::Agent rather than being
+        // rejected by reject_unknown_keys (which previously persisted the
+        // rejection error as last_result via fail_run, surfacing in GET
+        // /api/routines).
+        for key in ["lastResult", "last_result"] {
+            let action = RoutineAction::validate(json!({
+                "action": "agent",
+                "prompt": "run dependency update check",
+                key: "dependency update check dispatched"
+            }))
+            .unwrap();
+            match action {
+                RoutineAction::Agent { last_result, .. } => {
+                    assert_eq!(
+                        last_result.as_deref(),
+                        Some("dependency update check dispatched"),
+                        "{key} alias must populate last_result"
+                    );
+                }
+                other => panic!("unexpected action: {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -94,6 +94,7 @@ impl RoutineAgentExecutor {
         prompt: String,
         dm_user_id: Option<String>,
         checkpoint: Option<Value>,
+        last_result: Option<String>,
         next_due_at: Option<DateTime<Utc>>,
     ) -> Result<RoutineRunOutcome> {
         let action = "agent".to_string();
@@ -127,13 +128,18 @@ impl RoutineAgentExecutor {
                 fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
             }),
             Ok(started) => {
-                let last_result = "headless command consumed without starting an agent turn";
+                // Prefer the dispatch label the routine script returned (e.g.
+                // "dependency update check dispatched"); fall back to the
+                // generic message only when the script omitted lastResult.
+                let consumed_last_result = last_result
+                    .as_deref()
+                    .unwrap_or("headless command consumed without starting an agent turn");
                 let closed = store
                     .complete_agent_run(
                         &claimed.run_id,
                         Some(started.result_json.clone()),
                         checkpoint,
-                        Some(last_result),
+                        Some(consumed_last_result),
                         match next_due_at {
                             Some(value) => NextDueAtUpdate::Set(value),
                             None => NextDueAtUpdate::Preserve,
@@ -165,6 +171,7 @@ impl RoutineAgentExecutor {
                     prompt,
                     dm_user_id,
                     checkpoint,
+                    last_result,
                     next_due_at,
                     &agent_id,
                     "primary",
@@ -183,6 +190,7 @@ impl RoutineAgentExecutor {
         prompt: String,
         dm_user_id: Option<String>,
         checkpoint: Option<Value>,
+        last_result: Option<String>,
         next_due_at: Option<DateTime<Utc>>,
         failed_agent_id: &str,
         attempt_kind: &str,
@@ -261,14 +269,19 @@ impl RoutineAgentExecutor {
                         });
                     }
                     Ok(started) => {
-                        let last_result =
-                            "fallback headless command consumed without starting an agent turn";
+                        // Preserve the routine's dispatch label across the
+                        // fallback path too; only the agent that never started
+                        // a turn reaches here, so the script's lastResult is
+                        // still the most meaningful summary.
+                        let consumed_last_result = last_result.as_deref().unwrap_or(
+                            "fallback headless command consumed without starting an agent turn",
+                        );
                         let closed = store
                             .complete_agent_run(
                                 &claimed.run_id,
                                 Some(started.result_json.clone()),
                                 checkpoint,
-                                Some(last_result),
+                                Some(consumed_last_result),
                                 match next_due_at {
                                     Some(value) => NextDueAtUpdate::Set(value),
                                     None => NextDueAtUpdate::Preserve,

--- a/src/services/routines/runtime.rs
+++ b/src/services/routines/runtime.rs
@@ -727,6 +727,7 @@ async fn close_action(
             prompt,
             dm_user_id,
             checkpoint,
+            last_result,
             next_due_at,
         } => {
             let Some(agent_executor) = agent_executor else {
@@ -753,7 +754,15 @@ async fn close_action(
                 }));
             };
             agent_executor
-                .start_agent_run(store, claimed, prompt, dm_user_id, checkpoint, next_due_at)
+                .start_agent_run(
+                    store,
+                    claimed,
+                    prompt,
+                    dm_user_id,
+                    checkpoint,
+                    last_result,
+                    next_due_at,
+                )
                 .await
                 .map(Some)
         }
@@ -992,6 +1001,7 @@ mod tests {
         let action = RoutineAction::Agent {
             prompt: "# 자동화 후보 추천\n패턴: api-friction".to_string(),
             dm_user_id: None,
+            last_result: None,
             checkpoint: Some(json!({
                 "recommendations": [{
                     "decision_summary": "선택 이유: api-friction 후보가 기준을 충족했습니다.",


### PR DESCRIPTION
## 문제
`GET /api/routines`에서 dependency-update-watcher `last_result="unsupported RoutineAction field 'lastResult'"` — RoutineAction 역직렬화가 lastResult 필드를 거부해 루틴 실행 실패.

## 변경
RoutineAction 역직렬화/실행 경로 수정 (action.rs / runtime.rs / agent_executor.rs).

## 검증
- cargo fmt/check/test --lib 통과, agent-maintenance freshness passed.
- Codex(gpt-5.5, xhigh) 적대 리뷰: **VERDICT: CLEAN**.

Closes via comment. (audit:2026-06-18)