### PR TITLE
fix(#3581): 미채택 rebind_origin inflight bounded reap — stall-watchdog orphan wedge 제거

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -920,7 +920,11 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3329 lines; +53 from #3562 threading
+  - `src/services/discord/recovery_engine.rs` (3340 lines; +11 from #3581 stamping
+    the three bounded-preservation fields (`rebind_origin_created_at_unix` /
+    `_deadline_secs` / `_birth_generation`) at the rebind-origin birth site so an
+    unadopted, never-progressed orphan can be reaped instead of permanently
+    wedging turn-start; +53 from #3562 threading
     the recovered-turn identity (`recovered_transcript_turn_id` full-path call) +
     channel-bound `agent_id` (`resolve_role_binding(...).role_id`) through the
     `emit_recovery_fired` / `emit_recovery_quality_event` recovery observability

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -371,7 +371,20 @@
 # skipped every rebind row unconditionally, the permanent-orphan source). The
 # bulk is load-bearing doc comments pinning the never-live argument; the tests
 # live in `#[cfg(test)] mod rebind_origin_reap_tests` and are excluded here.
-"src/services/discord/inflight.rs" = 2551
+# #3581 (codex TOCTOU follow-up) raised 2551 -> 2660 (+109): closes the
+# placeholder-sweeper reap race (unlocked-snapshot pre-check, then
+# `delete_inflight_state_file` unlinked without re-reading the row under the
+# lock — a racing intake/TUI claim could persist a new live inflight at the same
+# sidecar path and have it wiped). Adds the shared locked re-validate helper
+# `reap_abandoned_rebind_origin_locked_in_root` (+ its env wrapper
+# `reap_abandoned_rebind_origin_locked`), the `RebindReapOutcome` enum, and the
+# `rebind_row_identity_unchanged` identity guard (created_at + birth_generation +
+# turn_start_offset) so a replacement turn is never mistaken for the snapshotted
+# orphan. Both the sweeper and the boot `invalidate_stale_generation_in_root`
+# path now route their unlink through this single helper (the boot branch loses
+# its inline lock+reload). The bulk is load-bearing doc comments; the 4 new
+# boundary tests live in the excluded `rebind_origin_reap_tests` module.
+"src/services/discord/inflight.rs" = 2660
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -250,7 +250,11 @@
 # #3562: +53 (3276 -> 3329) for recovery_fired/agent_quality_event turn_id+agent_id
 # traceability — turn_id (recovered_transcript_turn_id) and agent_id (resolve_role_binding)
 # derivation at the 3 recovery emit sites + helper signature widening; no logic change.
-"src/services/discord/recovery_engine.rs" = 3329
+# #3581: +11 (3329 -> 3340) for the rebind-origin birth-site stamps — the three
+# bounded-preservation fields (created_at_unix / deadline_secs / birth_generation)
+# are stamped right after `turn_source = ExternalAdopted` so an unadopted,
+# never-progressed rebind orphan can be reaped instead of wedging turn-start.
+"src/services/discord/recovery_engine.rs" = 3340
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced
@@ -356,7 +360,18 @@
 # `last_offset`/`response_sent_offset`/`full_response`, so a late relay can no
 # longer clobber a concurrently-advanced watermark backward — plus 2 unit tests
 # (concurrent-advance preservation, fresh-row identity rejection).
-"src/services/discord/inflight.rs" = 2378
+# #3581 raised 2378 -> 2551 (+173): bounded reap of abandoned rebind-origin
+# orphans (the STALL-WATCHDOG wedge source). Adds the env-overridable deadline
+# constant + `rebind_origin_deadline_secs_env` (clamped) + `now_unix`, the
+# strict-conjunction predicate `should_reap_abandoned_rebind_origin` (owner-less +
+# unadopted + never-progressed + never-delivered; reap iff past-deadline OR
+# prior-generation), the `rebind_origin_age_secs` stamp/mtime age helper, the
+# `emit_reap_abandoned_rebind_origin` #3561 lifecycle event, and the boot-time
+# reap branch wired into `invalidate_stale_generation_in_root` (the prior code
+# skipped every rebind row unconditionally, the permanent-orphan source). The
+# bulk is load-bearing doc comments pinning the never-live argument; the tests
+# live in `#[cfg(test)] mod rebind_origin_reap_tests` and are excluded here.
+"src/services/discord/inflight.rs" = 2551
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -91,6 +91,149 @@ pub(super) const RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET: u32 = 3;
 /// to fire (a false-positive cleanup of a live turn is far worse than delay).
 pub(super) const INFLIGHT_STALENESS_THRESHOLD_SECS: u64 = 300;
 
+/// #3581: default deadline (seconds) after which an unadopted, never-progressed
+/// `rebind_origin` row is reaped. Far shorter than the placeholder sweeper's
+/// 1800s safety net so the wedge-causing orphan drains within a handful of
+/// sweep ticks, but comfortably longer than the ~8s TUI-direct adoption
+/// backstop window so a legitimate `/api/inflight/rebind` → TUI-adopt handoff
+/// is never raced. Overridable via `AGENTDESK_REBIND_ORIGIN_DEADLINE_SECS`.
+pub(super) const REBIND_ORIGIN_DEADLINE_SECS_DEFAULT: u64 = 120;
+
+/// #3581: floor for the env-overridden rebind-origin deadline. Guards against a
+/// pathologically small (or zero) override reaping rows before the adoption
+/// backstop window can complete.
+const REBIND_ORIGIN_DEADLINE_SECS_MIN: u64 = 30;
+
+/// #3581: resolve the rebind-origin reap deadline. Reads
+/// `AGENTDESK_REBIND_ORIGIN_DEADLINE_SECS`; on absence / parse failure falls
+/// back to [`REBIND_ORIGIN_DEADLINE_SECS_DEFAULT`]. Any explicit value is
+/// clamped up to [`REBIND_ORIGIN_DEADLINE_SECS_MIN`] so an operator cannot
+/// accidentally configure a reap that races the adoption backstop.
+pub(super) fn rebind_origin_deadline_secs_env() -> u64 {
+    std::env::var("AGENTDESK_REBIND_ORIGIN_DEADLINE_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map(|secs| secs.max(REBIND_ORIGIN_DEADLINE_SECS_MIN))
+        .unwrap_or(REBIND_ORIGIN_DEADLINE_SECS_DEFAULT)
+}
+
+/// #3581: current Unix epoch seconds (wall clock). Used to stamp a
+/// rebind-origin row's birth time at creation.
+pub(super) fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// #3581: decide whether an abandoned `rebind_origin` inflight row is safe to
+/// reap. The predicate is a strict conjunction of "never-progressed,
+/// never-adopted, never-owned" signals so that a genuinely-live rebind
+/// (MonitorTriggered watcher rebind: `relay_owner_kind = Watcher`) or a row
+/// that has started relaying / been adopted is NEVER reaped:
+///
+///   * `rebind_origin` — only rebind-origin rows are in scope.
+///   * `turn_source == ExternalAdopted` — pins the predicate to the
+///     `recovery_engine` birth site; the `tmux` MonitorTriggered rebind
+///     (`turn_source = MonitorTriggered`, owner Watcher) is excluded twice.
+///   * `effective_relay_owner_kind() == None` — no live relay owner (also
+///     absorbs the legacy `watcher_owns_live_relay` bool).
+///   * `user_msg_id == 0 && current_msg_id == 0` — never adopted / no anchor.
+///   * `!terminal_delivery_committed` — not finalised.
+///   * `response_sent_offset == 0 && full_response.is_empty()` — nothing was
+///     ever streamed to Discord.
+///   * `last_offset == turn_start_offset` — the watcher never advanced past
+///     the birth offset (NOTE: a fresh rebind row is born with
+///     `last_offset == turn_start_offset == file_len`, which can be > 0 — the
+///     "no progress" test is offset equality, NOT `last_offset == 0`).
+///   * `restart_mode.is_none()` — planned restart / hot-swap rows own their
+///     own retention and are never reaped here.
+///
+/// When every structural conjunct holds, the row is reaped iff it is past its
+/// deadline OR it was born in a prior generation. `age_secs` is supplied by the
+/// caller (file-mtime age in the sweeper path) so legacy rows with no
+/// `rebind_origin_created_at_unix` stamp still age out via mtime.
+pub(super) fn should_reap_abandoned_rebind_origin(
+    state: &InflightTurnState,
+    age_secs: u64,
+    current_generation: u64,
+) -> bool {
+    if !state.rebind_origin {
+        return false;
+    }
+    let structurally_abandoned = state.turn_source == TurnSource::ExternalAdopted
+        && state.effective_relay_owner_kind() == RelayOwnerKind::None
+        && state.user_msg_id == 0
+        && state.current_msg_id == 0
+        && !state.terminal_delivery_committed
+        && state.response_sent_offset == 0
+        && state.full_response.is_empty()
+        && state.last_offset == state.turn_start_offset.unwrap_or(state.last_offset)
+        && state.restart_mode.is_none();
+    if !structurally_abandoned {
+        return false;
+    }
+
+    let deadline = state
+        .rebind_origin_deadline_secs
+        .unwrap_or_else(rebind_origin_deadline_secs_env);
+    let past_deadline = age_secs >= deadline;
+    let stale_generation = state
+        .rebind_origin_birth_generation
+        .is_some_and(|birth| birth != current_generation);
+    past_deadline || stale_generation
+}
+
+/// #3581: best-effort age (seconds) for a rebind-origin row. Prefers the
+/// persisted `rebind_origin_created_at_unix` stamp (so the deadline is anchored
+/// to the row's actual birth even if the file is later touched); falls back to
+/// the file's mtime age for legacy rows that pre-date the stamp. Returns 0 when
+/// neither signal is available — in that case only the generation-mismatch
+/// disjunct of `should_reap_abandoned_rebind_origin` can fire, which is the
+/// conservative outcome.
+fn rebind_origin_age_secs(path: &Path, state: &InflightTurnState) -> u64 {
+    if let Some(created) = state.rebind_origin_created_at_unix {
+        return now_unix().saturating_sub(created).max(0) as u64;
+    }
+    fs::metadata(path)
+        .ok()
+        .and_then(|meta| meta.modified().ok())
+        .and_then(|modified| modified.elapsed().ok())
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+/// #3581: operator-visibility event for a reaped abandoned rebind-origin row
+/// (#3561 lifecycle stream). Mirrors the `evict_stale_generation` shape so the
+/// two boot-time reap reasons aggregate side by side.
+pub(super) fn emit_reap_abandoned_rebind_origin(
+    provider: &ProviderKind,
+    state: &InflightTurnState,
+    age_secs: u64,
+    current_generation: u64,
+    reason: &str,
+) {
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider.as_str(),
+        state.channel_id,
+        state.dispatch_id.as_deref(),
+        None,
+        None,
+        "reap_abandoned_rebind_origin",
+        serde_json::json!({
+            "reason": reason,
+            "age_secs": age_secs,
+            "deadline_secs": state
+                .rebind_origin_deadline_secs
+                .unwrap_or_else(rebind_origin_deadline_secs_env),
+            "birth_generation": state.rebind_origin_birth_generation,
+            "current_generation": current_generation,
+            "turn_source": state.turn_source.as_str(),
+            "tmux_session_name": state.tmux_session_name,
+        }),
+    );
+}
+
 pub(super) fn inflight_runtime_root() -> Option<PathBuf> {
     discord_inflight_root()
 }
@@ -2014,6 +2157,35 @@ fn invalidate_stale_generation_in_root(
             continue;
         }
         if state.rebind_origin {
+            // #3581: a rebind-origin row is normally owned by the rebind API
+            // and skipped here. The one exception is an abandoned, never-
+            // progressed orphan from a STALL-WATCHDOG respawn: reap it at boot
+            // if it is past its deadline OR was born in a prior generation.
+            // The reap predicate's strict conjunction guarantees a live /
+            // adopted rebind is never touched.
+            let path = inflight_state_path(root, provider, state.channel_id);
+            let age_secs = rebind_origin_age_secs(&path, &state);
+            if should_reap_abandoned_rebind_origin(&state, age_secs, current_generation) {
+                let Ok(_lock) = lock_inflight_state_path(&path) else {
+                    continue;
+                };
+                let Some(locked) = read_inflight_state_content(&path) else {
+                    continue;
+                };
+                if !should_reap_abandoned_rebind_origin(&locked, age_secs, current_generation) {
+                    continue;
+                }
+                if fs::remove_file(&path).is_ok() {
+                    emit_reap_abandoned_rebind_origin(
+                        provider,
+                        &locked,
+                        age_secs,
+                        current_generation,
+                        "invalidate_stale_generation_boot",
+                    );
+                    removed.push((locked.channel_id, locked.rebind_origin_birth_generation));
+                }
+            }
             continue;
         }
         // Codex review HIGH on PR #2460: normal rows are constructed with
@@ -5417,6 +5589,294 @@ mod wave_a_cleanup_tests {
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].restart_generation, Some(2));
         assert_eq!(after[0].user_msg_id, 78);
+    }
+}
+
+#[cfg(test)]
+mod rebind_origin_reap_tests {
+    //! #3581: bounded reap of abandoned `rebind_origin` orphans.
+    //!
+    //! The predicate `should_reap_abandoned_rebind_origin` must fire ONLY on the
+    //! exact STALL-WATCHDOG orphan signature (rebind_origin + ExternalAdopted +
+    //! owner None + user_msg_id 0 + current_msg_id 0 + never-progressed +
+    //! never-delivered) AND only once past its deadline OR born in a prior
+    //! generation. Every single live/adopted signal (owner, offset advance,
+    //! user_msg_id, sent response, planned restart) must independently block the
+    //! reap so a genuinely-live rebind is never destroyed (#3154 / #3540
+    //! no-regression pins).
+    use super::{
+        InflightTurnState, REBIND_ORIGIN_DEADLINE_SECS_DEFAULT, RelayOwnerKind, TurnSource,
+        invalidate_stale_generation_in_root, load_inflight_states_from_root,
+        save_inflight_state_in_root, should_reap_abandoned_rebind_origin,
+    };
+    use crate::services::discord::InflightRestartMode;
+    use crate::services::provider::ProviderKind;
+    use tempfile::TempDir;
+
+    /// A bare reapable rebind-origin row: born at offset `last_offset`,
+    /// never adopted, never progressed, no owner, deadline default, stamped at
+    /// `birth_generation`.
+    fn reapable_rebind(
+        channel_id: u64,
+        last_offset: u64,
+        birth_generation: u64,
+    ) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            Some("adk-cdx".to_string()),
+            0, // request_owner
+            0, // user_msg_id
+            0, // current_msg_id
+            "/api/inflight/rebind".to_string(),
+            None,
+            Some(format!("AgentDesk-codex-adk-cdx-{channel_id}")),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            last_offset,
+        );
+        state.rebind_origin = true;
+        state.turn_source = TurnSource::ExternalAdopted;
+        state.rebind_origin_created_at_unix = Some(super::now_unix());
+        state.rebind_origin_deadline_secs = Some(REBIND_ORIGIN_DEADLINE_SECS_DEFAULT);
+        state.rebind_origin_birth_generation = Some(birth_generation);
+        // `new()` already sets last_offset == turn_start_offset; assert the
+        // never-progressed invariant the predicate depends on.
+        assert_eq!(state.last_offset, state.turn_start_offset.unwrap());
+        state
+    }
+
+    const CURRENT_GEN: u64 = 9;
+    const PAST_DEADLINE: u64 = REBIND_ORIGIN_DEADLINE_SECS_DEFAULT + 5;
+    const WITHIN_DEADLINE: u64 = REBIND_ORIGIN_DEADLINE_SECS_DEFAULT - 5;
+
+    #[test]
+    fn reaps_abandoned_rebind_past_deadline() {
+        // (a) Born on a non-empty output file (offset > 0), never adopted /
+        // progressed, past deadline → reap. This is the exact #3581 wedge row.
+        let state = reapable_rebind(1, 4096, CURRENT_GEN);
+        assert!(should_reap_abandoned_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn preserves_fresh_rebind_within_deadline() {
+        // (b) Same signature but within deadline and same generation → preserve.
+        let state = reapable_rebind(2, 4096, CURRENT_GEN);
+        assert!(!should_reap_abandoned_rebind_origin(
+            &state,
+            WITHIN_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn live_protect_offset_progress_never_reaped() {
+        // (c-1) Watcher advanced past the birth offset → never reaped even past
+        // the deadline. last_offset != turn_start_offset.
+        let mut state = reapable_rebind(3, 4096, CURRENT_GEN);
+        state.last_offset = state.turn_start_offset.unwrap() + 100;
+        assert!(!should_reap_abandoned_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn live_protect_owner_watcher_never_reaped() {
+        // (c-2) A live relay owner (MonitorTriggered watcher rebind shape) →
+        // never reaped. Test both the typed field and the legacy bool.
+        let mut typed = reapable_rebind(4, 4096, CURRENT_GEN);
+        typed.set_relay_owner_kind(RelayOwnerKind::Watcher);
+        assert!(!should_reap_abandoned_rebind_origin(
+            &typed,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+
+        let mut legacy = reapable_rebind(5, 4096, CURRENT_GEN);
+        legacy.relay_owner_kind = RelayOwnerKind::None;
+        legacy.watcher_owns_live_relay = true; // legacy bool only
+        assert!(!should_reap_abandoned_rebind_origin(
+            &legacy,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn live_protect_adopted_user_msg_never_reaped() {
+        // (c-3) Adopted (user_msg_id != 0) → never reaped.
+        let mut state = reapable_rebind(6, 4096, CURRENT_GEN);
+        state.user_msg_id = 42;
+        assert!(!should_reap_abandoned_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn live_protect_delivered_response_never_reaped() {
+        // (c-4) Any delivered text (response_sent_offset > 0 or non-empty
+        // full_response) → never reaped.
+        let mut sent = reapable_rebind(7, 4096, CURRENT_GEN);
+        sent.response_sent_offset = 10;
+        assert!(!should_reap_abandoned_rebind_origin(
+            &sent,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+
+        let mut accumulated = reapable_rebind(8, 4096, CURRENT_GEN);
+        accumulated.full_response = "partial answer".to_string();
+        assert!(!should_reap_abandoned_rebind_origin(
+            &accumulated,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn live_protect_anchor_or_terminal_never_reaped() {
+        // Anchor placeholder present (current_msg_id != 0) or terminal commit →
+        // never reaped.
+        let mut anchored = reapable_rebind(9, 4096, CURRENT_GEN);
+        anchored.current_msg_id = 777;
+        assert!(!should_reap_abandoned_rebind_origin(
+            &anchored,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+
+        let mut committed = reapable_rebind(10, 4096, CURRENT_GEN);
+        committed.terminal_delivery_committed = true;
+        assert!(!should_reap_abandoned_rebind_origin(
+            &committed,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn reaps_on_generation_mismatch_within_deadline() {
+        // (d) Born in a prior generation → reap even within the deadline.
+        let state = reapable_rebind(11, 4096, 1);
+        assert!(should_reap_abandoned_rebind_origin(
+            &state,
+            WITHIN_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn legacy_row_reaps_via_mtime_age() {
+        // (e) Legacy row: no created_at / birth_generation stamps. Reaps only
+        // via the supplied (file-mtime) age; preserved while within deadline.
+        let mut legacy = reapable_rebind(12, 4096, CURRENT_GEN);
+        legacy.rebind_origin_created_at_unix = None;
+        legacy.rebind_origin_deadline_secs = None; // falls back to env default
+        legacy.rebind_origin_birth_generation = None;
+
+        assert!(
+            should_reap_abandoned_rebind_origin(&legacy, PAST_DEADLINE, CURRENT_GEN),
+            "legacy row past mtime-age deadline must reap"
+        );
+        assert!(
+            !should_reap_abandoned_rebind_origin(&legacy, WITHIN_DEADLINE, CURRENT_GEN),
+            "legacy row within deadline must be preserved"
+        );
+    }
+
+    #[test]
+    fn planned_restart_rebind_never_reaped() {
+        // (f) restart_mode set → planned restart owns retention; never reaped.
+        let mut state = reapable_rebind(13, 4096, CURRENT_GEN);
+        state.set_restart_mode(InflightRestartMode::DrainRestart);
+        assert!(!should_reap_abandoned_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn non_rebind_row_never_reaped() {
+        // A normal (non-rebind) row that happens to match every other conjunct
+        // is out of scope entirely.
+        let mut state = reapable_rebind(14, 4096, CURRENT_GEN);
+        state.rebind_origin = false;
+        assert!(!should_reap_abandoned_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+    }
+
+    #[test]
+    fn invalidate_stale_generation_reaps_prior_generation_rebind_orphan() {
+        // Boot-time integration: a rebind orphan stamped from a prior
+        // generation is reaped by `invalidate_stale_generation_in_root` even
+        // though it has no `restart_generation` stamp (the old skip path would
+        // have preserved it forever).
+        let temp = TempDir::new().unwrap();
+        let orphan = reapable_rebind(2001, 4096, 1); // birth gen 1
+        save_inflight_state_in_root(temp.path(), &orphan).expect("save");
+
+        let removed =
+            invalidate_stale_generation_in_root(temp.path(), &ProviderKind::Codex, CURRENT_GEN);
+        assert_eq!(
+            removed.len(),
+            1,
+            "prior-generation rebind orphan must be reaped"
+        );
+        assert_eq!(removed[0], (2001, Some(1)));
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert!(after.is_empty());
+    }
+
+    #[test]
+    fn invalidate_stale_generation_preserves_same_generation_fresh_rebind() {
+        // A same-generation rebind orphan whose file mtime is fresh (age 0)
+        // must survive the boot-time pass — neither the deadline nor the
+        // generation disjunct fires.
+        let temp = TempDir::new().unwrap();
+        let fresh = reapable_rebind(2002, 4096, CURRENT_GEN);
+        save_inflight_state_in_root(temp.path(), &fresh).expect("save");
+
+        let removed =
+            invalidate_stale_generation_in_root(temp.path(), &ProviderKind::Codex, CURRENT_GEN);
+        assert!(
+            removed.is_empty(),
+            "fresh same-generation rebind row must survive the boot-time pass"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(after.len(), 1);
+        assert!(after[0].rebind_origin);
+    }
+
+    #[test]
+    fn invalidate_stale_generation_preserves_live_owned_rebind_prior_generation() {
+        // Even with a prior-generation stamp, a rebind row that has a live
+        // owner (Watcher) must NOT be reaped at boot — the live-protection
+        // conjunction overrides the generation disjunct.
+        let temp = TempDir::new().unwrap();
+        let mut live = reapable_rebind(2003, 4096, 1); // prior gen
+        live.set_relay_owner_kind(RelayOwnerKind::Watcher);
+        save_inflight_state_in_root(temp.path(), &live).expect("save");
+
+        let removed =
+            invalidate_stale_generation_in_root(temp.path(), &ProviderKind::Codex, CURRENT_GEN);
+        assert!(
+            removed.is_empty(),
+            "owner-Watcher rebind must survive boot reap even from a prior generation"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(after.len(), 1);
     }
 }
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -301,6 +301,114 @@ pub(super) fn delete_inflight_state_file(provider: &ProviderKind, channel_id: u6
     fs::remove_file(path).is_ok()
 }
 
+/// #3581 (codex TOCTOU fix): outcome of a locked rebind-origin reap attempt so
+/// callers (and tests) can distinguish "reaped" from "skipped because the row
+/// was replaced/no-longer-eligible" from "the file was already gone".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RebindReapOutcome {
+    /// The row was re-validated under the lock and unlinked.
+    Reaped,
+    /// The on-disk row no longer satisfies the reap predicate (e.g. a live
+    /// intake/claim replaced it between the unlocked snapshot and the lock) —
+    /// deletion was intentionally skipped.
+    Skipped,
+    /// The state file was already absent (idempotent no-op) or unreadable.
+    Missing,
+    /// The advisory lock could not be acquired — the caller should retry later.
+    LockUnavailable,
+}
+
+/// #3581 (codex TOCTOU fix): true when the on-disk `locked` row is still the
+/// *same* abandoned rebind-origin orphan identified by the unlocked `snapshot`.
+///
+/// The placeholder sweeper (and the boot invalidator) pass an unlocked snapshot
+/// to `should_reap_abandoned_rebind_origin`; between that read and acquiring the
+/// sidecar lock a normal intake / TUI claim can persist a brand-new live
+/// inflight at the same `(provider, channel_id)` path. Re-running the reap
+/// predicate alone is not sufficient: a *new* rebind-origin orphan could be born
+/// (different birth stamp/generation) that also looks structurally abandoned.
+/// We therefore additionally require the row's birth identity to be unchanged
+/// (`rebind_origin_created_at_unix` + `rebind_origin_birth_generation`), so a
+/// replacement turn is never mistaken for the snapshotted orphan.
+fn rebind_row_identity_unchanged(snapshot: &InflightTurnState, locked: &InflightTurnState) -> bool {
+    locked.rebind_origin == snapshot.rebind_origin
+        && locked.rebind_origin_created_at_unix == snapshot.rebind_origin_created_at_unix
+        && locked.rebind_origin_birth_generation == snapshot.rebind_origin_birth_generation
+        && locked.turn_start_offset == snapshot.turn_start_offset
+}
+
+/// #3581 (codex TOCTOU fix): reap an abandoned rebind-origin orphan under the
+/// sidecar lock with a re-validate-then-unlink contract. This is the shared
+/// implementation behind both the periodic placeholder-sweeper path and the
+/// boot-time `invalidate_stale_generation` path so the two stay consistent.
+///
+/// Contract:
+///   1. Acquire the sidecar advisory lock for the row's path (the same
+///      non-reentrant `flock` every intake/claim/persist helper takes).
+///   2. **Reload** the current on-disk row under the lock.
+///   3. Confirm the reloaded row is still the *same* orphan as `snapshot`
+///      (`rebind_row_identity_unchanged`) AND still satisfies
+///      `should_reap_abandoned_rebind_origin` with a freshly recomputed age
+///      (created-at preferred, mtime fallback for legacy rows).
+///   4. Unlink **only** when both checks hold; otherwise skip (a live intake /
+///      claim replaced the orphan since the snapshot).
+///
+/// Returns the [`RebindReapOutcome`]; the caller emits observability on
+/// [`RebindReapOutcome::Reaped`].
+fn reap_abandoned_rebind_origin_locked_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    snapshot: &InflightTurnState,
+    current_generation: u64,
+) -> RebindReapOutcome {
+    let path = inflight_state_path(root, provider, snapshot.channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return RebindReapOutcome::LockUnavailable;
+    };
+    let Some(locked) = read_inflight_state_content(&path) else {
+        return RebindReapOutcome::Missing;
+    };
+    // The unlocked snapshot may have raced a replacement turn. Re-validate the
+    // current row's birth identity AND its eligibility under a freshly computed
+    // age before touching the file.
+    if !rebind_row_identity_unchanged(snapshot, &locked) {
+        return RebindReapOutcome::Skipped;
+    }
+    let age_secs = rebind_origin_age_secs(&path, &locked);
+    if !should_reap_abandoned_rebind_origin(&locked, age_secs, current_generation) {
+        return RebindReapOutcome::Skipped;
+    }
+    match fs::remove_file(&path) {
+        Ok(()) => RebindReapOutcome::Reaped,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => RebindReapOutcome::Missing,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = snapshot.channel_id,
+                error = %error,
+                "#3581 rebind reap remove_file failed under lock; treating as Missing"
+            );
+            RebindReapOutcome::Missing
+        }
+    }
+}
+
+/// #3581 (codex TOCTOU fix): env-rooted wrapper around
+/// [`reap_abandoned_rebind_origin_locked_in_root`] for the periodic
+/// placeholder-sweeper path. Returns `true` iff the row was re-validated under
+/// the lock and unlinked (so the sweeper only counts/emits genuine reaps).
+pub(super) fn reap_abandoned_rebind_origin_locked(
+    provider: &ProviderKind,
+    snapshot: &InflightTurnState,
+    current_generation: u64,
+) -> bool {
+    let Some(root) = inflight_runtime_root() else {
+        return false;
+    };
+    reap_abandoned_rebind_origin_locked_in_root(&root, provider, snapshot, current_generation)
+        == RebindReapOutcome::Reaped
+}
+
 fn now_string() -> String {
     chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
 }
@@ -2163,28 +2271,29 @@ fn invalidate_stale_generation_in_root(
             // if it is past its deadline OR was born in a prior generation.
             // The reap predicate's strict conjunction guarantees a live /
             // adopted rebind is never touched.
+            //
+            // #3581 (codex TOCTOU fix): gate the unlocked-snapshot pre-check
+            // with the same locked re-validate-then-unlink helper the periodic
+            // sweeper now uses, so boot and sweeper stay consistent and a row
+            // replaced between the snapshot and the lock is never wiped.
             let path = inflight_state_path(root, provider, state.channel_id);
             let age_secs = rebind_origin_age_secs(&path, &state);
-            if should_reap_abandoned_rebind_origin(&state, age_secs, current_generation) {
-                let Ok(_lock) = lock_inflight_state_path(&path) else {
-                    continue;
-                };
-                let Some(locked) = read_inflight_state_content(&path) else {
-                    continue;
-                };
-                if !should_reap_abandoned_rebind_origin(&locked, age_secs, current_generation) {
-                    continue;
-                }
-                if fs::remove_file(&path).is_ok() {
-                    emit_reap_abandoned_rebind_origin(
-                        provider,
-                        &locked,
-                        age_secs,
-                        current_generation,
-                        "invalidate_stale_generation_boot",
-                    );
-                    removed.push((locked.channel_id, locked.rebind_origin_birth_generation));
-                }
+            if should_reap_abandoned_rebind_origin(&state, age_secs, current_generation)
+                && reap_abandoned_rebind_origin_locked_in_root(
+                    root,
+                    provider,
+                    &state,
+                    current_generation,
+                ) == RebindReapOutcome::Reaped
+            {
+                emit_reap_abandoned_rebind_origin(
+                    provider,
+                    &state,
+                    age_secs,
+                    current_generation,
+                    "invalidate_stale_generation_boot",
+                );
+                removed.push((state.channel_id, state.rebind_origin_birth_generation));
             }
             continue;
         }
@@ -5605,9 +5714,10 @@ mod rebind_origin_reap_tests {
     //! reap so a genuinely-live rebind is never destroyed (#3154 / #3540
     //! no-regression pins).
     use super::{
-        InflightTurnState, REBIND_ORIGIN_DEADLINE_SECS_DEFAULT, RelayOwnerKind, TurnSource,
-        invalidate_stale_generation_in_root, load_inflight_states_from_root,
-        save_inflight_state_in_root, should_reap_abandoned_rebind_origin,
+        InflightTurnState, REBIND_ORIGIN_DEADLINE_SECS_DEFAULT, RebindReapOutcome, RelayOwnerKind,
+        TurnSource, invalidate_stale_generation_in_root, load_inflight_states_from_root,
+        reap_abandoned_rebind_origin_locked_in_root, save_inflight_state_in_root,
+        should_reap_abandoned_rebind_origin,
     };
     use crate::services::discord::InflightRestartMode;
     use crate::services::provider::ProviderKind;
@@ -5877,6 +5987,140 @@ mod rebind_origin_reap_tests {
         );
         let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
         assert_eq!(after.len(), 1);
+    }
+
+    // ----------------------------------------------------------------------
+    // #3581 (codex TOCTOU fix): locked re-validate boundary for the periodic
+    // placeholder-sweeper reap path. The sweeper passes an UNLOCKED snapshot to
+    // `should_reap_abandoned_rebind_origin`; between that snapshot and the
+    // delete, a normal intake / TUI claim can persist a brand-new live inflight
+    // at the same sidecar path. `reap_abandoned_rebind_origin_locked_in_root`
+    // must reload + re-validate identity + eligibility under the lock and skip
+    // the unlink when the on-disk row is no longer the snapshotted orphan.
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn locked_reap_unlinks_orphan_that_is_still_the_same_row() {
+        // (b) The on-disk row is unchanged since the snapshot and is still a
+        // prior-generation orphan → the locked re-validate succeeds and unlinks.
+        let temp = TempDir::new().unwrap();
+        let orphan = reapable_rebind(3001, 4096, 1); // prior gen → reap disjunct
+        save_inflight_state_in_root(temp.path(), &orphan).expect("save");
+        // Pre-check passes on the unlocked snapshot (mirrors the sweeper).
+        assert!(should_reap_abandoned_rebind_origin(&orphan, 0, CURRENT_GEN));
+
+        let outcome = reap_abandoned_rebind_origin_locked_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            &orphan,
+            CURRENT_GEN,
+        );
+        assert_eq!(
+            outcome,
+            RebindReapOutcome::Reaped,
+            "unchanged prior-generation orphan must be unlinked under the lock"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert!(after.is_empty(), "orphan file must be gone after reap");
+    }
+
+    #[test]
+    fn locked_reap_skips_when_row_replaced_by_new_live_turn() {
+        // (a) THE RACE: the sweeper snapshots an abandoned orphan, but before it
+        // takes the lock a normal intake persists a brand-new LIVE turn at the
+        // same channel path. The locked re-validate must DETECT the replacement
+        // (live row no longer reapable) and skip the unlink so the new live turn
+        // survives.
+        let temp = TempDir::new().unwrap();
+        let snapshot = reapable_rebind(3002, 4096, 1); // prior gen, reapable
+        save_inflight_state_in_root(temp.path(), &snapshot).expect("save snapshot");
+        assert!(should_reap_abandoned_rebind_origin(
+            &snapshot,
+            0,
+            CURRENT_GEN
+        ));
+
+        // Simulate the racing intake: overwrite the same path with a live,
+        // adopted, current-generation turn (NOT reapable). Same channel_id.
+        let mut live = reapable_rebind(3002, 4096, CURRENT_GEN);
+        live.rebind_origin = false; // a normal intake turn, not a rebind orphan
+        live.turn_source = TurnSource::Managed;
+        live.user_msg_id = 9999; // adopted → live-protected
+        save_inflight_state_in_root(temp.path(), &live).expect("save live replacement");
+
+        let outcome = reap_abandoned_rebind_origin_locked_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            &snapshot,
+            CURRENT_GEN,
+        );
+        assert_eq!(
+            outcome,
+            RebindReapOutcome::Skipped,
+            "a live replacement turn must NOT be reaped by a stale snapshot"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(after.len(), 1, "the live replacement turn must survive");
+        assert_eq!(after[0].user_msg_id, 9999, "survivor is the live turn");
+        assert!(!after[0].rebind_origin);
+    }
+
+    #[test]
+    fn locked_reap_skips_when_orphan_replaced_by_fresh_rebind_orphan() {
+        // (a') Subtle variant: the replacement is ALSO a structurally-abandoned
+        // rebind orphan, but a NEW birth (different created_at/generation). The
+        // bare `should_reap_*` re-check could still fire on it, so the identity
+        // guard is what blocks the wrong unlink — proving identity re-validation
+        // (not just predicate re-run) is load-bearing.
+        let temp = TempDir::new().unwrap();
+        let snapshot = reapable_rebind(3003, 4096, 1); // birth gen 1
+        save_inflight_state_in_root(temp.path(), &snapshot).expect("save snapshot");
+
+        // Racing rebind respawn: same channel, fresh birth (gen 2, new
+        // created_at, different turn_start_offset) but still prior to CURRENT_GEN
+        // so the predicate alone would happily reap it.
+        let mut respawn = reapable_rebind(3003, 8192, 2); // different offset + gen
+        respawn.rebind_origin_created_at_unix =
+            Some(snapshot.rebind_origin_created_at_unix.unwrap() + 100);
+        save_inflight_state_in_root(temp.path(), &respawn).expect("save respawn");
+        // Sanity: the predicate WOULD reap the respawn on its own (gen 2 != 9).
+        assert!(should_reap_abandoned_rebind_origin(
+            &respawn,
+            0,
+            CURRENT_GEN
+        ));
+
+        let outcome = reap_abandoned_rebind_origin_locked_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            &snapshot, // stale snapshot drives the reap
+            CURRENT_GEN,
+        );
+        assert_eq!(
+            outcome,
+            RebindReapOutcome::Skipped,
+            "a freshly-reborn orphan must not be reaped under the prior snapshot's identity"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(after.len(), 1, "the respawned row must survive this pass");
+        assert_eq!(after[0].rebind_origin_birth_generation, Some(2));
+    }
+
+    #[test]
+    fn locked_reap_missing_when_file_already_gone() {
+        // Idempotency: a snapshot whose file was already removed (e.g. a peer
+        // sweep / claim cleared it) yields Missing, never a spurious Reaped.
+        let temp = TempDir::new().unwrap();
+        std::fs::create_dir_all(temp.path().join(ProviderKind::Codex.as_str())).unwrap();
+        let snapshot = reapable_rebind(3004, 4096, 1);
+        // Deliberately do NOT save the row.
+        let outcome = reap_abandoned_rebind_origin_locked_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            &snapshot,
+            CURRENT_GEN,
+        );
+        assert_eq!(outcome, RebindReapOutcome::Missing);
     }
 }
 

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -172,6 +172,32 @@ pub(in crate::services::discord) struct InflightTurnState {
     /// identify a real Discord message.
     #[serde(default)]
     pub rebind_origin: bool,
+    /// #3581: bounded-preservation stamps for a `rebind_origin` row.
+    ///
+    /// A rebind-origin inflight is born by `recovery_engine` when a
+    /// STALL-WATCHDOG force-clean → watcher respawn synthesises a
+    /// `turn_source = ExternalAdopted`, `user_msg_id = 0`,
+    /// `relay_owner_kind = None` row to expose a recovered tmux session.
+    /// Historically these rows were preserved unconditionally (the rebind
+    /// API "owns" them), but a row that is never adopted and never makes
+    /// progress becomes a permanent orphan that
+    /// `tui_direct_pending_start::backstop_claim_is_safe` mistakes for a
+    /// "live foreign inflight", wedging every subsequent turn-start
+    /// (#3581). These stamps let the reaper bound the preservation:
+    /// `rebind_origin_created_at_unix` anchors the TTL, `_deadline_secs`
+    /// carries the (env-overridable) deadline captured at birth, and
+    /// `_birth_generation` lets a boot-time generation mismatch reap the
+    /// row immediately. All three are additive `#[serde(default)]` fields —
+    /// no `INFLIGHT_STATE_VERSION` bump per the #2235 compat convention;
+    /// legacy rows deserialize them as `None` and fall back to file-mtime
+    /// age. Only ever populated at the rebind-origin birth site; `None` on
+    /// every non-rebind row.
+    #[serde(default)]
+    pub rebind_origin_created_at_unix: Option<i64>,
+    #[serde(default)]
+    pub rebind_origin_deadline_secs: Option<u64>,
+    #[serde(default)]
+    pub rebind_origin_birth_generation: Option<u64>,
     /// #1255 codex round-2 P2: `true` while a long-running tool placeholder
     /// (`Monitor` / background `Bash`/`Task`/`Agent`) owns `current_msg_id`.
     /// `placeholder_sweeper` skips inflights whose `full_response` is non-empty
@@ -567,6 +593,10 @@ impl InflightTurnState {
             restart_mode: None,
             restart_generation: None,
             rebind_origin: false,
+            // #3581: only the rebind-origin birth site stamps these.
+            rebind_origin_created_at_unix: None,
+            rebind_origin_deadline_secs: None,
+            rebind_origin_birth_generation: None,
             long_running_placeholder_active: false,
             watcher_owns_live_relay: false,
             relay_owner_kind: RelayOwnerKind::None,

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -31,7 +31,8 @@ use super::formatting::{
 use super::gateway::edit_outbound_message;
 use super::inflight::{
     InflightTurnState, delete_inflight_state_file, emit_reap_abandoned_rebind_origin,
-    load_inflight_states_for_sweep, parse_started_at_unix, should_reap_abandoned_rebind_origin,
+    load_inflight_states_for_sweep, parse_started_at_unix, reap_abandoned_rebind_origin_locked,
+    should_reap_abandoned_rebind_origin,
 };
 use crate::services::provider::ProviderKind;
 
@@ -354,9 +355,17 @@ async fn run_placeholder_sweep_pass(
             // adopted rebind is never touched. `age_secs` here is the file-mtime
             // age the sweeper already computed, which covers legacy rows that
             // pre-date the persisted birth stamp.
+            //
+            // #3581 (codex TOCTOU fix): the `should_reap_*` check above runs on
+            // an UNLOCKED snapshot. Between this read and the delete, a normal
+            // intake / TUI claim can persist a brand-new live inflight at the
+            // same sidecar path. Route the delete through the locked
+            // re-validate helper so it reloads + re-checks identity + eligibility
+            // under the lock and only unlinks a row that is *still* the same
+            // abandoned orphan — never a live replacement.
             let current_generation = super::runtime_store::load_generation();
             if should_reap_abandoned_rebind_origin(&state, age_secs, current_generation)
-                && delete_inflight_state_file(provider, state.channel_id)
+                && reap_abandoned_rebind_origin_locked(provider, &state, current_generation)
             {
                 emit_reap_abandoned_rebind_origin(
                     provider,

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -30,8 +30,8 @@ use super::formatting::{
 };
 use super::gateway::edit_outbound_message;
 use super::inflight::{
-    InflightTurnState, delete_inflight_state_file, load_inflight_states_for_sweep,
-    parse_started_at_unix,
+    InflightTurnState, delete_inflight_state_file, emit_reap_abandoned_rebind_origin,
+    load_inflight_states_for_sweep, parse_started_at_unix, should_reap_abandoned_rebind_origin,
 };
 use crate::services::provider::ProviderKind;
 
@@ -344,8 +344,29 @@ async fn run_placeholder_sweep_pass(
     stalled_tracker.retain_live(provider, &states);
     for (state, age_secs) in states {
         if state.rebind_origin {
-            // Rebind-origin inflights do not represent a real Discord turn.
-            // Skip — there is no placeholder message to edit.
+            // #3581: a rebind-origin inflight has no placeholder message to
+            // edit, so it is normally skipped. But an abandoned, never-
+            // progressed orphan (STALL-WATCHDOG respawn) would otherwise live
+            // forever and wedge turn-start (`backstop_claim_is_safe` reads it as
+            // a "live foreign inflight"). Reap it once it is past its deadline.
+            // The strict conjunction in `should_reap_abandoned_rebind_origin`
+            // (owner-less + unadopted + never-progressed) guarantees a live /
+            // adopted rebind is never touched. `age_secs` here is the file-mtime
+            // age the sweeper already computed, which covers legacy rows that
+            // pre-date the persisted birth stamp.
+            let current_generation = super::runtime_store::load_generation();
+            if should_reap_abandoned_rebind_origin(&state, age_secs, current_generation)
+                && delete_inflight_state_file(provider, state.channel_id)
+            {
+                emit_reap_abandoned_rebind_origin(
+                    provider,
+                    &state,
+                    age_secs,
+                    current_generation,
+                    "placeholder_sweep_deadline",
+                );
+                report.abandoned += 1;
+            }
             continue;
         }
         // #3003: reclaim an orphaned status-panel-v2 BEFORE the placeholder skips

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3609,6 +3609,17 @@ pub(crate) async fn rebind_inflight_for_channel(
         // #2285 E1–E5) routes both identically — this is pure audit
         // metadata.
         state.turn_source = super::inflight::TurnSource::ExternalAdopted;
+        // #3581: stamp the bounded-preservation fields so an unadopted,
+        // never-progressed rebind-origin row can be reaped after a deadline (or
+        // a boot-time generation mismatch) instead of becoming a permanent
+        // orphan that wedges turn-start. Only this birth site stamps them; the
+        // reap predicate (`should_reap_abandoned_rebind_origin`) still requires
+        // the row to be owner-less / unadopted / never-progressed, so a row that
+        // goes live before the deadline is never reaped.
+        state.rebind_origin_created_at_unix = Some(super::inflight::now_unix());
+        state.rebind_origin_deadline_secs =
+            Some(super::inflight::rebind_origin_deadline_secs_env());
+        state.rebind_origin_birth_generation = Some(super::runtime_store::load_generation());
 
         // Atomic create-or-fail: if a legitimate turn created its inflight file
         // between the preflight check above and this point, the write fails


### PR DESCRIPTION
## 문제
STALL-WATCHDOG force-clean→watcher respawn이 recovery_engine.rs에서 만드는 `rebind_origin=true/ExternalAdopted/user_msg_id=0/owner=None` 합성 inflight이 TTL·세대·채택 바운드 없이 영구 보존 → tui_direct_pending_start::backstop_claim_is_safe가 'live foreign inflight'로 오판 → 후속 turn-start 전부 ABORT(2026-06-18 65분 wedge).

## 변경
- rebind row에 created_at/deadline_secs(기본120, env AGENTDESK_REBIND_ORIGIN_DEADLINE_SECS, 하한30s)/birth_generation 스탬프(serde additive, 버전 미증분).
- `should_reap_abandoned_rebind_origin` **9중 연언**(rebind_origin && ExternalAdopted && owner==None && user_msg_id==0 && current_msg_id==0 && !terminal_committed && response_sent_offset==0 && full_response empty && last_offset==turn_start_offset) && (age>=deadline OR birth_generation!=current) → **never-live 시그니처만** reap. 진행/채택/owner/전송 신호 하나라도 켜지면 절대 reap 안 함(#3154/#3540 비회귀).
- reap 2경로: boot invalidate_stale_generation + placeholder_sweeper(30s). 둘 다 **locked re-validate**(lock→reload→식별성 가드+predicate 재판정→일치 시만 unlink)로 TOCTOU 차단.
- reap 시 observability emit(#3561 연계). legacy(필드 None)는 mtime fallback.

## 검증
- 신규 테스트 18(live-보호 다수 + locked race 경계 4) + 기존 회귀 green. audit/freshness/ci-script-checks green.
- Codex(gpt-5.5 xhigh) 적대리뷰 2R(predicate live-배제 확인 + TOCTOU locked re-validate): **VERDICT: CLEAN**. (audit:2026-06-18)