### PR TITLE
fix(#3588): idle 4시간 세션 정리가 resume까지 삭제 — 메모리 회수만 하고 resume 보존

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1007,7 +1007,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3722 lines; +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3720 lines; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리); +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;
@@ -1025,7 +1025,7 @@
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
     re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
     S4 mechanical placeholder/status-panel `.ui` rewiring).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1516 lines;
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1514 lines; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리);
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan; +54 from
     #3557 (A) codex r2: the headless watchdog was missing the per-turn hard

--- a/src/services/discord/dispatch_policy.rs
+++ b/src/services/discord/dispatch_policy.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::sync::OnceLock;
 
-use super::ChannelId;
 use super::QueueExitKind;
 use super::SharedData;
 use super::parse_dispatch_id;
@@ -47,10 +46,6 @@ pub(in crate::services::discord) fn strip_monitor_auto_turn_origin<'a>(
     }
 
     (Cow::Borrowed(text), false)
-}
-
-pub(super) fn session_retry_context_key(channel_id: ChannelId) -> String {
-    format!("session_retry_context:{}", channel_id.get())
 }
 
 pub(super) fn should_process_allowed_bot_turn_text(text: &str) -> bool {

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -215,8 +215,8 @@ pub use discord_io::{
 };
 pub(in crate::services::discord) use dispatch_policy::{
     is_allowed_turn_sender, prepend_monitor_auto_turn_origin, resolve_announce_bot_user_id,
-    resolve_notify_bot_user_id, session_retry_context_key, should_phase2_recover_message,
-    stale_dispatch_turn_for_text, strip_monitor_auto_turn_origin,
+    resolve_notify_bot_user_id, should_phase2_recover_message, stale_dispatch_turn_for_text,
+    strip_monitor_auto_turn_origin,
 };
 pub(crate) use inflight::latest_request_owner_user_id_for_channel;
 pub use settings::{
@@ -4037,9 +4037,7 @@ async fn maybe_cleanup_sessions(shared: &Arc<SharedData>) {
 
     struct ExpiredSessionCleanup {
         channel_id: ChannelId,
-        session_id: Option<String>,
         session_key: Option<String>,
-        retry_context: Option<String>,
     }
 
     let provider = shared.settings.read().await.provider.clone();
@@ -4057,7 +4055,6 @@ async fn maybe_cleanup_sessions(shared: &Arc<SharedData>) {
             })
             .map(|(ch, s)| ExpiredSessionCleanup {
                 channel_id: *ch,
-                session_id: s.session_id.clone(),
                 session_key: s.channel_name.as_ref().map(|name| {
                     let tmux_name = provider.build_tmux_session_name(name);
                     adk_session::build_namespaced_session_key(
@@ -4066,7 +4063,6 @@ async fn maybe_cleanup_sessions(shared: &Arc<SharedData>) {
                         &tmux_name,
                     )
                 }),
-                retry_context: s.recent_history_context(SESSION_RECOVERY_CONTEXT_MESSAGES),
             })
             .collect()
     };
@@ -4086,20 +4082,14 @@ async fn maybe_cleanup_sessions(shared: &Arc<SharedData>) {
             data.sessions.remove(&ch);
         }
     }
-    for expired_session in &expired {
-        if let Some(retry_context) = expired_session.retry_context.as_deref() {
-            let _ = internal_api::set_kv_value(
-                &session_retry_context_key(expired_session.channel_id),
-                retry_context,
-            );
-        }
-        if let Some(session_key) = expired_session.session_key.as_deref() {
-            adk_session::clear_provider_session_id(session_key, shared.api_port).await;
-        }
-        if let Some(session_id) = expired_session.session_id.as_deref() {
-            let _ = internal_api::clear_stale_session_id(session_id).await;
-        }
-    }
+    // #3588: idle 정리는 in-memory/worktree 메모리 회수만 수행하고 provider
+    // session(claude resume id)은 DB에 보존한다. 다음 턴에서
+    // `fetch_provider_session_id`로 복원되어 `--resume`으로 transcript가 이어진다.
+    // retry_context(session_retry_context_key) kv는 의도적으로 저장하지 않는다 —
+    // 같은 키를 `take_session_retry_context`가 다음 턴에 무조건 take/주입하므로,
+    // resume이 성공하는 idle 경로에서 저장하면 transcript 중복 + "새 세션 시작"
+    // 레이블 오표시가 발생한다. 진짜 reset(AssistantTurnCap)만 turn_start에서 저장한다.
+    // 명시적 세션 초기화는 idle recap의 `새 세션 시작` 버튼(idle_recap:clear)으로 한다.
     for expired_session in &expired {
         let cleared = mailbox_clear_channel(shared, &provider, expired_session.channel_id).await;
         if cleared.removed_token.is_some() {

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -263,8 +263,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     {
         let mut data = shared.core.lock().await;
         if let Some(session) = data.sessions.get_mut(&channel_id)
-            && let Some(reason) =
-                session_reset_reason_for_turn(session, tokio::time::Instant::now())
+            && let Some(reason) = session_reset_reason_for_turn(session)
         {
             if let Some(retry_context) = session
                 .recent_history_context(super::super::super::SESSION_RECOVERY_CONTEXT_MESSAGES)
@@ -641,7 +640,6 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             let ts = chrono::Local::now().format("%H:%M:%S");
             session_strategy_reason = session_reset_reason_lifecycle_code(reason);
             let display_reason = match reason {
-                SessionResetReason::IdleExpired => "idle timeout",
                 SessionResetReason::AssistantTurnCap => "assistant turn cap",
             };
             tracing::info!(

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -497,8 +497,7 @@ pub(in crate::services::discord) async fn handle_text_message(
     let (session_info, mut pending_uploads, session_was_cleared) = {
         let mut data = shared.core.lock().await;
         if let Some(session) = data.sessions.get_mut(&channel_id)
-            && let Some(reason) =
-                session_reset_reason_for_turn(session, tokio::time::Instant::now())
+            && let Some(reason) = session_reset_reason_for_turn(session)
         {
             if let Some(retry_context) = session
                 .recent_history_context(super::super::super::SESSION_RECOVERY_CONTEXT_MESSAGES)
@@ -1432,7 +1431,6 @@ pub(in crate::services::discord) async fn handle_text_message(
             let ts = chrono::Local::now().format("%H:%M:%S");
             session_strategy_reason = session_reset_reason_lifecycle_code(reason);
             let display_reason = match reason {
-                SessionResetReason::IdleExpired => "idle timeout",
                 SessionResetReason::AssistantTurnCap => "assistant turn cap",
             };
             tracing::info!(

--- a/src/services/discord/router/turn_start.rs
+++ b/src/services/discord/router/turn_start.rs
@@ -125,17 +125,18 @@ pub(in crate::services::discord) fn reserve_headless_turn() -> HeadlessTurnReser
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SessionResetReason {
-    IdleExpired,
     AssistantTurnCap,
 }
 
+// NOTE(#3588): idle 기반 세션 리셋은 제거됨. 4시간 idle 후에도 provider session
+// (claude resume id)을 보존해 다음 턴에 `--resume`으로 transcript를 이어간다.
+// in-memory/tmux 메모리 회수는 `maybe_cleanup_sessions`가 담당하되 resume id는
+// 남긴다. 명시적 초기화는 idle recap의 `새 세션 시작` 버튼(idle_recap:clear).
+// AssistantTurnCap(100턴)은 idle과 무관한 컨텍스트 폭주 방어 장치라 유지한다.
 pub(super) fn session_reset_reason_for_turn(
     session: &DiscordSession,
-    now: tokio::time::Instant,
 ) -> Option<SessionResetReason> {
-    if now.duration_since(session.last_active) > super::super::SESSION_MAX_IDLE {
-        Some(SessionResetReason::IdleExpired)
-    } else if session.assistant_turn_count() >= super::super::SESSION_MAX_ASSISTANT_TURNS {
+    if session.assistant_turn_count() >= super::super::SESSION_MAX_ASSISTANT_TURNS {
         Some(SessionResetReason::AssistantTurnCap)
     } else {
         None
@@ -144,7 +145,6 @@ pub(super) fn session_reset_reason_for_turn(
 
 pub(super) fn session_reset_reason_lifecycle_code(reason: SessionResetReason) -> &'static str {
     match reason {
-        SessionResetReason::IdleExpired => "idle_timeout",
         SessionResetReason::AssistantTurnCap => "assistant_turn_cap",
     }
 }


### PR DESCRIPTION
Closes #3588

## 문제
4시간(`SESSION_MAX_IDLE`) 이상 idle 후 짧은 답신(예: "1해")을 보내면 직전 대화 맥락을 잃고 fresh 세션으로 시작됨. context 토큰 급감(예: 147.5k→35.6k), 사용자 안내 없음.

## 원인
idle 4시간 기반 두 메커니즘이 provider session id(claude resume id)를 폐기:
1. `maybe_cleanup_sessions`(1h 주기 백그라운드): in-memory 회수와 함께 `clear_provider_session_id`/`clear_stale_session_id`로 **DB resume id까지 삭제**
2. `session_reset_reason_for_turn`: 다음 턴에 `IdleExpired`로 provider session/history clear

## 변경
- `maybe_cleanup_sessions`에서 DB resume id 삭제 호출 제거. **in-memory/worktree 메모리 회수는 유지** (기기 메모리 관리 그대로).
- `SessionResetReason::IdleExpired` 및 idle 트리거 제거. `AssistantTurnCap`(100턴)은 별개 안전장치라 유지.
- idle 경로의 `retry_context`(session_retry_context_key) kv 저장 제거 — 같은 키를 `take_session_retry_context`가 다음 턴에 무조건 take/주입하므로, resume이 성공하는 idle 경로에서 저장하면 transcript 중복 + "새 세션 시작" 레이블 오표시 발생.

## 효과
tmux/메모리가 회수돼도 다음 메시지에 DB resume id로 `--resume` 복원 → 대화 연속 + `세션 복원` 표시 정상화. 명시적 초기화는 idle recap의 `새 세션 시작` 버튼(idle_recap:clear)으로.

## 검증
- `cargo check --all-targets` exit 0 (최신 main rebase 후)
- session_strategy_lifecycle 테스트 41 passed
- 잔여 `IdleExpired` 참조 0, 두 clear 함수는 turn-cap·/goal·provider isolation 경로에서 계속 사용 (dead code 아님)

## codex 교차 리뷰 대응
- **MEDIUM (retry_context 중복 주입)**: 본 PR에서 반영 (idle 경로 retry_context 저장 제거)
- **HIGH (thread 세션 GC가 resume selector 행 삭제)**: 메인 채널 세션(`thread_channel_id NULL`)은 GC 무관이라 본 수정으로 해결됨. thread(dispatch) 세션 한정 사안은 #3589로 분리 추적 (regression 아님 — 기존 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
