### PR TITLE
fix(#3635): dead-watcher rebind-origin reap — liveness-gated, boot-exempt

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1252,13 +1252,14 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (3003 lines; #3635 added the
-    dead-watcher rebind-origin reap — `WatcherLiveness` DI trait +
-    `should_reap_dead_watcher_rebind_origin` + locked re-validate + sweeper entry,
-    the byte-for-byte-unchanged #3581 None-owner predicate is preserved verbatim).
-  - `src/services/discord/placeholder_sweeper.rs` (1002 lines; crossed the giant
-    threshold in #3635 when the dead-watcher reap branch joined the rebind-origin
-    sweep arm — tracked decompose target, see `giant-file-registry.md` (owner
+    lines) and `src/services/discord/inflight.rs` (3052 lines; #3635 added the
+    dead-watcher rebind-origin reap — `WatcherLiveness` DI trait, three-state tmux
+    pane liveness, spawn-blocking warm sweeper probe, and fs-only locked
+    re-validation; the byte-for-byte-unchanged #3581 None-owner predicate is
+    preserved verbatim).
+  - `src/services/discord/placeholder_sweeper.rs` (1004 lines; crossed the giant
+    threshold in #3635 when the dead-watcher reap branch joined the async
+    rebind-origin sweep arm — tracked decompose target, see `giant-file-registry.md` (owner
     `discord-relay`, deadline 2026-08-31, #3405)).
 - active_callsite_coverage: n/a.
 - invariants: watcher single-owner per #1222; placeholder lifecycle invariants

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1252,7 +1252,14 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (2766 lines).
+    lines) and `src/services/discord/inflight.rs` (3003 lines; #3635 added the
+    dead-watcher rebind-origin reap — `WatcherLiveness` DI trait +
+    `should_reap_dead_watcher_rebind_origin` + locked re-validate + sweeper entry,
+    the byte-for-byte-unchanged #3581 None-owner predicate is preserved verbatim).
+  - `src/services/discord/placeholder_sweeper.rs` (1002 lines; crossed the giant
+    threshold in #3635 when the dead-watcher reap branch joined the rebind-origin
+    sweep arm — tracked decompose target, see `giant-file-registry.md` (owner
+    `discord-relay`, deadline 2026-08-31, #3405)).
 - active_callsite_coverage: n/a.
 - invariants: watcher single-owner per #1222; placeholder lifecycle invariants
   per #1112; `/api/inflight/rebind` is the only path that synthesises an

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -450,7 +450,24 @@
 # Adds the 1h conservative age floor, lock-name/base-path helpers, root-explicit
 # testable sweep, runtime-root wrapper, and boot hook. Tests live in the excluded
 # `orphan_lock_reap_tests` module.
-"src/services/discord/inflight.rs" = 2771 # #3641 orphan-lock sweep
+# #3635 raised 2771 -> 3003 (+232): dead-watcher rebind-origin reap. A
+# Watcher-owned rebind orphan (the #897 birth shape, `relay_owner_kind =
+# Watcher`) can never satisfy the existing `should_reap_abandoned_rebind_origin`
+# `== None` owner conjunct, so it leaked on disk forever after the watcher died.
+# This adds a SEPARATE gate that leaves the byte-for-byte-unchanged None-owner
+# predicate (and its 19 live-protection pinning tests) intact: the new
+# `WatcherLiveness` DI trait + `RuntimeWatcherLiveness` operational oracle (tmux
+# has-live-pane + dispatched-sessions runtime-activity age, reused from #3169 /
+# #3629), `should_reap_dead_watcher_rebind_origin` (owner == Watcher + structural
+# conjunction + deadline/generation disjunct + proven-dead liveness gate), a
+# locked re-validate helper `reap_dead_watcher_rebind_origin_locked_in_root` that
+# re-probes liveness under the lock (TOCTOU: a watcher re-spawning mid-sweep is
+# never reaped), and the `sweep_reap_dead_watcher_rebind_origin` one-call sweeper
+# entry point. recovery_engine.rs (#3016 birth) is 0 lines changed; only the
+# warm placeholder-sweeper carries the liveness gate (never the boot path) so a
+# freshly-restarted live watcher is never false-classified as dead. Tests live in
+# the excluded `rebind_origin_reap_tests` module.
+"src/services/discord/inflight.rs" = 3003 # #3635 dead-watcher rebind reap
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).
@@ -494,6 +511,14 @@
 # shadow_mirror_delivered_frontier at the sink delivery call site (Phase B prereq;
 # irreducible 6-arg rustfmt-wrapped call). panel_msg_id has 0 prod readers -> dedup unchanged.
 "src/services/discord/session_relay_sink.rs" = 1738
+# #3635: placeholder_sweeper.rs crossed the 1000-prod-LoC giant threshold (993 ->
+# 1002) when the dead-watcher rebind-origin reap branch was added to the
+# rebind-origin arm of the sweep loop (the watcher-owned #897 orphan the #3581
+# None-owner predicate can never touch). Registered as a tracked [[entry]] in
+# scripts/giant_file_registry.toml (discord-relay, decompose_issue #3405). The
+# reap-eligibility logic lives in inflight.rs; this arm is the orchestration
+# shell. Frozen here so future sweep-arm growth is reviewable.
+"src/services/discord/placeholder_sweeper.rs" = 1002
 # #3479: turn_bridge/tmux_runtime.rs decomposed into tmux_runtime/ directory
 # modules (root tmux_runtime.rs 964 prod LoC + sub-1000-LoC
 # tmux_runtime/{interrupt_policy,process_table,pid_exit}.rs) — dropped below the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -450,24 +450,24 @@
 # Adds the 1h conservative age floor, lock-name/base-path helpers, root-explicit
 # testable sweep, runtime-root wrapper, and boot hook. Tests live in the excluded
 # `orphan_lock_reap_tests` module.
-# #3635 raised 2771 -> 3003 (+232): dead-watcher rebind-origin reap. A
+# #3635 raised 2771 -> 3052 (+281): dead-watcher rebind-origin reap. A
 # Watcher-owned rebind orphan (the #897 birth shape, `relay_owner_kind =
 # Watcher`) can never satisfy the existing `should_reap_abandoned_rebind_origin`
 # `== None` owner conjunct, so it leaked on disk forever after the watcher died.
 # This adds a SEPARATE gate that leaves the byte-for-byte-unchanged None-owner
 # predicate (and its 19 live-protection pinning tests) intact: the new
-# `WatcherLiveness` DI trait + `RuntimeWatcherLiveness` operational oracle (tmux
-# has-live-pane + dispatched-sessions runtime-activity age, reused from #3169 /
-# #3629), `should_reap_dead_watcher_rebind_origin` (owner == Watcher + structural
-# conjunction + deadline/generation disjunct + proven-dead liveness gate), a
-# locked re-validate helper `reap_dead_watcher_rebind_origin_locked_in_root` that
-# re-probes liveness under the lock (TOCTOU: a watcher re-spawning mid-sweep is
-# never reaped), and the `sweep_reap_dead_watcher_rebind_origin` one-call sweeper
-# entry point. recovery_engine.rs (#3016 birth) is 0 lines changed; only the
-# warm placeholder-sweeper carries the liveness gate (never the boot path) so a
-# freshly-restarted live watcher is never false-classified as dead. Tests live in
-# the excluded `rebind_origin_reap_tests` module.
-"src/services/discord/inflight.rs" = 3003 # #3635 dead-watcher rebind reap
+# `WatcherLiveness` DI trait + `RuntimeWatcherLiveness` operational oracle
+# (three-state tmux pane liveness + dispatched-sessions runtime-activity age,
+# reused from #3169 / #3629), the Watcher-owner structural predicate, and the
+# `sweep_reap_dead_watcher_rebind_origin` warm sweeper entry point. Codex review
+# follow-up removed the bool-collapse bug (`ProbeError` is unknown/preserve), runs
+# tmux subprocess probes outside the sidecar lock on `spawn_blocking` with a
+# timeout, and keeps the locked helper to cheap fs-only identity/structure plus
+# recent-runtime-activity rechecks. recovery_engine.rs (#3016 birth) is 0 lines
+# changed; only the warm placeholder-sweeper carries the liveness gate (never the
+# boot path) so a freshly-restarted live watcher is never false-classified as dead.
+# Tests live in the excluded `rebind_origin_reap_tests` module.
+"src/services/discord/inflight.rs" = 3052 # #3635 dead-watcher rebind reap
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).
@@ -512,13 +512,14 @@
 # irreducible 6-arg rustfmt-wrapped call). panel_msg_id has 0 prod readers -> dedup unchanged.
 "src/services/discord/session_relay_sink.rs" = 1738
 # #3635: placeholder_sweeper.rs crossed the 1000-prod-LoC giant threshold (993 ->
-# 1002) when the dead-watcher rebind-origin reap branch was added to the
+# 1004) when the dead-watcher rebind-origin reap branch was added to the
 # rebind-origin arm of the sweep loop (the watcher-owned #897 orphan the #3581
-# None-owner predicate can never touch). Registered as a tracked [[entry]] in
+# None-owner predicate can never touch) and then awaited the async, spawn_blocking
+# dead-watcher probe helper. Registered as a tracked [[entry]] in
 # scripts/giant_file_registry.toml (discord-relay, decompose_issue #3405). The
-# reap-eligibility logic lives in inflight.rs; this arm is the orchestration
-# shell. Frozen here so future sweep-arm growth is reviewable.
-"src/services/discord/placeholder_sweeper.rs" = 1002
+# reap-eligibility logic lives in inflight.rs; this arm is the orchestration shell.
+# Frozen here so future sweep-arm growth is reviewable.
+"src/services/discord/placeholder_sweeper.rs" = 1004
 # #3479: turn_bridge/tmux_runtime.rs decomposed into tmux_runtime/ directory
 # modules (root tmux_runtime.rs 964 prod LoC + sub-1000-LoC
 # tmux_runtime/{interrupt_policy,process_table,pid_exit}.rs) — dropped below the

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -309,6 +309,21 @@ deadline = "2026-08-31"
 decompose_issue = "#3405"
 
 [[entry]]
+# Crossed the 1000-prod-LoC threshold in #3635: the dead-watcher rebind-origin
+# reap added a second reap branch to the rebind-origin arm of the sweep loop
+# (the watcher-owned #897 orphan the #3581 None-owner predicate can never touch).
+# The file was already at 993 prod LoC (razor-thin under the threshold) from the
+# accreted #3003/#3581/#3641 sweep-arm logic; the contained #3635 branch tipped
+# it over. The pure reap-eligibility logic lives in inflight.rs — the sweeper
+# arm is the orchestration shell. Decompose the per-arm sweep handlers
+# (placeholder edit / status-panel / rebind reap) into a sweep-handlers submodule
+# once the rebind-origin lifecycle (#3581/#3635) stabilizes.
+file = "src/services/discord/placeholder_sweeper.rs"
+owner = "discord-relay"
+deadline = "2026-08-31"
+decompose_issue = "#3405"
+
+[[entry]]
 # Crossed the 1000-prod-LoC threshold when #3041 P1-0 landed the dormant
 # `DeliveryLeaseCell` finalizer messages/handlers on top of #3143's
 # `FinalizeContext::monitor()` + monitor turn-key/ledger-generation logic. The

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -116,6 +116,20 @@ pub(super) const ORPHAN_LOCK_REAP_MIN_AGE_SECS: i64 = 3600;
 /// backstop window can complete.
 const REBIND_ORIGIN_DEADLINE_SECS_MIN: u64 = 30;
 
+/// #3635: minimum quiescence (seconds) of *all* runtime liveness signals before
+/// a Watcher-owned rebind-origin row is treated as "proven dead" and made
+/// eligible for the dead-watcher reap path. Deliberately far larger than the
+/// stall-watchdog's positive-liveness window
+/// (`STALL_WATCHDOG_POSITIVE_LIVENESS_SECS` = 120s): a live Watcher that is
+/// merely between turns (mailbox idle, no fresh jsonl byte) must NEVER be
+/// false-classified as dead and reaped, because #3154/#3540 require a live
+/// Watcher rebind to survive so it can re-adopt the session across a restart.
+/// A 10-minute conservative floor means a false-negative (a genuinely dead
+/// watcher whose reap is merely delayed) is the only failure mode — never a
+/// false-positive (a live watcher reaped). The orphan is harmless while it
+/// lingers (#3631/PR #3634 classifies it idle), so delay is acceptable.
+pub(super) const DEAD_WATCHER_PROVEN_DEAD_SECS: u64 = 600;
+
 /// #3581: resolve the rebind-origin reap deadline. Reads
 /// `AGENTDESK_REBIND_ORIGIN_DEADLINE_SECS`; on absence / parse failure falls
 /// back to [`REBIND_ORIGIN_DEADLINE_SECS_DEFAULT`]. Any explicit value is
@@ -194,6 +208,133 @@ pub(super) fn should_reap_abandoned_rebind_origin(
         .rebind_origin_birth_generation
         .is_some_and(|birth| birth != current_generation);
     past_deadline || stale_generation
+}
+
+/// #3635: runtime-liveness oracle for the dead-watcher rebind-origin reap path.
+///
+/// A Watcher-owned rebind-origin orphan (born by `recovery_engine` with
+/// `relay_owner_kind = Watcher`, #897) can never satisfy
+/// [`should_reap_abandoned_rebind_origin`]'s `== None` owner conjunct, so the
+/// strict predicate leaves it on disk forever even after the watcher process
+/// has died (#3635). It must NOT be reaped on shape alone, though: #3154/#3540
+/// require a *live* Watcher rebind to survive so the watcher can re-adopt the
+/// session across a restart, and an idle-stuck dead-watcher row is shape-
+/// identical to a live-but-between-turns one. The only safe discriminator is a
+/// *runtime* liveness probe, which is injected here so unit tests can stub it
+/// (and so the keystone pinning tests, which run with no real tmux/jsonl, are
+/// never evaluated against a naive oracle that would mis-judge their synthetic
+/// session as dead).
+pub(super) trait WatcherLiveness {
+    /// True only when the watcher owning `state` is *provably* dead: its tmux
+    /// session has no live pane AND no runtime activity (jsonl/.generation
+    /// mtime) has advanced within [`DEAD_WATCHER_PROVEN_DEAD_SECS`]. Any
+    /// positive signal (or an unknown session name) yields `false` — the
+    /// conservative, live-protecting default.
+    fn is_proven_dead(&self, state: &InflightTurnState) -> bool;
+}
+
+/// #3635: production [`WatcherLiveness`] backed by the same runtime signals the
+/// stall-watchdog (#3169) and #3629 stall-liveness already trust:
+/// `tmux_diagnostics::tmux_session_has_live_pane` and
+/// `dispatched_sessions::latest_runtime_activity_unix_nanos`.
+pub(super) struct RuntimeWatcherLiveness;
+
+impl WatcherLiveness for RuntimeWatcherLiveness {
+    fn is_proven_dead(&self, state: &InflightTurnState) -> bool {
+        // No session name to probe ⇒ cannot prove death ⇒ never reap.
+        let Some(session) = state.tmux_session_name.as_deref() else {
+            return false;
+        };
+        let session = session.trim();
+        if session.is_empty() {
+            return false;
+        }
+        // A live tmux pane is a hard "alive" signal.
+        if crate::services::tmux_diagnostics::tmux_session_has_live_pane(session) {
+            return false;
+        }
+        // Fresh runtime activity (jsonl / .generation mtime) within the proven-
+        // dead window is also "alive". `latest_runtime_activity_unix_nanos`
+        // returns 0 when nothing is observable; a 0 (no resolvable temp file)
+        // is treated as "no recent activity" — but only the conjunction with a
+        // dead pane makes a row reapable, so a missing-file 0 alone never reaps.
+        let latest_nanos =
+            crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(session);
+        let activity_recent = latest_nanos > 0 && {
+            let age_secs = now_unix()
+                .saturating_sub(latest_nanos / 1_000_000_000)
+                .max(0) as u64;
+            age_secs < DEAD_WATCHER_PROVEN_DEAD_SECS
+        };
+        if activity_recent {
+            return false;
+        }
+        // Dead pane AND no recent runtime activity ⇒ proven dead.
+        true
+    }
+}
+
+/// #3635: decide whether a *Watcher-owned* abandoned rebind-origin row is safe
+/// to reap because its owning watcher is provably dead.
+///
+/// This is a separate gate that runs alongside (OR'd with)
+/// [`should_reap_abandoned_rebind_origin`] at the periodic sweeper call site —
+/// NOT at boot (see `invalidate_stale_generation_in_root`). It exists so the
+/// `relay_owner_kind == Watcher` orphan that the strict `== None` predicate can
+/// never touch is finally reaped once the watcher has demonstrably exited.
+///
+/// The structural conjunction is byte-identical to
+/// [`should_reap_abandoned_rebind_origin`] EXCEPT the owner conjunct flips from
+/// `== None` to `== Watcher`, and the reap is additionally gated on
+/// `liveness.is_proven_dead(state)`. A live watcher (positive tmux pane or
+/// recent runtime activity) is `is_proven_dead == false`, so this predicate is
+/// `false` and the row is preserved — the #3154/#3540 / keystone live-
+/// protection invariant holds verbatim. Every non-owner live signal (adoption,
+/// streamed bytes, anchor, terminal commit, offset progress, planned restart)
+/// still independently blocks the reap via the shared structural conjunction.
+pub(super) fn should_reap_dead_watcher_rebind_origin(
+    state: &InflightTurnState,
+    age_secs: u64,
+    current_generation: u64,
+    liveness: &dyn WatcherLiveness,
+) -> bool {
+    if !state.rebind_origin {
+        return false;
+    }
+    // Same structural-abandoned shape as the None-owner predicate, but pinned to
+    // a Watcher relay owner (the #897 rebind birth shape the None predicate can
+    // never match). Every other conjunct is identical so all the live-protection
+    // signals (adoption / streamed bytes / anchor / terminal / offset progress /
+    // planned restart) keep blocking the reap exactly as before.
+    let structurally_abandoned = state.turn_source == TurnSource::ExternalAdopted
+        && state.effective_relay_owner_kind() == RelayOwnerKind::Watcher
+        && state.user_msg_id == 0
+        && state.current_msg_id == 0
+        && !state.terminal_delivery_committed
+        && state.response_sent_offset == 0
+        && state.full_response.is_empty()
+        && state.last_offset == state.turn_start_offset.unwrap_or(state.last_offset)
+        && state.restart_mode.is_none();
+    if !structurally_abandoned {
+        return false;
+    }
+
+    // Past-deadline OR stale-generation matches the None-owner predicate's
+    // disjunct, so a dead-watcher orphan is not reaped the instant it is born.
+    let deadline = state
+        .rebind_origin_deadline_secs
+        .unwrap_or_else(rebind_origin_deadline_secs_env);
+    let past_deadline = age_secs >= deadline;
+    let stale_generation = state
+        .rebind_origin_birth_generation
+        .is_some_and(|birth| birth != current_generation);
+    if !(past_deadline || stale_generation) {
+        return false;
+    }
+
+    // FINAL gate: only reap when the owning watcher is provably dead. A live
+    // watcher (tmux pane up or recent runtime activity) is never reaped.
+    liveness.is_proven_dead(state)
 }
 
 /// #3581: best-effort age (seconds) for a rebind-origin row. Prefers the
@@ -522,6 +663,102 @@ pub(super) fn reap_abandoned_rebind_origin_locked(
     };
     reap_abandoned_rebind_origin_locked_in_root(&root, provider, snapshot, current_generation)
         == RebindReapOutcome::Reaped
+}
+
+/// #3635: locked re-validate-then-unlink for the *dead-watcher* rebind-origin
+/// reap path. Structurally identical to
+/// [`reap_abandoned_rebind_origin_locked_in_root`] but re-validates under the
+/// lock with [`should_reap_dead_watcher_rebind_origin`] (which includes a FRESH
+/// `liveness.is_proven_dead` probe). This closes the TOCTOU window where a
+/// watcher re-spawns between the unlocked snapshot and the lock: the locked
+/// re-probe sees the freshly-live pane / runtime activity and the helper Skips,
+/// so a watcher that came back to life is never reaped.
+fn reap_dead_watcher_rebind_origin_locked_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    snapshot: &InflightTurnState,
+    current_generation: u64,
+    liveness: &dyn WatcherLiveness,
+) -> RebindReapOutcome {
+    let path = inflight_state_path(root, provider, snapshot.channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return RebindReapOutcome::LockUnavailable;
+    };
+    let Some(locked) = read_inflight_state_content(&path) else {
+        return RebindReapOutcome::Missing;
+    };
+    // Birth-identity guard (same as the None-owner path): a replacement turn at
+    // the same sidecar path must never be mistaken for the snapshotted orphan.
+    if !rebind_row_identity_unchanged(snapshot, &locked) {
+        return RebindReapOutcome::Skipped;
+    }
+    let age_secs = rebind_origin_age_secs(&path, &locked);
+    // Re-run the FULL dead-watcher predicate (structure + deadline/generation +
+    // FRESH liveness probe) under the lock. A watcher that re-spawned since the
+    // snapshot now reads `is_proven_dead == false` ⇒ Skipped.
+    if !should_reap_dead_watcher_rebind_origin(&locked, age_secs, current_generation, liveness) {
+        return RebindReapOutcome::Skipped;
+    }
+    match fs::remove_file(&path) {
+        Ok(()) => RebindReapOutcome::Reaped,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => RebindReapOutcome::Missing,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = snapshot.channel_id,
+                error = %error,
+                "#3635 dead-watcher rebind reap remove_file failed under lock; treating as Missing"
+            );
+            RebindReapOutcome::Missing
+        }
+    }
+}
+
+/// #3635: env-rooted wrapper around
+/// [`reap_dead_watcher_rebind_origin_locked_in_root`] for the periodic
+/// placeholder-sweeper path. Returns `true` iff the row was re-validated under
+/// the lock (with a fresh liveness probe) and unlinked.
+pub(super) fn reap_dead_watcher_rebind_origin_locked(
+    provider: &ProviderKind,
+    snapshot: &InflightTurnState,
+    current_generation: u64,
+    liveness: &dyn WatcherLiveness,
+) -> bool {
+    let Some(root) = inflight_runtime_root() else {
+        return false;
+    };
+    reap_dead_watcher_rebind_origin_locked_in_root(
+        &root,
+        provider,
+        snapshot,
+        current_generation,
+        liveness,
+    ) == RebindReapOutcome::Reaped
+}
+
+/// #3635: the placeholder sweeper's single-call entry point for the dead-watcher
+/// rebind-origin reap. Wraps the unlocked pre-check
+/// ([`should_reap_dead_watcher_rebind_origin`]) and the locked re-validate
+/// ([`reap_dead_watcher_rebind_origin_locked`]) behind the production
+/// [`RuntimeWatcherLiveness`] oracle, returning `true` only when the row was
+/// genuinely unlinked. Keeping the oracle construction and the predicate/lock
+/// pairing here (not at the sweeper call site) keeps the warm-path wiring in one
+/// auditable place and the sweeper a one-liner.
+///
+/// Deliberately NOT called from the boot path
+/// (`invalidate_stale_generation_in_root`): at cold start a just-restarted live
+/// watcher's session reads as dead, so the liveness gate only ever fires in the
+/// warm 30s sweeper where a real runtime probe is meaningful (#3154/#3540 / the
+/// keystone boot-preservation invariant).
+pub(super) fn sweep_reap_dead_watcher_rebind_origin(
+    provider: &ProviderKind,
+    state: &InflightTurnState,
+    age_secs: u64,
+    current_generation: u64,
+) -> bool {
+    let liveness = RuntimeWatcherLiveness;
+    should_reap_dead_watcher_rebind_origin(state, age_secs, current_generation, &liveness)
+        && reap_dead_watcher_rebind_origin_locked(provider, state, current_generation, &liveness)
 }
 
 fn now_string() -> String {
@@ -5895,10 +6132,12 @@ mod rebind_origin_reap_tests {
     //! reap so a genuinely-live rebind is never destroyed (#3154 / #3540
     //! no-regression pins).
     use super::{
-        InflightTurnState, REBIND_ORIGIN_DEADLINE_SECS_DEFAULT, RebindReapOutcome, RelayOwnerKind,
-        TurnSource, invalidate_stale_generation_in_root, load_inflight_states_from_root,
-        reap_abandoned_rebind_origin_locked_in_root, save_inflight_state_in_root,
-        should_reap_abandoned_rebind_origin,
+        DEAD_WATCHER_PROVEN_DEAD_SECS, InflightTurnState, REBIND_ORIGIN_DEADLINE_SECS_DEFAULT,
+        RebindReapOutcome, RelayOwnerKind, TurnSource, WatcherLiveness,
+        invalidate_stale_generation_in_root, load_inflight_states_from_root,
+        reap_abandoned_rebind_origin_locked_in_root,
+        reap_dead_watcher_rebind_origin_locked_in_root, save_inflight_state_in_root,
+        should_reap_abandoned_rebind_origin, should_reap_dead_watcher_rebind_origin,
     };
     use crate::services::discord::InflightRestartMode;
     use crate::services::provider::ProviderKind;
@@ -6302,6 +6541,291 @@ mod rebind_origin_reap_tests {
             CURRENT_GEN,
         );
         assert_eq!(outcome, RebindReapOutcome::Missing);
+    }
+
+    // ----------------------------------------------------------------------
+    // #3635: dead-watcher rebind-origin reap. A Watcher-owned rebind orphan
+    // (the #897 birth shape) is invisible to `should_reap_abandoned_rebind_origin`
+    // (its `== None` owner conjunct can never hold), so it leaked forever even
+    // after the watcher died. `should_reap_dead_watcher_rebind_origin` reaps it
+    // ONLY when a runtime-liveness probe proves the watcher dead. A LIVE watcher
+    // (tmux pane up or recent runtime activity) is never reaped — the injected
+    // `WatcherLiveness` oracle lets us pin both directions without real tmux.
+    // ----------------------------------------------------------------------
+
+    /// Test [`WatcherLiveness`] oracle: returns a fixed proven-dead verdict so a
+    /// unit test can pin the alive vs proven-dead branch without spawning tmux or
+    /// touching jsonl/.generation files.
+    struct StubLiveness {
+        proven_dead: bool,
+    }
+    impl WatcherLiveness for StubLiveness {
+        fn is_proven_dead(&self, _state: &InflightTurnState) -> bool {
+            self.proven_dead
+        }
+    }
+    const DEAD: StubLiveness = StubLiveness { proven_dead: true };
+    const ALIVE: StubLiveness = StubLiveness { proven_dead: false };
+
+    /// A Watcher-owned reapable rebind orphan: identical to `reapable_rebind`
+    /// but with `relay_owner_kind = Watcher` (the #897 birth shape). This is the
+    /// row the None-owner predicate can never touch.
+    fn watcher_owned_rebind(
+        channel_id: u64,
+        last_offset: u64,
+        birth_generation: u64,
+    ) -> InflightTurnState {
+        let mut state = reapable_rebind(channel_id, last_offset, birth_generation);
+        state.set_relay_owner_kind(RelayOwnerKind::Watcher);
+        // Sanity: the legacy None-owner predicate refuses this row outright.
+        assert!(!should_reap_abandoned_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN
+        ));
+        state
+    }
+
+    #[test]
+    fn dead_watcher_rebind_reaps_when_proven_dead() {
+        // (A) Watcher-owned + past deadline + proven dead → reap. This is the
+        // exact #3635 leaked-row signature finally made reapable.
+        let state = watcher_owned_rebind(7001, 4096, CURRENT_GEN);
+        assert!(should_reap_dead_watcher_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+    }
+
+    #[test]
+    fn dead_watcher_rebind_reaps_on_prior_generation_when_dead() {
+        // (A') Generation disjunct mirrors the None-owner predicate: a prior-
+        // generation dead-watcher orphan reaps even within the deadline.
+        let state = watcher_owned_rebind(7002, 4096, 1); // prior gen
+        assert!(should_reap_dead_watcher_rebind_origin(
+            &state,
+            WITHIN_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+    }
+
+    #[test]
+    fn live_watcher_rebind_never_reaped_when_alive() {
+        // (B) THE LIVE-PROTECTION INVARIANT (#3154/#3540 homologue): a Watcher
+        // that is still alive (tmux pane up OR recent runtime activity) is NEVER
+        // reaped, even past the deadline and even from a prior generation.
+        let past = watcher_owned_rebind(7003, 4096, CURRENT_GEN);
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &past,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &ALIVE
+        ));
+        let prior_gen = watcher_owned_rebind(7004, 4096, 1);
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &prior_gen,
+            WITHIN_DEADLINE,
+            CURRENT_GEN,
+            &ALIVE
+        ));
+    }
+
+    #[test]
+    fn dead_watcher_rebind_never_reaped_within_deadline_same_generation() {
+        // (B') Even proven-dead, a current-generation orphan within its deadline
+        // is preserved — the deadline/generation disjunct gates first, before
+        // liveness. Matches the None-owner predicate's timing exactly.
+        let state = watcher_owned_rebind(7005, 4096, CURRENT_GEN);
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &state,
+            WITHIN_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+    }
+
+    #[test]
+    fn dead_watcher_reap_respects_structural_conjunction() {
+        // (C) Every non-owner live signal still independently blocks the reap,
+        // even with a proven-dead liveness verdict: adoption, anchor, terminal
+        // commit, streamed bytes, offset progress, planned restart.
+        let mut adopted = watcher_owned_rebind(7006, 4096, CURRENT_GEN);
+        adopted.user_msg_id = 42;
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &adopted,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+
+        let mut anchored = watcher_owned_rebind(7007, 4096, CURRENT_GEN);
+        anchored.current_msg_id = 777;
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &anchored,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+
+        let mut committed = watcher_owned_rebind(7008, 4096, CURRENT_GEN);
+        committed.terminal_delivery_committed = true;
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &committed,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+
+        let mut sent = watcher_owned_rebind(7009, 4096, CURRENT_GEN);
+        sent.response_sent_offset = 10;
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &sent,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+
+        let mut progressed = watcher_owned_rebind(7010, 4096, CURRENT_GEN);
+        progressed.last_offset = progressed.turn_start_offset.unwrap() + 100;
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &progressed,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+
+        let mut planned = watcher_owned_rebind(7011, 4096, CURRENT_GEN);
+        planned.set_restart_mode(InflightRestartMode::DrainRestart);
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &planned,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+    }
+
+    #[test]
+    fn none_owner_orphan_not_matched_by_dead_watcher_gate() {
+        // The two predicates are disjoint on the owner conjunct: a None-owner
+        // orphan (handled by the legacy predicate) is NOT in scope for the
+        // dead-watcher gate even when proven dead, so no double-reap path.
+        let none_owner = reapable_rebind(7012, 4096, CURRENT_GEN);
+        assert_eq!(
+            none_owner.effective_relay_owner_kind(),
+            RelayOwnerKind::None
+        );
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &none_owner,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+    }
+
+    #[test]
+    fn non_rebind_row_never_matched_by_dead_watcher_gate() {
+        let mut state = watcher_owned_rebind(7013, 4096, CURRENT_GEN);
+        state.rebind_origin = false;
+        assert!(!should_reap_dead_watcher_rebind_origin(
+            &state,
+            PAST_DEADLINE,
+            CURRENT_GEN,
+            &DEAD
+        ));
+    }
+
+    #[test]
+    fn locked_dead_watcher_reap_unlinks_when_still_proven_dead() {
+        // End-to-end through the locked re-validate helper: a proven-dead
+        // Watcher orphan that is unchanged under the lock is unlinked.
+        let temp = TempDir::new().unwrap();
+        let orphan = watcher_owned_rebind(7101, 4096, 1); // prior gen → reap disjunct
+        save_inflight_state_in_root(temp.path(), &orphan).expect("save");
+        assert!(should_reap_dead_watcher_rebind_origin(
+            &orphan,
+            0,
+            CURRENT_GEN,
+            &DEAD
+        ));
+
+        let outcome = reap_dead_watcher_rebind_origin_locked_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            &orphan,
+            CURRENT_GEN,
+            &DEAD,
+        );
+        assert_eq!(outcome, RebindReapOutcome::Reaped);
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert!(after.is_empty(), "dead-watcher orphan must be gone");
+    }
+
+    #[test]
+    fn locked_dead_watcher_reap_skips_when_watcher_becomes_live() {
+        // TOCTOU: the snapshot was proven-dead, but between the unlocked check
+        // and the lock the watcher re-spawned. The locked helper re-probes
+        // liveness (ALIVE) and must SKIP the unlink — a watcher that came back
+        // to life is never reaped. This is the #3154/#3540 live-protection
+        // invariant enforced at the lock boundary.
+        let temp = TempDir::new().unwrap();
+        let snapshot = watcher_owned_rebind(7102, 4096, 1); // prior gen, snapshot looked dead
+        save_inflight_state_in_root(temp.path(), &snapshot).expect("save");
+
+        let outcome = reap_dead_watcher_rebind_origin_locked_in_root(
+            temp.path(),
+            &ProviderKind::Codex,
+            &snapshot,
+            CURRENT_GEN,
+            &ALIVE, // re-spawned watcher: now alive under the lock
+        );
+        assert_eq!(
+            outcome,
+            RebindReapOutcome::Skipped,
+            "a watcher that re-spawned mid-sweep must NOT be reaped"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(after.len(), 1, "the re-spawned watcher's row must survive");
+        assert!(after[0].rebind_origin);
+    }
+
+    #[test]
+    fn boot_path_preserves_dead_watcher_rebind() {
+        // The boot path (`invalidate_stale_generation_in_root`) is intentionally
+        // NOT wired to the dead-watcher liveness gate: at cold start a just-
+        // restarted live watcher's synthetic session reads as dead, so applying
+        // the gate at boot would risk reaping a row a recovering watcher is about
+        // to re-adopt. A Watcher-owned dead-shape orphan from a PRIOR generation
+        // must therefore survive the boot pass entirely (only the warm 30s
+        // sweeper, with a real runtime probe, may reap it). This is the keystone
+        // `invalidate_stale_generation_preserves_live_owned_rebind_prior_generation`
+        // invariant, re-pinned for the #3635 owner-Watcher dead shape.
+        let temp = TempDir::new().unwrap();
+        let dead_shape = watcher_owned_rebind(7103, 4096, 1); // prior gen
+        save_inflight_state_in_root(temp.path(), &dead_shape).expect("save");
+
+        let removed =
+            invalidate_stale_generation_in_root(temp.path(), &ProviderKind::Codex, CURRENT_GEN);
+        assert!(
+            removed.is_empty(),
+            "boot must NOT reap a Watcher-owned rebind (no liveness gate at boot)"
+        );
+        let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(after.len(), 1);
+        assert!(after[0].rebind_origin);
+    }
+
+    #[test]
+    fn proven_dead_window_is_conservative() {
+        // The proven-dead floor must be far larger than the stall-watchdog's
+        // 120s positive-liveness window so a live-but-between-turns watcher is
+        // never false-classified as dead.
+        assert!(
+            DEAD_WATCHER_PROVEN_DEAD_SECS >= 600,
+            "proven-dead floor must be conservative (>= 10 minutes)"
+        );
     }
 }
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -241,6 +241,7 @@ pub(super) struct RuntimeWatcherLiveness;
 
 impl WatcherLiveness for RuntimeWatcherLiveness {
     fn is_proven_dead(&self, state: &InflightTurnState) -> bool {
+        use crate::services::platform::tmux::PaneLiveness;
         // No session name to probe ⇒ cannot prove death ⇒ never reap.
         let Some(session) = state.tmux_session_name.as_deref() else {
             return false;
@@ -249,28 +250,36 @@ impl WatcherLiveness for RuntimeWatcherLiveness {
         if session.is_empty() {
             return false;
         }
-        // A live tmux pane is a hard "alive" signal.
-        if crate::services::tmux_diagnostics::tmux_session_has_live_pane(session) {
-            return false;
+        // #3635 (codex review): use the THREE-state pane probe. A transient tmux
+        // probe failure (`ProbeError`) is "unknown", NOT "dead" — it must never
+        // license reaping a live-but-idle watcher. Only a *definitive* dead/absent
+        // answer is even a candidate for reap; any live signal or unknown answer
+        // preserves the row (the #3154/#3540 live-protection invariant at its
+        // weakest point).
+        match crate::services::tmux_diagnostics::tmux_session_pane_liveness(session) {
+            PaneLiveness::Live => return false,       // hard "alive" signal
+            PaneLiveness::ProbeError => return false, // unknown ⇒ preserve
+            PaneLiveness::DeadOrAbsent => {}          // candidate — confirm via activity
         }
-        // Fresh runtime activity (jsonl / .generation mtime) within the proven-
-        // dead window is also "alive". `latest_runtime_activity_unix_nanos`
-        // returns 0 when nothing is observable; a 0 (no resolvable temp file)
-        // is treated as "no recent activity" — but only the conjunction with a
-        // dead pane makes a row reapable, so a missing-file 0 alone never reaps.
-        let latest_nanos =
-            crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(session);
-        let activity_recent = latest_nanos > 0 && {
-            let age_secs = now_unix()
-                .saturating_sub(latest_nanos / 1_000_000_000)
-                .max(0) as u64;
-            age_secs < DEAD_WATCHER_PROVEN_DEAD_SECS
-        };
-        if activity_recent {
-            return false;
-        }
-        // Dead pane AND no recent runtime activity ⇒ proven dead.
-        true
+        // No live pane, definitively. Fresh runtime activity (jsonl / .generation
+        // mtime) within the window is still "alive" — a just-restarting watcher.
+        // Only a dead/absent session AND no recent activity is provably dead.
+        !watcher_runtime_activity_recent(session)
+    }
+}
+
+/// #3635: true when the watcher's runtime files (jsonl / `.generation` mtime)
+/// advanced within [`DEAD_WATCHER_PROVEN_DEAD_SECS`]. Pure fs stat — no tmux
+/// subprocess — so it is safe to call under the inflight sidecar lock. A 0
+/// (no resolvable temp file) is "no recent activity".
+fn watcher_runtime_activity_recent(session: &str) -> bool {
+    let latest_nanos =
+        crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(session);
+    latest_nanos > 0 && {
+        let age_secs = now_unix()
+            .saturating_sub(latest_nanos / 1_000_000_000)
+            .max(0) as u64;
+        age_secs < DEAD_WATCHER_PROVEN_DEAD_SECS
     }
 }
 
@@ -292,20 +301,38 @@ impl WatcherLiveness for RuntimeWatcherLiveness {
 /// protection invariant holds verbatim. Every non-owner live signal (adoption,
 /// streamed bytes, anchor, terminal commit, offset progress, planned restart)
 /// still independently blocks the reap via the shared structural conjunction.
+#[cfg(test)]
 pub(super) fn should_reap_dead_watcher_rebind_origin(
     state: &InflightTurnState,
     age_secs: u64,
     current_generation: u64,
     liveness: &dyn WatcherLiveness,
 ) -> bool {
+    dead_watcher_rebind_structurally_reapable(state, age_secs, current_generation)
+        // FINAL gate: only reap when the owning watcher is provably dead. A live
+        // watcher (tmux pane up or recent runtime activity) is never reaped; an
+        // unknown tmux probe also preserves (see `RuntimeWatcherLiveness`).
+        && liveness.is_proven_dead(state)
+}
+
+/// #3635: the structural + deadline/generation half of the dead-watcher reap
+/// predicate, WITHOUT the liveness probe. Split out so the locked re-validation
+/// can re-check these cheap, fs-only conditions under the sidecar lock without
+/// re-running a tmux subprocess (codex review ISSUE 2). The structural
+/// conjunction is byte-identical to [`should_reap_abandoned_rebind_origin`]
+/// EXCEPT the owner conjunct flips from `== None` to `== Watcher` (the #897
+/// rebind birth shape the None predicate can never match); every other conjunct
+/// keeps all the live-protection signals (adoption / streamed bytes / anchor /
+/// terminal / offset progress / planned restart) blocking the reap exactly as
+/// before.
+fn dead_watcher_rebind_structurally_reapable(
+    state: &InflightTurnState,
+    age_secs: u64,
+    current_generation: u64,
+) -> bool {
     if !state.rebind_origin {
         return false;
     }
-    // Same structural-abandoned shape as the None-owner predicate, but pinned to
-    // a Watcher relay owner (the #897 rebind birth shape the None predicate can
-    // never match). Every other conjunct is identical so all the live-protection
-    // signals (adoption / streamed bytes / anchor / terminal / offset progress /
-    // planned restart) keep blocking the reap exactly as before.
     let structurally_abandoned = state.turn_source == TurnSource::ExternalAdopted
         && state.effective_relay_owner_kind() == RelayOwnerKind::Watcher
         && state.user_msg_id == 0
@@ -328,13 +355,7 @@ pub(super) fn should_reap_dead_watcher_rebind_origin(
     let stale_generation = state
         .rebind_origin_birth_generation
         .is_some_and(|birth| birth != current_generation);
-    if !(past_deadline || stale_generation) {
-        return false;
-    }
-
-    // FINAL gate: only reap when the owning watcher is provably dead. A live
-    // watcher (tmux pane up or recent runtime activity) is never reaped.
-    liveness.is_proven_dead(state)
+    past_deadline || stale_generation
 }
 
 /// #3581: best-effort age (seconds) for a rebind-origin row. Prefers the
@@ -666,19 +687,26 @@ pub(super) fn reap_abandoned_rebind_origin_locked(
 }
 
 /// #3635: locked re-validate-then-unlink for the *dead-watcher* rebind-origin
-/// reap path. Structurally identical to
-/// [`reap_abandoned_rebind_origin_locked_in_root`] but re-validates under the
-/// lock with [`should_reap_dead_watcher_rebind_origin`] (which includes a FRESH
-/// `liveness.is_proven_dead` probe). This closes the TOCTOU window where a
-/// watcher re-spawns between the unlocked snapshot and the lock: the locked
-/// re-probe sees the freshly-live pane / runtime activity and the helper Skips,
-/// so a watcher that came back to life is never reaped.
+/// reap path. The expensive tmux liveness probe runs OUTSIDE this lock (see
+/// [`sweep_reap_dead_watcher_rebind_origin`], off the async runtime via
+/// `spawn_blocking`); under the lock we re-check only CHEAP, fs-only conditions —
+/// no tmux subprocess — so the per-channel sidecar lock is never held across
+/// blocking subprocess I/O (codex review ISSUE 2).
+///
+/// What the lock DOES close: the row-replacement race — a replacement turn that
+/// rewrote this sidecar path is rejected by the birth-identity guard, and a row
+/// that progressed (structural conjunction) is rejected. What it does NOT fully
+/// close (codex review ISSUE 3): a watcher whose tmux *pane* re-appears between
+/// the unlocked probe and this unlink. That window is tiny and the consequence
+/// is benign — the reaped artifact is a zero-msg-id orphan that a genuinely
+/// re-adopting watcher simply re-creates. As a last cheap guard we re-read the
+/// runtime-activity mtime under the lock, so a watcher that resumed *writing*
+/// (the most common resurrection signal) is still observed and the reap Skips.
 fn reap_dead_watcher_rebind_origin_locked_in_root(
     root: &Path,
     provider: &ProviderKind,
     snapshot: &InflightTurnState,
     current_generation: u64,
-    liveness: &dyn WatcherLiveness,
 ) -> RebindReapOutcome {
     let path = inflight_state_path(root, provider, snapshot.channel_id);
     let Ok(_lock) = lock_inflight_state_path(&path) else {
@@ -693,11 +721,20 @@ fn reap_dead_watcher_rebind_origin_locked_in_root(
         return RebindReapOutcome::Skipped;
     }
     let age_secs = rebind_origin_age_secs(&path, &locked);
-    // Re-run the FULL dead-watcher predicate (structure + deadline/generation +
-    // FRESH liveness probe) under the lock. A watcher that re-spawned since the
-    // snapshot now reads `is_proven_dead == false` ⇒ Skipped.
-    if !should_reap_dead_watcher_rebind_origin(&locked, age_secs, current_generation, liveness) {
+    // Re-check the cheap, fs-only half of the predicate under the lock (structure
+    // + deadline/generation). The tmux liveness probe already ran unlocked; we do
+    // NOT re-spawn it here (ISSUE 2 — no subprocess under the sidecar lock).
+    if !dead_watcher_rebind_structurally_reapable(&locked, age_secs, current_generation) {
         return RebindReapOutcome::Skipped;
+    }
+    // Last cheap guard: a watcher that resumed writing its jsonl/`.generation`
+    // since the unlocked probe reads as recent activity ⇒ alive ⇒ Skip. Pure fs
+    // stat (no subprocess), safe under the lock.
+    if let Some(session) = locked.tmux_session_name.as_deref() {
+        let session = session.trim();
+        if !session.is_empty() && watcher_runtime_activity_recent(session) {
+            return RebindReapOutcome::Skipped;
+        }
     }
     match fs::remove_file(&path) {
         Ok(()) => RebindReapOutcome::Reaped,
@@ -717,48 +754,60 @@ fn reap_dead_watcher_rebind_origin_locked_in_root(
 /// #3635: env-rooted wrapper around
 /// [`reap_dead_watcher_rebind_origin_locked_in_root`] for the periodic
 /// placeholder-sweeper path. Returns `true` iff the row was re-validated under
-/// the lock (with a fresh liveness probe) and unlinked.
+/// the lock (cheap fs-only re-checks; no tmux subprocess) and unlinked.
 pub(super) fn reap_dead_watcher_rebind_origin_locked(
     provider: &ProviderKind,
     snapshot: &InflightTurnState,
     current_generation: u64,
-    liveness: &dyn WatcherLiveness,
 ) -> bool {
     let Some(root) = inflight_runtime_root() else {
         return false;
     };
-    reap_dead_watcher_rebind_origin_locked_in_root(
-        &root,
-        provider,
-        snapshot,
-        current_generation,
-        liveness,
-    ) == RebindReapOutcome::Reaped
+    reap_dead_watcher_rebind_origin_locked_in_root(&root, provider, snapshot, current_generation)
+        == RebindReapOutcome::Reaped
 }
 
 /// #3635: the placeholder sweeper's single-call entry point for the dead-watcher
-/// rebind-origin reap. Wraps the unlocked pre-check
-/// ([`should_reap_dead_watcher_rebind_origin`]) and the locked re-validate
-/// ([`reap_dead_watcher_rebind_origin_locked`]) behind the production
-/// [`RuntimeWatcherLiveness`] oracle, returning `true` only when the row was
-/// genuinely unlinked. Keeping the oracle construction and the predicate/lock
-/// pairing here (not at the sweeper call site) keeps the warm-path wiring in one
-/// auditable place and the sweeper a one-liner.
+/// rebind-origin reap. Returns `true` only when the row was genuinely unlinked.
+/// Three stages, ordered cheapest-first:
+///   1. fs-only structural gate ([`dead_watcher_rebind_structurally_reapable`]) —
+///      most rows fail here with no tmux probe;
+///   2. the production [`RuntimeWatcherLiveness`] proven-dead probe, run on a
+///      `spawn_blocking` thread (it spawns tmux subprocesses) so the async
+///      sweeper runtime is never blocked, and OUTSIDE any lock (codex review
+///      ISSUE 2);
+///   3. the locked re-validate ([`reap_dead_watcher_rebind_origin_locked`]),
+///      which re-checks only cheap fs-only conditions under the sidecar lock.
 ///
 /// Deliberately NOT called from the boot path
 /// (`invalidate_stale_generation_in_root`): at cold start a just-restarted live
 /// watcher's session reads as dead, so the liveness gate only ever fires in the
 /// warm 30s sweeper where a real runtime probe is meaningful (#3154/#3540 / the
 /// keystone boot-preservation invariant).
-pub(super) fn sweep_reap_dead_watcher_rebind_origin(
+pub(super) async fn sweep_reap_dead_watcher_rebind_origin(
     provider: &ProviderKind,
     state: &InflightTurnState,
     age_secs: u64,
     current_generation: u64,
 ) -> bool {
-    let liveness = RuntimeWatcherLiveness;
-    should_reap_dead_watcher_rebind_origin(state, age_secs, current_generation, &liveness)
-        && reap_dead_watcher_rebind_origin_locked(provider, state, current_generation, &liveness)
+    // (1) Cheap, fs-only structural gate first — skip the subprocess entirely for
+    // the common case.
+    if !dead_watcher_rebind_structurally_reapable(state, age_secs, current_generation) {
+        return false;
+    }
+    // (2) The proven-dead probe spawns tmux subprocesses; run it off the async
+    // runtime via `spawn_blocking`, outside any lock. A join failure (panic /
+    // runtime shutdown) is treated as "unknown ⇒ preserve".
+    let probe_state = state.clone();
+    let proven_dead =
+        tokio::task::spawn_blocking(move || RuntimeWatcherLiveness.is_proven_dead(&probe_state))
+            .await
+            .unwrap_or(false);
+    if !proven_dead {
+        return false;
+    }
+    // (3) Locked re-validate (cheap fs-only re-checks; no subprocess under lock).
+    reap_dead_watcher_rebind_origin_locked(provider, state, current_generation)
 }
 
 fn now_string() -> String {
@@ -6738,9 +6787,10 @@ mod rebind_origin_reap_tests {
     }
 
     #[test]
-    fn locked_dead_watcher_reap_unlinks_when_still_proven_dead() {
-        // End-to-end through the locked re-validate helper: a proven-dead
-        // Watcher orphan that is unchanged under the lock is unlinked.
+    fn locked_dead_watcher_reap_unlinks_when_unlocked_probe_already_proved_dead() {
+        // End-to-end through the locked re-validate helper after the unlocked
+        // liveness probe already proved death: an unchanged Watcher orphan is
+        // unlinked by the cheap fs-only locked checks.
         let temp = TempDir::new().unwrap();
         let orphan = watcher_owned_rebind(7101, 4096, 1); // prior gen → reap disjunct
         save_inflight_state_in_root(temp.path(), &orphan).expect("save");
@@ -6756,7 +6806,6 @@ mod rebind_origin_reap_tests {
             &ProviderKind::Codex,
             &orphan,
             CURRENT_GEN,
-            &DEAD,
         );
         assert_eq!(outcome, RebindReapOutcome::Reaped);
         let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
@@ -6764,30 +6813,53 @@ mod rebind_origin_reap_tests {
     }
 
     #[test]
-    fn locked_dead_watcher_reap_skips_when_watcher_becomes_live() {
-        // TOCTOU: the snapshot was proven-dead, but between the unlocked check
-        // and the lock the watcher re-spawned. The locked helper re-probes
-        // liveness (ALIVE) and must SKIP the unlink — a watcher that came back
-        // to life is never reaped. This is the #3154/#3540 live-protection
-        // invariant enforced at the lock boundary.
+    fn locked_dead_watcher_reap_skips_when_runtime_activity_resumes() {
+        // TOCTOU: the snapshot was proven-dead by the unlocked tmux probe, but
+        // between that probe and the lock the watcher resumed writing runtime
+        // files. The locked helper must observe that cheap fs-only activity
+        // signal and skip the unlink without spawning tmux under the lock.
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let temp = TempDir::new().unwrap();
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
         let snapshot = watcher_owned_rebind(7102, 4096, 1); // prior gen, snapshot looked dead
         save_inflight_state_in_root(temp.path(), &snapshot).expect("save");
+        let session = snapshot
+            .tmux_session_name
+            .as_deref()
+            .expect("watcher-owned test row has a tmux session");
+        let generation_path =
+            crate::services::tmux_common::session_temp_path(session, "generation");
+        if let Some(parent) = std::path::Path::new(&generation_path).parent() {
+            std::fs::create_dir_all(parent).expect("create runtime sessions dir");
+        }
+        std::fs::write(&generation_path, "resumed").expect("touch generation marker");
 
         let outcome = reap_dead_watcher_rebind_origin_locked_in_root(
             temp.path(),
             &ProviderKind::Codex,
             &snapshot,
             CURRENT_GEN,
-            &ALIVE, // re-spawned watcher: now alive under the lock
         );
         assert_eq!(
             outcome,
             RebindReapOutcome::Skipped,
-            "a watcher that re-spawned mid-sweep must NOT be reaped"
+            "a watcher that resumed runtime writes mid-sweep must NOT be reaped"
         );
         let after = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
-        assert_eq!(after.len(), 1, "the re-spawned watcher's row must survive");
+        assert_eq!(after.len(), 1, "the resumed watcher's row must survive");
         assert!(after[0].rebind_origin);
     }
 
@@ -6802,7 +6874,22 @@ mod rebind_origin_reap_tests {
         // sweeper, with a real runtime probe, may reap it). This is the keystone
         // `invalidate_stale_generation_preserves_live_owned_rebind_prior_generation`
         // invariant, re-pinned for the #3635 owner-Watcher dead shape.
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let temp = TempDir::new().unwrap();
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
         let dead_shape = watcher_owned_rebind(7103, 4096, 1); // prior gen
         save_inflight_state_in_root(temp.path(), &dead_shape).expect("save");
 

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -369,7 +369,9 @@ async fn run_placeholder_sweep_pass(
                 &state,
                 age_secs,
                 current_generation,
-            ) {
+            )
+            .await
+            {
                 // #3635: the None-owner predicate above can NEVER touch a
                 // Watcher-owned rebind orphan (the #897 birth shape), so it leaked
                 // forever after its watcher died. `sweep_reap_dead_watcher_*`

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -32,7 +32,7 @@ use super::gateway::edit_outbound_message;
 use super::inflight::{
     InflightTurnState, delete_inflight_state_file, emit_reap_abandoned_rebind_origin,
     load_inflight_states_for_sweep, parse_started_at_unix, reap_abandoned_rebind_origin_locked,
-    should_reap_abandoned_rebind_origin,
+    should_reap_abandoned_rebind_origin, sweep_reap_dead_watcher_rebind_origin,
 };
 use crate::services::provider::ProviderKind;
 
@@ -345,24 +345,13 @@ async fn run_placeholder_sweep_pass(
     stalled_tracker.retain_live(provider, &states);
     for (state, age_secs) in states {
         if state.rebind_origin {
-            // #3581: a rebind-origin inflight has no placeholder message to
-            // edit, so it is normally skipped. But an abandoned, never-
-            // progressed orphan (STALL-WATCHDOG respawn) would otherwise live
-            // forever and wedge turn-start (`backstop_claim_is_safe` reads it as
-            // a "live foreign inflight"). Reap it once it is past its deadline.
-            // The strict conjunction in `should_reap_abandoned_rebind_origin`
-            // (owner-less + unadopted + never-progressed) guarantees a live /
-            // adopted rebind is never touched. `age_secs` here is the file-mtime
-            // age the sweeper already computed, which covers legacy rows that
-            // pre-date the persisted birth stamp.
-            //
-            // #3581 (codex TOCTOU fix): the `should_reap_*` check above runs on
-            // an UNLOCKED snapshot. Between this read and the delete, a normal
-            // intake / TUI claim can persist a brand-new live inflight at the
-            // same sidecar path. Route the delete through the locked
-            // re-validate helper so it reloads + re-checks identity + eligibility
-            // under the lock and only unlinks a row that is *still* the same
-            // abandoned orphan — never a live replacement.
+            // #3581: a rebind-origin inflight has no placeholder to edit (skipped)
+            // — but an abandoned, never-progressed orphan (STALL-WATCHDOG respawn)
+            // would live forever and wedge turn-start. Reap it once past its
+            // deadline; `should_reap_abandoned_rebind_origin`'s strict conjunction
+            // keeps any live/adopted rebind untouched, and the locked helper
+            // re-validates under the sidecar lock so a racing live intake/TUI claim
+            // is never clobbered (codex TOCTOU). `age_secs` = file-mtime age.
             let current_generation = super::runtime_store::load_generation();
             if should_reap_abandoned_rebind_origin(&state, age_secs, current_generation)
                 && reap_abandoned_rebind_origin_locked(provider, &state, current_generation)
@@ -373,6 +362,26 @@ async fn run_placeholder_sweep_pass(
                     age_secs,
                     current_generation,
                     "placeholder_sweep_deadline",
+                );
+                report.abandoned += 1;
+            } else if sweep_reap_dead_watcher_rebind_origin(
+                provider,
+                &state,
+                age_secs,
+                current_generation,
+            ) {
+                // #3635: the None-owner predicate above can NEVER touch a
+                // Watcher-owned rebind orphan (the #897 birth shape), so it leaked
+                // forever after its watcher died. `sweep_reap_dead_watcher_*`
+                // reaps it ONLY when a runtime-liveness probe proves the watcher
+                // dead (live watcher preserved per #3154/#3540); this warm path
+                // is the sole carrier of the liveness gate — see the helper.
+                emit_reap_abandoned_rebind_origin(
+                    provider,
+                    &state,
+                    age_secs,
+                    current_generation,
+                    "placeholder_sweep_dead_watcher",
                 );
                 report.abandoned += 1;
             }

--- a/src/services/platform/tmux.rs
+++ b/src/services/platform/tmux.rs
@@ -851,6 +851,68 @@ pub fn has_live_pane(session_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// #3635: three-state liveness of a tmux session's panes. Unlike [`has_live_pane`]
+/// (which collapses both "session absent" and "probe failed" to `false`), this
+/// distinguishes a *definitive* negative (`DeadOrAbsent`) from a *probe failure*
+/// (`ProbeError`). Callers deciding to destroy state on death MUST treat
+/// `ProbeError` as "unknown ⇒ preserve" — a transient tmux hiccup is not proof
+/// the owner died.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneLiveness {
+    /// Session exists and has at least one non-dead pane.
+    Live,
+    /// Session is definitively gone, or exists with only dead panes (the owning
+    /// process has exited). A clean negative answer from tmux.
+    DeadOrAbsent,
+    /// tmux could not be queried (binary spawn failure / non-success status on a
+    /// present session). The answer is unknown — callers must not treat this as
+    /// death.
+    ProbeError,
+}
+
+const PANE_LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Probe a session's pane liveness as a three-state answer (see [`PaneLiveness`]).
+pub fn pane_liveness(session_name: &str) -> PaneLiveness {
+    if is_blank_session_name(session_name) {
+        return PaneLiveness::DeadOrAbsent;
+    }
+    let mut has_session = tmux_command();
+    has_session.args(["has-session", "-t", &exact_target(session_name)]);
+    match wait_for_tmux_output(has_session, PANE_LIVENESS_PROBE_TIMEOUT, "tmux has-session") {
+        // Spawn/exec failure ⇒ we never reached tmux: unknown, not dead.
+        Err(_) => return PaneLiveness::ProbeError,
+        // Clean non-zero exit ⇒ no such session (or no server running): the
+        // session — and the process that lived in it — is gone.
+        Ok(output) if !output.status.success() => return PaneLiveness::DeadOrAbsent,
+        Ok(_) => {}
+    }
+    let mut list_panes = tmux_command();
+    list_panes.args([
+        "list-panes",
+        "-t",
+        &exact_target(session_name),
+        "-F",
+        "#{pane_dead}",
+    ]);
+    match wait_for_tmux_output(list_panes, PANE_LIVENESS_PROBE_TIMEOUT, "tmux list-panes") {
+        // list-panes failed on a session we just confirmed present ⇒ unknown.
+        Err(_) => PaneLiveness::ProbeError,
+        Ok(output) if !output.status.success() => PaneLiveness::ProbeError,
+        Ok(output) => {
+            if String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .any(|line| line.trim() == "0")
+            {
+                PaneLiveness::Live
+            } else {
+                // Present but every pane is dead ⇒ the process exited.
+                PaneLiveness::DeadOrAbsent
+            }
+        }
+    }
+}
+
 /// Set a tmux session option. Errors are silently ignored (fire-and-forget).
 pub fn set_option(session_name: &str, key: &str, value: &str) {
     let _ = tmux_command()

--- a/src/services/tmux_diagnostics.rs
+++ b/src/services/tmux_diagnostics.rs
@@ -16,6 +16,14 @@ pub fn tmux_session_has_live_pane(tmux_session_name: &str) -> bool {
     crate::services::platform::tmux::has_live_pane(tmux_session_name)
 }
 
+/// #3635: three-state pane liveness (`Live` / `DeadOrAbsent` / `ProbeError`).
+/// Use when a transient tmux probe failure must NOT be mistaken for death.
+pub fn tmux_session_pane_liveness(
+    tmux_session_name: &str,
+) -> crate::services::platform::tmux::PaneLiveness {
+    crate::services::platform::tmux::pane_liveness(tmux_session_name)
+}
+
 /// #3208: the current working directory of the live pane for a tmux session.
 /// Used by the follow-up readiness path to resolve the running Claude session's
 /// JSONL transcript when it lives in a rotating worktree that differs from the


### PR DESCRIPTION
## #3635: Watcher-owned rebind-origin inflight leak cleanup

### Problem
`recovery_engine.rs` can create rebind-origin inflight rows with `relay_owner_kind=Watcher`. The existing #3581 abandoned-rebind predicate intentionally requires `effective_relay_owner_kind()==None`, so Watcher-owned rebind-origin rows never age out after their watcher dies. A simple predicate relaxation is unsafe because live Watcher-owned rebind rows must remain adoptable across restarts.

### Fix
This keeps the existing None-owner predicate and its pinning tests intact, then adds a separate conservative warm-sweeper path for proven-dead Watcher-owned rebind rows:

- Added three-state tmux pane liveness: `Live`, `DeadOrAbsent`, `ProbeError`.
- `ProbeError` is treated as unknown/preserve, not dead.
- Runs tmux subprocess probing through `spawn_blocking` outside the sidecar lock, with bounded probe timeout.
- Locked reap helper only rechecks identity, structural eligibility, and recent runtime activity from the filesystem.
- Boot path remains exempt, so fresh restart/adoption behavior is preserved.
- `placeholder_sweeper` awaits the async dead-watcher reap arm only in the warm sweep path.

### Files
- `src/services/platform/tmux.rs`: three-state liveness probe.
- `src/services/tmux_diagnostics.rs`: diagnostics wrapper.
- `src/services/discord/inflight.rs`: separate dead-watcher structural gate, runtime liveness oracle, async sweep entry, tests.
- `src/services/discord/placeholder_sweeper.rs`: warm sweeper integration.
- `docs/agent-maintenance/change-surfaces.md`, `scripts/audit_maintainability_giant_baseline.toml`: line-count/ratchet sync.

### Verification
- `cargo fmt --check`
- `AGENTDESK_ROOT_DIR=$(mktemp -d) cargo test -q dead_watcher --lib` → 10 passed
- `cargo check -q`
- `./scripts/ci-script-checks.sh` with Python 3.11 shim → passed

🤖 Generated with Codex