### PR TITLE
fix(#3652): 중복 /clear soft_clear notify 제거 — 완료 표면 단일화

### DIFF
--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -26,6 +26,29 @@ enum ManagedSessionClearBehavior {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::services::discord) enum SoftClearNotifyMode {
+    Enqueue,
+    Suppress,
+}
+
+impl SoftClearNotifyMode {
+    fn should_enqueue(self) -> bool {
+        matches!(self, Self::Enqueue)
+    }
+}
+
+const SOFT_CLEAR_REASON_CODE: &str = "lifecycle.soft_clear";
+
+fn soft_clear_lifecycle_notify_row(
+    clear_source: &str,
+    notify_mode: SoftClearNotifyMode,
+) -> Option<(&'static str, String)> {
+    notify_mode
+        .should_enqueue()
+        .then(|| (SOFT_CLEAR_REASON_CODE, format!("🧹 세션 클리어 ({clear_source})")))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ManagedSessionResetBehavior {
     ResetManagedProcess,
     Noop,
@@ -323,6 +346,7 @@ pub(in crate::services::discord) async fn clear_channel_session_state(
     provider: &ProviderKind,
     channel_id: serenity::ChannelId,
     clear_source: &str,
+    notify_mode: SoftClearNotifyMode,
 ) {
     let tmux_name = {
         let data = shared.core.lock().await;
@@ -403,20 +427,24 @@ pub(in crate::services::discord) async fn clear_channel_session_state(
         ManagedSessionClearBehavior::Noop => {}
     }
 
-    // Notify bot message for session clear visibility
-    let sqlite_runtime_db = if shared.pg_pool.is_some() {
-        None
-    } else {
-        None::<&crate::db::Db>
-    };
-    crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
-        sqlite_runtime_db,
-        shared.pg_pool.as_ref(),
-        &format!("channel:{}", channel_id.get()),
-        session_key.as_deref(),
-        "lifecycle.soft_clear",
-        &format!("🧹 세션 클리어 ({clear_source})"),
-    );
+    if let Some((reason_code, content)) =
+        soft_clear_lifecycle_notify_row(clear_source, notify_mode)
+    {
+        // Notify bot message for clear paths that have no direct provider reply.
+        let sqlite_runtime_db = if shared.pg_pool.is_some() {
+            None
+        } else {
+            None::<&crate::db::Db>
+        };
+        crate::services::message_outbox::enqueue_lifecycle_notification_best_effort(
+            sqlite_runtime_db,
+            shared.pg_pool.as_ref(),
+            &format!("channel:{}", channel_id.get()),
+            session_key.as_deref(),
+            reason_code,
+            &content,
+        );
+    }
 }
 
 /// /stop — Cancel in-progress AI request
@@ -492,12 +520,44 @@ pub(in crate::services::discord) async fn cmd_clear(ctx: Context<'_>) -> Result<
         &ctx.data().provider,
         ctx.channel_id(),
         "/clear",
+        SoftClearNotifyMode::Suppress,
     )
     .await;
 
     ctx.say("Session cleared.").await?;
     tracing::info!("  [{ts}] ▶ [{user_name}] Session cleared");
     Ok(())
+}
+
+#[cfg(test)]
+mod soft_clear_notify_tests {
+    use super::{SOFT_CLEAR_REASON_CODE, SoftClearNotifyMode, soft_clear_lifecycle_notify_row};
+
+    #[test]
+    fn slash_and_text_clear_suppress_soft_clear_notify_row() {
+        assert_eq!(
+            soft_clear_lifecycle_notify_row("/clear", SoftClearNotifyMode::Suppress),
+            None,
+            "`/clear` and `!clear` already reply `Session cleared.` and must not enqueue a duplicate `lifecycle.soft_clear` notify row"
+        );
+        assert_eq!(
+            soft_clear_lifecycle_notify_row("!clear", SoftClearNotifyMode::Suppress),
+            None,
+            "`!clear` should leave the provider reply as the single user-visible completion surface"
+        );
+    }
+
+    #[test]
+    fn idle_recap_clear_keeps_soft_clear_notify_row() {
+        assert_eq!(
+            soft_clear_lifecycle_notify_row("idle_recap_clear", SoftClearNotifyMode::Enqueue),
+            Some((
+                SOFT_CLEAR_REASON_CODE,
+                "🧹 세션 클리어 (idle_recap_clear)".to_string(),
+            )),
+            "idle recap clear has no provider reply, so it must keep the single user-visible `lifecycle.soft_clear` notify row"
+        );
+    }
 }
 
 /// /down <file> — Download file from server

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -43,9 +43,12 @@ fn soft_clear_lifecycle_notify_row(
     clear_source: &str,
     notify_mode: SoftClearNotifyMode,
 ) -> Option<(&'static str, String)> {
-    notify_mode
-        .should_enqueue()
-        .then(|| (SOFT_CLEAR_REASON_CODE, format!("🧹 세션 클리어 ({clear_source})")))
+    notify_mode.should_enqueue().then(|| {
+        (
+            SOFT_CLEAR_REASON_CODE,
+            format!("🧹 세션 클리어 ({clear_source})"),
+        )
+    })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -427,8 +430,7 @@ pub(in crate::services::discord) async fn clear_channel_session_state(
         ManagedSessionClearBehavior::Noop => {}
     }
 
-    if let Some((reason_code, content)) =
-        soft_clear_lifecycle_notify_row(clear_source, notify_mode)
+    if let Some((reason_code, content)) = soft_clear_lifecycle_notify_row(clear_source, notify_mode)
     {
         // Notify bot message for clear paths that have no direct provider reply.
         let sqlite_runtime_db = if shared.pg_pool.is_some() {

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -39,8 +39,8 @@ pub(in crate::services::discord) use config::{
 };
 pub(super) use config::{cmd_adduser, cmd_allowall, cmd_allowed, cmd_allowedtools, cmd_removeuser};
 pub(in crate::services::discord) use control::{
-    clear_channel_session_state, reset_channel_provider_state, reset_managed_process_session,
-    reset_provider_session_if_pending,
+    SoftClearNotifyMode, clear_channel_session_state, reset_channel_provider_state,
+    reset_managed_process_session, reset_provider_session_if_pending,
 };
 pub(super) use control::{cmd_clear, cmd_down, cmd_shell, cmd_stop};
 pub(in crate::services::discord) use diagnostics::{

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -431,6 +431,7 @@ pub(in crate::services::discord) async fn handle_text_command(
                 &data.provider,
                 channel_id,
                 "!clear",
+                super::SoftClearNotifyMode::Suppress,
             )
             .await;
             let _ = msg.reply(&ctx.http, "Session cleared.").await;

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -147,6 +147,7 @@ pub(super) async fn handle_idle_recap_clear_interaction(
         &data.provider,
         component.channel_id,
         "idle_recap_clear",
+        crate::services::discord::commands::SoftClearNotifyMode::Enqueue,
     )
     .await;
     delete_previous_card(&ctx.http, channel_id, message_id).await;


### PR DESCRIPTION
## 이슈
Closes #3652 — /clear·!clear 시 중복되는 lifecycle.soft_clear notify 메시지 제거, 사용자 표시 완료 표면 1개만 유지.

## 변경 (codex 구현)
- `commands/control.rs`: `clear_channel_session_state`에 `SoftClearNotifyMode` 추가 — /clear·!clear는 soft_clear notify row 미생성('Session cleared.' 응답만), provider reply 없는 `idle_recap_clear`는 notify 유지(over-suppress 회피). 정책 단위 테스트 추가.
- `commands/{mod,text_commands}.rs`, `idle_recap_interaction.rs`: 호출부 모드 전달.

## 검증
- 로컬 python 게이트 통과(빌드 없음): freshness ✅, giant_file_ratchet ✅
- 컴파일/clippy/test = GitHub 클라우드 CI (로컬 빌드 0 방침; self-hosted macOS 체크는 맥미니 DB 보호 위해 일시 비활성)
- 교차모델 적대 리뷰: 구현=codex → 리뷰=opus, VERDICT CLEAN 필수

🤖 Generated with [Claude Code](https://claude.com/claude-code)