### PR TITLE
fix(#3610): delivery_record terminal anchor 기록 (Phase B PR-1 선결)

### DIFF
--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -442,7 +442,10 @@
 "src/services/discord/session_runtime.rs" = 1753
 # #3034 batch-8: +1 for a test-only `#[allow(dead_code)]` on
 # `session_bound_terminal_delivery_route_decision` (#3041 route decision, tested).
-"src/services/discord/session_relay_sink.rs" = 1731
+# #3610 PR-1: 1731 -> 1738 — pass terminal anchor (current_msg_id) explicitly to
+# shadow_mirror_delivered_frontier at the sink delivery call site (Phase B prereq;
+# irreducible 6-arg rustfmt-wrapped call). panel_msg_id has 0 prod readers -> dedup unchanged.
+"src/services/discord/session_relay_sink.rs" = 1738
 # #3479: turn_bridge/tmux_runtime.rs decomposed into tmux_runtime/ directory
 # modules (root tmux_runtime.rs 964 prod LoC + sub-1000-LoC
 # tmux_runtime/{interrupt_policy,process_table,pid_exit}.rs) — dropped below the

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -635,15 +635,30 @@ fn record_delivered_frontier_shadow(
 /// Integration wrapper for owner `Delivered` arms. Gated by [`should_shadow_mirror`]
 /// (flag ON AND `is_delivered`, I2). When it fires it extracts the in-memory
 /// authority (`confirmed_end_offset` + `confirmed_end_generation_mtime_ns`) from
-/// the relay coord and the `panel_msg_id`/`attempts` mirror from the fresh
-/// inflight, then shadow-writes. OFF or non-`Delivered` → returns immediately
-/// (no coord/inflight access, no write) → behavioral no-op.
+/// the relay coord and the `attempts` mirror from the fresh inflight, then
+/// shadow-writes. OFF or non-`Delivered` → returns immediately (no coord/inflight
+/// access, no write) → behavioral no-op.
+///
+/// #3610 (Phase B PR-1): `terminal_anchor_msg_id` is the durable TERMINAL ANCHOR
+/// the caller resolved — the Discord message id terminal-replace edits in place
+/// (= the placeholder/active-slot `current_msg_id`, the assistant response
+/// message). It is recorded verbatim into [`DeliveredCommit::panel_msg_id`]. This
+/// REPLACES the prior `fresh.status_message_id` read, which was the WRONG datum:
+/// `status_message_id` is the status-panel-v2 id (inflight/model.rs: "current_msg_id
+/// remains the assistant response"), not the terminal anchor, and is `null` on
+/// channels that do not use the status panel — yielding `panel_msg_id = null` on
+/// the very incidents PR-2's re-post will key off. Cross-channel callers (the
+/// bridge cutover, where the frontier-key channel differs from the edit-target
+/// channel) pass `None` and are out of this PR's scope. `None` writes a null
+/// anchor (unchanged from the absent-status-panel case), so OFF/None paths stay
+/// behaviorally identical.
 pub(in crate::services::discord) fn shadow_mirror_delivered_frontier(
     shared: &crate::services::discord::SharedData,
     provider: &ProviderKind,
     channel: ChannelId,
     range: (u64, u64),
     is_delivered: bool,
+    terminal_anchor_msg_id: Option<u64>,
 ) {
     if !should_shadow_mirror(is_delivered, delivery_record_shadow_enabled()) {
         return;
@@ -659,14 +674,13 @@ pub(in crate::services::discord) fn shadow_mirror_delivered_frontier(
         .as_ref()
         .map(|f| f.recovery_relay_attempts)
         .unwrap_or(0);
-    let panel_msg_id = fresh.as_ref().and_then(|f| f.status_message_id);
     record_delivered_frontier_shadow(
         provider,
         channel_id,
         range,
         generation_mtime_ns,
         attempts,
-        panel_msg_id,
+        terminal_anchor_msg_id,
         in_memory_confirmed_end,
     );
 }
@@ -1115,5 +1129,116 @@ mod tests {
             current_generation_durable_frontier_end_at(&malformed, 5),
             None
         );
+    }
+
+    // ---- #3610 (Phase B PR-1) terminal-anchor recording -----------------------
+    // `shadow_mirror_delivered_frontier` forwards the caller's
+    // `terminal_anchor_msg_id` verbatim as the `panel_msg_id` argument to
+    // `record_delivered_frontier_shadow_at` (the path-based testable core), so
+    // these exercise that core with the anchor semantics the three call sites use:
+    //   - sink/watcher (same-channel) → anchor = Some(current_msg_id)
+    //   - bridge cutover (cross-channel) → anchor = None
+    // The status-panel id (`status_message_id`) is no longer read; the recorded
+    // anchor is now the terminal `current_msg_id` the replace edits in place.
+
+    #[test]
+    fn anchor_msg_id_recorded_as_panel_msg_id_3610() {
+        // The sink/watcher path: the caller resolves the terminal anchor =
+        // `current_msg_id` (the active-slot / PlaceholderEdit-target message) and
+        // passes it as the `panel_msg_id` argument. It lands in
+        // `DeliveredCommit.panel_msg_id` verbatim — NOT the status-panel id.
+        let dir = tempfile::tempdir().unwrap();
+        let path = delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 36100);
+        // Anchor (current_msg_id) is a DIFFERENT value than any status-panel id
+        // would be — pinning that the recorded datum is the terminal anchor.
+        let terminal_anchor: u64 = 555_111_222;
+        record_delivered_frontier_shadow_at(&path, (0, 100), 700, 0, Some(terminal_anchor), 100)
+            .unwrap();
+        let written = read_record_at(&path).unwrap().delivered_frontier.unwrap();
+        assert_eq!(written.panel_msg_id, Some(terminal_anchor));
+        assert_eq!(written.range, (0, 100));
+    }
+
+    #[test]
+    fn anchor_none_records_null_panel_msg_id_3610() {
+        // The bridge cutover (cross-channel) passes `None`: the durable anchor
+        // stays null (unchanged from the absent-status-panel case), and the
+        // frontier still advances normally.
+        let dir = tempfile::tempdir().unwrap();
+        let path = delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 36101);
+        record_delivered_frontier_shadow_at(&path, (0, 100), 700, 0, None, 100).unwrap();
+        let written = read_record_at(&path).unwrap().delivered_frontier.unwrap();
+        assert_eq!(written.panel_msg_id, None);
+        assert_eq!(written.range, (0, 100));
+    }
+
+    #[test]
+    fn anchor_value_is_dedup_byte_invariant_3610() {
+        // ★ #3593 byte-impact 0: the recorded `panel_msg_id` (terminal anchor) is
+        // NEVER read by the offset-dedup path — the single durable-frontier reader
+        // (`current_generation_durable_frontier_end_at`) reads only `.range.1`. So
+        // two records with the SAME frontier END but DIFFERENT anchors
+        // (Some(current_msg_id) vs None, the old status_message_id=null incident
+        // case) MUST yield byte-identical dedup decisions.
+        let dir = tempfile::tempdir().unwrap();
+        let gen_ns = 700_000_000_i64;
+
+        let path_with_anchor =
+            delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 36102);
+        write_delivered_frontier_at(
+            &path_with_anchor,
+            DeliveredCommit {
+                range: (0, 443_154),
+                generation_mtime_ns: gen_ns,
+                attempts: 1,
+                panel_msg_id: Some(999_888_777), // #3610: terminal anchor present
+            },
+        )
+        .unwrap();
+
+        let path_null_anchor =
+            delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 36103);
+        write_delivered_frontier_at(
+            &path_null_anchor,
+            DeliveredCommit {
+                range: (0, 443_154),
+                generation_mtime_ns: gen_ns,
+                attempts: 1,
+                panel_msg_id: None, // pre-fix incident shape (status_message_id=null)
+            },
+        )
+        .unwrap();
+
+        // Same durable frontier END read out regardless of anchor.
+        let end_with = current_generation_durable_frontier_end_at(&path_with_anchor, gen_ns);
+        let end_null = current_generation_durable_frontier_end_at(&path_null_anchor, gen_ns);
+        assert_eq!(end_with, end_null);
+        assert_eq!(end_with, Some(443_154));
+
+        // Same dedup decision regardless of anchor (the #3593 suppress + the
+        // over-suppression no-regression both unchanged).
+        let fused_with = 0_u64.max(end_with.unwrap_or(0));
+        let fused_null = 0_u64.max(end_null.unwrap_or(0));
+        assert_eq!(fused_with, fused_null);
+        assert_eq!(
+            range_already_committed(422_855, fused_with),
+            range_already_committed(422_855, fused_null)
+        );
+        assert!(range_already_committed(422_855, fused_with)); // suppressed
+        assert_eq!(
+            range_already_committed(443_200, fused_with),
+            range_already_committed(443_200, fused_null)
+        );
+        assert!(!range_already_committed(443_200, fused_with)); // new answer relayed
+    }
+
+    #[test]
+    fn shadow_off_is_anchor_noop_3610() {
+        // SHADOW OFF → no write at all, so the anchor (whatever the caller resolves)
+        // is never recorded. `shadow_mirror_delivered_frontier`'s first gate is
+        // `should_shadow_mirror(is_delivered, enabled)`; OFF short-circuits before
+        // any coord/inflight access or write. Pinned here at the gate level.
+        assert!(!should_shadow_mirror(true, false)); // flag OFF → no anchor write
+        assert!(!should_shadow_mirror(false, true)); // not delivered → no anchor write (I2)
     }
 }

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -679,8 +679,16 @@ impl SessionBoundDiscordRelaySink {
         .await;
 
         // #3089 B1: shadow-mirror durable delivered frontier — flag-gated, observe-only, Delivered-only (I2), OFF=no-op.
+        // #3610 PR-1: anchor = `msg_id` (current_msg_id — true terminal anchor, not status_message_id).
         let b1_delivered = dr::outcome_is_shadow_delivered(&outcome);
-        dr::shadow_mirror_delivered_frontier(shared, provider, channel, (start, end), b1_delivered);
+        dr::shadow_mirror_delivered_frontier(
+            shared,
+            provider,
+            channel,
+            (start, end),
+            b1_delivered,
+            Some(msg_id.get()),
+        );
 
         match outcome {
             // Confirmed POST (edit OR #2757 fallback): controller already ran advance + commit;

--- a/src/services/discord/tmux_watcher/terminal_send.rs
+++ b/src/services/discord/tmux_watcher/terminal_send.rs
@@ -329,12 +329,16 @@ pub(in crate::services::discord) async fn deliver_short_replace_via_controller<
     .await;
 
     // #3089 B2a: shadow-mirror durable delivered frontier — flag-gated, observe-only, Delivered-only (I2), OFF=no-op. Extends B1's sink coverage to the watcher (A4) before B2b's authority flip.
+    // #3610 PR-1: anchor = `msg_id` — the controller active-slot `current_msg_id`
+    // (the assistant response message terminal-replace edits in place), NOT
+    // `status_message_id`. Records the true terminal anchor for PR-2.
     dr::shadow_mirror_delivered_frontier(
         shared,
         provider,
         channel_id,
         (start, end),
         dr::outcome_is_shadow_delivered(&outcome),
+        Some(msg_id.get()),
     );
 
     match outcome {

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -314,12 +314,18 @@ pub(super) async fn deliver_short_replace_via_controller(
     // OFFSET-AUTHORITY channel where `advance_tmux_relay_confirmed_end` advanced
     // `confirmed_end_offset`), NOT the edit-target `channel_id` — so the durable
     // frontier and the in-memory authority B2b fuses share one channel key.
+    // #3610 PR-1: anchor = `None`. The frontier is keyed by `watcher_owner_channel_id`
+    // (the OFFSET-AUTHORITY channel), which may DIFFER from the edit-target `channel_id`
+    // the `msg_id` belongs to — so this cross-channel cutover cannot assert the
+    // edit-target `msg_id` is the anchor on the frontier-key channel. Out of PR-1's
+    // scope (sink+watcher same-channel only); leave the anchor null as before.
     dr::shadow_mirror_delivered_frontier(
         shared,
         provider,
         watcher_owner_channel_id,
         (start, end),
         dr::outcome_is_shadow_delivered(&outcome),
+        None,
     );
     outcome
 }


### PR DESCRIPTION
## 근본원인
`shadow_mirror_delivered_frontier`(delivery_record.rs)가 `panel_msg_id = fresh.status_message_id`(status-panel-v2 id)를 기록 → **terminal anchor 아님**. terminal-replace는 `current_msg_id`를 edit하므로 anchor=current_msg_id. status-panel 미사용 채널은 status_message_id=null → #3607 사고의 `panel_msg_id=null` 정확히 재현.

## Fix
- sink(session_relay_sink.rs)·watcher(tmux_watcher/terminal_send.rs) 경로가 `anchor = current_msg_id` 명시 전달.
- bridge cutover(terminal_controller_cutover.rs)는 **anchor=None 유지**(frontier 키 채널 ≠ edit-target 채널일 수 있는 cross-channel — PR-1 범위 제외).

## #3593 dedup byte-영향 0
`DeliveredCommit.panel_msg_id` **비-테스트 reader 0개**(offset fusion은 `.range`만 read) → `range_already_committed`/`committed_floor_for_resend_dedup` 등 #3593/#3520 가드 불변.

## giant baseline
session_relay_sink.rs 1731→1738 admission — anchor 전달 6-arg 호출의 불가피한 rustfmt wrap(+7). 주석은 1줄로 트림. (baseline toml에 사유 기록.)

## 다음
PR-2(anchor-missing 감지 + transcript 재포스트)는 **이 PR 배포·관측(panel_msg_id 실제 채워짐 확인) 후** — 잘못된 anchor 신뢰 위험 + #3593 dedup 안정화 후. 중복 무발생 5겹 증명은 설계서 참조.

Refs #3610 (Phase B PR-1).