### PR TITLE
Agent handoff: fall back to primary mailbox for provider-specific agents

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1367,7 +1367,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3230 lines).
+  - `src/cli/migrate/apply.rs` (3231 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.
@@ -1390,7 +1390,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2529 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
@@ -1431,7 +1431,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
+  - `src/db/postgres.rs` (1141 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).
@@ -1461,7 +1461,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
-- `src/services/onboarding/mod.rs` (2936),
+- `src/services/onboarding/mod.rs` (2937),
   `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`

--- a/src/db/agents.rs
+++ b/src/db/agents.rs
@@ -127,9 +127,10 @@ impl AgentChannelBindings {
             // Codex instead of falling back to the Claude counterpart, which
             // would reserve a Claude turn on a Codex mailbox (P1, #3556).
             .or_else(|| {
-                (self.configured_provider_kind() == Some(ProviderKind::Codex))
-                    .then(|| self.legacy_primary_channel())
-                    .flatten()
+                (self.configured_provider_kind() == Some(ProviderKind::Codex)
+                    && normalized_channel(self.discord_channel_cc.clone()).is_none())
+                .then(|| self.legacy_primary_channel())
+                .flatten()
             })
     }
 
@@ -193,6 +194,28 @@ mod tests {
         assert_eq!(
             bindings.primary_channel().as_deref(),
             Some("1470000000000000005")
+        );
+    }
+
+    #[test]
+    fn resolved_primary_provider_keeps_codex_cc_only_binding_on_claude() {
+        // Config import can mirror channels.claude into both the legacy primary
+        // and explicit cc column for a Codex-configured row with no Codex
+        // mailbox. That explicit cc-only shape must remain Claude-owned.
+        let bindings = AgentChannelBindings {
+            provider: Some("codex".to_string()),
+            discord_channel_id: Some("1470000000000000006".to_string()),
+            discord_channel_cc: Some("1470000000000000006".to_string()),
+            ..AgentChannelBindings::default()
+        };
+
+        assert_eq!(
+            bindings.resolved_primary_provider_kind(),
+            Some(ProviderKind::Claude)
+        );
+        assert_eq!(
+            bindings.primary_channel().as_deref(),
+            Some("1470000000000000006")
         );
     }
 

--- a/src/db/agents.rs
+++ b/src/db/agents.rs
@@ -121,6 +121,16 @@ impl AgentChannelBindings {
     fn codex_channel(&self) -> Option<String> {
         normalized_channel(self.discord_channel_cdx.clone())
             .or_else(|| normalized_channel(self.discord_channel_alt.clone()))
+            // A Codex agent may be bound only via the legacy primary channel
+            // (discord_channel_id) without an explicit cdx/alt mailbox. Treat
+            // that primary channel as Codex-owned so provider resolution keeps
+            // Codex instead of falling back to the Claude counterpart, which
+            // would reserve a Claude turn on a Codex mailbox (P1, #3556).
+            .or_else(|| {
+                (self.configured_provider_kind() == Some(ProviderKind::Codex))
+                    .then(|| self.legacy_primary_channel())
+                    .flatten()
+            })
     }
 
     fn legacy_primary_channel(&self) -> Option<String> {
@@ -166,6 +176,23 @@ mod tests {
         assert_eq!(
             bindings.primary_channel().as_deref(),
             Some("1470000000000000002")
+        );
+    }
+
+    #[test]
+    fn resolved_primary_provider_keeps_codex_for_primary_only_binding() {
+        // A Codex agent bound only via discord_channel_id (no cdx/alt) must
+        // resolve to Codex, not slide to the Claude counterpart aliasing the
+        // same primary channel (#3556 P1 handoff fallback bug).
+        let bindings = binding("codex", "1470000000000000005");
+
+        assert_eq!(
+            bindings.resolved_primary_provider_kind(),
+            Some(ProviderKind::Codex)
+        );
+        assert_eq!(
+            bindings.primary_channel().as_deref(),
+            Some("1470000000000000005")
         );
     }
 

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1578,8 +1578,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         )
         .with_error_example(
             422,
-            json!({"path": {"id": "adk-dashboard"}, "body": {"from_agent_id": "project-agentdesk", "message": "hello", "channel_kind": "cc"}}),
-            json!({"error": "channel_kind unset", "to_agent_id": "adk-dashboard", "channel_kind": "cc", "available_kinds": ["cdx"]}),
+            json!({"path": {"id": "ghost-agent"}, "body": {"from_agent_id": "project-agentdesk", "message": "hello", "channel_kind": "cc"}}),
+            json!({"error": "channel_kind unset", "to_agent_id": "ghost-agent", "channel_kind": "cc", "available_kinds": []}),
         )
         .with_curl("curl -X POST http://localhost:8787/api/agents/adk-dashboard/message -H 'Content-Type: application/json' -d '{\"from_agent_id\":\"project-agentdesk\",\"message\":\"hello\",\"channel_kind\":\"cc\",\"prefix\":true,\"expect_reply\":true}'"),
         ep(

--- a/src/services/discord/agent_handoff.rs
+++ b/src/services/discord/agent_handoff.rs
@@ -770,6 +770,30 @@ mod tests {
     }
 
     #[test]
+    fn handoff_turn_target_keeps_codex_cc_only_binding_on_claude() {
+        // A Codex-configured row with only an explicit cc binding is Claude-owned;
+        // a missing cdx request must not reserve a Codex turn on that mailbox.
+        let codex_cc_only = AgentChannelBindings {
+            provider: Some("codex".to_string()),
+            discord_channel_id: Some("1495040912361914400".to_string()),
+            discord_channel_cc: Some("1495040912361914400".to_string()),
+            ..AgentChannelBindings::default()
+        };
+        let target = resolve_agent_handoff_turn_target(
+            &codex_cc_only,
+            "from",
+            "to",
+            "prompt",
+            AgentHandoffChannelKind::Cdx,
+            true,
+            None,
+        )
+        .expect("explicit cc-only fallback resolves via Claude");
+        assert_eq!(target.channel_id, "1495040912361914400");
+        assert_eq!(target.provider, ProviderKind::Claude);
+    }
+
+    #[test]
     fn handoff_turn_target_reaches_opencode_mailbox() {
         // opencode/gemini/qwen agents expose neither cc nor cdx; their mailbox
         // is discord_channel_id. Any requested kind must resolve there with the

--- a/src/services/discord/agent_handoff.rs
+++ b/src/services/discord/agent_handoff.rs
@@ -257,7 +257,14 @@ pub(crate) async fn send_agent_handoff(
         .map_err(|error| AgentHandoffError::internal(format!("query agent channels: {error}")))?
         .ok_or_else(|| AgentHandoffError::agent_not_found(to_agent_id))?;
 
-    let Some(channel_id) = channel_for_kind(&bindings, channel_kind) else {
+    // Honor an explicit cc/cdx binding when present, but fall back to the
+    // agent's primary channel so single-provider mailboxes that are not a
+    // cc/cdx slot (opencode/gemini/qwen — e.g. monitoring) and cross-provider
+    // sends (claude↔codex) remain reachable instead of erroring "channel_kind
+    // unset". The receiving channel's intake resolves the agent's real provider.
+    let Some(channel_id) =
+        channel_for_kind(&bindings, channel_kind).or_else(|| bindings.primary_channel())
+    else {
         return Err(AgentHandoffError::channel_kind_unset(
             to_agent_id,
             channel_kind,
@@ -372,12 +379,25 @@ fn resolve_agent_handoff_turn_target(
         return Err(AgentHandoffError::bad_request("prompt is required"));
     }
 
-    let Some(channel_id) = channel_for_kind(bindings, channel_kind) else {
-        return Err(AgentHandoffError::channel_kind_unset(
-            to_agent_id,
-            channel_kind,
-            available_channel_kinds(bindings),
-        ));
+    // Prefer the explicit cc/cdx mailbox; otherwise fall back to the agent's
+    // primary channel and its real provider so opencode/gemini/qwen mailboxes
+    // (and cross-provider sends) dispatch the turn on the correct CLI rather
+    // than rejecting with "channel_kind unset".
+    let (channel_id, provider) = match channel_for_kind(bindings, channel_kind) {
+        Some(channel_id) => (channel_id, provider_for_channel_kind(channel_kind)),
+        None => {
+            let Some(channel_id) = bindings.primary_channel() else {
+                return Err(AgentHandoffError::channel_kind_unset(
+                    to_agent_id,
+                    channel_kind,
+                    available_channel_kinds(bindings),
+                ));
+            };
+            let provider = bindings
+                .resolved_primary_provider_kind()
+                .unwrap_or_else(|| provider_for_channel_kind(channel_kind));
+            (channel_id, provider)
+        }
     };
 
     let Some(channel_id_num) =
@@ -399,7 +419,7 @@ fn resolve_agent_handoff_turn_target(
         channel_id,
         channel_id_num,
         channel_kind,
-        provider: provider_for_channel_kind(channel_kind),
+        provider,
         content,
     })
 }
@@ -705,9 +725,79 @@ mod tests {
     }
 
     #[test]
-    fn handoff_turn_target_rejects_unset_channel_kind() {
-        let error = resolve_agent_handoff_turn_target(
+    fn handoff_turn_target_falls_back_to_primary_for_single_provider() {
+        // Codex agent (only cdx set): a cc request must fall back to the cdx
+        // mailbox and the codex provider instead of rejecting, so cross-provider
+        // handoffs (e.g. a now-claude sender → codex peer) still reach it.
+        let target = resolve_agent_handoff_turn_target(
             &bindings(None, Some("222")),
+            "from",
+            "to",
+            "prompt",
+            AgentHandoffChannelKind::Cc,
+            true,
+            None,
+        )
+        .expect("falls back to the agent's primary channel");
+        assert_eq!(target.channel_id, "222");
+        assert_eq!(target.provider, ProviderKind::Codex);
+    }
+
+    #[test]
+    fn handoff_turn_target_keeps_codex_for_primary_only_binding() {
+        // Regression (#3556 P1): a Codex agent bound ONLY via discord_channel_id
+        // (no cdx/alt mailbox) must still resolve to the Codex provider. The
+        // earlier fallback derived Claude — codex_channel() found nothing, so
+        // resolution slid to the Claude counterpart aliasing the same primary
+        // channel — reserving a Claude turn on a Codex mailbox.
+        let codex = AgentChannelBindings {
+            provider: Some("codex".to_string()),
+            discord_channel_id: Some("1495040912361914399".to_string()),
+            ..AgentChannelBindings::default()
+        };
+        let target = resolve_agent_handoff_turn_target(
+            &codex,
+            "from",
+            "to",
+            "prompt",
+            AgentHandoffChannelKind::Cc,
+            true,
+            None,
+        )
+        .expect("codex primary-only binding resolves");
+        assert_eq!(target.channel_id, "1495040912361914399");
+        assert_eq!(target.provider, ProviderKind::Codex);
+    }
+
+    #[test]
+    fn handoff_turn_target_reaches_opencode_mailbox() {
+        // opencode/gemini/qwen agents expose neither cc nor cdx; their mailbox
+        // is discord_channel_id. Any requested kind must resolve there with the
+        // agent's real provider so monitoring (opencode) stays reachable.
+        let opencode = AgentChannelBindings {
+            provider: Some("opencode".to_string()),
+            discord_channel_id: Some("1495040912361914398".to_string()),
+            ..AgentChannelBindings::default()
+        };
+        let target = resolve_agent_handoff_turn_target(
+            &opencode,
+            "from",
+            "monitoring",
+            "prompt",
+            AgentHandoffChannelKind::Cdx,
+            true,
+            None,
+        )
+        .expect("opencode mailbox resolves via primary channel");
+        assert_eq!(target.channel_id, "1495040912361914398");
+        assert_eq!(target.provider, ProviderKind::OpenCode);
+    }
+
+    #[test]
+    fn handoff_turn_target_rejects_when_no_channel_at_all() {
+        // A genuinely unbound agent (no cc/cdx/primary channel) still errors.
+        let error = resolve_agent_handoff_turn_target(
+            &AgentChannelBindings::default(),
             "from",
             "to",
             "prompt",
@@ -717,7 +807,6 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::UNPROCESSABLE_ENTITY);
-        assert_eq!(error.body()["available_kinds"], json!(["cdx"]));
     }
 
     #[test]


### PR DESCRIPTION
## 목표
cc/cdx 전용 채널이 없는 agent handoff 대상도 primary Discord mailbox로 안전하게 turn-trigger handoff를 받을 수 있게 합니다. Codex primary-only agent는 Claude로 잘못 분류하지 않고 Codex provider를 유지합니다.

## 쉬운 설명
opencode, gemini, qwen처럼 cc/cdx 보조 mailbox가 없는 agent도 기본 Discord 채널이 있으면 handoff를 받을 수 있습니다. Codex agent가 primary channel만 가진 경우에도 Codex provider로 실행됩니다. 채널이 아예 없는 agent는 기존처럼 명확한 오류를 반환합니다.

## 개선되는 것
### Fix 1
cc/cdx channel이 비어 있어도 `discord_channel_id`가 있으면 handoff 대상 채널로 사용합니다.

### Fix 2
Codex primary-only binding이 Claude fallback으로 오분류되는 문제를 막습니다.

### Fix 3
opencode mailbox처럼 provider-specific primary channel만 가진 agent를 handoff 대상으로 해석합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| opencode agent에 cdx handoff | channel_kind unset 오류 | primary mailbox + OpenCode provider |
| Codex agent가 primary channel만 보유 | Claude provider로 잘못 예약 가능 | Codex provider 유지 |
| 채널이 전혀 없는 agent | 오류 | 오류 유지 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| cc/cdx 명시 채널 존재 | 명시 채널 우선 | 기존 동작 보존 |
| primary channel이 non-numeric | validation error | 잘못된 Discord 채널 차단 |
| target prompt blank | bad request | 빈 handoff 방지 |

## 해결한 내용
- `src/services/discord/agent_handoff.rs`: handoff target resolution에서 primary mailbox fallback과 provider 보존 로직 추가
- `src/db/agents.rs`: agent channel binding 조회에 필요한 provider/primary channel 정보 보강
- `src/server/routes/docs.rs`: handoff API 문서 응답을 새 fallback 계약에 맞게 갱신

## 포트 메모
`kunkunGames/AgentDesk` fork의 handoff fallback 변경을 `itismyfield/AgentDesk:main` 기준으로 선별 포트했습니다. 최신 upstream 함수 시그니처의 `expect_reply` 인자에 맞춰 테스트 호출부를 보정했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo test -p agentdesk --lib agent_handoff`
- `cargo check --all-targets`
