### PR TITLE
fix(#3664): DM 응답을 참여 봇(provider 봇)으로 라우팅 — announce/notify는 DM 비참여라 403

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -2,6 +2,15 @@
 
 Last refreshed: 2026-06-16 (against `main` @ `8ec7336e32eb6ef89e1143fab2543f2fc644ebac`)
 
+> #3664 outbound bot-selection note: the outbox drain (`src/server/mod.rs`)
+> now resolves the delivery bot via `message_outbox::delivery_bot_for_target_session`.
+> For a private (DM) session — tmux name `AgentDesk-<provider>-dm-<digits>` with a
+> `channel:<id>` target — outbound delivery routes through the **provider bot**
+> (e.g. claude), because the announce/notify bots are not participants in a user
+> DM and Discord rejects their send (`Missing Access` → 403). Guild channels keep
+> their configured announce/notify bot. The `send_gate` `dm_default_agent`
+> authorization still gates the provider-bot DM path (no #2047 weakening).
+
 > Implementation refresh for #1457 / #2368 / #2533 / #2535: v3 delivery now
 > covers dispatch outbox, review followups, issue announcements, monitoring
 > status, meeting notifications, short manual/DM notifications, gateway

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2518,12 +2518,7 @@ async fn message_outbox_loop(pg_pool: Arc<PgPool>, health_registry: Option<Arc<H
 
     let mut poll_interval = Duration::from_millis(500);
     let max_interval = Duration::from_secs(5);
-    // Periodic stale-row GC: prunes failed rows older than 7d and sent rows
-    // older than 30d. Without this, every config-rejected send (`unknown
-    // source role`, `channel not in role-map`) accumulates indefinitely; the
-    // 2026-05-09 incident found 7163+149+188 stale failed rows from sources
-    // that are now allowed but whose historical rejections were never cleaned
-    // up.
+    // Periodic stale-row GC: prune old terminal rows so config rejections do not accumulate.
     let mut next_gc_at = std::time::Instant::now() + Duration::from_secs(60);
 
     loop {
@@ -2553,6 +2548,11 @@ async fn message_outbox_loop(pg_pool: Arc<PgPool>, health_registry: Option<Arc<H
                 let pg_pool = pg_pool.clone();
                 async move {
                     let (correlation_id, semantic_event_id) = row.delivery_ids();
+                    let bot = crate::services::message_outbox::delivery_bot_for_target_session(
+                        &row.target,
+                        &row.bot,
+                        row.session_key.as_deref(),
+                    );
                     let (status, err_text) =
                         crate::services::discord::health::send_message_with_backends_and_delivery_options(
                             &health_registry,
@@ -2561,7 +2561,7 @@ async fn message_outbox_loop(pg_pool: Arc<PgPool>, health_registry: Option<Arc<H
                             &row.target,
                             &row.content,
                             &row.source,
-                            &row.bot,
+                            bot.as_ref(),
                             None,
                             Some(crate::services::discord::health::ManualOutboundDeliveryId {
                                 correlation_id: &correlation_id,

--- a/src/services/discord/idle_relay_drift.rs
+++ b/src/services/discord/idle_relay_drift.rs
@@ -336,6 +336,18 @@ fn try_begin_repair(tmux_session_name: &str, now: Instant) -> Option<RepairInfli
     })
 }
 
+/// Cross-OS no-op: tmux-based relay drift self-heal is unix-only, but the
+/// owner-resolution chokepoint that invokes this lives in non-`cfg(unix)` code,
+/// so a stub is required for the workspace to compile on non-unix targets (CI
+/// `Fast check cross OS`). The relay machinery never runs on those targets.
+#[cfg(not(unix))]
+pub(super) fn on_idle_relay_drift(
+    _shared: &std::sync::Arc<super::SharedData>,
+    _provider: crate::services::provider::ProviderKind,
+    _tmux_session_name: &str,
+) {
+}
+
 /// Entry point invoked from the owner-resolution chokepoint's drift (drop)
 /// branch. The resolver owns the single rate-limited drift WARN; this path only
 /// fires the Claude one-shot async repair (cooldown + single-flight gated).

--- a/src/services/discord/outbound/send_gate.rs
+++ b/src/services/discord/outbound/send_gate.rs
@@ -373,7 +373,11 @@ pub fn is_allowed_send_source_for(source: &str, caller: SendCallerClass) -> bool
 
 #[cfg(test)]
 mod send_source_tests {
-    use super::{SendCallerClass, is_allowed_send_source, is_allowed_send_source_for};
+    use super::{
+        SendCallerClass, dm_default_agent_authorizes_unmapped_private_channel,
+        is_allowed_send_source, is_allowed_send_source_for,
+    };
+    use crate::services::provider::ProviderKind;
 
     #[test]
     fn headless_turn_is_allowed_internal_send_source() {
@@ -451,6 +455,57 @@ mod send_source_tests {
                 is_allowed_send_source_for(label, SendCallerClass::LoopbackInternal),
                 "loopback caller must keep accepting `{label}`"
             );
+        }
+    }
+
+    #[test]
+    fn dm_default_agent_allows_headless_private_channel_when_provider_bound() {
+        let _lock = crate::config::shared_test_env_lock().lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("config")).unwrap();
+        std::fs::write(
+            temp.path().join("config/agentdesk.yaml"),
+            r#"
+discord:
+  dm_default_agent: family-counsel
+agents:
+  - id: family-counsel
+    name: Family Counsel
+    provider: claude
+    channels:
+      claude:
+        id: "123"
+        prompt_file: "/tmp/family-counsel.md"
+        workspace: "/tmp"
+        provider: claude
+"#,
+        )
+        .unwrap();
+        let previous_root = std::env::var_os("AGENTDESK_ROOT_DIR");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        assert!(dm_default_agent_authorizes_unmapped_private_channel(
+            true,
+            "headless_turn",
+            &ProviderKind::Claude,
+            true,
+        ));
+        assert!(!dm_default_agent_authorizes_unmapped_private_channel(
+            true,
+            "headless_turn",
+            &ProviderKind::Claude,
+            false,
+        ));
+        assert!(!dm_default_agent_authorizes_unmapped_private_channel(
+            false,
+            "headless_turn",
+            &ProviderKind::Claude,
+            true,
+        ));
+
+        match previous_root {
+            Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+            None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
         }
     }
 

--- a/src/services/discord/outbound/send_gate.rs
+++ b/src/services/discord/outbound/send_gate.rs
@@ -460,9 +460,9 @@ mod send_source_tests {
 
     #[test]
     fn dm_default_agent_allows_headless_private_channel_when_provider_bound() {
-        let _lock = crate::config::shared_test_env_lock().lock().unwrap();
-        let temp = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(temp.path().join("config")).unwrap();
+        let _lock = crate::config::shared_test_env_lock().lock().unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+        let temp = tempfile::tempdir().unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+        std::fs::create_dir_all(temp.path().join("config")).unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
         std::fs::write(
             temp.path().join("config/agentdesk.yaml"),
             r#"
@@ -480,7 +480,7 @@ agents:
         provider: claude
 "#,
         )
-        .unwrap();
+        .unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
         let previous_root = std::env::var_os("AGENTDESK_ROOT_DIR");
         unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
 

--- a/src/services/message_outbox.rs
+++ b/src/services/message_outbox.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use sqlx::PgPool;
 
 use crate::db::Db;
@@ -29,6 +31,49 @@ fn normalized_session_key(target: &str, session_key: Option<&str>) -> Option<Str
 
 fn normalized_reason_code(reason_code: Option<&str>) -> Option<&str> {
     reason_code.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn parse_channel_target(target: &str) -> Option<u64> {
+    target
+        .trim()
+        .strip_prefix("channel:")?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|id| *id > 0)
+}
+
+fn is_dm_session_channel_segment(value: &str) -> bool {
+    value
+        .strip_prefix("dm-")
+        .is_some_and(|user_id| !user_id.is_empty() && user_id.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn private_session_provider_from_key(session_key: Option<&str>) -> Option<String> {
+    let session_key = session_key
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let parsed = crate::services::discord::session_identity::SessionIdentity::parse(session_key);
+    let tmux_name = parsed
+        .as_ref()
+        .map(|identity| identity.tmux_name.as_str())
+        .unwrap_or(session_key);
+    let (provider, channel_segment) =
+        crate::services::provider::parse_provider_and_channel_from_tmux_name(tmux_name)?;
+    is_dm_session_channel_segment(&channel_segment).then(|| provider.as_str().to_string())
+}
+
+pub(crate) fn delivery_bot_for_target_session<'a>(
+    target: &str,
+    configured_bot: &'a str,
+    session_key: Option<&str>,
+) -> Cow<'a, str> {
+    if parse_channel_target(target).is_some()
+        && let Some(provider_bot) = private_session_provider_from_key(session_key)
+    {
+        return Cow::Owned(provider_bot);
+    }
+    Cow::Borrowed(configured_bot)
 }
 
 fn dedupe_key_for_message(
@@ -77,7 +122,7 @@ pub(crate) fn dedupe_key_for_message_for_test(
 
 #[cfg(test)]
 mod dedupe_key_tests {
-    use super::dedupe_key_for_message;
+    use super::{dedupe_key_for_message, delivery_bot_for_target_session};
 
     #[test]
     fn reason_code_dedupe_key_ignores_content() {
@@ -103,6 +148,51 @@ mod dedupe_key_tests {
         let second = dedupe_key_for_message("channel:123", "second", None, Some("session-abc"));
 
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn dm_session_routes_outbox_delivery_through_provider_bot() {
+        let bot = delivery_bot_for_target_session(
+            "channel:1479662682909966490",
+            "announce",
+            Some("claude/tok/mac-mini:AgentDesk-claude-dm-343742347"),
+        );
+
+        assert_eq!(bot.as_ref(), "claude");
+        let notify_bot = delivery_bot_for_target_session(
+            "channel:1479662682909966490",
+            "notify",
+            Some("claude/tok/mac-mini:AgentDesk-claude-dm-343742347"),
+        );
+        assert_eq!(notify_bot.as_ref(), "claude");
+        let raw_tmux_bot = delivery_bot_for_target_session(
+            "channel:1479662682909966490",
+            "announce",
+            Some("AgentDesk-claude-dm-343742347"),
+        );
+        assert_eq!(raw_tmux_bot.as_ref(), "claude");
+    }
+
+    #[test]
+    fn guild_session_keeps_configured_announce_bot() {
+        let bot = delivery_bot_for_target_session(
+            "channel:1504455726595051591",
+            "announce",
+            Some("claude/tok/mac-mini:AgentDesk-claude-adk-cc"),
+        );
+
+        assert_eq!(bot.as_ref(), "announce");
+    }
+
+    #[test]
+    fn notify_guild_delivery_keeps_info_only_bot() {
+        let bot = delivery_bot_for_target_session(
+            "channel:1504455726595051591",
+            "notify",
+            Some("codex/tok/mac-mini:AgentDesk-codex-adk-cc"),
+        );
+
+        assert_eq!(bot.as_ref(), "notify");
     }
 }
 


### PR DESCRIPTION
## 이슈 #3664 (P1)
사용자가 claude 봇에게 보낸 DM에 응답이 도달하지 않음(403 "channel not in role-map", 누적 100+건 유실 + watchdog force-clean 연쇄).

## 근본 원인 (실측 확인)
DM은 사용자가 메시지를 보낸 그 봇과의 1:1 채널. claude 봇만 두 DM 채널의 참여자(announce/notify/codex = Missing Access). 그런데 outbox는 DM 응답을 announce(또는 headless 기본 notify) 봇으로 보냄 → 비참여 → Discord 거부 → send_gate 403.

## 수정
- `src/server/mod.rs` outbox drain: `row.bot` 대신 `delivery_bot_for_target_session(...)` 결과로 send.
- `src/services/message_outbox.rs` `delivery_bot_for_target_session`: session_key/tmux명이 `AgentDesk-<provider>-dm-<digits>` (DM 세션)이면 provider 봇(claude DM→claude), 아니면 기존 bot 유지.
- `src/services/discord/outbound/send_gate.rs`: provider-bound headless private channel에서 dm_default_agent 인가 통과 검증 테스트.

## 비회귀
- guild 채널은 announce(또는 notify info-only) 그대로. DM만 provider 봇.
- #2047 confused-deputy 게이트 무약화(DM은 Discord가 봇별 접근 강제).

## 테스트
DM announce/notify→claude override, raw tmux DM명 처리, guild announce 유지, guild notify info-only 유지, dm_default_agent 인가 통과.

## 게이트
교차모델 적대 리뷰(codex 구현 → opus 리뷰) + CI green 전제. fmt/hotfile/giant/freshness 로컬 통과.