### PR TITLE
fix(#3631): rebind-origin inflight을 idle로 분류 (false active_foreground_stream + 큐 stall)

### DIFF
--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -156,11 +156,36 @@ struct RelayThreadProofSnapshot {
     stale_thread_proof: bool,
 }
 
+/// #3631: a rebind-origin inflight row (POST /api/inflight/rebind) is a
+/// synthetic origin marker — `turn_id`/`dispatch_id` null, `user_msg_id`/
+/// `current_msg_id` 0, `full_response` empty — NOT a real user/agent turn.
+/// With no mailbox cancel token there is no live turn, so the channel is idle.
+/// The classifier previously fell through to `Foreground`, falsely reporting
+/// `active_foreground_stream` and stranding queued messages (they never
+/// dispatch because no real turn ever ends to drain the queue). A cancel token
+/// present means a real turn HAS since started on the adopted session, so it is
+/// genuinely active — only treat it as idle when no cancel token is held.
+///
+/// Pure seam so the idle decision is unit-testable without constructing a full
+/// `InflightTurnState`.
+fn rebind_origin_inflight_is_idle(mailbox_has_cancel_token: bool, rebind_origin: bool) -> bool {
+    rebind_origin && !mailbox_has_cancel_token
+}
+
 fn relay_active_turn_from_inflight(
     mailbox_has_cancel_token: bool,
     inflight: Option<&discord::inflight::InflightTurnState>,
 ) -> RelayActiveTurn {
     if !mailbox_has_cancel_token && inflight.is_none() {
+        return RelayActiveTurn::None;
+    }
+
+    // #3631: a rebind-origin row (POST /api/inflight/rebind) is a synthetic
+    // origin marker, NOT a real user/agent turn — treat it as idle when there
+    // is no live turn. See `rebind_origin_inflight_is_idle`.
+    if inflight.is_some_and(|state| {
+        rebind_origin_inflight_is_idle(mailbox_has_cancel_token, state.rebind_origin)
+    }) {
         return RelayActiveTurn::None;
     }
 
@@ -813,4 +838,24 @@ pub(super) fn observe_global_active_invariant(
     }
 
     (raw_global_active, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rebind_origin_inflight_is_idle;
+
+    /// #3631: a rebind-origin row with NO cancel token is idle (so the channel
+    /// is not falsely reported as an active foreground stream and queued
+    /// messages can dispatch). A cancel token present (a real turn started on
+    /// the adopted session) or a non-rebind-origin row is NOT idle.
+    #[test]
+    fn rebind_origin_idle_only_without_cancel_token() {
+        // rebind-origin + no cancel token → idle.
+        assert!(rebind_origin_inflight_is_idle(false, true));
+        // rebind-origin + live cancel token → NOT idle (real turn running).
+        assert!(!rebind_origin_inflight_is_idle(true, true));
+        // not a rebind-origin row → never idle via this seam.
+        assert!(!rebind_origin_inflight_is_idle(false, false));
+        assert!(!rebind_origin_inflight_is_idle(true, false));
+    }
 }


### PR DESCRIPTION
## 문제 (#3631)
POST /api/inflight/rebind이 만든 rebind-origin 행이 idle 채널을 `active_foreground_stream`로 오보고. 신규 메시지가 큐에 갇혀 dequeue 안 됨(채널 1474933804887179286, 1478652735300829185 재현; 후자는 queue_depth=1로 실제 메시지 stranded 확인).

## 근본원인
`health/snapshot.rs::relay_active_turn_from_inflight`이 inflight 존재 시 background 신호가 없으면 **Foreground로 폴백**. rebind-origin 행(turn_id/dispatch_id null, user_msg_id/current_msg_id 0, full_response 빈, cancel token 없음)도 Foreground로 분류 → active_foreground_stream → 큐가 '활성 턴'을 기다리며 영구 대기(실행될 턴 없음).

## 수정
cancel token이 없으면(=live turn 증거 없음) rebind-origin 행을 `RelayActiveTurn::None`(idle)로 분류. cancel token이 있으면 adopted 세션에서 실제 턴이 시작된 것이므로 그대로 active. 순수 seam `rebind_origin_inflight_is_idle` + 단위 테스트.

## 안전성
- cancel token gate로 **실제 진행 중 턴 오분류 불가**(live turn은 cancel token 보유).
- health/snapshot.rs(read-only 분류 계층)만 변경 — **#3016 핫파일 미변경**.
- non-rebind-origin 행 동작 무변경.

## 게이트
- cargo check 클린, fmt 클린, ci-script-checks 통과, 단위 테스트 통과.

## 후속(분리)
reaping predicate(inflight.rs:165)가 `relay_owner_kind==None`을 요구해 watcher-소유 rebind-origin 행이 영구 미회수되는 불일치 — 별도 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)