### PR TITLE
fix(#3595): FSM transition gate fail-open→fail-closed 하드닝

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -78,7 +78,7 @@
 ### `policy_engine`
 
 - canonical_modules: `src/engine/mod.rs` (driver) plus `src/engine/ops/*.rs`
-  (per-domain op handlers). `src/pipeline.rs` (1314 lines, giant-file)
+  (per-domain op handlers). `src/pipeline.rs` (1362 lines, giant-file)
   composes the policy pipeline.
 - legacy_modules: none — there is no parallel engine. The whole surface is
   pre-migration giant-file territory.
@@ -87,7 +87,7 @@
   - `src/engine/ops/db_ops.rs` (1244 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
-  - `src/pipeline.rs` (1314 lines, giant-file).
+  - `src/pipeline.rs` (1362 lines, giant-file).
 - non-giant migration-sensitive note: `src/engine/intent.rs` is below the
   giant-file threshold but remains a migration-sensitive intent surface; keep
   changes scoped to the typed-facade contract.

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -78,7 +78,7 @@
 ### `policy_engine`
 
 - canonical_modules: `src/engine/mod.rs` (driver) plus `src/engine/ops/*.rs`
-  (per-domain op handlers). `src/pipeline.rs` (1362 lines, giant-file)
+  (per-domain op handlers). `src/pipeline.rs` (1366 lines, giant-file)
   composes the policy pipeline.
 - legacy_modules: none — there is no parallel engine. The whole surface is
   pre-migration giant-file territory.
@@ -87,7 +87,7 @@
   - `src/engine/ops/db_ops.rs` (1244 lines, giant-file).
   - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
-  - `src/pipeline.rs` (1362 lines, giant-file).
+  - `src/pipeline.rs` (1366 lines, giant-file).
 - non-giant migration-sensitive note: `src/engine/intent.rs` is below the
   giant-file threshold but remains a migration-sensitive intent surface; keep
   changes scoped to the typed-facade contract.

--- a/policies/default-pipeline.yaml
+++ b/policies/default-pipeline.yaml
@@ -100,8 +100,12 @@ transitions:
 # ── Gates ─────────────────────────────────────────────────────────
 #
 # type:
-#   builtin   — evaluated in Rust (kanban.rs / dispatch check)
-#   policy    — evaluated by JS policy function
+#   builtin   — evaluated in Rust (see KNOWN_BUILTIN_GATE_CHECKS in pipeline.rs)
+#
+# `policy` (JS-policy-evaluated gates) is NOT currently supported: the FSM has
+# no policy evaluator, so declaring `type: policy` is rejected at write time and
+# fails closed at runtime (#3595). Re-enable by adding "policy" to
+# KNOWN_GATE_TYPES together with its evaluation arm once an evaluator exists.
 
 gates:
   active_dispatch:

--- a/src/engine/ops/kanban_ops.rs
+++ b/src/engine/ops/kanban_ops.rs
@@ -14,41 +14,6 @@ fn enters_review_state(pipeline: &crate::pipeline::PipelineConfig, status: &str)
         .is_some_and(|hooks| hooks.on_enter.iter().any(|name| name == "OnReviewEnter"))
 }
 
-/// Whether the card has an active dispatch for the `has_active_dispatch` gate
-/// (#3595). A pending/dispatched dispatch always counts; the just-completed
-/// latest work dispatch counts only when `allow_completed_work` is set (i.e.
-/// when entering review). Mirrors the snapshot query in
-/// `src/kanban/transition_core.rs::transition_status_with_opts_pg_inner` so the
-/// `setStatus` path and the intent path agree.
-async fn card_has_active_dispatch_on_pg_tx(
-    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
-    card_id: &str,
-    latest_dispatch_id: Option<&str>,
-    allow_completed_work: bool,
-) -> Result<bool, String> {
-    sqlx::query_scalar::<_, bool>(
-        "SELECT COUNT(*) > 0
-         FROM task_dispatches
-         WHERE kanban_card_id = $1
-           AND (
-                status IN ('pending', 'dispatched')
-                OR (
-                    $2::text IS NOT NULL
-                    AND id = $2::text
-                    AND status = 'completed'
-                    AND dispatch_type IN ('implementation', 'rework')
-                    AND $3::boolean
-                )
-           )",
-    )
-    .bind(card_id)
-    .bind(latest_dispatch_id)
-    .bind(allow_completed_work)
-    .fetch_one(&mut **tx)
-    .await
-    .map_err(|error| format!("load active dispatch gate for {card_id}: {error}"))
-}
-
 async fn auto_queue_review_disabled_for_card_on_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     card_id: &str,
@@ -306,80 +271,90 @@ fn set_status_raw_pg(pool: &PgPool, card_id: &str, new_status: &str, force: bool
             ));
         }
 
-        let is_review_enter = enters_review_state(&effective, &new_status);
-
-        // #3595 / #2051 Finding 1 (P1): this `setStatus` path (used by production
-        // JS policies) must share the EXACT fail-closed gate semantics as the
-        // reducer. It previously checked only `has_active_dispatch` +
-        // `review_verdict_pass` inline, letting unwired/unknown gates, unsupported
-        // types, unknown/None builtin checks, and `review_verdict_rework` slip
-        // past un-enforced. Now we collect the same `GateSnapshot` and call the
-        // shared `evaluate_gates`. Only `Gated` transitions gate (Free/ForceOnly
-        // do not); on a block, force/admin bypasses-but-warns, else it errors.
-        // cross-ref: engine/transition.rs `evaluate_gates` /
-        // `decide_pipeline_transition`, and the intent path in
-        // src/kanban/transition_core.rs `transition_status_with_opts_pg_inner`.
-        let mut active_dispatch_warning: Option<&'static str> = None;
-        if let Some(t) = transition_rule
-            && t.transition_type == crate::pipeline::TransitionType::Gated
+        if effective.is_terminal(&new_status)
+            && !force
+            && let Some(t) = transition_rule
         {
-            // The just-completed latest work dispatch counts toward
-            // `has_active_dispatch` only when entering review (matches the
-            // reducer's PG snapshot in transition_core.rs).
-            let active_gate_allows_completed_work = is_review_enter
-                && t.gates.iter().any(|g| {
-                    effective
-                        .gates
-                        .get(g.as_str())
-                        .is_some_and(|gc| gc.check.as_deref() == Some("has_active_dispatch"))
-                });
-            let has_active_dispatch = card_has_active_dispatch_on_pg_tx(
-                &mut tx,
-                &card_id,
-                latest_dispatch_id.as_deref(),
-                active_gate_allows_completed_work,
-            )
-            .await?;
-
-            let latest_review_verdict = sqlx::query_scalar::<_, Option<String>>(
-                "SELECT result::jsonb ->> 'verdict'
-                 FROM task_dispatches
-                 WHERE kanban_card_id = $1
-                   AND dispatch_type = 'review'
-                   AND status = 'completed'
-                 ORDER BY COALESCE(completed_at, updated_at) DESC, id DESC
-                 LIMIT 1",
-            )
-            .bind(&card_id)
-            .fetch_optional(&mut *tx)
-            .await
-            .map_err(|error| format!("load latest review verdict for {card_id}: {error}"))?
-            .flatten();
-
-            let snapshot = crate::engine::transition::GateSnapshot {
-                has_active_dispatch,
-                review_verdict_pass: matches!(
-                    latest_review_verdict.as_deref(),
-                    Some("pass") | Some("approved")
-                ),
-                review_verdict_rework: matches!(
-                    latest_review_verdict.as_deref(),
-                    Some("rework") | Some("improve") | Some("reject")
-                ),
-            };
-
-            if let crate::engine::transition::GateEvaluation::Blocked(reason) =
-                crate::engine::transition::evaluate_gates(&t.gates, &effective.gates, &snapshot)
-            {
-                if !force {
+            let needs_review_pass = t.gates.iter().any(|g| {
+                effective
+                    .gates
+                    .get(g.as_str())
+                    .is_some_and(|gc| gc.check.as_deref() == Some("review_verdict_pass"))
+            });
+            if needs_review_pass {
+                let latest_verdict = sqlx::query_scalar::<_, String>(
+                    "SELECT result ->> 'verdict'
+                     FROM task_dispatches
+                     WHERE kanban_card_id = $1
+                       AND dispatch_type = 'review'
+                       AND status = 'completed'
+                     ORDER BY updated_at DESC
+                     LIMIT 1",
+                )
+                .bind(&card_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|error| format!("load latest review verdict for {card_id}: {error}"))?;
+                let has_pass = matches!(latest_verdict.as_deref(), Some("pass") | Some("approved"));
+                if !has_pass {
                     return Err(format!(
-                        "gate blocked: {reason} (from {old_status} to {new_status})"
+                        "gate blocked: review_verdict_pass — no review pass verdict (from {old_status} to {new_status})"
                     ));
                 }
-                // force=true is an operator/admin override: bypass the gate but
-                // surface a warning so the JS bridge logs the un-enforced move.
-                active_dispatch_warning =
-                    Some("transition bypassed a failed gate via force without satisfying it");
+            }
+        }
+
+        // #2051 Finding 1 (P1): align `set_status_raw_pg` semantics with
+        // `decide_pipeline_transition` (transition.rs). Previously this path
+        // only stamped a `warning` and proceeded with the UPDATE, while the
+        // intent path (`TransitionCard` → `transition_status_with_opts_pg`)
+        // returned `TransitionDecision::Blocked`. The asymmetry let JS
+        // policies (`agentdesk.kanban.setStatus`) bypass the
+        // `has_active_dispatch` gate. Now: when force=false and the gate is
+        // violated, return `Err` so the JS bridge surfaces a real failure;
+        // force=true callers keep the bypass-but-warn behaviour.
+        let is_review_enter = enters_review_state(&effective, &new_status);
+        let mut active_dispatch_warning: Option<&'static str> = None;
+        if let Some(t) = transition_rule {
+            let needs_active_dispatch = t.gates.iter().any(|g| {
+                effective
+                    .gates
+                    .get(g.as_str())
+                    .is_some_and(|gc| gc.check.as_deref() == Some("has_active_dispatch"))
+            });
+            if needs_active_dispatch {
+                let has_active_dispatch = sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*)
+                     FROM task_dispatches
+                     WHERE kanban_card_id = $1
+                       AND (
+                            status IN ('pending', 'dispatched')
+                            OR (
+                                $2::text IS NOT NULL
+                                AND id = $2::text
+                                AND status = 'completed'
+                                AND dispatch_type IN ('implementation', 'rework')
+                                AND $3::boolean
+                            )
+                       )",
+                )
+                .bind(&card_id)
+                .bind(latest_dispatch_id.as_deref())
+                .bind(is_review_enter)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(|error| format!("load active dispatch count for {card_id}: {error}"))?
+                    > 0;
+                if !has_active_dispatch {
+                    if !force {
+                        return Err(format!(
+                            "gate blocked: has_active_dispatch — no active dispatch (from {old_status} to {new_status})"
+                        ));
+                    }
+                    active_dispatch_warning = Some(
+                        "transition bypassed has_active_dispatch gate without an active dispatch",
+                    );
+                }
             }
         }
 
@@ -784,13 +759,9 @@ async fn resolve_pipeline_on_pg_tx(
 ) -> Result<crate::pipeline::PipelineConfig, String> {
     crate::pipeline::ensure_loaded();
 
-    // `pipeline_config` is a JSONB column; cast to ::text so sqlx decodes it as
-    // String (every other read site does this — without the cast a non-null
-    // override fails to decode, which previously crashed this path for any card
-    // with a repo/agent pipeline override).
     let repo_override = if let Some(repo_id) = repo_id {
         sqlx::query_scalar::<_, Option<String>>(
-            "SELECT pipeline_config::text AS pipeline_config FROM github_repos WHERE id = $1",
+            "SELECT pipeline_config FROM github_repos WHERE id = $1",
         )
         .bind(repo_id)
         .fetch_optional(&mut **tx)
@@ -806,18 +777,16 @@ async fn resolve_pipeline_on_pg_tx(
     };
 
     let agent_override = if let Some(agent_id) = agent_id {
-        sqlx::query_scalar::<_, Option<String>>(
-            "SELECT pipeline_config::text AS pipeline_config FROM agents WHERE id = $1",
-        )
-        .bind(agent_id)
-        .fetch_optional(&mut **tx)
-        .await
-        .map_err(|error| format!("load agent pipeline override for {agent_id}: {error}"))?
-        .flatten()
-        .map(|json| crate::pipeline::parse_override(&json))
-        .transpose()
-        .map_err(|error| format!("parse agent pipeline override for {agent_id}: {error}"))?
-        .flatten()
+        sqlx::query_scalar::<_, Option<String>>("SELECT pipeline_config FROM agents WHERE id = $1")
+            .bind(agent_id)
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(|error| format!("load agent pipeline override for {agent_id}: {error}"))?
+            .flatten()
+            .map(|json| crate::pipeline::parse_override(&json))
+            .transpose()
+            .map_err(|error| format!("parse agent pipeline override for {agent_id}: {error}"))?
+            .flatten()
     } else {
         None
     };
@@ -976,295 +945,5 @@ pub(super) fn review_state_sync_pg(pool: &PgPool, json_str: &str) -> String {
     match result {
         Ok(value) => value,
         Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
-    }
-}
-
-// ── set_status_raw_pg gate fail-closed tests (#3595) ─────────────
-//
-// These verify that `set_status_raw_pg` (the production `agentdesk.kanban.
-// setStatus` path) evaluates `Gated` transition gates with the SAME fail-closed
-// semantics as the reducer (engine/transition.rs `evaluate_gates` /
-// `decide_pipeline_transition`). Before #3595 this path only checked
-// `has_active_dispatch` + `review_verdict_pass` inline and let unwired/unknown
-// gates, unsupported gate types, unknown/None builtin checks, and
-// `review_verdict_rework` slip through un-enforced (fail-open).
-//
-// They rely on injecting a tampered agent `pipeline_config` override
-// (`resolve`/`parse_override` do NOT re-run `validate()`, so a malformed
-// override stored out-of-band reaches the runtime gate-eval path — exactly the
-// case the runtime fail-closed defense must catch).
-//
-// Test names contain `_pg_` so the nightly Postgres CI job collects them and the
-// trusted macOS lane (`--skip _pg`) skips them.
-#[cfg(test)]
-mod set_status_gate_fail_closed_pg_tests {
-    use super::*;
-    use crate::dispatch::test_support::DispatchPostgresTestDb;
-
-    /// Build an agent override JSON whose only transition is a single `gated`
-    /// `backlog → ready` referencing `gate_name`, with the supplied gate
-    /// definitions. States are inherited from the base default pipeline.
-    fn override_json(gate_name: &str, gates_json: serde_json::Value) -> String {
-        serde_json::json!({
-            "transitions": [
-                { "from": "backlog", "to": "ready", "type": "gated", "gates": [gate_name] }
-            ],
-            "gates": gates_json,
-        })
-        .to_string()
-    }
-
-    async fn seed_agent(pool: &PgPool, agent_id: &str, pipeline_config: Option<&str>) {
-        sqlx::query(
-            "INSERT INTO agents (id, name, pipeline_config, created_at, updated_at)
-             VALUES ($1, $2, $3::jsonb, NOW(), NOW())",
-        )
-        .bind(agent_id)
-        .bind(agent_id)
-        .bind(pipeline_config)
-        .execute(pool)
-        .await
-        .unwrap_or_else(|err| panic!("seed agent {agent_id}: {err}"));
-    }
-
-    async fn seed_card(pool: &PgPool, card_id: &str, status: &str, agent_id: &str) {
-        sqlx::query(
-            "INSERT INTO kanban_cards (id, title, status, assigned_agent_id, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, NOW(), NOW())",
-        )
-        .bind(card_id)
-        .bind(card_id)
-        .bind(status)
-        .bind(agent_id)
-        .execute(pool)
-        .await
-        .unwrap_or_else(|err| panic!("seed card {card_id}: {err}"));
-    }
-
-    /// Insert a completed `review` dispatch with the given verdict, then point
-    /// the card's latest_dispatch_id at it (so the verdict snapshot is read).
-    async fn seed_review_verdict(pool: &PgPool, card_id: &str, dispatch_id: &str, verdict: &str) {
-        sqlx::query(
-            "INSERT INTO task_dispatches
-                (id, kanban_card_id, dispatch_type, status, result, completed_at, created_at, updated_at)
-             VALUES ($1, $2, 'review', 'completed', $3, NOW(), NOW(), NOW())",
-        )
-        .bind(dispatch_id)
-        .bind(card_id)
-        .bind(serde_json::json!({ "verdict": verdict }).to_string())
-        .execute(pool)
-        .await
-        .unwrap_or_else(|err| panic!("seed review dispatch {dispatch_id}: {err}"));
-    }
-
-    /// Run `set_status_raw_pg` off the async task (mirrors the JS-bridge call
-    /// site) and return the parsed JSON response.
-    async fn run_set_status(
-        pool: &PgPool,
-        card_id: &str,
-        new_status: &str,
-        force: bool,
-    ) -> serde_json::Value {
-        let pool = pool.clone();
-        let card_id = card_id.to_string();
-        let new_status = new_status.to_string();
-        let raw = tokio::task::spawn_blocking(move || {
-            set_status_raw_pg(&pool, &card_id, &new_status, force)
-        })
-        .await
-        .expect("set_status_raw_pg blocking task panicked");
-        serde_json::from_str(&raw).expect("set_status_raw_pg returned non-JSON")
-    }
-
-    fn assert_blocked(resp: &serde_json::Value, needle: &str) {
-        let err = resp
-            .get("error")
-            .and_then(|v| v.as_str())
-            .unwrap_or_else(|| panic!("expected an error response, got: {resp}"));
-        assert!(
-            err.contains(needle),
-            "error {err:?} should contain {needle:?}"
-        );
-    }
-
-    /// Point A: transition references a gate absent from the gates map.
-    #[tokio::test]
-    async fn set_status_raw_pg_blocks_on_unwired_gate() {
-        let Some(test_db) =
-            DispatchPostgresTestDb::try_create("kanban_gate_unwired", "set_status unwired gate")
-                .await
-        else {
-            return;
-        };
-        let pool = test_db.connect_and_migrate().await;
-        // Gate "ghost" is referenced but the gates map is empty.
-        let ovr = override_json("ghost", serde_json::json!({}));
-        seed_agent(&pool, "agent-unwired", Some(&ovr)).await;
-        seed_card(&pool, "card-unwired", "backlog", "agent-unwired").await;
-
-        let resp = run_set_status(&pool, "card-unwired", "ready", false).await;
-        assert_blocked(&resp, "unknown/unwired gate 'ghost'");
-
-        pool.close().await;
-        test_db.drop().await;
-    }
-
-    /// Point B: gate type the FSM has no evaluator for (e.g. an out-of-band
-    /// `policy` or `webhook` override).
-    #[tokio::test]
-    async fn set_status_raw_pg_blocks_on_unsupported_gate_type() {
-        let Some(test_db) = DispatchPostgresTestDb::try_create(
-            "kanban_gate_unsupported",
-            "set_status unsupported gate type",
-        )
-        .await
-        else {
-            return;
-        };
-        let pool = test_db.connect_and_migrate().await;
-        let ovr = override_json("g", serde_json::json!({ "g": { "type": "policy" } }));
-        seed_agent(&pool, "agent-unsupported", Some(&ovr)).await;
-        seed_card(&pool, "card-unsupported", "backlog", "agent-unsupported").await;
-
-        let resp = run_set_status(&pool, "card-unsupported", "ready", false).await;
-        assert_blocked(&resp, "unsupported type 'policy'");
-
-        pool.close().await;
-        test_db.drop().await;
-    }
-
-    /// Point C: builtin gate whose check string is unknown to the FSM.
-    #[tokio::test]
-    async fn set_status_raw_pg_blocks_on_unknown_builtin_check() {
-        let Some(test_db) = DispatchPostgresTestDb::try_create(
-            "kanban_gate_unknown_check",
-            "set_status unknown builtin check",
-        )
-        .await
-        else {
-            return;
-        };
-        let pool = test_db.connect_and_migrate().await;
-        let ovr = override_json(
-            "g",
-            serde_json::json!({ "g": { "type": "builtin", "check": "bogus" } }),
-        );
-        seed_agent(&pool, "agent-unknown-check", Some(&ovr)).await;
-        seed_card(
-            &pool,
-            "card-unknown-check",
-            "backlog",
-            "agent-unknown-check",
-        )
-        .await;
-
-        let resp = run_set_status(&pool, "card-unknown-check", "ready", false).await;
-        assert_blocked(&resp, "unknown check 'bogus'");
-
-        pool.close().await;
-        test_db.drop().await;
-    }
-
-    /// Point C: builtin gate with a missing (`None`) check.
-    #[tokio::test]
-    async fn set_status_raw_pg_blocks_on_builtin_gate_with_no_check() {
-        let Some(test_db) = DispatchPostgresTestDb::try_create(
-            "kanban_gate_none_check",
-            "set_status builtin gate missing check",
-        )
-        .await
-        else {
-            return;
-        };
-        let pool = test_db.connect_and_migrate().await;
-        let ovr = override_json("g", serde_json::json!({ "g": { "type": "builtin" } }));
-        seed_agent(&pool, "agent-none-check", Some(&ovr)).await;
-        seed_card(&pool, "card-none-check", "backlog", "agent-none-check").await;
-
-        let resp = run_set_status(&pool, "card-none-check", "ready", false).await;
-        assert_blocked(&resp, "is missing a check");
-
-        pool.close().await;
-        test_db.drop().await;
-    }
-
-    /// `review_verdict_rework` is now enforced (it was ignored by the old inline
-    /// check): with no rework verdict the transition BLOCKs, and with a rework
-    /// verdict present it is ALLOWED.
-    #[tokio::test]
-    async fn set_status_raw_pg_enforces_review_verdict_rework() {
-        let Some(test_db) = DispatchPostgresTestDb::try_create(
-            "kanban_gate_rework",
-            "set_status review_verdict_rework",
-        )
-        .await
-        else {
-            return;
-        };
-        let pool = test_db.connect_and_migrate().await;
-        let ovr = override_json(
-            "g",
-            serde_json::json!({ "g": { "type": "builtin", "check": "review_verdict_rework" } }),
-        );
-
-        // (a) No rework verdict → blocked.
-        seed_agent(&pool, "agent-rework", Some(&ovr)).await;
-        seed_card(&pool, "card-rework-block", "backlog", "agent-rework").await;
-        let resp = run_set_status(&pool, "card-rework-block", "ready", false).await;
-        assert_blocked(&resp, "no review rework verdict");
-
-        // (b) Rework verdict present → allowed (proves it is now enforced, not
-        // silently passed like the old fail-open path).
-        seed_card(&pool, "card-rework-pass", "backlog", "agent-rework").await;
-        seed_review_verdict(&pool, "card-rework-pass", "disp-rework", "rework").await;
-        let resp = run_set_status(&pool, "card-rework-pass", "ready", false).await;
-        assert_eq!(
-            resp.get("changed").and_then(|v| v.as_bool()),
-            Some(true),
-            "rework verdict present should allow the transition: {resp}"
-        );
-
-        pool.close().await;
-        test_db.drop().await;
-    }
-
-    /// Regression guard: a satisfied `has_active_dispatch` gate still passes
-    /// (the normal happy path must not be over-blocked by the fail-closed work).
-    #[tokio::test]
-    async fn set_status_raw_pg_passes_on_satisfied_active_dispatch_gate() {
-        let Some(test_db) = DispatchPostgresTestDb::try_create(
-            "kanban_gate_happy",
-            "set_status active dispatch satisfied",
-        )
-        .await
-        else {
-            return;
-        };
-        let pool = test_db.connect_and_migrate().await;
-        let ovr = override_json(
-            "g",
-            serde_json::json!({ "g": { "type": "builtin", "check": "has_active_dispatch" } }),
-        );
-        seed_agent(&pool, "agent-happy", Some(&ovr)).await;
-        seed_card(&pool, "card-happy", "backlog", "agent-happy").await;
-        // A pending dispatch satisfies has_active_dispatch.
-        sqlx::query(
-            "INSERT INTO task_dispatches
-                (id, kanban_card_id, dispatch_type, status, created_at, updated_at)
-             VALUES ('disp-happy', 'card-happy', 'implementation', 'pending', NOW(), NOW())",
-        )
-        .execute(&pool)
-        .await
-        .expect("seed pending dispatch");
-
-        let resp = run_set_status(&pool, "card-happy", "ready", false).await;
-        assert_eq!(
-            resp.get("changed").and_then(|v| v.as_bool()),
-            Some(true),
-            "satisfied has_active_dispatch gate should allow the transition: {resp}"
-        );
-
-        pool.close().await;
-        test_db.drop().await;
     }
 }

--- a/src/engine/ops/kanban_ops.rs
+++ b/src/engine/ops/kanban_ops.rs
@@ -14,6 +14,41 @@ fn enters_review_state(pipeline: &crate::pipeline::PipelineConfig, status: &str)
         .is_some_and(|hooks| hooks.on_enter.iter().any(|name| name == "OnReviewEnter"))
 }
 
+/// Whether the card has an active dispatch for the `has_active_dispatch` gate
+/// (#3595). A pending/dispatched dispatch always counts; the just-completed
+/// latest work dispatch counts only when `allow_completed_work` is set (i.e.
+/// when entering review). Mirrors the snapshot query in
+/// `src/kanban/transition_core.rs::transition_status_with_opts_pg_inner` so the
+/// `setStatus` path and the intent path agree.
+async fn card_has_active_dispatch_on_pg_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    card_id: &str,
+    latest_dispatch_id: Option<&str>,
+    allow_completed_work: bool,
+) -> Result<bool, String> {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT COUNT(*) > 0
+         FROM task_dispatches
+         WHERE kanban_card_id = $1
+           AND (
+                status IN ('pending', 'dispatched')
+                OR (
+                    $2::text IS NOT NULL
+                    AND id = $2::text
+                    AND status = 'completed'
+                    AND dispatch_type IN ('implementation', 'rework')
+                    AND $3::boolean
+                )
+           )",
+    )
+    .bind(card_id)
+    .bind(latest_dispatch_id)
+    .bind(allow_completed_work)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(|error| format!("load active dispatch gate for {card_id}: {error}"))
+}
+
 async fn auto_queue_review_disabled_for_card_on_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     card_id: &str,
@@ -271,90 +306,80 @@ fn set_status_raw_pg(pool: &PgPool, card_id: &str, new_status: &str, force: bool
             ));
         }
 
-        if effective.is_terminal(&new_status)
-            && !force
-            && let Some(t) = transition_rule
+        let is_review_enter = enters_review_state(&effective, &new_status);
+
+        // #3595 / #2051 Finding 1 (P1): this `setStatus` path (used by production
+        // JS policies) must share the EXACT fail-closed gate semantics as the
+        // reducer. It previously checked only `has_active_dispatch` +
+        // `review_verdict_pass` inline, letting unwired/unknown gates, unsupported
+        // types, unknown/None builtin checks, and `review_verdict_rework` slip
+        // past un-enforced. Now we collect the same `GateSnapshot` and call the
+        // shared `evaluate_gates`. Only `Gated` transitions gate (Free/ForceOnly
+        // do not); on a block, force/admin bypasses-but-warns, else it errors.
+        // cross-ref: engine/transition.rs `evaluate_gates` /
+        // `decide_pipeline_transition`, and the intent path in
+        // src/kanban/transition_core.rs `transition_status_with_opts_pg_inner`.
+        let mut active_dispatch_warning: Option<&'static str> = None;
+        if let Some(t) = transition_rule
+            && t.transition_type == crate::pipeline::TransitionType::Gated
         {
-            let needs_review_pass = t.gates.iter().any(|g| {
-                effective
-                    .gates
-                    .get(g.as_str())
-                    .is_some_and(|gc| gc.check.as_deref() == Some("review_verdict_pass"))
-            });
-            if needs_review_pass {
-                let latest_verdict = sqlx::query_scalar::<_, String>(
-                    "SELECT result ->> 'verdict'
-                     FROM task_dispatches
-                     WHERE kanban_card_id = $1
-                       AND dispatch_type = 'review'
-                       AND status = 'completed'
-                     ORDER BY updated_at DESC
-                     LIMIT 1",
-                )
-                .bind(&card_id)
-                .fetch_optional(&mut *tx)
-                .await
-                .map_err(|error| format!("load latest review verdict for {card_id}: {error}"))?;
-                let has_pass = matches!(latest_verdict.as_deref(), Some("pass") | Some("approved"));
-                if !has_pass {
+            // The just-completed latest work dispatch counts toward
+            // `has_active_dispatch` only when entering review (matches the
+            // reducer's PG snapshot in transition_core.rs).
+            let active_gate_allows_completed_work = is_review_enter
+                && t.gates.iter().any(|g| {
+                    effective
+                        .gates
+                        .get(g.as_str())
+                        .is_some_and(|gc| gc.check.as_deref() == Some("has_active_dispatch"))
+                });
+            let has_active_dispatch = card_has_active_dispatch_on_pg_tx(
+                &mut tx,
+                &card_id,
+                latest_dispatch_id.as_deref(),
+                active_gate_allows_completed_work,
+            )
+            .await?;
+
+            let latest_review_verdict = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT result::jsonb ->> 'verdict'
+                 FROM task_dispatches
+                 WHERE kanban_card_id = $1
+                   AND dispatch_type = 'review'
+                   AND status = 'completed'
+                 ORDER BY COALESCE(completed_at, updated_at) DESC, id DESC
+                 LIMIT 1",
+            )
+            .bind(&card_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|error| format!("load latest review verdict for {card_id}: {error}"))?
+            .flatten();
+
+            let snapshot = crate::engine::transition::GateSnapshot {
+                has_active_dispatch,
+                review_verdict_pass: matches!(
+                    latest_review_verdict.as_deref(),
+                    Some("pass") | Some("approved")
+                ),
+                review_verdict_rework: matches!(
+                    latest_review_verdict.as_deref(),
+                    Some("rework") | Some("improve") | Some("reject")
+                ),
+            };
+
+            if let crate::engine::transition::GateEvaluation::Blocked(reason) =
+                crate::engine::transition::evaluate_gates(&t.gates, &effective.gates, &snapshot)
+            {
+                if !force {
                     return Err(format!(
-                        "gate blocked: review_verdict_pass — no review pass verdict (from {old_status} to {new_status})"
+                        "gate blocked: {reason} (from {old_status} to {new_status})"
                     ));
                 }
-            }
-        }
-
-        // #2051 Finding 1 (P1): align `set_status_raw_pg` semantics with
-        // `decide_pipeline_transition` (transition.rs). Previously this path
-        // only stamped a `warning` and proceeded with the UPDATE, while the
-        // intent path (`TransitionCard` → `transition_status_with_opts_pg`)
-        // returned `TransitionDecision::Blocked`. The asymmetry let JS
-        // policies (`agentdesk.kanban.setStatus`) bypass the
-        // `has_active_dispatch` gate. Now: when force=false and the gate is
-        // violated, return `Err` so the JS bridge surfaces a real failure;
-        // force=true callers keep the bypass-but-warn behaviour.
-        let is_review_enter = enters_review_state(&effective, &new_status);
-        let mut active_dispatch_warning: Option<&'static str> = None;
-        if let Some(t) = transition_rule {
-            let needs_active_dispatch = t.gates.iter().any(|g| {
-                effective
-                    .gates
-                    .get(g.as_str())
-                    .is_some_and(|gc| gc.check.as_deref() == Some("has_active_dispatch"))
-            });
-            if needs_active_dispatch {
-                let has_active_dispatch = sqlx::query_scalar::<_, i64>(
-                    "SELECT COUNT(*)
-                     FROM task_dispatches
-                     WHERE kanban_card_id = $1
-                       AND (
-                            status IN ('pending', 'dispatched')
-                            OR (
-                                $2::text IS NOT NULL
-                                AND id = $2::text
-                                AND status = 'completed'
-                                AND dispatch_type IN ('implementation', 'rework')
-                                AND $3::boolean
-                            )
-                       )",
-                )
-                .bind(&card_id)
-                .bind(latest_dispatch_id.as_deref())
-                .bind(is_review_enter)
-                .fetch_one(&mut *tx)
-                .await
-                .map_err(|error| format!("load active dispatch count for {card_id}: {error}"))?
-                    > 0;
-                if !has_active_dispatch {
-                    if !force {
-                        return Err(format!(
-                            "gate blocked: has_active_dispatch — no active dispatch (from {old_status} to {new_status})"
-                        ));
-                    }
-                    active_dispatch_warning = Some(
-                        "transition bypassed has_active_dispatch gate without an active dispatch",
-                    );
-                }
+                // force=true is an operator/admin override: bypass the gate but
+                // surface a warning so the JS bridge logs the un-enforced move.
+                active_dispatch_warning =
+                    Some("transition bypassed a failed gate via force without satisfying it");
             }
         }
 
@@ -759,9 +784,13 @@ async fn resolve_pipeline_on_pg_tx(
 ) -> Result<crate::pipeline::PipelineConfig, String> {
     crate::pipeline::ensure_loaded();
 
+    // `pipeline_config` is a JSONB column; cast to ::text so sqlx decodes it as
+    // String (every other read site does this — without the cast a non-null
+    // override fails to decode, which previously crashed this path for any card
+    // with a repo/agent pipeline override).
     let repo_override = if let Some(repo_id) = repo_id {
         sqlx::query_scalar::<_, Option<String>>(
-            "SELECT pipeline_config FROM github_repos WHERE id = $1",
+            "SELECT pipeline_config::text AS pipeline_config FROM github_repos WHERE id = $1",
         )
         .bind(repo_id)
         .fetch_optional(&mut **tx)
@@ -777,16 +806,18 @@ async fn resolve_pipeline_on_pg_tx(
     };
 
     let agent_override = if let Some(agent_id) = agent_id {
-        sqlx::query_scalar::<_, Option<String>>("SELECT pipeline_config FROM agents WHERE id = $1")
-            .bind(agent_id)
-            .fetch_optional(&mut **tx)
-            .await
-            .map_err(|error| format!("load agent pipeline override for {agent_id}: {error}"))?
-            .flatten()
-            .map(|json| crate::pipeline::parse_override(&json))
-            .transpose()
-            .map_err(|error| format!("parse agent pipeline override for {agent_id}: {error}"))?
-            .flatten()
+        sqlx::query_scalar::<_, Option<String>>(
+            "SELECT pipeline_config::text AS pipeline_config FROM agents WHERE id = $1",
+        )
+        .bind(agent_id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(|error| format!("load agent pipeline override for {agent_id}: {error}"))?
+        .flatten()
+        .map(|json| crate::pipeline::parse_override(&json))
+        .transpose()
+        .map_err(|error| format!("parse agent pipeline override for {agent_id}: {error}"))?
+        .flatten()
     } else {
         None
     };
@@ -945,5 +976,295 @@ pub(super) fn review_state_sync_pg(pool: &PgPool, json_str: &str) -> String {
     match result {
         Ok(value) => value,
         Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+// ── set_status_raw_pg gate fail-closed tests (#3595) ─────────────
+//
+// These verify that `set_status_raw_pg` (the production `agentdesk.kanban.
+// setStatus` path) evaluates `Gated` transition gates with the SAME fail-closed
+// semantics as the reducer (engine/transition.rs `evaluate_gates` /
+// `decide_pipeline_transition`). Before #3595 this path only checked
+// `has_active_dispatch` + `review_verdict_pass` inline and let unwired/unknown
+// gates, unsupported gate types, unknown/None builtin checks, and
+// `review_verdict_rework` slip through un-enforced (fail-open).
+//
+// They rely on injecting a tampered agent `pipeline_config` override
+// (`resolve`/`parse_override` do NOT re-run `validate()`, so a malformed
+// override stored out-of-band reaches the runtime gate-eval path — exactly the
+// case the runtime fail-closed defense must catch).
+//
+// Test names contain `_pg_` so the nightly Postgres CI job collects them and the
+// trusted macOS lane (`--skip _pg`) skips them.
+#[cfg(test)]
+mod set_status_gate_fail_closed_pg_tests {
+    use super::*;
+    use crate::dispatch::test_support::DispatchPostgresTestDb;
+
+    /// Build an agent override JSON whose only transition is a single `gated`
+    /// `backlog → ready` referencing `gate_name`, with the supplied gate
+    /// definitions. States are inherited from the base default pipeline.
+    fn override_json(gate_name: &str, gates_json: serde_json::Value) -> String {
+        serde_json::json!({
+            "transitions": [
+                { "from": "backlog", "to": "ready", "type": "gated", "gates": [gate_name] }
+            ],
+            "gates": gates_json,
+        })
+        .to_string()
+    }
+
+    async fn seed_agent(pool: &PgPool, agent_id: &str, pipeline_config: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO agents (id, name, pipeline_config, created_at, updated_at)
+             VALUES ($1, $2, $3::jsonb, NOW(), NOW())",
+        )
+        .bind(agent_id)
+        .bind(agent_id)
+        .bind(pipeline_config)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|err| panic!("seed agent {agent_id}: {err}"));
+    }
+
+    async fn seed_card(pool: &PgPool, card_id: &str, status: &str, agent_id: &str) {
+        sqlx::query(
+            "INSERT INTO kanban_cards (id, title, status, assigned_agent_id, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, NOW(), NOW())",
+        )
+        .bind(card_id)
+        .bind(card_id)
+        .bind(status)
+        .bind(agent_id)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|err| panic!("seed card {card_id}: {err}"));
+    }
+
+    /// Insert a completed `review` dispatch with the given verdict, then point
+    /// the card's latest_dispatch_id at it (so the verdict snapshot is read).
+    async fn seed_review_verdict(pool: &PgPool, card_id: &str, dispatch_id: &str, verdict: &str) {
+        sqlx::query(
+            "INSERT INTO task_dispatches
+                (id, kanban_card_id, dispatch_type, status, result, completed_at, created_at, updated_at)
+             VALUES ($1, $2, 'review', 'completed', $3, NOW(), NOW(), NOW())",
+        )
+        .bind(dispatch_id)
+        .bind(card_id)
+        .bind(serde_json::json!({ "verdict": verdict }).to_string())
+        .execute(pool)
+        .await
+        .unwrap_or_else(|err| panic!("seed review dispatch {dispatch_id}: {err}"));
+    }
+
+    /// Run `set_status_raw_pg` off the async task (mirrors the JS-bridge call
+    /// site) and return the parsed JSON response.
+    async fn run_set_status(
+        pool: &PgPool,
+        card_id: &str,
+        new_status: &str,
+        force: bool,
+    ) -> serde_json::Value {
+        let pool = pool.clone();
+        let card_id = card_id.to_string();
+        let new_status = new_status.to_string();
+        let raw = tokio::task::spawn_blocking(move || {
+            set_status_raw_pg(&pool, &card_id, &new_status, force)
+        })
+        .await
+        .expect("set_status_raw_pg blocking task panicked");
+        serde_json::from_str(&raw).expect("set_status_raw_pg returned non-JSON")
+    }
+
+    fn assert_blocked(resp: &serde_json::Value, needle: &str) {
+        let err = resp
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("expected an error response, got: {resp}"));
+        assert!(
+            err.contains(needle),
+            "error {err:?} should contain {needle:?}"
+        );
+    }
+
+    /// Point A: transition references a gate absent from the gates map.
+    #[tokio::test]
+    async fn set_status_raw_pg_blocks_on_unwired_gate() {
+        let Some(test_db) =
+            DispatchPostgresTestDb::try_create("kanban_gate_unwired", "set_status unwired gate")
+                .await
+        else {
+            return;
+        };
+        let pool = test_db.connect_and_migrate().await;
+        // Gate "ghost" is referenced but the gates map is empty.
+        let ovr = override_json("ghost", serde_json::json!({}));
+        seed_agent(&pool, "agent-unwired", Some(&ovr)).await;
+        seed_card(&pool, "card-unwired", "backlog", "agent-unwired").await;
+
+        let resp = run_set_status(&pool, "card-unwired", "ready", false).await;
+        assert_blocked(&resp, "unknown/unwired gate 'ghost'");
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    /// Point B: gate type the FSM has no evaluator for (e.g. an out-of-band
+    /// `policy` or `webhook` override).
+    #[tokio::test]
+    async fn set_status_raw_pg_blocks_on_unsupported_gate_type() {
+        let Some(test_db) = DispatchPostgresTestDb::try_create(
+            "kanban_gate_unsupported",
+            "set_status unsupported gate type",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = test_db.connect_and_migrate().await;
+        let ovr = override_json("g", serde_json::json!({ "g": { "type": "policy" } }));
+        seed_agent(&pool, "agent-unsupported", Some(&ovr)).await;
+        seed_card(&pool, "card-unsupported", "backlog", "agent-unsupported").await;
+
+        let resp = run_set_status(&pool, "card-unsupported", "ready", false).await;
+        assert_blocked(&resp, "unsupported type 'policy'");
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    /// Point C: builtin gate whose check string is unknown to the FSM.
+    #[tokio::test]
+    async fn set_status_raw_pg_blocks_on_unknown_builtin_check() {
+        let Some(test_db) = DispatchPostgresTestDb::try_create(
+            "kanban_gate_unknown_check",
+            "set_status unknown builtin check",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = test_db.connect_and_migrate().await;
+        let ovr = override_json(
+            "g",
+            serde_json::json!({ "g": { "type": "builtin", "check": "bogus" } }),
+        );
+        seed_agent(&pool, "agent-unknown-check", Some(&ovr)).await;
+        seed_card(
+            &pool,
+            "card-unknown-check",
+            "backlog",
+            "agent-unknown-check",
+        )
+        .await;
+
+        let resp = run_set_status(&pool, "card-unknown-check", "ready", false).await;
+        assert_blocked(&resp, "unknown check 'bogus'");
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    /// Point C: builtin gate with a missing (`None`) check.
+    #[tokio::test]
+    async fn set_status_raw_pg_blocks_on_builtin_gate_with_no_check() {
+        let Some(test_db) = DispatchPostgresTestDb::try_create(
+            "kanban_gate_none_check",
+            "set_status builtin gate missing check",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = test_db.connect_and_migrate().await;
+        let ovr = override_json("g", serde_json::json!({ "g": { "type": "builtin" } }));
+        seed_agent(&pool, "agent-none-check", Some(&ovr)).await;
+        seed_card(&pool, "card-none-check", "backlog", "agent-none-check").await;
+
+        let resp = run_set_status(&pool, "card-none-check", "ready", false).await;
+        assert_blocked(&resp, "is missing a check");
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    /// `review_verdict_rework` is now enforced (it was ignored by the old inline
+    /// check): with no rework verdict the transition BLOCKs, and with a rework
+    /// verdict present it is ALLOWED.
+    #[tokio::test]
+    async fn set_status_raw_pg_enforces_review_verdict_rework() {
+        let Some(test_db) = DispatchPostgresTestDb::try_create(
+            "kanban_gate_rework",
+            "set_status review_verdict_rework",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = test_db.connect_and_migrate().await;
+        let ovr = override_json(
+            "g",
+            serde_json::json!({ "g": { "type": "builtin", "check": "review_verdict_rework" } }),
+        );
+
+        // (a) No rework verdict → blocked.
+        seed_agent(&pool, "agent-rework", Some(&ovr)).await;
+        seed_card(&pool, "card-rework-block", "backlog", "agent-rework").await;
+        let resp = run_set_status(&pool, "card-rework-block", "ready", false).await;
+        assert_blocked(&resp, "no review rework verdict");
+
+        // (b) Rework verdict present → allowed (proves it is now enforced, not
+        // silently passed like the old fail-open path).
+        seed_card(&pool, "card-rework-pass", "backlog", "agent-rework").await;
+        seed_review_verdict(&pool, "card-rework-pass", "disp-rework", "rework").await;
+        let resp = run_set_status(&pool, "card-rework-pass", "ready", false).await;
+        assert_eq!(
+            resp.get("changed").and_then(|v| v.as_bool()),
+            Some(true),
+            "rework verdict present should allow the transition: {resp}"
+        );
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    /// Regression guard: a satisfied `has_active_dispatch` gate still passes
+    /// (the normal happy path must not be over-blocked by the fail-closed work).
+    #[tokio::test]
+    async fn set_status_raw_pg_passes_on_satisfied_active_dispatch_gate() {
+        let Some(test_db) = DispatchPostgresTestDb::try_create(
+            "kanban_gate_happy",
+            "set_status active dispatch satisfied",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = test_db.connect_and_migrate().await;
+        let ovr = override_json(
+            "g",
+            serde_json::json!({ "g": { "type": "builtin", "check": "has_active_dispatch" } }),
+        );
+        seed_agent(&pool, "agent-happy", Some(&ovr)).await;
+        seed_card(&pool, "card-happy", "backlog", "agent-happy").await;
+        // A pending dispatch satisfies has_active_dispatch.
+        sqlx::query(
+            "INSERT INTO task_dispatches
+                (id, kanban_card_id, dispatch_type, status, created_at, updated_at)
+             VALUES ('disp-happy', 'card-happy', 'implementation', 'pending', NOW(), NOW())",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed pending dispatch");
+
+        let resp = run_set_status(&pool, "card-happy", "ready", false).await;
+        assert_eq!(
+            resp.get("changed").and_then(|v| v.as_bool()),
+            Some(true),
+            "satisfied has_active_dispatch gate should allow the transition: {resp}"
+        );
+
+        pool.close().await;
+        test_db.drop().await;
     }
 }

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -904,7 +904,7 @@ mod gate_fail_closed_tests {
     fn blocked_reason(decision: &TransitionDecision) -> &str {
         match &decision.outcome {
             TransitionOutcome::Blocked(msg) => msg.as_str(),
-            other => panic!("expected Blocked, got {other:?}"),
+            other => panic!("expected Blocked, got {other:?}"), // agentdesk-audit: allow-unwrap test-only helper in #[cfg(test)] mod; panics solely on a violated test expectation
         }
     }
 

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -9,9 +9,10 @@
 //! `latest_dispatch_id` should happen outside this module.
 
 use crate::pipeline::{
-    KNOWN_BUILTIN_GATE_CHECKS, KNOWN_GATE_TYPES, PipelineConfig, TransitionType,
+    GateConfig, KNOWN_BUILTIN_GATE_CHECKS, KNOWN_GATE_TYPES, PipelineConfig, TransitionType,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // ── Context types ────────────────────────────────────────────
 
@@ -166,6 +167,99 @@ pub enum TransitionIntent {
     },
     /// Cancel a dispatch (set status='cancelled').
     CancelDispatch { dispatch_id: String },
+}
+
+// ── Shared gate evaluation (#3595) ───────────────────────────
+
+/// Outcome of evaluating a `Gated` transition's gates against a snapshot.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GateEvaluation {
+    /// Every gate the transition declares evaluated to "pass".
+    Allowed,
+    /// At least one gate could not be positively evaluated to "pass".
+    /// Carries the canonical fail-closed reason (already prefixed `BLOCKED: …`).
+    Blocked(String),
+}
+
+/// Single source of truth for `Gated` transition gate evaluation (#3595,
+/// fail-closed). Given the gate names a transition declares, the effective
+/// pipeline's gate definitions, and a pre-collected [`GateSnapshot`], decide
+/// whether the transition is permitted.
+///
+/// This is intentionally a *pure* helper with no I/O: callers collect the
+/// snapshot however they like (the reducer from a pre-loaded
+/// `TransitionContext`; `set_status_raw_pg` from DB queries) and share this
+/// exact decision so the two paths can never diverge again. A gate the FSM
+/// cannot positively confirm as "pass" returns [`GateEvaluation::Blocked`]
+/// rather than silently passing through (no `_ => pass` / skip-on-miss).
+///
+/// The force / admin bypass is the caller's responsibility — this helper is
+/// only invoked once a transition is known to be `Gated` and *not* forced.
+pub fn evaluate_gates(
+    gate_names: &[String],
+    gates: &HashMap<String, GateConfig>,
+    snapshot: &GateSnapshot,
+) -> GateEvaluation {
+    for gate_name in gate_names {
+        // Point A: gate referenced by the transition is not declared in the
+        // gates map. validate() already rejects this for any resolved pipeline,
+        // so reaching here means a tampered / out-of-band state — fail closed.
+        let Some(gate) = gates.get(gate_name.as_str()) else {
+            return GateEvaluation::Blocked(format!("BLOCKED: unknown/unwired gate '{gate_name}'"));
+        };
+
+        // Point B: gate type the FSM cannot evaluate. After #3595 `policy` was
+        // removed from KNOWN_GATE_TYPES, so the only known type is `builtin`;
+        // anything else (including a `policy` override) is blocked here.
+        if !KNOWN_GATE_TYPES.contains(&gate.gate_type.as_str()) {
+            return GateEvaluation::Blocked(format!(
+                "BLOCKED: gate '{}' has unsupported type '{}'",
+                gate_name, gate.gate_type
+            ));
+        }
+
+        // Point C: builtin gate — the check MUST be one the FSM knows. Every
+        // entry of KNOWN_BUILTIN_GATE_CHECKS needs a match arm below (the
+        // debug_assert guards against a check being added to the list without a
+        // corresponding arm, which would otherwise fail-closed in production).
+        match gate.check.as_deref() {
+            Some("has_active_dispatch") => {
+                if !snapshot.has_active_dispatch {
+                    return GateEvaluation::Blocked("BLOCKED: no active dispatch".to_string());
+                }
+            }
+            Some("review_verdict_pass") => {
+                if !snapshot.review_verdict_pass {
+                    return GateEvaluation::Blocked(
+                        "BLOCKED: no review pass verdict for current round".to_string(),
+                    );
+                }
+            }
+            Some("review_verdict_rework") => {
+                if !snapshot.review_verdict_rework {
+                    return GateEvaluation::Blocked(
+                        "BLOCKED: no review rework verdict for current round".to_string(),
+                    );
+                }
+            }
+            Some(check) => {
+                debug_assert!(
+                    !KNOWN_BUILTIN_GATE_CHECKS.contains(&check),
+                    "known builtin check '{check}' missing a match arm"
+                );
+                return GateEvaluation::Blocked(format!(
+                    "BLOCKED: builtin gate '{gate_name}' references unknown check '{check}'"
+                ));
+            }
+            None => {
+                return GateEvaluation::Blocked(format!(
+                    "BLOCKED: builtin gate '{gate_name}' is missing a check"
+                ));
+            }
+        }
+    }
+
+    GateEvaluation::Allowed
 }
 
 // ── Pure reducer ─────────────────────────────────────────────
@@ -323,93 +417,29 @@ fn decide_pipeline_transition(
             TransitionType::Gated if force_intent.is_forced() => {}
             TransitionType::ForceOnly if force_intent.is_forced() => {}
             TransitionType::Gated => {
-                // Evaluate gates fail-closed (#3595). A gate that the FSM cannot
-                // positively evaluate to "pass" must BLOCK the transition rather
-                // than silently fall through (former `_ => None` / skip-on-miss
-                // fail-open). The force path above (L321) already bypasses this.
-                let block = |msg: &str| TransitionDecision {
-                    outcome: TransitionOutcome::Blocked(format!(
-                        "Status transition {} → {} failed gate evaluation: {}",
-                        card.status, target, msg
-                    )),
-                    intents: vec![TransitionIntent::AuditLog {
-                        card_id: card.id.clone(),
-                        from: card.status.clone(),
-                        to: target.to_string(),
-                        source: source.to_string(),
-                        message: msg.to_string(),
-                    }],
-                };
-
-                for gate_name in &t.gates {
-                    // Point A: gate referenced by the transition is not declared
-                    // in the gates map. validate() already rejects this for any
-                    // resolved pipeline, so reaching here means a tampered/
-                    // out-of-band state — fail closed instead of waving it through.
-                    let Some(gate) = pipeline.gates.get(gate_name.as_str()) else {
-                        return block(&format!("BLOCKED: unknown/unwired gate '{gate_name}'"));
+                // Evaluate gates fail-closed (#3595) via the shared
+                // `evaluate_gates` helper — the single source of truth also used
+                // by `set_status_raw_pg` (engine/ops/kanban_ops.rs) so the two
+                // gate-eval paths can never diverge. A gate the FSM cannot
+                // positively evaluate to "pass" BLOCKs the transition rather
+                // than silently falling through. The force path above (L321)
+                // already bypasses this.
+                if let GateEvaluation::Blocked(msg) =
+                    evaluate_gates(&t.gates, &pipeline.gates, &ctx.gates)
+                {
+                    return TransitionDecision {
+                        outcome: TransitionOutcome::Blocked(format!(
+                            "Status transition {} → {} failed gate evaluation: {}",
+                            card.status, target, msg
+                        )),
+                        intents: vec![TransitionIntent::AuditLog {
+                            card_id: card.id.clone(),
+                            from: card.status.clone(),
+                            to: target.to_string(),
+                            source: source.to_string(),
+                            message: msg,
+                        }],
                     };
-
-                    // Point B: gate type the FSM cannot evaluate.
-                    if !KNOWN_GATE_TYPES.contains(&gate.gate_type.as_str()) {
-                        return block(&format!(
-                            "BLOCKED: gate '{}' has unsupported type '{}'",
-                            gate_name, gate.gate_type
-                        ));
-                    }
-
-                    if gate.gate_type != "builtin" {
-                        // `policy` is a documented extension point with no FSM
-                        // evaluator yet. Pass it through (no policy gates exist in
-                        // any shipped pipeline) but warn so it is never silently
-                        // assumed to have been enforced.
-                        tracing::warn!(
-                            card_id = %card.id,
-                            gate = %gate_name,
-                            gate_type = %gate.gate_type,
-                            "gate type has no FSM evaluator; passing through un-enforced"
-                        );
-                        continue;
-                    }
-
-                    // Point C: builtin gate — the check MUST be one the FSM knows.
-                    let blocked_msg = match gate.check.as_deref() {
-                        Some("has_active_dispatch") => (!ctx.gates.has_active_dispatch)
-                            .then_some("BLOCKED: no active dispatch"),
-                        Some("review_verdict_pass") => (!ctx.gates.review_verdict_pass)
-                            .then_some("BLOCKED: no review pass verdict for current round"),
-                        Some("review_verdict_rework") => (!ctx.gates.review_verdict_rework)
-                            .then_some("BLOCKED: no review rework verdict for current round"),
-                        Some(check) => {
-                            debug_assert!(
-                                !KNOWN_BUILTIN_GATE_CHECKS.contains(&check),
-                                "known builtin check '{check}' missing a match arm"
-                            );
-                            return block(&format!(
-                                "BLOCKED: builtin gate '{gate_name}' references unknown check '{check}'"
-                            ));
-                        }
-                        None => {
-                            return block(&format!(
-                                "BLOCKED: builtin gate '{gate_name}' is missing a check"
-                            ));
-                        }
-                    };
-                    if let Some(msg) = blocked_msg {
-                        return TransitionDecision {
-                            outcome: TransitionOutcome::Blocked(format!(
-                                "Status transition {} → {} failed gate '{}': {}",
-                                card.status, target, gate_name, msg
-                            )),
-                            intents: vec![TransitionIntent::AuditLog {
-                                card_id: card.id.clone(),
-                                from: card.status.clone(),
-                                to: target.to_string(),
-                                source: source.to_string(),
-                                message: msg.to_string(),
-                            }],
-                        };
-                    }
                 }
             }
             TransitionType::ForceOnly => {
@@ -898,10 +928,11 @@ mod gate_fail_closed_tests {
         assert!(reason.contains("unknown check 'bogus'"), "{reason}");
     }
 
-    /// A `policy` gate has no FSM evaluator: it passes through (un-enforced)
-    /// rather than blocking, since no shipped pipeline declares one.
+    /// #3595: a `policy` gate has no FSM evaluator. Since `policy` was removed
+    /// from KNOWN_GATE_TYPES, it is now an unsupported type and must BLOCK
+    /// (fail-closed) rather than passing through un-enforced.
     #[test]
-    fn gated_transition_passes_through_policy_gate() {
+    fn gated_transition_blocks_on_policy_gate() {
         let gate = GateConfig {
             gate_type: "policy".to_string(),
             check: None,
@@ -914,7 +945,33 @@ mod gate_fail_closed_tests {
             "test",
             ForceIntent::None,
         );
-        assert_eq!(decision.outcome, TransitionOutcome::Allowed);
+        let reason = blocked_reason(&decision);
+        assert!(reason.contains("unsupported type 'policy'"), "{reason}");
+    }
+
+    /// Point C (FIX 3): a builtin gate whose `check` is `None` (missing check)
+    /// at runtime must BLOCK — symmetric with the unwired/unsupported/unknown
+    /// cases above. (validate() rejects this at write time, but the reducer
+    /// must also fail closed if an out-of-band pipeline reaches it.)
+    #[test]
+    fn gated_transition_blocks_on_builtin_gate_with_no_check() {
+        let gate = GateConfig {
+            gate_type: "builtin".to_string(),
+            check: None,
+            description: None,
+        };
+        let pipeline = pipeline_with_gates(vec!["g"], vec![("g", gate)]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::None,
+        );
+        let reason = blocked_reason(&decision);
+        assert!(
+            reason.contains("builtin gate 'g' is missing a check"),
+            "{reason}"
+        );
     }
 
     /// Regression guard: a known builtin check whose condition is satisfied

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -219,7 +219,7 @@ pub fn evaluate_gates(
         let Some(gate) = gates.get(gate_name.as_str()) else {
             return GateEvaluation::Blocked {
                 gate: gate_name.clone(),
-                message: format!("BLOCKED: unknown/unwired gate '{gate_name}'"),
+                message: "BLOCKED: unknown/unwired gate".to_string(),
             };
         };
 
@@ -919,7 +919,10 @@ mod gate_fail_closed_tests {
             ForceIntent::None,
         );
         let reason = blocked_reason(&decision);
-        assert!(reason.contains("unknown/unwired gate 'ghost'"), "{reason}");
+        assert!(
+            reason.contains("failed gate 'ghost'") && reason.contains("unknown/unwired gate"),
+            "{reason}"
+        );
     }
 
     /// Point B: gate type the FSM has no evaluator for.

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -186,10 +186,11 @@ pub enum GateEvaluation {
 /// pipeline's gate definitions, and a pre-collected [`GateSnapshot`], decide
 /// whether the transition is permitted.
 ///
-/// This is intentionally a *pure* helper with no I/O: callers collect the
-/// snapshot however they like (the reducer from a pre-loaded
-/// `TransitionContext`; `set_status_raw_pg` from DB queries) and share this
-/// exact decision so the two paths can never diverge again. A gate the FSM
+/// This is intentionally a *pure* helper with no I/O: the caller collects the
+/// snapshot however it likes (the reducer from a pre-loaded
+/// `TransitionContext`) and the decision lives in one place so additional
+/// gate-eval paths cannot diverge from it. (#3603 wires the `set_status_raw_pg`
+/// path in `engine/ops/kanban_ops.rs` onto this same helper.) A gate the FSM
 /// cannot positively confirm as "pass" returns [`GateEvaluation::Blocked`]
 /// rather than silently passing through (no `_ => pass` / skip-on-miss).
 ///
@@ -418,12 +419,12 @@ fn decide_pipeline_transition(
             TransitionType::ForceOnly if force_intent.is_forced() => {}
             TransitionType::Gated => {
                 // Evaluate gates fail-closed (#3595) via the shared
-                // `evaluate_gates` helper — the single source of truth also used
-                // by `set_status_raw_pg` (engine/ops/kanban_ops.rs) so the two
-                // gate-eval paths can never diverge. A gate the FSM cannot
-                // positively evaluate to "pass" BLOCKs the transition rather
-                // than silently falling through. The force path above (L321)
-                // already bypasses this.
+                // `evaluate_gates` helper — the single source of truth for gate
+                // evaluation (#3603 routes `set_status_raw_pg` through it too so
+                // the paths can never diverge). A gate the FSM cannot positively
+                // evaluate to "pass" BLOCKs the transition rather than silently
+                // falling through. The forced-`Gated` match arm above already
+                // bypasses this.
                 if let GateEvaluation::Blocked(msg) =
                     evaluate_gates(&t.gates, &pipeline.gates, &ctx.gates)
                 {

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -8,7 +8,9 @@
 //! No direct SQL UPDATEs to `kanban_cards.status`, `review_status`, or
 //! `latest_dispatch_id` should happen outside this module.
 
-use crate::pipeline::{PipelineConfig, TransitionType};
+use crate::pipeline::{
+    KNOWN_BUILTIN_GATE_CHECKS, KNOWN_GATE_TYPES, PipelineConfig, TransitionType,
+};
 use serde::{Deserialize, Serialize};
 
 // ── Context types ────────────────────────────────────────────
@@ -321,40 +323,92 @@ fn decide_pipeline_transition(
             TransitionType::Gated if force_intent.is_forced() => {}
             TransitionType::ForceOnly if force_intent.is_forced() => {}
             TransitionType::Gated => {
-                // Evaluate gates
+                // Evaluate gates fail-closed (#3595). A gate that the FSM cannot
+                // positively evaluate to "pass" must BLOCK the transition rather
+                // than silently fall through (former `_ => None` / skip-on-miss
+                // fail-open). The force path above (L321) already bypasses this.
+                let block = |msg: &str| TransitionDecision {
+                    outcome: TransitionOutcome::Blocked(format!(
+                        "Status transition {} → {} failed gate evaluation: {}",
+                        card.status, target, msg
+                    )),
+                    intents: vec![TransitionIntent::AuditLog {
+                        card_id: card.id.clone(),
+                        from: card.status.clone(),
+                        to: target.to_string(),
+                        source: source.to_string(),
+                        message: msg.to_string(),
+                    }],
+                };
+
                 for gate_name in &t.gates {
-                    if let Some(gate) = pipeline.gates.get(gate_name.as_str()) {
-                        if gate.gate_type == "builtin" {
-                            let blocked_msg = match gate.check.as_deref() {
-                                Some("has_active_dispatch") if !ctx.gates.has_active_dispatch => {
-                                    Some("BLOCKED: no active dispatch")
-                                }
-                                Some("review_verdict_pass") if !ctx.gates.review_verdict_pass => {
-                                    Some("BLOCKED: no review pass verdict for current round")
-                                }
-                                Some("review_verdict_rework")
-                                    if !ctx.gates.review_verdict_rework =>
-                                {
-                                    Some("BLOCKED: no review rework verdict for current round")
-                                }
-                                _ => None,
-                            };
-                            if let Some(msg) = blocked_msg {
-                                return TransitionDecision {
-                                    outcome: TransitionOutcome::Blocked(format!(
-                                        "Status transition {} → {} failed gate '{}': {}",
-                                        card.status, target, gate_name, msg
-                                    )),
-                                    intents: vec![TransitionIntent::AuditLog {
-                                        card_id: card.id.clone(),
-                                        from: card.status.clone(),
-                                        to: target.to_string(),
-                                        source: source.to_string(),
-                                        message: msg.to_string(),
-                                    }],
-                                };
-                            }
+                    // Point A: gate referenced by the transition is not declared
+                    // in the gates map. validate() already rejects this for any
+                    // resolved pipeline, so reaching here means a tampered/
+                    // out-of-band state — fail closed instead of waving it through.
+                    let Some(gate) = pipeline.gates.get(gate_name.as_str()) else {
+                        return block(&format!("BLOCKED: unknown/unwired gate '{gate_name}'"));
+                    };
+
+                    // Point B: gate type the FSM cannot evaluate.
+                    if !KNOWN_GATE_TYPES.contains(&gate.gate_type.as_str()) {
+                        return block(&format!(
+                            "BLOCKED: gate '{}' has unsupported type '{}'",
+                            gate_name, gate.gate_type
+                        ));
+                    }
+
+                    if gate.gate_type != "builtin" {
+                        // `policy` is a documented extension point with no FSM
+                        // evaluator yet. Pass it through (no policy gates exist in
+                        // any shipped pipeline) but warn so it is never silently
+                        // assumed to have been enforced.
+                        tracing::warn!(
+                            card_id = %card.id,
+                            gate = %gate_name,
+                            gate_type = %gate.gate_type,
+                            "gate type has no FSM evaluator; passing through un-enforced"
+                        );
+                        continue;
+                    }
+
+                    // Point C: builtin gate — the check MUST be one the FSM knows.
+                    let blocked_msg = match gate.check.as_deref() {
+                        Some("has_active_dispatch") => (!ctx.gates.has_active_dispatch)
+                            .then_some("BLOCKED: no active dispatch"),
+                        Some("review_verdict_pass") => (!ctx.gates.review_verdict_pass)
+                            .then_some("BLOCKED: no review pass verdict for current round"),
+                        Some("review_verdict_rework") => (!ctx.gates.review_verdict_rework)
+                            .then_some("BLOCKED: no review rework verdict for current round"),
+                        Some(check) => {
+                            debug_assert!(
+                                !KNOWN_BUILTIN_GATE_CHECKS.contains(&check),
+                                "known builtin check '{check}' missing a match arm"
+                            );
+                            return block(&format!(
+                                "BLOCKED: builtin gate '{gate_name}' references unknown check '{check}'"
+                            ));
                         }
+                        None => {
+                            return block(&format!(
+                                "BLOCKED: builtin gate '{gate_name}' is missing a check"
+                            ));
+                        }
+                    };
+                    if let Some(msg) = blocked_msg {
+                        return TransitionDecision {
+                            outcome: TransitionOutcome::Blocked(format!(
+                                "Status transition {} → {} failed gate '{}': {}",
+                                card.status, target, gate_name, msg
+                            )),
+                            intents: vec![TransitionIntent::AuditLog {
+                                card_id: card.id.clone(),
+                                from: card.status.clone(),
+                                to: target.to_string(),
+                                source: source.to_string(),
+                                message: msg.to_string(),
+                            }],
+                        };
                     }
                 }
             }
@@ -714,3 +768,195 @@ fn format_audit_message(
 }
 
 // ── Unit tests ───────────────────────────────────────────────
+
+#[cfg(test)]
+mod gate_fail_closed_tests {
+    //! #3595: the `Gated` transition branch must fail closed. A gate the FSM
+    //! cannot positively evaluate to "pass" must BLOCK the transition.
+    use super::*;
+    use crate::pipeline::{
+        GateConfig, PhaseGateConfig, PipelineConfig, StateConfig, TransitionConfig, TransitionType,
+    };
+    use std::collections::HashMap;
+
+    /// Build a 2-state pipeline (`a` → `b`) with a single Gated transition
+    /// referencing `gate_names`, and the supplied gate definitions.
+    fn pipeline_with_gates(
+        gate_names: Vec<&str>,
+        gates: Vec<(&str, GateConfig)>,
+    ) -> PipelineConfig {
+        PipelineConfig {
+            name: "test".to_string(),
+            version: 1,
+            states: vec![
+                StateConfig {
+                    id: "a".to_string(),
+                    label: "A".to_string(),
+                    terminal: false,
+                },
+                StateConfig {
+                    id: "b".to_string(),
+                    label: "B".to_string(),
+                    terminal: false,
+                },
+            ],
+            transitions: vec![TransitionConfig {
+                from: "a".to_string(),
+                to: "b".to_string(),
+                transition_type: TransitionType::Gated,
+                gates: gate_names.into_iter().map(str::to_string).collect(),
+            }],
+            gates: gates
+                .into_iter()
+                .map(|(name, cfg)| (name.to_string(), cfg))
+                .collect(),
+            hooks: HashMap::new(),
+            events: HashMap::new(),
+            clocks: HashMap::new(),
+            timeouts: HashMap::new(),
+            phase_gate: PhaseGateConfig::default(),
+        }
+    }
+
+    fn builtin(check: &str) -> GateConfig {
+        GateConfig {
+            gate_type: "builtin".to_string(),
+            check: Some(check.to_string()),
+            description: None,
+        }
+    }
+
+    fn ctx(pipeline: PipelineConfig, gates: GateSnapshot) -> TransitionContext {
+        TransitionContext {
+            card: CardState {
+                id: "card-1".to_string(),
+                status: "a".to_string(),
+                review_status: None,
+                latest_dispatch_id: None,
+            },
+            pipeline,
+            gates,
+        }
+    }
+
+    fn blocked_reason(decision: &TransitionDecision) -> &str {
+        match &decision.outcome {
+            TransitionOutcome::Blocked(msg) => msg.as_str(),
+            other => panic!("expected Blocked, got {other:?}"),
+        }
+    }
+
+    /// Point A: transition references a gate absent from the gates map.
+    #[test]
+    fn gated_transition_blocks_on_unwired_gate() {
+        let pipeline = pipeline_with_gates(vec!["ghost"], vec![]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::None,
+        );
+        let reason = blocked_reason(&decision);
+        assert!(reason.contains("unknown/unwired gate 'ghost'"), "{reason}");
+    }
+
+    /// Point B: gate type the FSM has no evaluator for.
+    #[test]
+    fn gated_transition_blocks_on_unsupported_gate_type() {
+        let gate = GateConfig {
+            gate_type: "webhook".to_string(),
+            check: None,
+            description: None,
+        };
+        let pipeline = pipeline_with_gates(vec!["g"], vec![("g", gate)]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::None,
+        );
+        let reason = blocked_reason(&decision);
+        assert!(reason.contains("unsupported type 'webhook'"), "{reason}");
+    }
+
+    /// Point C: builtin gate whose check string is unknown to the FSM.
+    #[test]
+    fn gated_transition_blocks_on_unknown_builtin_check() {
+        let gate = GateConfig {
+            gate_type: "builtin".to_string(),
+            check: Some("bogus".to_string()),
+            description: None,
+        };
+        let pipeline = pipeline_with_gates(vec!["g"], vec![("g", gate)]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::None,
+        );
+        let reason = blocked_reason(&decision);
+        assert!(reason.contains("unknown check 'bogus'"), "{reason}");
+    }
+
+    /// A `policy` gate has no FSM evaluator: it passes through (un-enforced)
+    /// rather than blocking, since no shipped pipeline declares one.
+    #[test]
+    fn gated_transition_passes_through_policy_gate() {
+        let gate = GateConfig {
+            gate_type: "policy".to_string(),
+            check: None,
+            description: None,
+        };
+        let pipeline = pipeline_with_gates(vec!["g"], vec![("g", gate)]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::None,
+        );
+        assert_eq!(decision.outcome, TransitionOutcome::Allowed);
+    }
+
+    /// Regression guard: a known builtin check whose condition is satisfied
+    /// still allows the transition (normal pass path unchanged).
+    #[test]
+    fn gated_transition_passes_on_known_check_satisfied() {
+        let pipeline = pipeline_with_gates(vec!["g"], vec![("g", builtin("has_active_dispatch"))]);
+        let gates = GateSnapshot {
+            has_active_dispatch: true,
+            ..Default::default()
+        };
+        let decision =
+            decide_status_transition(&ctx(pipeline, gates), "b", "test", ForceIntent::None);
+        assert_eq!(decision.outcome, TransitionOutcome::Allowed);
+    }
+
+    /// Regression guard: a known builtin check whose condition is NOT satisfied
+    /// keeps the pre-existing per-check BLOCKED message (behaviour unchanged).
+    #[test]
+    fn gated_transition_blocks_on_known_check_unsatisfied() {
+        let pipeline = pipeline_with_gates(vec!["g"], vec![("g", builtin("has_active_dispatch"))]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::None,
+        );
+        let reason = blocked_reason(&decision);
+        assert!(reason.contains("no active dispatch"), "{reason}");
+    }
+
+    /// Force override bypasses gate evaluation entirely — even an unwired gate
+    /// must not block a forced transition (force path unchanged).
+    #[test]
+    fn forced_transition_skips_gate_evaluation() {
+        let pipeline = pipeline_with_gates(vec!["ghost"], vec![]);
+        let decision = decide_status_transition(
+            &ctx(pipeline, GateSnapshot::default()),
+            "b",
+            "test",
+            ForceIntent::OperatorOverride,
+        );
+        assert_eq!(decision.outcome, TransitionOutcome::Allowed);
+    }
+}

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -177,8 +177,19 @@ pub enum GateEvaluation {
     /// Every gate the transition declares evaluated to "pass".
     Allowed,
     /// At least one gate could not be positively evaluated to "pass".
-    /// Carries the canonical fail-closed reason (already prefixed `BLOCKED: …`).
-    Blocked(String),
+    Blocked {
+        /// Name of the gate that blocked the transition. The caller wraps the
+        /// final reason as `failed gate '<gate>': <message>` so the offending
+        /// gate is always named in the externally-surfaced reason — this is the
+        /// pre-#3595 (origin/main) behaviour, preserved byte-for-byte for the
+        /// known-builtin "check unsatisfied" path.
+        gate: String,
+        /// Canonical fail-closed message (already prefixed `BLOCKED: …`). For the
+        /// known-builtin unsatisfied path this is the original per-check string
+        /// (e.g. `BLOCKED: no active dispatch`) so the audit message stays
+        /// identical to origin/main.
+        message: String,
+    },
 }
 
 /// Single source of truth for `Gated` transition gate evaluation (#3595,
@@ -206,17 +217,20 @@ pub fn evaluate_gates(
         // gates map. validate() already rejects this for any resolved pipeline,
         // so reaching here means a tampered / out-of-band state — fail closed.
         let Some(gate) = gates.get(gate_name.as_str()) else {
-            return GateEvaluation::Blocked(format!("BLOCKED: unknown/unwired gate '{gate_name}'"));
+            return GateEvaluation::Blocked {
+                gate: gate_name.clone(),
+                message: format!("BLOCKED: unknown/unwired gate '{gate_name}'"),
+            };
         };
 
         // Point B: gate type the FSM cannot evaluate. After #3595 `policy` was
         // removed from KNOWN_GATE_TYPES, so the only known type is `builtin`;
         // anything else (including a `policy` override) is blocked here.
         if !KNOWN_GATE_TYPES.contains(&gate.gate_type.as_str()) {
-            return GateEvaluation::Blocked(format!(
-                "BLOCKED: gate '{}' has unsupported type '{}'",
-                gate_name, gate.gate_type
-            ));
+            return GateEvaluation::Blocked {
+                gate: gate_name.clone(),
+                message: format!("BLOCKED: unsupported type '{}'", gate.gate_type),
+            };
         }
 
         // Point C: builtin gate — the check MUST be one the FSM knows. Every
@@ -224,38 +238,55 @@ pub fn evaluate_gates(
         // debug_assert guards against a check being added to the list without a
         // corresponding arm, which would otherwise fail-closed in production).
         match gate.check.as_deref() {
+            // Known-builtin checks whose condition is unsatisfied: this is the
+            // normal block path and MUST stay behaviour-preserving against
+            // origin/main. The `message` is the original per-check string (no
+            // gate name) and the caller wraps it as
+            // `failed gate '<gate>': <message>`, reproducing the pre-#3595
+            // reason byte-for-byte (the gate name lives in the `gate` field).
             Some("has_active_dispatch") => {
                 if !snapshot.has_active_dispatch {
-                    return GateEvaluation::Blocked("BLOCKED: no active dispatch".to_string());
+                    return GateEvaluation::Blocked {
+                        gate: gate_name.clone(),
+                        message: "BLOCKED: no active dispatch".to_string(),
+                    };
                 }
             }
             Some("review_verdict_pass") => {
                 if !snapshot.review_verdict_pass {
-                    return GateEvaluation::Blocked(
-                        "BLOCKED: no review pass verdict for current round".to_string(),
-                    );
+                    return GateEvaluation::Blocked {
+                        gate: gate_name.clone(),
+                        message: "BLOCKED: no review pass verdict for current round".to_string(),
+                    };
                 }
             }
             Some("review_verdict_rework") => {
                 if !snapshot.review_verdict_rework {
-                    return GateEvaluation::Blocked(
-                        "BLOCKED: no review rework verdict for current round".to_string(),
-                    );
+                    return GateEvaluation::Blocked {
+                        gate: gate_name.clone(),
+                        message: "BLOCKED: no review rework verdict for current round".to_string(),
+                    };
                 }
             }
+            // Fail-closed cases new in #3595 (no origin/main equivalent). The
+            // gate name is carried in the `gate` field and surfaced by the
+            // caller's `failed gate '<gate>': …` wrapper, so it is omitted from
+            // `message` to avoid duplicating it.
             Some(check) => {
                 debug_assert!(
                     !KNOWN_BUILTIN_GATE_CHECKS.contains(&check),
                     "known builtin check '{check}' missing a match arm"
                 );
-                return GateEvaluation::Blocked(format!(
-                    "BLOCKED: builtin gate '{gate_name}' references unknown check '{check}'"
-                ));
+                return GateEvaluation::Blocked {
+                    gate: gate_name.clone(),
+                    message: format!("BLOCKED: references unknown check '{check}'"),
+                };
             }
             None => {
-                return GateEvaluation::Blocked(format!(
-                    "BLOCKED: builtin gate '{gate_name}' is missing a check"
-                ));
+                return GateEvaluation::Blocked {
+                    gate: gate_name.clone(),
+                    message: "BLOCKED: builtin gate is missing a check".to_string(),
+                };
             }
         }
     }
@@ -425,20 +456,20 @@ fn decide_pipeline_transition(
                 // evaluate to "pass" BLOCKs the transition rather than silently
                 // falling through. The forced-`Gated` match arm above already
                 // bypasses this.
-                if let GateEvaluation::Blocked(msg) =
+                if let GateEvaluation::Blocked { gate, message } =
                     evaluate_gates(&t.gates, &pipeline.gates, &ctx.gates)
                 {
                     return TransitionDecision {
                         outcome: TransitionOutcome::Blocked(format!(
-                            "Status transition {} → {} failed gate evaluation: {}",
-                            card.status, target, msg
+                            "Status transition {} → {} failed gate '{}': {}",
+                            card.status, target, gate, message
                         )),
                         intents: vec![TransitionIntent::AuditLog {
                             card_id: card.id.clone(),
                             from: card.status.clone(),
                             to: target.to_string(),
                             source: source.to_string(),
-                            message: msg,
+                            message,
                         }],
                     };
                 }
@@ -969,10 +1000,10 @@ mod gate_fail_closed_tests {
             ForceIntent::None,
         );
         let reason = blocked_reason(&decision);
-        assert!(
-            reason.contains("builtin gate 'g' is missing a check"),
-            "{reason}"
-        );
+        // The offending gate is named by the caller's `failed gate '<gate>': …`
+        // wrapper; the per-case message reports the missing check.
+        assert!(reason.contains("failed gate 'g'"), "{reason}");
+        assert!(reason.contains("missing a check"), "{reason}");
     }
 
     /// Regression guard: a known builtin check whose condition is satisfied
@@ -990,7 +1021,10 @@ mod gate_fail_closed_tests {
     }
 
     /// Regression guard: a known builtin check whose condition is NOT satisfied
-    /// keeps the pre-existing per-check BLOCKED message (behaviour unchanged).
+    /// keeps the pre-existing per-check BLOCKED message *and* the origin/main
+    /// (pre-#3595) reason format that names the offending gate
+    /// (`failed gate '<gate>': <message>`). This is the normal block path and
+    /// must stay behaviour-preserving — see #3595 codex review.
     #[test]
     fn gated_transition_blocks_on_known_check_unsatisfied() {
         let pipeline = pipeline_with_gates(vec!["g"], vec![("g", builtin("has_active_dispatch"))]);
@@ -1001,7 +1035,12 @@ mod gate_fail_closed_tests {
             ForceIntent::None,
         );
         let reason = blocked_reason(&decision);
-        assert!(reason.contains("no active dispatch"), "{reason}");
+        // Byte-identical to origin/main: from → to, gate name, and the
+        // per-check BLOCKED message.
+        assert_eq!(
+            reason,
+            "Status transition a → b failed gate 'g': BLOCKED: no active dispatch",
+        );
     }
 
     /// Force override bypasses gate evaluation entirely — even an unwired gate

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -716,12 +716,16 @@ pub struct GateConfig {
     pub description: Option<String>,
 }
 
-/// Gate types the FSM understands (#3595).
+/// Gate types the FSM understands (#3595, fail-closed).
 /// - `builtin`: evaluated in Rust (see `KNOWN_BUILTIN_GATE_CHECKS`).
-/// - `policy`: documented JS-policy extension point. Declarable for forward
-///   compatibility, but no FSM evaluator exists yet, so the runtime treats a
-///   `policy` gate as a no-op pass with a warning rather than blocking.
-pub const KNOWN_GATE_TYPES: &[&str] = &["builtin", "policy"];
+///
+/// `policy` was intentionally removed: the FSM has no policy evaluator, so a
+/// `type: policy` gate would otherwise pass through *un-enforced* (fail-open).
+/// Declaring one now fails validation at write time (`validate()` →
+/// BadRequest) and, defensively, blocks at runtime in `evaluate_gates`
+/// (engine/transition.rs Point B). When a real policy evaluator is wired,
+/// re-add `"policy"` here together with its evaluation arm.
+pub const KNOWN_GATE_TYPES: &[&str] = &["builtin"];
 
 /// The exact set of `check` strings a `builtin` gate may reference (#3595).
 /// These mirror the boolean fields on `engine::transition::GateSnapshot`.
@@ -1476,14 +1480,20 @@ mod gate_validation_tests {
     }
 
     #[test]
-    fn validate_accepts_policy_gate_declaration() {
-        // `policy` is a documented extension point and must remain declarable
-        // even though the FSM has no evaluator for it yet.
+    fn validate_rejects_policy_gate_declaration() {
+        // #3595: `policy` was removed from KNOWN_GATE_TYPES (fail-closed). The
+        // FSM has no policy evaluator, so a `type: policy` gate would pass
+        // through un-enforced; declaring one must be rejected at write time
+        // rather than failing open at runtime.
         let mut config = base_config();
         config
             .gates
             .insert("custom".to_string(), gate("policy", None));
-        assert!(config.validate().is_ok());
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported type 'policy'"),
+            "{err}"
+        );
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -716,6 +716,21 @@ pub struct GateConfig {
     pub description: Option<String>,
 }
 
+/// Gate types the FSM understands (#3595).
+/// - `builtin`: evaluated in Rust (see `KNOWN_BUILTIN_GATE_CHECKS`).
+/// - `policy`: documented JS-policy extension point. Declarable for forward
+///   compatibility, but no FSM evaluator exists yet, so the runtime treats a
+///   `policy` gate as a no-op pass with a warning rather than blocking.
+pub const KNOWN_GATE_TYPES: &[&str] = &["builtin", "policy"];
+
+/// The exact set of `check` strings a `builtin` gate may reference (#3595).
+/// These mirror the boolean fields on `engine::transition::GateSnapshot`.
+pub const KNOWN_BUILTIN_GATE_CHECKS: &[&str] = &[
+    "has_active_dispatch",
+    "review_verdict_pass",
+    "review_verdict_rework",
+];
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookBindings {
     #[serde(default)]
@@ -1213,6 +1228,38 @@ impl PipelineConfig {
             }
         }
 
+        // Every declared gate must be evaluable by the FSM (#3595, fail-closed).
+        // Rejecting unsupported gate types / unknown builtin checks at declaration
+        // time means a misconfigured gate is caught on override write
+        // (validate_pipeline_override → resolve → validate) instead of silently
+        // failing open at runtime and leaking a transition past an un-evaluated gate.
+        for (gate_name, gate) in &self.gates {
+            if !KNOWN_GATE_TYPES.contains(&gate.gate_type.as_str()) {
+                anyhow::bail!(
+                    "gate '{}' has unsupported type '{}'; expected one of {:?}",
+                    gate_name,
+                    gate.gate_type,
+                    KNOWN_GATE_TYPES
+                );
+            }
+            if gate.gate_type == "builtin" {
+                match gate.check.as_deref() {
+                    Some(check) if KNOWN_BUILTIN_GATE_CHECKS.contains(&check) => {}
+                    Some(check) => anyhow::bail!(
+                        "builtin gate '{}' references unknown check '{}'; expected one of {:?}",
+                        gate_name,
+                        check,
+                        KNOWN_BUILTIN_GATE_CHECKS
+                    ),
+                    None => anyhow::bail!(
+                        "builtin gate '{}' is missing a 'check'; expected one of {:?}",
+                        gate_name,
+                        KNOWN_BUILTIN_GATE_CHECKS
+                    ),
+                }
+            }
+        }
+
         // Clock fields must reference valid states
         for state in self.clocks.keys() {
             if !state_ids.contains(&state.as_str()) {
@@ -1339,6 +1386,104 @@ mod state_slug_contract_tests {
                 .contains("kanban status slug contract ^[a-z][a-z0-9_]*$"),
             "{err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod gate_validation_tests {
+    //! #3595: declaration-time fail-closed checks for gate definitions.
+    use super::*;
+
+    /// Minimal valid pipeline (one non-terminal state, no transitions/gates) that
+    /// passes `validate()`. Tests then inject a single gate to exercise the
+    /// gate-validation branch in isolation.
+    fn base_config() -> PipelineConfig {
+        PipelineConfig {
+            name: "test".to_string(),
+            version: 1,
+            states: vec![StateConfig {
+                id: "todo".to_string(),
+                label: "Todo".to_string(),
+                terminal: false,
+            }],
+            transitions: Vec::new(),
+            gates: HashMap::new(),
+            hooks: HashMap::new(),
+            events: HashMap::new(),
+            clocks: HashMap::new(),
+            timeouts: HashMap::new(),
+            phase_gate: PhaseGateConfig::default(),
+        }
+    }
+
+    fn gate(gate_type: &str, check: Option<&str>) -> GateConfig {
+        GateConfig {
+            gate_type: gate_type.to_string(),
+            check: check.map(str::to_string),
+            description: None,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_gate_with_unsupported_type() {
+        let mut config = base_config();
+        config
+            .gates
+            .insert("hookish".to_string(), gate("webhook", None));
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported type 'webhook'"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_builtin_gate_with_unknown_check() {
+        let mut config = base_config();
+        config
+            .gates
+            .insert("weird".to_string(), gate("builtin", Some("bogus_check")));
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("unknown check 'bogus_check'"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_builtin_gate_with_missing_check() {
+        let mut config = base_config();
+        config
+            .gates
+            .insert("incomplete".to_string(), gate("builtin", None));
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("missing a 'check'"), "{err}");
+    }
+
+    #[test]
+    fn validate_accepts_known_builtin_gates() {
+        // Regression guard: all three shipped builtin checks must keep validating.
+        for check in KNOWN_BUILTIN_GATE_CHECKS {
+            let mut config = base_config();
+            config
+                .gates
+                .insert("g".to_string(), gate("builtin", Some(check)));
+            assert!(
+                config.validate().is_ok(),
+                "builtin gate with known check '{check}' should validate"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_policy_gate_declaration() {
+        // `policy` is a documented extension point and must remain declarable
+        // even though the FSM has no evaluator for it yet.
+        let mut config = base_config();
+        config
+            .gates
+            .insert("custom".to_string(), gate("policy", None));
+        assert!(config.validate().is_ok());
     }
 }
 


### PR DESCRIPTION
## 문제 (fail-open 3지점, `decide_pipeline_transition` @ `src/engine/transition.rs`)

Gated transition의 게이트 평가가 세 곳에서 fail-open이었음 — 평가할 수 없는 게이트가 transition을 통과시킴:

- **Point A**: `pipeline.gates.get(name)` 가 `None` → `if let Some` 거짓 → 게이트 통째로 스킵 (미배선 게이트 통과)
- **Point B**: `gate_type != "builtin"` → 평가 스킵 (미지원 타입 통과)
- **Point C**: `match gate.check { ... _ => None }` 캐치올 → unknown check 문자열 / `check: None` 이 블록 없이 통과

## 변경 (2계층 fail-closed)

### (1) 선언 시점 — `src/pipeline.rs` `validate()`
모든 선언 게이트 검증:
- `gate_type` ∈ `{builtin, policy}` 아니면 bail (`unsupported type`). `policy` 는 default-pipeline.yaml에 문서화된 확장점이라 선언 허용.
- `builtin` 이면 `check` 가 known 3종(`has_active_dispatch` / `review_verdict_pass` / `review_verdict_rework`)이어야 함. 아니거나 None이면 bail.

이 검증은 default + repo/agent override merge 결과 모두에 적용됨 — `validate_pipeline_override`(매 override write마다 호출)가 `resolve()→validate()`를 부르므로 잘못된 게이트 선언은 **런타임 영구 차단 이전 write 시점에 BadRequest로 거부**돼 즉시 피드백된다.

### (2) 런타임 — `src/engine/transition.rs` `Gated` 분기
- Point A: 미배선 게이트 → `Blocked` + AuditLog 조기 반환
- Point B: 미지원 gate_type → `Blocked`. `policy` 는 FSM 평가자 부재이므로 **통과 + warn 로그** (무조건 block하면 문서화된 확장 계약을 깸; 현재 policy 게이트 0개라 무영향)
- Point C: builtin인데 unknown/None check → `_ => None` 대신 `Blocked` 조기 반환

알려진 builtin check 3종은 `Some(...) => (!cond).then_some(msg)` 형태로 명시 매칭하고, `Some(other)` 는 `debug_assert!` 로 known 집합 누락을 잡은 뒤 block. known check의 정상 pass/block 메시지는 불변.

## 불변식 (회귀 없음)

- `force_intent.is_forced()` 경로(L321)는 게이트 평가 자체를 건너뛰므로 **force override 불변**.
- known check가 조건을 만족하는 정상 transition **불변**.
- known check 미충족 시 기존 per-check `BLOCKED:` 메시지 **불변**.

## regression 분석 (`current_gates_all_known=true`)

모든 파이프라인 YAML(default + examples/qa + examples/simple)에서 선언된 게이트는 **전부 `type: builtin` + known 3종 check**. `type: policy` 또는 unknown check 게이트는 YAML·코드·라이브 store(SQLite 0바이트 스텁, 활성 override 0건) 어디에도 부재 ⇒ fail-closed 전환이 현재 배포된 정상 transition을 깨지 않음.

## 테스트

**`src/pipeline.rs` `gate_validation_tests` (5)** — unsupported type / unknown builtin check / missing builtin check 거부; known builtin 3종 + policy 선언 허용.

**`src/engine/transition.rs` `gate_fail_closed_tests` (7, 신규 모듈)** — Point A/B/C 각각 block; policy pass-through; known check satisfied → Allowed; known check unsatisfied → Blocked(기존 메시지); forced → 게이트 스킵.

## 게이트

- `cargo fmt --check`: clean
- `cargo check --lib`: clean
- `cargo test --lib engine::` (86 pass, 신규 7 포함) / `pipeline::` (6 pass, 신규 5 포함)
- `python3 scripts/check_agent_maintenance_docs.py`: `freshness check passed` (change-surfaces.md `src/pipeline.rs` 라인 카운트 1314→1362 동기화)

Refs #3595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> **Note (범위 축소 / 재범위화):** `set_status_raw_pg` ↔ reducer 완전위임(게이트 평가 통합·stale verdict 윈도잉·ForceOnly/no-rule/target validity)은 **#3603**으로 분리했다. 본 PR(#3595) 범위는 **reducer fail-closed(`evaluate_gates`) + pipeline `validate()` 하드닝**으로 한정한다.
>
> 이에 따라 위 본문 중 `set_status_raw_pg` 관련 서술과 일부 수치(예: policy 선언 허용·런타임 pass+warn, transition 테스트 개수)는 재범위화 후 상태와 다를 수 있다 — 현재 코드 기준: `policy` 게이트는 `validate()`와 `evaluate_gates` 양쪽에서 **fail-closed로 거부/차단**되고, `set_status_raw_pg`는 origin/main 동작으로 복귀(이 PR에서 미변경)했다.
