### PR TITLE
fix(#3630): cancel/stop + prompt_too_long 종료-전달도 durable frontier 기록 (중복 릴레이 잔여 차단)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1045,7 +1045,7 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6162 prod lines; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6221 prod lines; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -404,6 +404,12 @@
 
 ### Audited touches
 
+- #3630 frontier mirror for cancel/stop + prompt_too_long terminal arms:
+  turn_bridge now mirrors only Delivered+committed terminal-replace lease ranges
+  into the durable delivery-record frontier keyed by `watcher_owner_channel_id`.
+  Classification: worker-local relay frontier; no leader election, PG lease, or
+  cross-node gossip change.
+
 - #3573 `pause_reason` DB field + opt-in failure-pause auto-resume:
   `routines` table gains a nullable TEXT column (`pause_reason`) populated with
   `'failure'` (run failed/timed-out), `'manual'` (operator pause), or

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -142,7 +142,7 @@
 # #3560: +9 (6189 -> 6198) for the footer-mode migration reconcile — the
 # migrate_separate_status_panel_to_footer call + comment at the footer-mode entry
 # (helper body itself extracted to turn_bridge/status_panel.rs, net decomposition).
-"src/services/discord/turn_bridge/mod.rs" = 6198
+"src/services/discord/turn_bridge/mod.rs" = 6221 # #3630 frontier mirror for cancel/stop + prompt_too_long terminal arms
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -56,4 +56,4 @@
 # #3560: 6612 -> 6621 (+9), reviewable admission — footer-mode separate-panel
 # migration reconcile call + comment at the resume entry. Helper body lives in
 # turn_bridge/status_panel.rs; this is the minimal call-site cost.
-"src/services/discord/turn_bridge/mod.rs" = 6621
+"src/services/discord/turn_bridge/mod.rs" = 6644 # #3630 frontier mirror for cancel/stop + prompt_too_long arms

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -1057,6 +1057,56 @@ mod tests {
     }
 
     #[test]
+    fn replace_mirror_gate_records_only_delivered_committed_3630() {
+        let dir = tempfile::tempdir().unwrap();
+        let delivered_path =
+            delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 36_300);
+        let not_delivered_path =
+            delivery_record_path_in_root(dir.path(), &ProviderKind::Claude, 36_301);
+
+        let replace_committed = true;
+        let committed = true;
+        if replace_committed && committed {
+            record_delivered_frontier_shadow_at(
+                &delivered_path,
+                (7, 77),
+                123,
+                0,
+                Some(555),
+                Some(999),
+                77,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            read_record_at(&delivered_path)
+                .unwrap()
+                .delivered_frontier
+                .unwrap()
+                .range,
+            (7, 77)
+        );
+
+        // `commit_and_advance(.., NotDelivered)` can still return true, but the
+        // in-memory confirmed_end_offset did not advance, so M4 requires no record.
+        let replace_committed = false;
+        let committed = true;
+        if replace_committed && committed {
+            record_delivered_frontier_shadow_at(
+                &not_delivered_path,
+                (7, 77),
+                123,
+                0,
+                Some(555),
+                Some(999),
+                0,
+            )
+            .unwrap();
+        }
+        assert!(read_record_at(&not_delivered_path).is_none());
+    }
+
+    #[test]
     fn shadow_reports_divergence_but_still_writes_and_never_panics() {
         // A durable-vs-memory END mismatch is observe-only: it reports `true`
         // (logged upstream) and STILL writes the frontier — no panic.

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -4580,17 +4580,29 @@ pub(super) fn spawn_turn_bridge(
                 // `NoRange` has NO new bytes → no advance outside a lease (codex
                 // P1-b: a degenerate equal-nonzero range must not advance).
                 if let Some(lease) = stop_lease {
+                    let lease_range = lease.range();
                     let outcome = if replace_committed {
                         crate::services::discord::LeaseOutcome::Delivered
                     } else {
                         crate::services::discord::LeaseOutcome::NotDelivered
                     };
-                    lease.commit_and_advance(
+                    let committed = lease.commit_and_advance(
                         shared_owned.as_ref(),
                         watcher_owner_channel_id,
                         inflight_state.tmux_session_name.as_deref(),
                         outcome,
                     );
+                    if replace_committed && committed {
+                        super::outbound::delivery_record::shadow_mirror_delivered_frontier(
+                            shared_owned.as_ref(),
+                            &provider,
+                            watcher_owner_channel_id,
+                            lease_range,
+                            true,
+                            Some(current_msg_id.get()),
+                            Some(channel_id.get()),
+                        );
+                    }
                 }
                 if !replace_committed {
                     preserve_inflight_for_cleanup_retry = true;
@@ -4664,17 +4676,29 @@ pub(super) fn spawn_turn_bridge(
                 // B6 (codex P1-b): advance ONLY via a successful lease commit.
                 // NoRange has no new bytes → no advance outside the lease.
                 if let Some(lease) = plt_lease {
+                    let lease_range = lease.range();
                     let outcome = if replace_committed {
                         crate::services::discord::LeaseOutcome::Delivered
                     } else {
                         crate::services::discord::LeaseOutcome::NotDelivered
                     };
-                    lease.commit_and_advance(
+                    let committed = lease.commit_and_advance(
                         shared_owned.as_ref(),
                         watcher_owner_channel_id,
                         inflight_state.tmux_session_name.as_deref(),
                         outcome,
                     );
+                    if replace_committed && committed {
+                        super::outbound::delivery_record::shadow_mirror_delivered_frontier(
+                            shared_owned.as_ref(),
+                            &provider,
+                            watcher_owner_channel_id,
+                            lease_range,
+                            true,
+                            Some(current_msg_id.get()),
+                            Some(channel_id.get()),
+                        );
+                    }
                 }
                 if !replace_committed {
                     preserve_inflight_for_cleanup_retry = true;


### PR DESCRIPTION
## 배경 (#3630 재발)
#3633은 turn_bridge의 **legacy short-replace arm 1곳만** durable delivery-record frontier를 mirror했다. `LeaseOutcome::Delivered`로 commit하는 다른 종료-전달 arm들은 in-memory `confirmed_end_offset`만 advance하고 durable frontier를 기록하지 않아, 재시작 후 no-inflight/restored-seed watcher dedup(`effective_committed_offset = max(durable_end, in_memory)`)이 0을 보고 같은 터미널 body를 새 메시지로 **재릴레이** = 중복 재발.

재발 증거: #adk-cc(1479671298497183835) 2026-06-21 23:31 UTC, 동일 prose 첫 문단 2회. 당시 운영본 4037528db(#3633 포함) → 수정 불완전 확정.

## 변경
#3633의 검증된 `shadow_mirror_delivered_frontier` 패턴을 2개 arm에 확장:
- **cancel/stop replace** (`stop_lease`, mod.rs:4580)
- **prompt_too_long replace** (`plt_lease`, mod.rs:4676) — #3630 직접 원인 유력(context-reset 후 warm-followup→restored-seed)

각 arm: `lease.range()`를 commit **前** 캡처 → `committed = commit_and_advance(.., outcome)` → `if replace_committed && committed { shadow_mirror_delivered_frontier(.., lease_range, true, Some(current_msg_id), Some(channel_id)) }`.

## 불변식
- **M4**: mirror는 `replace_committed && committed`(=Delivered+commit성공)에서만. NotDelivered는 commit이 true 반환해도 confirmed_end_offset 미advance → 기록 금지(M4 위반·정당 retry 억제 방지). #3633 codex 리뷰 지적 그대로 적용.
- `commit_and_advance`/`confirmed_end_offset`/#3607 black-hole 보호 **불변**.
- **silent_turn arm(5024)은 스코프 제외**: 본문 미post라 재릴레이 콘텐츠 없음, msg_id 의미 불확실 → 필요시 별도.

## 테스트 / 게이트
- `replace_mirror_gate_records_only_delivered_committed_3630`: Delivered+committed에서 frontier 기록, NotDelivered에서 미기록 검증.
- `cargo fmt --check`/`cargo check --lib` 클린, `cargo test --lib turn_bridge` 197/197, `delivery_record` 46/46.
- freshness passed(turn_bridge 6221 동기, multinode-transition audited touch), `ci-script-checks.sh` EXIT=0 (hotfile 6621→6644, giant 6221, 둘 다 +23 최소).

## 리뷰
구현: codex(gpt-5.5). 적대 리뷰: opus(교차) — M4 게이트·lease.range commit前 캡처·바인딩 정확성·silent_turn 제외·#3607 불변 검증 → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)