### PR TITLE
feat(#3587 Phase 1): agentdesk.turn.start JS host primitive 신설

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,8 @@ src/
 │   │   ├── queue_ops.rs
 │   │   ├── review_automation_ops.rs
 │   │   ├── review_ops.rs
-│   │   └── runtime_ops.rs
+│   │   ├── runtime_ops.rs
+│   │   └── turn_ops.rs
 │   ├── hooks.rs
 │   ├── intent.rs
 │   ├── loader.rs
@@ -389,6 +390,7 @@ src/
 │   │   │   ├── recovery_ops.rs
 │   │   │   ├── restart.rs
 │   │   │   ├── session.rs
+│   │   │   ├── sidecar.rs
 │   │   │   ├── skill.rs
 │   │   │   ├── steer.rs
 │   │   │   ├── text_commands.rs
@@ -648,6 +650,7 @@ src/
 │   │   ├── settings.rs
 │   │   ├── shared_memory.rs
 │   │   ├── shared_state.rs
+│   │   ├── sidecar_interaction.rs
 │   │   ├── single_message_panel.rs
 │   │   ├── stall_recovery.rs
 │   │   ├── standby_relay.rs

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1436,6 +1436,7 @@ pub fn handle_dcserver(token: Option<String>) {
         match PolicyEngine::new_with_pg(&ad_config, Some(discord_pg_pool.clone())) {
             Ok(engine) => {
                 discord_engine = Some(engine.clone());
+                crate::engine::ops::turn_ops::set_global_health_registry(&health_registry);
                 let http_config = ad_config.clone();
                 let registry_for_http = health_registry.clone();
                 let http_pg_pool = Some(discord_pg_pool.clone());

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1437,6 +1437,12 @@ pub fn handle_dcserver(token: Option<String>) {
             Ok(engine) => {
                 discord_engine = Some(engine.clone());
                 crate::engine::ops::turn_ops::set_global_health_registry(&health_registry);
+                // #3587: capture the main runtime handle so the policy thread
+                // drives turn-start on the durable runtime (a throwaway runtime
+                // would abort the turn's spawned streaming/bridge tasks).
+                crate::engine::ops::turn_ops::set_global_runtime_handle(
+                    tokio::runtime::Handle::current(),
+                );
                 let http_config = ad_config.clone();
                 let registry_for_http = health_registry.clone();
                 let http_pg_pool = Some(discord_pg_pool.clone());

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -24,6 +24,7 @@ mod queue_ops;
 mod review_automation_ops;
 mod review_ops;
 mod runtime_ops;
+pub(crate) mod turn_ops;
 
 pub(crate) use db_ops::execute_policy_sql;
 pub(crate) use review_ops::{ADVANCE_REVIEW_ROUND_HINT_KEY, ensure_js_error_json};
@@ -81,7 +82,8 @@ fn register_globals_pg_only(
     exec_ops::register_exec_ops(ctx)?;
     pipeline_ops::register_pipeline_ops(ctx, pg_pool.clone())?;
     dm_reply_ops::register_dm_reply_ops(ctx, pg_pool.clone())?;
-    agent_ops::register_agent_ops(ctx, pg_pool)?;
+    agent_ops::register_agent_ops(ctx, pg_pool.clone())?;
+    turn_ops::register_turn_ops(ctx, pg_pool)?;
 
     Ok(())
 }

--- a/src/engine/ops/turn_ops.rs
+++ b/src/engine/ops/turn_ops.rs
@@ -33,6 +33,38 @@ fn get_health_registry() -> Option<std::sync::Arc<HealthRegistry>> {
         .and_then(Weak::upgrade)
 }
 
+// ── Main runtime handle ─────────────────────────────────────────────────────
+//
+// #3587: the policy-engine thread is a plain std::thread with no tokio runtime,
+// so driving the handoff through the generic async bridge builds a *throwaway*
+// runtime. `start_agent_handoff_turn` spawns the turn's streaming/bridge/
+// watchdog tasks onto the current runtime and returns immediately — but the
+// throwaway runtime is dropped the moment `block_on` returns, aborting those
+// tasks (JS would see `{ok:true}` for a turn that never actually runs).
+//
+// To fix this we drive the future on the *main* runtime handle (captured at
+// dcserver startup), which lives for the whole process, so the spawned tasks
+// survive after this synchronous call returns.
+static GLOBAL_RUNTIME_HANDLE: Mutex<Option<tokio::runtime::Handle>> = Mutex::new(None);
+
+/// Called once from dcserver setup (from within the async runtime) so the
+/// policy-engine thread can drive turn-start on the durable main runtime.
+pub fn set_global_runtime_handle(handle: tokio::runtime::Handle) {
+    if let Ok(mut slot) = GLOBAL_RUNTIME_HANDLE.lock() {
+        *slot = Some(handle);
+    }
+}
+
+fn get_runtime_handle() -> Option<tokio::runtime::Handle> {
+    GLOBAL_RUNTIME_HANDLE.lock().ok()?.clone()
+}
+
+/// Max time the policy thread blocks waiting for a turn to *start* (spawn). The
+/// turn itself runs on the main runtime past this point — this only bounds the
+/// synchronous start (binding lookup + headless spawn), so the policy engine
+/// never wedges if Postgres or the registry stalls.
+const TURN_START_BRIDGE_TIMEOUT_SECS: u64 = 30;
+
 // ── Host binding ───────────────────────────────────────────────────────────
 
 pub(super) fn register_turn_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
@@ -79,7 +111,14 @@ pub(super) fn register_turn_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) ->
                     optJson
                 );
                 var result = JSON.parse(raw);
-                if (!result.ok) throw new Error(result.error || "turn.start failed");
+                if (!result.ok) {
+                    var err = new Error(result.error || "turn.start failed");
+                    // Preserve the structured status (conflict/unavailable/
+                    // timeout/error) so callers can branch instead of regex-ing
+                    // the message.
+                    err.status = result.status;
+                    throw err;
+                }
                 return result;
             };
         })();
@@ -137,31 +176,53 @@ fn start_turn_raw(
         return err_json("Discord not available (standalone mode)", "unavailable");
     };
 
-    // Run the async handoff synchronously via the bridge.
+    let Some(runtime) = get_runtime_handle() else {
+        return err_json("policy runtime handle unavailable", "unavailable");
+    };
+
+    // The policy-engine host fn runs on a non-async thread. If it is somehow
+    // invoked from inside a runtime, `Handle::block_on` would panic — return a
+    // clean error instead of crashing the engine.
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return err_json("turn.start cannot run inside an async context", "error");
+    }
+
     let agent_id_owned = agent_id.to_string();
     let prompt_owned = prompt.to_string();
     let from_owned = from_agent_id.to_string();
-
     let pool_owned = pool.clone();
-    let result = crate::utils::async_bridge::block_on_result(
-        async move {
-            crate::services::discord::agent_handoff::start_agent_handoff_turn(
-                &registry,
-                &pool_owned,
-                &from_owned,
-                &agent_id_owned,
-                &prompt_owned,
-                channel_kind,
-                prefix,
-                None, // expect_reply: None → no contract appended
-                Some("js:turn.start".to_string()),
-                None, // metadata
-            )
-            .await
-            .map_err(|e| e.one_line())
-        },
-        |e: String| e,
-    );
+
+    // Drive the handoff on the MAIN runtime so the turn's spawned background
+    // tasks outlive this call (#3587). Bound only the *start* with a timeout —
+    // the turn itself keeps running on the main runtime afterwards.
+    let result: Result<
+        crate::services::discord::agent_handoff::AgentHandoffTurnResponse,
+        (u16, String),
+    > = runtime.block_on(async move {
+        let start_fut = crate::services::discord::agent_handoff::start_agent_handoff_turn(
+            &registry,
+            &pool_owned,
+            &from_owned,
+            &agent_id_owned,
+            &prompt_owned,
+            channel_kind,
+            prefix,
+            None, // expect_reply: None → no contract appended
+            Some("js:turn.start".to_string()),
+            None, // metadata
+        );
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(TURN_START_BRIDGE_TIMEOUT_SECS),
+            start_fut,
+        )
+        .await
+        {
+            Ok(Ok(response)) => Ok(response),
+            // Preserve the precise HTTP status so JS can distinguish 409/503.
+            Ok(Err(e)) => Err((e.status().as_u16(), e.one_line())),
+            Err(_) => Err((504, "turn.start timed out while starting".to_string())),
+        }
+    });
 
     match result {
         Ok(response) => {
@@ -169,14 +230,16 @@ fn start_turn_raw(
             v["ok"] = serde_json::Value::Bool(true);
             v.to_string()
         }
-        Err(err_msg) => {
-            // Detect conflict vs generic failure from the error string.
-            let status = if err_msg.contains("conflict") || err_msg.contains("409") {
-                "conflict"
-            } else if err_msg.contains("unavailable") || err_msg.contains("503") {
-                "unavailable"
-            } else {
-                "error"
+        Err((code, err_msg)) => {
+            // Classify by the real HTTP status, not by string-sniffing (the
+            // busy-mailbox conflict message is "agent mailbox is busy ...",
+            // which never contained "conflict"/"409").
+            let status = match code {
+                409 => "conflict",
+                503 => "unavailable",
+                404 => "not_found",
+                504 => "timeout",
+                _ => "error",
             };
             err_json(&err_msg, status)
         }

--- a/src/engine/ops/turn_ops.rs
+++ b/src/engine/ops/turn_ops.rs
@@ -1,0 +1,289 @@
+use rquickjs::{Ctx, Function, Object, Result as JsResult};
+use sqlx::PgPool;
+use std::sync::{Mutex, Weak};
+
+use crate::services::discord::health::HealthRegistry;
+
+// ── Global registry handle ─────────────────────────────────────────────────
+//
+// Mirrors the `cancel_tombstones` global-pool pattern: a process-scoped
+// `Weak<HealthRegistry>` set once at dcserver startup so the policy-engine
+// thread (which has no async executor or access to AppState) can call
+// `start_agent_handoff_turn` synchronously via the async bridge.
+//
+// `Weak` is intentional: the registry is owned by the Discord runtime.
+// If it's gone (standalone mode / unit tests without Discord), the host fn
+// returns `{ok:false, error:"Discord not available"}` without panicking.
+
+static GLOBAL_HEALTH_REGISTRY: Mutex<Option<Weak<HealthRegistry>>> = Mutex::new(None);
+
+/// Called once from dcserver setup (after both the engine and the registry
+/// exist) to wire the JS bridge to the live registry.
+pub fn set_global_health_registry(registry: &std::sync::Arc<HealthRegistry>) {
+    if let Ok(mut slot) = GLOBAL_HEALTH_REGISTRY.lock() {
+        *slot = Some(std::sync::Arc::downgrade(registry));
+    }
+}
+
+fn get_health_registry() -> Option<std::sync::Arc<HealthRegistry>> {
+    GLOBAL_HEALTH_REGISTRY
+        .lock()
+        .ok()?
+        .as_ref()
+        .and_then(Weak::upgrade)
+}
+
+// ── Host binding ───────────────────────────────────────────────────────────
+
+pub(super) fn register_turn_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
+    let ad: Object<'js> = ctx.globals().get("agentdesk")?;
+    let turn_obj = Object::new(ctx.clone())?;
+
+    // agentdesk.turn.__startRaw(agentId, prompt, optionsJson) → json_string
+    //
+    // `optionsJson` is a serialised object with optional fields:
+    //   channel_kind: "cc" | "cdx"  (default: "cc")
+    //   from_agent_id: string        (default: "policy-engine")
+    //   prefix: bool                 (default: true)
+    //
+    // Returns JSON that the JS wrapper parses into:
+    //   { ok: true,  turn_id, to_agent_id, channel_id, channel_kind, status }
+    //   { ok: false, error, status: "conflict" | "unavailable" | "error" }
+    let pg = pg_pool;
+    turn_obj.set(
+        "__startRaw",
+        Function::new(
+            ctx.clone(),
+            move |agent_id: String, prompt: String, options_json: String| -> String {
+                start_turn_raw(pg.as_ref(), &agent_id, &prompt, &options_json)
+            },
+        )?,
+    )?;
+
+    ad.set("turn", turn_obj)?;
+
+    // JS wrapper: agentdesk.turn.start(agentId, prompt, options?)
+    ctx.eval::<(), _>(
+        r#"
+        (function() {
+            agentdesk.turn.start = function(agentId, prompt, options) {
+                var opts = options || {};
+                var optJson = JSON.stringify({
+                    channel_kind: opts.channel_kind || "cc",
+                    from_agent_id: opts.from_agent_id || "policy-engine",
+                    prefix: typeof opts.prefix === "boolean" ? opts.prefix : true
+                });
+                var raw = agentdesk.turn.__startRaw(
+                    agentId  || "",
+                    prompt   || "",
+                    optJson
+                );
+                var result = JSON.parse(raw);
+                if (!result.ok) throw new Error(result.error || "turn.start failed");
+                return result;
+            };
+        })();
+        "#,
+    )?;
+
+    Ok(())
+}
+
+// ── Synchronous implementation ─────────────────────────────────────────────
+
+#[derive(serde::Deserialize, Default)]
+struct TurnStartOptions {
+    channel_kind: Option<String>,
+    from_agent_id: Option<String>,
+    prefix: Option<bool>,
+}
+
+fn start_turn_raw(
+    pg_pool: Option<&PgPool>,
+    agent_id: &str,
+    prompt: &str,
+    options_json: &str,
+) -> String {
+    let agent_id = agent_id.trim();
+    if agent_id.is_empty() {
+        return err_json("agent_id is required", "error");
+    }
+    let prompt = prompt.trim();
+    if prompt.is_empty() {
+        return err_json("prompt is required", "error");
+    }
+
+    let opts: TurnStartOptions = serde_json::from_str(options_json).unwrap_or_default();
+
+    let channel_kind_str = opts.channel_kind.as_deref().unwrap_or("cc");
+    let channel_kind = match crate::services::discord::agent_handoff::AgentHandoffChannelKind::parse(
+        Some(channel_kind_str),
+    ) {
+        Ok(kind) => kind,
+        Err(e) => return err_json(&e.one_line(), "error"),
+    };
+    let from_agent_id = opts
+        .from_agent_id
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("policy-engine");
+    let prefix = opts.prefix.unwrap_or(true);
+
+    let Some(pool) = pg_pool else {
+        return err_json("postgres backend is unavailable", "unavailable");
+    };
+
+    let Some(registry) = get_health_registry() else {
+        return err_json("Discord not available (standalone mode)", "unavailable");
+    };
+
+    // Run the async handoff synchronously via the bridge.
+    let agent_id_owned = agent_id.to_string();
+    let prompt_owned = prompt.to_string();
+    let from_owned = from_agent_id.to_string();
+
+    let pool_owned = pool.clone();
+    let result = crate::utils::async_bridge::block_on_result(
+        async move {
+            crate::services::discord::agent_handoff::start_agent_handoff_turn(
+                &registry,
+                &pool_owned,
+                &from_owned,
+                &agent_id_owned,
+                &prompt_owned,
+                channel_kind,
+                prefix,
+                None, // expect_reply: None → no contract appended
+                Some("js:turn.start".to_string()),
+                None, // metadata
+            )
+            .await
+            .map_err(|e| e.one_line())
+        },
+        |e: String| e,
+    );
+
+    match result {
+        Ok(response) => {
+            let mut v = response.to_value();
+            v["ok"] = serde_json::Value::Bool(true);
+            v.to_string()
+        }
+        Err(err_msg) => {
+            // Detect conflict vs generic failure from the error string.
+            let status = if err_msg.contains("conflict") || err_msg.contains("409") {
+                "conflict"
+            } else if err_msg.contains("unavailable") || err_msg.contains("503") {
+                "unavailable"
+            } else {
+                "error"
+            };
+            err_json(&err_msg, status)
+        }
+    }
+}
+
+fn err_json(error: &str, status: &str) -> String {
+    serde_json::json!({
+        "ok": false,
+        "error": error,
+        "status": status,
+    })
+    .to_string()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::engine::PolicyEngine;
+
+    fn test_engine() -> PolicyEngine {
+        let config = Config {
+            policies: crate::config::PoliciesConfig {
+                dir: std::path::PathBuf::from("/nonexistent"),
+                hot_reload: false,
+                ..crate::config::PoliciesConfig::default()
+            },
+            ..Config::default()
+        };
+        PolicyEngine::new_with_pg(&config, None).unwrap()
+    }
+
+    // ── Registration check ───────────────────────────────────────────────
+
+    #[test]
+    fn turn_start_host_fn_is_registered() {
+        let engine = test_engine();
+        // agentdesk.turn.__startRaw must exist as a function
+        let is_fn: bool = engine
+            .eval_js(r#"typeof agentdesk.turn.__startRaw === "function""#)
+            .unwrap();
+        assert!(is_fn, "agentdesk.turn.__startRaw should be a function");
+
+        // agentdesk.turn.start must exist as a function
+        let is_fn2: bool = engine
+            .eval_js(r#"typeof agentdesk.turn.start === "function""#)
+            .unwrap();
+        assert!(is_fn2, "agentdesk.turn.start should be a function");
+    }
+
+    // ── No-registry path ─────────────────────────────────────────────────
+
+    #[test]
+    fn turn_start_returns_error_without_registry() {
+        let engine = test_engine();
+        // Without a registry the raw fn returns a JSON error object (does not
+        // panic and does not throw).
+        let result: String = engine
+            .eval_js(
+                r#"JSON.stringify(
+                    JSON.parse(
+                        agentdesk.turn.__startRaw("some-agent", "hello", "{}")
+                    )
+                )"#,
+            )
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["ok"], serde_json::json!(false));
+        // Must carry either "postgres" or "Discord not available" in the error.
+        let error = v["error"].as_str().unwrap_or("");
+        assert!(
+            error.contains("postgres") || error.contains("Discord"),
+            "unexpected error: {error}"
+        );
+    }
+
+    // ── Argument validation ──────────────────────────────────────────────
+
+    #[test]
+    fn turn_start_raw_requires_agent_id() {
+        let result = start_turn_raw(None, "", "prompt", "{}");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["ok"], serde_json::json!(false));
+        assert_eq!(v["error"], "agent_id is required");
+    }
+
+    #[test]
+    fn turn_start_raw_requires_prompt() {
+        let result = start_turn_raw(None, "some-agent", "  ", "{}");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["ok"], serde_json::json!(false));
+        assert_eq!(v["error"], "prompt is required");
+    }
+
+    #[test]
+    fn turn_start_raw_rejects_invalid_channel_kind() {
+        let opts = r#"{"channel_kind":"invalid"}"#;
+        let result = start_turn_raw(None, "some-agent", "hello", opts);
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["ok"], serde_json::json!(false));
+        let error = v["error"].as_str().unwrap_or("");
+        assert!(
+            error.contains("channel_kind"),
+            "expected channel_kind error, got: {error}"
+        );
+    }
+}

--- a/src/engine/ops/turn_ops.rs
+++ b/src/engine/ops/turn_ops.rs
@@ -73,8 +73,10 @@ pub(super) fn register_turn_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) ->
     //   prefix: bool                 (default: true)
     //
     // Returns JSON that the JS wrapper parses into:
-    //   { ok: true,  turn_id, to_agent_id, channel_id, channel_kind, status }
-    //   { ok: false, error, status: "conflict" | "unavailable" | "error" }
+    //   { ok: true,  status: "dispatched", to_agent_id }   (turn started async)
+    //   { ok: false, error, status: "unavailable" | "error" }   (sync validation)
+    // The turn is dispatched fire-and-forget onto the main runtime; its outcome
+    // (started/conflict/error) is logged, not returned synchronously (#3587).
     let pg = pg_pool;
     turn_obj.set(
         "__startRaw",
@@ -174,33 +176,28 @@ fn start_turn_raw(
         return err_json("policy runtime handle unavailable", "unavailable");
     };
 
-    // The policy-engine host fn runs on a non-async thread. If it is somehow
-    // invoked from inside a runtime, `Handle::block_on` would panic — return a
-    // clean error instead of crashing the engine.
-    if tokio::runtime::Handle::try_current().is_ok() {
-        return err_json("turn.start cannot run inside an async context", "error");
-    }
-
     let agent_id_owned = agent_id.to_string();
     let prompt_owned = prompt.to_string();
     let from_owned = from_agent_id.to_string();
     let pool_owned = pool.clone();
 
-    // Drive the handoff on the MAIN runtime so the turn's spawned background
-    // tasks outlive this call (#3587).
+    // Fire-and-forget on the MAIN runtime — do NOT block the policy thread.
     //
-    // No timeout wrapper here: the start future is NOT cancel-safe — it claims
-    // the agent mailbox before spawning the turn, so dropping it mid-flight
-    // (e.g. on a timeout) would strand the mailbox as busy (#3587 re-review).
-    // It only awaits a bounded binding lookup + the headless spawn (which
-    // returns immediately, not after the turn), so we let it run to completion
-    // exactly like the HTTP handoff path. DB awaits are bounded by the pool's
-    // acquire/statement timeouts.
-    let result: Result<
-        crate::services::discord::agent_handoff::AgentHandoffTurnResponse,
-        (u16, String),
-    > = runtime.block_on(async move {
-        crate::services::discord::agent_handoff::start_agent_handoff_turn(
+    // The policy-engine host fn runs on a non-async thread that must return
+    // quickly (cf. agentdesk.message.queue, which only does a fast outbox
+    // insert). The turn-start path is the opposite: it claims the agent mailbox
+    // and *then* performs fallible pre-spawn work (session/workspace resolution,
+    // Discord REST) before spawning the turn's background tasks. Driving that
+    // synchronously from the policy thread is unsafe either way (#3587 reviews):
+    //   - with a timeout, cancelling mid-flight strands the claimed mailbox;
+    //   - without one, a slow/stalled start wedges the policy actor while the
+    //     mailbox stays claimed.
+    // So we spawn it onto the durable runtime (where its tasks must live anyway)
+    // and return immediately. The task is never cancelled, so the mailbox path
+    // always runs to completion exactly like the HTTP handoff caller; conflicts
+    // and errors are logged rather than surfaced synchronously to JS.
+    runtime.spawn(async move {
+        match crate::services::discord::agent_handoff::start_agent_handoff_turn(
             &registry,
             &pool_owned,
             &from_owned,
@@ -213,29 +210,36 @@ fn start_turn_raw(
             None, // metadata
         )
         .await
-        // Preserve the precise HTTP status so JS can distinguish 409/503.
-        .map_err(|e| (e.status().as_u16(), e.one_line()))
+        {
+            Ok(response) => {
+                tracing::info!(
+                    to_agent = %agent_id_owned,
+                    result = %response.to_value(),
+                    "js turn.start dispatched"
+                );
+            }
+            Err(e) => {
+                // Classify by the real HTTP status (the busy-mailbox conflict
+                // message is "agent mailbox is busy ...", not "conflict"/"409").
+                tracing::warn!(
+                    to_agent = %agent_id_owned,
+                    status = e.status().as_u16(),
+                    error = %e.one_line(),
+                    "js turn.start failed"
+                );
+            }
+        }
     });
 
-    match result {
-        Ok(response) => {
-            let mut v = response.to_value();
-            v["ok"] = serde_json::Value::Bool(true);
-            v.to_string()
-        }
-        Err((code, err_msg)) => {
-            // Classify by the real HTTP status, not by string-sniffing (the
-            // busy-mailbox conflict message is "agent mailbox is busy ...",
-            // which never contained "conflict"/"409").
-            let status = match code {
-                409 => "conflict",
-                503 => "unavailable",
-                404 => "not_found",
-                _ => "error",
-            };
-            err_json(&err_msg, status)
-        }
-    }
+    // The turn-start was dispatched onto the main runtime. We acknowledge the
+    // dispatch synchronously; the actual start outcome (started/conflict/error)
+    // is observable via logs and the target agent's activity.
+    serde_json::json!({
+        "ok": true,
+        "status": "dispatched",
+        "to_agent_id": agent_id,
+    })
+    .to_string()
 }
 
 fn err_json(error: &str, status: &str) -> String {

--- a/src/engine/ops/turn_ops.rs
+++ b/src/engine/ops/turn_ops.rs
@@ -59,12 +59,6 @@ fn get_runtime_handle() -> Option<tokio::runtime::Handle> {
     GLOBAL_RUNTIME_HANDLE.lock().ok()?.clone()
 }
 
-/// Max time the policy thread blocks waiting for a turn to *start* (spawn). The
-/// turn itself runs on the main runtime past this point — this only bounds the
-/// synchronous start (binding lookup + headless spawn), so the policy engine
-/// never wedges if Postgres or the registry stalls.
-const TURN_START_BRIDGE_TIMEOUT_SECS: u64 = 30;
-
 // ── Host binding ───────────────────────────────────────────────────────────
 
 pub(super) fn register_turn_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
@@ -193,13 +187,20 @@ fn start_turn_raw(
     let pool_owned = pool.clone();
 
     // Drive the handoff on the MAIN runtime so the turn's spawned background
-    // tasks outlive this call (#3587). Bound only the *start* with a timeout —
-    // the turn itself keeps running on the main runtime afterwards.
+    // tasks outlive this call (#3587).
+    //
+    // No timeout wrapper here: the start future is NOT cancel-safe — it claims
+    // the agent mailbox before spawning the turn, so dropping it mid-flight
+    // (e.g. on a timeout) would strand the mailbox as busy (#3587 re-review).
+    // It only awaits a bounded binding lookup + the headless spawn (which
+    // returns immediately, not after the turn), so we let it run to completion
+    // exactly like the HTTP handoff path. DB awaits are bounded by the pool's
+    // acquire/statement timeouts.
     let result: Result<
         crate::services::discord::agent_handoff::AgentHandoffTurnResponse,
         (u16, String),
     > = runtime.block_on(async move {
-        let start_fut = crate::services::discord::agent_handoff::start_agent_handoff_turn(
+        crate::services::discord::agent_handoff::start_agent_handoff_turn(
             &registry,
             &pool_owned,
             &from_owned,
@@ -210,18 +211,10 @@ fn start_turn_raw(
             None, // expect_reply: None → no contract appended
             Some("js:turn.start".to_string()),
             None, // metadata
-        );
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(TURN_START_BRIDGE_TIMEOUT_SECS),
-            start_fut,
         )
         .await
-        {
-            Ok(Ok(response)) => Ok(response),
-            // Preserve the precise HTTP status so JS can distinguish 409/503.
-            Ok(Err(e)) => Err((e.status().as_u16(), e.one_line())),
-            Err(_) => Err((504, "turn.start timed out while starting".to_string())),
-        }
+        // Preserve the precise HTTP status so JS can distinguish 409/503.
+        .map_err(|e| (e.status().as_u16(), e.one_line()))
     });
 
     match result {
@@ -238,7 +231,6 @@ fn start_turn_raw(
                 409 => "conflict",
                 503 => "unavailable",
                 404 => "not_found",
-                504 => "timeout",
                 _ => "error",
             };
             err_json(&err_msg, status)


### PR DESCRIPTION
## 범위 (#3587 Phase 1만)
policies/*.js에서 호출 가능한 `agentdesk.turn.start(agentId, prompt, options?)` JS host primitive 신설. 기존엔 `announce.message.queue`만 노출 — 턴-트리거 핸드오프를 JS에서 못 걸었음. **호출부 마이그레이션(Phase 2)은 회귀위험으로 미포함.**

## 구현
- `src/engine/ops/turn_ops.rs`(신규): `agentdesk.turn.__startRaw` Rust 클로저 등록 + JS 래퍼. `start_agent_handoff_turn`을 `block_on_result`로 동기 브리징.
- `HealthRegistry`는 `static Mutex<Option<Weak<HealthRegistry>>>` 프로세스-전역 주입(dcserver.rs).
- 테스트 5개(등록 확인, registry 없을 때 에러, agentId/prompt/channel_kind 검증).

## 리스크 (리뷰 집중)
- QuickJS 호스트 fn 내 `block_on` — tokio 런타임 스레드 컨텍스트에서 패닉/데드락 가능성.
- 전역 Weak registry 패턴의 수명/스레드 안전성.

## 검증
cargo fmt/check/test(5/5)/agent-maintenance/ci-script-checks 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)