### PR TITLE
fix(#3582): STALL-WATCHDOG 재발엔진 — force-clean 비파괴화 + live-but-quiet 오탐 차단

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -920,7 +920,11 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3340 lines; +11 from #3581 stamping
+  - `src/services/discord/recovery_engine.rs` (3349 lines; +9 from #3582 stamping
+    `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the
+    STALL-WATCHDOG force-clean -> respawn synthetic row (which lands here with
+    `existing_inflight = None`) is watcher-owned instead of degrading to
+    `relay_owner_kind = None`; +11 from #3581 stamping
     the three bounded-preservation fields (`rebind_origin_created_at_unix` /
     `_deadline_secs` / `_birth_generation`) at the rebind-origin birth site so an
     unadopted, never-progressed orphan can be reaped instead of permanently

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -254,7 +254,14 @@
 # bounded-preservation fields (created_at_unix / deadline_secs / birth_generation)
 # are stamped right after `turn_source = ExternalAdopted` so an unadopted,
 # never-progressed rebind orphan can be reaped instead of wedging turn-start.
-"src/services/discord/recovery_engine.rs" = 3340
+# #3582: +9 (3340 -> 3349) for the `set_relay_owner_kind(Watcher)` stamp (+ its
+# rationale comment) on the same rebind-origin birth site. The STALL-WATCHDOG
+# force-clean -> respawn path lands here with `existing_inflight = None`, so the
+# synthetic row used to default to `relay_owner_kind = None` and run every later
+# idle-tail / panel / routing check on the degraded bridge-owned path even though
+# the respawned watcher owns the live tmux relay (the #3582 "relay re-occurrence"
+# regression). No new direct-send; pure inflight-field stamp mirroring tmux.rs.
+"src/services/discord/recovery_engine.rs" = 3349
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -10,7 +10,27 @@ use crate::services::provider::ProviderKind;
 use super::snapshot::WatcherStateSnapshot;
 
 pub(super) const STALL_WATCHDOG_POSITIVE_LIVENESS_SECS: u64 = 120;
-pub(super) const STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS: u8 = 3;
+/// Hard ceiling on how many consecutive watchdog ticks a force-clean may be
+/// deferred while positive liveness keeps being observed. A deferral only ever
+/// fires when `has_positive_liveness` is true — i.e. fresh bytes are demonstrably
+/// flowing (pane offset advanced cross-tick, transcript/runtime jsonl mtime
+/// inside `POSITIVE_LIVENESS_SECS`, or a fresh background-synthetic anchor) — so
+/// a genuinely dead relay (every signal stale ⇒ `reason_codes == none`) takes the
+/// `ProceedNoEvidence` branch and is cleaned on the very first tick, untouched by
+/// this cap.
+///
+/// #3582: raised 3 -> 20. At the old value a *live* turn that kept emitting output
+/// for longer than `THRESHOLD_SECS + 3 * INTERVAL_SECS` (~600s + ~90s) was killed
+/// mid-stream the instant the cap was hit even though `reason_codes` still listed
+/// `pane_offset_advanced_recently,transcript_mtime_recent` — the confirmed
+/// 2026-06-18 12:07 false-positive (a "Response sent" landed 5s after the
+/// force-clean). The window is only ~90s of grace over the threshold, far short of
+/// a long but live turn. 20 deferrals = `20 * INTERVAL_SECS` (~600s) of extra
+/// grace, so the watchdog still only kills a turn that has been quiet (no
+/// liveness signal) — and a true live-spinner hang (pane bytes flow but no answer
+/// ever lands) is still bounded: once the cap is reached the force-clean proceeds,
+/// so the detection ceiling stays finite (R1).
+pub(super) const STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS: u8 = 20;
 pub(super) const STALL_LIVENESS_STATE_TTL_SECS: u64 = 1800;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -774,7 +794,7 @@ mod tests {
     }
 
     #[test]
-    fn liveness_deferral_cap_allows_cleanup_after_three_passes_and_logs_limit() {
+    fn liveness_deferral_cap_allows_cleanup_after_max_passes_and_logs_limit() {
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(3363);
         let tmux_session = "AgentDesk-codex-liveness-cap";
@@ -844,6 +864,94 @@ mod tests {
         );
     }
 
+    /// #3582 regression: the 2026-06-18 12:07 false-positive. A live turn that
+    /// keeps emitting output (fresh transcript mtime every tick) was force-cleaned
+    /// the instant the OLD cap of 3 was hit, even though `reason_codes` still
+    /// listed positive liveness — a "Response sent" landed 5s later. With the cap
+    /// raised to 20 the same strong-liveness streak that previously died at pass 4
+    /// keeps deferring, so a live-but-quiet turn survives well past the old window.
+    #[test]
+    fn strong_liveness_past_old_cap_still_defers_under_new_cap() {
+        const OLD_CAP: u8 = 3;
+        assert!(
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS > OLD_CAP,
+            "this regression only has teeth when the new cap exceeds the old one"
+        );
+
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3368);
+        let tmux_session = "AgentDesk-codex-liveness-12-07";
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        // A fresh temp transcript => `transcript_mtime_recent` is positive on
+        // every tick, mirroring the live turn whose JSONL kept being written.
+        let file = tempfile::NamedTempFile::new().expect("temp transcript");
+        let inflight = inflight_with_output(
+            channel.get(),
+            tmux_session,
+            Some(file.path().display().to_string()),
+        );
+        let snap = snapshot(channel.get(), tmux_session, Some(20));
+        let now = chrono::Utc::now().timestamp();
+
+        // Every tick from 1..=OLD_CAP+1 must STILL defer — at the old cap the
+        // (OLD_CAP+1)th pass returned ProceedAfterDeferralLimit and killed the
+        // live turn. Under the new cap it stays a Defer.
+        for expected_count in 1..=(OLD_CAP + 1) {
+            let decision = evaluate_stall_watchdog_liveness(
+                &provider,
+                channel,
+                &snap,
+                Some(&inflight),
+                now,
+                STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+            );
+            assert_eq!(
+                decision.action,
+                StallWatchdogLivenessAction::Defer {
+                    deferral_count: expected_count
+                },
+                "pass {expected_count} should still defer under the raised cap"
+            );
+        }
+
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+    }
+
+    /// #3582 corollary: the cap raise must NOT weaken detection of a genuinely
+    /// dead relay. When no liveness signal is present (`reason_codes == none`),
+    /// the decision is `ProceedNoEvidence` on the very first tick regardless of
+    /// the cap — exactly the 11:52 / 12:38 immediate-clean cases.
+    #[test]
+    fn no_liveness_still_proceeds_immediately_under_raised_cap() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3369);
+        let tmux_session = "AgentDesk-codex-liveness-dead-relay";
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        // No transcript path => no transcript mtime signal; stale inflight =>
+        // no other positive signal either.
+        let snap = snapshot(channel.get(), tmux_session, None);
+        let mut inflight = inflight_with_output(channel.get(), tmux_session, None);
+        inflight.updated_at = "2026-06-12 00:00:00".to_string();
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            1_800_000_000,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert_eq!(
+            decision.action,
+            StallWatchdogLivenessAction::ProceedNoEvidence,
+            "a dead relay must be cleaned on the first tick even with a raised cap"
+        );
+
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+    }
+
     #[test]
     fn liveness_deferral_streak_survives_desync_flap_without_positive_health() {
         let provider = ProviderKind::Codex;
@@ -860,7 +968,8 @@ mod tests {
         let snap = snapshot(channel.get(), tmux_session, Some(20));
         let now = chrono::Utc::now().timestamp();
 
-        for expected_count in 1..=2 {
+        // Build the streak up to one short of the cap.
+        for expected_count in 1..STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS {
             let decision = evaluate_stall_watchdog_liveness(
                 &provider,
                 channel,
@@ -878,6 +987,9 @@ mod tests {
             );
         }
 
+        // A transient desync flap (desynced toggles off but terminal delivery
+        // never committed) must NOT clear the in-flight deferral streak.
+        let pre_flap_count = STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS - 1;
         let mut flapped_snapshot = snap.clone();
         flapped_snapshot.desynced = false;
         flapped_snapshot.relay_health.desynced = false;
@@ -886,9 +998,11 @@ mod tests {
             channel,
             &flapped_snapshot,
         ));
-        assert_eq!(deferral_count(&key), Some(2));
+        assert_eq!(deferral_count(&key), Some(pre_flap_count));
 
-        let third = evaluate_stall_watchdog_liveness(
+        // The next tick reaches the cap (the final defer), then the one after
+        // proceeds with the force-clean.
+        let at_cap = evaluate_stall_watchdog_liveness(
             &provider,
             channel,
             &snap,
@@ -898,8 +1012,10 @@ mod tests {
             STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
         );
         assert_eq!(
-            third.action,
-            StallWatchdogLivenessAction::Defer { deferral_count: 3 }
+            at_cap.action,
+            StallWatchdogLivenessAction::Defer {
+                deferral_count: STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS
+            }
         );
 
         let decision = evaluate_stall_watchdog_liveness(

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3609,6 +3609,15 @@ pub(crate) async fn rebind_inflight_for_channel(
         // #2285 E1–E5) routes both identically — this is pure audit
         // metadata.
         state.turn_source = super::inflight::TurnSource::ExternalAdopted;
+        // #3582: bind the relay to the watcher we respawn below. The
+        // STALL-WATCHDOG force-clean -> respawn path reaches this birth site with
+        // `existing_inflight = None` (force-clean deleted the row first); without
+        // this stamp the synthetic row defaults to `relay_owner_kind = None` and
+        // every later idle-tail / panel / routing check runs the degraded
+        // bridge-owned path even though the watcher owns the live tmux relay. The
+        // monitor-auto-turn birth site (`tmux.rs`) already stamps Watcher the same
+        // way; `rebind_origin` and `relay_owner_kind` are independent flags.
+        state.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
         // #3581: stamp the bounded-preservation fields so an unadopted,
         // never-progressed rebind-origin row can be reaped after a deadline (or
         // a boot-time generation mismatch) instead of becoming a permanent
@@ -3833,6 +3842,49 @@ mod post_work_evidence_tests {
         state.any_tool_used = false;
         state.last_tool_summary = Some("Bash completed".to_string());
         assert!(recovery_has_post_work_ready_evidence(&state));
+    }
+
+    /// #3582 regression: the synthetic inflight that `rebind_inflight_for_channel`
+    /// creates when `existing_inflight = None` (the STALL-WATCHDOG force-clean ->
+    /// respawn path, which deletes the row first) must be stamped watcher-owned.
+    /// Before the fix this row defaulted to `relay_owner_kind = None`, so
+    /// `effective_relay_owner_kind()` resolved to `None` and every later idle-tail /
+    /// panel / routing check ran the degraded bridge-owned path even though the
+    /// watcher actually owns the live tmux relay. This mirrors the exact stamps the
+    /// birth site applies; if a refactor drops `set_relay_owner_kind(Watcher)` there
+    /// this assertion fails.
+    #[test]
+    fn synthetic_rebind_origin_row_is_watcher_owned() {
+        let mut state = inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            1_479_671_298_497_183_835,
+            Some("adk-cc".to_string()),
+            0, // request_owner_user_id — no originating Discord user
+            0, // user_msg_id
+            0, // current_msg_id (placeholder)
+            String::from("/api/inflight/rebind"),
+            None,
+            Some("AgentDesk-claude-adk-cc".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            None,
+            0,
+        );
+        // Birth-site stamps (must stay in sync with `rebind_inflight_for_channel`).
+        state.rebind_origin = true;
+        state.turn_source = inflight::TurnSource::ExternalAdopted;
+        state.set_relay_owner_kind(inflight::RelayOwnerKind::Watcher);
+
+        assert_eq!(
+            state.effective_relay_owner_kind(),
+            inflight::RelayOwnerKind::Watcher,
+            "force-clean respawn must leave the relay watcher-owned, not degraded to None",
+        );
+        assert!(
+            state.watcher_owns_live_relay,
+            "the legacy bool must agree so older deserializers also see watcher ownership",
+        );
+        // rebind_origin and watcher ownership are independent flags and must coexist.
+        assert!(state.rebind_origin);
     }
 }
 


### PR DESCRIPTION
## 문제
STALL-WATCHDOG가 live-but-quiet 장기 턴을 오탐→파괴적 force-clean으로 릴레이 소유권을 none으로 떨궈 idle-tail degraded 지속(재발 엔진). 2026-06-18 오전 3회 발동.

## 변경
- **(B) force-clean 비파괴화** (recovery_engine.rs): rebind_inflight_for_channel synthetic 생성 경로(existing_inflight=None)에 `set_relay_owner_kind(Watcher)` 추가. 이전엔 None→effective=None→degraded. 선례 tmux.rs:1661과 동일 패턴(이 경로만 누락이었음). respawn 실패 rescue/deadman 보존, mailbox 정리는 기존 identity-guarded 경로 유지.
- **(A) 오탐 차단** (stall_liveness.rs): STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS 3→20. 로그 확증: 12:07:32에 reasons='pane_offset_advanced,transcript_mtime_recent'(출력 흐르는 중)인데 cap=3 도달로 강행→live 턴 학살. **cap은 positive-liveness일 때만 영향 → reasons=none 진짜 dead는 deferral 없이 즉시 청소(검출 약화 0)**. cap 유한(20=~600s)이라 hung-but-spinning도 결국 bound.

## 검증
- 신규 회귀 테스트(synthetic owner==Watcher / strong-liveness-past-old-cap-still-defers(12:07 재현) / no-liveness-immediate-cleanup(11:52·12:38 보존)) + 기존 green. audit/freshness/ci-script-checks green.
- Codex(gpt-5.5 xhigh) 적대리뷰: **VERDICT: CLEAN**. (audit:2026-06-18)