### PR TITLE
fix(#3644): `send-to-agent --expect-reply` 필수화 — 모든 peer 핸드오프가 회신 기대를 명시

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -101,11 +101,9 @@ pub(crate) enum Commands {
         /// Send the body without the automatic handoff prefix
         #[arg(long = "no-prefix")]
         no_prefix: bool,
-        /// Reply-expectation contract appended to the handoff body:
-        /// `--expect-reply true` → 회신 필수, `--expect-reply false` → 회신 불필요,
-        /// omitted → no contract.
-        #[arg(long = "expect-reply")]
-        expect_reply: Option<bool>,
+        /// Required: `true` → 회신 필수, `false` → 회신 불필요.
+        #[arg(long = "expect-reply", action = clap::ArgAction::Set, required = true)]
+        expect_reply: bool,
         /// #3556 — reserve a headless turn on the target mailbox instead of
         /// posting an announce message. Authoritative wake-up: exits non-zero
         /// on 409 (mailbox busy). Mutually exclusive with the default
@@ -975,6 +973,75 @@ pub(crate) fn parse() -> ParseOutcome {
                 std::process::exit(1);
             }
             ParseOutcome::RunServer
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Parser, error::ErrorKind};
+
+    #[test]
+    fn send_to_agent_requires_expect_reply() {
+        let result = Cli::try_parse_from([
+            "agentdesk",
+            "send-to-agent",
+            "--from",
+            "a",
+            "--to",
+            "b",
+            "--message",
+            "hi",
+        ]);
+        let Err(error) = result else {
+            panic!("send-to-agent without --expect-reply should fail");
+        };
+
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn send_to_agent_parses_expect_reply_true() {
+        let cli = Cli::try_parse_from([
+            "agentdesk",
+            "send-to-agent",
+            "--from",
+            "a",
+            "--to",
+            "b",
+            "--message",
+            "hi",
+            "--expect-reply",
+            "true",
+        ])
+        .expect("send-to-agent with --expect-reply true should parse");
+
+        match cli.command.expect("subcommand") {
+            Commands::SendToAgent { expect_reply, .. } => assert!(expect_reply),
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn send_to_agent_parses_expect_reply_false() {
+        let cli = Cli::try_parse_from([
+            "agentdesk",
+            "send-to-agent",
+            "--from",
+            "a",
+            "--to",
+            "b",
+            "--message",
+            "hi",
+            "--expect-reply",
+            "false",
+        ])
+        .expect("send-to-agent with --expect-reply false should parse");
+
+        match cli.command.expect("subcommand") {
+            Commands::SendToAgent { expect_reply, .. } => assert!(!expect_reply),
+            _ => panic!("unexpected command"),
         }
     }
 }

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -306,7 +306,7 @@ pub(crate) async fn cmd_send_to_agent(
     message: &str,
     channel_kind: crate::services::discord::agent_handoff::AgentHandoffChannelKind,
     prefix: bool,
-    expect_reply: Option<bool>,
+    expect_reply: bool,
     start_turn: bool,
 ) -> Result<(), String> {
     run_command(true, false, |state| async move {
@@ -328,7 +328,7 @@ pub(crate) async fn cmd_send_to_agent(
                 message,
                 channel_kind,
                 prefix,
-                expect_reply,
+                Some(expect_reply),
                 Some("cli:send-to-agent".to_string()),
                 None,
             )
@@ -344,7 +344,7 @@ pub(crate) async fn cmd_send_to_agent(
             message,
             channel_kind,
             prefix,
-            expect_reply,
+            Some(expect_reply),
         )
         .await
         .map_err(|error| error.one_line())?;

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -21,7 +21,7 @@ pub fn print_help() {
     println!("    discord-sendmessage --channel <ID> --message <TEXT> [--key <HASH>]");
     println!("    discord-senddm --user <ID> --message <TEXT> [--key <HASH>]");
     println!(
-        "    send-to-agent --from <AGENT> --to <AGENT> --message <TEXT> [--channel-kind cc|cdx] [--no-prefix] [--expect-reply true|false]"
+        "    send-to-agent --from <AGENT> --to <AGENT> --message <TEXT> --expect-reply <true|false> [--channel-kind cc|cdx] [--no-prefix]"
     );
     println!("    reset-tmux              Kill all AgentDesk-* tmux sessions");
     println!(

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1573,7 +1573,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ),
         ])
         .with_example(
-            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "message": "hello", "channel_kind": "cc", "prefix": true}}),
+            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "message": "hello", "channel_kind": "cc", "prefix": true, "expect_reply": true}}),
             json!({"to_agent_id": "adk-dashboard", "channel_id": "1473922824350601297", "channel_kind": "cc", "message_id": "1500000000000000002", "bot": "announce", "prefixed": true}),
         )
         .with_error_example(
@@ -1581,7 +1581,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "message": "hello", "channel_kind": "cc"}}),
             json!({"error": "channel_kind unset", "to_agent_id": "adk-dashboard", "channel_kind": "cc", "available_kinds": ["cdx"]}),
         )
-        .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/message -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"message\":\"hello\",\"channel_kind\":\"cc\",\"prefix\":true}'"),
+        .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/message -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"message\":\"hello\",\"channel_kind\":\"cc\",\"prefix\":true,\"expect_reply\":true}'"),
         ep(
             "POST",
             "/api/agents/{id}/handoff",
@@ -1620,7 +1620,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ),
         ])
         .with_example(
-            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "prompt": "리뷰 코멘트 반영해서 PR 업데이트해줘", "channel_kind": "cc", "source": "agent-relay"}}),
+            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "prompt": "리뷰 코멘트 반영해서 PR 업데이트해줘", "channel_kind": "cc", "expect_reply": true, "source": "agent-relay"}}),
             json!({"ok": true, "to_agent_id": "adk-dashboard", "channel_id": "1473922824350601297", "channel_kind": "cc", "turn_id": "discord:1473922824350601297:9100000000000000000", "status": "started"}),
         )
         .with_error_example(
@@ -1628,7 +1628,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "prompt": "do it"}}),
             json!({"error": "turn already active for this agent mailbox", "status": "conflict"}),
         )
-        .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/handoff -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"prompt\":\"리뷰 반영해줘\",\"channel_kind\":\"cc\"}'"),
+        .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/handoff -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"prompt\":\"리뷰 반영해줘\",\"channel_kind\":\"cc\",\"expect_reply\":true}'"),
         ep(
             "GET",
             "/api/agents/{id}/cron",

--- a/src/services/discord/agent_handoff.rs
+++ b/src/services/discord/agent_handoff.rs
@@ -200,7 +200,7 @@ impl AgentHandoffError {
 fn reply_expectation_contract(from_agent_id: &str, expect_reply: bool) -> String {
     if expect_reply {
         format!(
-            "──────────\n📨 **회신 필수 계약**: 이 핸드오프는 회신을 요구합니다. 작업/검토를 마치면 결과·결론을 요청자 `{from_agent_id}`에게 반드시 회신하세요. 회신은 `agentdesk send-to-agent --from <self> --to {from_agent_id} --message \"...\"` 로 보냅니다(현재 요청의 callback 정보·채널 규칙 우선)."
+            "──────────\n📨 **회신 필수 계약**: 이 핸드오프는 회신을 요구합니다. 작업/검토를 마치면 결과·결론을 요청자 `{from_agent_id}`에게 반드시 회신하세요. 회신은 `agentdesk send-to-agent --from <self> --to {from_agent_id} --message \"...\" --expect-reply false` 로 보냅니다(현재 요청의 callback 정보·채널 규칙 우선)."
         )
     } else {
         "──────────\n📭 **회신 불필요 계약**: 이 핸드오프는 회신을 요구하지 않습니다. 별도 보고 없이 처리하세요(중대한 이슈를 발견한 경우에만 자율적으로 회신).".to_string()

--- a/src/services/discord/settings/content.rs
+++ b/src/services/discord/settings/content.rs
@@ -438,7 +438,7 @@ pub(in crate::services::discord) fn render_peer_agent_guidance(
         "Other specialist agents share this workspace. For requests mostly outside your scope:".to_string(),
         "1. Name 1-2 peer agents that fit better and why.".to_string(),
         "2. Ask \"해당 에이전트에게 전달할까요?\" and wait for approval.".to_string(),
-        "3. On approval, call `agentdesk send-to-agent --from <self> --to <peer> --message \"...\" [--channel-kind cc|cdx]` to forward context via the announce bot so the peer intake_gate can trigger.".to_string(),
+        "3. On approval, call `agentdesk send-to-agent --from <self> --to <peer> --message \"...\" --expect-reply <true|false> [--channel-kind cc|cdx]` to forward context via the announce bot so the peer intake_gate can trigger. Use `true` when a reply is needed, otherwise `false`.".to_string(),
         "If the user wants your perspective anyway, answer within your scope and note the handoff option.".to_string(),
         String::new(),
         "Available peer agents:".to_string(),


### PR DESCRIPTION
## 배경 (#3644, ch-td 요청)
이전엔 `--expect-reply` omitted 시 회신-계약 블록이 안 붙어, 핸드오프 받은 에이전트가 회신 필수/불필요를 알 수 없는 모호함이 있었다.

## 변경
- **CLI 필수화** (`args.rs`): `--expect-reply`를 `clap::ArgAction::Set + required = true`로 (`Option<bool>` → `bool`). 누락 시 `MissingRequiredArgument`로 비0 종료. 단위테스트 3개(누락→에러, true→true, false→false).
- **build/API 레이어 Option 유지** (`direct.rs`): CLI는 항상 값 보유 → `Some(expect_reply)` 전달. `agent_handoff` build 함수와 HTTP API(`agents.rs` message/handoff)의 `Option<bool>`는 그대로(호환). HTTP API는 여전히 expect_reply optional.
- **명령 구문 템플릿 atomic 갱신**: `content.rs` 피어 디렉터리 스텝3(`--expect-reply <true|false>` + 가이드), `agent_handoff.rs` 회신 안내(`--expect-reply false`), `utils.rs` print_help(필수 위치로 이동), `docs.rs` API 예시·curl(`expect_reply` 명시 — agents.rs가 실제로 받는 필드).

## 회귀 안전
실제 CLI `send-to-agent` 호출자는 프롬프트 템플릿(이번에 갱신)뿐. E2E `discord.py`는 주석과 달리 HTTP `turn/start`를 사용(CLI 미사용)하며 expect_reply 영향 없음. → 깨지는 호출자 없음.

## 적대 리뷰
opus 리뷰(구현=codex): clap idiom·테스트·템플릿 일관성·실호출자 안전성 검증 — VERDICT CLEAN.

## 검증
`cli::args` 3 passed, `cargo check --lib`+`--bin agentdesk` ok, fmt-check/agent-maintenance freshness/ci-script-checks(EXIT=0) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)