### PR TITLE
fix(#3654): task completion notify 카드를 footer 완료표시에 통합

### DIFF
--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -634,7 +634,9 @@ fn task_notification_success_completion_visible_in_snapshot(
             .subagents
             .iter()
             .any(|slot| slot.tool_use_id.as_deref() == Some(tool_use_id.as_str())),
-        StatusEvent::WorkflowEnd { success: true, .. } => true,
+        // Completion footers render Tasks/Subagents only. Suppressing Workflow
+        // completion cards here would drop the only completion signal.
+        StatusEvent::WorkflowEnd { .. } => false,
         _ => false,
     })
 }

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -215,6 +215,55 @@ impl PlaceholderLiveEvents {
         }
     }
 
+    /// #3393: bridge an observed `<task-notification>` XML user-record into the
+    /// live-panel terminal StatusEvents for `channel_id`.
+    pub(in crate::services::discord) fn bridge_task_notification_xml(
+        &self,
+        channel_id: ChannelId,
+        raw: &str,
+    ) {
+        let events = status_events::status_events_from_task_notification_xml(raw);
+        if events.is_empty() {
+            return;
+        }
+        let parsed = super::tui_task_card::parse_task_notification(raw);
+        tracing::info!(
+            channel_id = channel_id.get(),
+            kind = parsed.kind(),
+            tool_use_id = parsed.tool_use_id.as_deref().unwrap_or(""),
+            status = parsed.status.as_deref().unwrap_or(""),
+            "#3393: bridged user-record <task-notification> XML to live panel terminal StatusEvents"
+        );
+        self.push_status_events(channel_id, events);
+    }
+
+    pub(in crate::services::discord) fn task_notification_completion_visible_in_footer_for_mode(
+        &self,
+        channel_id: ChannelId,
+        raw: &str,
+        footer_mode_enabled: bool,
+    ) -> bool {
+        if !footer_mode_enabled {
+            return false;
+        }
+        let events =
+            status_events::status_events_from_task_notification_xml_for_footer_mode(raw, true);
+        if events.is_empty() {
+            return false;
+        }
+        let snapshot = self
+            .status_by_channel
+            .get(&channel_id)
+            .map(|entry| {
+                entry
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone()
+            })
+            .unwrap_or_default();
+        task_notification_success_completion_visible_in_snapshot(&snapshot, &events)
+    }
+
     pub(in crate::services::discord) fn set_session_panel_lifecycle_event(
         &self,
         channel_id: ChannelId,
@@ -563,4 +612,29 @@ impl PlaceholderLiveEvents {
             .unwrap_or_default();
         render_completion_footer(snapshot, provider, indicator)
     }
+}
+
+fn task_notification_success_completion_visible_in_snapshot(
+    snapshot: &StatusPanelState,
+    events: &[StatusEvent],
+) -> bool {
+    events.iter().any(|event| match event {
+        StatusEvent::BackgroundTaskEnd {
+            tool_use_id,
+            success: true,
+        } => snapshot.tasks.iter().any(|slot| {
+            slot.background && slot.tool_use_id.as_deref() == Some(tool_use_id.as_str())
+        }),
+        StatusEvent::SubagentEnd {
+            success: true,
+            tool_use_id: Some(tool_use_id),
+            ack_only: false,
+            ..
+        } => snapshot
+            .subagents
+            .iter()
+            .any(|slot| slot.tool_use_id.as_deref() == Some(tool_use_id.as_str())),
+        StatusEvent::WorkflowEnd { success: true, .. } => true,
+        _ => false,
+    })
 }

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -31,7 +31,7 @@ pub(super) struct SubagentSlot {
     pub(super) finished: Option<bool>,
     /// #3084: Task tool-use id that opened this slot, so `SubagentEnd` closes the
     /// exact slot among parallels instead of the first unfinished one.
-    tool_use_id: Option<String>,
+    pub(super) tool_use_id: Option<String>,
     /// #3086: TUI-parity accounting from the finishing `SubagentEnd`; drives the
     /// `Done (N tools · M tokens · Xs)` summary on the render line.
     summary: Option<SubagentSummary>,

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -5166,16 +5166,16 @@ fn task_notification_xml_workflow_gates_workflow_end_on_terminal_status() {
 }
 
 #[test]
-fn task_completion_card_suppression_allows_visible_workflow_completion_only() {
+fn workflow_completion_card_never_suppressed_because_footer_lacks_workflow_section() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_654_003);
 
     let completed = "<task-notification><task-id>wf-visible</task-id><status>completed</status>\
         <summary>Dynamic workflow \"probe\" completed</summary></task-notification>";
     assert!(
-        events
+        !events
             .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
-        "workflow completion is itself visible in the footer workflow section"
+        "completion footers do not render Workflow sections, so workflow completion cards must stay"
     );
     assert!(
         !events

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4964,6 +4964,95 @@ fn task_notification_xml_bridge_inert_when_footer_mode_off() {
     );
 }
 
+#[test]
+fn task_completion_card_suppression_requires_footer_mode_and_matching_background_slot() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_654_001);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "gh run watch",
+                "description": "Watch CI",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_bg_match"),
+            true,
+        ),
+    );
+
+    let completed = "<task-notification><task-id>bg1</task-id>\
+        <tool-use-id>toolu_bg_match</tool-use-id><status>completed</status>\
+        <summary>Background command \"Watch CI\" completed (exit code 0)</summary></task-notification>";
+    assert!(
+        events
+            .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
+        "footer-on matching background completion should suppress the notify card"
+    );
+    assert!(
+        !events
+            .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, false,),
+        "footer-off/legacy mode must keep the notify card"
+    );
+
+    let unknown = "<task-notification><task-id>bg2</task-id>\
+        <tool-use-id>toolu_bg_unknown</tool-use-id><status>completed</status>\
+        <summary>Background command \"Other\" completed (exit code 0)</summary></task-notification>";
+    assert!(
+        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, unknown, true),
+        "unknown tool-use-id has no footer completion surface, so the card must remain"
+    );
+
+    let failed = "<task-notification><task-id>bg3</task-id>\
+        <tool-use-id>toolu_bg_match</tool-use-id><status>failed</status>\
+        <summary>Background command \"Watch CI\" failed (exit code 1)</summary></task-notification>";
+    assert!(
+        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, failed, true),
+        "failure/error notifications keep their card for details instead of being footer-suppressed"
+    );
+}
+
+#[test]
+fn task_completion_card_suppression_requires_idful_matching_subagent_slot() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_654_002);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "scout",
+                "description": "Scout issue #3654",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_subagent_match"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("toolu_subagent_match")),
+    );
+
+    let completed = "<task-notification><task-id>sub1</task-id>\
+        <tool-use-id>toolu_subagent_match</tool-use-id><status>completed</status>\
+        <summary>Agent \"Scout issue #3654\" completed</summary></task-notification>";
+    assert!(
+        events
+            .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
+        "matching idful subagent completion should suppress the duplicate card"
+    );
+
+    let idless = "<task-notification><task-id>sub2</task-id><status>completed</status>\
+        <summary>Agent \"Scout issue #3654\" completed</summary></task-notification>";
+    assert!(
+        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, idless, true),
+        "id-less subagent completion cannot safely map to a footer slot"
+    );
+}
+
 // #3393 finding 1: an id-LESS subagent `<task-notification>` XML (no
 // `<tool-use-id>` child) must produce NO terminal effect. Before the fix the XML
 // bridge emitted `SubagentEnd { tool_use_id: None }`, the panel fell back to "the
@@ -5073,6 +5162,39 @@ fn task_notification_xml_workflow_gates_workflow_end_on_terminal_status() {
             .iter()
             .any(|e| matches!(e, StatusEvent::WorkflowEnd { success: false, .. })),
         "status=failed workflow XML must emit WorkflowEnd{{success:false}}: {failed_events:?}"
+    );
+}
+
+#[test]
+fn task_completion_card_suppression_allows_visible_workflow_completion_only() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_654_003);
+
+    let completed = "<task-notification><task-id>wf-visible</task-id><status>completed</status>\
+        <summary>Dynamic workflow \"probe\" completed</summary></task-notification>";
+    assert!(
+        events
+            .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
+        "workflow completion is itself visible in the footer workflow section"
+    );
+    assert!(
+        !events
+            .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, false,),
+        "footer-off/legacy mode must keep workflow completion cards"
+    );
+
+    let running = "<task-notification><task-id>wf-running</task-id><status>running</status>\
+        <summary>Dynamic workflow \"probe\" running</summary></task-notification>";
+    assert!(
+        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, running, true),
+        "non-terminal workflow notifications are not duplicate completion cards"
+    );
+
+    let failed = "<task-notification><task-id>wf-failed</task-id><status>failed</status>\
+        <summary>Dynamic workflow \"probe\" failed</summary></task-notification>";
+    assert!(
+        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, failed, true),
+        "failed workflow notifications keep their card for details"
     );
 }
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -811,19 +811,26 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             // its card but pushes NO terminal events, so a quoted live tool-use-id
             // cannot false-close a running slot. Layered with finding 1 (the XML
             // bridge requires a tool_use_id for any terminal End).
-            if is_start_anchored_task_notification(&prompt.prompt) {
-                bridge_task_notification_to_live_panel(shared, channel_id, &prompt.prompt);
+            let start_anchored_task_notification =
+                is_start_anchored_task_notification(&prompt.prompt);
+            if start_anchored_task_notification {
+                shared
+                    .ui
+                    .placeholder_live_events
+                    .bridge_task_notification_xml(channel_id, &prompt.prompt);
             }
             match super::tui_task_card::resolve_task_card_content(
                 &notify_http,
                 shared,
                 channel_id,
                 &prompt.prompt,
+                start_anchored_task_notification,
             )
             .await
             {
                 super::tui_task_card::TaskCardOutcome::Post { content } => content,
-                super::tui_task_card::TaskCardOutcome::Repeat => {
+                super::tui_task_card::TaskCardOutcome::Repeat
+                | super::tui_task_card::TaskCardOutcome::SuppressedByFooter => {
                     // #3075 codex P1 #2: a repeat early-returns before the bridge-tail
                     // lease-guard cleanup, but the lease recorded above would dangle and
                     // make `session_bound_external_lease_blocks_delivery` skip legitimate
@@ -4218,34 +4225,6 @@ fn resolve_owner_channel_authoritatively(
         }
         (None, None) => None,
     }
-}
-
-/// #3393: bridge an observed `<task-notification>` XML user-record into the live
-/// footer panel's terminal StatusEvents for `channel_id`. Background-task and
-/// subagent completions reach the transcript ONLY as this XML; the panel's own
-/// `system_status_events` parses a stream-json `system` record that never
-/// occurs, so without this bridge footer Tasks/Subagents never flip ✓ from real
-/// traffic and the #3391 delivered-ack eviction never triggers. The bridge is
-/// footer-mode gated INSIDE `status_events_from_task_notification_xml` (empty vec
-/// in legacy mode), and a terminal End for an unknown/id-less tool-use-id is a
-/// slot no-op, so a double notification cannot flip a slot back.
-fn bridge_task_notification_to_live_panel(shared: &SharedData, channel_id: ChannelId, raw: &str) {
-    let events = super::placeholder_live_events::status_events_from_task_notification_xml(raw);
-    if events.is_empty() {
-        return;
-    }
-    let parsed = super::tui_task_card::parse_task_notification(raw);
-    tracing::info!(
-        channel_id = channel_id.get(),
-        kind = parsed.kind(),
-        tool_use_id = parsed.tool_use_id.as_deref().unwrap_or(""),
-        status = parsed.status.as_deref().unwrap_or(""),
-        "#3393: bridged user-record <task-notification> XML to live panel terminal StatusEvents"
-    );
-    shared
-        .ui
-        .placeholder_live_events
-        .push_status_events(channel_id, events);
 }
 
 /// Local-completing slash-control prompts skip synthetic turn ownership.

--- a/src/services/discord/tui_task_card.rs
+++ b/src/services/discord/tui_task_card.rs
@@ -543,14 +543,13 @@ pub(super) enum CardSlot {
     /// place rather than posting a new message. `update_count` is the new
     /// (incremented) count.
     Edit { message_id: u64, update_count: u32 },
-    /// A card for this task-id has been RESERVED (a [`CardSlot::Post`] was handed
-    /// out) but its real message id has not been recorded yet via
-    /// [`record_card_message`] — another post for the same task-id is still in
-    /// flight. The caller MUST treat this as a no-op (drop this repeat) rather
-    /// than attempting to edit: there is no real message id to target, and
+    /// A card for this task-id has been RESERVED but has no Discord message id:
+    /// either a [`CardSlot::Post`] is still in flight or footer/status integration
+    /// intentionally suppressed the card. The caller MUST treat this as a no-op
+    /// rather than attempting to edit: there is no real message id to target, and
     /// constructing `MessageId::new(0)` would panic. The reserved slot is left
-    /// intact so the in-flight post still records its id and subsequent repeats
-    /// resolve to [`CardSlot::Edit`].
+    /// intact so an in-flight post can still record its id, while a footer-owned
+    /// task keeps later repeats collapsed.
     Pending,
 }
 
@@ -632,6 +631,25 @@ pub(super) fn record_posted_card(channel_id: u64, raw_prompt: &str, message_id: 
     record_card_message(channel_id, task_id.as_deref(), message_id);
 }
 
+/// Remember a footer-integrated task notification so repeat notifications with
+/// the same task-id stay collapsed even though no Discord card message exists.
+pub(super) fn record_footer_suppressed_card(channel_id: u64, raw_prompt: &str) {
+    let task_id = parse_task_notification(raw_prompt).task_id;
+    let Some(task_id) = task_id.as_deref().map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+    let mut store = CARD_STORE.lock().unwrap_or_else(|e| e.into_inner());
+    let now = Instant::now();
+    purge_and_bound(&mut store, channel_id, now);
+    let channel = store.by_channel.entry(channel_id).or_default();
+    let entry = channel.entry(task_id.to_string()).or_insert(TaskCardEntry {
+        message_id: 0,
+        update_count: 1,
+        touched_at: now,
+    });
+    entry.touched_at = now;
+}
+
 /// Drop the tracked card for a task-id (e.g. after an edit failed because the
 /// message is gone) so the next notification posts a fresh card.
 pub(super) fn forget_card(channel_id: u64, task_id: Option<&str>) {
@@ -647,9 +665,9 @@ pub(super) fn forget_card(channel_id: u64, task_id: Option<&str>) {
     }
 }
 
-/// Clear ONLY a still-reserved placeholder slot for a task-id — i.e. an entry a
-/// [`CardSlot::Post`] handed out whose real message id was never recorded
-/// (`message_id == 0`) because the first post FAILED (#3075 codex P2).
+/// Clear ONLY a still-reserved placeholder slot for a task-id — i.e. an entry
+/// with no real Discord message id (`message_id == 0`) because the first post
+/// FAILED (#3075 codex P2).
 ///
 /// Unlike [`forget_card`], this is an EXACT-MATCH on the placeholder we own: if
 /// the entry has since recorded a real message id (a concurrent post landed) or
@@ -657,7 +675,8 @@ pub(super) fn forget_card(channel_id: u64, task_id: Option<&str>) {
 /// untouched. This is the failure-path counterpart to [`record_card_message`]:
 /// a post either commits its real id (record) or releases its reservation
 /// (this), so a later same-task notification reserves fresh and reposts instead
-/// of being suppressed as `Pending` until the 1h stale purge.
+/// of being suppressed as `Pending` until the 1h stale purge. Footer-suppressed
+/// slots also use `message_id == 0`, but they never enter the post-failure path.
 ///
 /// Returns `true` if a placeholder was actually cleared.
 pub(super) fn forget_reserved_card(channel_id: u64, task_id: Option<&str>) -> bool {
@@ -717,6 +736,11 @@ pub(super) enum TaskCardOutcome {
     /// observation so a dangling lease cannot block session-bound / bridge-tail
     /// delivery (#3075 codex P1 #2).
     Repeat,
+    /// The live footer/status panel owns the visible successful completion for
+    /// this task notification. The caller must NOT post a notify card and should
+    /// early-return like [`TaskCardOutcome::Repeat`] after clearing its just-recorded
+    /// lease.
+    SuppressedByFooter,
 }
 
 /// Render the structured card for a `<task-notification>` and apply the #3075
@@ -728,14 +752,40 @@ pub(super) enum TaskCardOutcome {
 /// resulting message id. On a repeat sighting it edits the live card in place
 /// (or, if that message is gone, forgets it and reposts once; or, if the first
 /// post is still in flight, drops the repeat as a no-op) and returns
-/// [`TaskCardOutcome::Repeat`].
+/// [`TaskCardOutcome::Repeat`]. When footer suppression is allowed and active, the
+/// footer/status panel is the visible completion surface; no card is posted, but
+/// the task-id is still remembered so later repeats do not leak a delayed card.
 pub(super) async fn resolve_task_card_content(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
     raw_prompt: &str,
+    allow_footer_suppression: bool,
 ) -> TaskCardOutcome {
     let parsed = parse_task_notification(raw_prompt);
+    let suppress_card_for_footer = allow_footer_suppression
+        && shared
+            .ui
+            .placeholder_live_events
+            .task_notification_completion_visible_in_footer_for_mode(
+                channel_id,
+                raw_prompt,
+                super::single_message_panel::footer_mode_enabled(
+                    super::single_message_panel::enabled(),
+                    shared.ui.status_panel_v2_enabled,
+                ),
+            );
+    if suppress_card_for_footer {
+        record_footer_suppressed_card(channel_id.get(), raw_prompt);
+        tracing::info!(
+            channel_id = channel_id.get(),
+            task_id = parsed.task_id.as_deref().unwrap_or(""),
+            kind = parsed.kind(),
+            status = parsed.status.as_deref().unwrap_or(""),
+            "#3654: suppressed task completion notify card because footer/status panel owns the completion surface"
+        );
+        return TaskCardOutcome::SuppressedByFooter;
+    }
     let task_id = parsed.task_id.clone();
     match reserve_card_slot(channel_id.get(), task_id.as_deref()) {
         CardSlot::Post { update_count } => TaskCardOutcome::Post {
@@ -969,6 +1019,31 @@ mod tests {
         );
         assert!(card.contains("updated 5x"));
         assert!(card.contains("Latest: latest detail"));
+    }
+
+    #[test]
+    fn footer_suppressed_task_id_dedupes_later_repeats() {
+        let _guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_card_store_for_tests();
+        let channel = 3_654_u64;
+        let raw = payload(&[
+            ("task-id", "footer-owned-task"),
+            ("tool-use-id", "toolu_footer_owned"),
+            ("status", "completed"),
+            (
+                "summary",
+                "Background command \"Watch CI\" completed (exit code 0)",
+            ),
+        ]);
+
+        record_footer_suppressed_card(channel, &raw);
+        assert_eq!(
+            reserve_card_slot(channel, Some("footer-owned-task")),
+            CardSlot::Pending,
+            "a footer-integrated completion must reserve the task-id so repeats do not post a late card"
+        );
     }
 
     // #3075: a notification that OMITS tool-use-id (and even task-id) must still


### PR DESCRIPTION
## 이슈
Closes #3654 — footer/status panel이 성공 completion을 이미 표시하는 footer-on 모드에서 중복되는 task completion notify 카드를 suppress(통합).

## 변경 (codex 구현)
- `tui_prompt_relay.rs`, `tui_task_card.rs`, `placeholder_live_events/mod.rs`: footer-on + 매칭 성공 completion이면 notify 카드 suppress. footer-off/legacy·unknown/id-less·nonterminal·failure는 notify 유지(over-suppress 회피). suppress된 task-id를 dedupe store에 예약해 늦은 카드 누출 방지.
- 테스트 +122줄(footer on/off, terminal/nonterminal, failure 케이스).

## 검증
- 로컬: cargo fmt ✅, freshness ✅, giant_file_ratchet ✅, git diff --check ✅ (빌드 없음)
- 컴파일/clippy/test = 클라우드 CI
- 교차모델 리뷰: 구현=codex → 리뷰=opus, VERDICT CLEAN 필수

🤖 Generated with [Claude Code](https://claude.com/claude-code)