### PR TITLE
fix(#3607): 터미널 전달 후 TUI quiescence 타임아웃 카드 stuck 해소 — durable UI obligation sidecar + sweeper

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -660,6 +660,7 @@ src/
 │   │   ├── steering.rs
 │   │   ├── streaming_finalizer.rs
 │   │   ├── task_supervisor.rs
+│   │   ├── terminal_ui_obligation.rs
 │   │   ├── tmux.rs
 │   │   ├── tmux_error_detect.rs
 │   │   ├── tmux_kill_policy.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1045,7 +1045,7 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6221 prod lines; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6241 lines; production LoC; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.
@@ -1070,7 +1070,17 @@
     into `streaming_edit_text.rs` and the watcher-orphan spinner-cleanup
     decision + retry-spawn helpers into `watcher_orphan_cleanup.rs` (both
     re-exported, call sites byte-identical).
+    #3607 adds only the TimedOut+committed terminal-UI obligation hook in the
+    hot branch; the durable sidecar store + isolated sweeper live in
+    `terminal_ui_obligation.rs`. It edits only the turn's status card and does
+    not touch body delivery, offset authority, or `delivery_record.rs`.
     Hotfile — bugfix only outside the #3038 decompose plan).
+  - `src/services/discord/terminal_ui_obligation.rs` (545 prod LoC; #3607
+    worker-local durable terminal-UI obligation sidecar store plus isolated
+    status-card reconciliation sweeper. The file owns
+    `discord_terminal_ui_obligations/<provider>/<channel_id>.json`, pure
+    record/reconcile predicates, and boot-resumed status-card edit convergence.
+    It is below the giant-file threshold).
   - `src/services/discord/turn_bridge/cancel_finalize_policy.rs` (131 prod
     lines; pure cancel/finalize-policy decisions extracted from `mod.rs` by
     #3479: `classify_turn_finished_dispatch_kind`,

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -469,6 +469,15 @@
   leader election, gateway lease, PG ownership, startup order, worker ownership,
   or singleton assumption is touched; the recovery-fallback criterion is
   deferred to #3610.
+- #3607 terminal-UI obligation durable sidecar + sweeper: the
+  TimedOut+committed terminal path writes a worker-local sidecar obligation and
+  edits only the existing status card to "delivered / session-end confirming";
+  `terminal_ui_obligation.rs` owns the durable sidecar and isolated sweeper that
+  converges the same card to ✅ on pane idle or ⚠ on deadline. This is a
+  worker-local UI reconcile over per-channel runtime state, not a body-delivery
+  authority: no assistant body repost, no response/confirmed offset movement,
+  no `delivery_record.rs` frontier reuse, and no new leader election, gateway
+  lease, PG ownership, startup order, worker ownership, or singleton assumption.
 - #3560 single_message_panel default-ON + footer-mode migration guard: the
   `single_message_panel` flag is now default-ON (opt-out via
   `AGENTDESK_SINGLE_MESSAGE_PANEL=0|false`) and `turn_bridge/mod.rs` gained a

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -142,7 +142,10 @@
 # #3560: +9 (6189 -> 6198) for the footer-mode migration reconcile — the
 # migrate_separate_status_panel_to_footer call + comment at the footer-mode entry
 # (helper body itself extracted to turn_bridge/status_panel.rs, net decomposition).
-"src/services/discord/turn_bridge/mod.rs" = 6221 # #3630 frontier mirror for cancel/stop + prompt_too_long terminal arms
+# #3607: +20 raw / +20 prod for the TimedOut+committed terminal-UI obligation
+# hook. The durable sidecar store + isolated sweeper live in
+# terminal_ui_obligation.rs; this keeps the hot-file cost to the call-site hook.
+"src/services/discord/turn_bridge/mod.rs" = 6241 # #3607 terminal-UI obligation hook
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -56,4 +56,6 @@
 # #3560: 6612 -> 6621 (+9), reviewable admission — footer-mode separate-panel
 # migration reconcile call + comment at the resume entry. Helper body lives in
 # turn_bridge/status_panel.rs; this is the minimal call-site cost.
-"src/services/discord/turn_bridge/mod.rs" = 6644 # #3630 frontier mirror for cancel/stop + prompt_too_long arms
+# #3607: 6644 -> 6664 (+20), TimedOut+committed terminal-UI obligation hook;
+# durable sidecar + sweeper body lives in terminal_ui_obligation.rs.
+"src/services/discord/turn_bridge/mod.rs" = 6664 # #3607 terminal-UI obligation hook

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -77,6 +77,7 @@ mod status_panel_orphan_store;
 mod steering;
 pub(in crate::services::discord) mod streaming_finalizer;
 pub(in crate::services::discord) mod task_supervisor;
+mod terminal_ui_obligation;
 #[cfg(unix)]
 mod tmux;
 #[cfg(unix)]

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -31,7 +31,7 @@ use completion_footer::{CompletionFooterRender, render_completion_footer};
 use context_panel::ContextPanelSnapshot;
 use recent_events::render_events;
 use session_panel::SessionPanelSnapshot;
-use status_panel::{StatusPanelState, render_status_panel};
+use status_panel::{CompletedKind, DerivedStatus, StatusPanelState, render_status_panel};
 pub(in crate::services::discord) use task_panel::TaskPanelInfo;
 use task_panel::{TaskPanelSnapshot, clean_task_panel_value};
 
@@ -41,9 +41,7 @@ use common::{
     STATUS_PANEL_WORKFLOW_LIMIT, STATUS_PANEL_WORKFLOW_PHASE_LIMIT,
 };
 #[cfg(test)]
-use status_panel::{
-    CompletedKind, DerivedStatus, render_recent_section_header, truncate_status_panel_sections,
-};
+use status_panel::{render_recent_section_header, truncate_status_panel_sections};
 
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
@@ -86,6 +84,13 @@ pub(in crate::services::discord) struct LiveContextPanelSnapshot {
     pub(in crate::services::discord) provider_session_id: Option<String>,
     pub(in crate::services::discord) used_tokens: u64,
     pub(in crate::services::discord) context_window_tokens: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum TerminalUiObligationPanelStatus {
+    Pending,
+    Completed,
+    Deadline,
 }
 
 impl PlaceholderLiveEvents {
@@ -433,6 +438,41 @@ impl PlaceholderLiveEvents {
             provider,
             started_at_unix,
             chrono::Utc::now().timestamp(),
+        )
+    }
+
+    pub(in crate::services::discord) fn render_terminal_ui_obligation_panel(
+        &self,
+        channel_id: ChannelId,
+        provider: &ProviderKind,
+        started_at_unix: i64,
+        status: TerminalUiObligationPanelStatus,
+    ) -> String {
+        let mut snapshot = self
+            .status_by_channel
+            .get(&channel_id)
+            .map(|entry| {
+                entry
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone()
+            })
+            .unwrap_or_default();
+        snapshot.status = match status {
+            TerminalUiObligationPanelStatus::Pending => DerivedStatus::TerminalDeliveryPending,
+            TerminalUiObligationPanelStatus::Completed => DerivedStatus::Completed {
+                kind: CompletedKind::Foreground,
+            },
+            TerminalUiObligationPanelStatus::Deadline => DerivedStatus::TerminalDeliveryUnconfirmed,
+        };
+        let completed = matches!(status, TerminalUiObligationPanelStatus::Completed);
+        render_status_panel(
+            snapshot,
+            self.render_block(channel_id),
+            provider,
+            started_at_unix,
+            chrono::Utc::now().timestamp(),
+            !completed,
         )
     }
 

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -42,11 +42,14 @@ pub(super) struct SubagentSlot {
     /// `TaskToolSlot::ordinal`) backing slot-identity subagent eviction.
     ordinal: u64,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) enum DerivedStatus {
+    #[default]
     Running,
     MonitorWait,
     ScheduleWakeup(Option<u64>),
+    TerminalDeliveryPending,
+    TerminalDeliveryUnconfirmed,
     Completed {
         kind: CompletedKind,
     },
@@ -75,12 +78,6 @@ impl CompletedKind {
         } else {
             Self::Foreground
         }
-    }
-}
-
-impl Default for DerivedStatus {
-    fn default() -> Self {
-        Self::Running
     }
 }
 
@@ -606,6 +603,10 @@ fn render_derived_status(status: &DerivedStatus) -> String {
             format!("⏰ scheduled wakeup ({eta_secs}s 후)")
         }
         DerivedStatus::ScheduleWakeup(None) => "⏰ scheduled wakeup".to_string(),
+        DerivedStatus::TerminalDeliveryPending => "↻ 응답 전달됨 · 세션 종료 확인 중".to_string(),
+        DerivedStatus::TerminalDeliveryUnconfirmed => {
+            "⚠ 응답 전달됨 · 세션 종료 미확인".to_string()
+        }
         DerivedStatus::Completed {
             kind: CompletedKind::Background,
         } => "✅ **백그라운드 완료**".to_string(),

--- a/src/services/discord/runtime_bootstrap/framework_setup.rs
+++ b/src/services/discord/runtime_bootstrap/framework_setup.rs
@@ -141,6 +141,15 @@ pub(super) async fn run_bot_framework_setup(
         health_registry_for_setup.started_at_unix(),
     );
 
+    // #3607: durable UI-only reconciliation for terminal-delivered turns whose
+    // TUI quiescence confirmation timed out. The sidecar survives restart; the
+    // sweeper picks up existing records on its first immediate tick.
+    super::terminal_ui_obligation::spawn_terminal_ui_obligation_sweeper(
+        ctx.http.clone(),
+        shared_clone.clone(),
+        provider_for_setup.clone(),
+    );
+
     // #2436 (#2427 B wire): heartbeat-gap → explicit
     // inflight cleanup. Faster cadence than the placeholder
     // sweeper so a silently hung watcher loop is evicted

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -129,6 +129,14 @@ pub(super) fn discord_status_panel_orphans_root() -> Option<PathBuf> {
     runtime_root().map(|root| root.join("discord_status_panel_orphans"))
 }
 
+/// #3607: durable UI-only obligations for terminal-delivered turns whose TUI
+/// quiescence gate timed out after the answer was already committed. This store
+/// owns only status-card edits; it is intentionally separate from inflight and
+/// delivery-record relay frontiers.
+pub(crate) fn discord_terminal_ui_obligations_root() -> Option<PathBuf> {
+    runtime_root().map(|root| root.join("discord_terminal_ui_obligations"))
+}
+
 /// #1332 round-3 codex review P2: per-channel sidecar root for the
 /// `queued_placeholders` mapping. Persisted next to `discord_pending_queue/`
 /// so a dcserver restart can re-attach restored mailbox queue entries to the

--- a/src/services/discord/terminal_ui_obligation.rs
+++ b/src/services/discord/terminal_ui_obligation.rs
@@ -1,0 +1,717 @@
+//! Durable status-card reconciliation for #3607.
+//!
+//! This sidecar owns only terminal UI status-card edits after the terminal body
+//! was already delivered. It deliberately does not read-modify-write inflight
+//! response fields or delivery-record frontiers.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use poise::serenity_prelude as serenity;
+use serde::{Deserialize, Serialize};
+use serenity::{ChannelId, MessageId};
+
+use super::inflight::{self, InflightTurnState};
+use super::placeholder_live_events::TerminalUiObligationPanelStatus;
+use super::{SharedData, http, runtime_store};
+use crate::services::provider::ProviderKind;
+
+const SWEEP_INTERVAL_SECS: u64 = 15;
+const OBLIGATION_DEADLINE_SECS: i64 = 600;
+const EDIT_RETRY_GIVE_UP_GRACE_SECS: i64 = (SWEEP_INTERVAL_SECS as i64) * 2;
+
+static SWEEPER_STARTED: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(in crate::services::discord) struct TerminalUiObligation {
+    #[serde(default)]
+    pub(in crate::services::discord) channel_id: u64,
+    #[serde(default)]
+    pub(in crate::services::discord) provider: String,
+    #[serde(default)]
+    pub(in crate::services::discord) status_message_id: u64,
+    #[serde(default)]
+    pub(in crate::services::discord) generation_mtime_ns: i64,
+    #[serde(default)]
+    pub(in crate::services::discord) pending_state_text: String,
+    #[serde(default)]
+    pub(in crate::services::discord) completion_text: String,
+    #[serde(default)]
+    pub(in crate::services::discord) deadline_text: String,
+    #[serde(default)]
+    pub(in crate::services::discord) created_unix: i64,
+    #[serde(default)]
+    pub(in crate::services::discord) deadline_unix: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum TerminalUiReconcileAction {
+    Complete,
+    Deadline,
+    Wait,
+}
+
+#[derive(Debug)]
+enum TerminalUiSessionLookup {
+    Current(TerminalUiSessionSnapshot),
+    Stale(&'static str),
+    Missing(&'static str),
+}
+
+#[derive(Debug)]
+struct TerminalUiSessionSnapshot {
+    tmux_session_name: String,
+    output_path: Option<String>,
+    current_offset: u64,
+}
+
+pub(in crate::services::discord) fn terminal_ui_obligation_now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+pub(in crate::services::discord) fn build_terminal_ui_obligation(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    status_message_id: MessageId,
+    generation_mtime_ns: i64,
+    pending_state_text: String,
+    completion_text: String,
+    deadline_text: String,
+    created_unix: i64,
+) -> TerminalUiObligation {
+    TerminalUiObligation {
+        channel_id: channel_id.get(),
+        provider: provider.as_str().to_string(),
+        status_message_id: status_message_id.get(),
+        generation_mtime_ns,
+        pending_state_text,
+        completion_text,
+        deadline_text,
+        created_unix,
+        deadline_unix: created_unix.saturating_add(OBLIGATION_DEADLINE_SECS),
+    }
+}
+
+pub(in crate::services::discord) fn should_record_terminal_ui_obligation(
+    terminal_delivery_committed: bool,
+    gate_timed_out: bool,
+    status_message_id_present: bool,
+) -> bool {
+    terminal_delivery_committed && gate_timed_out && status_message_id_present
+}
+
+pub(in crate::services::discord) async fn record_terminal_ui_obligation_pending_status(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    status_message_id: MessageId,
+    status_panel_started_at: i64,
+    inflight_state: &InflightTurnState,
+) {
+    let pending_state_text = shared
+        .ui
+        .placeholder_live_events
+        .render_terminal_ui_obligation_panel(
+            channel_id,
+            provider,
+            status_panel_started_at,
+            TerminalUiObligationPanelStatus::Pending,
+        );
+    let completion_text = shared
+        .ui
+        .placeholder_live_events
+        .render_terminal_ui_obligation_panel(
+            channel_id,
+            provider,
+            status_panel_started_at,
+            TerminalUiObligationPanelStatus::Completed,
+        );
+    let deadline_text = shared
+        .ui
+        .placeholder_live_events
+        .render_terminal_ui_obligation_panel(
+            channel_id,
+            provider,
+            status_panel_started_at,
+            TerminalUiObligationPanelStatus::Deadline,
+        );
+    let created_unix = terminal_ui_obligation_now_unix();
+    let obligation = build_terminal_ui_obligation(
+        provider,
+        channel_id,
+        status_message_id,
+        terminal_ui_generation_mtime_for_inflight(inflight_state),
+        pending_state_text.clone(),
+        completion_text,
+        deadline_text,
+        created_unix,
+    );
+    match write_obligation(&obligation) {
+        Ok(()) => {
+            edit_terminal_ui_pending_status(
+                shared,
+                provider,
+                channel_id,
+                status_message_id,
+                &pending_state_text,
+            )
+            .await;
+        }
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = channel_id.get(),
+                status_message_id = status_message_id.get(),
+                error = %error,
+                "failed to persist terminal UI obligation after committed TUI quiescence timeout"
+            );
+        }
+    }
+}
+
+async fn edit_terminal_ui_pending_status(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    status_message_id: MessageId,
+    pending_state_text: &str,
+) {
+    let Some(http) = shared.serenity_http_or_token_fallback() else {
+        tracing::warn!(
+            provider = %provider.as_str(),
+            channel = channel_id.get(),
+            status_message_id = status_message_id.get(),
+            "missing Discord HTTP handle for terminal UI obligation pending status; sweeper will retry"
+        );
+        return;
+    };
+    match http::edit_channel_message(&http, channel_id, status_message_id, pending_state_text).await
+    {
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = channel_id.get(),
+                status_message_id = status_message_id.get(),
+                error = %error,
+                "failed to edit terminal UI obligation pending status; sweeper will retry"
+            );
+        }
+    }
+}
+
+pub(in crate::services::discord) fn terminal_ui_obligation_generation_is_current(
+    obligation_generation_mtime_ns: i64,
+    current_generation_mtime_ns: i64,
+) -> bool {
+    obligation_generation_mtime_ns != 0
+        && current_generation_mtime_ns != 0
+        && obligation_generation_mtime_ns == current_generation_mtime_ns
+}
+
+pub(in crate::services::discord) fn terminal_ui_reconcile_action(
+    pane_idle: bool,
+    now_unix: i64,
+    deadline_unix: i64,
+) -> TerminalUiReconcileAction {
+    if pane_idle {
+        TerminalUiReconcileAction::Complete
+    } else if now_unix >= deadline_unix {
+        TerminalUiReconcileAction::Deadline
+    } else {
+        TerminalUiReconcileAction::Wait
+    }
+}
+
+pub(in crate::services::discord) fn terminal_ui_generation_mtime_for_inflight(
+    state: &InflightTurnState,
+) -> i64 {
+    state
+        .last_watcher_relayed_generation_mtime_ns
+        .filter(|generation| *generation != 0)
+        .or_else(|| {
+            state
+                .tmux_session_name
+                .as_deref()
+                .map(read_tmux_generation_mtime_ns)
+                .filter(|generation| *generation != 0)
+        })
+        .unwrap_or_else(|| runtime_store::load_generation() as i64)
+}
+
+pub(in crate::services::discord) fn write_obligation(
+    obligation: &TerminalUiObligation,
+) -> Result<(), String> {
+    let root = runtime_store::discord_terminal_ui_obligations_root()
+        .ok_or_else(|| "runtime root unavailable for terminal UI obligation".to_string())?;
+    write_obligation_in_root(&root, obligation)
+}
+
+#[allow(dead_code)] // #3607 public sidecar API; production currently sweeps via list_obligations.
+pub(in crate::services::discord) fn read_obligation(
+    provider: &ProviderKind,
+    channel_id: u64,
+) -> Option<TerminalUiObligation> {
+    let root = runtime_store::discord_terminal_ui_obligations_root()?;
+    read_obligation_in_root(&root, provider.as_str(), channel_id)
+}
+
+pub(in crate::services::discord) fn list_obligations() -> Vec<TerminalUiObligation> {
+    let Some(root) = runtime_store::discord_terminal_ui_obligations_root() else {
+        return Vec::new();
+    };
+    list_obligations_in_root(&root)
+}
+
+#[allow(dead_code)] // #3607 public sidecar API; production currently clears by stored provider key.
+pub(in crate::services::discord) fn clear_obligation(
+    provider: &ProviderKind,
+    channel_id: u64,
+) -> bool {
+    clear_obligation_by_key(provider.as_str(), channel_id)
+}
+
+pub(crate) fn spawn_terminal_ui_obligation_sweeper(
+    http: Arc<serenity::Http>,
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+) {
+    let started_key = provider.as_str().to_string();
+    {
+        let mut started = SWEEPER_STARTED
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !started.insert(started_key) {
+            return;
+        }
+    }
+
+    super::task_supervisor::spawn_observed("terminal_ui_obligation_sweeper", async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(SWEEP_INTERVAL_SECS));
+        loop {
+            interval.tick().await;
+            sweep_terminal_ui_obligations(&http, &shared, &provider).await;
+        }
+    });
+}
+
+async fn sweep_terminal_ui_obligations(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+) {
+    let now_unix = terminal_ui_obligation_now_unix();
+    for obligation in list_obligations()
+        .into_iter()
+        .filter(|obligation| obligation.provider == provider.as_str())
+    {
+        reconcile_terminal_ui_obligation(http, shared, provider, obligation, now_unix).await;
+    }
+}
+
+async fn reconcile_terminal_ui_obligation(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    obligation: TerminalUiObligation,
+    now_unix: i64,
+) {
+    if obligation.channel_id == 0 || obligation.status_message_id == 0 {
+        let _ = clear_obligation_by_key(&obligation.provider, obligation.channel_id);
+        return;
+    }
+    let channel_id = ChannelId::new(obligation.channel_id);
+    let lookup = resolve_terminal_ui_session(shared, provider, channel_id, &obligation).await;
+    let snapshot = match lookup {
+        TerminalUiSessionLookup::Current(snapshot) => snapshot,
+        TerminalUiSessionLookup::Stale(reason) => {
+            if clear_obligation_by_key(&obligation.provider, obligation.channel_id) {
+                tracing::warn!(
+                    provider = %obligation.provider,
+                    channel = obligation.channel_id,
+                    status_message_id = obligation.status_message_id,
+                    reason,
+                    "cleared stale terminal UI obligation without editing status card"
+                );
+            }
+            return;
+        }
+        TerminalUiSessionLookup::Missing(reason) => {
+            if now_unix
+                >= obligation
+                    .deadline_unix
+                    .saturating_add(EDIT_RETRY_GIVE_UP_GRACE_SECS)
+            {
+                if clear_obligation_by_key(&obligation.provider, obligation.channel_id) {
+                    tracing::warn!(
+                        provider = %obligation.provider,
+                        channel = obligation.channel_id,
+                        status_message_id = obligation.status_message_id,
+                        reason,
+                        "cleared terminal UI obligation after reconcile context stayed unavailable"
+                    );
+                }
+            }
+            return;
+        }
+    };
+
+    let pane_idle = terminal_ui_session_ready_for_input(provider, &snapshot);
+    let action = terminal_ui_reconcile_action(pane_idle, now_unix, obligation.deadline_unix);
+    let Some(content) = (match action {
+        TerminalUiReconcileAction::Complete => Some(obligation.completion_text.as_str()),
+        TerminalUiReconcileAction::Deadline => Some(obligation.deadline_text.as_str()),
+        TerminalUiReconcileAction::Wait => None,
+    }) else {
+        return;
+    };
+
+    super::discord_io::rate_limit_wait(shared, channel_id).await;
+    match http::edit_channel_message(
+        http,
+        channel_id,
+        MessageId::new(obligation.status_message_id),
+        content,
+    )
+    .await
+    {
+        Ok(_) => {
+            let _ = clear_obligation_by_key(&obligation.provider, obligation.channel_id);
+        }
+        Err(error) => {
+            tracing::warn!(
+                provider = %obligation.provider,
+                channel = obligation.channel_id,
+                status_message_id = obligation.status_message_id,
+                action = ?action,
+                error = %error,
+                "terminal UI obligation status-card edit failed; will retry"
+            );
+            if now_unix
+                >= obligation
+                    .deadline_unix
+                    .saturating_add(EDIT_RETRY_GIVE_UP_GRACE_SECS)
+            {
+                let _ = clear_obligation_by_key(&obligation.provider, obligation.channel_id);
+            }
+        }
+    }
+}
+
+async fn resolve_terminal_ui_session(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    obligation: &TerminalUiObligation,
+) -> TerminalUiSessionLookup {
+    if let Some(state) = inflight::load_inflight_state(provider, channel_id.get()) {
+        if state.status_message_id != Some(obligation.status_message_id) {
+            return TerminalUiSessionLookup::Stale("status_message_id_mismatch");
+        }
+        let current_generation_mtime_ns = terminal_ui_generation_mtime_for_inflight(&state);
+        if !terminal_ui_obligation_generation_is_current(
+            obligation.generation_mtime_ns,
+            current_generation_mtime_ns,
+        ) {
+            return TerminalUiSessionLookup::Stale("generation_mismatch");
+        }
+        let Some(tmux_session_name) = clean_nonempty(state.tmux_session_name.as_deref()) else {
+            return TerminalUiSessionLookup::Missing("inflight_missing_tmux_session");
+        };
+        let output_path = resolve_terminal_ui_output_path(
+            shared,
+            tmux_session_name,
+            state.output_path.as_deref(),
+        );
+        return TerminalUiSessionLookup::Current(TerminalUiSessionSnapshot {
+            tmux_session_name: tmux_session_name.to_string(),
+            current_offset: output_path.as_deref().map(output_file_len).unwrap_or(0),
+            output_path,
+        });
+    }
+
+    let Some(tmux_session_name) =
+        resolve_terminal_ui_tmux_session(shared, provider, channel_id).await
+    else {
+        return TerminalUiSessionLookup::Missing("missing_tmux_session");
+    };
+    let current_generation_mtime_ns = terminal_ui_generation_mtime_for_tmux(&tmux_session_name);
+    if !terminal_ui_obligation_generation_is_current(
+        obligation.generation_mtime_ns,
+        current_generation_mtime_ns,
+    ) {
+        return TerminalUiSessionLookup::Stale("generation_mismatch");
+    }
+    let output_path = resolve_terminal_ui_output_path(shared, &tmux_session_name, None);
+    TerminalUiSessionLookup::Current(TerminalUiSessionSnapshot {
+        tmux_session_name,
+        current_offset: output_path.as_deref().map(output_file_len).unwrap_or(0),
+        output_path,
+    })
+}
+
+async fn resolve_terminal_ui_tmux_session(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+) -> Option<String> {
+    if let Some(binding) = shared.tmux_watchers.channel_binding(&channel_id) {
+        return Some(binding.tmux_session_name);
+    }
+    if !provider.uses_managed_tmux_backend() {
+        return None;
+    }
+    let channel_name = {
+        let data = shared.core.lock().await;
+        data.sessions
+            .get(&channel_id)
+            .and_then(|session| session.channel_name.clone())
+    }?;
+    let tmux_session_name = provider.build_tmux_session_name(&channel_name);
+    if crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name)
+        || terminal_ui_generation_mtime_for_tmux(&tmux_session_name) != 0
+    {
+        Some(tmux_session_name)
+    } else {
+        None
+    }
+}
+
+fn resolve_terminal_ui_output_path(
+    shared: &Arc<SharedData>,
+    tmux_session_name: &str,
+    inflight_output_path: Option<&str>,
+) -> Option<String> {
+    clean_nonempty(inflight_output_path)
+        .map(str::to_string)
+        .or_else(|| shared.tmux_watchers.watcher_output_path(tmux_session_name))
+        .or_else(|| {
+            crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name)
+                .map(|binding| binding.relay_output_path().to_string())
+        })
+        .or_else(|| {
+            let (output_path, _) = super::turn_bridge::tmux_runtime_paths(tmux_session_name);
+            Some(output_path)
+        })
+}
+
+fn terminal_ui_session_ready_for_input(
+    provider: &ProviderKind,
+    snapshot: &TerminalUiSessionSnapshot,
+) -> bool {
+    let runtime_binding = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+        &snapshot.tmux_session_name,
+    );
+    let runtime_kind = runtime_binding
+        .as_ref()
+        .map(|binding| binding.runtime_kind)
+        .or_else(|| {
+            crate::services::tmux_common::resolve_tmux_runtime_kind_marker(
+                &snapshot.tmux_session_name,
+            )
+        });
+    if let Some(output_path) = snapshot.output_path.as_deref()
+        && let Some(ready) = crate::services::tui_turn_state::jsonl_ready_for_input(
+            provider,
+            runtime_kind,
+            Path::new(output_path),
+            Some(snapshot.current_offset),
+        )
+    {
+        return ready.is_ready();
+    }
+    crate::services::tui_turn_state::pane_ready_fallback_allowed(provider, runtime_kind)
+        && crate::services::provider::tmux_session_ready_for_input(
+            &snapshot.tmux_session_name,
+            provider,
+        )
+}
+
+fn terminal_ui_generation_mtime_for_tmux(tmux_session_name: &str) -> i64 {
+    let generation_mtime_ns = read_tmux_generation_mtime_ns(tmux_session_name);
+    if generation_mtime_ns != 0 {
+        generation_mtime_ns
+    } else {
+        runtime_store::load_generation() as i64
+    }
+}
+
+#[cfg(unix)]
+fn read_tmux_generation_mtime_ns(tmux_session_name: &str) -> i64 {
+    super::tmux::read_generation_file_mtime_ns(tmux_session_name)
+}
+
+#[cfg(not(unix))]
+fn read_tmux_generation_mtime_ns(_tmux_session_name: &str) -> i64 {
+    0
+}
+
+fn output_file_len(output_path: &str) -> u64 {
+    fs::metadata(output_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+fn clean_nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn obligation_path_in_root(root: &Path, provider: &str, channel_id: u64) -> PathBuf {
+    root.join(provider).join(format!("{channel_id}.json"))
+}
+
+fn write_obligation_in_root(root: &Path, obligation: &TerminalUiObligation) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(obligation)
+        .map_err(|error| format!("serialize terminal UI obligation: {error}"))?;
+    runtime_store::atomic_write(
+        &obligation_path_in_root(root, &obligation.provider, obligation.channel_id),
+        &json,
+    )
+}
+
+fn read_obligation_in_root(
+    root: &Path,
+    provider: &str,
+    channel_id: u64,
+) -> Option<TerminalUiObligation> {
+    let path = obligation_path_in_root(root, provider, channel_id);
+    let data = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn list_obligations_in_root(root: &Path) -> Vec<TerminalUiObligation> {
+    let Ok(provider_entries) = fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut obligations = Vec::new();
+    for provider_entry in provider_entries.filter_map(Result::ok) {
+        let provider_path = provider_entry.path();
+        if !provider_path.is_dir() {
+            continue;
+        }
+        let Ok(channel_entries) = fs::read_dir(provider_path) else {
+            continue;
+        };
+        for channel_entry in channel_entries.filter_map(Result::ok) {
+            let path = channel_entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(data) = fs::read_to_string(&path) else {
+                continue;
+            };
+            if let Ok(obligation) = serde_json::from_str::<TerminalUiObligation>(&data) {
+                obligations.push(obligation);
+            }
+        }
+    }
+    obligations.sort_by(|left, right| {
+        left.provider
+            .cmp(&right.provider)
+            .then(left.channel_id.cmp(&right.channel_id))
+    });
+    obligations
+}
+
+fn clear_obligation_by_key(provider: &str, channel_id: u64) -> bool {
+    let Some(root) = runtime_store::discord_terminal_ui_obligations_root() else {
+        return false;
+    };
+    clear_obligation_in_root(&root, provider, channel_id)
+}
+
+fn clear_obligation_in_root(root: &Path, provider: &str, channel_id: u64) -> bool {
+    let path = obligation_path_in_root(root, provider, channel_id);
+    match fs::remove_file(path) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => {
+            tracing::warn!(
+                provider,
+                channel_id,
+                error = %error,
+                "failed to clear terminal UI obligation sidecar"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_obligation(channel_id: u64) -> TerminalUiObligation {
+        TerminalUiObligation {
+            channel_id,
+            provider: ProviderKind::Claude.as_str().to_string(),
+            status_message_id: 456,
+            generation_mtime_ns: 789,
+            pending_state_text: "pending".to_string(),
+            completion_text: "complete".to_string(),
+            deadline_text: "deadline".to_string(),
+            created_unix: 1000,
+            deadline_unix: 1600,
+        }
+    }
+
+    #[test]
+    fn obligation_store_round_trips_lists_and_clears() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let obligation = sample_obligation(123);
+
+        write_obligation_in_root(temp.path(), &obligation).expect("write obligation");
+
+        assert_eq!(
+            read_obligation_in_root(temp.path(), ProviderKind::Claude.as_str(), 123),
+            Some(obligation.clone())
+        );
+        assert_eq!(list_obligations_in_root(temp.path()), vec![obligation]);
+        assert!(clear_obligation_in_root(
+            temp.path(),
+            ProviderKind::Claude.as_str(),
+            123
+        ));
+        assert!(read_obligation_in_root(temp.path(), ProviderKind::Claude.as_str(), 123).is_none());
+        assert!(list_obligations_in_root(temp.path()).is_empty());
+    }
+
+    #[test]
+    fn terminal_ui_obligation_generation_match_requires_nonzero_same_generation() {
+        assert!(terminal_ui_obligation_generation_is_current(10, 10));
+        assert!(!terminal_ui_obligation_generation_is_current(10, 11));
+        assert!(!terminal_ui_obligation_generation_is_current(0, 0));
+        assert!(!terminal_ui_obligation_generation_is_current(10, 0));
+    }
+
+    #[test]
+    fn should_record_terminal_ui_obligation_only_for_committed_timedout_status_card() {
+        assert!(should_record_terminal_ui_obligation(true, true, true));
+        assert!(!should_record_terminal_ui_obligation(false, true, true));
+        assert!(!should_record_terminal_ui_obligation(true, false, true));
+        assert!(!should_record_terminal_ui_obligation(true, true, false));
+    }
+
+    #[test]
+    fn terminal_ui_reconcile_action_prefers_complete_then_deadline_then_wait() {
+        assert_eq!(
+            terminal_ui_reconcile_action(true, 10, 10),
+            TerminalUiReconcileAction::Complete
+        );
+        assert_eq!(
+            terminal_ui_reconcile_action(false, 10, 10),
+            TerminalUiReconcileAction::Deadline
+        );
+        assert_eq!(
+            terminal_ui_reconcile_action(false, 9, 10),
+            TerminalUiReconcileAction::Wait
+        );
+    }
+}

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -5696,6 +5696,26 @@ pub(super) fn spawn_turn_bridge(
                     if tui_quiescence_timeout_requires_inflight_retry(terminal_delivery_committed) {
                         preserve_inflight_for_cleanup_retry = true;
                     } else {
+                        let terminal_ui_status_msg_id = normalize_status_panel_message_id(
+                            inflight_state.status_message_id.map(MessageId::new),
+                        );
+                        if super::terminal_ui_obligation::should_record_terminal_ui_obligation(
+                                terminal_delivery_committed,
+                                true,
+                                terminal_ui_status_msg_id.is_some(),
+                            )
+                            && let Some(status_msg_id) = terminal_ui_status_msg_id
+                        {
+                            super::terminal_ui_obligation::record_terminal_ui_obligation_pending_status(
+                                shared_owned.as_ref(),
+                                &provider,
+                                channel_id,
+                                status_msg_id,
+                                status_panel_started_at,
+                                &inflight_state,
+                            )
+                            .await;
+                        }
                         tracing::warn!(
                             provider = %provider.as_str(),
                             channel = channel_id.get(),


### PR DESCRIPTION
## 문제 (#3607)
릴레이 본문은 정상 전달됐는데 status 카드가 "⠸ 진행 중" 스피너에 영구 stuck.

**근본 원인** (turn_bridge/mod.rs:5686-5725): `terminal_delivery_committed=true` + TUI quiescence `TimedOut` 분기에서 완료 카드 전이를 억제(`should_emit_completion()=false`)하고 inflight cleanup을 그대로 진행 → 카드가 owner·durable obligation 없이 stuck. 코드 주석의 "sweeper reconciles"는 거짓(placeholder sweeper는 QUEUED만 처리).

## 수정 (durable)
- **P1a `terminal_ui_obligation.rs` (신규)**: 별도 durable sidecar store `<runtime>/discord_terminal_ui_obligations/<provider>/<channel>.json`. inflight/delivery-record frontier와 **완전히 분리** — `status_message_id` 카드 edit만 소유.
- **P1b turn_bridge/mod.rs (+20줄)**: TimedOut+committed else-branch에서 카드를 `↻ 응답 전달됨 · 세션 종료 확인 중`으로 edit + obligation persist. cleanup 흐름(`preserve=false`) 미변경.
- **P1c sweeper (15s)**: pane idle→`✅` 완료, deadline(600s) 초과→`⚠ 세션 종료 미확인`, 성공 시 clear. **stale generation/msg-id mismatch는 edit 없이 clear(새 턴 카드 보호)**. edit 실패·context 소실은 deadline+grace 후 clear(영구 retry 방지).
- **P1d framework_setup.rs**: boot에서 provider별 sweeper spawn(즉시 첫 tick) → 재시작 생존.

## HARD 불변식 (전부 준수)
status card edit만. `current_msg_id`/`full_response`/`response_sent_offset`/`confirmed_end_offset`/`committed_relay_offset`/`delivered_frontier`/`delivery_record`/`commit_and_advance`/`SendFull`/`turn_finalizer`/turn-drain **미접촉**. None-orphan finalizer 경로 미변경. (#3630/#3011/무중단배포 비회귀)

## 적대 리뷰 (opus, 구현자=codex)
generation 가드 정합성 검증: P1b 저장 generation(`last_watcher_relayed_generation_mtime_ns` = `read_generation_file_mtime_ns(session)`)과 sweeper 비교 generation이 동일 함수·동일 파일 → 같은 턴 일치, 새 턴 불일치. **false-stale/new-turn-overwrite 위험 없음.** VERDICT: CLEAN.

## 검증
- `cargo fmt --check`: PASS
- `cargo check --lib`: 에러 없음 (경고는 전부 main 기존, 신규 모듈 무경고)
- `cargo test --lib terminal_ui_obligation`: 4 passed / `turn_bridge`: 197 passed
- `ci-script-checks.sh`: EXIT=0 / agent-maintenance freshness: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)