### PR TITLE
fix(#3560): single-message-panel default-ON + rollout drift 해소

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -52,9 +52,11 @@
   instead of looping back through the internal HTTP cleanup route. The singleton
   assumption remains unchanged: the task is still spawned from the leased
   gateway runtime.
-- 2026-06-12 audit note (#3089 S0): `runtime_bootstrap` only initializes the
-  default-off `single_message_panel` flag for startup logging. Gateway lease,
-  startup order, worker ownership, and singleton assumptions are unchanged.
+- 2026-06-12 audit note (#3089 S0; updated #3560): `runtime_bootstrap` only
+  initializes the `single_message_panel` flag for startup logging. Since #3560
+  the flag is default-ON (opt-out via `AGENTDESK_SINGLE_MESSAGE_PANEL=0|false`).
+  Gateway lease, startup order, worker ownership, and singleton assumptions are
+  unchanged.
 - 2026-06-17 audit note (#3548): PR analyzer hygiene guard work is confined to
   `scripts/analyze_prs.py`; gateway lease, startup order, worker ownership, and
   singleton assumptions are unchanged.
@@ -402,6 +404,17 @@
 
 ### Audited touches
 
+- #3560 single_message_panel default-ON + footer-mode migration guard: the
+  `single_message_panel` flag is now default-ON (opt-out via
+  `AGENTDESK_SINGLE_MESSAGE_PANEL=0|false`) and `turn_bridge/mod.rs` gained a
+  deployment-boundary migration guard. When a turn that created a *separate*
+  status panel under the old default-OFF runtime resumes under footer mode, the
+  bridge now reconciles (edits to a migration notice) and clears its OWN
+  `inflight_state.status_message_id` instead of orphaning that Discord message.
+  This is purely worker-local: it operates on the resuming turn's own per-turn
+  inflight handle and its own gateway, with no node ownership, lease, or
+  singleton implication. Gateway lease, startup order, worker ownership, and
+  singleton assumptions are unchanged.
 - #3540 phantom-synthetic-inflight fix: two worker-local, in-memory-state-only
   touches with no multinode ownership/lease/singleton implications.
   (A) `tui_prompt_dedupe.rs` gained a process-global `relayed_entry_ids_by_tmux`

--- a/docs/design/3089-turn-output-controller.md
+++ b/docs/design/3089-turn-output-controller.md
@@ -1,6 +1,6 @@
 # #3089 — Unify Discord agent-output delivery behind one controller
 
-Status: **Design** (pre-implementation, hardened by one adversarial review round). Issue: #3089. Parent EPIC: #3016 (TurnFinalizer single-authority, closed). Folds in: #3235 (idle-tail dedup), #3078 (status-panel lifecycle), #3088 (TUI external-input streaming parity), #3082 (queued-notice chunk split), #3416 (same-turn offset-monotonic backward write).
+Status: **Design** — single_message_panel rollout gate is now default-ON as of #3560 (opt-out via `AGENTDESK_SINGLE_MESSAGE_PANEL=0|false`); Phases A–C of the controller refactor remain in progress. Issue: #3089. Parent EPIC: #3016 (TurnFinalizer single-authority, closed). Folds in: #3235 (idle-tail dedup), #3078 (status-panel lifecycle), #3088 (TUI external-input streaming parity), #3082 (queued-notice chunk split), #3416 (same-turn offset-monotonic backward write).
 
 This document is the synthesis of three independently-authored proposals (Gateway / Finalizer-actor / durable-datamodel), reconciled adversarially, then hardened against a design-review pass (3 High + 4 Medium findings, all folded in). It is the plan of record for #3089; each phase below becomes its own PR.
 

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -57,6 +57,11 @@ direct_discord_sends = [
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:b4849c24f5cb7d09",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:1c6f6dcd93167903",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9b9526b38f0691a8",
+  # #3560: footer-mode migration reconcile — edits a pre-default-ON *separate*
+  # status panel to a migration notice before dropping its handle (behaviorally
+  # the same direct resume-notice edit already allowlisted in mod.rs; extracted
+  # into turn_bridge/status_panel.rs as migrate_separate_status_panel_to_footer).
+  "src/services/discord/turn_bridge/status_panel.rs#direct_discord_sends:650f7b34584abb84",
   # #3089 S2: existing status-panel-v2 response-placeholder send moved out of
   # turn_bridge/mod.rs into the bridge footer helper while preserving behavior.
   # #3479 SPC-shadow removal: re-fingerprinted (same `gateway.send_message`

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -117,7 +117,10 @@
 # spawn_watcher_orphan_spinner_cleanup_retry) into
 # `turn_bridge/watcher_orphan_cleanup.rs` (both re-exported, call sites
 # byte-identical). Locks in the shrink win (ratchet down only).
-"src/services/discord/turn_bridge/mod.rs" = 6189
+# #3560: +9 (6189 -> 6198) for the footer-mode migration reconcile — the
+# migrate_separate_status_panel_to_footer call + comment at the footer-mode entry
+# (helper body itself extracted to turn_bridge/status_panel.rs, net decomposition).
+"src/services/discord/turn_bridge/mod.rs" = 6198
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437
@@ -134,8 +137,9 @@
 # #3038 S3: lowered 4980 -> 4965 (-15) as the cluster-E field block (13
 # restart-lifecycle fields) moved into `shared_state::RestartLifecycle`.
 # Locks in the shrink win (ratchet down only).
-# #3089 S0: +5 for default-off single_message_panel wrapper/log trigger in
-# mod.rs; parser/cache body lives in `single_message_panel.rs`.
+# #3089 S0 (updated #3560): +5 for the single_message_panel wrapper/log trigger
+# in mod.rs; parser/cache body lives in `single_message_panel.rs`. As of #3560
+# the flag is default-ON (opt-out via AGENTDESK_SINGLE_MESSAGE_PANEL=0|false).
 # #3038 S4: lowered 4970 -> 4967 (-3) as the cluster-F field block (5
 # live-placeholder/status-panel fields) moved into `shared_state::PlaceholderState`.
 # Locks in the shrink win (ratchet down only).

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -25,4 +25,7 @@
 [hotfile_ratchet]
 "src/services/discord/tmux_watcher.rs" = 10086
 "src/services/discord/tui_prompt_relay.rs" = 7789
-"src/services/discord/turn_bridge/mod.rs" = 6612
+# #3560: 6612 -> 6621 (+9), reviewable admission — footer-mode separate-panel
+# migration reconcile call + comment at the resume entry. Helper body lives in
+# turn_bridge/status_panel.rs; this is the minimal call-site cost.
+"src/services/discord/turn_bridge/mod.rs" = 6621

--- a/src/services/discord/placeholder_live_events/background_task_events.rs
+++ b/src/services/discord/placeholder_live_events/background_task_events.rs
@@ -6,9 +6,10 @@ use super::common::{EVENT_LINE_MAX_CHARS, normalize_summary, normalize_tool_key,
 
 pub(super) fn slots_enabled_by_footer_flag() -> bool {
     // #3089: background Bash task slots are deliberately footer-mode gated so the
-    // legacy separate status-panel / completion-card render path is unchanged when
-    // AGENTDESK_SINGLE_MESSAGE_PANEL is off. `status_panel_v2_enabled` is already
-    // checked by the callers before status events are pushed/rendered.
+    // legacy separate status-panel / completion-card render path is unchanged only
+    // when AGENTDESK_SINGLE_MESSAGE_PANEL=0/false (opt-out). As of #3560 the gate is
+    // default-ON, so unset/other values render in footer mode. `status_panel_v2_enabled`
+    // is already checked by the callers before status events are pushed/rendered.
     super::super::single_message_panel::enabled()
 }
 

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -67,8 +67,17 @@ pub(in crate::services::discord) fn enabled() -> bool {
 }
 
 fn parse_single_message_panel_flag(raw: Option<&str>) -> bool {
-    raw.map(str::trim)
-        .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+    // #3560: default-ON (opt-out). The rollout gate previously short-circuited a
+    // missing env var to `false`, so any environment without an explicit
+    // `AGENTDESK_SINGLE_MESSAGE_PANEL=1` silently fell back to the legacy panel.
+    // Mirror the original explicit truthy-allowlist as an explicit disable-list:
+    // only the documented opt-out tokens "0" / case-insensitive "false" disable
+    // the feature. Everything else — unset, empty, or garbage — stays enabled so
+    // a default-ON feature is never quietly switched off by an empty env value.
+    match raw.map(str::trim) {
+        None => true,
+        Some(value) => value != "0" && !value.eq_ignore_ascii_case("false"),
+    }
 }
 
 pub(in crate::services::discord) fn footer_mode_enabled(
@@ -1026,13 +1035,19 @@ mod tests {
     }
 
     #[test]
-    fn single_message_panel_flag_defaults_off_when_unset() {
-        assert!(!super::parse_single_message_panel_flag(None));
+    fn single_message_panel_flag_defaults_on_when_unset() {
+        // #3560: missing env var means default-ON (opt-out), not the legacy OFF.
+        assert!(super::parse_single_message_panel_flag(None));
     }
 
     #[test]
-    fn single_message_panel_flag_accepts_only_documented_truthy_values() {
-        for raw in ["1", "true", "TRUE", "TrUe", " true "] {
+    fn single_message_panel_flag_treats_non_optout_values_as_enabled() {
+        // #3560: only "0" / "false" disable the gate. Everything else — including
+        // an empty string or garbage — keeps the default-ON feature enabled so it
+        // is never quietly switched off by an unintended env value.
+        for raw in [
+            "1", "true", "TRUE", "TrUe", " true ", "", "yes", "on", "garbage",
+        ] {
             assert!(
                 super::parse_single_message_panel_flag(Some(raw)),
                 "{raw:?} should enable the flag"
@@ -1041,11 +1056,13 @@ mod tests {
     }
 
     #[test]
-    fn single_message_panel_flag_rejects_falsy_and_garbage_values() {
-        for raw in ["", "0", "false", "FALSE", "yes", "on", "garbage"] {
+    fn single_message_panel_flag_rejects_documented_optout_values() {
+        // #3560: the disable-list mirrors the original truthy-allowlist — only the
+        // documented opt-out tokens "0" and case-insensitive "false" turn it off.
+        for raw in ["0", "false", "FALSE"] {
             assert!(
                 !super::parse_single_message_panel_flag(Some(raw)),
-                "{raw:?} should leave the flag disabled"
+                "{raw:?} should disable the flag"
             );
         }
     }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -175,7 +175,7 @@ use stale_resume::{
     stream_error_requires_terminal_session_reset,
 };
 use status_panel::{
-    bridge_epilogue_identity_guards_inflight_clear,
+    bridge_epilogue_identity_guards_inflight_clear, migrate_separate_status_panel_to_footer,
     should_open_long_running_placeholder_controller,
     status_panel_completion_ready_after_terminal_body, status_panel_message_id_for_turn,
 };
@@ -1570,8 +1570,17 @@ pub(super) fn spawn_turn_bridge(
             bridge.reuse_status_panel_message,
         );
         if single_message_panel_footer_mode {
+            // #3560 codex review: a turn that created a *separate* status panel
+            // under default-OFF can be resumed here under footer mode. Clearing
+            // the handle alone would orphan that Discord message, so reconcile
+            // it (edit to a migration notice) before dropping it.
+            migrate_separate_status_panel_to_footer(
+                gateway.as_ref(),
+                channel_id,
+                &mut inflight_state,
+            )
+            .await;
             status_panel_msg_id = None;
-            inflight_state.status_message_id = None;
         }
         let mut last_status_panel_text = String::new();
         let mut status_panel_dirty = shared_owned.ui.status_panel_v2_enabled;

--- a/src/services/discord/turn_bridge/status_panel.rs
+++ b/src/services/discord/turn_bridge/status_panel.rs
@@ -436,6 +436,52 @@ pub(super) fn status_panel_message_id_for_turn(
     Some(status_msg_id)
 }
 
+/// #3560 codex review: default-OFF → default-ON deployment migration guard.
+///
+/// When `single_message_panel` was default-OFF a bridge turn may have already
+/// created a *separate* status panel (a real Discord message tracked by
+/// `inflight_state.status_message_id`). After #3560 the same turn can be
+/// resumed under footer mode, where the separate panel is no longer used.
+/// Previously the resume path simply cleared `status_message_id` to `None`,
+/// orphaning that Discord message (a stuck panel that never completes).
+///
+/// This helper closes that gap: before clearing the handle, it edits the old
+/// panel into a short migration notice (mirroring the
+/// `long_running_placeholder_active` reconciliation path) so the message is
+/// visibly finalized rather than left dangling. Synthetic-headless ids are not
+/// real Discord messages, so they are dropped without an edit.
+///
+/// Returns `true` when an old separate panel existed and was reconciled
+/// (regardless of edit success), `false` when there was nothing to migrate.
+/// This is worker-local: it operates only on the resuming turn's own handle.
+pub(super) async fn migrate_separate_status_panel_to_footer<G: TurnGateway + ?Sized>(
+    gateway: &G,
+    channel_id: ChannelId,
+    inflight_state: &mut InflightTurnState,
+) -> bool {
+    let Some(raw_id) = inflight_state.status_message_id.take() else {
+        return false;
+    };
+    let old_id = MessageId::new(raw_id);
+    if is_synthetic_headless_message_id(old_id) {
+        // Not a real Discord message — nothing to finalize.
+        return true;
+    }
+    let migration_notice = "🔁 상태 패널이 통합 패널로 이전되었습니다.";
+    if let Err(error) = gateway
+        .edit_message(channel_id, old_id, migration_notice)
+        .await
+    {
+        tracing::warn!(
+            "[turn_bridge] failed to finalize migrated separate status panel {} in channel {}: {}",
+            old_id,
+            channel_id,
+            error
+        );
+    }
+    true
+}
+
 #[cfg(test)]
 #[path = "status_panel_tests.rs"]
 mod status_panel_v2_rework_tests;

--- a/src/services/discord/turn_bridge/status_panel_tests.rs
+++ b/src/services/discord/turn_bridge/status_panel_tests.rs
@@ -1,8 +1,8 @@
 use super::{
     ChannelId, InflightTurnState, MessageId, ProviderKind, StatusPanelCompletionAction,
     bridge_epilogue_identity_guards_inflight_clear, complete_status_panel_v2,
-    should_open_long_running_placeholder_controller, status_panel_completion_action,
-    status_panel_completion_edit_aliases_newer_turn,
+    migrate_separate_status_panel_to_footer, should_open_long_running_placeholder_controller,
+    status_panel_completion_action, status_panel_completion_edit_aliases_newer_turn,
     status_panel_completion_ready_after_terminal_body, status_panel_message_id_for_turn,
 };
 use crate::services::discord::formatting::ReplaceLongMessageOutcome;
@@ -210,6 +210,80 @@ fn resume_turn_discards_synthetic_status_panel_message_id() {
 
     assert_eq!(status_panel_msg_id, None);
     assert_eq!(state.status_message_id, None);
+}
+
+// #3560 codex review: default-OFF → default-ON migration guard. A turn that
+// created a real separate status panel under default-OFF must have that panel
+// finalized (edited to a migration notice) when it resumes under footer mode,
+// instead of orphaning the Discord message.
+#[tokio::test]
+async fn footer_migration_edits_and_clears_existing_separate_panel() {
+    let gateway = StatusPanelFallbackGateway::default();
+    let mut state = test_inflight_state();
+    state.status_message_id = Some(9_876_543_210);
+
+    let migrated =
+        migrate_separate_status_panel_to_footer(&gateway, ChannelId::new(4321), &mut state).await;
+
+    assert!(
+        migrated,
+        "an existing separate panel should report a migration"
+    );
+    assert_eq!(
+        state.status_message_id, None,
+        "handle must be cleared after migration"
+    );
+    let edited = gateway.edited_message_ids.lock().expect("edited ids lock");
+    assert_eq!(
+        edited.as_slice(),
+        &[MessageId::new(9_876_543_210)],
+        "the old separate panel must be edited exactly once"
+    );
+}
+
+// Synthetic-headless ids are not real Discord messages, so footer migration
+// clears the handle without issuing an edit.
+#[tokio::test]
+async fn footer_migration_skips_synthetic_headless_panel() {
+    let gateway = StatusPanelFallbackGateway::default();
+    let mut state = test_inflight_state();
+    state.status_message_id = Some(9_100_000_000_000_000_123);
+
+    let migrated =
+        migrate_separate_status_panel_to_footer(&gateway, ChannelId::new(4321), &mut state).await;
+
+    assert!(migrated);
+    assert_eq!(state.status_message_id, None);
+    assert!(
+        gateway
+            .edited_message_ids
+            .lock()
+            .expect("edited ids lock")
+            .is_empty(),
+        "synthetic-headless panels must not be edited"
+    );
+}
+
+// When no separate panel handle exists (footer mode from the start) the
+// migration is a no-op and reports nothing was migrated.
+#[tokio::test]
+async fn footer_migration_noop_without_existing_panel() {
+    let gateway = StatusPanelFallbackGateway::default();
+    let mut state = test_inflight_state();
+    state.status_message_id = None;
+
+    let migrated =
+        migrate_separate_status_panel_to_footer(&gateway, ChannelId::new(4321), &mut state).await;
+
+    assert!(!migrated);
+    assert_eq!(state.status_message_id, None);
+    assert!(
+        gateway
+            .edited_message_ids
+            .lock()
+            .expect("edited ids lock")
+            .is_empty()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 문제
single_message_panel이 release env(AGENTDESK_SINGLE_MESSAGE_PANEL=1)에만 의존하고 코드 기본값은 OFF라, env 누락 환경은 legacy 패널로 조용히 회귀. 설계문서도 pre-implementation 상태.

## 변경
- 코드 기본값 default-ON(opt-out: env가 '0'/'false'일 때만 비활성).
- footer-mode 전환 시 default-OFF 때 만든 separate status panel을 안내문으로 정리(orphan 방지) — `migrate_separate_status_panel_to_footer` helper(turn_bridge/status_panel.rs) + 테스트 3.
- docs/design/3089 Status 갱신, 문서 stale 참조(multinode-transition / audit baseline) 갱신.
- giant/hotfile baseline + direct_discord_sends allowlist 문서화 bump(turn_bridge +9, 사유 주석).

## 검증
- fmt/check/test(turn_bridge 182, single_message_panel 59, migration 3) 통과, ci-script-checks(giant/hotfile ratchet/freshness) 전부 green.
- Codex(gpt-5.5, xhigh) 적대리뷰: 동작 **CLEAN** (잔여는 baseline 수치였고 해소). (audit:2026-06-18)