### PR TITLE
Config: expand hot-reload coverage and restart-required reporting

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1367,7 +1367,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3230 lines).
+  - `src/cli/migrate/apply.rs` (3231 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.
@@ -1390,7 +1390,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2559 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
@@ -1431,7 +1431,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
+  - `src/db/postgres.rs` (1141 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).
@@ -1461,7 +1461,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
-- `src/services/onboarding/mod.rs` (2936),
+- `src/services/onboarding/mod.rs` (2937),
   `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,9 +65,11 @@ pub struct Config {
     /// without a restart, mirroring the policies watcher: the candidate file is
     /// pre-validated (parsed + runtime defaults applied) and only then atomically
     /// swapped in; a parse/validation failure keeps the running config. Infra
-    /// fields (`server` bind/port/auth, `database`, `data.dir`) are NOT
-    /// hot-swapped — a change to those is applied to the shared snapshot but
-    /// logged as restart-required, since live subsystems bound them at boot.
+    /// fields (`server` bind/port/auth, `database`, `data.dir`, `discord` client
+    /// and bot bindings, `providers` runtimes, `mcp_servers` child processes, the
+    /// `mcp` credential watcher, and the `memory` backend) are NOT hot-swapped —
+    /// a change to those is applied to the shared snapshot but logged as
+    /// restart-required, since live subsystems bound them at boot.
     #[serde(default = "default_true")]
     pub config_hot_reload: bool,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2480,9 +2480,9 @@ pub fn load() -> Result<Config> {
     let config = config
         .apply_runtime_defaults()
         .resolve_runtime_relative_paths(runtime_root.as_deref());
-    validate_config(&config).with_context(|| format!("Invalid config: {path_display}"))?;
     register_config_secrets(&config);
     audit_config_file_permissions_if_secret_bearing(&path, &config);
+    validate_config(&config).with_context(|| format!("Invalid config: {path_display}"))?;
 
     // Ensure data dir exists
     std::fs::create_dir_all(&config.data.dir)?;
@@ -2516,9 +2516,9 @@ pub fn load_from_path(path: &Path) -> Result<Config> {
     let config = config
         .apply_runtime_defaults()
         .resolve_runtime_relative_paths(runtime_root.as_deref());
-    validate_config(&config).with_context(|| format!("Invalid config {}", path.display()))?;
     register_config_secrets(&config);
     audit_config_file_permissions_if_secret_bearing(path, &config);
+    validate_config(&config).with_context(|| format!("Invalid config {}", path.display()))?;
     Ok(config)
 }
 
@@ -2663,6 +2663,29 @@ mod secret_bearing_config_file_tests {
             let loaded = load_from_path(&path).unwrap();
             assert_eq!(loaded.database.password.as_deref(), Some("database-secret"));
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_from_path_hardens_secret_file_before_semantic_validation_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentdesk.yaml");
+        let mut config = Config::default();
+        config.database.password = Some("database-secret".to_string());
+        config.escalation.schedule.timezone = Some("Mars/Olympus".to_string());
+        save_to_path(&path, &config).unwrap();
+
+        let mut loose_permissions = std::fs::metadata(&path).unwrap().permissions();
+        loose_permissions.set_mode(0o644);
+        std::fs::set_permissions(&path, loose_permissions).unwrap();
+
+        let error = format!("{:#}", load_from_path(&path).unwrap_err());
+
+        assert!(error.contains("schedule.timezone must be a valid IANA timezone"));
+        let hardened_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(hardened_mode, 0o600);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,12 +65,12 @@ pub struct Config {
     /// without a restart, mirroring the policies watcher: the candidate file is
     /// pre-validated (parsed + runtime defaults applied) and only then atomically
     /// swapped in; a parse/validation failure keeps the running config. Infra
-    /// fields (`server` bind/port/auth, `database`, `data.dir`, `discord` client
-    /// and bot bindings, `providers` runtimes, `agents` per-channel runtime
-    /// hosting overrides, `mcp_servers` child processes, the `mcp` credential
-    /// watcher, and the `memory` backend) are NOT hot-swapped — a change to
-    /// those is applied to the shared snapshot but logged as restart-required,
-    /// since live subsystems bound them at boot.
+    /// fields (`server` bind/port/auth, `database`, `data.dir`, `cluster`,
+    /// Discord/provider/agent launch and voice runtimes, MCP child processes and
+    /// credential watcher, `memory`, GitHub sync cadence, prompt retention, and
+    /// the config watcher flag itself) are NOT hot-swapped — a change to those is
+    /// applied to the shared snapshot but logged as restart-required, since live
+    /// subsystems bound them at boot.
     #[serde(default = "default_true")]
     pub config_hot_reload: bool,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::voice::{VoiceConfig, barge_in::BargeInSensitivity};
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -66,10 +66,11 @@ pub struct Config {
     /// pre-validated (parsed + runtime defaults applied) and only then atomically
     /// swapped in; a parse/validation failure keeps the running config. Infra
     /// fields (`server` bind/port/auth, `database`, `data.dir`, `discord` client
-    /// and bot bindings, `providers` runtimes, `mcp_servers` child processes, the
-    /// `mcp` credential watcher, and the `memory` backend) are NOT hot-swapped —
-    /// a change to those is applied to the shared snapshot but logged as
-    /// restart-required, since live subsystems bound them at boot.
+    /// and bot bindings, `providers` runtimes, `agents` per-channel runtime
+    /// hosting overrides, `mcp_servers` child processes, the `mcp` credential
+    /// watcher, and the `memory` backend) are NOT hot-swapped — a change to
+    /// those is applied to the shared snapshot but logged as restart-required,
+    /// since live subsystems bound them at boot.
     #[serde(default = "default_true")]
     pub config_hot_reload: bool,
 }
@@ -2471,6 +2472,7 @@ pub fn load() -> Result<Config> {
     let config = config
         .apply_runtime_defaults()
         .resolve_runtime_relative_paths(runtime_root.as_deref());
+    validate_config(&config).with_context(|| format!("Invalid config: {path_display}"))?;
     register_config_secrets(&config);
     audit_config_file_permissions_if_secret_bearing(&path, &config);
 
@@ -2506,9 +2508,35 @@ pub fn load_from_path(path: &Path) -> Result<Config> {
     let config = config
         .apply_runtime_defaults()
         .resolve_runtime_relative_paths(runtime_root.as_deref());
+    validate_config(&config).with_context(|| format!("Invalid config {}", path.display()))?;
     register_config_secrets(&config);
     audit_config_file_permissions_if_secret_bearing(path, &config);
     Ok(config)
+}
+
+fn validate_config(config: &Config) -> Result<()> {
+    validate_escalation_schedule(&config.escalation.schedule)
+}
+
+fn validate_escalation_schedule(schedule: &EscalationScheduleConfig) -> Result<()> {
+    if let Some(timezone) = schedule.timezone.as_deref()
+        && timezone.parse::<chrono_tz::Tz>().is_err()
+    {
+        bail!("schedule.timezone must be a valid IANA timezone");
+    }
+    if let Some(pm_hours) = schedule.pm_hours.as_deref()
+        && parse_escalation_time_window(pm_hours).is_none()
+    {
+        bail!("schedule.pm_hours must be HH:MM-HH:MM");
+    }
+    Ok(())
+}
+
+fn parse_escalation_time_window(raw: &str) -> Option<(chrono::NaiveTime, chrono::NaiveTime)> {
+    let (start, end) = raw.trim().split_once('-')?;
+    let start = chrono::NaiveTime::parse_from_str(start.trim(), "%H:%M").ok()?;
+    let end = chrono::NaiveTime::parse_from_str(end.trim(), "%H:%M").ok()?;
+    Some((start, end))
 }
 
 fn register_config_secrets(config: &Config) {
@@ -2568,6 +2596,32 @@ pub fn save_to_path(path: &Path, config: &Config) -> Result<()> {
 #[cfg(test)]
 mod secret_bearing_config_file_tests {
     use super::*;
+
+    #[test]
+    fn load_from_path_rejects_invalid_escalation_schedule_timezone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentdesk.yaml");
+        let mut config = Config::default();
+        config.escalation.schedule.timezone = Some("Mars/Olympus".to_string());
+        save_to_path(&path, &config).unwrap();
+
+        let error = format!("{:#}", load_from_path(&path).unwrap_err());
+
+        assert!(error.contains("schedule.timezone must be a valid IANA timezone"));
+    }
+
+    #[test]
+    fn load_from_path_rejects_invalid_escalation_schedule_pm_hours() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentdesk.yaml");
+        let mut config = Config::default();
+        config.escalation.schedule.pm_hours = Some("soon".to_string());
+        save_to_path(&path, &config).unwrap();
+
+        let error = format!("{:#}", load_from_path(&path).unwrap_err());
+
+        assert!(error.contains("schedule.pm_hours must be HH:MM-HH:MM"));
+    }
 
     #[test]
     fn save_and_load_harden_secret_bearing_config_file() {

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -137,7 +137,7 @@ struct AgentProviderRuntimeBindingKey {
     channel_id: u64,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Default, PartialEq, Eq)]
 struct AgentProviderRuntimeBindingValue {
     tui_hosting: Option<bool>,
     runtime: Option<String>,
@@ -146,7 +146,8 @@ struct AgentProviderRuntimeBindingValue {
 fn agent_provider_runtime_bindings(
     config: &Config,
 ) -> BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue> {
-    let mut bindings = BTreeMap::new();
+    let mut bindings: BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue> =
+        BTreeMap::new();
     for agent in &config.agents {
         for (channel_kind, channel) in agent.channels.iter() {
             let Some(channel) = channel else {
@@ -160,24 +161,23 @@ fn agent_provider_runtime_bindings(
             };
             let tui_hosting = channel.tui_hosting();
             let runtime = channel.runtime_mode_raw();
-            if tui_hosting.is_none() && runtime.is_none() {
-                continue;
-            }
             let provider_id = channel
                 .provider()
                 .unwrap_or_else(|| channel_kind.to_string())
                 .trim()
                 .to_ascii_lowercase();
-            bindings.insert(
-                AgentProviderRuntimeBindingKey {
+            let entry = bindings
+                .entry(AgentProviderRuntimeBindingKey {
                     provider_id,
                     channel_id,
-                },
-                AgentProviderRuntimeBindingValue {
-                    tui_hosting,
-                    runtime,
-                },
-            );
+                })
+                .or_default();
+            if tui_hosting.is_some() {
+                entry.tui_hosting = tui_hosting;
+            }
+            if runtime.is_some() {
+                entry.runtime = runtime;
+            }
         }
     }
     bindings
@@ -605,6 +605,33 @@ mod tests {
         let mut tui_changed = old.clone();
         tui_changed.agents[0] = test_agent_with_claude_channel("123", Some(true), Some("pipe"));
         assert_eq!(restart_required_changes(&old, &tui_changed), vec!["agents"]);
+    }
+
+    #[test]
+    fn restart_required_changes_flags_agent_channel_launch_bindings() {
+        let old = Config::default();
+        let mut new = old.clone();
+        new.agents
+            .push(test_agent_with_claude_channel("123", None, None));
+
+        assert_eq!(restart_required_changes(&old, &new), vec!["agents"]);
+    }
+
+    #[test]
+    fn restart_required_changes_preserves_split_duplicate_agent_channel_overrides() {
+        let mut old = Config::default();
+        old.agents
+            .push(test_agent_with_claude_channel("123", None, Some("pipe")));
+        old.agents
+            .push(test_agent_with_claude_channel("123", Some(false), None));
+
+        let mut new = Config::default();
+        new.agents
+            .push(test_agent_with_claude_channel("123", None, Some("tui")));
+        new.agents
+            .push(test_agent_with_claude_channel("123", Some(false), None));
+
+        assert_eq!(restart_required_changes(&old, &new), vec!["agents"]);
     }
 
     #[test]

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -25,7 +25,7 @@
 //! follows the existing global-runtime-setter precedent
 //! (`set_runtime_cluster_config`) so consumers opt in by reading [`current`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
@@ -134,7 +134,7 @@ fn discord_boot_config_changed(old: &DiscordConfig, new: &DiscordConfig) -> bool
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct AgentProviderRuntimeBindingKey {
     provider_id: String,
-    channel_id: u64,
+    target: String,
 }
 
 #[derive(Default, PartialEq, Eq)]
@@ -143,22 +143,42 @@ struct AgentProviderRuntimeBindingValue {
     runtime: Option<String>,
 }
 
-fn agent_provider_runtime_bindings(
-    config: &Config,
-) -> BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue> {
+#[derive(Default, PartialEq, Eq)]
+struct AgentLaunchFingerprint {
+    provider_keys: BTreeSet<String>,
+    agent_ids: BTreeSet<String>,
+    channel_ids: BTreeSet<u64>,
+    runtime_bindings: BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue>,
+}
+
+fn agent_launch_fingerprint(config: &Config) -> AgentLaunchFingerprint {
     let mut bindings: BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue> =
         BTreeMap::new();
+    let mut provider_keys = BTreeSet::new();
+    let mut agent_ids = BTreeSet::new();
+    let mut channel_ids = BTreeSet::new();
     for agent in &config.agents {
+        let agent_id = agent.id.trim().to_ascii_lowercase();
+        if !agent_id.is_empty() {
+            agent_ids.insert(agent_id);
+        }
         for (channel_kind, channel) in agent.channels.iter() {
             let Some(channel) = channel else {
                 continue;
             };
-            let Some(channel_id) = channel
-                .channel_id()
-                .and_then(|value| value.parse::<u64>().ok())
-            else {
+            let Some(target) = channel.target() else {
                 continue;
             };
+            let normalized_provider_key = channel_kind.trim().to_ascii_lowercase();
+            if !normalized_provider_key.is_empty() {
+                provider_keys.insert(normalized_provider_key);
+            }
+            if let Some(channel_id) = channel
+                .channel_id()
+                .and_then(|value| value.parse::<u64>().ok())
+            {
+                channel_ids.insert(channel_id);
+            }
             let tui_hosting = channel.tui_hosting();
             let runtime = channel.runtime_mode_raw();
             let provider_id = channel
@@ -166,10 +186,11 @@ fn agent_provider_runtime_bindings(
                 .unwrap_or_else(|| channel_kind.to_string())
                 .trim()
                 .to_ascii_lowercase();
+            let target = target.trim().to_ascii_lowercase();
             let entry = bindings
                 .entry(AgentProviderRuntimeBindingKey {
                     provider_id,
-                    channel_id,
+                    target,
                 })
                 .or_default();
             if tui_hosting.is_some() {
@@ -180,7 +201,12 @@ fn agent_provider_runtime_bindings(
             }
         }
     }
-    bindings
+    AgentLaunchFingerprint {
+        provider_keys,
+        agent_ids,
+        channel_ids,
+        runtime_bindings: bindings,
+    }
 }
 
 /// The infra sections that are bound into long-lived objects at boot and cannot
@@ -205,6 +231,11 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     if section_changed(&old.data, &new.data) {
         changed.push("data");
     }
+    // The policy engine constructs its QuickJS runtime, directory watcher, and
+    // hook timeout/memory limits at boot.
+    if section_changed(&old.policies, &new.policies) {
+        changed.push("policies");
+    }
     // The Discord client + bot bindings/ids are constructed at boot.
     if discord_boot_config_changed(&old.discord, &new.discord) {
         changed.push("discord");
@@ -214,8 +245,10 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
         changed.push("providers");
     }
     // Per-agent channel provider runtime/tui_hosting bindings are installed
-    // into process-global maps at boot by `services::provider_hosting`.
-    if agent_provider_runtime_bindings(old) != agent_provider_runtime_bindings(new) {
+    // into process-global maps at boot by `services::provider_hosting`; the
+    // Discord bot launcher also uses provider keys, agent ids, and channel ids
+    // to decide which configured bots actually run.
+    if agent_launch_fingerprint(old) != agent_launch_fingerprint(new) {
         changed.push("agents");
     }
     // MCP servers are spawned as child processes at boot.
@@ -229,6 +262,13 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     // The memory backend (file paths / MCP endpoint) is bound at boot.
     if section_changed(&old.memory, &new.memory) {
         changed.push("memory");
+    }
+    // Prompt-manifest retention is installed into a set-once boot snapshot.
+    if section_changed(
+        &old.prompt_manifest_retention,
+        &new.prompt_manifest_retention,
+    ) {
+        changed.push("prompt_manifest_retention");
     }
     changed
 }
@@ -458,6 +498,18 @@ mod tests {
         }
     }
 
+    fn test_agent_with_named_claude_channel(channel_name: &str) -> crate::config::AgentDef {
+        let mut agent = test_agent_with_claude_channel("123", None, None);
+        agent.channels.claude = Some(crate::config::AgentChannel::Detailed(
+            crate::config::AgentChannelConfig {
+                name: Some(channel_name.to_string()),
+                provider: Some("claude".to_string()),
+                ..crate::config::AgentChannelConfig::default()
+            },
+        ));
+        agent
+    }
+
     // A valid edit validates and swaps into the live snapshot.
     #[test]
     fn reload_applies_valid_config() {
@@ -508,6 +560,10 @@ mod tests {
         new = old.clone();
         new.data.dir = old.data.dir.join("moved");
         assert_eq!(restart_required_changes(&old, &new), vec!["data"]);
+
+        new = old.clone();
+        new.policies.hook_timeout_ms = old.policies.hook_timeout_ms.wrapping_add(1);
+        assert_eq!(restart_required_changes(&old, &new), vec!["policies"]);
     }
 
     // A hot-swappable-only change (routine tunable) reports no restart-required.
@@ -559,6 +615,16 @@ mod tests {
         let mut memory = base.clone();
         memory.memory = Some(crate::config::MemoryConfig::default());
         assert_eq!(restart_required_changes(&base, &memory), vec!["memory"]);
+
+        let mut prompt_retention = base.clone();
+        prompt_retention.prompt_manifest_retention.full_content_days = base
+            .prompt_manifest_retention
+            .full_content_days
+            .wrapping_add(1);
+        assert_eq!(
+            restart_required_changes(&base, &prompt_retention),
+            vec!["prompt_manifest_retention"]
+        );
     }
 
     #[test]
@@ -615,6 +681,19 @@ mod tests {
             .push(test_agent_with_claude_channel("123", None, None));
 
         assert_eq!(restart_required_changes(&old, &new), vec!["agents"]);
+
+        let mut name_target = old.clone();
+        name_target
+            .agents
+            .push(test_agent_with_named_claude_channel("voice-codex"));
+        assert_eq!(restart_required_changes(&old, &name_target), vec!["agents"]);
+
+        let mut renamed_agent = new.clone();
+        renamed_agent.agents[0].id = "renamed-dispatcher".to_string();
+        assert_eq!(
+            restart_required_changes(&new, &renamed_agent),
+            vec!["agents"]
+        );
     }
 
     #[test]

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -13,9 +13,11 @@
 //!
 //! Subsystems read the live snapshot via [`current`] each cycle, so settings
 //! they re-read per tick (e.g. routine tunables) take effect without a restart.
-//! Infra fields (`server` bind/port/auth, `database`, `data`) are bound into
-//! long-lived objects at boot and cannot be swapped under a running process; a
-//! change to those is still stored in the snapshot but reported by
+//! Infra fields (`server` bind/port/auth, `database`, `data`, `discord` client
+//! and bot bindings, `providers` runtimes, `mcp_servers` child processes, the
+//! `mcp` credential watcher, and the `memory` backend) are bound into long-lived
+//! objects at boot and cannot be swapped under a running process; a change to
+//! those is still stored in the snapshot but reported by
 //! [`restart_required_changes`] and logged as restart-required.
 //!
 //! The whole-`Config` value is NOT threaded through every reader — instead this
@@ -83,9 +85,17 @@ fn section_changed<T: Serialize>(old: &T, new: &T) -> bool {
     }
 }
 
-/// The infra sections that are bound at boot and cannot be hot-swapped under a
-/// running process. A change here is applied to the snapshot but needs a restart
-/// to take full effect.
+/// The infra sections that are bound into long-lived objects at boot and cannot
+/// be hot-swapped under a running process. A change here is applied to the
+/// snapshot but needs a restart to take full effect, so it is reported to the
+/// operator (logged as restart-required) instead of silently appearing to apply.
+///
+/// Without this list, editing e.g. a Discord bot token, an `mcp_servers` entry,
+/// or a `providers` runtime in `agentdesk.yaml` would swap into the snapshot
+/// with no observable effect and no warning — the exact "the edit did nothing"
+/// trap. Section-level granularity matches `section_changed`; note that fields
+/// marked `skip_serializing` (e.g. bot tokens) do not move the serialized form,
+/// so a token-only change is not detected here (same caveat as `server.auth_token`).
 pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str> {
     let mut changed = Vec::new();
     if section_changed(&old.server, &new.server) {
@@ -96,6 +106,26 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     }
     if section_changed(&old.data, &new.data) {
         changed.push("data");
+    }
+    // The Discord client + bot bindings/ids are constructed at boot.
+    if section_changed(&old.discord, &new.discord) {
+        changed.push("discord");
+    }
+    // Provider runtimes (TUI hosting, remote SSH) are wired up at boot.
+    if section_changed(&old.providers, &new.providers) {
+        changed.push("providers");
+    }
+    // MCP servers are spawned as child processes at boot.
+    if section_changed(&old.mcp_servers, &new.mcp_servers) {
+        changed.push("mcp_servers");
+    }
+    // The MCP credential watcher (and its dedupe window) is started at boot.
+    if section_changed(&old.mcp, &new.mcp) {
+        changed.push("mcp");
+    }
+    // The memory backend (file paths / MCP endpoint) is bound at boot.
+    if section_changed(&old.memory, &new.memory) {
+        changed.push("memory");
     }
     changed
 }
@@ -338,5 +368,46 @@ mod tests {
         new.routines.max_agent_polls_per_tick =
             old.routines.max_agent_polls_per_tick.wrapping_add(1);
         assert!(restart_required_changes(&old, &new).is_empty());
+    }
+
+    // Each boot-bound section is surfaced as restart-required, so editing e.g. a
+    // Discord binding, a provider runtime, an MCP server, the credential watcher,
+    // or the memory backend in `agentdesk.yaml` is reported rather than silently
+    // swapped into the snapshot with no running effect.
+    #[test]
+    fn restart_required_changes_flags_boot_bound_sections() {
+        let base = Config::default();
+
+        let mut discord = base.clone();
+        discord.discord.owner_id = Some(42);
+        assert_eq!(restart_required_changes(&base, &discord), vec!["discord"]);
+
+        let mut providers = base.clone();
+        providers.providers.insert(
+            "codex".to_string(),
+            crate::config::ProviderConfig::default(),
+        );
+        assert_eq!(
+            restart_required_changes(&base, &providers),
+            vec!["providers"]
+        );
+
+        let mut mcp_servers = base.clone();
+        mcp_servers.mcp_servers.insert(
+            "memento".to_string(),
+            crate::config::McpServerConfig::default(),
+        );
+        assert_eq!(
+            restart_required_changes(&base, &mcp_servers),
+            vec!["mcp_servers"]
+        );
+
+        let mut mcp = base.clone();
+        mcp.mcp.watch_credentials = !base.mcp.watch_credentials;
+        assert_eq!(restart_required_changes(&base, &mcp), vec!["mcp"]);
+
+        let mut memory = base.clone();
+        memory.memory = Some(crate::config::MemoryConfig::default());
+        assert_eq!(restart_required_changes(&base, &memory), vec!["memory"]);
     }
 }

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -13,12 +13,12 @@
 //!
 //! Subsystems read the live snapshot via [`current`] each cycle, so settings
 //! they re-read per tick (e.g. routine tunables) take effect without a restart.
-//! Infra fields (`server` bind/port/auth, `database`, `data`, `discord` client
-//! and bot bindings, `providers` runtimes, `agents` per-channel runtime hosting
-//! overrides, `mcp_servers` child processes, the `mcp` credential watcher, and
-//! the `memory` backend) are bound into long-lived objects at boot and cannot be
-//! swapped under a running process; a change to those is still stored in the
-//! snapshot but reported by
+//! Boot-bound fields (`server` bind/port/auth, `database`, `data`, `cluster`,
+//! Discord client and bot bindings, provider runtimes, agent launch/voice
+//! bindings, global voice runtime settings, MCP child processes/credentials,
+//! memory backend, GitHub sync cadence, prompt retention, and watcher flags) are
+//! bound into long-lived objects at boot and cannot be swapped under a running
+//! process; a change to those is still stored in the snapshot but reported by
 //! [`restart_required_changes`] and logged as restart-required.
 //!
 //! The whole-`Config` value is NOT threaded through every reader — instead this
@@ -34,7 +34,10 @@ use std::time::{Duration, Instant};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Serialize;
 
-use crate::config::{BotConfig, Config, DiscordBotAuthConfig, DiscordConfig};
+use crate::config::{
+    AgentVoiceConfig, BotConfig, Config, DiscordBotAuthConfig, DiscordConfig, RoutinesConfig,
+};
+use crate::voice::barge_in::BargeInSensitivity;
 
 /// Process-global live config snapshot. `None` until [`install`] runs at boot.
 static LIVE: OnceLock<RwLock<Arc<Config>>> = OnceLock::new();
@@ -149,6 +152,16 @@ struct AgentLaunchFingerprint {
     agent_ids: BTreeSet<String>,
     channel_ids: BTreeSet<u64>,
     runtime_bindings: BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue>,
+    voice_bindings: Vec<AgentVoiceRestartFingerprint>,
+}
+
+#[derive(PartialEq, Eq)]
+struct AgentVoiceRestartFingerprint {
+    agent_id: String,
+    fallback_provider: String,
+    voice_enabled: bool,
+    sensitivity_mode: Option<BargeInSensitivity>,
+    voice: AgentVoiceConfig,
 }
 
 fn agent_launch_fingerprint(config: &Config) -> AgentLaunchFingerprint {
@@ -157,10 +170,20 @@ fn agent_launch_fingerprint(config: &Config) -> AgentLaunchFingerprint {
     let mut provider_keys = BTreeSet::new();
     let mut agent_ids = BTreeSet::new();
     let mut channel_ids = BTreeSet::new();
+    let mut voice_bindings = Vec::new();
     for agent in &config.agents {
         let agent_id = agent.id.trim().to_ascii_lowercase();
         if !agent_id.is_empty() {
             agent_ids.insert(agent_id);
+        }
+        if agent_voice_restart_relevant(agent) {
+            voice_bindings.push(AgentVoiceRestartFingerprint {
+                agent_id: agent.id.trim().to_ascii_lowercase(),
+                fallback_provider: agent.provider.trim().to_ascii_lowercase(),
+                voice_enabled: agent.voice_enabled,
+                sensitivity_mode: agent.sensitivity_mode,
+                voice: agent.voice.clone(),
+            });
         }
         for (channel_kind, channel) in agent.channels.iter() {
             let Some(channel) = channel else {
@@ -206,6 +229,32 @@ fn agent_launch_fingerprint(config: &Config) -> AgentLaunchFingerprint {
         agent_ids,
         channel_ids,
         runtime_bindings: bindings,
+        voice_bindings,
+    }
+}
+
+fn agent_voice_restart_relevant(agent: &crate::config::AgentDef) -> bool {
+    !agent.voice_enabled || agent.sensitivity_mode.is_some() || !agent.voice.is_default()
+}
+
+#[derive(PartialEq, Eq)]
+struct RoutinesRestartFingerprint {
+    enabled: bool,
+    script_dirs: Vec<PathBuf>,
+    tick_interval_secs: u64,
+    default_timezone: String,
+    agent_timeout_secs: u64,
+    max_checkpoint_bytes: usize,
+}
+
+fn routines_restart_fingerprint(routines: &RoutinesConfig) -> RoutinesRestartFingerprint {
+    RoutinesRestartFingerprint {
+        enabled: routines.enabled,
+        script_dirs: routines.script_dirs(),
+        tick_interval_secs: routines.tick_interval_secs,
+        default_timezone: routines.default_timezone.clone(),
+        agent_timeout_secs: routines.agent_timeout_secs,
+        max_checkpoint_bytes: routines.max_checkpoint_bytes,
     }
 }
 
@@ -214,12 +263,12 @@ fn agent_launch_fingerprint(config: &Config) -> AgentLaunchFingerprint {
 /// snapshot but needs a restart to take full effect, so it is reported to the
 /// operator (logged as restart-required) instead of silently appearing to apply.
 ///
-/// Without this list, editing e.g. a Discord bot token, an `mcp_servers` entry,
-/// or a `providers` runtime in `agentdesk.yaml` would swap into the snapshot
-/// with no observable effect and no warning — the exact "the edit did nothing"
-/// trap. Most sections use serialized equality for broad coverage, while
-/// secret-bearing or order-sensitive sections use deterministic non-logging
-/// fingerprints.
+/// Without this list, editing e.g. a Discord bot token, a cluster role, an
+/// `mcp_servers` entry, or a `providers` runtime in `agentdesk.yaml` would swap
+/// into the snapshot with no observable effect and no warning — the exact "the
+/// edit did nothing" trap. Most sections use serialized equality for broad
+/// coverage, while secret-bearing or order-sensitive sections use deterministic
+/// non-logging fingerprints.
 pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str> {
     let mut changed = Vec::new();
     if section_changed(&old.server, &new.server) {
@@ -230,6 +279,10 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     }
     if section_changed(&old.data, &new.data) {
         changed.push("data");
+    }
+    // Cluster runtime and wait-queue snapshots are installed at boot.
+    if old.cluster != new.cluster {
+        changed.push("cluster");
     }
     // The policy engine constructs its QuickJS runtime, directory watcher, and
     // hook timeout/memory limits at boot.
@@ -251,9 +304,19 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     if agent_launch_fingerprint(old) != agent_launch_fingerprint(new) {
         changed.push("agents");
     }
+    // Discord voice receive/STT/TTS workers are constructed during gateway setup.
+    if old.voice != new.voice {
+        changed.push("voice");
+    }
     // MCP servers are spawned as child processes at boot.
     if section_changed(&old.mcp_servers, &new.mcp_servers) {
         changed.push("mcp_servers");
+    }
+    // Review slim-mode MCP catalogs are generated during provider bootstrap.
+    if normalized_string_set(&old.review_mcp_allowlist)
+        != normalized_string_set(&new.review_mcp_allowlist)
+    {
+        changed.push("review_mcp_allowlist");
     }
     // The MCP credential watcher (and its dedupe window) is started at boot.
     if section_changed(&old.mcp, &new.mcp) {
@@ -263,6 +326,19 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     if section_changed(&old.memory, &new.memory) {
         changed.push("memory");
     }
+    // GitHub sync worker cadence is captured when the worker starts.
+    if old.github.sync_interval_minutes != new.github.sync_interval_minutes {
+        changed.push("github");
+    }
+    // Discord placeholder/status-panel flags are copied into shared UI state at boot.
+    if old.placeholder != new.placeholder {
+        changed.push("placeholder");
+    }
+    // Routine worker startup, script dirs, tick cadence, store limits/timezone, and
+    // agent timeout are boot-bound. Per-tick caps and alert knobs are live-read.
+    if routines_restart_fingerprint(&old.routines) != routines_restart_fingerprint(&new.routines) {
+        changed.push("routines");
+    }
     // Prompt-manifest retention is installed into a set-once boot snapshot.
     if section_changed(
         &old.prompt_manifest_retention,
@@ -270,7 +346,20 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
     ) {
         changed.push("prompt_manifest_retention");
     }
+    // The file watcher itself is created (or skipped) from the boot value.
+    if old.config_hot_reload != new.config_hot_reload {
+        changed.push("config_hot_reload");
+    }
     changed
+}
+
+fn normalized_string_set(values: &[String]) -> BTreeSet<String> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// Re-read, validate, and (on success) atomically swap in the config at `path`.
@@ -569,10 +658,33 @@ mod tests {
     // A hot-swappable-only change (routine tunable) reports no restart-required.
     #[test]
     fn routine_tunable_change_needs_no_restart() {
-        let old = Config::default();
+        let mut old = Config::default();
+        old.routines.enabled = true;
         let mut new = old.clone();
         new.routines.max_agent_polls_per_tick =
             old.routines.max_agent_polls_per_tick.wrapping_add(1);
+        assert!(restart_required_changes(&old, &new).is_empty());
+
+        new = old.clone();
+        new.routines.max_due_per_tick = old.routines.max_due_per_tick.wrapping_add(1);
+        assert!(restart_required_changes(&old, &new).is_empty());
+
+        new = old.clone();
+        new.routines.hot_reload = !old.routines.hot_reload;
+        assert!(restart_required_changes(&old, &new).is_empty());
+
+        new = old.clone();
+        new.routines.stale_paused_alert_secs = old.routines.stale_paused_alert_secs.wrapping_add(1);
+        assert!(restart_required_changes(&old, &new).is_empty());
+
+        new = old.clone();
+        new.routines.stale_paused_alert_ttl_secs =
+            old.routines.stale_paused_alert_ttl_secs.wrapping_add(1);
+        assert!(restart_required_changes(&old, &new).is_empty());
+
+        new = old.clone();
+        new.routines.failure_pause_auto_resume_secs =
+            old.routines.failure_pause_auto_resume_secs.wrapping_add(1);
         assert!(restart_required_changes(&old, &new).is_empty());
     }
 
@@ -616,6 +728,37 @@ mod tests {
         memory.memory = Some(crate::config::MemoryConfig::default());
         assert_eq!(restart_required_changes(&base, &memory), vec!["memory"]);
 
+        let mut cluster = base.clone();
+        cluster.cluster.enabled = !base.cluster.enabled;
+        assert_eq!(restart_required_changes(&base, &cluster), vec!["cluster"]);
+
+        let mut global_voice = base.clone();
+        global_voice.voice.enabled = !base.voice.enabled;
+        assert_eq!(
+            restart_required_changes(&base, &global_voice),
+            vec!["voice"]
+        );
+
+        let mut review_mcp_allowlist = base.clone();
+        review_mcp_allowlist
+            .review_mcp_allowlist
+            .push("memento".to_string());
+        assert_eq!(
+            restart_required_changes(&base, &review_mcp_allowlist),
+            vec!["review_mcp_allowlist"]
+        );
+
+        let mut github = base.clone();
+        github.github.sync_interval_minutes = base.github.sync_interval_minutes.wrapping_add(1);
+        assert_eq!(restart_required_changes(&base, &github), vec!["github"]);
+
+        let mut placeholder = base.clone();
+        placeholder.placeholder.live_events_enabled = !base.placeholder.live_events_enabled;
+        assert_eq!(
+            restart_required_changes(&base, &placeholder),
+            vec!["placeholder"]
+        );
+
         let mut prompt_retention = base.clone();
         prompt_retention.prompt_manifest_retention.full_content_days = base
             .prompt_manifest_retention
@@ -624,6 +767,64 @@ mod tests {
         assert_eq!(
             restart_required_changes(&base, &prompt_retention),
             vec!["prompt_manifest_retention"]
+        );
+
+        let mut config_hot_reload = base.clone();
+        config_hot_reload.config_hot_reload = !base.config_hot_reload;
+        assert_eq!(
+            restart_required_changes(&base, &config_hot_reload),
+            vec!["config_hot_reload"]
+        );
+    }
+
+    #[test]
+    fn restart_required_changes_flags_boot_bound_routine_settings() {
+        let base = Config::default();
+
+        let mut enabled = base.clone();
+        enabled.routines.enabled = !base.routines.enabled;
+        assert_eq!(restart_required_changes(&base, &enabled), vec!["routines"]);
+
+        let mut dir = base.clone();
+        dir.routines.dir = PathBuf::from("./alternate-routines");
+        assert_eq!(restart_required_changes(&base, &dir), vec!["routines"]);
+
+        let mut additional_dirs = base.clone();
+        additional_dirs
+            .routines
+            .additional_dirs
+            .push(PathBuf::from("./operator-routines"));
+        assert_eq!(
+            restart_required_changes(&base, &additional_dirs),
+            vec!["routines"]
+        );
+
+        let mut tick_interval = base.clone();
+        tick_interval.routines.tick_interval_secs =
+            base.routines.tick_interval_secs.wrapping_add(1);
+        assert_eq!(
+            restart_required_changes(&base, &tick_interval),
+            vec!["routines"]
+        );
+
+        let mut timezone = base.clone();
+        timezone.routines.default_timezone = "UTC".to_string();
+        assert_eq!(restart_required_changes(&base, &timezone), vec!["routines"]);
+
+        let mut agent_timeout = base.clone();
+        agent_timeout.routines.agent_timeout_secs =
+            base.routines.agent_timeout_secs.wrapping_add(1);
+        assert_eq!(
+            restart_required_changes(&base, &agent_timeout),
+            vec!["routines"]
+        );
+
+        let mut checkpoint_limit = base.clone();
+        checkpoint_limit.routines.max_checkpoint_bytes =
+            base.routines.max_checkpoint_bytes.wrapping_add(1);
+        assert_eq!(
+            restart_required_changes(&base, &checkpoint_limit),
+            vec!["routines"]
         );
     }
 
@@ -692,6 +893,27 @@ mod tests {
         renamed_agent.agents[0].id = "renamed-dispatcher".to_string();
         assert_eq!(
             restart_required_changes(&new, &renamed_agent),
+            vec!["agents"]
+        );
+    }
+
+    #[test]
+    fn restart_required_changes_flags_agent_voice_bindings() {
+        let mut old = Config::default();
+        old.agents
+            .push(test_agent_with_claude_channel("123", None, None));
+
+        let mut voice_channel_changed = old.clone();
+        voice_channel_changed.agents[0].voice.channel_id = Some("456".to_string());
+        assert_eq!(
+            restart_required_changes(&old, &voice_channel_changed),
+            vec!["agents"]
+        );
+
+        let mut foreground_changed = voice_channel_changed.clone();
+        foreground_changed.agents[0].voice.foreground.provider = Some("codex".to_string());
+        assert_eq!(
+            restart_required_changes(&voice_channel_changed, &foreground_changed),
             vec!["agents"]
         );
     }

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -25,7 +25,7 @@
 //! follows the existing global-runtime-setter precedent
 //! (`set_runtime_cluster_config`) so consumers opt in by reading [`current`].
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
@@ -132,15 +132,21 @@ fn discord_boot_config_changed(old: &DiscordConfig, new: &DiscordConfig) -> bool
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct AgentProviderRuntimeBinding {
+struct AgentProviderRuntimeBindingKey {
     provider_id: String,
     channel_id: u64,
+}
+
+#[derive(PartialEq, Eq)]
+struct AgentProviderRuntimeBindingValue {
     tui_hosting: Option<bool>,
     runtime: Option<String>,
 }
 
-fn agent_provider_runtime_bindings(config: &Config) -> BTreeSet<AgentProviderRuntimeBinding> {
-    let mut bindings = BTreeSet::new();
+fn agent_provider_runtime_bindings(
+    config: &Config,
+) -> BTreeMap<AgentProviderRuntimeBindingKey, AgentProviderRuntimeBindingValue> {
+    let mut bindings = BTreeMap::new();
     for agent in &config.agents {
         for (channel_kind, channel) in agent.channels.iter() {
             let Some(channel) = channel else {
@@ -162,12 +168,16 @@ fn agent_provider_runtime_bindings(config: &Config) -> BTreeSet<AgentProviderRun
                 .unwrap_or_else(|| channel_kind.to_string())
                 .trim()
                 .to_ascii_lowercase();
-            bindings.insert(AgentProviderRuntimeBinding {
-                provider_id,
-                channel_id,
-                tui_hosting,
-                runtime,
-            });
+            bindings.insert(
+                AgentProviderRuntimeBindingKey {
+                    provider_id,
+                    channel_id,
+                },
+                AgentProviderRuntimeBindingValue {
+                    tui_hosting,
+                    runtime,
+                },
+            );
         }
     }
     bindings
@@ -595,5 +605,34 @@ mod tests {
         let mut tui_changed = old.clone();
         tui_changed.agents[0] = test_agent_with_claude_channel("123", Some(true), Some("pipe"));
         assert_eq!(restart_required_changes(&old, &tui_changed), vec!["agents"]);
+    }
+
+    #[test]
+    fn restart_required_changes_preserves_duplicate_agent_channel_last_wins() {
+        let mut old = Config::default();
+        old.agents.push(test_agent_with_claude_channel(
+            "123",
+            Some(false),
+            Some("pipe"),
+        ));
+        old.agents.push(test_agent_with_claude_channel(
+            "123",
+            Some(false),
+            Some("tui"),
+        ));
+
+        let mut new = Config::default();
+        new.agents.push(test_agent_with_claude_channel(
+            "123",
+            Some(false),
+            Some("tui"),
+        ));
+        new.agents.push(test_agent_with_claude_channel(
+            "123",
+            Some(false),
+            Some("pipe"),
+        ));
+
+        assert_eq!(restart_required_changes(&old, &new), vec!["agents"]);
     }
 }

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -14,16 +14,18 @@
 //! Subsystems read the live snapshot via [`current`] each cycle, so settings
 //! they re-read per tick (e.g. routine tunables) take effect without a restart.
 //! Infra fields (`server` bind/port/auth, `database`, `data`, `discord` client
-//! and bot bindings, `providers` runtimes, `mcp_servers` child processes, the
-//! `mcp` credential watcher, and the `memory` backend) are bound into long-lived
-//! objects at boot and cannot be swapped under a running process; a change to
-//! those is still stored in the snapshot but reported by
+//! and bot bindings, `providers` runtimes, `agents` per-channel runtime hosting
+//! overrides, `mcp_servers` child processes, the `mcp` credential watcher, and
+//! the `memory` backend) are bound into long-lived objects at boot and cannot be
+//! swapped under a running process; a change to those is still stored in the
+//! snapshot but reported by
 //! [`restart_required_changes`] and logged as restart-required.
 //!
 //! The whole-`Config` value is NOT threaded through every reader — instead this
 //! follows the existing global-runtime-setter precedent
 //! (`set_runtime_cluster_config`) so consumers opt in by reading [`current`].
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
@@ -32,7 +34,7 @@ use std::time::{Duration, Instant};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Serialize;
 
-use crate::config::Config;
+use crate::config::{BotConfig, Config, DiscordBotAuthConfig, DiscordConfig};
 
 /// Process-global live config snapshot. `None` until [`install`] runs at boot.
 static LIVE: OnceLock<RwLock<Arc<Config>>> = OnceLock::new();
@@ -85,6 +87,92 @@ fn section_changed<T: Serialize>(old: &T, new: &T) -> bool {
     }
 }
 
+#[derive(PartialEq, Eq)]
+struct DiscordRestartFingerprint {
+    bots: BTreeMap<String, DiscordBotRestartFingerprint>,
+    guild_id: Option<String>,
+    dm_default_agent: Option<String>,
+    owner_id: Option<u64>,
+}
+
+#[derive(PartialEq, Eq)]
+struct DiscordBotRestartFingerprint {
+    token: Option<String>,
+    description: Option<String>,
+    provider: Option<String>,
+    agent: Option<String>,
+    auth: DiscordBotAuthConfig,
+}
+
+fn discord_restart_fingerprint(discord: &DiscordConfig) -> DiscordRestartFingerprint {
+    DiscordRestartFingerprint {
+        bots: discord
+            .bots
+            .iter()
+            .map(|(name, bot)| (name.clone(), discord_bot_restart_fingerprint(bot)))
+            .collect(),
+        guild_id: discord.guild_id.clone(),
+        dm_default_agent: discord.dm_default_agent.clone(),
+        owner_id: discord.owner_id,
+    }
+}
+
+fn discord_bot_restart_fingerprint(bot: &BotConfig) -> DiscordBotRestartFingerprint {
+    DiscordBotRestartFingerprint {
+        token: bot.token.clone(),
+        description: bot.description.clone(),
+        provider: bot.provider.clone(),
+        agent: bot.agent.clone(),
+        auth: bot.auth.clone(),
+    }
+}
+
+fn discord_boot_config_changed(old: &DiscordConfig, new: &DiscordConfig) -> bool {
+    discord_restart_fingerprint(old) != discord_restart_fingerprint(new)
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct AgentProviderRuntimeBinding {
+    provider_id: String,
+    channel_id: u64,
+    tui_hosting: Option<bool>,
+    runtime: Option<String>,
+}
+
+fn agent_provider_runtime_bindings(config: &Config) -> BTreeSet<AgentProviderRuntimeBinding> {
+    let mut bindings = BTreeSet::new();
+    for agent in &config.agents {
+        for (channel_kind, channel) in agent.channels.iter() {
+            let Some(channel) = channel else {
+                continue;
+            };
+            let Some(channel_id) = channel
+                .channel_id()
+                .and_then(|value| value.parse::<u64>().ok())
+            else {
+                continue;
+            };
+            let tui_hosting = channel.tui_hosting();
+            let runtime = channel.runtime_mode_raw();
+            if tui_hosting.is_none() && runtime.is_none() {
+                continue;
+            }
+            let provider_id = channel
+                .provider()
+                .unwrap_or_else(|| channel_kind.to_string())
+                .trim()
+                .to_ascii_lowercase();
+            bindings.insert(AgentProviderRuntimeBinding {
+                provider_id,
+                channel_id,
+                tui_hosting,
+                runtime,
+            });
+        }
+    }
+    bindings
+}
+
 /// The infra sections that are bound into long-lived objects at boot and cannot
 /// be hot-swapped under a running process. A change here is applied to the
 /// snapshot but needs a restart to take full effect, so it is reported to the
@@ -93,9 +181,9 @@ fn section_changed<T: Serialize>(old: &T, new: &T) -> bool {
 /// Without this list, editing e.g. a Discord bot token, an `mcp_servers` entry,
 /// or a `providers` runtime in `agentdesk.yaml` would swap into the snapshot
 /// with no observable effect and no warning — the exact "the edit did nothing"
-/// trap. Section-level granularity matches `section_changed`; note that fields
-/// marked `skip_serializing` (e.g. bot tokens) do not move the serialized form,
-/// so a token-only change is not detected here (same caveat as `server.auth_token`).
+/// trap. Most sections use serialized equality for broad coverage, while
+/// secret-bearing or order-sensitive sections use deterministic non-logging
+/// fingerprints.
 pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str> {
     let mut changed = Vec::new();
     if section_changed(&old.server, &new.server) {
@@ -108,12 +196,17 @@ pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str>
         changed.push("data");
     }
     // The Discord client + bot bindings/ids are constructed at boot.
-    if section_changed(&old.discord, &new.discord) {
+    if discord_boot_config_changed(&old.discord, &new.discord) {
         changed.push("discord");
     }
     // Provider runtimes (TUI hosting, remote SSH) are wired up at boot.
     if section_changed(&old.providers, &new.providers) {
         changed.push("providers");
+    }
+    // Per-agent channel provider runtime/tui_hosting bindings are installed
+    // into process-global maps at boot by `services::provider_hosting`.
+    if agent_provider_runtime_bindings(old) != agent_provider_runtime_bindings(new) {
+        changed.push("agents");
     }
     // MCP servers are spawned as child processes at boot.
     if section_changed(&old.mcp_servers, &new.mcp_servers) {
@@ -308,6 +401,52 @@ mod tests {
         std::fs::write(path, body).unwrap();
     }
 
+    fn test_bot(token: &str) -> crate::config::BotConfig {
+        crate::config::BotConfig {
+            token: Some(token.to_string()),
+            description: Some("test bot".to_string()),
+            provider: Some("claude".to_string()),
+            agent: Some("dispatcher".to_string()),
+            auth: crate::config::DiscordBotAuthConfig {
+                allowed_channel_ids: Some(vec![42]),
+                ..crate::config::DiscordBotAuthConfig::default()
+            },
+        }
+    }
+
+    fn test_agent_with_claude_channel(
+        channel_id: &str,
+        tui_hosting: Option<bool>,
+        runtime: Option<&str>,
+    ) -> crate::config::AgentDef {
+        crate::config::AgentDef {
+            id: "dispatcher".to_string(),
+            name: "Dispatcher".to_string(),
+            name_ko: None,
+            aliases: Vec::new(),
+            wake_word: None,
+            voice_enabled: true,
+            sensitivity_mode: None,
+            voice: crate::config::AgentVoiceConfig::default(),
+            provider: "codex".to_string(),
+            channels: crate::config::AgentChannels {
+                claude: Some(crate::config::AgentChannel::Detailed(
+                    crate::config::AgentChannelConfig {
+                        id: Some(channel_id.to_string()),
+                        provider: Some("claude".to_string()),
+                        tui_hosting,
+                        runtime: runtime.map(str::to_string),
+                        ..crate::config::AgentChannelConfig::default()
+                    },
+                )),
+                ..crate::config::AgentChannels::default()
+            },
+            keywords: Vec::new(),
+            department: None,
+            avatar_emoji: None,
+        }
+    }
+
     // A valid edit validates and swaps into the live snapshot.
     #[test]
     fn reload_applies_valid_config() {
@@ -409,5 +548,51 @@ mod tests {
         let mut memory = base.clone();
         memory.memory = Some(crate::config::MemoryConfig::default());
         assert_eq!(restart_required_changes(&base, &memory), vec!["memory"]);
+    }
+
+    #[test]
+    fn restart_required_changes_detects_discord_token_only_rotation() {
+        let mut old = Config::default();
+        old.discord
+            .bots
+            .insert("notify".to_string(), test_bot("old"));
+        let mut new = old.clone();
+        new.discord.bots.get_mut("notify").unwrap().token = Some("new".to_string());
+
+        assert_eq!(restart_required_changes(&old, &new), vec!["discord"]);
+    }
+
+    #[test]
+    fn restart_required_changes_ignores_discord_bot_hashmap_order() {
+        let mut old = Config::default();
+        old.discord.bots.insert("alpha".to_string(), test_bot("a"));
+        old.discord.bots.insert("beta".to_string(), test_bot("b"));
+
+        let mut new = Config::default();
+        new.discord.bots.insert("beta".to_string(), test_bot("b"));
+        new.discord.bots.insert("alpha".to_string(), test_bot("a"));
+
+        assert!(restart_required_changes(&old, &new).is_empty());
+    }
+
+    #[test]
+    fn restart_required_changes_flags_agent_channel_runtime_bindings() {
+        let mut old = Config::default();
+        old.agents.push(test_agent_with_claude_channel(
+            "123",
+            Some(false),
+            Some("pipe"),
+        ));
+
+        let mut runtime_changed = old.clone();
+        runtime_changed.agents[0] = test_agent_with_claude_channel("123", Some(false), Some("tui"));
+        assert_eq!(
+            restart_required_changes(&old, &runtime_changed),
+            vec!["agents"]
+        );
+
+        let mut tui_changed = old.clone();
+        tui_changed.agents[0] = test_agent_with_claude_channel("123", Some(true), Some("pipe"));
+        assert_eq!(restart_required_changes(&old, &tui_changed), vec!["agents"]);
     }
 }

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -444,6 +444,7 @@ mod tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 

--- a/src/services/escalation_settings.rs
+++ b/src/services/escalation_settings.rs
@@ -29,32 +29,44 @@ pub(crate) fn normalize_optional_string(value: Option<String>) -> Option<String>
 /// Compute the escalation settings implied by static config (no override).
 ///
 /// Prefers the hot-reloaded live config snapshot ([`crate::config_live_reload::current`])
-/// over the passed-in (boot-captured) `config`, so an `agentdesk.yaml` edit to the
-/// escalation owner / PM channel / schedule applies without a restart when no
-/// persisted Postgres override is set. Falls back to the passed `config` when the
-/// live snapshot is not installed (unit tests, pre-boot). Mirrors the
-/// `services::dispatch_gate` live-read precedent.
+/// for the escalation/kanban fields, so an `agentdesk.yaml` edit to the escalation
+/// owner / PM channel / schedule applies without a restart when no persisted
+/// Postgres override is set. Falls back to the passed `config` when the live
+/// snapshot is not installed (unit tests, pre-boot). The legacy fallback to
+/// `discord.owner_id` intentionally stays boot-bound because the Discord section
+/// is restart-required and bot authorization was captured during bootstrap.
+/// Mirrors the `services::dispatch_gate` live-read precedent.
 pub(crate) fn escalation_defaults(config: &Config) -> EscalationSettings {
     let live = crate::config_live_reload::current();
-    let config = live.as_deref().unwrap_or(config);
+    let live_config = live.as_deref().unwrap_or(config);
+    escalation_defaults_from_configs(config, live_config)
+}
+
+fn escalation_defaults_from_configs(
+    boot_config: &Config,
+    live_config: &Config,
+) -> EscalationSettings {
     EscalationSettings {
-        mode: config.escalation.mode.clone(),
-        owner_user_id: config.escalation.owner_user_id.or(config.discord.owner_id),
+        mode: live_config.escalation.mode,
+        owner_user_id: live_config
+            .escalation
+            .owner_user_id
+            .or(boot_config.discord.owner_id),
         pm_channel_id: normalize_optional_string(
-            config
+            live_config
                 .escalation
                 .pm_channel_id
                 .clone()
-                .or_else(|| config.kanban.human_alert_channel_id.clone()),
+                .or_else(|| live_config.kanban.human_alert_channel_id.clone()),
         ),
         schedule: EscalationScheduleSettings {
-            pm_hours: config
+            pm_hours: live_config
                 .escalation
                 .schedule
                 .pm_hours
                 .clone()
                 .unwrap_or_else(|| DEFAULT_ESCALATION_PM_HOURS.to_string()),
-            timezone: config
+            timezone: live_config
                 .escalation
                 .schedule
                 .timezone
@@ -119,4 +131,36 @@ pub(crate) fn effective_owner_user_id_with_backends(
     }
 
     escalation_defaults(config).owner_user_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escalation_defaults_from_configs;
+    use crate::config::Config;
+
+    #[test]
+    fn escalation_defaults_keep_discord_owner_fallback_boot_bound() {
+        let mut boot = Config::default();
+        boot.discord.owner_id = Some(111);
+        let mut live = boot.clone();
+        live.discord.owner_id = Some(222);
+        live.escalation.owner_user_id = None;
+
+        let defaults = escalation_defaults_from_configs(&boot, &live);
+
+        assert_eq!(defaults.owner_user_id, Some(111));
+    }
+
+    #[test]
+    fn escalation_defaults_still_use_live_escalation_owner_override() {
+        let mut boot = Config::default();
+        boot.discord.owner_id = Some(111);
+        let mut live = boot.clone();
+        live.discord.owner_id = Some(222);
+        live.escalation.owner_user_id = Some(333);
+
+        let defaults = escalation_defaults_from_configs(&boot, &live);
+
+        assert_eq!(defaults.owner_user_id, Some(333));
+    }
 }

--- a/src/services/escalation_settings.rs
+++ b/src/services/escalation_settings.rs
@@ -27,7 +27,16 @@ pub(crate) fn normalize_optional_string(value: Option<String>) -> Option<String>
 }
 
 /// Compute the escalation settings implied by static config (no override).
+///
+/// Prefers the hot-reloaded live config snapshot ([`crate::config_live_reload::current`])
+/// over the passed-in (boot-captured) `config`, so an `agentdesk.yaml` edit to the
+/// escalation owner / PM channel / schedule applies without a restart when no
+/// persisted Postgres override is set. Falls back to the passed `config` when the
+/// live snapshot is not installed (unit tests, pre-boot). Mirrors the
+/// `services::dispatch_gate` live-read precedent.
 pub(crate) fn escalation_defaults(config: &Config) -> EscalationSettings {
+    let live = crate::config_live_reload::current();
+    let config = live.as_deref().unwrap_or(config);
     EscalationSettings {
         mode: config.escalation.mode.clone(),
         owner_user_id: config.escalation.owner_user_id.or(config.discord.owner_id),


### PR DESCRIPTION
## 목표
`agentdesk.yaml` hot-reload가 더 많은 runtime tunable을 반영하고, 즉시 반영되지 않는 boot-bound 설정 변경은 restart-required로 명확히 보고하게 합니다.

## 쉬운 설명
일부 설정은 파일을 바꾸면 재시작 없이 running config에 반영됩니다. 반면 Discord/provider/MCP/memory처럼 부팅 시 고정되는 영역은 hot-reload가 적용되더라도 재시작이 필요하다는 로그를 남깁니다. escalation 설정은 live config snapshot을 우선 읽도록 보강했습니다.

## 개선되는 것
### Fix 1
config reload 결과가 restart-required section 목록을 포함합니다.

### Fix 2
boot-bound 설정과 routine tunable 설정을 구분해 잘못된 무중단 반영 기대를 줄입니다.

### Fix 3
escalation settings lookup이 hot-reloaded live config를 우선 사용합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| routine tunable 변경 | reload 적용 여부만 확인 | restart 불필요로 처리 |
| Discord/provider 설정 변경 | 적용 범위가 불명확 | restart-required section 로그 |
| escalation 설정 변경 | stale config를 볼 수 있음 | live snapshot 우선 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| invalid config reload | 기존 snapshot 유지 | fail-closed 유지 |
| boot-bound 변경 | reload는 되지만 restart-needed 보고 | 운영자 혼동 감소 |
| generated docs | PR에서 제외 | upstream 현 구조 존중 |

## 해결한 내용
- `src/config_live_reload.rs`: restart-required change detection과 reload outcome 보강
- `src/config.rs`: hot-reload 대상/비대상 설정 주석 및 default coverage 보강
- `src/services/escalation_settings.rs`: live config snapshot 우선 lookup 추가

## 포트 메모
`kunkunGames/AgentDesk` fork의 config hot-reload 변경을 `itismyfield/AgentDesk:main` 기준으로 선별 포트했습니다. upstream에서 없는 generated inventory docs는 되살리지 않고 코드 변경만 유지했습니다.

## 검증
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo test -p agentdesk --lib config_live_reload`
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo check --all-targets`
