### PR TITLE
feat(#3605): scope-assessment depth → card metadata (T2)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -110,7 +110,7 @@
   - `src/dispatch/dispatch_context.rs` (2805 lines).
   - `src/dispatch/dispatch_create.rs` (1381 lines).
   - `src/dispatch/dispatch_status.rs` (1487 lines).
-  - `src/services/dispatches/outbox_route.rs` (1089 lines; route extraction
+  - `src/services/dispatches/outbox_route.rs` (1101 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
   - `src/services/dispatches/discord_delivery/orchestration.rs` (1490 lines;
     delivery orchestration surface extracted from the route layer in #1760,
@@ -1439,7 +1439,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
-- `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
+- `src/services/dispatches/outbox_route.rs` (1101) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -108,8 +108,8 @@
 - legacy_modules: none.
 - do_not_edit_without_migration_plan (giant-file, awaiting split issue):
   - `src/dispatch/dispatch_context.rs` (2805 lines).
-  - `src/dispatch/dispatch_create.rs` (1389 lines).
-  - `src/dispatch/dispatch_status.rs` (1487 lines).
+  - `src/dispatch/dispatch_create.rs` (1385 lines).
+  - `src/dispatch/dispatch_status.rs` (1495 lines).
   - `src/services/dispatches/outbox_route.rs` (1101 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
   - `src/services/dispatches/discord_delivery/orchestration.rs` (1490 lines;

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -108,7 +108,7 @@
 - legacy_modules: none.
 - do_not_edit_without_migration_plan (giant-file, awaiting split issue):
   - `src/dispatch/dispatch_context.rs` (2805 lines).
-  - `src/dispatch/dispatch_create.rs` (1381 lines).
+  - `src/dispatch/dispatch_create.rs` (1389 lines).
   - `src/dispatch/dispatch_status.rs` (1487 lines).
   - `src/services/dispatches/outbox_route.rs` (1101 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).

--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -538,3 +538,288 @@ test("kanban-rules _loadCardAlertContext uses typed facade agentdesk.cards.get",
     github_issue_number: 456
   });
 });
+
+// ── #3605 (T2): scope-assessment dispatch ───────────────────────
+
+function findScopeAssessmentMeta(state) {
+  // The scope-assessment trigger writes a metadata UPDATE carrying
+  // scope_assessment_status; preflight also writes one (without it). Pick the
+  // execution whose object param actually has the scope marker.
+  return state.executions
+    .filter((execution) => /UPDATE kanban_cards SET metadata = \?/.test(execution.sql))
+    .map((execution) => execution.params[0])
+    .find((written) => written && typeof written === "object" && (
+      written.scope_assessment_status != null || written.scope_depth != null
+    ));
+}
+
+test("kanban-rules dispatches scope-assessment once when a card enters requested and preflight clears", () => {
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope": {
+        id: "card-scope",
+        title: "Scope card",
+        github_issue_number: null,
+        github_issue_url: null,
+        status: "requested",
+        description: "This issue body is comfortably longer than thirty characters of text.",
+        assigned_agent_id: "agent-7",
+        metadata: "{}",
+        blocked_reason: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      { match: "SELECT metadata FROM kanban_cards WHERE id = ?", result: [{ metadata: "{}" }] },
+      {
+        match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
+        result: []
+      },
+      {
+        match: "SELECT assigned_agent_id, title FROM kanban_cards WHERE id = ?",
+        result: [{ assigned_agent_id: "agent-7", title: "Scope card" }]
+      }
+    ])
+  });
+
+  policy.onCardTransition({ card_id: "card-scope", from: "backlog", to: "requested" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  const created = state.dispatchCreates[0];
+  assert.equal(created.dispatchType, "scope-assessment");
+  assert.equal(created.agentId, "agent-7");
+  assert.match(created.title, /^\[Scope Assessment\]/);
+
+  const scopeMeta = findScopeAssessmentMeta(state);
+  assert.ok(scopeMeta, "expected a scope metadata write");
+  assert.equal(scopeMeta.scope_assessment_status, "pending");
+  assert.ok(scopeMeta.scope_assessment_dispatch_id);
+  // T2 is inert: no escalation/manual intervention from the trigger.
+  assert.deepEqual(state.manualInterventions, []);
+});
+
+test("kanban-rules does not dispatch scope-assessment twice when status already set", () => {
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope-dup": {
+        id: "card-scope-dup",
+        title: "Scope dup card",
+        github_issue_number: null,
+        github_issue_url: null,
+        status: "requested",
+        description: "This issue body is comfortably longer than thirty characters of text.",
+        assigned_agent_id: "agent-7",
+        metadata: JSON.stringify({ scope_assessment_status: "pending" }),
+        blocked_reason: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: JSON.stringify({ scope_assessment_status: "pending" }) }]
+      },
+      {
+        match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
+        result: []
+      },
+      {
+        match: "SELECT assigned_agent_id, title FROM kanban_cards WHERE id = ?",
+        result: [{ assigned_agent_id: "agent-7", title: "Scope dup card" }]
+      }
+    ])
+  });
+
+  policy.onCardTransition({ card_id: "card-scope-dup", from: "backlog", to: "requested" });
+
+  assert.equal(state.dispatchCreates.length, 0);
+});
+
+test("kanban-rules does not dispatch scope-assessment when preflight is already_applied", () => {
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope-applied": {
+        id: "card-scope-applied",
+        title: "Already implemented scope card",
+        github_issue_number: null,
+        github_issue_url: null,
+        status: "requested",
+        description: "This body is long enough to pass the description length gate easily.",
+        assigned_agent_id: "agent-7",
+        metadata: null,
+        blocked_reason: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      { match: "SELECT metadata FROM kanban_cards WHERE id = ?", result: [] },
+      {
+        match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
+        result: [{ id: "dispatch-old" }]
+      },
+      {
+        match: "SELECT id FROM auto_queue_entries WHERE kanban_card_id = ? AND status = 'pending'",
+        result: []
+      }
+    ])
+  });
+
+  policy.onCardTransition({ card_id: "card-scope-applied", from: "backlog", to: "requested" });
+
+  assert.equal(state.dispatchCreates.length, 0);
+});
+
+test("kanban-rules records scope-assessment result on the card metadata and stays inert", () => {
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope-done": {
+        id: "card-scope-done",
+        title: "Scope done card",
+        status: "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-7",
+        deferred_dod_json: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM task_dispatches WHERE id = ?",
+        result: [
+          {
+            id: "dispatch-scope",
+            kanban_card_id: "card-scope-done",
+            to_agent_id: "agent-7",
+            dispatch_type: "scope-assessment",
+            chain_depth: 0,
+            created_at: "2026-06-19 09:00:00",
+            result: JSON.stringify({
+              scope_depth: "plan_only",
+              scope_reason: "medium change touching two modules",
+              scope_risk: "could grow if migration needed"
+            }),
+            context: "{}",
+            status: "completed"
+          }
+        ]
+      },
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: JSON.stringify({ keep: "yes", scope_assessment_status: "pending" }) }]
+      }
+    ])
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-scope" });
+
+  const written = assertMetadataObjectParam(findMetadataExecution(state));
+  assert.equal(written.keep, "yes");
+  assert.equal(written.scope_depth, "plan_only");
+  assert.equal(written.scope_reason, "medium change touching two modules");
+  assert.equal(written.scope_risk, "could grow if migration needed");
+  assert.equal(written.scope_assessment_status, "completed");
+  assert.deepEqual(written.scope_assessment_result, {
+    scope_depth: "plan_only",
+    scope_reason: "medium change touching two modules",
+    scope_risk: "could grow if migration needed"
+  });
+  // Inert: no status change, no review entry, no manual intervention.
+  assert.deepEqual(state.statusCalls, []);
+  assert.deepEqual(state.manualInterventions, []);
+  // Guard: scope-assessment must not flow into the review/create-pr lifecycle,
+  // so it never queries the PM-gate card-detail shape.
+  assert.equal(state.queries.some((query) => /title, status, priority/.test(query.sql)), false);
+});
+
+test("kanban-rules falls back to full when scope-assessment result is unusable", () => {
+  const cases = [
+    { label: "empty object", result: "{}" },
+    { label: "unparsable", result: "not json" },
+    { label: "garbage depth", result: JSON.stringify({ scope_depth: "garbage" }) }
+  ];
+
+  for (const testCase of cases) {
+    const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+      cards: {
+        "card-scope-fb": {
+          id: "card-scope-fb",
+          title: "Scope fallback card",
+          status: "requested",
+          priority: "medium",
+          assigned_agent_id: "agent-7",
+          deferred_dod_json: null
+        }
+      },
+      dbQuery: createSqlRouter([
+        {
+          match: "FROM task_dispatches WHERE id = ?",
+          result: [
+            {
+              id: "dispatch-scope-fb",
+              kanban_card_id: "card-scope-fb",
+              to_agent_id: "agent-7",
+              dispatch_type: "scope-assessment",
+              chain_depth: 0,
+              created_at: "2026-06-19 09:00:00",
+              result: testCase.result,
+              context: "{}",
+              status: "completed"
+            }
+          ]
+        },
+        {
+          match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+          result: [{ metadata: "{}" }]
+        }
+      ])
+    });
+
+    policy.onDispatchCompleted({ dispatch_id: "dispatch-scope-fb" });
+
+    const written = assertMetadataObjectParam(findMetadataExecution(state));
+    assert.equal(written.scope_depth, "full", testCase.label + ": depth should fall back to full");
+    assert.match(written.scope_reason, /fallback to full/, testCase.label + ": reason diagnostic");
+    assert.match(written.scope_risk, /fallback to full/, testCase.label + ": risk diagnostic");
+    assert.equal(written.scope_assessment_status, "completed", testCase.label);
+  }
+});
+
+test("kanban-rules normalizes scope_depth case and dashes", () => {
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope-norm": {
+        id: "card-scope-norm",
+        title: "Scope normalize card",
+        status: "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-7",
+        deferred_dod_json: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM task_dispatches WHERE id = ?",
+        result: [
+          {
+            id: "dispatch-scope-norm",
+            kanban_card_id: "card-scope-norm",
+            to_agent_id: "agent-7",
+            dispatch_type: "scope-assessment",
+            chain_depth: 0,
+            created_at: "2026-06-19 09:00:00",
+            result: JSON.stringify({ scope_depth: " Plan-Only ", scope_reason: "r", scope_risk: "k" }),
+            context: "{}",
+            status: "completed"
+          }
+        ]
+      },
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: "{}" }]
+      }
+    ])
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-scope-norm" });
+
+  const written = assertMetadataObjectParam(findMetadataExecution(state));
+  assert.equal(written.scope_depth, "plan_only");
+  assert.equal(written.scope_reason, "r");
+  assert.equal(written.scope_risk, "k");
+});

--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -633,6 +633,50 @@ test("kanban-rules does not dispatch scope-assessment twice when status already 
   assert.equal(state.dispatchCreates.length, 0);
 });
 
+test("kanban-rules skips scope-assessment when the card has no assigned agent (#3605)", () => {
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope-noassignee": {
+        id: "card-scope-noassignee",
+        title: "Unassigned scope card",
+        github_issue_number: null,
+        github_issue_url: null,
+        status: "requested",
+        // Long body containing "DoD" → preflight returns "clear" so the
+        // scope-assessment trigger is reached (not short-circuited earlier).
+        description: "This issue body is comfortably longer than thirty characters and lists a DoD.",
+        assigned_agent_id: null,
+        metadata: "{}",
+        blocked_reason: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      { match: "SELECT metadata FROM kanban_cards WHERE id = ?", result: [{ metadata: "{}" }] },
+      {
+        match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
+        result: []
+      },
+      // _maybeDispatchScopeAssessment's own lookup: assignee is falsy → skip.
+      {
+        match: "SELECT assigned_agent_id, title FROM kanban_cards WHERE id = ?",
+        result: [{ assigned_agent_id: null, title: "Unassigned scope card" }]
+      }
+    ])
+  });
+
+  policy.onCardTransition({ card_id: "card-scope-noassignee", from: "backlog", to: "requested" });
+
+  // No assignee → cannot route to "the assigned agent": log + return, no dispatch.
+  assert.equal(state.dispatchCreates.length, 0);
+  // And no scope metadata is written (status stays unset so a later requested
+  // entry can re-evaluate once an agent is assigned).
+  assert.equal(findScopeAssessmentMeta(state), undefined);
+  assert.ok(
+    state.logs.info.some((line) => /no assigned agent — skipping scope-assessment/.test(line)),
+    "expected the no-assignee skip to be logged"
+  );
+});
+
 test("kanban-rules does not dispatch scope-assessment when preflight is already_applied", () => {
   const { policy, state } = loadPolicy("policies/kanban-rules.js", {
     cards: {

--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -710,6 +710,51 @@ test("kanban-rules does not dispatch scope-assessment when preflight is already_
   assert.equal(state.dispatchCreates.length, 0);
 });
 
+test("kanban-rules does not dispatch scope-assessment when preflight is consult_required (codex R2 #3605)", () => {
+  // A short, non-empty body (<30 chars) → preflight returns "consult_required":
+  // the issue needs counterpart consultation FIRST. The scope-assessment trigger
+  // must NOT fire here — scope is meaningless until the consultation clarifies the
+  // issue, and emitting it would add a redundant side-path dispatch. Only
+  // "clear"/"assumption_ok" (preflight cleared) warrant a pre-implementation
+  // scope read.
+  const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-scope-consult": {
+        id: "card-scope-consult",
+        title: "Vague scope card",
+        github_issue_number: null,
+        github_issue_url: null,
+        status: "requested",
+        // < 30 chars, non-empty → consult_required (kanban-preflight Check 3).
+        description: "Too short, needs consult",
+        assigned_agent_id: "agent-7",
+        metadata: "{}",
+        blocked_reason: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      { match: "SELECT metadata FROM kanban_cards WHERE id = ?", result: [{ metadata: "{}" }] },
+      {
+        match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
+        result: []
+      },
+      // If the (buggy) trigger reached _maybeDispatchScopeAssessment, this is the
+      // lookup it would run. Provide a valid assignee so the ONLY thing that can
+      // stop a dispatch is the consult_required trigger-condition guard itself.
+      {
+        match: "SELECT assigned_agent_id, title FROM kanban_cards WHERE id = ?",
+        result: [{ assigned_agent_id: "agent-7", title: "Vague scope card" }]
+      }
+    ])
+  });
+
+  policy.onCardTransition({ card_id: "card-scope-consult", from: "backlog", to: "requested" });
+
+  // consult_required → no scope-assessment dispatch, no scope metadata written.
+  assert.equal(state.dispatchCreates.length, 0);
+  assert.equal(findScopeAssessmentMeta(state), undefined);
+});
+
 test("kanban-rules records scope-assessment result on the card metadata and stays inert", () => {
   const { policy, state } = loadPolicy("policies/kanban-rules.js", {
     cards: {

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -224,6 +224,12 @@ test("timeouts reconcile fallback does not advance a completed scope-assessment 
             deferred_dod_json: null
           }
         ]
+      },
+      {
+        // #3605 (T2): the fallback now records scope_depth via the shared
+        // recorder, which reads the card metadata first.
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: "{}" }]
       }
     ])
   });
@@ -241,6 +247,70 @@ test("timeouts reconcile fallback does not advance a completed scope-assessment 
     state.executions.filter((e) => /UPDATE agents SET xp = xp/.test(e.sql)).length,
     0
   );
+  // #3605 (T2): but the fallback MUST still record scope_depth (parity with the
+  // live hook) — previously it only `continue`d and lost the result entirely.
+  const metaWrite = state.executions.find((e) =>
+    /UPDATE kanban_cards SET metadata = \?/.test(e.sql)
+  );
+  assert.ok(metaWrite, "fallback must persist scope-assessment metadata");
+  const meta = metaWrite.params[0];
+  assert.equal(meta.scope_depth, "direct");
+  assert.equal(meta.scope_assessment_status, "completed");
+});
+
+test("timeouts reconcile fallback applies full fallback for an unparsable scope-assessment (#3605)", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { pm_decision_gate_enabled: true },
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT key, value FROM kv_meta WHERE key LIKE 'reconcile_dispatch:%'",
+        result: [{ key: "reconcile_dispatch:dispatch-scope-fb", value: "dispatch-scope-fb" }]
+      },
+      {
+        match: "SELECT id, kanban_card_id, to_agent_id, dispatch_type, chain_depth, status, result, context FROM task_dispatches WHERE id = ?",
+        result: [
+          {
+            id: "dispatch-scope-fb",
+            kanban_card_id: "card-scope-fb",
+            to_agent_id: "agent-1",
+            dispatch_type: "scope-assessment",
+            chain_depth: 0,
+            status: "completed",
+            result: "not json at all",
+            context: "{}"
+          }
+        ]
+      },
+      {
+        match: "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
+        result: [
+          {
+            id: "card-scope-fb",
+            status: "requested",
+            priority: "medium",
+            assigned_agent_id: "agent-1",
+            deferred_dod_json: null
+          }
+        ]
+      },
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: "{}" }]
+      }
+    ])
+  });
+
+  policy._section_R();
+
+  // Unparsable result → cautious "full" fallback, recorded even on the
+  // missed-hook path; card still inert (no advance).
+  assert.deepEqual(state.statusCalls, []);
+  const metaWrite = state.executions.find((e) =>
+    /UPDATE kanban_cards SET metadata = \?/.test(e.sql)
+  );
+  assert.ok(metaWrite, "fallback must persist scope metadata even when unparsable");
+  assert.equal(metaWrite.params[0].scope_depth, "full");
+  assert.match(metaWrite.params[0].scope_reason, /fallback to full/);
 });
 
 test("timeouts review timeout module escalates overdue DoD waits", () => {

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -128,6 +128,121 @@ test("timeouts card timeout module marks requested dispatches failed before retr
   assert.deepEqual(toPlain(state.executions[0].params), ["card-requested-1"]);
 });
 
+test("timeouts requested sweep skips consultation side-path dispatches (#256)", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { requested_timeout_min: 30 },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM kanban_cards kc LEFT JOIN task_dispatches td ON td.id = kc.latest_dispatch_id",
+        result: [
+          {
+            id: "card-consult-1",
+            assigned_agent_id: "agent-1",
+            latest_dispatch_id: "dispatch-consult-1",
+            retry_count: 0,
+            dispatch_type: "consultation"
+          }
+        ]
+      }
+    ])
+  });
+
+  policy._section_A();
+
+  // Consultation side-path: never marked failed, never retried/escalated.
+  assert.deepEqual(state.dispatchMarkFailedCalls, []);
+  assert.deepEqual(state.manualInterventions, []);
+  assert.equal(
+    state.executions.filter((e) => /UPDATE kanban_cards SET requested_at/.test(e.sql)).length,
+    0
+  );
+});
+
+test("timeouts requested sweep skips scope-assessment side-path even when overdue (#3605)", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { requested_timeout_min: 30 },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM kanban_cards kc LEFT JOIN task_dispatches td ON td.id = kc.latest_dispatch_id",
+        result: [
+          {
+            id: "card-scope-1",
+            assigned_agent_id: "agent-1",
+            latest_dispatch_id: "dispatch-scope-1",
+            retry_count: 0,
+            dispatch_type: "scope-assessment"
+          }
+        ]
+      }
+    ])
+  });
+
+  policy._section_A();
+
+  // #3605 (T2) inert side-path: the requested-timeout sweep must NOT mark the
+  // scope-assessment dispatch failed nor retry/escalate the card, exactly like
+  // consultation. A scope-assessment that lingers in `requested` is harmless.
+  assert.deepEqual(state.dispatchMarkFailedCalls, []);
+  assert.deepEqual(state.manualInterventions, []);
+  assert.equal(
+    state.executions.filter((e) => /UPDATE kanban_cards SET requested_at/.test(e.sql)).length,
+    0
+  );
+});
+
+test("timeouts reconcile fallback does not advance a completed scope-assessment (#3605)", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { pm_decision_gate_enabled: true },
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT key, value FROM kv_meta WHERE key LIKE 'reconcile_dispatch:%'",
+        result: [{ key: "reconcile_dispatch:dispatch-scope-r", value: "dispatch-scope-r" }]
+      },
+      {
+        match: "SELECT id, kanban_card_id, to_agent_id, dispatch_type, chain_depth, status, result, context FROM task_dispatches WHERE id = ?",
+        result: [
+          {
+            id: "dispatch-scope-r",
+            kanban_card_id: "card-scope-r",
+            to_agent_id: "agent-1",
+            dispatch_type: "scope-assessment",
+            chain_depth: 0,
+            status: "completed",
+            result: JSON.stringify({ scope_depth: "direct" }),
+            context: "{}"
+          }
+        ]
+      },
+      {
+        match: "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
+        result: [
+          {
+            id: "card-scope-r",
+            status: "requested",
+            priority: "medium",
+            assigned_agent_id: "agent-1",
+            deferred_dod_json: null
+          }
+        ]
+      }
+    ])
+  });
+
+  policy._section_R();
+
+  // Missed-hook fallback must mirror kanban-rules.js onDispatchCompleted: a
+  // completed scope-assessment is an inert side-path. No card advance (no
+  // setStatus to review), no XP grant, no PM-gate-driven status changes.
+  assert.deepEqual(state.statusCalls, []);
+  assert.deepEqual(state.reviewStatusCalls, []);
+  assert.deepEqual(state.reviewStateSyncs, []);
+  // XP UPDATE (agents SET xp = xp + ?) must not fire for a side-path.
+  assert.equal(
+    state.executions.filter((e) => /UPDATE agents SET xp = xp/.test(e.sql)).length,
+    0
+  );
+});
+
 test("timeouts review timeout module escalates overdue DoD waits", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     dbQuery: createSqlRouter([

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -176,6 +176,13 @@ var autoQueue = {
     if (dispatches.length === 0) return;
 
     var dispatch = dispatches[0];
+
+    // #3605 (T2): scope-assessment is a side-path owned by kanban-rules
+    // (records scope_depth on the card metadata). It never participates in the
+    // auto-queue phase-gate continuation, so guard it out explicitly rather
+    // than relying on the phase_gate context check below.
+    if (dispatch.dispatch_type === "scope-assessment") return;
+
     var context = {};
     if (dispatch.context && dispatch.context !== "{}" && dispatch.context !== "[]") {
       try { context = JSON.parse(dispatch.context); } catch (e) { context = {}; }

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -20,6 +20,8 @@ var _autoQueueDispatchLib = require("./lib/auto-queue-dispatch");
 var _autoQueuePhaseGateLib = require("./lib/auto-queue-phase-gate");
 var _autoQueueLifecycleLib = require("./lib/auto-queue-lifecycle");
 var _autoQueueErrorRecoveryLib = require("./lib/auto-queue-error-recovery");
+// #3605 (T2): canonical inert side-path predicate (consultation, scope-assessment).
+var isSidePathDispatch = require("./lib/dispatch-side-path").isSidePathDispatch;
 
 // ── log helpers (re-export the names the rest of the file used) ────────
 var _autoQueueHasValue = _autoQueueLogLib.hasValue;
@@ -177,11 +179,13 @@ var autoQueue = {
 
     var dispatch = dispatches[0];
 
-    // #3605 (T2): scope-assessment is a side-path owned by kanban-rules
-    // (records scope_depth on the card metadata). It never participates in the
-    // auto-queue phase-gate continuation, so guard it out explicitly rather
-    // than relying on the phase_gate context check below.
-    if (dispatch.dispatch_type === "scope-assessment") return;
+    // #256/#3605 (T2): inert side-paths (consultation, scope-assessment) are
+    // owned by kanban-rules (preflight/scope_depth metadata) and never
+    // participate in the auto-queue phase-gate continuation. Guard them out
+    // explicitly via the shared predicate rather than relying solely on the
+    // phase_gate context check below. (Both already lack a phase_gate context,
+    // so this is an explicit, future-proof early return — no behavior change.)
+    if (isSidePathDispatch(dispatch.dispatch_type)) return;
 
     var context = {};
     if (dispatch.context && dispatch.context !== "{}" && dispatch.context !== "[]") {

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -531,13 +531,25 @@ var rules = {
       // "clear" and "assumption_ok" → do nothing, auto-queue will create implementation dispatch
 
       // #3605 (T2): scope-assessment side-path. Once per card, right after
-      // preflight clears (NOT invalid/already_applied → those went terminal
-      // above), dispatch a scope-assessment to the ASSIGNED agent so it can
-      // record the issue's scale (scope_depth) before implementation. This is
-      // the only clean hook between assignment and the implementation dispatch
-      // (no per-assign hook exists). The depth is inert in T2 (no flow change);
-      // the T3 consumer reads it later.
-      if (preflight.status !== "invalid" && preflight.status !== "already_applied") {
+      // preflight CLEARS, dispatch a scope-assessment to the ASSIGNED agent so
+      // it can record the issue's scale (scope_depth) before implementation.
+      // This is the only clean hook between assignment and the implementation
+      // dispatch (no per-assign hook exists). The depth is inert in T2 (no flow
+      // change); the T3 consumer reads it later.
+      //
+      // codex R2 (#3605): fire ONLY on the "preflight cleared" statuses
+      // ("clear" / "assumption_ok"), NOT merely "not invalid/already_applied".
+      // The previous wide condition also fired on "consult_required" (issue is
+      // too short/unclear and needs counterpart consultation FIRST) — emitting a
+      // scope-assessment there is premature: scope is meaningless until the
+      // consultation clarifies the issue, and it adds a redundant side-path
+      // dispatch. invalid/already_applied went terminal above; consult_required
+      // is handled by the consultation path; only clear/assumption_ok proceed to
+      // implementation and warrant a pre-implementation scope read.
+      if (
+        preflight.status === "clear" ||
+        preflight.status === "assumption_ok"
+      ) {
         _maybeDispatchScopeAssessment(payload.card_id);
       }
     }

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -45,6 +45,16 @@ var _autoRefreshInventoryDocs = _inventory._autoRefreshInventoryDocs;
 var _preflight = require("./lib/kanban-preflight");
 var _runPreflight = _preflight._runPreflight;
 
+// #3605 (T2): scope-assessment result recorder is shared with
+// timeouts/reconciliation.js (missed-hook fallback) so both paths record
+// scope_depth + fall back to "full" identically.
+var _scopeAssessment = require("./lib/kanban-scope-assessment");
+var _recordScopeAssessment = _scopeAssessment._recordScopeAssessment;
+
+// #3605 (T2): canonical inert side-path dispatch-type predicate (shared).
+var _sidePath = require("./lib/dispatch-side-path");
+var isSidePathDispatch = _sidePath.isSidePathDispatch;
+
 // #3605 (T2): scope-assessment dispatch creation. Unlike consultation (#256)
 // which swaps to the counter-provider, this is sent to the ASSIGNED agent on
 // its primary channel — "scope-assessment" is intentionally absent from
@@ -64,15 +74,6 @@ function _createScopeAssessmentDispatch(cardId, agentId, title) {
     agentdesk.log.warn("[scope] scope-assessment dispatch failed for " + cardId + ": " + e);
     return null;
   }
-}
-
-// #3605 (T2): canonical scope_depth whitelist. Any agent output outside this set
-// (missing / unparsable / timeout / typo) falls back to "full" (most cautious).
-var SCOPE_DEPTH_VALUES = { full: true, plan_only: true, direct: true };
-function _normalizeScopeDepth(raw) {
-  if (typeof raw !== "string") return null;
-  var v = raw.trim().toLowerCase().replace(/-/g, "_");
-  return SCOPE_DEPTH_VALUES[v] ? v : null;
 }
 
 // #3605 (T2): once-only scope-assessment trigger. Reads the card's
@@ -110,38 +111,6 @@ function _maybeDispatchScopeAssessment(cardId) {
   agentdesk.log.info("[scope] Card " + cardId + " → scope-assessment dispatch " + dispatchId + " (agent " + agentId + ")");
 }
 
-// #3605 (T2): record scope-assessment result on the card metadata. Fail-safe
-// normalization: any scope_depth outside {full,plan_only,direct} → "full"
-// (most cautious). Missing reason/risk become diagnostic strings. No flow
-// change (inert) — depth is consumed by the T3 phase.
-function _recordScopeAssessment(cardId, dispatch) {
-  var parsed = {};
-  try { parsed = JSON.parse(dispatch.result || "{}"); } catch (e) { parsed = {}; }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) parsed = {};
-
-  var depth = _normalizeScopeDepth(parsed.scope_depth);
-  var fellBack = depth === null;
-  if (fellBack) depth = "full";
-
-  var reason = (typeof parsed.scope_reason === "string" && parsed.scope_reason.trim() !== "")
-    ? parsed.scope_reason
-    : (fellBack ? "unspecified (fallback to full)" : "unspecified");
-  var risk = (typeof parsed.scope_risk === "string" && parsed.scope_risk.trim() !== "")
-    ? parsed.scope_risk
-    : (fellBack ? "unspecified (fallback to full)" : "unspecified");
-
-  _mergeCardMetadata(cardId, {
-    scope_depth: depth,
-    scope_reason: reason,
-    scope_risk: risk,
-    scope_assessment_status: "completed",
-    scope_assessment_result: parsed
-  });
-  agentdesk.log.info(
-    "[scope] Card " + cardId + " scope-assessment completed: depth=" + depth +
-    (fellBack ? " (fallback)" : "")
-  );
-}
 
 // ── Policy ───────────────────────────────────────────────────
 

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -45,6 +45,104 @@ var _autoRefreshInventoryDocs = _inventory._autoRefreshInventoryDocs;
 var _preflight = require("./lib/kanban-preflight");
 var _runPreflight = _preflight._runPreflight;
 
+// #3605 (T2): scope-assessment dispatch creation. Unlike consultation (#256)
+// which swaps to the counter-provider, this is sent to the ASSIGNED agent on
+// its primary channel — "scope-assessment" is intentionally absent from
+// `use_counter_model_channel` (outbox_route.rs), so routing falls back to the
+// assigned agent's primary channel. Kept local (not in auto-queue lib) because
+// this is a kanban-rules side-path, not an auto-queue lifecycle operation.
+function _createScopeAssessmentDispatch(cardId, agentId, title) {
+  try {
+    var dispatchId = agentdesk.dispatch.create(
+      cardId,
+      agentId,
+      "scope-assessment",
+      "[Scope Assessment] " + (title || cardId)
+    );
+    return dispatchId || null;
+  } catch (e) {
+    agentdesk.log.warn("[scope] scope-assessment dispatch failed for " + cardId + ": " + e);
+    return null;
+  }
+}
+
+// #3605 (T2): canonical scope_depth whitelist. Any agent output outside this set
+// (missing / unparsable / timeout / typo) falls back to "full" (most cautious).
+var SCOPE_DEPTH_VALUES = { full: true, plan_only: true, direct: true };
+function _normalizeScopeDepth(raw) {
+  if (typeof raw !== "string") return null;
+  var v = raw.trim().toLowerCase().replace(/-/g, "_");
+  return SCOPE_DEPTH_VALUES[v] ? v : null;
+}
+
+// #3605 (T2): once-only scope-assessment trigger. Reads the card's
+// `scope_assessment_status`; if already set (pending/completed/skipped) it is a
+// no-op (dedupe). Otherwise it resolves the assigned agent, dispatches the
+// scope-assessment, and immediately marks `scope_assessment_status:"pending"`
+// (mirrors consultation.rs writing consultation_status="pending" up-front).
+function _maybeDispatchScopeAssessment(cardId) {
+  var meta = _loadCardMetadata(cardId);
+  if (meta.scope_assessment_status) {
+    // pending / completed / skipped → already handled, never dispatch twice.
+    return;
+  }
+  var rows = agentdesk.db.query(
+    "SELECT assigned_agent_id, title FROM kanban_cards WHERE id = ?",
+    [cardId]
+  );
+  if (rows.length === 0 || !rows[0].assigned_agent_id) {
+    // No assignee yet → cannot route to "the assigned agent". Skip silently;
+    // the trigger re-evaluates on the next requested entry.
+    agentdesk.log.info("[scope] Card " + cardId + " has no assigned agent — skipping scope-assessment");
+    return;
+  }
+  var agentId = rows[0].assigned_agent_id;
+  var dispatchId = _createScopeAssessmentDispatch(cardId, agentId, rows[0].title);
+  if (!dispatchId) {
+    // Dispatch creation failed — do NOT mark pending so a later requested entry
+    // can retry. T2 is inert, so a missing scope-assessment never blocks flow.
+    return;
+  }
+  _mergeCardMetadata(cardId, {
+    scope_assessment_status: "pending",
+    scope_assessment_dispatch_id: dispatchId
+  });
+  agentdesk.log.info("[scope] Card " + cardId + " → scope-assessment dispatch " + dispatchId + " (agent " + agentId + ")");
+}
+
+// #3605 (T2): record scope-assessment result on the card metadata. Fail-safe
+// normalization: any scope_depth outside {full,plan_only,direct} → "full"
+// (most cautious). Missing reason/risk become diagnostic strings. No flow
+// change (inert) — depth is consumed by the T3 phase.
+function _recordScopeAssessment(cardId, dispatch) {
+  var parsed = {};
+  try { parsed = JSON.parse(dispatch.result || "{}"); } catch (e) { parsed = {}; }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) parsed = {};
+
+  var depth = _normalizeScopeDepth(parsed.scope_depth);
+  var fellBack = depth === null;
+  if (fellBack) depth = "full";
+
+  var reason = (typeof parsed.scope_reason === "string" && parsed.scope_reason.trim() !== "")
+    ? parsed.scope_reason
+    : (fellBack ? "unspecified (fallback to full)" : "unspecified");
+  var risk = (typeof parsed.scope_risk === "string" && parsed.scope_risk.trim() !== "")
+    ? parsed.scope_risk
+    : (fellBack ? "unspecified (fallback to full)" : "unspecified");
+
+  _mergeCardMetadata(cardId, {
+    scope_depth: depth,
+    scope_reason: reason,
+    scope_risk: risk,
+    scope_assessment_status: "completed",
+    scope_assessment_result: parsed
+  });
+  agentdesk.log.info(
+    "[scope] Card " + cardId + " scope-assessment completed: depth=" + depth +
+    (fellBack ? " (fallback)" : "")
+  );
+}
+
 // ── Policy ───────────────────────────────────────────────────
 
 var rules = {
@@ -184,6 +282,16 @@ var rules = {
 
     // #197: e2e-test dispatches — handled by deploy-pipeline policy
     if (dispatch.dispatch_type === "e2e-test") return;
+
+    // #3605 (T2): scope-assessment dispatch completed — record depth on the
+    // card metadata and stop. This is a side-path (the card never advanced to
+    // in_progress on attach — see transition.rs skip_kickoff), so completion
+    // must NOT flow into the PM gate / review / XP lifecycle below. The depth
+    // is inert in T2: no redispatch, no escalate, no manual intervention.
+    if (dispatch.dispatch_type === "scope-assessment") {
+      _recordScopeAssessment(dispatch.kanban_card_id, dispatch);
+      return;
+    }
 
     // #256: Consultation dispatch completed — update preflight metadata
     if (dispatch.dispatch_type === "consultation") {
@@ -452,6 +560,17 @@ var rules = {
         agentdesk.log.info("[preflight] Card " + payload.card_id + " needs consultation: " + preflight.summary);
       }
       // "clear" and "assumption_ok" → do nothing, auto-queue will create implementation dispatch
+
+      // #3605 (T2): scope-assessment side-path. Once per card, right after
+      // preflight clears (NOT invalid/already_applied → those went terminal
+      // above), dispatch a scope-assessment to the ASSIGNED agent so it can
+      // record the issue's scale (scope_depth) before implementation. This is
+      // the only clean hook between assignment and the implementation dispatch
+      // (no per-assign hook exists). The depth is inert in T2 (no flow change);
+      // the T3 consumer reads it later.
+      if (preflight.status !== "invalid" && preflight.status !== "already_applied") {
+        _maybeDispatchScopeAssessment(payload.card_id);
+      }
     }
   },
 

--- a/policies/lib/dispatch-side-path.js
+++ b/policies/lib/dispatch-side-path.js
@@ -1,0 +1,31 @@
+/** @module policies/lib/dispatch-side-path
+ *
+ * #3605 (T2): canonical "inert side-path" dispatch-type set, shared across the
+ * JS policy layer (kanban-rules, timeouts/*). A side-path dispatch records
+ * information about a card without ever advancing, completing, or failing it: it
+ * stays pinned in `requested` and its completion must not flow into the
+ * implementation / review / PM-gate lifecycle.
+ *
+ * `consultation` (#256) was the first such type; `scope-assessment` (#3605) is
+ * the second. Centralizing the set here means every `=== "consultation"`
+ * side-path guard is replaced by `isSidePathDispatch(type)` so the two are
+ * mirrored consistently and future side-path types are added in exactly one
+ * place. This is the JS counterpart of Rust
+ * `dispatch::SIDE_PATH_DISPATCH_TYPES` / `dispatch_is_side_path`.
+ *
+ * NB: this set is intentionally about lifecycle inertness only. It is NOT the
+ * "counter-model channel" set (review|e2e-test|consultation) — scope-assessment
+ * routes to the assigned agent's primary channel, so channel routing is a
+ * separate concern and must not read this predicate.
+ */
+
+var SIDE_PATH_DISPATCH_TYPES = ["consultation", "scope-assessment"];
+
+function isSidePathDispatch(dispatchType) {
+  return SIDE_PATH_DISPATCH_TYPES.indexOf(dispatchType) !== -1;
+}
+
+module.exports = {
+  SIDE_PATH_DISPATCH_TYPES: SIDE_PATH_DISPATCH_TYPES,
+  isSidePathDispatch: isSidePathDispatch
+};

--- a/policies/lib/kanban-scope-assessment.js
+++ b/policies/lib/kanban-scope-assessment.js
@@ -1,0 +1,64 @@
+/** @module policies/lib/kanban-scope-assessment
+ *
+ * #3605 (T2): scope-assessment side-path result recording. Extracted from
+ * kanban-rules.js so the missed-hook fallback in timeouts/reconciliation.js can
+ * call the SAME recorder instead of dropping the result. Both the live
+ * onDispatchCompleted hook (kanban-rules.js) and the DB-fallback replay
+ * (reconciliation.js) must record scope_depth + fall back to "full" identically;
+ * keeping the logic in one module is the only way to guarantee parity.
+ *
+ * The recorder is inert: it writes metadata only and never advances the card.
+ * It depends on the global `agentdesk` surface via kanban-card-metadata.
+ */
+
+var _cardMetadata = require("./kanban-card-metadata");
+var _mergeCardMetadata = _cardMetadata._mergeCardMetadata;
+
+// Canonical scope_depth whitelist. Any agent output outside this set
+// (missing / unparsable / timeout / typo) falls back to "full" (most cautious).
+var SCOPE_DEPTH_VALUES = { full: true, plan_only: true, direct: true };
+
+function _normalizeScopeDepth(raw) {
+  if (typeof raw !== "string") return null;
+  var v = raw.trim().toLowerCase().replace(/-/g, "_");
+  return SCOPE_DEPTH_VALUES[v] ? v : null;
+}
+
+// Record scope-assessment result on the card metadata. Fail-safe normalization:
+// any scope_depth outside {full,plan_only,direct} → "full" (most cautious).
+// Missing reason/risk become diagnostic strings. No flow change (inert) — depth
+// is consumed by the T3 phase. `dispatch` only needs a `.result` field.
+function _recordScopeAssessment(cardId, dispatch) {
+  var parsed = {};
+  try { parsed = JSON.parse(dispatch.result || "{}"); } catch (e) { parsed = {}; }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) parsed = {};
+
+  var depth = _normalizeScopeDepth(parsed.scope_depth);
+  var fellBack = depth === null;
+  if (fellBack) depth = "full";
+
+  var reason = (typeof parsed.scope_reason === "string" && parsed.scope_reason.trim() !== "")
+    ? parsed.scope_reason
+    : (fellBack ? "unspecified (fallback to full)" : "unspecified");
+  var risk = (typeof parsed.scope_risk === "string" && parsed.scope_risk.trim() !== "")
+    ? parsed.scope_risk
+    : (fellBack ? "unspecified (fallback to full)" : "unspecified");
+
+  _mergeCardMetadata(cardId, {
+    scope_depth: depth,
+    scope_reason: reason,
+    scope_risk: risk,
+    scope_assessment_status: "completed",
+    scope_assessment_result: parsed
+  });
+  agentdesk.log.info(
+    "[scope] Card " + cardId + " scope-assessment completed: depth=" + depth +
+    (fellBack ? " (fallback)" : "")
+  );
+}
+
+module.exports = {
+  SCOPE_DEPTH_VALUES: SCOPE_DEPTH_VALUES,
+  _normalizeScopeDepth: _normalizeScopeDepth,
+  _recordScopeAssessment: _recordScopeAssessment
+};

--- a/policies/timeouts/card-timeouts.js
+++ b/policies/timeouts/card-timeouts.js
@@ -1,3 +1,5 @@
+var isSidePathDispatch = require("../lib/dispatch-side-path").isSidePathDispatch;
+
 module.exports = function attachCardTimeouts(timeouts, helpers) {
   var sendDeadlockAlert = helpers.sendDeadlockAlert;
   var MAX_DISPATCH_RETRIES = helpers.MAX_DISPATCH_RETRIES;
@@ -48,14 +50,13 @@ module.exports = function attachCardTimeouts(timeouts, helpers) {
           agentdesk.log.info("[timeout] Card " + rc.id + " in " + aInitial + " without dispatch — preflight, skipping timeout");
           continue;
         }
-        // #256: Skip cards with consultation dispatch — consultation has its own
-        // lifecycle via onDispatchCompleted; let it resolve naturally.
-        // #3605 (T2): scope-assessment is the same kind of requested-pinned
-        // side-path — skip_kickoff (transition.rs) keeps the card in `requested`
-        // and makes the scope-assessment the latest_dispatch_id. Mirror the
-        // consultation guard so the requested-timeout sweep never marks the
-        // scope-assessment failed and retries/escalates the card. T2 is inert.
-        if (rc.dispatch_type === "consultation" || rc.dispatch_type === "scope-assessment") {
+        // #256/#3605 (T2): skip cards whose latest dispatch is an inert
+        // side-path (consultation, scope-assessment). They are requested-pinned
+        // (skip_kickoff keeps the card in `requested` while the side-path is the
+        // latest_dispatch_id) and resolve via onDispatchCompleted. The
+        // requested-timeout sweep must never mark a side-path failed nor
+        // retry/escalate the card. Shared predicate covers both types.
+        if (isSidePathDispatch(rc.dispatch_type)) {
           agentdesk.log.info("[timeout] Card " + rc.id + " in " + aInitial + " with " + rc.dispatch_type + " dispatch — skipping timeout");
           continue;
         }

--- a/policies/timeouts/card-timeouts.js
+++ b/policies/timeouts/card-timeouts.js
@@ -50,8 +50,13 @@ module.exports = function attachCardTimeouts(timeouts, helpers) {
         }
         // #256: Skip cards with consultation dispatch — consultation has its own
         // lifecycle via onDispatchCompleted; let it resolve naturally.
-        if (rc.dispatch_type === "consultation") {
-          agentdesk.log.info("[timeout] Card " + rc.id + " in " + aInitial + " with consultation dispatch — skipping timeout");
+        // #3605 (T2): scope-assessment is the same kind of requested-pinned
+        // side-path — skip_kickoff (transition.rs) keeps the card in `requested`
+        // and makes the scope-assessment the latest_dispatch_id. Mirror the
+        // consultation guard so the requested-timeout sweep never marks the
+        // scope-assessment failed and retries/escalates the card. T2 is inert.
+        if (rc.dispatch_type === "consultation" || rc.dispatch_type === "scope-assessment") {
+          agentdesk.log.info("[timeout] Card " + rc.id + " in " + aInitial + " with " + rc.dispatch_type + " dispatch — skipping timeout");
           continue;
         }
         // Dispatch를 failed로 — skip state changes if dispatch was already terminal

--- a/policies/timeouts/reconciliation.js
+++ b/policies/timeouts/reconciliation.js
@@ -1,3 +1,5 @@
+var _recordScopeAssessment = require("../lib/kanban-scope-assessment")._recordScopeAssessment;
+
 module.exports = function attachReconciliation(timeouts, helpers) {
   var sendDeadlockAlert = helpers.sendDeadlockAlert;
   var MAX_DISPATCH_RETRIES = helpers.MAX_DISPATCH_RETRIES;
@@ -68,14 +70,18 @@ module.exports = function attachReconciliation(timeouts, helpers) {
         var rPending = rInitial;
         if (agentdesk.pipeline.isTerminal(card.status, rCfg)) continue;
         if (di.dispatch_type === "review" || di.dispatch_type === "review-decision") continue;
-        // #3605 (T2): scope-assessment is a requested-pinned side-path. It never
-        // advances the card (kanban-rules.js onDispatchCompleted early-returns
-        // after recording scope_depth). This missed-hook fallback must mirror
-        // that: a completed scope-assessment must NOT run the PM gate / XP /
-        // review advance below, otherwise the fallback would mis-promote the
-        // card as if it were an implementation. Skip without advancing.
+        // #3605 (T2): scope-assessment is a requested-pinned side-path. This
+        // missed-hook fallback must mirror kanban-rules.js onDispatchCompleted
+        // EXACTLY: record scope_depth on the card (with the same full-fallback
+        // for missing/unparsable results) AND stay inert — never run the PM gate
+        // / XP / review advance below. Previously this only `continue`d, so a
+        // scope-assessment whose hook was missed lost its scope_depth entirely
+        // and never got the cautious "full" fallback. Calling the shared
+        // recorder fixes both. (_recordScopeAssessment merges status=completed,
+        // so it is idempotent if the hook later fires too.)
         if (di.dispatch_type === "scope-assessment") {
-          agentdesk.log.info("[reconcile] " + card.id + " scope-assessment completed — inert side-path, no advance");
+          _recordScopeAssessment(di.kanban_card_id, di);
+          agentdesk.log.info("[reconcile] " + card.id + " scope-assessment completed — recorded scope_depth, inert side-path (no advance)");
           continue;
         }
         if (di.dispatch_type === "rework") {

--- a/policies/timeouts/reconciliation.js
+++ b/policies/timeouts/reconciliation.js
@@ -68,6 +68,16 @@ module.exports = function attachReconciliation(timeouts, helpers) {
         var rPending = rInitial;
         if (agentdesk.pipeline.isTerminal(card.status, rCfg)) continue;
         if (di.dispatch_type === "review" || di.dispatch_type === "review-decision") continue;
+        // #3605 (T2): scope-assessment is a requested-pinned side-path. It never
+        // advances the card (kanban-rules.js onDispatchCompleted early-returns
+        // after recording scope_depth). This missed-hook fallback must mirror
+        // that: a completed scope-assessment must NOT run the PM gate / XP /
+        // review advance below, otherwise the fallback would mis-promote the
+        // card as if it were an implementation. Skip without advancing.
+        if (di.dispatch_type === "scope-assessment") {
+          agentdesk.log.info("[reconcile] " + card.id + " scope-assessment completed — inert side-path, no advance");
+          continue;
+        }
         if (di.dispatch_type === "rework") {
           agentdesk.kanban.setStatus(card.id, rReview);
           agentdesk.log.info("[reconcile] " + card.id + " rework done → " + rReview);

--- a/src/dispatch/dispatch_channel.rs
+++ b/src/dispatch/dispatch_channel.rs
@@ -4,6 +4,39 @@ pub(super) fn dispatch_uses_alt_channel(dispatch_type: &str) -> bool {
     matches!(dispatch_type, "review" | "e2e-test" | "consultation")
 }
 
+/// #3605 (T2): canonical set of "inert side-path" dispatch types — dispatches
+/// that record information about a card without ever advancing, completing, or
+/// failing it. They attach to the card (becoming `latest_dispatch_id`) but stay
+/// pinned in `requested`: they must never kick off the implementation lifecycle
+/// (see [`dispatch_type_skips_kickoff`]) and, crucially, their terminal
+/// completion must NOT finalize the bound auto_queue entry as `done` (otherwise
+/// a card would close with no implementation dispatch — see
+/// `dispatch_status::should_skip_auto_queue_terminal_sync`).
+///
+/// `consultation` (#256) was the first such type; `scope-assessment` (#3605) is
+/// the second. Centralizing the set here means every side-path guard mirrors the
+/// two consistently and future side-path types are added in exactly one place.
+pub(crate) const SIDE_PATH_DISPATCH_TYPES: &[&str] = &["consultation", "scope-assessment"];
+
+/// Whether `dispatch_type` is an inert side-path (see
+/// [`SIDE_PATH_DISPATCH_TYPES`]). Side-paths are owned by the policy layer
+/// (kanban-rules onDispatchCompleted) and must be treated as non-implementation,
+/// non-card-advancing work everywhere a guard distinguishes them.
+pub(crate) fn dispatch_is_side_path(dispatch_type: Option<&str>) -> bool {
+    dispatch_type.is_some_and(|t| SIDE_PATH_DISPATCH_TYPES.contains(&t))
+}
+
+/// Whether attaching `dispatch_type` to a card must NOT transition the card into
+/// its kickoff (in_progress) state. This is the broader set: review-family
+/// dispatches stay in their own review lifecycle, and inert side-paths
+/// ([`dispatch_is_side_path`]) stay pinned in `requested`. Used by both
+/// `transition::decide_dispatch_attached` (skip_kickoff) and
+/// `dispatch_create` (kickoff_state gate) so the two layers cannot drift.
+pub(crate) fn dispatch_type_skips_kickoff(dispatch_type: &str) -> bool {
+    matches!(dispatch_type, "review" | "review-decision" | "rework")
+        || dispatch_is_side_path(Some(dispatch_type))
+}
+
 pub(super) fn resolve_dispatch_channel_id(channel: &str) -> Option<u64> {
     channel
         .parse::<u64>()
@@ -57,4 +90,60 @@ pub(crate) fn dispatch_destination_provider_override(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+#[cfg(test)]
+mod side_path_predicate_tests {
+    use super::*;
+
+    #[test]
+    fn side_path_set_is_exactly_consultation_and_scope_assessment() {
+        // #3605 (T2): lock the canonical side-path set. consultation (#256) and
+        // scope-assessment (#3605) are the two inert side-paths. If a new
+        // side-path type is added it should be added HERE (one place) and this
+        // test updated — every guard reads through dispatch_is_side_path.
+        assert_eq!(
+            SIDE_PATH_DISPATCH_TYPES,
+            ["consultation", "scope-assessment"]
+        );
+        assert!(dispatch_is_side_path(Some("consultation")));
+        assert!(dispatch_is_side_path(Some("scope-assessment")));
+        assert!(!dispatch_is_side_path(Some("implementation")));
+        assert!(!dispatch_is_side_path(Some("review")));
+        assert!(!dispatch_is_side_path(Some("rework")));
+        assert!(!dispatch_is_side_path(None));
+    }
+
+    #[test]
+    fn skip_kickoff_covers_review_family_and_side_paths() {
+        // Review-family dispatches and inert side-paths must not kick a card to
+        // its in_progress state. This is the union used by transition.rs,
+        // dispatch_create, and phase_gate.
+        for t in [
+            "review",
+            "review-decision",
+            "rework",
+            "consultation",
+            "scope-assessment",
+        ] {
+            assert!(dispatch_type_skips_kickoff(t), "{t} must skip kickoff");
+        }
+        for t in ["implementation", "e2e-test", "pm-decision"] {
+            assert!(!dispatch_type_skips_kickoff(t), "{t} must NOT skip kickoff");
+        }
+    }
+
+    #[test]
+    fn side_path_is_a_strict_subset_of_skip_kickoff() {
+        // Every side-path must also skip kickoff (it stays in `requested`), but
+        // not every skip-kickoff type is a side-path (review-family is not).
+        for t in SIDE_PATH_DISPATCH_TYPES {
+            assert!(
+                dispatch_type_skips_kickoff(t),
+                "side-path {t} must be within the skip-kickoff set"
+            );
+        }
+        assert!(dispatch_type_skips_kickoff("review"));
+        assert!(!dispatch_is_side_path(Some("review")));
+    }
 }

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -762,18 +762,14 @@ async fn create_dispatch_core_internal(
         }
         base
     };
-    // NB: this is the broader "skip kickoff" set, not just review types — it
-    // already includes consultation. #3605 (T2): scope-assessment is the same
-    // kind of requested-pinned side-path as consultation, so it must NOT pass a
-    // kickoff_state into the transition. transition.rs::decide_dispatch_attached
-    // independently guards this via skip_kickoff (it already lists
-    // scope-assessment), so this is defense-in-depth parity across both layers;
-    // the only consumer is the kickoff_state gate below.
-    let is_review_type = dispatch_type == "review"
-        || dispatch_type == "review-decision"
-        || dispatch_type == "rework"
-        || dispatch_type == "consultation"
-        || dispatch_type == "scope-assessment";
+    // #3605 (T2): the broader "skip kickoff" set — review-family plus inert
+    // side-paths (consultation, scope-assessment). A side-path must NOT pass a
+    // kickoff_state into the transition so the card stays in `requested`. Shared
+    // with transition.rs::decide_dispatch_attached and phase_gate via
+    // dispatch_type_skips_kickoff; the only consumer is the kickoff_state gate
+    // below. (Variable name kept as `is_review_type` to avoid churn in the
+    // downstream helper signatures it feeds.)
+    let is_review_type = crate::dispatch::dispatch_type_skips_kickoff(dispatch_type);
     validate_dispatch_target_on_pg(
         pg_pool,
         kanban_card_id,

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -762,10 +762,18 @@ async fn create_dispatch_core_internal(
         }
         base
     };
+    // NB: this is the broader "skip kickoff" set, not just review types — it
+    // already includes consultation. #3605 (T2): scope-assessment is the same
+    // kind of requested-pinned side-path as consultation, so it must NOT pass a
+    // kickoff_state into the transition. transition.rs::decide_dispatch_attached
+    // independently guards this via skip_kickoff (it already lists
+    // scope-assessment), so this is defense-in-depth parity across both layers;
+    // the only consumer is the kickoff_state gate below.
     let is_review_type = dispatch_type == "review"
         || dispatch_type == "review-decision"
         || dispatch_type == "rework"
-        || dispatch_type == "consultation";
+        || dispatch_type == "consultation"
+        || dispatch_type == "scope-assessment";
     validate_dispatch_target_on_pg(
         pg_pool,
         kanban_card_id,

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -215,8 +215,16 @@ fn should_skip_auto_queue_terminal_sync(
         return false;
     }
 
+    // #3605 (T2): inert side-paths (consultation, scope-assessment) attach to a
+    // card and can briefly become its latest_dispatch_id, so the auto-queue
+    // activate path may bind a pending entry to them. Their completion must NOT
+    // finalize that entry as `done` — otherwise a card closes with no
+    // implementation dispatch ever having run. Skip the terminal sync for the
+    // whole side-path set, exactly as consultation has always been skipped.
+    if crate::dispatch::dispatch_is_side_path(dispatch_type) {
+        return true;
+    }
     match dispatch_type {
-        Some("consultation") => true,
         Some("implementation" | "rework") => !auto_queue_review_disabled,
         _ => false,
     }
@@ -1586,5 +1594,47 @@ mod auto_queue_terminal_sync_policy_tests {
             true,
             false
         ));
+    }
+
+    #[test]
+    fn scope_assessment_terminal_completion_never_finalizes_auto_queue_entry() {
+        // #3605 (T2): a scope-assessment is an inert side-path. If an auto-queue
+        // entry was bound to it (because it transiently became the card's
+        // latest_dispatch_id), its completion must NOT finalize that entry as
+        // `done` — that would close the card with no implementation dispatch.
+        // Mirror of the consultation guard above; review_disabled must not matter.
+        let result = serde_json::json!({"scope_depth": "full"});
+        for review_disabled in [false, true] {
+            assert!(
+                should_skip_auto_queue_terminal_sync(
+                    Some("scope-assessment"),
+                    "completed",
+                    Some(&result),
+                    true,
+                    review_disabled,
+                ),
+                "scope-assessment completion must skip terminal sync (review_disabled={review_disabled})"
+            );
+        }
+    }
+
+    #[test]
+    fn side_path_dispatch_types_are_all_skipped_on_completion() {
+        // Guard the centralized SIDE_PATH_DISPATCH_TYPES set: every member must
+        // skip the auto-queue terminal sync on completion so future additions to
+        // the set automatically inherit the protection.
+        let result = serde_json::json!({"summary": "side-path"});
+        for dispatch_type in crate::dispatch::SIDE_PATH_DISPATCH_TYPES {
+            assert!(
+                should_skip_auto_queue_terminal_sync(
+                    Some(dispatch_type),
+                    "completed",
+                    Some(&result),
+                    true,
+                    false,
+                ),
+                "{dispatch_type} is a side-path and must skip terminal sync"
+            );
+        }
     }
 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -14,6 +14,10 @@ pub use dispatch_cancel::{
 };
 pub(crate) use dispatch_channel::dispatch_destination_provider_override;
 #[allow(unused_imports)]
+pub(crate) use dispatch_channel::{
+    SIDE_PATH_DISPATCH_TYPES, dispatch_is_side_path, dispatch_type_skips_kickoff,
+};
+#[allow(unused_imports)]
 pub use dispatch_channel::{
     drain_unified_thread_kill_signals, is_unified_thread_channel_active,
     is_unified_thread_channel_name_active,

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -589,26 +589,28 @@ fn decide_dispatch_attached(
     kickoff_state: Option<&str>,
 ) -> TransitionDecision {
     let card = &ctx.card;
-    let is_review_type = matches!(dispatch_type, "review" | "review-decision" | "rework");
     // #3605 (T2): scope-assessment is a side-path that records the issue's scale
     // (scope_depth) before implementation. Like consultation it must stay in
     // `requested` — attaching it must NOT kick the card into the in_progress
     // state, otherwise it would race the real implementation dispatch and break
-    // the "side-path before implementation" intent.
-    let skip_kickoff =
-        is_review_type || dispatch_type == "consultation" || dispatch_type == "scope-assessment";
+    // the "side-path before implementation" intent. Shared predicate keeps this
+    // in lockstep with dispatch_create / phase_gate.
+    let skip_kickoff = crate::dispatch::dispatch_type_skips_kickoff(dispatch_type);
 
     let mut intents = vec![];
 
-    // Always set latest_dispatch_id
+    // Always set latest_dispatch_id. NB: side-paths (consultation,
+    // scope-assessment) deliberately become latest_dispatch_id too — exactly
+    // like consultation — so the card↔dispatch link is consistent. The
+    // protection against a side-path closing the card lives in the terminal-sync
+    // guards (dispatch_status / turn_bridge completion), not here.
     intents.push(TransitionIntent::SetLatestDispatchId {
         card_id: card.id.clone(),
         dispatch_id: Some(dispatch_id.to_string()),
     });
 
-    // Non-review and non-consultation dispatches transition to kickoff state.
-    // Consultation and scope-assessment dispatches stay in requested
-    // (side-paths, not implementation).
+    // Review-family and inert side-path dispatches stay in their current state
+    // (requested); only real implementation work transitions to kickoff.
     if !skip_kickoff {
         if let Some(kickoff) = kickoff_state {
             if card.status != kickoff {

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -590,7 +590,13 @@ fn decide_dispatch_attached(
 ) -> TransitionDecision {
     let card = &ctx.card;
     let is_review_type = matches!(dispatch_type, "review" | "review-decision" | "rework");
-    let skip_kickoff = is_review_type || dispatch_type == "consultation";
+    // #3605 (T2): scope-assessment is a side-path that records the issue's scale
+    // (scope_depth) before implementation. Like consultation it must stay in
+    // `requested` — attaching it must NOT kick the card into the in_progress
+    // state, otherwise it would race the real implementation dispatch and break
+    // the "side-path before implementation" intent.
+    let skip_kickoff =
+        is_review_type || dispatch_type == "consultation" || dispatch_type == "scope-assessment";
 
     let mut intents = vec![];
 
@@ -601,7 +607,8 @@ fn decide_dispatch_attached(
     });
 
     // Non-review and non-consultation dispatches transition to kickoff state.
-    // Consultation dispatches stay in requested (side-path, not implementation).
+    // Consultation and scope-assessment dispatches stay in requested
+    // (side-paths, not implementation).
     if !skip_kickoff {
         if let Some(kickoff) = kickoff_state {
             if card.status != kickoff {
@@ -1058,5 +1065,112 @@ mod gate_fail_closed_tests {
             ForceIntent::OperatorOverride,
         );
         assert_eq!(decision.outcome, TransitionOutcome::Allowed);
+    }
+}
+
+#[cfg(test)]
+mod dispatch_attached_tests {
+    //! #3605 (T2): a scope-assessment dispatch is a side-path. Like consultation
+    //! it must NOT kick the card into the kickoff (in_progress) state when
+    //! attached, so the assessment can run while the card stays in `requested`
+    //! and the real implementation dispatch is created separately.
+    use super::*;
+    use crate::pipeline::{
+        PhaseGateConfig, PipelineConfig, StateConfig, TransitionConfig, TransitionType,
+    };
+    use std::collections::HashMap;
+
+    /// Two-state pipeline `requested` → `in_progress` (in_progress is the kickoff
+    /// target for `requested`).
+    fn pipeline() -> PipelineConfig {
+        PipelineConfig {
+            name: "test".to_string(),
+            version: 1,
+            states: vec![
+                StateConfig {
+                    id: "requested".to_string(),
+                    label: "Requested".to_string(),
+                    terminal: false,
+                },
+                StateConfig {
+                    id: "in_progress".to_string(),
+                    label: "In Progress".to_string(),
+                    terminal: false,
+                },
+            ],
+            transitions: vec![TransitionConfig {
+                from: "requested".to_string(),
+                to: "in_progress".to_string(),
+                transition_type: TransitionType::Free,
+                gates: vec![],
+            }],
+            gates: HashMap::new(),
+            hooks: HashMap::new(),
+            events: HashMap::new(),
+            clocks: HashMap::new(),
+            timeouts: HashMap::new(),
+            phase_gate: PhaseGateConfig::default(),
+        }
+    }
+
+    fn ctx_requested() -> TransitionContext {
+        TransitionContext {
+            card: CardState {
+                id: "card-1".to_string(),
+                status: "requested".to_string(),
+                review_status: None,
+                latest_dispatch_id: None,
+            },
+            pipeline: pipeline(),
+            gates: GateSnapshot::default(),
+        }
+    }
+
+    fn attach(dispatch_type: &str) -> TransitionDecision {
+        decide_transition(
+            &ctx_requested(),
+            &TransitionEvent::DispatchAttached {
+                dispatch_id: "d-1".to_string(),
+                dispatch_type: dispatch_type.to_string(),
+                kickoff_state: Some("in_progress".to_string()),
+            },
+        )
+    }
+
+    fn kicks_to_in_progress(decision: &TransitionDecision) -> bool {
+        decision.intents.iter().any(|intent| {
+            matches!(
+                intent,
+                TransitionIntent::UpdateStatus { to, .. } if to == "in_progress"
+            )
+        })
+    }
+
+    /// Control: an implementation dispatch DOES kick the card to in_progress.
+    #[test]
+    fn implementation_dispatch_kicks_to_in_progress() {
+        assert!(kicks_to_in_progress(&attach("implementation")));
+    }
+
+    /// #3605: a scope-assessment dispatch must NOT kick the card to in_progress
+    /// (skip_kickoff), mirroring consultation.
+    #[test]
+    fn scope_assessment_dispatch_stays_in_requested() {
+        let decision = attach("scope-assessment");
+        assert!(
+            !kicks_to_in_progress(&decision),
+            "scope-assessment must not advance the card to in_progress"
+        );
+        // It still records the latest dispatch id (shared with all attaches).
+        assert!(decision.intents.iter().any(|intent| matches!(
+            intent,
+            TransitionIntent::SetLatestDispatchId { dispatch_id: Some(id), .. } if id == "d-1"
+        )));
+    }
+
+    /// Equivalence guard: scope-assessment behaves like consultation here.
+    #[test]
+    fn consultation_dispatch_stays_in_requested() {
+        assert!(!kicks_to_in_progress(&attach("consultation")));
     }
 }

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -1449,6 +1449,211 @@ mod tests {
             "one newly-created dispatch should consume the last available slot"
         );
     }
+
+    /// #3605 (codex R2) FIX1 regression: the auto-queue activate attach decision
+    /// must treat an inert side-path (consultation / scope-assessment) that has
+    /// become a card's `latest_dispatch_id` as NON-attachable, so a pending
+    /// auto_queue implementation entry is not hijacked onto the side-path
+    /// dispatch (which would leave it stuck in `dispatched` — the side-path
+    /// terminal completion skips the auto-queue terminal sync, and stale recovery
+    /// only reclaims cancelled/failed entries).
+    ///
+    /// These exercise the REAL production loader `load_activate_card_state_pg`
+    /// against real Postgres rows, then the `has_active_dispatch()` predicate the
+    /// activate loop branches on at `activate_with_deps_pg` (the
+    /// attach-vs-create-impl-dispatch fork). The module is `*_pg_tests` so its
+    /// tests are skipped via `--skip _pg_` when no local Postgres is configured.
+    mod side_path_hijack_pg_tests {
+        use super::super::load_activate_card_state_pg;
+        use crate::db::auto_queue::test_support::TestPostgresDb;
+        use sqlx::PgPool;
+
+        async fn seed_base(pool: &PgPool) {
+            sqlx::query(
+                "INSERT INTO auto_queue_runs (id, repo, agent_id, status, max_concurrent_threads)
+             VALUES ('run-1', 'repo-1', 'agent-1', 'active', 2)",
+            )
+            .execute(pool)
+            .await
+            .expect("seed run");
+            sqlx::query(
+                "INSERT INTO agents (id, name, provider, discord_channel_id)
+             VALUES ('agent-1', 'Agent 1', 'claude', '123')",
+            )
+            .execute(pool)
+            .await
+            .expect("seed agent");
+            sqlx::query(
+                "INSERT INTO kanban_cards (id, title, status, assigned_agent_id, repo_id)
+             VALUES ('card-1', 'Card 1', 'requested', 'agent-1', 'repo-1')",
+            )
+            .execute(pool)
+            .await
+            .expect("seed card");
+            sqlx::query(
+                "INSERT INTO auto_queue_entries
+                (id, run_id, kanban_card_id, agent_id, status, thread_group, batch_phase)
+             VALUES ('entry-1', 'run-1', 'card-1', 'agent-1', 'pending', 0, 0)",
+            )
+            .execute(pool)
+            .await
+            .expect("seed pending entry");
+        }
+
+        /// Attaches a live (dispatched) dispatch of `dispatch_type` to `card-1` and
+        /// points the card's `latest_dispatch_id` at it — exactly the state
+        /// `engine::transition::decide_dispatch_attached` produces when a dispatch is
+        /// attached to a card.
+        async fn attach_live_dispatch(pool: &PgPool, dispatch_id: &str, dispatch_type: &str) {
+            sqlx::query(
+            "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title)
+             VALUES ($1, 'card-1', 'agent-1', $2, 'dispatched', 'D')",
+        )
+        .bind(dispatch_id)
+        .bind(dispatch_type)
+        .execute(pool)
+        .await
+        .expect("seed dispatch");
+            sqlx::query("UPDATE kanban_cards SET latest_dispatch_id = $1 WHERE id = 'card-1'")
+                .bind(dispatch_id)
+                .execute(pool)
+                .await
+                .expect("set latest_dispatch_id");
+        }
+
+        #[tokio::test]
+        async fn scope_assessment_latest_dispatch_is_not_attachable_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            // A scope-assessment side-path is in-flight and is the card's
+            // latest_dispatch_id (status `dispatched`) while the impl entry is still
+            // pending — the exact hijack-prone state.
+            attach_live_dispatch(&pool, "dispatch-scope", "scope-assessment").await;
+
+            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
+                .await
+                .expect("load card state");
+
+            // The scope-assessment IS the latest dispatch and IS live...
+            assert_eq!(state.latest_dispatch_id.as_deref(), Some("dispatch-scope"));
+            assert_eq!(state.latest_dispatch_status.as_deref(), Some("dispatched"));
+            assert_eq!(
+                state.latest_dispatch_type.as_deref(),
+                Some("scope-assessment")
+            );
+            // ...but it must NOT be treated as an attachable implementation dispatch,
+            // so the activate loop falls through to creating a real impl dispatch
+            // instead of binding the pending entry to the side-path (the #3605 root
+            // bug: entry hijacked → stuck `dispatched`).
+            assert!(
+                !state.has_active_dispatch(),
+                "scope-assessment side-path must not be an attachable active dispatch"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn consultation_latest_dispatch_is_not_attachable_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            // Parity guard: consultation (the original side-path) is treated
+            // identically — even if it ever reached activate with a pending entry.
+            attach_live_dispatch(&pool, "dispatch-consult", "consultation").await;
+
+            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
+                .await
+                .expect("load card state");
+
+            assert_eq!(state.latest_dispatch_type.as_deref(), Some("consultation"));
+            assert!(
+                !state.has_active_dispatch(),
+                "consultation side-path must not be an attachable active dispatch"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn implementation_latest_dispatch_is_attachable_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            // Positive control: a genuine live implementation dispatch IS attachable
+            // — the side-path exclusion must not over-fire and suppress the normal
+            // idempotent reattach path.
+            attach_live_dispatch(&pool, "dispatch-impl", "implementation").await;
+
+            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
+                .await
+                .expect("load card state");
+
+            assert_eq!(
+                state.latest_dispatch_type.as_deref(),
+                Some("implementation")
+            );
+            assert!(
+                state.has_active_dispatch(),
+                "a live implementation dispatch must remain an attachable active dispatch"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn scope_assessment_completion_does_not_finalize_pending_entry_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            attach_live_dispatch(&pool, "dispatch-scope", "scope-assessment").await;
+
+            // FIX1 keeps the entry from ever binding to the side-path, so the entry
+            // stays `pending` (not `dispatched`). Completing the scope-assessment
+            // then runs the terminal-sync, which must NOT reach back and finalize the
+            // still-pending impl entry as `done` (that would close the card with no
+            // implementation ever run).
+            sqlx::query(
+            "UPDATE task_dispatches SET status = 'completed', completed_at = NOW() WHERE id = 'dispatch-scope'",
+        )
+        .execute(&pool)
+        .await
+        .expect("complete scope-assessment");
+
+            let mut tx = pool.begin().await.expect("begin tx");
+            let changed = crate::db::auto_queue::sync_dispatch_terminal_entries_on_pg_tx(
+                &mut tx,
+                "dispatch-scope",
+                crate::db::auto_queue::ENTRY_STATUS_DONE,
+                "test_scope_assessment_completion",
+                false,
+            )
+            .await
+            .expect("terminal sync");
+            tx.commit().await.expect("commit tx");
+
+            assert_eq!(
+                changed, 0,
+                "side-path completion must not finalize the pending impl entry"
+            );
+            let entry_status: String =
+                sqlx::query_scalar("SELECT status FROM auto_queue_entries WHERE id = 'entry-1'")
+                    .fetch_one(&pool)
+                    .await
+                    .expect("entry status");
+            assert_eq!(
+                entry_status, "pending",
+                "impl entry must remain pending — not stuck `dispatched` nor wrongly `done`"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+    }
 }
 
 impl ActivateLockReleaseGuard {

--- a/src/services/auto_queue/phase_gate.rs
+++ b/src/services/auto_queue/phase_gate.rs
@@ -256,10 +256,13 @@ async fn create_activate_dispatch_pg_inner(
     };
 
     let dispatch_id = uuid::Uuid::new_v4().to_string();
-    let kickoff_state = if matches!(
-        dispatch_type,
-        "review" | "review-decision" | "rework" | "consultation"
-    ) {
+    // #3605 (T2): review-family and inert side-paths (consultation,
+    // scope-assessment) must not pass a kickoff_state, so attaching them leaves
+    // the card pinned in `requested`. Shared with transition.rs/dispatch_create
+    // via dispatch_type_skips_kickoff so the three layers cannot drift —
+    // previously this matches! omitted scope-assessment, letting an activate
+    // dispatch kick the card into in_progress.
+    let kickoff_state = if crate::dispatch::dispatch_type_skips_kickoff(dispatch_type) {
         None
     } else {
         Some(

--- a/src/services/auto_queue/view.rs
+++ b/src/services/auto_queue/view.rs
@@ -72,18 +72,53 @@ pub(super) struct ActivateCardState {
     pub(super) title: String,
     pub(super) latest_dispatch_id: Option<String>,
     pub(super) latest_dispatch_status: Option<String>,
+    /// #3605 (codex R2): dispatch_type of `latest_dispatch_id`. Needed so the
+    /// auto-queue attach decision can distinguish an attachable IMPLEMENTATION
+    /// dispatch from an inert side-path (consultation / scope-assessment) that
+    /// merely became latest_dispatch_id. `None` when there is no latest dispatch
+    /// or it is not pending/dispatched.
+    pub(super) latest_dispatch_type: Option<String>,
     pub(super) entry_status: String,
     pub(super) repo_id: Option<String>,
     pub(super) assigned_agent_id: Option<String>,
 }
 
 impl ActivateCardState {
+    /// Whether the card has an active, ATTACHABLE implementation dispatch — i.e.
+    /// one the auto-queue activate/restore paths may bind a pending entry to
+    /// instead of creating a new dispatch.
+    ///
+    /// #3605 (codex R2) ROOT FIX — side-path hijacking: side-path dispatches
+    /// (consultation, scope-assessment) deliberately become `latest_dispatch_id`
+    /// (engine::transition::decide_dispatch_attached) but are inert — they record
+    /// info about the card without ever advancing/completing it. They must NOT be
+    /// treated as an attachable active dispatch: attaching a pending auto_queue
+    /// entry to a side-path leaves the entry bound to a dispatch whose terminal
+    /// completion is skipped (dispatch_status::should_skip_auto_queue_terminal_sync),
+    /// so the entry sticks in `dispatched` and the real implementation dispatch is
+    /// never created (stale recovery only reclaims cancelled/failed). Excluding
+    /// side-paths here makes activate fall through to creating a proper
+    /// implementation dispatch.
+    ///
+    /// consultation already avoided this only because its dedicated JS path
+    /// (auto-queue-error-recovery `_createConsultationDispatch` →
+    /// `record_consultation_dispatch_on_pg`) atomically marks the bound entry
+    /// `dispatched` at creation, so the entry is never pending when activate runs.
+    /// scope-assessment's JS path writes card metadata only and never touches the
+    /// entry, exposing this latent gap; the guard now closes it for the whole
+    /// side-path set.
+    ///
+    /// NB: this is the auto-queue `ActivateCardState` predicate only. It is
+    /// independent of the FSM review gate `has_active_dispatch`
+    /// (engine::transition::GateSnapshot / kanban::transition_core), which is a
+    /// separate count-based query and is intentionally left unchanged.
     pub(super) fn has_active_dispatch(&self) -> bool {
         self.latest_dispatch_id.is_some()
             && matches!(
                 self.latest_dispatch_status.as_deref(),
                 Some("pending") | Some("dispatched")
             )
+            && !crate::dispatch::dispatch_is_side_path(self.latest_dispatch_type.as_deref())
     }
 }
 
@@ -148,21 +183,35 @@ pub(super) async fn load_activate_card_state_pg(
     let mut latest_dispatch_id: Option<String> = row
         .try_get("latest_dispatch_id")
         .map_err(|error| format!("decode latest_dispatch_id for {card_id}: {error}"))?;
-    let mut latest_dispatch_status = if let Some(dispatch_id) = latest_dispatch_id.as_deref() {
-        sqlx::query_scalar::<_, String>("SELECT status FROM task_dispatches WHERE id = $1")
-            .bind(dispatch_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|error| format!("load postgres dispatch status for {dispatch_id}: {error}"))?
-    } else {
-        None
-    };
+    // #3605 (codex R2): also load the dispatch_type so has_active_dispatch() can
+    // exclude inert side-paths (consultation, scope-assessment) from the
+    // attachable-implementation-dispatch decision.
+    let mut latest_dispatch_status: Option<String> = None;
+    let mut latest_dispatch_type: Option<String> = None;
+    if let Some(dispatch_id) = latest_dispatch_id.as_deref() {
+        if let Some(dispatch_row) =
+            sqlx::query("SELECT status, dispatch_type FROM task_dispatches WHERE id = $1")
+                .bind(dispatch_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(|error| {
+                    format!("load postgres dispatch status for {dispatch_id}: {error}")
+                })?
+        {
+            latest_dispatch_status = dispatch_row
+                .try_get("status")
+                .map_err(|error| format!("decode dispatch status for {dispatch_id}: {error}"))?;
+            latest_dispatch_type = dispatch_row
+                .try_get("dispatch_type")
+                .map_err(|error| format!("decode dispatch type for {dispatch_id}: {error}"))?;
+        }
+    }
     if !matches!(
         latest_dispatch_status.as_deref(),
         Some("pending") | Some("dispatched")
     ) {
         if let Some(row) = sqlx::query(
-            "SELECT td.id, td.status
+            "SELECT td.id, td.status, td.dispatch_type
              FROM sessions s
              JOIN task_dispatches td ON td.id = s.active_dispatch_id
              WHERE td.kanban_card_id = $1
@@ -182,6 +231,9 @@ pub(super) async fn load_activate_card_state_pg(
             latest_dispatch_status = Some(row.try_get("status").map_err(|error| {
                 format!("decode live session dispatch status for {card_id}: {error}")
             })?);
+            latest_dispatch_type = row.try_get("dispatch_type").map_err(|error| {
+                format!("decode live session dispatch type for {card_id}: {error}")
+            })?;
         }
     }
     let entry_status =
@@ -203,6 +255,7 @@ pub(super) async fn load_activate_card_state_pg(
             .map_err(|error| format!("decode title for {card_id}: {error}"))?,
         latest_dispatch_id,
         latest_dispatch_status,
+        latest_dispatch_type,
         entry_status,
         repo_id: row
             .try_get("repo_id")

--- a/src/services/discord/prompt_builder/dispatch_contract.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract.rs
@@ -404,6 +404,27 @@ pub(super) fn render_dispatch_contract(
                  - review verdict API는 사용하지 않는다."
             ))
         }
+        // #3605 (T2): scope-assessment — the assigned agent evaluates the
+        // issue's SCALE only (no implementation) and returns a structured
+        // `scope_depth`. The depth drives later phases (T3); here it is just
+        // recorded on the card. Any value outside {full,plan_only,direct} is
+        // normalized to "full" downstream, so emphasize emitting one of them.
+        Some("scope-assessment") => {
+            let dispatch_id = current_task.dispatch_id?;
+            Some(format!(
+                "[Dispatch Contract]\n\
+                 - 이 dispatch는 \"범위 평가\" 전용이다. 구현/수정/커밋은 하지 않는다.\n\
+                 - 이 이슈의 스케일을 판단해 `scope_depth`를 다음 중 하나로 결정한다:\n\
+                 \u{20}\u{20}- `full`: 설계 + 계획(plan)이 필요한 큰 변경\n\
+                 \u{20}\u{20}- `plan_only`: 계획은 필요하지만 설계 부담이 적은 중간 규모\n\
+                 \u{20}\u{20}- `direct`: 계획 없이 바로 처리 가능한 소규모 직접 수정\n\
+                 - 판단이 불명확하면 `full`로 둔다(가장 안전).\n\
+                 - 완료 시 `PATCH /api/dispatches/{dispatch_id}`로 dispatch를 종료한다.\n\
+                 - result에는 반드시 `scope_depth`(full|plan_only|direct), `scope_reason`(판단 근거), `scope_risk`(과소평가 시 위험)를 넣는다.\n\
+                 - 예시 body: `{{\"status\":\"completed\",\"result\":{{\"scope_depth\":\"plan_only\",\"scope_reason\":\"...\",\"scope_risk\":\"...\"}}}}`\n\
+                 - review verdict API는 사용하지 않는다."
+            ))
+        }
         Some("e2e-test") | Some("consultation") | Some("pm-decision") => {
             let dispatch_id = current_task.dispatch_id?;
             Some(format!(

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -550,6 +550,33 @@ fn phase_gate_contract_requires_verdict_and_checks() {
 }
 
 #[test]
+fn scope_assessment_contract_requires_scope_depth_and_patch_completion() {
+    // #3605 (T2): the scope-assessment contract must instruct the agent to
+    // evaluate scale only, emit one of full|plan_only|direct, and complete via
+    // the standard PATCH path.
+    let current_task = CurrentTaskContext {
+        dispatch_id: Some("dispatch-scope-1"),
+        ..CurrentTaskContext::default()
+    };
+    let contract = render_dispatch_contract(Some("scope-assessment"), &current_task)
+        .expect("scope-assessment dispatch contract");
+
+    assert!(contract.contains("[Dispatch Contract]"));
+    assert!(contract.contains("PATCH /api/dispatches/dispatch-scope-1"));
+    // Scale evaluation only — no implementation.
+    assert!(contract.contains("구현"));
+    // All three depth labels are documented.
+    assert!(contract.contains("full"));
+    assert!(contract.contains("plan_only"));
+    assert!(contract.contains("direct"));
+    // The structured result keys are required.
+    assert!(contract.contains("scope_depth"));
+    assert!(contract.contains("scope_reason"));
+    assert!(contract.contains("scope_risk"));
+    assert!(contract.contains("review verdict API는 사용하지 않는다"));
+}
+
+#[test]
 fn review_lite_prompt_keeps_review_contract_while_trimming_full_sections() {
     use super::super::settings::RoleBinding;
 

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -563,8 +563,23 @@ fn scope_assessment_contract_requires_scope_depth_and_patch_completion() {
 
     assert!(contract.contains("[Dispatch Contract]"));
     assert!(contract.contains("PATCH /api/dispatches/dispatch-scope-1"));
-    // Scale evaluation only — no implementation.
-    assert!(contract.contains("구현"));
+    // #3605 (T2): the contract must affirmatively forbid implementation, not
+    // merely mention the word "구현". A bare `contains("구현")` would also pass a
+    // contract that *instructs* the agent to implement (e.g. "구현하라"), so
+    // assert the explicit "evaluate only / do not implement" directive verbatim.
+    assert!(
+        contract.contains("구현/수정/커밋은 하지 않는다"),
+        "scope-assessment contract must explicitly forbid implementation, got: {contract}"
+    );
+    assert!(
+        contract.contains("\"범위 평가\" 전용"),
+        "scope-assessment contract must declare it is evaluation-only, got: {contract}"
+    );
+    // Negative guard: it must NOT carry an implementation directive.
+    assert!(
+        !contract.contains("구현하라") && !contract.contains("구현한다"),
+        "scope-assessment contract must not instruct the agent to implement, got: {contract}"
+    );
     // All three depth labels are documented.
     assert!(contract.contains("full"));
     assert!(contract.contains("plan_only"));

--- a/src/services/discord/turn_bridge/completion_guard/completion_postgres.rs
+++ b/src/services/discord/turn_bridge/completion_guard/completion_postgres.rs
@@ -44,8 +44,16 @@ fn should_sync_runtime_auto_queue_terminal_entry(
     _result: &serde_json::Value,
     auto_queue_review_disabled: bool,
 ) -> bool {
+    // #3605 (T2): inert side-paths (consultation, scope-assessment) must never
+    // finalize a bound auto_queue entry on completion — mirror of
+    // dispatch_status::should_skip_auto_queue_terminal_sync for the live
+    // turn_bridge/watcher completion path. Without this, a scope-assessment
+    // completing through the runtime path would mark the entry done and close
+    // the card with no implementation dispatch.
+    if crate::dispatch::dispatch_is_side_path(dispatch_type) {
+        return false;
+    }
     match dispatch_type {
-        Some("consultation") => false,
         Some("implementation" | "rework") => auto_queue_review_disabled,
         _ => true,
     }
@@ -595,5 +603,19 @@ mod runtime_completion_policy_tests {
             &normal_result,
             false
         ));
+        // #3605 (T2): scope-assessment must NOT sync the runtime terminal entry,
+        // exactly like consultation — otherwise the live turn_bridge/watcher
+        // completion path would finalize the bound entry and close the card with
+        // no implementation dispatch. review_disabled must not change this.
+        for review_disabled in [false, true] {
+            assert!(
+                !should_sync_runtime_auto_queue_terminal_entry(
+                    Some("scope-assessment"),
+                    &normal_result,
+                    review_disabled,
+                ),
+                "scope-assessment must not sync runtime terminal entry (review_disabled={review_disabled})"
+            );
+        }
     }
 }

--- a/src/services/dispatches/outbox_route.rs
+++ b/src/services/dispatches/outbox_route.rs
@@ -717,6 +717,11 @@ pub(crate) fn use_counter_model_channel(dispatch_type: Option<&str>) -> bool {
     // "review", "e2e-test" (#197), and "consultation" (#256) go to the counter-model channel.
     // "review-decision" is routed back to the original implementation provider
     // so it reuses the implementation-side thread rather than the reviewer channel.
+    //
+    // #3605 (T2): "scope-assessment" is intentionally NOT listed here. Unlike
+    // consultation, the assigned agent itself evaluates the scope, so the
+    // dispatch must stay on the assigned agent's PRIMARY channel (the default
+    // when this returns false).
     matches!(
         dispatch_type,
         Some("review") | Some("e2e-test") | Some("consultation")
@@ -768,6 +773,7 @@ fn dispatch_type_label(dispatch_type: Option<&str>) -> &'static str {
         Some("pm-decision") => "🎯 PM 판단",
         Some("e2e-test") => "🧪 E2E 테스트",
         Some("consultation") => "💬 상담",
+        Some("scope-assessment") => "📐 범위 평가",
         Some("phase-gate") => "🚦 Phase Gate",
         _ => "dispatch",
     }
@@ -919,6 +925,12 @@ fn dispatch_instruction_line(
         }
         Some("consultation") => {
             "한 줄 지시: 필요한 조사/판단만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("scope-assessment") => {
+            // #3605 (T2): scale evaluation only — no implementation. Detailed
+            // scope_depth contract lives in the [Dispatch Contract] section.
+            "한 줄 지시: 구현하지 말고 이 이슈의 스케일(scope_depth)만 평가하세요. 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
                 .to_string()
         }
         Some("phase-gate") => {


### PR DESCRIPTION
## 요약 (#3605 T2)

담당 에이전트가 구현 전에 이슈의 **스케일(scope_depth)** 을 평가하는 `scope-assessment` dispatch를 신설하고, 그 결과를 카드 metadata에 **기록만** 한다 (T2 = inert, 흐름 변경 없음). consultation(#256)의 metadata-flag 패턴을 클론하되 counter-provider swap은 하지 않는다.

## 설계 (consultation 클론, 단 담당 에이전트 + primary 채널)

- **트리거:** `kanban-rules.js onCardTransition`, 카드가 `requested` 진입 + preflight가 invalid/already_applied가 아닐 때 **1회**. 배정 직후 + 구현 dispatch 생성 전의 유일한 깨끗한 훅.
- **중복 방지:** 카드 metadata `scope_assessment_status` 슬롯. set이면(pending/completed/skipped) no-op. 생성 직후 즉시 `pending` 마킹(consultation_status="pending" up-front와 동형). 미배정 카드는 skip.
- **채널:** consultation과 달리 `use_counter_model_channel`에 **미등록** → 담당 에이전트 **primary 채널**로 자동 라우팅 (이슈 명시 "담당 에이전트가 평가").
- **결과 저장:** `onDispatchCompleted`에서 `scope-assessment` 분기 → `{scope_depth, scope_reason, scope_risk}`를 `_mergeCardMetadata`. side-path라 PM gate/review/XP 라이프사이클로 새지 않게 early-return.

## 기본값 (fail-safe)

`scope_depth`가 `full|plan_only|direct`(trim+lowercase+`-`→`_` 정규화) 외 값(미emit/파싱불가/타임아웃/오타)이면 → **`full`**(가장 안전). reason/risk 누락 시 `"unspecified (fallback to full)"` 진단 문자열.

## skip_kickoff (필수)

`transition.rs decide_dispatch_attached`의 `skip_kickoff`에 `scope-assessment` 추가. 이게 없으면 dispatch attach가 카드를 즉시 `in_progress`로 밀어 "구현 전 side-path" 의도가 깨지고 구현 dispatch와 경합. consultation과 동일하게 `requested`에 머무름 (구현 dispatch는 auto-queue가 별도 생성, scope-assessment는 흐름을 막지 않음).

## 변경 파일

- `policies/kanban-rules.js` — 트리거(`_maybeDispatchScopeAssessment`) + 결과 저장(`_recordScopeAssessment`) + 정규화 + dispatch 생성 헬퍼
- `policies/auto-queue.js` — `scope-assessment` 가드(phase-gate 흐름 차단)
- `src/engine/transition.rs` — `skip_kickoff`에 scope-assessment 추가 + dispatch-attached 테스트 3개
- `src/services/discord/prompt_builder/dispatch_contract.rs` — scope-assessment 전용 contract arm (스케일 평가 지시 프롬프트: full/plan_only/direct 판단 + result 키, 구현 금지)
- `src/services/dispatches/outbox_route.rs` — Discord 라벨 `📐 범위 평가` + 한 줄 지시 + counter-channel 미등록 근거 주석
- `docs/agent-maintenance/change-surfaces.md` — outbox_route.rs 라인수 동기

## 테스트 / 게이트

- JS: kanban-rules 트리거(1회)/중복방지/invalid 미생성/결과저장(inert)/full 폴백(3케이스)/정규화 = 18 통과, 전체 policies **156 통과**
- Rust: transition dispatch-attached(impl=kickoff / scope-assessment·consultation=requested 유지), dispatch_contract scope-assessment arm = 통과
- 게이트 전부 통과: `cargo fmt --check`, `cargo check --lib`, 모듈 테스트, `check_agent_maintenance_docs.py`(freshness passed), `audit_state_lint_hardening.py`(passed)

## 범위 제한

T3 consumer(depth로 흐름 분기 — direct는 plan skip 등)는 **별도 phased PR**. 본 PR은 depth 기록까지만.

Closes #3605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)