### PR TITLE
feat(#3556): 턴-트리거 핸드오프 API/CLI를 알림-only와 분리 (코어, 하위호환)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1299,9 +1299,9 @@
     relocated the `require_explicit_bearer_token` /
     `resolve_requesting_agent_id_with_pg` auth/identity helpers to
     `crate::services::kanban`).
-  - `src/server/routes/docs.rs` (5900 lines; +4 from #3293 documenting
-    the stale-mailbox repair `purge` body param + registry-purge response
-    fields).
+  - `src/server/routes/docs.rs` (5940 lines; +40 from #3556 documenting
+    the agent-to-agent turn-trigger handoff endpoint `/api/agents/{id}/handoff`
+    paired example + 409 conflict error example + curl).
   - `src/server/routes/escalation.rs` (1376 lines).
   - `src/server/routes/meetings.rs` (1675 lines).
   - `src/server/routes/review_verdict/decision_route.rs` was decomposed in

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -101,6 +101,12 @@ pub(crate) enum Commands {
         /// Send the body without the automatic handoff prefix
         #[arg(long = "no-prefix")]
         no_prefix: bool,
+        /// #3556 — reserve a headless turn on the target mailbox instead of
+        /// posting an announce message. Authoritative wake-up: exits non-zero
+        /// on 409 (mailbox busy). Mutually exclusive with the default
+        /// announce-post behavior.
+        #[arg(long = "start-turn")]
+        start_turn: bool,
     },
     /// Submit a review verdict without HTTP server dependency
     ReviewVerdict {

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -305,6 +305,7 @@ pub(crate) async fn cmd_send_to_agent(
     message: &str,
     channel_kind: crate::services::discord::agent_handoff::AgentHandoffChannelKind,
     prefix: bool,
+    start_turn: bool,
 ) -> Result<(), String> {
     run_command(true, false, |state| async move {
         let registry = state
@@ -314,6 +315,24 @@ pub(crate) async fn cmd_send_to_agent(
         let pool = state
             .pg_pool_ref()
             .ok_or_else(|| "postgres pool unavailable".to_string())?;
+        // #3556 — --start-turn and the default announce post are mutually
+        // exclusive: we either reserve a turn or post a message, never both.
+        if start_turn {
+            let response = crate::services::discord::agent_handoff::start_agent_handoff_turn(
+                registry,
+                pool,
+                from_agent_id,
+                to_agent_id,
+                message,
+                channel_kind,
+                prefix,
+                Some("cli:send-to-agent".to_string()),
+                None,
+            )
+            .await
+            .map_err(|error| error.one_line())?;
+            return Ok(response.to_value());
+        }
         let response = crate::services::discord::agent_handoff::send_agent_handoff(
             registry,
             pool,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -102,12 +102,14 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
             message,
             channel_kind,
             no_prefix,
+            start_turn,
         } => exit_for_cli(super::direct::run_async(super::direct::cmd_send_to_agent(
             &from_agent_id,
             &to_agent_id,
             &message,
             agent_handoff_channel_kind(channel_kind),
             !no_prefix,
+            start_turn,
         ))),
         Commands::ReviewVerdict {
             dispatch_id,

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -95,6 +95,23 @@ pub struct AgentMessageBody {
     pub prefix: Option<bool>,
 }
 
+/// #3556 — turn-trigger handoff. Unlike `AgentMessageBody` (announce post),
+/// this reserves a headless turn on the target's cc/cdx mailbox and never posts
+/// an announce message, so the receiving agent is authoritatively woken.
+#[derive(Debug, Deserialize)]
+pub struct AgentHandoffBody {
+    pub from_agent_id: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub channel_kind: Option<String>,
+    #[serde(default)]
+    pub prefix: Option<bool>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
 fn pg_required_response() -> (StatusCode, Json<serde_json::Value>) {
     (
         StatusCode::SERVICE_UNAVAILABLE,
@@ -1097,6 +1114,55 @@ pub async fn agent_message(
         &body.message,
         channel_kind,
         body.prefix.unwrap_or(true),
+    )
+    .await
+    {
+        Ok(response) => (StatusCode::OK, Json(response.to_value())),
+        Err(error) => (error.status(), Json(error.body())),
+    }
+}
+
+/// POST /api/agents/{id}/handoff
+/// #3556 — agent-to-agent turn-trigger handoff. Resolves the target's cc/cdx
+/// mailbox and reserves a headless turn directly on it. Unlike
+/// `/api/agents/{id}/message`, no announce message is posted: the turn is the
+/// authoritative effect, so success/failure carry turn semantics (200 started,
+/// 409 mailbox busy, 404 not found, 422 channel_kind unset, 503 unavailable).
+/// This is the "execution intent" counterpart to the announce-only "notify"
+/// path, and it cannot trip the #3576 announce-trigger double-run because it
+/// never lands a message on the cc channel.
+pub async fn agent_handoff(
+    State(state): State<super::AppState>,
+    axum::extract::Path(to_agent_id): axum::extract::Path<String>,
+    axum::Json(body): axum::Json<AgentHandoffBody>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(pool) = state.pg_pool_ref() else {
+        return pg_required_response();
+    };
+    let Some(registry) = state.health_registry.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "Discord not available (standalone mode)"})),
+        );
+    };
+
+    let channel_kind = match crate::services::discord::agent_handoff::AgentHandoffChannelKind::parse(
+        body.channel_kind.as_deref(),
+    ) {
+        Ok(channel_kind) => channel_kind,
+        Err(error) => return (error.status(), Json(error.body())),
+    };
+
+    match crate::services::discord::agent_handoff::start_agent_handoff_turn(
+        registry,
+        pool,
+        &body.from_agent_id,
+        &to_agent_id,
+        &body.prompt,
+        channel_kind,
+        body.prefix.unwrap_or(true),
+        body.source,
+        body.metadata,
     )
     .await
     {

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -259,6 +259,7 @@ pub(crate) const TOP_40_PAIRED_PATHS: &[(&str, &str)] = &[
     ("GET", "/api/agents/{id}"),
     ("PATCH", "/api/agents/{id}"),
     ("POST", "/api/agents/setup"),
+    ("POST", "/api/agents/{id}/handoff"),
     ("POST", "/api/agents/{id}/turn/start"),
     ("POST", "/api/agents/{id}/turn/stop"),
     ("GET", "/api/agents/{id}/quality"),
@@ -1573,6 +1574,45 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             json!({"error": "channel_kind unset", "to_agent_id": "adk-dashboard", "channel_kind": "cc", "available_kinds": ["cdx"]}),
         )
         .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/message -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"message\":\"hello\",\"channel_kind\":\"cc\",\"prefix\":true}'"),
+        ep(
+            "POST",
+            "/api/agents/{id}/handoff",
+            "agents",
+            "#3556 — agent-to-agent turn-trigger handoff. Reserves a headless turn on the target's cc/cdx mailbox instead of posting an announce message, so the receiving agent is authoritatively woken. Returns 409 when a turn is already active for that mailbox (a semantic the announce-only /message path does not have). Use /message for human-readable notifications and /handoff for execution intent.",
+        )
+        .with_params([
+            ("id", path_param("Target agent id")),
+            ("from_agent_id", body_param("string", true, "Source agent id")),
+            ("prompt", body_param("string", true, "Instruction to execute in the handoff turn")),
+            (
+                "channel_kind",
+                body_param("string", false, "Target mailbox: cc (default) or cdx")
+                    .with_enum(&["cc", "cdx"])
+                    .with_default(json!("cc")),
+            ),
+            (
+                "prefix",
+                body_param("boolean", false, "Add the from->to handoff prefix to the prompt").with_default(true),
+            ),
+            (
+                "source",
+                body_param("string", false, "Optional trigger source label"),
+            ),
+            (
+                "metadata",
+                body_param("object", false, "Optional trigger metadata injected into the turn context"),
+            ),
+        ])
+        .with_example(
+            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "prompt": "리뷰 코멘트 반영해서 PR 업데이트해줘", "channel_kind": "cc", "source": "agent-relay"}}),
+            json!({"ok": true, "to_agent_id": "adk-dashboard", "channel_id": "1473922824350601297", "channel_kind": "cc", "turn_id": "discord:1473922824350601297:9100000000000000000", "status": "started"}),
+        )
+        .with_error_example(
+            409,
+            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "prompt": "do it"}}),
+            json!({"error": "turn already active for this agent mailbox", "status": "conflict"}),
+        )
+        .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/handoff -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"prompt\":\"리뷰 반영해줘\",\"channel_kind\":\"cc\"}'"),
         ep(
             "GET",
             "/api/agents/{id}/cron",

--- a/src/server/routes/domains/agents.rs
+++ b/src/server/routes/domains/agents.rs
@@ -36,6 +36,7 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
             .route("/agents/{id}/offices", get(agents::agent_offices))
             .route("/agents/{id}/signal", post(agents::agent_signal))
             .route("/agents/{id}/message", post(agents::agent_message))
+            .route("/agents/{id}/handoff", post(agents::agent_handoff))
             .route("/agents/{id}/cron", get(cron_api::agent_cron_jobs))
             .route("/agents/{id}/skills", get(agents::agent_skills))
             .route(

--- a/src/services/discord/agent_handoff.rs
+++ b/src/services/discord/agent_handoff.rs
@@ -4,7 +4,9 @@ use serde_json::{Value, json};
 use sqlx::PgPool;
 
 use super::health::{self, HealthRegistry};
+use super::router::{HeadlessTurnStartError, HeadlessTurnStartOutcome};
 use crate::db::agents::AgentChannelBindings;
+use crate::services::provider::ProviderKind;
 
 const ANNOUNCE_BOT: &str = "announce";
 
@@ -90,6 +92,24 @@ impl AgentHandoffError {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             body: json!({"error": "announce bot not configured"}),
+        }
+    }
+
+    /// 409 — a turn is already active for the target mailbox. This semantic is
+    /// unique to the turn-trigger handoff (#3556); the announce-only path
+    /// silently coalesced into the running turn instead.
+    fn conflict(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            body: json!({"error": message.into(), "status": "conflict"}),
+        }
+    }
+
+    /// 503 — the headless turn could not be reserved (runtime unavailable).
+    fn turn_unavailable(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            body: json!({"error": message.into()}),
         }
     }
 
@@ -255,6 +275,174 @@ pub(crate) async fn send_agent_handoff(
     })
 }
 
+/// Successful outcome of a turn-trigger handoff (#3556). Unlike
+/// [`AgentHandoffResponse`] (announce message post), this carries the reserved
+/// `turn_id` and lifecycle `status` so the caller learns the turn was actually
+/// scheduled — not merely that a message was best-effort delivered.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AgentHandoffTurnResponse {
+    pub(crate) to_agent_id: String,
+    pub(crate) channel_id: String,
+    pub(crate) channel_kind: &'static str,
+    pub(crate) turn_id: String,
+    pub(crate) status: &'static str,
+}
+
+impl AgentHandoffTurnResponse {
+    pub(crate) fn to_value(&self) -> Value {
+        let mut value = serde_json::to_value(self).unwrap_or_else(|_| json!({}));
+        if let Value::Object(map) = &mut value {
+            map.insert("ok".to_string(), Value::Bool(true));
+        }
+        value
+    }
+}
+
+/// Provider that owns a given handoff channel binding. The cc binding is the
+/// Claude mailbox; cdx is the Codex mailbox. Mapping the turn to the binding's
+/// owning provider keeps the handoff envelope and the reserved turn on the same
+/// channel so the announce-bot double-trigger (#3576) cannot fire.
+fn provider_for_channel_kind(channel_kind: AgentHandoffChannelKind) -> ProviderKind {
+    match channel_kind {
+        AgentHandoffChannelKind::Cc => ProviderKind::Claude,
+        AgentHandoffChannelKind::Cdx => ProviderKind::Codex,
+    }
+}
+
+/// Registry-independent resolution for a turn-trigger handoff: validates the
+/// agents, resolves the cc/cdx binding to a numeric Discord channel id, derives
+/// the owning provider, and builds the handoff envelope content. Split out from
+/// [`start_agent_handoff_turn`] so the resolution contract is unit-testable
+/// without a live [`HealthRegistry`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentHandoffTurnTarget {
+    pub(crate) to_agent_id: String,
+    pub(crate) channel_id: String,
+    pub(crate) channel_id_num: u64,
+    pub(crate) channel_kind: AgentHandoffChannelKind,
+    pub(crate) provider: ProviderKind,
+    pub(crate) content: String,
+}
+
+fn resolve_agent_handoff_turn_target(
+    bindings: &AgentChannelBindings,
+    from_agent_id: &str,
+    to_agent_id: &str,
+    prompt: &str,
+    channel_kind: AgentHandoffChannelKind,
+    prefix: bool,
+) -> Result<AgentHandoffTurnTarget, AgentHandoffError> {
+    let from_agent_id = from_agent_id.trim();
+    if from_agent_id.is_empty() {
+        return Err(AgentHandoffError::bad_request("from_agent_id is required"));
+    }
+    let to_agent_id = to_agent_id.trim();
+    if to_agent_id.is_empty() {
+        return Err(AgentHandoffError::bad_request("to_agent_id is required"));
+    }
+    if prompt.trim().is_empty() {
+        return Err(AgentHandoffError::bad_request("prompt is required"));
+    }
+
+    let Some(channel_id) = channel_for_kind(bindings, channel_kind) else {
+        return Err(AgentHandoffError::channel_kind_unset(
+            to_agent_id,
+            channel_kind,
+            available_channel_kinds(bindings),
+        ));
+    };
+
+    let Some(channel_id_num) =
+        crate::services::dispatches::outbox_route::resolve_channel_alias_pub(&channel_id)
+            .or_else(|| channel_id.parse::<u64>().ok())
+            .filter(|id| *id > 0)
+    else {
+        return Err(AgentHandoffError::internal(format!(
+            "agent {to_agent_id} {} channel is invalid: {channel_id}",
+            channel_kind.as_str()
+        )));
+    };
+
+    let content = build_agent_handoff_content(from_agent_id, to_agent_id, prompt, prefix);
+
+    Ok(AgentHandoffTurnTarget {
+        to_agent_id: to_agent_id.to_string(),
+        channel_id,
+        channel_id_num,
+        channel_kind,
+        provider: provider_for_channel_kind(channel_kind),
+        content,
+    })
+}
+
+/// Map a headless turn-start result to the handoff API contract (#3556):
+/// `started`/`consumed` → 200 with `turn_id`, `Conflict` → 409 (mailbox busy —
+/// a semantic the announce-only path never had), `Internal` → 503.
+fn map_turn_start_result(
+    target: &AgentHandoffTurnTarget,
+    result: Result<HeadlessTurnStartOutcome, HeadlessTurnStartError>,
+) -> Result<AgentHandoffTurnResponse, AgentHandoffError> {
+    match result {
+        Ok(outcome) => Ok(AgentHandoffTurnResponse {
+            to_agent_id: target.to_agent_id.clone(),
+            channel_id: target.channel_id.clone(),
+            channel_kind: target.channel_kind.as_str(),
+            turn_id: outcome.turn_id,
+            status: outcome.status.as_str(),
+        }),
+        Err(HeadlessTurnStartError::Conflict(error)) => Err(AgentHandoffError::conflict(error)),
+        Err(HeadlessTurnStartError::Internal(error)) => {
+            Err(AgentHandoffError::turn_unavailable(error))
+        }
+    }
+}
+
+/// Turn-trigger handoff (#3556). Resolves the cc/cdx binding and reserves a
+/// headless turn directly on that mailbox — never posts an announce message —
+/// so the handoff is an authoritative, synchronous turn reservation rather than
+/// "post and hope". Because no announce message lands on the cc channel, the
+/// #3576 announce-trigger branch cannot start an unintended second turn.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn start_agent_handoff_turn(
+    registry: &HealthRegistry,
+    pg_pool: &PgPool,
+    from_agent_id: &str,
+    to_agent_id: &str,
+    prompt: &str,
+    channel_kind: AgentHandoffChannelKind,
+    prefix: bool,
+    source: Option<String>,
+    metadata: Option<Value>,
+) -> Result<AgentHandoffTurnResponse, AgentHandoffError> {
+    let to_agent_id_trimmed = to_agent_id.trim();
+    let bindings = crate::db::agents::load_agent_channel_bindings_pg(pg_pool, to_agent_id_trimmed)
+        .await
+        .map_err(|error| AgentHandoffError::internal(format!("query agent channels: {error}")))?
+        .ok_or_else(|| AgentHandoffError::agent_not_found(to_agent_id_trimmed))?;
+
+    let target = resolve_agent_handoff_turn_target(
+        &bindings,
+        from_agent_id,
+        to_agent_id,
+        prompt,
+        channel_kind,
+        prefix,
+    )?;
+
+    let result = health::start_headless_agent_turn(
+        registry,
+        poise::serenity_prelude::ChannelId::new(target.channel_id_num),
+        target.provider.clone(),
+        target.content.clone(),
+        source,
+        metadata,
+        None,
+    )
+    .await;
+
+    map_turn_start_result(&target, result)
+}
+
 fn channel_for_kind(
     bindings: &AgentChannelBindings,
     channel_kind: AgentHandoffChannelKind,
@@ -409,5 +597,162 @@ mod tests {
         );
         assert_eq!(error.status(), StatusCode::BAD_GATEWAY);
         assert_eq!(error.body()["discord_status"], 403);
+    }
+
+    // ── #3556 turn-trigger handoff ────────────────────────────────────────
+
+    #[test]
+    fn handoff_turn_maps_channel_kind_to_owning_provider() {
+        assert_eq!(
+            provider_for_channel_kind(AgentHandoffChannelKind::Cc),
+            ProviderKind::Claude
+        );
+        assert_eq!(
+            provider_for_channel_kind(AgentHandoffChannelKind::Cdx),
+            ProviderKind::Codex
+        );
+    }
+
+    #[test]
+    fn handoff_turn_target_resolves_channel_provider_and_envelope() {
+        let target = resolve_agent_handoff_turn_target(
+            &bindings(Some("111"), Some("222")),
+            "project-agentdesk",
+            "adk-dashboard",
+            "리뷰 반영해줘",
+            AgentHandoffChannelKind::Cdx,
+            true,
+        )
+        .expect("cdx binding resolves");
+        assert_eq!(target.to_agent_id, "adk-dashboard");
+        assert_eq!(target.channel_id, "222");
+        assert_eq!(target.channel_id_num, 222);
+        assert_eq!(target.channel_kind, AgentHandoffChannelKind::Cdx);
+        assert_eq!(target.provider, ProviderKind::Codex);
+        assert_eq!(
+            target.content,
+            "[project-agentdesk → adk-dashboard 핸드오프]\n\n리뷰 반영해줘"
+        );
+    }
+
+    #[test]
+    fn handoff_turn_target_honors_no_prefix() {
+        let target = resolve_agent_handoff_turn_target(
+            &bindings(Some("111"), None),
+            "from",
+            "to",
+            "raw prompt",
+            AgentHandoffChannelKind::Cc,
+            false,
+        )
+        .expect("cc binding resolves");
+        assert_eq!(target.content, "raw prompt");
+    }
+
+    #[test]
+    fn handoff_turn_target_rejects_unset_channel_kind() {
+        let error = resolve_agent_handoff_turn_target(
+            &bindings(None, Some("222")),
+            "from",
+            "to",
+            "prompt",
+            AgentHandoffChannelKind::Cc,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(error.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(error.body()["available_kinds"], json!(["cdx"]));
+    }
+
+    #[test]
+    fn handoff_turn_target_requires_prompt() {
+        let error = resolve_agent_handoff_turn_target(
+            &bindings(Some("111"), None),
+            "from",
+            "to",
+            "   ",
+            AgentHandoffChannelKind::Cc,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(error.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error.body()["error"], "prompt is required");
+    }
+
+    #[test]
+    fn handoff_turn_target_rejects_non_numeric_channel() {
+        let error = resolve_agent_handoff_turn_target(
+            &bindings(Some("not-a-channel"), None),
+            "from",
+            "to",
+            "prompt",
+            AgentHandoffChannelKind::Cc,
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    fn sample_target() -> AgentHandoffTurnTarget {
+        AgentHandoffTurnTarget {
+            to_agent_id: "adk-dashboard".to_string(),
+            channel_id: "111".to_string(),
+            channel_id_num: 111,
+            channel_kind: AgentHandoffChannelKind::Cc,
+            provider: ProviderKind::Claude,
+            content: "envelope".to_string(),
+        }
+    }
+
+    #[test]
+    fn handoff_turn_success_maps_to_started_response() {
+        let target = sample_target();
+        let response = map_turn_start_result(
+            &target,
+            Ok(HeadlessTurnStartOutcome {
+                turn_id: "discord:111:222".to_string(),
+                status: super::super::router::HeadlessTurnStartStatus::Started,
+            }),
+        )
+        .expect("started outcome maps to response");
+        let value = response.to_value();
+        assert_eq!(value["ok"], json!(true));
+        assert_eq!(value["to_agent_id"], "adk-dashboard");
+        assert_eq!(value["channel_id"], "111");
+        assert_eq!(value["channel_kind"], "cc");
+        assert_eq!(value["turn_id"], "discord:111:222");
+        assert_eq!(value["status"], "started");
+    }
+
+    #[test]
+    fn handoff_turn_conflict_maps_to_409() {
+        let target = sample_target();
+        let error = map_turn_start_result(
+            &target,
+            Err(HeadlessTurnStartError::Conflict(
+                "turn already active for this agent mailbox".to_string(),
+            )),
+        )
+        .unwrap_err();
+        assert_eq!(error.status(), StatusCode::CONFLICT);
+        assert_eq!(error.body()["status"], "conflict");
+        assert_eq!(
+            error.body()["error"],
+            "turn already active for this agent mailbox"
+        );
+    }
+
+    #[test]
+    fn handoff_turn_internal_maps_to_503() {
+        let target = sample_target();
+        let error = map_turn_start_result(
+            &target,
+            Err(HeadlessTurnStartError::Internal(
+                "runtime unavailable".to_string(),
+            )),
+        )
+        .unwrap_err();
+        assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(error.body()["error"], "runtime unavailable");
     }
 }

--- a/src/services/discord/router/mod.rs
+++ b/src/services/discord/router/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use message_handler::{IntakeRequest, execute_intake_turn_core};
 pub(super) use turn_start::reserve_headless_turn;
 pub(crate) use turn_start::{
     HeadlessTurnReservation, HeadlessTurnStartError, HeadlessTurnStartOutcome,
+    HeadlessTurnStartStatus,
 };
 
 // Re-export items used across submodules


### PR DESCRIPTION
## 문제
`send-to-agent`/`/api/agents/{id}/message`가 'trigger-capable handoff'라면서 announce-bot 메시지만 best-effort post → 받는 에이전트 턴 시작 불확실(메시지 성공해도 턴 미시작 가능).

## 변경 (코어 분리, additive·하위호환)
- **신설 `POST /api/agents/{id}/handoff`**: cc/cdx 바인딩 resolve → `start_headless_agent_turn` 직접 호출(동기·권위적 턴 예약). **announce 메시지 절대 미post** → #3576 announce 이중 트리거를 구조적으로 차단. 200 started / **409 mailbox busy**(신규 시맨틱) / 404 / 422 channel_kind unset / 503.
- **CLI `adk send-to-agent --start-turn`** 옵트인(기본 announce-post 불변, 상호배타).
- **하위호환**: /message·/discord/send-to-agent·CLI 기본 동작 byte 불변. **dispatch_policy #3576 분기 0 변경**(announce-trigger 흐름 보존, 5 테스트 PASS).
- **마이그레이션은 후속 이슈**: routine executor는 이미 보장 시맨틱이라 미변경, JS host primitive 미존재 → 안전한 동반 전환 0건.

## 검증
- 신규 테스트(agent_handoff 9 + 409/404/422 시맨틱) + #3576 회귀 5 + routes 90 PASS. /api/docs 갱신. 게이트 green.
- Codex(gpt-5.5 xhigh) 적대리뷰(#3576 비회귀·이중 트리거 차단·하위호환 전수): **VERDICT: CLEAN**. (audit:2026-06-18)