### PR TITLE
fix(#3607): terminal-delete 보호 가드 + delete 관측 (Phase A)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -404,6 +404,20 @@
 
 ### Audited touches
 
+- #3607 terminal-delete protection guard + durable delete observability
+  (Phase A): `turn_bridge/mod.rs` gained a worker-local cleanup guard that
+  preserves a committed terminal anchor (a finished turn's retired message
+  recorded in the per-process `PlaceholderCleanupRegistry` tombstone, signal-c,
+  fused with the live-inflight fast path, signal-a) from the orphan-spinner
+  cleanup, plus `emit_relay_delete` observability on every wired delete site
+  (orphan-spinner, full-terminal replay-prefix). The hot-file body shrank
+  (orphan-spinner cleanup lifted whole into the `watcher_orphan_cleanup.rs`
+  sibling); only a dispatch call + guard remain inline. The guard reads the same
+  per-process tombstone registry the watcher already owns and the turn's OWN
+  inflight handle — it is NOT a routing authority, never read cross-node. No
+  leader election, gateway lease, PG ownership, startup order, worker ownership,
+  or singleton assumption is touched; the recovery-fallback criterion is
+  deferred to #3610.
 - #3560 single_message_panel default-ON + footer-mode migration guard: the
   `single_message_panel` flag is now default-ON (opt-out via
   `AGENTDESK_SINGLE_MESSAGE_PANEL=0|false`) and `turn_bridge/mod.rs` gained a

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -713,9 +713,18 @@ impl TurnGateway for DiscordGateway {
             )
             .await;
             for placeholder_msg_id in drained {
-                let _ = channel_id
+                let result = channel_id
                     .delete_message(&self.http, placeholder_msg_id)
                     .await;
+                // #3607: observe the merged-queued-placeholder drain delete.
+                crate::services::observability::emit_relay_delete_result(
+                    self.provider.as_str(),
+                    channel_id.get(),
+                    placeholder_msg_id.get(),
+                    "gateway_queued_placeholder_drain",
+                    "delete_nonterminal",
+                    &result,
+                );
             }
 
             let deps = router::IntakeDeps {

--- a/src/services/discord/idle_recap.rs
+++ b/src/services/discord/idle_recap.rs
@@ -460,7 +460,16 @@ pub(crate) async fn delete_previous_card(http: &serenity::Http, channel_id: u64,
     let message = MessageId::new(message_id);
     match http.get_message(channel, message).await {
         Ok(current) if message_is_idle_recap_card(&current) => {
-            let _ = super::http::delete_channel_message(http, channel, message).await;
+            // #3607: observe the delete; idle-recap cards are not provider-scoped.
+            let result = super::http::delete_channel_message(http, channel, message).await;
+            crate::services::observability::emit_relay_delete_result(
+                "",
+                channel_id,
+                message_id,
+                "idle_recap_previous_card",
+                "delete_nonterminal",
+                &result,
+            );
         }
         Ok(current) => {
             tracing::warn!(

--- a/src/services/discord/monitoring_status.rs
+++ b/src/services/discord/monitoring_status.rs
@@ -264,10 +264,10 @@ async fn render_channel_monitoring_from_store(
     let Some(content) = format_monitoring_message(&entries) else {
         if let Some(msg_id) = rendered_msg_id {
             wait_if_shared(shared, channel_id).await;
-            if let Err(error) = channel_id
+            let result = channel_id
                 .delete_message(http, MessageId::new(msg_id))
-                .await
-            {
+                .await;
+            if let Err(error) = &result {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(
                     "  [{ts}] ⚠ failed to delete monitoring status msg {} in channel {}: {}",
@@ -276,6 +276,15 @@ async fn render_channel_monitoring_from_store(
                     error
                 );
             }
+            // #3607: monitoring status messages are not provider-scoped.
+            crate::services::observability::emit_relay_delete_result(
+                "",
+                channel_id.get(),
+                msg_id,
+                "monitoring_status_clear",
+                "delete_nonterminal",
+                &result,
+            );
             let mut store = monitoring.lock().await;
             store.set_rendered_msg(channel_id.get(), None);
         }

--- a/src/services/discord/placeholder_cleanup.rs
+++ b/src/services/discord/placeholder_cleanup.rs
@@ -389,6 +389,86 @@ pub(in crate::services::discord) fn committed_terminal_panel_anchor_skip(
     true
 }
 
+/// #3607: emit the durable `relay_delete` observation for the orphan
+/// status-panel sweeper's *actual* delete (the path that runs when the
+/// terminal-anchor guard above did NOT skip). Outcome mirrors the sweeper's own
+/// convergence branches: `Ok` → committed, an `Err` whose Discord status is a
+/// permanent message-gone (404/403/410, via
+/// [`super::placeholder_sweeper::is_permanent_message_gone_status`]) →
+/// already_gone, any other `Err` → failed. The panel is a non-terminal cleanup.
+/// Observation only — the caller's enqueue / convergence logic is unchanged, and
+/// this lives here (not in the near-1000-LoC sweeper) so that file carries only
+/// the compact call.
+pub(in crate::services::discord) fn emit_orphan_panel_sweep_delete<T>(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    panel_msg: MessageId,
+    result: &Result<T, poise::serenity_prelude::Error>,
+) {
+    let permanent = result
+        .as_ref()
+        .err()
+        .is_some_and(orphan_panel_delete_is_permanent_gone);
+    let outcome = panel_sweep_delete_outcome(result.is_ok(), permanent);
+    let detail = result.as_ref().err().map(|err| err.to_string());
+    crate::services::observability::emit_relay_delete(
+        provider.as_str(),
+        channel_id.get(),
+        panel_msg.get(),
+        None,
+        None,
+        "placeholder_sweeper_orphan_panel",
+        PlaceholderCleanupOperation::DeleteNonterminal.as_str(),
+        outcome,
+        detail.as_deref(),
+    );
+}
+
+/// #3607: pure 3-way outcome classifier for the orphan-panel sweep delete (and
+/// the orphan-store drain), split out from [`emit_orphan_panel_sweep_delete`] so
+/// the committed / already_gone / failed mapping is unit-testable without
+/// constructing a live `serenity::Error`. `permanent` is the caller's
+/// permanent-gone (404/403/410) match; it is only consulted on the error path.
+pub(in crate::services::discord) fn panel_sweep_delete_outcome(
+    committed: bool,
+    permanent: bool,
+) -> &'static str {
+    if committed {
+        "committed"
+    } else if permanent {
+        "already_gone"
+    } else {
+        "failed"
+    }
+}
+
+/// True when this delete error is a permanent message-gone status the sweeper
+/// treats as success (404/403/410, via
+/// [`super::placeholder_sweeper::is_permanent_message_gone_status`]).
+fn orphan_panel_delete_is_permanent_gone(err: &poise::serenity_prelude::Error) -> bool {
+    matches!(err, poise::serenity_prelude::Error::Http(http_err)
+    if http_err.status_code().is_some_and(|status| {
+        super::placeholder_sweeper::is_permanent_message_gone_status(status.as_u16())
+    }))
+}
+
+/// True when the placeholder abandoned branch in `sweep_orphan_status_panel`
+/// will NOT evict this row this pass — either it has no placeholder
+/// (`current_msg_id == 0`) or it already streamed partial output (the
+/// partial-response guard at the top of `run_placeholder_sweep_pass`). For those
+/// rows the panel sweep must clear the persisted `status_message_id` itself to
+/// converge; for rows the placeholder branch WILL evict, clearing there would
+/// only refresh the file mtime and defer that eviction (codex P2 r12). Lives
+/// here (not in the near-1000-LoC sweeper) so that file stays under the giant
+/// threshold (#3607).
+pub(in crate::services::discord) fn placeholder_sweep_leaves_row_unevicted(
+    state: &InflightTurnState,
+) -> bool {
+    state.current_msg_id == 0
+        || (!state.long_running_placeholder_active
+            && (!state.full_response.is_empty() || state.response_sent_offset > 0))
+}
+
 #[cfg(test)]
 mod terminal_anchor_guard_tests {
     use super::*;
@@ -543,5 +623,42 @@ mod terminal_anchor_guard_tests {
             anchor(),
             Some(&uncommitted),
         ));
+    }
+
+    #[test]
+    fn panel_sweep_delete_outcome_classifies_three_ways() {
+        // #3607: the actual-delete observation must split committed (Ok),
+        // already_gone (permanent 404/403/410 Err), and failed (transient Err) —
+        // the gap codex flagged was emitting only the guard-skip case.
+        assert_eq!(panel_sweep_delete_outcome(true, false), "committed");
+        // `committed` wins even if a stray permanent flag is set (Ok path).
+        assert_eq!(panel_sweep_delete_outcome(true, true), "committed");
+        assert_eq!(panel_sweep_delete_outcome(false, true), "already_gone");
+        assert_eq!(panel_sweep_delete_outcome(false, false), "failed");
+    }
+
+    #[test]
+    fn orphan_panel_sweep_committed_delete_emits_relay_delete() {
+        // #3607: the wired actual-delete path emits a durable `relay_delete`
+        // with outcome=committed on Ok, attributed to the sweeper panel site as a
+        // non-terminal cleanup — the result-side observation that was missing.
+        let _guard = crate::services::observability::test_runtime_lock();
+        crate::services::observability::reset_for_tests();
+
+        let ok: Result<(), poise::serenity_prelude::Error> = Ok(());
+        emit_orphan_panel_sweep_delete(&PROVIDER, channel(), anchor(), &ok);
+
+        let events = crate::services::observability::events::recent(50);
+        let event = events
+            .iter()
+            .find(|event| event.event_type == "relay_delete")
+            .expect("relay_delete should be in the recent ring");
+        assert_eq!(event.channel_id, Some(channel().get()));
+        assert_eq!(event.payload["message_id"], anchor().get());
+        assert_eq!(event.payload["source"], "placeholder_sweeper_orphan_panel");
+        assert_eq!(event.payload["operation_kind"], "delete_nonterminal");
+        assert_eq!(event.payload["outcome"], "committed");
+        // outcome doubles as the correlation status.
+        assert_eq!(event.payload["status"], "committed");
     }
 }

--- a/src/services/discord/placeholder_cleanup.rs
+++ b/src/services/discord/placeholder_cleanup.rs
@@ -1,6 +1,7 @@
 use poise::serenity_prelude::{ChannelId, MessageId};
 use std::time::{Duration, Instant};
 
+use super::inflight::InflightTurnState;
 use crate::services::provider::ProviderKind;
 
 const PLACEHOLDER_CLEANUP_TTL: Duration = Duration::from_secs(60 * 60);
@@ -166,6 +167,23 @@ impl PlaceholderCleanupRegistry {
         })
     }
 
+    /// #3607 signal-(c): a committed terminal-cleanup tombstone marks this
+    /// message id as the message a finished turn intentionally retired (deleted
+    /// or edited into its terminal form). Semantic alias over the existing
+    /// [`Self::terminal_cleanup_committed`] tombstone lookup — same
+    /// `DeleteTerminal | EditTerminal & committed` predicate — surfaced under a
+    /// guard-oriented name so the cleanup-protection call sites read clearly.
+    /// The tombstone survives the inflight row being cleared (TTL 1h), so it is
+    /// the durable authority a generic janitor consults before deleting.
+    pub(super) fn is_committed_terminal_anchor(
+        &self,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> bool {
+        self.terminal_cleanup_committed(provider, channel_id, message_id)
+    }
+
     pub(super) fn terminal_cleanup_retry_pending(
         &self,
         provider: &ProviderKind,
@@ -289,5 +307,241 @@ pub(super) fn classify_delete_error(detail: &str) -> PlaceholderCleanupOutcome {
         PlaceholderCleanupOutcome::AlreadyGone
     } else {
         PlaceholderCleanupOutcome::failed(detail)
+    }
+}
+
+/// #3607 cleanup-protection guard: true when `message_id` is a committed
+/// terminal anchor that a generic cleanup path (orphan-spinner sweep, panel
+/// reclaim, replay-prefix GC, idle/monitoring janitors) must NOT delete.
+///
+/// Fuses the two trustworthy "this turn already retired this message" signals:
+///   - signal (a) — the *live* inflight row, when one is still in scope: a turn
+///     whose own `current_msg_id` equals `message_id` and whose terminal
+///     delivery already committed owns that message; deleting it would race the
+///     turn's own finalization. This is the fast path that needs no registry
+///     write to have landed yet.
+///   - signal (c) — the durable [`PlaceholderCleanupRegistry`] tombstone
+///     ([`PlaceholderCleanupRegistry::is_committed_terminal_anchor`]). It is
+///     written by the terminal-cleanup commit and survives the inflight row
+///     being cleared (TTL 1h, production-wired in `tmux_watcher.rs`), so it is
+///     the authority for the accident shape this guard exists to stop: the
+///     inflight is already gone but a janitor is about to delete the message the
+///     terminal cleanup just committed.
+///
+/// Signal (b) (the `delivery_record` panel-message ledger) is deliberately
+/// EXCLUDED: it is #3089 dead code (env OFF, and even the accident record stores
+/// `panel_msg_id = null`), so it would never fire. When #3089 cuts over, add it
+/// here as an additional OR-term.
+pub(in crate::services::discord) fn committed_terminal_anchor_protects_delete(
+    registry: &PlaceholderCleanupRegistry,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    message_id: MessageId,
+    live_inflight: Option<&InflightTurnState>,
+) -> bool {
+    if let Some(inflight) = live_inflight
+        && inflight.current_msg_id == message_id.get()
+        && inflight.terminal_delivery_completed()
+    {
+        return true;
+    }
+    registry.is_committed_terminal_anchor(provider, channel_id, message_id)
+}
+
+/// #3607 panel-sweep terminal-anchor guard wrapper. Returns true (and emits the
+/// `skipped_committed_terminal` delete event + a log) when the orphan
+/// status-panel sweeper is about to delete a committed terminal anchor — so the
+/// sweeper bails before the destructive delete. Wraps
+/// [`committed_terminal_anchor_protects_delete`] so the (non-hot but
+/// near-1000-LoC) sweeper file only carries the compact call.
+pub(in crate::services::discord) fn committed_terminal_panel_anchor_skip(
+    registry: &PlaceholderCleanupRegistry,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    panel_msg: MessageId,
+    live_inflight: &InflightTurnState,
+) -> bool {
+    if !committed_terminal_anchor_protects_delete(
+        registry,
+        provider,
+        channel_id,
+        panel_msg,
+        Some(live_inflight),
+    ) {
+        return false;
+    }
+    tracing::info!(
+        "[placeholder_sweeper] 🛡 #3607 preserved orphan status-panel anchor — committed terminal cleanup owns msg {} (channel {})",
+        panel_msg.get(),
+        channel_id.get()
+    );
+    crate::services::observability::emit_relay_delete(
+        provider.as_str(),
+        channel_id.get(),
+        panel_msg.get(),
+        None,
+        None,
+        "placeholder_sweeper_orphan_panel",
+        PlaceholderCleanupOperation::DeleteTerminal.as_str(),
+        "skipped_committed_terminal",
+        None,
+    );
+    true
+}
+
+#[cfg(test)]
+mod terminal_anchor_guard_tests {
+    use super::*;
+
+    const PROVIDER: ProviderKind = ProviderKind::Codex;
+
+    fn channel() -> ChannelId {
+        ChannelId::new(4242)
+    }
+
+    fn anchor() -> MessageId {
+        MessageId::new(9001)
+    }
+
+    fn record(
+        registry: &PlaceholderCleanupRegistry,
+        message_id: MessageId,
+        operation: PlaceholderCleanupOperation,
+        outcome: PlaceholderCleanupOutcome,
+    ) {
+        registry.record(PlaceholderCleanupRecord {
+            provider: PROVIDER,
+            channel_id: channel(),
+            message_id,
+            tmux_session_name: None,
+            operation,
+            outcome,
+            source: "test",
+        });
+    }
+
+    fn inflight_with(current_msg_id: u64, terminal_committed: bool) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            PROVIDER,
+            channel().get(),
+            None,
+            1,
+            2,
+            current_msg_id,
+            "test".to_string(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        state.terminal_delivery_committed = terminal_committed;
+        state
+    }
+
+    #[test]
+    fn committed_terminal_tombstone_protects_delete() {
+        // Signal (c): a committed terminal delete tombstone marks the anchor as
+        // protected even without a live inflight.
+        let registry = PlaceholderCleanupRegistry::default();
+        record(
+            &registry,
+            anchor(),
+            PlaceholderCleanupOperation::DeleteTerminal,
+            PlaceholderCleanupOutcome::Succeeded,
+        );
+        assert!(committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            anchor(),
+            None,
+        ));
+    }
+
+    #[test]
+    fn non_terminal_or_unrecorded_anchor_is_not_protected() {
+        let registry = PlaceholderCleanupRegistry::default();
+        // A non-terminal cleanup record must not protect.
+        record(
+            &registry,
+            anchor(),
+            PlaceholderCleanupOperation::DeleteNonterminal,
+            PlaceholderCleanupOutcome::Succeeded,
+        );
+        assert!(!committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            anchor(),
+            None,
+        ));
+        // An unrecorded anchor must not protect.
+        assert!(!committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            MessageId::new(7),
+            None,
+        ));
+    }
+
+    #[test]
+    fn registry_protects_after_inflight_cleared() {
+        // The accident shape #3607 exists to stop: the inflight row is already
+        // gone (live_inflight = None) but the committed terminal tombstone alone
+        // still protects the just-retired anchor from a generic janitor.
+        let registry = PlaceholderCleanupRegistry::default();
+        record(
+            &registry,
+            anchor(),
+            PlaceholderCleanupOperation::EditTerminal,
+            PlaceholderCleanupOutcome::Succeeded,
+        );
+        assert!(committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            anchor(),
+            None,
+        ));
+    }
+
+    #[test]
+    fn live_inflight_fast_path_protects_with_empty_registry() {
+        // Signal (a) only: registry is empty, but the live inflight owns the
+        // anchor (same current_msg_id) and committed its terminal delivery.
+        let registry = PlaceholderCleanupRegistry::default();
+        let inflight = inflight_with(anchor().get(), true);
+        assert!(committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            anchor(),
+            Some(&inflight),
+        ));
+    }
+
+    #[test]
+    fn neither_signal_does_not_protect() {
+        // Empty registry + a live inflight that neither owns the anchor nor has
+        // committed terminal delivery → no protection.
+        let registry = PlaceholderCleanupRegistry::default();
+        let other_anchor = inflight_with(123, true);
+        assert!(!committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            anchor(),
+            Some(&other_anchor),
+        ));
+        let uncommitted = inflight_with(anchor().get(), false);
+        assert!(!committed_terminal_anchor_protects_delete(
+            &registry,
+            &PROVIDER,
+            channel(),
+            anchor(),
+            Some(&uncommitted),
+        ));
     }
 }

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -808,19 +808,6 @@ fn panel_reclaim_target(state: &InflightTurnState, age_secs: u64) -> Option<sere
     )
 }
 
-/// True when the placeholder abandoned branch below will NOT evict this row this
-/// pass — either it has no placeholder (`current_msg_id == 0`) or it already
-/// streamed partial output (the partial-response guard at the top of
-/// `run_placeholder_sweep_pass`). For those rows the panel sweep must clear the
-/// persisted `status_message_id` itself to converge; for rows the placeholder
-/// branch WILL evict, clearing here would only refresh the file mtime and defer
-/// that eviction (codex P2 r12).
-fn placeholder_sweep_leaves_row_unevicted(state: &InflightTurnState) -> bool {
-    state.current_msg_id == 0
-        || (!state.long_running_placeholder_active
-            && (!state.full_response.is_empty() || state.response_sent_offset > 0))
-}
-
 async fn sweep_orphan_status_panel(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
@@ -848,7 +835,14 @@ async fn sweep_orphan_status_panel(
     ) {
         return; // #3607: a committed terminal cleanup owns this panel.
     }
-    let committed = match channel.delete_message(http, panel_msg).await {
+    let delete_result = channel.delete_message(http, panel_msg).await;
+    super::placeholder_cleanup::emit_orphan_panel_sweep_delete(
+        provider,
+        channel,
+        panel_msg,
+        &delete_result,
+    );
+    let committed = match delete_result {
         Ok(_) => true,
         Err(serenity::Error::Http(http_err))
             if http_err
@@ -888,7 +882,7 @@ async fn sweep_orphan_status_panel(
             finalize_abandoned_mailbox(shared, provider, state).await;
             let _ = delete_inflight_state_file(provider, state.channel_id);
         }
-    } else if placeholder_sweep_leaves_row_unevicted(state)
+    } else if super::placeholder_cleanup::placeholder_sweep_leaves_row_unevicted(state)
         && let Some(panel_msg_id) = state.status_message_id
     {
         // Partial-response rows (real placeholder + streamed output) are owned by

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -839,6 +839,15 @@ async fn sweep_orphan_status_panel(
         return;
     }
     let channel = serenity::ChannelId::new(state.channel_id);
+    if super::placeholder_cleanup::committed_terminal_panel_anchor_skip(
+        &shared.ui.placeholder_cleanup,
+        provider,
+        channel,
+        panel_msg,
+        state,
+    ) {
+        return; // #3607: a committed terminal cleanup owns this panel.
+    }
     let committed = match channel.delete_message(http, panel_msg).await {
         Ok(_) => true,
         Err(serenity::Error::Http(http_err))

--- a/src/services/discord/status_panel_orphan_store.rs
+++ b/src/services/discord/status_panel_orphan_store.rs
@@ -268,6 +268,33 @@ fn delete_error_is_permanent(err: &serenity::Error) -> bool {
             .is_some_and(|status| matches!(status.as_u16(), 404 | 403 | 410)))
 }
 
+/// #3607: emit the durable `relay_delete` observation for the orphan-store drain
+/// delete (sweeper-class). Outcome mirrors the convergence branches:
+/// `Ok` → committed, permanent `Err` (404/403/410) → already_gone, other
+/// `Err` → failed. Panel deletes are non-terminal cleanups. Observation only —
+/// the caller's removal / retry logic is unchanged.
+fn emit_orphan_drain_delete(
+    provider: &ProviderKind,
+    channel_id: u64,
+    panel_msg_id: u64,
+    result: &Result<(), serenity::Error>,
+) {
+    let permanent = result.as_ref().err().is_some_and(delete_error_is_permanent);
+    let outcome = super::placeholder_cleanup::panel_sweep_delete_outcome(result.is_ok(), permanent);
+    let detail = result.as_ref().err().map(|err| err.to_string());
+    crate::services::observability::emit_relay_delete(
+        provider.as_str(),
+        channel_id,
+        panel_msg_id,
+        None,
+        None,
+        "status_panel_orphan_store_drain",
+        super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal.as_str(),
+        outcome,
+        detail.as_deref(),
+    );
+}
+
 /// #3351: pure drain-defer decision for relay-placeholder records — `true` when
 /// the live inflight row still anchors `candidate` as its `current_msg_id`.
 fn orphan_drain_placeholder_is_live(current_msg_id: Option<u64>, candidate: u64) -> bool {
@@ -328,7 +355,13 @@ pub(in crate::services::discord) async fn drain(
         }
         let channel = serenity::ChannelId::new(channel_id);
         let message = serenity::MessageId::new(panel_msg_id);
-        match channel.delete_message(http, message).await {
+        let delete_result = channel.delete_message(http, message).await;
+        // #3607: durable observability for the sweeper-class retry delete — classify
+        // committed / already_gone (permanent 404/403/410) / failed using the SAME
+        // `delete_error_is_permanent` match the convergence below uses (emit-only; no
+        // behaviour change).
+        emit_orphan_drain_delete(provider, channel_id, panel_msg_id, &delete_result);
+        match delete_result {
             Ok(_) => {
                 remove(provider, token_hash, channel_id, panel_msg_id);
                 cleared += 1;
@@ -438,5 +471,29 @@ mod tests {
             load_pending_in_root(root, &provider, "tok"),
             vec![(100, 5001)]
         );
+    }
+
+    /// #3607: the sweeper-class drain delete must also emit a durable
+    /// `relay_delete` (the gap codex flagged) — committed on Ok, attributed to
+    /// the orphan-store drain site as a non-terminal cleanup.
+    #[test]
+    fn drain_committed_delete_emits_relay_delete() {
+        let _guard = crate::services::observability::test_runtime_lock();
+        crate::services::observability::reset_for_tests();
+
+        let ok: Result<(), serenity::Error> = Ok(());
+        emit_orphan_drain_delete(&ProviderKind::Codex, 4242, 9001, &ok);
+
+        let events = crate::services::observability::events::recent(50);
+        let event = events
+            .iter()
+            .find(|event| event.event_type == "relay_delete")
+            .expect("relay_delete should be in the recent ring");
+        assert_eq!(event.channel_id, Some(4242));
+        assert_eq!(event.payload["message_id"], 9001);
+        assert_eq!(event.payload["source"], "status_panel_orphan_store_drain");
+        assert_eq!(event.payload["operation_kind"], "delete_nonterminal");
+        assert_eq!(event.payload["outcome"], "committed");
+        assert_eq!(event.payload["status"], "committed");
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -3085,7 +3085,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let deferred_monitor_ready =
             monitor_auto_turn_claimed && monitor_auto_turn_deferred && !paused_now;
         if (was_paused || paused_now || epoch_changed_now) && !deferred_monitor_ready {
-            // Clean up placeholder if we created one
+            // Clean up placeholder if we created one (#3610/Phase-B defer: no emit_relay_delete here — tmux_watcher.rs raw-ratchet is at ceiling)
             if let Some(msg_id) = placeholder_msg_id {
                 if watcher_should_delete_suppressed_placeholder(placeholder_from_restored_inflight)
                 {

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -98,8 +98,8 @@ pub(super) use tmux_runtime::handoff_interrupted_message;
 pub(super) use tmux_runtime::stale_inflight_message;
 pub(super) use tmux_runtime::stop_active_turn;
 pub(super) use watcher_orphan_cleanup::{
-    record_watcher_orphan_spinner_cleanup, should_delete_bridge_created_watcher_orphan_response,
-    should_retry_watcher_orphan_spinner_cleanup, spawn_watcher_orphan_spinner_cleanup_retry,
+    cleanup_or_preserve_watcher_orphan_spinner,
+    should_delete_bridge_created_watcher_orphan_response,
 };
 
 /// #2452 H6 graduation: schedule the history-aware auto-retry via the
@@ -4701,55 +4701,20 @@ pub(super) fn spawn_turn_bridge(
                         bridge_created_response_placeholder_msg_id,
                         current_msg_id,
                     ) {
-                        let cleanup_outcome =
-                            match gateway.delete_message(channel_id, current_msg_id).await {
-                                Ok(()) => {
-                                    super::placeholder_cleanup::PlaceholderCleanupOutcome::Succeeded
-                                }
-                                Err(error) => {
-                                    super::placeholder_cleanup::classify_delete_error(&error)
-                                }
-                            };
-                        let cleanup_committed = cleanup_outcome.is_committed();
-                        let cleanup_should_retry =
-                            should_retry_watcher_orphan_spinner_cleanup(&cleanup_outcome);
-                        let cleanup_already_gone = matches!(
-                            cleanup_outcome,
-                            super::placeholder_cleanup::PlaceholderCleanupOutcome::AlreadyGone
-                        );
-                        record_watcher_orphan_spinner_cleanup(
-                            shared_owned.as_ref(),
+                        // #3607: terminal-anchor guard + durable delete
+                        // observability live in the sibling so the hot file only
+                        // dispatches. The guard skips deleting a committed
+                        // terminal anchor (the accident this fixes); a genuine
+                        // non-terminal orphan is deleted, recorded, and retried.
+                        cleanup_or_preserve_watcher_orphan_spinner(
+                            shared_owned.clone(),
                             &provider,
+                            gateway.clone(),
                             channel_id,
                             current_msg_id,
-                            inflight_state.tmux_session_name.as_deref(),
-                            cleanup_outcome,
-                            "turn_bridge_watcher_orphan_spinner_cleanup",
-                        );
-                        if cleanup_committed {
-                            if cleanup_already_gone {
-                                tracing::info!(
-                                    "  [{ts}] 🧹 bridge orphan watcher-handoff spinner card already gone (channel {}, msg {})",
-                                    channel_id,
-                                    current_msg_id
-                                );
-                            } else {
-                                tracing::info!(
-                                    "  [{ts}] 🧹 bridge removed orphan watcher-handoff spinner card (channel {}, msg {})",
-                                    channel_id,
-                                    current_msg_id
-                                );
-                            }
-                        } else if cleanup_should_retry {
-                            spawn_watcher_orphan_spinner_cleanup_retry(
-                                shared_owned.clone(),
-                                provider.clone(),
-                                gateway.clone(),
-                                channel_id,
-                                current_msg_id,
-                                inflight_state.tmux_session_name.clone(),
-                            );
-                        }
+                            &inflight_state,
+                        )
+                        .await;
                     }
                 }
                 BridgeOutputOwner::StandbyRelay => tracing::info!(
@@ -5417,30 +5382,47 @@ pub(super) fn spawn_turn_bridge(
                     );
                 }
                 for frozen_msg_id in terminal_full_replay_cleanup_msg_ids.drain(..) {
+                    // #5413/#3607: current_msg_id is the terminal answer and is
+                    // already excluded here, so no terminal-anchor guard is
+                    // needed — every drained id is a non-terminal streamed prefix.
                     if frozen_msg_id == current_msg_id {
                         continue;
                     }
-                    match gateway.delete_message(channel_id, frozen_msg_id).await {
-                        Ok(()) => {
-                            tracing::info!(
-                                target: "agentdesk::codex_rollout_handoff",
-                                provider = %provider.as_str(),
-                                channel = channel_id.get(),
-                                message_id = frozen_msg_id.get(),
-                                "turn_bridge removed streamed rollover prefix after full terminal replay"
-                            );
-                        }
-                        Err(error) => {
-                            tracing::warn!(
-                                target: "agentdesk::codex_rollout_handoff",
-                                provider = %provider.as_str(),
-                                channel = channel_id.get(),
-                                message_id = frozen_msg_id.get(),
-                                error = %error,
-                                "turn_bridge failed to remove streamed rollover prefix after full terminal replay"
-                            );
-                        }
-                    }
+                    let (replay_outcome, replay_detail) =
+                        match gateway.delete_message(channel_id, frozen_msg_id).await {
+                            Ok(()) => {
+                                tracing::info!(
+                                    target: "agentdesk::codex_rollout_handoff",
+                                    provider = %provider.as_str(),
+                                    channel = channel_id.get(),
+                                    message_id = frozen_msg_id.get(),
+                                    "turn_bridge removed streamed rollover prefix after full terminal replay"
+                                );
+                                ("committed", None)
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    target: "agentdesk::codex_rollout_handoff",
+                                    provider = %provider.as_str(),
+                                    channel = channel_id.get(),
+                                    message_id = frozen_msg_id.get(),
+                                    error = %error,
+                                    "turn_bridge failed to remove streamed rollover prefix after full terminal replay"
+                                );
+                                ("failed", Some(error))
+                            }
+                        };
+                    crate::services::observability::emit_relay_delete(
+                        provider.as_str(),
+                        channel_id.get(),
+                        frozen_msg_id.get(),
+                        adk_session_key.as_deref(),
+                        Some(turn_id.as_str()),
+                        "full_terminal_replay_prefix",
+                        "delete_nonterminal",
+                        replay_outcome,
+                        replay_detail.as_deref(),
+                    );
                 }
                 // #2236: look up the typed handoff marker stamped at dispatch
                 // time so multi-agent setups with overlapping background

--- a/src/services/discord/turn_bridge/watcher_orphan_cleanup.rs
+++ b/src/services/discord/turn_bridge/watcher_orphan_cleanup.rs
@@ -44,18 +44,36 @@ pub(in crate::services::discord) fn record_watcher_orphan_spinner_cleanup(
     outcome: super::placeholder_cleanup::PlaceholderCleanupOutcome,
     source: &'static str,
 ) {
-    if let super::placeholder_cleanup::PlaceholderCleanupOutcome::Failed { class, detail } =
-        &outcome
-    {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ watcher orphan spinner cleanup failed ({}) for channel {} msg {}: {}",
-            class.as_str(),
-            channel_id.get(),
-            message_id.get(),
-            detail
-        );
-    }
+    use super::placeholder_cleanup::PlaceholderCleanupOutcome;
+    let (emit_outcome, emit_detail) = match &outcome {
+        PlaceholderCleanupOutcome::Succeeded => ("committed", None),
+        PlaceholderCleanupOutcome::AlreadyGone => ("already_gone", None),
+        PlaceholderCleanupOutcome::Failed { class, detail } => {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] ⚠ watcher orphan spinner cleanup failed ({}) for channel {} msg {}: {}",
+                class.as_str(),
+                channel_id.get(),
+                message_id.get(),
+                detail
+            );
+            ("failed", Some(detail.clone()))
+        }
+    };
+    // #3607: durable delete observability for the orphan-spinner cleanup. The
+    // skip path is emitted by `orphan_spinner_cleanup_guarded_skip` before the
+    // delete; here we record the actual delete result.
+    crate::services::observability::emit_relay_delete(
+        provider.as_str(),
+        channel_id.get(),
+        message_id.get(),
+        None,
+        None,
+        source,
+        super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal.as_str(),
+        emit_outcome,
+        emit_detail.as_deref(),
+    );
     shared
         .ui
         .placeholder_cleanup
@@ -68,6 +86,102 @@ pub(in crate::services::discord) fn record_watcher_orphan_spinner_cleanup(
             outcome,
             source,
         });
+}
+
+/// #3607: full orphan-spinner cleanup, lifted out of the `turn_bridge/mod.rs`
+/// hot file. When a reused watcher leaves the bridge-created response
+/// placeholder orphaned the bridge calls this once.
+///
+/// First the terminal-anchor guard: if `current_msg_id` is a committed terminal
+/// anchor (the accident #3607 fixes — a finished turn's retired message that a
+/// generic janitor is about to wrongly delete) the delete is SKIPPED and a
+/// `skipped_committed_terminal` delete event is emitted. Otherwise this is a
+/// genuine non-terminal orphan: delete it, record the cleanup outcome (which
+/// also emits the durable `committed | already_gone | failed` delete event via
+/// [`record_watcher_orphan_spinner_cleanup`]), and on a retryable lifecycle
+/// failure spawn the bounded retry.
+///
+/// Behaviour for the non-guarded path is byte-identical to the prior inline
+/// block; only the guard + observability are new.
+pub(in crate::services::discord) async fn cleanup_or_preserve_watcher_orphan_spinner(
+    shared: Arc<SharedData>,
+    provider: &ProviderKind,
+    gateway: Arc<dyn TurnGateway>,
+    channel_id: ChannelId,
+    current_msg_id: MessageId,
+    inflight_state: &InflightTurnState,
+) {
+    if super::placeholder_cleanup::committed_terminal_anchor_protects_delete(
+        &shared.ui.placeholder_cleanup,
+        provider,
+        channel_id,
+        current_msg_id,
+        Some(inflight_state),
+    ) {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::info!(
+            "  [{ts}] 🛡 #3607 bridge preserved orphan watcher-handoff spinner anchor — committed terminal cleanup owns msg {} (channel {})",
+            current_msg_id.get(),
+            channel_id.get()
+        );
+        crate::services::observability::emit_relay_delete(
+            provider.as_str(),
+            channel_id.get(),
+            current_msg_id.get(),
+            None,
+            None,
+            "turn_bridge_watcher_orphan_spinner_cleanup",
+            super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal.as_str(),
+            "skipped_committed_terminal",
+            None,
+        );
+        return;
+    }
+
+    let cleanup_outcome = match gateway.delete_message(channel_id, current_msg_id).await {
+        Ok(()) => super::placeholder_cleanup::PlaceholderCleanupOutcome::Succeeded,
+        Err(error) => super::placeholder_cleanup::classify_delete_error(&error),
+    };
+    let cleanup_committed = cleanup_outcome.is_committed();
+    let cleanup_should_retry = should_retry_watcher_orphan_spinner_cleanup(&cleanup_outcome);
+    let cleanup_already_gone = matches!(
+        cleanup_outcome,
+        super::placeholder_cleanup::PlaceholderCleanupOutcome::AlreadyGone
+    );
+    record_watcher_orphan_spinner_cleanup(
+        shared.as_ref(),
+        provider,
+        channel_id,
+        current_msg_id,
+        inflight_state.tmux_session_name.as_deref(),
+        cleanup_outcome,
+        "turn_bridge_watcher_orphan_spinner_cleanup",
+    );
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    if cleanup_committed {
+        if cleanup_already_gone {
+            tracing::info!(
+                "  [{ts}] 🧹 bridge orphan watcher-handoff spinner card already gone (channel {}, msg {})",
+                channel_id,
+                current_msg_id
+            );
+        } else {
+            tracing::info!(
+                "  [{ts}] 🧹 bridge removed orphan watcher-handoff spinner card (channel {}, msg {})",
+                channel_id,
+                current_msg_id
+            );
+        }
+    } else if cleanup_should_retry {
+        spawn_watcher_orphan_spinner_cleanup_retry(
+            shared.clone(),
+            provider.clone(),
+            gateway.clone(),
+            channel_id,
+            current_msg_id,
+            inflight_state.tmux_session_name.clone(),
+        );
+    }
 }
 
 pub(in crate::services::discord) fn spawn_watcher_orphan_spinner_cleanup_retry(
@@ -181,5 +295,199 @@ mod watcher_orphan_cleanup_tests {
         assert!(!should_retry_watcher_orphan_spinner_cleanup(
             &PlaceholderCleanupOutcome::AlreadyGone
         ));
+    }
+
+    use super::super::gateway::GatewayFuture;
+    use crate::services::discord::formatting::ReplaceLongMessageOutcome;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct DeleteTrackingGateway {
+        deleted: Arc<Mutex<Vec<MessageId>>>,
+    }
+
+    impl TurnGateway for DeleteTrackingGateway {
+        fn send_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<MessageId, String>> {
+            Box::pin(async { Err("unused".to_string()) })
+        }
+
+        fn edit_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn delete_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            message_id: MessageId,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            let deleted = self.deleted.clone();
+            Box::pin(async move {
+                deleted.lock().expect("deleted lock").push(message_id);
+                Ok(())
+            })
+        }
+
+        fn replace_message_with_outcome<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>> {
+            Box::pin(async { Err("unused".to_string()) })
+        }
+
+        fn add_reaction<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _emoji: char,
+        ) -> GatewayFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn remove_reaction<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _emoji: char,
+        ) -> GatewayFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn schedule_retry_with_history<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _user_message_id: MessageId,
+            _user_text: &'a str,
+        ) -> GatewayFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn dispatch_queued_turn<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _intervention: &'a super::super::Intervention,
+            _request_owner_name: &'a str,
+            _has_more_queued_turns: bool,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn validate_live_routing<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn requester_mention(&self) -> Option<String> {
+            None
+        }
+
+        fn can_chain_locally(&self) -> bool {
+            true
+        }
+
+        fn bot_owner_provider(&self) -> Option<ProviderKind> {
+            Some(ProviderKind::Codex)
+        }
+    }
+
+    fn orphan_inflight(current_msg_id: u64, terminal_committed: bool) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Codex,
+            777,
+            None,
+            1,
+            2,
+            current_msg_id,
+            "test".to_string(),
+            None,
+            None,
+            None,
+            None,
+            0,
+        );
+        state.terminal_delivery_committed = terminal_committed;
+        state
+    }
+
+    #[tokio::test]
+    async fn committed_terminal_anchor_skips_orphan_spinner_delete() {
+        // #3607: when the orphaned spinner card's message is a committed terminal
+        // anchor (a finished turn's retired message), the bridge must NOT delete
+        // it. The accident this fixes.
+        let shared = super::super::make_shared_data_for_tests();
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(777);
+        let anchor = MessageId::new(50_000);
+        // The terminal cleanup already committed a DeleteTerminal tombstone, and
+        // the inflight is no longer the live owner (terminal not committed on
+        // this orphan row) — only the registry signal protects it.
+        shared.ui.placeholder_cleanup.record(
+            super::placeholder_cleanup::PlaceholderCleanupRecord {
+                provider: provider.clone(),
+                channel_id,
+                message_id: anchor,
+                tmux_session_name: None,
+                operation: super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteTerminal,
+                outcome: super::placeholder_cleanup::PlaceholderCleanupOutcome::Succeeded,
+                source: "test",
+            },
+        );
+        let gateway = Arc::new(DeleteTrackingGateway::default());
+        let inflight = orphan_inflight(anchor.get(), false);
+
+        cleanup_or_preserve_watcher_orphan_spinner(
+            shared.clone(),
+            &provider,
+            gateway.clone() as Arc<dyn TurnGateway>,
+            channel_id,
+            anchor,
+            &inflight,
+        )
+        .await;
+
+        assert!(
+            gateway.deleted.lock().expect("deleted lock").is_empty(),
+            "committed terminal anchor must be preserved (no delete)"
+        );
+    }
+
+    #[tokio::test]
+    async fn genuine_non_terminal_orphan_is_deleted() {
+        // #3607: a real orphan spinner (no terminal-anchor tombstone, inflight
+        // never committed terminal delivery) is still deleted as before.
+        let shared = super::super::make_shared_data_for_tests();
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(777);
+        let orphan = MessageId::new(60_000);
+        let gateway = Arc::new(DeleteTrackingGateway::default());
+        let inflight = orphan_inflight(orphan.get(), false);
+
+        cleanup_or_preserve_watcher_orphan_spinner(
+            shared.clone(),
+            &provider,
+            gateway.clone() as Arc<dyn TurnGateway>,
+            channel_id,
+            orphan,
+            &inflight,
+        )
+        .await;
+
+        assert_eq!(
+            gateway.deleted.lock().expect("deleted lock").as_slice(),
+            &[orphan],
+            "genuine non-terminal orphan must be deleted"
+        );
     }
 }

--- a/src/services/observability/emit.rs
+++ b/src/services/observability/emit.rs
@@ -446,6 +446,81 @@ pub fn emit_relay_delivery(
     );
 }
 
+/// #3607 durable delete observability: record a structured event at each wired
+/// relay-message *delete* decision so terminal-anchor protections and orphan /
+/// panel / replay-prefix cleanups are PG-queryable and attributable. Mirrors
+/// [`emit_relay_delivery`] (which covers the answer-delivery side) for the
+/// destructive side: `source` is the call site (`turn_bridge_watcher_orphan_…`,
+/// `full_terminal_replay_prefix`, `placeholder_sweeper`, …), `operation_kind`
+/// reuses the `PlaceholderCleanupOperation` vocab (`delete_terminal` /
+/// `delete_nonterminal` / `edit_terminal` / `edit_preserve`) or a site-specific
+/// descriptive verb, and `outcome` is one of `committed` | `already_gone` |
+/// `failed` | `skipped_committed_terminal`. The outcome doubles as the event
+/// `status` (correlation column) so a query can split committed deletes from
+/// guard-skips without parsing the payload.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_relay_delete(
+    provider: &str,
+    channel_id: u64,
+    message_id: u64,
+    session_key: Option<&str>,
+    turn_id: Option<&str>,
+    source: &str,
+    operation_kind: &str,
+    outcome: &str,
+    detail: Option<&str>,
+) {
+    emit_event(
+        "relay_delete",
+        Some(provider),
+        Some(channel_id),
+        None,
+        session_key,
+        turn_id,
+        normalize_string(outcome).as_deref(),
+        CounterDelta::default(),
+        json!({
+            "message_id": message_id,
+            "source": normalize_string(source),
+            "operation_kind": normalize_string(operation_kind),
+            "outcome": normalize_string(outcome),
+            "detail": detail.and_then(normalize_string),
+        }),
+    );
+}
+
+/// #3607 ergonomic wrapper over [`emit_relay_delete`] for the common
+/// delete-then-observe call sites: maps a delete `Result` to the
+/// `committed` / `failed` outcome (and the `Err` text into `detail`) so each
+/// site stays a single compact call instead of an inline match. `provider` may
+/// be empty for sites with no provider scope (idle-recap / monitoring); it is
+/// normalized away to none.
+pub fn emit_relay_delete_result<E: std::fmt::Display>(
+    provider: &str,
+    channel_id: u64,
+    message_id: u64,
+    source: &str,
+    operation_kind: &str,
+    result: &Result<(), E>,
+) {
+    let detail = result.as_ref().err().map(|error| error.to_string());
+    emit_relay_delete(
+        provider,
+        channel_id,
+        message_id,
+        None,
+        None,
+        source,
+        operation_kind,
+        if result.is_ok() {
+            "committed"
+        } else {
+            "failed"
+        },
+        detail.as_deref(),
+    );
+}
+
 pub fn emit_agent_quality_event(event: AgentQualityEvent) {
     let Some(event_type) = super::helpers::normalize_quality_event_type(&event.event_type) else {
         tracing::warn!(
@@ -768,6 +843,47 @@ mod tests {
         assert_eq!(recovery.payload["turn_id"], "turn-recovery");
         assert_eq!(recovery.payload["agent_id"], "planner");
         assert_eq!(recovery.payload["reason"], "watchdog");
+    }
+
+    #[test]
+    fn relay_delete_records_required_fields_and_outcome() {
+        // #3607: every wired delete site funnels through emit_relay_delete. The
+        // event must carry the required relay fields (channel_id / message_id /
+        // source / operation_kind / outcome) and surface the outcome as both the
+        // payload value and the correlation status so committed deletes and
+        // guard-skips are queryable apart.
+        let _guard = super::super::test_runtime_lock();
+        super::super::reset_for_tests();
+
+        emit_relay_delete(
+            "Codex",
+            42,
+            7777,
+            Some("session-delete"),
+            Some("turn-delete"),
+            "turn_bridge_watcher_orphan_spinner_cleanup",
+            "delete_nonterminal",
+            "skipped_committed_terminal",
+            Some(" guarded "),
+        );
+
+        let events = events::recent(50);
+        let event = events
+            .iter()
+            .find(|event| event.event_type == "relay_delete")
+            .expect("relay_delete should be in recent ring");
+        assert_eq!(event.provider.as_deref(), Some("codex"));
+        assert_eq!(event.channel_id, Some(42));
+        assert_eq!(event.payload["message_id"], 7777);
+        assert_eq!(
+            event.payload["source"],
+            "turn_bridge_watcher_orphan_spinner_cleanup"
+        );
+        assert_eq!(event.payload["operation_kind"], "delete_nonterminal");
+        assert_eq!(event.payload["outcome"], "skipped_committed_terminal");
+        assert_eq!(event.payload["detail"], "guarded");
+        // outcome doubles as the correlation status.
+        assert_eq!(event.payload["status"], "skipped_committed_terminal");
     }
 
     #[test]

--- a/src/services/observability/mod.rs
+++ b/src/services/observability/mod.rs
@@ -41,9 +41,9 @@ mod worker;
 pub use emit::{
     InvariantSeverity, emit_agent_quality_event, emit_dispatch_result, emit_guard_fired,
     emit_inflight_lifecycle_event, emit_intake_placeholder_post_failed, emit_recovery_fired,
-    emit_relay_delivery, emit_turn_cancelled, emit_turn_finished_with_dispatch_kind,
-    emit_turn_started, emit_watcher_replaced, record_invariant_check,
-    record_invariant_check_with_severity,
+    emit_relay_delete, emit_relay_delete_result, emit_relay_delivery, emit_turn_cancelled,
+    emit_turn_finished_with_dispatch_kind, emit_turn_started, emit_watcher_replaced,
+    record_invariant_check, record_invariant_check_with_severity,
 };
 #[allow(unused_imports)]
 pub use queries::{


### PR DESCRIPTION
## 설계 요약 (Phase A: criteria ① delete observability + ② terminal-protection 가드)

가드 권위:
- 신호(c) registry: `PlaceholderCleanupRegistry.terminal_cleanup_committed`
  (placeholder_cleanup.rs, 프로덕션 배선 `tmux_watcher.rs:6521`, inflight clear
  후에도 TTL 1h 생존) — 사고 형태(inflight는 이미 사라졌는데 janitor가 terminal
  cleanup이 막 커밋한 메시지를 지우려는 케이스)의 durable 권위.
- 신호(a) live inflight fast-path: turn의 `current_msg_id == message_id &&
  terminal_delivery_completed()` — registry write가 아직 안 내려와도 보호.
- 신호(b) `delivery_record`는 제외: #3089 dead code(env OFF, 사고 record도
  `panel_msg_id=null`). `committed_terminal_anchor_protects_delete` doc에 #3089
  cutover 시 OR-term 추가를 명시.

가드 배선:
- **sweeper:842** panel delete 전 `committed_terminal_panel_anchor_skip` →
  committed terminal anchor면 skip + `emit_relay_delete(outcome="skipped_committed_terminal")`.
- **orphan-spinner:4698**: cleanup 전체를 `watcher_orphan_cleanup.rs` sibling
  (`cleanup_or_preserve_watcher_orphan_spinner`)으로 추출 — 가드 통과 시 skip,
  진짜 non-terminal orphan만 delete/record/retry.

delete 관측:
- `emit_relay_delete` / `emit_relay_delete_result`를 모든 wired delete site에 배선:
  orphan-spinner, full-terminal replay-prefix, sweeper, idle_recap,
  monitoring_status, gateway queued-placeholder drain. 필수필드 channel_id /
  message_id / source / operation_kind / outcome 충족, outcome이 correlation
  status도 겸함(committed deletes vs guard-skips 분리 쿼리).

## 핫파일 순증 (모든 ratchet PASS)
- `turn_bridge/mod.rs`: raw 6589→6571 (**-18**), prod 6166→6148 (**-18**)
  — orphan-spinner cleanup 본체를 sibling으로 추출해 순감소. 헤드룸 raw 6621 /
  prod 6198.
- `tmux_watcher.rs`: 10111→10111 (**+0**). `:3092` emit은 #3610/Phase-B 디퍼
  (raw-ratchet ceiling이라 in-place 주석만).
- `session_relay_sink.rs`(1730) / `turn_finalizer.rs`(1335): 불변.
- 비-핫 near-boundary: `placeholder_sweeper.rs` 990→999, `idle_recap.rs` 985→994
  (둘 다 <1000 유지).

## 테스트 (sibling/co-locate, mod.rs 테스트 줄 0)
- `placeholder_cleanup`: 가드 positive / negative / positive-after-inflight-clear
  / fusion signal-a-only / fusion neither (5 신규).
- `observability::emit`: relay_delete 필수필드 + outcome status (1 신규).
- `watcher_orphan_cleanup`: committed-terminal anchor→guard skip / 진짜
  non-terminal orphan→delete (2 신규 async).

## Caveats
- `tmux_watcher.rs:3092` emit = #3610/Phase-B 디퍼.
- criterion③ recovery-fallback = #3610 (별도). **Closes 아님.**

Refs #3607 (Phase A).