### PR TITLE
feat(#3561): 릴레이 누락 신호 운영자 경보 (terminal-ack-timeout / inflight-cleared / owner-unknown / offset invariant)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -725,6 +725,7 @@ src/
 │   │   ├── quality_alert.rs
 │   │   ├── queries.rs
 │   │   ├── recovery_audit.rs
+│   │   ├── relay_signal_alert.rs
 │   │   ├── retention.rs
 │   │   ├── session_inventory.rs
 │   │   ├── turn_lifecycle.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1322,7 +1322,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2436 lines).
+  - `src/config.rs` (2447 lines).
   - `src/server/mod.rs` (2587 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
@@ -1395,7 +1395,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   split before further non-bugfix growth.
 - `src/services/onboarding/mod.rs` (2936),
   `src/services/dispatched_sessions.rs` (1328), and
-  `src/services/settings.rs` (1104) — service-layer route support surfaces
+  `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
@@ -1445,7 +1445,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   helpers before adding non-bugfix behavior. (+5 from #3169 exposing the idle-
   kill `latest_runtime_activity_unix_nanos` jsonl-mtime probe to the stall-
   watchdog liveness guard.)
-- `src/services/settings.rs` (1104) — settings domain service extracted from
+- `src/services/settings.rs` (1114) — settings domain service extracted from
   the route layer in #1519. Keep follow-up changes bugfix-only unless the file
   is split further.
 - `src/services/routines/{store.rs (2844), migrated.rs (1286),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1161,6 +1161,16 @@ pub struct KanbanConfig {
     pub human_alert_channel_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pm_decision_gate_enabled: Option<bool>,
+    /// #3561 — operator override for the relay-signal alert threshold. When
+    /// set, every per-hour relay invariant signal (terminal-ack timeout,
+    /// uncommitted-inflight-cleared, owner-unknown, offset invariant
+    /// violation) fires once its hourly window count reaches this value,
+    /// overriding the conservative per-signal code defaults. `None` keeps the
+    /// built-in defaults; it does NOT disable alerting (the alert target —
+    /// `kanban_human_alert_channel_id` — remaining unset is the real off
+    /// switch, so an unconfigured deploy never spams).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_alert_threshold: Option<u32>,
 }
 
 impl KanbanConfig {
@@ -1169,6 +1179,7 @@ impl KanbanConfig {
             && self.deadlock_manager_channel_id.is_none()
             && self.human_alert_channel_id.is_none()
             && self.pm_decision_gate_enabled.is_none()
+            && self.relay_alert_threshold.is_none()
     }
 }
 

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -65,6 +65,7 @@ impl MaintenanceJobRegistry {
             Arc::new(NoopHeartbeatJob),
             Arc::new(AgentQualityRollupJob),
             Arc::new(QualityRegressionAlerterJob),
+            Arc::new(RelaySignalAlerterJob),
             Arc::new(CancelTombstonePruneJob),
             Arc::new(PromptManifestRetentionJob::new(prompt_manifest_retention)),
             Arc::new(VoiceTurnLinkGcJob),
@@ -159,6 +160,40 @@ impl MaintenanceJob for QualityRegressionAlerterJob {
                 job = self.name(),
                 alerts_dispatched = sent,
                 "agent quality regression alerter completed"
+            );
+            Ok(())
+        })
+    }
+}
+
+/// #3561 — hourly relay-loss signal monitor + operator alert.
+///
+/// Aggregates the restart-safe `observability_events` stream (relay root-cause
+/// counters + offset invariant violations) over the trailing hour and enqueues
+/// a single de-duplicated Discord alert per signal when its count crosses the
+/// (conservative, config-overridable) threshold. Double off-switch: no alert
+/// target configured ⇒ no enqueue, so unconfigured deploys never spam. The 30s
+/// startup stagger sequences it after the quality alerter on the same hourly
+/// tick so the two alert pipelines do not race for a connection at boot.
+struct RelaySignalAlerterJob;
+
+impl MaintenanceJob for RelaySignalAlerterJob {
+    fn name(&self) -> &'static str {
+        "relay_signal_alerter"
+    }
+
+    fn schedule(&self) -> MaintenanceSchedule {
+        MaintenanceSchedule::every(Duration::from_secs(60 * 60), Duration::from_secs(30))
+    }
+
+    fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
+        Box::pin(async move {
+            let alerts =
+                crate::services::observability::enqueue_relay_signal_alerts_pg(pool).await?;
+            tracing::info!(
+                job = self.name(),
+                alerts_dispatched = alerts,
+                "relay signal alerter completed"
             );
             Ok(())
         })
@@ -1021,5 +1056,27 @@ mod registry_membership_tests {
         assert_eq!(job.name(), "voice.turn_link_gc");
         let schedule = job.schedule();
         assert_eq!(schedule.every_ms(), 60 * 60 * 1_000);
+    }
+
+    /// #3561 — the relay-loss operator monitor must be registered so the
+    /// leader scheduler actually evaluates the relay signal thresholds hourly;
+    /// otherwise the alert pipeline silently never runs.
+    #[test]
+    fn static_registry_includes_relay_signal_alerter() {
+        let registry = MaintenanceJobRegistry::static_registry();
+        let names: Vec<&'static str> = registry.jobs().iter().map(|job| job.name()).collect();
+        assert!(
+            names.contains(&"relay_signal_alerter"),
+            "relay_signal_alerter must be registered so the leader scheduler \
+             evaluates relay-loss signal thresholds hourly (#3561). \
+             present jobs: {names:?}"
+        );
+    }
+
+    #[test]
+    fn relay_signal_alerter_schedule_is_hourly() {
+        let job = RelaySignalAlerterJob;
+        assert_eq!(job.name(), "relay_signal_alerter");
+        assert_eq!(job.schedule().every_ms(), 60 * 60 * 1_000);
     }
 }

--- a/src/services/observability/mod.rs
+++ b/src/services/observability/mod.rs
@@ -29,6 +29,7 @@ mod helpers;
 mod pg_io;
 mod quality_alert;
 mod queries;
+mod relay_signal_alert;
 mod retention;
 mod worker;
 
@@ -48,6 +49,9 @@ pub use emit::{
 pub use queries::{
     query_agent_quality_ranking_with, query_agent_quality_summary, run_agent_quality_rollup_pg,
 };
+// #3561 — operator relay-loss signal monitor. Driven by the hourly
+// `RelaySignalAlerterJob` maintenance job (see `server::maintenance`).
+pub(crate) use relay_signal_alert::enqueue_relay_signal_alerts_pg;
 
 pub(super) const EVENT_BATCH_SIZE: usize = 64;
 pub(super) const EVENT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
@@ -70,6 +74,77 @@ pub(super) const QUALITY_SAMPLE_GUARD: i64 = 5;
 pub(super) const QUALITY_ALERT_DEDUPE_MS: i64 = 24 * 60 * 60 * 1000;
 pub(super) const QUALITY_REVIEW_DROP_THRESHOLD: f64 = 0.20;
 pub(super) const QUALITY_TURN_DROP_THRESHOLD: f64 = 0.15;
+
+// #3561 — relay-loss operator monitor. Each signal alerts at most once per
+// hour (`RELAY_SIGNAL_ALERT_DEDUPE_TTL_SECS`), so the dedupe window matches the
+// job cadence. The per-signal `default_threshold` values are conservative:
+//   * `relay_terminal_ack_timeout` (duplicate-emit vector) tolerates a few per
+//     hour before it's worth waking an operator.
+//   * `relay_owner_unknown` (relay started with unknown owner) is rarer and
+//     more suspicious, so a lower bar.
+//   * `relay_uncommitted_inflight_cleared` (LEAKED ANSWER — a non-empty reply
+//     was dropped) and `offset_invariant_violation` (persisted bad offset
+//     state) are severe enough that a single occurrence warrants an alert.
+// All are overridable per-deploy via `kanban.relay_alert_threshold`
+// (mirrored to kv_meta `kanban_relay_alert_threshold` by `services::settings`).
+pub(super) const RELAY_SIGNAL_ALERT_DEDUPE_TTL_SECS: i64 = 60 * 60;
+
+/// One relay-loss signal as projected onto the `observability_events` table.
+/// `event_type` + `status` uniquely identify the persisted rows that count
+/// toward this signal's hourly window. `default_threshold` is the conservative
+/// built-in trip point (overridable per-deploy via
+/// `kanban.relay_alert_threshold`).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RelaySignal {
+    /// Stable identifier used in the dedupe key and the alert body.
+    pub(super) key: &'static str,
+    /// `observability_events.event_type` filter.
+    pub(super) event_type: &'static str,
+    /// `observability_events.status` values that map to this signal. The relay
+    /// root-cause counters store the counter name in `status`
+    /// (`emit_relay_root_cause_counter`); the offset invariants store the
+    /// invariant name in `status` (`record_invariant_check`).
+    pub(super) statuses: &'static [&'static str],
+    /// Conservative built-in hourly trip threshold.
+    pub(super) default_threshold: u32,
+    /// Human-readable label for the operator alert.
+    pub(super) label: &'static str,
+}
+
+/// Canonical relay-loss signal table monitored by the #3561 operator alert
+/// job. Each entry maps 1:1 onto rows the emit path already persists to
+/// `observability_events` (see `emit::emit_relay_root_cause_counter` and
+/// `emit::record_invariant_check_with_severity`).
+pub(super) const RELAY_SIGNAL_DEFINITIONS: &[RelaySignal] = &[
+    RelaySignal {
+        key: "relay_terminal_ack_timeout",
+        event_type: "relay_root_cause_counter",
+        statuses: &["relay_terminal_ack_timeout"],
+        default_threshold: 5,
+        label: "터미널 ACK 타임아웃(중복 송신 벡터)",
+    },
+    RelaySignal {
+        key: "relay_uncommitted_inflight_cleared",
+        event_type: "relay_root_cause_counter",
+        statuses: &["relay_uncommitted_inflight_cleared"],
+        default_threshold: 1,
+        label: "미커밋 inflight 정리(답변 누출 벡터)",
+    },
+    RelaySignal {
+        key: "relay_owner_unknown",
+        event_type: "relay_root_cause_counter",
+        statuses: &["relay_owner_unknown"],
+        default_threshold: 3,
+        label: "릴레이 owner 불명",
+    },
+    RelaySignal {
+        key: "offset_invariant_violation",
+        event_type: "invariant_violation",
+        statuses: &["last_offset_monotonic", "response_sent_offset_monotonic"],
+        default_threshold: 1,
+        label: "오프셋 단조성 불변식 위반",
+    },
+];
 pub(super) const AGENT_QUALITY_EVENT_TYPES: &[&str] = &[
     "turn_start",
     "turn_complete",

--- a/src/services/observability/relay_signal_alert.rs
+++ b/src/services/observability/relay_signal_alert.rs
@@ -1,0 +1,381 @@
+//! #3561 — operator monitor + Discord alert for relay-loss signals.
+//!
+//! The internal `relay_health` machinery (RelayHealthSnapshot, relay_recovery)
+//! exists for *recovery*, but there was no operator-facing alert when the
+//! relay-loss invariant signals spike — outages were only discovered after the
+//! fact by grepping logs. This job aggregates the restart-safe
+//! `observability_events` stream (the durable mirror of the relay root-cause
+//! counters + offset invariant violations) over a 1-hour window and enqueues a
+//! single de-duplicated Discord alert per signal per hour when a signal crosses
+//! its threshold.
+//!
+//! Design notes (see #3561):
+//!   * Source of truth is the persistent `observability_events` table, NOT the
+//!     in-memory atomics — atomics reset to 0 on every process restart and are
+//!     per-provider scoped, which breaks delta bookkeeping across deploys.
+//!   * Driven by the hourly `MaintenanceJob` scheduler (PG pool in hand), the
+//!     same proven harness `agent_quality_rollup` uses — not the per-provider
+//!     stall watchdog (hot path, single-provider scope).
+//!   * Anti-spam is a TOCTOU-safe kv_meta dedupe-slot claim mirroring
+//!     `quality_alert.rs`, keyed by `relay_alert:{signal}:{hour_bucket}` with a
+//!     1-hour TTL so each signal alerts at most once per hour.
+//!   * Delivery reuses the existing `message_outbox` enqueue path (bot
+//!     "notify"). It deliberately does NOT use the announce-bot fallback, whose
+//!     messages are re-ingested as agent input and would inject noise.
+//!   * Double off-switch: the alert target (`kanban_human_alert_channel_id`)
+//!     being unset short-circuits to 0 alerts, so an unconfigured deploy is
+//!     guaranteed never to spam.
+
+use anyhow::{Result, anyhow};
+use sqlx::PgPool;
+
+use super::{RELAY_SIGNAL_ALERT_DEDUPE_TTL_SECS, RELAY_SIGNAL_DEFINITIONS, RelaySignal};
+
+fn normalize_channel_target(channel: &str) -> Option<String> {
+    let channel = channel.trim();
+    if channel.is_empty() {
+        return None;
+    }
+    Some(if channel.starts_with("channel:") {
+        channel.to_string()
+    } else {
+        format!("channel:{channel}")
+    })
+}
+
+/// Resolve the operator alert target. Reuses the same kv_meta key the
+/// agent-quality alert pipeline uses (`kanban_human_alert_channel_id`) so a
+/// single operator config drives both. `None` ⇒ the job short-circuits and
+/// never enqueues, guaranteeing an unconfigured deploy stays silent.
+async fn relay_alert_target_pg(pool: &PgPool) -> Result<Option<String>> {
+    let value = sqlx::query_scalar::<_, String>(
+        "SELECT value
+         FROM kv_meta
+         WHERE key = 'kanban_human_alert_channel_id'
+           AND value IS NOT NULL
+           AND btrim(value) <> ''
+         LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| anyhow!("load relay signal alert target: {error}"))?;
+    Ok(value.as_deref().and_then(normalize_channel_target))
+}
+
+/// Read the operator threshold override from kv_meta (mirrored from
+/// `config.kanban.relay_alert_threshold` by `services::settings`). A non-numeric
+/// or absent value yields `None`, so each signal falls back to its conservative
+/// built-in default. Defensive parse: legacy/operator-written junk never breaks
+/// the job — it just means "use the defaults".
+async fn relay_alert_threshold_override_pg(pool: &PgPool) -> Result<Option<u32>> {
+    let value = sqlx::query_scalar::<_, String>(
+        "SELECT value
+         FROM kv_meta
+         WHERE key = 'kanban_relay_alert_threshold'
+           AND value IS NOT NULL
+           AND btrim(value) <> ''
+         LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| anyhow!("load relay alert threshold override: {error}"))?;
+    Ok(value.and_then(|raw| raw.trim().parse::<u32>().ok()))
+}
+
+/// The hourly bucket a `now_ms` timestamp falls into. Stable within the hour so
+/// repeated job ticks inside the same window resolve to the same dedupe key.
+fn hour_bucket(now_ms: i64) -> i64 {
+    now_ms.div_euclid(3_600_000)
+}
+
+/// Dedupe key for one signal in one hourly window. Mirrors the
+/// `agent_quality_alert:*` key shape so the kv_meta slot semantics match.
+pub(super) fn relay_alert_dedupe_key(signal_key: &str, now_ms: i64) -> String {
+    format!("relay_alert:{signal_key}:{}", hour_bucket(now_ms))
+}
+
+/// Effective threshold for `signal`: the operator override when present, else
+/// the conservative built-in default. A `0` override is ignored (treated as
+/// "use default") so a misconfigured `relay_alert_threshold = 0` cannot turn
+/// every window into a spam storm.
+pub(super) fn effective_threshold(signal: &RelaySignal, override_threshold: Option<u32>) -> u32 {
+    match override_threshold {
+        Some(value) if value > 0 => value,
+        _ => signal.default_threshold,
+    }
+}
+
+/// #3561: atomically claim the dedupe slot for `key` iff the previous claim is
+/// older than `RELAY_SIGNAL_ALERT_DEDUPE_TTL_SECS`. Mirrors
+/// `quality_alert::claim_quality_alert_slot_pg` — single-statement TOCTOU-safe
+/// claim, defensive `^[0-9]+$` guard against legacy non-numeric kv_meta values.
+async fn claim_relay_alert_slot_pg(pool: &PgPool, key: &str, now_ms: i64) -> Result<bool> {
+    let dedupe_ms = RELAY_SIGNAL_ALERT_DEDUPE_TTL_SECS.saturating_mul(1000);
+    let claimed = sqlx::query_scalar::<_, i32>(
+        "INSERT INTO kv_meta (key, value)
+         VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE
+             SET value = EXCLUDED.value
+             WHERE CASE
+                 WHEN kv_meta.value ~ '^[0-9]+$'
+                     THEN kv_meta.value::bigint + $3 <= ($2)::bigint
+                 ELSE TRUE
+             END
+         RETURNING 1",
+    )
+    .bind(key)
+    .bind(now_ms.to_string())
+    .bind(dedupe_ms)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| anyhow!("claim relay alert dedupe key {key}: {error}"))?;
+    Ok(claimed.is_some())
+}
+
+/// Best-effort rollback of a freshly-claimed dedupe slot when the subsequent
+/// outbox INSERT fails, so the next cycle can retry.
+async fn release_relay_alert_slot_pg(pool: &PgPool, key: &str) -> Result<()> {
+    sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+        .bind(key)
+        .execute(pool)
+        .await
+        .map_err(|error| anyhow!("release relay alert dedupe key {key}: {error}"))?;
+    Ok(())
+}
+
+/// Count the rows for one signal inside the trailing 1-hour window. Uses the
+/// indexed `created_at` column plus the `event_type` / `status` filters.
+async fn count_signal_last_hour_pg(pool: &PgPool, signal: &RelaySignal) -> Result<i64> {
+    let count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*)::bigint
+         FROM observability_events
+         WHERE event_type = $1
+           AND status = ANY($2)
+           AND created_at >= NOW() - INTERVAL '1 hour'",
+    )
+    .bind(signal.event_type)
+    .bind(signal.statuses)
+    .fetch_one(pool)
+    .await
+    .map_err(|error| anyhow!("count relay signal {}: {error}", signal.key))?;
+    Ok(count)
+}
+
+pub(super) fn relay_alert_content(signal: &RelaySignal, count: i64, threshold: u32) -> String {
+    format!(
+        "릴레이 누락 신호 임계 초과: `{}` ({}) 최근 1시간 {count}건 (임계 {threshold}). 운영 점검 필요.",
+        signal.key, signal.label,
+    )
+}
+
+async fn enqueue_relay_alert_pg(
+    pool: &PgPool,
+    target: &str,
+    dedupe_key: &str,
+    content: &str,
+    now_ms: i64,
+) -> Result<bool> {
+    // Claim the dedupe slot atomically *before* enqueueing so concurrent
+    // leaders cannot double-post the same signal in the same window.
+    if !claim_relay_alert_slot_pg(pool, dedupe_key, now_ms).await? {
+        return Ok(false);
+    }
+
+    let enqueued = match crate::services::message_outbox::enqueue_outbox_pg(
+        pool,
+        crate::services::message_outbox::OutboxMessage {
+            target,
+            content,
+            bot: "notify",
+            source: "relay_signal_rollup",
+            reason_code: Some("relay_signal.threshold"),
+            session_key: Some(dedupe_key),
+        },
+    )
+    .await
+    {
+        Ok(enqueued) => enqueued,
+        Err(error) => {
+            if let Err(rollback_err) = release_relay_alert_slot_pg(pool, dedupe_key).await {
+                tracing::warn!(
+                    "[relay-signal] failed to release dedupe slot {dedupe_key} after outbox error: {rollback_err}"
+                );
+            }
+            return Err(anyhow!("enqueue relay signal alert: {error}"));
+        }
+    };
+
+    Ok(enqueued)
+}
+
+/// #3561 entry point: evaluate every relay-loss signal over the trailing hour
+/// and enqueue one de-duplicated operator alert per breached signal. Returns
+/// the number of alerts enqueued this cycle (0 when no target is configured or
+/// no signal breached its threshold). Never panics; an individual signal's
+/// failure surfaces as the job error so the scheduler records it.
+pub(crate) async fn enqueue_relay_signal_alerts_pg(pool: &PgPool) -> Result<u64> {
+    // Off-switch #1: no operator alert target ⇒ stay completely silent.
+    let Some(target) = relay_alert_target_pg(pool).await? else {
+        return Ok(0);
+    };
+
+    let override_threshold = relay_alert_threshold_override_pg(pool).await?;
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let mut alert_count = 0u64;
+
+    for signal in RELAY_SIGNAL_DEFINITIONS {
+        let count = count_signal_last_hour_pg(pool, signal).await?;
+        let threshold = effective_threshold(signal, override_threshold);
+        if count < i64::from(threshold) {
+            continue;
+        }
+        let dedupe_key = relay_alert_dedupe_key(signal.key, now_ms);
+        let content = relay_alert_content(signal, count, threshold);
+        if enqueue_relay_alert_pg(pool, &target, &dedupe_key, &content, now_ms).await? {
+            alert_count = alert_count.saturating_add(1);
+            tracing::warn!(
+                signal = signal.key,
+                count,
+                threshold,
+                "[relay-signal] relay-loss signal crossed threshold; operator alert enqueued"
+            );
+        }
+    }
+
+    Ok(alert_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signal(key: &'static str, default_threshold: u32) -> RelaySignal {
+        RelaySignal {
+            key,
+            event_type: "relay_root_cause_counter",
+            statuses: &["relay_terminal_ack_timeout"],
+            default_threshold,
+            label: "test signal",
+        }
+    }
+
+    #[test]
+    fn dedupe_key_is_stable_within_the_hour() {
+        // Hour-aligned base so +59m stays inside the same hourly bucket.
+        let base = 472_222i64 * 3_600_000;
+        let a = relay_alert_dedupe_key("relay_terminal_ack_timeout", base);
+        let b = relay_alert_dedupe_key("relay_terminal_ack_timeout", base + 59 * 60 * 1000);
+        assert_eq!(a, b, "same hour bucket must share a dedupe key");
+        assert!(a.starts_with("relay_alert:relay_terminal_ack_timeout:"));
+    }
+
+    #[test]
+    fn dedupe_key_rolls_over_at_the_hour_boundary() {
+        let bucket0 = 0i64;
+        let bucket1 = 3_600_000i64; // exactly one hour later
+        assert_ne!(
+            relay_alert_dedupe_key("sig", bucket0),
+            relay_alert_dedupe_key("sig", bucket1),
+            "crossing the hour boundary must produce a fresh dedupe key"
+        );
+    }
+
+    #[test]
+    fn dedupe_key_is_per_signal() {
+        let now = 1_700_000_000_000i64;
+        assert_ne!(
+            relay_alert_dedupe_key("relay_owner_unknown", now),
+            relay_alert_dedupe_key("relay_terminal_ack_timeout", now),
+            "distinct signals must not share a dedupe slot in the same hour"
+        );
+    }
+
+    #[test]
+    fn effective_threshold_prefers_positive_override() {
+        let sig = signal("s", 5);
+        assert_eq!(effective_threshold(&sig, Some(2)), 2);
+    }
+
+    #[test]
+    fn effective_threshold_ignores_zero_and_missing_override() {
+        let sig = signal("s", 5);
+        assert_eq!(
+            effective_threshold(&sig, None),
+            5,
+            "absent override falls back to the conservative default"
+        );
+        assert_eq!(
+            effective_threshold(&sig, Some(0)),
+            5,
+            "a 0 override must not turn every window into a spam storm"
+        );
+    }
+
+    #[test]
+    fn alert_content_names_the_signal_and_counts() {
+        let sig = signal("relay_terminal_ack_timeout", 5);
+        let content = relay_alert_content(&sig, 7, 5);
+        assert!(content.contains("relay_terminal_ack_timeout"));
+        assert!(content.contains('7'));
+        assert!(content.contains('5'));
+    }
+
+    #[test]
+    fn channel_target_normalization() {
+        assert_eq!(
+            normalize_channel_target("123").as_deref(),
+            Some("channel:123")
+        );
+        assert_eq!(
+            normalize_channel_target("channel:123").as_deref(),
+            Some("channel:123")
+        );
+        assert_eq!(normalize_channel_target("   ").as_deref(), None);
+        assert_eq!(normalize_channel_target("").as_deref(), None);
+    }
+
+    /// The canonical signal table must cover every relay-loss vector #3561
+    /// scopes: the three relay root-cause counters plus the two offset
+    /// invariant violations. A missing entry silently drops a signal from the
+    /// operator monitor, so guard the membership explicitly.
+    #[test]
+    fn signal_table_covers_documented_relay_loss_vectors() {
+        let keys: Vec<&str> = RELAY_SIGNAL_DEFINITIONS.iter().map(|s| s.key).collect();
+        for expected in [
+            "relay_terminal_ack_timeout",
+            "relay_uncommitted_inflight_cleared",
+            "relay_owner_unknown",
+            "offset_invariant_violation",
+        ] {
+            assert!(
+                keys.contains(&expected),
+                "relay signal table must monitor {expected}; present: {keys:?}"
+            );
+        }
+    }
+
+    /// Every status string in the table must be one the emit path actually
+    /// writes to `observability_events.status`, otherwise the window query
+    /// counts zero forever. These mirror `emit_relay_root_cause_counter`
+    /// (metrics.rs) and the offset invariants (inflight.rs / tmux.rs).
+    #[test]
+    fn signal_statuses_match_emit_path_names() {
+        let mut statuses: Vec<&str> = RELAY_SIGNAL_DEFINITIONS
+            .iter()
+            .flat_map(|s| s.statuses.iter().copied())
+            .collect();
+        statuses.sort_unstable();
+        for expected in [
+            "last_offset_monotonic",
+            "relay_owner_unknown",
+            "relay_terminal_ack_timeout",
+            "relay_uncommitted_inflight_cleared",
+            "response_sent_offset_monotonic",
+        ] {
+            assert!(
+                statuses.contains(&expected),
+                "status `{expected}` must be monitored; present: {statuses:?}"
+            );
+        }
+    }
+}

--- a/src/services/settings.rs
+++ b/src/services/settings.rs
@@ -86,6 +86,15 @@ const CONFIG_KEYS: &[(&str, &str, &str, &str, Option<&str>)] = &[
         None,
     ),
     (
+        // #3561 — operator override for the per-hour relay-loss signal alert
+        // threshold. Empty/absent ⇒ conservative per-signal code defaults.
+        "kanban_relay_alert_threshold",
+        "quality",
+        "릴레이 누락 신호 경보 임계",
+        "Relay Signal Alert Threshold",
+        None,
+    ),
+    (
         "review_enabled",
         "review",
         "리뷰 활성화",
@@ -490,6 +499,7 @@ fn yaml_section_value(config: &crate::config::Config, key: &str) -> Option<Strin
         "deadlock_manager_channel_id" => config.kanban.deadlock_manager_channel_id.clone(),
         "kanban_human_alert_channel_id" => config.kanban.human_alert_channel_id.clone(),
         "agent_quality_monitoring_channel_id" => None,
+        "kanban_relay_alert_threshold" => stringified_number(config.kanban.relay_alert_threshold),
         "review_enabled" => stringified_bool(config.review.enabled),
         "max_review_rounds" => stringified_number(config.review.max_rounds),
         "pm_decision_gate_enabled" => stringified_bool(config.kanban.pm_decision_gate_enabled),


### PR DESCRIPTION
## 문제
내부 relay_health는 복구용으로만 존재, 릴레이 누락 신호에 대한 운영자 경보/대시보드 부재 → 장애가 사후 로그 grep으로만 발견.

## 변경
- restart-safe하게 영속 `observability_events`(relay_root_cause_counter / invariant_violation, status 컬럼)를 1시간 윈도우로 집계하는 `RelaySignalAlerterJob`(MaintenanceJob, 시간당) 신설.
- 보수적 기본 임계 + config override(`kanban.relay_alert_threshold`, **기본 off**) 초과 시, kv_meta TOCTOU dedupe slot(신호당 시간당 1회)으로 기존 `enqueue_outbox_pg`(notify) 경보. **새 직접 send 없음**.
- watchdog hot path 회피. target(human_alert_channel) 미설정 시 즉시 0건 종료.
- frame MissingTarget / watcher_relay 폴백률은 영속 이벤트 부재로 1차 제외 → hot-path 계측 필요한 후속.

## 검증
- relay_signal 11 + maintenance/settings/config 테스트 통과, audit(direct_discord_sends=0)/ci-script-checks/freshness green.
- Codex(gpt-5.5, xhigh) 적대리뷰: **VERDICT: CLEAN**. (audit:2026-06-18)