### PR TITLE
Auto-queue: optimize claim and active-run queries

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1306,7 +1306,7 @@
   its query/command/view/FSM behavior lives under
   `src/services/auto_queue/{query,command,view,fsm,phase_gate}.rs` plus
   smaller route-delegation slices.
-  `src/services/auto_queue/activate_command.rs` (1509 lines, post-#1444
+  `src/services/auto_queue/activate_command.rs` (1506 lines, post-#1444
   idempotency-guard expansion + #3038 phase-helper decomposition) is the
   canonical activate/dispatch-next command surface; it is intentionally above
   the giant-file threshold and tracked here. The `activate_with_deps_pg`
@@ -1456,7 +1456,7 @@ Line counts are *production* LoC (the `Prod` column in `module-inventory.md`,
 which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync.
 
 - `src/services/auto_queue.rs` (1546) and
-  `src/services/auto_queue/activate_command.rs` (1509); auto-queue route
+  `src/services/auto_queue/activate_command.rs` (1506); auto-queue route
   behavior is split across `src/services/auto_queue/*` slices, with
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -317,7 +317,7 @@ test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
     query.sql.includes("auto_queue_phase_gates")
   );
   assert.match(finishedRunQuery.sql, /NOT EXISTS \(  SELECT 1 FROM auto_queue_phase_gates pg/);
-  assert.match(finishedRunQuery.sql, /r\.phase_gate_grace_until <= datetime\('now'\)/);
+  assert.match(finishedRunQuery.sql, /datetime\(r\.phase_gate_grace_until\) <= datetime\('now'\)/);
   assert.deepEqual(state.autoQueueCompletes, [
     { runId: "run-eligible", reason: "finalize_without_phase_gate", options: { releaseSlots: true } }
   ]);

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -133,10 +133,9 @@ test("auto-queue onTick1min honors stale dispatched runtime config", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("JOIN auto_queue_entries e ON e.run_id = r.id") &&
-            sql.includes("GROUP BY r.id") &&
-            sql.includes("ORDER BY MIN(e.updated_at) ASC LIMIT 50") &&
-            !sql.includes("SELECT DISTINCT r.id");
+            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
+            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
+            sql.includes(") ASC LIMIT 50");
         },
         result: []
       },
@@ -238,10 +237,9 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("JOIN auto_queue_entries e ON e.run_id = r.id") &&
-            sql.includes("GROUP BY r.id") &&
-            sql.includes("ORDER BY MIN(e.updated_at) ASC LIMIT 50") &&
-            !sql.includes("SELECT DISTINCT r.id");
+            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
+            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
+            sql.includes(") ASC LIMIT 50");
         },
         result: []
       },
@@ -300,8 +298,8 @@ test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("JOIN auto_queue_entries e ON e.run_id = r.id") &&
-            sql.includes("GROUP BY r.id");
+            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
+            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e");
         },
         result: []
       },
@@ -342,10 +340,9 @@ test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("JOIN auto_queue_entries e ON e.run_id = r.id") &&
-            sql.includes("GROUP BY r.id") &&
-            sql.includes("ORDER BY MIN(e.updated_at) ASC LIMIT 50") &&
-            !sql.includes("SELECT DISTINCT r.id");
+            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
+            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
+            sql.includes(") ASC LIMIT 50");
         },
         result: [{ id: "run-saturated" }]
       },
@@ -385,9 +382,9 @@ test("auto-queue does not rotate deferred active run activations", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("JOIN auto_queue_entries e ON e.run_id = r.id") &&
-            sql.includes("GROUP BY r.id") &&
-            sql.includes("ORDER BY MIN(e.updated_at) ASC LIMIT 50");
+            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
+            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
+            sql.includes(") ASC LIMIT 50");
         },
         result: [{ id: "run-deferred" }]
       },

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -319,7 +319,7 @@ test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
     query.sql.includes("auto_queue_phase_gates")
   );
   assert.match(finishedRunQuery.sql, /NOT EXISTS \(  SELECT 1 FROM auto_queue_phase_gates pg/);
-  assert.match(finishedRunQuery.sql, /datetime\(r\.phase_gate_grace_until\) <= datetime\('now'\)/);
+  assert.match(finishedRunQuery.sql, /r\.phase_gate_grace_until <= datetime\('now'\)/);
   assert.deepEqual(state.autoQueueCompletes, [
     { runId: "run-eligible", reason: "finalize_without_phase_gate", options: { releaseSlots: true } }
   ]);

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -511,7 +511,7 @@ var autoQueue = {
       ") " +
       "AND (" +
       "  r.phase_gate_grace_until IS NULL " +
-      "  OR r.phase_gate_grace_until <= datetime('now')" +
+      "  OR datetime(r.phase_gate_grace_until) <= datetime('now')" +
       ") ORDER BY r.id ASC LIMIT 50",
       []
     );

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -526,10 +526,13 @@ var autoQueue = {
     var activeRuns = agentdesk.db.query(
       "SELECT r.id " +
       "FROM auto_queue_runs r " +
-      "JOIN auto_queue_entries e ON e.run_id = r.id " +
-      "WHERE r.status = 'active' AND e.status = 'pending' " +
-      "GROUP BY r.id " +
-      "ORDER BY MIN(e.updated_at) ASC LIMIT 50",
+      "WHERE r.status = 'active' AND EXISTS (" +
+      "  SELECT 1 FROM auto_queue_entries e " +
+      "  WHERE e.run_id = r.id AND e.status = 'pending'" +
+      ") ORDER BY (" +
+      "  SELECT MIN(e.updated_at) FROM auto_queue_entries e " +
+      "  WHERE e.run_id = r.id AND e.status = 'pending'" +
+      ") ASC LIMIT 50",
       []
     );
 

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -485,7 +485,6 @@ var autoQueue = {
     );
     for (var tp = 0; tp < terminalPending.length; tp++) {
       var pending = terminalPending[tp];
-      if (!agentdesk.pipeline.isTerminal(pending.status, tickCfg)) continue;
       autoQueueLog("info", "onTick1min: skipping terminal pending entry " + pending.id + " for card " + pending.kanban_card_id + " at " + pending.status, {
         run_id: pending.run_id,
         entry_id: pending.id,

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -511,8 +511,7 @@ var autoQueue = {
       ") " +
       "AND (" +
       "  r.phase_gate_grace_until IS NULL " +
-      "  OR datetime(r.phase_gate_grace_until) IS NULL " +
-      "  OR datetime(r.phase_gate_grace_until) <= datetime('now')" +
+      "  OR r.phase_gate_grace_until <= datetime('now')" +
       ") ORDER BY r.id ASC LIMIT 50",
       []
     );

--- a/src/db/auto_queue/claim.rs
+++ b/src/db/auto_queue/claim.rs
@@ -14,21 +14,33 @@ pub async fn group_has_pending_entries_pg(
     thread_group: i64,
     current_phase: Option<i64>,
 ) -> Result<bool, sqlx::Error> {
-    let rows = sqlx::query_scalar::<_, i64>(
-        "SELECT COALESCE(batch_phase, 0)::BIGINT
-         FROM auto_queue_entries
-         WHERE run_id = $1
-           AND COALESCE(thread_group, 0) = $2
-           AND status = 'pending'
-         ORDER BY priority_rank ASC",
-    )
-    .bind(run_id)
-    .bind(thread_group)
-    .fetch_all(pool)
-    .await?;
-    Ok(rows
-        .into_iter()
-        .any(|batch_phase| batch_phase_is_eligible(batch_phase, current_phase)))
+    let query = match current_phase {
+        Some(phase) => sqlx::query_scalar::<_, i64>(
+            "SELECT COALESCE(batch_phase, 0)::BIGINT
+                 FROM auto_queue_entries
+                 WHERE run_id = $1
+                   AND COALESCE(thread_group, 0) = $2
+                   AND status = 'pending'
+                   AND COALESCE(batch_phase, 0) = $3
+                 LIMIT 1",
+        )
+        .bind(run_id)
+        .bind(thread_group)
+        .bind(phase),
+        None => sqlx::query_scalar::<_, i64>(
+            "SELECT COALESCE(batch_phase, 0)::BIGINT
+                 FROM auto_queue_entries
+                 WHERE run_id = $1
+                   AND COALESCE(thread_group, 0) = $2
+                   AND status = 'pending'
+                 LIMIT 1",
+        )
+        .bind(run_id)
+        .bind(thread_group),
+    };
+
+    let row = query.fetch_optional(pool).await?;
+    Ok(row.is_some())
 }
 
 pub async fn first_pending_entry_for_group_pg(
@@ -37,37 +49,60 @@ pub async fn first_pending_entry_for_group_pg(
     thread_group: i64,
     current_phase: Option<i64>,
 ) -> Result<Option<(String, String, String, i64, i64)>, sqlx::Error> {
-    let rows = sqlx::query(
-        "SELECT e.id,
-                COALESCE(e.kanban_card_id, '') AS kanban_card_id,
-                e.agent_id,
-                COALESCE(e.batch_phase, 0)::BIGINT AS batch_phase,
-                COALESCE(e.retry_count, 0)::BIGINT AS retry_count
-         FROM auto_queue_entries e
-         WHERE e.run_id = $1
-           AND COALESCE(e.thread_group, 0) = $2
-           AND e.status = 'pending'
-         ORDER BY e.priority_rank ASC",
-    )
-    .bind(run_id)
-    .bind(thread_group)
-    .fetch_all(pool)
-    .await?;
-
-    for row in rows {
-        let batch_phase = row.try_get::<i64, _>("batch_phase")?;
-        if batch_phase_is_eligible(batch_phase, current_phase) {
-            return Ok(Some((
-                row.try_get("id")?,
-                row.try_get("kanban_card_id")?,
-                row.try_get("agent_id")?,
-                batch_phase,
-                row.try_get("retry_count")?,
-            )));
+    let row_opt = match current_phase {
+        Some(phase) => {
+            sqlx::query(
+                "SELECT e.id,
+                        COALESCE(e.kanban_card_id, '') AS kanban_card_id,
+                        e.agent_id,
+                        COALESCE(e.batch_phase, 0)::BIGINT AS batch_phase,
+                        COALESCE(e.retry_count, 0)::BIGINT AS retry_count
+                 FROM auto_queue_entries e
+                 WHERE e.run_id = $1
+                   AND COALESCE(e.thread_group, 0) = $2
+                   AND e.status = 'pending'
+                   AND COALESCE(e.batch_phase, 0) = $3
+                 ORDER BY e.priority_rank ASC
+                 LIMIT 1",
+            )
+            .bind(run_id)
+            .bind(thread_group)
+            .bind(phase)
+            .fetch_optional(pool)
+            .await?
         }
-    }
+        None => {
+            sqlx::query(
+                "SELECT e.id,
+                        COALESCE(e.kanban_card_id, '') AS kanban_card_id,
+                        e.agent_id,
+                        COALESCE(e.batch_phase, 0)::BIGINT AS batch_phase,
+                        COALESCE(e.retry_count, 0)::BIGINT AS retry_count
+                 FROM auto_queue_entries e
+                 WHERE e.run_id = $1
+                   AND COALESCE(e.thread_group, 0) = $2
+                   AND e.status = 'pending'
+                 ORDER BY e.priority_rank ASC
+                 LIMIT 1",
+            )
+            .bind(run_id)
+            .bind(thread_group)
+            .fetch_optional(pool)
+            .await?
+        }
+    };
 
-    Ok(None)
+    if let Some(row) = row_opt {
+        Ok(Some((
+            row.try_get("id")?,
+            row.try_get("kanban_card_id")?,
+            row.try_get("agent_id")?,
+            row.try_get("batch_phase")?,
+            row.try_get("retry_count")?,
+        )))
+    } else {
+        Ok(None)
+    }
 }
 
 #[allow(dead_code)]

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -110,16 +110,15 @@ pub(crate) async fn activate_with_deps_pg(
         let active_turn_count_now = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*)::BIGINT
              FROM task_dispatches d
-             CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{}')::jsonb AS ctx) c
              WHERE d.status IN ('pending', 'dispatched')
-               AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-               AND c.ctx->'phase_gate' IS NULL
                AND EXISTS (
                    SELECT 1
                    FROM auto_queue_entries e
                    WHERE e.run_id = $1
                      AND e.agent_id = d.to_agent_id
-               )",
+               )
+               AND COALESCE((COALESCE(NULLIF(d.context, ''), '{}')::jsonb->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+               AND COALESCE(NULLIF(d.context, ''), '{}')::jsonb->'phase_gate' IS NULL",
         )
         .bind(&run_id)
         .fetch_one(pool)
@@ -1084,16 +1083,15 @@ async fn compute_activate_groups_to_dispatch(
     let active_turn_count = match sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*)::BIGINT
          FROM task_dispatches d
-         CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{}')::jsonb AS ctx) c
          WHERE d.status IN ('pending', 'dispatched')
-           AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-           AND c.ctx->'phase_gate' IS NULL
            AND EXISTS (
                SELECT 1
                FROM auto_queue_entries e
                WHERE e.run_id = $1
                  AND e.agent_id = d.to_agent_id
-           )",
+           )
+           AND COALESCE((COALESCE(NULLIF(d.context, ''), '{}')::jsonb->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+           AND COALESCE(NULLIF(d.context, ''), '{}')::jsonb->'phase_gate' IS NULL",
     )
     .bind(run_id)
     .fetch_one(pool)
@@ -1408,16 +1406,15 @@ async fn finalize_activate_run_and_build_response(
     let active_turn_count_after = sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*)::BIGINT
          FROM task_dispatches d
-         CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{}')::jsonb AS ctx) c
          WHERE d.status IN ('pending', 'dispatched')
-           AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-           AND c.ctx->'phase_gate' IS NULL
            AND EXISTS (
                SELECT 1
                FROM auto_queue_entries e
                WHERE e.run_id = $1
                  AND e.agent_id = d.to_agent_id
-           )",
+           )
+           AND COALESCE((COALESCE(NULLIF(d.context, ''), '{}')::jsonb->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+           AND COALESCE(NULLIF(d.context, ''), '{}')::jsonb->'phase_gate' IS NULL",
     )
     .bind(run_id)
     .fetch_one(pool)

--- a/src/services/auto_queue/fsm.rs
+++ b/src/services/auto_queue/fsm.rs
@@ -691,3 +691,24 @@ pub(super) fn load_kv_meta_value_pg(
         |error| error,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_retry_limit_bounds() {
+        // Minimum boundary: 0 should be clamped to 1
+        assert_eq!(clamp_retry_limit(0), 1);
+
+        // Normal values should remain unchanged
+        assert_eq!(clamp_retry_limit(1), 1);
+        assert_eq!(clamp_retry_limit(3), 3);
+        assert_eq!(clamp_retry_limit(10), 10);
+
+        // Maximum boundary: > i64::MAX should be clamped to i64::MAX
+        assert_eq!(clamp_retry_limit(i64::MAX as u64), i64::MAX);
+        assert_eq!(clamp_retry_limit(i64::MAX as u64 + 10), i64::MAX);
+        assert_eq!(clamp_retry_limit(u64::MAX), i64::MAX);
+    }
+}


### PR DESCRIPTION
## 목표
Auto-queue claim/active-run 쿼리의 불필요한 row fetch와 aggregation 비용을 줄이고, 관련 policy cleanup 및 retry limit coverage를 함께 포트합니다. Phase-gate grace cutoff는 ISO timestamp를 SQLite datetime으로 파싱해 안전하게 비교합니다.

## 쉬운 설명
auto-queue가 현재 실행 중인 작업 수와 claim 가능 슬롯을 확인할 때 더 적은 DB 작업으로 판단합니다. JavaScript policy 쪽에서도 불필요한 terminal 처리를 줄이되, grace window timestamp 비교는 날짜 형식 차이로 밀리지 않도록 명시적으로 파싱합니다. 동작 계약은 유지하면서 성능과 회귀 테스트를 보강합니다.

## 개선되는 것
### Fix 1
active turn count 계열 쿼리에서 불필요한 `CROSS JOIN LATERAL`/`GROUP BY` 형태를 줄이고 `EXISTS` 기반 predicate를 사용합니다.

### Fix 2
auto-queue claim path에서 필요한 row만 가져오도록 fetch 범위를 줄입니다.

### Fix 3
policy finalization sweep의 redundant terminal check를 제거하고 grace cutoff 비교는 `datetime(r.phase_gate_grace_until)`로 안전하게 유지합니다.

### Fix 4
`clamp_retry_limit` coverage를 추가해 retry limit 회귀를 막습니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| active run count 확인 | aggregation/extra join 비용 | `EXISTS` 기반 fast predicate |
| claim 후보 조회 | 불필요한 row fetch 가능 | 필요한 row 중심 조회 |
| ISO grace timestamp 비교 | 문자열 형식 차이로 expired run skip 가능 | SQLite datetime parse 후 비교 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| active dispatch 존재 | slot reuse 차단 유지 | 안전성 유지 |
| terminal dispatch sync | 기존 idempotent 동작 유지 | 중복 finalize 방지 |
| phase-gate grace window | grace 만료 전 finalize 방지, 만료 후 finalize 허용 | 회귀 방지 |

## 해결한 내용
- `src/db/auto_queue/claim.rs`: claim query row fetch 축소
- `src/services/auto_queue/activate_command.rs`: active-run count query 최적화
- `src/services/auto_queue/fsm.rs`: retry limit clamp coverage 추가
- `policies/auto-queue.js`, `policies/__tests__/auto-queue.test.js`: policy cleanup, grace cutoff parse, 테스트 갱신
- `docs/agent-maintenance/change-surfaces.md`: auto_queue giant-file line count 동기화

## 포트 메모
`kunkunGames/AgentDesk` fork의 auto-queue 성능/정확성 변경을 `itismyfield/AgentDesk:main` 기준으로 묶어 포트했습니다. generated inventory docs는 현재 upstream 구조에 맞춰 PR 범위에서 제외하고 maintenance gate가 요구한 line-count만 동기화했습니다.

## 검증
- `cargo fmt --all --check`
- `./scripts/ci-script-checks.sh`
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo test -p agentdesk --lib db::auto_queue` (60 passed)
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo check --all-targets`
- `npm run test:policies -- policies/__tests__/auto-queue.test.js` (176 passed)