### PR TITLE
fix(#3643): DM 전송 실패 경로 관측성 추가 — 실제 봇·Discord 에러 코드 로깅

### DIFF
--- a/src/services/discord/outbound/send_api.rs
+++ b/src/services/discord/outbound/send_api.rs
@@ -109,7 +109,19 @@ pub async fn handle_senddm(registry: &HealthRegistry, body: &str) -> (&'static s
 
     let http = match resolve_bot_http(registry, &request.bot).await {
         Ok(h) => h,
-        Err(resp) => return resp,
+        Err(resp) => {
+            // #3643: a DM that resolves no bot HTTP handle (unknown/misconfigured
+            // bot name) previously failed silently server-side — only the caller
+            // saw the HTTP error. Log the resolved bot + target so a recurring DM
+            // routing failure is attributable to the bot, not guessed.
+            tracing::warn!(
+                bot = %request.bot,
+                user_id = request.user_id,
+                status = resp.0,
+                "DM send aborted: failed to resolve bot HTTP handle (unknown/misconfigured bot?)"
+            );
+            return resp;
+        }
     };
     let user_id_text = request.user_id.to_string();
     let dm_delivery_id = request.delivery_id();
@@ -136,8 +148,10 @@ pub async fn handle_senddm(registry: &HealthRegistry, body: &str) -> (&'static s
         } => {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
-                "  [{ts}] 📨 DM: → user {} via shared outbound",
-                request.user_id
+                bot = %request.bot,
+                "  [{ts}] 📨 DM: → user {} via shared outbound (bot={})",
+                request.user_id,
+                request.bot
             );
             let mut response = serde_json::json!({
                 "ok": true,
@@ -149,10 +163,26 @@ pub async fn handle_senddm(registry: &HealthRegistry, body: &str) -> (&'static s
             }
             ("200 OK", response.to_string())
         }
-        ManualDeliveryOutcome::Failed { detail } => (
-            "500 Internal Server Error",
-            format!(r#"{{"ok":false,"error":"DM send failed: {}"}}"#, detail),
-        ),
+        ManualDeliveryOutcome::Failed { detail } => {
+            // #3643: surface the bot identity + Discord error (e.g. 50001 Missing
+            // Access) server-side. Without this the failure was visible only to
+            // the caller, so reports could not distinguish wrong-bot routing from
+            // an announce-bot permission/shared-guild gap. `detail` carries the
+            // serenity error string including the Discord error code.
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                bot = %request.bot,
+                user_id = request.user_id,
+                detail = %detail,
+                "  [{ts}] ⚠ DM: send failed → user {} (bot={})",
+                request.user_id,
+                request.bot
+            );
+            (
+                "500 Internal Server Error",
+                format!(r#"{{"ok":false,"error":"DM send failed: {}"}}"#, detail),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## 배경 (#3643)
원 보고: "DM 아웃바운드가 announce 봇 대신 범용 relay 봇으로 발송 → Missing Access + role-map 403 영구 실패".

**검증 결과 보고는 부정확**: `handle_senddm`은 이미 `bot` 미지정 시 `announce` 기본값(send_api.rs:230, :110), DM은 role-map/authorization ladder를 우회(바로 `create_dm_channel`), 그리고 런타임 로그 전수 grep에서 실제 50001/Missing Access/senddm 실패 기록 **0건**(family-counsel 채널 릴레이는 정상 동작 중). → 보고 증상 재현·관측 안 됨.

**진짜 문제 = 무관측**: `handle_senddm`의 Failed arm(send_api.rs:152)이 caller에 500을 반환만 하고 서버 로그를 안 남김. bot resolve 실패(:112)도 무로깅. → 어떤 봇/실제 에러인지 판별 불가가 오진의 근본 원인.

## 변경 (로깅만, 동작 무변경)
`src/services/discord/outbound/send_api.rs`:
- (a) bot HTTP resolve 실패 시 `bot`·`status` warn 후 기존과 동일하게 반환.
- (b) DM 전송 실패 시 `bot`·`user_id`·`detail`(serenity 에러=Discord 코드 포함) warn.
- (c) 성공 로그에도 `bot` 명시.

제어흐름·반환값(HTTP status, body) 변경 없음. 재발 시 실제 봇+에러 코드가 로그에 남아 **코드 라우팅 vs 운영(봇 권한/공유길드) 문제**를 즉시 구분 가능.

## 검증
cargo check exit 0(신규 경고 없음), `cargo test --lib send_api` 11 passed, fmt-check/ci-script-checks(EXIT=0)/agent-maintenance freshness 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)