### PR TITLE
fix(#3641): boot-time orphan discord_inflight .json.lock sweep (무한 누적 차단)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1241,8 +1241,8 @@
     `giant-file-registry.md` (owner `automation-pipeline`, deadline
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
-    discord_config_audit.rs, router/intake_gate.rs, inflight.rs}`
-    (all 1000+ production lines).
+    discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
+    lines) and `src/services/discord/inflight.rs` (2771 lines).
 - active_callsite_coverage: n/a.
 - invariants: watcher single-owner per #1222; placeholder lifecycle invariants
   per #1112; `/api/inflight/rebind` is the only path that synthesises an

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -848,6 +848,12 @@
   token-built Http fallback on standby nodes) are byte-identical and stay
   process-local. No new multinode ownership, singleton, or lease assumption
   is introduced.
+- #3641 (boot-time orphan inflight `.lock` sweep): `inflight.rs` now removes
+  old `discord_inflight/{provider}/*.json.lock` sidecars only when the matching
+  `.json` inflight row is absent and the lock mtime is past the conservative
+  age floor. This is worker-local filesystem hygiene for advisory-lock sidecars:
+  it does not touch live `.json` rows, durable queues, leases, leader/standby
+  ownership, or cross-node routing semantics.
 - Active-session audit: `active_session_audit` adds read-only health diagnostics
   plus optional local repair-path metadata for stale running-session rows. It
   does not move Discord gateway startup, worker ownership, durable queue claims,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -425,7 +425,12 @@
 # path now route their unlink through this single helper (the boot branch loses
 # its inline lock+reload). The bulk is load-bearing doc comments; the 4 new
 # boundary tests live in the excluded `rebind_origin_reap_tests` module.
-"src/services/discord/inflight.rs" = 2660
+# #3641 raised 2660 -> 2771 (+111): boot-time orphan `.json.lock` sweep for
+# `discord_inflight/{provider}` sidecars whose matching `.json` row is gone.
+# Adds the 1h conservative age floor, lock-name/base-path helpers, root-explicit
+# testable sweep, runtime-root wrapper, and boot hook. Tests live in the excluded
+# `orphan_lock_reap_tests` module.
+"src/services/discord/inflight.rs" = 2771 # #3641 orphan-lock sweep
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -99,6 +99,13 @@ pub(super) const INFLIGHT_STALENESS_THRESHOLD_SECS: u64 = 300;
 /// is never raced. Overridable via `AGENTDESK_REBIND_ORIGIN_DEADLINE_SECS`.
 pub(super) const REBIND_ORIGIN_DEADLINE_SECS_DEFAULT: u64 = 120;
 
+/// #3641: orphan sidecar lock files are cosmetic after process death because
+/// `flock` releases with the fd, but stale paths can accumulate forever once the
+/// matching `.json` state row has been cleaned/quarantined. Keep the reap
+/// conservative so a fresh lock created just before its `.json` row is written is
+/// never touched.
+pub(super) const ORPHAN_LOCK_REAP_MIN_AGE_SECS: i64 = 3600;
+
 /// #3581: floor for the env-overridden rebind-origin deadline. Guards against a
 /// pathologically small (or zero) override reaping rows before the adoption
 /// backstop window can complete.
@@ -236,6 +243,109 @@ pub(super) fn emit_reap_abandoned_rebind_origin(
 
 pub(super) fn inflight_runtime_root() -> Option<PathBuf> {
     discord_inflight_root()
+}
+
+fn is_inflight_json_lock_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".json.lock"))
+}
+
+fn inflight_json_path_for_lock(lock_path: &Path) -> Option<PathBuf> {
+    let file_name = lock_path.file_name()?.to_str()?;
+    let json_file_name = file_name.strip_suffix(".lock")?;
+    Some(lock_path.with_file_name(json_file_name))
+}
+
+fn metadata_mtime_unix_secs(metadata: &fs::Metadata) -> Option<i64> {
+    metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs() as i64)
+}
+
+/// #3641: boot-time cleanup for orphan `discord_inflight/{provider}/*.json.lock`
+/// sidecars whose matching `.json` state file no longer exists. The lock file is
+/// never authoritative by itself: live turns are protected by the existence of
+/// the `.json` row, and fresh first-acquire locks are protected by the age floor.
+pub(super) fn reap_orphan_inflight_locks_in_root(root: &Path, now_unix: i64) -> usize {
+    let mut removed = 0usize;
+    for provider in [ProviderKind::Claude, ProviderKind::Codex] {
+        let provider_dir = inflight_provider_dir(root, &provider);
+        let provider_name = provider.as_str();
+        let Ok(lock_entries) = fs::read_dir(&provider_dir) else {
+            continue;
+        };
+
+        for lock_entry in lock_entries {
+            let Ok(lock_entry) = lock_entry else {
+                continue;
+            };
+            let lock_path = lock_entry.path();
+            if !is_inflight_json_lock_path(&lock_path) {
+                continue;
+            }
+            let Some(json_path) = inflight_json_path_for_lock(&lock_path) else {
+                continue;
+            };
+            if json_path.exists() {
+                continue;
+            }
+
+            let Ok(metadata) = lock_entry.metadata() else {
+                tracing::warn!(
+                    provider = provider_name,
+                    path = %lock_path.display(),
+                    "#3641 failed to stat inflight orphan-lock candidate"
+                );
+                continue;
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+            let Some(mtime_unix) = metadata_mtime_unix_secs(&metadata) else {
+                continue;
+            };
+            let age_secs = now_unix.saturating_sub(mtime_unix).max(0);
+            if age_secs < ORPHAN_LOCK_REAP_MIN_AGE_SECS {
+                continue;
+            }
+            if json_path.exists() {
+                continue;
+            }
+
+            match fs::remove_file(&lock_path) {
+                Ok(()) => removed += 1,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    tracing::warn!(
+                        provider = provider_name,
+                        path = %lock_path.display(),
+                        error = %error,
+                        "#3641 failed to remove orphan inflight lock file"
+                    );
+                }
+            }
+        }
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            removed,
+            root = %root.display(),
+            "#3641 reaped orphan inflight lock file(s)"
+        );
+    }
+    removed
+}
+
+pub(super) fn reap_orphan_inflight_locks() -> usize {
+    let Some(root) = inflight_runtime_root() else {
+        return 0;
+    };
+    reap_orphan_inflight_locks_in_root(&root, now_unix())
 }
 
 /// #2235: expose the local `INFLIGHT_STATE_VERSION` so the recovery engine
@@ -5474,6 +5584,82 @@ mod stall_recovery_tests {
         assert!(
             reason.contains("removing stale inflight state file"),
             "unexpected removal reason: {reason}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod orphan_lock_reap_tests {
+    //! #3641: orphan `.json.lock` sidecars are not seen by the `.json` row scans.
+    use super::{ORPHAN_LOCK_REAP_MIN_AGE_SECS, reap_orphan_inflight_locks_in_root};
+    use crate::services::provider::ProviderKind;
+    use filetime::{FileTime, set_file_mtime};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn write_file_with_age(path: &Path, now_unix: i64, age_secs: i64) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, b"lock").unwrap();
+        set_file_mtime(
+            path,
+            FileTime::from_unix_time(now_unix.saturating_sub(age_secs), 0),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reaps_only_old_orphan_json_lock_files() {
+        let temp = TempDir::new().unwrap();
+        let now_unix = 1_800_000_000;
+        let old_age = ORPHAN_LOCK_REAP_MIN_AGE_SECS + 10;
+        let recent_age = ORPHAN_LOCK_REAP_MIN_AGE_SECS - 10;
+        let provider_dir = temp.path().join(ProviderKind::Codex.as_str());
+
+        let old_orphan_lock = provider_dir.join("101.json.lock");
+        write_file_with_age(&old_orphan_lock, now_unix, old_age);
+
+        let matched_json = provider_dir.join("202.json");
+        let matched_lock = provider_dir.join("202.json.lock");
+        std::fs::write(&matched_json, b"{}").unwrap();
+        write_file_with_age(&matched_lock, now_unix, old_age);
+
+        let recent_orphan_lock = provider_dir.join("303.json.lock");
+        write_file_with_age(&recent_orphan_lock, now_unix, recent_age);
+
+        let quarantine_marker = provider_dir.join("404.json.rebind-stall-123");
+        write_file_with_age(&quarantine_marker, now_unix, old_age);
+
+        let non_json_lock = provider_dir.join("505.lock");
+        write_file_with_age(&non_json_lock, now_unix, old_age);
+
+        let removed = reap_orphan_inflight_locks_in_root(temp.path(), now_unix);
+
+        assert_eq!(removed, 1, "only the old orphan .json.lock is reaped");
+        assert!(
+            !old_orphan_lock.exists(),
+            "old orphan lock with no matching .json must be removed"
+        );
+        assert!(
+            matched_json.exists(),
+            "matching .json state row must never be touched"
+        );
+        assert!(
+            matched_lock.exists(),
+            "lock with matching .json state row must be kept even when old"
+        );
+        assert!(
+            recent_orphan_lock.exists(),
+            "recent orphan lock must stay below the age floor"
+        );
+        assert!(
+            quarantine_marker.exists(),
+            "quarantine marker must not match the .json.lock sweep"
+        );
+        assert!(
+            non_json_lock.exists(),
+            "non-.json.lock files are out of scope"
         );
     }
 }

--- a/src/services/discord/runtime_bootstrap/recovery_flush.rs
+++ b/src/services/discord/runtime_bootstrap/recovery_flush.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+static ORPHAN_INFLIGHT_LOCK_SWEEP_ONCE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
 /// Restore inflight turns FIRST, then flush restart reports (leader-only).
 /// Recovery skips channels that have a pending restart report, so the report
 /// must still be on disk when recovery runs. After recovery completes, the
@@ -213,6 +215,12 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                 // stranded on the channel.
                 stale_cards_to_delete = filter_outcome.stale_cards;
             }
+
+            // #3641: orphan `.json.lock` sidecars are invisible to the `.json`
+            // row scans below, so sweep them once per process before inflight
+            // recovery starts. The sweep itself enumerates provider subdirs.
+            let _ = ORPHAN_INFLIGHT_LOCK_SWEEP_ONCE
+                .get_or_init(super::inflight::reap_orphan_inflight_locks);
 
             // #2437 (#2427 C wire) boot-time generation
             // invalidate. Remove non-planned-restart inflight


### PR DESCRIPTION
## 배경
`discord_inflight/{provider}/{channel}.json.lock`가 대응 `.json` 정리/격리 후에도 영구 잔존. boot 스캔(#2437 invalidate 등)은 `.json` 행만 순회 → orphan `.lock` 무한 누적(운영 74개 관측). flock은 프로세스 死 시 OS 자동 해제라 **cosmetic**(기능 차단 아님)이나 inode/디렉토리 누적.

## 변경
- `reap_orphan_inflight_locks_in_root(root, now_unix)` (inflight.rs): claude/codex provider 하위 `*.json.lock` 순회 → 대응 `.json` 부재 **AND** mtime `1h`(ORPHAN_LOCK_REAP_MIN_AGE_SECS) 초과 시에만 `remove_file`(best-effort). 런타임 wrapper `reap_orphan_inflight_locks()`.
- boot hook: `recovery_flush.rs`에서 `OnceLock`으로 **프로세스당 1회**, #2437 boot invalidate 직전 실행.

## 안전 불변식
- 활성 턴(`.json` 존재) → 절대 미터치(이중 체크).
- 신규 first-acquire(`.json` 미기록, <1h) → age floor로 배제.
- quarantine 마커(`.rebind-stall-*`/`.orphan-noreply-*`/`.cleared-*` 등 non-`.json.lock`) → suffix 정확 매칭으로 미터치.
- 제거 실패는 warn+continue(NotFound 무시), panic 없음.

## 테스트 / 게이트
- `orphan_lock_reap_tests::reaps_only_old_orphan_json_lock_files`: 5경계(old orphan 제거 / matched-json 보존 / recent 보존 / quarantine 마커 보존 / non-json-lock 보존), `filetime`로 mtime 결정적.
- `cargo fmt --check`/`cargo check --lib` 클린, `cargo test --lib inflight` 233 passed, freshness passed, `ci-script-checks.sh` EXIT=0 (giant 2660→2771, 테스트 excluded 모듈).

## 스코프 노트
boot hook은 recovery_flush(leader-flush 경로)에 위치 — 노드별 root sweep은 recovery 실행 노드 기준(multinode audited touch 기록). cosmetic이라 영향 미미. silent_turn 등 별개 quarantine 정리는 범위 밖.

## 리뷰
구현: codex(gpt-5.5). 적대 리뷰: opus(교차) — suffix 매칭·base 산출·`.json` 보호·mtime 방향·boot-once·테스트 5경계 검증 → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)