### PR TITLE
feat(#3579): frame_ack_outcome NotAttempted 센티넬 분리 — watcher-owned 미시도와 실제 실패 구분 (동작 무변경)

### DIFF
--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -77,7 +77,13 @@
 # `persist_watcher_relay_watermark_locked` single-flock RMW helper, gated on the
 # captured `inflight_identity_before_relay` (+10 lines of identity-guarded calls
 # and explanatory comments).
-"src/services/discord/tmux_watcher.rs" = 6935
+# #3579 raised 6935 -> 6946: the `session_bound_ack_outcome` INIT switched from
+# the `MissingTarget` failure sentinel to the new watcher-owned `NotAttempted`
+# non-attempt sentinel, with a load-bearing explanatory comment block at the init
+# site documenting why the skipped-ack-wait benign case is now distinct from the
+# real `wait_for_session_bound_relay_delivery_ack` target-none failure. NO new
+# direct send / behavior change — provenance/aggregation classification only.
+"src/services/discord/tmux_watcher.rs" = 6946
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275
@@ -91,7 +97,12 @@
 # tmux_watcher/** 700-line namespace cap; their moved unit tests live in sibling
 # *_tests.rs files (excluded from the production splitter).
 "src/services/discord/tmux_watcher/supervisor_relay.rs" = 393
-"src/services/discord/tmux_watcher/session_bound_ack.rs" = 404
+# #3579 raised 404 -> 427: added the `NotAttempted` enum variant + its fold arm
+# and a doc block distinguishing the watcher-owned non-attempt from the real
+# `MissingTarget` target-none failure (behavior-preserving; resend decision folds
+# to `DeliveryOutcome::Unknown` identically). Stays well under the 700-line cap;
+# the new sentinel-distinction unit tests live in sibling session_bound_ack_tests.rs.
+"src/services/discord/tmux_watcher/session_bound_ack.rs" = 427
 # #3479 Phase-1 rank-2 child modules (streaming UTF-8 chunk decoder + terminal-
 # readiness predicates / pure buffer reconcilers), frozen at landed production LoC.
 # Both sit under the tmux_watcher/** 700-line namespace cap; their moved unit tests

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -34,7 +34,13 @@
 # new `persist_watcher_relay_watermark_locked` single-flock RMW helper, gated on
 # the captured `inflight_identity_before_relay`. The helper body lives in
 # inflight.rs; this is the identity-guarded call-site + comment cost.
-"src/services/discord/tmux_watcher.rs" = 10098
+# #3579: 10098 -> 10111 (+13), reviewable admission — the `session_bound_ack_outcome`
+# INIT switched from the `MissingTarget` failure sentinel to the new watcher-owned
+# `NotAttempted` non-attempt sentinel, plus a load-bearing comment block at the init
+# site explaining why the skipped-ack-wait benign case is now distinct from the real
+# target-none failure. Behavior-preserving (folds to the same resend decision); the
+# new sentinel-distinction tests live in the sibling session_bound_ack_tests.rs file.
+"src/services/discord/tmux_watcher.rs" = 10111
 "src/services/discord/tui_prompt_relay.rs" = 7789
 # #3560: 6612 -> 6621 (+9), reviewable admission — footer-mode separate-panel
 # migration reconcile call + comment at the resume entry. Helper body lives in

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -4317,7 +4317,18 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let relay_producer_session_name = cached_relay_producer
             .as_ref()
             .map(|producer| producer.session_name());
-        let mut session_bound_ack_outcome = SessionBoundRelayAckOutcome::MissingTarget;
+        // #3579: INIT the ack outcome to the watcher-owned NON-attempt sentinel.
+        // When `session_bound_relay_should_own_terminal_delivery` returns false
+        // (e.g. relay_owner=Watcher) the ack-wait block below is SKIPPED and this
+        // init value is what the flight recorder logs as `frame_ack_outcome`. It
+        // is BENIGN (the watcher owns terminal delivery; the sink-delegated ack
+        // path is intentionally not taken) — distinct from `MissingTarget`, which
+        // `wait_for_session_bound_relay_delivery_ack` returns only when the block
+        // ACTUALLY RAN but had no target (a real unconfirmed). Before #3579 this
+        // init was `MissingTarget`, conflating the two and inflating relay-loss
+        // tallies. Behavior is unchanged: `NotAttempted` folds to the same
+        // `DeliveryOutcome::Unknown` as `MissingTarget` for the resend decision.
+        let mut session_bound_ack_outcome = SessionBoundRelayAckOutcome::NotAttempted;
         let session_bound_terminal_delivery_attempted =
             session_bound_relay_should_own_terminal_delivery(
                 relay_decision.should_direct_send,
@@ -8989,7 +9000,9 @@ TUI-E2E-marker ssh-direct
         let relay_decision = terminal_relay_decision(has_assistant_response, None, true);
         let watcher_direct_send = watcher_should_direct_send_after_session_bound_ack(
             relay_decision.should_direct_send,
-            SessionBoundRelayAckOutcome::MissingTarget,
+            // #3579: the non-attempt sentinel folds to `Unknown` exactly like the
+            // old `MissingTarget` init, so the watcher-direct gate is unchanged.
+            SessionBoundRelayAckOutcome::NotAttempted,
             false,
         );
 

--- a/src/services/discord/tmux_watcher/session_bound_ack.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack.rs
@@ -27,6 +27,22 @@ use super::supervisor_relay::SessionBoundRelayAckTarget;
 ///     [`session_bound_ack_delivery_outcome`]). They stay DISTINCT variants here
 ///     so the flight-recorder / metrics keep their exact provenance.
 ///
+/// #3579: `NotAttempted` is the watcher-owned NON-attempt sentinel. It is the
+/// INIT value of `session_bound_ack_outcome` (tmux_watcher.rs) and is what the
+/// flight recorder logs as `frame_ack_outcome` when the session-bound ack-wait
+/// block was SKIPPED entirely — i.e. `session_bound_relay_should_own_terminal_delivery`
+/// returned false (typically `relay_owner=Watcher`, so the WATCHER itself owns the
+/// terminal delivery and the sink-delegated ack path is intentionally not taken).
+/// This is a BENIGN, expected steady-state — NOT a relay loss. Before #3579 the
+/// init was `MissingTarget`, which conflated this watcher-owned non-attempt with
+/// the genuine `wait_for_session_bound_relay_delivery_ack` `target.is_none()`
+/// failure path, inflating operator/audit relay-loss tallies. `NotAttempted` is
+/// distinct precisely so the recorder/metrics can EXCLUDE it as benign while
+/// `MissingTarget` keeps meaning "ack-wait ran but had no target" (a real
+/// unconfirmed). For the resend DECISION it folds to `DeliveryOutcome::Unknown`
+/// IDENTICALLY to `MissingTarget` — behavior is unchanged; only the provenance
+/// label/aggregation classification differs.
+///
 /// §3.2 SAFETY INVARIANT: BOTH `NotDelivered` AND every `Unknown`-class arm route
 /// through `watcher_terminal_resend_action` (committed-offset reconciliation).
 /// There is NO blind skip for `NotDelivered` and NO blind 10s re-send for any
@@ -40,6 +56,9 @@ pub(super) enum SessionBoundRelayAckOutcome {
     SinkError,
     TimedOut,
     MissingTarget,
+    /// #3579: the session-bound ack-wait was never attempted (watcher-owned
+    /// terminal delivery). Benign steady-state, distinct from `MissingTarget`.
+    NotAttempted,
 }
 
 /// #3041 P1-5: collapse the watcher ACK onto the canonical cross-actor 3-way
@@ -59,7 +78,11 @@ pub(super) fn session_bound_ack_delivery_outcome(
         | SessionBoundRelayAckOutcome::Dropped
         | SessionBoundRelayAckOutcome::SinkError
         | SessionBoundRelayAckOutcome::TimedOut
-        | SessionBoundRelayAckOutcome::MissingTarget => DeliveryOutcome::Unknown,
+        | SessionBoundRelayAckOutcome::MissingTarget
+        // #3579: the watcher-owned non-attempt folds to `Unknown` IDENTICALLY to
+        // `MissingTarget` for the resend DECISION (committed-offset reconciliation),
+        // so behavior is preserved exactly — only the provenance label differs.
+        | SessionBoundRelayAckOutcome::NotAttempted => DeliveryOutcome::Unknown,
     }
 }
 

--- a/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack_tests.rs
@@ -49,6 +49,74 @@ fn relay_slot_guard_release_is_idempotent_and_does_not_clobber_reacquire() {
     );
 }
 
+/// #3579: the `NotAttempted` vs `MissingTarget` sentinel split. `NotAttempted`
+/// is the watcher-owned NON-attempt (the ack-wait block was skipped); it must
+/// stay DISTINCT from the genuine `MissingTarget` failure (the ack-wait ran but
+/// had no target) so the flight recorder / metrics can exclude the former as
+/// benign — yet both must fold to the SAME resend decision so delivery behavior
+/// is unchanged.
+mod not_attempted_sentinel {
+    use super::super::{
+        SessionBoundRelayAckOutcome, session_bound_ack_delivery_outcome,
+        wait_for_session_bound_relay_delivery_ack,
+    };
+    use crate::services::cluster::stream_relay::DeliveryOutcome;
+
+    /// The watcher-owned non-attempt sentinel is a DISTINCT enum value from the
+    /// real `MissingTarget` failure — they must never compare equal, or the
+    /// recorder's benign-vs-failure classification collapses (#3579 regression).
+    #[test]
+    fn not_attempted_is_distinct_from_missing_target() {
+        assert_ne!(
+            SessionBoundRelayAckOutcome::NotAttempted,
+            SessionBoundRelayAckOutcome::MissingTarget,
+            "the benign non-attempt must not equal the real target-none failure"
+        );
+        // The Debug labels the flight recorder logs as `frame_ack_outcome` must
+        // also differ, so log-grep / audit aggregation can tell them apart.
+        assert_ne!(
+            format!("{:?}", SessionBoundRelayAckOutcome::NotAttempted),
+            format!("{:?}", SessionBoundRelayAckOutcome::MissingTarget),
+        );
+        assert_eq!(
+            format!("{:?}", SessionBoundRelayAckOutcome::NotAttempted),
+            "NotAttempted"
+        );
+    }
+
+    /// Behavior-preserving: the non-attempt folds to the SAME cross-actor
+    /// `DeliveryOutcome::Unknown` as `MissingTarget` for the resend DECISION, so
+    /// the watcher-direct fallback / §3.2 reconciliation is byte-for-byte
+    /// unchanged — #3579 alters provenance/aggregation only, never delivery.
+    #[test]
+    fn not_attempted_folds_identically_to_missing_target() {
+        assert_eq!(
+            session_bound_ack_delivery_outcome(SessionBoundRelayAckOutcome::NotAttempted),
+            DeliveryOutcome::Unknown,
+        );
+        assert_eq!(
+            session_bound_ack_delivery_outcome(SessionBoundRelayAckOutcome::NotAttempted),
+            session_bound_ack_delivery_outcome(SessionBoundRelayAckOutcome::MissingTarget),
+            "the resend decision must be identical to the old MissingTarget init"
+        );
+    }
+
+    /// The REAL failure path is untouched: when the ack-wait actually runs with
+    /// no target, it still returns `MissingTarget` (NOT `NotAttempted`). This is
+    /// the genuine unconfirmed the recorder/metrics MUST still surface.
+    #[tokio::test]
+    async fn ack_wait_with_no_target_still_returns_missing_target() {
+        let outcome =
+            wait_for_session_bound_relay_delivery_ack(None, std::time::Duration::from_millis(1))
+                .await;
+        assert_eq!(
+            outcome,
+            SessionBoundRelayAckOutcome::MissingTarget,
+            "a ran-but-no-target ack-wait is a real failure, not the benign non-attempt"
+        );
+    }
+}
+
 /// #3151: the deterministic decision seam for the in-flight sink-delivery
 /// marker gate (`watcher_terminal_resend_action_gated`). Table-drives the gate
 /// over every lease-snapshot variant and asserts the reclaim side-effect flag.

--- a/src/services/observability/relay_signal_alert.rs
+++ b/src/services/observability/relay_signal_alert.rs
@@ -354,6 +354,37 @@ mod tests {
         }
     }
 
+    /// #3579: the operator alert table must NEVER count the watcher-owned
+    /// `frame_ack_outcome` non-attempt as a relay-loss signal. `NotAttempted`
+    /// (the session-bound ack-wait was intentionally SKIPPED because the watcher
+    /// owns terminal delivery) is a BENIGN steady-state, distinct from the real
+    /// `MissingTarget` failure. Wiring either the raw enum debug string
+    /// (`NotAttempted`) or a generic `frame_ack`/`missing_target` counter into a
+    /// signal here would resurrect the false-positive relay-loss tally #3579
+    /// fixes (the ~2307/month phantom misses). Guard the exclusion explicitly so
+    /// a future alert-table edit cannot silently re-conflate them.
+    #[test]
+    fn signal_table_excludes_benign_watcher_owned_non_attempt() {
+        let mut keys: Vec<&str> = RELAY_SIGNAL_DEFINITIONS.iter().map(|s| s.key).collect();
+        let statuses: Vec<&str> = RELAY_SIGNAL_DEFINITIONS
+            .iter()
+            .flat_map(|s| s.statuses.iter().copied())
+            .collect();
+        keys.extend_from_slice(&statuses);
+        for benign in [
+            "NotAttempted",
+            "not_attempted",
+            "frame_ack_outcome",
+            "frame_ack",
+        ] {
+            assert!(
+                !keys.contains(&benign),
+                "relay signal table must NOT count the benign watcher-owned \
+                 non-attempt `{benign}` as a relay-loss signal (#3579); present: {keys:?}"
+            );
+        }
+    }
+
     /// Every status string in the table must be one the emit path actually
     /// writes to `observability_events.status`, otherwise the window query
     /// counts zero forever. These mirror `emit_relay_root_cause_counter`


### PR DESCRIPTION
## 문제
`frame_ack_outcome=MissingTarget`이 (A)watcher-owned 미시도(정상)와 (B)실제 target 실패를 뭉뚱그려 운영자/감사 오탐.

## 변경 (동작 무변경)
- SessionBoundRelayAckOutcome에 `NotAttempted` 추가. tmux_watcher.rs init값 MissingTarget→NotAttempted(ack-wait skip=attempted false에서만 살아남음).
- NotAttempted는 fold에서 DeliveryOutcome::Unknown으로 MissingTarget과 동일 → **전달 동작 byte 단위 불변**. 실제 target.is_none()→MissingTarget 경로 유지.
- frame_ack_outcome 로깅은 enum 그대로 출력해 NotAttempted/MissingTarget/성공 구분. #3561 RELAY_SIGNAL_DEFINITIONS는 frame_ack_outcome 미모니터(가드 테스트 추가).

## 검증
- 신규 테스트 4(구분/동일 fold/실제 실패/alert benign 제외) + 회귀 green. audit/hotfile/freshness/ci-script-checks green.
- Codex(gpt-5.5 xhigh) 적대리뷰(전달 동작 byte 불변 전수 확인): **VERDICT: CLEAN**. (audit:2026-06-18)