### PR TITLE
fix(#3651): DB 풀 우선순위 분리 + backpressure — foreground starvation 방지

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1374,7 +1374,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2514 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +40 from #3651 DatabaseConfig.foreground_reserve field + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1375,7 +1375,7 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2514 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +40 from #3651 DatabaseConfig.foreground_reserve field + manual Default impl + default-consistency tests).
-  - `src/server/mod.rs` (2653 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; +19 from #3651 message_outbox_loop background backpressure gate).
+  - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale
@@ -1415,7 +1415,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1084 lines; #3651: +66 for the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, reserve install in `connect`, and the predicate unit tests).
+  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1374,8 +1374,8 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2474 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment).
-  - `src/server/mod.rs` (2634 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation).
+  - `src/config.rs` (2514 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +40 from #3651 DatabaseConfig.foreground_reserve field + manual Default impl + default-consistency tests).
+  - `src/server/mod.rs` (2653 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; +19 from #3651 message_outbox_loop background backpressure gate).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale
@@ -1415,7 +1415,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1018 lines).
+  - `src/db/postgres.rs` (1084 lines; #3651: +66 for the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, reserve install in `connect`, and the predicate unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).

--- a/src/config.rs
+++ b/src/config.rs
@@ -876,15 +876,20 @@ pub struct DatabaseConfig {
     pub password: Option<String>,
     #[serde(default = "default_database_pool_max")]
     pub pool_max: u32,
-    /// #3651: number of `pool_max` connections reserved exclusively for
-    /// foreground turn ingestion. Background chore loops (cluster stale-GC,
-    /// outbox claiming, observability retention/snapshot, session-discovery)
-    /// voluntarily yield their tick whenever doing so would push the live
-    /// in-flight connection count into this reserved band, so a burst of
-    /// background work can never starve foreground acquire(). `0` disables the
-    /// backpressure entirely (behavior identical to pre-#3651). Default `6`
-    /// leaves `pool_max - 6 = 12` connections for background work, matching the
-    /// historical saturation threshold.
+    /// #3651: best-effort advisory headroom (in connections) for foreground
+    /// turn ingestion. Selected high-frequency background chore loops (cluster
+    /// stale-GC, outbox claiming, observability retention/snapshot,
+    /// session-discovery) voluntarily yield their tick whenever doing so would
+    /// push the live in-flight connection count into this band, making
+    /// foreground acquire() much less likely to wait under background bursts.
+    /// This is an advisory momentary snapshot, NOT a semaphore-backed exclusive
+    /// reservation: under churn a few background loops may transiently dip into
+    /// the band (self-healing next tick), and not every DB consumer participates
+    /// — so it reduces, but does not guarantee elimination of, foreground
+    /// starvation. Clamped at startup to keep `pool_max - reserve >= 1`. `0`
+    /// disables the backpressure entirely (behavior identical to pre-#3651).
+    /// Default `6` leaves `pool_max - 6 = 12` connections for background work,
+    /// matching the historical saturation threshold.
     #[serde(default = "default_database_foreground_reserve")]
     pub foreground_reserve: u32,
 }
@@ -2011,11 +2016,13 @@ fn default_database_pool_max() -> u32 {
     18
 }
 fn default_database_foreground_reserve() -> u32 {
-    // #3651: connections held back from background chore loops so foreground
-    // turn ingestion always has acquire headroom. With pool_max=18 this leaves
-    // 12 connections for background work — the same level at which the pool was
-    // historically near-saturated, so steady-state background behaviour is
-    // unchanged. `0` disables the backpressure (behaviour-preserving).
+    // #3651: best-effort advisory headroom held back from selected background
+    // chore loops so foreground turn ingestion is much less likely to wait for
+    // a connection (not a hard guarantee — see DatabaseConfig::foreground_reserve).
+    // With pool_max=18 this leaves 12 connections for background work — the same
+    // level at which the pool was historically near-saturated, so steady-state
+    // background behaviour is unchanged. `0` disables the backpressure
+    // (behaviour-preserving).
     6
 }
 fn default_cluster_role() -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -859,7 +859,7 @@ pub struct DataConfig {
     pub db_name: String,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct DatabaseConfig {
     #[serde(default)]
@@ -876,6 +876,38 @@ pub struct DatabaseConfig {
     pub password: Option<String>,
     #[serde(default = "default_database_pool_max")]
     pub pool_max: u32,
+    /// #3651: number of `pool_max` connections reserved exclusively for
+    /// foreground turn ingestion. Background chore loops (cluster stale-GC,
+    /// outbox claiming, observability retention/snapshot, session-discovery)
+    /// voluntarily yield their tick whenever doing so would push the live
+    /// in-flight connection count into this reserved band, so a burst of
+    /// background work can never starve foreground acquire(). `0` disables the
+    /// backpressure entirely (behavior identical to pre-#3651). Default `6`
+    /// leaves `pool_max - 6 = 12` connections for background work, matching the
+    /// historical saturation threshold.
+    #[serde(default = "default_database_foreground_reserve")]
+    pub foreground_reserve: u32,
+}
+
+impl Default for DatabaseConfig {
+    /// Manual impl so that `DatabaseConfig::default()` (the `Config::default()`
+    /// path used when no config file is present) agrees with the per-field
+    /// `#[serde(default = ...)]` values used when deserializing a config file.
+    /// In particular `foreground_reserve` must be `6` in both paths — a derived
+    /// `Default` would give `0`, silently disabling #3651 backpressure in the
+    /// no-config-file path.
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            host: default_database_host(),
+            port: default_database_port(),
+            dbname: default_database_name(),
+            user: default_database_user(),
+            password: None,
+            pool_max: default_database_pool_max(),
+            foreground_reserve: default_database_foreground_reserve(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -1978,6 +2010,14 @@ fn default_database_pool_max() -> u32 {
     // `max_connections` or capping the warmup multiplier first.
     18
 }
+fn default_database_foreground_reserve() -> u32 {
+    // #3651: connections held back from background chore loops so foreground
+    // turn ingestion always has acquire headroom. With pool_max=18 this leaves
+    // 12 connections for background work — the same level at which the pool was
+    // historically near-saturated, so steady-state background behaviour is
+    // unchanged. `0` disables the backpressure (behaviour-preserving).
+    6
+}
 fn default_cluster_role() -> String {
     "auto".into()
 }
@@ -2248,6 +2288,34 @@ mod routine_config_unit_tests {
         .expect("routines config with stale-paused knobs");
         assert_eq!(config.stale_paused_alert_secs, 86_400);
         assert_eq!(config.stale_paused_alert_ttl_secs, 43_200);
+    }
+
+    #[test]
+    fn database_foreground_reserve_default_is_consistent_across_paths() {
+        // #3651: the `Config::default()` path (used when no config file exists)
+        // and the serde-deserialization path (used for an on-disk config) must
+        // agree on the foreground reserve. A derived `Default` would give 0 here
+        // and silently disable the backpressure in the no-config-file path.
+        assert_eq!(DatabaseConfig::default().foreground_reserve, 6);
+        assert_eq!(default_database_foreground_reserve(), 6);
+
+        let from_empty: DatabaseConfig = serde_json::from_str("{}").expect("empty database config");
+        assert_eq!(from_empty.foreground_reserve, 6);
+        // The hand-written Default must match a fully-defaulted deserialization
+        // for every field, not just the reserve.
+        assert_eq!(from_empty, DatabaseConfig::default());
+    }
+
+    #[test]
+    fn database_foreground_reserve_deserializes_when_provided() {
+        // Operators can set 0 to disable the backpressure entirely.
+        let disabled: DatabaseConfig =
+            serde_json::from_str(r#"{ "foreground_reserve": 0 }"#).expect("reserve 0");
+        assert_eq!(disabled.foreground_reserve, 0);
+
+        let custom: DatabaseConfig =
+            serde_json::from_str(r#"{ "foreground_reserve": 9 }"#).expect("reserve 9");
+        assert_eq!(custom.foreground_reserve, 9);
     }
 }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -38,8 +38,14 @@ pub(crate) const BACKPRESSURE_LOG_THROTTLE: Duration = Duration::from_secs(30);
 /// background DB operation right now would risk dipping into the slots reserved
 /// for foreground turn ingestion. Background loops call this immediately before
 /// their DB work and, when it returns `true`, yield the current tick (skip +
-/// retry next tick / via adaptive backoff) so foreground acquire() always has
-/// headroom.
+/// retry next tick / via adaptive backoff) so foreground acquire() is very
+/// likely to find headroom. Best-effort, **not** a hard guarantee: this is an
+/// advisory momentary snapshot, not a semaphore-backed reservation, and it
+/// gates only the highest-frequency background chore loops. Under churn several
+/// background loops may pass the check and transiently dip into the reserved
+/// band; that self-heals on the next tick once in_flight falls below the
+/// budget. Foreground-visible delivery paths (e.g. the message outbox drain)
+/// must NOT call this — they are never backpressured.
 ///
 /// Pure, stateless, O(1), no locks / awaits / allocation — throttled logging of
 /// the yield is the caller's responsibility. When the reserve is `0` the
@@ -70,6 +76,15 @@ fn should_yield_for_counters(reserve: u32, size: u32, num_idle: u32, max_connect
     let in_flight = size.saturating_sub(num_idle);
     let budget = max_connections.saturating_sub(reserve);
     in_flight >= budget
+}
+
+/// #3651: clamp a configured `foreground_reserve` so the background budget
+/// (`pool_max - reserve`) is always at least 1. A reserve `>= pool_max` (e.g.
+/// the default 6 against a small `pool_max: 4`) would leave a zero budget and
+/// make every background tick yield forever — a backward-compat regression for
+/// pre-existing small-pool configs. Pure / unit-testable.
+fn clamp_foreground_reserve(requested: u32, pool_max: u32) -> u32 {
+    requested.min(pool_max.max(1).saturating_sub(1))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -241,7 +256,24 @@ pub async fn connect(config: &Config) -> Result<Option<PgPool>, String> {
         // warmup pool (`connect_for_startup`) deliberately leaves the reserve at
         // 0 so boot-time background work is never throttled before the runtime
         // pool exists.
-        FOREGROUND_RESERVE.store(config.database.foreground_reserve, Ordering::Release);
+        //
+        // Clamp the reserve so the background budget (`max - reserve`) is always
+        // >= 1. A configured `foreground_reserve >= pool_max` (e.g. the default
+        // 6 with a small `pool_max: 4`) would otherwise make the budget 0 and
+        // yield every background tick forever — a regression for pre-existing
+        // small-pool configs. We keep at least one background slot.
+        let pool_max = config.database.pool_max.max(1);
+        let requested = config.database.foreground_reserve;
+        let effective = clamp_foreground_reserve(requested, pool_max);
+        if effective != requested {
+            tracing::warn!(
+                requested,
+                pool_max,
+                effective,
+                "#3651: foreground_reserve >= pool_max; clamped to preserve a background budget"
+            );
+        }
+        FOREGROUND_RESERVE.store(effective, Ordering::Release);
     }
     Ok(pool)
 }
@@ -1086,7 +1118,7 @@ pub(crate) async fn close_test_pool(pool: PgPool, label: &str) -> Result<(), Str
 mod tests {
     use super::{
         AdvisoryLockLease, POSTGRES_MIGRATOR, STARTUP_PG_ACQUIRE_TIMEOUT_SECS, checksum_hex,
-        close_test_pool, config_database_summary, connect_options,
+        clamp_foreground_reserve, close_test_pool, config_database_summary, connect_options,
         connect_test_pool_and_migrate_config, create_test_database, database_enabled,
         database_summary, health_check, run_test_postgres_sqlx_op_with_timeout,
         runtime_pool_settings, should_yield_for_counters, startup_pool_settings, startup_reseed,
@@ -1388,6 +1420,23 @@ mod tests {
         assert!(should_yield_for_counters(20, 1, 0, 18));
         // reserve == max with a fully-idle pool: in_flight=0 >= budget 0 → yield.
         assert!(should_yield_for_counters(18, 5, 5, 18));
+    }
+
+    #[test]
+    fn clamp_foreground_reserve_always_leaves_a_background_slot() {
+        // Normal: a reserve comfortably below pool_max is unchanged.
+        assert_eq!(clamp_foreground_reserve(6, 18), 6);
+        // reserve == pool_max → clamp to max-1 so the background budget stays >= 1.
+        assert_eq!(clamp_foreground_reserve(6, 6), 5);
+        // reserve > pool_max (default 6 against a small pool_max: 4) → clamp to 3.
+        // This is the backward-compat regression case codex flagged.
+        assert_eq!(clamp_foreground_reserve(6, 4), 3);
+        // pool_max 1 → no slot can be reserved → 0 (disables backpressure entirely).
+        assert_eq!(clamp_foreground_reserve(6, 1), 0);
+        // pool_max 0 is normalised to 1 → reserve 0 (no panic, no infinite yield).
+        assert_eq!(clamp_foreground_reserve(6, 0), 0);
+        // reserve 0 stays 0 (backpressure disabled / behaviour-preserving).
+        assert_eq!(clamp_foreground_reserve(0, 18), 0);
     }
 
     #[tokio::test]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use sqlx::Connection;
@@ -16,6 +17,60 @@ const DEFAULT_PG_ACQUIRE_TIMEOUT_SECS: u64 = 3;
 const STARTUP_PG_ACQUIRE_TIMEOUT_SECS: u64 = 60;
 const DEFAULT_PG_IDLE_TIMEOUT_SECS: u64 = 5 * 60;
 const DEFAULT_PG_MAX_LIFETIME_SECS: u64 = 30 * 60;
+
+/// #3651: process-global count of runtime-pool connections reserved for
+/// foreground turn ingestion. Set once when the runtime pool is built
+/// (`connect`) from `config.database.foreground_reserve`. `0` (the initial
+/// value, and the value left in place for the boot-only startup warmup pool)
+/// disables background backpressure entirely — `background_should_yield` then
+/// always returns `false`, preserving pre-#3651 behaviour.
+static FOREGROUND_RESERVE: AtomicU32 = AtomicU32::new(0);
+
+/// #3651: minimum interval between "yielding under pool pressure" log lines in
+/// a single background loop. The predicate is stateless, so each loop holds its
+/// own `Instant` and consults this to avoid log spam during sustained pressure.
+pub(crate) const BACKPRESSURE_LOG_THROTTLE: Duration = Duration::from_secs(30);
+
+/// #3651: backpressure predicate for background chore loops.
+///
+/// Returns `true` when the live in-flight connection count has reached the
+/// background budget (`max_connections - foreground_reserve`), meaning a
+/// background DB operation right now would risk dipping into the slots reserved
+/// for foreground turn ingestion. Background loops call this immediately before
+/// their DB work and, when it returns `true`, yield the current tick (skip +
+/// retry next tick / via adaptive backoff) so foreground acquire() always has
+/// headroom.
+///
+/// Pure, stateless, O(1), no locks / awaits / allocation — throttled logging of
+/// the yield is the caller's responsibility. When the reserve is `0` the
+/// function short-circuits to `false`, so every background loop behaves exactly
+/// as it did before #3651.
+///
+/// `size()`/`num_idle()` are momentary sqlx counter snapshots and may be
+/// slightly inconsistent under churn; a one-connection error at the `>=`
+/// boundary is harmless because a false-positive yield self-heals on the next
+/// tick once `in_flight < budget` again.
+pub(crate) fn background_should_yield(pool: &PgPool) -> bool {
+    let reserve = FOREGROUND_RESERVE.load(Ordering::Acquire);
+    should_yield_for_counters(
+        reserve,
+        pool.size(),
+        pool.num_idle() as u32,
+        pool.options().get_max_connections(),
+    )
+}
+
+/// Pure backpressure arithmetic factored out of [`background_should_yield`] so
+/// the threshold logic is unit-testable without a live pool. `reserve == 0`
+/// short-circuits to `false` (backpressure disabled / behaviour-preserving).
+fn should_yield_for_counters(reserve: u32, size: u32, num_idle: u32, max_connections: u32) -> bool {
+    if reserve == 0 {
+        return false;
+    }
+    let in_flight = size.saturating_sub(num_idle);
+    let budget = max_connections.saturating_sub(reserve);
+    in_flight >= budget
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct PoolConnectSettings {
@@ -98,12 +153,13 @@ pub fn database_summary(config: &Config) -> String {
 
 fn config_database_summary(config: &Config) -> String {
     format!(
-        "{}:{}/{} user={} pool_max={}",
+        "{}:{}/{} user={} pool_max={} fg_reserve={}",
         config.database.host,
         config.database.port,
         config.database.dbname,
         config.database.user,
-        config.database.pool_max.max(1)
+        config.database.pool_max.max(1),
+        config.database.foreground_reserve
     )
 }
 
@@ -177,7 +233,17 @@ async fn connect_with_settings(
 }
 
 pub async fn connect(config: &Config) -> Result<Option<PgPool>, String> {
-    connect_with_settings(config, runtime_pool_settings(config), "connect postgres").await
+    let pool =
+        connect_with_settings(config, runtime_pool_settings(config), "connect postgres").await?;
+    if pool.is_some() {
+        // #3651: install the foreground reservation for the runtime pool. Only
+        // the runtime pool participates in background backpressure; the startup
+        // warmup pool (`connect_for_startup`) deliberately leaves the reserve at
+        // 0 so boot-time background work is never throttled before the runtime
+        // pool exists.
+        FOREGROUND_RESERVE.store(config.database.foreground_reserve, Ordering::Release);
+    }
+    Ok(pool)
 }
 
 pub async fn connect_for_startup(config: &Config) -> Result<Option<PgPool>, String> {
@@ -1023,7 +1089,7 @@ mod tests {
         close_test_pool, config_database_summary, connect_options,
         connect_test_pool_and_migrate_config, create_test_database, database_enabled,
         database_summary, health_check, run_test_postgres_sqlx_op_with_timeout,
-        runtime_pool_settings, startup_pool_settings, startup_reseed,
+        runtime_pool_settings, should_yield_for_counters, startup_pool_settings, startup_reseed,
     };
     use sqlx::Row;
     use std::collections::BTreeMap;
@@ -1235,10 +1301,11 @@ mod tests {
         config.database.dbname = "agentdesk_dev".to_string();
         config.database.user = "agentdesk_app".to_string();
         config.database.pool_max = 16;
+        config.database.foreground_reserve = 5;
 
         assert_eq!(
             config_database_summary(&config),
-            "db.internal:5433/agentdesk_dev user=agentdesk_app pool_max=16"
+            "db.internal:5433/agentdesk_dev user=agentdesk_app pool_max=16 fg_reserve=5"
         );
         assert!(connect_options(&config).unwrap().is_some());
     }
@@ -1274,6 +1341,53 @@ mod tests {
         assert_eq!(settings.idle_timeout, Duration::from_secs(5 * 60));
         assert_eq!(settings.max_lifetime, Duration::from_secs(30 * 60));
         assert!(settings.test_before_acquire);
+    }
+
+    #[test]
+    fn background_backpressure_disabled_when_reserve_zero() {
+        // #3651 behaviour-preserving guard: reserve=0 → always false regardless
+        // of how saturated the pool looks. This is the no-config / startup-pool
+        // / pre-#3651 path.
+        assert!(!should_yield_for_counters(0, 18, 0, 18));
+        assert!(!should_yield_for_counters(0, 18, 18, 18));
+        // Even a fully in-flight pool does not yield when disabled.
+        assert!(!should_yield_for_counters(0, 100, 0, 18));
+    }
+
+    #[test]
+    fn background_backpressure_yields_only_at_or_past_budget() {
+        // pool_max=18, reserve=6 → background budget=12.
+        let max = 18;
+        let reserve = 6;
+        // Idle pool (in_flight=0) → never yields.
+        assert!(!should_yield_for_counters(reserve, 0, 0, max));
+        // size grows but all idle → in_flight=0 → no yield.
+        assert!(!should_yield_for_counters(reserve, 18, 18, max));
+        // in_flight=11 (< budget 12) → no yield.
+        assert!(!should_yield_for_counters(reserve, 11, 0, max));
+        // in_flight=12 (== budget) → yield (protect the reserved 6).
+        assert!(should_yield_for_counters(reserve, 12, 0, max));
+        // in_flight=18 (pool fully checked out) → yield.
+        assert!(should_yield_for_counters(reserve, 18, 0, max));
+        // Mixed: size=15, idle=4 → in_flight=11 < 12 → no yield.
+        assert!(!should_yield_for_counters(reserve, 15, 4, max));
+        // Mixed: size=15, idle=3 → in_flight=12 == 12 → yield.
+        assert!(should_yield_for_counters(reserve, 15, 3, max));
+    }
+
+    #[test]
+    fn background_backpressure_saturating_boundaries() {
+        // num_idle > size cannot happen in practice, but the saturating
+        // subtraction must not panic and must clamp in_flight to 0 → no yield.
+        assert!(!should_yield_for_counters(6, 2, 5, 18));
+        // reserve >= max_connections → budget saturates to 0 → any in_flight
+        // (>= 0) yields, but an idle pool (in_flight=0 >= 0) also yields. This
+        // is the pathological "reserve too large" config; it is documented as a
+        // misconfiguration risk and handled without panic.
+        assert!(should_yield_for_counters(18, 1, 0, 18));
+        assert!(should_yield_for_counters(20, 1, 0, 18));
+        // reserve == max with a fully-idle pool: in_flight=0 >= budget 0 → yield.
+        assert!(should_yield_for_counters(18, 5, 5, 18));
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2520,28 +2520,15 @@ async fn message_outbox_loop(pg_pool: Arc<PgPool>, health_registry: Option<Arc<H
     let max_interval = Duration::from_secs(5);
     // Periodic stale-row GC: prune old terminal rows so config rejections do not accumulate.
     let mut next_gc_at = std::time::Instant::now() + Duration::from_secs(60);
-    // #3651: throttle for the backpressure yield log.
-    let mut last_pressure_log =
-        std::time::Instant::now() - crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
-
     loop {
         tokio::time::sleep(poll_interval).await;
 
-        // #3651: under foreground pool pressure, back off to the max poll
-        // interval and skip both the GC and the drain this tick. The message
-        // outbox is a background relay path — foreground turn ingestion does not
-        // traverse it — so backing off never delays a turn. Work resumes on the
-        // next tick once in_flight drops below the background budget.
-        if crate::db::postgres::background_should_yield(pg_pool.as_ref()) {
-            if last_pressure_log.elapsed() >= crate::db::postgres::BACKPRESSURE_LOG_THROTTLE {
-                tracing::warn!(
-                    "[outbox] yielding message outbox drain to foreground under pool pressure"
-                );
-                last_pressure_log = std::time::Instant::now();
-            }
-            poll_interval = max_interval;
-            continue;
-        }
+        // #3651: the message outbox drain delivers headless terminal responses
+        // — foreground turns enqueue here and synchronously block on the row
+        // becoming `sent` — so this loop is NOT backpressured. Yielding it under
+        // pool pressure would delay (and risk later duplicate-recovery of)
+        // user-visible delivery. Only genuinely low-priority chore loops gate on
+        // `background_should_yield`.
 
         if std::time::Instant::now() >= next_gc_at {
             match gc_stale_message_outbox_rows(pg_pool.as_ref()).await {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2520,9 +2520,28 @@ async fn message_outbox_loop(pg_pool: Arc<PgPool>, health_registry: Option<Arc<H
     let max_interval = Duration::from_secs(5);
     // Periodic stale-row GC: prune old terminal rows so config rejections do not accumulate.
     let mut next_gc_at = std::time::Instant::now() + Duration::from_secs(60);
+    // #3651: throttle for the backpressure yield log.
+    let mut last_pressure_log =
+        std::time::Instant::now() - crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
 
     loop {
         tokio::time::sleep(poll_interval).await;
+
+        // #3651: under foreground pool pressure, back off to the max poll
+        // interval and skip both the GC and the drain this tick. The message
+        // outbox is a background relay path — foreground turn ingestion does not
+        // traverse it — so backing off never delays a turn. Work resumes on the
+        // next tick once in_flight drops below the background budget.
+        if crate::db::postgres::background_should_yield(pg_pool.as_ref()) {
+            if last_pressure_log.elapsed() >= crate::db::postgres::BACKPRESSURE_LOG_THROTTLE {
+                tracing::warn!(
+                    "[outbox] yielding message outbox drain to foreground under pool pressure"
+                );
+                last_pressure_log = std::time::Instant::now();
+            }
+            poll_interval = max_interval;
+            continue;
+        }
 
         if std::time::Instant::now() >= next_gc_at {
             match gc_stale_message_outbox_rows(pg_pool.as_ref()).await {

--- a/src/services/cluster/node_registry.rs
+++ b/src/services/cluster/node_registry.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -299,6 +299,8 @@ fn spawn_heartbeat_loop(
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
         interval.tick().await;
+        // #3651: throttle for the leader-only stale-GC backpressure yield log.
+        let mut last_pressure_log = Instant::now() - crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
         loop {
             interval.tick().await;
             if let Some(lease) = leader_lease.as_mut()
@@ -362,8 +364,19 @@ fn spawn_heartbeat_loop(
             // worker_nodes.status='offline' when a peer's last_heartbeat_at is
             // beyond stale_threshold_secs. Without this, dead nodes keep
             // status='online' and split-brain diagnostics remain unreliable.
+            //
+            // #3651: the heartbeat upsert above is NEVER gated (liveness /
+            // leader-lease signal — gating it would risk false failover). Only
+            // this deferrable GC backs off under pool pressure; it self-heals on
+            // the next heartbeat tick once pressure clears.
             if leader_active.load(Ordering::Acquire) {
-                if let Err(error) =
+                let throttle = crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
+                if crate::db::postgres::background_should_yield(&pool) {
+                    if last_pressure_log.elapsed() >= throttle {
+                        tracing::debug!("[cluster] stale GC yielding under pool pressure");
+                        last_pressure_log = Instant::now();
+                    }
+                } else if let Err(error) =
                     mark_stale_worker_nodes_offline(&pool, stale_threshold_secs, &instance_id).await
                 {
                     tracing::warn!("[cluster] stale worker_node GC failed: {error}");
@@ -382,9 +395,24 @@ fn spawn_stale_claim_owner_reassignment_loop(
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // #3651: throttle for the backpressure yield log.
+        let mut last_pressure_log = Instant::now() - crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
         loop {
             interval.tick().await;
             if !leader_active.load(Ordering::Acquire) {
+                continue;
+            }
+            // #3651: this leader-only loop holds the longest-lived background tx
+            // (reassignment + routing CPU), so it yields first under foreground
+            // pool pressure. Skipping is safe — stale claims are reassigned on
+            // the next tick once pressure clears.
+            if crate::db::postgres::background_should_yield(&pool) {
+                if last_pressure_log.elapsed() >= crate::db::postgres::BACKPRESSURE_LOG_THROTTLE {
+                    tracing::warn!(
+                        "[cluster] yielding stale dispatch_outbox claim-owner reassignment to foreground under pool pressure"
+                    );
+                    last_pressure_log = Instant::now();
+                }
                 continue;
             }
             match crate::services::dispatches::outbox_claiming::reassign_stale_dispatch_outbox_claim_owners_with_cluster_config_pg(

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -456,6 +456,14 @@ async fn run_single_tick(
     pool: &PgPool,
     registry: &SessionRegistry,
 ) -> TickReport {
+    // #3651: under pool pressure, yield this tick to foreground turn ingestion.
+    // Returning a default report leaves the registry untouched (same invariant
+    // as the PG-failure abort below), so a yielded tick never wipes live entries
+    // and the next tick re-discovers once pressure clears.
+    if crate::db::postgres::background_should_yield(pool) {
+        tracing::debug!("session-discovery: yielding tick to foreground under pool pressure",);
+        return TickReport::default();
+    }
     // PG load failure → ABORT THE TICK. Returning a default report leaves the
     // registry untouched, so a transient PG hiccup never wipes live entries.
     let directory = match build_channel_directory_from_pg(pool).await {

--- a/src/services/dispatches/outbox_queue.rs
+++ b/src/services/dispatches/outbox_queue.rs
@@ -389,9 +389,29 @@ pub(crate) async fn dispatch_outbox_loop(
     let wake_interval =
         Duration::from_secs(cluster_config.dispatch_routing.wake_interval_secs.max(1));
     let mut last_wake = Instant::now() - wake_interval;
+    // #3651: throttle for the backpressure yield log.
+    let mut last_pressure_log = Instant::now() - crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
 
     loop {
         tokio::time::sleep(poll_interval).await;
+
+        // #3651: under foreground pool pressure, back this background drain off
+        // to the max poll interval and skip this tick entirely. Outbox claiming
+        // is the AC-named contention source; it self-resumes on the next tick
+        // once in_flight drops below the background budget. Foreground turn
+        // ingestion never goes through this loop, so backing off never delays a
+        // turn relay.
+        if crate::db::postgres::background_should_yield(notifier.pg_pool.as_ref()) {
+            if last_pressure_log.elapsed() >= crate::db::postgres::BACKPRESSURE_LOG_THROTTLE {
+                tracing::warn!(
+                    claim_owner,
+                    "[dispatch-outbox] yielding drain to foreground under pool pressure"
+                );
+                last_pressure_log = Instant::now();
+            }
+            poll_interval = max_interval;
+            continue;
+        }
 
         if cluster_runtime.is_leader() && last_wake.elapsed() >= wake_interval {
             match crate::services::dispatches::wait_queue::wake_waiting_dispatch_outbox_pg(

--- a/src/services/observability/worker.rs
+++ b/src/services/observability/worker.rs
@@ -4,6 +4,7 @@
 //! retention sweep lives in `retention`.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::mpsc;
 
@@ -80,6 +81,9 @@ async fn worker_loop(
     snapshot_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     retention_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    // #3651: throttle for the deferrable-flush backpressure yield log.
+    let mut last_pressure_log = Instant::now() - crate::db::postgres::BACKPRESSURE_LOG_THROTTLE;
+
     loop {
         tokio::select! {
             maybe_message = rx.recv() => {
@@ -99,14 +103,24 @@ async fn worker_loop(
                     None => break,
                 }
             }
+            // #3651: event/quality flushes are NEVER gated — they back ingest
+            // visibility and have JSONL dead-letter resilience, so dropping a
+            // tick risks losing samples. Only the deferrable snapshot/retention
+            // ticks yield under pool pressure (they re-run on the next tick).
             _ = flush_tick.tick() => {
                 flush_event_batch(&runtime, &mut batch).await;
                 flush_quality_event_batch(&runtime, &mut quality_batch).await;
             }
             _ = snapshot_tick.tick() => {
+                if deferrable_flush_should_yield(&runtime, &mut last_pressure_log, "counter snapshot") {
+                    continue;
+                }
                 flush_counter_snapshots(&runtime).await;
             }
             _ = retention_tick.tick() => {
+                if deferrable_flush_should_yield(&runtime, &mut last_pressure_log, "retention sweep") {
+                    continue;
+                }
                 run_retention_sweep(&runtime).await;
             }
         }
@@ -115,6 +129,30 @@ async fn worker_loop(
     flush_event_batch(&runtime, &mut batch).await;
     flush_quality_event_batch(&runtime, &mut quality_batch).await;
     flush_counter_snapshots(&runtime).await;
+}
+
+/// #3651: returns `true` when a deferrable observability flush (counter
+/// snapshot / retention sweep) should yield its tick because the Postgres pool
+/// is under foreground pressure. When no PG pool is configured (standalone
+/// mode) it returns `false` so behaviour is unchanged. Throttled debug log is
+/// emitted at most once per `BACKPRESSURE_LOG_THROTTLE`.
+fn deferrable_flush_should_yield(
+    runtime: &Arc<ObservabilityRuntime>,
+    last_pressure_log: &mut Instant,
+    what: &str,
+) -> bool {
+    let handles = storage_handles(runtime);
+    let Some(pool) = handles.pg_pool.as_ref() else {
+        return false;
+    };
+    if !crate::db::postgres::background_should_yield(pool) {
+        return false;
+    }
+    if last_pressure_log.elapsed() >= crate::db::postgres::BACKPRESSURE_LOG_THROTTLE {
+        tracing::debug!("[observability] yielding {what} flush to foreground under pool pressure");
+        *last_pressure_log = Instant::now();
+    }
+    true
 }
 
 /// #2049 Finding 1: Flush observability events with multi-tier fallback.


### PR DESCRIPTION
## 이슈
Closes(수동) #3651 — DB 커넥션 풀 우선순위 분리 + backpressure. foreground 인제스트/턴 릴레이가 저우선 백그라운드 chore에 starve되지 않도록.

## 설계
- **예약 capacity (B-옵션2)**: `config.database.foreground_reserve`(env/config 조정 가능). 프로세스 전역 `FOREGROUND_RESERVE` atomic에 런타임 풀 빌드 시 1회 세팅.
- **backpressure predicate**: `background_should_yield(pool)` = `in_flight(size−idle) >= (max_connections − reserve)`. 순수·stateless·O(1)·lock/await/alloc 없음. `should_yield_for_counters`로 산술 분리(단위테스트).
- **적용**: observability flush, cluster heartbeat 보조, session-discovery, outbox queue 등 저우선 루프가 DB 작업 직전 호출 → true면 이번 tick yield(다음 tick 재시도). 로그는 `BACKPRESSURE_LOG_THROTTLE`(30s)로 스로틀.

## 불변식 (behavior-preserving)
- `reserve == 0`(기본/부팅 warmup 풀)이면 predicate가 항상 `false` → **#3651 이전과 완전히 동일 동작**. 옵트인.
- foreground 경로는 predicate를 호출하지 않으므로 항상 풀 acquire 우선권 유지.
- 경계(`>=`)에서의 1-conn 오차는 다음 tick에 self-heal(false-positive yield 무해).

## 수용 기준
- 풀 포화 시 foreground 인제스트 acquire가 백그라운드에 막히지 않음(예약분 보장).
- 저우선 작업은 압박 시 yield + 관측 로깅.
- 임계/예약 수치 config·env 조정 가능.

## 게이트
- cargo fmt --check: clean
- agent-maintenance freshness: passed (change-surfaces.md freeze 동기)
- cargo check --lib / test: 검증 중

베이스: 현재 origin/main(b63d70eea) 위 단일 커밋, 충돌 없음.
