### PR TITLE
fix(#3656): registry drift eager repair + watchdog turn-anchored age (relay 누락/오탐 동시 해소)

### DIFF
--- a/DRIFT_REPAIR_ANALYSIS.md
+++ b/DRIFT_REPAIR_ANALYSIS.md
@@ -1,0 +1,597 @@
+# Issue #3656: Drift Recovery Machine Analysis — Very Thorough Dissection
+
+## Executive Summary
+
+The drift recovery machine in `idle_relay_drift.rs` (lines 241-367) is **NOT suitable for immediate (sub-second) invocation from the drop site** (`tui_prompt_relay.rs::resolve_owner_channel_authoritatively`) due to:
+
+1. **60-second cooldown + single-flight gate** (lines 316-337): blocks rapid re-attempts after the first repair attempt, even on failure.
+2. **Async task spawn overhead**: repair is never synchronous — it spawns an observed task (`task_supervisor::spawn_observed`) that runs the full decision core async.
+3. **Potential drift re-occurrence after repair**: the restored binding can be cleared by rehydration sweeps or watcher removal, making drift "sticky" with re-trigger risk.
+
+The repair is designed for **periodic autonomous healing** (triggered by the ~500ms idle poll loop), NOT **eager on-demand repair** from the drop site.
+
+---
+
+## 1. `evaluate_drift_repair` (lines 241–291): Decision Core
+
+### Input/Output Contract
+
+**Input (`RepairInputs`, lines 217–231):**
+- `settings_channel: Option<u64>` — Settings-derived binding (from `resolve_rehydrated_claude_tmux_channel_id`)
+- `db_channel: Option<u64>` — Durable `sessions.channel_id` column
+- `db_instance: Option<String>` — Owner instance ID from DB row
+- `local_instance: String` — This process's instance ID
+- `mirror_channel: Option<u64>` — Dedupe mirror's last-seen channel (drift witness)
+- `pane_live: bool` — Whether the tmux session has a live pane
+
+**Output (`RepairDecision`, lines 206–213):**
+```rust
+pub(super) enum RepairDecision {
+    Promote { source: RepairSource, channel: u64 },  // Two sources
+    Blocked(BlockReason),                             // Four block reasons
+    NoSource,                                         // No durable value
+}
+```
+
+### Exact Decision Tree (lines 241–291)
+
+**Gate 1: Dead Pane Check (lines 242–250)**
+```rust
+if !inputs.pane_live {
+    if inputs.settings_channel.is_none() && inputs.db_channel.is_none() {
+        return RepairDecision::NoSource;
+    }
+    return RepairDecision::Blocked(BlockReason::DeadPane);
+}
+```
+- **Line 242**: If pane is dead → can NEVER promote (mirrors #3105 dead-pane semantics)
+- **Line 246**: If no candidate at all → `NoSource` (not a spurious block)
+- **Line 249**: Otherwise → `Blocked(DeadPane)` (candidate exists but pane is dead)
+
+**Gate 2: Settings Priority (lines 252–257)**
+```rust
+if let Some(channel) = inputs.settings_channel {
+    return RepairDecision::Promote {
+        source: RepairSource::Settings,
+        channel,
+    };
+}
+```
+- **Line 252–256**: Settings channel ALWAYS wins when pane is live.
+- **No guard**: settings binding is already trust-verified (#3105 trust level).
+- **Immediate return**: no further checks if settings hits.
+
+**Gate 3: DB Channel Requirement (lines 259–261)**
+```rust
+let Some(db_channel) = inputs.db_channel else {
+    return RepairDecision::NoSource;
+};
+```
+- **Line 259–260**: If no DB source → `NoSource` (keep the drop, #3018 semantics preserved).
+
+**Guard (b): Instance Isolation (lines 266–275)**
+```rust
+if let Some(db_instance) = inputs.db_instance.as_deref().map(str::trim)
+    .filter(|value| !value.is_empty())
+{
+    if db_instance != inputs.local_instance.trim() {
+        return RepairDecision::Blocked(BlockReason::ForeignInstance);
+    }
+}
+```
+- **Line 266–270**: Extract non-empty trimmed instance ID from DB row.
+- **Line 272**: ONLY block if instance differs from local instance.
+- **Implication**: Missing `db_instance` or empty string → **NOT blocked** (silently accepted as local).
+
+**Guard (c): Mirror Witness + Agreement (lines 281–290)**
+```rust
+match inputs.mirror_channel {
+    None => RepairDecision::Blocked(BlockReason::NoMirrorWitness),
+    Some(mirror_channel) if mirror_channel != db_channel => {
+        RepairDecision::Blocked(BlockReason::MirrorMismatch)
+    }
+    Some(_) => RepairDecision::Promote {
+        source: RepairSource::SessionsTable,
+        channel: db_channel,
+    },
+}
+```
+- **Line 282**: No mirror → `Blocked(NoMirrorWitness)` — drift condition itself requires mirror presence.
+- **Line 283–284**: Mirror disagrees with DB (name reuse / rebind window) → `Blocked(MirrorMismatch)`.
+  - **Misdelivery protection**: NEW dispatch already recorded different channel, old DB row is stale.
+- **Line 286–288**: Mirror agrees → `Promote(SessionsTable, db_channel)`.
+
+### Summary of Branches (line-by-line)
+
+| Condition | Line | Return |
+|-----------|------|--------|
+| `!pane_live && no_candidate` | 246 | `NoSource` |
+| `!pane_live && candidate_exists` | 249 | `Blocked(DeadPane)` |
+| `settings_channel.is_some() && pane_live` | 254–256 | `Promote(Settings, channel)` |
+| `db_channel.is_none()` | 260 | `NoSource` |
+| `db_instance != local_instance` | 273 | `Blocked(ForeignInstance)` |
+| `mirror_channel.is_none()` | 282 | `Blocked(NoMirrorWitness)` |
+| `mirror_channel != db_channel` | 284 | `Blocked(MirrorMismatch)` |
+| `mirror_channel == db_channel` | 287–289 | `Promote(SessionsTable, db_channel)` |
+
+---
+
+## 2. Cooldown + Single-Flight State Machine (lines 316–337)
+
+### `try_begin_repair` Function Signature
+
+```rust
+#[cfg(unix)]
+fn try_begin_repair(tmux_session_name: &str, now: Instant) -> Option<RepairInflightGuard> {
+```
+
+**Returns:**
+- `Some(guard)` → caller may proceed; guard must be held until repair completes.
+- `None` → repair already inflight OR 60s cooldown not elapsed.
+
+### Exact State Machine (lines 316–337)
+
+**Step 1: Lock & Cleanup (lines 318–320)**
+```rust
+let mut map = DRIFT_STATE.lock().unwrap_or_else(|error| error.into_inner());
+purge_expired_locked(&mut map, now);
+```
+- Acquire global `DRIFT_STATE` mutex (process-wide).
+- Purge any per-session state untouched >24h (line 85: `DRIFT_STATE_TTL`).
+
+**Step 2: Get or Initialize Session State (lines 321–323)**
+```rust
+let state = map
+    .entry(tmux_session_name.to_string())
+    .or_insert_with(|| DriftState::new(now));
+```
+- Create `DriftState` if not present (line 99–108):
+  - `first_seen_at: now`
+  - `last_touched_at: now`
+  - `last_warn_at: None`
+  - `suppressed_count: 0`
+  - `last_repair_attempt_at: None`
+  - `repair_inflight: false`
+
+**Step 3: Single-Flight Check (lines 324–326)**
+```rust
+if state.repair_inflight {
+    return None;
+}
+```
+- If another repair is already running → **IMMEDIATE REJECT** (no backoff timer).
+- Single-flight prevents concurrent repairs for the same session.
+
+**Step 4: Cooldown Check (lines 327–330)**
+```rust
+if let Some(last) = state.last_repair_attempt_at {
+    if now.saturating_duration_since(last) < DRIFT_REPAIR_COOLDOWN {
+        return None;
+    }
+}
+```
+- **Line 81**: `DRIFT_REPAIR_COOLDOWN = Duration::from_secs(60)`.
+- If `last_repair_attempt_at` is set AND less than 60s ago → **BLOCK** (cooldown active).
+- If `last_repair_attempt_at` is `None` → **ALLOW** (first attempt, no cooldown yet).
+
+**Step 5: Claim Slot (lines 332–337)**
+```rust
+state.last_repair_attempt_at = Some(now);
+state.repair_inflight = true;
+Some(RepairInflightGuard {
+    tmux_session_name: tmux_session_name.to_string(),
+})
+```
+- Mark the time of this repair attempt.
+- Set `repair_inflight` flag to block concurrent attempts.
+- Return guard; **on guard drop** (line 301–309), `repair_inflight` is cleared by RAII.
+
+### Scenario: Cooldown Blocks Eager Repair
+
+**Timeline:**
+1. **t=0s**: `on_idle_relay_drift` called → `try_begin_repair` → ALLOWED (first attempt).
+   - `last_repair_attempt_at = t0`; `repair_inflight = true`.
+   - Async task spawned.
+2. **t=0.5s**: Same session drift detected again (next idle poll, ~500ms cycle).
+   - `on_idle_relay_drift` called → `try_begin_repair` → **REJECTED** (single-flight active).
+   - Repair task from step 1 still running.
+3. **t=5s**: Repair task completes, `repair_inflight` cleared by guard drop.
+   - Drift detected again (idle poll) → `try_begin_repair` → **REJECTED** (cooldown active, 60s not elapsed).
+   - Repair is **rate-limited** until **t=60s**.
+4. **t=60s+**: Cooldown expires → `try_begin_repair` → **ALLOWED**.
+
+**Impact**: Even if the first repair **FAILS**, the 60s cooldown still activates, blocking eager re-attempts.
+
+---
+
+## 3. `on_idle_relay_drift` / `attempt_drift_repair` (lines 343–443)
+
+### Entry Point: `on_idle_relay_drift` (lines 343–367)
+
+```rust
+pub(super) fn on_idle_relay_drift(
+    shared: &Arc<SharedData>,
+    provider: ProviderKind,
+    tmux_session_name: &str,
+) {
+```
+
+**Step 1: Provider Filter (lines 351–353)**
+```rust
+if provider != ProviderKind::Claude {
+    return;
+}
+```
+- **Repair is Claude-only** (settings resolver is Claude-specific; routine hook flow is Claude/routine only).
+- Codex drift gets rate-limited WARN only, no repair.
+
+**Step 2: Try Claim Slot (lines 355–358)**
+```rust
+let now = Instant::now();
+let Some(guard) = try_begin_repair(tmux_session_name, now) else {
+    return;
+};
+```
+- **Immediate return** if cooldown or single-flight blocks.
+- **No async fallback**: if the slot is occupied or cooldown is active, the function exits synchronously.
+
+**Step 3: Async Spawn (lines 360–366)**
+```rust
+let shared = shared.clone();
+let tmux_session_name = tmux_session_name.to_string();
+super::task_supervisor::spawn_observed("idle_relay_drift_repair", async move {
+    attempt_drift_repair(&shared, &tmux_session_name, guard).await;
+});
+```
+- **Fully async**: spawns on the Tokio runtime via `task_supervisor::spawn_observed`.
+- Guard is **moved into the task** → kept held for the entire async operation.
+- **No synchronous completion**: function returns immediately after spawn.
+
+### Async Repair Task: `attempt_drift_repair` (lines 370–443)
+
+**Data Collection Phase (lines 375–405):**
+
+1. **Settings Channel (line 377)** — Synchronous, no lock:
+   ```rust
+   let settings_channel = super::tui_prompt_relay::
+       resolve_rehydrated_claude_tmux_channel_id(tmux_session_name);
+   ```
+   - **No await**: purely synchronous list scan over registered bindings.
+
+2. **DB Channel + Instance (line 381)** — Async DB query:
+   ```rust
+   let (db_channel, db_instance) = load_db_channel(shared, tmux_session_name).await;
+   ```
+   - **Awaited**: may block on DB I/O (lines 446–472).
+   - **Candidates**: tries both namespaced and legacy session keys.
+
+3. **Mirror Channel (line 385)** — Synchronous, read-only:
+   ```rust
+   let mirror_channel = crate::services::tui_prompt_dedupe::
+       owner_channel_for_tmux_session(tmux_session_name);
+   ```
+   - **No lock**: read-only access to in-memory dedupe mirror map.
+
+4. **Pane Live Check (lines 388–395)** — Blocking pool task:
+   ```rust
+   let pane_live = {
+       let probe_name = tmux_session_name.to_string();
+       tokio::task::spawn_blocking(move || {
+           crate::services::tmux_diagnostics::tmux_session_has_live_pane(&probe_name)
+       })
+       .await
+       .unwrap_or(false)
+   };
+   ```
+   - **Spawned on blocking pool**: synchronous tmux subprocess call.
+   - **Awaited**: may block on tmux I/O.
+   - **Fallback**: if the task is cancelled/panics → `false` (conservative, blocks repair).
+
+**Decision Phase (line 407):**
+```rust
+match evaluate_drift_repair(&inputs) {
+    RepairDecision::Promote { source, channel } => {
+        let repaired = shared
+            .tmux_watchers
+            .restore_owner_channel_for_tmux_session(tmux_session_name, ChannelId::new(channel));
+        if repaired {
+            tracing::warn!(...);
+        }
+    }
+    RepairDecision::Blocked(reason) => {
+        tracing::warn!(...);
+    }
+    RepairDecision::NoSource => {
+        tracing::debug!(...);
+    }
+}
+```
+
+**Registry Promotion (line 413):**
+- **Synchronous, lock-held**: `restore_owner_channel_for_tmux_session` takes the registry lock briefly.
+- **Idempotent**: no-ops if value unchanged or live watcher already owns it.
+- Returns `true` only on first/changed registration.
+
+---
+
+## 4. Settings Channel Behavior (agentdesk.yaml Registration)
+
+### Does `settings_channel` Always Resolve for Registered Bindings?
+
+**Answer: NO.** Settings binding is a **best-effort match** that fails silently if:
+
+1. **Tmux session name doesn't match** any registered binding pattern.
+   - Routine sessions like `claude-routine-token-daily-report-…` match NO settings channel.
+   - That's the **core problem** #3306 solves: permanent drift for routine sessions.
+
+2. **Ambiguous match** (multiple conflicting bindings).
+   - If two settings bindings claim the same session name, the second is skipped (line not shown, but implied by rehydration logic).
+
+3. **Channel ID mismatch** during rehydration.
+   - Segments are tried in order (channel_id, fallback_name); if a segment resolves but conflicts, it's skipped.
+
+**Relevant code** (`resolve_rehydrated_claude_tmux_channel_id`, lines 4263+):
+- Iterates registered bindings.
+- For each binding, tries segment matching (channel_id text, fallback_name).
+- Returns the FIRST unambiguous hit; **returns `None` if no hit**.
+
+### What Gets Written to Registry on Promotion?
+
+**Function**: `restore_owner_channel_for_tmux_session` (mod.rs lines 1012–1033)
+
+```rust
+pub(super) fn restore_owner_channel_for_tmux_session(
+    &self,
+    tmux_session_name: &str,
+    channel_id: ChannelId,
+) -> bool {
+    let _guard = lock_tmux_watcher_registry();
+    if self.owner_channel_by_tmux_session.contains_key(tmux_session_name) {
+        self.restored_owner_by_tmux_session.remove(tmux_session_name);
+        return false;
+    }
+    let changed = self.restored_owner_by_tmux_session
+        .get(tmux_session_name)
+        .map(|entry| *entry.value())
+        != Some(channel_id);
+    self.restored_owner_by_tmux_session.insert(tmux_session_name.to_string(), channel_id);
+    changed
+}
+```
+
+**Registry Map Written To**: `restored_owner_by_tmux_session` (DashMap<String, ChannelId>).
+
+**Reads From**: `owner_channel_for_tmux_session` (mod.rs lines 978–995)
+- Checks `owner_channel_by_tmux_session` (live watcher, authority).
+- Falls back to `restored_owner_by_tmux_session` (#3105 restored, still authoritative).
+- **Never checks the mirror** (preserves #3018 "never route from mirror" invariant).
+
+---
+
+## 5. Access from Drop Site: Reusability & Barriers
+
+### Drop Site Signature & Available Context
+
+**Resolver Location**: `tui_prompt_relay.rs::resolve_owner_channel_authoritatively` (line 4203)
+
+```rust
+fn resolve_owner_channel_authoritatively(
+    tmux_session_name: &str,
+    registry_owner: Option<ChannelId>,
+    dedupe_owner: Option<u64>,
+) -> Option<ChannelId> {
+```
+
+**Caller**: `owner_channel_for_tmux_session` (line 4195)
+
+```rust
+fn owner_channel_for_tmux_session(
+    shared: &Arc<SharedData>,
+    tmux_session_name: &str,
+) -> Option<ChannelId> {
+    let registry_owner = shared
+        .tmux_watchers
+        .owner_channel_for_tmux_session(tmux_session_name);
+    let dedupe_owner = crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(tmux_session_name);
+    resolve_owner_channel_authoritatively(tmux_session_name, registry_owner, dedupe_owner)
+}
+```
+
+**Invocation Site** (idle loop, line ~4180):
+
+```rust
+for (tmux_session_name, binding) in
+    crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(RuntimeHandoffKind::ClaudeTui)
+{
+    let Some(channel_id) = owner_channel_for_tmux_session(&shared, &tmux_session_name) else {
+        super::idle_relay_drift::on_idle_relay_drift(
+            &shared,
+            ProviderKind::Claude,
+            &tmux_session_name,
+        );
+        continue;
+    }
+    // Route to channel_id...
+}
+```
+
+### Available State at Drop Site
+
+| Item | Available? | Synchronicity | Notes |
+|------|-----------|---|---|
+| `shared: &Arc<SharedData>` | ✓ | sync | Contains `tmux_watchers` registry, `pg_pool`, instance ID. |
+| `tmux_session_name: &str` | ✓ | sync | From dedupe runtime bindings. |
+| `ProviderKind` | ✓ | sync | Known at invocation (Claude). |
+| Registry query results | ✓ | sync | Already resolved in `owner_channel_for_tmux_session`. |
+| Mirror query results | ✓ | sync | Already resolved in `owner_channel_for_tmux_session`. |
+
+### What Repair Needs vs. What's Available
+
+**`on_idle_relay_drift` signature** (line 343):
+```rust
+pub(super) fn on_idle_relay_drift(
+    shared: &Arc<SharedData>,
+    provider: ProviderKind,
+    tmux_session_name: &str,
+)
+```
+
+**Requirements → Available?**
+- `shared` → ✓ Available (passed to idle loop).
+- `provider` → ✓ Available (known as Claude at drop site).
+- `tmux_session_name` → ✓ Available (parameter).
+
+**Conclusion: Repair IS directly callable from drop site.**
+
+### Required Handles for Synchronous Invocation
+
+If someone attempted to call repair **synchronously** from drop site (NOT async spawn):
+
+1. **`shared.tmux_watchers`** → needed for `restore_owner_channel_for_tmux_session` (registry lock).
+2. **`shared.pg_pool`** → needed for `load_db_channel` (DB queries).
+3. **`shared.token_hash`** → needed for session key candidates.
+4. **Tokio runtime** → needed for `spawn_blocking` (pane live check).
+
+All are accessible via `&Arc<SharedData>`.
+
+---
+
+## 6. Drift Persistence & Re-occurrence Risk ("Stickiness")
+
+### Promotion Persistence
+
+**Question**: Does the promoted binding "stick" or can it be cleared, causing drift to re-occur?
+
+**Answer: Binding can be cleared** (not sticky), re-enabling drift.
+
+### Clearing Paths
+
+**Path 1: Rehydration Sweep** (`tui_prompt_relay/rehydration.rs`)
+
+```rust
+// When a dead pane is detected:
+shared.tmux_watchers.clear_restored_owner_for_tmux_session(&tmux_session_name);
+if crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(&tmux_session_name) {
+    tracing::warn!(...);
+}
+```
+
+- The rehydration loop (line ~4170, periodic pass) **actively clears** restored owners for dead panes.
+- If the watcher gets cleaned up and the pane is declared dead, the restoration is erased.
+- **Next idle poll**: drift re-occurs (mirror still present, registry now empty).
+
+**Path 2: Watcher Removal** (`mod.rs::remove_tmux_session_locked`)
+
+```rust
+fn remove_tmux_session_locked(
+    &self,
+    _guard: &std::sync::MutexGuard<'_>,
+    tmux_session_name: &str,
+) -> Option<(ChannelId, TmuxWatcherHandle)> {
+    let (_, owner_channel_id) = self
+        .owner_channel_by_tmux_session
+        .remove(tmux_session_name)?;
+    self.tmux_session_by_channel.remove(&owner_channel_id);
+    self.by_tmux_session
+        .remove(tmux_session_name)
+        .map(|(_, handle)| (owner_channel_id, handle))
+}
+```
+
+- Removes from `owner_channel_by_tmux_session` (live watcher authority).
+- **Does NOT clear** `restored_owner_by_tmux_session` (that requires explicit call to `clear_restored_owner_for_tmux_session`).
+
+**Path 3: Watcher Respawn**
+
+- If a watcher reconnects (`rehydrate_existing_claude_tui_bindings`, line ~4170), it:
+  - **Re-claims** `owner_channel_by_tmux_session` via `claim_owner_channel_for_tmux_session`.
+  - Does **not automatically clear** the restored binding.
+  - If new watcher has the same channel → no problem (redundant).
+  - If new watcher has a different channel (rebind) → **restored binding is stale** but not cleared.
+
+### Drift Re-occurrence Scenario
+
+**Timeline:**
+1. **t=0s**: Drift detected, repair triggered, settings binding promoted to `restored_owner_by_tmux_session[session]`.
+   - Idle relay routes again.
+2. **t=10s**: Rehydration sweep detects pane is dead → calls `clear_restored_owner_for_tmux_session`.
+   - `restored_owner_by_tmux_session[session]` cleared.
+3. **t=15s**: Pane comes back live (reconnect).
+   - Dedupe mirror still has old channel (24h TTL in-memory).
+   - Registry is empty (watcher removed, restoration cleared).
+   - **Drift re-occurs** on next idle poll (~500ms).
+4. **t=15.5s+**: New repair triggered by drift, BUT...
+   - If last repair was at t=0s and it's now t=15.5s, **cooldown expired** (60s threshold). ✓ Repair allowed.
+   - If last repair was at t=10s (e.g., a second repair attempt before pane died), **cooldown may still be active**. ✗ Repair blocked until t=70s.
+
+### Stickiness Assessment
+
+**Sticky: NO** — the restored binding is not permanently protected. It can be cleared by rehydration or manual cleanup. Drift can re-occur if:
+- The pane is re-evaluated and declared dead.
+- A watcher respawn clears the old restoration.
+- Explicit `clear_restored_owner_for_tmux_session` is called.
+
+**Risk**: If drift re-occurs within 60s of the previous repair attempt (even if repair failed), it's rate-limited and cannot be repaired again. This could cause a gap window.
+
+---
+
+## Summary Table: Repair Machine Characteristics
+
+| Aspect | Behavior | Details |
+|--------|----------|---------|
+| **Entry Point** | `on_idle_relay_drift(&shared, provider, tmux_name)` | Called from idle loop (~500ms) on drift detection. |
+| **Provider Scope** | Claude-only | Codex gets rate-limited WARN only, no repair. |
+| **Synchronicity** | Fully async | Spawned as observed task; returns immediately. |
+| **Cooldown** | 60 seconds | After ANY repair attempt (success/fail), blocks retries for 60s. |
+| **Single-Flight** | Per-session | One repair in-flight per tmux session; concurrent attempts rejected. |
+| **Decision Core** | IO-free pure function | `evaluate_drift_repair(&inputs) -> RepairDecision` (unit-testable). |
+| **Settings Priority** | Always wins (pane-live) | If settings resolves → promote immediately, skip DB/mirror checks. |
+| **DB Source Guards** | 3-fold | (1) live pane, (2) instance match, (3) mirror agreement. |
+| **Mirror Use** | Block-only gate | Never routes from mirror; only validates DB channel. |
+| **Registry Promotion** | Idempotent | Writes to `restored_owner_by_tmux_session` map. |
+| **Stickiness** | Non-persistent | Binding can be cleared by rehydration or watcher removal. |
+| **Callable from Drop Site** | YES | All required handles (`shared`, `provider`, `tmux_name`) available. |
+| **Eager Invocation** | **BLOCKED by cooldown** | Cannot be called synchronously from drop site; async spawn required; 60s cooldown prevents rapid re-attempts. |
+
+---
+
+## Recommendations
+
+### For On-Drop (Immediate) Repair via Drop Site
+
+**Current Design**: NOT suitable. The repair machine is designed for periodic autonomous healing via the idle loop.
+
+**If immediate repair is desired:**
+
+1. **Decouple decision from cooldown**: Create a separate synchronous `evaluate_drift_repair_immediately()` that does NOT consult `DRIFT_STATE` cooldown. Call it from drop site to emit a *synchronous* decision log (no async spawn).
+
+2. **Eager synchronous restoration**: If the pure decision core returns `Promote { source, channel }`, immediately call `restore_owner_channel_for_tmux_session` **synchronously** from drop site (before returning `None`).
+   - **Trade-off**: Blocks the idle loop briefly on each drift (registry lock is synchronous anyway).
+   - **Benefit**: Repair is immediate (sub-millisecond, not 60s delayed).
+
+3. **Keep async repair as background opt**: Keep the current `on_idle_relay_drift` async spawn as a fallback for **complex sources** (e.g., DB queries on high latency). Drop site repair handles fast paths only.
+
+### For Preventing Drift Re-occurrence
+
+1. **Protect restoration from rehydration clearing**: Add a flag to `DriftState` tracking "repair succeeded"; don't clear the restored binding during rehydration if repair recently succeeded.
+
+2. **Extend cooldown after rehydration clears**: If rehydration clears a binding, don't reset the cooldown; let the next repair (after cooldown expires) re-promote.
+
+3. **Monitor drift lifecycle**: Track drift first-seen → repaired → cleared timeline to detect pathological re-repair loops.
+
+---
+
+## Code Locations (Exact Lines)
+
+| Component | File | Lines |
+|-----------|------|-------|
+| `evaluate_drift_repair` | `idle_relay_drift.rs` | 241–291 |
+| `RepairInputs` / `RepairDecision` | `idle_relay_drift.rs` | 206–231 |
+| `try_begin_repair` | `idle_relay_drift.rs` | 316–337 |
+| `on_idle_relay_drift` | `idle_relay_drift.rs` | 343–367 |
+| `attempt_drift_repair` | `idle_relay_drift.rs` | 370–443 |
+| `resolve_owner_channel_authoritatively` | `tui_prompt_relay.rs` | 4203–4228 |
+| `owner_channel_for_tmux_session` | `tui_prompt_relay.rs` | 4195–4200 |
+| Drop site idle loop | `tui_prompt_relay.rs` | ~4180–4190 |
+| `restore_owner_channel_for_tmux_session` | `mod.rs` | 1012–1033 |
+| `owner_channel_for_tmux_session` (registry) | `mod.rs` | 978–995 |

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -993,7 +993,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2726 lines; +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2722 lines; #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -993,7 +993,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2722 lines; +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2726 lines; +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1190,7 +1190,7 @@ pub fn spawn_watchdog(port: u16) {
 /// All gates must hold:
 /// - `attached == true` and `desynced == true` (snapshot already classified
 ///   the watcher as detached/diverged), AND
-/// - `inflight_updated_at` is older than `threshold_secs` seconds
+/// - `inflight_started_at` is older than `threshold_secs` seconds
 ///   (defaults to `2 * INFLIGHT_STALENESS_THRESHOLD_SECS`), AND
 /// - `terminal_delivery_committed == false` (the in-flight row is NOT a
 ///   normally-completed turn that is merely sleeping; see below).
@@ -1308,21 +1308,25 @@ async fn preserve_resume_selector_on_force_clean(
 /// turns keeps the watchdog targeting only genuinely hung (never-completed)
 /// turns.
 ///
-/// #3041 post-restart grace: `inflight_updated_at` is frozen at the wall-clock
-/// time of the last relay write *before* a dcserver restart. Right after a
-/// deploy/restart every watcher is transiently `desynced` (relay offsets not
-/// yet re-synced) while its inflight row already reads arbitrarily stale — so
-/// the bare `now - updated_at >= threshold` test fires immediately and
-/// force-kills a perfectly healthy work session that simply hadn't re-synced
-/// yet. Anchoring the age at `max(updated_at, boot)` restarts the staleness
-/// clock at boot, giving the watcher a full `threshold_secs` window after the
-/// restart to re-sync (which clears `desynced` and the kill never happens).
-/// A genuinely hung turn stays desynced past that window and is still cleaned.
+/// #3041 post-restart grace: the current turn's `started_at` may predate a
+/// dcserver restart. Right after deploy/restart every watcher is transiently
+/// `desynced` (relay offsets not yet re-synced), so the bare
+/// `now - started_at >= threshold` test could fire immediately and force-kill
+/// a perfectly healthy work session that simply hadn't re-synced yet. Anchoring
+/// the age at `max(started_at, boot)` restarts the staleness clock at boot,
+/// giving the watcher a full `threshold_secs` window after restart to re-sync
+/// (which clears `desynced` and the kill never happens). A genuinely hung turn
+/// stays desynced past that window and is still cleaned.
+///
+/// #3656: use the current turn identity's `started_at`, not `updated_at`.
+/// Session/channel scoped inflight update timestamps can be refreshed across
+/// consecutive turns; anchoring cleanup to `started_at` prevents one session key
+/// from accumulating several short turns into a fake 30-minute stall.
 pub(crate) fn stall_watchdog_should_force_clean(
     attached: bool,
     desynced: bool,
     inflight_terminal_delivery_committed: bool,
-    inflight_updated_at: Option<&str>,
+    inflight_started_at: Option<&str>,
     now_unix_secs: i64,
     threshold_secs: u64,
     boot_unix_secs: i64,
@@ -1335,16 +1339,16 @@ pub(crate) fn stall_watchdog_should_force_clean(
     if inflight_terminal_delivery_committed {
         return false;
     }
-    let Some(updated_at) = inflight_updated_at else {
+    let Some(started_at) = inflight_started_at else {
         return false;
     };
-    let Some(updated_at_unix) = discord::inflight::parse_updated_at_unix(updated_at) else {
+    let Some(started_at_unix) = discord::inflight::parse_updated_at_unix(started_at) else {
         return false;
     };
     // #3041: never count staleness that accrued before this process booted —
-    // a pre-restart-frozen `updated_at` must not instantly satisfy the
+    // a pre-restart turn `started_at` must not instantly satisfy the
     // threshold the moment the watchdog's initial delay elapses.
-    let age_anchor = updated_at_unix.max(boot_unix_secs);
+    let age_anchor = started_at_unix.max(boot_unix_secs);
     let age_secs = now_unix_secs.saturating_sub(age_anchor);
     age_secs >= 0 && (age_secs as u64) >= threshold_secs
 }
@@ -1713,7 +1717,7 @@ pub(crate) async fn run_stall_watchdog_pass(
             snapshot.attached,
             snapshot.desynced,
             snapshot.inflight_terminal_delivery_committed,
-            snapshot.inflight_updated_at.as_deref(),
+            snapshot.inflight_started_at.as_deref(),
             now_unix_secs,
             STALL_WATCHDOG_THRESHOLD_SECS,
             registry.started_at_unix(),
@@ -3540,8 +3544,8 @@ mod stall_watchdog_pure_tests {
         };
         let stale_str = to_local(stale_unix);
         let fresh_str = to_local(now_unix - 5);
-        // Boot far in the past so `max(updated_at, boot)` resolves to
-        // `updated_at` — these cases assert the pre-#3041 semantics.
+        // Boot far in the past so `max(started_at, boot)` resolves to
+        // `started_at` — these cases assert the pre-#3041 semantics.
         let boot_unix = stale_unix - 100;
 
         // Happy path: attached + desynced + stale + not-committed → clean.
@@ -3577,7 +3581,7 @@ mod stall_watchdog_pure_tests {
             boot_unix,
         ));
 
-        // fresh updated_at → no clean (live-turn safety net).
+        // fresh started_at → no clean (live-turn safety net).
         assert!(!stall_watchdog_should_force_clean(
             true,
             true,
@@ -3588,7 +3592,7 @@ mod stall_watchdog_pure_tests {
             boot_unix,
         ));
 
-        // missing updated_at → no clean.
+        // missing started_at → no clean.
         assert!(!stall_watchdog_should_force_clean(
             true,
             true,
@@ -3599,7 +3603,7 @@ mod stall_watchdog_pure_tests {
             boot_unix,
         ));
 
-        // unparseable updated_at → no clean.
+        // unparseable started_at → no clean.
         assert!(!stall_watchdog_should_force_clean(
             true,
             true,
@@ -3638,6 +3642,35 @@ mod stall_watchdog_pure_tests {
             STALL_WATCHDOG_THRESHOLD_SECS,
             /* boot_unix_secs */ now_unix - (STALL_WATCHDOG_THRESHOLD_SECS as i64) - 1,
         ));
+    }
+
+    /// #3656: consecutive short turns under the same session key must not
+    /// inherit an old channel-level update anchor. The force-clean age is based
+    /// on the current turn's `started_at`, so a freshly-started turn is not
+    /// killed just because a prior turn in the same session was old.
+    #[test]
+    fn stall_watchdog_age_uses_current_turn_started_at() {
+        let now_unix = chrono::Utc::now().timestamp();
+        let fresh_started_unix = now_unix - 5;
+        let fresh_started = chrono::Local
+            .timestamp_opt(fresh_started_unix, 0)
+            .single()
+            .expect("valid local time")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        assert!(
+            !stall_watchdog_should_force_clean(
+                true,
+                true,
+                false,
+                Some(fresh_started.as_str()),
+                now_unix,
+                STALL_WATCHDOG_THRESHOLD_SECS,
+                now_unix - 10_000,
+            ),
+            "a fresh current-turn started_at must reset the watchdog age even for the same session"
+        );
     }
 
     /// #3126 false-positive guard: a normally-completed turn that is now idle

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1317,11 +1317,7 @@ async fn preserve_resume_selector_on_force_clean(
 /// giving the watcher a full `threshold_secs` window after restart to re-sync
 /// (which clears `desynced` and the kill never happens). A genuinely hung turn
 /// stays desynced past that window and is still cleaned.
-///
-/// #3656: use the current turn identity's `started_at`, not `updated_at`.
-/// Session/channel scoped inflight update timestamps can be refreshed across
-/// consecutive turns; anchoring cleanup to `started_at` prevents one session key
-/// from accumulating several short turns into a fake 30-minute stall.
+/// #3656: age from the current turn's `started_at` (not `updated_at`) so consecutive short turns under one session key don't accumulate into a fake stall.
 pub(crate) fn stall_watchdog_should_force_clean(
     attached: bool,
     desynced: bool,

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -38,6 +38,8 @@ struct StallLivenessKey {
     provider: String,
     channel_id: u64,
     tmux_session: Option<String>,
+    user_msg_id: Option<u64>,
+    started_at: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -152,12 +154,12 @@ impl StallWatchdogJudgmentBasis {
         now_unix_secs: i64,
         boot_unix_secs: i64,
     ) -> Self {
-        let updated_at_unix = snapshot
-            .inflight_updated_at
+        let started_at_unix = snapshot
+            .inflight_started_at
             .as_deref()
             .and_then(crate::services::discord::inflight::parse_updated_at_unix);
         let inflight_age_anchor_unix_secs =
-            updated_at_unix.map(|updated| updated.max(boot_unix_secs));
+            started_at_unix.map(|started| started.max(boot_unix_secs));
         Self {
             inflight_age_secs: inflight_age_anchor_unix_secs
                 .map(|anchor| saturating_age_secs(anchor, now_unix_secs)),
@@ -183,7 +185,7 @@ pub(super) fn evaluate_stall_watchdog_liveness(
     freshness_secs: u64,
     max_deferrals: u8,
 ) -> StallWatchdogLivenessDecision {
-    let key = StallLivenessKey::new(provider, channel_id, snapshot.tmux_session.as_deref());
+    let key = StallLivenessKey::from_snapshot(provider, channel_id, snapshot);
     let evidence = StallWatchdogLivenessEvidence::collect(&key, snapshot, inflight, now_unix_secs);
     if !evidence.has_positive_liveness(freshness_secs) {
         DEFERRAL_STATE.remove(&key);
@@ -229,9 +231,9 @@ pub(super) fn clear_stall_watchdog_liveness_state(
     channel_id: ChannelId,
     tmux_session: Option<&str>,
 ) {
-    let key = StallLivenessKey::new(provider, channel_id, tmux_session);
-    DEFERRAL_STATE.remove(&key);
-    OFFSET_OBSERVATIONS.remove(&key);
+    let probe = StallLivenessKey::new(provider, channel_id, tmux_session, None, None);
+    DEFERRAL_STATE.retain(|key, _| !key.matches_session(&probe));
+    OFFSET_OBSERVATIONS.retain(|key, _| !key.matches_session(&probe));
 }
 
 pub(super) fn clear_stall_watchdog_liveness_state_if_healthy(
@@ -388,12 +390,40 @@ pub(super) fn log_stall_watchdog_force_cleanup_judgment(
 }
 
 impl StallLivenessKey {
-    fn new(provider: &ProviderKind, channel_id: ChannelId, tmux_session: Option<&str>) -> Self {
+    fn new(
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        tmux_session: Option<&str>,
+        user_msg_id: Option<u64>,
+        started_at: Option<&str>,
+    ) -> Self {
         Self {
             provider: provider.as_str().to_string(),
             channel_id: channel_id.get(),
             tmux_session: tmux_session.map(str::to_string),
+            user_msg_id,
+            started_at: started_at.map(str::to_string),
         }
+    }
+
+    fn from_snapshot(
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        snapshot: &WatcherStateSnapshot,
+    ) -> Self {
+        Self::new(
+            provider,
+            channel_id,
+            snapshot.tmux_session.as_deref(),
+            snapshot.inflight_user_msg_id,
+            snapshot.inflight_started_at.as_deref(),
+        )
+    }
+
+    fn matches_session(&self, probe: &Self) -> bool {
+        self.provider == probe.provider
+            && self.channel_id == probe.channel_id
+            && self.tmux_session == probe.tmux_session
     }
 }
 
@@ -569,6 +599,7 @@ mod tests {
     use std::io::{self, Write};
     use std::sync::{Arc, Mutex};
 
+    use chrono::TimeZone;
     use poise::serenity_prelude::ChannelId;
     use tracing_subscriber::fmt::MakeWriter;
 
@@ -702,7 +733,13 @@ mod tests {
         channel: ChannelId,
         tmux_session: &str,
     ) -> StallLivenessKey {
-        StallLivenessKey::new(provider, channel, Some(tmux_session))
+        StallLivenessKey::new(
+            provider,
+            channel,
+            Some(tmux_session),
+            Some(9001),
+            Some("2026-06-12 00:00:00"),
+        )
     }
 
     fn liveness_state_presence(key: &StallLivenessKey) -> (bool, bool) {
@@ -794,6 +831,28 @@ mod tests {
     }
 
     #[test]
+    fn judgment_basis_uses_started_at_not_updated_at() {
+        let channel = ChannelId::new(3370);
+        let tmux_session = "AgentDesk-codex-liveness-started-anchor";
+        let mut snap = snapshot(channel.get(), tmux_session, None);
+        snap.inflight_started_at = Some("2026-06-12 00:10:00".to_string());
+        snap.inflight_updated_at = Some("2026-06-12 00:00:00".to_string());
+
+        let now = chrono::Local
+            .with_ymd_and_hms(2026, 6, 12, 0, 10, 5)
+            .single()
+            .expect("valid local time")
+            .timestamp();
+        let basis = StallWatchdogJudgmentBasis::from_snapshot(&snap, now, now - 10_000);
+
+        assert_eq!(
+            basis.inflight_age_secs,
+            Some(5),
+            "watchdog liveness logs/judgment must age the current turn from started_at"
+        );
+    }
+
+    #[test]
     fn liveness_deferral_cap_allows_cleanup_after_max_passes_and_logs_limit() {
         let provider = ProviderKind::Codex;
         let channel = ChannelId::new(3363);
@@ -862,6 +921,62 @@ mod tests {
             logs.contains("liveness_deferral_limit_reached=true"),
             "{logs}"
         );
+    }
+
+    #[test]
+    fn liveness_deferrals_are_scoped_to_current_turn_identity() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3371);
+        let tmux_session = "AgentDesk-codex-liveness-turn-identity";
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let file = tempfile::NamedTempFile::new().expect("temp transcript");
+        let inflight = inflight_with_output(
+            channel.get(),
+            tmux_session,
+            Some(file.path().display().to_string()),
+        );
+        let snap = snapshot(channel.get(), tmux_session, Some(20));
+        let now = chrono::Utc::now().timestamp();
+
+        for expected_count in 1..=2 {
+            let decision = evaluate_stall_watchdog_liveness(
+                &provider,
+                channel,
+                &snap,
+                Some(&inflight),
+                now,
+                STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+            );
+            assert_eq!(
+                decision.action,
+                StallWatchdogLivenessAction::Defer {
+                    deferral_count: expected_count
+                }
+            );
+        }
+
+        let mut next_turn = snap.clone();
+        next_turn.inflight_user_msg_id = Some(9003);
+        next_turn.mailbox_active_user_msg_id = Some(9003);
+        next_turn.inflight_started_at = Some("2026-06-12 00:05:00".to_string());
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &next_turn,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+
+        assert_eq!(
+            decision.action,
+            StallWatchdogLivenessAction::Defer { deferral_count: 1 },
+            "a new user_msg_id + started_at under the same tmux session gets a fresh deferral budget"
+        );
+
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
     }
 
     /// #3582 regression: the 2026-06-18 12:07 false-positive. A live turn that

--- a/src/services/discord/idle_relay_drift.rs
+++ b/src/services/discord/idle_relay_drift.rs
@@ -1,12 +1,12 @@
-//! #3306: registry/dedupe-mirror drift self-heal for the idle transcript relay.
+//! #3306/#3656: registry/dedupe-mirror drift self-heal for TUI relay owner lookup.
 //!
 //! ## Problem
 //!
-//! `claude_idle_transcript_relay` resolves a tmux-session→channel owner from the
-//! authoritative `tmux_watchers` registry. #3018 made the registry the SINGLE
-//! authority: a registry miss while the `tui_prompt_dedupe` mirror still holds a
-//! mapping is observable DRIFT, and the resolver drops (never routes from the
-//! mirror, which is not a reverse authority). That decision is preserved.
+//! TUI relay paths resolve a tmux-session→channel owner from the authoritative
+//! `tmux_watchers` registry. #3018 made the registry the SINGLE authority: a
+//! registry miss while the `tui_prompt_dedupe` mirror still holds a mapping is
+//! observable DRIFT, and the resolver drops (never routes from the mirror, which
+//! is not a reverse authority). That decision is preserved.
 //!
 //! For ROUTINE tmux sessions (e.g. `…claude-routine-token-daily-report-…`) the
 //! drift becomes PERMANENT: the watcher slot is freed when the routine turn ends
@@ -336,9 +336,9 @@ fn try_begin_repair(tmux_session_name: &str, now: Instant) -> Option<RepairInfli
     })
 }
 
-/// Entry point invoked from the idle relay loop's drift (drop) branch. The
-/// resolver owns the single rate-limited drift WARN; this path only fires the
-/// Claude one-shot async repair (cooldown + single-flight gated).
+/// Entry point invoked from the owner-resolution chokepoint's drift (drop)
+/// branch. The resolver owns the single rate-limited drift WARN; this path only
+/// fires the Claude one-shot async repair (cooldown + single-flight gated).
 #[cfg(unix)]
 pub(super) fn on_idle_relay_drift(
     shared: &Arc<SharedData>,
@@ -349,6 +349,9 @@ pub(super) fn on_idle_relay_drift(
     // durable DB column is written by the Claude/routine hook flow. Codex drift
     // is WARN-only at the resolver.
     if provider != ProviderKind::Claude {
+        return;
+    }
+    if tokio::runtime::Handle::try_current().is_err() {
         return;
     }
 
@@ -501,6 +504,15 @@ pub(super) fn reset_drift_state_for_tests() {
         .lock()
         .unwrap_or_else(|error| error.into_inner());
     map.clear();
+}
+
+#[cfg(test)]
+pub(super) fn repair_attempt_recorded_for_tests(tmux_session_name: &str) -> bool {
+    let map = DRIFT_STATE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    map.get(tmux_session_name)
+        .is_some_and(|state| state.last_repair_attempt_at.is_some())
 }
 
 #[cfg(test)]

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -2487,15 +2487,11 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
                     RuntimeHandoffKind::ClaudeTui,
                 )
             {
-                let Some(channel_id) = owner_channel_for_tmux_session(&shared, &tmux_session_name)
+                let Some(channel_id) =
+                    owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, &tmux_session_name)
                 else {
-                    // #3018/#3306: registry miss ⇒ drop. The drift handler
-                    // rate-limits the WARN and self-heals from a durable source.
-                    super::idle_relay_drift::on_idle_relay_drift(
-                        &shared,
-                        ProviderKind::Claude,
-                        &tmux_session_name,
-                    );
+                    // #3018/#3306/#3656: registry miss ⇒ drop. The resolver
+                    // rate-limits the WARN and the chokepoint triggers repair.
                     continue;
                 };
                 if super::inflight::load_inflight_state(&ProviderKind::Claude, channel_id.get())
@@ -3058,15 +3054,11 @@ fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                 if active_tails.contains(&tmux_session_name) {
                     continue;
                 }
-                let Some(channel_id) = owner_channel_for_tmux_session(&shared, &tmux_session_name)
+                let Some(channel_id) =
+                    owner_channel_for_tmux_session(&shared, &ProviderKind::Codex, &tmux_session_name)
                 else {
-                    // #3018/#3306: registry miss ⇒ drop. Codex gets the
-                    // rate-limited drift WARN only (no settings/DB self-heal).
-                    super::idle_relay_drift::on_idle_relay_drift(
-                        &shared,
-                        ProviderKind::Codex,
-                        &tmux_session_name,
-                    );
+                    // #3018/#3306/#3656: registry miss ⇒ drop. The resolver
+                    // rate-limits the WARN; Codex remains repair-ineligible.
                     continue;
                 };
                 if super::inflight::load_inflight_state(&ProviderKind::Codex, channel_id.get())
@@ -4171,7 +4163,8 @@ fn owner_channel_for_prompt(
     shared: &Arc<SharedData>,
     prompt: &ObservedTuiPrompt,
 ) -> Option<ChannelId> {
-    owner_channel_for_tmux_session(shared, &prompt.tmux_session_name)
+    let provider = ProviderKind::from_str(&prompt.provider)?;
+    owner_channel_for_tmux_session(shared, &provider, &prompt.tmux_session_name)
 }
 
 /// Resolve the owner channel for a tmux session.
@@ -4188,6 +4181,7 @@ fn owner_channel_for_prompt(
 /// surfaced rather than silently papered over by routing to the stale mirror.
 fn owner_channel_for_tmux_session(
     shared: &Arc<SharedData>,
+    provider: &ProviderKind,
     tmux_session_name: &str,
 ) -> Option<ChannelId> {
     let registry_owner = shared
@@ -4195,7 +4189,12 @@ fn owner_channel_for_tmux_session(
         .owner_channel_for_tmux_session(tmux_session_name);
     let dedupe_owner =
         crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(tmux_session_name);
-    resolve_owner_channel_authoritatively(tmux_session_name, registry_owner, dedupe_owner)
+    let resolved =
+        resolve_owner_channel_authoritatively(tmux_session_name, registry_owner, dedupe_owner);
+    if resolved.is_none() && registry_owner.is_none() && dedupe_owner.is_some() {
+        super::idle_relay_drift::on_idle_relay_drift(shared, provider.clone(), tmux_session_name);
+    }
+    resolved
 }
 
 /// Pure decision core for [`owner_channel_for_tmux_session`], split out so the
@@ -4661,6 +4660,32 @@ mod tests {
         );
     }
 
+    // #3656: repair must be triggered at the owner-resolution chokepoint, not
+    // only by the idle loops' `None` branches. This pins the first drift drop:
+    // registry miss + mirror hit still returns None (single authority), but it
+    // immediately arms the repair single-flight so settings/live-pane promotion
+    // can happen on the async repair path without waiting for watchdog reconcile.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn owner_channel_chokepoint_triggers_drift_repair_on_drift_drop() {
+        let shared = super::super::make_shared_data_for_tests();
+        let tmux = "AgentDesk-claude-drift-chokepoint-fix3656";
+        let owner = ChannelId::new(1_504_468_805_772_903_656);
+
+        crate::services::tui_prompt_dedupe::register_tmux_channel(tmux, owner.get());
+        assert_eq!(
+            owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, tmux),
+            None,
+            "registry miss + mirror hit still drops rather than routing from the mirror"
+        );
+        assert!(
+            super::super::idle_relay_drift::repair_attempt_recorded_for_tests(tmux),
+            "the chokepoint must arm a repair attempt on the first drift drop"
+        );
+
+        crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(tmux);
+    }
+
     // #3105: a LIVE TUI session where the dedupe mirror holds a channel but the
     // `tmux_watchers` registry is missing must NOT be permanently dropped. The
     // fix self-heals by promoting the authoritative (settings-derived) channel
@@ -4686,7 +4711,7 @@ mod tests {
         // (1)+(2): the mirror alone must never be used as the delivery owner —
         // the resolver drops (the #3018 single-authority rule stays intact).
         assert_eq!(
-            owner_channel_for_tmux_session(&shared, tmux),
+            owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, tmux),
             None,
             "registry miss + dedupe mirror hit must drop, never route from the mirror"
         );
@@ -4701,7 +4726,7 @@ mod tests {
             "first restore reports a change (single bounded incident)"
         );
         assert_eq!(
-            owner_channel_for_tmux_session(&shared, tmux),
+            owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, tmux),
             Some(owner),
             "after authoritative re-registration the live session must route again"
         );
@@ -4735,7 +4760,7 @@ mod tests {
         // Drift precondition: mirror holds a mapping, registry misses ⇒ drop.
         crate::services::tui_prompt_dedupe::register_tmux_channel(tmux, owner.get());
         assert_eq!(
-            owner_channel_for_tmux_session(&shared, tmux),
+            owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, tmux),
             None,
             "registry miss + mirror hit must drop (drift), never route from mirror"
         );
@@ -4748,7 +4773,7 @@ mod tests {
             .restore_owner_channel_for_tmux_session(tmux, owner);
         assert!(repaired, "first drift-triggered restore reports a change");
         assert_eq!(
-            owner_channel_for_tmux_session(&shared, tmux),
+            owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, tmux),
             Some(owner),
             "after the drift-triggered authoritative restore the session routes again"
         );
@@ -4817,7 +4842,7 @@ mod tests {
             "precondition: dead session's binding is in the relay loop's iteration set"
         );
         assert_eq!(
-            owner_channel_for_tmux_session(&shared, tmux),
+            owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, tmux),
             None,
             "precondition: registry misses + mirror hit == the drift the relay loop hits"
         );

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -2490,8 +2490,7 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
                 let Some(channel_id) =
                     owner_channel_for_tmux_session(&shared, &ProviderKind::Claude, &tmux_session_name)
                 else {
-                    // #3018/#3306/#3656: registry miss ⇒ drop. The resolver
-                    // rate-limits the WARN and the chokepoint triggers repair.
+                    // #3018/#3306/#3656: registry miss ⇒ drop; chokepoint repairs.
                     continue;
                 };
                 if super::inflight::load_inflight_state(&ProviderKind::Claude, channel_id.get())
@@ -3057,8 +3056,7 @@ fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                 let Some(channel_id) =
                     owner_channel_for_tmux_session(&shared, &ProviderKind::Codex, &tmux_session_name)
                 else {
-                    // #3018/#3306/#3656: registry miss ⇒ drop. The resolver
-                    // rate-limits the WARN; Codex remains repair-ineligible.
+                    // #3018/#3306/#3656: registry miss ⇒ drop; Codex repair-ineligible.
                     continue;
                 };
                 if super::inflight::load_inflight_state(&ProviderKind::Codex, channel_id.get())
@@ -4660,11 +4658,7 @@ mod tests {
         );
     }
 
-    // #3656: repair must be triggered at the owner-resolution chokepoint, not
-    // only by the idle loops' `None` branches. This pins the first drift drop:
-    // registry miss + mirror hit still returns None (single authority), but it
-    // immediately arms the repair single-flight so settings/live-pane promotion
-    // can happen on the async repair path without waiting for watchdog reconcile.
+    // #3656: the owner-resolution chokepoint must arm repair on the first drift drop.
     #[cfg(unix)]
     #[tokio::test]
     async fn owner_channel_chokepoint_triggers_drift_repair_on_drift_drop() {


### PR DESCRIPTION
## 이슈
#3656 (P1). registry drift로 idle-relay 출력이 ~21~33분 드롭되고 STALL-WATCHDOG 600s reconcile에서야 복구. 동반으로 watchdog가 연속 짧은 턴을 '30분 정지'로 오판(deadlock-manager 보고).

## Root Cause (codex 검증)
- **Axis 1**: drift 감지는 `owner_channel_for_tmux_session` chokepoint에서 되지만 repair 트리거(`on_idle_relay_drift`)가 idle loop 2곳에만 배선됨. observed-prompt 경로/긴 foreground 턴 경로엔 미배선 → watchdog만이 (우연히) 복구하던 유일 경로.
- **Axis 2**: force-clean age를 현재 턴 `started_at`이 아닌 `inflight_updated_at`(채널 단위) 기준으로 계산 + liveness deferral key가 session 단위라 연속 턴이 age/counter 공유 → 오탐.

## 위험한 상호작용 → 한 PR 원자 배포
watchdog force-clean이 현재 drift를 고치는 유일 경로라, Axis 2(오탐 제거)만 하면 복구 경로가 사라져 악화. Axis 1 eager repair가 실제 복구를 보장한 뒤 Axis 2가 안전 → 두 축을 함께.

## 변경
- `tui_prompt_relay.rs`: provider-aware chokepoint에서 registry miss + mirror hit 시 repair 즉시 트리거(모든 드롭 경로 커버).
- `idle_relay_drift.rs`: chokepoint 기반 정리 + test helper.
- `recovery.rs`: force-clean age anchor를 current turn `started_at`으로.
- `stall_liveness.rs`: judgment basis도 `started_at` 기준, deferral/offset key에 `user_msg_id + started_at` 추가.

## 테스트
chokepoint drift-drop이 repair 즉시 arm / watchdog age가 current-turn started_at 기준 / liveness basis started_at 사용 / 같은 session의 새 턴이 새 deferral budget 획득.

## 게이트
교차모델 적대 리뷰(codex 구현 → opus 리뷰) + CI green 전제. #3016 코어 핫파일 미접촉.