### PR TITLE
fix(#3628): 루틴 터미널 실패→pause 프로듀서 배선 (게이트 기본 OFF)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1365,7 +1365,7 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2458 lines; +11 from #3573 failure_pause_auto_resume_secs config field).
-  - `src/server/mod.rs` (2635 lines; +42 from #3573 auto-resume tick + backoff-race fix + #3628 dormancy note).
+  - `src/server/mod.rs` (2634 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2757,18 +2757,15 @@ async fn routine_runtime_loop(
                 }
             }
         }
-        // #3573: opt-in auto-resume for failure-paused routines. Only routines
-        // with `pause_reason = 'failure'` are eligible; manual/migration_invalid/
-        // NULL rows are never touched. The `ResumeRequiresNextDueAt` guard is
-        // applied inside `auto_resume_failure_paused_routine`. The knob defaults
-        // to 0 (disabled); set to e.g. 3600 to enable with a 1-hour backoff.
-        //
-        // NOTE (#3628): no production path writes `pause_reason = 'failure'`
-        // yet (the only writer is uncalled), so this scan is intentionally
-        // dormant — it resumes rows a future failure→pause wiring will create.
-        // That wiring is a separate behavior change tracked in #3628.
+        // #3573/#3628: opt-in auto-resume for failure-paused routines. Only
+        // routines with `pause_reason = 'failure'` are eligible; manual/
+        // migration_invalid/NULL rows are never touched. The
+        // `ResumeRequiresNextDueAt` guard is applied inside
+        // `auto_resume_failure_paused_routine`. The knob defaults to 0
+        // (disabled); set to e.g. 3600 to enable with a 1-hour backoff.
         let auto_resume_secs = routines_config.failure_pause_auto_resume_secs;
-        if auto_resume_secs > 0 {
+        let pause_on_terminal_failure = routines_config.failure_pause_auto_resume_secs > 0;
+        if pause_on_terminal_failure {
             let now = chrono::Utc::now();
             let cutoff = now - chrono::Duration::seconds(auto_resume_secs as i64);
             match store.list_failure_paused_routines(cutoff).await {
@@ -2810,6 +2807,7 @@ async fn routine_runtime_loop(
             &store,
             &agent_executor,
             routines_config.max_agent_polls_per_tick,
+            pause_on_terminal_failure,
         )
         .await
         {
@@ -2829,6 +2827,7 @@ async fn routine_runtime_loop(
             Some(&agent_executor),
             Some(&discord_logger),
             routines_config.max_due_per_tick,
+            pause_on_terminal_failure,
         )
         .await
         {

--- a/src/server/routes/routines.rs
+++ b/src/server/routes/routines.rs
@@ -495,12 +495,14 @@ pub async fn run_routine_now(
     let discord_logger = routine_discord_logger(&state)?;
     discord_logger.log_run_started(&store, &claimed).await;
     let run_id = claimed.run_id.clone();
+    let pause_on_terminal_failure = state.config.routines.failure_pause_auto_resume_secs > 0;
     let Some(outcome) = execute_claimed_script_run(
         &store,
         &loader,
         Some(&agent_executor),
         Some(&discord_logger),
         claimed,
+        pause_on_terminal_failure,
     )
     .await
     .map_err(store_error)?

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -14,6 +14,7 @@ use super::runtime::RoutineRunOutcome;
 use super::session_control::RoutineSessionController;
 use super::store::{
     ClaimedRoutineRun, NextDueAtUpdate, RecoveredRoutineRun, RoutineStore, RunningAgentRoutineRun,
+    terminal_failure_should_pause,
 };
 
 const FRESH_CONTEXT_GUARANTEED: bool = false;
@@ -96,6 +97,7 @@ impl RoutineAgentExecutor {
         checkpoint: Option<Value>,
         last_result: Option<String>,
         next_due_at: Option<DateTime<Utc>>,
+        pause_on_terminal_failure: bool,
     ) -> Result<RoutineRunOutcome> {
         let action = "agent".to_string();
         let agent_id = claimed
@@ -114,6 +116,7 @@ impl RoutineAgentExecutor {
                 dm_user_id.as_deref(),
                 &checkpoint,
                 next_due_at,
+                pause_on_terminal_failure,
             )
             .await;
         match result {
@@ -177,6 +180,7 @@ impl RoutineAgentExecutor {
                     "primary",
                     &message,
                     action,
+                    pause_on_terminal_failure,
                 )
                 .await
             }
@@ -196,6 +200,7 @@ impl RoutineAgentExecutor {
         attempt_kind: &str,
         message: &str,
         action: String,
+        pause_on_terminal_failure: bool,
     ) -> Result<RoutineRunOutcome> {
         match claimed_failure_recovery_plan(&claimed, failed_agent_id, attempt_kind) {
             AgentFailureRecoveryPlan::Retry {
@@ -253,6 +258,7 @@ impl RoutineAgentExecutor {
                         dm_user_id.as_deref(),
                         &checkpoint,
                         next_due_at,
+                        pause_on_terminal_failure,
                     )
                     .await
                 {
@@ -316,6 +322,7 @@ impl RoutineAgentExecutor {
                             combined,
                             Some(&fallback_agent_id),
                             "fallback",
+                            pause_on_terminal_failure,
                         )
                         .await;
                     }
@@ -331,6 +338,7 @@ impl RoutineAgentExecutor {
             message.to_string(),
             Some(failed_agent_id),
             attempt_kind,
+            pause_on_terminal_failure,
         )
         .await
     }
@@ -339,13 +347,17 @@ impl RoutineAgentExecutor {
         &self,
         store: &RoutineStore,
         limit: u32,
+        pause_on_terminal_failure: bool,
     ) -> Result<Vec<RoutineRunOutcome>> {
         store.heartbeat_running_agent_runs().await?;
         let pending = store.list_running_agent_runs(limit).await?;
         let mut outcomes = Vec::new();
         for run in pending {
             if run.turn_id.is_none() {
-                if let Some(outcome) = self.restart_due_retry(store, run).await? {
+                if let Some(outcome) = self
+                    .restart_due_retry(store, run, pause_on_terminal_failure)
+                    .await?
+                {
                     outcomes.push(outcome);
                 }
                 continue;
@@ -420,6 +432,7 @@ impl RoutineAgentExecutor {
                         result_json,
                         failed_agent_id.as_deref(),
                         &attempt_kind,
+                        pause_on_terminal_failure,
                     )
                     .await?
                 {
@@ -435,6 +448,7 @@ impl RoutineAgentExecutor {
         &self,
         store: &RoutineStore,
         run: RunningAgentRoutineRun,
+        pause_on_terminal_failure: bool,
     ) -> Result<Option<RoutineRunOutcome>> {
         let prompt = match pending_prompt(run.result_json.as_ref()) {
             Some(prompt) => prompt.to_string(),
@@ -491,6 +505,7 @@ impl RoutineAgentExecutor {
                 None,
                 &checkpoint,
                 next_due_at,
+                pause_on_terminal_failure,
             )
             .await
         {
@@ -544,6 +559,7 @@ impl RoutineAgentExecutor {
                     result_json,
                     Some(&agent_id),
                     "retry",
+                    pause_on_terminal_failure,
                 )
                 .await
             }
@@ -558,6 +574,7 @@ impl RoutineAgentExecutor {
         result_json: Option<Value>,
         failed_agent_id: Option<&str>,
         attempt_kind: &str,
+        pause_on_terminal_failure: bool,
     ) -> Result<Option<RoutineRunOutcome>> {
         match running_failure_recovery_plan(&run, failed_agent_id, attempt_kind) {
             AgentFailureRecoveryPlan::Retry {
@@ -609,9 +626,15 @@ impl RoutineAgentExecutor {
             } => {
                 let Some(prompt) = pending_prompt(run.result_json.as_ref()).map(str::to_string)
                 else {
-                    let closed = store
-                        .fail_agent_run(&run.run_id, message, result_json.clone(), None)
-                        .await?;
+                    let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
+                        store
+                            .fail_run_and_pause_routine(&run.run_id, message, result_json.clone())
+                            .await?
+                    } else {
+                        store
+                            .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+                            .await?
+                    };
                     return Ok(closed.then(|| RoutineRunOutcome {
                         run_id: run.run_id,
                         routine_id: run.routine_id,
@@ -636,6 +659,7 @@ impl RoutineAgentExecutor {
                         None,
                         &checkpoint,
                         next_due_at,
+                        pause_on_terminal_failure,
                     )
                     .await
                 {
@@ -683,9 +707,19 @@ impl RoutineAgentExecutor {
                         );
                         let result_json =
                             Some(merge_pending_result(&run, "failed", Some(&combined), None));
-                        let closed = store
-                            .fail_agent_run(&run.run_id, &combined, result_json.clone(), None)
-                            .await?;
+                        let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
+                            store
+                                .fail_run_and_pause_routine(
+                                    &run.run_id,
+                                    &combined,
+                                    result_json.clone(),
+                                )
+                                .await?
+                        } else {
+                            store
+                                .fail_agent_run(&run.run_id, &combined, result_json.clone(), None)
+                                .await?
+                        };
                         return Ok(closed.then(|| RoutineRunOutcome {
                             run_id: run.run_id,
                             routine_id: run.routine_id,
@@ -704,9 +738,15 @@ impl RoutineAgentExecutor {
 
         let result_json =
             result_json.or_else(|| Some(merge_pending_result(&run, "failed", Some(message), None)));
-        let closed = store
-            .fail_agent_run(&run.run_id, message, result_json.clone(), None)
-            .await?;
+        let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
+            store
+                .fail_run_and_pause_routine(&run.run_id, message, result_json.clone())
+                .await?
+        } else {
+            store
+                .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+                .await?
+        };
         Ok(closed.then(|| RoutineRunOutcome {
             run_id: run.run_id,
             routine_id: run.routine_id,
@@ -885,6 +925,7 @@ impl RoutineAgentExecutor {
         dm_user_id: Option<&str>,
         checkpoint: &Option<Value>,
         next_due_at: Option<DateTime<Utc>>,
+        _pause_on_terminal_failure: bool,
     ) -> Result<StartedAgentTurn> {
         let Some(registry) = self.health_registry.as_deref() else {
             return Err(anyhow!(
@@ -1522,6 +1563,7 @@ async fn fail_claimed_agent_run(
     message: String,
     failed_agent_id: Option<&str>,
     attempt_kind: &str,
+    pause_on_terminal_failure: bool,
 ) -> Result<RoutineRunOutcome> {
     let result_json = Some(json!({
         "status": "failed_to_start",
@@ -1533,9 +1575,15 @@ async fn fail_claimed_agent_run(
         "script_ref": claimed.script_ref,
         "fresh_context_guaranteed": FRESH_CONTEXT_GUARANTEED,
     }));
-    let closed = store
-        .fail_agent_run(&claimed.run_id, &message, result_json.clone(), None)
-        .await?;
+    let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
+        store
+            .fail_run_and_pause_routine(&claimed.run_id, &message, result_json.clone())
+            .await?
+    } else {
+        store
+            .fail_agent_run(&claimed.run_id, &message, result_json.clone(), None)
+            .await?
+    };
     if !closed {
         return Err(anyhow!(
             "routine agent run {} was already closed before failed outcome",

--- a/src/services/routines/runtime.rs
+++ b/src/services/routines/runtime.rs
@@ -13,7 +13,7 @@ use super::loader::{
     RoutineScriptLoader, RoutineTickAgent, RoutineTickContext, RoutineTickRoutine, RoutineTickRun,
 };
 use super::migrated::{is_migrated_launchd_script_ref, validate_migrated_launchd_activation};
-use super::store::{ClaimedRoutineRun, RoutineStore};
+use super::store::{ClaimedRoutineRun, RoutineStore, terminal_failure_should_pause};
 use crate::error::{AppError, AppResult, ErrorCode};
 
 #[derive(Debug, Clone, Serialize)]
@@ -35,6 +35,7 @@ pub async fn run_due_tick(
     agent_executor: Option<&RoutineAgentExecutor>,
     discord_logger: Option<&RoutineDiscordLogger>,
     max_due_per_tick: u32,
+    pause_on_terminal_failure: bool,
 ) -> Result<Vec<RoutineRunOutcome>> {
     let claimed = store.claim_due_runs(max_due_per_tick).await?;
     let mut outcomes = Vec::with_capacity(claimed.len());
@@ -81,7 +82,16 @@ pub async fn run_due_tick(
             }
             continue;
         }
-        match execute_claimed_script_run(store, loader, agent_executor, discord_logger, run).await {
+        match execute_claimed_script_run(
+            store,
+            loader,
+            agent_executor,
+            discord_logger,
+            run,
+            pause_on_terminal_failure,
+        )
+        .await
+        {
             Ok(Some(outcome)) => {
                 if let Some(logger) = discord_logger {
                     logger.log_run_outcome(store, &outcome).await;
@@ -131,8 +141,11 @@ pub async fn poll_agent_turns(
     store: &RoutineStore,
     agent_executor: &RoutineAgentExecutor,
     max_per_tick: u32,
+    pause_on_terminal_failure: bool,
 ) -> Result<Vec<RoutineRunOutcome>> {
-    agent_executor.poll_agent_runs(store, max_per_tick).await
+    agent_executor
+        .poll_agent_runs(store, max_per_tick, pause_on_terminal_failure)
+        .await
 }
 
 pub async fn execute_claimed_script_run(
@@ -141,6 +154,7 @@ pub async fn execute_claimed_script_run(
     agent_executor: Option<&RoutineAgentExecutor>,
     discord_logger: Option<&RoutineDiscordLogger>,
     claimed: ClaimedRoutineRun,
+    pause_on_terminal_failure: bool,
 ) -> Result<Option<RoutineRunOutcome>> {
     let fresh_context_guaranteed = false;
     let agent = load_tick_agent_context(store, claimed.agent_id.as_deref()).await?;
@@ -247,9 +261,15 @@ pub async fn execute_claimed_script_run(
                 "error": message,
                 "script_ref": claimed.script_ref,
             }));
-            let closed = store
-                .fail_run(&claimed.run_id, &message, result_json.clone(), None)
-                .await?;
+            let closed = if terminal_failure_should_pause(pause_on_terminal_failure) {
+                store
+                    .fail_run_and_pause_routine(&claimed.run_id, &message, result_json.clone())
+                    .await?
+            } else {
+                store
+                    .fail_run(&claimed.run_id, &message, result_json.clone(), None)
+                    .await?
+            };
             if !closed {
                 return Ok(None);
             }
@@ -284,6 +304,7 @@ pub async fn execute_claimed_script_run(
         claimed,
         action,
         fresh_context_guaranteed,
+        pause_on_terminal_failure,
     )
     .await
 }
@@ -608,6 +629,7 @@ async fn close_action(
     claimed: ClaimedRoutineRun,
     action: RoutineAction,
     fresh_context_guaranteed: bool,
+    pause_on_terminal_failure: bool,
 ) -> Result<Option<RoutineRunOutcome>> {
     let action_name = action.action_name().to_string();
     match action {
@@ -762,6 +784,7 @@ async fn close_action(
                     checkpoint,
                     last_result,
                     next_due_at,
+                    pause_on_terminal_failure,
                 )
                 .await
                 .map(Some)

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -26,6 +26,15 @@ const RESUME_NEXT_DUE_REQUIRED_MESSAGE: &str =
 pub const PAUSE_REASON_FAILURE: &str = "failure";
 pub const PAUSE_REASON_MANUAL: &str = "manual";
 pub const PAUSE_REASON_MIGRATION_INVALID: &str = "migration_invalid";
+
+pub(crate) fn terminal_failure_should_pause(pause_on_terminal_failure: bool) -> bool {
+    terminal_failure_pause_reason(pause_on_terminal_failure).is_some()
+}
+
+fn terminal_failure_pause_reason(pause_on_terminal_failure: bool) -> Option<&'static str> {
+    pause_on_terminal_failure.then_some(PAUSE_REASON_FAILURE)
+}
+
 const API_FRICTION_OBSERVATION_QUERY: &str = r#"
             SELECT fingerprint,
                    endpoint,
@@ -3952,6 +3961,18 @@ mod tests {
         assert_eq!(super::PAUSE_REASON_FAILURE, "failure");
         assert_eq!(super::PAUSE_REASON_MANUAL, "manual");
         assert_eq!(super::PAUSE_REASON_MIGRATION_INVALID, "migration_invalid");
+    }
+
+    #[test]
+    fn terminal_failure_pause_gate_controls_failure_pause_reason() {
+        assert!(!super::terminal_failure_should_pause(false));
+        assert_eq!(super::terminal_failure_pause_reason(false), None);
+
+        assert!(super::terminal_failure_should_pause(true));
+        assert_eq!(
+            super::terminal_failure_pause_reason(true),
+            Some(super::PAUSE_REASON_FAILURE)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 배경
#3573가 failure-paused 루틴 auto-resume 스캔을 추가했지만, `pause_reason='failure'`를 쓰는 **유일한 프로듀서** `fail_run_and_pause_routine`에 production 호출부가 없어 스캔이 dormant였다 (#3628 갭).

## 변경
`failure_pause_auto_resume_secs > 0` 게이트 뒤에서 **5개 에이전트-실행 터미널 싱크**를 `fail_run_and_pause_routine`로 라우팅:
1. `runtime.rs` `execute_claimed_script_run` — JS 스크립트 실패
2. `agent_executor` `handle_running_agent_failure` — no-prompt fallback
3. `agent_executor` `handle_running_agent_failure` — fallback start Err
4. `agent_executor` `handle_running_agent_failure` — `Fail` plan fall-through
5. `agent_executor` `fail_claimed_agent_run` — start_turn 터미널 sink

게이트는 `server/mod.rs` `routine_runtime_loop`(due tick + agent poll)와 `routes/routines.rs` `run_routine_now`에서 `failure_pause_auto_resume_secs > 0`로 계산해 시그니처로 스레딩.

## 불변식
- **게이트 OFF(기본 0) = byte-for-byte 불변**: else 분기가 원래 `fail_run(.., None)`/`fail_agent_run(.., None)`와 동일.
- **비게이트(의도적)**: 구조적/전제조건 실패(prompt 누락 / agent_id 누락 / executor 미구성)와 Retry·restart-validation 경로 — 영구 오류가 pause→auto-resume 오실레이션을 일으키지 않도록 제외.
- discord 핫파일(#3016) 무변경.

## 테스트 / 게이트
- `terminal_failure_pause_gate_controls_failure_pause_reason` 단위 테스트 추가.
- `cargo fmt --check` 클린, `cargo check --lib` 클린, `cargo test --lib routines` 148 passed/0 failed.
- agent-maintenance freshness passed (change-surfaces.md: server/mod.rs 2635→2634, 주석 압축으로 net -1).
- `ci-script-checks.sh` EXIT=0 (giant/hotfile ratchet 포함).

## 리뷰
구현: codex(gpt-5.5). 적대 리뷰: opus(교차 모델) — 5개 싱크 정확 게이팅·게이트-OFF 불변·비게이트 경로 정당성 검증 → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)