### PR TITLE
feat: 핸드오프 엔드포인트에 회신 기대 여부(expect_reply) 매개변수 추가

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1299,9 +1299,10 @@
     relocated the `require_explicit_bearer_token` /
     `resolve_requesting_agent_id_with_pg` auth/identity helpers to
     `crate::services::kanban`).
-  - `src/server/routes/docs.rs` (5940 lines; +40 from #3556 documenting
+  - `src/server/routes/docs.rs` (5956 lines; +40 from #3556 documenting
     the agent-to-agent turn-trigger handoff endpoint `/api/agents/{id}/handoff`
-    paired example + 409 conflict error example + curl).
+    paired example + 409 conflict error example + curl; +16 documenting the
+    `expect_reply` reply-expectation param on /message and /handoff).
   - `src/server/routes/escalation.rs` (1376 lines).
   - `src/server/routes/meetings.rs` (1675 lines).
   - `src/server/routes/review_verdict/decision_route.rs` was decomposed in

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -101,6 +101,11 @@ pub(crate) enum Commands {
         /// Send the body without the automatic handoff prefix
         #[arg(long = "no-prefix")]
         no_prefix: bool,
+        /// Reply-expectation contract appended to the handoff body:
+        /// `--expect-reply true` → 회신 필수, `--expect-reply false` → 회신 불필요,
+        /// omitted → no contract.
+        #[arg(long = "expect-reply")]
+        expect_reply: Option<bool>,
         /// #3556 — reserve a headless turn on the target mailbox instead of
         /// posting an announce message. Authoritative wake-up: exits non-zero
         /// on 409 (mailbox busy). Mutually exclusive with the default

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -299,12 +299,14 @@ pub(crate) async fn cmd_send(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn cmd_send_to_agent(
     from_agent_id: &str,
     to_agent_id: &str,
     message: &str,
     channel_kind: crate::services::discord::agent_handoff::AgentHandoffChannelKind,
     prefix: bool,
+    expect_reply: Option<bool>,
     start_turn: bool,
 ) -> Result<(), String> {
     run_command(true, false, |state| async move {
@@ -326,6 +328,7 @@ pub(crate) async fn cmd_send_to_agent(
                 message,
                 channel_kind,
                 prefix,
+                expect_reply,
                 Some("cli:send-to-agent".to_string()),
                 None,
             )
@@ -341,6 +344,7 @@ pub(crate) async fn cmd_send_to_agent(
             message,
             channel_kind,
             prefix,
+            expect_reply,
         )
         .await
         .map_err(|error| error.one_line())?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -102,6 +102,7 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
             message,
             channel_kind,
             no_prefix,
+            expect_reply,
             start_turn,
         } => exit_for_cli(super::direct::run_async(super::direct::cmd_send_to_agent(
             &from_agent_id,
@@ -109,6 +110,7 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
             &message,
             agent_handoff_channel_kind(channel_kind),
             !no_prefix,
+            expect_reply,
             start_turn,
         ))),
         Commands::ReviewVerdict {

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -21,7 +21,7 @@ pub fn print_help() {
     println!("    discord-sendmessage --channel <ID> --message <TEXT> [--key <HASH>]");
     println!("    discord-senddm --user <ID> --message <TEXT> [--key <HASH>]");
     println!(
-        "    send-to-agent --from <AGENT> --to <AGENT> --message <TEXT> [--channel-kind cc|cdx] [--no-prefix]"
+        "    send-to-agent --from <AGENT> --to <AGENT> --message <TEXT> [--channel-kind cc|cdx] [--no-prefix] [--expect-reply true|false]"
     );
     println!("    reset-tmux              Kill all AgentDesk-* tmux sessions");
     println!(

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -93,6 +93,10 @@ pub struct AgentMessageBody {
     pub channel_kind: Option<String>,
     #[serde(default)]
     pub prefix: Option<bool>,
+    /// Reply-expectation contract appended to the handoff body. `Some(true)` →
+    /// 회신 필수, `Some(false)` → 회신 불필요, omitted → no contract (default).
+    #[serde(default)]
+    pub expect_reply: Option<bool>,
 }
 
 /// #3556 — turn-trigger handoff. Unlike `AgentMessageBody` (announce post),
@@ -106,6 +110,10 @@ pub struct AgentHandoffBody {
     pub channel_kind: Option<String>,
     #[serde(default)]
     pub prefix: Option<bool>,
+    /// Reply-expectation contract appended to the handoff body. `Some(true)` →
+    /// 회신 필수, `Some(false)` → 회신 불필요, omitted → no contract (default).
+    #[serde(default)]
+    pub expect_reply: Option<bool>,
     #[serde(default)]
     pub source: Option<String>,
     #[serde(default)]
@@ -1114,6 +1122,7 @@ pub async fn agent_message(
         &body.message,
         channel_kind,
         body.prefix.unwrap_or(true),
+        body.expect_reply,
     )
     .await
     {
@@ -1161,6 +1170,7 @@ pub async fn agent_handoff(
         &body.prompt,
         channel_kind,
         body.prefix.unwrap_or(true),
+        body.expect_reply,
         body.source,
         body.metadata,
     )

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1563,6 +1563,14 @@ fn all_endpoints() -> Vec<EndpointDoc> {
                 "prefix",
                 body_param("boolean", false, "Add the handoff prefix").with_default(true),
             ),
+            (
+                "expect_reply",
+                body_param(
+                    "boolean",
+                    false,
+                    "Reply-expectation contract appended to the body: true → 회신 필수, false → 회신 불필요, omitted → no contract",
+                ),
+            ),
         ])
         .with_example(
             json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "message": "hello", "channel_kind": "cc", "prefix": true}}),
@@ -1593,6 +1601,14 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             (
                 "prefix",
                 body_param("boolean", false, "Add the from->to handoff prefix to the prompt").with_default(true),
+            ),
+            (
+                "expect_reply",
+                body_param(
+                    "boolean",
+                    false,
+                    "Reply-expectation contract appended to the prompt: true → 회신 필수, false → 회신 불필요, omitted → no contract",
+                ),
             ),
             (
                 "source",

--- a/src/services/discord/agent_handoff.rs
+++ b/src/services/discord/agent_handoff.rs
@@ -193,19 +193,43 @@ impl AgentHandoffError {
     }
 }
 
+/// Reply-expectation contract (#3620 follow-up) appended to the end of a handoff
+/// body. `true` → 회신 필수 (the receiver must report back to the requester),
+/// `false` → 회신 불필요 (no callback expected). Kept aligned with the role
+/// response-contract: replies follow the request's callback info + channel rules.
+fn reply_expectation_contract(from_agent_id: &str, expect_reply: bool) -> String {
+    if expect_reply {
+        format!(
+            "──────────\n📨 **회신 필수 계약**: 이 핸드오프는 회신을 요구합니다. 작업/검토를 마치면 결과·결론을 요청자 `{from_agent_id}`에게 반드시 회신하세요. 회신은 `agentdesk send-to-agent --from <self> --to {from_agent_id} --message \"...\"` 로 보냅니다(현재 요청의 callback 정보·채널 규칙 우선)."
+        )
+    } else {
+        "──────────\n📭 **회신 불필요 계약**: 이 핸드오프는 회신을 요구하지 않습니다. 별도 보고 없이 처리하세요(중대한 이슈를 발견한 경우에만 자율적으로 회신).".to_string()
+    }
+}
+
+/// Build the handoff body. When `expect_reply` is `Some`, a reply-expectation
+/// contract is appended to the end of the message; `None` keeps the legacy
+/// behavior (no contract) for backward compatibility.
 pub(crate) fn build_agent_handoff_content(
     from_agent_id: &str,
     to_agent_id: &str,
     message: &str,
     prefix: bool,
+    expect_reply: Option<bool>,
 ) -> String {
-    if prefix {
+    let mut content = if prefix {
         format!("[{from_agent_id} → {to_agent_id} 핸드오프]\n\n{message}")
     } else {
         message.to_string()
+    };
+    if let Some(expect_reply) = expect_reply {
+        content.push_str("\n\n");
+        content.push_str(&reply_expectation_contract(from_agent_id, expect_reply));
     }
+    content
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_agent_handoff(
     registry: &HealthRegistry,
     pg_pool: &PgPool,
@@ -214,6 +238,7 @@ pub(crate) async fn send_agent_handoff(
     message: &str,
     channel_kind: AgentHandoffChannelKind,
     prefix: bool,
+    expect_reply: Option<bool>,
 ) -> Result<AgentHandoffResponse, AgentHandoffError> {
     let from_agent_id = from_agent_id.trim();
     if from_agent_id.is_empty() {
@@ -240,7 +265,8 @@ pub(crate) async fn send_agent_handoff(
         ));
     };
 
-    let content = build_agent_handoff_content(from_agent_id, to_agent_id, message, prefix);
+    let content =
+        build_agent_handoff_content(from_agent_id, to_agent_id, message, prefix, expect_reply);
     let target = format!("channel:{channel_id}");
     let (status, response_body) = health::send_message_with_backends(
         registry,
@@ -324,6 +350,7 @@ pub(crate) struct AgentHandoffTurnTarget {
     pub(crate) content: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_agent_handoff_turn_target(
     bindings: &AgentChannelBindings,
     from_agent_id: &str,
@@ -331,6 +358,7 @@ fn resolve_agent_handoff_turn_target(
     prompt: &str,
     channel_kind: AgentHandoffChannelKind,
     prefix: bool,
+    expect_reply: Option<bool>,
 ) -> Result<AgentHandoffTurnTarget, AgentHandoffError> {
     let from_agent_id = from_agent_id.trim();
     if from_agent_id.is_empty() {
@@ -363,7 +391,8 @@ fn resolve_agent_handoff_turn_target(
         )));
     };
 
-    let content = build_agent_handoff_content(from_agent_id, to_agent_id, prompt, prefix);
+    let content =
+        build_agent_handoff_content(from_agent_id, to_agent_id, prompt, prefix, expect_reply);
 
     Ok(AgentHandoffTurnTarget {
         to_agent_id: to_agent_id.to_string(),
@@ -411,6 +440,7 @@ pub(crate) async fn start_agent_handoff_turn(
     prompt: &str,
     channel_kind: AgentHandoffChannelKind,
     prefix: bool,
+    expect_reply: Option<bool>,
     source: Option<String>,
     metadata: Option<Value>,
 ) -> Result<AgentHandoffTurnResponse, AgentHandoffError> {
@@ -427,6 +457,7 @@ pub(crate) async fn start_agent_handoff_turn(
         prompt,
         channel_kind,
         prefix,
+        expect_reply,
     )?;
 
     let result = health::start_headless_agent_turn(
@@ -552,13 +583,35 @@ mod tests {
     #[test]
     fn handoff_prefix_can_be_enabled_or_disabled() {
         assert_eq!(
-            build_agent_handoff_content("project-agentdesk", "adk-dashboard", "hello", true),
+            build_agent_handoff_content("project-agentdesk", "adk-dashboard", "hello", true, None),
             "[project-agentdesk → adk-dashboard 핸드오프]\n\nhello"
         );
         assert_eq!(
-            build_agent_handoff_content("project-agentdesk", "adk-dashboard", "hello", false),
+            build_agent_handoff_content("project-agentdesk", "adk-dashboard", "hello", false, None),
             "hello"
         );
+    }
+
+    #[test]
+    fn handoff_reply_expectation_appends_contract() {
+        // None → no contract (backward compatible).
+        assert_eq!(
+            build_agent_handoff_content("a", "b", "hi", false, None),
+            "hi"
+        );
+        // Some(true) → 회신 필수 contract referencing the requester.
+        let required = build_agent_handoff_content("a", "b", "hi", false, Some(true));
+        assert!(required.starts_with("hi\n\n"));
+        assert!(required.contains("회신 필수 계약"));
+        assert!(required.contains("`a`"));
+        // Some(false) → 회신 불필요 contract.
+        let not_required = build_agent_handoff_content("a", "b", "hi", false, Some(false));
+        assert!(not_required.starts_with("hi\n\n"));
+        assert!(not_required.contains("회신 불필요 계약"));
+        // Contract appends after the prefix envelope too.
+        let prefixed = build_agent_handoff_content("a", "b", "hi", true, Some(true));
+        assert!(prefixed.starts_with("[a → b 핸드오프]\n\nhi\n\n"));
+        assert!(prefixed.contains("회신 필수 계약"));
     }
 
     #[test]
@@ -622,6 +675,7 @@ mod tests {
             "리뷰 반영해줘",
             AgentHandoffChannelKind::Cdx,
             true,
+            None,
         )
         .expect("cdx binding resolves");
         assert_eq!(target.to_agent_id, "adk-dashboard");
@@ -644,6 +698,7 @@ mod tests {
             "raw prompt",
             AgentHandoffChannelKind::Cc,
             false,
+            None,
         )
         .expect("cc binding resolves");
         assert_eq!(target.content, "raw prompt");
@@ -658,6 +713,7 @@ mod tests {
             "prompt",
             AgentHandoffChannelKind::Cc,
             true,
+            None,
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::UNPROCESSABLE_ENTITY);
@@ -673,6 +729,7 @@ mod tests {
             "   ",
             AgentHandoffChannelKind::Cc,
             true,
+            None,
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::BAD_REQUEST);
@@ -688,6 +745,7 @@ mod tests {
             "prompt",
             AgentHandoffChannelKind::Cc,
             true,
+            None,
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## 요약
핸드오프 호출 시 `expect_reply` 매개변수로 회신 기대 여부를 받고, 값에 따라 핸드오프 메시지 말미에 회신 계약을 명시합니다.
- `true` → **회신 필수 계약** (작업/검토 완료 후 요청자에게 결과 회신 요구)
- `false` → **회신 불필요 계약**
- 생략 → 계약 없음 (하위호환)

## 적용 범위
- API: `POST /api/agents/{id}/message`(announce), `POST /api/agents/{id}/handoff`(turn-trigger) 본문에 `expect_reply: bool` (optional)
- CLI: `send-to-agent --expect-reply <true|false>`
- 양 경로가 공유하는 `build_agent_handoff_content`에서 계약을 append → 한 곳 수정으로 양쪽 적용
- `/api/docs` 양 엔드포인트 파라미터 문서 갱신

계약 문구는 role response_contract(회신은 현재 요청의 callback 정보·채널 규칙 우선)와 정렬했고, 회신 필수 계약은 요청자 id와 `send-to-agent` 회신 방법을 명시합니다.

## 검증
- `cargo check` 에러 0, `cargo clippy` 신규 경고 0, `fmt --check`/audit 통과
- 단위 테스트 16건 통과(신규 `handoff_reply_expectation_appends_contract` 포함: 계약 append + 하위호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)