### PR TITLE
fix(#3566): dcserver 로그 WARN 노이즈 3종 정리 (policy-hook 임계값 / Gemini oauth / repo 매핑)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -83,7 +83,7 @@
 - legacy_modules: none — there is no parallel engine. The whole surface is
   pre-migration giant-file territory.
 - do_not_edit_without_migration_plan:
-  - `src/engine/mod.rs` (1265 lines, giant-file).
+  - `src/engine/mod.rs` (1279 lines, giant-file).
   - `src/engine/ops/db_ops.rs` (1244 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
@@ -1323,9 +1323,9 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2417 lines).
-  - `src/server/mod.rs` (2514 lines).
+  - `src/server/mod.rs` (2549 lines).
   - `src/receipt.rs` (1842 lines).
-  - `src/github/sync.rs` (1488 lines).
+  - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -24,6 +24,12 @@ use hooks::Hook;
 use loader::PolicyStore;
 
 const POLICY_HOOK_WARN_THRESHOLD: Duration = Duration::from_millis(100);
+/// Tick hooks (onTick/onTick30s/onTick1min/onTick5min) routinely run auto-queue /
+/// timeout sweeps measured at 500-600ms, so the flat 100ms threshold produced a
+/// "policy hook slow" WARN every cycle. Use a dedicated, higher threshold for tick
+/// hooks (aligned with `POLICY_TICK_WARN_MS` in server/mod.rs) while keeping the
+/// tighter 100ms bound for non-tick hooks so their genuine slow-WARNs survive.
+const POLICY_TICK_HOOK_WARN_THRESHOLD: Duration = Duration::from_millis(500);
 
 /// Inner state of the policy engine (not Clone).
 struct PolicyEngineInner {
@@ -971,7 +977,15 @@ impl PolicyEngine {
                 let elapsed = policy_start.elapsed();
                 let effects_after = Self::count_pending_effects(&ctx);
                 let effects_count = effects_after.saturating_sub(effects_before);
-                if elapsed >= POLICY_HOOK_WARN_THRESHOLD {
+                let warn_threshold = if matches!(
+                    hook,
+                    Hook::OnTick | Hook::OnTick30s | Hook::OnTick1min | Hook::OnTick5min
+                ) {
+                    POLICY_TICK_HOOK_WARN_THRESHOLD
+                } else {
+                    POLICY_HOOK_WARN_THRESHOLD
+                };
+                if elapsed >= warn_threshold {
                     tracing::warn!(
                         policy_name,
                         hook = %hook,

--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -3,6 +3,7 @@
 use chrono::{Duration as ChronoDuration, NaiveDate, Utc};
 use sqlx::{PgPool, Row};
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 const ISSUE_JSON_FIELDS: &str =
@@ -115,6 +116,13 @@ fn merge_unique_issues(target: &mut Vec<GhIssue>, extras: Vec<GhIssue>) {
     target.extend(extras.into_iter().filter(|issue| seen.insert(issue.number)));
 }
 
+/// Repos for which we've already emitted the "no repo_dirs mapping" WARN.
+/// When a repo lacks an `agentdesk.yaml` `repo_dirs` entry, mainline sync runs
+/// every ~10 minutes and would otherwise spam an identical WARN forever (#3566).
+/// We log once per repo_id at WARN, then drop to DEBUG. A new/misconfigured
+/// repo_id still WARNs on its first cycle. Reset on process restart (intended).
+static REPO_MAPPING_WARN_SENT: OnceLock<dashmap::DashSet<String>> = OnceLock::new();
+
 fn mainline_issue_numbers_for_repo(repo: &str) -> Vec<i64> {
     let repo_dir = match crate::services::platform::shell::resolve_repo_dir_for_target(Some(repo)) {
         Ok(Some(repo_dir)) => repo_dir,
@@ -123,9 +131,26 @@ fn mainline_issue_numbers_for_repo(repo: &str) -> Vec<i64> {
             return Vec::new();
         }
         Err(error) => {
-            tracing::warn!(
-                "[github-sync] {repo}: repo dir resolution failed for mainline sync: {error}"
-            );
+            // Only the genuine "no repo_dirs mapping" failure is benign/noisy and
+            // safe to rate-suppress. Persistent misconfiguration errors — invalid
+            // mapped dir, non-git worktree, wrong remote — must keep WARNing with an
+            // accurate label so they aren't hidden behind a "no mapping" message (#3566).
+            if crate::services::platform::shell::is_no_repo_mapping_error(&error) {
+                let warned = REPO_MAPPING_WARN_SENT.get_or_init(dashmap::DashSet::new);
+                if warned.insert(repo.to_string()) {
+                    tracing::warn!(
+                        "[github-sync] {repo}: repo dir resolution failed for mainline sync (no repo_dirs mapping); suppressing further repeats — {error}"
+                    );
+                } else {
+                    tracing::debug!(
+                        "[github-sync] {repo}: repo dir resolution failed (no mapping, suppressed): {error}"
+                    );
+                }
+            } else {
+                tracing::warn!(
+                    "[github-sync] {repo}: repo dir resolution failed for mainline sync (misconfiguration): {error}"
+                );
+            }
             return Vec::new();
         }
     };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -38,6 +38,13 @@ const GITHUB_SYNC_ADVISORY_LOCK_ID: i64 = 7_801_002;
 const POLICY_TICK_WARN_MS: u128 = 500;
 const POLICY_TICK_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Set once the rate-limit sync loop has emitted its first WARN about absent
+/// Gemini OAuth credentials. When Gemini is simply not configured, the loop runs
+/// every 2 minutes and would otherwise spam an identical WARN forever (#3566).
+/// First miss logs at WARN; subsequent misses drop to DEBUG. Transient errors
+/// (network/API) bypass this flag and keep WARNing every cycle.
+static GEMINI_CREDS_MISSING_WARNED: AtomicBool = AtomicBool::new(false);
+
 /// Monotonically increasing count of policy tick hook timeouts (#747).
 /// Incremented each time `fire_tick_hook_by_name_with_timeout` returns
 /// because the wall-clock timeout elapsed before the spawn_blocking task
@@ -1008,7 +1015,35 @@ async fn rate_limit_sync_loop(pg_pool: Arc<PgPool>) {
                 tracing::info!("[rate-limit-sync] Gemini: {} buckets cached", n);
             }
             Err(e) => {
-                tracing::warn!("[rate-limit-sync] Gemini rate_limit fetch failed: {e}");
+                let msg = e.to_string();
+                // Only suppress the genuine "not configured / file missing" case,
+                // classified at the source (provider_auth) by `io::ErrorKind`:
+                //   - "no home dir"            (no $HOME)
+                //   - NotFound                 (oauth_creds.json does not exist)
+                // PermissionDenied / IsADirectory / transient I/O are tagged
+                // differently and corrupt/partial creds ("no access_token" /
+                // "no refresh_token") are separate problems — all keep WARNing,
+                // so we deliberately do NOT match on "oauth_creds.json" broadly
+                // here (#3566 over-suppress fix, codex r2).
+                let creds_missing =
+                    crate::services::provider_auth::is_gemini_unconfigured_error(&e);
+                if creds_missing {
+                    // Gemini simply isn't configured — log once, then drop to DEBUG
+                    // so the 2-minute sync loop doesn't spam an identical WARN (#3566).
+                    if !GEMINI_CREDS_MISSING_WARNED.swap(true, Ordering::AcqRel) {
+                        tracing::warn!(
+                            "[rate-limit-sync] Gemini credentials not configured ({msg}); suppressing further repeats"
+                        );
+                    } else {
+                        tracing::debug!(
+                            "[rate-limit-sync] Gemini credentials absent; skipping (suppressed)"
+                        );
+                    }
+                } else {
+                    // Transient errors (network/API/token refresh) and corrupt/partial
+                    // credentials keep WARNing.
+                    tracing::warn!("[rate-limit-sync] Gemini rate_limit fetch failed: {e}");
+                }
             }
         }
 

--- a/src/services/git/mod.rs
+++ b/src/services/git/mod.rs
@@ -16,7 +16,10 @@ pub use commit_resolver::{
     git_tracked_change_paths_strict,
 };
 pub(crate) use remote::parse_github_repo_from_remote;
-pub use repo_resolver::{resolve_repo_dir, resolve_repo_dir_for_id, resolve_repo_dir_for_target};
+pub use repo_resolver::{
+    is_no_repo_mapping_error, resolve_repo_dir, resolve_repo_dir_for_id,
+    resolve_repo_dir_for_target,
+};
 #[allow(unused_imports)]
 pub use runner::{GitCommand, GitCommandError};
 pub use worktree_resolver::{

--- a/src/services/git/repo_resolver.rs
+++ b/src/services/git/repo_resolver.rs
@@ -163,6 +163,27 @@ fn ensure_git_worktree(path: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Stable sentinel prefix for the "no `repo_dirs` mapping" resolver error.
+///
+/// This is the *only* resolver failure that is purely a "not configured" signal
+/// (no entry in `github.repo_dirs`, and the default repo's remote doesn't match).
+/// Other failures from [`resolve_repo_dir_for_id`] / [`resolve_repo_dir_for_target`]
+/// — invalid mapped dir, non-git worktree, wrong remote — are persistent
+/// misconfiguration and must surface as real WARNs (#3566). Callers that want to
+/// rate-suppress only the "not configured" case match on this via
+/// [`is_no_repo_mapping_error`].
+const NO_REPO_MAPPING_ERROR_PREFIX: &str = "No local repo mapping for";
+
+/// Returns `true` when `error` is the "no `repo_dirs` mapping" resolver failure
+/// (i.e. the repo simply isn't configured), as opposed to a persistent
+/// misconfiguration error (invalid dir / non-git worktree / wrong remote).
+///
+/// Used by log call sites to rate-suppress only the benign "not configured"
+/// case while keeping genuine configuration errors at WARN (#3566).
+pub fn is_no_repo_mapping_error(error: &str) -> bool {
+    error.starts_with(NO_REPO_MAPPING_ERROR_PREFIX)
+}
+
 /// Resolve the local git directory for a specific GitHub repo id.
 ///
 /// Resolution order:
@@ -198,7 +219,7 @@ pub fn resolve_repo_dir_for_id(repo_id: Option<&str>) -> Result<Option<String>, 
     }
 
     Err(format!(
-        "No local repo mapping for '{}'; configure github.repo_dirs.{} in agentdesk config",
+        "{NO_REPO_MAPPING_ERROR_PREFIX} '{}'; configure github.repo_dirs.{} in agentdesk config",
         requested, requested
     ))
 }
@@ -226,4 +247,37 @@ pub fn resolve_repo_dir_for_target(target_repo: Option<&str>) -> Result<Option<S
     }
 
     resolve_repo_dir_for_id(Some(requested))
+}
+
+#[cfg(test)]
+mod no_repo_mapping_classification_tests {
+    use super::{NO_REPO_MAPPING_ERROR_PREFIX, is_no_repo_mapping_error};
+
+    #[test]
+    fn classifies_the_no_mapping_error_as_suppressible() {
+        // Mirrors the exact error produced by resolve_repo_dir_for_id when no
+        // repo_dirs entry exists and the default remote doesn't match.
+        let err = format!(
+            "{NO_REPO_MAPPING_ERROR_PREFIX} 'owner/repo'; configure github.repo_dirs.owner/repo in agentdesk config"
+        );
+        assert!(is_no_repo_mapping_error(&err));
+    }
+
+    #[test]
+    fn keeps_persistent_misconfiguration_errors_as_real_warns() {
+        // These are persistent setup errors and must NOT be classified as the
+        // benign "no mapping" case (#3566 over-suppress fix).
+        assert!(!is_no_repo_mapping_error(
+            "'/some/dir' is not a git worktree"
+        ));
+        assert!(!is_no_repo_mapping_error(
+            "Configured repo dir '/some/dir' resolves to 'a/b' instead of requested 'c/d'"
+        ));
+        assert!(!is_no_repo_mapping_error(
+            "git rev-parse failed for '/some/dir': boom"
+        ));
+        assert!(!is_no_repo_mapping_error(
+            "cannot resolve repo path 'rel/path': boom"
+        ));
+    }
 }

--- a/src/services/platform/mod.rs
+++ b/src/services/platform/mod.rs
@@ -20,6 +20,7 @@ pub use shell::hostname_short;
 #[allow(unused_imports)]
 pub use crate::services::git::{
     ManagedWorktreeCleanup, cleanup_managed_worktree, ensure_worktree_for_issue,
-    find_latest_commit_for_issue, find_worktree_for_issue, git_head_commit, resolve_repo_dir,
-    resolve_repo_dir_for_id, resolve_repo_dir_for_target,
+    find_latest_commit_for_issue, find_worktree_for_issue, git_head_commit,
+    is_no_repo_mapping_error, resolve_repo_dir, resolve_repo_dir_for_id,
+    resolve_repo_dir_for_target,
 };

--- a/src/services/platform/shell.rs
+++ b/src/services/platform/shell.rs
@@ -11,8 +11,9 @@ pub(crate) use crate::services::git::{
     git_branch_containing_commit, git_branch_name, git_dispatch_baseline_commit, git_head_commit,
     git_latest_commit_for_issue, git_mainline_commit_for_issue_since, git_mainline_head_commit,
     git_mainline_issue_numbers, git_merge_base, git_tracked_change_paths,
-    git_tracked_change_paths_strict, is_mainlike_branch, parse_github_repo_from_remote,
-    resolve_repo_dir, resolve_repo_dir_for_id, resolve_repo_dir_for_target,
+    git_tracked_change_paths_strict, is_mainlike_branch, is_no_repo_mapping_error,
+    parse_github_repo_from_remote, resolve_repo_dir, resolve_repo_dir_for_id,
+    resolve_repo_dir_for_target,
 };
 
 /// Build a `Command` for the platform shell, ready for further customization.

--- a/src/services/provider_auth.rs
+++ b/src/services/provider_auth.rs
@@ -1,4 +1,13 @@
+use std::io::ErrorKind;
 use std::path::PathBuf;
+
+/// Stable marker embedded in the error returned by [`read_gemini_oauth_creds`]
+/// when `~/.gemini/oauth_creds.json` is simply absent (`ErrorKind::NotFound`),
+/// i.e. Gemini is not configured. Callers match on this (via
+/// [`is_gemini_unconfigured_error`]) to suppress repeated "not configured"
+/// noise, while genuine I/O failures (PermissionDenied / IsADirectory / other)
+/// keep their original message and must stay loud.
+pub const GEMINI_OAUTH_NOT_FOUND: &str = "gemini oauth creds not found";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ProviderAuthSpec {
@@ -104,10 +113,28 @@ pub fn codex_access_token() -> Option<String> {
 pub fn read_gemini_oauth_creds() -> Result<(PathBuf, serde_json::Value), anyhow::Error> {
     let path = expanded_auth_path("~/.gemini/oauth_creds.json")
         .ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|error| anyhow::anyhow!("cannot read ~/.gemini/oauth_creds.json: {error}"))?;
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        if error.kind() == ErrorKind::NotFound {
+            // File absent = Gemini not configured. Tag with the stable marker so
+            // callers can suppress repeated noise; keep the path for context.
+            anyhow::anyhow!("{GEMINI_OAUTH_NOT_FOUND}: ~/.gemini/oauth_creds.json")
+        } else {
+            // PermissionDenied / IsADirectory / transient I/O are real problems —
+            // do NOT tag them, so they keep WARNing.
+            anyhow::anyhow!("cannot read ~/.gemini/oauth_creds.json: {error}")
+        }
+    })?;
     let creds = serde_json::from_str(&raw)?;
     Ok((path, creds))
+}
+
+/// True when `error` means Gemini is simply not configured (no $HOME, or
+/// `~/.gemini/oauth_creds.json` does not exist). Permission/IO/parse failures
+/// and corrupt-or-partial credentials (`no access_token` / `no refresh_token`)
+/// return `false` so they keep WARNing. (#3566)
+pub fn is_gemini_unconfigured_error(error: &anyhow::Error) -> bool {
+    let msg = error.to_string();
+    msg.contains("no home dir") || msg.contains(GEMINI_OAUTH_NOT_FOUND)
 }
 
 fn detect_claude_oauth_source() -> Option<String> {
@@ -370,6 +397,59 @@ mod tests {
     use std::sync::{Mutex, MutexGuard};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // Mirrors the `read_to_string` error mapping in `read_gemini_oauth_creds`
+    // so the NotFound-vs-other classification can be exercised without touching
+    // the real `~/.gemini/oauth_creds.json` path. (#3566)
+    fn map_read_error(kind: ErrorKind) -> anyhow::Error {
+        let error = std::io::Error::from(kind);
+        if error.kind() == ErrorKind::NotFound {
+            anyhow::anyhow!("{GEMINI_OAUTH_NOT_FOUND}: ~/.gemini/oauth_creds.json")
+        } else {
+            anyhow::anyhow!("cannot read ~/.gemini/oauth_creds.json: {error}")
+        }
+    }
+
+    #[test]
+    fn gemini_not_found_is_unconfigured() {
+        let err = map_read_error(ErrorKind::NotFound);
+        assert!(
+            is_gemini_unconfigured_error(&err),
+            "missing oauth_creds.json must be treated as unconfigured (suppressible): {err}"
+        );
+    }
+
+    #[test]
+    fn gemini_no_home_dir_is_unconfigured() {
+        let err = anyhow::anyhow!("no home dir");
+        assert!(is_gemini_unconfigured_error(&err));
+    }
+
+    #[test]
+    fn gemini_permission_denied_is_not_unconfigured() {
+        let err = map_read_error(ErrorKind::PermissionDenied);
+        assert!(
+            !is_gemini_unconfigured_error(&err),
+            "PermissionDenied is a real problem and must keep WARNing: {err}"
+        );
+    }
+
+    #[test]
+    fn gemini_is_a_directory_is_not_unconfigured() {
+        // `IsADirectory` is unstable to name directly; reuse a generic non-NotFound
+        // kind to prove anything other than NotFound stays loud.
+        let err = map_read_error(ErrorKind::Other);
+        assert!(!is_gemini_unconfigured_error(&err));
+    }
+
+    #[test]
+    fn gemini_corrupt_creds_are_not_unconfigured() {
+        // Partial creds surface as separate errors and must keep WARNing.
+        let err = anyhow::anyhow!("no access_token in oauth_creds.json");
+        assert!(!is_gemini_unconfigured_error(&err));
+        let err = anyhow::anyhow!("no refresh_token in oauth_creds.json");
+        assert!(!is_gemini_unconfigured_error(&err));
+    }
 
     fn env_guard() -> MutexGuard<'static, ()> {
         ENV_LOCK.lock().unwrap()


### PR DESCRIPTION
## 변경
- **policy-hook slow WARN**: tick 계열(OnTick/30s/1min/5min) 한정으로 임계값 상향(다른 정책 정당한 slow WARN은 유지).
- **Gemini oauth WARN**: 파일 미존재(io::ErrorKind::NotFound)/미설정만 최초 1회 후 강등. PermissionDenied/IO/부분손상(no access/refresh token)은 정상 WARN 유지 (provider_auth 분류 헬퍼 + 테스트 5).
- **repo resolver WARN**: 진짜 'no repo_dirs mapping' sentinel만 강등, non-git/wrong-remote/invalid-dir는 정상 WARN.

## 검증
- fmt/check/test(provider_auth 12, server 163) 통과, maintenance freshness passed.
- Codex(gpt-5.5, xhigh) 적대리뷰 3라운드: **VERDICT: CLEAN**. (audit:2026-06-18)