### PR TITLE
fix(#3598): triage-rules를 route-only로 축소 — PMD 분류 요청 핑 제거

### DIFF
--- a/policies/__tests__/triage-rules.test.js
+++ b/policies/__tests__/triage-rules.test.js
@@ -1,0 +1,129 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { loadPolicy } = require("./support/harness");
+
+// triage-rules is route-only (issue #3598): it auto-assigns backlog cards by
+// `agent:<id>` label and sets priority by `priority:*` label. It must NOT emit
+// any PMD "classification request" ping. Unlabeled cards are a no-op.
+//
+// The default agentdesk mock does not expose cards.list/assign/setPriority or
+// agents.get, so we inject them via extraAgentdesk and record their calls.
+function loadTriage(cards, agents) {
+  const assignCalls = [];
+  const setPriorityCalls = [];
+  const listCalls = [];
+  const infoLogs = [];
+
+  const { state, policy } = loadPolicy("policies/triage-rules.js", {
+    extraAgentdesk: {
+      cards: {
+        list(filter) {
+          listCalls.push(filter);
+          return cards;
+        },
+        assign(cardId, agentId) {
+          assignCalls.push({ cardId, agentId });
+        },
+        setPriority(cardId, priority) {
+          setPriorityCalls.push({ cardId, priority });
+        }
+      },
+      agents: {
+        get(agentId) {
+          return Object.prototype.hasOwnProperty.call(agents, agentId)
+            ? agents[agentId]
+            : null;
+        }
+      },
+      log: {
+        info(message) {
+          infoLogs.push(String(message));
+        },
+        debug() {},
+        warn() {},
+        error() {}
+      }
+    }
+  });
+
+  assert.ok(policy, "triage-rules policy should be registered");
+  assert.equal(typeof policy.onTick, "function", "policy should expose onTick");
+  policy.onTick();
+
+  return { state, assignCalls, setPriorityCalls, listCalls, infoLogs };
+}
+
+test("agent:<id> label assigns the card to the resolved agent", () => {
+  const { state, assignCalls, setPriorityCalls } = loadTriage(
+    [{ id: "card-1", metadata: { labels: "agent:alpha" } }],
+    { alpha: { id: "alpha" } }
+  );
+
+  assert.deepEqual(assignCalls, [{ cardId: "card-1", agentId: "alpha" }]);
+  assert.equal(setPriorityCalls.length, 0);
+  // route-only: never pings PMD
+  assert.equal(state.messageQueues.length, 0);
+});
+
+test("agent label resolves via ch- prefix fallback when exact match misses", () => {
+  const { state, assignCalls } = loadTriage(
+    [{ id: "card-2", metadata: { labels: "agent:beta" } }],
+    { "ch-beta": { id: "ch-beta" } } // exact "beta" misses, "ch-beta" hits
+  );
+
+  assert.deepEqual(assignCalls, [{ cardId: "card-2", agentId: "ch-beta" }]);
+  assert.equal(state.messageQueues.length, 0);
+});
+
+test("unlabeled card is a no-op (no assign, no priority, no PMD ping)", () => {
+  const { state, assignCalls, setPriorityCalls } = loadTriage(
+    [{ id: "card-3", metadata: { labels: "" } }],
+    {}
+  );
+
+  assert.deepEqual(assignCalls, []);
+  assert.deepEqual(setPriorityCalls, []);
+  assert.equal(state.messageQueues.length, 0);
+});
+
+test("priority-only label sets priority without assigning (card stays unassigned)", () => {
+  const { state, assignCalls, setPriorityCalls } = loadTriage(
+    [{ id: "card-4", metadata: { labels: "priority:high" } }],
+    {}
+  );
+
+  assert.deepEqual(setPriorityCalls, [{ cardId: "card-4", priority: "high" }]);
+  assert.equal(assignCalls.length, 0);
+  assert.equal(state.messageQueues.length, 0);
+});
+
+test("agent label that resolves to no agent does not assign", () => {
+  const { assignCalls } = loadTriage(
+    [{ id: "card-5", metadata: { labels: "agent:ghost" } }],
+    {} // neither "ghost" nor "ch-ghost" resolves
+  );
+
+  assert.equal(assignCalls.length, 0);
+});
+
+test("regression: PMD classification ping is never emitted across mixed cards", () => {
+  const { state } = loadTriage(
+    [
+      { id: "c-agent", metadata: { labels: "agent:alpha" } },
+      { id: "c-prio", metadata: { labels: "priority:urgent" } },
+      {
+        id: "c-bare",
+        metadata: { labels: "" },
+        github_issue_url: "https://github.com/x/y/issues/1",
+        github_issue_number: 1,
+        title: "bare"
+      }
+    ],
+    { alpha: { id: "alpha" } }
+  );
+
+  // No announce ping for any card, including the unlabeled one that previously
+  // triggered a PMD classification request.
+  assert.equal(state.messageQueues.length, 0);
+});

--- a/policies/triage-rules.js
+++ b/policies/triage-rules.js
@@ -31,30 +31,6 @@ var triage = {
         }
       }
 
-      // If no agent label found, request PMD classification (async)
-      if (!agentMatch) {
-        // Check if we already requested classification (avoid spam)
-        var triageKey = "triage_requested:" + card.id;
-        var alreadyRequested = agentdesk.kv.get(triageKey);
-        if (alreadyRequested === null) {
-          agentdesk.kv.set(triageKey, new Date().toISOString(), 86400);
-          // Send classification request to PMD via announce bot
-          if (card.github_issue_url) {
-            var pmdCh = agentdesk.config.get("kanban_manager_channel_id");
-            if (pmdCh) {
-              var issueLink = "[" + card.title + " #" + (card.github_issue_number || "?") + "](<" + card.github_issue_url + ">)";
-              agentdesk.message.queue(
-                "channel:" + pmdCh,
-                "📋 Triage 분류 요청: " + issueLink,
-                "announce",
-                "system"
-              );
-              agentdesk.log.info("[triage] PMD classification requested for " + card.id);
-            }
-          }
-        }
-      }
-
       // Auto-set priority based on labels
       if (labels.indexOf("priority:urgent") >= 0 || labels.indexOf("critical") >= 0) {
         if ((card.priority || "medium") === "medium") {


### PR DESCRIPTION
## 설계
`policies/triage-rules.js` 를 route-only 로 축소한다. 라벨 없는 backlog 이슈에 대해 announce 봇으로 PMD(kanban_manager) 채널에 "분류 요청" 핑을 보내던 비동기 분류 요청 로직을 제거하고, 라벨 기반 라우팅/우선순위만 남긴다.

## 변경
- **triage-rules.js**: 기존 `if (!agentMatch) { ... }` 블록(PMD 분류 요청) 전체 삭제. 이 블록만 사용하던 `kv.get/set("triage_requested:*")`, `config.get("kanban_manager_channel_id")`, `message.queue(... "announce" ...)`, `[triage] PMD classification requested` 로그가 함께 사라짐.
  - 유지: `cards.list` (backlog/unassigned/metadata_present), agent 라우팅(`agents.get` exact + `"ch-"` prefix fallback → `cards.assign`), 우선순위(`setPriority` urgent/high/low).
  - `kanban_manager_channel_id` 는 `merge-notification-dispatcher.js` 가 독립적으로 사용하므로 그대로 둠. 다른 정책에서 `triage_requested` KV 를 읽는 곳은 없음.
- **(신규) policies/__tests__/triage-rules.test.js**: node:test + harness `loadPolicy` 기반. 기본 mock 에 없는 `cards.list/assign/setPriority`·`agents.get`·`log` 를 `extraAgentdesk` 로 주입.

## 동작 변경(의도)
라벨 없는 backlog 이슈는 더 이상 PMD 로 라우팅되지 않고 unassigned 로 남는다(no-op). 영역→담당 기본 매핑은 후속(T2) 범위.

## 테스트
`npm run test:policies` (= `node --test policies/__tests__/*.test.js`) 전체 그린 (150 pass / 0 fail). 신규 케이스:
- agent:<id> 라벨 → `cards.assign(card.id, resolvedId)` 1회
- exact miss + `ch-`+id hit → ch- prefix 로 resolve 되어 assign
- 라벨 없음 → assign·setPriority·messageQueues 모두 0 (no-op)
- priority:high 만 → `setPriority(card.id,'high')` + assign 0 (unassigned 유지)
- agent 라벨이 어떤 에이전트로도 resolve 안 됨 → assign 0
- regression: 혼합 카드(agent/priority/bare)에서도 `messageQueues.length === 0` (PMD 핑 제거 가드)

음성 검증: 수정 파일 내 `kanban_manager_channel_id`·`triage_requested`·`message.queue`·`분류 요청` 문자열 0건 확인.

## 게이트
- `cargo fmt` && `cargo fmt --check`: clean
- `cargo check --lib`: clean
- `npm run test:policies`: 150 pass
- `generate_inventory_docs.py` → `check_agent_maintenance_docs.py`: "agent-maintenance freshness check passed"

Refs #3598