### PR TITLE
fix(#3653): 세션 복원 notify(📋) 제거 — session/status panel로 흡수

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1007,7 +1007,7 @@
     force-clean watcher-respawn follow-through + always-run cross-tick
     retry/dead-man (P1-a: no early return on zero candidates), delegating the
     new behaviour to `health/watcher_respawn.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3680 lines; -40 from #3591 100턴 세션 리셋(AssistantTurnCap) 제거: reset 판정/clear/DB clear/display 블록 삭제; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리); +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3615 lines; -65 from #3653 removing the separate session-restore notify bot send path so restore is absorbed by the session/status panel; -40 from #3591 100턴 세션 리셋(AssistantTurnCap) 제거: reset 판정/clear/DB clear/display 블록 삭제; -2 from #3588 idle 세션 리셋 제거(IdleExpired display arm + `now` 인자 정리); +23 from #3557 Codex review: cap the INITIAL watchdog deadline at the provider hard ceiling (+one-shot ceiling warn); +27 from #3557 (A) per-turn hard-ceiling clamp wired into the watchdog auto-extend block; +1 from #3479 item-3 `shared.dispatch.<field>` nesting;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; #3464 extracted the
     unauthorized-voice-announcement scope decision to `voice_announcement_scope.rs`;

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -478,6 +478,7 @@ fn status_panel_renders_session_resumed_line_from_lifecycle_details() {
     assert!(rendered.contains("기존 세션 복원"));
     assert!(rendered.contains("provider session claude#8f21abcd…"));
     assert!(rendered.contains("tmux kept"));
+    assert!(!rendered.contains("📋 세션 복원"));
 }
 
 /// #3087 — when a new session INSTANCE begins (a new tmux spawn → new

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -15,8 +15,6 @@ use super::response_format::{
     merge_reply_contexts, should_note_memento_context_loaded, wrap_user_prompt_with_author,
 };
 pub(in crate::services::discord) use super::turn_start::reserve_headless_turn;
-#[cfg(test)]
-use super::turn_start::session_strategy_lifecycle_event;
 pub(crate) use super::turn_start::{
     HeadlessTurnReservation, HeadlessTurnStartError, HeadlessTurnStartOutcome,
     HeadlessTurnStartStatus,
@@ -28,6 +26,8 @@ use super::turn_start::{
     release_mailbox_after_placeholder_post_failure, session_runtime_state_after_redirect,
     take_session_retry_context,
 };
+#[cfg(test)]
+use super::turn_start::{session_strategy_lifecycle_event, should_emit_session_strategy_lifecycle};
 use crate::services::agent_protocol::RuntimeHandoffKind;
 use crate::services::memory::{
     RecallMode, RecallRequest, RecallResponse, RecallSizeBucket, build_memory_backend,

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -19,62 +19,6 @@ pub(super) const fn queue_pending_reactions_to_clear() -> [char; 2] {
     ['📬', '➕']
 }
 
-pub(super) async fn send_restore_notification(
-    shared: &Arc<SharedData>,
-    fallback_http: &Arc<serenity::Http>,
-    channel_id: ChannelId,
-    provider: &ProviderKind,
-    restored_session_id: Option<&str>,
-) {
-    let sid_full = restored_session_id.unwrap_or("?");
-    let sid_short: String = sid_full.chars().take(8).collect();
-    let restore_msg = format!(
-        "📋 세션 복원: {} (session: {})",
-        provider.as_str(),
-        sid_short
-    );
-
-    if let Some(registry) = shared.health_registry() {
-        match super::super::super::health::resolve_bot_http(registry.as_ref(), "notify").await {
-            Ok(notify_http) => match channel_id.say(&*notify_http, &restore_msg).await {
-                Ok(_) => return,
-                Err(err) => {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
-                        "  [{ts}] ⚠ Restore notify send failed in channel {}: {} — falling back to provider bot",
-                        channel_id,
-                        err
-                    );
-                }
-            },
-            Err((status, body)) => {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
-                    "  [{ts}] ⚠ Restore notify bot unavailable in channel {}: {} {} — falling back to provider bot",
-                    channel_id,
-                    status,
-                    body
-                );
-            }
-        }
-    } else {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ Restore notify bot unavailable in channel {}: health registry dropped — falling back to provider bot",
-            channel_id
-        );
-    }
-
-    if let Err(err) = channel_id.say(fallback_http, &restore_msg).await {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚠ Restore fallback send failed in channel {}: {}",
-            channel_id,
-            err
-        );
-    }
-}
-
 /// Bundle of Discord-runtime dependencies that `handle_text_message`
 /// reads from outside its per-message parameters. Phase 2-pre.2 of
 /// intake-node-routing (docs/design/intake-node-routing.md): the body
@@ -1417,15 +1361,6 @@ pub(in crate::services::discord) async fn handle_text_message(
                     session.restore_provider_session(Some(restored_session_id.clone()));
                     memento_context_loaded = session.memento_context_loaded;
                 }
-                // Notify: session restored — send before placeholder so it appears first
-                send_restore_notification(
-                    shared,
-                    http,
-                    channel_id,
-                    &provider,
-                    Some(restored_session_id.as_str()),
-                )
-                .await;
                 session_id = Some(restored_session_id);
             } else if let Some((recovered, recovered_memento_context_loaded)) =
                 restore_live_tui_provider_session_from_binding(

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -61,6 +61,34 @@ fn session_strategy_lifecycle_event_records_fresh_and_resumed_details() {
 }
 
 #[test]
+fn db_provider_session_restore_success_does_not_request_notify_message() {
+    let event = session_strategy_lifecycle_event(
+        Some("provider-session-123"),
+        "db_provider_session_restored",
+        None,
+    );
+
+    assert_eq!(event.meta().kind, "session_resumed");
+    assert!(!event.meta().notify_user);
+    assert_eq!(event.notification_reason_code(), None);
+    assert!(
+        event.notification_content().is_none(),
+        "successful DB session restore must not emit the old `📋 세션 복원` notify message"
+    );
+
+    match event {
+        TurnEvent::SessionResumed(details) => {
+            assert_eq!(details.reason, "db_provider_session_restored");
+            assert_eq!(
+                details.provider_session_id.as_deref(),
+                Some("provider-session-123")
+            );
+        }
+        other => panic!("expected session_resumed event, got {other:?}"),
+    }
+}
+
+#[test]
 fn cli_just_spawned_for_emit_handles_none_and_blank_session_names() {
     // Non-tmux mode (ProcessBackend / no managed session) always
     // re-spawns the CLI per turn, so the helper must report "just

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -61,22 +61,33 @@ fn session_strategy_lifecycle_event_records_fresh_and_resumed_details() {
 }
 
 #[test]
-fn db_provider_session_restore_success_does_not_request_notify_message() {
+fn db_provider_session_restore_existing_cli_renders_session_panel_line() {
+    assert!(
+        should_emit_session_strategy_lifecycle(
+            Some("provider-session-123"),
+            "db_provider_session_restored",
+            false,
+        ),
+        "cold DB restore must surface a session lifecycle row even when tmux survived restart"
+    );
+    assert!(
+        !should_emit_session_strategy_lifecycle(
+            Some("provider-session-123"),
+            "runtime_cached_provider_session",
+            false,
+        ),
+        "steady-state turn-to-turn continuation must stay suppressed"
+    );
+
     let event = session_strategy_lifecycle_event(
         Some("provider-session-123"),
         "db_provider_session_restored",
         None,
     );
+    let kind = event.meta().kind;
+    let details = event.details_json();
 
-    assert_eq!(event.meta().kind, "session_resumed");
-    assert!(!event.meta().notify_user);
-    assert_eq!(event.notification_reason_code(), None);
-    assert!(
-        event.notification_content().is_none(),
-        "successful DB session restore must not emit the old `📋 세션 복원` notify message"
-    );
-
-    match event {
+    match &event {
         TurnEvent::SessionResumed(details) => {
             assert_eq!(details.reason, "db_provider_session_restored");
             assert_eq!(
@@ -86,6 +97,20 @@ fn db_provider_session_restore_success_does_not_request_notify_message() {
         }
         other => panic!("expected session_resumed event, got {other:?}"),
     }
+
+    let events =
+        crate::services::discord::placeholder_live_events::PlaceholderLiveEvents::default();
+    let channel_id = serenity::ChannelId::new(3_653);
+    assert!(events.set_session_panel_lifecycle_event(channel_id, None, kind, &details));
+
+    let rendered = events.render_status_panel(
+        channel_id,
+        &crate::services::provider::ProviderKind::Claude,
+        1_700_000_000,
+    );
+    assert!(rendered.contains("기존 세션 복원"));
+    assert!(rendered.contains("provider session claude#provider…"));
+    assert!(!rendered.contains("📋 세션 복원"));
 }
 
 #[test]

--- a/src/services/discord/router/turn_start.rs
+++ b/src/services/discord/router/turn_start.rs
@@ -199,10 +199,10 @@ pub(super) async fn emit_session_strategy_lifecycle(
     let provider_session_id = provider_session_id
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let resumed = provider_session_id.is_some();
-    if resumed && !cli_was_just_spawned {
+    if !should_emit_session_strategy_lifecycle(provider_session_id, reason, cli_was_just_spawned) {
         return;
     }
+    let resumed = provider_session_id.is_some();
     let event = session_strategy_lifecycle_event(
         provider_session_id,
         reason,
@@ -235,6 +235,21 @@ pub(super) async fn emit_session_strategy_lifecycle(
             turn_id
         );
     }
+}
+
+pub(super) fn should_emit_session_strategy_lifecycle(
+    provider_session_id: Option<&str>,
+    reason: &str,
+    cli_was_just_spawned: bool,
+) -> bool {
+    let resumed = provider_session_id.is_some_and(|value| !value.trim().is_empty());
+    if !resumed || cli_was_just_spawned {
+        return true;
+    }
+
+    // This reason is assigned only at the cold DB restore boundary where
+    // in-memory session_id was None before fetching the persisted provider id.
+    reason == "db_provider_session_restored"
 }
 
 pub(super) fn session_strategy_lifecycle_event(


### PR DESCRIPTION
## 이슈
Closes #3653 — 세션 복원 시 별도 '📋 세션 복원' notify 메시지 제거, 복원 표시를 session/status panel(`session_resumed`)로 흡수(중복 알림 제거).

## 변경 (codex 구현)
- `router/message_handler/intake_turn.rs`: `send_restore_notification` 및 DB restore 성공 시 notify 호출 제거(-65)
- 회귀 테스트 추가: `session_strategy_lifecycle_tests.rs`, `placeholder_live_events/tests.rs` — restore 성공이 notify 없이 `session_resumed`/status panel로만 남음을 고정
- `change-surfaces.md` freeze 동기화(3615)

## 검증
- 로컬: cargo fmt ✅, freshness ✅, giant_file_ratchet ✅ (빌드 없음)
- 컴파일/clippy/test = 클라우드 CI
- 교차모델 리뷰: 구현=codex → 리뷰=opus, VERDICT CLEAN 필수

🤖 Generated with [Claude Code](https://claude.com/claude-code)