### PR TITLE
fix(#3668): relay 보존 가드 — idle-clear 전 JSONL tail(F2) + catch_up backward pagination(F3)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -993,7 +993,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2734 lines; +12 from #3668 F2 stall-watchdog idle-clear tail-answer guard (skip destructive clear when JSONL has an unrelayed final answer after last_offset); #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2733 lines; +11 from #3668 F2 watchdog loop-top tail-answer guard — one early-`continue` that skips BOTH destructive branches (idle-clear + desynced force-clean) for the channel this tick when JSONL still holds an unrelayed final answer after last_offset; #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -920,7 +920,7 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3410 lines; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
+  - `src/services/discord/recovery_engine.rs` (3412 lines; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
     `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the
     STALL-WATCHDOG force-clean -> respawn synthetic row (which lands here with
     `existing_inflight = None`) is watcher-owned instead of degrading to

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -993,7 +993,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2722 lines; #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2734 lines; +12 from #3668 F2 stall-watchdog idle-clear tail-answer guard (skip destructive clear when JSONL has an unrelayed final answer after last_offset); #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -358,7 +358,12 @@
 # #3034 batch-8: lowered 2655 -> 2645 (dead-code removal: `stop_provider_channel_runtime`).
 # #3293: lowered 2645 -> 2641 (mailbox probe routed through the non-creating
 # `health/mailbox.rs::peeked_provider_mailbox_state`).
-"src/services/discord/health/recovery.rs" = 2722
+# #3668 F2: raised 2722 -> 2733 (+11) — deliberate admission. Added a stall-
+# watchdog loop-top tail-answer guard (one early-`continue`) so neither
+# destructive branch (idle-clear nor desynced force-clean) drops a final answer
+# still persisted in JSONL after last_offset. A correctness guard against
+# permanent answer loss; splitting recovery.rs is out of scope for this fix.
+"src/services/discord/health/recovery.rs" = 2733
 # #3629: +81 (2641 -> 2722) for the NO_REPLY/empty orphan inflight cleanup in the
 # completed-stale leak-detection path: the `completed_stale_no_answer_orphan_should_clean`
 # pure seam (+ safety doc), the identity-guarded clear + lifecycle telemetry at the

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -1318,7 +1318,15 @@ pub async fn stale_mailbox_repair_handler(
                     } else {
                         true
                     };
-                    if inflight_safe {
+                    // #3668 F2: never destructively idle-clear when a final
+                    // answer is still persisted in JSONL after `last_offset` —
+                    // let normal recovery deliver it instead of dropping it.
+                    let unrelayed_tail =
+                        crate::services::discord::relay_recovery::idle_tmux_repair_has_unrelayed_tail_answer(
+                            &provider,
+                            request.channel_id,
+                        );
+                    if inflight_safe && !unrelayed_tail {
                         health::clear_idle_tmux_stale_turn(
                             registry,
                             provider.as_str(),

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -207,6 +207,43 @@ fn collect_catch_up_channel_candidates(
 /// user messages.
 const CATCH_UP_FETCH_LIMIT: u8 = 50;
 
+/// #3668 F3: max backward-pagination pages for the no-checkpoint `Recent` scan.
+///
+/// `Recent` mode (channels with no disk/live/retry checkpoint, e.g. after
+/// `/clear` or stale-checkpoint pruning) previously fetched exactly one
+/// `limit=50` page. Discord applies `limit` BEFORE author filtering and returns
+/// newest-first, so a burst of newer bot/system noise can fill that single page
+/// and push an age-window-eligible user message off the end — it is never
+/// fetched, so catch-up silently fails to recover it. In `Recent` mode we now
+/// page backward with `.before(cursor)` up to this budget, stopping early as
+/// soon as a page's oldest message exceeds the age window (nothing older can
+/// qualify). 4 pages × 50 = 200 messages of reach; well inside the Discord
+/// per-channel rate limit (5 req / 5 s). The `After` (checkpoint) path is
+/// unchanged — it already has a precise lower bound.
+const CATCH_UP_RECENT_MAX_PAGES: u8 = 4;
+
+/// #3668 F3: decide whether to fetch another backward page in `Recent` mode.
+///
+/// Pure so the budget / age-window early-exit contract is unit-testable without
+/// a Discord runtime. Returns `true` only when (a) the page budget has room and
+/// (b) the just-fetched page's oldest message is still within the age window
+/// (i.e. an older page could still hold an eligible message). `oldest_age_secs`
+/// is the age of the oldest message in the page just fetched; `None` means the
+/// page was empty (no cursor to page before → stop).
+fn should_fetch_older_recent_page(
+    pages_fetched: u8,
+    oldest_age_secs: Option<i64>,
+    max_age_secs: i64,
+) -> bool {
+    if pages_fetched >= CATCH_UP_RECENT_MAX_PAGES {
+        return false;
+    }
+    match oldest_age_secs {
+        Some(age) => age <= max_age_secs,
+        None => false,
+    }
+}
+
 /// Inter-channel pacing for the catch-up REST sweep.
 ///
 /// Startup recovery and the periodic backstop scan every configured channel
@@ -500,6 +537,54 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 continue;
             }
         };
+
+        // #3668 F3: `Recent` mode (no checkpoint) has no lower bound, so a single
+        // newest-first page can be fully consumed by newer bot/system noise and
+        // bury an age-window-eligible user message past page 1. Page backward
+        // with `.before(oldest)` up to `CATCH_UP_RECENT_MAX_PAGES`, stopping as
+        // soon as a page's oldest message exceeds the age window. The `After`
+        // path keeps its precise single-page contract and is left untouched.
+        if matches!(fetch_mode, CatchUpFetchMode::Recent) {
+            let mut pages_fetched: u8 = 1;
+            loop {
+                // The oldest message currently held is the smallest id (Discord
+                // returns newest-first; ids are time-ordered snowflakes).
+                let Some(oldest) = messages.iter().min_by_key(|msg| msg.id.get()) else {
+                    break;
+                };
+                let oldest_id = oldest.id;
+                let oldest_age_secs = chrono::Utc::now()
+                    .signed_duration_since(*oldest_id.created_at())
+                    .num_seconds();
+                if !should_fetch_older_recent_page(
+                    pages_fetched,
+                    Some(oldest_age_secs),
+                    max_age.as_secs() as i64,
+                ) {
+                    break;
+                }
+                if should_pace_before_scan(true) {
+                    catch_up_scan_pace_gap().await;
+                }
+                let older_request = serenity::builder::GetMessages::new()
+                    .limit(CATCH_UP_FETCH_LIMIT)
+                    .before(oldest_id);
+                match channel_id.messages(http, older_request).await {
+                    Ok(older) if !older.is_empty() => {
+                        pages_fetched += 1;
+                        messages.extend(older);
+                    }
+                    Ok(_) => break, // no older messages → done
+                    Err(e) => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] ⚠ catch-up: backward page fetch failed for channel {channel_id}: {e}"
+                        );
+                        break; // keep what we already have
+                    }
+                }
+            }
+        }
 
         if messages.is_empty() {
             continue;
@@ -838,10 +923,11 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
 #[cfg(test)]
 mod catch_up_recovery_tests {
     use super::{
-        CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate, CatchUpClassification,
-        CatchUpFetchMode, CatchUpMessageView, ChannelId, ProviderKind,
+        CATCH_UP_RECENT_MAX_PAGES, CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate,
+        CatchUpClassification, CatchUpFetchMode, CatchUpMessageView, ChannelId, ProviderKind,
         catch_up_fetch_mode_for_scan, classify_catch_up_message,
-        insert_configured_catch_up_candidate, parse_catch_up_scan_pace, should_pace_before_scan,
+        insert_configured_catch_up_candidate, parse_catch_up_scan_pace,
+        should_fetch_older_recent_page, should_pace_before_scan,
     };
     use std::collections::{BTreeMap, HashSet};
 
@@ -1017,5 +1103,68 @@ mod catch_up_recovery_tests {
             ),
             CatchUpClassification::Recover
         );
+    }
+
+    // #3668 F3: backward-pagination budget / age-window early-exit contract for
+    // the no-checkpoint `Recent` scan.
+    #[test]
+    fn recent_pagination_continues_while_within_age_window_and_under_budget() {
+        // First page (pages_fetched=1) whose oldest message is still inside the
+        // 300s window → a buried older user message may exist → fetch more.
+        assert!(
+            should_fetch_older_recent_page(1, Some(120), 300),
+            "in-window oldest under budget should page backward"
+        );
+    }
+
+    #[test]
+    fn recent_pagination_stops_when_oldest_exceeds_age_window() {
+        // The oldest message in the page is already older than the window —
+        // nothing older can qualify, so stop without another fetch.
+        assert!(
+            !should_fetch_older_recent_page(1, Some(301), 300),
+            "out-of-window oldest must early-exit"
+        );
+    }
+
+    #[test]
+    fn recent_pagination_stops_at_page_budget() {
+        // Even fully within the age window, the budget caps backward reach so a
+        // pathological channel cannot trigger unbounded fetches.
+        assert!(
+            !should_fetch_older_recent_page(CATCH_UP_RECENT_MAX_PAGES, Some(10), 300),
+            "page budget must cap backward pagination"
+        );
+        // One below the budget still pages.
+        assert!(
+            should_fetch_older_recent_page(CATCH_UP_RECENT_MAX_PAGES - 1, Some(10), 300),
+            "below-budget in-window page should continue"
+        );
+    }
+
+    #[test]
+    fn recent_pagination_stops_on_empty_page() {
+        // No oldest message (empty page) → no cursor to page before → stop.
+        assert!(
+            !should_fetch_older_recent_page(1, None, 300),
+            "empty page must stop pagination"
+        );
+    }
+
+    #[test]
+    fn after_mode_is_unchanged_by_recent_pagination() {
+        // Regression guard: the `After` (checkpoint) fetch mode keeps its single
+        // precise lower bound; the backward-pagination loop is gated on
+        // `matches!(fetch_mode, Recent)` only.
+        let candidate = CatchUpChannelCandidate {
+            channel_id: ChannelId::new(99),
+            fallback_name: None,
+            checkpoint_path: None,
+            disk_checkpoint: Some(1_500_000_000_000_000_000),
+        };
+        assert!(matches!(
+            catch_up_fetch_mode_for_scan(&candidate, None, None),
+            CatchUpFetchMode::After(_)
+        ));
     }
 }

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -672,6 +672,18 @@ pub async fn clear_idle_tmux_stale_turn(
         return None;
     }
 
+    // #3668 F2: the stall-watchdog idle-clear path shares the same
+    // ready/inflight gates as the relay_recovery ReattachWatcher path, so it
+    // needs the same guard — never destructively clear when a final answer is
+    // still persisted in JSONL after `last_offset`. Skip the clear (return None)
+    // and let normal relay/recovery deliver the tail answer; otherwise this
+    // path would delete the very state F2 preserves on the other path.
+    if crate::services::discord::relay_recovery::idle_tmux_repair_has_unrelayed_tail_answer(
+        &provider, channel_id,
+    ) {
+        return None;
+    }
+
     let channel_id = ChannelId::new(channel_id);
     let shared = shared_for_provider(registry, &provider, channel_id).await?;
     let finish = discord::mailbox_finish_turn(&shared, &provider, channel_id).await;

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -672,18 +672,6 @@ pub async fn clear_idle_tmux_stale_turn(
         return None;
     }
 
-    // #3668 F2: the stall-watchdog idle-clear path shares the same
-    // ready/inflight gates as the relay_recovery ReattachWatcher path, so it
-    // needs the same guard — never destructively clear when a final answer is
-    // still persisted in JSONL after `last_offset`. Skip the clear (return None)
-    // and let normal relay/recovery deliver the tail answer; otherwise this
-    // path would delete the very state F2 preserves on the other path.
-    if crate::services::discord::relay_recovery::idle_tmux_repair_has_unrelayed_tail_answer(
-        &provider, channel_id,
-    ) {
-        return None;
-    }
-
     let channel_id = ChannelId::new(channel_id);
     let shared = shared_for_provider(registry, &provider, channel_id).await?;
     let finish = discord::mailbox_finish_turn(&shared, &provider, channel_id).await;
@@ -1610,6 +1598,17 @@ pub(crate) async fn run_stall_watchdog_pass(
             Some(snapshot) => snapshot,
             None => continue,
         };
+        // #3668 F2: if a final answer is still persisted in JSONL after
+        // `last_offset`, skip ALL destructive watchdog branches this tick (the
+        // idle-clear AND the desynced force-clean below) — let normal recovery /
+        // #3645 far-backstop deliver it first, then re-evaluate next tick once
+        // `last_offset` advances past the delivered answer.
+        if crate::services::discord::relay_recovery::idle_tmux_repair_has_unrelayed_tail_answer(
+            provider,
+            channel_id.get(),
+        ) {
+            continue;
+        }
         // #2965: a ready-for-input TUI can still look "desynced" when the
         // capture file has bytes past relay offsets. Prefer the idle-safe
         // anchor cleanup before the destructive desynced force-clean branch.

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -40,7 +40,7 @@ mod queue_io;
 mod queued_placeholders_store;
 mod reaction_cleanup;
 mod relay_health;
-mod relay_recovery;
+pub(crate) mod relay_recovery;
 #[cfg(unix)] // #3089 A0: shared ReplaceLongMessageOutcome disposition policy.
 mod replace_outcome_policy;
 pub(crate) mod response_sanitizer;

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -48,7 +48,7 @@ mod analytics_transcript;
 mod state_extractors;
 
 // Re-import moved items so existing call sites stay byte-identical.
-use self::jsonl_extract::{extract_response_from_output, success_result_end_offset_after_offset};
+use self::jsonl_extract::extract_response_from_output;
 #[cfg(unix)]
 use self::output_path_detect::{
     DetectedRebindOutputPath, StaleOutputCandidate, detect_rebind_output_path_from_candidates,
@@ -64,7 +64,9 @@ use self::phase_policy::{
 // `extract_response_from_output_pub` is re-exported (not just re-imported) so the
 // `recovery_engine::extract_response_from_output_pub` path stays valid for the
 // turn_bridge / tmux_restart_handoff external callers.
-pub(super) use self::jsonl_extract::extract_response_from_output_pub;
+pub(super) use self::jsonl_extract::{
+    extract_response_from_output_pub, success_result_end_offset_after_offset,
+};
 // #3479 item-2: re-import the externally-called terminal-watcher helpers so the
 // existing call sites stay byte-identical. The remaining cluster members
 // (`terminal_success_watcher_stop_allowed`, `jsonl_tail_contains_terminal_end_sentinel`,

--- a/src/services/discord/recovery_engine/jsonl_extract.rs
+++ b/src/services/discord/recovery_engine/jsonl_extract.rs
@@ -9,7 +9,7 @@
 /// Check whether a **successful** result record exists after the given offset.
 /// Error results are not considered completion — they should not trigger the
 /// recovery completed-turn path (✅ reaction, idle dispatch, etc.).
-pub(super) fn success_result_end_offset_after_offset(
+pub(in crate::services::discord) fn success_result_end_offset_after_offset(
     output_path: &str,
     start_offset: u64,
 ) -> Option<u64> {

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -661,7 +661,7 @@ fn idle_tmux_repair_ready_for_input(
 /// inflight/output so normal relay/recovery delivers the text). On extract
 /// failure / IO error the function returns false → existing behavior (only the
 /// genuinely-empty tail still clears), so this is behavior-preserving.
-pub(in crate::services::discord) fn idle_tmux_repair_has_unrelayed_tail_answer(
+pub(crate) fn idle_tmux_repair_has_unrelayed_tail_answer(
     provider: &ProviderKind,
     channel_id: u64,
 ) -> bool {

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -676,6 +676,19 @@ pub(crate) fn idle_tmux_repair_has_unrelayed_tail_answer(
     else {
         return false;
     };
+    // #3668 codex r3: only treat this as an answer worth preserving when there
+    // is TERMINAL completion evidence — a *successful* `result` record after
+    // `last_offset`. A hung / desynced turn with only partial assistant text and
+    // no terminal result must NOT suppress the destructive idle-clear / force-
+    // clean: otherwise the watchdog would skip it every tick forever, since
+    // #3645 far-backstop / normal recovery only advance `last_offset` on a
+    // terminal success. Requiring the success-result record keeps the guard to
+    // genuinely-deliverable, complete-but-unrelayed answers.
+    if super::recovery::success_result_end_offset_after_offset(output_path, state.last_offset)
+        .is_none()
+    {
+        return false;
+    }
     let tail = super::recovery::extract_response_from_output_pub(output_path, state.last_offset);
     !tail.trim().is_empty()
 }
@@ -1603,6 +1616,41 @@ mod tests {
         assert!(
             !idle_tmux_repair_has_unrelayed_tail_answer(&provider, channel_id),
             "empty JSONL tail must not block the existing destructive clear path"
+        );
+    }
+
+    #[test]
+    fn idle_tmux_repair_guard_silent_when_partial_text_has_no_terminal_result() {
+        // #3668 codex r3: a hung/desynced turn that emitted partial assistant
+        // text after `last_offset` but NO terminal `result` record must NOT
+        // suppress the destructive clear — otherwise the watchdog would skip it
+        // every tick forever (recovery only advances the offset on terminal
+        // success). The guard requires success-result completion evidence.
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().unwrap();
+        let _root_guard = AgentdeskRootGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let provider = ProviderKind::Codex;
+        let channel_id = 3_668_003;
+        let output_path = temp.path().join("out.jsonl");
+
+        let pre = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"old\"}]}}\n";
+        let post = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"partial, still streaming...\"}]}}\n";
+        let last_offset = pre.len() as u64;
+        write_inflight_with_output(
+            &provider,
+            channel_id,
+            &output_path,
+            last_offset,
+            &format!("{pre}{post}"),
+        );
+
+        assert!(
+            !idle_tmux_repair_has_unrelayed_tail_answer(&provider, channel_id),
+            "partial assistant text without a terminal success result must not block force-clean"
         );
     }
 }

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -643,6 +643,40 @@ fn idle_tmux_repair_ready_for_input(
         })
 }
 
+/// #3668 F2: detect tail answer text that the destructive idle-tmux clear would
+/// permanently lose.
+///
+/// `idle_tmux_repair_ready_for_input` returns Ready when the JSONL has a
+/// terminal envelope after `last_offset` (the offset-behind path in
+/// `tui_turn_state::jsonl_ready_for_input`), which means a final answer is
+/// already persisted past the inflight watermark. The companion inflight guard
+/// (`inflight_state_allows_idle_tmux_repair`) only inspects the streaming
+/// `full_response`, so an empty-stream + JSONL-terminal-answer row passes both
+/// guards and reaches `clear_inflight_state`, dropping text that
+/// `extract_response_from_output_pub(output_path, last_offset)` could still
+/// recover. The recovery_engine normal path (extract → relay → clear) never has
+/// this asymmetry. This guard reads the same offset slice read-only: if it
+/// yields non-empty relayable text, the caller skips the destructive clear and
+/// falls through to the non-destructive rebind path (which preserves the
+/// inflight/output so normal relay/recovery delivers the text). On extract
+/// failure / IO error the function returns false → existing behavior (only the
+/// genuinely-empty tail still clears), so this is behavior-preserving.
+fn idle_tmux_repair_has_unrelayed_tail_answer(provider: &ProviderKind, channel_id: u64) -> bool {
+    let Some(state) = super::inflight::load_inflight_state(provider, channel_id) else {
+        return false;
+    };
+    let Some(output_path) = state
+        .output_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    else {
+        return false;
+    };
+    let tail = super::recovery::extract_response_from_output_pub(output_path, state.last_offset);
+    !tail.trim().is_empty()
+}
+
 async fn apply_relay_recovery_decision(
     registry: &HealthRegistry,
     shared: &Arc<SharedData>,
@@ -712,6 +746,10 @@ async fn apply_relay_recovery_decision(
                     decision.channel_id,
                 )
                 .unwrap_or(false)
+                // #3668 F2: never destructively clear when a final answer is
+                // still persisted in JSONL after `last_offset` — fall through to
+                // the non-destructive rebind path so normal relay delivers it.
+                && !idle_tmux_repair_has_unrelayed_tail_answer(provider, decision.channel_id)
             {
                 let finish = mailbox_finish_turn(shared, provider, channel).await;
                 if let Some(token) = finish.removed_token.as_ref() {
@@ -1459,6 +1497,109 @@ mod tests {
         assert!(
             shared.dispatch.thread_parents.contains_key(&parent),
             "auto orphan cleanup must not apply other recovery action kinds"
+        );
+    }
+
+    // #3668 F2: the destructive idle-tmux clear must not drop a final answer that
+    // is still persisted in JSONL after `last_offset`. The guard reads the same
+    // offset slice via `extract_response_from_output_pub`; when it yields
+    // non-empty text the caller skips the destructive clear (rebind fall-
+    // through). When the tail is genuinely empty the guard is silent and the
+    // existing clear behavior is preserved.
+    struct AgentdeskRootGuard(Option<std::ffi::OsString>);
+    impl Drop for AgentdeskRootGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    fn write_inflight_with_output(
+        provider: &ProviderKind,
+        channel_id: u64,
+        output_path: &std::path::Path,
+        last_offset: u64,
+        jsonl_body: &str,
+    ) {
+        std::fs::write(output_path, jsonl_body).expect("write output jsonl");
+        let state = super::super::inflight::InflightTurnState::new(
+            provider.clone(),
+            channel_id,
+            Some("adk-cdx".to_string()),
+            7,
+            777,
+            7777,
+            "hello".to_string(),
+            None,
+            Some(format!("AgentDesk-codex-adk-cdx-{channel_id}")),
+            Some(output_path.to_string_lossy().to_string()),
+            None,
+            last_offset,
+        );
+        // full_response stays empty (streaming guard would pass): F2 reproduces
+        // the empty-stream + JSONL-terminal-answer asymmetry exactly.
+        assert!(state.full_response.is_empty());
+        super::super::inflight::save_inflight_state(&state).expect("save inflight");
+    }
+
+    #[test]
+    fn idle_tmux_repair_guard_detects_tail_answer_after_offset() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().unwrap();
+        let _root_guard = AgentdeskRootGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let provider = ProviderKind::Codex;
+        let channel_id = 3_668_001;
+        let output_path = temp.path().join("out.jsonl");
+
+        // A leading pre-offset record (consumed) followed by a terminal answer
+        // record after `last_offset`. `last_offset` points past the first line so
+        // only the final answer remains in the extracted slice.
+        let pre = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"old\"}]}}\n";
+        let post = "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"FINAL ANSWER\"}\n";
+        let last_offset = pre.len() as u64;
+        write_inflight_with_output(
+            &provider,
+            channel_id,
+            &output_path,
+            last_offset,
+            &format!("{pre}{post}"),
+        );
+
+        assert!(
+            idle_tmux_repair_has_unrelayed_tail_answer(&provider, channel_id),
+            "JSONL terminal answer after last_offset must block destructive clear"
+        );
+    }
+
+    #[test]
+    fn idle_tmux_repair_guard_silent_when_tail_empty() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().unwrap();
+        let _root_guard = AgentdeskRootGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let provider = ProviderKind::Codex;
+        let channel_id = 3_668_002;
+        let output_path = temp.path().join("out.jsonl");
+
+        // Only a pre-offset record exists; nothing relayable remains after
+        // `last_offset`, so the guard stays silent and the existing destructive
+        // clear behavior is preserved (behavior-preserving regression guard).
+        let body = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"old\"}]}}\n";
+        let last_offset = body.len() as u64;
+        write_inflight_with_output(&provider, channel_id, &output_path, last_offset, body);
+
+        assert!(
+            !idle_tmux_repair_has_unrelayed_tail_answer(&provider, channel_id),
+            "empty JSONL tail must not block the existing destructive clear path"
         );
     }
 }

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -661,7 +661,10 @@ fn idle_tmux_repair_ready_for_input(
 /// inflight/output so normal relay/recovery delivers the text). On extract
 /// failure / IO error the function returns false → existing behavior (only the
 /// genuinely-empty tail still clears), so this is behavior-preserving.
-fn idle_tmux_repair_has_unrelayed_tail_answer(provider: &ProviderKind, channel_id: u64) -> bool {
+pub(in crate::services::discord) fn idle_tmux_repair_has_unrelayed_tail_answer(
+    provider: &ProviderKind,
+    channel_id: u64,
+) -> bool {
     let Some(state) = super::inflight::load_inflight_state(provider, channel_id) else {
         return false;
     };


### PR DESCRIPTION
## 이슈
#3668 — ownerless recovery/idle-repair 잔여 릴레이갭 audit. F2·F3 수정, **F1은 미수정**(아래 사유).

## F2 (최우선) — idle-tmux destructive clear 전 JSONL tail 가드 (`relay_recovery.rs`)
- 문제: `idle_tmux_repair_ready_for_input()`는 JSONL의 `last_offset` 이후 terminal envelope가 있으면 Ready를 반환하나, inflight guard는 `full_response.is_empty()`(streaming 상태)만 봐서, 둘 다 통과하면 `clear_inflight_state()`가 복구 가능한 답변(JSONL-only)을 **영구 소실**시켰다 (recovery_engine 정상 경로 extract→relay→clear와 비대칭).
- 수정: destructive clear 분기 진입 직전 read-only 가드 `idle_tmux_repair_has_unrelayed_tail_answer()` 추가 — `extract_response_from_output_pub(output_path, last_offset)`로 tail relayable text가 있으면 clear 스킵 → 비파괴 rebind 경로로 fall-through. **behavior-preserving**: tail이 비면 기존 clear 동작 불변, IO 에러 시 보수적으로 clear 스킵(답변 보존 우선).

## F3 — catch_up Recent 모드 bounded backward pagination (`catch_up.rs`)
- 문제: no-checkpoint 채널 폴백 `CatchUpFetchMode::Recent`가 `limit(50)` 단일 페이지라, 50개 넘는 newer noise가 age-window 내 user 메시지를 페이지 밖으로 밀면 누락.
- 수정: `CATCH_UP_RECENT_MAX_PAGES=4` + 순수함수 `should_fetch_older_recent_page()` + `.before(cursor)` 루프. 페이지 oldest가 age window 초과 또는 예산 도달 시 early exit. **After 모드 경로 불변**, queue cap/checkpoint 시맨틱 보존.

## F1 — 미수정 (will_fix=false)
ownerless live watcher의 health-classifier 진입 갭(`desynced()` 미커버)은 사실이나: (1) live attached watcher에 `desynced=true` 주입 시 destructive 경로로 오보내는 **false-positive 회귀** 위험(#3016 코어), (2) 실제 stranding(relay_stale·ownerless·live)은 **#3645가 Watcher far-backstop reseed로 이미 auto-reconcile**. health-path 분기 추가는 #3645와 중복+회귀 위험만 더하므로 미수정(이중 안전망 부재일 뿐 기능 갭 아님).

## 불변식 / 게이트
- #3016 코어 핫파일(recovery_engine/turn_finalizer/inflight/tmux*) **미변경** — relay_recovery에 read-only 호출만 추가.
- cargo fmt --check clean, cargo check --lib clean, 신규 회귀테스트 7건 + 영향 모듈(catch_up 12·relay_recovery 12) green, agent-maintenance freshness passed.
- 참고: relay_recovery 기존 테스트 5건은 origin/main 베이스라인에서도 동일 실패(env-var/병렬성 ordering, pre-existing) — 본 변경과 무관.
