### PR TITLE
fix(#3557): per-turn hard timeout/ceiling + 장기턴 클러스터 경보 + Codex recv 근본 수정

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -807,6 +807,7 @@ src/
 │   ├── issue_announcements.rs
 │   ├── kanban.rs
 │   ├── kanban_cards.rs
+│   ├── long_turn_watchdog.rs
 │   ├── mcp_config.rs
 │   ├── message_outbox.rs
 │   ├── mod.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -870,13 +870,17 @@
     `compose_recap_header` and `attach_live_context_usage` keep byte-identical
     call sites, while the rest of the selection helpers stay module-private;
     below the giant-file threshold).
-  - `src/services/codex_tmux_wrapper.rs` (1289 lines; Codex tmux wrapper JSON
+  - `src/services/codex_tmux_wrapper.rs` (1355 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan; +65 from #3275: capture per-call
     `token_count.info.last_token_usage` and re-emit it as a Claude-compatible
     nested `usage` on the success result frame so watcher-owned codex turns
     persist token telemetry — never the session-cumulative
-    `info.total_token_usage`).
+    `info.total_token_usage`; +66 from #3557 (B): bound the post-first-event
+    `recv()` with an idle recv-timeout + absolute per-turn ceiling so a hung
+    Codex process that stops emitting JSON without exiting is killed and rejoins
+    the error path instead of looking "busy" to the watcher indefinitely — the
+    13125s outlier source).
   - `src/services/tui_prompt_dedupe.rs` (1613 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +176 from #3540: stable JSONL entry-identity
@@ -990,7 +994,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3672 lines; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3699 lines; +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;
@@ -1340,7 +1344,7 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2447 lines).
-  - `src/server/mod.rs` (2587 lines).
+  - `src/server/mod.rs` (2593 lines; +6 from #3557 (A) long_turn_watchdog spawn).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -870,7 +870,7 @@
     `compose_recap_header` and `attach_live_context_usage` keep byte-identical
     call sites, while the rest of the selection helpers stay module-private;
     below the giant-file threshold).
-  - `src/services/codex_tmux_wrapper.rs` (1355 lines; Codex tmux wrapper JSON
+  - `src/services/codex_tmux_wrapper.rs` (1385 lines; +30 from #3557 Codex review: cap the idle recv_timeout by the remaining hard-ceiling budget (+boundary tests); Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan; +65 from #3275: capture per-call
     `token_count.info.last_token_usage` and re-emit it as a Claude-compatible
@@ -994,7 +994,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3699 lines; +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3722 lines; +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -870,7 +870,7 @@
     `compose_recap_header` and `attach_live_context_usage` keep byte-identical
     call sites, while the rest of the selection helpers stay module-private;
     below the giant-file threshold).
-  - `src/services/codex_tmux_wrapper.rs` (1385 lines; +30 from #3557 Codex review: cap the idle recv_timeout by the remaining hard-ceiling budget (+boundary tests); Codex tmux wrapper JSON
+  - `src/services/codex_tmux_wrapper.rs` (1403 lines; +30 from #3557 Codex review: cap the idle recv_timeout by the remaining hard-ceiling budget (+boundary tests); Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan; +65 from #3275: capture per-call
     `token_count.info.last_token_usage` and re-emit it as a Claude-compatible
@@ -880,7 +880,12 @@
     `recv()` with an idle recv-timeout + absolute per-turn ceiling so a hung
     Codex process that stops emitting JSON without exiting is killed and rejoins
     the error path instead of looking "busy" to the watcher indefinitely — the
-    13125s outlier source).
+    13125s outlier source; +18 from #3557 (B) codex r2: this path runs `codex
+    exec` over a pipe (no tmux pane to `capture-pane`), so the JSON stream is the
+    only liveness signal — raised the generous idle default 1800s -> 3600s so a
+    normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
+    hang, with the 4h hard ceiling as the real backstop, and noted the limitation
+    in the idle-kill error message + a delayed-event test).
   - `src/services/tui_prompt_dedupe.rs` (1613 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +176 from #3540: stable JSONL entry-identity
@@ -1012,9 +1017,16 @@
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
     re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
     S4 mechanical placeholder/status-panel `.ui` rewiring).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1462 lines;
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1516 lines;
     headless Discord turn launch/terminal-response path split from the router
-    message handler; bugfix only outside a further extraction plan).
+    message handler; bugfix only outside a further extraction plan; +54 from
+    #3557 (A) codex r2: the headless watchdog was missing the per-turn hard
+    ceiling cap that the foreground intake path already had — and it also
+    `mark_async_managed`s the token so the sync watchdog stops enforcing, leaving
+    this async loop as the ONLY bound. Added the initial-deadline
+    `min(now+timeout, ceiling)` cap + one-shot ceiling warn and the auto-extend
+    `clamp_auto_extend_deadline_ms` clamp, reusing the shared discord/mod.rs
+    helpers, so headless Codex honors its 4h ceiling end to end).
   - `src/services/discord/meeting_orchestrator.rs` (3222 lines after #3034
     dead-code sweep removed `is_meeting_channel`).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (964 prod lines; provider

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -164,7 +164,10 @@
 # stale-dispatch turn gating + its tests, allowed-turn-sender / bot-user-id
 # resolvers, phase2 recovery predicate) moved verbatim to the capped sibling
 # `dispatch_policy.rs`, lowering the frozen baseline 4243 -> 4074 (-169).
-"src/services/discord/mod.rs" = 4056
+# #3557 (A): per-turn hard-ceiling backstop helpers (turn_hard_ceiling_timeout,
+# codex_turn_hard_ceiling_timeout, turn_hard_ceiling_deadline_ms,
+# clamp_auto_extend_deadline_ms) + their unit tests. +55 prod LoC. 4056 -> 4111.
+"src/services/discord/mod.rs" = 4111
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).
@@ -255,7 +258,10 @@
 # FIX #6 (Codex P2): +6 (3771 -> 3777) for the `set_followup_requeue_context`
 # call that persists the originating Intervention's reply/upload/voice context on
 # the follow-up inflight row so a PRE-submit busy-timeout requeue can rebuild it.
-"src/services/discord/router/message_handler/intake_turn.rs" = 3672
+# #3557 (A): hard-ceiling clamp wired into the watchdog auto-extend block so a
+# turn keeping inflight warm forever can no longer push the deadline without
+# bound (Codex 13125s outlier source). +27 prod LoC. 3672 -> 3699.
+"src/services/discord/router/message_handler/intake_turn.rs" = 3699
 "src/services/discord/meeting_orchestrator.rs" = 3227
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -261,7 +261,12 @@
 # #3557 (A): hard-ceiling clamp wired into the watchdog auto-extend block so a
 # turn keeping inflight warm forever can no longer push the deadline without
 # bound (Codex 13125s outlier source). +27 prod LoC. 3672 -> 3699.
-"src/services/discord/router/message_handler/intake_turn.rs" = 3699
+# #3557 (A) codex r2 baseline correction: the prior commit froze 3699 but the
+# splitter actually counts 3722 production LoC for this file (the auto-extend
+# clamp + the init-time ceiling-cap block landed together, the latter undercounted
+# in the prior bump). No new code lands here this round; this only corrects the
+# frozen value to the file's true LoC so the ratchet gate passes. 3699 -> 3722.
+"src/services/discord/router/message_handler/intake_turn.rs" = 3722
 "src/services/discord/meeting_orchestrator.rs" = 3227
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered
@@ -410,7 +415,14 @@
 # into child modules. Pure move; each child is well under the 1000-prod-LoC
 # giant threshold so no new ratchet/registry entry is needed.
 "src/services/discord/turn_finalizer.rs" = 1337
-"src/services/discord/router/message_handler/headless_turn.rs" = 1462
+# #3557 (A) codex r2: the headless watchdog was missing the per-turn hard
+# ceiling cap that the foreground intake path already had — and it also
+# `mark_async_managed`s the token (sync watchdog stops enforcing), so this async
+# loop is the ONLY bound. Added the initial-deadline `min(now+timeout, ceiling)`
+# cap + one-shot ceiling warn and the auto-extend `clamp_auto_extend_deadline_ms`
+# clamp (reusing the shared discord/mod.rs helpers). +54 prod LoC (the new test
+# module is excluded from the production count). 1462 -> 1516.
+"src/services/discord/router/message_handler/headless_turn.rs" = 1516
 # #3038 S2: lowered 1054 -> 954 (-100) as the session-override bookkeeping
 # helpers (fast-mode reset-entry codec + reset-pending probes/clears +
 # enablement probes + sync_session_reset_pending) moved verbatim to the

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -354,6 +354,12 @@ pub(crate) async fn run(
     if let Some(pool) = pg_pool.clone() {
         crate::services::dispatch_watchdog::spawn(pool);
     }
+    // #3557 (A): long-turn cluster probe — pages out when a burst of >10m turns
+    // finishes inside one window (the stall watchdog's blind spot for
+    // delegated_to_watcher turns, which stay desynced=false).
+    if let Some(pool) = pg_pool.clone() {
+        crate::services::long_turn_watchdog::spawn(pool);
+    }
     crate::pipeline::refresh_override_health_report(pg_pool.as_ref()).await;
     let boot_reconcile_engine = match startup_pg_pool.as_ref() {
         Some(pool) => Some(crate::engine::PolicyEngine::new_with_pg(

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -526,11 +526,41 @@ fn run_turn(
         let next_line = if saw_any_stdout {
             // After the first event, bound inter-event silence: a hung Codex that
             // stops emitting without exiting used to block here forever.
-            match stdout_rx.recv_timeout(idle_recv_timeout) {
+            //
+            // #3557 (B) Codex-review fix: cap the idle recv by the REMAINING
+            // ceiling budget. Previously the loop entered `recv_timeout` with the
+            // full idle window (1800s) regardless of how close the run was to the
+            // hard ceiling, so an event at 3h59m followed by a hang killed Codex
+            // only at 4h29m (ceiling + idle). Clamping the wait to the ceiling
+            // remainder keeps the absolute ceiling honored even mid-recv; when no
+            // budget remains we kill immediately on the next loop iteration via
+            // the `start.elapsed() >= hard_ceiling` check at the top.
+            let elapsed = start.elapsed();
+            let ceiling_remaining = hard_ceiling.saturating_sub(elapsed);
+            if ceiling_remaining.is_zero() {
+                crate::services::process::kill_pid_tree(child_pid);
+                let _ = child.wait();
+                return Err(format!(
+                    "Codex turn exceeded hard ceiling of {}s",
+                    hard_ceiling.as_secs()
+                ));
+            }
+            let wait = idle_recv_timeout.min(ceiling_remaining);
+            match stdout_rx.recv_timeout(wait) {
                 Ok(line) => line,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
+                    // A timeout here is either the idle window or the ceiling
+                    // remainder elapsing; the top-of-loop ceiling check would
+                    // also catch the latter, but kill now to avoid one more
+                    // idle wait. Report the cause for diagnosis.
                     crate::services::process::kill_pid_tree(child_pid);
                     let _ = child.wait();
+                    if wait < idle_recv_timeout {
+                        return Err(format!(
+                            "Codex turn exceeded hard ceiling of {}s (idle recv capped by ceiling remainder)",
+                            hard_ceiling.as_secs()
+                        ));
+                    }
                     return Err(format!(
                         "Codex produced no JSON event for {}s (idle hang)",
                         idle_recv_timeout.as_secs()
@@ -2424,5 +2454,41 @@ mod turn_timeout_tests {
         let start = std::time::Instant::now();
         std::thread::sleep(Duration::from_millis(20));
         assert!(start.elapsed() >= ceiling);
+    }
+
+    /// #3557 (B) Codex-review fix: the idle recv must be capped by the REMAINING
+    /// ceiling budget so a post-first-event hang can never run past the ceiling
+    /// by a full idle window. This mirrors `idle_recv_timeout.min(remaining)`.
+    /// Mid-run, with budget left, the cap wins only when it is the smaller of
+    /// the two.
+    #[test]
+    fn idle_recv_is_capped_by_ceiling_remainder() {
+        let idle = Duration::from_secs(1800);
+        // Plenty of budget left: idle window governs (cap does not bite).
+        let remaining_lots = Duration::from_secs(3600);
+        assert_eq!(idle.min(remaining_lots), idle);
+        // Near the ceiling: the remainder governs, so a hang is killed at the
+        // ceiling, not ceiling+idle.
+        let remaining_little = Duration::from_secs(60);
+        assert_eq!(idle.min(remaining_little), remaining_little);
+        assert!(idle.min(remaining_little) < idle);
+    }
+
+    /// At/over the ceiling the remainder is zero, which the run loop treats as
+    /// "kill now" rather than entering another recv. Verify the saturating
+    /// remainder is zero exactly when elapsed has reached the ceiling.
+    #[test]
+    fn ceiling_remainder_is_zero_at_or_past_ceiling() {
+        let ceiling = Duration::from_secs(4 * 3600);
+        // elapsed == ceiling => zero remainder => immediate kill branch.
+        assert!(ceiling.saturating_sub(ceiling).is_zero());
+        // elapsed > ceiling => still zero (saturating), never a huge wait.
+        let past = ceiling + Duration::from_secs(120);
+        assert!(ceiling.saturating_sub(past).is_zero());
+        // elapsed < ceiling => positive remainder used as the recv cap.
+        let before = ceiling - Duration::from_secs(120);
+        let remaining = ceiling.saturating_sub(before);
+        assert!(!remaining.is_zero());
+        assert_eq!(remaining, Duration::from_secs(120));
     }
 }

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -18,9 +18,22 @@ const DEFAULT_CODEX_FIRST_EVENT_TIMEOUT_SECS: u64 = 120;
 /// least one event, the run loop previously blocked on `recv()` forever, so a
 /// Codex process that hung mid-turn (tool/API hang) without emitting another
 /// JSON event and without exiting kept the watcher believing the pane was busy
-/// — the direct cause of the 13125s outlier. We now bound inter-event silence;
-/// the generous 1800s default never trips a healthy long-running tool call.
-const DEFAULT_CODEX_TURN_IDLE_RECV_SECS: u64 = 1800;
+/// — the direct cause of the 13125s outlier. We now bound inter-event silence.
+///
+/// #3557 (B) Codex-review r2 fix: this wrapper runs `codex exec` as a direct
+/// child process and reads its JSON event stream over an OS pipe — there is NO
+/// tmux pane to `capture-pane`, so the "pane liveness" check is not available
+/// on this path. The only liveness signal IS the JSON stream, which `recv` here
+/// already measures. A single long SILENT tool run (e.g. a multi-minute
+/// `cargo build` issued through a shell tool) emits the tool-call-start event,
+/// then nothing until the tool returns — so the idle window must clear the
+/// longest plausible single tool execution, not merely a typical reasoning gap.
+/// We therefore raise the generous default to 3600s (was 1800s) so a normal
+/// long-running tool run is never mistaken for an idle hang. The 4h hard ceiling
+/// (`DEFAULT_CODEX_TURN_HARD_CEILING_SECS`) is the real backstop: idle-kill only
+/// trips on a Codex that is BOTH silent on its event stream AND not exiting, and
+/// even then the ceiling guarantees termination regardless of idle tuning.
+const DEFAULT_CODEX_TURN_IDLE_RECV_SECS: u64 = 3600;
 /// #3557 (B): absolute wall-clock ceiling for a single Codex `exec` turn,
 /// measured from process spawn. A hung Codex that *does* keep dribbling events
 /// would slip past the idle window, so this is the hard backstop. Default 4h
@@ -561,8 +574,13 @@ fn run_turn(
                             hard_ceiling.as_secs()
                         ));
                     }
+                    // NOTE: this path runs `codex exec` over a pipe (no tmux
+                    // pane), so we cannot confirm pane activity before killing —
+                    // the JSON event stream is the only liveness signal we have.
+                    // A genuinely busy-but-silent tool run is covered by the
+                    // generous idle window; the 4h hard ceiling is the backstop.
                     return Err(format!(
-                        "Codex produced no JSON event for {}s (idle hang)",
+                        "Codex produced no JSON event for {}s (idle hang; no tmux pane to confirm activity — relied on JSON-stream liveness, hard ceiling is the backstop)",
                         idle_recv_timeout.as_secs()
                     ));
                 }
@@ -2433,6 +2451,48 @@ mod turn_timeout_tests {
                 Duration::from_secs(DEFAULT_CODEX_TURN_IDLE_RECV_SECS)
             );
         }
+    }
+
+    /// #3557 (B) Codex-review r2 fix: this wrapper runs `codex exec` over a pipe
+    /// (no tmux pane), so a long SILENT tool run cannot be distinguished from an
+    /// idle hang via pane activity — the JSON stream is the only liveness
+    /// signal. To avoid killing a normal long-running tool (e.g. a big build),
+    /// the idle window must be generous and the 4h hard ceiling must stay the
+    /// real backstop. Lock both: the default idle window is now >= 1h AND is
+    /// strictly smaller than the hard ceiling (otherwise the idle window would
+    /// be dead code that the ceiling always preempts).
+    #[test]
+    fn idle_window_is_generous_and_below_hard_ceiling() {
+        assert_eq!(DEFAULT_CODEX_TURN_IDLE_RECV_SECS, 3600);
+        assert!(
+            DEFAULT_CODEX_TURN_IDLE_RECV_SECS >= 3600,
+            "idle window must clear the longest plausible single silent tool run"
+        );
+        assert!(
+            DEFAULT_CODEX_TURN_IDLE_RECV_SECS < DEFAULT_CODEX_TURN_HARD_CEILING_SECS,
+            "the hard ceiling must remain the real backstop, above the idle window"
+        );
+    }
+
+    /// A live event arriving before the (generous) idle window elapses must NOT
+    /// be treated as a hang: a long-running tool that emits its completion event
+    /// within the window passes through cleanly. Models the post-first-event
+    /// branch: a delayed-but-present event resolves to `Ok`, not a Timeout kill.
+    #[test]
+    fn delayed_event_within_idle_window_is_not_killed() {
+        let (tx, rx) = mpsc::channel::<Result<Option<String>, String>>();
+        // Simulate a silent tool run that finishes and emits a completion event
+        // shortly before the idle window would expire.
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            let _ = tx.send(Ok(Some("{\"type\":\"item.completed\"}\n".to_string())));
+        });
+        // Generous window relative to the simulated tool latency: the event wins.
+        let received = rx.recv_timeout(Duration::from_millis(500));
+        assert!(
+            matches!(received, Ok(Ok(Some(_)))),
+            "a tool event arriving within the idle window must not trip the idle-kill path"
+        );
     }
 
     #[test]

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -14,6 +14,18 @@ use crate::services::tmux_wrapper::{InputMode, render_for_terminal};
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
 const TMUX_PROMPT_B64_CHUNK_PREFIX: &str = "__AGENTDESK_B64_CHUNK__:";
 const DEFAULT_CODEX_FIRST_EVENT_TIMEOUT_SECS: u64 = 120;
+/// #3557 (B): idle window after the first event. Once Codex has emitted at
+/// least one event, the run loop previously blocked on `recv()` forever, so a
+/// Codex process that hung mid-turn (tool/API hang) without emitting another
+/// JSON event and without exiting kept the watcher believing the pane was busy
+/// — the direct cause of the 13125s outlier. We now bound inter-event silence;
+/// the generous 1800s default never trips a healthy long-running tool call.
+const DEFAULT_CODEX_TURN_IDLE_RECV_SECS: u64 = 1800;
+/// #3557 (B): absolute wall-clock ceiling for a single Codex `exec` turn,
+/// measured from process spawn. A hung Codex that *does* keep dribbling events
+/// would slip past the idle window, so this is the hard backstop. Default 4h
+/// matches the per-turn Codex ceiling and clears any legitimate Codex turn.
+const DEFAULT_CODEX_TURN_HARD_CEILING_SECS: u64 = 4 * 3600;
 
 pub fn run(
     output_file: &str,
@@ -337,6 +349,29 @@ fn codex_first_event_timeout() -> std::time::Duration {
     std::time::Duration::from_secs(seconds)
 }
 
+/// #3557 (B): idle inter-event recv timeout after the first event. Override via
+/// `AGENTDESK_CODEX_TURN_IDLE_RECV_SECS`.
+fn codex_turn_idle_recv_timeout() -> std::time::Duration {
+    let seconds = std::env::var("AGENTDESK_CODEX_TURN_IDLE_RECV_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(DEFAULT_CODEX_TURN_IDLE_RECV_SECS);
+    std::time::Duration::from_secs(seconds)
+}
+
+/// #3557 (B): absolute per-turn ceiling for a Codex `exec` run. Override via
+/// `AGENTDESK_CODEX_TURN_HARD_CEILING_SECS` (shared with the orchestrator-side
+/// auto-extend ceiling so a single knob bounds the Codex turn end to end).
+fn codex_turn_hard_ceiling() -> std::time::Duration {
+    let seconds = std::env::var("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(DEFAULT_CODEX_TURN_HARD_CEILING_SECS);
+    std::time::Duration::from_secs(seconds)
+}
+
 fn cleanup(output_file: &str, input_fifo: &str) {
     let _ = std::fs::remove_file(output_file);
     let _ = std::fs::remove_file(input_fifo);
@@ -469,12 +504,42 @@ fn run_turn(
     let start = std::time::Instant::now();
     let mut saw_any_stdout = false;
     let first_event_timeout = codex_first_event_timeout();
+    // #3557 (B): bound a turn that hung after its first event (idle window) and a
+    // turn that drips events forever (absolute ceiling). Both kill the Codex
+    // process tree so the turn rejoins the normal error path instead of looking
+    // "busy" to the watcher indefinitely.
+    let idle_recv_timeout = codex_turn_idle_recv_timeout();
+    let hard_ceiling = codex_turn_hard_ceiling();
 
     loop {
+        // Absolute wall-clock ceiling, checked every iteration so even a Codex
+        // that keeps emitting events past the limit is terminated.
+        if start.elapsed() >= hard_ceiling {
+            crate::services::process::kill_pid_tree(child_pid);
+            let _ = child.wait();
+            return Err(format!(
+                "Codex turn exceeded hard ceiling of {}s",
+                hard_ceiling.as_secs()
+            ));
+        }
+
         let next_line = if saw_any_stdout {
-            stdout_rx
-                .recv()
-                .map_err(|_| "Codex stdout reader disconnected".to_string())?
+            // After the first event, bound inter-event silence: a hung Codex that
+            // stops emitting without exiting used to block here forever.
+            match stdout_rx.recv_timeout(idle_recv_timeout) {
+                Ok(line) => line,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    crate::services::process::kill_pid_tree(child_pid);
+                    let _ = child.wait();
+                    return Err(format!(
+                        "Codex produced no JSON event for {}s (idle hang)",
+                        idle_recv_timeout.as_secs()
+                    ));
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err("Codex stdout reader disconnected".to_string());
+                }
+            }
         } else {
             match stdout_rx.recv_timeout(first_event_timeout) {
                 Ok(line) => line,
@@ -2295,4 +2360,69 @@ fn emit_json_line(
         .map_err(|e| format!("write output line: {}", e))?;
     render_for_terminal(&line);
     Ok(())
+}
+
+#[cfg(test)]
+mod turn_timeout_tests {
+    use super::{
+        DEFAULT_CODEX_TURN_HARD_CEILING_SECS, DEFAULT_CODEX_TURN_IDLE_RECV_SECS,
+        codex_turn_hard_ceiling, codex_turn_idle_recv_timeout,
+    };
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// #3557 (B): after the first event the run loop must bound inter-event
+    /// silence. This mirrors the post-`saw_any_stdout` branch: a channel that
+    /// never produces another line must surface a Timeout (the kill+Err path),
+    /// not block forever as the old unconditional `recv()` did.
+    #[test]
+    fn idle_recv_timeout_fires_when_no_further_events() {
+        let (_tx, rx) = mpsc::channel::<Result<Option<String>, String>>();
+        // Keep _tx alive (so it's not Disconnected) and never send.
+        let result = rx.recv_timeout(Duration::from_millis(50));
+        assert!(matches!(result, Err(mpsc::RecvTimeoutError::Timeout)));
+    }
+
+    /// A live event stream still passes through `recv_timeout` cleanly.
+    #[test]
+    fn idle_recv_timeout_passes_through_live_event() {
+        let (tx, rx) = mpsc::channel::<Result<Option<String>, String>>();
+        tx.send(Ok(Some("{\"type\":\"event\"}\n".to_string())))
+            .unwrap();
+        let received = rx.recv_timeout(Duration::from_secs(1));
+        assert!(matches!(received, Ok(Ok(Some(_)))));
+    }
+
+    #[test]
+    fn idle_recv_timeout_defaults_to_generous_window() {
+        // Only assert the default when the env override is not set, so this is
+        // robust under a polluted shell.
+        if std::env::var("AGENTDESK_CODEX_TURN_IDLE_RECV_SECS").is_err() {
+            assert_eq!(
+                codex_turn_idle_recv_timeout(),
+                Duration::from_secs(DEFAULT_CODEX_TURN_IDLE_RECV_SECS)
+            );
+        }
+    }
+
+    #[test]
+    fn hard_ceiling_defaults_to_four_hours() {
+        if std::env::var("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS").is_err() {
+            assert_eq!(
+                codex_turn_hard_ceiling(),
+                Duration::from_secs(DEFAULT_CODEX_TURN_HARD_CEILING_SECS)
+            );
+            assert_eq!(DEFAULT_CODEX_TURN_HARD_CEILING_SECS, 4 * 3600);
+        }
+    }
+
+    /// The ceiling check is a pure elapsed comparison; verify the predicate the
+    /// run loop uses (`start.elapsed() >= hard_ceiling`).
+    #[test]
+    fn ceiling_predicate_triggers_when_elapsed_exceeds_limit() {
+        let ceiling = Duration::from_millis(10);
+        let start = std::time::Instant::now();
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(start.elapsed() >= ceiling);
+    }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -336,6 +336,60 @@ pub(super) fn turn_idle_timeout() -> Duration {
     *CACHED.get_or_init(|| env_duration_secs("AGENTDESK_TURN_IDLE_TIMEOUT_SECS", 3600))
 }
 
+/// #3557 (A): per-turn HARD ceiling measured from turn start. Unlike
+/// [`turn_watchdog_timeout`] (which the auto-extend loop pushes forward
+/// indefinitely while inflight stays warm — the root of the unbounded turn
+/// length), this is an absolute wall-clock cap on a single turn that the
+/// auto-extend loop clamps to. Default 6h matches the current effective cap so
+/// this is non-destructive by default; lower it via
+/// `AGENTDESK_TURN_HARD_CEILING_SECS` to enforce a real backstop. When the
+/// ceiling is hit, no further extension is granted and the next watchdog tick
+/// drives the turn through the existing reconcile/cancel path.
+pub(super) fn turn_hard_ceiling_timeout() -> Duration {
+    static CACHED: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| env_duration_secs("AGENTDESK_TURN_HARD_CEILING_SECS", 6 * 3600))
+}
+
+/// #3557 (A): Codex-specific per-turn HARD ceiling. Codex `exec` turns are the
+/// source of the worst outliers (a 13125s≈3.6h turn from a hung Codex process
+/// that emitted no terminal event), so they get a tighter default ceiling (4h)
+/// than the generic [`turn_hard_ceiling_timeout`]. Override via
+/// `AGENTDESK_CODEX_TURN_HARD_CEILING_SECS`.
+pub(super) fn codex_turn_hard_ceiling_timeout() -> Duration {
+    static CACHED: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| env_duration_secs("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS", 4 * 3600))
+}
+
+/// #3557 (A): the absolute hard-ceiling deadline (ms) for a turn given when it
+/// started and which provider runs it. Codex uses the tighter
+/// [`codex_turn_hard_ceiling_timeout`]; every other provider uses the generic
+/// [`turn_hard_ceiling_timeout`]. The auto-extend loop never pushes the
+/// watchdog deadline past this value.
+pub(super) fn turn_hard_ceiling_deadline_ms(turn_started_ms: i64, provider: &ProviderKind) -> i64 {
+    let ceiling = if matches!(provider, ProviderKind::Codex) {
+        codex_turn_hard_ceiling_timeout()
+    } else {
+        turn_hard_ceiling_timeout()
+    };
+    turn_started_ms.saturating_add(ceiling.as_millis() as i64)
+}
+
+/// #3557 (A): clamp a proposed auto-extend deadline so it never exceeds the
+/// per-turn hard ceiling. Returns the clamped deadline and whether clamping
+/// actually capped the proposal (so the caller can warn exactly once). The
+/// proposal is only ever lowered, never raised — a ceiling already in the past
+/// hard-stops further extension.
+pub(super) fn clamp_auto_extend_deadline_ms(
+    proposed_deadline_ms: i64,
+    ceiling_deadline_ms: i64,
+) -> (i64, bool) {
+    if proposed_deadline_ms > ceiling_deadline_ms {
+        (ceiling_deadline_ms, true)
+    } else {
+        (proposed_deadline_ms, false)
+    }
+}
+
 /// Extend the watchdog deadline for a channel and move the per-turn max cap
 /// with it. Also refreshes the in-memory voice-background handoff marker TTL so
 /// extended turns keep their routing metadata (#2352). When `pg_pool` is `Some`
@@ -4752,6 +4806,68 @@ mod queued_placeholder_cluster_characterization_tests {
                 LeaseSnapshot::Committed { outcome, .. } => outcome,
                 other => panic!("expected Committed, got {other:?}"),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod hard_ceiling_tests {
+    use super::{
+        ProviderKind, clamp_auto_extend_deadline_ms, codex_turn_hard_ceiling_timeout,
+        turn_hard_ceiling_deadline_ms, turn_hard_ceiling_timeout,
+    };
+
+    #[test]
+    fn clamp_caps_proposal_above_ceiling() {
+        let ceiling = 1_000_000;
+        let (clamped, did_clamp) = clamp_auto_extend_deadline_ms(ceiling + 50_000, ceiling);
+        assert_eq!(clamped, ceiling);
+        assert!(did_clamp);
+    }
+
+    #[test]
+    fn clamp_leaves_proposal_below_ceiling_untouched() {
+        let ceiling = 1_000_000;
+        let proposed = ceiling - 50_000;
+        let (clamped, did_clamp) = clamp_auto_extend_deadline_ms(proposed, ceiling);
+        assert_eq!(clamped, proposed);
+        assert!(!did_clamp);
+    }
+
+    #[test]
+    fn clamp_at_exact_ceiling_is_not_a_clamp() {
+        let ceiling = 1_000_000;
+        let (clamped, did_clamp) = clamp_auto_extend_deadline_ms(ceiling, ceiling);
+        assert_eq!(clamped, ceiling);
+        assert!(
+            !did_clamp,
+            "equal-to-ceiling must not be reported as clamped"
+        );
+    }
+
+    #[test]
+    fn codex_uses_tighter_ceiling_than_generic() {
+        // Defaults: generic 6h, codex 4h. Codex's ceiling deadline must be
+        // strictly earlier than the generic provider's for the same start.
+        let start = 10_000_000;
+        let codex = turn_hard_ceiling_deadline_ms(start, &ProviderKind::Codex);
+        let claude = turn_hard_ceiling_deadline_ms(start, &ProviderKind::Claude);
+        assert_eq!(
+            codex,
+            start + codex_turn_hard_ceiling_timeout().as_millis() as i64
+        );
+        assert_eq!(
+            claude,
+            start + turn_hard_ceiling_timeout().as_millis() as i64
+        );
+        // Only assert ordering when the env hasn't overridden defaults.
+        if std::env::var("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS").is_err()
+            && std::env::var("AGENTDESK_TURN_HARD_CEILING_SECS").is_err()
+        {
+            assert!(
+                codex < claude,
+                "codex ceiling ({codex}) must be earlier than generic ceiling ({claude})"
+            );
         }
     }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -4870,4 +4870,59 @@ mod hard_ceiling_tests {
             );
         }
     }
+
+    /// #3557 (A) Codex-review fix: the INITIAL watchdog deadline must already be
+    /// capped at the provider ceiling, not only the auto-extend clamp. This
+    /// reproduces the `min(now + watchdog_timeout, ceiling_deadline)` the
+    /// watchdog now applies at spawn. With a 6h watchdog timeout and the tighter
+    /// 4h Codex ceiling, the initial deadline must land at 4h (the ceiling), so
+    /// a hung Codex turn is reconciled at 4h instead of 6h.
+    #[test]
+    fn initial_deadline_is_capped_at_codex_ceiling() {
+        // Only meaningful with default ceilings (codex 4h < generic/timeout 6h).
+        if std::env::var("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS").is_ok()
+            || std::env::var("AGENTDESK_TURN_TIMEOUT_SECS").is_ok()
+        {
+            return;
+        }
+        let now_ms: i64 = 1_000_000_000;
+        let watchdog_timeout_ms = super::turn_watchdog_timeout().as_millis() as i64; // 6h
+        let proposed_initial_dl = now_ms + watchdog_timeout_ms;
+        let codex_ceiling = turn_hard_ceiling_deadline_ms(now_ms, &ProviderKind::Codex);
+        let initial = std::cmp::min(proposed_initial_dl, codex_ceiling);
+        assert_eq!(
+            initial, codex_ceiling,
+            "Codex initial deadline must be capped at the 4h ceiling, not the 6h timeout"
+        );
+        assert!(
+            initial < proposed_initial_dl,
+            "the cap must actually lower the initial deadline below the 6h timeout"
+        );
+        // The cap binds => the init-time warn condition (`proposed > ceiling`)
+        // is true, so the operator gets the one-shot ceiling warning.
+        assert!(proposed_initial_dl > codex_ceiling);
+    }
+
+    /// For a non-Codex provider whose ceiling equals the watchdog timeout (the
+    /// non-destructive default), the initial cap is a no-op: `min` leaves the
+    /// timeout-based deadline untouched and the init warn does NOT fire.
+    #[test]
+    fn initial_deadline_uncapped_when_ceiling_equals_timeout() {
+        if std::env::var("AGENTDESK_TURN_HARD_CEILING_SECS").is_ok()
+            || std::env::var("AGENTDESK_TURN_TIMEOUT_SECS").is_ok()
+        {
+            return;
+        }
+        let now_ms: i64 = 2_000_000_000;
+        let watchdog_timeout_ms = super::turn_watchdog_timeout().as_millis() as i64;
+        let proposed_initial_dl = now_ms + watchdog_timeout_ms;
+        let claude_ceiling = turn_hard_ceiling_deadline_ms(now_ms, &ProviderKind::Claude);
+        let initial = std::cmp::min(proposed_initial_dl, claude_ceiling);
+        // Defaults: generic ceiling 6h == watchdog timeout 6h.
+        assert_eq!(initial, proposed_initial_dl);
+        assert!(
+            proposed_initial_dl <= claude_ceiling,
+            "with equal defaults the init warn (proposed > ceiling) must not fire"
+        );
+    }
 }

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -914,8 +914,33 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         let timeout = super::super::super::turn_watchdog_timeout();
         let now_ms = chrono::Utc::now().timestamp_millis();
         let turn_started_ms = now_ms;
-        let deadline_ms = now_ms + timeout.as_millis() as i64;
+        // #3557 (A) Codex-review r2 fix: mirror the foreground intake_turn.rs
+        // ceiling cap on the headless path. This path also calls
+        // `mark_async_managed()` so the per-provider sync watchdog stops
+        // enforcing the deadline — meaning ONLY this async loop bounds the turn.
+        // Previously the initial deadline was always `now + 6h` and the
+        // auto-extend stored `now + 6h` unclamped, so headless Codex turns
+        // ignored the tighter 4h ceiling and could be re-extended without a
+        // hard backstop. Cap the initial deadline at the provider ceiling so
+        // the bound is honored end to end (same helper as the foreground path).
+        let ceiling_deadline_ms =
+            super::super::super::turn_hard_ceiling_deadline_ms(turn_started_ms, &provider);
+        let proposed_initial_dl = now_ms + timeout.as_millis() as i64;
+        let deadline_ms = std::cmp::min(proposed_initial_dl, ceiling_deadline_ms);
         let max_deadline_ms = deadline_ms;
+        // When the ceiling already caps the initial deadline (e.g. Codex 4h <
+        // 6h watchdog timeout) the auto-extend clamp warn below never fires
+        // (its `current_dl < ceiling_ms` guard is false once the deadline is
+        // parked at the ceiling), so surface the bound once here instead.
+        if proposed_initial_dl > ceiling_deadline_ms {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            let ceiling_min = (ceiling_deadline_ms - now_ms) / 1000 / 60;
+            tracing::warn!(
+                "  [{ts}] ⛔ WATCHDOG: hard ceiling ({ceiling_min}m) caps initial deadline for headless channel {} (provider={}) — turn will be reconciled at the ceiling",
+                channel_id.get(),
+                provider_label
+            );
+        }
         // claude-e rollout Phase 1 (counter-review round 3 with Codex):
         // see the text-watchdog setup above for the rationale.
         watchdog_token.mark_async_managed();
@@ -973,7 +998,35 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
                                     let updated_ms = updated.and_utc().timestamp_millis();
                                     let age_ms = now_ms_check - updated_ms;
                                     if age_ms < 300_000 {
-                                        let new_dl = now_ms_check + timeout.as_millis() as i64;
+                                        // #3557 (A) Codex-review r2 fix: clamp the
+                                        // headless auto-extend to the per-turn hard
+                                        // ceiling, exactly like the foreground path.
+                                        // Without this a headless Codex turn that
+                                        // keeps inflight warm could push the deadline
+                                        // past its 4h ceiling indefinitely (this path
+                                        // is `mark_async_managed`, so the sync
+                                        // watchdog does not enforce it either).
+                                        let ceiling_ms =
+                                            super::super::super::turn_hard_ceiling_deadline_ms(
+                                                turn_started_ms,
+                                                &watchdog_provider,
+                                            );
+                                        let proposed_dl = now_ms_check + timeout.as_millis() as i64;
+                                        let (new_dl, clamped) =
+                                            super::super::super::clamp_auto_extend_deadline_ms(
+                                                proposed_dl,
+                                                ceiling_ms,
+                                            );
+                                        // Warn exactly once when the ceiling first
+                                        // bites: `current_dl < ceiling_ms` only holds
+                                        // before the deadline is parked at the ceiling.
+                                        if clamped && current_dl < ceiling_ms {
+                                            let ts = chrono::Local::now().format("%H:%M:%S");
+                                            tracing::warn!(
+                                                "  [{ts}] ⛔ WATCHDOG: hard ceiling reached for headless channel {} — auto-extend clamped, turn will be reconciled at deadline",
+                                                watchdog_channel_id_num
+                                            );
+                                        }
                                         if new_dl > current_dl {
                                             watchdog_token.watchdog_deadline_ms.store(
                                                 new_dl,
@@ -1459,4 +1512,97 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         turn_id: reservation.turn_id(channel_id),
         status: HeadlessTurnStartStatus::Started,
     })
+}
+
+#[cfg(test)]
+mod headless_hard_ceiling_tests {
+    //! #3557 (A) Codex-review r2: the headless watchdog now mirrors the
+    //! foreground intake path's per-turn hard ceiling cap (the headless path
+    //! had been missing it, and it also `mark_async_managed`s the token so the
+    //! sync watchdog does not enforce — leaving this async loop as the ONLY
+    //! bound). These tests reproduce the exact arithmetic the headless loop
+    //! applies (initial-deadline `min` cap + auto-extend clamp) so a regression
+    //! that drops the cap is caught at the headless call site, not only in the
+    //! shared helper tests in `discord/mod.rs`.
+    use super::super::super::super::{
+        ProviderKind, clamp_auto_extend_deadline_ms, turn_hard_ceiling_deadline_ms,
+        turn_watchdog_timeout,
+    };
+
+    /// Codex's tighter 4h ceiling must cap the headless INITIAL deadline below
+    /// the 6h watchdog timeout — exactly the `min(now + timeout, ceiling)` the
+    /// headless spawn now uses. Skipped when env overrides the defaults.
+    #[test]
+    fn headless_initial_deadline_capped_at_codex_ceiling() {
+        if std::env::var("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS").is_ok()
+            || std::env::var("AGENTDESK_TURN_TIMEOUT_SECS").is_ok()
+        {
+            return;
+        }
+        let now_ms: i64 = 1_700_000_000_000;
+        let proposed_initial_dl = now_ms + turn_watchdog_timeout().as_millis() as i64; // ~6h
+        let codex_ceiling = turn_hard_ceiling_deadline_ms(now_ms, &ProviderKind::Codex);
+        let initial = std::cmp::min(proposed_initial_dl, codex_ceiling);
+        assert_eq!(
+            initial, codex_ceiling,
+            "headless Codex initial deadline must land at the 4h ceiling, not 6h"
+        );
+        assert!(
+            initial < proposed_initial_dl,
+            "the headless cap must actually lower the deadline below the watchdog timeout"
+        );
+        // The init-time one-shot warn fires exactly when proposed > ceiling.
+        assert!(proposed_initial_dl > codex_ceiling);
+    }
+
+    /// For a default-Claude turn (generic ceiling == watchdog timeout) the
+    /// headless initial cap is a no-op and the init warn must NOT fire.
+    #[test]
+    fn headless_initial_deadline_uncapped_for_default_claude() {
+        if std::env::var("AGENTDESK_TURN_HARD_CEILING_SECS").is_ok()
+            || std::env::var("AGENTDESK_TURN_TIMEOUT_SECS").is_ok()
+        {
+            return;
+        }
+        let now_ms: i64 = 1_700_000_000_000;
+        let proposed_initial_dl = now_ms + turn_watchdog_timeout().as_millis() as i64;
+        let claude_ceiling = turn_hard_ceiling_deadline_ms(now_ms, &ProviderKind::Claude);
+        let initial = std::cmp::min(proposed_initial_dl, claude_ceiling);
+        assert_eq!(initial, proposed_initial_dl);
+        assert!(
+            proposed_initial_dl <= claude_ceiling,
+            "with equal defaults the headless init warn (proposed > ceiling) must not fire"
+        );
+    }
+
+    /// The headless AUTO-EXTEND must clamp to the ceiling: a turn that keeps
+    /// inflight warm can no longer push the deadline past its Codex ceiling.
+    /// Mirrors `clamp_auto_extend_deadline_ms(now + timeout, ceiling)`.
+    #[test]
+    fn headless_auto_extend_clamped_at_codex_ceiling() {
+        if std::env::var("AGENTDESK_CODEX_TURN_HARD_CEILING_SECS").is_ok()
+            || std::env::var("AGENTDESK_TURN_TIMEOUT_SECS").is_ok()
+        {
+            return;
+        }
+        // Turn started 3h ago; an auto-extend would propose now + 6h, well past
+        // the 4h Codex ceiling (1h of budget left), so the clamp must bind.
+        let turn_started_ms: i64 = 1_700_000_000_000;
+        let now_ms_check = turn_started_ms + 3 * 3600 * 1000;
+        let ceiling_ms = turn_hard_ceiling_deadline_ms(turn_started_ms, &ProviderKind::Codex);
+        let proposed_dl = now_ms_check + turn_watchdog_timeout().as_millis() as i64;
+        let (new_dl, clamped) = clamp_auto_extend_deadline_ms(proposed_dl, ceiling_ms);
+        assert!(
+            clamped,
+            "auto-extend past the Codex ceiling must be clamped"
+        );
+        assert_eq!(
+            new_dl, ceiling_ms,
+            "clamped deadline must park at the ceiling"
+        );
+        assert!(
+            new_dl < proposed_dl,
+            "the clamp must lower the proposed extension to the ceiling"
+        );
+    }
 }

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2651,7 +2651,34 @@ pub(in crate::services::discord) async fn handle_text_message(
                                 let age_ms = now_ms_check - updated_ms;
                                 // If inflight was updated within the last 5 minutes, auto-extend
                                 if age_ms < 300_000 {
-                                    let new_dl = now_ms_check + timeout.as_millis() as i64;
+                                    // #3557 (A): clamp the auto-extend so a turn
+                                    // that keeps inflight warm forever cannot push
+                                    // the deadline indefinitely. The hard ceiling
+                                    // is measured from turn start and is tighter
+                                    // for Codex (the 13125s outlier source).
+                                    let ceiling_ms =
+                                        super::super::super::turn_hard_ceiling_deadline_ms(
+                                            turn_started_ms,
+                                            &watchdog_provider,
+                                        );
+                                    let proposed_dl = now_ms_check + timeout.as_millis() as i64;
+                                    let (new_dl, clamped) =
+                                        super::super::super::clamp_auto_extend_deadline_ms(
+                                            proposed_dl,
+                                            ceiling_ms,
+                                        );
+                                    // Warn exactly once when the ceiling first bites:
+                                    // `current_dl < ceiling_ms` is only true before
+                                    // the deadline has been parked at the ceiling. On
+                                    // later ticks `current_dl == ceiling_ms` so this is
+                                    // false and the warn does not repeat.
+                                    if clamped && current_dl < ceiling_ms {
+                                        let ts = chrono::Local::now().format("%H:%M:%S");
+                                        tracing::warn!(
+                                            "  [{ts}] ⛔ WATCHDOG: hard ceiling reached for channel {} — auto-extend clamped, turn will be reconciled at deadline",
+                                            channel_id
+                                        );
+                                    }
                                     if new_dl > current_dl {
                                         watchdog_token
                                             .watchdog_deadline_ms

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2579,8 +2579,31 @@ pub(in crate::services::discord) async fn handle_text_message(
         // extension for alert context; it is no longer an absolute cap.
         let now_ms = chrono::Utc::now().timestamp_millis();
         let turn_started_ms = now_ms;
-        let deadline_ms = now_ms + timeout.as_millis() as i64;
+        // #3557 (A) Codex-review fix: the per-turn hard ceiling must bind the
+        // INITIAL deadline, not only the auto-extend clamp. Previously the
+        // initial deadline was always `now + turn_watchdog_timeout()` (6h), and
+        // the auto-extend clamp could not lower it because the store is gated by
+        // `new_dl > current_dl`. So a Codex turn (4h ceiling) was still cancelled
+        // at 6h and the clamp warn never fired. Cap the initial deadline at the
+        // provider ceiling here so the tighter Codex bound is honored end to end.
+        let ceiling_deadline_ms =
+            super::super::super::turn_hard_ceiling_deadline_ms(turn_started_ms, &provider);
+        let proposed_initial_dl = now_ms + timeout.as_millis() as i64;
+        let deadline_ms = std::cmp::min(proposed_initial_dl, ceiling_deadline_ms);
         let max_deadline_ms = deadline_ms;
+        // When the ceiling already caps the initial deadline (e.g. Codex 4h <
+        // 6h watchdog timeout) the auto-extend clamp warn below never fires
+        // (its `current_dl < ceiling_ms` guard is false once the deadline is
+        // parked at the ceiling), so surface the bound once here instead.
+        if proposed_initial_dl > ceiling_deadline_ms {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            let ceiling_min = (ceiling_deadline_ms - now_ms) / 1000 / 60;
+            tracing::warn!(
+                "  [{ts}] ⛔ WATCHDOG: hard ceiling ({ceiling_min}m) caps initial deadline for channel {} (provider={}) — turn will be reconciled at the ceiling",
+                channel_id,
+                provider_label
+            );
+        }
         // claude-e rollout Phase 1 (counter-review round 3 with Codex):
         // mark this token as async-managed so the per-provider sync
         // watchdog (`enforce_watchdog_deadline` in `spawn_cancel_watchdog`)

--- a/src/services/long_turn_watchdog.rs
+++ b/src/services/long_turn_watchdog.rs
@@ -1,0 +1,216 @@
+//! Long-turn cluster watchdog (#3557 (A)).
+//!
+//! The stall watchdog (`watchdog.rs`) only fires when a turn's watchdog token is
+//! marked `desynced=true`. The `delegated_to_watcher` handoff path leaves
+//! `desynced=false`, so a cluster of legitimately *finished but very long* turns
+//! (the #3557 symptom in #adk-cc: avg 548s, >180s 63%, Codex outliers to
+//! 13125s) is invisible to it. This probe closes that blind spot.
+//!
+//! It scans `observability_events` for `turn_finished` rows whose payload
+//! `duration_ms` exceeds 600000 (10 min) inside a rolling 5-minute window. When
+//! at least `LONG_TURN_CLUSTER_THRESHOLD` such turns land in one window it pages
+//! out once to the deadlock-manager channel (or the shared fallback), so an
+//! operator sees a sustained slow-turn cluster forming.
+//!
+//! Detection only — it never cancels turns. The per-turn hard ceiling and Codex
+//! recv timeout (the same issue) own enforcement; this is the human-visible
+//! signal that those backstops (or a deeper deadlock) are being exercised.
+
+use std::time::Duration;
+
+use serde_json::json;
+use sqlx::{PgPool, Row};
+
+/// Scan cadence and window length. A 5-minute window matched to a 5-minute scan
+/// keeps the probe cheap (one indexed range scan) while still catching a cluster
+/// soon after it forms.
+const SCAN_INTERVAL: Duration = Duration::from_secs(300);
+
+/// A turn longer than this (ms) counts toward the cluster. 600000ms == 10 min.
+/// The issue flags >180s as the chronic problem and >600s as the acute tail;
+/// 600s is the conservative, low-noise tier worth paging on.
+const LONG_TURN_MS_THRESHOLD: i64 = 600_000;
+
+/// Number of long turns inside one window required to page out. 3 distinguishes
+/// a genuine cluster from a single legitimately long turn.
+const LONG_TURN_CLUSTER_THRESHOLD: i64 = 3;
+
+/// Window length used by the SQL aggregation (kept equal to `SCAN_INTERVAL` so
+/// successive scans tile the timeline without gaps or double counting).
+const WINDOW_SECONDS: i64 = 300;
+
+/// Spawn the watchdog as a background task. The query is a single indexed range
+/// scan every 5 minutes, so always-on is fine.
+pub fn spawn(pool: PgPool) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SCAN_INTERVAL);
+        // Skip the immediate first tick so boot reconcile finishes first.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if let Err(error) = scan_once(&pool).await {
+                tracing::warn!("[long_turn_watchdog] scan failed: {error}");
+            }
+        }
+    });
+}
+
+/// Per-window aggregate the SQL produces.
+struct LongTurnWindow {
+    long_turn_count: i64,
+    max_duration_ms: i64,
+    codex_count: i64,
+}
+
+async fn scan_once(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let window = query_long_turn_window(pool).await?;
+
+    if !cluster_breached(window.long_turn_count) {
+        return Ok(());
+    }
+
+    let target = resolve_alert_channel();
+    let message = format_long_turn_alert(&window);
+
+    tracing::warn!(
+        long_turn_count = window.long_turn_count,
+        max_duration_ms = window.max_duration_ms,
+        codex_count = window.codex_count,
+        "[long_turn_watchdog] long-turn cluster detected"
+    );
+
+    crate::services::observability::events::record_simple(
+        "long_turn_cluster",
+        None,
+        None,
+        json!({
+            "long_turn_count": window.long_turn_count,
+            "max_duration_ms": window.max_duration_ms,
+            "codex_count": window.codex_count,
+            "threshold_ms": LONG_TURN_MS_THRESHOLD,
+            "cluster_threshold": LONG_TURN_CLUSTER_THRESHOLD,
+            "window_seconds": WINDOW_SECONDS,
+        }),
+    );
+
+    if let Err(error) = enqueue_alert(pool, &target, &message).await {
+        tracing::warn!("[long_turn_watchdog] enqueue alert failed: {error}");
+    }
+
+    Ok(())
+}
+
+/// Aggregate `turn_finished` rows in the last `WINDOW_SECONDS` whose
+/// `payload_json->>'duration_ms'` exceeds the long-turn threshold.
+async fn query_long_turn_window(pool: &PgPool) -> Result<LongTurnWindow, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT
+             COUNT(*)::bigint AS long_turn_count,
+             COALESCE(MAX((payload_json->>'duration_ms')::bigint), 0)::bigint AS max_duration_ms,
+             COUNT(*) FILTER (WHERE provider = 'codex')::bigint AS codex_count
+         FROM observability_events
+         WHERE event_type = 'turn_finished'
+           AND created_at >= NOW() - make_interval(secs => $1::int)
+           AND (payload_json->>'duration_ms') IS NOT NULL
+           AND (payload_json->>'duration_ms') ~ '^[0-9]+$'
+           AND (payload_json->>'duration_ms')::bigint > $2",
+    )
+    .bind(WINDOW_SECONDS)
+    .bind(LONG_TURN_MS_THRESHOLD)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(LongTurnWindow {
+        long_turn_count: row.try_get("long_turn_count").unwrap_or(0),
+        max_duration_ms: row.try_get("max_duration_ms").unwrap_or(0),
+        codex_count: row.try_get("codex_count").unwrap_or(0),
+    })
+}
+
+/// Whether a window's long-turn count meets the cluster threshold.
+fn cluster_breached(long_turn_count: i64) -> bool {
+    long_turn_count >= LONG_TURN_CLUSTER_THRESHOLD
+}
+
+/// Resolve the alert channel: the configured deadlock-manager channel if set,
+/// otherwise the shared fallback (`#adk-cc`). The fallback const in `slo` is the
+/// adk-cc snowflake `1479671298497183835`, the issue's investigation channel.
+fn resolve_alert_channel() -> String {
+    crate::config::load()
+        .ok()
+        .and_then(|config| {
+            config
+                .kanban
+                .deadlock_manager_channel_id
+                .as_ref()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| crate::services::slo::FALLBACK_ALERT_CHANNEL.to_string())
+}
+
+fn format_long_turn_alert(window: &LongTurnWindow) -> String {
+    let window_min = WINDOW_SECONDS / 60;
+    let max_min = window.max_duration_ms / 1000 / 60;
+    format!(
+        "[LONG-TURN] {} turns >{}m finished in last {}m (codex={}, max={}m) — possible turn-length cluster/deadlock, check #3557 backstops",
+        window.long_turn_count,
+        LONG_TURN_MS_THRESHOLD / 1000 / 60,
+        window_min,
+        window.codex_count,
+        max_min,
+    )
+}
+
+async fn enqueue_alert(pool: &PgPool, target: &str, content: &str) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO message_outbox (target, content, bot, source, reason_code, status)
+         VALUES ($1, $2, 'notify', 'long_turn_watchdog', 'long_turn_cluster', 'pending')",
+    )
+    .bind(target)
+    .bind(content)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cluster_threshold_triggers_at_three() {
+        assert!(!cluster_breached(0));
+        assert!(!cluster_breached(LONG_TURN_CLUSTER_THRESHOLD - 1));
+        assert!(cluster_breached(LONG_TURN_CLUSTER_THRESHOLD));
+        assert!(cluster_breached(LONG_TURN_CLUSTER_THRESHOLD + 5));
+    }
+
+    #[test]
+    fn fallback_channel_is_adk_cc_when_unconfigured() {
+        // With no deadlock_manager_channel_id configured in the test env, the
+        // resolver must fall back to the shared adk-cc alert channel rather
+        // than panicking or returning empty.
+        let channel = resolve_alert_channel();
+        assert!(!channel.is_empty());
+        // The shared fallback const is the adk-cc investigation channel.
+        assert_eq!(channel, crate::services::slo::FALLBACK_ALERT_CHANNEL);
+    }
+
+    #[test]
+    fn alert_message_contains_actionable_context() {
+        let window = LongTurnWindow {
+            long_turn_count: 4,
+            max_duration_ms: 13_125_000,
+            codex_count: 2,
+        };
+        let msg = format_long_turn_alert(&window);
+        assert!(msg.contains("LONG-TURN"));
+        assert!(msg.contains("4 turns"));
+        assert!(msg.contains(">10m"));
+        assert!(msg.contains("codex=2"));
+        // 13125s ≈ 218 min.
+        assert!(msg.contains("max=218m"));
+        assert!(msg.contains("#3557"));
+    }
+}

--- a/src/services/long_turn_watchdog.rs
+++ b/src/services/long_turn_watchdog.rs
@@ -39,6 +39,36 @@ const LONG_TURN_CLUSTER_THRESHOLD: i64 = 3;
 /// successive scans tile the timeline without gaps or double counting).
 const WINDOW_SECONDS: i64 = 300;
 
+/// #3557 (A) Codex-review fix: alert cooldown (seconds). A sustained or
+/// overlapping cluster spans many consecutive 5-minute scans; without a cooldown
+/// the raw insert paged once per scan (every 5 min) for the cluster's whole
+/// lifetime. This dedupe window (via `message_outbox` `dedupe_key` + TTL,
+/// following the #3561/#3564 `enqueue_outbox_pg_with_ttl` precedent) collapses a
+/// persistent cluster to one page per window. 30 min ≫ the 5-min scan cadence so
+/// repeated scans coalesce, while still re-paging if a cluster is still forming a
+/// half-hour later. Override via `AGENTDESK_LONG_TURN_ALERT_COOLDOWN_SECS`.
+const LONG_TURN_ALERT_COOLDOWN_SECS: i64 = 1800;
+
+/// Stable dedupe session key for the cluster alert. The same key every scan is
+/// what lets the `dedupe_key` (derived from target + reason_code + session_key)
+/// collapse repeated alerts inside the cooldown TTL into a single outbox row.
+const LONG_TURN_ALERT_SESSION_KEY: &str = "long_turn_watchdog:cluster";
+
+/// `message_outbox.reason_code` for the cluster alert. Combined with the stable
+/// session key above this gives a reason-code identity (content-independent)
+/// dedupe key, so the alert dedupes even though its rendered counts vary scan to
+/// scan.
+const LONG_TURN_ALERT_REASON_CODE: &str = "long_turn_cluster";
+
+/// Read the alert cooldown, allowing an env override for ops tuning.
+fn alert_cooldown_secs() -> i64 {
+    std::env::var("AGENTDESK_LONG_TURN_ALERT_COOLDOWN_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(LONG_TURN_ALERT_COOLDOWN_SECS)
+}
+
 /// Spawn the watchdog as a background task. The query is a single indexed range
 /// scan every 5 minutes, so always-on is fine.
 pub fn spawn(pool: PgPool) {
@@ -93,8 +123,19 @@ async fn scan_once(pool: &PgPool) -> Result<(), sqlx::Error> {
         }),
     );
 
-    if let Err(error) = enqueue_alert(pool, &target, &message).await {
-        tracing::warn!("[long_turn_watchdog] enqueue alert failed: {error}");
+    match enqueue_alert(pool, &target, &message).await {
+        Ok(true) => {}
+        Ok(false) => {
+            // Suppressed by the cooldown dedupe key — the cluster is still
+            // active but already paged inside this window.
+            tracing::debug!(
+                "[long_turn_watchdog] cluster alert suppressed by cooldown ({}s window)",
+                alert_cooldown_secs()
+            );
+        }
+        Err(error) => {
+            tracing::warn!("[long_turn_watchdog] enqueue alert failed: {error}");
+        }
     }
 
     Ok(())
@@ -162,16 +203,32 @@ fn format_long_turn_alert(window: &LongTurnWindow) -> String {
     )
 }
 
-async fn enqueue_alert(pool: &PgPool, target: &str, content: &str) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "INSERT INTO message_outbox (target, content, bot, source, reason_code, status)
-         VALUES ($1, $2, 'notify', 'long_turn_watchdog', 'long_turn_cluster', 'pending')",
+/// Enqueue the cluster alert through the deduped `message_outbox` path so a
+/// persistent/overlapping cluster pages at most once per cooldown window.
+///
+/// #3557 (A) Codex-review fix: the previous raw `INSERT` had no `dedupe_key`, so
+/// every 5-minute scan over a long-lived cluster inserted a fresh row and the
+/// channel got spammed. Routing through `enqueue_outbox_pg_with_ttl` with a
+/// stable session key + reason code mirrors the `dispatch_watchdog`
+/// `last_stuck_alert_at` cooldown intent using the durable DB dedupe key
+/// (#3561/#3564 precedent), so suppression survives process restarts too.
+///
+/// Returns `Ok(true)` when a new alert row was actually enqueued and `Ok(false)`
+/// when the cooldown suppressed it as a duplicate.
+async fn enqueue_alert(pool: &PgPool, target: &str, content: &str) -> Result<bool, sqlx::Error> {
+    crate::services::message_outbox::enqueue_outbox_pg_with_ttl(
+        pool,
+        crate::services::message_outbox::OutboxMessage {
+            target,
+            content,
+            bot: "notify",
+            source: "long_turn_watchdog",
+            reason_code: Some(LONG_TURN_ALERT_REASON_CODE),
+            session_key: Some(LONG_TURN_ALERT_SESSION_KEY),
+        },
+        alert_cooldown_secs(),
     )
-    .bind(target)
-    .bind(content)
-    .execute(pool)
-    .await?;
-    Ok(())
+    .await
 }
 
 #[cfg(test)]
@@ -212,5 +269,53 @@ mod tests {
         // 13125s ≈ 218 min.
         assert!(msg.contains("max=218m"));
         assert!(msg.contains("#3557"));
+    }
+
+    /// #3557 (A) Codex-review fix: the alert cooldown must be a positive window
+    /// strictly larger than the 5-minute scan cadence, otherwise consecutive
+    /// scans over a persistent cluster would each page (the spam the dedupe
+    /// fixes).
+    #[test]
+    fn alert_cooldown_exceeds_scan_cadence_by_default() {
+        if std::env::var("AGENTDESK_LONG_TURN_ALERT_COOLDOWN_SECS").is_err() {
+            assert_eq!(alert_cooldown_secs(), LONG_TURN_ALERT_COOLDOWN_SECS);
+            assert!(
+                alert_cooldown_secs() > SCAN_INTERVAL.as_secs() as i64,
+                "cooldown ({}s) must exceed the scan cadence ({}s) so repeated scans coalesce",
+                alert_cooldown_secs(),
+                SCAN_INTERVAL.as_secs()
+            );
+        }
+    }
+
+    /// The dedupe identity (session key + reason code) must be stable across
+    /// scans — that stability is exactly what collapses repeated alerts into a
+    /// single outbox row via the `dedupe_key`. A drifting key would defeat the
+    /// suppression, so pin both constants to non-empty, content-independent
+    /// values.
+    #[test]
+    fn dedupe_identity_is_stable_and_content_independent() {
+        assert!(!LONG_TURN_ALERT_SESSION_KEY.trim().is_empty());
+        assert!(!LONG_TURN_ALERT_REASON_CODE.trim().is_empty());
+        // The reason code is the message_outbox dedupe identity kind; with a
+        // reason_code present the dedupe key ignores the (varying) rendered
+        // content, so two different alert bodies dedupe to the same row.
+        let key_a = crate::services::message_outbox::dedupe_key_for_message_for_test(
+            "channel:123",
+            "3 turns >10m ...",
+            Some(LONG_TURN_ALERT_REASON_CODE),
+            Some(LONG_TURN_ALERT_SESSION_KEY),
+        );
+        let key_b = crate::services::message_outbox::dedupe_key_for_message_for_test(
+            "channel:123",
+            "9 turns >10m ... (different counts)",
+            Some(LONG_TURN_ALERT_REASON_CODE),
+            Some(LONG_TURN_ALERT_SESSION_KEY),
+        );
+        assert_eq!(
+            key_a, key_b,
+            "same session key + reason code must dedupe regardless of rendered counts"
+        );
+        assert!(key_a.is_some());
     }
 }

--- a/src/services/message_outbox.rs
+++ b/src/services/message_outbox.rs
@@ -62,6 +62,19 @@ fn dedupe_key_for_message(
     Some(format!("message_outbox:v1:{}", hasher.finalize().to_hex()))
 }
 
+/// Test-only accessor for [`dedupe_key_for_message`] so sibling modules can
+/// assert their dedupe identity is stable (e.g. `long_turn_watchdog` verifying
+/// its cluster alert dedupes across scans). Not part of the runtime API.
+#[cfg(test)]
+pub(crate) fn dedupe_key_for_message_for_test(
+    target: &str,
+    content: &str,
+    reason_code: Option<&str>,
+    session_key: Option<&str>,
+) -> Option<String> {
+    dedupe_key_for_message(target, content, reason_code, session_key)
+}
+
 #[cfg(test)]
 mod dedupe_key_tests {
     use super::dedupe_key_for_message;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -44,6 +44,7 @@ pub mod git;
 pub mod issue_announcements;
 pub mod kanban;
 pub mod kanban_cards;
+pub mod long_turn_watchdog;
 // #3034: 81 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during maintenance dead-code cleanup.
 #[allow(dead_code)]


### PR DESCRIPTION
## 문제
#adk-cc 만성 장기 턴/deadlock(W25 avg 548s, >180s 63%), Codex 3h+ outlier(최대 13125s) — 턴 hard ceiling 부재.

## 변경
- **per-turn hard ceiling** (AGENTDESK_TURN_HARD_CEILING_SECS 기본 6h, Codex 4h): intake+headless 양 경로의 deadline을 초기/연장 모두 ceiling으로 clamp(도달 시 기존 reconcile auto-cancel/통지 발동). 기본값 비파괴.
- **long_turn_watchdog** 신설: turn_finished >600s를 5분 윈도우 집계 ≥3건이면 message_outbox로 1회 경보(30분 cooldown dedupe).
- **(B) Codex 근본**: codex_tmux_wrapper recv 무한대기 → idle recv-timeout(generous 3600s) + 총경과 ceiling 캡으로 hung Codex kill(13125s outlier 직접 원인). 일반 bridge race는 자기복구 확인해 진단만(turn_bridge 미변경).

## 검증
- 신규/회귀 테스트 다수 통과, audit/hotfile/freshness/ci-script-checks green.
- Codex(gpt-5.5, xhigh) 적대리뷰 3R(intake→headless, near-ceiling→idle 누락 전수 확인): **VERDICT: CLEAN**. (audit:2026-06-18)