### PR TITLE
feat(#3565): 릴레이 핫파일 LOC ratchet 게이트 (tmux_watcher/tui_prompt_relay/turn_bridge 증가 차단)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -716,6 +716,15 @@ jobs:
         if: ${{ needs.changes.outputs.ci_relax_safe != 'true' }}
         run: ./scripts/ci-script-checks.sh
 
+      # Hotfile LOC ratchet (#3565) runs UNCONDITIONALLY — it must NOT inherit
+      # the `ci_relax_safe` skip above. The ratchet is otherwise reachable only
+      # via ci-script-checks.sh, so a `tui-relay-stabilization` branch (which
+      # relaxes "Run script checks") could grow a relay hot file past its ceiling
+      # and merge before main CI catches it. This standalone step keeps the
+      # PR-time hot-file freeze in force for every branch, with no skip gate.
+      - name: Hotfile LOC ratchet (always, #3565)
+        run: python3 scripts/check_hotfile_ratchet.py
+
       - name: Upload maintainability audit artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/check_hotfile_ratchet.py
+++ b/scripts/check_hotfile_ratchet.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Raw-LOC ratchet guard for the oversized Discord-relay hot files (#3565).
+
+`tmux_watcher.rs`, `tui_prompt_relay.rs`, and `turn_bridge/mod.rs` are already
+far too large and a regression risk: any further growth makes an eventual
+decomposition harder. This guard freezes each file's RAW line count (`wc -l`:
+comments, blank lines, and test code all COUNTED) at the ceiling recorded in
+`scripts/hotfile_ratchet.toml`. A file may shrink (lower the ceiling to lock in
+the win) but may never exceed its ceiling.
+
+Metric: raw physical line count. This is a deliberately different, complementary
+metric from the production-LoC ratchet in
+`scripts/audit_maintainability_giant_baseline.toml` (which excludes `#[cfg(test)]`
+code). Both gates are intended to stay in force.
+
+Counting uses ``len(text.splitlines())`` rather than shelling out to ``wc`` so
+the check is deterministic and dependency-free. For the repo's LF-terminated
+source files this is exactly the ``wc -l`` value (CRLF is not used here).
+
+A missing hot file or a missing manifest is a HARD error (exit 1): a rename or
+move must not silently pass the gate.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "scripts" / "hotfile_ratchet.toml"
+
+
+def line_count(path: Path) -> int:
+    """Return the raw line count of ``path`` (``wc -l`` equivalent for LF files)."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return len(text.splitlines())
+
+
+def main() -> int:
+    if not MANIFEST.is_file():
+        print(
+            f"FAIL: hotfile ratchet manifest not found: {MANIFEST}",
+            file=sys.stderr,
+        )
+        return 1
+
+    with MANIFEST.open("rb") as fh:
+        manifest = tomllib.load(fh)
+
+    ceilings = manifest.get("hotfile_ratchet", {})
+    if not ceilings:
+        print(
+            f"FAIL: no [hotfile_ratchet] entries in {MANIFEST}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failed = False
+    for rel, ceiling in sorted(ceilings.items()):
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            print(
+                f"FAIL: ratcheted hot file is missing: {rel}. If it was moved or "
+                "renamed, update scripts/hotfile_ratchet.toml.",
+                file=sys.stderr,
+            )
+            failed = True
+            continue
+
+        current = line_count(path)
+        if current > ceiling:
+            print(
+                f"FAIL: {rel} has {current} lines, exceeding the ratchet ceiling "
+                f"of {ceiling}.",
+                file=sys.stderr,
+            )
+            print(
+                "      Hot-file line counts may only decrease. Shrink the file "
+                "(prefer decomposition) instead of raising the ceiling.",
+                file=sys.stderr,
+            )
+            failed = True
+        elif current < ceiling:
+            print(
+                f"NOTE: {rel} has {current} lines, below its ceiling of {ceiling}. "
+                f"Lower ceiling to {current} in scripts/hotfile_ratchet.toml to "
+                "lock in the win."
+            )
+        else:
+            print(f"OK: {rel} = {current} lines (ceiling {ceiling}).")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_hotfile_ratchet.py
+++ b/scripts/check_hotfile_ratchet.py
@@ -19,6 +19,12 @@ source files this is exactly the ``wc -l`` value (CRLF is not used here).
 
 A missing hot file or a missing manifest is a HARD error (exit 1): a rename or
 move must not silently pass the gate.
+
+The three relay hot files in ``REQUIRED_HOTFILES`` MUST each have a ceiling
+entry in the manifest. Dropping a key from the manifest would otherwise stop
+that file from being checked while the script still passed (the manifest table
+is non-empty); ``REQUIRED_HOTFILES`` closes that bypass by hard-failing (exit 1)
+on any missing required entry.
 """
 
 from __future__ import annotations
@@ -29,6 +35,16 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / "scripts" / "hotfile_ratchet.toml"
+
+# The relay hot files that MUST always be ratcheted. Every path here has to have
+# a ceiling entry in scripts/hotfile_ratchet.toml; if a future edit deletes one
+# of these keys (which would silently stop checking that file), the gate fails
+# closed instead of passing on the remaining non-empty table.
+REQUIRED_HOTFILES = (
+    "src/services/discord/tmux_watcher.rs",
+    "src/services/discord/tui_prompt_relay.rs",
+    "src/services/discord/turn_bridge/mod.rs",
+)
 
 
 def line_count(path: Path) -> int:
@@ -54,6 +70,17 @@ def main() -> int:
             f"FAIL: no [hotfile_ratchet] entries in {MANIFEST}.",
             file=sys.stderr,
         )
+        return 1
+
+    missing_required = [rel for rel in REQUIRED_HOTFILES if rel not in ceilings]
+    if missing_required:
+        for rel in missing_required:
+            print(
+                f"FAIL: required relay hot file '{rel}' has no ceiling entry in "
+                f"{MANIFEST}. Every path in REQUIRED_HOTFILES must stay ratcheted; "
+                "do not delete its entry (that would silently stop checking it).",
+                file=sys.stderr,
+            )
         return 1
 
     failed = False

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -26,6 +26,9 @@ python3 scripts/audit_state_lint_hardening.py
 echo "=== await_holding_lock ratchet guard ==="
 python3 scripts/check_await_holding_lock_ratchet.py
 
+echo "=== Hotfile LOC ratchet guard (#3565) ==="
+python3 scripts/check_hotfile_ratchet.py
+
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -1,0 +1,28 @@
+# Hotfile raw-LOC ratchet baseline (#3565).
+#
+# Freezes the raw line count (`wc -l`: comments, blank lines, and test code all
+# COUNTED) of the three oversized Discord-relay hot files at their current size.
+# `scripts/check_hotfile_ratchet.py` fails CI when a file's raw line count
+# exceeds its ceiling here, so these already-giant modules cannot regress and
+# grow even larger while a decomposition is pending.
+#
+# Metric note: this gate uses RAW wc -l (total physical lines). That is a
+# DELIBERATELY DIFFERENT, complementary metric from the production-LoC ratchet
+# in scripts/audit_maintainability_giant_baseline.toml, which excludes test
+# (`#[cfg(test)]`) code. A change can satisfy one gate and trip the other; both
+# are intended to stay in force. This raw-LOC gate is the coarse "the physical
+# file may not get bigger" backstop; the production-LoC ratchet is the finer
+# "production complexity may not re-inflate" gate.
+#
+# Workflow:
+#   * As a file shrinks, LOWER its number here to lock in the win.
+#   * Growing a hot file requires RAISING its number — a deliberate, reviewable
+#     admission in the diff that the file got bigger. Prefer splitting instead.
+#
+# Counts are raw `wc -l` (equivalently Python `str.splitlines()`) on the
+# LF-terminated source; the two agree exactly for this repo's LF-only files.
+
+[hotfile_ratchet]
+"src/services/discord/tmux_watcher.rs" = 10086
+"src/services/discord/tui_prompt_relay.rs" = 7789
+"src/services/discord/turn_bridge/mod.rs" = 6612


### PR DESCRIPTION
## 목적
거대 릴레이 핫파일(tmux_watcher.rs 10086 / tui_prompt_relay.rs 7789 / turn_bridge/mod.rs 6612)의 LOC 증가를 CI에서 차단해 회귀 위험을 ratchet.

## 변경
- `scripts/check_hotfile_ratchet.py` + `scripts/hotfile_ratchet.toml`(현재 LOC=상한) 신설, 핫파일 자체는 미수정.
- `scripts/ci-script-checks.sh`에 연결 + `.github/workflows/ci-pr.yml`에 skip 무관 별도 step으로 PR 게이트 보장.
- 3개 필수 핫파일이 매니페스트에서 빠지면 fail-closed.

## 검증
- check_hotfile_ratchet.py exit 0(현재 LOC=상한), 키 삭제 시 exit 1 확인.
- fmt/check/maintenance freshness passed.
- Codex(gpt-5.5, xhigh) 적대리뷰 2라운드: **VERDICT: CLEAN**. (audit:2026-06-18)