### PR TITLE
fix(observability): #3646 relay owner 신호 분리 + inflight-clear 불변식 신호 + terminal 라이프사이클 이벤트 (관측 전용)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -637,6 +637,7 @@ src/
 │   │   ├── reaction_cleanup.rs
 │   │   ├── recovery_engine.rs
 │   │   ├── relay_health.rs
+│   │   ├── relay_owner_observability.rs
 │   │   ├── relay_recovery.rs
 │   │   ├── replace_outcome_policy.rs
 │   │   ├── response_sanitizer.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -909,3 +909,21 @@
   snapshot and its own `DEFERRAL_STATE`/`OFFSET_OBSERVATIONS` dashmaps. No lease,
   durable queue, leader/standby ownership, gateway startup order, or singleton
   assumption is touched.
+- #3646 (relay-owner observability — OBSERVATION-ONLY): splits the relay flight
+  recorder's collapsed `relay_owner_kind` into two distinct signals so the #3607
+  None-ledger vs Watcher-finalize ambiguity is PG-resolvable, and adds three
+  terminal lifecycle events (`terminal_body_commit` / `terminal_ui_transition` /
+  `inflight_clear` + a NON-FATAL invariant signal). The watcher side
+  (`tmux_watcher.rs`) emits `inflight_relay_owner` from the node-local pre-relay
+  inflight snapshot; the finalizer side (`turn_finalizer.rs`) emits
+  `finalizer_ledger_owner` reading the **worker-local** `turn_finalizer` actor
+  ledger entry's `relay_owner` — the same per-process in-memory map already
+  documented above (re-seeded by #3293's `reseed_watcher_owned_finalizer_ledger`).
+  The two signals JOIN on `discord:<channel>:<user_msg_id>`. All payload/derivation
+  logic lives in the non-hot `relay_owner_observability.rs`. NO relay/cleanup
+  behaviour, branch, ordering, or condition changes; the emits only gate the EMIT
+  (never the cleanup) and the invariant is an error-event + `debug_assert!` (no
+  operational panic). **Worker-local**: both owner reads are node-local (inflight
+  file + in-process ledger on the node that holds the live pane); the events flow
+  through the existing `emit_inflight_lifecycle_event` PG/jsonl sink. No lease,
+  durable queue, leader/standby ownership, or singleton assumption is introduced.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -84,7 +84,15 @@
 # real `wait_for_session_bound_relay_delivery_ack` target-none failure. NO new
 # direct send / behavior change — provenance/aggregation classification only.
 # #3610 PR-1d: watcher legacy long-chunk arm anchor instrumentation (+M4 reasoning comments)
-"src/services/discord/tmux_watcher.rs" = 6970
+# #3646 raised 6970 -> 7059 (+89 prod LoC): OBSERVATION-ONLY relay-owner split +
+# three terminal lifecycle event emits (terminal_body_commit / terminal_ui_transition /
+# inflight_clear + a NON-FATAL invariant signal). NO relay/cleanup behaviour change —
+# the flight-recorder owner field was split (one tracing field) and three thin
+# pass-through emit call sites were added; all orchestration/payload/invariant logic
+# lives in the sibling non-hot relay_owner_observability.rs. The emits only gate the
+# EMIT (never the cleanup); the invariant is error-event + debug_assert (no operational
+# panic). Resolves the #3607 None-ledger vs Watcher-finalize ambiguity.
+"src/services/discord/tmux_watcher.rs" = 7059
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275
@@ -537,7 +545,13 @@
 # tunables + terminal-or-defer verdict pair (turn_finalizer/watcher_backstop.rs)
 # into child modules. Pure move; each child is well under the 1000-prod-LoC
 # giant threshold so no new ratchet/registry entry is needed.
-"src/services/discord/turn_finalizer.rs" = 1337
+# #3646 raised 1337 -> 1364 (+27 prod LoC): OBSERVATION-ONLY finalizer_ledger_owner
+# companion emit + the `terminal_event_kind_str` wire-string helper. The actor-owned
+# ledger entry's `relay_owner` is the SECOND owner signal the watcher cannot read
+# synchronously; it is emitted (keyed on the same turn_id) right after the Phase gate
+# so it JOINs the watcher terminal_body_commit in PG. Read-only: it does NOT inspect or
+# change the clear_inflight / defer / finalize decision. Resolves #3607 owner ambiguity.
+"src/services/discord/turn_finalizer.rs" = 1364
 # #3557 (A) codex r2: the headless watchdog was missing the per-turn hard
 # ceiling cap that the foreground intake path already had — and it also
 # `mark_async_managed`s the token (sync watchdog stops enforcing), so this async

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -92,7 +92,10 @@
 # lives in the sibling non-hot relay_owner_observability.rs. The emits only gate the
 # EMIT (never the cleanup); the invariant is error-event + debug_assert (no operational
 # panic). Resolves the #3607 None-ledger vs Watcher-finalize ambiguity.
-"src/services/discord/tmux_watcher.rs" = 7059
+# #3646 codex review #3678: 7059 -> 7065 (+6 prod LoC): preserve the legacy
+# `relay_owner_kind` tracing field as a back-compat alias next to the new
+# `inflight_relay_owner` (owner string lifted into a `let`). Tracing fields only.
+"src/services/discord/tmux_watcher.rs" = 7065
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275
@@ -551,7 +554,12 @@
 # synchronously; it is emitted (keyed on the same turn_id) right after the Phase gate
 # so it JOINs the watcher terminal_body_commit in PG. Read-only: it does NOT inspect or
 # change the clear_inflight / defer / finalize decision. Resolves #3607 owner ambiguity.
-"src/services/discord/turn_finalizer.rs" = 1364
+# #3646 codex review #3678: 1364 -> 1373 (+9 prod LoC): key the finalizer_ledger_owner
+# emit on the RESOLVED entry identity (`entry.turn_key`) instead of the submitted `key`,
+# so id-0 terminals that collapse onto a real registered turn keep the real turn_id and
+# JOIN correctly against the watcher event (the #3607 cases the signal exists for). Plus
+# the clarifying rationale comment. Still read-only; no decision-path change.
+"src/services/discord/turn_finalizer.rs" = 1373
 # #3557 (A) codex r2: the headless watchdog was missing the per-turn hard
 # ceiling cap that the foreground intake path already had — and it also
 # `mark_async_managed`s the token (sync watchdog stops enforcing), so this async

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -51,7 +51,17 @@
 # with load-bearing comments. The record/format LOGIC lives in the sibling
 # terminal_send.rs (a thin pass-through to delivery_record.rs's PR-1c helper); this is
 # the minimal frozen-file call-site cost.
-"src/services/discord/tmux_watcher.rs" = 10135
+# #3646: 10135 -> 10224 (+89), reviewable admission — OBSERVATION-ONLY relay-owner
+# split + three terminal lifecycle events (NO relay/cleanup behaviour change). The
+# flight-recorder owner field split (one tracing field -> `inflight_relay_owner`) plus
+# three thin pass-through emit call sites (`terminal_body_commit` at the commit
+# chokepoint, `terminal_ui_transition` after the visible-completion block,
+# `inflight_clear` + a NON-FATAL invariant signal at the committed-output clear — the
+# #3607 chokepoint). All emit orchestration + payload builders + the invariant live in
+# the sibling NON-hot `relay_owner_observability.rs`; this is the minimal frozen-file
+# cost (the emits are guarded only to gate the EMIT, never the cleanup, and the
+# invariant's bool return is discarded). See #3646.
+"src/services/discord/tmux_watcher.rs" = 10224
 "src/services/discord/tui_prompt_relay.rs" = 7789
 # #3560: 6612 -> 6621 (+9), reviewable admission — footer-mode separate-panel
 # migration reconcile call + comment at the resume entry. Helper body lives in

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -61,7 +61,11 @@
 # the sibling NON-hot `relay_owner_observability.rs`; this is the minimal frozen-file
 # cost (the emits are guarded only to gate the EMIT, never the cleanup, and the
 # invariant's bool return is discarded). See #3646.
-"src/services/discord/tmux_watcher.rs" = 10224
+# #3646 codex review #3678: 10224 -> 10230 (+6) — preserve the legacy
+# `relay_owner_kind` tracing field as a back-compat alias alongside the new
+# `inflight_relay_owner` (lifted the owner-string into a `let` so both fields can
+# emit it). Tracing fields only, no control-flow change.
+"src/services/discord/tmux_watcher.rs" = 10230
 "src/services/discord/tui_prompt_relay.rs" = 7789
 # #3560: 6612 -> 6621 (+9), reviewable admission — footer-mode separate-panel
 # migration reconcile call + comment at the resume entry. Helper body lives in

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -62,6 +62,10 @@ mod runtime_bootstrap;
 // #1446 stall-deadlock recovery: shared post-clear bookkeeping for the THREAD-GUARD
 // + stall-watchdog cleanup paths so neither leaks `global_active` / cancel tokens.
 pub mod runtime_store;
+// #3646 OBSERVATION-ONLY: pure payload builders + owner-split derivation for the
+// relay flight recorder's two-signal owner separation and the three terminal
+// lifecycle events. No relay/cleanup behaviour lives here.
+mod relay_owner_observability;
 pub(crate) mod session_identity;
 mod session_runtime;
 pub(crate) mod settings;

--- a/src/services/discord/relay_owner_observability.rs
+++ b/src/services/discord/relay_owner_observability.rs
@@ -1,0 +1,458 @@
+//! #3646 — relay owner observation (OBSERVATION-ONLY, behaviour unchanged).
+//!
+//! Background: the relay flight recorder (`tmux_watcher.rs`) read the relay
+//! owner ONLY from the pre-relay inflight snapshot (`inflight_before_relay`).
+//! Once the bridge cleared inflight but the finalizer ledger still held a
+//! `Watcher`/finalized entry, the recorder collapsed both distinct states into
+//! a single `relay_owner_kind="none"`. That one ambiguous signal was the direct
+//! cause of the #3607 misdiagnosis loop: a real None-ledger turn and a
+//! "bridge cleared inflight but ledger is Watcher-finalized" turn looked
+//! identical in the logs.
+//!
+//! This module is PURE and side-effect free. It only builds the JSON payloads
+//! and derives the terminal-UI transition outcome / the inflight-clear invariant
+//! condition for the three new observation events that `tmux_watcher.rs` and
+//! `turn_finalizer.rs` emit through the existing
+//! `crate::services::observability::emit_inflight_lifecycle_event` infra. No
+//! relay / cleanup branch, ordering, or condition is changed by anything here —
+//! callers read values they already hold and pass them in.
+
+use serde_json::{Value, json};
+
+/// Stable `kind` strings for the three #3646 lifecycle observation events plus
+/// the finalizer-side ledger-owner companion. Centralised so the PG/jsonl
+/// consumers and the unit tests share one source of truth.
+pub(in crate::services::discord) mod event_kind {
+    pub(in crate::services::discord) const TERMINAL_BODY_COMMIT: &str = "terminal_body_commit";
+    pub(in crate::services::discord) const TERMINAL_UI_TRANSITION: &str = "terminal_ui_transition";
+    pub(in crate::services::discord) const INFLIGHT_CLEAR: &str = "inflight_clear";
+    pub(in crate::services::discord) const FINALIZER_LEDGER_OWNER: &str = "finalizer_ledger_owner";
+}
+
+/// Counter name for the #3646 inflight-clear invariant breach (the #3607
+/// state: terminal delivery committed, but cleared with neither a visible UI
+/// completion nor a persisted terminal-UI obligation). Used by the
+/// error-level invariant signal — NOT a control-flow gate.
+pub(in crate::services::discord) const INFLIGHT_CLEAR_COMMITTED_NO_UI_FINISH_INVARIANT: &str =
+    "inflight_clear_committed_no_ui_finish";
+
+/// The visible-UI-transition outcome the watcher took for a committed terminal
+/// turn. Maps onto the issue #3646 `outcome` enum
+/// (`committed | gate_suppressed | edit_failed | stale_identity`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum TerminalUiOutcome {
+    /// The completion was emitted to the user (gate said `should_emit_completion`).
+    Committed,
+    /// The TUI quiescence gate suppressed the visible completion (TimedOut).
+    GateSuppressed,
+    /// The pre-relay snapshot was a stale NEWER turn, so the older committed
+    /// range did not touch that newer turn's panel.
+    StaleIdentity,
+}
+
+impl TerminalUiOutcome {
+    pub(in crate::services::discord) fn as_str(self) -> &'static str {
+        match self {
+            Self::Committed => "committed",
+            Self::GateSuppressed => "gate_suppressed",
+            Self::StaleIdentity => "stale_identity",
+        }
+    }
+
+    /// Derive the observed UI transition from the watcher's already-computed
+    /// signals. PURE: identical inputs the watcher already branches on, no new
+    /// decision is taken — this only LABELS the path the watcher took.
+    ///
+    /// Precedence mirrors the watcher control flow:
+    /// 1. a stale NEWER-turn snapshot short-circuits the visible completion EDIT
+    ///    (`#3142` gate) → `StaleIdentity`;
+    /// 2. otherwise, the TUI completion gate decides: emit → `Committed`,
+    ///    suppress → `GateSuppressed`.
+    pub(in crate::services::discord) fn derive(
+        is_stale_newer_turn: bool,
+        should_emit_completion: bool,
+    ) -> Self {
+        if is_stale_newer_turn {
+            Self::StaleIdentity
+        } else if should_emit_completion {
+            Self::Committed
+        } else {
+            Self::GateSuppressed
+        }
+    }
+}
+
+/// Build the `discord:<channel>:<user_msg_id>` turn identity string the #3646
+/// events carry so the watcher-side `inflight_relay_owner` and the
+/// finalizer-side `ledger_relay_owner` rows JOIN on one key in PG.
+pub(in crate::services::discord) fn turn_identity_string(
+    channel_id: u64,
+    user_msg_id: u64,
+) -> String {
+    format!("discord:{channel_id}:{user_msg_id}")
+}
+
+/// Build the `terminal_body_commit` event payload (#3646 event 1/3). Records
+/// BOTH owner signals available at the commit chokepoint: `inflight_relay_owner`
+/// from the pre-relay snapshot, and `ledger_relay_owner` which is NOT readable
+/// here (the ledger is actor-owned in `turn_finalizer`) so it is `null` and the
+/// companion `finalizer_ledger_owner` event supplies it on the same `turn_id`.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::services::discord) fn terminal_body_commit_extra(
+    turn_identity: &str,
+    user_msg_id: u64,
+    finalizer_turn_id: u64,
+    status_message_id: u64,
+    committed_range_start: u64,
+    committed_range_end: u64,
+    inflight_relay_owner: &str,
+    terminal_delivery_committed: bool,
+) -> Value {
+    json!({
+        "turn_identity": turn_identity,
+        "user_msg_id": user_msg_id,
+        "finalizer_turn_id": finalizer_turn_id,
+        "status_message_id": status_message_id,
+        "committed_range": [committed_range_start, committed_range_end],
+        "inflight_relay_owner": inflight_relay_owner,
+        // Not readable at the watcher commit site (actor-owned ledger); the
+        // `finalizer_ledger_owner` event carries it under the same turn_id.
+        "ledger_relay_owner": Value::Null,
+        "terminal_delivery_committed": terminal_delivery_committed,
+    })
+}
+
+/// Build the `terminal_ui_transition` event payload (#3646 event 2/3).
+pub(in crate::services::discord) fn terminal_ui_transition_extra(
+    outcome: TerminalUiOutcome,
+    gate_outcome: &str,
+    pane_quiescent: Option<bool>,
+    obligation_id: Option<u64>,
+) -> Value {
+    json!({
+        "outcome": outcome.as_str(),
+        "gate_outcome": gate_outcome,
+        "pane_quiescent": pane_quiescent,
+        "obligation_id": obligation_id,
+    })
+}
+
+/// The #3646 inflight-clear invariant: a committed terminal delivery cleared
+/// WITHOUT either a visible UI completion or a persisted terminal-UI obligation
+/// is the #3607 state. Returns `true` when the invariant is VIOLATED.
+///
+/// PURE: callers pass values they already hold. This does NOT gate the clear —
+/// the clear runs regardless; the result only drives an error-level signal.
+pub(in crate::services::discord) fn inflight_clear_invariant_violated(
+    terminal_delivery_committed: bool,
+    terminal_ui_committed: bool,
+    terminal_ui_obligation_persisted: bool,
+) -> bool {
+    terminal_delivery_committed && !(terminal_ui_committed || terminal_ui_obligation_persisted)
+}
+
+/// Build the `inflight_clear` event payload (#3646 event 3/3).
+pub(in crate::services::discord) fn inflight_clear_extra(
+    terminal_delivery_committed: bool,
+    terminal_ui_committed: bool,
+    terminal_ui_obligation_persisted: bool,
+    invariant_violated: bool,
+) -> Value {
+    json!({
+        "terminal_delivery_committed": terminal_delivery_committed,
+        "terminal_ui_committed": terminal_ui_committed,
+        "terminal_ui_obligation_persisted": terminal_ui_obligation_persisted,
+        "invariant_violated": invariant_violated,
+    })
+}
+
+/// Build the `finalizer_ledger_owner` companion payload (emitted from
+/// `turn_finalizer` where the actor-owned ledger entry's `relay_owner` IS
+/// readable). JOINs to the watcher-side `terminal_body_commit` on `turn_id`.
+pub(in crate::services::discord) fn finalizer_ledger_owner_extra(
+    ledger_relay_owner: &str,
+    terminal_event: &str,
+    clear_inflight: bool,
+) -> Value {
+    json!({
+        "ledger_relay_owner": ledger_relay_owner,
+        "terminal_event": terminal_event,
+        "clear_inflight": clear_inflight,
+    })
+}
+
+// ----------------------------------------------------------------------------
+// Emit wrappers. These own the orchestration (turn-id derivation + the
+// `emit_inflight_lifecycle_event` call) so the #3016 hot file
+// (`tmux_watcher.rs`) and `turn_finalizer.rs` only pass the signals they
+// already hold. OBSERVATION-ONLY: each is a single fire-and-forget emit, no
+// control flow.
+// ----------------------------------------------------------------------------
+
+/// Emit #3646 event 1/3 (`terminal_body_commit`). `user_msg_id == 0`
+/// (external/injected/TUI-direct) carries no correlation turn_id but still emits
+/// the `turn_identity` field for JOINs.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::services::discord) fn emit_terminal_body_commit(
+    provider: &str,
+    channel_id: u64,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    finalizer_turn_id: u64,
+    user_msg_id: u64,
+    status_message_id: u64,
+    committed_range_start: u64,
+    committed_range_end: u64,
+    inflight_relay_owner: &str,
+    terminal_delivery_committed: bool,
+) {
+    let turn_identity = turn_identity_string(channel_id, user_msg_id);
+    let turn_id = (user_msg_id != 0).then(|| turn_identity.clone());
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider,
+        channel_id,
+        dispatch_id,
+        session_key,
+        turn_id.as_deref(),
+        event_kind::TERMINAL_BODY_COMMIT,
+        terminal_body_commit_extra(
+            &turn_identity,
+            user_msg_id,
+            finalizer_turn_id,
+            status_message_id,
+            committed_range_start,
+            committed_range_end,
+            inflight_relay_owner,
+            terminal_delivery_committed,
+        ),
+    );
+}
+
+/// Emit #3646 event 2/3 (`terminal_ui_transition`). `obligation_id` is always
+/// `None` from the watcher path (the watcher does not persist obligations).
+#[allow(clippy::too_many_arguments)]
+pub(in crate::services::discord) fn emit_terminal_ui_transition(
+    provider: &str,
+    channel_id: u64,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    user_msg_id: u64,
+    outcome: TerminalUiOutcome,
+    gate_outcome: &str,
+    pane_quiescent: Option<bool>,
+) {
+    let turn_id = (user_msg_id != 0).then(|| turn_identity_string(channel_id, user_msg_id));
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider,
+        channel_id,
+        dispatch_id,
+        session_key,
+        turn_id.as_deref(),
+        event_kind::TERMINAL_UI_TRANSITION,
+        terminal_ui_transition_extra(outcome, gate_outcome, pane_quiescent, None),
+    );
+}
+
+/// Emit #3646 event 3/3 (`inflight_clear`) plus the non-fatal ERROR-level
+/// invariant signal for the #3607 state (committed cleared without UI finish).
+/// The clear itself has ALREADY run at the call site — this records the signals
+/// and fires the invariant; it NEVER gates cleanup. `record_invariant_check_*`
+/// only tracing-logs + emits + bumps `guard_fires`; its bool is discarded.
+pub(in crate::services::discord) fn emit_inflight_clear_with_invariant(
+    provider: &str,
+    channel_id: u64,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    turn_id: Option<&str>,
+    terminal_delivery_committed: bool,
+    terminal_ui_committed: bool,
+    terminal_ui_obligation_persisted: bool,
+) {
+    let invariant_violated = inflight_clear_invariant_violated(
+        terminal_delivery_committed,
+        terminal_ui_committed,
+        terminal_ui_obligation_persisted,
+    );
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider,
+        channel_id,
+        dispatch_id,
+        session_key,
+        turn_id,
+        event_kind::INFLIGHT_CLEAR,
+        inflight_clear_extra(
+            terminal_delivery_committed,
+            terminal_ui_committed,
+            terminal_ui_obligation_persisted,
+            invariant_violated,
+        ),
+    );
+    // #3646: NON-FATAL invariant signal — NO panic/assert! on the operational
+    // relay/cleanup path (turn-wedge / crash risk). `condition = NOT violated`.
+    let _ = crate::services::observability::record_invariant_check_with_severity(
+        !invariant_violated,
+        crate::services::observability::InvariantViolation {
+            provider: Some(provider),
+            channel_id: Some(channel_id),
+            dispatch_id,
+            session_key,
+            turn_id,
+            invariant: INFLIGHT_CLEAR_COMMITTED_NO_UI_FINISH_INVARIANT,
+            code_location: "tmux_watcher.rs:inflight_clear",
+            message: "committed terminal delivery cleared without visible UI completion or persisted terminal-UI obligation (#3607)",
+            details: inflight_clear_extra(
+                terminal_delivery_committed,
+                terminal_ui_committed,
+                terminal_ui_obligation_persisted,
+                invariant_violated,
+            ),
+        },
+        crate::services::observability::InvariantSeverity::Error,
+    );
+    // Dev-only secondary guard: surfaces the #3607 state loudly in debug/test
+    // builds; compiles OUT of release/operational binaries so it can never wedge
+    // a turn or crash the relay path in production.
+    debug_assert!(
+        !invariant_violated,
+        "#3646/#3607: committed terminal cleared without UI completion or persisted obligation"
+    );
+}
+
+/// Emit the #3646 `finalizer_ledger_owner` companion from the finalizer actor
+/// task, where the ledger entry's `relay_owner` is readable. JOINs to the
+/// watcher `terminal_body_commit` on the same turn_id.
+pub(in crate::services::discord) fn emit_finalizer_ledger_owner(
+    provider: &str,
+    channel_id: u64,
+    user_msg_id: u64,
+    ledger_relay_owner: &str,
+    terminal_event: &str,
+    clear_inflight: bool,
+) {
+    let turn_id = (user_msg_id != 0).then(|| turn_identity_string(channel_id, user_msg_id));
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider,
+        channel_id,
+        None,
+        None,
+        turn_id.as_deref(),
+        event_kind::FINALIZER_LEDGER_OWNER,
+        finalizer_ledger_owner_extra(ledger_relay_owner, terminal_event, clear_inflight),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ui_outcome_stale_identity_takes_precedence_over_gate() {
+        // A stale NEWER-turn snapshot short-circuits the visible completion EDIT
+        // regardless of the gate decision (#3142 gate before the gate emit).
+        assert_eq!(
+            TerminalUiOutcome::derive(true, true),
+            TerminalUiOutcome::StaleIdentity
+        );
+        assert_eq!(
+            TerminalUiOutcome::derive(true, false),
+            TerminalUiOutcome::StaleIdentity
+        );
+    }
+
+    #[test]
+    fn ui_outcome_committed_when_gate_emits_and_not_stale() {
+        assert_eq!(
+            TerminalUiOutcome::derive(false, true),
+            TerminalUiOutcome::Committed
+        );
+        assert_eq!(TerminalUiOutcome::Committed.as_str(), "committed");
+    }
+
+    #[test]
+    fn ui_outcome_gate_suppressed_when_gate_does_not_emit() {
+        assert_eq!(
+            TerminalUiOutcome::derive(false, false),
+            TerminalUiOutcome::GateSuppressed
+        );
+        assert_eq!(
+            TerminalUiOutcome::GateSuppressed.as_str(),
+            "gate_suppressed"
+        );
+    }
+
+    #[test]
+    fn invariant_violated_only_on_committed_without_ui_or_obligation() {
+        // #3607 state: committed, but neither UI completion nor obligation.
+        assert!(inflight_clear_invariant_violated(true, false, false));
+        // A visible UI completion satisfies the invariant.
+        assert!(!inflight_clear_invariant_violated(true, true, false));
+        // A persisted obligation satisfies the invariant (the bridge gate-timeout path).
+        assert!(!inflight_clear_invariant_violated(true, false, true));
+        // Both → satisfied.
+        assert!(!inflight_clear_invariant_violated(true, true, true));
+        // No committed delivery → nothing to violate (empty-turn / suppressed cleanup).
+        assert!(!inflight_clear_invariant_violated(false, false, false));
+    }
+
+    #[test]
+    fn turn_identity_string_format() {
+        assert_eq!(turn_identity_string(123, 456), "discord:123:456");
+        // id-0 (external/injected/TUI-direct) turns keep a stable, JOINable key.
+        assert_eq!(turn_identity_string(123, 0), "discord:123:0");
+    }
+
+    #[test]
+    fn terminal_body_commit_extra_carries_both_owner_signals_split() {
+        let extra = terminal_body_commit_extra("discord:1:2", 2, 7, 42, 100, 250, "watcher", true);
+        assert_eq!(extra["turn_identity"], "discord:1:2");
+        assert_eq!(extra["user_msg_id"], 2);
+        assert_eq!(extra["finalizer_turn_id"], 7);
+        assert_eq!(extra["status_message_id"], 42);
+        assert_eq!(extra["committed_range"], json!([100, 250]));
+        // The two owner signals are SEPARATE fields, never collapsed into one.
+        assert_eq!(extra["inflight_relay_owner"], "watcher");
+        assert!(extra["ledger_relay_owner"].is_null());
+        assert_eq!(extra["terminal_delivery_committed"], true);
+    }
+
+    #[test]
+    fn terminal_ui_transition_extra_fields() {
+        let extra = terminal_ui_transition_extra(
+            TerminalUiOutcome::GateSuppressed,
+            "TimedOut",
+            Some(false),
+            None,
+        );
+        assert_eq!(extra["outcome"], "gate_suppressed");
+        assert_eq!(extra["gate_outcome"], "TimedOut");
+        assert_eq!(extra["pane_quiescent"], false);
+        assert!(extra["obligation_id"].is_null());
+
+        let extra2 = terminal_ui_transition_extra(
+            TerminalUiOutcome::Committed,
+            "ConfirmedIdle",
+            Some(true),
+            Some(99),
+        );
+        assert_eq!(extra2["outcome"], "committed");
+        assert_eq!(extra2["pane_quiescent"], true);
+        assert_eq!(extra2["obligation_id"], 99);
+    }
+
+    #[test]
+    fn inflight_clear_extra_carries_three_signals_and_flag() {
+        let extra = inflight_clear_extra(true, false, false, true);
+        assert_eq!(extra["terminal_delivery_committed"], true);
+        assert_eq!(extra["terminal_ui_committed"], false);
+        assert_eq!(extra["terminal_ui_obligation_persisted"], false);
+        assert_eq!(extra["invariant_violated"], true);
+    }
+
+    #[test]
+    fn finalizer_ledger_owner_extra_fields() {
+        let extra = finalizer_ledger_owner_extra("watcher", "Terminal", false);
+        assert_eq!(extra["ledger_relay_owner"], "watcher");
+        assert_eq!(extra["terminal_event"], "Terminal");
+        assert_eq!(extra["clear_inflight"], false);
+    }
+}

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -4565,7 +4565,15 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             any_tool_used = tool_state.any_tool_used,
             has_post_tool_text = tool_state.has_post_tool_text,
             inflight_present = inflight_before_relay.is_some(),
-            relay_owner_kind = inflight_before_relay
+            // #3646 OBSERVATION-ONLY owner split: this is the INFLIGHT-snapshot
+            // owner ONLY. The collapsed `relay_owner_kind="none"` could mean
+            // either a real None-ledger turn OR "bridge cleared inflight but the
+            // ledger is still Watcher/finalized" — the #3607 ambiguity. Renamed to
+            // `inflight_relay_owner` so the finalizer-side `finalizer_ledger_owner`
+            // event (ledger entry's relay_owner, same turn_id) supplies the second
+            // signal and the two JOIN in PG. Field rename only — control flow
+            // unchanged (this is a tracing field, not a branch).
+            inflight_relay_owner = inflight_before_relay
                 .as_ref()
                 .map(|state| state.effective_relay_owner_kind().as_str())
                 .unwrap_or("none"),
@@ -5470,6 +5478,43 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 runtime_binding_candidate_offset.unwrap_or(current_offset),
             );
 
+        // #3646 OBSERVATION-ONLY (event 1/3 — terminal_body_commit): emit once the
+        // body commit decision is in hand. The `if terminal_output_committed` guard
+        // only GATES the emit, never the cleanup; `inflight_relay_owner` (snapshot)
+        // and the finalizer-side `ledger_relay_owner` JOIN on turn_id to resolve the
+        // #3607 None-ledger vs Watcher-finalize confusion. Orchestration lives in
+        // relay_owner_observability (non-hot file); this is a thin pass-through.
+        if terminal_output_committed {
+            crate::services::discord::relay_owner_observability::emit_terminal_body_commit(
+                watcher_provider.as_str(),
+                channel_id.get(),
+                inflight_before_relay
+                    .as_ref()
+                    .and_then(|s| s.dispatch_id.as_deref()),
+                inflight_before_relay
+                    .as_ref()
+                    .and_then(|s| s.session_key.as_deref()),
+                pinned_finalizer_turn_id(
+                    inflight_before_relay.as_ref(),
+                    &tmux_session_name,
+                    current_offset,
+                ),
+                pinned_finalize_user_msg_id(
+                    inflight_before_relay.as_ref(),
+                    &tmux_session_name,
+                    current_offset,
+                ),
+                status_panel_msg_id.map(|id| id.get()).unwrap_or(0),
+                turn_data_start_offset,
+                terminal_event_consumed_offset(current_offset, &all_data),
+                inflight_before_relay
+                    .as_ref()
+                    .map(|state| state.effective_relay_owner_kind().as_str())
+                    .unwrap_or("none"),
+                terminal_delivery_committed,
+            );
+        }
+
         // #2161 TUI completion gate: ClaudeTui can land a `result` JSONL event before the
         // pane is quiescent; without it the user sees `응답 완료` while the pane still
         // streams. On gate timeout (Codex H2) do NOT emit `TurnCompleted` — the sweeper /
@@ -5680,6 +5725,42 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // frame ends and the next frame re-seeds `status_panel_msg_id`, so the
             // top-of-interval abandon reclaim never observes this finalized panel's
             // id again — no explicit reset needed here.
+        }
+
+        // #3646 OBSERVATION-ONLY (event 2/3 — terminal_ui_transition): label the
+        // visible-UI path the watcher took. Reads the same signals the EDIT/finalize
+        // block already branched on (`watcher_tui_gate_outcome` + the #3142
+        // stale-newer gate) — no new decision, only RECORDS committed /
+        // gate_suppressed / stale_identity. The guard gates the EMIT, not the
+        // cleanup. Orchestration lives in relay_owner_observability (non-hot file).
+        if terminal_output_committed {
+            let ui_transition_pane_quiescent = match watcher_tui_gate_outcome {
+                TuiCompletionGateOutcome::ConfirmedIdle => Some(true),
+                TuiCompletionGateOutcome::TimedOut => Some(false),
+                // NotGated / SkippedDead: quiescence was not probed.
+                TuiCompletionGateOutcome::NotGated | TuiCompletionGateOutcome::SkippedDead => None,
+            };
+            crate::services::discord::relay_owner_observability::emit_terminal_ui_transition(
+                watcher_provider.as_str(),
+                channel_id.get(),
+                inflight_before_relay
+                    .as_ref()
+                    .and_then(|s| s.dispatch_id.as_deref()),
+                inflight_before_relay
+                    .as_ref()
+                    .and_then(|s| s.session_key.as_deref()),
+                pinned_finalize_user_msg_id(
+                    inflight_before_relay.as_ref(),
+                    &tmux_session_name,
+                    current_offset,
+                ),
+                crate::services::discord::relay_owner_observability::TerminalUiOutcome::derive(
+                    inflight_before_relay_is_stale_newer_turn,
+                    watcher_tui_gate_outcome.should_emit_completion(),
+                ),
+                &format!("{watcher_tui_gate_outcome:?}"),
+                ui_transition_pane_quiescent,
+            );
         }
 
         // Advance the shared confirmed-delivery watermark on any committed
@@ -6353,6 +6434,28 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         "has_assistant_response": has_assistant_response,
                         "full_response_len": full_response.len(),
                     }),
+                );
+                // #3646 OBSERVATION-ONLY (event 3/3 — inflight_clear + invariant
+                // signal): the committed-output, non-stale watcher clear — the exact
+                // #3607 chokepoint. The clear ABOVE has already run; this only
+                // RECORDS the live lifecycle signals and fires a NON-FATAL
+                // ERROR-level invariant signal if a committed terminal was cleared
+                // with neither a visible UI completion nor a persisted obligation
+                // (#3607). Never gates cleanup. `terminal_ui_obligation_persisted` is
+                // `false` on the watcher path (obligations are the bridge
+                // gate-timeout path; the watcher's TimedOut gate routes through the
+                // finalizer GateTimeout submit, which suppresses THIS clear via
+                // `lifecycle_stage_paused`). Orchestration + the non-fatal invariant
+                // live in relay_owner_observability (non-hot file).
+                crate::services::discord::relay_owner_observability::emit_inflight_clear_with_invariant(
+                    provider_kind.as_str(),
+                    channel_id.get(),
+                    watcher_dispatch_id_owned.as_deref(),
+                    watcher_session_key_owned.as_deref(),
+                    watcher_turn_id.as_deref(),
+                    terminal_delivery_committed,
+                    terminal_output_committed && watcher_tui_gate_outcome.should_emit_completion(),
+                    false,
                 );
             }
             // codex P2 (#1670): cleanup (mailbox_finish_turn + cancel_token

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -4552,6 +4552,19 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 watcher_provider.as_str(),
             );
         }
+        // #3646 OBSERVATION-ONLY owner split: this is the INFLIGHT-snapshot owner
+        // ONLY. The collapsed `="none"` could mean either a real None-ledger turn
+        // OR "bridge cleared inflight but the ledger is still Watcher/finalized" —
+        // the #3607 ambiguity. The finalizer-side `finalizer_ledger_owner` event
+        // (ledger entry's relay_owner, same turn_id) supplies the second signal and
+        // the two JOIN in PG. Computed once so we can emit it under BOTH the new
+        // `inflight_relay_owner` name AND the legacy `relay_owner_kind` alias
+        // (codex review #3678: keep the old field so existing dashboards/alerts/
+        // runbooks that grep `relay_owner_kind=` don't break).
+        let inflight_relay_owner_kind = inflight_before_relay
+            .as_ref()
+            .map(|state| state.effective_relay_owner_kind().as_str())
+            .unwrap_or("none");
         tracing::info!(
             target: "agentdesk::relay_flight_recorder",
             provider = watcher_provider.as_str(),
@@ -4565,18 +4578,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             any_tool_used = tool_state.any_tool_used,
             has_post_tool_text = tool_state.has_post_tool_text,
             inflight_present = inflight_before_relay.is_some(),
-            // #3646 OBSERVATION-ONLY owner split: this is the INFLIGHT-snapshot
-            // owner ONLY. The collapsed `relay_owner_kind="none"` could mean
-            // either a real None-ledger turn OR "bridge cleared inflight but the
-            // ledger is still Watcher/finalized" — the #3607 ambiguity. Renamed to
-            // `inflight_relay_owner` so the finalizer-side `finalizer_ledger_owner`
-            // event (ledger entry's relay_owner, same turn_id) supplies the second
-            // signal and the two JOIN in PG. Field rename only — control flow
-            // unchanged (this is a tracing field, not a branch).
-            inflight_relay_owner = inflight_before_relay
-                .as_ref()
-                .map(|state| state.effective_relay_owner_kind().as_str())
-                .unwrap_or("none"),
+            // #3646: new disambiguated name. Field rename/add only — control flow
+            // unchanged (these are tracing fields, not branches).
+            inflight_relay_owner = inflight_relay_owner_kind,
+            // #3646: legacy alias preserved for backward-compatible log greps.
+            relay_owner_kind = inflight_relay_owner_kind,
             session_bound_enabled = session_bound_discord_delivery_enabled,
             fully_mirrored = session_bound_relay_turn_fully_mirrored,
             frame_ack = session_bound_relay_frame_ack_reached(all_data_session_bound_relay_ack.as_ref()),

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -941,10 +941,19 @@ async fn handle_terminal(
     // so the two owner signals JOIN in PG and the #3607 "None-ledger vs
     // Watcher-finalize" ambiguity resolves. Read-only: it neither inspects nor
     // changes the clear_inflight / defer / finalize decision that follows.
+    //
+    // codex review #3678: key on the RESOLVED entry identity (`entry.turn_key`),
+    // NOT the submitted `key`. A channel-only id-0 terminal collapses onto the
+    // channel's real registered turn via `resolve_ledger_key`; that entry's
+    // `turn_key` carries the real `user_msg_id`. Keying on the submitted `key`
+    // would emit `user_msg_id=0` for exactly those collapsed terminals, dropping
+    // the turn_id and breaking the JOIN against the watcher event — the #3607
+    // cases this signal exists to disambiguate. Genuine orphans (id-0 with no
+    // live entry) still carry id-0 here, which is correct (no real turn exists).
     super::relay_owner_observability::emit_finalizer_ledger_owner(
         entry.provider.as_str(),
-        key.channel_id.get(),
-        key.user_msg_id,
+        entry.turn_key.channel_id.get(),
+        entry.turn_key.user_msg_id,
         entry.relay_owner.as_str(),
         terminal_event_kind_str(&event),
         ctx.clear_inflight,

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -219,6 +219,18 @@ pub(in crate::services::discord) enum TerminalEvent {
     RelayMiss,
 }
 
+/// #3646 OBSERVATION-ONLY: stable wire string for the `finalizer_ledger_owner`
+/// event's `terminal_event` field (avoids leaking `GateTimeout`'s inner struct
+/// into the payload via `Debug`).
+fn terminal_event_kind_str(event: &TerminalEvent) -> &'static str {
+    match event {
+        TerminalEvent::Complete => "complete",
+        TerminalEvent::Cancel => "cancel",
+        TerminalEvent::GateTimeout { .. } => "gate_timeout",
+        TerminalEvent::RelayMiss => "relay_miss",
+    }
+}
+
 /// Per-submission knobs that keep each routed call-site behaviourally
 /// identical to its pre-#3016 inline sequence during the incremental window.
 /// Routed sites preserve their old side-effects; only ownership moves.
@@ -920,6 +932,23 @@ async fn handle_terminal(
         }
         Phase::Pending => {}
     }
+
+    // #3646 OBSERVATION-ONLY (finalizer_ledger_owner companion): emit the
+    // actor-owned ledger entry's `relay_owner` — the SECOND owner signal the
+    // watcher-side `terminal_body_commit` event cannot read (the ledger lives on
+    // this actor task; a synchronous cross-task query from the watcher would be
+    // new behaviour). Keyed on the same `discord:<channel>:<user_msg_id>` turn id
+    // so the two owner signals JOIN in PG and the #3607 "None-ledger vs
+    // Watcher-finalize" ambiguity resolves. Read-only: it neither inspects nor
+    // changes the clear_inflight / defer / finalize decision that follows.
+    super::relay_owner_observability::emit_finalizer_ledger_owner(
+        entry.provider.as_str(),
+        key.channel_id.get(),
+        key.user_msg_id,
+        entry.relay_owner.as_str(),
+        terminal_event_kind_str(&event),
+        ctx.clear_inflight,
+    );
 
     // Gate-timeout with a still-busy pane AND a live relay owner is the only
     // event that defers instead of finalizing now.


### PR DESCRIPTION
## 요약 (#3646, 관측 전용 — 동작 무변경)

relay flight recorder의 단일 `relay_owner_kind` 신호가 두 상태(진짜 None-ledger vs bridge가 inflight만 지웠고 ledger엔 Watcher/finalize됨)를 혼동 → #3607 오진 루프의 직접 원인. 이를 owner 신호 분리 + terminal 라이프사이클 가시화 + inflight-clear 불변식 신호로 해소한다.

### 변경 (3가지, 전부 관측 전용)
1. **Owner 신호 분리**: flight recorder의 `relay_owner_kind` → `inflight_relay_owner`(watcher 스냅샷)로 명명 분리. actor-owned라 watcher에서 동기 read 불가한 ledger owner는 finalizer 측 `finalizer_ledger_owner` 이벤트로 분리 emit(같은 turn_id로 PG JOIN).
2. **Terminal 라이프사이클 이벤트 3종**: `terminal_body_commit` / `terminal_ui_transition` / `inflight_clear` 을 기존 `emit_inflight_lifecycle_event` 인프라로 emit.
3. **Inflight-clear 불변식 신호 (비치명적)**: `record_invariant_check_with_severity`(ERROR 이벤트 + `guard_fires` 카운터) + dev-only `debug_assert!` 로 포착. **운영 경로 panic/assert! 없음**, 정리 자체를 막지 않음(clear가 먼저 실행), 반환값 무시.

### 불변식 / 안전성
- 모든 payload 빌더·outcome derive·불변식·emit 오케스트레이션은 **신규 비핫파일** `relay_owner_observability.rs`에 격리(단위테스트 9종).
- `tmux_watcher.rs`(#3016 핫파일)는 thin pass-through emit 3곳 + 필드명 분리만 — 분기/순서/조건 한 줄도 무변경. 유일한 삭제 라인은 tracing 필드 rename.
- `turn_finalizer.rs` emit은 Phase 게이트 직후 `entry.relay_owner` read-only, `()` 반환.

### 테스트 / CI 게이트
- `cargo fmt --check` / `cargo check --lib` / `cargo test --lib relay_owner_observability`(9/9) 통과.
- agent-maintenance freshness 통과, hotfile/giant ratchet 동기(tmux_watcher 10135→10224, giant tmux_watcher 6970→7059·turn_finalizer 1337→1364, 각 #3646 근거 주석).
- multinode-transition.md worker-local #3646 노트 추가, ARCHITECTURE.md 신규 모듈 반영.

### 알려진 비차단 항목
- `TerminalUiOutcome`에 `edit_failed` variant 미포함(관측 신호 충실도 갭만 — 동작/panic/owner 분리에 영향 없음). 후속 관측 정밀화 대상.