### PR TITLE
fix(build): #3673 release strip이 proc-macro dylib을 깨는 문제 해결 (build-override strip=false)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,19 @@ opt-level = "z"
 lto = true
 strip = true
 
+# #3673: do NOT strip proc-macro / build-script artifacts. Under the current
+# macOS toolchain (rustc 1.94.1, ld-27031, Darwin 27) `strip = true` on a
+# proc-macro cdylib produces a mis-aligned LINKEDIT string pool, so the compiler
+# can no longer `dlopen` it (observed: `libsqlx_macros-*.dylib` ... "mis-aligned
+# LINKEDIT string pool" -> E0432 on sqlx's Encode/Decode/Type/FromRow re-exports),
+# breaking the optimized release build that `deploy-release.sh` runs.
+# `build-override` covers build scripts, proc-macros and their deps — keeping them
+# unstripped fixes dlopen while the final delivered binary stays fully stripped
+# (size benefit retained). Verified: `cargo build --release -p sqlx` fails without
+# this override and succeeds with it on the affected toolchain.
+[profile.release.build-override]
+strip = false
+
 [profile.release-fast]
 inherits = "release"
 opt-level = 1


### PR DESCRIPTION
## 문제 (#3673)
`[profile.release] strip = true`가 proc-macro/build-script dylib까지 strip하는데, 현 macOS 툴체인(rustc 1.94.1, ld-27031, Darwin 27)에서 strip된 proc-macro cdylib의 LINKEDIT string pool이 misalign되어 컴파일러가 `dlopen` 불가가 된다.

```
error: .../libsqlx_macros-*.dylib: dlopen(...): (mis-aligned LINKEDIT string pool, fileOffset=0x007A05C4)
error[E0432]: unresolved imports `self::encode::Encode`, ... `super::Type`
```

→ `deploy-release.sh`의 최적화 release 빌드가 실패. 그동안 `AGENTDESK_DEPLOY_FAST=1`(release-fast, strip=false)로 우회 중이었으나 LTO 미적용·심볼 포함이라 항구적 해법이 아니었음.

## 해결
`[profile.release.build-override] strip = false` 추가. Cargo의 `build-override`는 **빌드 스크립트·proc-macro·그 의존성**에 적용되므로 이들만 unstrip 유지 → `dlopen` 복구. 최종 배포 바이너리는 `[profile.release] strip = true`가 그대로 적용되어 **완전히 strip**된다(크기 이점 유지).

## 검증 (macbook, rustc 1.94.1 — 이슈 재현 머신)
- **수정 전**: `cargo build --release -p sqlx` → exit 101 (sqlx_macros dlopen 실패, mis-aligned LINKEDIT 재현 확정)
- **수정 후**: `cargo build --release` (전체 LTO) → **성공 (7m05s)**, 최종 바이너리 `agentdesk` 38M이고 **strip 확인**(`nm -a` 심볼 280개, debug info/`__debug` 세그먼트 0)

## 영향
- 표준 `deploy-release.sh`의 LTO+strip 최적화 빌드 복구.
- `AGENTDESK_DEPLOY_FAST=1` 우회 더 이상 불필요.
- 런타임/소스 동작 무변경 (빌드 프로파일 설정만).