### PR TITLE
fix(#3576): announce bot 트리거 분기 복원 — #3478 회귀 수정 (PM 트리아지·deadlock·send-to-agent 복구)

### DIFF
--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -266,7 +266,12 @@
 # `handle_event` (mirrors the model-picker / idle-recap arms — the dispatch can
 # only live in the root event handler). The cancel handler body itself lives in
 # the non-giant `steering.rs`, not here. Combined with #3446: 2969 -> 2975.
-"src/services/discord/router/intake_gate.rs" = 2977
+# #3576 announce-trigger restore: +1 (2977 -> 2978) for the extra
+# `announce_bot_id,` argument line on the `is_allowed_turn_sender` call in
+# `handle_event` (restores the announce branch removed by #3478). The call
+# site lives in the root event handler; the gate logic itself stays in the
+# non-giant `dispatch_policy.rs`.
+"src/services/discord/router/intake_gate.rs" = 2978
 "src/services/discord/formatting.rs" = 2802
 # #3038 run_bot S0/S1: lowered 2802 -> 1918 by adding characterization tests and
 # moving restored_state, queued_placeholders, startup_doctor, orphan_recovery,

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -243,6 +243,7 @@ pub(in crate::services::discord) fn classify_catch_up_message(
     existing_ids: &std::collections::HashSet<u64>,
     max_age_secs: i64,
     allowed_bot_ids: &[u64],
+    announce_bot_id: Option<u64>,
 ) -> CatchUpClassification {
     if !msg.is_processable_kind {
         return CatchUpClassification::SystemKind;
@@ -261,6 +262,7 @@ pub(in crate::services::discord) fn classify_catch_up_message(
     }
     if !is_allowed_turn_sender(
         allowed_bot_ids,
+        announce_bot_id,
         msg.author_id,
         msg.author_is_bot,
         &msg.trimmed_text,
@@ -419,6 +421,7 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
             let settings = shared.settings.read().await;
             settings.allowed_bot_ids.clone()
         };
+        let announce_bot_id = resolve_announce_bot_user_id(shared).await;
         let mut max_recovered_id: Option<u64> = None;
         let mut stats = CatchUpScanStats::default();
         stats.returned = messages.len();
@@ -458,6 +461,7 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 &existing_ids,
                 max_age.as_secs() as i64,
                 &allowed_bot_ids,
+                announce_bot_id,
             );
             // Codex P2 round 2 on #1301: check the cap BEFORE recording the
             // recover, otherwise `stats.recovered` would tally a message we
@@ -657,6 +661,7 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
             let mid = msg.id.get();
             if !is_allowed_turn_sender(
                 &allowed_bot_ids_phase2,
+                announce_bot_id_phase2,
                 msg.author.id.get(),
                 msg.author.bot,
                 text,
@@ -799,12 +804,48 @@ mod catch_up_recovery_tests {
         let existing = HashSet::new();
 
         assert_eq!(
-            classify_catch_up_message(&view, Some(current_bot_id), &existing, 300, &[]),
+            classify_catch_up_message(&view, Some(current_bot_id), &existing, 300, &[], None),
             CatchUpClassification::Recover
         );
         assert_eq!(
-            classify_catch_up_message(&view, Some(owner_user_id), &existing, 300, &[]),
+            classify_catch_up_message(&view, Some(owner_user_id), &existing, 300, &[], None),
             CatchUpClassification::SelfAuthored
+        );
+    }
+
+    #[test]
+    fn announce_bot_message_recovers_without_dispatch_marker() {
+        // #3576: a catch-up scan must recover announce-authored trigger
+        // traffic even without the DISPATCH:/monitor marker.
+        let announce_id = 7777;
+        let current_bot_id = 9001;
+        let view = CatchUpMessageView {
+            message_id: 1504813049431724054,
+            author_id: announce_id,
+            author_is_bot: true,
+            is_processable_kind: true,
+            age_secs: 60,
+            trimmed_text: "PM triage: claude, please pick up #42".to_string(),
+        };
+        let existing = HashSet::new();
+
+        // Without the announce_bot_id hint the bot message is NotAllowed
+        // (no marker), proving the parameter is load-bearing.
+        assert_eq!(
+            classify_catch_up_message(&view, Some(current_bot_id), &existing, 300, &[], None),
+            CatchUpClassification::NotAllowed
+        );
+        // With the announce_bot_id hint it recovers.
+        assert_eq!(
+            classify_catch_up_message(
+                &view,
+                Some(current_bot_id),
+                &existing,
+                300,
+                &[],
+                Some(announce_id),
+            ),
+            CatchUpClassification::Recover
         );
     }
 }

--- a/src/services/discord/dispatch_policy.rs
+++ b/src/services/discord/dispatch_policy.rs
@@ -177,6 +177,99 @@ mod dispatch_turn_gate_tests {
     }
 }
 
+#[cfg(test)]
+mod allowed_turn_sender_tests {
+    use super::is_allowed_turn_sender;
+
+    const ANNOUNCE_ID: u64 = 1001;
+    const OTHER_BOT_ID: u64 = 2002;
+    const HUMAN_ID: u64 = 3003;
+
+    #[test]
+    fn announce_bot_triggers_without_dispatch_marker() {
+        // #3576: announce-authored PM-triage / deadlock / send-to-agent
+        // text triggers a turn even without the DISPATCH:/monitor marker.
+        assert!(is_allowed_turn_sender(
+            &[ANNOUNCE_ID, OTHER_BOT_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            "PM triage: please pick up issue #42",
+        ));
+    }
+
+    #[test]
+    fn announce_bot_with_dispatch_marker_triggers() {
+        assert!(is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            "DISPATCH:1f3c2b1a-0000-4000-8000-000000000000\n── implementation dispatch ──",
+        ));
+    }
+
+    #[test]
+    fn announce_bot_legacy_issue_card_is_suppressed() {
+        // Conservative guard: catch-up replays of announce-authored issue /
+        // completion cards must NOT trigger turns.
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            "📋 **새 이슈 #42** — fix the thing\n> 상태: 🟡 open",
+        ));
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            ANNOUNCE_ID,
+            true,
+            "✅ **#42 완료** — fix the thing",
+        ));
+    }
+
+    #[test]
+    fn non_announce_allowed_bot_still_requires_dispatch_marker() {
+        // Security (#706): a non-announce allowed bot is dropped when its
+        // message lacks the DISPATCH:/monitor-origin marker.
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID, OTHER_BOT_ID],
+            Some(ANNOUNCE_ID),
+            OTHER_BOT_ID,
+            true,
+            "just a status note, no marker",
+        ));
+        // …but the same bot WITH the marker triggers.
+        assert!(is_allowed_turn_sender(
+            &[ANNOUNCE_ID, OTHER_BOT_ID],
+            Some(ANNOUNCE_ID),
+            OTHER_BOT_ID,
+            true,
+            "DISPATCH:1f3c2b1a-0000-4000-8000-000000000000",
+        ));
+    }
+
+    #[test]
+    fn human_message_is_unaffected() {
+        assert!(is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            HUMAN_ID,
+            false,
+            "hello agent",
+        ));
+        // An unknown bot (not announce, not allowed) is still dropped.
+        assert!(!is_allowed_turn_sender(
+            &[ANNOUNCE_ID],
+            Some(ANNOUNCE_ID),
+            OTHER_BOT_ID,
+            true,
+            "spam",
+        ));
+    }
+}
+
 pub(in crate::services::discord) async fn resolve_announce_bot_user_id(
     shared: &SharedData,
 ) -> Option<u64> {
@@ -197,14 +290,55 @@ pub(in crate::services::discord) async fn resolve_notify_bot_user_id(
 
 pub(in crate::services::discord) fn is_allowed_turn_sender(
     allowed_bot_ids: &[u64],
+    announce_bot_id: Option<u64>,
     author_id: u64,
     author_is_bot: bool,
     text: &str,
 ) -> bool {
+    if announce_bot_id.is_some_and(|id| id == author_id) {
+        // #3576 (restores the announce branch removed by #3478): the
+        // `announce` bot is the authoritative trigger source. Its live
+        // traffic — dispatch envelopes, PM-triage / deadlock / escalation
+        // cards, and agent-to-agent `/api/discord/send` messages — must
+        // start turns WITHOUT requiring the `DISPATCH:` / monitor-origin
+        // marker that gates other allowed bots. The `should_process_*`
+        // marker gate (#706 security) only applies to non-announce bots.
+        //
+        // The lone exception is the legacy issue-announcement / completion
+        // card (📋/✅) shape: issue cards now route through notify-bot
+        // (#1448 follow-up, and #3478 removed the announce-token fallback
+        // in `issue_announcements.rs`), so announce never authors them in
+        // live traffic. This guard remains a conservative safety net for
+        // catch-up replays of pre-cutover announce-authored cards so they
+        // don't spawn spurious turns.
+        return !is_legacy_announce_issue_card(text);
+    }
     if allowed_bot_ids.contains(&author_id) {
         return should_process_allowed_bot_turn_text(text);
     }
     !author_is_bot
+}
+
+/// Conservative guard (#3576) that suppresses announce-authored issue
+/// announcement / completion cards from triggering turns. Live issue cards
+/// route through notify-bot, which never reaches the announce branch above;
+/// this only catches catch-up replays of pre-cutover announce-authored cards.
+fn is_legacy_announce_issue_card(text: &str) -> bool {
+    let head = text.trim_start();
+    if head.starts_with("📋 **새 이슈 #") {
+        return true;
+    }
+    if let Some(rest) = head.strip_prefix("✅ **#") {
+        let digits_end = rest
+            .char_indices()
+            .find(|(_, ch)| !ch.is_ascii_digit())
+            .map(|(idx, _)| idx)
+            .unwrap_or(rest.len());
+        if digits_end > 0 && rest[digits_end..].starts_with(" 완료** —") {
+            return true;
+        }
+    }
+    false
 }
 
 pub(in crate::services::discord) fn should_phase2_recover_message(

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -2006,6 +2006,7 @@ pub(in crate::services::discord) async fn handle_event(
             if is_allowed_bot_sender
                 && !super::super::is_allowed_turn_sender(
                     &settings_snapshot.allowed_bot_ids,
+                    announce_bot_id,
                     user_id.get(),
                     new_message.author.bot,
                     raw_text,

--- a/src/services/discord/runtime_bootstrap/recovery_flush.rs
+++ b/src/services/discord/runtime_bootstrap/recovery_flush.rs
@@ -55,6 +55,8 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                 let settings = shared_for_tmux2.settings.read().await;
                 settings.allowed_bot_ids.clone()
             };
+            let announce_bot_id_for_restore =
+                super::resolve_announce_bot_user_id(&shared_for_tmux2).await;
             // P1-1: Restore dispatch_role_overrides from queue snapshots
             for (thread_channel_id, alt_channel_id) in &restored_overrides {
                 if !matches!(
@@ -95,6 +97,7 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                     for item in items {
                         if !super::is_allowed_turn_sender(
                             &allowed_bot_ids_for_restore,
+                            announce_bot_id_for_restore,
                             item.author_id.get(),
                             item.author_is_bot,
                             &item.text,


### PR DESCRIPTION
## 문제 (P1)
2026-06-15 #3478(c57fcd11c)이 `is_allowed_turn_sender`에서 announce_bot_id 분기를 삭제 → announce bot 메시지가 DISPATCH 마커 없으면 드롭. **PM 트리아지·deadlock watchdog·send-to-agent 핸드오프가 전부 침묵** (로그 `⏭ BOT-INTAKE: skipping non-turn bot message` 방증).

## 변경 (option 1: 분기 복원)
- `is_allowed_turn_sender`에 announce_bot_id 예외 복원 — announce가 author면 마커 없이 트리거(authoritative source). 비-announce allowed bot은 #706 DISPATCH 게이팅 유지(보안 비회귀).
- `is_legacy_announce_issue_card`(📋/✅ 카드) 차단은 보수적 유지(catch-up 안전망).
- announce_bot_id 파라미터 + 4 호출처(intake_gate / catch_up classify·phase2 / recovery_flush) 복원.

## 검증
- 단위 테스트: announce 마커없이 트리거 / 비-announce 봇 마커없이 드롭(보안) / legacy 카드 차단 / catch-up·recovery 복원. dispatch_policy·catch_up·intake_gate·router 테스트 통과.
- audit/freshness/ci-script-checks green. Codex(gpt-5.5, xhigh) 적대리뷰: **VERDICT: CLEAN**. (audit:2026-06-18)

Closes #3576 후속 코멘트로 처리.