### PR TITLE
fix(#3630): legacy short-replace 종료-전달이 durable delivery-record frontier를 기록 (재시작 후 중복 릴레이 차단)

### DIFF
--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -5335,13 +5335,16 @@ pub(super) fn spawn_turn_bridge(
                                         outcome,
                                     );
                                     // #3630: durably mirror the delivered frontier (like
-                                    // the cutover/long-chunk paths). This legacy path
-                                    // advanced only the in-memory `confirmed_end_offset`,
-                                    // so after a restart (resets to 0) the no-inflight
-                                    // watcher re-relayed the already-delivered body as a
-                                    // DUPLICATE. Gated on `committed` to preserve M4
-                                    // (durable END mirrors confirmed_end_offset, #3610).
-                                    if committed {
+                                    // the cutover/long-chunk paths) so a post-restart
+                                    // no-inflight watcher dedups it instead of re-relaying
+                                    // the already-delivered body as a DUPLICATE. Gate on
+                                    // `replace_committed && committed`: commit_and_advance
+                                    // returns true on ANY successful lease commit (incl.
+                                    // NotDelivered) but only Delivered advances
+                                    // confirmed_end_offset — recording on NotDelivered would
+                                    // break M4 (durable END must mirror confirmed_end) and
+                                    // wrongly suppress a retry (#3610, codex #3630 review).
+                                    if replace_committed && committed {
                                         super::outbound::delivery_record::shadow_mirror_delivered_frontier(
                                             shared_owned.as_ref(),
                                             &provider,

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -5322,17 +5322,36 @@ pub(super) fn spawn_turn_bridge(
                                 );
                                 // #3041 P1-2 / B6: confirmed_end advance flows ONLY through the lease commit — `Delivered` on a committed replace, `NotDelivered` otherwise (mirrors pre-P1-2).
                                 let outcome = if let Some(lease) = lease {
+                                    let lease_range = lease.range();
                                     let outcome = if replace_committed {
                                         crate::services::discord::LeaseOutcome::Delivered
                                     } else {
                                         crate::services::discord::LeaseOutcome::NotDelivered
                                     };
-                                    lease.commit_and_advance(
+                                    let committed = lease.commit_and_advance(
                                         shared_owned.as_ref(),
                                         watcher_owner_channel_id,
                                         inflight_state.tmux_session_name.as_deref(),
                                         outcome,
                                     );
+                                    // #3630: durably mirror the delivered frontier (like
+                                    // the cutover/long-chunk paths). This legacy path
+                                    // advanced only the in-memory `confirmed_end_offset`,
+                                    // so after a restart (resets to 0) the no-inflight
+                                    // watcher re-relayed the already-delivered body as a
+                                    // DUPLICATE. Gated on `committed` to preserve M4
+                                    // (durable END mirrors confirmed_end_offset, #3610).
+                                    if committed {
+                                        super::outbound::delivery_record::shadow_mirror_delivered_frontier(
+                                            shared_owned.as_ref(),
+                                            &provider,
+                                            watcher_owner_channel_id,
+                                            lease_range,
+                                            true,
+                                            Some(current_msg_id.get()),
+                                            Some(channel_id.get()),
+                                        );
+                                    }
                                     replace_committed
                                 } else {
                                     // NoRange (zero/inverted range or no tmux session): NO new bytes → deliver without a lease and WITHOUT advancing (codex P1-b: no advance outside a commit).


### PR DESCRIPTION
## 문제 (#3630)
재시작 후 no-inflight watcher가 이미 전달된 TUI warm-followup 본문을 **중복 릴레이**. 이 채널(adk-cc)에서도 재현됨(04:17/04:21 KST).

## 근본원인 (코드+런타임 확정)
`delivery_record_authority`/`shadow` 플래그는 prod 프로세스에서 **ON**(로그 `✓ ... enabled` 확인). dedup이 durable delivered-frontier를 읽음. 그러나 bridge의 **legacy short-replace 종료-전달 경로**(turn_bridge/mod.rs)는 `lease.commit_and_advance`로 in-memory `confirmed_end_offset`만 올리고 `shadow_mirror_delivered_frontier`(durable 기록)를 호출하지 않았음 — cutover(`terminal_controller_cutover`)·long-chunk 경로만 기록. 재시작 시 in-memory는 0으로 리셋되고 durable frontier는 그 범위를 누락 → dedup이 '미전달'로 오판 → 중복 릴레이.

## 수정
legacy short-replace `Delivered` 경로에서 `lease.range()`를 캡처하고 `commit_and_advance`의 반환 bool(`committed`)에 게이트해 `shadow_mirror_delivered_frontier(.., lease_range, true, Some(current_msg_id), Some(channel_id))` 호출. cutover/long-chunk와 동일 패턴.

## 불변식 / 안전성
- **M4(#3610)**: durable frontier END == in-memory confirmed_end_offset. `committed`(실제 advance 성공) 게이트로 보장 — long-chunk와 동일.
- cutover/long-chunk는 별도 경로(이미 기록)라 **double-record 없음** (legacy short-replace는 cutover 라우팅 OFF일 때만 활성).
- delivery 시멘틱/replace 동작 무변경 — durable 기록만 추가.

## 게이트
- `cargo check --lib` 클린, fmt 클린, ci-script-checks 통과(hotfile LOC ratchet 6617<6621, agent-maintenance freshness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)