### PR TITLE
fix(#3562): recovery_fired에 turn_id + agent_id 기록 — 복구 트리거 역추적성

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -894,7 +894,12 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3276 lines; the #3479 SPC-shadow
+  - `src/services/discord/recovery_engine.rs` (3329 lines; +53 from #3562 threading
+    the recovered-turn identity (`recovered_transcript_turn_id` full-path call) +
+    channel-bound `agent_id` (`resolve_role_binding(...).role_id`) through the
+    `emit_recovery_fired` / `emit_recovery_quality_event` recovery observability
+    pair at all three production fire sites so events back-trace which agent/turn
+    triggered the recovery; the #3479 SPC-shadow
     removal deleted the dead `StatusPanelController` recovery-completion shadow
     block + `assert_recovery_completion_parity` fn + its dead test, leaving the
     legacy `completion_target` let-else and `complete_status_panel_v2_with_http`

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -230,7 +230,10 @@
 # #3479 SPC-shadow removal: lowered 3330 -> 3276 (deleted the dead StatusPanelController
 # recovery-completion shadow block + assert_recovery_completion_parity fn + its dead test;
 # legacy completion_target let-else and complete_status_panel_v2_with_http IO unchanged).
-"src/services/discord/recovery_engine.rs" = 3276
+# #3562: +53 (3276 -> 3329) for recovery_fired/agent_quality_event turn_id+agent_id
+# traceability — turn_id (recovered_transcript_turn_id) and agent_id (resolve_role_binding)
+# derivation at the 3 recovery emit sites + helper signature widening; no logic change.
+"src/services/discord/recovery_engine.rs" = 3329
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -280,17 +280,24 @@ fn emit_recovery_quality_event(
     channel_id: u64,
     dispatch_id: Option<&str>,
     session_key: Option<&str>,
+    turn_id: Option<&str>,
+    agent_id: Option<&str>,
     reason: &str,
 ) {
     crate::services::observability::emit_agent_quality_event(
         crate::services::observability::AgentQualityEvent {
-            source_event_id: session_key
+            // #3562: prefer the turn_id as the source_event_id so this quality
+            // row joins back to turn_started/turn_finished on the same standard
+            // key (turn_analytics keys source_event_id = turn_id). Fall back to
+            // the legacy session_key → dispatch_id chain when no turn_id exists.
+            source_event_id: turn_id
                 .map(str::to_string)
+                .or_else(|| session_key.map(str::to_string))
                 .or_else(|| dispatch_id.map(str::to_string)),
             correlation_id: dispatch_id
                 .map(str::to_string)
                 .or_else(|| session_key.map(str::to_string)),
-            agent_id: None,
+            agent_id: agent_id.map(str::to_string),
             provider: Some(provider.as_str().to_string()),
             channel_id: Some(channel_id.to_string()),
             card_id: None,
@@ -299,6 +306,7 @@ fn emit_recovery_quality_event(
             payload: serde_json::json!({
                 "reason": reason,
                 "session_key": session_key,
+                "turn_id": turn_id,
             }),
         },
     );
@@ -1240,27 +1248,41 @@ pub(super) async fn restore_inflight_turns(
         );
         let restart_report_exists =
             super::restart_report::load_restart_report(provider, state.channel_id).is_some();
+        // #3562: derive the turn identity and agent role so the recovery_fired
+        // observability events back-trace to a specific agent/turn. `turn_id`
+        // matches the recovered-transcript key (joins turn_started/turn_finished
+        // for message-bearing turns); `agent_id` is the role bound to the channel.
+        let recovery_turn_id = self::analytics_transcript::recovered_transcript_turn_id(
+            state.channel_id,
+            state.user_msg_id,
+            state.session_key.as_deref(),
+            state.turn_start_offset,
+            &state.started_at,
+        );
+        let recovery_agent_id =
+            resolve_role_binding(channel_id, state.channel_name.as_deref()).map(|b| b.role_id);
+        let recovery_reason = if restart_report_exists {
+            "restart_report"
+        } else {
+            "restore_inflight"
+        };
         crate::services::observability::emit_recovery_fired(
             provider.as_str(),
             state.channel_id,
             state.dispatch_id.as_deref(),
             state.session_key.as_deref(),
-            if restart_report_exists {
-                "restart_report"
-            } else {
-                "restore_inflight"
-            },
+            Some(recovery_turn_id.as_str()),
+            recovery_agent_id.as_deref(),
+            recovery_reason,
         );
         emit_recovery_quality_event(
             provider,
             state.channel_id,
             state.dispatch_id.as_deref(),
             state.session_key.as_deref(),
-            if restart_report_exists {
-                "restart_report"
-            } else {
-                "restore_inflight"
-            },
+            Some(recovery_turn_id.as_str()),
+            recovery_agent_id.as_deref(),
+            recovery_reason,
         );
 
         // No generation gate — adopt mode allows old-gen session recovery. If a
@@ -2750,11 +2772,25 @@ pub(super) async fn restore_inflight_turns(
                             .or_else(|| parse_dispatch_id(&state.user_text));
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::error!("  [{ts}] {error}; main-workspace fallback blocked");
+                        // #3562: back-trace the recovery to a specific agent/turn.
+                        let recovery_turn_id =
+                            self::analytics_transcript::recovered_transcript_turn_id(
+                                state.channel_id,
+                                state.user_msg_id,
+                                state.session_key.as_deref(),
+                                state.turn_start_offset,
+                                &state.started_at,
+                            );
+                        let recovery_agent_id =
+                            resolve_role_binding(channel_id, state.channel_name.as_deref())
+                                .map(|b| b.role_id);
                         crate::services::observability::emit_recovery_fired(
                             provider.as_str(),
                             state.channel_id,
                             dispatch_id.as_deref(),
                             state.session_key.as_deref(),
+                            Some(recovery_turn_id.as_str()),
+                            recovery_agent_id.as_deref(),
                             "worktree_missing_main_fallback_blocked",
                         );
                         emit_recovery_quality_event(
@@ -2762,6 +2798,8 @@ pub(super) async fn restore_inflight_turns(
                             state.channel_id,
                             dispatch_id.as_deref(),
                             state.session_key.as_deref(),
+                            Some(recovery_turn_id.as_str()),
+                            recovery_agent_id.as_deref(),
                             "worktree_missing_main_fallback_blocked",
                         );
                         let relay_ok = relay_recovered_terminal_text_to_placeholder(
@@ -2981,11 +3019,24 @@ pub(super) async fn restore_inflight_turns(
                     .or_else(|| parse_dispatch_id(&state.user_text));
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::error!("  [{ts}] {error}; main-workspace fallback blocked");
+                // #3562: back-trace the recovery to a specific agent/turn.
+                let recovery_turn_id = self::analytics_transcript::recovered_transcript_turn_id(
+                    state.channel_id,
+                    state.user_msg_id,
+                    state.session_key.as_deref(),
+                    state.turn_start_offset,
+                    &state.started_at,
+                );
+                let recovery_agent_id =
+                    resolve_role_binding(channel_id, state.channel_name.as_deref())
+                        .map(|b| b.role_id);
                 crate::services::observability::emit_recovery_fired(
                     provider.as_str(),
                     state.channel_id,
                     dispatch_id.as_deref(),
                     state.session_key.as_deref(),
+                    Some(recovery_turn_id.as_str()),
+                    recovery_agent_id.as_deref(),
                     "worktree_missing_main_fallback_blocked",
                 );
                 emit_recovery_quality_event(
@@ -2993,6 +3044,8 @@ pub(super) async fn restore_inflight_turns(
                     state.channel_id,
                     dispatch_id.as_deref(),
                     state.session_key.as_deref(),
+                    Some(recovery_turn_id.as_str()),
+                    recovery_agent_id.as_deref(),
                     "worktree_missing_main_fallback_blocked",
                 );
                 let relay_ok = relay_recovered_terminal_text_to_placeholder(

--- a/src/services/observability/emit.rs
+++ b/src/services/observability/emit.rs
@@ -139,15 +139,23 @@ pub fn emit_recovery_fired(
     channel_id: u64,
     dispatch_id: Option<&str>,
     session_key: Option<&str>,
+    turn_id: Option<&str>,
+    agent_id: Option<&str>,
     reason: &str,
 ) {
+    // #3562: thread the turn identity and agent role through so consumers can
+    // back-trace *which* agent/turn triggered the recovery. `turn_id` rides the
+    // dedicated correlation column (enrich_payload_with_correlation also mirrors
+    // it into payload_json for jsonl/dashboard parsers). `observability_events`
+    // has no `agent_id` column, so `agent_id` lives only in payload_json — a
+    // backward-compatible add (older rows simply omit the key).
     emit_event(
         "recovery_fired",
         Some(provider),
         Some(channel_id),
         dispatch_id,
         session_key,
-        None,
+        turn_id,
         normalize_string(reason).as_deref(),
         CounterDelta {
             recovery_fires: 1,
@@ -155,6 +163,7 @@ pub fn emit_recovery_fired(
         },
         json!({
             "reason": normalize_string(reason),
+            "agent_id": agent_id.and_then(normalize_string),
         }),
     );
 }
@@ -629,6 +638,8 @@ mod tests {
             42,
             Some("dispatch-recovery"),
             Some("session-recovery"),
+            Some("turn-recovery"),
+            Some("planner"),
             "watchdog",
         );
         emit_turn_cancelled(
@@ -746,6 +757,17 @@ mod tests {
         assert_eq!(quality.payload["dispatch_id"], "dispatch-quality");
         assert_eq!(quality.payload["source_event_id"], "turn-quality");
         assert_eq!(quality.payload["status"], "review_pass");
+
+        // #3562: recovery_fired must carry the turn identity (correlation column +
+        // mirrored into payload_json) and the agent_id (payload_json only) so
+        // consumers can back-trace which agent/turn triggered the recovery.
+        let recovery = events
+            .iter()
+            .find(|event| event.event_type == "recovery_fired")
+            .expect("recovery_fired should be in recent ring");
+        assert_eq!(recovery.payload["turn_id"], "turn-recovery");
+        assert_eq!(recovery.payload["agent_id"], "planner");
+        assert_eq!(recovery.payload["reason"], "watchdog");
     }
 
     #[test]


### PR DESCRIPTION
## 문제
`recovery_fired` 이벤트가 turn_id 없고 agent_id=null이라 어느 에이전트/턴이 복구를 유발했는지 역추적 불가 (월 195건 전량 restore_inflight).

## 변경
- `emit_recovery_fired`(emit.rs)에 turn_id/agent_id 파라미터 추가. observability_events엔 agent_id 컬럼이 없어 payload_json에 기록(하위호환), turn_id는 enrich_payload_with_correlation이 mirror.
- `emit_recovery_quality_event`(recovery_engine.rs)에 turn_id/agent_id 추가, source_event_id를 turn_id 우선으로.
- 호출처 3곳에서 `recovered_transcript_turn_id`(풀패스, cfg(test) 게이트 회피)와 `resolve_role_binding(...).role_id`로 도출.

## 검증
- fmt/check/test(emit 3 / recovery_engine 32) 통과, maintenance freshness passed. 스키마 마이그레이션 불필요(turn_id 컬럼 기존 존재).
- Codex(gpt-5.5, xhigh) 적대리뷰: **VERDICT: CLEAN**. (audit:2026-06-18)