### PR TITLE
fix(#3597): voice exactly-once 테스트를 nightly PG잡이 수집하도록 _pg_ 명명 정합

### DIFF
--- a/src/services/discord/router/message_handler/voice_announcement_route.rs
+++ b/src/services/discord/router/message_handler/voice_announcement_route.rs
@@ -212,7 +212,7 @@ mod voice_route_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn durable_duplicate_voice_announcement_invokes_foreground_once() {
+    async fn durable_duplicate_voice_announcement_pg_invokes_foreground_once() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         let channel_id = ChannelId::new(44_003);


### PR DESCRIPTION
## 문제
`voice_announcement_route.rs:215` `durable_duplicate_voice_announcement_invokes_foreground_once` 는 `TestPostgresDb`로 Postgres가 필수인데, **어느 CI 잡에서도 실질 실행되지 않았다**:

- PR게이트(`ci-pr.yml:377-381`)는 `transition/auto_queue/cancel/review_decision/invariant` 서브셋만, 그것도 모두 `--skip _pg --skip pg_ --skip postgres` → 미수집.
- nightly PG잡(`ci-nightly.yml:214` `cargo test postgres_`, `:218` `cargo test _pg_`)은 substring 매칭인데 이름에 `_pg_`/`postgres_`가 없어 미수집.
- 비-PG nightly 레인(`:121`,`:155`)은 수집하나 Postgres 서비스가 없어 실질 미실행.

## 변경
테스트 함수명 1줄 리네임 (최소·정확성 우선):
`durable_duplicate_voice_announcement_invokes_foreground_once`
→ `durable_duplicate_voice_announcement_pg_invokes_foreground_once`

`_pg_` substring이 들어가 nightly PG-routes 스텝(`cargo test _pg_`, Postgres 서비스 보유)이 수집·실행한다. bootstrap 스텝(`cargo test postgres_`)에는 안 잡히고(올바름), Postgres 없는 레인의 `--skip _pg`로 정확히 제외된다(올바름).

## 검증
- **CI 수집(정적)**: `cargo test --lib _pg_ -- --list` 에 새 이름 **수집됨(1)**, `cargo test --lib postgres_ -- --list` 에는 **미수집(0)** — 의도대로.
- **실제 그린**: 로컬 Postgres로 단독 실행 → `1 passed; 0 failed`.
- **참조 깨짐 없음**: 구 이름 전역 git grep **0건** (DoD: 이름 변경 시 참조 깨짐 없음 충족).

## 게이트
- (a) `cargo fmt --check` 클린
- (b) `cargo check --lib` exit 0 (신규 경고 없음)
- (c) 변경 모듈 테스트 그린 (위 실제 실행)
- (d) `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed`

## Non-goals
dispatch exactly-once(`multinode_dispatch_claims_exactly_once...`)는 이미 nightly multinode_regression에서 실행 — 본 이슈 범위 아님.

Refs #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)