### PR TITLE
fix(#3676): recover Codex relay-dead watcher safely

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -404,6 +404,7 @@ src/
 │   │   │   ├── recovery.rs
 │   │   │   ├── redaction.rs
 │   │   │   ├── relay_auto_heal.rs
+│   │   │   ├── relay_dead_reattach.rs
 │   │   │   ├── runtime_resolve.rs
 │   │   │   ├── session_enrichment.rs
 │   │   │   ├── snapshot.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -886,9 +886,13 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (1613 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1633 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
-    outside an extraction plan; +176 from #3540: stable JSONL entry-identity
+    outside an extraction plan; +20 from #3676: Codex rollout user prompts now
+    prefer the stable message entry id when present so Codex TUI direct prompt
+    relay can use the same entry-identity replay suppression as Claude while
+    distinct Codex message ids still publish distinct direct prompts; +176
+    from #3540: stable JSONL entry-identity
     (`uuid`) dedup — `extract_claude_transcript_user_prompt_with_entry_id`
     returns `(prompt, Option<uuid>)`, a `relayed_entry_ids_by_tmux` ledger
     (PROMPT_ANCHOR_TTL-purged, ring-capped) + `PromptObservation::SuppressedReplayedEntry`,
@@ -993,7 +997,11 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2736 lines; +3 from #3671 passing the turn's RAW restart-invariant age (`judgment_basis.turn_age_secs`, not the boot-floored anchor age) into `evaluate_stall_watchdog_liveness` so the stall-watchdog force-clean defers indefinitely under positive liveness up to an age-based absolute backstop (4h, aligned to the Codex per-turn hard ceiling) that repeated restarts cannot reset, instead of a brittle 20-tick count — fixes the ~40-minute restart-survived deploy turn that was force-killed while demonstrably live; +11 from #3668 F2 watchdog loop-top tail-answer guard — one early-`continue` that skips BOTH destructive branches (idle-clear + desynced force-clean) for the channel this tick when JSONL still holds an unrelayed final answer after last_offset; #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
+  - `src/services/discord/health/recovery.rs` (2730 lines; #3676 moved
+    `tmux_alive_relay_dead` watchdog reattach logic into sibling
+    `health/relay_dead_reattach.rs`, leaving recovery.rs with only the
+    pre-cleanup hook so final transcript output can be delivered without
+    cancelling a healthy mid-first-output watcher; +3 from #3671 passing the turn's RAW restart-invariant age (`judgment_basis.turn_age_secs`, not the boot-floored anchor age) into `evaluate_stall_watchdog_liveness` so the stall-watchdog force-clean defers indefinitely under positive liveness up to an age-based absolute backstop (4h, aligned to the Codex per-turn hard ceiling) that repeated restarts cannot reset, instead of a brittle 20-tick count — fixes the ~40-minute restart-survived deploy turn that was force-killed while demonstrably live; +11 from #3668 F2 watchdog loop-top tail-answer guard — one early-`continue` that skips BOTH destructive branches (idle-clear + desynced force-clean) for the channel this tick when JSONL still holds an unrelayed final answer after last_offset; #3656 stall-watchdog force-clean ages from current turn `started_at` not `updated_at` (turn-scoped, net 0 after comment condense); +85 from #3629 NO_REPLY/empty orphan inflight identity-guarded cleanup in the completed-stale leak detection path; +3 from #3479 item-3 `shared.dispatch.<field>` nesting; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the
@@ -1482,12 +1490,14 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/claude_tui/hosting/` child modules, ratchets claude.rs at 2950
   production LoC, and leaves the #3262 turn-lock machinery in the claude.rs
   root.)
-- `src/services/codex_tui/rollout_tail.rs` (1768) — Codex TUI rollout tail
+- `src/services/codex_tui/rollout_tail.rs` (1772) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix and the #3343 message-boundary
   separator unified across the streamed `StreamMessage::Text` surface and the
   `final_text` assembly (one shared `push_message_text` boundary writer; the
-  newline witness is the single source of truth so the two surfaces mirror).
+  newline witness is the single source of truth so the two surfaces mirror);
+  +4 from #3676 threading Codex rollout user-message entry ids into TUI prompt
+  dedupe so restart/offset rewind cannot mint duplicate direct-input anchors.
 - `src/services/codex_tui/input.rs` (1366) — Codex TUI input readiness
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -1394,7 +1394,8 @@ fn observe_rollout_user_prompt(json: &Value, state: &mut RolloutParseState) {
     let Some(tmux_session_name) = state.tmux_session_name.clone() else {
         return;
     };
-    let Some(prompt) = crate::services::tui_prompt_dedupe::extract_codex_rollout_user_prompt(json)
+    let Some((prompt, entry_id)) =
+        crate::services::tui_prompt_dedupe::extract_codex_rollout_user_prompt_with_entry_id(json)
     else {
         return;
     };
@@ -1417,14 +1418,17 @@ fn observe_rollout_user_prompt(json: &Value, state: &mut RolloutParseState) {
         );
         return;
     }
-    let observation = crate::services::tui_prompt_dedupe::observe_prompt_by_tmux(
+    let observation = crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
         "codex",
         &tmux_session_name,
         &prompt,
+        entry_id.as_deref(),
+        chrono::Utc::now(),
     );
     tracing::debug!(
         tmux_session_name,
         observation = ?observation,
+        entry_id = entry_id.as_deref().unwrap_or(""),
         "observed Codex rollout user prompt"
     );
 }

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -21,6 +21,7 @@ mod provider_probe;
 mod recovery;
 mod redaction;
 mod relay_auto_heal;
+mod relay_dead_reattach;
 mod runtime_resolve;
 mod session_enrichment;
 mod snapshot;

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -11,7 +11,7 @@ use crate::services::discord::{self as discord, SharedData};
 use crate::services::provider::{CancelToken, ProviderKind};
 
 use super::HealthRegistry;
-use super::{relay_auto_heal, stall_liveness, watcher_respawn};
+use super::{relay_auto_heal, relay_dead_reattach, stall_liveness, watcher_respawn};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RuntimeTurnStopResult {
@@ -1524,27 +1524,19 @@ pub(crate) const STALL_WATCHDOG_INTERVAL_SECS: u64 = 30;
 /// recovered turn as "desynced" mid-bootstrap.
 pub(crate) const STALL_WATCHDOG_INITIAL_DELAY_SECS: u64 = 90;
 
-/// Force-cleanup window: requires `inflight_updated_at` to be at least
-/// this old before the watchdog clears the desynced watcher. Strictly
-/// larger than `INFLIGHT_STALENESS_THRESHOLD_SECS` (the THREAD-GUARD's
-/// trigger) so the watchdog never races ahead of an in-flight intake call.
+/// Force-cleanup window; strictly larger than THREAD-GUARD staleness so the
+/// watchdog never races ahead of an in-flight intake call.
 pub(crate) const STALL_WATCHDOG_THRESHOLD_SECS: u64 =
     2 * discord::inflight::INFLIGHT_STALENESS_THRESHOLD_SECS;
 
-/// #3169: freshness window for the jsonl-mtime liveness probe that gates the
-/// desynced force-clean. Anchored at the force-clean threshold: any provider
-/// event written within the same window the watchdog uses to judge staleness
-/// proves the "desync" is a loop mid-write, so the force-clean is deferred.
-/// A genuinely hung turn writes nothing for the whole window and is still
-/// cleaned (at most one extra pass for a boundary-marginal real hang).
+/// #3169: freshness window for the jsonl-mtime liveness probe. Provider events
+/// inside this staleness window prove loop mid-write, not a hung desync.
 pub(crate) const STALL_WATCHDOG_LIVENESS_FRESHNESS_SECS: u64 = STALL_WATCHDOG_THRESHOLD_SECS;
 
 /// Run a single stall-watchdog pass against one provider+SharedData.
 ///
-/// Iterates every attached watcher (via `tmux_watchers.iter()`), pulls the
-/// `WatcherStateSnapshot` for the owning channel, and force-cleans any
-/// channel whose snapshot satisfies `stall_watchdog_should_force_clean`.
-/// Returns the number of channels cleaned this pass for telemetry/logging.
+/// Iterates every attached watcher and cleans channels whose snapshot satisfies
+/// the watchdog predicates. Returns the number of channels cleaned this pass.
 pub(crate) async fn run_stall_watchdog_pass(
     registry: &HealthRegistry,
     provider: &ProviderKind,
@@ -1553,13 +1545,8 @@ pub(crate) async fn run_stall_watchdog_pass(
     stall_liveness::gc_stall_watchdog_liveness_state(now_unix_secs);
     watcher_respawn::gc_watcher_absence_state(now_unix_secs);
 
-    // Multi-bot deployments register several runtimes under one provider
-    // name. Sweep *every* runtime's watcher channels (a name-only lookup
-    // would only ever visit the first-registered runtime, so the second
-    // bot's stalled turns would never be force-cleaned -- turn looks cut
-    // off, progress stops updating). Keep the runtime that exposed each
-    // watcher so the snapshot/cleanup below targets the same mailbox and
-    // relay coordinates.
+    // Sweep every same-provider runtime; name-only lookup would miss later
+    // bots, so keep the runtime that exposed each watcher.
     let runtimes = registry.all_shared_for_provider(provider).await;
     if runtimes.is_empty() {
         return 0;
@@ -1582,15 +1569,12 @@ pub(crate) async fn run_stall_watchdog_pass(
             }
         }
     }
-    // #3410 P1-a: no early return on empty candidates — the trailing retry +
-    // dead-man are keyed on WATCHER ABSENCE, not on live-watcher candidates, so
-    // they must run even when a force-clean killed the last channel's watcher
-    // (zero candidates next tick); gating them would strand it forever.
+    // #3410 P1-a: no early return on empty candidates; trailing retry/dead-man
+    // are keyed on watcher absence, not live-watcher candidates.
     let mut cleaned = 0usize;
     for (channel_id, shared) in candidate_channels {
-        // Use the already-selected runtime. A provider-name scan can be
-        // fooled by provider+channel inflight JSON and inspect the first
-        // same-provider runtime instead of the bot that owns this watcher.
+        // Use the selected runtime so same-provider multi-bot snapshots target
+        // the bot that owns this watcher.
         let snapshot = match registry
             .snapshot_watcher_state_for_shared(provider, shared.clone(), channel_id.get())
             .await
@@ -1598,11 +1582,21 @@ pub(crate) async fn run_stall_watchdog_pass(
             Some(snapshot) => snapshot,
             None => continue,
         };
-        // #3668 F2: if a final answer is still persisted in JSONL after
-        // `last_offset`, skip ALL destructive watchdog branches this tick (the
-        // idle-clear AND the desynced force-clean below) — let normal recovery /
-        // #3645 far-backstop deliver it first, then re-evaluate next tick once
-        // `last_offset` advances past the delivered answer.
+        if relay_dead_reattach::try_apply(
+            registry,
+            shared.clone(),
+            provider,
+            channel_id,
+            &snapshot,
+            now_unix_secs,
+        )
+        .await
+        {
+            cleaned += 1;
+            continue;
+        }
+        // #3668 F2: if JSONL still holds an unrelayed final answer after
+        // `last_offset`, skip destructive watchdog branches this tick.
         if crate::services::discord::relay_recovery::idle_tmux_repair_has_unrelayed_tail_answer(
             provider,
             channel_id.get(),

--- a/src/services/discord/health/relay_dead_reattach.rs
+++ b/src/services/discord/health/relay_dead_reattach.rs
@@ -1,0 +1,238 @@
+use std::sync::Arc;
+
+use poise::serenity_prelude::ChannelId;
+
+use super::snapshot::WatcherStateSnapshot;
+use super::{HealthRegistry, recovery, stall_liveness};
+use crate::services::discord::relay_health::RelayStallState;
+use crate::services::discord::{self, SharedData};
+use crate::services::provider::ProviderKind;
+
+fn outbound_activity_is_recent(
+    last_outbound_activity_ms: Option<i64>,
+    now_unix_secs: i64,
+    threshold_secs: u64,
+) -> bool {
+    let Some(last_outbound_activity_ms) = last_outbound_activity_ms else {
+        return false;
+    };
+    let now_ms = now_unix_secs.saturating_mul(1000);
+    if last_outbound_activity_ms >= now_ms {
+        return true;
+    }
+    let age_ms = now_ms.saturating_sub(last_outbound_activity_ms) as u64;
+    age_ms < threshold_secs.saturating_mul(1000)
+}
+
+fn should_reattach_relay_dead_watcher(
+    snapshot: &WatcherStateSnapshot,
+    channel_id: ChannelId,
+    latest_runtime_activity_unix_nanos: i64,
+    now_unix_secs: i64,
+    boot_unix_secs: i64,
+) -> bool {
+    if snapshot.relay_stall_state != RelayStallState::TmuxAliveRelayDead
+        || !snapshot.attached
+        || snapshot.watcher_owner_channel_id != Some(channel_id.get())
+        || snapshot.tmux_session_alive != Some(true)
+        || outbound_activity_is_recent(
+            snapshot.relay_health.last_outbound_activity_ms,
+            now_unix_secs,
+            recovery::STALL_WATCHDOG_THRESHOLD_SECS,
+        )
+    {
+        return false;
+    }
+    if !recovery::stall_watchdog_should_force_clean(
+        snapshot.attached,
+        true,
+        snapshot.inflight_terminal_delivery_committed,
+        snapshot.inflight_started_at.as_deref(),
+        now_unix_secs,
+        recovery::STALL_WATCHDOG_THRESHOLD_SECS,
+        boot_unix_secs,
+    ) {
+        return false;
+    }
+    !stall_liveness::stall_watchdog_jsonl_liveness_defers_force_clean(
+        latest_runtime_activity_unix_nanos,
+        now_unix_secs,
+        recovery::STALL_WATCHDOG_LIVENESS_FRESHNESS_SECS,
+    )
+}
+
+pub(super) async fn try_apply(
+    registry: &HealthRegistry,
+    shared: Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &WatcherStateSnapshot,
+    now_unix_secs: i64,
+) -> bool {
+    let Some(latest_activity_unix_nanos) = snapshot
+        .tmux_session
+        .as_deref()
+        .map(crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos)
+    else {
+        return false;
+    };
+    if !should_reattach_relay_dead_watcher(
+        snapshot,
+        channel_id,
+        latest_activity_unix_nanos,
+        now_unix_secs,
+        registry.started_at_unix(),
+    ) {
+        return false;
+    }
+    match discord::relay_recovery::auto_apply_relay_recovery_for_shared(
+        registry,
+        shared,
+        provider,
+        channel_id.get(),
+        discord::relay_recovery::RelayRecoveryActionKind::ReattachWatcher,
+        discord::relay_recovery::RelayRecoveryApplySource::StallWatchdog,
+    )
+    .await
+    {
+        Ok(response) => response.applied,
+        Err(error) => {
+            tracing::warn!(
+                target: "agentdesk::discord::relay_recovery",
+                provider = provider.as_str(),
+                channel_id = channel_id.get(),
+                status = error.status_str(),
+                body = %error.body(),
+                "relay-dead watcher reattach skipped"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::relay_health::{RelayActiveTurn, RelayHealthSnapshot};
+    use chrono::TimeZone;
+
+    fn local_string(unix: i64) -> String {
+        chrono::Local
+            .timestamp_opt(unix, 0)
+            .single()
+            .expect("valid local time")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    }
+
+    fn snapshot(started_at: &str) -> WatcherStateSnapshot {
+        WatcherStateSnapshot {
+            provider: "codex".to_string(),
+            attached: true,
+            tmux_session: Some("AgentDesk-codex-test".to_string()),
+            watcher_owner_channel_id: Some(42),
+            last_relay_offset: 0,
+            inflight_state_present: true,
+            last_relay_ts_ms: 0,
+            last_capture_offset: Some(128),
+            unread_bytes: Some(128),
+            desynced: true,
+            reconnect_count: 0,
+            inflight_started_at: Some(started_at.to_string()),
+            inflight_updated_at: Some(started_at.to_string()),
+            inflight_user_msg_id: Some(1),
+            inflight_current_msg_id: Some(2),
+            tmux_session_alive: Some(true),
+            has_pending_queue: false,
+            mailbox_active_user_msg_id: Some(1),
+            inflight_terminal_delivery_committed: false,
+            relay_stall_state: RelayStallState::TmuxAliveRelayDead,
+            relay_health: RelayHealthSnapshot {
+                provider: "codex".to_string(),
+                channel_id: 42,
+                active_turn: RelayActiveTurn::Foreground,
+                tmux_session: Some("AgentDesk-codex-test".to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: true,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: Some(42),
+                watcher_owns_live_relay: true,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(2),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(1),
+                queue_depth: 0,
+                pending_discord_callback_msg_id: Some(2),
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: None,
+                last_outbound_activity_ms: None,
+                last_capture_offset: Some(128),
+                last_relay_offset: 0,
+                unread_bytes: Some(128),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+        }
+    }
+
+    #[test]
+    fn relay_dead_watcher_reattach_requires_stale_turn_and_stale_jsonl() {
+        let now = chrono::Utc::now().timestamp();
+        let stale = local_string(now - (recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64) - 1);
+        let fresh = local_string(now - 5);
+        let stale_activity = (now - (recovery::STALL_WATCHDOG_LIVENESS_FRESHNESS_SECS as i64) - 1)
+            .saturating_mul(1_000_000_000);
+        let fresh_activity = (now - 5).saturating_mul(1_000_000_000);
+
+        let boot = now - (recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64) - 100;
+        assert!(should_reattach_relay_dead_watcher(
+            &snapshot(&stale),
+            ChannelId::new(42),
+            stale_activity,
+            now,
+            boot,
+        ));
+        let mut wrong_state = snapshot(&stale);
+        wrong_state.relay_stall_state = RelayStallState::ActiveForegroundStream;
+        let mut wrong_owner = snapshot(&stale);
+        wrong_owner.watcher_owner_channel_id = Some(99);
+        let mut committed = snapshot(&stale);
+        committed.inflight_terminal_delivery_committed = true;
+        let mut fresh_outbound = snapshot(&stale);
+        fresh_outbound.relay_health.last_outbound_activity_ms = Some((now - 5) * 1000);
+        let recent_boot = now - 5;
+
+        for (name, candidate, activity, boot_unix_secs) in [
+            ("wrong stall state", wrong_state, stale_activity, boot),
+            ("wrong owner", wrong_owner, stale_activity, boot),
+            ("terminal committed", committed, stale_activity, boot),
+            ("fresh inflight", snapshot(&fresh), stale_activity, boot),
+            (
+                "fresh runtime activity",
+                snapshot(&stale),
+                fresh_activity,
+                boot,
+            ),
+            ("fresh outbound", fresh_outbound, stale_activity, boot),
+            (
+                "post-restart grace",
+                snapshot(&stale),
+                stale_activity,
+                recent_boot,
+            ),
+        ] {
+            assert!(
+                !should_reattach_relay_dead_watcher(
+                    &candidate,
+                    ChannelId::new(42),
+                    activity,
+                    now,
+                    boot_unix_secs,
+                ),
+                "{name}"
+            );
+        }
+    }
+}

--- a/src/services/discord/relay_health.rs
+++ b/src/services/discord/relay_health.rs
@@ -123,6 +123,22 @@ impl RelayHealthSnapshot {
             || self.watcher_attached
             || self.bridge_inflight_present
     }
+
+    /// True for the restart/desync signature where a watcher handle still looks
+    /// live and may even own the tmux session, but the relay frontier never
+    /// advanced while the transcript/capture accumulated bytes.
+    pub(in crate::services::discord) fn relay_frontier_never_advanced_with_unread_tail(
+        &self,
+    ) -> bool {
+        self.desynced
+            && self.tmux_alive == Some(true)
+            && self.last_relay_ts_ms.is_none()
+            && self.last_relay_offset == 0
+            && self
+                .last_capture_offset
+                .is_some_and(|capture| capture > self.last_relay_offset)
+            && self.unread_bytes.is_some_and(|bytes| bytes > 0)
+    }
 }
 
 pub(in crate::services::discord) struct RelayStallClassifier;
@@ -134,7 +150,11 @@ impl RelayStallClassifier {
         let live_watcher_owns_relay = snapshot.watcher_attached
             && !snapshot.watcher_attached_stale
             && snapshot.watcher_owns_live_relay;
-        if snapshot.tmux_alive == Some(true) && snapshot.desynced && !live_watcher_owns_relay {
+        if snapshot.tmux_alive == Some(true)
+            && snapshot.desynced
+            && (!live_watcher_owns_relay
+                || snapshot.relay_frontier_never_advanced_with_unread_tail())
+        {
             return RelayStallState::TmuxAliveRelayDead;
         }
 
@@ -198,7 +218,7 @@ mod tests {
                 RelayStallState::ExplicitBackgroundWork,
             ),
             (
-                "live owned watcher plus foreground desync remains an active stream",
+                "live owned watcher with a dead relay frontier is classified relay-dead",
                 RelayHealthSnapshot {
                     active_turn: RelayActiveTurn::Foreground,
                     bridge_inflight_present: true,
@@ -208,6 +228,24 @@ mod tests {
                     watcher_owns_live_relay: true,
                     last_capture_offset: Some(128),
                     last_relay_offset: 0,
+                    unread_bytes: Some(128),
+                    desynced: true,
+                    ..RelayHealthSnapshot::test_snapshot()
+                },
+                RelayStallState::TmuxAliveRelayDead,
+            ),
+            (
+                "live owned watcher with relay progress remains an active stream",
+                RelayHealthSnapshot {
+                    active_turn: RelayActiveTurn::Foreground,
+                    bridge_inflight_present: true,
+                    mailbox_has_cancel_token: true,
+                    tmux_alive: Some(true),
+                    watcher_attached: true,
+                    watcher_owns_live_relay: true,
+                    last_relay_ts_ms: Some(1_777_001_234_000),
+                    last_capture_offset: Some(256),
+                    last_relay_offset: 128,
                     unread_bytes: Some(128),
                     desynced: true,
                     ..RelayHealthSnapshot::test_snapshot()

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -87,6 +87,7 @@ pub(in crate::services::discord) struct RelayRecoveryEvidence {
     pub desynced: bool,
     pub last_capture_offset: Option<u64>,
     pub last_relay_offset: u64,
+    pub last_relay_ts_ms: Option<i64>,
     pub unread_bytes: Option<u64>,
     pub last_outbound_activity_ms: Option<i64>,
 }
@@ -268,6 +269,7 @@ fn evidence_from_snapshot(snapshot: &RelayHealthSnapshot) -> RelayRecoveryEviden
         desynced: snapshot.desynced,
         last_capture_offset: snapshot.last_capture_offset,
         last_relay_offset: snapshot.last_relay_offset,
+        last_relay_ts_ms: snapshot.last_relay_ts_ms,
         unread_bytes: snapshot.unread_bytes,
         last_outbound_activity_ms: snapshot.last_outbound_activity_ms,
     }
@@ -314,7 +316,8 @@ fn eligible_reattach_watcher(snapshot: &RelayHealthSnapshot) -> bool {
         && snapshot.mailbox_has_cancel_token
         && (!snapshot.watcher_attached
             || snapshot.watcher_attached_stale
-            || !snapshot.watcher_owns_live_relay)
+            || !snapshot.watcher_owns_live_relay
+            || snapshot.relay_frontier_never_advanced_with_unread_tail())
         && snapshot.desynced
         && is_agentdesk_tmux_session(snapshot.tmux_session.as_deref())
 }
@@ -613,6 +616,29 @@ fn reattach_apply_status(watcher_spawned: bool) -> &'static str {
     }
 }
 
+fn relay_frontier_dead_reattach_owner(decision: &RelayRecoveryDecision) -> Option<ChannelId> {
+    let evidence = &decision.evidence;
+    if decision.relay_stall_state != RelayStallState::TmuxAliveRelayDead
+        || !evidence.desynced
+        || evidence.tmux_alive != Some(true)
+        || !evidence.watcher_attached
+        || !evidence.watcher_owns_live_relay
+        || evidence.last_relay_ts_ms.is_some()
+        || evidence.last_relay_offset != 0
+        || !evidence
+            .last_capture_offset
+            .is_some_and(|capture| capture > evidence.last_relay_offset)
+        || !evidence.unread_bytes.is_some_and(|bytes| bytes > 0)
+    {
+        return None;
+    }
+    Some(ChannelId::new(
+        evidence
+            .watcher_owner_channel_id
+            .unwrap_or(decision.channel_id),
+    ))
+}
+
 fn forget_completion_footer_for_relay_recovery(channel_id: ChannelId) {
     super::single_message_panel::completion_footer_forget_registered_target(channel_id);
 }
@@ -800,6 +826,21 @@ async fn apply_relay_recovery_decision(
                     reattach_initial_offset: None,
                     reattach_error: None,
                 };
+            }
+            if let Some(owner_channel_id) = relay_frontier_dead_reattach_owner(decision)
+                && let Some((_, watcher)) = shared.tmux_watchers.remove(&owner_channel_id)
+            {
+                watcher.cancel.store(true, Ordering::Relaxed);
+                tracing::warn!(
+                    target: "agentdesk::discord::relay_recovery",
+                    provider = provider.as_str(),
+                    channel_id = decision.channel_id,
+                    watcher_owner_channel_id = owner_channel_id.get(),
+                    last_relay_offset = decision.evidence.last_relay_offset,
+                    last_capture_offset = ?decision.evidence.last_capture_offset,
+                    unread_bytes = ?decision.evidence.unread_bytes,
+                    "relay recovery cancelled live-looking watcher with dead relay frontier before reattach"
+                );
             }
             match registry
                 .rebind_inflight(
@@ -1111,6 +1152,11 @@ mod tests {
         assert_ne!(decision.action, RelayRecoveryActionKind::ObserveOnly);
         assert_eq!(decision.action, RelayRecoveryActionKind::ReattachWatcher);
         assert!(
+            decision.auto_heal.eligible,
+            "zero-frontier unread relay-dead turns must be eligible for bounded reattach"
+        );
+        assert_eq!(decision.auto_heal.skipped_reason, None);
+        assert!(
             decision.auto_heal.bounded,
             "relay-dead foreground turns must surface bounded recovery metadata"
         );
@@ -1129,6 +1175,49 @@ mod tests {
         );
         assert!(decision.evidence.watcher_owns_live_relay);
         assert_eq!(decision.evidence.active_turn, RelayActiveTurn::Foreground);
+        assert_eq!(
+            relay_frontier_dead_reattach_owner(&decision),
+            Some(ChannelId::new(1509350393350459434))
+        );
+    }
+
+    #[test]
+    fn watcher_owned_live_relay_with_relay_progress_is_not_frontier_dead_takeover() {
+        let snapshot = RelayHealthSnapshot {
+            provider: "claude".to_string(),
+            channel_id: 1509350393350459434,
+            active_turn: RelayActiveTurn::Foreground,
+            tmux_session: Some("AgentDesk-claude-adk-claude-pipe-e2e".to_string()),
+            tmux_alive: Some(true),
+            watcher_attached: true,
+            watcher_owner_channel_id: Some(1509350393350459434),
+            watcher_owns_live_relay: true,
+            bridge_inflight_present: true,
+            mailbox_has_cancel_token: true,
+            mailbox_active_user_msg_id: Some(9001),
+            bridge_current_msg_id: Some(9002),
+            last_relay_ts_ms: Some(1_777_001_234_000),
+            last_capture_offset: Some(7968),
+            last_relay_offset: 4096,
+            unread_bytes: Some(3872),
+            desynced: true,
+            ..snapshot()
+        };
+        let relay_stall_state = RelayStallClassifier::classify(&snapshot);
+        let decision = plan_relay_recovery(&snapshot, relay_stall_state, 1_000);
+
+        assert_eq!(relay_stall_state, RelayStallState::ActiveForegroundStream);
+        assert_eq!(decision.action, RelayRecoveryActionKind::ObserveOnly);
+        assert_eq!(relay_frontier_dead_reattach_owner(&decision), None);
+
+        let forced_dead_decision =
+            plan_relay_recovery(&snapshot, RelayStallState::TmuxAliveRelayDead, 1_000);
+        assert_eq!(
+            relay_frontier_dead_reattach_owner(&forced_dead_decision),
+            None,
+            "a live-owned watcher that already advanced its relay frontier must never be \
+             cancelled by the dead-frontier reattach path"
+        );
     }
 
     /// #3277 (Defect D) + deploy-preserved ownerless restore eligibility table:

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -3093,19 +3093,22 @@ fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                     CodexIdleRolloutScan::Prompt {
                         prompt,
                         line_end_offset,
+                        entry_id,
                     } => {
                         let observed_at = chrono::Utc::now();
                         let observation =
-                            crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_at(
+                            crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
                                 ProviderKind::Codex.as_str(),
                                 &tmux_session_name,
                                 &prompt,
+                                entry_id.as_deref(),
                                 observed_at,
                             );
                         tracing::info!(
                             tmux_session_name = %tmux_session_name,
                             channel_id = channel_id.get(),
                             observation = ?observation,
+                            entry_id = entry_id.as_deref().unwrap_or(""),
                             "codex idle rollout relay observed prompt"
                         );
                         if !codex_idle_prompt_observation_should_tail_response(observation) {
@@ -6869,64 +6872,6 @@ mod tests {
         assert_eq!(
             claude_tui_rehydrate_start_offset(&transcript),
             body.len() as u64
-        );
-    }
-
-    #[test]
-    fn codex_idle_rollout_scan_finds_user_prompt_and_stops_at_prompt_end() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let rollout = dir.path().join("rollout.jsonl");
-        let before = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\"}}\n";
-        let prompt = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"direct prompt\"}]}}\n";
-        let after = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\"}]}}\n";
-        std::fs::write(&rollout, format!("{before}{prompt}{after}")).expect("write rollout");
-
-        assert_eq!(
-            scan_codex_idle_rollout_for_prompt(&rollout, 0).expect("scan"),
-            CodexIdleRolloutScan::Prompt {
-                prompt: "direct prompt".to_string(),
-                line_end_offset: (before.len() + prompt.len()) as u64,
-            }
-        );
-        assert_eq!(
-            scan_codex_idle_rollout_for_prompt(&rollout, (before.len() + prompt.len()) as u64,)
-                .expect("scan after prompt"),
-            CodexIdleRolloutScan::NoPrompt {
-                offset: (before.len() + prompt.len() + after.len()) as u64,
-            }
-        );
-    }
-
-    #[test]
-    fn codex_idle_rollout_scan_preserves_partial_trailing_jsonl() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let rollout = dir.path().join("rollout.jsonl");
-        let complete = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\"}}\n";
-        let partial =
-            "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\"";
-        std::fs::write(&rollout, format!("{complete}{partial}")).expect("write rollout");
-
-        assert_eq!(
-            scan_codex_idle_rollout_for_prompt(&rollout, 0).expect("scan partial"),
-            CodexIdleRolloutScan::NoPrompt {
-                offset: complete.len() as u64,
-            }
-        );
-    }
-
-    #[test]
-    fn codex_idle_rollout_scan_restarts_when_file_shrinks() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let rollout = dir.path().join("rollout.jsonl");
-        let prompt = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"after shrink\"}]}}\n";
-        std::fs::write(&rollout, prompt).expect("write rollout");
-
-        assert_eq!(
-            scan_codex_idle_rollout_for_prompt(&rollout, 99_999).expect("scan shrunken"),
-            CodexIdleRolloutScan::Prompt {
-                prompt: "after shrink".to_string(),
-                line_end_offset: prompt.len() as u64,
-            }
         );
     }
 

--- a/src/services/discord/tui_prompt_relay/idle_transcript_scan.rs
+++ b/src/services/discord/tui_prompt_relay/idle_transcript_scan.rs
@@ -43,6 +43,7 @@ pub(super) enum CodexIdleRolloutScan {
     Prompt {
         prompt: String,
         line_end_offset: u64,
+        entry_id: Option<String>,
     },
 }
 
@@ -279,13 +280,142 @@ pub(super) fn scan_codex_idle_rollout_for_prompt(
             }
             continue;
         };
-        if let Some(prompt) =
-            crate::services::tui_prompt_dedupe::extract_codex_rollout_user_prompt(&json)
+        if let Some((prompt, entry_id)) =
+            crate::services::tui_prompt_dedupe::extract_codex_rollout_user_prompt_with_entry_id(
+                &json,
+            )
         {
             return Ok(CodexIdleRolloutScan::Prompt {
                 prompt,
                 line_end_offset: offset,
+                entry_id,
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_idle_rollout_scan_finds_user_prompt_and_stops_at_prompt_end() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout = dir.path().join("rollout.jsonl");
+        let before = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\"}}\n";
+        let prompt = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"direct prompt\"}]}}\n";
+        let after = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"answer\"}]}}\n";
+        std::fs::write(&rollout, format!("{before}{prompt}{after}")).expect("write rollout");
+
+        assert_eq!(
+            scan_codex_idle_rollout_for_prompt(&rollout, 0).expect("scan"),
+            CodexIdleRolloutScan::Prompt {
+                prompt: "direct prompt".to_string(),
+                line_end_offset: (before.len() + prompt.len()) as u64,
+                entry_id: None,
+            }
+        );
+        assert_eq!(
+            scan_codex_idle_rollout_for_prompt(&rollout, (before.len() + prompt.len()) as u64)
+                .expect("scan after prompt"),
+            CodexIdleRolloutScan::NoPrompt {
+                offset: (before.len() + prompt.len() + after.len()) as u64,
+            }
+        );
+    }
+
+    #[test]
+    fn codex_idle_rollout_scan_preserves_partial_trailing_jsonl() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout = dir.path().join("rollout.jsonl");
+        let complete = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\"}}\n";
+        let partial =
+            "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\"";
+        std::fs::write(&rollout, format!("{complete}{partial}")).expect("write rollout");
+
+        assert_eq!(
+            scan_codex_idle_rollout_for_prompt(&rollout, 0).expect("scan partial"),
+            CodexIdleRolloutScan::NoPrompt {
+                offset: complete.len() as u64,
+            }
+        );
+    }
+
+    #[test]
+    fn codex_idle_rollout_scan_restarts_when_file_shrinks() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout = dir.path().join("rollout.jsonl");
+        let prompt = "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"after shrink\"}]}}\n";
+        std::fs::write(&rollout, prompt).expect("write rollout");
+
+        assert_eq!(
+            scan_codex_idle_rollout_for_prompt(&rollout, 99_999).expect("scan shrunken"),
+            CodexIdleRolloutScan::Prompt {
+                prompt: "after shrink".to_string(),
+                line_end_offset: prompt.len() as u64,
+                entry_id: None,
+            }
+        );
+    }
+
+    #[test]
+    fn codex_idle_rollout_scan_threads_entry_id_into_replay_dedupe() {
+        let _guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout = dir.path().join("rollout.jsonl");
+        let entry_id = "codex-user-entry-3676";
+        let prompt = format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"id\":\"{entry_id}\",\"type\":\"message\",\"role\":\"user\",\"content\":[{{\"type\":\"input_text\",\"text\":\"direct codex prompt\"}}]}}}}\n"
+        );
+        std::fs::write(&rollout, &prompt).expect("write rollout");
+
+        let (text, line_end_offset, scanned_entry_id) =
+            match scan_codex_idle_rollout_for_prompt(&rollout, 0).expect("scan") {
+                CodexIdleRolloutScan::Prompt {
+                    prompt,
+                    line_end_offset,
+                    entry_id,
+                } => (prompt, line_end_offset, entry_id),
+                other => panic!("expected Codex prompt, got {other:?}"),
+            };
+        assert_eq!(text, "direct codex prompt");
+        assert_eq!(line_end_offset, prompt.len() as u64);
+        assert_eq!(scanned_entry_id.as_deref(), Some(entry_id));
+
+        let first = crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
+            crate::services::provider::ProviderKind::Codex.as_str(),
+            "AgentDesk-codex-entry-id",
+            &text,
+            scanned_entry_id.as_deref(),
+            chrono::Utc::now(),
+        );
+        assert_eq!(
+            first,
+            crate::services::tui_prompt_dedupe::PromptObservation::PublishedSshDirect
+        );
+
+        let (re_prompt, re_entry_id) =
+            match scan_codex_idle_rollout_for_prompt(&rollout, 0).expect("rescan") {
+                CodexIdleRolloutScan::Prompt {
+                    prompt, entry_id, ..
+                } => (prompt, entry_id),
+                other => panic!("expected rescan prompt, got {other:?}"),
+            };
+        assert_eq!(re_prompt, text);
+        assert_eq!(re_entry_id.as_deref(), Some(entry_id));
+        let second = crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
+            crate::services::provider::ProviderKind::Codex.as_str(),
+            "AgentDesk-codex-entry-id",
+            &re_prompt,
+            re_entry_id.as_deref(),
+            chrono::Utc::now(),
+        );
+        assert_eq!(
+            second,
+            crate::services::tui_prompt_dedupe::PromptObservation::SuppressedReplayedEntry
+        );
     }
 }

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -1182,13 +1182,33 @@ pub fn extract_prompt_from_hook_payload(payload: &Value) -> Option<String> {
 }
 
 pub fn extract_codex_rollout_user_prompt(json: &Value) -> Option<String> {
+    extract_codex_rollout_user_prompt_with_entry_id(json).map(|(prompt, _)| prompt)
+}
+
+pub fn extract_codex_rollout_user_prompt_with_entry_id(
+    json: &Value,
+) -> Option<(String, Option<String>)> {
     let payload = json.get("payload")?;
     if payload.get("type").and_then(Value::as_str) != Some("message")
         || payload.get("role").and_then(Value::as_str) != Some("user")
     {
         return None;
     }
-    reject_synthetic_tui_user_prompt(extract_message_content_text(payload)?)
+    let prompt = reject_synthetic_tui_user_prompt(extract_message_content_text(payload)?)?;
+    let entry_id = extract_codex_rollout_entry_id(json, payload);
+    Some((prompt, entry_id))
+}
+
+fn extract_codex_rollout_entry_id(json: &Value, payload: &Value) -> Option<String> {
+    payload
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("item_id").and_then(Value::as_str))
+        .or_else(|| json.get("id").and_then(Value::as_str))
+        .or_else(|| json.get("item_id").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 pub fn extract_claude_transcript_user_prompt(json: &Value) -> Option<String> {
@@ -2902,6 +2922,7 @@ mod tests {
         let json = serde_json::json!({
             "type": "response_item",
             "payload": {
+                "id": "codex-entry-1",
                 "type": "message",
                 "role": "user",
                 "content": [
@@ -2914,6 +2935,97 @@ mod tests {
         assert_eq!(
             extract_codex_rollout_user_prompt(&json).as_deref(),
             Some("hello\nworld")
+        );
+        let (prompt, entry_id) =
+            extract_codex_rollout_user_prompt_with_entry_id(&json).expect("codex user prompt");
+        assert_eq!(prompt, "hello\nworld");
+        assert_eq!(entry_id.as_deref(), Some("codex-entry-1"));
+    }
+
+    #[test]
+    fn extracts_codex_rollout_top_level_entry_id() {
+        let json = serde_json::json!({
+            "type": "response_item",
+            "id": "codex-top-entry",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    { "type": "input_text", "text": "hello from codex" }
+                ]
+            }
+        });
+
+        let (prompt, entry_id) =
+            extract_codex_rollout_user_prompt_with_entry_id(&json).expect("codex user prompt");
+        assert_eq!(prompt, "hello from codex");
+        assert_eq!(entry_id.as_deref(), Some("codex-top-entry"));
+    }
+
+    #[test]
+    fn codex_distinct_message_entry_ids_publish_distinct_direct_prompts() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let first = serde_json::json!({
+            "type": "response_item",
+            "id": "codex-turn-container",
+            "payload": {
+                "id": "codex-message-entry-1",
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": "first direct prompt" }]
+            }
+        });
+        let second = serde_json::json!({
+            "type": "response_item",
+            "id": "codex-turn-container",
+            "payload": {
+                "id": "codex-message-entry-2",
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": "second direct prompt" }]
+            }
+        });
+        let (first_prompt, first_entry_id) =
+            extract_codex_rollout_user_prompt_with_entry_id(&first).expect("first codex prompt");
+        let (second_prompt, second_entry_id) =
+            extract_codex_rollout_user_prompt_with_entry_id(&second).expect("second codex prompt");
+        assert_eq!(first_entry_id.as_deref(), Some("codex-message-entry-1"));
+        assert_eq!(second_entry_id.as_deref(), Some("codex-message-entry-2"));
+
+        let now = Utc::now();
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "codex",
+                "tmux-codex-distinct-ids",
+                &first_prompt,
+                first_entry_id.as_deref(),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect
+        );
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "codex",
+                "tmux-codex-distinct-ids",
+                &second_prompt,
+                second_entry_id.as_deref(),
+                now,
+            ),
+            PromptObservation::PublishedSshDirect,
+            "distinct Codex message item ids must not collapse separate direct prompts \
+             even when the top-level response_item id is shared"
+        );
+        assert_eq!(
+            observe_prompt_by_tmux_with_entry_id_at(
+                "codex",
+                "tmux-codex-distinct-ids",
+                &first_prompt,
+                first_entry_id.as_deref(),
+                now,
+            ),
+            PromptObservation::SuppressedReplayedEntry,
+            "only the exact already-relayed Codex message item id is replay-suppressed"
         );
     }
 


### PR DESCRIPTION
## Summary
- Classify the Codex/Claude relay-dead signature where tmux is alive, the watcher still looks live/owned, but the relay frontier never advanced while unread capture bytes exist.
- Let the stall watchdog attempt bounded `ReattachWatcher` before destructive cleanup, but only after stale-turn, post-boot grace, no-recent-outbound, stale-JSONL liveness, and live-owner gates.
- Thread Codex rollout user-prompt entry ids through direct-input replay dedupe, preferring payload message ids over top-level ids and preserving Discord-origin suppression.
- Keep CI ratchets green by moving the relay-dead watchdog reattach gate/apply path into `health/relay_dead_reattach.rs` and moving Codex scanner tests out of the `tui_prompt_relay.rs` hot file.

## Verification
- `cargo fmt -- --check`
- `git diff --check`
- `git diff --cached --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `python3 scripts/audit_maintainability.py --check` (hard gates clean; existing route SRP baseline warnings only)
- `cargo check --lib`
- `cargo test --lib relay_stall_classifier_is_table_driven -- --nocapture`
- `cargo test --lib relay_dead_watcher_reattach_requires_stale_turn_and_stale_jsonl -- --nocapture`
- `cargo test --lib watcher_owned_live_relay_with_relay_progress_is_not_frontier_dead_takeover -- --nocapture`
- `cargo test --lib codex_distinct_message_entry_ids_publish_distinct_direct_prompts -- --nocapture`
- `cargo test --lib codex_idle_rollout_scan_threads_entry_id_into_replay_dedupe -- --nocapture`
- `AGENTDESK_ROOT_DIR="$(mktemp -d)" cargo test --lib relay_recovery -- --nocapture`
- `cargo test --lib extracts_codex_rollout -- --nocapture`
- `cargo test --lib launch_discord_prompt_suppresses_late_rollout_user_message -- --nocapture`

## Review
- `claude -p --model opus` adversarial review rounds: R1 ISSUES, R2 ISSUES, R3 `VERDICT: CLEAN`.
- CI hotfile/giant-file follow-up extraction reviews: R4 `VERDICT: CLEAN`, R5 ISSUES (missing wrong-stall-state negative test), R6 `VERDICT: CLEAN`.
