### PR TITLE
fix(#3645): id-0 finalizer identity hole — stable finalizer_turn_id로 reseed 탈락/보호상실 finalize 차단

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -414,6 +414,7 @@ src/
 │   │   │   └── scrollback.rs
 │   │   ├── inflight/
 │   │   │   ├── budget.rs
+│   │   │   ├── finalizer_identity.rs
 │   │   │   ├── model.rs
 │   │   │   └── store.rs
 │   │   ├── outbound/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -135,7 +135,7 @@
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
     construction from the watcher-spawn handle).
-  - `src/services/discord/tmux.rs` (2049 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2048 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
     status/footer stripping in the placeholder suppression decisions;
@@ -920,7 +920,7 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3421 lines; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
+  - `src/services/discord/recovery_engine.rs` (3410 lines; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
     `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the
     STALL-WATCHDOG force-clean -> respawn synthetic row (which lands here with
     `existing_inflight = None`) is watcher-owned instead of degrading to
@@ -1045,7 +1045,7 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6241 lines; production LoC; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6234 lines; production LoC; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.
@@ -1252,7 +1252,7 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (2771 lines).
+    lines) and `src/services/discord/inflight.rs` (2766 lines).
 - active_callsite_coverage: n/a.
 - invariants: watcher single-owner per #1222; placeholder lifecycle invariants
   per #1112; `/api/inflight/rebind` is the only path that synthesises an

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -6,6 +6,7 @@
 //! relay producers/consumers must keep the invariants there satisfied.
 
 pub(in crate::services::discord) mod budget;
+mod finalizer_identity;
 mod model;
 
 // #3479: the pure domain model moved to `model.rs`; re-export every public
@@ -29,6 +30,10 @@ pub(in crate::services::discord::inflight) use store::{
     inflight_state_path, lock_inflight_state_path,
 };
 
+use finalizer_identity::{
+    backfill_finalizer_turn_id_under_lock, parse_inflight_state_content,
+    parse_inflight_state_content_with_finalizer_backfill, read_inflight_state_content,
+};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -380,7 +385,7 @@ pub(super) fn load_inflight_states_for_sweep(
         let Ok(content) = fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(state) = serde_json::from_str::<InflightTurnState>(&content) else {
+        let Ok(state) = parse_inflight_state_content(&content) else {
             continue;
         };
         if state.provider_kind().as_ref() != Some(provider) {
@@ -829,13 +834,14 @@ fn save_inflight_state_create_new_in_root(
         fs::create_dir_all(parent).map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
     }
     let _lock = lock_inflight_state_path(&path).map_err(CreateNewInflightError::Internal)?;
+    let mut updated = state.clone();
+    updated.ensure_finalizer_turn_id();
     validate_inflight_state_for_save(
         root,
         &path,
-        state,
+        &updated,
         "src/services/discord/inflight.rs:save_inflight_state_create_new_in_root",
     );
-    let mut updated = state.clone();
     updated.updated_at = now_string();
     let json = serde_json::to_string_pretty(&updated)
         .map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
@@ -872,15 +878,16 @@ fn save_inflight_state_in_root(root: &Path, state: &InflightTurnState) -> Result
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let _lock = lock_inflight_state_path(&path)?;
+    let mut updated = state.clone();
+    updated.ensure_finalizer_turn_id();
     if !validate_inflight_state_for_save(
         root,
         &path,
-        state,
+        &updated,
         "src/services/discord/inflight.rs:save_inflight_state_in_root",
     ) {
         return Ok(());
     }
-    let mut updated = state.clone();
     updated.updated_at = now_string();
     let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
     atomic_write(&path, &json)
@@ -921,13 +928,14 @@ fn save_inflight_state_if_absent_in_root(
     if path.exists() {
         return Ok(false);
     }
+    let mut updated = state.clone();
+    updated.ensure_finalizer_turn_id();
     validate_inflight_state_for_save(
         root,
         &path,
-        state,
+        &updated,
         "src/services/discord/inflight.rs:save_inflight_state_if_absent_in_root",
     );
-    let mut updated = state.clone();
     updated.updated_at = now_string();
     let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
     atomic_write(&path, &json)?;
@@ -1027,13 +1035,14 @@ pub(super) fn save_inflight_state_if_matches_identity_in_root(
     }
     // #3089 B3: verdict observe-only here — this path already identity/offset-
     // gates above; the #3416 backward vector is the plain overwrite tails.
+    let mut updated = state.clone();
+    updated.ensure_finalizer_turn_id();
     let _ = validate_inflight_state_for_save(
         root,
         &path,
-        state,
+        &updated,
         "src/services/discord/inflight.rs:save_inflight_state_if_matches_identity_in_root",
     );
-    let mut updated = state.clone();
     updated.updated_at = now_string();
     let Ok(json) = serde_json::to_string_pretty(&updated) else {
         return GuardedSaveOutcome::IoError;
@@ -1339,7 +1348,7 @@ fn status_panel_id_is_real(id: Option<u64>) -> bool {
 /// posture as `load_inflight_state`).
 fn load_inflight_state_unlocked(path: &Path) -> Option<InflightTurnState> {
     let data = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&data).ok()
+    parse_inflight_state_content(&data).ok()
 }
 
 /// Shared lock-held persist tail: validate, stamp `updated_at`, atomic-write.
@@ -1350,10 +1359,11 @@ fn persist_under_lock(
     state: &InflightTurnState,
     caller: &'static str,
 ) -> Result<(), String> {
-    if !validate_inflight_state_for_save(root, path, state, caller) {
+    let mut updated = state.clone();
+    updated.ensure_finalizer_turn_id();
+    if !validate_inflight_state_for_save(root, path, &updated, caller) {
         return Ok(());
     }
-    let mut updated = state.clone();
     updated.updated_at = now_string();
     let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
     atomic_write(path, &json)
@@ -1406,10 +1416,9 @@ pub(crate) enum GuardedClearOutcome {
 /// on-disk inflight still describes the turn we believe just finished.
 ///
 /// Guards:
-/// * `expected_user_msg_id` — required to defeat the Pitfall #1 race where
-///   a stale `TurnCompleted` arrives after the next turn has already
-///   written its inflight. `0` is treated as "no guard available" and we
-///   refuse to delete to stay on the conservative side.
+/// * `expected_user_msg_id` — required to defeat the Pitfall #1 race. It
+///   matches either the Discord `user_msg_id` or the row's `finalizer_turn_id`;
+///   `0` is treated as "no guard available" and refused.
 /// * `restart_mode = Some(_)` — preserved (planned drain/hot-swap turns
 ///   must survive across the dcserver restart they were saved for).
 /// * `rebind_origin = true` — preserved (Pitfall #5).
@@ -1501,7 +1510,7 @@ pub(super) fn clear_inflight_state_if_matches_in_root(
     let Ok(data) = fs::read_to_string(&path) else {
         return GuardedClearOutcome::Missing;
     };
-    let Ok(state) = serde_json::from_str::<InflightTurnState>(&data) else {
+    let Ok(state) = parse_inflight_state_content(&data) else {
         // Malformed file: treat like Missing — the loader-side eviction
         // will GC the malformed payload on the next read.
         return GuardedClearOutcome::Missing;
@@ -1512,7 +1521,7 @@ pub(super) fn clear_inflight_state_if_matches_in_root(
     if state.rebind_origin {
         return GuardedClearOutcome::RebindOriginSkipped;
     }
-    if expected_user_msg_id == 0 || state.user_msg_id != expected_user_msg_id {
+    if !state.matches_finalizer_turn_id(expected_user_msg_id) {
         return GuardedClearOutcome::UserMsgMismatch;
     }
     // #2450: save and guarded-clear share the same sidecar lock, so the
@@ -1536,10 +1545,10 @@ pub(super) fn clear_inflight_state_if_matches_in_root(
         let Ok(reread) = fs::read_to_string(&path) else {
             return GuardedClearOutcome::Missing;
         };
-        let Ok(restate) = serde_json::from_str::<InflightTurnState>(&reread) else {
+        let Ok(restate) = parse_inflight_state_content(&reread) else {
             return GuardedClearOutcome::Missing;
         };
-        if restate.user_msg_id != expected_user_msg_id
+        if !restate.matches_finalizer_turn_id(expected_user_msg_id)
             || restate.restart_mode.is_some()
             || restate.rebind_origin
         {
@@ -1720,6 +1729,7 @@ fn clear_inflight_state_if_matches_identity_after_delivery_in_root(
     delivered_state.response_sent_offset =
         normalize_response_sent_offset(full_response, response_sent_offset);
     delivered_state.last_offset = last_offset;
+    delivered_state.ensure_finalizer_turn_id();
     delivered_state.updated_at = now_string();
 
     let mirrored_delivery = match serde_json::to_string_pretty(&delivered_state)
@@ -1900,6 +1910,7 @@ fn refresh_inflight_last_offset_if_matches_identity_in_root(
     }
 
     state.last_offset = last_offset;
+    state.ensure_finalizer_turn_id();
     state.updated_at = now_string();
     serde_json::to_string_pretty(&state)
         .map_err(|error| error.to_string())
@@ -2472,8 +2483,13 @@ pub(super) fn load_inflight_state(
 ) -> Option<InflightTurnState> {
     let root = inflight_runtime_root()?;
     let path = inflight_state_path(&root, provider, channel_id);
-    let data = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&data).ok()
+    let data = fs::read_to_string(&path).ok()?;
+    let (state, backfilled) = parse_inflight_state_content_with_finalizer_backfill(&data).ok()?;
+    if backfilled {
+        backfill_finalizer_turn_id_under_lock(&root, &path, provider).or(Some(state))
+    } else {
+        Some(state)
+    }
 }
 
 pub(super) fn load_inflight_states(provider: &ProviderKind) -> Vec<InflightTurnState> {
@@ -2597,35 +2613,6 @@ fn stale_removal_reason(
     }
 }
 
-fn parse_inflight_state_content(content: &str) -> serde_json::Result<InflightTurnState> {
-    let mut state = serde_json::from_str::<InflightTurnState>(content)?;
-    // #2235: the tolerant `runtime_kind` deserializer collapses both
-    // "field absent" (legacy v7 rows) and "present-but-unknown variant"
-    // (rows written by a future binary) to `runtime_kind = None`.
-    // Recovery treats these two cases differently — absent legacy rows
-    // recover via heuristics; present-unknown rows silent-skip. Re-parse
-    // the JSON as a value to disambiguate and record the verdict on the
-    // transient `runtime_kind_unknown_on_disk` flag.
-    if state.runtime_kind.is_none()
-        && let Ok(raw_value) = serde_json::from_str::<serde_json::Value>(content)
-        && let Some(raw_runtime) = raw_value.get("runtime_kind")
-        && let Some(raw_str) = raw_runtime.as_str()
-        && !raw_str.is_empty()
-        && !matches!(
-            raw_str,
-            "legacy_tmux_wrapper" | "claude_tui" | "codex_tui" | "process_backend"
-        )
-    {
-        state.runtime_kind_unknown_on_disk = true;
-    }
-    Ok(state)
-}
-
-fn read_inflight_state_content(path: &Path) -> Option<InflightTurnState> {
-    let content = fs::read_to_string(path).ok()?;
-    parse_inflight_state_content(&content).ok()
-}
-
 fn stale_removal_reason_for_path(
     path: &Path,
     state: &InflightTurnState,
@@ -2658,26 +2645,27 @@ fn load_inflight_states_from_root(root: &Path, provider: &ProviderKind) -> Vec<I
             );
             continue;
         };
-        let mut state = match parse_inflight_state_content(&content) {
-            Ok(state) => state,
-            Err(_) => {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::info!(
-                    "  [{ts}] ⚠ removing malformed inflight state file: {}",
-                    path.display()
-                );
-                let Ok(_lock) = lock_inflight_state_path(&path) else {
-                    continue;
-                };
-                match read_inflight_state_content(&path) {
-                    Some(locked_state) => locked_state,
-                    None => {
-                        let _ = fs::remove_file(&path);
+        let (mut state, mut finalizer_backfilled) =
+            match parse_inflight_state_content_with_finalizer_backfill(&content) {
+                Ok(parsed) => parsed,
+                Err(_) => {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::info!(
+                        "  [{ts}] ⚠ removing malformed inflight state file: {}",
+                        path.display()
+                    );
+                    let Ok(_lock) = lock_inflight_state_path(&path) else {
                         continue;
+                    };
+                    match read_inflight_state_content(&path) {
+                        Some(locked_state) => (locked_state, false),
+                        None => {
+                            let _ = fs::remove_file(&path);
+                            continue;
+                        }
                     }
                 }
-            }
-        };
+            };
         if state.provider_kind().as_ref() != Some(provider) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
@@ -2695,6 +2683,7 @@ fn load_inflight_states_from_root(root: &Path, provider: &ProviderKind) -> Vec<I
                 let _ = fs::remove_file(&path);
                 continue;
             }
+            finalizer_backfilled = false;
             state = locked_state;
         }
         if stale_removal_reason_for_path(&path, &state, current_generation).is_some() {
@@ -2717,6 +2706,12 @@ fn load_inflight_states_from_root(root: &Path, provider: &ProviderKind) -> Vec<I
                 let _ = fs::remove_file(&path);
                 continue;
             }
+            finalizer_backfilled = false;
+            state = locked_state;
+        }
+        if finalizer_backfilled
+            && let Some(locked_state) = backfill_finalizer_turn_id_under_lock(root, &path, provider)
+        {
             state = locked_state;
         }
         if let Some(tmux_session_name) = state
@@ -6321,8 +6316,8 @@ mod recovery_relay_attempts_tests {
     //! (the infinite-WARN-loop carrier), and never weaken the pane-alive
     //! stale-removal guard.
     use super::{
-        InflightTurnState, RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET, load_inflight_states_from_root,
-        save_inflight_state_in_root,
+        InflightTurnState, RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET, inflight_state_path,
+        load_inflight_states_from_root, save_inflight_state_in_root,
     };
     use crate::services::discord::InflightRestartMode;
     use crate::services::provider::ProviderKind;
@@ -6399,6 +6394,61 @@ mod recovery_relay_attempts_tests {
         let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].recovery_relay_attempts, 2);
+    }
+
+    #[test]
+    fn finalizer_turn_id_uses_injected_prompt_and_round_trips() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_932);
+        state.user_msg_id = 0;
+        state.current_msg_id = 0;
+        state.injected_prompt_message_id = Some(555_777);
+        save_inflight_state_in_root(temp.path(), &state).expect("save");
+
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(loaded[0].finalizer_turn_id, 555_777);
+
+        let reloaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(reloaded[0].finalizer_turn_id, loaded[0].finalizer_turn_id);
+    }
+
+    #[test]
+    fn missing_finalizer_turn_id_is_backfilled_and_restart_stable() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_933);
+        state.user_msg_id = 0;
+        state.current_msg_id = 0;
+        state.injected_prompt_message_id = None;
+        let path = inflight_state_path(temp.path(), &ProviderKind::Codex, state.channel_id);
+        save_inflight_state_in_root(temp.path(), &state).expect("save");
+        let mut raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        raw.as_object_mut().unwrap().remove("finalizer_turn_id");
+        std::fs::write(&path, serde_json::to_string_pretty(&raw).unwrap()).unwrap();
+
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_ne!(loaded[0].finalizer_turn_id, 0);
+        let backfilled = loaded[0].finalizer_turn_id;
+        let reloaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(reloaded[0].finalizer_turn_id, backfilled);
+    }
+
+    #[test]
+    fn guarded_clear_accepts_finalizer_turn_id_for_zero_user_msg_id() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_934);
+        state.user_msg_id = 0;
+        state.current_msg_id = 0;
+        state.finalizer_turn_id = 812_934;
+        save_inflight_state_in_root(temp.path(), &state).expect("save");
+
+        let outcome = super::clear_inflight_state_if_matches_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            state.channel_id,
+            state.finalizer_turn_id,
+        );
+        assert_eq!(outcome, super::GuardedClearOutcome::Cleared);
     }
 
     /// The boot-time `mark_all_inflight_states_restart_mode` pass rewrites

--- a/src/services/discord/inflight/budget.rs
+++ b/src/services/discord/inflight/budget.rs
@@ -87,6 +87,7 @@ pub(in crate::services::discord) fn bump_recovery_relay_attempts_if_matches_iden
         return GuardedSaveOutcome::IdentityMismatch;
     }
     on_disk.recovery_relay_attempts = on_disk.recovery_relay_attempts.saturating_add(1);
+    on_disk.ensure_finalizer_turn_id();
     on_disk.updated_at = super::now_string();
     let Ok(json) = serde_json::to_string_pretty(&on_disk) else {
         return GuardedSaveOutcome::IoError;

--- a/src/services/discord/inflight/finalizer_identity.rs
+++ b/src/services/discord/inflight/finalizer_identity.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::path::Path;
+
+use super::{InflightTurnState, lock_inflight_state_path, persist_under_lock};
+use crate::services::provider::ProviderKind;
+
+pub(super) fn parse_inflight_state_content(content: &str) -> serde_json::Result<InflightTurnState> {
+    parse_inflight_state_content_with_finalizer_backfill(content).map(|(state, _)| state)
+}
+
+pub(super) fn parse_inflight_state_content_with_finalizer_backfill(
+    content: &str,
+) -> serde_json::Result<(InflightTurnState, bool)> {
+    let mut state = serde_json::from_str::<InflightTurnState>(content)?;
+    if state.runtime_kind.is_none()
+        && let Ok(raw_value) = serde_json::from_str::<serde_json::Value>(content)
+        && let Some(raw_runtime) = raw_value.get("runtime_kind")
+        && let Some(raw_str) = raw_runtime.as_str()
+        && !raw_str.is_empty()
+        && !matches!(
+            raw_str,
+            "legacy_tmux_wrapper" | "claude_tui" | "codex_tui" | "process_backend"
+        )
+    {
+        state.runtime_kind_unknown_on_disk = true;
+    }
+    let finalizer_backfilled = state.ensure_finalizer_turn_id();
+    Ok((state, finalizer_backfilled))
+}
+
+pub(super) fn read_inflight_state_content(path: &Path) -> Option<InflightTurnState> {
+    let content = fs::read_to_string(path).ok()?;
+    parse_inflight_state_content(&content).ok()
+}
+
+pub(super) fn backfill_finalizer_turn_id_under_lock(
+    root: &Path,
+    path: &Path,
+    provider: &ProviderKind,
+) -> Option<InflightTurnState> {
+    let Ok(_lock) = lock_inflight_state_path(path) else {
+        return None;
+    };
+    let content = fs::read_to_string(path).ok()?;
+    let (state, backfilled) =
+        parse_inflight_state_content_with_finalizer_backfill(&content).ok()?;
+    if backfilled && state.provider_kind().as_ref() == Some(provider) {
+        let _ = persist_under_lock(
+            root,
+            path,
+            &state,
+            "src/services/discord/inflight/finalizer_identity.rs:backfill_finalizer_turn_id_under_lock",
+        );
+    }
+    Some(state)
+}

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -29,6 +29,48 @@ pub(in crate::services::discord) fn optional_message_id(
     }
 }
 
+const SYNTHETIC_FINALIZER_TURN_ID_MASK: u64 = i64::MAX as u64;
+const SYNTHETIC_FINALIZER_TURN_ID_FLOOR: u64 = 1_000_000_000_000_000_000;
+
+fn mix_finalizer_hash(mut hash: u64, bytes: &[u8]) -> u64 {
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+fn synthetic_finalizer_turn_id(
+    provider: &str,
+    channel_id: u64,
+    started_at: &str,
+    tmux_session_name: Option<&str>,
+    output_path: Option<&str>,
+    turn_start_offset: Option<u64>,
+    last_offset: u64,
+    born_generation: u64,
+) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325;
+    let offset = turn_start_offset.unwrap_or(last_offset);
+    hash = mix_finalizer_hash(hash, provider.as_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    hash = mix_finalizer_hash(hash, &channel_id.to_le_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    hash = mix_finalizer_hash(hash, started_at.as_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    hash = mix_finalizer_hash(hash, tmux_session_name.unwrap_or("").as_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    hash = mix_finalizer_hash(hash, output_path.unwrap_or("").as_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    hash = mix_finalizer_hash(hash, &offset.to_le_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    hash = mix_finalizer_hash(hash, &born_generation.to_le_bytes());
+    hash = mix_finalizer_hash(hash, &[0xff]);
+    (hash % (SYNTHETIC_FINALIZER_TURN_ID_MASK - SYNTHETIC_FINALIZER_TURN_ID_FLOOR))
+        + SYNTHETIC_FINALIZER_TURN_ID_FLOOR
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(in crate::services::discord) struct InflightTurnState {
     pub version: u32,
@@ -43,6 +85,11 @@ pub(in crate::services::discord) struct InflightTurnState {
     pub thread_title: Option<String>,
     pub request_owner_user_id: u64,
     pub user_msg_id: u64,
+    /// Nonzero identity used by the single-authority finalizer ledger. It is
+    /// independent of Discord user-message anchoring: real user id wins, then a
+    /// pinned injected prompt id, then a persisted synthetic id for id-0 turns.
+    #[serde(default)]
+    pub finalizer_turn_id: u64,
     /// Discord message id for the live status panel when status-panel-v2 is
     /// enabled. `current_msg_id` remains the assistant response message.
     #[serde(default)]
@@ -540,13 +587,29 @@ impl InflightTurnState {
         last_offset: u64,
     ) -> Self {
         let now = now_string();
+        let provider_name = provider.as_str().to_string();
+        let born_generation = super::super::runtime_store::load_generation();
+        let finalizer_turn_id = if user_msg_id != 0 {
+            user_msg_id
+        } else {
+            synthetic_finalizer_turn_id(
+                &provider_name,
+                channel_id,
+                &now,
+                tmux_session_name.as_deref(),
+                output_path.as_deref(),
+                Some(last_offset),
+                last_offset,
+                born_generation,
+            )
+        };
         let runtime_kind = input_fifo_path
             .as_deref()
             .filter(|path| !path.is_empty())
             .map(|_| RuntimeHandoffKind::LegacyTmuxWrapper);
         Self {
             version: INFLIGHT_STATE_VERSION,
-            provider: provider.as_str().to_string(),
+            provider: provider_name,
             channel_id,
             channel_name,
             logical_channel_id: Some(channel_id),
@@ -554,6 +617,7 @@ impl InflightTurnState {
             thread_title: None,
             request_owner_user_id,
             user_msg_id,
+            finalizer_turn_id,
             status_message_id: None,
             current_msg_id,
             current_msg_len: 0,
@@ -580,7 +644,7 @@ impl InflightTurnState {
             task_notification_kind: None,
             started_at: now.clone(),
             updated_at: now,
-            born_generation: super::super::runtime_store::load_generation(),
+            born_generation,
             recovery_relay_attempts: 0,
             any_tool_used: false,
             has_post_tool_text: false,
@@ -612,6 +676,43 @@ impl InflightTurnState {
 
     pub fn provider_kind(&self) -> Option<ProviderKind> {
         ProviderKind::from_str(&self.provider)
+    }
+
+    pub(in crate::services::discord) fn effective_finalizer_turn_id(&self) -> u64 {
+        if self.user_msg_id != 0 {
+            return self.user_msg_id;
+        }
+        if let Some(id) = self.injected_prompt_message_id.filter(|id| *id != 0) {
+            return id;
+        }
+        if self.finalizer_turn_id != 0 {
+            return self.finalizer_turn_id;
+        }
+        synthetic_finalizer_turn_id(
+            &self.provider,
+            self.channel_id,
+            &self.started_at,
+            self.tmux_session_name.as_deref(),
+            self.output_path.as_deref(),
+            self.turn_start_offset,
+            self.last_offset,
+            self.born_generation,
+        )
+    }
+
+    pub(in crate::services::discord) fn ensure_finalizer_turn_id(&mut self) -> bool {
+        let resolved = self.effective_finalizer_turn_id();
+        if self.finalizer_turn_id == resolved {
+            false
+        } else {
+            self.finalizer_turn_id = resolved;
+            true
+        }
+    }
+
+    pub(in crate::services::discord) fn matches_finalizer_turn_id(&self, expected: u64) -> bool {
+        expected != 0
+            && (self.user_msg_id == expected || self.effective_finalizer_turn_id() == expected)
     }
 
     pub(in crate::services::discord) fn effective_relay_owner_kind(&self) -> RelayOwnerKind {

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1009,37 +1009,25 @@ pub(super) async fn finish_recovered_turn_mailbox(
     let _ = stop_source;
 }
 
-/// #3248 gap-1 — re-seed the single-authority finalizer ledger for a
-/// watcher-owned turn re-attached by recovery after a mid-turn dcserver restart
-/// (e.g. `SKIP_TURN_DRAIN=1` deploy). The in-memory ledger is empty post-restart,
-/// so without this the watcher's channel-only (id-0) GateTimeout creates a
-/// `RelayOwnerKind::None` entry that finalizes-as-orphan (the 8s gate-backstop
-/// arms only for `relay_owner != None`; the far-backstop reconcile collects only
-/// `relay_owner == Watcher` rows) — the live pane never auto-reconciles until a
-/// NEW user turn. Registering with the Watcher owner reproduces the bridge
-/// handoff (`turn_bridge/mod.rs` `register_start(.., Watcher, ..)`) so the
-/// gate-timeout DEFERS (arms the backstop) and the reconcile can collect the row.
-///
-/// IDEMPOTENT: the actor's `Start` handler is `entry().and_modify().or_insert()`
-/// — never resurrects a `Finalized` turn, `get_or_insert`s the deadline (never
-/// pushes it forward) — so a later bridge handoff `register_start` of the SAME
-/// `TurnKey` is a no-op refresh (the normal, non-restart path is unaffected).
+/// #3248/#3645: recovery must re-seed a Watcher-owned ledger entry after
+/// restart, keyed by the stable finalizer id, so busy GateTimeout defers and
+/// the far-backstop can reconcile. `register_start` is idempotent for the same
+/// `TurnKey`, so a later bridge handoff is a no-op refresh.
 fn reseed_watcher_owned_finalizer_ledger(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
-    user_msg_id: MessageId,
+    finalizer_turn_id: u64,
     provider: &ProviderKind,
 ) {
-    // id-0 would key the channel-only orphan slot; the sole caller already
-    // returns early on id-0, but guard here so this path only ever seeds a
-    // full-identity Watcher entry.
-    if user_msg_id.get() == 0 {
+    // id-0 would key the channel-only orphan slot. Only seed a full-identity
+    // Watcher entry; synthetic live turns use their persisted finalizer_turn_id.
+    if finalizer_turn_id == 0 {
         return;
     }
     shared.turn_finalizer.register_start(
         super::turn_finalizer::TurnKey::new(
             channel_id,
-            user_msg_id.get(),
+            finalizer_turn_id,
             shared.restart.current_generation,
         ),
         provider.clone(),
@@ -1052,12 +1040,13 @@ pub(super) async fn reregister_active_turn_from_inflight(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
 ) -> bool {
-    if state.current_msg_id == 0 || state.user_msg_id == 0 || state.request_owner_user_id == 0 {
+    let finalizer_turn_id = state.effective_finalizer_turn_id();
+    if finalizer_turn_id == 0 {
         return false;
     }
 
     let channel_id = ChannelId::new(state.channel_id);
-    let user_msg_id = MessageId::new(state.user_msg_id);
+    let finalizer_msg_id = MessageId::new(finalizer_turn_id);
     let snapshot = super::mailbox_snapshot(shared, channel_id).await;
     let Some(provider) = ProviderKind::from_str(&state.provider) else {
         tracing::error!(
@@ -1071,7 +1060,7 @@ pub(super) async fn reregister_active_turn_from_inflight(
         tracing::warn!(
             provider = %provider.as_str(),
             channel = state.channel_id,
-            user_msg_id = state.user_msg_id,
+            finalizer_turn_id,
             "inflight reregister skipped: terminal delivery already committed; clearing stale active turn state"
         );
         finish_recovered_turn_mailbox(
@@ -1086,7 +1075,7 @@ pub(super) async fn reregister_active_turn_from_inflight(
     }
     if snapshot.cancel_token.is_some() {
         if let Some(token) = snapshot.cancel_token.as_ref()
-            && snapshot.active_user_message_id == Some(user_msg_id)
+            && snapshot.active_user_message_id == Some(finalizer_msg_id)
         {
             super::ensure_cancel_token_bound_from_inflight_state(
                 &provider,
@@ -1095,13 +1084,16 @@ pub(super) async fn reregister_active_turn_from_inflight(
                 "inflight reregister existing active turn",
             );
         }
-        let restored = snapshot.active_user_message_id == Some(user_msg_id);
+        let restored = snapshot.active_user_message_id == Some(finalizer_msg_id);
         if restored {
-            // #3248 gap-1: existing-active-turn rebind — re-seed the empty
-            // post-restart ledger so the watcher gate-timeout arms its backstop.
-            reseed_watcher_owned_finalizer_ledger(shared, channel_id, user_msg_id, &provider);
+            reseed_watcher_owned_finalizer_ledger(shared, channel_id, finalizer_turn_id, &provider);
         }
         return restored;
+    }
+
+    if state.request_owner_user_id == 0 {
+        reseed_watcher_owned_finalizer_ledger(shared, channel_id, finalizer_turn_id, &provider);
+        return false;
     }
 
     let cancel_token = Arc::new(CancelToken::new());
@@ -1117,14 +1109,11 @@ pub(super) async fn reregister_active_turn_from_inflight(
         channel_id,
         cancel_token,
         UserId::new(state.request_owner_user_id),
-        user_msg_id,
+        finalizer_msg_id,
     )
     .await;
     if started {
-        // #3248 gap-1: freshly re-attached active turn — seed the empty
-        // post-restart ledger with the Watcher owner (idempotent vs. a later
-        // bridge handoff) so the live pane auto-reconciles without a new user turn.
-        reseed_watcher_owned_finalizer_ledger(shared, channel_id, user_msg_id, &provider);
+        reseed_watcher_owned_finalizer_ledger(shared, channel_id, finalizer_turn_id, &provider);
     }
     started
 }
@@ -4060,28 +4049,47 @@ mod reregister_ledger_reseed_tests {
         );
     }
 
-    // Safety: a recovery turn WITHOUT a real user_msg_id (== 0) must be skipped by
-    // the early guard — it must NOT register a channel-only (id-0) orphan ledger
-    // entry that could collide with the watcher's id-0 submissions.
     #[tokio::test(flavor = "current_thread")]
-    async fn zero_user_msg_id_is_not_registered() {
+    async fn zero_user_msg_id_reseeds_with_finalizer_turn_id() {
         let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
         let ch = ChannelId::new(52_483);
-        // user_msg_id == 0 (and thus the early guard returns false before any
-        // register_start).
         let mut state = active_turn_state(ch.get(), 0);
         state.user_msg_id = 0;
         state.current_msg_id = 0;
+        state.finalizer_turn_id = 9_010_777;
 
         let restored = super::reregister_active_turn_from_inflight(&shared, &state).await;
-        assert!(!restored, "a zero-id recovery turn is not re-attached");
         assert!(
-            !shared
+            restored,
+            "a zero user_msg_id turn with a stable finalizer_turn_id is re-attached"
+        );
+        assert!(
+            shared
                 .turn_finalizer
                 .has_live_watcher_pending(ch, shared.restart.current_generation)
                 .await,
-            "a zero user_msg_id turn must NOT seed an orphan ledger entry"
+            "zero-id recovery must seed a Watcher entry under finalizer_turn_id"
         );
+        let outcome = shared
+            .turn_finalizer
+            .submit_terminal(
+                super::super::turn_finalizer::TurnKey::new(
+                    ch,
+                    state.finalizer_turn_id,
+                    shared.restart.current_generation,
+                ),
+                ProviderKind::Claude,
+                super::super::turn_finalizer::TerminalEvent::GateTimeout {
+                    pane_quiescent: Some(false),
+                },
+                super::super::turn_finalizer::FinalizeContext::watcher(),
+                shared.clone(),
+            )
+            .await;
+        assert!(matches!(
+            outcome,
+            super::super::turn_finalizer::FinalizeOutcome::Deferred
+        ));
     }
 
     // #3089 A0 — characterization of the recovery probe-classified outcome

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2437,11 +2437,10 @@ async fn finish_restored_watcher_active_turn(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
-    // #3016: the turn's real `user_msg_id`, captured by the caller BEFORE it
-    // cleared inflight (a reload here returns `None`). 0 means "unknown" (true
-    // orphan); a real id makes the finalizer ledger match exact so a stale
-    // channel-only terminal cannot finalize a queued follow-up turn.
-    user_msg_id: u64,
+    // #3016/#3645: finalizer ledger identity captured by the caller BEFORE it
+    // cleared inflight (a reload here returns `None`). Real Discord turns use
+    // `user_msg_id`; id-0 synthetic turns use their persisted finalizer_turn_id.
+    finalizer_turn_id: u64,
     finish_mailbox_on_completion: bool,
     // #3016 option A: the caller observed a *normal completion* (terminal output
     // committed / pane confirmed idle past the relay) and wants the single-
@@ -2456,8 +2455,8 @@ async fn finish_restored_watcher_active_turn(
     kickoff_queue: bool,
     // #3350 codex r1-1: the caller's PRE-CLEAR row snapshot for the #3303
     // DeferredClaim marker ensure — inflight is cleared before this helper
-    // (see `user_msg_id`), so a row re-load cannot authenticate the watcher's
-    // synthetic turns. `None` keeps the row-reload fallback.
+    // (see `finalizer_turn_id`), so a row re-load cannot authenticate the
+    // watcher's synthetic turns. `None` keeps the row-reload fallback.
     claim_snapshot: Option<super::turn_finalizer::SyntheticClaimSnapshot>,
     stop_source: &'static str,
 ) -> bool {
@@ -2490,7 +2489,7 @@ async fn finish_restored_watcher_active_turn(
     // instead of calling mailbox_finish_turn + counter + side-effects inline. The ledger
     // phase gate makes this exactly-once across bridge and watcher: whichever submits
     // first finalizes; the loser gets `AlreadyFinalized` and the watcher simply skips
-    // the queue kickoff (the winner already owns it). Use the REAL `user_msg_id` the
+    // the queue kickoff (the winner already owns it). Use the finalizer id the
     // caller captured BEFORE clearing inflight (reloading inflight here returns `None`
     // because the watcher already wiped it). The exact id makes the ledger match
     // precise: a stale terminal from an already-finalized turn resolves to that turn's
@@ -2504,7 +2503,7 @@ async fn finish_restored_watcher_active_turn(
         .submit_terminal_with_claim_snapshot(
             super::turn_finalizer::TurnKey::new(
                 channel_id,
-                user_msg_id,
+                finalizer_turn_id,
                 shared.restart.current_generation,
             ),
             provider.clone(),

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -4613,7 +4613,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             prompt_anchor_present_before_relay || external_input_lease_before_relay;
 
         // #3041 P1-1: acquire the delivery lease BEFORE the watcher direct-sends. Lease
-        // identity = the turn-pinned id (`pinned_finalize_user_msg_id`, the #3141
+        // identity = the turn-pinned id (`pinned_finalizer_turn_id`, the #3141
         // id-pinning) + the byte range `[data_start_offset, terminal_event_consumed_offset)`
         // — the SAME consumed end the commit/advance uses, so acquire and commit carry one
         // identity. Acquire only on the watcher-direct path (delegation is the sink's lease
@@ -4626,7 +4626,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // The actor CommitDelivery/ReleaseDelivery messages remain dormant.
         let watcher_lease_turn = crate::services::discord::turn_finalizer::TurnKey::new(
             channel_id,
-            pinned_finalize_user_msg_id(
+            pinned_finalizer_turn_id(
                 inflight_before_relay.as_ref(),
                 &tmux_session_name,
                 current_offset,
@@ -5528,29 +5528,24 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             );
             // #3016 phase 3: the silent SKIP the EPIC targets. The
             // `terminal_output_committed && !lifecycle_stage_paused` blocks below are
-            // skipped, so nothing finalizes until the 1800s placeholder sweeper —
-            // which never fires if the pane stays busy. Instead submit a gate-timeout
-            // with `pane_quiescent: Some(false)`: the finalizer arms a SHORT bounded
-            // deadline (GATE_BACKSTOP) and its reconciler finalizes when it elapses.
-            // The mailbox release does NOT inject into a busy pane (the hosted-TUI
-            // pre-submit guard requeues follow-up input). Only fire when terminal
-            // output was actually committed, matching the skipped block's precondition.
+            // skipped, so submit a busy gate-timeout: the finalizer arms the short
+            // GATE_BACKSTOP and reconciles later. Only fire after committed output.
             if terminal_output_committed {
-                // Prefer the real `user_msg_id` from inflight so this resolves to the
-                // exact Watcher-owned ledger entry (→ DEFERS to the backstop); a
-                // channel-only id-0 could resolve onto a different live entry.
-                let gate_user_msg_id = crate::services::discord::inflight::load_inflight_state(
-                    &watcher_provider,
-                    channel_id.get(),
-                )
-                .map(|s| s.user_msg_id)
-                .unwrap_or(0);
+                // Prefer the persisted finalizer id from inflight so this resolves
+                // to the exact Watcher-owned ledger entry (→ DEFERS to backstop).
+                let gate_finalizer_turn_id =
+                    crate::services::discord::inflight::load_inflight_state(
+                        &watcher_provider,
+                        channel_id.get(),
+                    )
+                    .map(|s| s.effective_finalizer_turn_id())
+                    .unwrap_or(0);
                 let _ = shared
                     .turn_finalizer
                     .submit_terminal(
                         crate::services::discord::turn_finalizer::TurnKey::new(
                             channel_id,
-                            gate_user_msg_id,
+                            gate_finalizer_turn_id,
                             shared.restart.current_generation,
                         ),
                         watcher_provider.clone(),
@@ -6295,7 +6290,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // removed — exactly-once is the ledger phase gate's job.
             // #3016 (codex R3): do NOT delete on-disk inflight owned by a
             // NEWER follow-up turn — the same offset decision that zeroes
-            // `pinned_finalize_user_msg_id` below gates this clear, so a
+            // `pinned_finalizer_turn_id` below gates this clear, so a
             // stale-range pass cannot wipe it. Only the on-disk file is gated;
             // the in-memory `inflight_state` and `cleared_by_watcher` keep
             // their semantics.
@@ -6366,32 +6361,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // queue-kickoff side-effect stays gated on `dispatch_ok`. The redundant
             // `should_kickoff_queue` block further below is also `dispatch_ok`-gated
             // as a fallback for paths where the helper short-circuited.
-            // #3016 (codex R1+R2): derive the finalize id from the TURN-PINNED
-            // pre-relay snapshot, never the late `inflight_state` re-read — the
-            // watcher loop is not turn-scoped (L~7327 warning), so a follow-up may
-            // rewrite on-disk inflight after relay/emit and a stale-id match would
-            // `finish_turn_if_matches` the WRONG follow-up turn.
-            //
-            // R2 (offset-aliasing): even `inflight_before_relay` is not pinned to the
-            // OUTPUT RANGE — the watcher-yield guard (tmux.rs:2110-2111) proceeds on
-            // this old range when a follow-up starts AT/AFTER `current_offset`,
-            // leaving the newer id in the snapshot. `pinned_finalize_user_msg_id`
-            // mirrors the guard's range test (`turn_start_offset.unwrap_or(last) <
-            // current_offset`), so a newer turn yields 0 (turn_finalizer L~526 refuses
-            // the mismatch); session-match + `user_msg_id != 0` kept. `current_offset`
-            // is this range's end (same as `commit_watcher_direct_terminal_session_idle`).
-            //
-            // R3 cross-ref: `completion_is_stale_for_newer_turn` (complement of that
-            // `< current_offset` test) gates the `⏳ → ✅` / transcript / analytics
-            // block and the `clear_inflight_state` above, keeping "yields 0" and
-            // "skip destructive side-effects" consistent by construction.
-            let restored_user_msg_id = pinned_finalize_user_msg_id(
+            // #3016/#3645: derive the finalizer id from the TURN-PINNED pre-relay
+            // snapshot, with `pinned_finalizer_turn_id` mirroring the output-range
+            // guard so newer same-session follow-ups yield 0 and skip destructive
+            // completion side effects consistently.
+            let restored_finalizer_turn_id = pinned_finalizer_turn_id(
                 inflight_before_relay.as_ref(),
                 &tmux_session_name,
                 current_offset,
             );
+            let same_session_snapshot_present = inflight_before_relay.as_ref().is_some_and(|s| {
+                s.tmux_session_name.as_deref().map(str::trim) == Some(tmux_session_name.trim())
+            });
             // #3016 (codex B1): SKIP the normal-completion finalize ENTIRELY in the
-            // stale-newer-turn case — do NOT call it with `restored_user_msg_id == 0`.
+            // stale-newer-turn case — do NOT call it with a channel-only id 0.
             // A 0-id submit is unsafe, not a no-op: `normal_completion = true`
             // finalizes UNCONDITIONALLY, and a 0-id `TurnKey` reaches
             // `resolve_channel_only` (turn_finalizer.rs:161-181) which collapses onto
@@ -6402,18 +6385,21 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // NOTHING here; the newer turn finalizes itself when ITS output commits in
             // a later loop iteration. `completion_is_stale_for_newer_turn` is the exact
             // complement of the `< current_offset` range test in
-            // `pinned_finalize_user_msg_id`, so "id == 0" and "skip" are one predicate.
+            // `pinned_finalizer_turn_id`; a same-session snapshot whose pinned id
+            // resolves to 0 is skipped rather than submitted channel-only.
             //
             // Skip-path bookkeeping: `watcher_drove_finalize = false`. #3016
             // phase-5b2: the legacy `mailbox_finalize_owed` flag is removed — the
             // newer turn finalizes via its own real-id path, and the stale-skip is
             // already kickoff-suppressed by `has_active_turn` (the newer live turn).
-            let watcher_drove_finalize = if !completion_is_stale_for_newer_turn {
+            let watcher_drove_finalize = if !completion_is_stale_for_newer_turn
+                && (restored_finalizer_turn_id != 0 || !same_session_snapshot_present)
+            {
                 finish_restored_watcher_active_turn(
                     &shared,
                     &provider_kind,
                     channel_id,
-                    restored_user_msg_id,
+                    restored_finalizer_turn_id,
                     finish_mailbox_on_completion,
                     // #3016 option A: terminal output was committed above
                     // (`terminal_output_committed && !lifecycle_stage_paused`), the

--- a/src/services/discord/tmux_watcher/turn_identity.rs
+++ b/src/services/discord/tmux_watcher/turn_identity.rs
@@ -211,6 +211,20 @@ pub(super) fn pinned_finalize_user_msg_id(
         .unwrap_or(0)
 }
 
+pub(super) fn pinned_finalizer_turn_id(
+    inflight_before_relay: Option<&crate::services::discord::inflight::InflightTurnState>,
+    tmux_session_name: &str,
+    current_offset: u64,
+) -> u64 {
+    inflight_before_relay
+        .filter(|state| {
+            state.tmux_session_name.as_deref().map(str::trim) == Some(tmux_session_name.trim())
+                && state.turn_start_offset.unwrap_or(state.last_offset) < current_offset
+        })
+        .map(|state| state.effective_finalizer_turn_id())
+        .unwrap_or(0)
+}
+
 /// #3016 (codex R3): the watcher's `terminal_output_committed &&
 /// !lifecycle_stage_paused` block runs MORE destructive side-effects than the
 /// finalize on a LATE re-read `inflight_state` (loaded AFTER the relay, NOT

--- a/src/services/discord/tmux_watcher/turn_identity_tests.rs
+++ b/src/services/discord/tmux_watcher/turn_identity_tests.rs
@@ -129,6 +129,20 @@ fn pinned_finalize_id_zero_user_msg_id_returns_zero() {
 }
 
 #[test]
+fn pinned_finalizer_turn_id_uses_synthetic_identity_for_zero_user_msg_id() {
+    let mut state = state_with_offsets(0, "AgentDesk-codex-adk-cdx", Some(10), 10);
+    state.finalizer_turn_id = 1_234_567;
+    assert_eq!(
+        pinned_finalizer_turn_id(Some(&state), "AgentDesk-codex-adk-cdx", 50),
+        1_234_567
+    );
+    assert_eq!(
+        pinned_finalizer_turn_id(Some(&state), "AgentDesk-codex-adk-cdx", 10),
+        0
+    );
+}
+
+#[test]
 fn pinned_finalize_id_none_returns_zero() {
     // (e) No pre-relay snapshot → 0.
     assert_eq!(

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1175,7 +1175,7 @@ fn handle_watcher_runtime_handoff(
             shared_owned.turn_finalizer.register_start(
                 super::turn_finalizer::TurnKey::new(
                     channel_id,
-                    inflight_state.user_msg_id,
+                    inflight_state.effective_finalizer_turn_id(),
                     shared_owned.restart.current_generation,
                 ),
                 provider.clone(),
@@ -3086,18 +3086,16 @@ pub(super) fn spawn_turn_bridge(
                                     // `handle_watcher_runtime_handoff` helper.
                                     // This legacy `StreamMessage::TmuxReady`
                                     // handoff does NOT go through that helper, so
-                                    // without this the watcher's channel-only
-                                    // (id-0) GateTimeout/Complete submissions
-                                    // would create a `RelayOwnerKind::None`
-                                    // ledger entry — and a busy-pane gate-timeout
-                                    // would then finalize immediately instead of
-                                    // arming the deadline-backstop. Registering
-                                    // here with the Watcher owner makes the
-                                    // gate-timeout defer correctly.
+                                    // without this the watcher terminal would
+                                    // have no Watcher-owned ledger entry — and
+                                    // a busy-pane gate-timeout would finalize
+                                    // immediately instead of arming the
+                                    // deadline-backstop. Registering here with
+                                    // the same finalizer id makes it defer.
                                     shared_owned.turn_finalizer.register_start(
                                         super::turn_finalizer::TurnKey::new(
                                             channel_id,
-                                            inflight_state.user_msg_id,
+                                            inflight_state.effective_finalizer_turn_id(),
                                             shared_owned.restart.current_generation,
                                         ),
                                         provider.clone(),
@@ -4134,10 +4132,7 @@ pub(super) fn spawn_turn_bridge(
                     .submit_terminal(
                         super::turn_finalizer::TurnKey::new(
                             channel_id,
-                            // user_msg_id == 0 collapses to the channel-only
-                            // terminal that `turn_finalizer` already supports
-                            // (recovery/orphan path) instead of panicking.
-                            user_msg_id.map(|id| id.get()).unwrap_or(0),
+                            inflight_state.effective_finalizer_turn_id(),
                             shared_owned.restart.current_generation,
                         ),
                         provider.clone(),
@@ -4226,9 +4221,7 @@ pub(super) fn spawn_turn_bridge(
                 .submit_terminal(
                     super::turn_finalizer::TurnKey::new(
                         channel_id,
-                        // user_msg_id == 0 → channel-only terminal key, which
-                        // turn_finalizer already supports (recovery/orphan path).
-                        user_msg_id.map(|id| id.get()).unwrap_or(0),
+                        inflight_state.effective_finalizer_turn_id(),
                         shared_owned.restart.current_generation,
                     ),
                     provider.clone(),

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -427,7 +427,7 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
         shared_owned.turn_finalizer.register_start(
             TurnKey::new(
                 channel_id,
-                inflight_state.user_msg_id,
+                inflight_state.effective_finalizer_turn_id(),
                 shared_owned.restart.current_generation,
             ),
             provider.clone(),


### PR DESCRIPTION
## 이슈 #3645 (런타임 버그)
복구 시 turn identity가 0인 inflight(restored synthetic/ task-notification/외부 입력)가 finalizer ledger 보호에서 탈락 → restored watcher의 id-0 GateTimeout terminal이 `relay_owner=None` entry를 만들고 #3011 보호(GateTimeout deferral·far-backstop·inflight 보존·진행중 UI-repair owner)를 우회해 **즉시 finalize**(over-finalize/보호상실).

## 채택 설계 (후보 C): nonzero·restart-stable finalizer_turn_id
- 우선순위: real `user_msg_id` → pinned `injected_prompt_message_id` → row 생성/legacy backfill 시 deterministic synthetic id(persist). 항상 nonzero, restart-stable.
- 네 경로 공유: register_start / recovery reseed / watcher terminal submit / bridge terminal submit.
- 효과: live synthetic turn은 안정 id로 Watcher reseed → 이후 GateTimeout이 같은 키로 정상 defer + far-backstop arm. true dead orphan(inflight 없음)은 여전히 id-0 channel-only 즉시 finalize.

## 불변식 비회귀 (핵심)
- **turn_finalizer.rs 미접촉** (or_insert:902/defer guard:931/resolve_ledger_key:139/register_start and_modify:746-774) — 호출자 측만 변경해 #3016 핫파일 회귀 표면 최소화.
- #3011 None 즉시-finalize 유지(stable-identity live turn만 reseed), #3630 committed/body 미접촉, restart-safe(무중단 배포 silent-reattach 무충돌).

## 변경 (caller-side only)
inflight/model.rs(+finalizer_turn_id 필드/발급/effective/matches), inflight/finalizer_identity.rs(legacy parse/backfill), inflight.rs(save/load/backfill/guarded clear), recovery_engine.rs(reseed/reregister guard를 finalizer id 기준), tmux_watcher.rs·tmux.rs·turn_bridge/mod.rs·watcher_handoff.rs(register/terminal key shared id).

## 테스트
id-0 synthetic reseed+busy GateTimeout defer / injected-prompt round-trip / legacy backfill restart-stable / guarded clear id-0 허용 / pinned synthetic. 기존 orphan·stale id-0 테스트 유지.

## 게이트
교차모델 적대 리뷰(codex 구현 → opus 리뷰) + CI green 전제. fmt/hotfile-ratchet/giant-audit 로컬 통과.