### PR TITLE
fix(#3620): 게이트웨이 lease keepalive 실패 시 self-fence 대신 재획득 — 일시적 DB 단절 영구 정지 해소

### DIFF
--- a/src/services/discord/runtime_bootstrap/gateway_lease.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_lease.rs
@@ -103,19 +103,41 @@ pub(super) async fn run_bot_acquire_gateway_lease(
     }
 }
 
-/// Spawn the gateway singleton-lease keepalive loop. On lease loss this
-/// self-fences: flips shutdown flags, cancels tmux watchers, drains pending
-/// queues, persists last_message_ids, and shuts down all shards. Spawned
-/// after the client is built (needs `shard_manager`) and before the gateway
-/// backend run. Returns the JoinHandle so run_bot can abort it on backend exit.
+/// Spawn the gateway singleton-lease keepalive loop.
+///
+/// Every tick it keepalives the held advisory lock. A keepalive error means the
+/// underlying Postgres connection died, which releases the advisory lock
+/// server-side (it is session-scoped) — but that is almost always a TRANSIENT
+/// blip (DB restart, brief network drop), not a genuine hand-off to another
+/// instance. Fencing on the very first error previously left the process alive
+/// forever with a dead, never-reacquired gateway (#3620: a startup DB blip took
+/// the Discord relay down for ~2h until a manual restart).
+///
+/// So instead of fencing on the first error, it re-acquires the lock on a fresh
+/// connection — mirroring the cluster-leader lease
+/// (`node_registry::spawn_heartbeat_loop`), which auto-recovered from the same
+/// blip while this loop did not:
+///   * re-acquired (`Ok(Some)`)  → the gateway never went down; keep serving.
+///   * held elsewhere (`Ok(None)`) → another instance owns the singleton now,
+///     so self-fence to avoid a split-brain (two live gateways).
+///   * db unreachable (`Err`)    → nobody can hold the lock while the DB is
+///     down, so keep the gateway up and retry on the next tick.
+///
+/// The self-fence path flips shutdown flags, cancels tmux watchers, drains
+/// pending queues, persists last_message_ids, and shuts down all shards.
+/// Spawned after the client is built (needs `shard_manager`) and before the
+/// gateway backend run. Returns the JoinHandle so run_bot can abort it on
+/// backend exit.
 pub(super) fn run_bot_spawn_gateway_lease_keepalive(
-    mut lease: crate::db::postgres::AdvisoryLockLease,
+    lease: crate::db::postgres::AdvisoryLockLease,
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
+    token_hash: String,
     shard_manager: Arc<serenity::gateway::ShardManager>,
 ) -> tokio::task::JoinHandle<()> {
     let shared_for_lease = shared.clone();
     let provider_for_lease = provider.clone();
+    let mut current_lease = Some(lease);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(DISCORD_GATEWAY_LEASE_KEEPALIVE_INTERVAL);
         interval.tick().await;
@@ -127,63 +149,110 @@ pub(super) fn run_bot_spawn_gateway_lease_keepalive(
                 .shutting_down
                 .load(std::sync::atomic::Ordering::SeqCst)
             {
-                let _ = lease.unlock().await;
+                if let Some(lease) = current_lease.take() {
+                    let _ = lease.unlock().await;
+                }
                 return;
             }
 
-            if let Err(error) = lease.keepalive().await {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::error!(
-                    "  [{ts}] ⛔ GATEWAY-LEASE: {} lost singleton lease: {} — self-fencing",
-                    provider_for_lease.display_name(),
-                    error
-                );
-
-                shared_for_lease
-                    .bot_connected
-                    .store(false, std::sync::atomic::Ordering::SeqCst);
-                shared_for_lease
-                    .restart
-                    .shutting_down
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
-                shared_for_lease
-                    .restart
-                    .restart_pending
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
-
-                for entry in shared_for_lease.tmux_watchers.iter() {
-                    entry
-                        .value()
-                        .cancel
-                        .store(true, std::sync::atomic::Ordering::SeqCst);
+            // Keepalive the held lease. On error the lock connection died (the
+            // advisory lock is released server-side), so drop it and fall
+            // through to the re-acquire arm below.
+            if let Some(lease) = current_lease.as_mut() {
+                match lease.keepalive().await {
+                    Ok(()) => continue,
+                    Err(error) => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] ⚠ GATEWAY-LEASE: {} keepalive failed: {} — re-acquiring (gateway stays up)",
+                            provider_for_lease.display_name(),
+                            error
+                        );
+                        current_lease = None;
+                    }
                 }
+            }
 
-                let drain = mailbox_restart_drain_all(&shared_for_lease, &provider_for_lease).await;
-                let queue_count = drain.queued_count;
-                if !drain.persistence_errors.is_empty() {
-                    tracing::error!(
-                        failures = drain.persistence_errors.len(),
-                        "gateway lease self-fence observed pending-queue persistence failure(s)"
-                    );
-                }
-                if queue_count > 0 {
+            // We hold no lease — try to re-acquire on a fresh connection.
+            let Some(pool) = shared_for_lease.pg_pool.as_ref() else {
+                // No PG pool (standalone/no-DB path): nothing to keepalive.
+                return;
+            };
+            match try_acquire_discord_gateway_lease(pool, &token_hash, &provider_for_lease).await {
+                Ok(Some(new_lease)) => {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::info!(
-                        "  [{ts}] 📋 GATEWAY-LEASE: persisted {queue_count} pending queue item(s) before self-fence"
+                        "  [{ts}] 🔐 GATEWAY-LEASE: {} re-acquired singleton lease after transient loss",
+                        provider_for_lease.display_name()
+                    );
+                    current_lease = Some(new_lease);
+                }
+                Err(error) => {
+                    // DB still unreachable — no other instance can hold the lock
+                    // while the DB is down, so keep the gateway up and retry.
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::warn!(
+                        "  [{ts}] ⚠ GATEWAY-LEASE: {} re-acquire deferred (db unavailable): {} — retrying next tick",
+                        provider_for_lease.display_name(),
+                        error
                     );
                 }
+                Ok(None) => {
+                    // A genuine hand-off: another instance now holds the
+                    // singleton. Self-fence to avoid two live gateways.
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::error!(
+                        "  [{ts}] ⛔ GATEWAY-LEASE: {} singleton lease taken by another instance — self-fencing",
+                        provider_for_lease.display_name()
+                    );
 
-                let ids: std::collections::HashMap<u64, u64> = shared_for_lease
-                    .last_message_ids
-                    .iter()
-                    .map(|entry| (entry.key().get(), *entry.value()))
-                    .collect();
-                if !ids.is_empty() {
-                    runtime_store::save_all_last_message_ids(provider_for_lease.as_str(), &ids);
+                    shared_for_lease
+                        .bot_connected
+                        .store(false, std::sync::atomic::Ordering::SeqCst);
+                    shared_for_lease
+                        .restart
+                        .shutting_down
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
+                    shared_for_lease
+                        .restart
+                        .restart_pending
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+                    for entry in shared_for_lease.tmux_watchers.iter() {
+                        entry
+                            .value()
+                            .cancel
+                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+
+                    let drain =
+                        mailbox_restart_drain_all(&shared_for_lease, &provider_for_lease).await;
+                    let queue_count = drain.queued_count;
+                    if !drain.persistence_errors.is_empty() {
+                        tracing::error!(
+                            failures = drain.persistence_errors.len(),
+                            "gateway lease self-fence observed pending-queue persistence failure(s)"
+                        );
+                    }
+                    if queue_count > 0 {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] 📋 GATEWAY-LEASE: persisted {queue_count} pending queue item(s) before self-fence"
+                        );
+                    }
+
+                    let ids: std::collections::HashMap<u64, u64> = shared_for_lease
+                        .last_message_ids
+                        .iter()
+                        .map(|entry| (entry.key().get(), *entry.value()))
+                        .collect();
+                    if !ids.is_empty() {
+                        runtime_store::save_all_last_message_ids(provider_for_lease.as_str(), &ids);
+                    }
+
+                    shard_manager.shutdown_all().await;
+                    return;
                 }
-
-                shard_manager.shutdown_all().await;
-                return;
             }
         }
     })

--- a/src/services/discord/runtime_bootstrap/gateway_runtime.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_runtime.rs
@@ -123,6 +123,7 @@ pub(super) async fn run_bot_start_gateway_runtime(
             lease,
             &shared,
             &provider,
+            settings::discord_token_hash(token),
             client.shard_manager.clone(),
         )
     });


### PR DESCRIPTION
Closes #3620

## 문제
게이트웨이 singleton-lease keepalive 루프(`gateway_lease.rs`)가 `keepalive()` **1회 실패**(일시적 Postgres 연결 단절)에 즉시 영구 self-fence. self-fence는 `restart_pending` atomic만 세우고 마커파일/`check_deferred_restart`/`process::exit`를 거치지 않아 **프로세스는 살아있고 게이트웨이만 죽은 채 방치** → 자동 재획득·재시작 없음. 2026-06-21 부팅 중 DB blip이 Discord relay를 ~2시간 중단시킴.

대조: 클러스터 리더 lock(`node_registry::spawn_heartbeat_loop`)은 같은 blip에서 fence 없이 다음 tick에 재획득해 ~9초 만에 자동 복구됨. 게이트웨이 lease엔 이 재획득 arm이 없었음.

## 수정
리더 lease 패턴을 차용해 keepalive 에러 시 **fence 대신 fresh 연결로 재획득**:
- `Ok(Some)`: 게이트웨이 유지한 채 계속 (전송 무중단) — incident 케이스 해소
- `Ok(None)`: 다른 인스턴스가 singleton 보유 → split-brain 방지 위해 self-fence
- `Err`: DB 미가용(아무도 lock 못 잡음) → 게이트웨이 유지, 다음 tick 재시도

advisory lock은 session-scoped → 연결이 죽으면 server-side에서 자동 해제되므로 fresh 연결 재획득이 안전. `token_hash`를 keepalive 루프에 전달해 재획득 lock_id를 계산.

## 변경 파일
- `gateway_lease.rs`: keepalive 루프를 재획득 루프로 교체(self-fence는 genuine 손실 시에만)
- `gateway_runtime.rs`: keepalive 호출에 `token_hash` 전달

## 검증
- `cargo check` 통과(에러 0), `cargo clippy` 신규 경고 0, `cargo fmt --check`/audit 통과
- 적대적 코드 리뷰 1회(구현≠리뷰어) 수행

## 후속(범위 밖)
genuine 손실(`Ok(None)`) self-fence 후 프로세스가 lingering하는 별개 결함은 멀티노드에서만 드물게 발생 — 이 PR은 incident(transient blip)를 해소. 필요 시 별도 이슈로 process-exit 경로 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)