### PR TITLE
fix(#3591): 100턴 세션 리셋(AssistantTurnCap + turn-end cap) 제거 — auto-compact가 컨텍스트 관리

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1007,7 +1007,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3720 lines; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리); +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3680 lines; -40 from #3591 100턴 세션 리셋(AssistantTurnCap) 제거: reset 판정/clear/DB clear/display 블록 삭제; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리); +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;
@@ -1025,7 +1025,7 @@
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
     re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
     S4 mechanical placeholder/status-panel `.ui` rewiring).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1514 lines; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리);
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1469 lines; -45 from #3591 100턴 세션 리셋(AssistantTurnCap) 제거: reset 판정/clear/DB clear/display 블록 삭제; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리);
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan; +54 from
     #3557 (A) codex r2: the headless watchdog was missing the per-turn hard
@@ -1203,7 +1203,7 @@
     `audit_maintainability_config.toml`; the root is no longer a prod giant and
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
-  - `src/services/discord/session_runtime.rs` (1753 lines).
+  - `src/services/discord/session_runtime.rs` (1712 lines; -41 from #3591 dead `assistant_turn_count`/`recent_history_context` 메서드 제거 — 100턴/idle 세션 리셋 폐기 연쇄).
   - `src/services/discord/voice_barge_in.rs` (2823 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -252,8 +252,6 @@ const SESSION_CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 ho
 // lunch / sync meeting" gaps while still bounding zombie growth via the
 // cleanup interval reaper at `mod.rs:2093`.
 const SESSION_MAX_IDLE: Duration = Duration::from_secs(4 * 60 * 60); // 4 hours
-const SESSION_MAX_ASSISTANT_TURNS: usize = 100;
-const SESSION_RECOVERY_CONTEXT_MESSAGES: usize = 10;
 const DEAD_SESSION_REAP_INTERVAL: Duration = Duration::from_secs(60); // 1 minute
 const RESTART_REPORT_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const DEFERRED_RESTART_POLL_INTERVAL: Duration = Duration::from_secs(10);
@@ -4088,7 +4086,8 @@ async fn maybe_cleanup_sessions(shared: &Arc<SharedData>) {
     // retry_context(session_retry_context_key) kv는 의도적으로 저장하지 않는다 —
     // 같은 키를 `take_session_retry_context`가 다음 턴에 무조건 take/주입하므로,
     // resume이 성공하는 idle 경로에서 저장하면 transcript 중복 + "새 세션 시작"
-    // 레이블 오표시가 발생한다. 진짜 reset(AssistantTurnCap)만 turn_start에서 저장한다.
+    // 레이블 오표시가 발생한다. (#3591에서 100턴 세션 리셋도 제거되어 reset 기반
+    // 저장 경로는 없다; resume 실패 복구만 auto_retry_with_history가 별도로 저장한다.)
     // 명시적 세션 초기화는 idle recap의 `새 세션 시작` 버튼(idle_recap:clear)으로 한다.
     for expired_session in &expired {
         let cleared = mailbox_clear_channel(shared, &provider, expired_session.channel_id).await;

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -22,11 +22,10 @@ pub(crate) use super::turn_start::{
     HeadlessTurnStartStatus,
 };
 use super::turn_start::{
-    SessionResetReason, cli_just_spawned_for_emit, dispatch_reset_lifecycle_code,
-    emit_session_strategy_lifecycle, load_session_runtime_state, log_session_strategy_diagnostic,
+    cli_just_spawned_for_emit, dispatch_reset_lifecycle_code, emit_session_strategy_lifecycle,
+    load_session_runtime_state, log_session_strategy_diagnostic,
     refresh_session_strategy_after_pending_reset, release_mailbox_after_hosted_tui_busy_pre_submit,
-    release_mailbox_after_placeholder_post_failure, session_reset_reason_for_turn,
-    session_reset_reason_lifecycle_code, session_runtime_state_after_redirect,
+    release_mailbox_after_placeholder_post_failure, session_runtime_state_after_redirect,
     take_session_retry_context,
 };
 use crate::services::agent_protocol::RuntimeHandoffKind;

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -257,31 +257,6 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             channel_id.get()
         )));
     }
-    let mut session_reset_reason = None;
-    let mut reset_session_id_to_clear = None;
-
-    {
-        let mut data = shared.core.lock().await;
-        if let Some(session) = data.sessions.get_mut(&channel_id)
-            && let Some(reason) = session_reset_reason_for_turn(session)
-        {
-            if let Some(retry_context) = session
-                .recent_history_context(super::super::super::SESSION_RECOVERY_CONTEXT_MESSAGES)
-            {
-                let _ = super::super::super::turn_bridge::store_session_retry_context(
-                    None::<&crate::db::Db>,
-                    shared.pg_pool.as_ref(),
-                    channel_id.get(),
-                    &retry_context,
-                );
-            }
-            session_reset_reason = Some(reason);
-            reset_session_id_to_clear = session.session_id.clone();
-            session.clear_provider_session();
-            session.history.clear();
-        }
-    }
-
     let (mut session_id, mut memento_context_loaded, mut current_path) = {
         let mut data = shared.core.lock().await;
         if let Some(info) = load_session_runtime_state(&mut data.sessions, channel_id) {
@@ -573,15 +548,6 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             "failed to refresh routine headless session identity"
         );
     }
-    if session_reset_reason.is_some() {
-        if let Some(ref key) = adk_session_key {
-            super::super::super::adk_session::clear_provider_session_id(key, shared.api_port).await;
-        }
-        if let Some(ref session_id_to_clear) = reset_session_id_to_clear {
-            let _ = super::super::super::internal_api::clear_stale_session_id(session_id_to_clear)
-                .await;
-        }
-    }
     let headless_goal_kind = classify_codex_goal_command_for_provider(
         &provider,
         prompt,
@@ -635,17 +601,6 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             tracing::info!(
                 "  [{ts}] ↻ Skipping DB provider session restore for headless channel {} due to prior /clear",
                 channel_id.get()
-            );
-        } else if let Some(reason) = session_reset_reason {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            session_strategy_reason = session_reset_reason_lifecycle_code(reason);
-            let display_reason = match reason {
-                SessionResetReason::AssistantTurnCap => "assistant turn cap",
-            };
-            tracing::info!(
-                "  [{ts}] ↻ Skipping DB provider session restore for headless channel {} due to {}",
-                channel_id.get(),
-                display_reason
             );
         } else if let Some(ref key) = adk_session_key {
             let restored = super::super::super::adk_session::fetch_provider_session_id(

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -491,29 +491,9 @@ pub(in crate::services::discord) async fn handle_text_message(
         .await;
         return Ok(());
     }
-    let mut session_reset_reason = None;
-    let mut reset_session_id_to_clear = None;
     // Get session info, allowed tools, and pending uploads
     let (session_info, mut pending_uploads, session_was_cleared) = {
         let mut data = shared.core.lock().await;
-        if let Some(session) = data.sessions.get_mut(&channel_id)
-            && let Some(reason) = session_reset_reason_for_turn(session)
-        {
-            if let Some(retry_context) = session
-                .recent_history_context(super::super::super::SESSION_RECOVERY_CONTEXT_MESSAGES)
-            {
-                let _ = super::super::super::turn_bridge::store_session_retry_context(
-                    None::<&crate::db::Db>,
-                    shared.pg_pool.as_ref(),
-                    channel_id.get(),
-                    &retry_context,
-                );
-            }
-            session_reset_reason = Some(reason);
-            reset_session_id_to_clear = session.session_id.clone();
-            session.clear_provider_session();
-            session.history.clear();
-        }
         let info = load_session_runtime_state(&mut data.sessions, channel_id);
         let (uploads, was_cleared) = data
             .sessions
@@ -1339,15 +1319,6 @@ pub(in crate::services::discord) async fn handle_text_message(
         (channel_name, tmux_session_name)
     };
     let adk_session_key = build_adk_session_key(shared, channel_id, &provider).await;
-    if session_reset_reason.is_some() {
-        if let Some(ref key) = adk_session_key {
-            super::super::super::adk_session::clear_provider_session_id(key, shared.api_port).await;
-        }
-        if let Some(ref session_id_to_clear) = reset_session_id_to_clear {
-            let _ = super::super::super::internal_api::clear_stale_session_id(session_id_to_clear)
-                .await;
-        }
-    }
     let turn_goal_kind = if !dispatch_reset_provider_state && !dispatch_recreate_tmux {
         classify_codex_goal_command_for_provider(
             &provider,
@@ -1426,17 +1397,6 @@ pub(in crate::services::discord) async fn handle_text_message(
                 "  [{ts}] ↻ Skipping DB provider session restore for dispatch reset_provider_state={} recreate_tmux={}",
                 dispatch_reset_provider_state,
                 dispatch_recreate_tmux
-            );
-        } else if let Some(reason) = session_reset_reason {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            session_strategy_reason = session_reset_reason_lifecycle_code(reason);
-            let display_reason = match reason {
-                SessionResetReason::AssistantTurnCap => "assistant turn cap",
-            };
-            tracing::info!(
-                "  [{ts}] ↻ Skipping DB provider session restore for channel {} due to {}",
-                channel_id.get(),
-                display_reason
             );
         } else if let Some(ref key) = adk_session_key {
             let restored = super::super::super::adk_session::fetch_provider_session_id(

--- a/src/services/discord/router/turn_start.rs
+++ b/src/services/discord/router/turn_start.rs
@@ -123,31 +123,12 @@ pub(in crate::services::discord) fn reserve_headless_turn() -> HeadlessTurnReser
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum SessionResetReason {
-    AssistantTurnCap,
-}
-
-// NOTE(#3588): idle 기반 세션 리셋은 제거됨. 4시간 idle 후에도 provider session
-// (claude resume id)을 보존해 다음 턴에 `--resume`으로 transcript를 이어간다.
-// in-memory/tmux 메모리 회수는 `maybe_cleanup_sessions`가 담당하되 resume id는
-// 남긴다. 명시적 초기화는 idle recap의 `새 세션 시작` 버튼(idle_recap:clear).
-// AssistantTurnCap(100턴)은 idle과 무관한 컨텍스트 폭주 방어 장치라 유지한다.
-pub(super) fn session_reset_reason_for_turn(
-    session: &DiscordSession,
-) -> Option<SessionResetReason> {
-    if session.assistant_turn_count() >= super::super::SESSION_MAX_ASSISTANT_TURNS {
-        Some(SessionResetReason::AssistantTurnCap)
-    } else {
-        None
-    }
-}
-
-pub(super) fn session_reset_reason_lifecycle_code(reason: SessionResetReason) -> &'static str {
-    match reason {
-        SessionResetReason::AssistantTurnCap => "assistant_turn_cap",
-    }
-}
+// NOTE(#3588, #3591): idle 기반 + 턴수 기반(100턴) 세션 리셋이 모두 제거됨.
+// idle/턴수와 무관하게 provider session(claude resume id)을 보존해 다음 턴에
+// `--resume`으로 transcript를 이어간다. 컨텍스트 폭주는 auto-compact가 관리한다.
+// in-memory/tmux 메모리 회수는 `maybe_cleanup_sessions`/idle-kill이 담당하되
+// resume id는 남긴다. 명시적 초기화는 idle recap의 `새 세션 시작` 버튼
+// (idle_recap:clear) 또는 `/clear`로만 한다.
 
 pub(super) fn dispatch_reset_lifecycle_code(
     reset_provider_state: bool,

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -150,47 +150,6 @@ impl DiscordSession {
         self.memento_reflected = false;
     }
 
-    pub(super) fn assistant_turn_count(&self) -> usize {
-        self.history
-            .iter()
-            .filter(|item| item.item_type == HistoryType::Assistant)
-            .count()
-    }
-
-    pub(super) fn recent_history_context(&self, max_messages: usize) -> Option<String> {
-        if max_messages == 0 {
-            return None;
-        }
-
-        let mut lines = self
-            .history
-            .iter()
-            .rev()
-            .filter_map(|item| {
-                let speaker = match item.item_type {
-                    HistoryType::User => "User",
-                    HistoryType::Assistant => "Assistant",
-                    _ => return None,
-                };
-                let content = item.content.trim();
-                if content.is_empty() {
-                    return None;
-                }
-                Some(format!(
-                    "{speaker}: {}",
-                    content.chars().take(300).collect::<String>()
-                ))
-            })
-            .take(max_messages)
-            .collect::<Vec<_>>();
-
-        if lines.is_empty() {
-            return None;
-        }
-
-        lines.reverse();
-        Some(lines.join("\n"))
-    }
     /// Validate `current_path` and return it if it exists on disk.
     /// If the path is stale (deleted), clear `current_path` and `worktree`, log, and return `None`.
     pub(super) fn validated_path(&mut self, channel_id: impl std::fmt::Display) -> Option<String> {

--- a/src/services/discord/turn_bridge/memory_lifecycle.rs
+++ b/src/services/discord/turn_bridge/memory_lifecycle.rs
@@ -8,8 +8,6 @@ use crate::services::provider::ProviderKind;
 use crate::ui::ai_screen::{HistoryItem, HistoryType};
 use poise::serenity_prelude::ChannelId;
 
-pub(super) const PROVIDER_SESSION_ASSISTANT_TURN_CAP: usize = 100;
-
 pub(super) fn spawn_memory_capture_task(
     channel_id: ChannelId,
     capture_memory_settings: settings::ResolvedMemorySettings,
@@ -354,13 +352,6 @@ pub(super) struct TurnEndMemoryPlan {
     pub(super) spawn_capture: bool,
 }
 
-fn assistant_turn_count(history: &[HistoryItem]) -> usize {
-    history
-        .iter()
-        .filter(|item| item.item_type == HistoryType::Assistant && !item.content.trim().is_empty())
-        .count()
-}
-
 pub(super) fn plan_turn_end_memory(
     session: &DiscordSession,
     backend: settings::MemoryBackendKind,
@@ -384,18 +375,13 @@ pub(super) fn plan_turn_end_memory(
         });
     }
 
-    let assistant_turn_cap_reached = persist_transcript
-        && assistant_turn_count(&session.history).saturating_add(1)
-            >= PROVIDER_SESSION_ASSISTANT_TURN_CAP;
+    // #3591: 턴수 기반(100턴) 세션 리셋 제거. 컨텍스트 폭주는 auto-compact가 관리.
     let session_end_reason = if terminal_session_reset_required {
         Some(SessionEndReason::LocalSessionReset)
-    } else if assistant_turn_cap_reached {
-        Some(SessionEndReason::TurnCapReached)
     } else {
         None
     };
-    let clear_provider_session =
-        resume_failure_detected || terminal_session_reset_required || assistant_turn_cap_reached;
+    let clear_provider_session = resume_failure_detected || terminal_session_reset_required;
 
     Some(TurnEndMemoryPlan {
         session_end_reason,

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -47,7 +47,7 @@ use crate::services::agent_protocol::{
     RuntimeHandoff, RuntimeHandoffKind, StatusEvent, TaskNotificationKind,
 };
 use crate::services::memory::{
-    CaptureRequest, SessionEndReason, TokenUsage, resolve_memory_role_id, resolve_memory_session_id,
+    CaptureRequest, TokenUsage, resolve_memory_role_id, resolve_memory_session_id,
 };
 use crate::services::observability::session_inventory::{
     format_child_inventory_progress, load_child_inventory_by_parent_key_pg,
@@ -73,8 +73,7 @@ pub(super) use completion_guard::{
     runtime_db_fallback_complete_with_result, streaming_final_complete_dispatch_with_result,
 };
 pub(super) use recovery_text::{
-    auto_retry_with_history, build_session_retry_context_from_history, release_retry_pending,
-    store_session_retry_context, take_session_retry_context_for_turn_with_audit,
+    auto_retry_with_history, release_retry_pending, take_session_retry_context_for_turn_with_audit,
 };
 use single_message_footer::*;
 pub(super) use stale_resume::result_event_has_stale_resume_error;
@@ -5843,9 +5842,7 @@ pub(super) fn spawn_turn_bridge(
         let mut should_analyze_recall_feedback = false;
         let mut should_spawn_memory_capture = false;
         let mut reflect_request = None;
-        let mut session_end_reason = None;
         let mut clear_provider_session = false;
-        let mut retry_context_to_store = None;
         let capture_memory_settings = settings::memory_settings_for_binding(role_binding.as_ref());
         let session_id_to_persist = {
             let mut data = shared_owned.core.lock().await;
@@ -5858,7 +5855,6 @@ pub(super) fn spawn_turn_bridge(
                     terminal_session_reset_required,
                     should_record_final_turn,
                 ) {
-                    session_end_reason = memory_plan.session_end_reason;
                     clear_provider_session = memory_plan.clear_provider_session;
                     if memory_plan.persist_transcript {
                         session.history.push(HistoryItem {
@@ -5870,11 +5866,6 @@ pub(super) fn spawn_turn_bridge(
                             content: full_response.clone(),
                         });
                         should_persist_transcript = true;
-                        if memory_plan.session_end_reason == Some(SessionEndReason::TurnCapReached)
-                        {
-                            retry_context_to_store =
-                                build_session_retry_context_from_history(&session.history);
-                        }
                     }
                     if let Some(reason) = memory_plan.session_end_reason {
                         reflect_request = take_memento_reflect_request(
@@ -5902,42 +5893,12 @@ pub(super) fn spawn_turn_bridge(
             }
         };
 
-        if let Some(retry_context) = retry_context_to_store.as_deref()
-            && let Err(err) = store_session_retry_context(
-                None::<&crate::db::Db>,
-                shared_owned.pg_pool.as_ref(),
-                channel_id.get(),
-                retry_context,
-            )
-        {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
-                "  [{ts}] ⚠ failed to store retry context for channel {}: {}",
-                channel_id.get(),
-                err
-            );
-        }
-
         // Persist or clear provider session_id in DB so fresh-session transitions
         // survive dcserver restarts and idle cleanup.
         if clear_provider_session {
             if let Some(session_key) = adk_session_key.as_deref() {
                 super::adk_session::clear_provider_session_id(session_key, shared_owned.api_port)
                     .await;
-                if session_end_reason == Some(SessionEndReason::TurnCapReached) {
-                    crate::services::termination_audit::record_termination_with_handles(
-                        None::<&crate::db::Db>,
-                        shared_owned.pg_pool.as_ref(),
-                        session_key,
-                        dispatch_id.as_deref(),
-                        "turn_bridge",
-                        "turn_cap_reached",
-                        Some("provider session cleared after assistant turn cap"),
-                        None,
-                        None,
-                        None,
-                    );
-                }
             }
         } else if let (Some(session_key), Some(persisted_sid)) =
             (adk_session_key.as_deref(), session_id_to_persist.as_deref())

--- a/src/services/discord/turn_bridge/recovery_text.rs
+++ b/src/services/discord/turn_bridge/recovery_text.rs
@@ -9,10 +9,8 @@ use crate::services::observability::turn_lifecycle::{
     RecoveryContextDetails, RecoveryDetails, TurnEvent, TurnLifecycleEmit, emit_turn_lifecycle,
 };
 use crate::services::provider::ProviderKind;
-use crate::ui::ai_screen::{HistoryItem, HistoryType};
 use serenity::all::{ChannelId, MessageId};
 
-const SESSION_RETRY_CONTEXT_LIMIT: usize = 10;
 const SESSION_RETRY_CONTEXT_ITEM_CHAR_LIMIT: usize = 300;
 const DISCORD_RECENT_MESSAGES_RECOVERY_SOURCE: &str = "discord_recent_messages";
 
@@ -177,43 +175,6 @@ fn take_session_retry_context_runtime_pg(key: &str) -> Option<String> {
     .flatten()
 }
 
-pub(in crate::services::discord) fn build_session_retry_context_from_history(
-    history: &[HistoryItem],
-) -> Option<String> {
-    let lines = history
-        .iter()
-        .filter_map(|item| {
-            let label = match item.item_type {
-                HistoryType::User => "User",
-                HistoryType::Assistant | HistoryType::Error => "Assistant",
-                HistoryType::System | HistoryType::ToolUse | HistoryType::ToolResult => {
-                    return None;
-                }
-            };
-            let content = item.content.trim();
-            if content.is_empty() {
-                return None;
-            }
-            let excerpt = content
-                .chars()
-                .take(SESSION_RETRY_CONTEXT_ITEM_CHAR_LIMIT)
-                .collect::<String>();
-            Some(format!("{label}: {excerpt}"))
-        })
-        .rev()
-        .take(SESSION_RETRY_CONTEXT_LIMIT)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect::<Vec<_>>();
-
-    if lines.is_empty() {
-        None
-    } else {
-        Some(lines.join("\n"))
-    }
-}
-
 fn store_session_retry_context_impl(
     db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
@@ -246,15 +207,6 @@ fn store_session_retry_context_impl(
     }
 
     Ok(())
-}
-
-pub(in crate::services::discord) fn store_session_retry_context(
-    db: Option<&crate::db::Db>,
-    pg_pool: Option<&sqlx::PgPool>,
-    channel_id: u64,
-    history: &str,
-) -> Result<(), String> {
-    store_session_retry_context_impl(db, pg_pool, channel_id, history, None)
 }
 
 /// Store the session retry (recovery) context together with its recovery

--- a/src/services/memory/mod.rs
+++ b/src/services/memory/mod.rs
@@ -115,7 +115,6 @@ pub(crate) struct CaptureRequest {
 pub(crate) enum SessionEndReason {
     IdleExpiry,
     LocalSessionReset,
-    TurnCapReached,
 }
 
 impl SessionEndReason {
@@ -123,7 +122,6 @@ impl SessionEndReason {
         match self {
             Self::IdleExpiry => "idle_expiry",
             Self::LocalSessionReset => "local_session_reset",
-            Self::TurnCapReached => "turn_cap_reached",
         }
     }
 }


### PR DESCRIPTION
Closes #3591

## 문제
100턴 도달 시 provider session(claude resume id)을 clear해 대화 맥락을 잃는 메커니즘이 **두 곳**에 있었다. 60% auto-compact가 토큰 기반으로 컨텍스트를 관리하므로 턴수 기반 강제 리셋은 불필요.

## 변경 — 100턴 리셋 2곳 모두 제거
1. **turn 시작 리셋** (`SessionResetReason::AssistantTurnCap`): `SessionResetReason` enum + `session_reset_reason_for_turn` + `session_reset_reason_lifecycle_code`(turn_start.rs), `SESSION_MAX_ASSISTANT_TURNS`(mod.rs), `assistant_turn_count()` 메서드(session_runtime.rs), headless_turn/intake_turn의 reset 블록, message_handler import 제거.
2. **turn 끝 캡** (`PROVIDER_SESSION_ASSISTANT_TURN_CAP` → `SessionEndReason::TurnCapReached`): memory_lifecycle.rs의 cap 판정, turn_bridge의 TurnCapReached 분기(retry_context 저장/audit), memory/mod.rs의 variant 제거.
3. dead가 된 retry_context 저장(`store_session_retry_context` no-audit, `build_session_retry_context_from_history`) 정리.

## 효과
세션은 idle/턴수와 무관하게 resume을 이어가고, 컨텍스트는 auto-compact가 관리. 명시적 초기화는 idle recap `새 세션 시작` 버튼/`/clear`만.

## 유지 (제거 안 함)
- `take_session_retry_context`/`format_session_retry_context` (매 턴 호출), `store_session_retry_context_with_audit` (resume 실패 복구 `auto_retry_with_history` 경로)
- `clear_provider_session`/`_id`/`clear_stale_session_id` (dispatch reset·/goal·/clear·provider isolation)
- `SessionEndReason::IdleExpiry`/`LocalSessionReset`

## 검증
- `cargo build --all-targets` exit 0 · `cargo fmt --check` clean · freshness gate passed · 관련 테스트 223 passed · 잔여 참조 0
- codex 교차 리뷰 **VERDICT: 핵심 CLEAN** (다른 reset 경로 무손상, plan_turn_end_memory 정확, retry_context/reflect 무결)

## codex LOW 처리
잔여 `turn cap` 문자열 4곳은 enum dead가 아니라 **방어적 kill-reason 매칭(tmux.rs/dispatched_sessions.rs — 다른 turn-관련 reason에도 대응)** + 주석/테스트 리터럴이라 기능 무관. 매칭 로직은 의도적으로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
