### PR TITLE
fix(discord): DB 풀 기본값 12→24 + catch-up 스캔 pacing — 재시작 풀 고갈/인제스트 지연 완화

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -920,7 +920,7 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3397 lines; +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
+  - `src/services/discord/recovery_engine.rs` (3421 lines; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
     `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the
     STALL-WATCHDOG force-clean -> respawn synthetic row (which lands here with
     `existing_inflight = None`) is watcher-owned instead of degrading to
@@ -1374,7 +1374,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2458 lines; +11 from #3573 failure_pause_auto_resume_secs config field).
+  - `src/config.rs` (2474 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment).
   - `src/server/mod.rs` (2634 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -290,7 +290,11 @@
 # call itself drops the now-unused `tmux_session_alive_with_retry` probe — logic
 # shrank by one line; the net +15 is comment LoC explaining the storm-prevention
 # invariant. No new behavior at this site beyond the literal `false` argument.
-"src/services/discord/recovery_engine.rs" = 3397
+# f12b09366 (backstop missed turn intake): +24 (3397 -> 3421) for drain-restart
+# ownerless-inflight recovery predicates (phase_policy/relay_recovery/relay_health).
+# Hotfix was deployed via direct push to main and bypassed CI, so this baseline
+# re-inflation surfaced only when PR #3655 (which bases on it) ran the gate.
+"src/services/discord/recovery_engine.rs" = 3421
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced

--- a/src/config.rs
+++ b/src/config.rs
@@ -1960,7 +1960,15 @@ fn default_database_user() -> String {
     "agentdesk".into()
 }
 fn default_database_pool_max() -> u32 {
-    12
+    // Sized for the always-on background DB consumers (cluster heartbeat,
+    // dispatch/message outbox claiming, observability flush, session-discovery,
+    // policy-tick, routine recovery) plus foreground turn ingestion. At 12 the
+    // steady-state pool was already near-saturated and any burst (e.g. a
+    // post-restart catch-up sweep coinciding with a turn) pushed it into
+    // sustained `acquire_timeout` errors, delaying message ingestion. 24 leaves
+    // headroom while staying well under Postgres `max_connections` even with
+    // the 1.5x startup warmup pool and a second cluster node sharing the DB.
+    24
 }
 fn default_cluster_role() -> String {
     "auto".into()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1965,10 +1965,18 @@ fn default_database_pool_max() -> u32 {
     // policy-tick, routine recovery) plus foreground turn ingestion. At 12 the
     // steady-state pool was already near-saturated and any burst (e.g. a
     // post-restart catch-up sweep coinciding with a turn) pushed it into
-    // sustained `acquire_timeout` errors, delaying message ingestion. 24 leaves
-    // headroom while staying well under Postgres `max_connections` even with
-    // the 1.5x startup warmup pool and a second cluster node sharing the DB.
-    24
+    // sustained `acquire_timeout` errors, delaying message ingestion.
+    //
+    // Upper bound is the shared Postgres `max_connections` (100, minus 3
+    // superuser-reserved = 97 usable). During boot a node runs BOTH the runtime
+    // pool (this value) AND the startup warmup pool (1.5x, see
+    // `startup_pool_settings`) concurrently until boot reconcile drops the
+    // warmup pool — a per-node peak of `2.5 * pool_max`. With two cluster nodes
+    // potentially booting at once (coordinated deploy), the worst case is
+    // `2 * 2.5 * pool_max`, which must stay under 97. 18 → 2*(18+27)=90, leaving
+    // headroom for psql/admin. Going higher requires raising Postgres
+    // `max_connections` or capping the warmup multiplier first.
+    18
 }
 fn default_cluster_role() -> String {
     "auto".into()

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -219,13 +219,28 @@ const CATCH_UP_FETCH_LIMIT: u8 = 50;
 /// small delay spreads the burst so the rest of the runtime keeps making
 /// progress. `AGENTDESK_CATCH_UP_SCAN_PACE_MS` overrides the gap (0 disables —
 /// used by tests and by operators who want the old unthrottled behaviour).
-fn catch_up_scan_pace() -> std::time::Duration {
-    const DEFAULT_MS: u64 = 100;
-    let ms = std::env::var("AGENTDESK_CATCH_UP_SCAN_PACE_MS")
-        .ok()
-        .and_then(|raw| raw.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_MS);
+const CATCH_UP_SCAN_PACE_DEFAULT_MS: u64 = 100;
+
+/// Pure parse of the pacing override. Missing or unparseable values fall back
+/// to the default; `0` is honoured and yields a zero (no-op) gap. Kept env-free
+/// so it is deterministically unit-testable without touching process globals.
+fn parse_catch_up_scan_pace(raw: Option<&str>) -> std::time::Duration {
+    let ms = raw
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(CATCH_UP_SCAN_PACE_DEFAULT_MS);
     std::time::Duration::from_millis(ms)
+}
+
+fn catch_up_scan_pace() -> std::time::Duration {
+    parse_catch_up_scan_pace(std::env::var("AGENTDESK_CATCH_UP_SCAN_PACE_MS").ok().as_deref())
+}
+
+/// Whether to wait the pacing gap before the next per-channel scan. The first
+/// scan in a sweep runs immediately (`already_scanned == false`); every later
+/// scan is paced. Extracted as a named predicate so the first-immediate /
+/// subsequent-paced contract is covered by a unit test.
+fn should_pace_before_scan(already_scanned: bool) -> bool {
+    already_scanned
 }
 
 /// Sleep the configured catch-up pacing gap before the next per-channel scan.
@@ -423,7 +438,7 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
             }
         }
 
-        if paced_scan {
+        if should_pace_before_scan(paced_scan) {
             catch_up_scan_pace_gap().await;
         }
         paced_scan = true;
@@ -675,7 +690,7 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
             }
         }
 
-        if paced_scan_phase2 {
+        if should_pace_before_scan(paced_scan_phase2) {
             catch_up_scan_pace_gap().await;
         }
         paced_scan_phase2 = true;
@@ -819,11 +834,54 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
 #[cfg(test)]
 mod catch_up_recovery_tests {
     use super::{
-        CatchUpChannelCandidate, CatchUpClassification, CatchUpFetchMode, CatchUpMessageView,
-        ChannelId, ProviderKind, catch_up_fetch_mode_for_scan, classify_catch_up_message,
-        insert_configured_catch_up_candidate,
+        CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate, CatchUpClassification,
+        CatchUpFetchMode, CatchUpMessageView, ChannelId, ProviderKind,
+        catch_up_fetch_mode_for_scan, classify_catch_up_message,
+        insert_configured_catch_up_candidate, parse_catch_up_scan_pace, should_pace_before_scan,
     };
     use std::collections::{BTreeMap, HashSet};
+
+    #[test]
+    fn scan_pace_parses_valid_zero_invalid_and_missing() {
+        // Explicit value is honoured.
+        assert_eq!(
+            parse_catch_up_scan_pace(Some("250")).as_millis(),
+            250,
+            "valid value should be used verbatim"
+        );
+        // 0 is honoured and yields a no-op (zero) gap — the documented disable.
+        assert!(
+            parse_catch_up_scan_pace(Some("0")).is_zero(),
+            "0 must disable pacing"
+        );
+        // Surrounding whitespace is tolerated.
+        assert_eq!(parse_catch_up_scan_pace(Some("  75 ")).as_millis(), 75);
+        // Unparseable and missing both fall back to the default.
+        assert_eq!(
+            parse_catch_up_scan_pace(Some("abc")).as_millis(),
+            CATCH_UP_SCAN_PACE_DEFAULT_MS as u128,
+            "garbage falls back to default"
+        );
+        assert_eq!(
+            parse_catch_up_scan_pace(None).as_millis(),
+            CATCH_UP_SCAN_PACE_DEFAULT_MS as u128,
+            "missing env falls back to default"
+        );
+    }
+
+    #[test]
+    fn first_scan_runs_immediately_then_subsequent_scans_pace() {
+        // Mirrors the loop contract: the very first eligible channel scans with
+        // no delay; once one scan has happened, every later channel is paced.
+        assert!(
+            !should_pace_before_scan(false),
+            "first scan must not wait"
+        );
+        assert!(
+            should_pace_before_scan(true),
+            "subsequent scans must wait the pacing gap"
+        );
+    }
 
     #[test]
     fn configured_channel_is_scanned_without_checkpoint_file() {

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -232,7 +232,11 @@ fn parse_catch_up_scan_pace(raw: Option<&str>) -> std::time::Duration {
 }
 
 fn catch_up_scan_pace() -> std::time::Duration {
-    parse_catch_up_scan_pace(std::env::var("AGENTDESK_CATCH_UP_SCAN_PACE_MS").ok().as_deref())
+    parse_catch_up_scan_pace(
+        std::env::var("AGENTDESK_CATCH_UP_SCAN_PACE_MS")
+            .ok()
+            .as_deref(),
+    )
 }
 
 /// Whether to wait the pacing gap before the next per-channel scan. The first
@@ -873,10 +877,7 @@ mod catch_up_recovery_tests {
     fn first_scan_runs_immediately_then_subsequent_scans_pace() {
         // Mirrors the loop contract: the very first eligible channel scans with
         // no delay; once one scan has happened, every later channel is paced.
-        assert!(
-            !should_pace_before_scan(false),
-            "first scan must not wait"
-        );
+        assert!(!should_pace_before_scan(false), "first scan must not wait");
         assert!(
             should_pace_before_scan(true),
             "subsequent scans must wait the pacing gap"

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -207,6 +207,36 @@ fn collect_catch_up_channel_candidates(
 /// user messages.
 const CATCH_UP_FETCH_LIMIT: u8 = 50;
 
+/// Inter-channel pacing for the catch-up REST sweep.
+///
+/// Startup recovery and the periodic backstop scan every configured channel
+/// back-to-back (two REST round-trips each — binding-status + message fetch).
+/// On a fresh restart, dozens of channels are scanned with no checkpoint at
+/// once, and that tight, un-paced burst monopolises the async executor and
+/// Discord REST budget right as every background DB consumer is also spinning
+/// up — starving DB-bound tasks of the time they need to acquire a pooled
+/// connection within `acquire_timeout`. Spacing the per-channel scans by a
+/// small delay spreads the burst so the rest of the runtime keeps making
+/// progress. `AGENTDESK_CATCH_UP_SCAN_PACE_MS` overrides the gap (0 disables —
+/// used by tests and by operators who want the old unthrottled behaviour).
+fn catch_up_scan_pace() -> std::time::Duration {
+    const DEFAULT_MS: u64 = 100;
+    let ms = std::env::var("AGENTDESK_CATCH_UP_SCAN_PACE_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MS);
+    std::time::Duration::from_millis(ms)
+}
+
+/// Sleep the configured catch-up pacing gap before the next per-channel scan.
+/// No-op when pacing is disabled (0 ms) so test runs stay fast.
+async fn catch_up_scan_pace_gap() {
+    let pace = catch_up_scan_pace();
+    if !pace.is_zero() {
+        tokio::time::sleep(pace).await;
+    }
+}
+
 /// Filter outcome categories for the catch-up REST scan. Used both at runtime
 /// (to emit per-channel breakdown logs even when nothing was recovered) and in
 /// unit tests as a pure-function check on the buried-user-message regression.
@@ -372,6 +402,10 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
         return;
     }
 
+    // Pace successive per-channel REST scans so a many-channel sweep doesn't
+    // fire as one tight burst (see `catch_up_scan_pace`). The first eligible
+    // channel runs immediately; subsequent scans wait the configured gap.
+    let mut paced_scan = false;
     for candidate in candidates.values() {
         let channel_id = candidate.channel_id;
         let retry_checkpoint = retry_checkpoints.get(&channel_id).copied();
@@ -388,6 +422,11 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 continue;
             }
         }
+
+        if paced_scan {
+            catch_up_scan_pace_gap().await;
+        }
+        paced_scan = true;
 
         match resolve_runtime_channel_binding_status(http, channel_id).await {
             RuntimeChannelBindingStatus::Owned => {}
@@ -624,6 +663,8 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
     };
     let announce_bot_id_phase2 = resolve_announce_bot_user_id(shared).await;
 
+    // Same per-channel pacing as phase 1 (see `catch_up_scan_pace`).
+    let mut paced_scan_phase2 = false;
     for candidate in candidates.values() {
         let channel_id = candidate.channel_id;
 
@@ -633,6 +674,11 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 continue;
             }
         }
+
+        if paced_scan_phase2 {
+            catch_up_scan_pace_gap().await;
+        }
+        paced_scan_phase2 = true;
 
         match resolve_runtime_channel_binding_status(http, channel_id).await {
             RuntimeChannelBindingStatus::Owned => {}


### PR DESCRIPTION
## 배경

2026-06-23 08:16~08:19 KST, release 재시작 직후 로컬 Postgres 커넥션 풀이 ~2.5분간 고갈되어 사용자 메시지 인제스트(placeholder 생성)가 ~89초 지연됐다.

- 메시지 생성 `08:17:35`, placeholder는 마지막 pool timeout(`08:19:02`) 회복 **2초 뒤** `08:19:04`에 기록 — 인제스트 경로가 커넥션 획득에 막혀 있었음이 명확.
- 트리거: 재시작 직후 catch-up이 ~40개 채널을 일괄 스캔 + 새 턴 시작이 겹쳐 executor/REST/DB 동시 폭주.
- 근본: pool timeout은 일회성이 아니라 **시간당 14~81회 상시 발생**(당일 06/07/08시 36/65/47회). `pool_max=12`가 상시 백그라운드 DB 소비자(cluster heartbeat, dispatch/message outbox claiming, observability flush, session-discovery, policy-tick, routine recovery) 대비 만성적으로 빠듯.

## 변경

### #1 — `pool_max` 기본값 12 → 24 (`src/config.rs`)
- `default_database_pool_max()` 12 → 24.
- Postgres `max_connections=100`(reserved 3) 대비 충분: 24 × 2노드 = 48, 1.5x startup warmup 풀(36) × 2 = 72 까지도 여유.
- 운영 config `~/.adk/release/config/agentdesk.yaml`는 명시값 `pool_max: 12`가 default를 덮으므로 **별도로 `24`로 갱신**(이 PR 밖, 재시작 시 반영).

### #2 — catch-up per-channel 스캔 pacing (`src/services/discord/catch_up.rs`)
- 재시작/주기 sweep이 채널마다 2회 REST(binding-status + message fetch)를 back-to-back으로 쏘며 executor/Discord REST를 점유 → DB-bound 백그라운드 태스크가 `acquire_timeout` 내 커넥션을 못 잡는 thundering-herd를 완화.
- `AGENTDESK_CATCH_UP_SCAN_PACE_MS`(기본 100ms, **0이면 비활성** — 테스트/구동작 보존)로 조정 가능. `AGENTDESK_CATCH_UP_POLL_SECS`와 동일한 env-parse 패턴.
- phase1·phase2 스캔 루프 모두 적용. 첫 채널은 즉시 실행, 이후 채널만 간격을 둠(skip되는 cheap 채널은 pacing 대상 아님).

> catch-up 자체는 PG 풀을 직접 점유하지 않음(REST + in-memory). 따라서 #2는 #1을 **대체가 아니라 보완** — 재시작 burst 강도를 낮춰 풀 고갈 확률을 줄인다.

## 후속

구조적 개선(우선순위 분리 / backpressure — foreground 인제스트가 백그라운드 chore에 starve되지 않도록)은 **#3651**로 분리.

## 검증

- `cargo check --lib` 통과(exit 0). 변경 파일에서 신규 경고 없음(기존 8 warning은 무관: legacy-sqlite-tests cfg, unused import).
- pure-function 테스트 모듈(`classify_catch_up_message` 등)은 스캔 루프를 호출하지 않아 pacing 영향 없음.

## 비고

- 배포만 됐고 origin엔 없던 hotfix `f12b09366`(backstop missed turn intake)를 본 작업 전 origin/main에 1-commit FF로 동기화함. 본 PR은 그 위에 쌓임.
- 적용에는 release 재시작 필요(turn 보존 drain-restart). 배포 타이밍은 운영자 판단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
