### PR TITLE
feat(#3594 T3): depth-gated plan/plan-review 흐름

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -110,7 +110,7 @@
   - `src/dispatch/dispatch_context.rs` (2805 lines).
   - `src/dispatch/dispatch_create.rs` (1385 lines).
   - `src/dispatch/dispatch_status.rs` (1495 lines).
-  - `src/services/dispatches/outbox_route.rs` (1101 lines; route extraction
+  - `src/services/dispatches/outbox_route.rs` (1120 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
   - `src/services/dispatches/discord_delivery/orchestration.rs` (1490 lines;
     delivery orchestration surface extracted from the route layer in #1760,
@@ -1280,7 +1280,7 @@
   its query/command/view/FSM behavior lives under
   `src/services/auto_queue/{query,command,view,fsm,phase_gate}.rs` plus
   smaller route-delegation slices.
-  `src/services/auto_queue/activate_command.rs` (1457 lines, post-#1444
+  `src/services/auto_queue/activate_command.rs` (1477 lines, post-#1444
   idempotency-guard expansion + #3038 phase-helper decomposition) is the
   canonical activate/dispatch-next command surface; it is intentionally above
   the giant-file threshold and tracked here. The `activate_with_deps_pg`
@@ -1429,7 +1429,7 @@ Line counts are *production* LoC (the `Prod` column in `module-inventory.md`,
 which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync.
 
 - `src/services/auto_queue.rs` (1546) and
-  `src/services/auto_queue/activate_command.rs` (1457); auto-queue route
+  `src/services/auto_queue/activate_command.rs` (1477); auto-queue route
   behavior is split across `src/services/auto_queue/*` slices, with
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
@@ -1439,7 +1439,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
-- `src/services/dispatches/outbox_route.rs` (1101) — dispatch outbox route
+- `src/services/dispatches/outbox_route.rs` (1120) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -109,7 +109,7 @@
 - do_not_edit_without_migration_plan (giant-file, awaiting split issue):
   - `src/dispatch/dispatch_context.rs` (2805 lines).
   - `src/dispatch/dispatch_create.rs` (1385 lines).
-  - `src/dispatch/dispatch_status.rs` (1495 lines).
+  - `src/dispatch/dispatch_status.rs` (1508 lines).
   - `src/services/dispatches/outbox_route.rs` (1120 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
   - `src/services/dispatches/discord_delivery/orchestration.rs` (1490 lines;
@@ -1280,7 +1280,7 @@
   its query/command/view/FSM behavior lives under
   `src/services/auto_queue/{query,command,view,fsm,phase_gate}.rs` plus
   smaller route-delegation slices.
-  `src/services/auto_queue/activate_command.rs` (1477 lines, post-#1444
+  `src/services/auto_queue/activate_command.rs` (1509 lines, post-#1444
   idempotency-guard expansion + #3038 phase-helper decomposition) is the
   canonical activate/dispatch-next command surface; it is intentionally above
   the giant-file threshold and tracked here. The `activate_with_deps_pg`
@@ -1429,7 +1429,7 @@ Line counts are *production* LoC (the `Prod` column in `module-inventory.md`,
 which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync.
 
 - `src/services/auto_queue.rs` (1546) and
-  `src/services/auto_queue/activate_command.rs` (1477); auto-queue route
+  `src/services/auto_queue/activate_command.rs` (1509); auto-queue route
   behavior is split across `src/services/auto_queue/*` slices, with
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;

--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -577,6 +577,12 @@ test("kanban-rules dispatches scope-assessment once when a card enters requested
       {
         match: "SELECT assigned_agent_id, title FROM kanban_cards WHERE id = ?",
         result: [{ assigned_agent_id: "agent-7", title: "Scope card" }]
+      },
+      {
+        // #3594 (T3, codex Finding 2): scope-assessment claims the card's pending
+        // auto-queue entry onto its dispatch (consultation pattern).
+        match: "FROM auto_queue_entries e JOIN auto_queue_runs r",
+        result: [{ id: "entry-scope-1", agent_id: "agent-7" }]
       }
     ])
   });
@@ -593,6 +599,19 @@ test("kanban-rules dispatches scope-assessment once when a card enters requested
   assert.ok(scopeMeta, "expected a scope metadata write");
   assert.equal(scopeMeta.scope_assessment_status, "pending");
   assert.ok(scopeMeta.scope_assessment_dispatch_id);
+
+  // #3594 (T3, codex Finding 2): the pending entry must be CLAIMED onto the
+  // scope-assessment dispatch — marked `dispatched` + linked (via the Rust
+  // updateEntryStatus path that writes auto_queue_entry_dispatch_history) — so
+  // scope-completion's resume finds it and the depth gate (plan/plan-review) is
+  // not bypassed by the activate fallback creating a plain implementation.
+  const claim = state.autoQueueStatusUpdates.find(
+    (u) => u.entryId === "entry-scope-1" && u.status === "dispatched"
+  );
+  assert.ok(claim, "scope-assessment must claim the pending entry as dispatched");
+  assert.equal(claim.extra.dispatchId, scopeMeta.scope_assessment_dispatch_id);
+  assert.equal(claim.reason, "scope_assessment_claim");
+
   // T2 is inert: no escalation/manual intervention from the trigger.
   assert.deepEqual(state.manualInterventions, []);
 });
@@ -792,10 +811,11 @@ test("kanban-rules records scope-assessment result on the card metadata and stay
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
         result: [{ metadata: JSON.stringify({ keep: "yes", scope_assessment_status: "pending" }) }]
       },
-      // #3594 (T3): plan_only depth now triggers a plan dispatch via the
-      // consultation-resume path; with no linked auto-queue entry it defers to
-      // the activate path (no dispatch created), leaving the inert assertions
-      // below valid while still exercising the depth branch.
+      // #3594 (T3): no auto-queue entry exists for this card (manual/API path),
+      // so the plan stage finds nothing to claim and creates no entry-bound
+      // dispatch — the inert assertions below stay valid while still exercising
+      // the plan_only depth branch. (The full chain with a real entry is covered
+      // by the depth-gated-chain integration tests below.)
       { match: "FROM auto_queue_entries e", result: [] }
     ])
   });
@@ -861,8 +881,8 @@ test("kanban-rules falls back to full when scope-assessment result is unusable",
           match: "SELECT metadata FROM kanban_cards WHERE id = ?",
           result: [{ metadata: "{}" }]
         },
-        // #3594 (T3): full-fallback depth triggers a plan dispatch; no linked
-        // auto-queue entry → defers (no dispatch created).
+        // #3594 (T3): no auto-queue entry for this card → full-fallback plan
+        // stage creates no entry-bound dispatch (manual/API path).
         { match: "FROM auto_queue_entries e", result: [] }
       ])
     });
@@ -1084,6 +1104,13 @@ test("T3: plan completion (depth=full in context) publishes a plan-review dispat
   assert.equal(state.dispatchCreates.length, 1);
   assert.equal(state.dispatchCreates[0].dispatchType, "plan-review", "full plan completion → plan-review");
   assert.equal(state.dispatchCreates[0].context.scope_depth, "full");
+  // #3594 (T3, codex Finding 3): the plan body must be forwarded to the reviewer
+  // so it actually reviews the plan (not just {scope_depth}).
+  assert.equal(
+    state.dispatchCreates[0].context.parent_plan,
+    "big design...",
+    "plan-review dispatch must carry the plan body as parent_plan"
+  );
   assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_plan_review");
 });
 
@@ -1093,7 +1120,7 @@ test("T3: plan-review pass → implementation dispatch", () => {
     dispatchId: "dispatch-pr-pass",
     dispatchType: "plan-review",
     cardStatus: "in_progress",
-    context: JSON.stringify({ scope_depth: "full", auto_queue: true }),
+    context: JSON.stringify({ scope_depth: "full", auto_queue: true, parent_plan: "approved design body" }),
     result: JSON.stringify({ verdict: "pass", summary: "plan ok" })
   });
 
@@ -1101,6 +1128,13 @@ test("T3: plan-review pass → implementation dispatch", () => {
 
   assert.equal(state.dispatchCreates.length, 1);
   assert.equal(state.dispatchCreates[0].dispatchType, "implementation", "plan-review pass → impl");
+  // #3594 (T3, codex Finding 3): the approved plan (carried in the plan-review
+  // context) must flow into the impl dispatch so the implementer sees it.
+  assert.equal(
+    state.dispatchCreates[0].context.parent_plan,
+    "approved design body",
+    "impl dispatch must carry the approved plan body forward"
+  );
   assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_plan_review_pass");
 });
 
@@ -1154,4 +1188,222 @@ test("T3: scope/plan dispatches never enter the PM-gate / review lifecycle", () 
   assert.deepEqual(state.statusCalls, [], "plan completion must not setStatus (no review advance)");
   assert.deepEqual(state.reviewStatusCalls, []);
   assert.deepEqual(state.manualInterventions, []);
+});
+
+// ── #3594 (T3) ★ depth-gated-chain integration tests ──────────────
+//
+// These drive the FULL multi-stage chain through the real kanban-rules
+// onDispatchCompleted arms with a STATEFUL auto-queue entry, asserting the
+// codex-required invariants end-to-end:
+//   - full:      scope → plan (NOT impl) → plan-review → impl. Each stage keeps
+//                the SAME entry alive (dispatched), only impl is the terminal
+//                work dispatch. The plan body flows plan → plan-review → impl.
+//   - plan_only: scope → plan → impl.
+//   - direct:    scope → impl (no plan).
+// The harness simulates the consultation-resume contract: a dispatch "claims" the
+// entry by linking it (auto_queue_entry_dispatch_history) + marking it dispatched,
+// and _findAutoQueueEntriesByDispatch returns the entry only while it is linked to
+// the queried dispatch AND still `dispatched`. That is exactly the lifecycle the
+// Rust updateEntryStatus path implements, so the JS chain is exercised faithfully.
+function makeChainHarness(initialScopeMeta) {
+  // Mutable simulation state.
+  const entry = { id: "entry-chain", agent_id: "agent-chain", status: "pending", linkedDispatchId: null };
+  let cardMeta = Object.assign({}, initialScopeMeta || {});
+  const dispatches = {}; // id → { dispatch_type, context, result, status }
+  let dispatchSeq = 0;
+
+  function registerDispatch(dispatchType, context, result) {
+    dispatchSeq += 1;
+    const id = "dispatch-chain-" + dispatchSeq;
+    dispatches[id] = {
+      id,
+      kanban_card_id: "card-chain",
+      to_agent_id: "agent-chain",
+      dispatch_type: dispatchType,
+      chain_depth: 0,
+      created_at: "2026-06-19 09:0" + dispatchSeq + ":00",
+      context: context || "{}",
+      result: result || "{}",
+      status: "completed"
+    };
+    return id;
+  }
+
+  const harness = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-chain": {
+        id: "card-chain",
+        title: "Chain card",
+        status: "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-chain",
+        deferred_dod_json: null
+      }
+    },
+    // dispatch.create registers a new (already-"completed") dispatch row so the
+    // next onDispatchCompleted can read its context. Returns the new id.
+    dispatchCreate(cardId, agentId, dispatchType, title, context) {
+      const ctxJson = context ? JSON.stringify(context) : "{}";
+      const id = registerDispatch(dispatchType, ctxJson, "{}");
+      harness.state.dispatchCreates.push({ cardId, agentId, dispatchType, title, context: context || null, id });
+      return id;
+    },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM task_dispatches WHERE id = ?",
+        result: (sql, params) => {
+          const row = dispatches[params[0]];
+          return row ? [row] : [];
+        }
+      },
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: () => [{ metadata: JSON.stringify(cardMeta) }]
+      },
+      {
+        // _findAutoQueueEntriesByDispatch(dispatchId, false): entry is returned
+        // only while linked to the queried dispatch AND status 'dispatched'.
+        match: (sql) => /LEFT JOIN auto_queue_entry_dispatch_history/.test(sql),
+        result: (sql, params) => {
+          const dispatchId = params[0];
+          if (entry.status === "dispatched" && entry.linkedDispatchId === dispatchId) {
+            return [{ id: entry.id, agent_id: entry.agent_id }];
+          }
+          return [];
+        }
+      },
+      {
+        // _findPendingEntryForCard: returns the pending entry by card.
+        match: (sql) => /FROM auto_queue_entries e JOIN auto_queue_runs r/.test(sql),
+        result: () => (entry.status === "pending" ? [{ id: entry.id, agent_id: entry.agent_id }] : [])
+      }
+    ]),
+    dbExecute(sql, params) {
+      // Capture card metadata writes so scope_assessment_status flips persist.
+      if (/UPDATE kanban_cards SET metadata = \?/.test(sql) && params && typeof params[0] === "object") {
+        cardMeta = Object.assign({}, params[0]);
+      }
+      return { changes: 1 };
+    }
+  });
+
+  // updateEntryStatus mutates the simulated entry: 'dispatched' (re)links to the
+  // given dispatchId; terminal statuses settle it.
+  harness.agentdesk.autoQueue.updateEntryStatus = function (entryId, status, reason, opts) {
+    harness.state.autoQueueStatusUpdates.push({ entryId, status, reason, extra: opts || null });
+    if (entryId !== entry.id) return;
+    entry.status = status;
+    if (status === "dispatched" && opts && opts.dispatchId) {
+      entry.linkedDispatchId = opts.dispatchId;
+    }
+  };
+
+  return {
+    policy: harness.module.policy,
+    state: harness.state,
+    entry,
+    registerDispatch,
+    patchDispatchResult(dispatchId, result) {
+      if (dispatches[dispatchId]) {
+        dispatches[dispatchId].result = typeof result === "string" ? result : JSON.stringify(result);
+      }
+    },
+    setMeta(patch) { cardMeta = Object.assign({}, cardMeta, patch); },
+    getMeta() { return cardMeta; }
+  };
+}
+
+function lastCreate(state) {
+  return state.dispatchCreates[state.dispatchCreates.length - 1];
+}
+
+test("T3 ★ full chain: scope→plan→plan-review→impl keeps one entry alive, only impl is terminal work, plan body flows through", () => {
+  const h = makeChainHarness({ scope_assessment_status: "pending" });
+  // Stage 0: scope-assessment dispatch already exists + claimed the entry
+  // (as _maybeDispatchScopeAssessment does). Seed that linkage.
+  const scopeId = h.registerDispatch("scope-assessment", "{}",
+    JSON.stringify({ scope_depth: "full", scope_reason: "big", scope_risk: "high" }));
+  h.entry.status = "dispatched";
+  h.entry.linkedDispatchId = scopeId;
+
+  // Stage 1: scope-assessment completes (depth=full) → plan (NOT impl).
+  h.policy.onDispatchCompleted({ dispatch_id: scopeId });
+  let c = lastCreate(h.state);
+  assert.equal(c.dispatchType, "plan", "full scope completion must create a PLAN, not implementation");
+  const planId = c.id;
+  assert.equal(h.entry.status, "dispatched", "entry must stay alive (dispatched) after scope→plan");
+  assert.equal(h.entry.linkedDispatchId, planId, "entry must re-link to the plan dispatch");
+
+  // Stage 2: the SAME plan dispatch the chain created completes with a plan body
+  // → plan-review carrying that body. Patch the created plan dispatch's result
+  // (the agent's PATCH would set result.plan) and complete it by its id.
+  h.patchDispatchResult(planId, { plan: "PLAN-BODY-XYZ", summary: "planned" });
+  h.policy.onDispatchCompleted({ dispatch_id: planId });
+  c = lastCreate(h.state);
+  assert.equal(c.dispatchType, "plan-review", "full plan completion must create a plan-review");
+  assert.equal(c.context.parent_plan, "PLAN-BODY-XYZ", "plan-review must carry the plan body forward");
+  const reviewId = c.id;
+  assert.equal(h.entry.status, "dispatched", "entry stays alive after plan→plan-review");
+  assert.equal(h.entry.linkedDispatchId, reviewId, "entry re-links to plan-review dispatch");
+
+  // Stage 3: the SAME plan-review dispatch passes → impl carrying the approved
+  // plan body (which rode in the plan-review context, then forwarded to impl).
+  h.patchDispatchResult(reviewId, { verdict: "pass", summary: "ok" });
+  h.policy.onDispatchCompleted({ dispatch_id: reviewId });
+  c = lastCreate(h.state);
+  assert.equal(c.dispatchType, "implementation", "plan-review pass must create the implementation dispatch");
+  assert.equal(c.context.parent_plan, "PLAN-BODY-XYZ", "impl must carry the approved plan body");
+  const implId = c.id;
+  assert.equal(h.entry.linkedDispatchId, implId, "entry re-links to the impl dispatch");
+  assert.equal(h.entry.status, "dispatched", "entry bound to impl (review-enabled impl holds dispatched until card terminal)");
+
+  // Exactly 3 staged dispatches were created across the whole chain: plan,
+  // plan-review, implementation — no extra/duplicate dispatches.
+  assert.deepEqual(
+    h.state.dispatchCreates.map((d) => d.dispatchType),
+    ["plan", "plan-review", "implementation"],
+    "the full chain creates exactly plan → plan-review → implementation"
+  );
+  // Never escalated / never advanced via PM gate during the staged chain.
+  assert.deepEqual(h.state.manualInterventions, []);
+});
+
+test("T3 ★ plan_only chain: scope→plan→impl (no plan-review)", () => {
+  const h = makeChainHarness({ scope_assessment_status: "pending" });
+  const scopeId = h.registerDispatch("scope-assessment", "{}",
+    JSON.stringify({ scope_depth: "plan_only", scope_reason: "mid", scope_risk: "low" }));
+  h.entry.status = "dispatched";
+  h.entry.linkedDispatchId = scopeId;
+
+  h.policy.onDispatchCompleted({ dispatch_id: scopeId });
+  let c = lastCreate(h.state);
+  assert.equal(c.dispatchType, "plan", "plan_only scope completion → plan");
+  const planId = c.id;
+  assert.equal(h.entry.linkedDispatchId, planId);
+
+  // Complete the SAME plan dispatch (with a body) → impl, no plan-review.
+  h.patchDispatchResult(planId, { plan: "PLAN-PO", summary: "planned" });
+  h.policy.onDispatchCompleted({ dispatch_id: planId });
+  c = lastCreate(h.state);
+  assert.equal(c.dispatchType, "implementation", "plan_only plan completion → impl (no plan-review)");
+  assert.equal(c.context.parent_plan, "PLAN-PO", "impl carries plan body on plan_only path too");
+  assert.equal(h.entry.linkedDispatchId, c.id, "entry re-links to impl on plan_only path");
+  assert.deepEqual(
+    h.state.dispatchCreates.map((d) => d.dispatchType),
+    ["plan", "implementation"],
+    "plan_only chain creates exactly plan → implementation (no plan-review)"
+  );
+});
+
+test("T3 ★ direct chain: scope→impl (no plan)", () => {
+  const h = makeChainHarness({ scope_assessment_status: "pending" });
+  const scopeId = h.registerDispatch("scope-assessment", "{}",
+    JSON.stringify({ scope_depth: "direct", scope_reason: "tiny", scope_risk: "none" }));
+  h.entry.status = "dispatched";
+  h.entry.linkedDispatchId = scopeId;
+
+  h.policy.onDispatchCompleted({ dispatch_id: scopeId });
+  const c = lastCreate(h.state);
+  assert.equal(c.dispatchType, "implementation", "direct scope completion → impl immediately (no plan)");
+  assert.equal(h.entry.linkedDispatchId, c.id, "entry binds straight to the impl dispatch");
 });

--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -791,7 +791,12 @@ test("kanban-rules records scope-assessment result on the card metadata and stay
       {
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
         result: [{ metadata: JSON.stringify({ keep: "yes", scope_assessment_status: "pending" }) }]
-      }
+      },
+      // #3594 (T3): plan_only depth now triggers a plan dispatch via the
+      // consultation-resume path; with no linked auto-queue entry it defers to
+      // the activate path (no dispatch created), leaving the inert assertions
+      // below valid while still exercising the depth branch.
+      { match: "FROM auto_queue_entries e", result: [] }
     ])
   });
 
@@ -855,7 +860,10 @@ test("kanban-rules falls back to full when scope-assessment result is unusable",
         {
           match: "SELECT metadata FROM kanban_cards WHERE id = ?",
           result: [{ metadata: "{}" }]
-        }
+        },
+        // #3594 (T3): full-fallback depth triggers a plan dispatch; no linked
+        // auto-queue entry → defers (no dispatch created).
+        { match: "FROM auto_queue_entries e", result: [] }
       ])
     });
 
@@ -901,7 +909,10 @@ test("kanban-rules normalizes scope_depth case and dashes", () => {
       {
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
         result: [{ metadata: "{}" }]
-      }
+      },
+      // #3594 (T3): normalized plan_only depth triggers a plan dispatch; no
+      // linked auto-queue entry → defers (no dispatch created).
+      { match: "FROM auto_queue_entries e", result: [] }
     ])
   });
 
@@ -911,4 +922,236 @@ test("kanban-rules normalizes scope_depth case and dashes", () => {
   assert.equal(written.scope_depth, "plan_only");
   assert.equal(written.scope_reason, "r");
   assert.equal(written.scope_risk, "k");
+});
+
+// ── #3594 (T3): depth-gated flow ─────────────────────────────────────────────
+
+// Build an onDispatchCompleted scenario for a scope/plan/plan-review dispatch
+// with a single linked auto-queue entry so the next-dispatch is actually
+// created (not deferred). `dispatchType` is the COMPLETED dispatch type;
+// `result`/`context` are its JSON strings; `metadata` is the card's current
+// metadata object (post-record for scope-assessment).
+function loadFlowScenario(opts) {
+  const cardId = opts.cardId || "card-flow";
+  const dispatchId = opts.dispatchId || "dispatch-flow";
+  const entries = Object.prototype.hasOwnProperty.call(opts, "entries")
+    ? opts.entries
+    : [{ id: "entry-flow", agent_id: "agent-flow" }];
+  return loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      [cardId]: {
+        id: cardId,
+        title: opts.title || "Flow card",
+        status: opts.cardStatus || "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-flow",
+        deferred_dod_json: null
+      }
+    },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM task_dispatches WHERE id = ?",
+        result: [
+          {
+            id: dispatchId,
+            kanban_card_id: cardId,
+            to_agent_id: "agent-flow",
+            dispatch_type: opts.dispatchType,
+            chain_depth: 0,
+            created_at: "2026-06-19 09:00:00",
+            result: opts.result || "{}",
+            context: opts.context || "{}",
+            status: "completed"
+          }
+        ]
+      },
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: JSON.stringify(opts.metadata || {}) }]
+      },
+      { match: "FROM auto_queue_entries e", result: entries }
+    ])
+  });
+}
+
+test("T3: scope-assessment depth=direct creates an implementation dispatch directly", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-direct",
+    dispatchId: "dispatch-scope-direct",
+    dispatchType: "scope-assessment",
+    result: JSON.stringify({ scope_depth: "direct", scope_reason: "tiny", scope_risk: "low" }),
+    // metadata AFTER _recordScopeAssessment writes scope_depth=direct.
+    metadata: { scope_assessment_status: "pending", scope_depth: "direct" }
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-scope-direct" });
+
+  assert.equal(state.dispatchCreates.length, 1, "direct should create exactly one dispatch");
+  assert.equal(state.dispatchCreates[0].dispatchType, "implementation");
+  assert.equal(state.dispatchCreates[0].cardId, "card-direct");
+  // entry resumed as dispatched, not plan/plan-review.
+  assert.equal(state.autoQueueStatusUpdates.length, 1);
+  assert.equal(state.autoQueueStatusUpdates[0].status, "dispatched");
+  assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_direct");
+  // no plan-review channel, no review/PM flow.
+  assert.deepEqual(state.statusCalls, []);
+  assert.deepEqual(state.manualInterventions, []);
+});
+
+test("T3: scope-assessment depth=plan_only creates a plan dispatch carrying depth", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-plan-only",
+    dispatchId: "dispatch-scope-po",
+    dispatchType: "scope-assessment",
+    result: JSON.stringify({ scope_depth: "plan_only", scope_reason: "med", scope_risk: "mid" }),
+    metadata: { scope_assessment_status: "pending", scope_depth: "plan_only" }
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-scope-po" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "plan");
+  // depth rides in the plan dispatch context so the plan-completion arm branches
+  // without re-reading metadata.
+  assert.equal(state.dispatchCreates[0].context.scope_depth, "plan_only");
+  assert.equal(state.dispatchCreates[0].context.auto_queue, true);
+  assert.equal(state.autoQueueStatusUpdates[0].status, "dispatched");
+  assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_plan");
+});
+
+test("T3: scope-assessment depth=full creates a plan dispatch carrying full", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-full",
+    dispatchId: "dispatch-scope-full",
+    dispatchType: "scope-assessment",
+    result: JSON.stringify({ scope_depth: "full", scope_reason: "big", scope_risk: "high" }),
+    metadata: { scope_assessment_status: "pending", scope_depth: "full" }
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-scope-full" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "plan");
+  assert.equal(state.dispatchCreates[0].context.scope_depth, "full");
+});
+
+test("T3: fail-safe — unknown/missing scope_depth metadata is treated as full (plan)", () => {
+  // _recordScopeAssessment already normalizes to "full", but guard the gate too:
+  // metadata with NO scope_depth must still resolve to the full flow → plan.
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-unknown",
+    dispatchId: "dispatch-scope-unk",
+    dispatchType: "scope-assessment",
+    result: "{}",
+    metadata: { scope_assessment_status: "pending" } // no scope_depth at all
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-scope-unk" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "plan", "unknown depth must take the cautious full flow → plan");
+});
+
+test("T3: plan completion (depth=plan_only in context) creates the implementation dispatch", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-plan-done-po",
+    dispatchId: "dispatch-plan-po",
+    dispatchType: "plan",
+    cardStatus: "in_progress",
+    context: JSON.stringify({ scope_depth: "plan_only", auto_queue: true }),
+    result: JSON.stringify({ plan: "design...", summary: "done" })
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-plan-po" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "implementation", "plan_only plan completion → impl, no plan-review");
+  assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_plan_done");
+});
+
+test("T3: plan completion (depth=full in context) publishes a plan-review dispatch", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-plan-done-full",
+    dispatchId: "dispatch-plan-full",
+    dispatchType: "plan",
+    cardStatus: "in_progress",
+    context: JSON.stringify({ scope_depth: "full", auto_queue: true }),
+    result: JSON.stringify({ plan: "big design...", summary: "done" })
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-plan-full" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "plan-review", "full plan completion → plan-review");
+  assert.equal(state.dispatchCreates[0].context.scope_depth, "full");
+  assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_plan_review");
+});
+
+test("T3: plan-review pass → implementation dispatch", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-pr-pass",
+    dispatchId: "dispatch-pr-pass",
+    dispatchType: "plan-review",
+    cardStatus: "in_progress",
+    context: JSON.stringify({ scope_depth: "full", auto_queue: true }),
+    result: JSON.stringify({ verdict: "pass", summary: "plan ok" })
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-pr-pass" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "implementation", "plan-review pass → impl");
+  assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_plan_review_pass");
+});
+
+test("T3: plan-review rework → re-plan dispatch", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-pr-rework",
+    dispatchId: "dispatch-pr-rework",
+    dispatchType: "plan-review",
+    cardStatus: "in_progress",
+    context: JSON.stringify({ scope_depth: "full", auto_queue: true }),
+    result: JSON.stringify({ verdict: "rework", notes: "missing migration step" })
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-pr-rework" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "plan", "plan-review rework → re-plan");
+  assert.equal(state.dispatchCreates[0].context.scope_depth, "full");
+});
+
+test("T3: plan-review with missing/ambiguous verdict re-plans (cautious default)", () => {
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-pr-amb",
+    dispatchId: "dispatch-pr-amb",
+    dispatchType: "plan-review",
+    cardStatus: "in_progress",
+    context: JSON.stringify({ scope_depth: "full", auto_queue: true }),
+    result: JSON.stringify({ summary: "forgot the verdict" })
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-pr-amb" });
+
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "plan", "ambiguous verdict must NOT advance to impl — re-plan");
+});
+
+test("T3: scope/plan dispatches never enter the PM-gate / review lifecycle", () => {
+  // A plan completion must early-return before the PM gate, so it never queries
+  // the PM-gate card-detail shape nor sets review status.
+  const { policy, state } = loadFlowScenario({
+    cardId: "card-no-pmgate",
+    dispatchId: "dispatch-plan-nopm",
+    dispatchType: "plan",
+    cardStatus: "in_progress",
+    context: JSON.stringify({ scope_depth: "plan_only", auto_queue: true }),
+    result: JSON.stringify({ plan: "x" })
+  });
+
+  policy.onDispatchCompleted({ dispatch_id: "dispatch-plan-nopm" });
+
+  assert.deepEqual(state.statusCalls, [], "plan completion must not setStatus (no review advance)");
+  assert.deepEqual(state.reviewStatusCalls, []);
+  assert.deepEqual(state.manualInterventions, []);
 });

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -229,16 +229,22 @@ test("timeouts reconcile fallback does not advance a completed scope-assessment 
         // #3605 (T2): the fallback now records scope_depth via the shared
         // recorder, which reads the card metadata first.
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
-        result: [{ metadata: "{}" }]
-      }
+        result: [{ metadata: JSON.stringify({ scope_depth: "direct", scope_assessment_status: "completed" }) }]
+      },
+      // #3594 (T3): the fallback now also GATES the depth flow (direct → impl).
+      // With no linked auto-queue entry it defers to the activate path (no
+      // dispatch created), so the no-review-advance assertions below still hold.
+      { match: "FROM auto_queue_entries e", result: [] }
     ])
   });
 
   policy._section_R();
 
   // Missed-hook fallback must mirror kanban-rules.js onDispatchCompleted: a
-  // completed scope-assessment is an inert side-path. No card advance (no
-  // setStatus to review), no XP grant, no PM-gate-driven status changes.
+  // completed scope-assessment never advances the card to REVIEW (no setStatus
+  // to review), grants no XP, and runs no PM-gate-driven status change. (T3 may
+  // create a depth-gated NEXT dispatch, but only when an auto-queue entry is
+  // linked — none here, so it defers.)
   assert.deepEqual(state.statusCalls, []);
   assert.deepEqual(state.reviewStatusCalls, []);
   assert.deepEqual(state.reviewStateSyncs, []);
@@ -296,14 +302,17 @@ test("timeouts reconcile fallback applies full fallback for an unparsable scope-
       {
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
         result: [{ metadata: "{}" }]
-      }
+      },
+      // #3594 (T3): full-fallback depth gates to a plan dispatch; no linked
+      // auto-queue entry → defers (no dispatch created), so the card stays inert.
+      { match: "FROM auto_queue_entries e", result: [] }
     ])
   });
 
   policy._section_R();
 
   // Unparsable result → cautious "full" fallback, recorded even on the
-  // missed-hook path; card still inert (no advance).
+  // missed-hook path; card never advances to review (no setStatus).
   assert.deepEqual(state.statusCalls, []);
   const metaWrite = state.executions.find((e) =>
     /UPDATE kanban_cards SET metadata = \?/.test(e.sql)
@@ -311,6 +320,63 @@ test("timeouts reconcile fallback applies full fallback for an unparsable scope-
   assert.ok(metaWrite, "fallback must persist scope metadata even when unparsable");
   assert.equal(metaWrite.params[0].scope_depth, "full");
   assert.match(metaWrite.params[0].scope_reason, /fallback to full/);
+});
+
+test("timeouts reconcile fallback gates depth flow when an auto-queue entry is linked (#3594 T3)", () => {
+  // Parity with the live hook: a missed scope-assessment completion whose card
+  // has a linked auto-queue entry must create the depth-gated next dispatch
+  // (direct → implementation) so the run does not stall waiting for a hook that
+  // was dropped.
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { pm_decision_gate_enabled: true },
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT key, value FROM kv_meta WHERE key LIKE 'reconcile_dispatch:%'",
+        result: [{ key: "reconcile_dispatch:dispatch-scope-g", value: "dispatch-scope-g" }]
+      },
+      {
+        match: "SELECT id, kanban_card_id, to_agent_id, dispatch_type, chain_depth, status, result, context FROM task_dispatches WHERE id = ?",
+        result: [
+          {
+            id: "dispatch-scope-g",
+            kanban_card_id: "card-scope-g",
+            to_agent_id: "agent-1",
+            dispatch_type: "scope-assessment",
+            chain_depth: 0,
+            status: "completed",
+            result: JSON.stringify({ scope_depth: "direct" }),
+            context: "{}"
+          }
+        ]
+      },
+      {
+        match: "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
+        result: [
+          {
+            id: "card-scope-g",
+            status: "requested",
+            priority: "medium",
+            assigned_agent_id: "agent-1",
+            deferred_dod_json: null
+          }
+        ]
+      },
+      {
+        match: "SELECT metadata FROM kanban_cards WHERE id = ?",
+        result: [{ metadata: JSON.stringify({ scope_depth: "direct", scope_assessment_status: "completed" }) }]
+      },
+      { match: "FROM auto_queue_entries e", result: [{ id: "entry-g", agent_id: "agent-1" }] }
+    ])
+  });
+
+  policy._section_R();
+
+  // No review advance, but the gated implementation dispatch IS created.
+  assert.deepEqual(state.statusCalls, []);
+  assert.equal(state.dispatchCreates.length, 1);
+  assert.equal(state.dispatchCreates[0].dispatchType, "implementation");
+  assert.equal(state.autoQueueStatusUpdates[0].status, "dispatched");
+  assert.equal(state.autoQueueStatusUpdates[0].reason, "scope_gate_direct_reconcile");
 });
 
 test("timeouts review timeout module escalates overdue DoD waits", () => {

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -58,6 +58,7 @@ var _recordScopeAssessment = _scopeAssessment._recordScopeAssessment;
 // flow identically instead of stranding the card after recording depth.
 var _scopeGate = require("./lib/kanban-scope-gate");
 var _resolveScopeFlow = _scopeGate._resolveScopeFlow;
+var _claimPendingEntryForDispatch = _scopeGate._claimPendingEntryForDispatch;
 var _createImplDispatch = _scopeGate._createImplDispatch;
 var _createPlanDispatch = _scopeGate._createPlanDispatch;
 var _createPlanReviewDispatch = _scopeGate._createPlanReviewDispatch;
@@ -119,6 +120,16 @@ function _maybeDispatchScopeAssessment(cardId) {
     scope_assessment_status: "pending",
     scope_assessment_dispatch_id: dispatchId
   });
+  // #3594 (T3, codex Finding 2): CLAIM the card's pending auto-queue entry onto
+  // the scope-assessment dispatch (consultation pattern). This links the entry to
+  // the staged dispatch chain (auto_queue_entry_dispatch_history) so scope
+  // completion's resume can find it and create the depth-gated next dispatch
+  // (direct→impl, plan_only/full→plan), instead of the entry staying pending and
+  // the activate fallback creating a plain `implementation` that bypasses the
+  // depth gate. The Rust `entry_status != "pending"` guard then naturally blocks
+  // activate from racing in (double safety with the `scope_assessment_pending`
+  // gate). No-op for manual/API cards with no pending entry.
+  _claimPendingEntryForDispatch(cardId, dispatchId, "scope_assessment_claim");
   agentdesk.log.info("[scope] Card " + cardId + " → scope-assessment dispatch " + dispatchId + " (agent " + agentId + ")");
 }
 
@@ -306,11 +317,16 @@ var rules = {
     if (dispatch.dispatch_type === "plan") {
       var planDepth = (dispatchContext && dispatchContext.scope_depth) || "full";
       var planFlow = _resolveScopeFlow(planDepth);
+      // #3594 (T3, codex Finding 3): carry the plan body forward so the next
+      // stage actually sees it. The plan dispatch's result holds {plan: "..."}.
+      var planResult = {};
+      try { planResult = JSON.parse(dispatch.result || "{}"); } catch (e) { planResult = {}; }
+      var planText = (planResult && typeof planResult.plan === "string") ? planResult.plan : null;
       if (planFlow.needsPlanReview) {
-        _createPlanReviewDispatch(dispatch.kanban_card_id, dispatch, card, planDepth);
+        _createPlanReviewDispatch(dispatch.kanban_card_id, dispatch, card, planDepth, planText);
         agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan done (depth=" + planDepth + ") → plan-review dispatch");
       } else {
-        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_plan_done");
+        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_plan_done", planText);
         agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan done (depth=plan_only) → implementation dispatch");
       }
       return;
@@ -328,7 +344,13 @@ var rules = {
       var verdict = planReviewResult.verdict;
       var prDepth = (dispatchContext && dispatchContext.scope_depth) || "full";
       if (verdict === "pass") {
-        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_plan_review_pass");
+        // #3594 (T3, codex Finding 3): forward the approved plan body (carried in
+        // the plan-review dispatch context as parent_plan) into the impl dispatch
+        // so the implementer sees the plan that was reviewed and approved.
+        var approvedPlan = (dispatchContext && typeof dispatchContext.parent_plan === "string")
+          ? dispatchContext.parent_plan
+          : null;
+        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_plan_review_pass", approvedPlan);
         agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan-review pass → implementation dispatch");
       } else {
         _createPlanDispatch(dispatch.kanban_card_id, dispatch, card, prDepth);

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -51,6 +51,17 @@ var _runPreflight = _preflight._runPreflight;
 var _scopeAssessment = require("./lib/kanban-scope-assessment");
 var _recordScopeAssessment = _scopeAssessment._recordScopeAssessment;
 
+// #3594 (T3): depth → flow resolver + next-dispatch helpers. The scope-assessment
+// completion handler reads the recorded scope_depth and branches:
+// direct → impl now, plan_only → plan (→impl), full → plan (→plan-review→impl).
+// Shared with timeouts/reconciliation.js so the missed-hook fallback gates the
+// flow identically instead of stranding the card after recording depth.
+var _scopeGate = require("./lib/kanban-scope-gate");
+var _resolveScopeFlow = _scopeGate._resolveScopeFlow;
+var _createImplDispatch = _scopeGate._createImplDispatch;
+var _createPlanDispatch = _scopeGate._createPlanDispatch;
+var _createPlanReviewDispatch = _scopeGate._createPlanReviewDispatch;
+
 // #3605 (T2): canonical inert side-path dispatch-type predicate (shared).
 var _sidePath = require("./lib/dispatch-side-path");
 var isSidePathDispatch = _sidePath.isSidePathDispatch;
@@ -252,13 +263,77 @@ var rules = {
     // #197: e2e-test dispatches — handled by deploy-pipeline policy
     if (dispatch.dispatch_type === "e2e-test") return;
 
-    // #3605 (T2): scope-assessment dispatch completed — record depth on the
-    // card metadata and stop. This is a side-path (the card never advanced to
-    // in_progress on attach — see transition.rs skip_kickoff), so completion
-    // must NOT flow into the PM gate / review / XP lifecycle below. The depth
-    // is inert in T2: no redispatch, no escalate, no manual intervention.
+    // #3605 (T2) + #3594 (T3): scope-assessment dispatch completed. First record
+    // the depth on the card metadata (T2 recorder, fail-safe to "full"). This is
+    // a side-path (the card never advanced to in_progress on attach — see
+    // transition.rs skip_kickoff), so completion must NOT flow into the PM gate /
+    // review / XP lifecycle below. T3 then ACTIVATES the recorded depth to gate
+    // the next stage instead of returning inert:
+    //   direct    → create the implementation dispatch directly (skip plan).
+    //   plan_only → create a "plan" dispatch (plan-completion arm creates impl).
+    //   full      → create a "plan" dispatch (plan → plan-review → impl).
+    //   unknown   → "full" (most cautious) via _resolveScopeFlow.
+    // The depth is read back from metadata after recording so a missed-hook
+    // replay (reconciliation.js) and the live hook branch identically.
     if (dispatch.dispatch_type === "scope-assessment") {
       _recordScopeAssessment(dispatch.kanban_card_id, dispatch);
+      var scopeMeta = _loadCardMetadata(dispatch.kanban_card_id);
+      var scopeDepth = scopeMeta.scope_depth || "full";
+      var flow = _resolveScopeFlow(scopeDepth);
+      if (!flow.needsPlan) {
+        // direct → implement now (consultation-resume path).
+        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_direct");
+        agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " depth=direct → implementation dispatch");
+      } else {
+        // plan_only / full → plan first; the plan-completion arm fans out.
+        _createPlanDispatch(dispatch.kanban_card_id, dispatch, card, scopeDepth);
+        agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " depth=" + scopeDepth + " → plan dispatch");
+      }
+      return;
+    }
+
+    // #3594 (T3): "plan" work-dispatch completed. depth rides in the plan
+    // dispatch context (set by _createPlanDispatch) so we branch without
+    // re-reading card metadata:
+    //   plan_only → create the implementation dispatch now.
+    //   full      → publish a "plan-review" (Option P: ordinary dispatch, NOT
+    //               the counter-model review kernel).
+    // The plan dispatch is a normal work-dispatch (not a side-path), so it kicked
+    // the card into in_progress on attach; it is intentionally NOT in
+    // dispatch_status.rs's ("implementation"|"rework") terminal-sync set, so its
+    // completion does not finalize the auto-queue entry — the JS follow-up below
+    // re-dispatches the bound entry instead.
+    if (dispatch.dispatch_type === "plan") {
+      var planDepth = (dispatchContext && dispatchContext.scope_depth) || "full";
+      var planFlow = _resolveScopeFlow(planDepth);
+      if (planFlow.needsPlanReview) {
+        _createPlanReviewDispatch(dispatch.kanban_card_id, dispatch, card, planDepth);
+        agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan done (depth=" + planDepth + ") → plan-review dispatch");
+      } else {
+        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_plan_done");
+        agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan done (depth=plan_only) → implementation dispatch");
+      }
+      return;
+    }
+
+    // #3594 (T3): "plan-review" completed (full depth only). Read result.verdict
+    // directly (Option P — no review-kernel verdict API):
+    //   pass   → create the implementation dispatch.
+    //   rework → re-publish a "plan" dispatch for another design pass.
+    // Any other/missing verdict is treated as rework (re-plan) — the cautious
+    // default, never silently advancing to impl on an ambiguous review.
+    if (dispatch.dispatch_type === "plan-review") {
+      var planReviewResult = {};
+      try { planReviewResult = JSON.parse(dispatch.result || "{}"); } catch (e) { planReviewResult = {}; }
+      var verdict = planReviewResult.verdict;
+      var prDepth = (dispatchContext && dispatchContext.scope_depth) || "full";
+      if (verdict === "pass") {
+        _createImplDispatch(dispatch.kanban_card_id, dispatch, card, "scope_gate_plan_review_pass");
+        agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan-review pass → implementation dispatch");
+      } else {
+        _createPlanDispatch(dispatch.kanban_card_id, dispatch, card, prDepth);
+        agentdesk.log.info("[scope-gate] " + dispatch.kanban_card_id + " plan-review verdict=" + (verdict || "<none>") + " → re-plan dispatch");
+      }
       return;
     }
 

--- a/policies/lib/kanban-scope-gate.js
+++ b/policies/lib/kanban-scope-gate.js
@@ -1,0 +1,205 @@
+/** @module policies/lib/kanban-scope-gate
+ *
+ * #3594 (T3): depth-gated flow resolution + next-dispatch creation helpers.
+ *
+ * T2 (#3605) recorded a `scope_depth` ∈ {direct, plan_only, full} on the card
+ * (or fell back to "full" when the assessment was missing/unparsable) but left
+ * it INERT. T3 activates that depth in the scope-assessment completion handler
+ * (kanban-rules.js onDispatchCompleted) to gate the lifecycle:
+ *
+ *   - direct    → skip plan + plan-review; create the implementation dispatch
+ *                 directly (reusing the consultation-resume path).
+ *   - plan_only → create a "plan" dispatch; its completion creates impl.
+ *   - full      → create a "plan" dispatch; its completion publishes a
+ *                 "plan-review"; plan-review pass → impl, rework → re-plan.
+ *   - unknown/null → treated as "full" (most cautious), mirroring the
+ *                 _recordScopeAssessment fallback in kanban-scope-assessment.js.
+ *
+ * This module owns ONLY the minimal flow-resolution + dispatch-creation glue.
+ * It deliberately does NOT introduce a PhaseRun/ReviewRun kernel or a gate DSL
+ * (G3) — plan/plan-review are ordinary `task_dispatches` rows whose follow-up is
+ * decided by the kanban-rules onDispatchCompleted arms.
+ *
+ * The dispatch-creation helpers encapsulate the consultation-resume pattern
+ * (#256: `_findAutoQueueEntriesByDispatch` + `agentdesk.dispatch.create` +
+ * `agentdesk.autoQueue.updateEntryStatus(entry, "dispatched", ...)`) so the
+ * scope-gate and the missed-hook fallback (timeouts/reconciliation.js) create
+ * identical follow-up dispatches. On any creation failure they leave the linked
+ * auto-queue entry untouched (pending) and warn, so the queue can retry rather
+ * than stranding the entry in `dispatched`.
+ *
+ * Depends on the global `agentdesk` surface plus the card-metadata lookup lib.
+ */
+
+var _cardMetadata = require("./kanban-card-metadata");
+var _findAutoQueueEntriesByDispatch = _cardMetadata._findAutoQueueEntriesByDispatch;
+
+// Canonical depth → flow mapping. Anything not exactly "direct" or "plan_only"
+// (including null/undefined/typos) resolves to the most cautious full flow:
+// plan + plan-review. This mirrors kanban-scope-assessment._recordScopeAssessment,
+// which already normalizes unknown depths to "full" on the way in — the double
+// guard means a corrupted/absent metadata read still fails safe here.
+function _resolveScopeFlow(depth) {
+  if (depth === "direct") {
+    return { needsPlan: false, needsPlanReview: false };
+  }
+  if (depth === "plan_only") {
+    return { needsPlan: true, needsPlanReview: false };
+  }
+  // "full" and every unknown/missing value → most cautious.
+  return { needsPlan: true, needsPlanReview: true };
+}
+
+// Resume the linked auto-queue entry (if any) with a freshly-created dispatch of
+// `dispatchType`, reusing the consultation-resume semantics (#256, Finding 15):
+// dispatch the FIRST linked entry and mark every other linked entry `skipped` so
+// the queue does not loop duplicates. Returns the created dispatch id, or null
+// on failure (entries left pending so a later sweep can retry).
+//
+// `extraContext` is merged into the auto_queue dispatch context (used to carry
+// scope_depth on the "plan" dispatch so the plan-completion arm does not have to
+// re-read card metadata).
+function _resumeEntriesWithDispatch(cardId, dispatch, card, dispatchType, title, resumeReason, extraContext) {
+  var aqEntries = _findAutoQueueEntriesByDispatch(dispatch.id, false);
+  if (aqEntries.length === 0) {
+    // No linked auto-queue entry yet (manual/API card, or scope fired before the
+    // generate transaction inserted entries). The Rust activate path will create
+    // the proper dispatch once the impl-block clears (scope_assessment_status is
+    // now "completed"). For plan/full this means the activate fallback creates an
+    // IMPLEMENTATION dispatch — acceptable: the scope-gate's plan stage is a
+    // best-effort enrichment on the auto-queue path, and the cautious default of
+    // "still produce an implementation" preserves forward progress.
+    agentdesk.log.info(
+      "[scope-gate] " + cardId + " has no linked auto-queue entry for " +
+      dispatchType + " — deferring to activate path"
+    );
+    return null;
+  }
+  var primary = aqEntries[0];
+  var context = {
+    auto_queue: true,
+    entry_id: primary.id,
+    parent_dispatch_id: dispatch.id
+  };
+  if (extraContext && typeof extraContext === "object") {
+    for (var k in extraContext) {
+      if (Object.prototype.hasOwnProperty.call(extraContext, k)) {
+        context[k] = extraContext[k];
+      }
+    }
+  }
+  var nextDispatchId = null;
+  try {
+    nextDispatchId = agentdesk.dispatch.create(
+      cardId,
+      primary.agent_id,
+      dispatchType,
+      title || (card && card.title) || dispatchType,
+      context
+    );
+  } catch (e) {
+    agentdesk.log.warn(
+      "[scope-gate] " + cardId + " " + dispatchType +
+      " dispatch creation threw — entry left pending: " + e
+    );
+    return null;
+  }
+  if (!nextDispatchId) {
+    agentdesk.log.warn(
+      "[scope-gate] " + cardId + " " + dispatchType +
+      " dispatch creation returned no id — entry left pending"
+    );
+    return null;
+  }
+  try {
+    agentdesk.autoQueue.updateEntryStatus(
+      primary.id,
+      "dispatched",
+      resumeReason,
+      { dispatchId: nextDispatchId }
+    );
+  } catch (e) {
+    agentdesk.log.warn(
+      "[scope-gate] " + cardId + " " + dispatchType + " dispatch " + nextDispatchId +
+      " created but entry status update failed: " + e
+    );
+  }
+  if (aqEntries.length > 1) {
+    for (var aqi = 1; aqi < aqEntries.length; aqi++) {
+      try {
+        agentdesk.autoQueue.updateEntryStatus(
+          aqEntries[aqi].id,
+          "skipped",
+          resumeReason + "_duplicate",
+          { primaryEntryId: primary.id }
+        );
+      } catch (skipErr) {
+        agentdesk.log.warn(
+          "[scope-gate] could not mark duplicate aq entry " +
+          aqEntries[aqi].id + " as skipped: " + skipErr
+        );
+      }
+    }
+    agentdesk.log.warn(
+      "[scope-gate] " + dispatchType + " for " + cardId + " linked to " +
+      aqEntries.length + " auto_queue entries — dispatched primary " + primary.id +
+      " and skipped the remaining " + (aqEntries.length - 1)
+    );
+  }
+  return nextDispatchId;
+}
+
+// direct (or any terminal stage that resolves to "implement now"): create the
+// implementation dispatch via the consultation-resume path.
+function _createImplDispatch(cardId, dispatch, card, resumeReason) {
+  return _resumeEntriesWithDispatch(
+    cardId,
+    dispatch,
+    card,
+    "implementation",
+    (card && card.title) || "Implementation",
+    resumeReason || "scope_gate_impl",
+    null
+  );
+}
+
+// plan_only / full: create the "plan" work-dispatch. The resolved depth rides in
+// the dispatch context so the plan-completion arm can branch (plan_only→impl,
+// full→plan-review) WITHOUT re-reading card metadata (which a concurrent path
+// could have mutated).
+function _createPlanDispatch(cardId, dispatch, card, depth) {
+  return _resumeEntriesWithDispatch(
+    cardId,
+    dispatch,
+    card,
+    "plan",
+    "[Plan] " + ((card && card.title) || cardId),
+    "scope_gate_plan",
+    { scope_depth: depth }
+  );
+}
+
+// full: after a plan completes, publish the "plan-review". This is NOT routed
+// through the counter-model review kernel (Option P) — it is an ordinary
+// dispatch whose verdict (pass|rework) is read directly by the kanban-rules
+// plan-review arm. Reuses the resume path so the bound entry stays attached to
+// the in-flight review stage rather than being re-created by activate.
+function _createPlanReviewDispatch(cardId, dispatch, card, depth) {
+  return _resumeEntriesWithDispatch(
+    cardId,
+    dispatch,
+    card,
+    "plan-review",
+    "[Plan Review] " + ((card && card.title) || cardId),
+    "scope_gate_plan_review",
+    { scope_depth: depth }
+  );
+}
+
+module.exports = {
+  _resolveScopeFlow: _resolveScopeFlow,
+  _resumeEntriesWithDispatch: _resumeEntriesWithDispatch,
+  _createImplDispatch: _createImplDispatch,
+  _createPlanDispatch: _createPlanDispatch,
+  _createPlanReviewDispatch: _createPlanReviewDispatch
+};

--- a/policies/lib/kanban-scope-gate.js
+++ b/policies/lib/kanban-scope-gate.js
@@ -34,6 +34,61 @@
 var _cardMetadata = require("./kanban-card-metadata");
 var _findAutoQueueEntriesByDispatch = _cardMetadata._findAutoQueueEntriesByDispatch;
 
+// #3594 (T3, codex Finding 2): the FIRST stage (scope-assessment) must CLAIM the
+// card's pending auto-queue entry onto its own dispatch — exactly as consultation
+// does at creation (record_consultation_dispatch_on_pg) — otherwise the entry is
+// never linked to the staged dispatch chain and scope-completion's resume cannot
+// find it, so the activate fallback creates a plain `implementation` dispatch and
+// the depth gate (plan/plan-review) is bypassed entirely.
+//
+// Returns the claimed entry row {id, agent_id} or null when there is no pending
+// entry to claim (manual/API card, or the entry has not been generated yet — in
+// which case the Rust activate `scope_assessment_pending` gate holds the entry
+// pending until scope completes, and the resume path's by-card fallback below
+// re-discovers it). On any failure it warns and returns null (entry untouched).
+//
+// Unlike recordConsultationDispatch (which also stamps consultation_status on the
+// card metadata) this uses the generic entry-status claim, so it links the entry
+// via auto_queue_entry_dispatch_history + marks it `dispatched` WITHOUT polluting
+// the card's scope metadata.
+function _findPendingEntryForCard(cardId) {
+  var rows = agentdesk.db.query(
+    "SELECT e.id, e.agent_id FROM auto_queue_entries e " +
+    "JOIN auto_queue_runs r ON r.id = e.run_id " +
+    "WHERE e.kanban_card_id = ? AND e.status = 'pending' " +
+    "  AND r.status IN ('active', 'paused') " +
+    "ORDER BY e.priority_rank ASC, e.created_at ASC LIMIT 1",
+    [cardId]
+  );
+  return rows.length > 0 ? rows[0] : null;
+}
+
+function _claimPendingEntryForDispatch(cardId, dispatchId, reason) {
+  var entry = _findPendingEntryForCard(cardId);
+  if (!entry) {
+    return null;
+  }
+  try {
+    agentdesk.autoQueue.updateEntryStatus(
+      entry.id,
+      "dispatched",
+      reason,
+      { dispatchId: dispatchId }
+    );
+    agentdesk.log.info(
+      "[scope-gate] claimed pending entry " + entry.id + " for " + cardId +
+      " onto dispatch " + dispatchId + " (" + reason + ")"
+    );
+    return entry;
+  } catch (e) {
+    agentdesk.log.warn(
+      "[scope-gate] failed to claim pending entry " + entry.id + " for " + cardId +
+      " onto dispatch " + dispatchId + ": " + e
+    );
+    return null;
+  }
+}
+
 // Canonical depth → flow mapping. Anything not exactly "direct" or "plan_only"
 // (including null/undefined/typos) resolves to the most cautious full flow:
 // plan + plan-review. This mirrors kanban-scope-assessment._recordScopeAssessment,
@@ -62,18 +117,33 @@ function _resolveScopeFlow(depth) {
 function _resumeEntriesWithDispatch(cardId, dispatch, card, dispatchType, title, resumeReason, extraContext) {
   var aqEntries = _findAutoQueueEntriesByDispatch(dispatch.id, false);
   if (aqEntries.length === 0) {
-    // No linked auto-queue entry yet (manual/API card, or scope fired before the
-    // generate transaction inserted entries). The Rust activate path will create
-    // the proper dispatch once the impl-block clears (scope_assessment_status is
-    // now "completed"). For plan/full this means the activate fallback creates an
-    // IMPLEMENTATION dispatch — acceptable: the scope-gate's plan stage is a
-    // best-effort enrichment on the auto-queue path, and the cautious default of
-    // "still produce an implementation" preserves forward progress.
+    // The parent dispatch has no linked `dispatched` entry. With the Finding-2 fix
+    // the scope-assessment claims the pending entry up-front, so the staged chain
+    // (scope→plan→plan-review→impl) keeps the SAME entry linked at each hop and
+    // this branch is normally unreachable on the auto-queue path. But the entry
+    // may have been generated AFTER scope-assessment fired (held pending by the
+    // Rust activate `scope_assessment_pending` gate). Recover it: find the card's
+    // pending entry and claim it onto this staged dispatch so the chain proceeds
+    // instead of yielding to the activate fallback (which would create a plain
+    // `implementation`, bypassing the depth gate).
+    var recovered = _findPendingEntryForCard(cardId);
+    if (!recovered) {
+      // Genuinely no auto-queue entry (manual/API card). There is no entry to
+      // claim or resume, so this staged-resume helper creates nothing and returns
+      // null — exactly as before T3. Manual/API cards drive their own dispatch
+      // lifecycle outside the auto-queue resume path, so forward progress is not
+      // this helper's responsibility here.
+      agentdesk.log.info(
+        "[scope-gate] " + cardId + " has no auto-queue entry for " +
+        dispatchType + " — no staged dispatch created (manual/API card)"
+      );
+      return null;
+    }
+    aqEntries = [recovered];
     agentdesk.log.info(
-      "[scope-gate] " + cardId + " has no linked auto-queue entry for " +
-      dispatchType + " — deferring to activate path"
+      "[scope-gate] " + cardId + " recovered late pending entry " + recovered.id +
+      " for " + dispatchType + " (claiming onto staged dispatch)"
     );
-    return null;
   }
   var primary = aqEntries[0];
   var context = {
@@ -149,9 +219,28 @@ function _resumeEntriesWithDispatch(cardId, dispatch, card, dispatchType, title,
   return nextDispatchId;
 }
 
+// #3594 (T3, codex Finding 3): build the downstream dispatch context, carrying
+// the resolved depth and (when present) the parent PLAN text. The plan body is
+// propagated as `parent_plan` so the prompt builder (render_dispatch_context_section)
+// renders it into the plan-review / impl prompt — that is what lets a plan-review
+// actually see the plan it must review, and a full→impl see the approved plan.
+// Only a non-empty string is forwarded so plan_only/direct (no review) and
+// manual cards stay clean.
+function _stageContext(depth, planText) {
+  var ctx = { scope_depth: depth };
+  if (typeof planText === "string" && planText.trim() !== "") {
+    ctx.parent_plan = planText;
+  }
+  return ctx;
+}
+
 // direct (or any terminal stage that resolves to "implement now"): create the
-// implementation dispatch via the consultation-resume path.
-function _createImplDispatch(cardId, dispatch, card, resumeReason) {
+// implementation dispatch via the consultation-resume path. `planText` (optional)
+// is the approved plan body forwarded so the impl agent sees it (full → impl).
+function _createImplDispatch(cardId, dispatch, card, resumeReason, planText) {
+  var extra = (typeof planText === "string" && planText.trim() !== "")
+    ? { parent_plan: planText }
+    : null;
   return _resumeEntriesWithDispatch(
     cardId,
     dispatch,
@@ -159,14 +248,15 @@ function _createImplDispatch(cardId, dispatch, card, resumeReason) {
     "implementation",
     (card && card.title) || "Implementation",
     resumeReason || "scope_gate_impl",
-    null
+    extra
   );
 }
 
 // plan_only / full: create the "plan" work-dispatch. The resolved depth rides in
 // the dispatch context so the plan-completion arm can branch (plan_only→impl,
 // full→plan-review) WITHOUT re-reading card metadata (which a concurrent path
-// could have mutated).
+// could have mutated). The plan dispatch itself has no parent plan (it IS the
+// plan stage), so only `scope_depth` is carried.
 function _createPlanDispatch(cardId, dispatch, card, depth) {
   return _resumeEntriesWithDispatch(
     cardId,
@@ -184,7 +274,9 @@ function _createPlanDispatch(cardId, dispatch, card, depth) {
 // dispatch whose verdict (pass|rework) is read directly by the kanban-rules
 // plan-review arm. Reuses the resume path so the bound entry stays attached to
 // the in-flight review stage rather than being re-created by activate.
-function _createPlanReviewDispatch(cardId, dispatch, card, depth) {
+// `planText` is the completed plan dispatch's `result.plan`, forwarded as
+// `parent_plan` so the reviewer actually sees the plan body (codex Finding 3).
+function _createPlanReviewDispatch(cardId, dispatch, card, depth, planText) {
   return _resumeEntriesWithDispatch(
     cardId,
     dispatch,
@@ -192,12 +284,14 @@ function _createPlanReviewDispatch(cardId, dispatch, card, depth) {
     "plan-review",
     "[Plan Review] " + ((card && card.title) || cardId),
     "scope_gate_plan_review",
-    { scope_depth: depth }
+    _stageContext(depth, planText)
   );
 }
 
 module.exports = {
   _resolveScopeFlow: _resolveScopeFlow,
+  _findPendingEntryForCard: _findPendingEntryForCard,
+  _claimPendingEntryForDispatch: _claimPendingEntryForDispatch,
   _resumeEntriesWithDispatch: _resumeEntriesWithDispatch,
   _createImplDispatch: _createImplDispatch,
   _createPlanDispatch: _createPlanDispatch,

--- a/policies/timeouts/reconciliation.js
+++ b/policies/timeouts/reconciliation.js
@@ -1,4 +1,15 @@
 var _recordScopeAssessment = require("../lib/kanban-scope-assessment")._recordScopeAssessment;
+// #3594 (T3): the missed-hook replay must gate the depth flow IDENTICALLY to the
+// live kanban-rules onDispatchCompleted, otherwise a dropped scope-assessment /
+// plan / plan-review completion event would either bypass the gate (impl created
+// before depth is known) or strand the card (plan completed, no follow-up). Reuse
+// the same scope-gate helpers the live handler uses.
+var _scopeGate = require("../lib/kanban-scope-gate");
+var _resolveScopeFlow = _scopeGate._resolveScopeFlow;
+var _createImplDispatch = _scopeGate._createImplDispatch;
+var _createPlanDispatch = _scopeGate._createPlanDispatch;
+var _createPlanReviewDispatch = _scopeGate._createPlanReviewDispatch;
+var _loadCardMetadata = require("../lib/kanban-card-metadata")._loadCardMetadata;
 
 module.exports = function attachReconciliation(timeouts, helpers) {
   var sendDeadlockAlert = helpers.sendDeadlockAlert;
@@ -70,18 +81,56 @@ module.exports = function attachReconciliation(timeouts, helpers) {
         var rPending = rInitial;
         if (agentdesk.pipeline.isTerminal(card.status, rCfg)) continue;
         if (di.dispatch_type === "review" || di.dispatch_type === "review-decision") continue;
-        // #3605 (T2): scope-assessment is a requested-pinned side-path. This
-        // missed-hook fallback must mirror kanban-rules.js onDispatchCompleted
-        // EXACTLY: record scope_depth on the card (with the same full-fallback
-        // for missing/unparsable results) AND stay inert — never run the PM gate
-        // / XP / review advance below. Previously this only `continue`d, so a
-        // scope-assessment whose hook was missed lost its scope_depth entirely
-        // and never got the cautious "full" fallback. Calling the shared
-        // recorder fixes both. (_recordScopeAssessment merges status=completed,
-        // so it is idempotent if the hook later fires too.)
+        // #3605 (T2) + #3594 (T3): scope-assessment missed-hook replay must
+        // mirror kanban-rules.js onDispatchCompleted EXACTLY. (1) Record
+        // scope_depth (same full-fallback for missing/unparsable results), then
+        // (2) ACTIVATE the depth gate: direct → impl now, plan_only/full → plan.
+        // It must NOT fall through to the PM gate / XP / review advance below.
+        // (_recordScopeAssessment merges status=completed, so it is idempotent if
+        // the live hook also fires; the dispatch helpers are no-ops if the entry
+        // was already resumed.)
         if (di.dispatch_type === "scope-assessment") {
           _recordScopeAssessment(di.kanban_card_id, di);
-          agentdesk.log.info("[reconcile] " + card.id + " scope-assessment completed — recorded scope_depth, inert side-path (no advance)");
+          var rScopeMeta = _loadCardMetadata(di.kanban_card_id);
+          var rScopeDepth = rScopeMeta.scope_depth || "full";
+          var rFlow = _resolveScopeFlow(rScopeDepth);
+          if (!rFlow.needsPlan) {
+            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_direct_reconcile");
+          } else {
+            _createPlanDispatch(di.kanban_card_id, di, card, rScopeDepth);
+          }
+          agentdesk.log.info("[reconcile] " + card.id + " scope-assessment completed — recorded scope_depth=" + rScopeDepth + ", gated flow (no advance)");
+          continue;
+        }
+        // #3594 (T3): "plan" missed-hook replay — mirror the live plan arm.
+        // depth rides in the plan dispatch context: plan_only → impl, full →
+        // plan-review. Stays out of the PM gate / review advance below.
+        if (di.dispatch_type === "plan") {
+          var rPlanContext = {};
+          try { rPlanContext = JSON.parse(di.context || "{}"); } catch (e) { rPlanContext = {}; }
+          var rPlanDepth = rPlanContext.scope_depth || "full";
+          if (_resolveScopeFlow(rPlanDepth).needsPlanReview) {
+            _createPlanReviewDispatch(di.kanban_card_id, di, card, rPlanDepth);
+          } else {
+            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_plan_done_reconcile");
+          }
+          agentdesk.log.info("[reconcile] " + card.id + " plan completed (depth=" + rPlanDepth + ") — gated next stage");
+          continue;
+        }
+        // #3594 (T3): "plan-review" missed-hook replay — mirror the live arm.
+        // Read result.verdict directly: pass → impl, otherwise re-plan.
+        if (di.dispatch_type === "plan-review") {
+          var rPrResult = {};
+          try { rPrResult = JSON.parse(di.result || "{}"); } catch (e) { rPrResult = {}; }
+          var rPrContext = {};
+          try { rPrContext = JSON.parse(di.context || "{}"); } catch (e) { rPrContext = {}; }
+          var rPrDepth = rPrContext.scope_depth || "full";
+          if (rPrResult.verdict === "pass") {
+            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_plan_review_pass_reconcile");
+          } else {
+            _createPlanDispatch(di.kanban_card_id, di, card, rPrDepth);
+          }
+          agentdesk.log.info("[reconcile] " + card.id + " plan-review completed (verdict=" + (rPrResult.verdict || "<none>") + ") — gated next stage");
           continue;
         }
         if (di.dispatch_type === "rework") {

--- a/policies/timeouts/reconciliation.js
+++ b/policies/timeouts/reconciliation.js
@@ -109,10 +109,14 @@ module.exports = function attachReconciliation(timeouts, helpers) {
           var rPlanContext = {};
           try { rPlanContext = JSON.parse(di.context || "{}"); } catch (e) { rPlanContext = {}; }
           var rPlanDepth = rPlanContext.scope_depth || "full";
+          // #3594 (T3, codex Finding 3): forward the plan body to the next stage.
+          var rPlanResult = {};
+          try { rPlanResult = JSON.parse(di.result || "{}"); } catch (e) { rPlanResult = {}; }
+          var rPlanText = (rPlanResult && typeof rPlanResult.plan === "string") ? rPlanResult.plan : null;
           if (_resolveScopeFlow(rPlanDepth).needsPlanReview) {
-            _createPlanReviewDispatch(di.kanban_card_id, di, card, rPlanDepth);
+            _createPlanReviewDispatch(di.kanban_card_id, di, card, rPlanDepth, rPlanText);
           } else {
-            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_plan_done_reconcile");
+            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_plan_done_reconcile", rPlanText);
           }
           agentdesk.log.info("[reconcile] " + card.id + " plan completed (depth=" + rPlanDepth + ") — gated next stage");
           continue;
@@ -126,7 +130,12 @@ module.exports = function attachReconciliation(timeouts, helpers) {
           try { rPrContext = JSON.parse(di.context || "{}"); } catch (e) { rPrContext = {}; }
           var rPrDepth = rPrContext.scope_depth || "full";
           if (rPrResult.verdict === "pass") {
-            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_plan_review_pass_reconcile");
+            // #3594 (T3, codex Finding 3): forward the approved plan (carried in
+            // the plan-review context) into impl.
+            var rApprovedPlan = (rPrContext && typeof rPrContext.parent_plan === "string")
+              ? rPrContext.parent_plan
+              : null;
+            _createImplDispatch(di.kanban_card_id, di, card, "scope_gate_plan_review_pass_reconcile", rApprovedPlan);
           } else {
             _createPlanDispatch(di.kanban_card_id, di, card, rPrDepth);
           }

--- a/src/db/agents.rs
+++ b/src/db/agents.rs
@@ -206,6 +206,50 @@ mod tests {
             Some("1470000000000000004")
         );
     }
+
+    /// #3594 (T3, codex R2 Finding 2): the dispatch-channel resolver
+    /// (`resolve_agent_dispatch_channel_pg`) and the delivery router
+    /// (`outbox_route::use_counter_model_channel`) MUST classify counter-model
+    /// channels identically. The resolver now calls the shared predicate, so this
+    /// pins the contract: `plan-review` (the channel that regressed) and the
+    /// review family resolve to the counter-model channel, while the
+    /// agent-owned stages (`plan`, `scope-assessment`, `implementation`) and the
+    /// absent case resolve to the primary channel.
+    ///
+    /// Mutation check: dropping `plan-review` from `use_counter_model_channel`
+    /// flips the `plan-review` assertion (→ primary), failing this test.
+    #[test]
+    fn dispatch_channel_counter_model_set_matches_outbox_router() {
+        use crate::services::dispatches::outbox_route::use_counter_model_channel;
+
+        // `resolve_agent_dispatch_channel_pg` now selects the counter-model vs
+        // primary channel SOLELY via this shared predicate, so pinning the
+        // predicate's classification IS the contract for that resolver — the
+        // earlier `review|e2e-test|consultation` drift (missing `plan-review`)
+        // cannot recur without failing here.
+        //
+        // Counter-model channel (checked by the counterpart model).
+        for dt in ["review", "e2e-test", "consultation", "plan-review"] {
+            assert!(
+                use_counter_model_channel(Some(dt)),
+                "{dt} must resolve to the counter-model channel (parity with outbox_route)"
+            );
+        }
+        // Primary channel (agent designs / self-assesses / implements).
+        for dt in [
+            "plan",
+            "scope-assessment",
+            "implementation",
+            "review-decision",
+        ] {
+            assert!(
+                !use_counter_model_channel(Some(dt)),
+                "{dt} must resolve to the PRIMARY channel"
+            );
+        }
+        // Absent dispatch_type → primary.
+        assert!(!use_counter_model_channel(None));
+    }
 }
 
 fn normalized_channel(value: Option<String>) -> Option<String> {
@@ -303,7 +347,16 @@ pub async fn resolve_agent_dispatch_channel_pg(
     Ok(load_agent_channel_bindings_pg(pool, agent_id)
         .await?
         .and_then(|bindings| {
-            if matches!(dispatch_type, Some("review" | "e2e-test" | "consultation")) {
+            // #3594 (T3, codex R2 Finding 2): resolve the counter-model-vs-primary
+            // channel through the SINGLE source of truth
+            // `outbox_route::use_counter_model_channel` instead of a duplicated
+            // `matches!` set. Previously this set was `review|e2e-test|consultation`
+            // and had silently drifted from `use_counter_model_channel` (which also
+            // routes `plan-review` to the counter-model channel), so a `plan-review`
+            // dispatch was validated/routed against the PRIMARY channel at creation
+            // while delivery used the counter-model channel. Calling the shared
+            // predicate makes the two layers structurally impossible to drift again.
+            if crate::services::dispatches::outbox_route::use_counter_model_channel(dispatch_type) {
                 bindings.counter_model_channel()
             } else {
                 bindings.primary_channel()

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -224,6 +224,19 @@ fn should_skip_auto_queue_terminal_sync(
     if crate::dispatch::dispatch_is_side_path(dispatch_type) {
         return true;
     }
+    // #3594 (T3): plan / plan-review are multi-stage WORK dispatches (not
+    // side-paths: they DO kick the card to in_progress on attach and must NOT
+    // trigger a review-transition), but their completion is consumed by the
+    // kanban-rules JS fan-out (plan → plan-review|impl, plan-review → impl|re-plan),
+    // which RE-DISPATCHES the same bound auto-queue entry to the next stage.
+    // If their completion finalized the entry as `done` here, the chain would die
+    // and the card would close with no implementation ever run. So skip the
+    // auto-queue terminal sync for them too — JS owns the entry transition. They
+    // are deliberately classified as "multi-stage work, JS-resumed", distinct
+    // from both side-paths (no review) and terminal impl/rework (finalize).
+    if matches!(dispatch_type, Some("plan" | "plan-review")) {
+        return true;
+    }
     match dispatch_type {
         Some("implementation" | "rework") => !auto_queue_review_disabled,
         _ => false,
@@ -1614,6 +1627,48 @@ mod auto_queue_terminal_sync_policy_tests {
                     review_disabled,
                 ),
                 "scope-assessment completion must skip terminal sync (review_disabled={review_disabled})"
+            );
+        }
+    }
+
+    #[test]
+    fn plan_and_plan_review_completion_skips_terminal_sync_but_is_not_a_side_path() {
+        // #3594 (T3): plan / plan-review are multi-stage WORK dispatches. Their
+        // completion is consumed by the kanban-rules JS fan-out, which re-dispatches
+        // the bound auto-queue entry to the next stage. So their completion must
+        // SKIP the terminal sync (entry stays alive for the JS follow-up) — but they
+        // are NOT side-paths (they kick the card to in_progress and must not trigger
+        // a review-transition). review_disabled must not matter.
+        let result = serde_json::json!({"plan": "design + steps"});
+        for dispatch_type in ["plan", "plan-review"] {
+            for review_disabled in [false, true] {
+                assert!(
+                    should_skip_auto_queue_terminal_sync(
+                        Some(dispatch_type),
+                        "completed",
+                        Some(&result),
+                        true,
+                        review_disabled,
+                    ),
+                    "{dispatch_type} completion must skip terminal sync (review_disabled={review_disabled})"
+                );
+            }
+            // Sanity: plan/plan-review are NOT in the side-path set (no review-transition).
+            assert!(
+                !crate::dispatch::dispatch_is_side_path(Some(dispatch_type)),
+                "{dispatch_type} must not be classified as a side-path"
+            );
+            // A non-completed (failed) plan must NOT skip — failure finalization
+            // (sync to failed) still applies on the failure terminal status.
+            assert!(
+                !should_skip_auto_queue_terminal_sync(
+                    Some(dispatch_type),
+                    "failed",
+                    Some(&result),
+                    true,
+                    false,
+                ),
+                "{dispatch_type} failure must not be skipped"
             );
         }
     }

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -210,6 +210,26 @@ pub(crate) async fn activate_with_deps_pg(
             continue;
         }
 
+        // #3594 (T3): defer impl creation while a scope-assessment is in flight.
+        // scope-assessment is a side-path excluded from has_active_dispatch()
+        // (#3605), so without this guard activate would fall through and create an
+        // implementation dispatch BEFORE the depth (direct/plan_only/full) is
+        // known — bypassing the depth gate entirely. Leaving the entry `pending`
+        // lets the next activate tick resume it once the policy layer completes
+        // scope-assessment (status → "completed") and creates the depth-gated
+        // dispatch. Strictly `"pending"`-only (absent ≠ pending), so cards that
+        // never ran scope-assessment are unaffected — the core no-regression
+        // invariant.
+        if initial_state.scope_assessment_pending() {
+            crate::auto_queue_log!(
+                info,
+                "activate_defer_scope_assessment_pending_pg_3594",
+                entry_log_ctx.clone(),
+                "[auto-queue] deferring entry {entry_id} for card {card_id}: scope-assessment pending — entry stays pending",
+            );
+            continue;
+        }
+
         if effective.is_terminal(&initial_state.status) || initial_state.status == "done" {
             if let Err(error) = crate::db::auto_queue::update_entry_status_on_pg(
                 pool,
@@ -1648,6 +1668,100 @@ mod tests {
             assert_eq!(
                 entry_status, "pending",
                 "impl entry must remain pending — not stuck `dispatched` nor wrongly `done`"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        // #3594 (T3) ─ impl-before-depth race gate. While a scope-assessment is
+        // in flight (`scope_assessment_status == "pending"`), the activate loop
+        // must DEFER creating an implementation dispatch — otherwise (because
+        // scope-assessment is excluded from has_active_dispatch, #3605) activate
+        // would fall through and create impl before the depth that gates the flow
+        // is known. The gate the loop reads is `scope_assessment_pending()`,
+        // computed by the real production loader from card metadata. These
+        // exercise that loader against real Postgres rows.
+        async fn set_scope_status(pool: &PgPool, status: Option<&str>) {
+            let metadata = match status {
+                Some(s) => serde_json::json!({ "scope_assessment_status": s }).to_string(),
+                None => "{}".to_string(),
+            };
+            sqlx::query("UPDATE kanban_cards SET metadata = $1::jsonb WHERE id = 'card-1'")
+                .bind(metadata)
+                .execute(pool)
+                .await
+                .expect("set scope metadata");
+        }
+
+        #[tokio::test]
+        async fn scope_assessment_pending_defers_impl_creation_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            // scope-assessment is in flight and is the card's latest dispatch; the
+            // impl entry is still pending — the gating-prone state.
+            attach_live_dispatch(&pool, "dispatch-scope", "scope-assessment").await;
+            set_scope_status(&pool, Some("pending")).await;
+
+            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
+                .await
+                .expect("load card state");
+
+            // The activate loop's `if scope_assessment_pending() { continue; }`
+            // guard fires here → no impl dispatch is created, entry stays pending.
+            assert!(
+                state.scope_assessment_pending(),
+                "scope-assessment pending must defer impl creation"
+            );
+            // And the side-path is (independently) non-attachable, so even the
+            // attach path would not bind the entry.
+            assert!(!state.has_active_dispatch());
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn scope_assessment_completed_releases_impl_creation_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            // After scope-assessment completes (direct depth), the policy layer
+            // flips status → "completed". The gate must release so activate
+            // resumes and creates the implementation dispatch on the next tick.
+            set_scope_status(&pool, Some("completed")).await;
+
+            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
+                .await
+                .expect("load card state");
+
+            assert!(
+                !state.scope_assessment_pending(),
+                "completed scope-assessment must NOT block impl creation"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn card_without_scope_assessment_never_blocks_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
+            seed_base(&pool).await;
+            // CORE NO-REGRESSION: a card that never ran scope-assessment has NO
+            // scope_assessment_status key. absent ≠ pending, so the gate must NOT
+            // fire and activate behaves exactly as before T3 (creates impl).
+            set_scope_status(&pool, None).await;
+
+            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
+                .await
+                .expect("load card state");
+
+            assert!(
+                !state.scope_assessment_pending(),
+                "a card with no scope-assessment must never be blocked (absent ≠ pending)"
             );
 
             pool.close().await;

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -1674,71 +1674,212 @@ mod tests {
             pg_db.drop().await;
         }
 
-        // #3594 (T3) ─ impl-before-depth race gate. While a scope-assessment is
-        // in flight (`scope_assessment_status == "pending"`), the activate loop
-        // must DEFER creating an implementation dispatch — otherwise (because
-        // scope-assessment is excluded from has_active_dispatch, #3605) activate
-        // would fall through and create impl before the depth that gates the flow
-        // is known. The gate the loop reads is `scope_assessment_pending()`,
-        // computed by the real production loader from card metadata. These
-        // exercise that loader against real Postgres rows.
+        // #3594 (T3) impl-before-depth race gate: the EFFECTIVE row-counting tests
+        // that drive the real `activate_with_deps_pg` live in the sibling module
+        // `depth_gate_activate_pg_tests` below. The earlier predicate-only tests
+        // (asserting just `scope_assessment_pending()` on a loaded state without
+        // running activate or counting dispatch rows) were vacuous — they passed
+        // even with the loop guard deleted — and have been replaced.
+    }
+
+    /// #3594 (T3, codex Finding 4): EFFECTIVE race-gate tests. The previous
+    /// `scope_assessment_*_pg` tests only asserted the `scope_assessment_pending()`
+    /// PREDICATE on a loaded `ActivateCardState` — they never ran the real activate
+    /// entry point, so deleting the loop guard left them green (vacuous).
+    ///
+    /// These drive the REAL `activate_with_deps_pg` against real Postgres rows and
+    /// assert on what the gate actually controls. Creating a *fresh* implementation
+    /// dispatch needs a resolvable git worktree a unit fixture cannot cheaply
+    /// provide, so to keep the post-gate step observable WITHOUT worktree infra each
+    /// card is seeded with a pre-existing live (dispatched) implementation dispatch.
+    /// The activate loop's order is: scope-pending guard FIRST, then the
+    /// `has_active_dispatch()` attach step. So:
+    ///   - scope pending  → the `if scope_assessment_pending() { continue; }` guard
+    ///                       fires BEFORE the attach step: the pending entry is NOT
+    ///                       bound (stays `pending`), and no NEW impl dispatch row is
+    ///                       created (exactly one pre-existing impl row remains).
+    ///   - scope completed → the guard does NOT fire, so the loop reaches the attach
+    ///                       step and binds the entry to the existing impl dispatch
+    ///                       (entry → `dispatched`).
+    ///   - no scope-assessment key → core no-regression: identical to "completed"
+    ///                       (absent ≠ pending) — entry binds.
+    ///
+    /// Mutation check: deleting the loop guard makes the "pending" case fall through
+    /// to the attach step too → its entry becomes `dispatched` → the pending-case
+    /// `entry stays pending` assertion fails. (Verified by hand.)
+    mod depth_gate_activate_pg_tests {
+        use super::super::activate_with_deps_pg;
+        use super::super::{ActivateBody, AutoQueueActivateDeps};
+        use crate::db::auto_queue::test_support::TestPostgresDb;
+        use sqlx::PgPool;
+        use std::sync::Arc;
+
+        async fn seed_run_card_entry(pool: &PgPool) {
+            sqlx::query(
+                "INSERT INTO auto_queue_runs (id, repo, agent_id, status, max_concurrent_threads, thread_group_count)
+                 VALUES ('run-dg', 'repo-1', 'agent-dg', 'active', 2, 1)",
+            )
+            .execute(pool)
+            .await
+            .expect("seed run");
+            sqlx::query(
+                "INSERT INTO agents (id, name, provider, discord_channel_id)
+                 VALUES ('agent-dg', 'Agent DG', 'claude', '999')",
+            )
+            .execute(pool)
+            .await
+            .expect("seed agent");
+            sqlx::query(
+                "INSERT INTO kanban_cards (id, title, status, assigned_agent_id, repo_id)
+                 VALUES ('card-dg', 'Card DG', 'in_progress', 'agent-dg', 'repo-1')",
+            )
+            .execute(pool)
+            .await
+            .expect("seed card");
+            sqlx::query(
+                "INSERT INTO auto_queue_entries
+                    (id, run_id, kanban_card_id, agent_id, status, thread_group, batch_phase)
+                 VALUES ('entry-dg', 'run-dg', 'card-dg', 'agent-dg', 'pending', 0, 0)",
+            )
+            .execute(pool)
+            .await
+            .expect("seed pending entry");
+            // Assign the agent's slot 0 to this run+group so the activate planner's
+            // `assigned_groups_with_pending_entries_pg` selects the group and the
+            // per-entry loop runs for `entry-dg`.
+            sqlx::query(
+                "INSERT INTO auto_queue_slots
+                    (agent_id, slot_index, assigned_run_id, assigned_thread_group, thread_id_map)
+                 VALUES ('agent-dg', 0, 'run-dg', 0, CAST('{}' AS jsonb))",
+            )
+            .execute(pool)
+            .await
+            .expect("seed assigned slot");
+        }
+
+        /// Seed a live (dispatched) IMPLEMENTATION dispatch as the card's latest, so
+        /// the activate loop's attach path (`has_active_dispatch()` true) can bind
+        /// the entry to it WITHOUT creating a fresh worktree-requiring dispatch.
+        async fn seed_existing_impl_dispatch(pool: &PgPool) {
+            sqlx::query(
+                "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title)
+                 VALUES ('impl-existing', 'card-dg', 'agent-dg', 'implementation', 'dispatched', 'Impl')",
+            )
+            .execute(pool)
+            .await
+            .expect("seed existing impl dispatch");
+            sqlx::query(
+                "UPDATE kanban_cards SET latest_dispatch_id = 'impl-existing' WHERE id = 'card-dg'",
+            )
+            .execute(pool)
+            .await
+            .expect("set latest_dispatch_id");
+        }
+
         async fn set_scope_status(pool: &PgPool, status: Option<&str>) {
             let metadata = match status {
                 Some(s) => serde_json::json!({ "scope_assessment_status": s }).to_string(),
                 None => "{}".to_string(),
             };
-            sqlx::query("UPDATE kanban_cards SET metadata = $1::jsonb WHERE id = 'card-1'")
+            sqlx::query("UPDATE kanban_cards SET metadata = $1::jsonb WHERE id = 'card-dg'")
                 .bind(metadata)
                 .execute(pool)
                 .await
                 .expect("set scope metadata");
         }
 
+        fn make_deps(pool: &PgPool) -> AutoQueueActivateDeps {
+            let config = crate::config::Config::default();
+            let engine = crate::engine::PolicyEngine::new_with_pg(&config, Some(pool.clone()))
+                .expect("test policy engine");
+            AutoQueueActivateDeps {
+                pg_pool: Some(pool.clone()),
+                engine,
+                config: Arc::new(config),
+                health_registry: None,
+                guild_id: None,
+            }
+        }
+
+        fn activate_body() -> ActivateBody {
+            ActivateBody {
+                run_id: Some("run-dg".to_string()),
+                repo: None,
+                agent_id: None,
+                thread_group: None,
+                unified_thread: None,
+                active_only: None,
+            }
+        }
+
+        async fn impl_dispatch_row_count(pool: &PgPool) -> i64 {
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*)::BIGINT FROM task_dispatches
+                 WHERE kanban_card_id = 'card-dg' AND dispatch_type = 'implementation'",
+            )
+            .fetch_one(pool)
+            .await
+            .expect("count impl dispatches")
+        }
+
+        async fn entry_status(pool: &PgPool) -> String {
+            sqlx::query_scalar::<_, String>(
+                "SELECT status FROM auto_queue_entries WHERE id = 'entry-dg'",
+            )
+            .fetch_one(pool)
+            .await
+            .expect("entry status")
+        }
+
         #[tokio::test]
-        async fn scope_assessment_pending_defers_impl_creation_pg() {
+        async fn scope_pending_defers_entry_not_bound_no_new_impl_row_pg() {
             let pg_db = TestPostgresDb::create().await;
-            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
-            seed_base(&pool).await;
-            // scope-assessment is in flight and is the card's latest dispatch; the
-            // impl entry is still pending — the gating-prone state.
-            attach_live_dispatch(&pool, "dispatch-scope", "scope-assessment").await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            seed_existing_impl_dispatch(&pool).await;
+            // scope-assessment in flight → the loop's scope-pending guard fires
+            // BEFORE the attach step, so the entry is never bound.
             set_scope_status(&pool, Some("pending")).await;
 
-            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
-                .await
-                .expect("load card state");
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
 
-            // The activate loop's `if scope_assessment_pending() { continue; }`
-            // guard fires here → no impl dispatch is created, entry stays pending.
-            assert!(
-                state.scope_assessment_pending(),
-                "scope-assessment pending must defer impl creation"
+            // The gate fired: the entry was NOT bound to the existing impl dispatch.
+            assert_eq!(
+                entry_status(&pool).await,
+                "pending",
+                "scope-assessment pending must defer: the entry stays pending (not attached)"
             );
-            // And the side-path is (independently) non-attachable, so even the
-            // attach path would not bind the entry.
-            assert!(!state.has_active_dispatch());
+            // And no NEW impl dispatch was created — only the seeded one remains.
+            assert_eq!(
+                impl_dispatch_row_count(&pool).await,
+                1,
+                "no new implementation dispatch must be created while scope is pending"
+            );
 
             pool.close().await;
             pg_db.drop().await;
         }
 
         #[tokio::test]
-        async fn scope_assessment_completed_releases_impl_creation_pg() {
+        async fn scope_completed_releases_gate_entry_binds_pg() {
             let pg_db = TestPostgresDb::create().await;
-            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
-            seed_base(&pool).await;
-            // After scope-assessment completes (direct depth), the policy layer
-            // flips status → "completed". The gate must release so activate
-            // resumes and creates the implementation dispatch on the next tick.
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            seed_existing_impl_dispatch(&pool).await;
+            // scope-assessment completed → the gate releases; the loop reaches the
+            // attach step and binds the entry to the existing impl dispatch.
             set_scope_status(&pool, Some("completed")).await;
 
-            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
-                .await
-                .expect("load card state");
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
 
-            assert!(
-                !state.scope_assessment_pending(),
-                "completed scope-assessment must NOT block impl creation"
+            assert_eq!(
+                entry_status(&pool).await,
+                "dispatched",
+                "completed scope-assessment must release the gate so the entry binds to the impl dispatch"
             );
 
             pool.close().await;
@@ -1746,22 +1887,24 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn card_without_scope_assessment_never_blocks_pg() {
+        async fn card_without_scope_assessment_entry_binds_no_regression_pg() {
             let pg_db = TestPostgresDb::create().await;
-            let pool = pg_db.connect_and_migrate_with_max_connections(4).await;
-            seed_base(&pool).await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            seed_existing_impl_dispatch(&pool).await;
             // CORE NO-REGRESSION: a card that never ran scope-assessment has NO
-            // scope_assessment_status key. absent ≠ pending, so the gate must NOT
-            // fire and activate behaves exactly as before T3 (creates impl).
+            // scope_assessment_status key. absent ≠ pending → the gate must NOT fire
+            // and the entry binds exactly as before T3.
             set_scope_status(&pool, None).await;
 
-            let state = load_activate_card_state_pg(&pool, "card-1", "entry-1")
-                .await
-                .expect("load card state");
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
 
-            assert!(
-                !state.scope_assessment_pending(),
-                "a card with no scope-assessment must never be blocked (absent ≠ pending)"
+            assert_eq!(
+                entry_status(&pool).await,
+                "dispatched",
+                "a card with no scope-assessment must bind the entry (no regression)"
             );
 
             pool.close().await;

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -531,6 +531,38 @@ pub(crate) async fn activate_with_deps_pg(
             );
         }
 
+        // #3594 (T3, codex R2 Finding 1): pick the dispatch_type DEPTH-AWARELY.
+        // A "late" entry — generated AFTER scope-assessment completed, so it was
+        // never claimed by the JS scope-completion resume NOR its by-card
+        // fallback — reaches here `pending` with the scope-pending gate already
+        // released. Creating a plain `"implementation"` would bypass the depth
+        // gate (plan / plan-review). `activate_next_dispatch_type` mirrors the JS
+        // `_resolveScopeFlow`: full/plan_only → `"plan"` (unless a plan already
+        // completed), direct/absent/plan-done → `"implementation"`. The plan we
+        // create here carries the entry, so when it completes the JS
+        // plan-completion arm fans out to plan-review (full) / impl (plan_only)
+        // exactly as on the normal path. Idempotency: `create_*_dispatch_for_entry_pg`
+        // short-circuits to any existing live dispatch of the SAME type, so a
+        // concurrent JS-created plan is never duplicated; the completed-plan
+        // guard stops re-creating a plan after one finished.
+        let next_dispatch_type = initial_state.activate_next_dispatch_type();
+        if next_dispatch_type == "plan" {
+            // Carry the resolved depth on the plan dispatch context so the JS
+            // plan-completion arm branches (plan_only→impl, full→plan-review)
+            // WITHOUT re-reading card metadata — matching the JS
+            // `_createPlanDispatch` `{ scope_depth }` contract. Defaults to "full"
+            // only if the depth somehow read empty (impossible once
+            // scope_depth is present, but fail-safe to the most cautious flow).
+            let depth = initial_state.scope_depth.as_deref().unwrap_or("full");
+            dispatch_extra_fields.push(("scope_depth", json!(depth)));
+            crate::auto_queue_log!(
+                info,
+                "activate_late_entry_depth_gated_plan_pg_3594",
+                entry_log_ctx.clone().maybe_slot_index(slot_index),
+                "[auto-queue] late entry {entry_id} for card {card_id}: scope_depth={depth} → creating depth-gated `plan` dispatch (not plain implementation)",
+            );
+        }
+
         let dispatch_context = build_auto_queue_dispatch_context(
             &entry_id,
             *group,
@@ -542,7 +574,7 @@ pub(crate) async fn activate_with_deps_pg(
             pool,
             &card_id,
             &agent_id,
-            "implementation",
+            next_dispatch_type,
             &initial_state.title,
             &dispatch_context,
             ActivateDispatchEntryAttachment::new(
@@ -1813,13 +1845,54 @@ mod tests {
         }
 
         async fn impl_dispatch_row_count(pool: &PgPool) -> i64 {
+            dispatch_row_count_of_type(pool, "implementation").await
+        }
+
+        /// #3594 (T3, codex R2 Finding 1): count dispatch rows of an arbitrary
+        /// `dispatch_type` for `card-dg`. Used by the late-entry depth-aware tests
+        /// to assert that activate created a `plan` (or did NOT) instead of a
+        /// plain `implementation`.
+        async fn dispatch_row_count_of_type(pool: &PgPool, dispatch_type: &str) -> i64 {
             sqlx::query_scalar::<_, i64>(
                 "SELECT COUNT(*)::BIGINT FROM task_dispatches
-                 WHERE kanban_card_id = 'card-dg' AND dispatch_type = 'implementation'",
+                 WHERE kanban_card_id = 'card-dg' AND dispatch_type = $1",
             )
+            .bind(dispatch_type)
             .fetch_one(pool)
             .await
-            .expect("count impl dispatches")
+            .expect("count dispatches of type")
+        }
+
+        /// #3594 (T3, codex R2 Finding 1): set BOTH `scope_assessment_status` and
+        /// `scope_depth` on `card-dg` metadata — the late-entry state where the
+        /// scope-assessment already COMPLETED (so the scope-pending gate is
+        /// released) and recorded a depth, exactly as
+        /// `kanban-scope-assessment._recordScopeAssessment` writes it.
+        async fn set_scope_completed_with_depth(pool: &PgPool, depth: &str) {
+            let metadata = serde_json::json!({
+                "scope_assessment_status": "completed",
+                "scope_depth": depth,
+            })
+            .to_string();
+            sqlx::query("UPDATE kanban_cards SET metadata = $1::jsonb WHERE id = 'card-dg'")
+                .bind(metadata)
+                .execute(pool)
+                .await
+                .expect("set scope metadata with depth");
+        }
+
+        /// #3594 (T3, codex R2 Finding 1): seed a COMPLETED `plan` dispatch so the
+        /// `has_completed_plan_dispatch` guard fires — the "plan already finished"
+        /// idempotency case where activate must advance to `implementation`, not
+        /// re-create a plan.
+        async fn seed_completed_plan_dispatch(pool: &PgPool) {
+            sqlx::query(
+                "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, completed_at)
+                 VALUES ('plan-done', 'card-dg', 'agent-dg', 'plan', 'completed', 'Plan', NOW())",
+            )
+            .execute(pool)
+            .await
+            .expect("seed completed plan dispatch");
         }
 
         async fn entry_status(pool: &PgPool) -> String {
@@ -1906,6 +1979,225 @@ mod tests {
                 "dispatched",
                 "a card with no scope-assessment must bind the entry (no regression)"
             );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        // ── #3594 (T3, codex R2 Finding 1): LATE-ENTRY depth-aware tests ──────
+        //
+        // The "late entry" ordering: a card runs scope-assessment FIRST (so
+        // `/queue/generate` skipped it while the scope dispatch was
+        // pending/dispatched). scope-assessment COMPLETES → its JS resume + the
+        // by-card fallback find NO auto-queue entry yet (it was never generated).
+        // THEN `/queue/generate` finally creates the entry (`pending`) — it
+        // reaches activate with `scope_assessment_status == "completed"` (gate
+        // released) and NO active dispatch. Pre-fix, activate created a plain
+        // `implementation`, bypassing the depth gate. These assert activate is now
+        // depth-aware: it creates a `plan` for full/plan_only (mirroring the JS
+        // `_resolveScopeFlow`), and stays on `implementation` for direct / absent
+        // / plan-already-done (no regression).
+        //
+        // The full/plan_only cards seed NO existing dispatch, so activate reaches
+        // the CREATE path; `plan` does not require a fresh worktree
+        // (dispatch_type_requires_fresh_worktree = implementation|rework only), so
+        // the plan dispatch is creatable in a PG-only fixture. The direct/absent
+        // cards seed an existing live `implementation` dispatch so activate
+        // ATTACHES to it (proving it chose `implementation`) without needing
+        // worktree infra to create a fresh impl.
+
+        async fn plan_dispatch_row_count(pool: &PgPool) -> i64 {
+            dispatch_row_count_of_type(pool, "plan").await
+        }
+
+        /// Read the `scope_depth` carried on the newly-created `plan` dispatch
+        /// context — must equal the card's recorded depth so the JS
+        /// plan-completion arm branches (plan_only→impl, full→plan-review)
+        /// without re-reading metadata.
+        async fn latest_plan_dispatch_scope_depth(pool: &PgPool) -> Option<String> {
+            sqlx::query_scalar::<_, Option<String>>(
+                "SELECT context::jsonb->>'scope_depth'
+                 FROM task_dispatches
+                 WHERE kanban_card_id = 'card-dg' AND dispatch_type = 'plan'
+                 ORDER BY created_at DESC
+                 LIMIT 1",
+            )
+            .fetch_one(pool)
+            .await
+            .expect("read plan dispatch scope_depth")
+        }
+
+        #[tokio::test]
+        async fn late_entry_full_depth_creates_plan_not_impl_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            // No existing dispatch → activate reaches the create path.
+            set_scope_completed_with_depth(&pool, "full").await;
+
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+
+            // Depth-aware: a `plan` dispatch was created, NOT a plain impl.
+            assert_eq!(
+                plan_dispatch_row_count(&pool).await,
+                1,
+                "full late entry must create a depth-gated `plan` dispatch"
+            );
+            assert_eq!(
+                impl_dispatch_row_count(&pool).await,
+                0,
+                "full late entry must NOT create a plain `implementation` dispatch (depth gate bypass)"
+            );
+            // The resolved depth rides on the plan context so the JS
+            // plan-completion arm fans out to plan-review (full) without re-reading
+            // card metadata.
+            assert_eq!(
+                latest_plan_dispatch_scope_depth(&pool).await.as_deref(),
+                Some("full"),
+                "plan dispatch must carry scope_depth=full for the JS plan-completion fan-out"
+            );
+            // The late entry was bound to the plan dispatch (not left pending).
+            assert_eq!(entry_status(&pool).await, "dispatched");
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn late_entry_plan_only_depth_creates_plan_not_impl_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            set_scope_completed_with_depth(&pool, "plan_only").await;
+
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+
+            assert_eq!(
+                plan_dispatch_row_count(&pool).await,
+                1,
+                "plan_only late entry must create a `plan` dispatch"
+            );
+            assert_eq!(
+                impl_dispatch_row_count(&pool).await,
+                0,
+                "plan_only late entry must NOT create a plain `implementation` dispatch"
+            );
+            // plan_only must still carry its depth so the plan-completion arm goes
+            // plan→impl (NOT plan-review). The activate side does not itself create
+            // plan-review; it only seeds the plan stage with the correct depth.
+            assert_eq!(
+                latest_plan_dispatch_scope_depth(&pool).await.as_deref(),
+                Some("plan_only"),
+                "plan dispatch must carry scope_depth=plan_only"
+            );
+            assert_eq!(entry_status(&pool).await, "dispatched");
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn late_entry_direct_depth_creates_impl_no_plan_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            // direct → fast track. Seed an existing live impl so activate ATTACHES
+            // (no worktree-requiring fresh-impl create) — proving it chose the
+            // `implementation` path, NOT `plan`.
+            seed_existing_impl_dispatch(&pool).await;
+            set_scope_completed_with_depth(&pool, "direct").await;
+
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+
+            // No plan stage for direct.
+            assert_eq!(
+                plan_dispatch_row_count(&pool).await,
+                0,
+                "direct late entry must NOT create a `plan` dispatch (fast track)"
+            );
+            // It attached to the existing impl (the `implementation` decision).
+            assert_eq!(
+                entry_status(&pool).await,
+                "dispatched",
+                "direct late entry must bind to the implementation dispatch"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        #[tokio::test]
+        async fn late_entry_full_depth_with_completed_plan_does_not_create_new_plan_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            // full depth, but a plan ALREADY completed AND the impl is already
+            // live. activate attaches the entry to the existing impl (the
+            // `has_active_dispatch()` branch fires before the create branch), so it
+            // must NOT spin up a SECOND plan. This pins the end-to-end invariant
+            // "a finished plan is never re-run by activate"; the create-path
+            // decision for the same state (completed plan → `implementation`) is
+            // unit-tested directly in `view::activate_next_dispatch_type_tests`
+            // (which needs no worktree infra).
+            seed_completed_plan_dispatch(&pool).await;
+            seed_existing_impl_dispatch(&pool).await;
+            set_scope_completed_with_depth(&pool, "full").await;
+
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+
+            // No NEW plan was created — only the pre-existing completed plan remains.
+            assert_eq!(
+                plan_dispatch_row_count(&pool).await,
+                1,
+                "a completed plan must not be re-created (idempotency)"
+            );
+            assert_eq!(
+                entry_status(&pool).await,
+                "dispatched",
+                "with a completed plan + live impl, activate binds the entry to the implementation dispatch"
+            );
+
+            pool.close().await;
+            pg_db.drop().await;
+        }
+
+        /// Core no-regression, explicit plan-absence form: a card that never ran
+        /// scope-assessment (no `scope_depth` key) must NEVER get a `plan` stage
+        /// from activate — it stays on the plain `implementation` path exactly as
+        /// before T3. (The sibling
+        /// `card_without_scope_assessment_entry_binds_no_regression_pg` asserts the
+        /// entry binds; this adds the `plan` must NOT exist invariant.)
+        ///
+        /// Mutation check: if `activate_next_dispatch_type` dropped the
+        /// `scope_depth.is_none()` short-circuit and treated absent as plan-worthy,
+        /// this test would see a `plan` dispatch created and fail.
+        #[tokio::test]
+        async fn absent_scope_depth_never_creates_plan_no_regression_pg() {
+            let pg_db = TestPostgresDb::create().await;
+            let pool = pg_db.connect_and_migrate_with_max_connections(8).await;
+            seed_run_card_entry(&pool).await;
+            seed_existing_impl_dispatch(&pool).await;
+            // No scope metadata at all (absent ≠ scope-assessed).
+            set_scope_status(&pool, None).await;
+
+            let deps = make_deps(&pool);
+            let (status, _body) = activate_with_deps_pg(&deps, activate_body()).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+
+            assert_eq!(
+                plan_dispatch_row_count(&pool).await,
+                0,
+                "a card that never ran scope-assessment must NEVER get a plan stage from activate"
+            );
+            assert_eq!(entry_status(&pool).await, "dispatched");
 
             pool.close().await;
             pg_db.drop().await;

--- a/src/services/auto_queue/view.rs
+++ b/src/services/auto_queue/view.rs
@@ -81,6 +81,17 @@ pub(super) struct ActivateCardState {
     pub(super) entry_status: String,
     pub(super) repo_id: Option<String>,
     pub(super) assigned_agent_id: Option<String>,
+    /// #3594 (T3): whether the card's `scope_assessment_status` metadata is
+    /// exactly `"pending"`. While a scope-assessment is in flight the activate
+    /// loop must NOT create an implementation dispatch yet — the depth that
+    /// gates the flow (direct / plan_only / full) is not known until the
+    /// scope-assessment completes, and scope-assessment is a side-path that is
+    /// deliberately excluded from `has_active_dispatch()` (so activate would
+    /// otherwise fall through and create impl, bypassing the gate). This is the
+    /// only "pending" guard: a card that never ran scope-assessment has NO
+    /// `scope_assessment_status` key → `false` here → no behavior change (the
+    /// core no-regression invariant — absent ≠ pending).
+    pub(super) scope_assessment_pending: bool,
 }
 
 impl ActivateCardState {
@@ -119,6 +130,18 @@ impl ActivateCardState {
                 Some("pending") | Some("dispatched")
             )
             && !crate::dispatch::dispatch_is_side_path(self.latest_dispatch_type.as_deref())
+    }
+
+    /// #3594 (T3): whether the activate loop must defer creating an
+    /// implementation dispatch because a scope-assessment is still in flight for
+    /// this card (`scope_assessment_status == "pending"`). Once the
+    /// scope-assessment completes, the policy layer (kanban-rules onDispatch
+    /// completed) flips the status to `"completed"` and creates the depth-gated
+    /// next dispatch (impl directly for `direct`, or `plan`), so this returns
+    /// `false` and activate resumes normally on the next tick. Strictly
+    /// `"pending"`-only: a card with no scope-assessment never blocks here.
+    pub(super) fn scope_assessment_pending(&self) -> bool {
+        self.scope_assessment_pending
     }
 }
 
@@ -170,7 +193,9 @@ pub(super) async fn load_activate_card_state_pg(
     entry_id: &str,
 ) -> Result<ActivateCardState, String> {
     let row = sqlx::query(
-        "SELECT status, title, latest_dispatch_id, repo_id, assigned_agent_id
+        "SELECT status, title, latest_dispatch_id, repo_id, assigned_agent_id,
+                COALESCE(metadata->>'scope_assessment_status', '') = 'pending'
+                    AS scope_assessment_pending
          FROM kanban_cards
          WHERE id = $1",
     )
@@ -263,6 +288,9 @@ pub(super) async fn load_activate_card_state_pg(
         assigned_agent_id: row
             .try_get("assigned_agent_id")
             .map_err(|error| format!("decode assigned_agent_id for {card_id}: {error}"))?,
+        scope_assessment_pending: row
+            .try_get("scope_assessment_pending")
+            .map_err(|error| format!("decode scope_assessment_pending for {card_id}: {error}"))?,
     })
 }
 

--- a/src/services/auto_queue/view.rs
+++ b/src/services/auto_queue/view.rs
@@ -92,6 +92,24 @@ pub(super) struct ActivateCardState {
     /// `scope_assessment_status` key → `false` here → no behavior change (the
     /// core no-regression invariant — absent ≠ pending).
     pub(super) scope_assessment_pending: bool,
+    /// #3594 (T3, codex R2 Finding 1): the card's recorded `scope_depth`
+    /// (`metadata->>'scope_depth'`), one of `direct` / `plan_only` / `full`
+    /// (already normalized + full-fallback on write by
+    /// `policies/lib/kanban-scope-assessment._recordScopeAssessment`). `None`
+    /// when the card never ran scope-assessment (no key) — the core
+    /// no-regression case: activate must NOT insert a plan stage for such cards.
+    /// Drives `activate_next_dispatch_type` so a late entry (one generated AFTER
+    /// scope-assessment completed, missed by both the JS scope-completion resume
+    /// AND its by-card fallback) does not reach the plain-`implementation`
+    /// activate path and bypass the depth gate.
+    pub(super) scope_depth: Option<String>,
+    /// #3594 (T3, codex R2 Finding 1): whether this card already has a
+    /// `completed` `plan` dispatch. When true the plan stage is already behind
+    /// us, so activate creates `implementation` (not another `plan`) — the
+    /// plan-review fan-out (full) is owned by the JS plan-completion arm, which
+    /// already ran for that completed plan. Idempotency anchor: prevents
+    /// activate from re-creating a plan after one finished.
+    pub(super) has_completed_plan_dispatch: bool,
 }
 
 impl ActivateCardState {
@@ -142,6 +160,44 @@ impl ActivateCardState {
     /// `"pending"`-only: a card with no scope-assessment never blocks here.
     pub(super) fn scope_assessment_pending(&self) -> bool {
         self.scope_assessment_pending
+    }
+
+    /// #3594 (T3, codex R2 Finding 1): the dispatch_type activate must create
+    /// for this card's pending entry — `"plan"` to honor the depth gate, or
+    /// `"implementation"` for the fast track. This is the activate-side mirror of
+    /// the JS `policies/lib/kanban-scope-gate._resolveScopeFlow(depth)`; it MUST
+    /// stay in lockstep with that mapping (same depth → same first stage).
+    ///
+    /// activate only inserts the **plan** stage when it is missing — it never
+    /// inserts plan-review (that is the JS plan-completion arm's job once a plan
+    /// dispatch exists; the plan dispatch activate creates here carries the
+    /// linked entry, so when it completes the JS arm finds it and fans out to
+    /// plan-review (full) / impl (plan_only) exactly as on the normal path).
+    ///
+    /// Returns `"plan"` iff:
+    ///   - `scope_depth` is present (the card WAS scope-assessed) — absent ≠
+    ///     scope-assessed, so a card that never ran scope-assessment stays on the
+    ///     plain-`implementation` path (the core no-regression invariant), AND
+    ///   - `scope_depth != "direct"` — `direct` is the fast track (`needsPlan:
+    ///     false`), AND
+    ///   - no `completed` plan dispatch exists yet — once a plan finished the
+    ///     stage is behind us and we advance to `implementation`.
+    ///
+    /// A present-but-unrecognized depth (corrupted metadata; in practice
+    /// impossible since the writer normalizes to {direct,plan_only,full}) is
+    /// treated as plan-worthy, mirroring `_resolveScopeFlow`'s "unknown → full"
+    /// most-cautious fallback.
+    pub(super) fn activate_next_dispatch_type(&self) -> &'static str {
+        let needs_plan = match self.scope_depth.as_deref() {
+            None => false,
+            Some("direct") => false,
+            Some(_) => true,
+        };
+        if needs_plan && !self.has_completed_plan_dispatch {
+            "plan"
+        } else {
+            "implementation"
+        }
     }
 }
 
@@ -195,7 +251,14 @@ pub(super) async fn load_activate_card_state_pg(
     let row = sqlx::query(
         "SELECT status, title, latest_dispatch_id, repo_id, assigned_agent_id,
                 COALESCE(metadata->>'scope_assessment_status', '') = 'pending'
-                    AS scope_assessment_pending
+                    AS scope_assessment_pending,
+                metadata->>'scope_depth' AS scope_depth,
+                EXISTS (
+                    SELECT 1 FROM task_dispatches td
+                    WHERE td.kanban_card_id = kanban_cards.id
+                      AND td.dispatch_type = 'plan'
+                      AND td.status = 'completed'
+                ) AS has_completed_plan_dispatch
          FROM kanban_cards
          WHERE id = $1",
     )
@@ -291,6 +354,12 @@ pub(super) async fn load_activate_card_state_pg(
         scope_assessment_pending: row
             .try_get("scope_assessment_pending")
             .map_err(|error| format!("decode scope_assessment_pending for {card_id}: {error}"))?,
+        scope_depth: row
+            .try_get("scope_depth")
+            .map_err(|error| format!("decode scope_depth for {card_id}: {error}"))?,
+        has_completed_plan_dispatch: row.try_get("has_completed_plan_dispatch").map_err(
+            |error| format!("decode has_completed_plan_dispatch for {card_id}: {error}"),
+        )?,
     })
 }
 
@@ -339,4 +408,107 @@ pub(super) async fn resolve_activate_pipeline_pg(
         repo_override.as_ref(),
         agent_override.as_ref(),
     ))
+}
+
+/// #3594 (T3, codex R2 Finding 1): pure (no-PG) coverage of the activate-side
+/// depth gate `ActivateCardState::activate_next_dispatch_type`, which mirrors the
+/// JS `policies/lib/kanban-scope-gate._resolveScopeFlow`. The PG tests in
+/// `activate_command::depth_gate_activate_pg_tests` prove the end-to-end create
+/// path; these pin every branch of the decision itself (including the
+/// `has_completed_plan_dispatch` idempotency arm the PG attach-path short-circuits
+/// before reaching the create decision).
+#[cfg(test)]
+mod activate_next_dispatch_type_tests {
+    use super::ActivateCardState;
+
+    /// Build a minimal `ActivateCardState` varying only the two fields the gate
+    /// reads. The rest are inert defaults — the gate does not consult them.
+    fn state(scope_depth: Option<&str>, has_completed_plan_dispatch: bool) -> ActivateCardState {
+        ActivateCardState {
+            status: "in_progress".to_string(),
+            title: "T".to_string(),
+            latest_dispatch_id: None,
+            latest_dispatch_status: None,
+            latest_dispatch_type: None,
+            entry_status: "pending".to_string(),
+            repo_id: None,
+            assigned_agent_id: None,
+            scope_assessment_pending: false,
+            scope_depth: scope_depth.map(str::to_string),
+            has_completed_plan_dispatch,
+        }
+    }
+
+    #[test]
+    fn full_and_plan_only_without_completed_plan_create_plan() {
+        // Mirrors _resolveScopeFlow needsPlan=true for full/plan_only.
+        assert_eq!(
+            state(Some("full"), false).activate_next_dispatch_type(),
+            "plan"
+        );
+        assert_eq!(
+            state(Some("plan_only"), false).activate_next_dispatch_type(),
+            "plan"
+        );
+    }
+
+    #[test]
+    fn direct_is_fast_track_implementation() {
+        // _resolveScopeFlow("direct") → needsPlan=false.
+        assert_eq!(
+            state(Some("direct"), false).activate_next_dispatch_type(),
+            "implementation"
+        );
+    }
+
+    #[test]
+    fn absent_scope_depth_is_implementation_no_regression() {
+        // Core no-regression: a card that never ran scope-assessment (absent ≠
+        // scope-assessed) must stay on the plain implementation path. This is the
+        // ONE place the activate gate diverges from _resolveScopeFlow's
+        // "unknown→full": _resolveScopeFlow is only ever called post-assessment
+        // (depth always present), whereas activate sees never-assessed cards too.
+        assert_eq!(
+            state(None, false).activate_next_dispatch_type(),
+            "implementation"
+        );
+    }
+
+    #[test]
+    fn completed_plan_advances_to_implementation_even_for_full() {
+        // Idempotency: once a plan finished the stage is behind us. full/plan_only
+        // with a completed plan → implementation (NOT another plan). The
+        // plan-review fan-out for full is owned by the JS plan-completion arm that
+        // already ran for that completed plan.
+        assert_eq!(
+            state(Some("full"), true).activate_next_dispatch_type(),
+            "implementation"
+        );
+        assert_eq!(
+            state(Some("plan_only"), true).activate_next_dispatch_type(),
+            "implementation"
+        );
+        // direct + completed plan is still implementation (vacuously).
+        assert_eq!(
+            state(Some("direct"), true).activate_next_dispatch_type(),
+            "implementation"
+        );
+    }
+
+    #[test]
+    fn unrecognized_present_depth_is_cautious_plan() {
+        // Defensive double-guard parity with _resolveScopeFlow: a present-but-
+        // unknown depth (corrupted metadata; impossible on the normal path since
+        // the writer normalizes to {direct,plan_only,full}) is treated as
+        // plan-worthy (most cautious), NOT as absent.
+        assert_eq!(
+            state(Some("weird"), false).activate_next_dispatch_type(),
+            "plan"
+        );
+        // ...unless a plan already completed.
+        assert_eq!(
+            state(Some("weird"), true).activate_next_dispatch_type(),
+            "implementation"
+        );
+    }
 }

--- a/src/services/discord/prompt_builder/dispatch_contract.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract.rs
@@ -425,6 +425,41 @@ pub(super) fn render_dispatch_contract(
                  - review verdict API는 사용하지 않는다."
             ))
         }
+        // #3594 (T3): plan — the assigned agent produces a DESIGN + implementation
+        // PLAN only; it must NOT implement or commit. Its completion is consumed
+        // by kanban-rules (plan_only → impl, full → plan-review). The plan text
+        // goes in `result.plan` so the downstream plan-review / impl dispatch can
+        // reference it.
+        Some("plan") => {
+            let dispatch_id = current_task.dispatch_id?;
+            Some(format!(
+                "[Dispatch Contract]\n\
+                 - 이 dispatch는 \"설계/구현계획\" 전용이다. 코드 구현/수정/커밋은 하지 않는다.\n\
+                 - 이슈를 분석해 (1) 설계 개요 (2) 단계별 구현 계획 (3) 영향 범위/리스크를 산출한다.\n\
+                 - 완료 시 `PATCH /api/dispatches/{dispatch_id}`로 dispatch를 종료한다.\n\
+                 - result에는 반드시 `plan`(설계+구현계획 본문)을 넣는다.\n\
+                 - 예시 body: `{{\"status\":\"completed\",\"result\":{{\"plan\":\"설계: ...\\n계획: 1) ... 2) ...\",\"summary\":\"계획 요약\"}}}}`\n\
+                 - review verdict API는 사용하지 않는다."
+            ))
+        }
+        // #3594 (T3): plan-review — review the parent plan dispatch's `plan`
+        // output and emit a verdict. Option P: this is NOT routed through the
+        // counter-model review kernel, so the agent must NOT call the review
+        // verdict API; the verdict is read directly from `result.verdict`
+        // (pass | rework) by kanban-rules (pass → impl, rework → re-plan).
+        Some("plan-review") => {
+            let dispatch_id = current_task.dispatch_id?;
+            Some(format!(
+                "[Dispatch Contract]\n\
+                 - 이 dispatch는 부모 plan dispatch가 산출한 구현계획(plan)을 \"검토\"한다. 코드 구현/커밋은 하지 않는다.\n\
+                 - 계획의 타당성/누락/리스크를 점검하고 통과 여부를 판정한다.\n\
+                 - 완료 시 `PATCH /api/dispatches/{dispatch_id}`로 dispatch를 종료한다.\n\
+                 - result.verdict는 반드시 `pass`(계획 승인 → 구현 진행) 또는 `rework`(계획 보완 필요 → 재계획) 중 하나로 넣는다.\n\
+                 - rework면 `notes`에 보완해야 할 지점을 구체적으로 적는다.\n\
+                 - 예시 body: `{{\"status\":\"completed\",\"result\":{{\"verdict\":\"pass\",\"summary\":\"계획 적절\"}}}}`\n\
+                 - review verdict API(`POST /api/reviews/verdict`)는 사용하지 않는다."
+            ))
+        }
         Some("e2e-test") | Some("consultation") | Some("pm-decision") => {
             let dispatch_id = current_task.dispatch_id?;
             Some(format!(

--- a/src/services/discord/prompt_builder/dispatch_contract.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract.rs
@@ -88,6 +88,30 @@ fn render_dispatch_context_section(
         sections.push("Dispatch Trigger: auto-queue".to_string());
     }
 
+    // #3594 (T3, codex Finding 3): surface the parent PLAN dispatch's output so a
+    // plan-review (and full→impl) dispatch actually sees the plan body it must
+    // review / implement. The kanban-rules scope-gate copies the completed plan
+    // dispatch's `result.plan` into the downstream dispatch context under
+    // `parent_plan` (it already holds the plan result in hand at fan-out time),
+    // and this renders it verbatim into the prompt. Without this the agent only
+    // saw `{scope_depth}` and had to re-derive the plan from the issue alone.
+    // Truncated defensively so an oversized plan cannot blow up the system prompt.
+    if let Some(plan) = context
+        .get("parent_plan")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        const PARENT_PLAN_PROMPT_LIMIT: usize = 8000;
+        let rendered = if plan.chars().count() > PARENT_PLAN_PROMPT_LIMIT {
+            let truncated: String = plan.chars().take(PARENT_PLAN_PROMPT_LIMIT).collect();
+            format!("{truncated}\n… (plan truncated)")
+        } else {
+            plan.to_string()
+        };
+        sections.push(format!("Parent Plan (from the plan dispatch):\n{rendered}"));
+    }
+
     let reset_provider_state = context
         .get("reset_provider_state")
         .and_then(|value| value.as_bool())

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -592,6 +592,68 @@ fn scope_assessment_contract_requires_scope_depth_and_patch_completion() {
 }
 
 #[test]
+fn parent_plan_context_is_rendered_into_the_current_task_section() {
+    // #3594 (T3, codex Finding 3): a plan-review (or full→impl) dispatch carries
+    // the parent plan body in its context under `parent_plan`. It must surface in
+    // the [Current Task] / [Dispatch Context] block so the agent actually sees the
+    // plan it must review / implement.
+    use super::dispatch_contract::render_current_task_section;
+
+    let dispatch_context = serde_json::json!({
+        "auto_queue": true,
+        "scope_depth": "full",
+        "parent_plan": "Design: split module X.\nSteps: 1) extract Y 2) wire Z"
+    });
+    let dispatch_context_raw = dispatch_context.to_string();
+    let current_task = CurrentTaskContext {
+        dispatch_id: Some("dispatch-plan-review-1"),
+        dispatch_context: Some(&dispatch_context_raw),
+        ..CurrentTaskContext::default()
+    };
+
+    let section = render_current_task_section(&current_task, Some("plan-review"))
+        .expect("current task section");
+    assert!(
+        section.contains("Parent Plan (from the plan dispatch):"),
+        "the parent plan must be labelled in the prompt, got: {section}"
+    );
+    assert!(
+        section.contains("Design: split module X.")
+            && section.contains("Steps: 1) extract Y 2) wire Z"),
+        "the full plan body must be rendered verbatim, got: {section}"
+    );
+}
+
+#[test]
+fn parent_plan_is_truncated_when_oversized() {
+    // Defensive: an oversized plan must be truncated so it cannot blow up the
+    // system prompt, with an explicit truncation marker.
+    use super::dispatch_contract::render_current_task_section;
+
+    let huge_plan = "x".repeat(20_000);
+    let dispatch_context = serde_json::json!({ "parent_plan": huge_plan });
+    let dispatch_context_raw = dispatch_context.to_string();
+    let current_task = CurrentTaskContext {
+        dispatch_id: Some("dispatch-plan-review-2"),
+        dispatch_context: Some(&dispatch_context_raw),
+        ..CurrentTaskContext::default()
+    };
+
+    let section = render_current_task_section(&current_task, Some("plan-review"))
+        .expect("current task section");
+    assert!(
+        section.contains("… (plan truncated)"),
+        "oversized plan must be truncated with a marker"
+    );
+    // The rendered plan portion must be far smaller than the original 20k chars.
+    assert!(
+        section.chars().count() < 12_000,
+        "truncated section must be bounded, got {} chars",
+        section.chars().count()
+    );
+}
+
+#[test]
 fn review_lite_prompt_keeps_review_contract_while_trimming_full_sections() {
     use super::super::settings::RoleBinding;
 

--- a/src/services/discord/turn_bridge/completion_guard.rs
+++ b/src/services/discord/turn_bridge/completion_guard.rs
@@ -46,7 +46,20 @@ pub(super) async fn fetch_dispatch_snapshot(
 
 fn should_complete_work_dispatch(snapshot: &DispatchSnapshot) -> bool {
     matches!(snapshot.status.as_str(), "pending" | "dispatched")
-        && matches!(snapshot.dispatch_type.as_str(), "implementation" | "rework")
+        && matches!(
+            snapshot.dispatch_type.as_str(),
+            // #3594 (T3): "plan"/"plan-review" are work-dispatches (they kick the
+            // card into in_progress and are NOT side-paths). They must be
+            // eligible for the idle/turn-end auto-completion safety net just like
+            // implementation/rework — otherwise a plan agent that goes idle
+            // WITHOUT explicitly PATCH-completing would stall forever
+            // (OnDispatchCompleted never fires, the depth-gated lifecycle hangs).
+            // The downstream completion is benign for them: they produce no
+            // tracked changes, and their JS follow-up reads the plan dispatch
+            // context (scope_depth) / plan-review result.verdict (missing →
+            // cautious re-plan), not a commit SHA.
+            "implementation" | "rework" | "plan" | "plan-review"
+        )
 }
 
 fn normalize_review_decision_text(text: &str) -> String {
@@ -867,5 +880,64 @@ pub(super) async fn complete_work_dispatch_on_turn_end(
         } else {
             tracing::error!("all completion paths exhausted; dispatch stranded");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DispatchSnapshot, should_complete_work_dispatch};
+
+    fn snap(dispatch_type: &str, status: &str) -> DispatchSnapshot {
+        DispatchSnapshot {
+            dispatch_type: dispatch_type.to_string(),
+            status: status.to_string(),
+            kanban_card_id: None,
+            context: None,
+        }
+    }
+
+    #[test]
+    fn idle_auto_completion_covers_work_dispatch_types_including_plan() {
+        // #3594 (T3): plan / plan-review are work-dispatches and MUST be eligible
+        // for the idle/turn-end auto-completion safety net, alongside the
+        // pre-existing implementation / rework. Without this a plan agent that
+        // goes idle without PATCHing would stall (OnDispatchCompleted never
+        // fires).
+        for dispatch_type in ["implementation", "rework", "plan", "plan-review"] {
+            assert!(
+                should_complete_work_dispatch(&snap(dispatch_type, "dispatched")),
+                "{dispatch_type} must be eligible for idle auto-completion"
+            );
+            assert!(
+                should_complete_work_dispatch(&snap(dispatch_type, "pending")),
+                "{dispatch_type} (pending) must be eligible for idle auto-completion"
+            );
+        }
+    }
+
+    #[test]
+    fn idle_auto_completion_excludes_side_paths_and_review_family() {
+        // Side-paths (scope-assessment, consultation) and the review family must
+        // NOT be auto-completed by the work-dispatch turn-end path — they have
+        // their own lifecycles. Guards against the plan allowlist over-firing.
+        for dispatch_type in [
+            "scope-assessment",
+            "consultation",
+            "review",
+            "review-decision",
+            "create-pr",
+        ] {
+            assert!(
+                !should_complete_work_dispatch(&snap(dispatch_type, "dispatched")),
+                "{dispatch_type} must NOT be auto-completed by the work-dispatch path"
+            );
+        }
+    }
+
+    #[test]
+    fn idle_auto_completion_requires_live_status() {
+        // Only pending/dispatched are completable; a terminal status is a no-op.
+        assert!(!should_complete_work_dispatch(&snap("plan", "completed")));
+        assert!(!should_complete_work_dispatch(&snap("plan", "failed")));
     }
 }

--- a/src/services/discord/turn_bridge/completion_guard/completion_postgres.rs
+++ b/src/services/discord/turn_bridge/completion_guard/completion_postgres.rs
@@ -53,6 +53,16 @@ fn should_sync_runtime_auto_queue_terminal_entry(
     if crate::dispatch::dispatch_is_side_path(dispatch_type) {
         return false;
     }
+    // #3594 (T3): plan / plan-review are multi-stage WORK dispatches whose
+    // completion the kanban-rules JS fan-out consumes to RE-DISPATCH the bound
+    // auto-queue entry to the next stage (plan → plan-review|impl, plan-review →
+    // impl|re-plan). Finalizing the entry here (the live turn_bridge/watcher
+    // completion path) would break that chain and close the card with no
+    // implementation. Mirror of dispatch_status::should_skip_auto_queue_terminal_sync
+    // — do NOT sync; JS owns the entry transition.
+    if matches!(dispatch_type, Some("plan" | "plan-review")) {
+        return false;
+    }
     match dispatch_type {
         Some("implementation" | "rework") => auto_queue_review_disabled,
         _ => true,
@@ -616,6 +626,22 @@ mod runtime_completion_policy_tests {
                 ),
                 "scope-assessment must not sync runtime terminal entry (review_disabled={review_disabled})"
             );
+        }
+        // #3594 (T3): plan / plan-review completion (via the live turn_bridge/watcher
+        // path) must NOT sync the bound auto-queue entry — the kanban-rules JS
+        // fan-out re-dispatches it to the next stage. review_disabled must not change
+        // this. Mirror of dispatch_status::should_skip_auto_queue_terminal_sync.
+        for dispatch_type in ["plan", "plan-review"] {
+            for review_disabled in [false, true] {
+                assert!(
+                    !should_sync_runtime_auto_queue_terminal_entry(
+                        Some(dispatch_type),
+                        &normal_result,
+                        review_disabled,
+                    ),
+                    "{dispatch_type} must not sync runtime terminal entry (review_disabled={review_disabled})"
+                );
+            }
         }
     }
 }

--- a/src/services/dispatches/outbox_route.rs
+++ b/src/services/dispatches/outbox_route.rs
@@ -722,9 +722,14 @@ pub(crate) fn use_counter_model_channel(dispatch_type: Option<&str>) -> bool {
     // consultation, the assigned agent itself evaluates the scope, so the
     // dispatch must stay on the assigned agent's PRIMARY channel (the default
     // when this returns false).
+    //
+    // #3594 (T3): "plan-review" goes to the counter-model channel — like a
+    // review, the plan is checked by the counterpart model. "plan" itself is
+    // NOT listed (the assigned agent designs on its PRIMARY channel, mirroring
+    // implementation), so it is intentionally absent here.
     matches!(
         dispatch_type,
-        Some("review") | Some("e2e-test") | Some("consultation")
+        Some("review") | Some("e2e-test") | Some("consultation") | Some("plan-review")
     )
 }
 
@@ -774,6 +779,10 @@ fn dispatch_type_label(dispatch_type: Option<&str>) -> &'static str {
         Some("e2e-test") => "🧪 E2E 테스트",
         Some("consultation") => "💬 상담",
         Some("scope-assessment") => "📐 범위 평가",
+        // #3594 (T3): plan = design/implementation-plan stage; plan-review =
+        // counter-model check of that plan before implementation.
+        Some("plan") => "🗺️ 계획",
+        Some("plan-review") => "🧭 계획 리뷰",
         Some("phase-gate") => "🚦 Phase Gate",
         _ => "dispatch",
     }
@@ -931,6 +940,16 @@ fn dispatch_instruction_line(
             // #3605 (T2): scale evaluation only — no implementation. Detailed
             // scope_depth contract lives in the [Dispatch Contract] section.
             "한 줄 지시: 구현하지 말고 이 이슈의 스케일(scope_depth)만 평가하세요. 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("plan") => {
+            // #3594 (T3): design + implementation plan only, no implementation.
+            "한 줄 지시: 구현하지 말고 설계와 구현계획(result.plan)만 작성하세요. 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("plan-review") => {
+            // #3594 (T3): review the parent plan; verdict pass|rework in result.
+            "한 줄 지시: 부모 plan의 구현계획을 검토하고 result.verdict를 pass|rework로 판정하세요. 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
                 .to_string()
         }
         Some("phase-gate") => {


### PR DESCRIPTION
T2가 심은 `scope_depth`(direct|plan_only|full)를 **활성화**: scope-assessment 완료 → depth 분기.

## 흐름 게이팅
- **direct** → impl 즉시 생성(빠른 트랙, consultation-resume 경로 재사용)
- **plan_only** → `plan` dispatch → 완료 시 impl
- **full** → `plan` → `plan-review`(pass→impl / rework→재계획)
- **unknown/null** → full(가장 보수적, `_resolveScopeFlow` 폴백)

게이팅 두뇌 = `kanban-rules.js` onDispatchCompleted scope-assessment 핸들러(기존 inert `return` → active화). 신규 `policies/lib/kanban-scope-gate.js`가 `_resolveScopeFlow` + plan/plan-review/impl 다음-dispatch 헬퍼(consultation-resume 패턴 캡슐화, 실패 시 엔트리 pending 유지)를 소유. `timeouts/reconciliation.js` missed-hook 폴백도 동일 게이팅(스톨/우회 방지).

## impl 조기생성 차단(race) — Rust 폴백
scope-assessment 트리거(card→requested)는 `/api/queue/generate` 트랜잭션에서 entry INSERT보다 **먼저** 발생 → JS 점유는 entry가 없어 no-op이라 부적합. 따라서 activate per-card 게이트에 `scope_assessment_status==="pending"`이면 `continue`(`view.rs` 로더 + 1-statement). **정확히 "pending"으로만 한정** → scope 미발행 카드 무회귀(absent≠pending).

## plan/plan-review = work-dispatch (Option P)
- `dispatch_contract.rs`: plan(설계+구현계획, 구현 금지) / plan-review(`result.verdict=pass|rework`, **review verdict API 미사용**).
- `outbox_route.rs`: plan-review만 counter-model 채널(plan은 primary 유지).
- `completion_guard.rs`: `should_complete_work_dispatch` 허용목록에 plan/plan-review 추가 — idle-without-PATCH 시 stall 방지(기존 idle 자동완료 게이트가 impl/rework 한정). side-path/review-family는 계속 제외.

review 커널(onReviewEnter/review_round) **무건드림** — review-automation은 plan/plan-review를 early-return. G3 커널(PhaseRun/ReviewRun/gate DSL) **미선취**.

## 테스트
- `kanban-rules.test.js` T3 13건: direct/plan_only/full 분기, fail-safe(unknown→full), plan 완료(plan_only→impl, full→plan-review), plan-review pass/rework/ambiguous, PM-gate 무진입.
- `timeouts.test.js`: 게이팅 폴백(entry 있음→dispatch 생성, 없음→defer).
- `completion_guard` 단위: plan/plan-review idle 자동완료 허용, side-path/review 제외.
- **`activate_command.rs` `_pg_` race 3건**: scope pending→impl 무생성 / 완료(direct)→해제 / 미발행→무차단.

게이트 7개 전부 PASS(fmt/check/test:policies 173·cargo test 모듈 114·PG race 7/check_hotfile_ratchet/audit_maintainability/inventory+freshness/state_lint). change-surfaces.md 동기(outbox 1120, activate 1477).

Refs #3594 (T3, Track T 완료).

🤖 Generated with [Claude Code](https://claude.com/claude-code)