### PR TITLE
Relay recovery: reattach ownerless inflight after restart

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -986,7 +986,7 @@
     one-arm gate at `relay_recovered_terminal_text_to_placeholder` is offset by
     non-#-tag prose-comment compaction in the same root, the cutover body lives in
     the sub-1000-prod-LoC sibling `recovery_paths/controller_cutover.rs`).
-  - `src/services/discord/relay_recovery.rs` (1008 lines; #3680 split relay
+  - `src/services/discord/relay_recovery.rs` (1007 lines; #3680 split relay
     recovery reattach/self-heal path; new behavior is bugfix-only until a
     follow-up extraction drops it below the giant-file threshold).
   - `src/services/discord/health.rs` (417 prod lines after the #3038 Phase A

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -986,6 +986,9 @@
     one-arm gate at `relay_recovered_terminal_text_to_placeholder` is offset by
     non-#-tag prose-comment compaction in the same root, the cutover body lives in
     the sub-1000-prod-LoC sibling `recovery_paths/controller_cutover.rs`).
+  - `src/services/discord/relay_recovery.rs` (1008 lines; #3680 split relay
+    recovery reattach/self-heal path; new behavior is bugfix-only until a
+    follow-up extraction drops it below the giant-file threshold).
   - `src/services/discord/health.rs` (417 prod lines after the #3038 Phase A
     directory decomposition; module root keeps the `HealthRegistry` core +
     re-export surface, and the former monolith body lives in flat

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -924,7 +924,7 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3412 lines; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
+  - `src/services/discord/recovery_engine.rs` (3438 lines; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
     `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the
     STALL-WATCHDOG force-clean -> respawn synthetic row (which lands here with
     `existing_inflight = None`) is watcher-owned instead of degrading to
@@ -1260,7 +1260,7 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (3052 lines; #3635 added the
+    lines) and `src/services/discord/inflight.rs` (3134 lines; #3635 added the
     dead-watcher rebind-origin reap — `WatcherLiveness` DI trait, three-state tmux
     pane liveness, spawn-blocking warm sweeper probe, and fs-only locked
     re-validation; the byte-for-byte-unchanged #3581 None-owner predicate is
@@ -1269,6 +1269,11 @@
     threshold in #3635 when the dead-watcher reap branch joined the async
     rebind-origin sweep arm — tracked decompose target, see `giant-file-registry.md` (owner
     `discord-relay`, deadline 2026-08-31, #3405)).
+  - `src/services/discord/relay_recovery.rs` (1008 lines; crossed the giant
+    threshold in #3680 while adding bounded, channel-scoped ownerless-inflight
+    relay reattach guards. Bugfix only until split; tracked decompose target,
+    see `giant-file-registry.md` (owner `discord-relay`, deadline 2026-08-31,
+    #3405)).
 - active_callsite_coverage: n/a.
 - invariants: watcher single-owner per #1222; placeholder lifecycle invariants
   per #1112; `/api/inflight/rebind` is the only path that synthesises an
@@ -1367,7 +1372,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3230 lines).
+  - `src/cli/migrate/apply.rs` (3231 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.
@@ -1390,7 +1395,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2529 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
@@ -1431,7 +1436,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
+  - `src/db/postgres.rs` (1141 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).
@@ -1461,7 +1466,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
-- `src/services/onboarding/mod.rs` (2936),
+- `src/services/onboarding/mod.rs` (2937),
   `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1263,7 +1263,7 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (3134 lines; #3680 relay
+    lines) and `src/services/discord/inflight.rs` (3138 lines; #3680 relay
     recovery review hardening; #3635 added the
     dead-watcher rebind-origin reap — `WatcherLiveness` DI trait, three-state tmux
     pane liveness, spawn-blocking warm sweeper probe, and fs-only locked

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -305,7 +305,7 @@
 # ownerless-inflight recovery predicates (phase_policy/relay_recovery/relay_health).
 # Hotfix was deployed via direct push to main and bypassed CI, so this baseline
 # re-inflation surfaced only when PR #3655 (which bases on it) ran the gate.
-"src/services/discord/recovery_engine.rs" = 3421
+"src/services/discord/recovery_engine.rs" = 3438
 # #3034 batch-8: lowered 3771 -> 3770 (dead-code removal).
 # #3038 S1: +1 (3770 -> 3771) for the mechanical `shared.queued_placeholders` ->
 # `shared.queued.queued_placeholders` re-wire (one extra method-chain line) forced
@@ -478,7 +478,8 @@
 # changed; only the warm placeholder-sweeper carries the liveness gate (never the
 # boot path) so a freshly-restarted live watcher is never false-classified as dead.
 # Tests live in the excluded `rebind_origin_reap_tests` module.
-"src/services/discord/inflight.rs" = 3052 # #3635 dead-watcher rebind reap
+"src/services/discord/inflight.rs" = 3134 # #3680 existing-inflight rebind adoption guards
+"src/services/discord/relay_recovery.rs" = 1008 # #3680 ownerless relay recovery reattach
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -478,7 +478,7 @@
 # changed; only the warm placeholder-sweeper carries the liveness gate (never the
 # boot path) so a freshly-restarted live watcher is never false-classified as dead.
 # Tests live in the excluded `rebind_origin_reap_tests` module.
-"src/services/discord/inflight.rs" = 3134 # #3680 existing-inflight rebind adoption guards
+"src/services/discord/inflight.rs" = 3138 # #3680 relay recovery review hardening / adoption guards
 "src/services/discord/relay_recovery.rs" = 1008 # #3680 ownerless relay recovery reattach
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -324,6 +324,17 @@ deadline = "2026-08-31"
 decompose_issue = "#3405"
 
 [[entry]]
+# Crossed the 1000-prod-LoC threshold in #3680: relay recovery gained the
+# bounded watcher-reattach planner/apply guards for ownerless inflight recovery
+# and multi-runtime channel ownership. Keep future relay recovery orchestration
+# growth honest; split action planning/apply execution into child modules once
+# the reattach lifecycle stabilizes.
+file = "src/services/discord/relay_recovery.rs"
+owner = "discord-relay"
+deadline = "2026-08-31"
+decompose_issue = "#3405"
+
+[[entry]]
 # Crossed the 1000-prod-LoC threshold when #3041 P1-0 landed the dormant
 # `DeliveryLeaseCell` finalizer messages/handlers on top of #3143's
 # `FinalizeContext::monitor()` + monitor turn-key/ledger-generation logic. The

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -125,6 +125,21 @@ pub async fn build_channel_directory_from_pg(
 /// post-restart adoption path silently broken (issue #2465).
 pub type ChannelNameMap = HashMap<(String, ProviderKind, String), String>;
 type SessionTmuxSegmentMap = HashMap<(ProviderKind, String), String>;
+const SESSION_TMUX_SEGMENTS_QUERY: &str = "SELECT provider, channel_id, session_key
+         FROM sessions
+         WHERE NULLIF(TRIM(channel_id), '') IS NOT NULL
+           AND NULLIF(TRIM(session_key), '') IS NOT NULL
+           AND LOWER(TRIM(COALESCE(status, ''))) IN (
+             'connected',
+             'turn_active',
+             'awaiting_bg',
+             'awaiting_user',
+             'idle',
+             'working'
+           )
+         ORDER BY last_heartbeat DESC NULLS LAST,
+                  created_at DESC NULLS LAST,
+                  id DESC";
 
 /// Build the channel-name map from the live yaml config. Returns an empty map
 /// on any failure so discovery degrades gracefully (legacy snowflake-keyed
@@ -205,14 +220,9 @@ async fn build_channel_directory_from_pg_with_config(
 async fn load_session_tmux_segments_pg(
     pool: &PgPool,
 ) -> Result<SessionTmuxSegmentMap, sqlx::Error> {
-    let rows = sqlx::query(
-        "SELECT provider, channel_id, session_key
-         FROM sessions
-         WHERE NULLIF(TRIM(channel_id), '') IS NOT NULL
-           AND NULLIF(TRIM(session_key), '') IS NOT NULL",
-    )
-    .fetch_all(pool)
-    .await?;
+    let rows = sqlx::query(SESSION_TMUX_SEGMENTS_QUERY)
+        .fetch_all(pool)
+        .await?;
 
     let mut map = SessionTmuxSegmentMap::new();
     for row in rows {
@@ -876,6 +886,30 @@ mod tests {
         );
 
         assert_eq!(report.matched, 1, "snowflake fallback must still match");
+    }
+
+    #[test]
+    fn session_tmux_segment_fallback_uses_live_recent_session_rows() {
+        let query = SESSION_TMUX_SEGMENTS_QUERY;
+
+        assert!(
+            query.contains("LOWER(TRIM(COALESCE(status, ''))) IN"),
+            "fallback query must filter status before deriving tmux segments"
+        );
+        assert!(
+            query.contains("'turn_active'") && query.contains("'idle'"),
+            "live runtime statuses must remain eligible"
+        );
+        assert!(
+            !query.contains("'disconnected'") && !query.contains("'aborted'"),
+            "stale terminal statuses must not be eligible"
+        );
+        assert!(
+            query.contains("ORDER BY last_heartbeat DESC NULLS LAST")
+                && query.contains("created_at DESC NULLS LAST")
+                && query.contains("id DESC"),
+            "newest live session rows must be considered before older rows"
+        );
     }
 
     /// Regression for #2470: claude code 2.1.143 rewrites its process title to

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -108,19 +108,21 @@ pub async fn build_channel_directory_from_pg(
     pool: &PgPool,
 ) -> Result<ChannelDirectory, sqlx::Error> {
     let live_session_names = HashSet::new();
-    build_channel_directory_from_pg_for_live_sessions(pool, &live_session_names).await
+    build_channel_directory_from_pg_for_live_sessions(pool, &live_session_names, None).await
 }
 
 async fn build_channel_directory_from_pg_for_live_sessions(
     pool: &PgPool,
     live_session_names: &HashSet<String>,
+    local_instance_id: Option<&str>,
 ) -> Result<ChannelDirectory, sqlx::Error> {
     // load_graceful() does sync filesystem IO + yaml parse — push to a blocking
     // thread so we don't stall the tokio runtime on every discovery tick.
     let name_map = tokio::task::spawn_blocking(build_yaml_channel_name_map)
         .await
         .unwrap_or_default();
-    let session_tmux_segments = load_session_tmux_segments_pg(pool, live_session_names).await?;
+    let session_tmux_segments =
+        load_session_tmux_segments_pg(pool, live_session_names, local_instance_id).await?;
     build_channel_directory_from_pg_with_config(pool, name_map, session_tmux_segments).await
 }
 
@@ -134,7 +136,7 @@ async fn build_channel_directory_from_pg_for_live_sessions(
 /// post-restart adoption path silently broken (issue #2465).
 pub type ChannelNameMap = HashMap<(String, ProviderKind, String), String>;
 type SessionTmuxSegmentMap = HashMap<(ProviderKind, String), String>;
-const SESSION_TMUX_SEGMENTS_QUERY: &str = "SELECT provider, channel_id, session_key
+const SESSION_TMUX_SEGMENTS_QUERY: &str = "SELECT provider, channel_id, session_key, instance_id
          FROM sessions
          WHERE NULLIF(TRIM(channel_id), '') IS NOT NULL
            AND NULLIF(TRIM(session_key), '') IS NOT NULL
@@ -231,6 +233,7 @@ async fn build_channel_directory_from_pg_with_config(
 async fn load_session_tmux_segments_pg(
     pool: &PgPool,
     live_session_names: &HashSet<String>,
+    local_instance_id: Option<&str>,
 ) -> Result<SessionTmuxSegmentMap, sqlx::Error> {
     let rows = sqlx::query(SESSION_TMUX_SEGMENTS_QUERY)
         .fetch_all(pool)
@@ -241,6 +244,7 @@ async fn load_session_tmux_segments_pg(
         let channel_id: Option<String> = row.try_get("channel_id")?;
         let session_key: Option<String> = row.try_get("session_key")?;
         let provider_hint: Option<String> = row.try_get("provider")?;
+        let row_instance_id: Option<String> = row.try_get("instance_id")?;
         let Some(channel_id) = normalize_nonempty(channel_id.as_deref()) else {
             continue;
         };
@@ -251,6 +255,15 @@ async fn load_session_tmux_segments_pg(
         else {
             continue;
         };
+        if !session_row_matches_local_instance(row_instance_id.as_deref(), local_instance_id) {
+            tracing::debug!(
+                session_key = %session_key,
+                row_instance_id = row_instance_id.as_deref().unwrap_or("<none>"),
+                local_instance_id = local_instance_id.unwrap_or("<none>"),
+                "session-discovery: ignoring non-local session row while deriving tmux segment",
+            );
+            continue;
+        }
         let Some((provider, tmux_segment)) =
             live_tmux_segment_from_session_key(session_key, live_session_names)
         else {
@@ -287,6 +300,20 @@ async fn load_session_tmux_segments_pg(
         }
     }
     Ok(map)
+}
+
+fn normalized_instance_id(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn session_row_matches_local_instance(
+    row_instance_id: Option<&str>,
+    local_instance_id: Option<&str>,
+) -> bool {
+    let Some(local) = normalized_instance_id(local_instance_id) else {
+        return true;
+    };
+    normalized_instance_id(row_instance_id).is_some_and(|row| row == local)
 }
 
 fn normalize_nonempty(value: Option<&str>) -> Option<String> {
@@ -621,6 +648,7 @@ async fn run_single_tick(
     let directory = match build_channel_directory_from_pg_for_live_sessions(
         pool,
         &live_session_names,
+        instance_id,
     )
     .await
     {
@@ -935,6 +963,10 @@ mod tests {
         let query = SESSION_TMUX_SEGMENTS_QUERY;
 
         assert!(
+            query.contains("instance_id"),
+            "fallback tmux segments must preserve session row ownership"
+        );
+        assert!(
             query.contains("LOWER(TRIM(COALESCE(status, ''))) IN"),
             "fallback query must filter status before deriving tmux segments"
         );
@@ -1007,6 +1039,26 @@ mod tests {
         assert_eq!(
             report.matched, 1,
             "skipping stale fallback must leave channel_id matching intact"
+        );
+    }
+
+    #[test]
+    fn session_tmux_segment_fallback_requires_local_instance_ownership() {
+        assert!(
+            session_row_matches_local_instance(Some(NODE_A), Some(NODE_A)),
+            "local session rows remain eligible"
+        );
+        assert!(
+            !session_row_matches_local_instance(Some(NODE_B), Some(NODE_A)),
+            "foreign session rows must not seed local tmux segment fallbacks"
+        );
+        assert!(
+            !session_row_matches_local_instance(None, Some(NODE_A)),
+            "missing row ownership is not enough when this node has an instance id"
+        );
+        assert!(
+            session_row_matches_local_instance(Some(NODE_B), None),
+            "single-node/legacy callers without a local instance keep compatibility"
         );
     }
 

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -42,7 +42,7 @@
 //! [`request_discovery_tick`] for that purpose so future PRs can nudge the
 //! loop without changing this module.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -103,15 +103,24 @@ pub fn request_discovery_tick() {
 ///
 /// Logs at WARN if the directory builder rejects a per-binding collision so
 /// operators can fix the config without aborting the whole tick.
+#[allow(dead_code)] // compatibility helper; the discovery tick uses the live-session-filtered path
 pub async fn build_channel_directory_from_pg(
     pool: &PgPool,
+) -> Result<ChannelDirectory, sqlx::Error> {
+    let live_session_names = HashSet::new();
+    build_channel_directory_from_pg_for_live_sessions(pool, &live_session_names).await
+}
+
+async fn build_channel_directory_from_pg_for_live_sessions(
+    pool: &PgPool,
+    live_session_names: &HashSet<String>,
 ) -> Result<ChannelDirectory, sqlx::Error> {
     // load_graceful() does sync filesystem IO + yaml parse — push to a blocking
     // thread so we don't stall the tokio runtime on every discovery tick.
     let name_map = tokio::task::spawn_blocking(build_yaml_channel_name_map)
         .await
         .unwrap_or_default();
-    let session_tmux_segments = load_session_tmux_segments_pg(pool).await?;
+    let session_tmux_segments = load_session_tmux_segments_pg(pool, live_session_names).await?;
     build_channel_directory_from_pg_with_config(pool, name_map, session_tmux_segments).await
 }
 
@@ -137,6 +146,8 @@ const SESSION_TMUX_SEGMENTS_QUERY: &str = "SELECT provider, channel_id, session_
              'idle',
              'working'
            )
+           AND last_heartbeat IS NOT NULL
+           AND last_heartbeat > NOW() - INTERVAL '10 minutes'
          ORDER BY last_heartbeat DESC NULLS LAST,
                   created_at DESC NULLS LAST,
                   id DESC";
@@ -219,6 +230,7 @@ async fn build_channel_directory_from_pg_with_config(
 /// dcserver restarts instead of logging it as an unowned operator session.
 async fn load_session_tmux_segments_pg(
     pool: &PgPool,
+    live_session_names: &HashSet<String>,
 ) -> Result<SessionTmuxSegmentMap, sqlx::Error> {
     let rows = sqlx::query(SESSION_TMUX_SEGMENTS_QUERY)
         .fetch_all(pool)
@@ -239,7 +251,9 @@ async fn load_session_tmux_segments_pg(
         else {
             continue;
         };
-        let Some((provider, tmux_segment)) = tmux_segment_from_session_key(session_key) else {
+        let Some((provider, tmux_segment)) =
+            live_tmux_segment_from_session_key(session_key, live_session_names)
+        else {
             continue;
         };
         if let Some(hint) = provider_hint
@@ -282,9 +296,28 @@ fn normalize_nonempty(value: Option<&str>) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn tmux_segment_from_session_key(session_key: &str) -> Option<(ProviderKind, String)> {
+fn tmux_name_and_segment_from_session_key(
+    session_key: &str,
+) -> Option<(&str, ProviderKind, String)> {
     let (_, tmux_name) = session_key.rsplit_once(':')?;
-    parse_provider_and_channel_from_tmux_name(tmux_name)
+    let (provider, tmux_segment) = parse_provider_and_channel_from_tmux_name(tmux_name)?;
+    Some((tmux_name, provider, tmux_segment))
+}
+
+fn live_tmux_segment_from_session_key(
+    session_key: &str,
+    live_session_names: &HashSet<String>,
+) -> Option<(ProviderKind, String)> {
+    let (tmux_name, provider, tmux_segment) = tmux_name_and_segment_from_session_key(session_key)?;
+    if !live_session_names.contains(tmux_name) {
+        tracing::debug!(
+            session_key = %session_key,
+            tmux_name = %tmux_name,
+            "session-discovery: ignoring non-live session row while deriving tmux segment",
+        );
+        return None;
+    }
+    Some((provider, tmux_segment))
 }
 
 /// Extract the `(provider, channel_id)` pairs an agent declares. Today this
@@ -567,18 +600,6 @@ async fn run_single_tick(
         tracing::debug!("session-discovery: yielding tick to foreground under pool pressure",);
         return TickReport::default();
     }
-    // PG load failure → ABORT THE TICK. Returning a default report leaves the
-    // registry untouched, so a transient PG hiccup never wipes live entries.
-    let directory = match build_channel_directory_from_pg(pool).await {
-        Ok(dir) => dir,
-        Err(error) => {
-            tracing::warn!(
-                ?error,
-                "session-discovery: agent-binding load failed; skipping tick to preserve registry",
-            );
-            return TickReport::default();
-        }
-    };
     let enumeration_result = tokio::task::spawn_blocking(list_sessions_with_pane_command).await;
     let enumeration = match enumeration_result {
         Ok(Ok(sessions)) => sessions,
@@ -588,6 +609,27 @@ async fn run_single_tick(
         }
         Err(error) => {
             tracing::warn!(?error, "session-discovery: tmux enumeration join failed");
+            return TickReport::default();
+        }
+    };
+    let live_session_names: HashSet<String> = enumeration
+        .iter()
+        .map(|session| session.session_name.clone())
+        .collect();
+    // PG load failure → ABORT THE TICK. Returning a default report leaves the
+    // registry untouched, so a transient PG hiccup never wipes live entries.
+    let directory = match build_channel_directory_from_pg_for_live_sessions(
+        pool,
+        &live_session_names,
+    )
+    .await
+    {
+        Ok(dir) => dir,
+        Err(error) => {
+            tracing::warn!(
+                ?error,
+                "session-discovery: agent-binding load failed; skipping tick to preserve registry",
+            );
             return TickReport::default();
         }
     };
@@ -905,10 +947,66 @@ mod tests {
             "stale terminal statuses must not be eligible"
         );
         assert!(
+            query.contains("last_heartbeat IS NOT NULL")
+                && query.contains("last_heartbeat > NOW() - INTERVAL '10 minutes'"),
+            "fallback tmux segments must come from current-runtime heartbeat rows"
+        );
+        assert!(
             query.contains("ORDER BY last_heartbeat DESC NULLS LAST")
                 && query.contains("created_at DESC NULLS LAST")
                 && query.contains("id DESC"),
             "newest live session rows must be considered before older rows"
+        );
+    }
+
+    #[test]
+    fn session_tmux_segment_fallback_requires_live_tmux_session() {
+        let snowflake = "1234567890";
+        let stale_named_session =
+            expected_session_name_for(None, &ProviderKind::Claude, "old-channel-name");
+        let live_snowflake_session =
+            expected_session_name_for(None, &ProviderKind::Claude, snowflake);
+        let live_named_session =
+            expected_session_name_for(None, &ProviderKind::Claude, "current-channel-name");
+        let live_session_names = std::collections::HashSet::from([
+            live_snowflake_session.clone(),
+            live_named_session.clone(),
+        ]);
+
+        assert!(
+            live_tmux_segment_from_session_key(
+                &format!("provider-cli:{stale_named_session}"),
+                &live_session_names,
+            )
+            .is_none(),
+            "stale DB session rows must not install a tmux_segment fallback"
+        );
+        assert_eq!(
+            live_tmux_segment_from_session_key(
+                &format!("provider-cli:{live_named_session}"),
+                &live_session_names,
+            ),
+            Some((ProviderKind::Claude, "current-channel-name".to_string())),
+            "live tmux-verified session rows remain eligible"
+        );
+
+        let directory = ChannelDirectory::from_bindings(vec![binding(
+            snowflake,
+            "legacy-agent",
+            ProviderKind::Claude,
+        )]);
+        let registry = SessionRegistry::new();
+
+        let report = reconcile_from_enumeration(
+            Some(NODE_A),
+            vec![enumerated(&live_snowflake_session, "claude")],
+            &directory,
+            &registry,
+        );
+
+        assert_eq!(
+            report.matched, 1,
+            "skipping stale fallback must leave channel_id matching intact"
         );
     }
 

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -42,12 +42,13 @@
 //! [`request_discovery_tick`] for that purpose so future PRs can nudge the
 //! loop without changing this module.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use sqlx::PgPool;
+use sqlx::{PgPool, Row as SqlxRow};
 use tokio::sync::Notify;
 
 use super::session_matcher::{
@@ -56,7 +57,7 @@ use super::session_matcher::{
 };
 use super::session_registry::{RegistryChange, SessionRegistry, global_session_registry};
 use crate::services::platform::tmux::{EnumeratedSession, list_sessions_with_pane_command};
-use crate::services::provider::ProviderKind;
+use crate::services::provider::{ProviderKind, parse_provider_and_channel_from_tmux_name};
 
 /// Knobs for the discovery loop. Production callers use [`Self::default`].
 /// Kept as a struct (rather than a bare `Duration`) so future tuning (jitter,
@@ -110,7 +111,8 @@ pub async fn build_channel_directory_from_pg(
     let name_map = tokio::task::spawn_blocking(build_yaml_channel_name_map)
         .await
         .unwrap_or_default();
-    build_channel_directory_from_pg_with_config(pool, name_map).await
+    let session_tmux_segments = load_session_tmux_segments_pg(pool).await?;
+    build_channel_directory_from_pg_with_config(pool, name_map, session_tmux_segments).await
 }
 
 /// Lookup table: `(agent_id, provider, channel_id) → channel_name`. Built once
@@ -121,7 +123,8 @@ pub async fn build_channel_directory_from_pg(
 /// Without this, the directory keys collapse to `(provider, channel_id)` and
 /// fail to match `AgentDesk-{provider}-{channel_name}` sessions, leaving the
 /// post-restart adoption path silently broken (issue #2465).
-pub type ChannelNameMap = std::collections::HashMap<(String, ProviderKind, String), String>;
+pub type ChannelNameMap = HashMap<(String, ProviderKind, String), String>;
+type SessionTmuxSegmentMap = HashMap<(ProviderKind, String), String>;
 
 /// Build the channel-name map from the live yaml config. Returns an empty map
 /// on any failure so discovery degrades gracefully (legacy snowflake-keyed
@@ -149,6 +152,7 @@ pub fn build_yaml_channel_name_map() -> ChannelNameMap {
 async fn build_channel_directory_from_pg_with_config(
     pool: &PgPool,
     name_map: ChannelNameMap,
+    session_tmux_segments: SessionTmuxSegmentMap,
 ) -> Result<ChannelDirectory, sqlx::Error> {
     let all = crate::db::agents::load_all_agent_channel_bindings_pg(pool).await?;
 
@@ -166,7 +170,12 @@ async fn build_channel_directory_from_pg_with_config(
             // `channel_id` preserves legacy bindings without a yaml entry.
             let tmux_segment = name_map
                 .get(&(agent_id.clone(), provider.clone(), channel_id.clone()))
-                .cloned();
+                .cloned()
+                .or_else(|| {
+                    session_tmux_segments
+                        .get(&(provider.clone(), channel_id.clone()))
+                        .cloned()
+                });
             let binding = ChannelBinding {
                 channel_id,
                 agent_id: agent_id.clone(),
@@ -183,6 +192,89 @@ async fn build_channel_directory_from_pg_with_config(
         }
     }
     Ok(directory)
+}
+
+/// Best-effort post-restart adoption aid:
+///
+/// `agentdesk.yaml` is the preferred source for a Discord channel's tmux
+/// segment, but some operator/by-id channels only exist in the database. Live
+/// provider sessions still persist their exact `session_key` as
+/// `...:AgentDesk-{provider}-{tmux_segment}`. Use that runtime fact as a
+/// fallback so discovery can re-bind an already-running tmux session after
+/// dcserver restarts instead of logging it as an unowned operator session.
+async fn load_session_tmux_segments_pg(
+    pool: &PgPool,
+) -> Result<SessionTmuxSegmentMap, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT provider, channel_id, session_key
+         FROM sessions
+         WHERE NULLIF(TRIM(channel_id), '') IS NOT NULL
+           AND NULLIF(TRIM(session_key), '') IS NOT NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut map = SessionTmuxSegmentMap::new();
+    for row in rows {
+        let channel_id: Option<String> = row.try_get("channel_id")?;
+        let session_key: Option<String> = row.try_get("session_key")?;
+        let provider_hint: Option<String> = row.try_get("provider")?;
+        let Some(channel_id) = normalize_nonempty(channel_id.as_deref()) else {
+            continue;
+        };
+        let Some(session_key) = session_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        else {
+            continue;
+        };
+        let Some((provider, tmux_segment)) = tmux_segment_from_session_key(session_key) else {
+            continue;
+        };
+        if let Some(hint) = provider_hint
+            .as_deref()
+            .and_then(|value| ProviderKind::from_str(value.trim()))
+            && hint != provider
+        {
+            tracing::debug!(
+                session_key = %session_key,
+                provider_hint = ?hint,
+                parsed_provider = ?provider,
+                "session-discovery: ignoring mismatched sessions.provider while deriving tmux segment",
+            );
+        }
+        match map.entry((provider, channel_id)) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(tmux_segment);
+            }
+            std::collections::hash_map::Entry::Occupied(existing)
+                if existing.get() != &tmux_segment =>
+            {
+                tracing::debug!(
+                    channel_id = %existing.key().1,
+                    provider = ?existing.key().0,
+                    existing_tmux_segment = %existing.get(),
+                    candidate_tmux_segment = %tmux_segment,
+                    "session-discovery: keeping first runtime tmux segment for channel",
+                );
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {}
+        }
+    }
+    Ok(map)
+}
+
+fn normalize_nonempty(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn tmux_segment_from_session_key(session_key: &str) -> Option<(ProviderKind, String)> {
+    let (_, tmux_name) = session_key.rsplit_once(':')?;
+    parse_provider_and_channel_from_tmux_name(tmux_name)
 }
 
 /// Extract the `(provider, channel_id)` pairs an agent declares. Today this
@@ -203,6 +295,7 @@ fn channel_pairs_for_agent(
     // Claude → discord_channel_cc; Codex → discord_channel_cdx.
     push(ProviderKind::Claude, bindings.discord_channel_cc.clone());
     push(ProviderKind::Codex, bindings.discord_channel_cdx.clone());
+    push(ProviderKind::Codex, bindings.discord_channel_alt.clone());
 
     // Legacy primary channel: routed under the configured provider when set.
     if let Some(provider_str) = bindings.provider.as_deref() {

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -269,17 +269,14 @@ async fn load_session_tmux_segments_pg(
         else {
             continue;
         };
-        if let Some(hint) = provider_hint
-            .as_deref()
-            .and_then(|value| ProviderKind::from_str(value.trim()))
-            && hint != provider
-        {
+        if !provider_hint_matches_session_provider(provider_hint.as_deref(), &provider) {
             tracing::debug!(
                 session_key = %session_key,
-                provider_hint = ?hint,
+                provider_hint = provider_hint.as_deref().unwrap_or("<none>"),
                 parsed_provider = ?provider,
                 "session-discovery: ignoring mismatched sessions.provider while deriving tmux segment",
             );
+            continue;
         }
         match map.entry((provider, channel_id)) {
             std::collections::hash_map::Entry::Vacant(entry) => {
@@ -306,6 +303,28 @@ fn normalized_instance_id(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|value| !value.is_empty())
 }
 
+fn default_instance_hostname(value: &str) -> Option<&str> {
+    let (hostname, pid) = value.rsplit_once('-')?;
+    if hostname.is_empty() || pid.is_empty() || !pid.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    Some(hostname)
+}
+
+fn provider_hint_matches_session_provider(
+    provider_hint: Option<&str>,
+    parsed_provider: &ProviderKind,
+) -> bool {
+    match provider_hint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(ProviderKind::from_str)
+    {
+        Some(hint) => hint == *parsed_provider,
+        None => true,
+    }
+}
+
 fn session_row_matches_local_instance(
     row_instance_id: Option<&str>,
     local_instance_id: Option<&str>,
@@ -313,7 +332,14 @@ fn session_row_matches_local_instance(
     let Some(local) = normalized_instance_id(local_instance_id) else {
         return true;
     };
-    normalized_instance_id(row_instance_id).is_some_and(|row| row == local)
+    let Some(row) = normalized_instance_id(row_instance_id) else {
+        return false;
+    };
+    row == local
+        || matches!(
+            (default_instance_hostname(row), default_instance_hostname(local)),
+            (Some(row_host), Some(local_host)) if row_host == local_host
+        )
 }
 
 fn normalize_nonempty(value: Option<&str>) -> Option<String> {
@@ -1049,8 +1075,20 @@ mod tests {
             "local session rows remain eligible"
         );
         assert!(
+            session_row_matches_local_instance(Some("mac-mini-123"), Some("mac-mini-456")),
+            "default hostname-PID instance ids on the same host remain eligible across restart"
+        );
+        assert!(
             !session_row_matches_local_instance(Some(NODE_B), Some(NODE_A)),
             "foreign session rows must not seed local tmux segment fallbacks"
+        );
+        assert!(
+            !session_row_matches_local_instance(Some("mac-book-123"), Some("mac-mini-456")),
+            "default hostname-PID instance ids on different hosts must not match"
+        );
+        assert!(
+            !session_row_matches_local_instance(Some("mac-mini-release"), Some("mac-mini-prod")),
+            "operator-provided stable instance ids must still match exactly"
         );
         assert!(
             !session_row_matches_local_instance(None, Some(NODE_A)),
@@ -1059,6 +1097,22 @@ mod tests {
         assert!(
             session_row_matches_local_instance(Some(NODE_B), None),
             "single-node/legacy callers without a local instance keep compatibility"
+        );
+    }
+
+    #[test]
+    fn session_tmux_segment_fallback_rejects_provider_hint_mismatch() {
+        assert!(provider_hint_matches_session_provider(
+            Some("claude"),
+            &ProviderKind::Claude
+        ));
+        assert!(
+            !provider_hint_matches_session_provider(Some("claude"), &ProviderKind::Codex),
+            "sessions.provider mismatch must discard the runtime tmux segment fallback"
+        );
+        assert!(
+            provider_hint_matches_session_provider(Some("unknown-provider"), &ProviderKind::Codex),
+            "unparseable legacy provider hints remain non-authoritative"
         );
     }
 

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -389,8 +389,9 @@ impl HealthRegistry {
                 tracing::warn!(
                     provider = provider.as_str(),
                     channel_id,
-                    "watcher-state provider/channel runtime resolve timed out; falling back to provider scan",
+                    "watcher-state provider/channel runtime resolve timed out; skipping provider scan to preserve channel ownership",
                 );
+                return None;
             }
         }
 
@@ -857,7 +858,12 @@ pub(super) fn observe_global_active_invariant(
 
 #[cfg(test)]
 mod tests {
-    use super::rebind_origin_inflight_is_idle;
+    use std::sync::Arc;
+
+    use poise::serenity_prelude::{ChannelId, MessageId, UserId};
+
+    use super::{HealthRegistry, rebind_origin_inflight_is_idle};
+    use crate::services::provider::{CancelToken, ProviderKind};
 
     /// #3631: a rebind-origin row with NO cancel token is idle (so the channel
     /// is not falsely reported as an active foreground stream and queued
@@ -872,5 +878,38 @@ mod tests {
         // not a rebind-origin row → never idle via this seam.
         assert!(!rebind_origin_inflight_is_idle(false, false));
         assert!(!rebind_origin_inflight_is_idle(true, false));
+    }
+
+    #[tokio::test]
+    async fn provider_scoped_snapshot_timeout_does_not_fallback_to_provider_scan() {
+        let registry = HealthRegistry::new();
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        registry
+            .register(ProviderKind::Codex.as_str().to_string(), shared.clone())
+            .await;
+
+        let channel = ChannelId::new(42);
+        let token = Arc::new(CancelToken::new());
+        assert!(
+            crate::services::discord::mailbox_try_start_turn(
+                shared.as_ref(),
+                channel,
+                token,
+                UserId::new(1),
+                MessageId::new(2),
+            )
+            .await,
+            "test mailbox turn should make fallback provider scan look engaged"
+        );
+
+        let _settings_guard = shared.settings.write().await;
+        let snapshot = registry
+            .snapshot_watcher_state_for_provider(&ProviderKind::Codex, channel.get())
+            .await;
+
+        assert!(
+            snapshot.is_none(),
+            "provider/channel resolve timeout must not scan a possibly wrong same-provider runtime"
+        );
     }
 }

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -375,8 +375,23 @@ impl HealthRegistry {
         channel_id: u64,
     ) -> Option<WatcherStateSnapshot> {
         let channel = ChannelId::new(channel_id);
-        if let Some(shared) = self.shared_for_provider_on_channel(provider, channel).await {
-            return watcher_state_snapshot_for_shared(provider.as_str(), shared, channel).await;
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.shared_for_provider_on_channel(provider, channel),
+        )
+        .await
+        {
+            Ok(Some(shared)) => {
+                return watcher_state_snapshot_for_shared(provider.as_str(), shared, channel).await;
+            }
+            Ok(None) => {}
+            Err(_) => {
+                tracing::warn!(
+                    provider = provider.as_str(),
+                    channel_id,
+                    "watcher-state provider/channel runtime resolve timed out; falling back to provider scan",
+                );
+            }
         }
 
         self.snapshot_watcher_state_filtered(channel_id, Some(provider))

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1274,17 +1274,32 @@ pub(in crate::services::discord) fn save_inflight_state_if_matches_identity(
     )
 }
 
-pub(in crate::services::discord) fn set_relay_owner_kind_if_matches_identity(
-    provider: &ProviderKind,
-    channel_id: u64,
+pub(in crate::services::discord) fn save_existing_inflight_rebind_adoption_if_matches_identity(
+    state: &InflightTurnState,
     expected: &InflightTurnIdentity,
     expected_turn_start_offset: Option<u64>,
-    relay_owner_kind: RelayOwnerKind,
 ) -> GuardedSaveOutcome {
     let Some(root) = inflight_runtime_root() else {
         return GuardedSaveOutcome::IoError;
     };
-    let path = inflight_state_path(&root, provider, channel_id);
+    save_existing_inflight_rebind_adoption_if_matches_identity_in_root(
+        &root,
+        state,
+        expected,
+        expected_turn_start_offset,
+    )
+}
+
+fn save_existing_inflight_rebind_adoption_if_matches_identity_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    expected_turn_start_offset: Option<u64>,
+) -> GuardedSaveOutcome {
+    let Some(provider) = state.provider_kind() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let path = inflight_state_path(root, &provider, state.channel_id);
     if let Some(parent) = path.parent() {
         if fs::create_dir_all(parent).is_err() {
             return GuardedSaveOutcome::IoError;
@@ -1296,10 +1311,13 @@ pub(in crate::services::discord) fn set_relay_owner_kind_if_matches_identity(
     let Ok(data) = fs::read_to_string(&path) else {
         return GuardedSaveOutcome::Missing;
     };
-    let Ok(mut on_disk) = serde_json::from_str::<InflightTurnState>(&data) else {
+    let Ok(on_disk) = serde_json::from_str::<InflightTurnState>(&data) else {
         return GuardedSaveOutcome::IdentityMismatch;
     };
-    if on_disk.restart_mode.is_some() || on_disk.rebind_origin {
+    if on_disk.rebind_origin {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if on_disk.restart_mode != state.restart_mode {
         return GuardedSaveOutcome::IdentityMismatch;
     }
     if expected.user_msg_id == 0 || !expected.matches_state(&on_disk) {
@@ -1310,9 +1328,17 @@ pub(in crate::services::discord) fn set_relay_owner_kind_if_matches_identity(
             return GuardedSaveOutcome::IdentityMismatch;
         }
     }
-    on_disk.set_relay_owner_kind(relay_owner_kind);
-    on_disk.updated_at = now_string();
-    let Ok(json) = serde_json::to_string_pretty(&on_disk) else {
+
+    let mut updated = state.clone();
+    updated.ensure_finalizer_turn_id();
+    let _ = validate_inflight_state_for_save(
+        root,
+        &path,
+        &updated,
+        "src/services/discord/inflight.rs:save_existing_inflight_rebind_adoption_if_matches_identity_in_root",
+    );
+    updated.updated_at = now_string();
+    let Ok(json) = serde_json::to_string_pretty(&updated) else {
         return GuardedSaveOutcome::IoError;
     };
     match atomic_write(&path, &json) {
@@ -1320,10 +1346,10 @@ pub(in crate::services::discord) fn set_relay_owner_kind_if_matches_identity(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel = state.channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
-                "inflight relay-owner update failed; leaving on-disk row untouched"
+                "existing inflight rebind adoption save failed; leaving on-disk row untouched"
             );
             GuardedSaveOutcome::IoError
         }
@@ -3121,6 +3147,7 @@ mod stall_recovery_tests {
         offset_monotonic_invariant_severity, persist_watcher_relay_watermark_locked_in_root,
         persist_watcher_stream_progress_locked_in_root,
         refresh_inflight_last_offset_if_matches_identity_in_root,
+        save_existing_inflight_rebind_adoption_if_matches_identity_in_root,
         save_inflight_state_if_matches_identity_in_root, save_inflight_state_in_root,
         validate_inflight_state_for_save,
     };
@@ -4536,6 +4563,22 @@ mod stall_recovery_tests {
         )
     }
 
+    struct EnvReset(Option<std::ffi::OsString>);
+    impl Drop for EnvReset {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    fn set_agentdesk_root_for_test(path: &Path) -> EnvReset {
+        let reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", path) };
+        reset
+    }
+
     /// #2427 D/A wire — happy path. When the on-disk inflight has a
     /// matching `user_msg_id` and is neither a planned-restart marker
     /// nor a rebind origin, the explicit signal removes it.
@@ -5748,6 +5791,93 @@ mod stall_recovery_tests {
             rows[0].restart_mode.is_some(),
             "the planned-restart marker must be preserved for recovery"
         );
+    }
+
+    #[test]
+    fn existing_rebind_adoption_persists_paths_for_planned_restart() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = TempDir::new().unwrap();
+        let _env_reset = set_agentdesk_root_for_test(temp.path());
+        let mut on_disk = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 777);
+        on_disk.user_msg_id = 777;
+        on_disk.current_msg_id = 778;
+        on_disk.set_restart_mode(InflightRestartMode::DrainRestart);
+        save_inflight_state_in_root(temp.path(), &on_disk).unwrap();
+
+        let expected = InflightTurnIdentity::from_state(&on_disk);
+        let mut adopted = on_disk.clone();
+        adopted.tmux_session_name = Some("AgentDesk-claude-adk-restored".to_string());
+        adopted.output_path = Some("/tmp/restored-output.jsonl".to_string());
+        adopted.input_fifo_path = Some("/tmp/restored-input.fifo".to_string());
+        adopted.set_relay_owner_kind(RelayOwnerKind::Watcher);
+
+        let outcome = save_existing_inflight_rebind_adoption_if_matches_identity_in_root(
+            temp.path(),
+            &adopted,
+            &expected,
+            on_disk.turn_start_offset,
+        );
+
+        assert_eq!(outcome, GuardedSaveOutcome::Saved);
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].tmux_session_name.as_deref(),
+            Some("AgentDesk-claude-adk-restored")
+        );
+        assert_eq!(
+            rows[0].output_path.as_deref(),
+            Some("/tmp/restored-output.jsonl")
+        );
+        assert_eq!(
+            rows[0].input_fifo_path.as_deref(),
+            Some("/tmp/restored-input.fifo")
+        );
+        assert_eq!(
+            rows[0].effective_relay_owner_kind(),
+            RelayOwnerKind::Watcher
+        );
+        assert_eq!(
+            rows[0].restart_mode,
+            Some(InflightRestartMode::DrainRestart)
+        );
+    }
+
+    #[test]
+    fn existing_rebind_adoption_does_not_clobber_rebind_origin() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = TempDir::new().unwrap();
+        let _env_reset = set_agentdesk_root_for_test(temp.path());
+        let mut on_disk = build_inflight_for_guard_tests(ProviderKind::Claude, 322, 777);
+        on_disk.user_msg_id = 777;
+        on_disk.current_msg_id = 778;
+        on_disk.rebind_origin = true;
+        save_inflight_state_in_root(temp.path(), &on_disk).unwrap();
+
+        let expected = InflightTurnIdentity::from_state(&on_disk);
+        let mut adopted = on_disk.clone();
+        adopted.tmux_session_name = Some("AgentDesk-claude-adk-restored".to_string());
+        adopted.output_path = Some("/tmp/restored-output.jsonl".to_string());
+        adopted.input_fifo_path = Some("/tmp/restored-input.fifo".to_string());
+        adopted.set_relay_owner_kind(RelayOwnerKind::Watcher);
+
+        let outcome = save_existing_inflight_rebind_adoption_if_matches_identity_in_root(
+            temp.path(),
+            &adopted,
+            &expected,
+            on_disk.turn_start_offset,
+        );
+
+        assert_eq!(outcome, GuardedSaveOutcome::IdentityMismatch);
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].rebind_origin);
+        assert_eq!(rows[0].output_path.as_deref(), Some("/tmp/out.jsonl"));
+        assert_eq!(rows[0].effective_relay_owner_kind(), RelayOwnerKind::None);
     }
 
     #[cfg(unix)]

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1274,6 +1274,62 @@ pub(in crate::services::discord) fn save_inflight_state_if_matches_identity(
     )
 }
 
+pub(in crate::services::discord) fn set_relay_owner_kind_if_matches_identity(
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    expected_turn_start_offset: Option<u64>,
+    relay_owner_kind: RelayOwnerKind,
+) -> GuardedSaveOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let path = inflight_state_path(&root, provider, channel_id);
+    if let Some(parent) = path.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return GuardedSaveOutcome::IoError;
+        }
+    }
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let Ok(data) = fs::read_to_string(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    let Ok(mut on_disk) = serde_json::from_str::<InflightTurnState>(&data) else {
+        return GuardedSaveOutcome::IdentityMismatch;
+    };
+    if on_disk.restart_mode.is_some() || on_disk.rebind_origin {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if expected.user_msg_id == 0 || !expected.matches_state(&on_disk) {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if let Some(expected_offset) = expected_turn_start_offset {
+        if on_disk.turn_start_offset != Some(expected_offset) {
+            return GuardedSaveOutcome::IdentityMismatch;
+        }
+    }
+    on_disk.set_relay_owner_kind(relay_owner_kind);
+    on_disk.updated_at = now_string();
+    let Ok(json) = serde_json::to_string_pretty(&on_disk) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    match atomic_write(&path, &json) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = channel_id,
+                expected_user_msg_id = expected.user_msg_id,
+                error = %error,
+                "inflight relay-owner update failed; leaving on-disk row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}
+
 /// Root-explicit inner form of [`save_inflight_state_if_matches_identity`] for
 /// unit tests (avoids `AGENTDESK_ROOT_DIR` env-var races).
 pub(super) fn save_inflight_state_if_matches_identity_in_root(

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1329,7 +1329,11 @@ fn save_existing_inflight_rebind_adoption_if_matches_identity_in_root(
         }
     }
 
-    let mut updated = state.clone();
+    let mut updated = on_disk;
+    updated.tmux_session_name = state.tmux_session_name.clone();
+    updated.output_path = state.output_path.clone();
+    updated.input_fifo_path = state.input_fifo_path.clone();
+    updated.set_relay_owner_kind(state.effective_relay_owner_kind());
     updated.ensure_finalizer_turn_id();
     let _ = validate_inflight_state_for_save(
         root,
@@ -5843,6 +5847,62 @@ mod stall_recovery_tests {
             rows[0].restart_mode,
             Some(InflightRestartMode::DrainRestart)
         );
+    }
+
+    #[test]
+    fn existing_rebind_adoption_merges_into_fresh_on_disk_row() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = TempDir::new().unwrap();
+        let _env_reset = set_agentdesk_root_for_test(temp.path());
+        let mut on_disk = build_inflight_for_guard_tests(ProviderKind::Claude, 323, 777);
+        on_disk.user_msg_id = 777;
+        on_disk.current_msg_id = 778;
+        save_inflight_state_in_root(temp.path(), &on_disk).unwrap();
+
+        let expected = InflightTurnIdentity::from_state(&on_disk);
+        let mut adopted = on_disk.clone();
+        adopted.tmux_session_name = Some("AgentDesk-claude-adk-restored".to_string());
+        adopted.output_path = Some("/tmp/restored-output.jsonl".to_string());
+        adopted.input_fifo_path = Some("/tmp/restored-input.fifo".to_string());
+        adopted.set_relay_owner_kind(RelayOwnerKind::Watcher);
+
+        let mut progressed = on_disk.clone();
+        progressed.last_offset = 4096;
+        progressed.last_watcher_relayed_offset = Some(2048);
+        progressed.full_response = "newer streamed text".to_string();
+        save_inflight_state_in_root(temp.path(), &progressed).unwrap();
+
+        let outcome = save_existing_inflight_rebind_adoption_if_matches_identity_in_root(
+            temp.path(),
+            &adopted,
+            &expected,
+            on_disk.turn_start_offset,
+        );
+
+        assert_eq!(outcome, GuardedSaveOutcome::Saved);
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].tmux_session_name.as_deref(),
+            Some("AgentDesk-claude-adk-restored")
+        );
+        assert_eq!(
+            rows[0].output_path.as_deref(),
+            Some("/tmp/restored-output.jsonl")
+        );
+        assert_eq!(
+            rows[0].input_fifo_path.as_deref(),
+            Some("/tmp/restored-input.fifo")
+        );
+        assert_eq!(
+            rows[0].effective_relay_owner_kind(),
+            RelayOwnerKind::Watcher
+        );
+        assert_eq!(rows[0].last_offset, 4096);
+        assert_eq!(rows[0].last_watcher_relayed_offset, Some(2048));
+        assert_eq!(rows[0].full_response, "newer streamed text");
     }
 
     #[test]

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3635,20 +3635,22 @@ pub(crate) async fn rebind_inflight_for_channel(
         existing.output_path = Some(output_path.clone());
         existing.input_fifo_path = Some(input_fifo.clone());
         existing.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
-        let save_outcome = super::inflight::set_relay_owner_kind_if_matches_identity(
-            provider,
-            existing.channel_id,
-            &expected,
-            expected_turn_start_offset,
-            super::inflight::RelayOwnerKind::Watcher,
-        );
+        let save_outcome =
+            super::inflight::save_existing_inflight_rebind_adoption_if_matches_identity(
+                &existing,
+                &expected,
+                expected_turn_start_offset,
+            );
         if !matches!(save_outcome, super::inflight::GuardedSaveOutcome::Saved) {
             tracing::warn!(
                 channel_id,
                 tmux_session = %tmux_session_name,
                 ?save_outcome,
-                "rebind could not stamp existing inflight as watcher-owned",
+                "rebind could not persist existing inflight watcher adoption",
             );
+            return Err(RebindError::Internal(format!(
+                "persist existing inflight watcher adoption for channel {channel_id}: {save_outcome:?}"
+            )));
         }
         existing
     } else {

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3522,16 +3522,28 @@ pub(crate) async fn rebind_inflight_for_channel(
     // Validate provider↔channel binding against the settings snapshot,
     // mirroring what `restore_inflight_turns` requires for watcher revival.
     let settings_snapshot = shared.settings.read().await.clone();
+    let channel_lookup_timeout = std::time::Duration::from_secs(5);
     let is_dm = matches!(
-        discord_channel_id.to_channel(http).await,
-        Ok(serenity::model::channel::Channel::Private(_))
+        tokio::time::timeout(channel_lookup_timeout, discord_channel_id.to_channel(http)).await,
+        Ok(Ok(serenity::model::channel::Channel::Private(_)))
     );
-    let (allowlist_channel_id, provider_channel_name) =
-        if let Some((pid, pname)) = super::resolve_thread_parent(http, discord_channel_id).await {
-            (pid, pname.or(channel_name.clone()))
-        } else {
+    let (allowlist_channel_id, provider_channel_name) = match tokio::time::timeout(
+        channel_lookup_timeout,
+        super::resolve_thread_parent(http, discord_channel_id),
+    )
+    .await
+    {
+        Ok(Some((pid, pname))) => (pid, pname.or(channel_name.clone())),
+        Ok(None) => (discord_channel_id, channel_name.clone()),
+        Err(_) => {
+            tracing::warn!(
+                channel_id,
+                provider = provider.as_str(),
+                "rebind channel metadata lookup timed out; falling back to direct channel validation",
+            );
             (discord_channel_id, channel_name.clone())
-        };
+        }
+    };
     if validate_bot_channel_routing_with_provider_channel(
         &settings_snapshot,
         provider,
@@ -3617,14 +3629,26 @@ pub(crate) async fn rebind_inflight_for_channel(
     };
 
     let recovered_state_for_session = if let Some(mut existing) = existing_inflight.clone() {
+        let expected = super::inflight::InflightTurnIdentity::from_state(&existing);
+        let expected_turn_start_offset = existing.turn_start_offset;
         existing.tmux_session_name = Some(tmux_session_name.clone());
         existing.output_path = Some(output_path.clone());
         existing.input_fifo_path = Some(input_fifo.clone());
         existing.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
-        if let Err(error) = super::inflight::save_inflight_state(&existing) {
-            return Err(RebindError::Internal(format!(
-                "stamp existing inflight for watcher reattach: {error}"
-            )));
+        let save_outcome = super::inflight::set_relay_owner_kind_if_matches_identity(
+            provider,
+            existing.channel_id,
+            &expected,
+            expected_turn_start_offset,
+            super::inflight::RelayOwnerKind::Watcher,
+        );
+        if !matches!(save_outcome, super::inflight::GuardedSaveOutcome::Saved) {
+            tracing::warn!(
+                channel_id,
+                tmux_session = %tmux_session_name,
+                ?save_outcome,
+                "rebind could not stamp existing inflight as watcher-owned",
+            );
         }
         existing
     } else {

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -413,8 +413,7 @@ pub(in crate::services::discord) fn plan_relay_recovery(
             )
         }
         RelayStallState::QueueBlocked => {
-            let eligible = snapshot.queue_depth > 0
-                && matches!(snapshot.active_turn, RelayActiveTurn::None)
+            let eligible = matches!(snapshot.active_turn, RelayActiveTurn::None)
                 && !snapshot.mailbox_has_cancel_token
                 && snapshot.mailbox_active_user_msg_id.is_none();
             (
@@ -1175,6 +1174,25 @@ mod tests {
             "queued work is stranded behind an idle mailbox; bounded queue drain can restore delivery"
         );
         assert!(decision.auto_heal.eligible);
+        assert_eq!(decision.auto_heal.skipped_reason, None);
+    }
+
+    #[test]
+    fn queue_blocked_allows_disk_backed_queue_to_reach_drain_helper() {
+        let decision = plan_relay_recovery(
+            &RelayHealthSnapshot {
+                queue_depth: 0,
+                ..snapshot()
+            },
+            RelayStallState::QueueBlocked,
+            1_000,
+        );
+
+        assert_eq!(decision.action, RelayRecoveryActionKind::DrainPendingQueue);
+        assert!(
+            decision.auto_heal.eligible,
+            "disk-backed pending queues are hydrated by the drain helper"
+        );
         assert_eq!(decision.auto_heal.skipped_reason, None);
     }
 

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -508,20 +508,6 @@ async fn resolve_recovery_shared(
     provider: &ProviderKind,
     decision: &RelayRecoveryDecision,
 ) -> Option<Arc<SharedData>> {
-    let expected_tmux = decision.affected.tmux_session.as_deref();
-    for shared in registry.all_shared_for_provider(provider).await {
-        let Some(snapshot) = registry
-            .snapshot_watcher_state_for_shared(provider, shared.clone(), decision.channel_id)
-            .await
-        else {
-            continue;
-        };
-        if expected_tmux.is_none() || snapshot.relay_health.tmux_session.as_deref() == expected_tmux
-        {
-            return Some(shared);
-        }
-    }
-
     let channel = ChannelId::new(decision.channel_id);
     match tokio::time::timeout(
         std::time::Duration::from_secs(2),
@@ -530,14 +516,14 @@ async fn resolve_recovery_shared(
     .await
     {
         Ok(Some(shared)) => Some(shared),
-        Ok(None) => registry.shared_for_provider(provider).await,
+        Ok(None) => None,
         Err(_) => {
             tracing::warn!(
                 provider = provider.as_str(),
                 channel_id = decision.channel_id,
-                "relay recovery provider/channel runtime resolve timed out; falling back to provider runtime",
+                "relay recovery provider/channel runtime resolve timed out; skipping channel-scoped recovery",
             );
-            registry.shared_for_provider(provider).await
+            None
         }
     }
 }

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -29,6 +29,7 @@ pub(in crate::services::discord) enum RelayRecoveryActionKind {
     ClearStaleThreadProof,
     ClearOrphanPendingToken,
     ReattachWatcher,
+    DrainPendingQueue,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -66,6 +67,7 @@ impl RelayRecoveryActionKind {
             Self::ClearStaleThreadProof => "clear_stale_thread_proof",
             Self::ClearOrphanPendingToken => "clear_orphan_pending_token",
             Self::ReattachWatcher => "reattach_watcher",
+            Self::DrainPendingQueue => "drain_pending_queue",
         }
     }
 }
@@ -311,9 +313,15 @@ fn eligible_reattach_watcher(snapshot: &RelayHealthSnapshot) -> bool {
     // fresh-heartbeat live watcher still makes this ineligible: auto-heal
     // never replaces a live handle (that case is the finalizer far-backstop's
     // job, #3277 Defect C).
+    //
+    // A mailbox token is strong live-turn evidence, but it is not required for
+    // post-restart adoption: a valid inflight row can outlive the in-memory
+    // mailbox token while the AgentDesk tmux session keeps producing output.
+    // In that inflight-only shape, allow bounded reattach when there is no
+    // competing mailbox owner.
     snapshot.tmux_alive == Some(true)
         && snapshot.bridge_inflight_present
-        && snapshot.mailbox_has_cancel_token
+        && (snapshot.mailbox_has_cancel_token || snapshot.mailbox_active_user_msg_id.is_none())
         && (!snapshot.watcher_attached
             || snapshot.watcher_attached_stale
             || !snapshot.watcher_owns_live_relay
@@ -404,12 +412,22 @@ pub(in crate::services::discord) fn plan_relay_recovery(
                 }),
             )
         }
-        RelayStallState::QueueBlocked => (
-            RelayRecoveryActionKind::ObserveOnly,
-            "queued work is already surfaced as degraded health; relay recovery has no safe local cleanup",
-            false,
-            Some("operator_inspection_required"),
-        ),
+        RelayStallState::QueueBlocked => {
+            let eligible = snapshot.queue_depth > 0
+                && matches!(snapshot.active_turn, RelayActiveTurn::None)
+                && !snapshot.mailbox_has_cancel_token
+                && snapshot.mailbox_active_user_msg_id.is_none();
+            (
+                RelayRecoveryActionKind::DrainPendingQueue,
+                if eligible {
+                    "queued work is stranded behind an idle mailbox; bounded queue drain can restore delivery"
+                } else {
+                    "queued work exists but live turn evidence prevents automatic queue drain"
+                },
+                eligible,
+                (!eligible).then_some("queue_blocked_has_live_turn_evidence"),
+            )
+        }
     };
 
     RelayRecoveryDecision {
@@ -471,8 +489,7 @@ pub(in crate::services::discord) async fn run_relay_recovery(
     // Channel-aware: multi-bot deployments register several runtimes per
     // provider, so a name-only lookup would auto-heal the wrong runtime's
     // relay state for this channel.
-    let shared = registry
-        .shared_for_provider_on_channel(&provider, ChannelId::new(decision.channel_id))
+    let shared = resolve_recovery_shared(registry, &provider, &decision)
         .await
         .ok_or_else(|| RelayRecoveryError::ProviderUnavailable(decision.provider.clone()))?;
     Ok(apply_relay_recovery_plan(
@@ -484,6 +501,45 @@ pub(in crate::services::discord) async fn run_relay_recovery(
         RelayRecoveryApplySource::Manual,
     )
     .await)
+}
+
+async fn resolve_recovery_shared(
+    registry: &HealthRegistry,
+    provider: &ProviderKind,
+    decision: &RelayRecoveryDecision,
+) -> Option<Arc<SharedData>> {
+    let expected_tmux = decision.affected.tmux_session.as_deref();
+    for shared in registry.all_shared_for_provider(provider).await {
+        let Some(snapshot) = registry
+            .snapshot_watcher_state_for_shared(provider, shared.clone(), decision.channel_id)
+            .await
+        else {
+            continue;
+        };
+        if expected_tmux.is_none() || snapshot.relay_health.tmux_session.as_deref() == expected_tmux
+        {
+            return Some(shared);
+        }
+    }
+
+    let channel = ChannelId::new(decision.channel_id);
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        registry.shared_for_provider_on_channel(provider, channel),
+    )
+    .await
+    {
+        Ok(Some(shared)) => Some(shared),
+        Ok(None) => registry.shared_for_provider(provider).await,
+        Err(_) => {
+            tracing::warn!(
+                provider = provider.as_str(),
+                channel_id = decision.channel_id,
+                "relay recovery provider/channel runtime resolve timed out; falling back to provider runtime",
+            );
+            registry.shared_for_provider(provider).await
+        }
+    }
 }
 
 pub(in crate::services::discord) async fn auto_apply_relay_recovery_for_shared(
@@ -594,6 +650,7 @@ fn relay_recovery_status_counts_as_applied(status: &'static str) -> bool {
             | "reattached_watcher"
             | "reuse_existing_live_watcher"
             | "cleared_idle_tmux_stale_turn"
+            | "scheduled_pending_queue_drain"
     )
 }
 
@@ -782,6 +839,7 @@ async fn apply_relay_recovery_decision(
             let channel = ChannelId::new(decision.channel_id);
             forget_completion_footer_for_relay_recovery(channel);
             if let Some(tmux_session) = decision.affected.tmux_session.as_deref()
+                && decision.evidence.unread_bytes.unwrap_or(0) == 0
                 && idle_tmux_repair_ready_for_input(provider, decision.channel_id, tmux_session)
                 && super::inflight::inflight_state_allows_idle_tmux_repair(
                     provider,
@@ -885,6 +943,32 @@ async fn apply_relay_recovery_decision(
                 },
             }
         }
+        RelayRecoveryActionKind::DrainPendingQueue => {
+            let channel = ChannelId::new(decision.channel_id);
+            let outcome = super::health::schedule_pending_queue_drain_after_cancel(
+                registry,
+                provider.as_str(),
+                channel,
+                "relay_recovery_queue_blocked",
+            )
+            .await;
+            let after = mailbox_snapshot(shared, channel).await;
+            RelayRecoveryApplyResult {
+                status: if outcome.queue_depth_after > 0 {
+                    "scheduled_pending_queue_drain"
+                } else {
+                    "pending_queue_empty"
+                },
+                removed_thread_proofs: 0,
+                removed_mailbox_token: false,
+                post_mailbox_has_cancel_token: Some(after.cancel_token.is_some()),
+                post_mailbox_queue_depth: Some(after.intervention_queue.len()),
+                reattach_watcher_spawned: None,
+                reattach_watcher_replaced: None,
+                reattach_initial_offset: None,
+                reattach_error: None,
+            }
+        }
         RelayRecoveryActionKind::ObserveOnly => RelayRecoveryApplyResult {
             status: "skipped",
             removed_thread_proofs: 0,
@@ -948,6 +1032,13 @@ mod tests {
     fn auto_heal_test_lock() -> &'static tokio::sync::Mutex<()> {
         static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
+
+    fn isolated_agentdesk_root() -> (AgentdeskRootGuard, tempfile::TempDir) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let guard = AgentdeskRootGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        (guard, temp)
     }
 
     async fn registry_with_shared(provider: ProviderKind) -> (HealthRegistry, Arc<SharedData>) {
@@ -1082,7 +1173,7 @@ mod tests {
     }
 
     #[test]
-    fn queue_blocked_is_honest_observe_only_because_health_already_degrades() {
+    fn queue_blocked_schedules_bounded_pending_queue_drain_when_idle() {
         let decision = plan_relay_recovery(
             &RelayHealthSnapshot {
                 queue_depth: 2,
@@ -1092,15 +1183,33 @@ mod tests {
             1_000,
         );
 
-        assert_eq!(decision.action, RelayRecoveryActionKind::ObserveOnly);
+        assert_eq!(decision.action, RelayRecoveryActionKind::DrainPendingQueue);
         assert_eq!(
             decision.reason,
-            "queued work is already surfaced as degraded health; relay recovery has no safe local cleanup"
+            "queued work is stranded behind an idle mailbox; bounded queue drain can restore delivery"
         );
+        assert!(decision.auto_heal.eligible);
+        assert_eq!(decision.auto_heal.skipped_reason, None);
+    }
+
+    #[test]
+    fn queue_blocked_does_not_drain_when_live_turn_evidence_remains() {
+        let decision = plan_relay_recovery(
+            &RelayHealthSnapshot {
+                active_turn: RelayActiveTurn::Foreground,
+                mailbox_has_cancel_token: true,
+                queue_depth: 2,
+                ..snapshot()
+            },
+            RelayStallState::QueueBlocked,
+            1_000,
+        );
+
+        assert_eq!(decision.action, RelayRecoveryActionKind::DrainPendingQueue);
         assert!(!decision.auto_heal.eligible);
         assert_eq!(
             decision.auto_heal.skipped_reason,
-            Some("operator_inspection_required")
+            Some("queue_blocked_has_live_turn_evidence")
         );
     }
 
@@ -1310,7 +1419,7 @@ mod tests {
     }
 
     #[test]
-    fn live_agentdesk_tmux_relay_dead_without_mailbox_token_needs_operator() {
+    fn live_agentdesk_tmux_relay_dead_without_mailbox_token_can_adopt_ownerless_inflight() {
         let decision = plan_relay_recovery(
             &RelayHealthSnapshot {
                 tmux_session: Some("AgentDesk-codex-42".to_string()),
@@ -1325,11 +1434,8 @@ mod tests {
         );
 
         assert_eq!(decision.action, RelayRecoveryActionKind::ReattachWatcher);
-        assert!(!decision.auto_heal.eligible);
-        assert_eq!(
-            decision.auto_heal.skipped_reason,
-            Some("reattach_missing_required_live_evidence")
-        );
+        assert!(decision.auto_heal.eligible);
+        assert_eq!(decision.auto_heal.skipped_reason, None);
     }
 
     #[test]
@@ -1391,6 +1497,7 @@ mod tests {
     async fn auto_apply_orphan_pending_token_clears_mailbox_token() {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
+        let (_root_guard, _root_dir) = isolated_agentdesk_root();
         let provider = ProviderKind::Codex;
         let (registry, shared) = registry_with_shared(provider.clone()).await;
         let channel = ChannelId::new(3_360_001);
@@ -1439,6 +1546,7 @@ mod tests {
     async fn probe_auto_apply_is_rate_limited_per_channel_action() {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
+        let (_root_guard, _root_dir) = isolated_agentdesk_root();
         let provider = ProviderKind::Codex;
         let (registry, shared) = registry_with_shared(provider.clone()).await;
         let channel = ChannelId::new(3_360_002);
@@ -1487,6 +1595,7 @@ mod tests {
     async fn watchdog_auto_apply_is_rate_limited_after_first_token_reclaim() {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
+        let (_root_guard, _root_dir) = isolated_agentdesk_root();
         let provider = ProviderKind::Codex;
         let (registry, shared) = registry_with_shared(provider.clone()).await;
         let channel = ChannelId::new(3_360_005);
@@ -1573,6 +1682,7 @@ mod tests {
     async fn auto_apply_is_limited_to_requested_action_kind() {
         let _guard = auto_heal_test_lock().lock().await;
         clear_auto_heal_attempts_for_tests();
+        let (_root_guard, _root_dir) = isolated_agentdesk_root();
         let provider = ProviderKind::Codex;
         let (registry, shared) = registry_with_shared(provider.clone()).await;
         let parent = ChannelId::new(3_360_003);
@@ -1651,6 +1761,7 @@ mod tests {
 
     #[test]
     fn idle_tmux_repair_guard_detects_tail_answer_after_offset() {
+        let _guard = auto_heal_test_lock().blocking_lock();
         let _lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -1684,6 +1795,7 @@ mod tests {
 
     #[test]
     fn idle_tmux_repair_guard_silent_when_tail_empty() {
+        let _guard = auto_heal_test_lock().blocking_lock();
         let _lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
@@ -1715,6 +1827,7 @@ mod tests {
         // suppress the destructive clear — otherwise the watchdog would skip it
         // every tick forever (recovery only advances the offset on terminal
         // success). The guard requires success-result completion evidence.
+        let _guard = auto_heal_test_lock().blocking_lock();
         let _lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());


### PR DESCRIPTION
## 목표
재시작 또는 relay desync 이후 tmux 세션과 inflight 상태는 살아 있지만 watcher 소유권/relay offset이 끊긴 Discord relay를 안전하게 reattach합니다. 라이브 watcher를 무리하게 교체하지 않으면서, ownerless inflight는 복구 가능한 상태로 인정하는 것이 목표입니다.

## 쉬운 설명
AgentDesk가 재시작된 뒤에도 기존 tmux 세션이 계속 출력 중이면 relay watcher가 다시 붙을 수 있습니다. mailbox token이 메모리에서 사라진 경우라도 inflight와 tmux 증거가 충분하면 수동 조작 없이 복구 후보가 됩니다. 반대로 이미 살아 있는 watcher가 relay를 소유한 경우에는 자동 교체하지 않습니다. 테스트는 실제 release runtime root를 건드리지 않도록 temp root로 격리했습니다.

## 개선되는 것
### Fix 1
watcher가 끊겼거나 relay frontier가 멈춘 경우 bounded reattach 경로로 복구할 수 있습니다.

### Fix 2
mailbox token이 없어도 ownerless inflight와 AgentDesk tmux 세션 증거가 있으면 post-restart adoption을 허용합니다.

### Fix 3
relay recovery 테스트가 `AGENTDESK_ROOT_DIR` 전역 환경변수 충돌 없이 temp root에서 실행됩니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 재시작 후 tmux/inflight는 남고 watcher 소유권이 비어 있음 | operator rebind 필요 | bounded reattach 후보 |
| live watcher가 이미 relay 소유 | 교체 가능성 또는 불명확한 판정 | observe/operator-gated 유지 |
| 테스트 환경이 live release root를 상속 | 테스트 실패 또는 위험 가드 | temp root 격리 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| fresh heartbeat live watcher | 자동 교체하지 않음 | 중복 relay 방지 |
| orphan token cleanup rate limit | window당 1회 제한 | 반복 cleanup 방지 |
| JSONL tail에 최종 답변 존재 | destructive clear 차단 | 답변 유실 방지 |

## 해결한 내용
- `src/services/discord/relay_recovery.rs`: reattach eligibility와 auto-heal 테스트 격리 보강
- `src/services/discord/recovery_engine.rs`: 기존 inflight rebind 시 watcher owner stamping 보존
- `src/services/discord/inflight.rs`: relay owner/identity 기반 저장 보조 경로 추가
- `src/services/discord/health/snapshot.rs`: recovery 판단에 필요한 relay evidence 보강
- `src/services/cluster/session_discovery.rs`: session discovery evidence 보강

## 포트 메모
`kunkunGames/AgentDesk` fork의 relay recovery reattach 변경을 `itismyfield/AgentDesk:main` 기준으로 선별 포트했습니다. 최신 upstream과 충돌한 recovery phase/owner-stamping 부분은 upstream 로직을 보존하면서 reattach 변경만 합쳤습니다.

## 검증
- `cargo fmt --all --check`
- `cargo test -p agentdesk --lib relay_recovery`
