### PR TITLE
Dashboard: improve office accessibility and safe external links

### DIFF
--- a/dashboard/src/components/MeetingIssuePreview.tsx
+++ b/dashboard/src/components/MeetingIssuePreview.tsx
@@ -173,7 +173,7 @@ export default function MeetingIssuePreview({
                       <a
                         href={issueResult.issue_url}
                         target="_blank"
-                        rel="noreferrer"
+                        rel="noopener noreferrer"
                         className="mt-1 inline-flex max-w-full break-all hover:underline"
                         style={{ color: "#34d399" }}
                       >

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -237,12 +237,14 @@ export default function OfficeManagerModal({
                 <div className="space-y-4">
                   <div>
                 <label
+                  htmlFor="office-name-en"
                   className="block text-xs font-medium mb-1"
                   style={{ color: "var(--th-text-secondary)" }}
                 >
                   {tr("이름 (영문)", "Name (EN)")}
                 </label>
                 <input
+                  id="office-name-en"
                   value={draft.name}
                   onChange={(e) => setDraft((prev) => ({ ...prev, name: e.target.value }))}
                   className="w-full px-3 py-2 rounded-lg text-sm"
@@ -256,12 +258,14 @@ export default function OfficeManagerModal({
               </div>
                   <div>
                     <label
+                      htmlFor="office-name-ko"
                       className="block text-xs font-medium mb-1"
                       style={{ color: "var(--th-text-secondary)" }}
                     >
                       {tr("이름 (한국어)", "Name (KO)")}
                     </label>
                     <input
+                      id="office-name-ko"
                       value={draft.name_ko}
                       onChange={(e) => setDraft((prev) => ({ ...prev, name_ko: e.target.value }))}
                       className="w-full px-3 py-2 rounded-lg text-sm"

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -446,8 +446,18 @@ export default function OfficeManagerModal({
                 return (
                   <SurfaceCard
                     key={a.id}
+                    role="switch"
+                    aria-checked={inOffice}
+                    aria-label={tr(`${a.name_ko || a.name} - 오피스 멤버 토글`, `Toggle ${a.name} in office members`)}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        toggleAgent(a.id);
+                      }
+                    }}
                     onClick={() => toggleAgent(a.id)}
-                    className="w-full cursor-pointer p-2.5 text-left transition-all"
+                    className="w-full cursor-pointer p-2.5 text-left transition-all focus:outline-none focus:ring-2 focus:ring-[var(--th-accent-primary)] focus:ring-offset-2 focus:ring-offset-[var(--th-bg-surface)]"
                     style={{
                       background: inOffice
                         ? "color-mix(in srgb, var(--th-accent-primary-soft) 22%, var(--th-bg-surface) 78%)"

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -109,7 +109,7 @@ export default function OfficeManagerModal({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label={tr("오피스 관리", "Manage Offices")}
+        aria-labelledby="office-manager-title"
         className="mx-4 flex max-h-[84vh] w-full max-w-2xl flex-col rounded-[28px] border"
         style={{
           background:
@@ -123,6 +123,7 @@ export default function OfficeManagerModal({
           style={{ borderBottom: "1px solid color-mix(in srgb, var(--th-border) 72%, transparent)" }}
         >
           <h2
+            id="office-manager-title"
             className="text-lg font-bold"
             style={{ color: "var(--th-text-heading)" }}
           >

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -135,7 +135,7 @@ export default function OfficeManagerModal({
             {view === "agents" &&
               `${agentsOffice?.icon ?? ""} ${isKo ? agentsOffice?.name_ko : agentsOffice?.name} — ${tr("멤버 관리", "Manage Members")}`}
           </h2>
-          <SurfaceActionButton tone="neutral" compact onClick={onClose}>
+          <SurfaceActionButton tone="neutral" compact onClick={onClose} aria-label={tr("닫기", "Close")}>
             <X size={16} />
           </SurfaceActionButton>
         </div>

--- a/dashboard/src/components/OfficeManagerView.tsx
+++ b/dashboard/src/components/OfficeManagerView.tsx
@@ -217,6 +217,7 @@ export default function OfficeManagerView({
           <div className="mt-4 space-y-2">
             {order.map((office, index) => {
               const active = !creating && office.id === selectedId;
+              const displayName = isKo ? office.name_ko || office.name : office.name;
               return (
                 <SurfaceCard
                   key={office.id}
@@ -258,6 +259,7 @@ export default function OfficeManagerView({
                         borderColor: "color-mix(in srgb, var(--th-border) 64%, transparent)",
                       }}
                       title={tr("위로", "Move Up")}
+                      aria-label={tr(`${displayName} 위로 이동`, `Move ${displayName} Up`)}
                     >
                       <ArrowUp size={13} />
                     </button>
@@ -273,6 +275,7 @@ export default function OfficeManagerView({
                         borderColor: "color-mix(in srgb, var(--th-border) 64%, transparent)",
                       }}
                       title={tr("아래로", "Move Down")}
+                      aria-label={tr(`${displayName} 아래로 이동`, `Move ${displayName} Down`)}
                     >
                       <ArrowDown size={13} />
                     </button>

--- a/dashboard/src/components/agent-manager/AutoQueueEntryRow.tsx
+++ b/dashboard/src/components/agent-manager/AutoQueueEntryRow.tsx
@@ -181,7 +181,7 @@ export function EntryRow({
                       key={key}
                       href={href}
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                       onClick={(event) => event.stopPropagation()}
                       className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium transition-colors hover:brightness-110"
                       style={{

--- a/dashboard/src/components/agent-manager/BacklogCardDrawer.tsx
+++ b/dashboard/src/components/agent-manager/BacklogCardDrawer.tsx
@@ -294,7 +294,7 @@ export default function BacklogCardDrawer({
                 <a
                   href={githubIssueUrl}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center rounded-full px-3 py-2 text-sm font-medium hover:underline"
                   style={{ color: "#93c5fd" }}
                 >

--- a/dashboard/src/components/agent-manager/BacklogIssueDetail.tsx
+++ b/dashboard/src/components/agent-manager/BacklogIssueDetail.tsx
@@ -164,7 +164,7 @@ export default function BacklogIssueDetail({
           <a
             href={issue.url}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="rounded-xl px-4 py-2 text-sm text-center hover:underline"
             style={{ color: "#93c5fd" }}
           >

--- a/dashboard/src/components/agent-manager/KanbanBoard.tsx
+++ b/dashboard/src/components/agent-manager/KanbanBoard.tsx
@@ -255,7 +255,7 @@ export default function KanbanBoard({
                         <a
                           href={githubIssueUrl}
                           target="_blank"
-                          rel="noreferrer"
+                          rel="noopener noreferrer"
                           className="shrink-0 text-xs hover:underline"
                           onClick={(event) => event.stopPropagation()}
                           style={{ color: "#93c5fd" }}

--- a/dashboard/src/components/agent-manager/KanbanCardDetail.tsx
+++ b/dashboard/src/components/agent-manager/KanbanCardDetail.tsx
@@ -389,7 +389,7 @@ export default function KanbanCardDetail({
             <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("GitHub", "GitHub")}</div>
             <div style={{ color: "var(--th-text-primary)" }}>
               {githubIssueUrl ? (
-                <a href={githubIssueUrl} target="_blank" rel="noreferrer" className="hover:underline" style={{ color: "#93c5fd" }}>
+                <a href={githubIssueUrl} target="_blank" rel="noopener noreferrer" className="hover:underline" style={{ color: "#93c5fd" }}>
                   #{selectedCard.github_issue_number ?? "-"}
                 </a>
               ) : (

--- a/dashboard/src/components/agent-manager/KanbanColumn.tsx
+++ b/dashboard/src/components/agent-manager/KanbanColumn.tsx
@@ -206,7 +206,7 @@ function BacklogIssueCard({
         <a
           href={issue.url}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="text-xs hover:underline"
           style={{ color: "#93c5fd" }}
           onClick={(event) => event.stopPropagation()}
@@ -318,7 +318,7 @@ function KanbanCardArticle({
           <a
             href={githubIssueUrl}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="text-xs hover:underline"
             style={{ color: "var(--info)" }}
             onClick={(event) => event.stopPropagation()}

--- a/dashboard/src/components/office-view/OfficeAgentDrawer.tsx
+++ b/dashboard/src/components/office-view/OfficeAgentDrawer.tsx
@@ -309,7 +309,7 @@ export default function OfficeAgentDrawer({
                     <a
                       href={currentTaskIssueUrl}
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                       className="rounded-full border px-2.5 py-1 text-xs font-semibold transition hover:opacity-90"
                       style={{
                         borderColor: "color-mix(in srgb, var(--th-accent-info) 30%, var(--th-border) 70%)",
@@ -445,7 +445,7 @@ export default function OfficeAgentDrawer({
                     {(summary.webUrl || summary.deepLink) && (
                       <div className="mt-3 flex flex-wrap gap-2">
                         {summary.webUrl && (
-                          <a href={summary.webUrl} target="_blank" rel="noreferrer">
+                          <a href={summary.webUrl} target="_blank" rel="noopener noreferrer">
                             <SurfaceActionButton tone="info" compact>
                               {t(isKo, "웹에서 열기", "Open web")}
                             </SurfaceActionButton>
@@ -532,14 +532,14 @@ export default function OfficeAgentDrawer({
                     {(entry.card_issue_url || session?.channel_web_url || session?.channel_deeplink_url) && (
                       <div className="mt-3 flex flex-wrap gap-2">
                         {entry.card_issue_url && (
-                          <a href={entry.card_issue_url} target="_blank" rel="noreferrer">
+                          <a href={entry.card_issue_url} target="_blank" rel="noopener noreferrer">
                             <SurfaceActionButton tone="neutral" compact>
                               {t(isKo, "GitHub 이슈", "GitHub issue")}
                             </SurfaceActionButton>
                           </a>
                         )}
                         {session?.channel_web_url && (
-                          <a href={session.channel_web_url} target="_blank" rel="noreferrer">
+                          <a href={session.channel_web_url} target="_blank" rel="noopener noreferrer">
                             <SurfaceActionButton tone="info" compact>
                               {t(isKo, "Discord 웹", "Discord web")}
                             </SurfaceActionButton>


### PR DESCRIPTION
## 목표
Dashboard의 Office/Agent Manager UI 접근성을 개선하고, 새 탭 외부 링크에 `noopener noreferrer`를 일관되게 적용합니다.

## 쉬운 설명
Office manager modal과 agent toggle 카드가 스크린리더/키보드 사용자에게 더 명확하게 동작합니다. 외부 링크는 새 탭을 열 때 opener 접근을 차단합니다. UI 동작은 유지하면서 접근성 속성과 링크 보안 속성만 보강합니다.

## 개선되는 것
### Fix 1
OfficeManagerModal dialog title, close button, input label 연결을 보강합니다.

### Fix 2
Office agent toggle card의 keyboard interaction과 aria labeling을 개선합니다.

### Fix 3
`target=_blank` dashboard 링크에 `rel="noopener noreferrer"`를 적용합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| modal screen reader 탐색 | title/label 연결이 불완전 | dialog title/input label 연결 |
| toggle card keyboard 조작 | 일부 카드 조작이 불명확 | keyboard accessible toggle |
| 새 탭 외부 링크 | opener 접근 가능 | noopener noreferrer 적용 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 기존 클릭 동작 | 유지 | behavior change 없음 |
| 내부 링크 | 변경 없음 | 외부 새 탭 링크만 보강 |
| dashboard build | 성공 | 타입/번들 검증 완료 |

## 해결한 내용
- `dashboard/src/components/OfficeManagerModal.tsx`: dialog title, close button aria-label, form label 연결
- `dashboard/src/components/OfficeManagerView.tsx`, `dashboard/src/components/office-view/OfficeAgentDrawer.tsx`: office controls aria-label 보강
- `dashboard/src/components/agent-manager/*`: 새 탭 링크 rel 속성 보강
- `dashboard/src/components/MeetingIssuePreview.tsx`: 새 탭 링크 rel 속성 보강

## 포트 메모
`kunkunGames/AgentDesk` fork의 dashboard 접근성 및 링크 안전성 변경을 `itismyfield/AgentDesk:main` 기준으로 묶어 포트했습니다.

## 검증
- `npm --prefix dashboard ci`
- `npm --prefix dashboard run build`
