### PR TITLE
fix(#3637): 프롬프트 draft cleanup cancel-agnostic + 모든 post-paste 에러 exit 중앙화

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1474,12 +1474,13 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1636) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1656) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:
   startup-dialog auto-dismiss and keeping the follow-up readiness wait alive
-  while the prior turn streams.)
+  while the prior turn streams; +20 from #3637 centralizing post-paste error
+  cleanup and making draft clearing cancel-agnostic.)
 - `src/services/memory/memento.rs` (1893).
 - `src/services/dispatched_sessions.rs` (1328) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -32,6 +32,7 @@ const PROMPT_READY_POST_EVENT_SETTLE: Duration = Duration::from_millis(50);
 const PROMPT_SUBMIT_INITIAL_SETTLE: Duration = Duration::from_millis(120);
 const PROMPT_SUBMIT_RETRY_SETTLE: Duration = Duration::from_millis(350);
 const PROMPT_SUBMIT_CONFIRM_RETRIES: usize = 2;
+const PROMPT_DRAFT_CLEANUP_CANCEL_TOKEN: Option<&CancelToken> = None;
 /// Upper bound for how long we wait for an interactive selector overlay (e.g.
 /// `/effort`) to mount after submitting the slash command, before giving up and
 /// reporting failure rather than sending navigation keys into a composer.
@@ -682,8 +683,23 @@ fn run_actions_with_submission_confirmation(
     actions: &[TuiInputAction],
     cancel_token: Option<&CancelToken>,
 ) -> Result<(), String> {
-    run_actions(session_name, actions, cancel_token)?;
-    confirm_prompt_submission_left_editor(session_name, cancel_token)
+    let actions_contained_paste = actions_contain_paste_buffer(actions);
+    let result = run_actions(session_name, actions, cancel_token)
+        .and_then(|()| confirm_prompt_submission_left_editor(session_name, cancel_token));
+    if should_clear_draft_on_error(actions_contained_paste, result.is_err()) {
+        clear_prompt_draft_before_error(session_name);
+    }
+    result
+}
+
+fn actions_contain_paste_buffer(actions: &[TuiInputAction]) -> bool {
+    actions
+        .iter()
+        .any(|action| matches!(action, TuiInputAction::PasteBuffer(_)))
+}
+
+fn should_clear_draft_on_error(actions_contained_paste: bool, result_is_err: bool) -> bool {
+    actions_contained_paste && result_is_err
 }
 
 fn confirm_prompt_submission_left_editor(
@@ -712,7 +728,6 @@ fn confirm_prompt_submission_left_editor(
             }
             PromptSubmitConfirmationDecision::FailedDraftStuck => {
                 log_prompt_submit_left_draft(session_name, &snapshot);
-                clear_prompt_draft_before_error(session_name, cancel_token);
                 return Err(format!(
                     "claude tui prompt submit left draft after {} enter retries; prompt_marker_detected={}; prompt_draft_detected={}; capture_available={}",
                     PROMPT_SUBMIT_CONFIRM_RETRIES,
@@ -776,8 +791,19 @@ fn prompt_submit_settle_for_attempt(attempt: usize) -> Duration {
     }
 }
 
-fn clear_prompt_draft_before_error(session_name: &str, cancel_token: Option<&CancelToken>) {
+fn clear_prompt_draft_before_error(session_name: &str) {
     let snapshot = prompt_readiness_snapshot(session_name);
+    let actions = prompt_draft_cleanup_actions(&snapshot);
+    if let Err(error) = run_actions(session_name, &actions, PROMPT_DRAFT_CLEANUP_CANCEL_TOKEN) {
+        tracing::warn!(
+            tmux_session_name = session_name,
+            error = %error,
+            "failed to clear Claude TUI draft after prompt submit retries"
+        );
+    }
+}
+
+fn prompt_draft_cleanup_actions(snapshot: &PromptReadinessSnapshot) -> Vec<TuiInputAction> {
     let mut actions = vec![
         TuiInputAction::CtrlU,
         TuiInputAction::Escape,
@@ -786,13 +812,7 @@ fn clear_prompt_draft_before_error(session_name: &str, cancel_token: Option<&Can
     if let Some(count) = claude_prompt_draft_backspace_budget_from_tail(&snapshot.pane_tail) {
         actions.push(TuiInputAction::Backspace(count));
     }
-    if let Err(error) = run_actions(session_name, &actions, cancel_token) {
-        tracing::warn!(
-            tmux_session_name = session_name,
-            error = %error,
-            "failed to clear Claude TUI draft after prompt submit retries"
-        );
-    }
+    actions
 }
 
 pub(crate) fn claude_prompt_draft_backspace_budget_from_tail(pane_tail: &str) -> Option<usize> {
@@ -1338,7 +1358,7 @@ fn wait_for_prompt_ready_polling(
                     readiness = readiness.label(),
                     "claude_tui clearing stranded follow-up prompt draft after readiness timeout so retry can re-inject cleanly"
                 );
-                clear_prompt_draft_before_error(session_name, cancel_token);
+                clear_prompt_draft_before_error(session_name);
             }
             return Err(format!(
                 "{PROMPT_READY_TIMEOUT_ERROR_PREFIX} {} prompt input readiness after {}s; reason={}; previous_tui_turn_still_running={}; prompt_marker_detected={}; prompt_draft_detected={}; capture_available={}",
@@ -2039,6 +2059,46 @@ mod tests {
         assert_eq!(
             prompt_submit_confirmation_decision(&dead, 0, 2),
             PromptSubmitConfirmationDecision::FailedSessionDead
+        );
+    }
+
+    #[test]
+    fn prompt_submit_cleanup_on_error_is_limited_to_paste_actions() {
+        let literal_actions = vec![
+            TuiInputAction::Literal("abc".to_string()),
+            TuiInputAction::Enter,
+        ];
+        assert!(!actions_contain_paste_buffer(&literal_actions));
+        assert!(!should_clear_draft_on_error(false, true));
+
+        let paste_actions = vec![
+            TuiInputAction::PasteBuffer("line1\nline2".to_string()),
+            TuiInputAction::Enter,
+        ];
+        assert!(actions_contain_paste_buffer(&paste_actions));
+        assert!(!should_clear_draft_on_error(true, false));
+        assert!(should_clear_draft_on_error(true, true));
+    }
+
+    #[test]
+    fn prompt_draft_cleanup_actions_are_cancel_agnostic() {
+        let snapshot = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: true,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "❯\u{00a0}commit this".to_string(),
+        };
+
+        assert!(PROMPT_DRAFT_CLEANUP_CANCEL_TOKEN.is_none());
+        assert_eq!(
+            prompt_draft_cleanup_actions(&snapshot),
+            vec![
+                TuiInputAction::CtrlU,
+                TuiInputAction::Escape,
+                TuiInputAction::CtrlU,
+                TuiInputAction::Backspace("commit this".chars().count() + 4),
+            ]
         );
     }
 


### PR DESCRIPTION
## 배경
프롬프트가 tmux TUI 입력창에 paste만 되고 Enter 미제출로 다음 턴이 영구 stuck (3회 관측, #3637).

## 근본 원인 (`src/services/claude_tui/input.rs`)
이미 Enter 재시도 + draft 정리 메커니즘이 있었으나 cancel_token 경로가 정리를 우회:
1. cancel이 paste↔Enter 사이에 fire → `run_actions`가 Enter 전에 Err 전파.
2. 정리(`clear_prompt_draft_before_error`)가 `FailedDraftStuck` 단일 분기에만 있어 cancel-전파 exit(685/696/698/735)는 우회.
3. 정리 자체가 `run_actions(.., cancel_token)`로 실행 → cancel 상태면 첫 `check_prompt_cancel?`에서 bail → CtrlU가 실제로 안 돎.

## 수정
- **(a) cancel-agnostic 정리**: `PROMPT_DRAFT_CLEANUP_CANCEL_TOKEN`(None)로 실행해 cancel 상태에서도 CtrlU/Escape/CtrlU가 실제 수행. (`cancel_requested(None)=false` → `check_prompt_cancel(None)=Ok`)
- **(b) 중앙화**: `run_actions_with_submission_confirmation`에서 actions에 PasteBuffer가 있고 결과가 Err이면(취소/세션사망/draft-stuck 등 모든 경로) 반환 전 1회 정리. `FailedDraftStuck` 단일-분기 정리는 제거(이중 정리 없음). **성공 경로 불변.**

## 불변식
- 성공 시 정리 안 함. paste 없는 시퀀스(slider/overlay 등 `run_actions` 직접 호출)는 영향 없음.
- 정리 액션엔 sleep 없음 → dead 세션에서도 빠른 Err, hang 없음.
- input.rs는 #3016 코어 핫파일 아님.

## 테스트 / 게이트
- `should_clear_draft_on_error`(paste∧err) 결정 로직 + cleanup 액션 cancel-agnostic 검증 2건 추가.
- `cargo fmt --check` / `cargo check --lib` 클린, `cargo test --lib claude_tui` 264 passed.
- agent-maintenance freshness passed (input.rs LoC 1656 동기).
- `ci-script-checks.sh` EXIT=0.

## 리뷰
구현: codex(gpt-5.5). 적대 리뷰: opus(교차 모델) — cancel-agnostic 린치핀(`cancel_requested(None)=false`)·중앙화 정확성·성공경로 불변·엣지(paste 미실행 no-op, dead 세션 무hang) 검증 → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)