### PR TITLE
fix(#3629): NO_REPLY/empty orphan inflight를 watchdog leak-detection에서 identity-guarded 정리

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -993,7 +993,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2637 lines; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2713 lines; +76 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -993,7 +993,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2713 lines; +76 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2722 lines; +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -351,7 +351,12 @@
 # #3034 batch-8: lowered 2655 -> 2645 (dead-code removal: `stop_provider_channel_runtime`).
 # #3293: lowered 2645 -> 2641 (mailbox probe routed through the non-creating
 # `health/mailbox.rs::peeked_provider_mailbox_state`).
-"src/services/discord/health/recovery.rs" = 2641
+"src/services/discord/health/recovery.rs" = 2722
+# #3629: +81 (2641 -> 2722) for the NO_REPLY/empty orphan inflight cleanup in the
+# completed-stale leak-detection path: the `completed_stale_no_answer_orphan_should_clean`
+# pure seam (+ safety doc), the identity-guarded clear + lifecycle telemetry at the
+# call site, and its unit test. P1 bugfix (#3629); the clean logic needs the
+# file-private detection context so it lives here until the inflight/recovery split.
 # #3293: +11 for the additive `recovery_relay_attempts` restart-budget counter
 # (field + `RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET`), lowered 2466 -> 2465 to
 # lock the net position.

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1394,6 +1394,31 @@ pub(crate) fn inflight_completed_stale_leak_detected(
     age_secs >= 0 && (age_secs as u64) >= threshold_secs
 }
 
+/// #3629: clean-vs-preserve fork for a completed-stale inflight that has NO
+/// unrelayed answer. Reached only after [`inflight_completed_stale_leak_detected`]
+/// already held — i.e. the relay is healthy, the mailbox has NO active turn,
+/// the tmux session is alive, and the row is stale. The sole remaining
+/// discriminator is whether the turn ever committed a terminal delivery:
+///
+/// - `terminal_delivery_committed == true` → the answer WAS delivered and the
+///   session is merely idle now (e.g. a #3126 wakeup-waiting loop, or a turn
+///   whose answer the watcher relayed). PRESERVE — the user may still send the
+///   next message and the delivered response must not be disturbed.
+/// - `terminal_delivery_committed == false` → nothing was ever delivered AND
+///   there is nothing left to deliver (no unrelayed answer): a NO_REPLY / empty
+///   terminal turn. The bridge left an inflight row that no answer will ever
+///   fill and that no live turn owns, so it never self-clears and the external
+///   deadlock monitor flags it every ~30 min forever (#3629). CLEAN it.
+///
+/// The actual removal at the call site is identity-guarded, so a newer turn's
+/// row is never clobbered — this predicate only decides intent. Kept as a pure
+/// seam so the fork is unit-testable without driving the watchdog loop.
+pub(crate) fn completed_stale_no_answer_orphan_should_clean(
+    terminal_delivery_committed: bool,
+) -> bool {
+    !terminal_delivery_committed
+}
+
 fn outbound_activity_is_recent(
     last_outbound_activity_ms: Option<i64>,
     now_unix_secs: i64,
@@ -1757,6 +1782,57 @@ pub(crate) async fn run_stall_watchdog_pass(
                         .is_some()
                 });
                 if !has_unrelayed_answer {
+                    // #3629: a completed-stale row with no unrelayed answer is
+                    // either a delivered-and-idle turn (committed → preserve) or
+                    // a never-committed NO_REPLY/empty orphan (clean). See
+                    // `completed_stale_no_answer_orphan_should_clean`. We only
+                    // reach here when the mailbox has NO active turn and the
+                    // relay is healthy, so a real live/hung turn (which holds an
+                    // active mailbox turn) can never be cleaned here.
+                    let terminal_committed = leak_inflight
+                        .as_ref()
+                        .is_some_and(|s| s.terminal_delivery_committed);
+                    if completed_stale_no_answer_orphan_should_clean(terminal_committed) {
+                        // Identity-guarded removal: a newer turn that has since
+                        // written this channel's row yields UserMsgMismatch and
+                        // is preserved; planned-restart / rebind-origin rows are
+                        // skipped. We only ever delete THIS leaked turn's row.
+                        let this_turn_user_msg_id =
+                            leak_inflight.as_ref().map(|s| s.user_msg_id).unwrap_or(0);
+                        let clear_outcome = if this_turn_user_msg_id != 0 {
+                            discord::inflight::clear_inflight_state_if_matches(
+                                provider,
+                                channel_id.get(),
+                                this_turn_user_msg_id,
+                            )
+                        } else {
+                            discord::inflight::clear_inflight_state_if_matches_zero_owned(
+                                provider,
+                                channel_id.get(),
+                            )
+                        };
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] 🧹 #3629 cleaned NO_REPLY/empty orphan inflight on channel {} (provider={}, outcome={:?})",
+                            channel_id,
+                            provider.as_str(),
+                            clear_outcome
+                        );
+                        crate::services::observability::emit_inflight_lifecycle_event(
+                            provider.as_str(),
+                            channel_id.get(),
+                            leak_dispatch_id.as_deref(),
+                            leak_session_key.as_deref(),
+                            leak_turn_id.as_deref(),
+                            "leak_cleaned_noreply_orphan",
+                            serde_json::json!({
+                                "guarded_clear_outcome": format!("{clear_outcome:?}"),
+                                "inflight_started_at": snapshot.inflight_started_at,
+                                "inflight_updated_at": snapshot.inflight_updated_at,
+                                "tmux_session_alive": snapshot.tmux_session_alive,
+                            }),
+                        );
+                    }
                     continue;
                 }
                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -2639,12 +2715,13 @@ mod stall_watchdog_pure_tests {
     use super::super::stall_liveness::stall_watchdog_jsonl_liveness_defers_force_clean;
     use super::{
         LeakRecoveryLedgerIdentity, STALL_WATCHDOG_THRESHOLD_SECS,
-        force_clean_should_preserve_resume_selector, inflight_completed_stale_leak_detected,
-        leak_recovery_chunk_fingerprints, leak_recovery_clear_chunk_ledger,
-        leak_recovery_confirmed_chunk_count, leak_recovery_confirmed_prefix_from_ledger,
-        leak_recovery_record_confirmed_chunk, leak_recovery_unrelayed_range,
-        preserve_cancel_should_skip_provider_interrupt_for_idle_tui, render_leak_recovery_delivery,
-        stale_idle_foreground_queue_detected, stall_watchdog_should_force_clean,
+        completed_stale_no_answer_orphan_should_clean, force_clean_should_preserve_resume_selector,
+        inflight_completed_stale_leak_detected, leak_recovery_chunk_fingerprints,
+        leak_recovery_clear_chunk_ledger, leak_recovery_confirmed_chunk_count,
+        leak_recovery_confirmed_prefix_from_ledger, leak_recovery_record_confirmed_chunk,
+        leak_recovery_unrelayed_range, preserve_cancel_should_skip_provider_interrupt_for_idle_tui,
+        render_leak_recovery_delivery, stale_idle_foreground_queue_detected,
+        stall_watchdog_should_force_clean,
         stall_watchdog_should_force_clean_orphan_explicit_background_work,
     };
     use crate::services::discord::relay_health::{RelayActiveTurn, RelayStallState};
@@ -2959,6 +3036,17 @@ mod stall_watchdog_pure_tests {
             .expect("valid local time")
             .format("%Y-%m-%d %H:%M:%S")
             .to_string()
+    }
+
+    /// #3629: a completed-stale, no-unrelayed-answer row is cleaned ONLY when it
+    /// never committed a terminal delivery (NO_REPLY/empty orphan). A committed
+    /// delivered-and-idle row (#3126 wakeup-waiting) must be preserved.
+    #[test]
+    fn completed_stale_no_answer_orphan_cleans_only_uncommitted() {
+        // NO_REPLY / empty terminal turn: nothing delivered → orphan → clean.
+        assert!(completed_stale_no_answer_orphan_should_clean(false));
+        // Delivered-and-idle turn (#3126): committed → preserve, never clean.
+        assert!(!completed_stale_no_answer_orphan_should_clean(true));
     }
 
     /// `inflight_completed_stale_leak_detected` requires every signal of the

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1410,13 +1410,24 @@ pub(crate) fn inflight_completed_stale_leak_detected(
 ///   fill and that no live turn owns, so it never self-clears and the external
 ///   deadlock monitor flags it every ~30 min forever (#3629). CLEAN it.
 ///
-/// The actual removal at the call site is identity-guarded, so a newer turn's
-/// row is never clobbered — this predicate only decides intent. Kept as a pure
-/// seam so the fork is unit-testable without driving the watchdog loop.
+/// The removal at the call site is identity-guarded against the on-disk
+/// `user_msg_id`, so a newer turn's row is never clobbered — this predicate only
+/// decides intent. Kept as a pure seam so the fork is unit-testable without
+/// driving the watchdog loop.
+///
+/// `this_turn_user_msg_id == 0` is NEVER cleaned (codex #3629 review): a zero-id
+/// row cannot be distinguished from a LIVE recovery/TUI-direct turn
+/// (`RecoveryKickoff` holds a live cancel_token with `active_user_message_id =
+/// None`, so the "no active mailbox turn" precondition does not prove it is
+/// dead) nor from a NEWER pinned zero-id turn (the zero-owned guard only checks
+/// `user_msg_id == 0`, not identity). Only a real, non-zero user_msg_id can be
+/// identity-guarded safely, so zero-id rows keep the prior detection-only
+/// behavior.
 pub(crate) fn completed_stale_no_answer_orphan_should_clean(
     terminal_delivery_committed: bool,
+    this_turn_user_msg_id: u64,
 ) -> bool {
-    !terminal_delivery_committed
+    !terminal_delivery_committed && this_turn_user_msg_id != 0
 }
 
 fn outbound_activity_is_recent(
@@ -1784,33 +1795,31 @@ pub(crate) async fn run_stall_watchdog_pass(
                 if !has_unrelayed_answer {
                     // #3629: a completed-stale row with no unrelayed answer is
                     // either a delivered-and-idle turn (committed → preserve) or
-                    // a never-committed NO_REPLY/empty orphan (clean). See
-                    // `completed_stale_no_answer_orphan_should_clean`. We only
+                    // a never-committed NO_REPLY/empty orphan (clean). We only
                     // reach here when the mailbox has NO active turn and the
-                    // relay is healthy, so a real live/hung turn (which holds an
-                    // active mailbox turn) can never be cleaned here.
+                    // relay is healthy. Only a real, NON-ZERO user_msg_id is
+                    // cleaned — zero-id rows are never auto-cleaned because they
+                    // can be a live recovery/TUI-direct turn or a newer pinned
+                    // zero-id turn (codex #3629 review). See
+                    // `completed_stale_no_answer_orphan_should_clean`.
                     let terminal_committed = leak_inflight
                         .as_ref()
                         .is_some_and(|s| s.terminal_delivery_committed);
-                    if completed_stale_no_answer_orphan_should_clean(terminal_committed) {
+                    let this_turn_user_msg_id =
+                        leak_inflight.as_ref().map(|s| s.user_msg_id).unwrap_or(0);
+                    if completed_stale_no_answer_orphan_should_clean(
+                        terminal_committed,
+                        this_turn_user_msg_id,
+                    ) {
                         // Identity-guarded removal: a newer turn that has since
                         // written this channel's row yields UserMsgMismatch and
                         // is preserved; planned-restart / rebind-origin rows are
                         // skipped. We only ever delete THIS leaked turn's row.
-                        let this_turn_user_msg_id =
-                            leak_inflight.as_ref().map(|s| s.user_msg_id).unwrap_or(0);
-                        let clear_outcome = if this_turn_user_msg_id != 0 {
-                            discord::inflight::clear_inflight_state_if_matches(
-                                provider,
-                                channel_id.get(),
-                                this_turn_user_msg_id,
-                            )
-                        } else {
-                            discord::inflight::clear_inflight_state_if_matches_zero_owned(
-                                provider,
-                                channel_id.get(),
-                            )
-                        };
+                        let clear_outcome = discord::inflight::clear_inflight_state_if_matches(
+                            provider,
+                            channel_id.get(),
+                            this_turn_user_msg_id,
+                        );
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::warn!(
                             "  [{ts}] 🧹 #3629 cleaned NO_REPLY/empty orphan inflight on channel {} (provider={}, outcome={:?})",
@@ -3039,14 +3048,24 @@ mod stall_watchdog_pure_tests {
     }
 
     /// #3629: a completed-stale, no-unrelayed-answer row is cleaned ONLY when it
-    /// never committed a terminal delivery (NO_REPLY/empty orphan). A committed
-    /// delivered-and-idle row (#3126 wakeup-waiting) must be preserved.
+    /// never committed a terminal delivery (NO_REPLY/empty orphan) AND it has a
+    /// real, non-zero user_msg_id. A committed delivered-and-idle row (#3126
+    /// wakeup-waiting) and any zero-id row (live recovery / newer pinned zero-id
+    /// turn, codex #3629 review) must be preserved.
     #[test]
-    fn completed_stale_no_answer_orphan_cleans_only_uncommitted() {
-        // NO_REPLY / empty terminal turn: nothing delivered → orphan → clean.
-        assert!(completed_stale_no_answer_orphan_should_clean(false));
-        // Delivered-and-idle turn (#3126): committed → preserve, never clean.
-        assert!(!completed_stale_no_answer_orphan_should_clean(true));
+    fn completed_stale_no_answer_orphan_cleans_only_uncommitted_nonzero() {
+        let real_id = 9_100_084_013_837_195_159u64;
+        // NO_REPLY / empty terminal turn with a real id: orphan → clean.
+        assert!(completed_stale_no_answer_orphan_should_clean(
+            false, real_id
+        ));
+        // Delivered-and-idle turn (#3126): committed → preserve.
+        assert!(!completed_stale_no_answer_orphan_should_clean(
+            true, real_id
+        ));
+        // Zero-id rows are NEVER auto-cleaned, regardless of committed state.
+        assert!(!completed_stale_no_answer_orphan_should_clean(false, 0));
+        assert!(!completed_stale_no_answer_orphan_should_clean(true, 0));
     }
 
     /// `inflight_completed_stale_leak_detected` requires every signal of the


### PR DESCRIPTION
## 문제 (#3629)
NO_REPLY/empty 응답으로 끝난 DM 프로브 턴이 `terminal_delivery_committed=false`인 inflight 행을 남김. tmux 세션은 살아있고(live-but-quiet, #3582 보호 대상) mailbox엔 active turn 없음. watcher-keyed sweeper들은 watcher가 이미 종료돼 못 지우고, stall-watchdog force-clean은 #3582로 비파괴화됨 → orphan 영구 잔존 → 외부 deadlock 모니터가 30분마다 '장시간 턴/Deadlock 의심' + extend-timeout 409 오탐 반복.

## 수정
`recovery.rs`의 `inflight_completed_stale_leak_detected`는 이미 이 패턴(데드락-매니저 30/45/60분 알람)을 탐지하나, unrelayed answer가 없으면(=NO_REPLY) `continue`로 방치(detection-only)했음. 이 지점에서 `terminal_delivery_committed==false`(전달분 전무=NO_REPLY orphan)일 때만 **identity-guarded clear**로 정리. `committed==true`(전달완료 idle=#3126 wakeup-waiting)는 보존.

## 불변식 / 안전성
1. 탐지 함수가 `mailbox_active_user_msg_id.is_none()`(active turn 없음)을 전제 → 실제 deadlock(active turn 보유)은 절대 정리 안 됨 — **over-suppress 불가**.
2. `clear_inflight_state_if_matches[_zero_owned]` identity-guard → 새 turn/planned-restart/rebind-origin row clobber 불가(UserMsgMismatch→보존).
3. spawn_turn_bridge(**#3016**)/delivery-lease(**#3041**) **미변경** — 핫파일 영향 없음.
4. #3126(committed idle), #3582(live-but-quiet, unrelayed answer 보유 시 has_unrelayed_answer로 분기) 회귀 없음.

## 테스트
- 순수 판정 seam `completed_stale_no_answer_orphan_should_clean` + 단위 테스트(uncommitted만 clean).
- `cargo check --lib` 클린, fmt 클린, agent-maintenance freshness 동기(recovery.rs 2713).

🤖 Generated with [Claude Code](https://claude.com/claude-code)