### PR TITLE
Reconciler: preserve rebind-origin inflight files during sweep

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1266,7 +1266,7 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (7382 lines; #3680 relay
+    lines) and `src/services/discord/inflight.rs` (3137 lines; #3680 relay
     recovery review hardening; #3685 exposes the inflight sidecar lock
     crate-wide for locked legacy rebind backfill; #3635 added the
     dead-watcher rebind-origin reap — `WatcherLiveness` DI trait, three-state tmux

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1394,7 +1394,7 @@
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
-  - `src/reconcile.rs` (1825 lines; #3685 rebind-origin stale-inflight
+  - `src/reconcile.rs` (1851 lines; #3685 rebind-origin stale-inflight
     preservation review hardening; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1367,7 +1367,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3230 lines).
+  - `src/cli/migrate/apply.rs` (3231 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.
@@ -1390,11 +1390,11 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2529 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
-  - `src/reconcile.rs` (1818 lines; periodic reconcile loop covering stale
+  - `src/reconcile.rs` (1825 lines; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).
 - active_callsite_coverage: n/a.
@@ -1431,7 +1431,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
+  - `src/db/postgres.rs` (1141 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).
@@ -1461,7 +1461,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
-- `src/services/onboarding/mod.rs` (2936),
+- `src/services/onboarding/mod.rs` (2937),
   `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1260,7 +1260,8 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (3052 lines; #3635 added the
+    lines) and `src/services/discord/inflight.rs` (3051 lines; #3685 exposes the
+    inflight sidecar lock crate-wide for locked legacy rebind backfill; #3635 added the
     dead-watcher rebind-origin reap — `WatcherLiveness` DI trait, three-state tmux
     pane liveness, spawn-blocking warm sweeper probe, and fs-only locked
     re-validation; the byte-for-byte-unchanged #3581 None-owner predicate is
@@ -1394,7 +1395,7 @@
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
-  - `src/reconcile.rs` (1851 lines; #3685 rebind-origin stale-inflight
+  - `src/reconcile.rs` (1868 lines; #3685 rebind-origin stale-inflight
     preservation review hardening; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1394,7 +1394,7 @@
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
-  - `src/reconcile.rs` (1816 lines; periodic reconcile loop covering stale
+  - `src/reconcile.rs` (1818 lines; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).
 - active_callsite_coverage: n/a.

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1696,13 +1696,22 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
             }
             let is_managed_lifecycle = fs::read_to_string(&fpath)
                 .ok()
-                .and_then(|body| serde_json::from_str::<LifecycleExt>(&body).ok())
-                .is_some_and(|v| {
+                .and_then(|body| {
+                    let v = serde_json::from_str::<LifecycleExt>(&body).ok()?;
                     let planned_restart = v.restart_mode.is_some_and(|rm| !rm.is_null());
-                    let external_rebind_origin = v.rebind_origin
-                        && matches!(v.turn_source.as_deref(), None | Some("external_adopted"));
-                    planned_restart || external_rebind_origin
-                });
+                    if planned_restart {
+                        return Some(true);
+                    }
+                    if !v.rebind_origin {
+                        return Some(false);
+                    }
+                    match v.turn_source.as_deref() {
+                        Some("external_adopted") => Some(true),
+                        None => Some(backfill_legacy_rebind_origin_turn_source(&fpath, &body)),
+                        _ => Some(false),
+                    }
+                })
+                .unwrap_or(false);
             if is_managed_lifecycle {
                 continue;
             }
@@ -1717,6 +1726,23 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
         }
     }
     removed
+}
+
+fn backfill_legacy_rebind_origin_turn_source(path: &std::path::Path, body: &str) -> bool {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let Some(object) = value.as_object_mut() else {
+        return false;
+    };
+    object.insert(
+        "turn_source".to_string(),
+        serde_json::Value::String("external_adopted".to_string()),
+    );
+    let Ok(updated) = serde_json::to_string_pretty(&value) else {
+        return false;
+    };
+    std::fs::write(path, format!("{updated}\n")).is_ok()
 }
 
 #[cfg(test)]
@@ -1778,6 +1804,10 @@ mod stale_inflight_sweep_tests {
             legacy.exists(),
             "legacy rebind-origin rows predate turn_source and remain placeholder-managed"
         );
+        let updated: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&legacy).expect("legacy body"))
+                .expect("updated legacy json");
+        assert_eq!(updated["turn_source"], "external_adopted");
     }
 
     #[test]

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1683,19 +1683,21 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
             if !age_ok {
                 continue;
             }
-            // Only remove when restart_mode is absent. A file with a restart_mode
-            // set is owned by a planned lifecycle (drain/hot-swap); the existing
-            // inflight retention helpers cover those.
+            // Only remove when restart_mode is absent and rebind_origin is false.
+            // A file with a restart_mode set is owned by a planned lifecycle
+            // (drain/hot-swap); a rebind_origin file is managed by the placeholder
+            // sweeper. The existing inflight retention helpers cover those.
             #[derive(serde::Deserialize)]
-            struct RestartModeExt {
+            struct LifecycleExt {
                 restart_mode: Option<serde_json::Value>,
+                #[serde(default)]
+                rebind_origin: bool,
             }
-            let restart_mode_present = fs::read_to_string(&fpath)
+            let is_managed_lifecycle = fs::read_to_string(&fpath)
                 .ok()
-                .and_then(|body| serde_json::from_str::<RestartModeExt>(&body).ok())
-                .and_then(|v| v.restart_mode.filter(|rm| !rm.is_null()).map(|_| true))
-                .unwrap_or(false);
-            if restart_mode_present {
+                .and_then(|body| serde_json::from_str::<LifecycleExt>(&body).ok())
+                .is_some_and(|v| v.restart_mode.is_some_and(|rm| !rm.is_null()) || v.rebind_origin);
+            if is_managed_lifecycle {
                 continue;
             }
             if fs::remove_file(&fpath).is_ok() {

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1683,20 +1683,26 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
             if !age_ok {
                 continue;
             }
-            // Only remove when restart_mode is absent and rebind_origin is false.
-            // A file with a restart_mode set is owned by a planned lifecycle
-            // (drain/hot-swap); a rebind_origin file is managed by the placeholder
-            // sweeper. The existing inflight retention helpers cover those.
+            // Only remove when restart_mode is absent and the file is not an
+            // externally adopted rebind-origin placeholder. Planned restart
+            // rows are owned by drain/hot-swap lifecycle; externally adopted
+            // rebind-origin rows are managed by the placeholder sweeper.
             #[derive(serde::Deserialize)]
             struct LifecycleExt {
                 restart_mode: Option<serde_json::Value>,
                 #[serde(default)]
                 rebind_origin: bool,
+                turn_source: Option<String>,
             }
             let is_managed_lifecycle = fs::read_to_string(&fpath)
                 .ok()
                 .and_then(|body| serde_json::from_str::<LifecycleExt>(&body).ok())
-                .is_some_and(|v| v.restart_mode.is_some_and(|rm| !rm.is_null()) || v.rebind_origin);
+                .is_some_and(|v| {
+                    let planned_restart = v.restart_mode.is_some_and(|rm| !rm.is_null());
+                    let external_rebind_origin =
+                        v.rebind_origin && v.turn_source.as_deref() == Some("external_adopted");
+                    planned_restart || external_rebind_origin
+                });
             if is_managed_lifecycle {
                 continue;
             }
@@ -1711,6 +1717,69 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
         }
     }
     removed
+}
+
+#[cfg(test)]
+mod stale_inflight_sweep_tests {
+    use super::sweep_stale_inflight_files_at;
+    use filetime::{FileTime, set_file_mtime};
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{Duration, SystemTime},
+    };
+
+    fn write_stale_inflight(root: &std::path::Path, name: &str, body: &str) -> PathBuf {
+        let provider_dir = root.join("claude");
+        fs::create_dir_all(&provider_dir).expect("provider dir");
+        let path = provider_dir.join(format!("{name}.json"));
+        fs::write(&path, body).expect("write inflight");
+        let old_mtime = FileTime::from_system_time(SystemTime::now() - Duration::from_secs(3600));
+        set_file_mtime(&path, old_mtime).expect("set mtime");
+        path
+    }
+
+    #[test]
+    fn stale_sweep_preserves_external_rebind_origin_only() {
+        let root = tempfile::tempdir().expect("temp root");
+        let external = write_stale_inflight(
+            root.path(),
+            "external",
+            r#"{"rebind_origin":true,"turn_source":"external_adopted"}"#,
+        );
+        let monitor = write_stale_inflight(
+            root.path(),
+            "monitor",
+            r#"{"rebind_origin":true,"turn_source":"monitor_triggered"}"#,
+        );
+
+        let removed = sweep_stale_inflight_files_at(root.path(), Duration::from_secs(60));
+
+        assert_eq!(removed, 1);
+        assert!(
+            external.exists(),
+            "external adopted rebind-origin is placeholder-managed"
+        );
+        assert!(
+            !monitor.exists(),
+            "monitor-triggered stale rebind-origin remains sweepable"
+        );
+    }
+
+    #[test]
+    fn stale_sweep_preserves_planned_restart_rows() {
+        let root = tempfile::tempdir().expect("temp root");
+        let planned = write_stale_inflight(
+            root.path(),
+            "planned",
+            r#"{"restart_mode":"hot_swap","rebind_origin":false}"#,
+        );
+
+        let removed = sweep_stale_inflight_files_at(root.path(), Duration::from_secs(60));
+
+        assert_eq!(removed, 0);
+        assert!(planned.exists());
+    }
 }
 
 /// Remove `discord_uploads/<channel>/*` files older than

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1707,7 +1707,7 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
                     }
                     match v.turn_source.as_deref() {
                         Some("external_adopted") => Some(true),
-                        None => Some(backfill_legacy_rebind_origin_turn_source(&fpath, &body)),
+                        None => Some(backfill_legacy_rebind_origin_turn_source(&fpath)),
                         _ => Some(false),
                     }
                 })
@@ -1728,13 +1728,30 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
     removed
 }
 
-fn backfill_legacy_rebind_origin_turn_source(path: &std::path::Path, body: &str) -> bool {
-    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(body) else {
+fn backfill_legacy_rebind_origin_turn_source(path: &std::path::Path) -> bool {
+    let Ok(_lock) = crate::services::discord::lock_inflight_state_path(path) else {
+        return false;
+    };
+    let Ok(body) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&body) else {
         return false;
     };
     let Some(object) = value.as_object_mut() else {
         return false;
     };
+    if object.get("rebind_origin") != Some(&serde_json::Value::Bool(true)) {
+        return false;
+    }
+    match object
+        .get("turn_source")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("external_adopted") => return true,
+        Some(_) => return false,
+        None => {}
+    }
     object.insert(
         "turn_source".to_string(),
         serde_json::Value::String("external_adopted".to_string()),
@@ -1742,7 +1759,7 @@ fn backfill_legacy_rebind_origin_turn_source(path: &std::path::Path, body: &str)
     let Ok(updated) = serde_json::to_string_pretty(&value) else {
         return false;
     };
-    std::fs::write(path, format!("{updated}\n")).is_ok()
+    crate::services::discord::runtime_store::atomic_write(path, &format!("{updated}\n")).is_ok()
 }
 
 #[cfg(test)]

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -1699,8 +1699,8 @@ pub(crate) fn sweep_stale_inflight_files_at(root: &std::path::Path, max_age: Dur
                 .and_then(|body| serde_json::from_str::<LifecycleExt>(&body).ok())
                 .is_some_and(|v| {
                     let planned_restart = v.restart_mode.is_some_and(|rm| !rm.is_null());
-                    let external_rebind_origin =
-                        v.rebind_origin && v.turn_source.as_deref() == Some("external_adopted");
+                    let external_rebind_origin = v.rebind_origin
+                        && matches!(v.turn_source.as_deref(), None | Some("external_adopted"));
                     planned_restart || external_rebind_origin
                 });
             if is_managed_lifecycle {
@@ -1763,6 +1763,20 @@ mod stale_inflight_sweep_tests {
         assert!(
             !monitor.exists(),
             "monitor-triggered stale rebind-origin remains sweepable"
+        );
+    }
+
+    #[test]
+    fn stale_sweep_preserves_legacy_rebind_origin_without_turn_source() {
+        let root = tempfile::tempdir().expect("temp root");
+        let legacy = write_stale_inflight(root.path(), "legacy", r#"{"rebind_origin":true}"#);
+
+        let removed = sweep_stale_inflight_files_at(root.path(), Duration::from_secs(60));
+
+        assert_eq!(removed, 0);
+        assert!(
+            legacy.exists(),
+            "legacy rebind-origin rows predate turn_source and remain placeholder-managed"
         );
     }
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -26,9 +26,8 @@ mod store;
 // is named nowhere outside `store` (it only flows as a return type), so it keeps
 // its module-tree visibility there without a parent re-export.
 use store::inflight_provider_dir;
-pub(in crate::services::discord::inflight) use store::{
-    inflight_state_path, lock_inflight_state_path,
-};
+pub(in crate::services::discord::inflight) use store::inflight_state_path;
+pub(crate) use store::lock_inflight_state_path;
 
 use finalizer_identity::{
     backfill_finalizer_turn_id_under_lock, parse_inflight_state_content,

--- a/src/services/discord/inflight/store.rs
+++ b/src/services/discord/inflight/store.rs
@@ -20,7 +20,7 @@ pub(in crate::services::discord::inflight) fn inflight_state_path(
     inflight_provider_dir(root, provider).join(format!("{channel_id}.json"))
 }
 
-pub(in crate::services::discord::inflight) struct InflightStateFileLock {
+pub(crate) struct InflightStateFileLock {
     _file: fs::File,
 }
 
@@ -39,9 +39,7 @@ fn inflight_state_lock_path(path: &Path) -> PathBuf {
     path.with_extension("json.lock")
 }
 
-pub(in crate::services::discord::inflight) fn lock_inflight_state_path(
-    path: &Path,
-) -> Result<InflightStateFileLock, String> {
+pub(crate) fn lock_inflight_state_path(path: &Path) -> Result<InflightStateFileLock, String> {
     let lock_path = inflight_state_lock_path(path);
     if let Some(parent) = lock_path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -184,6 +184,7 @@ use formatting::{
     send_long_message_raw, truncate_str,
 };
 pub(crate) use inflight::clear_inflight_state;
+pub(crate) use inflight::lock_inflight_state_path;
 use inflight::{InflightTurnState, load_inflight_states, save_inflight_state};
 use prompt_builder::{RecoveryContextManifestInput, build_system_prompt_with_manifest};
 use recovery_engine::restore_inflight_turns;


### PR DESCRIPTION
## 목표
Reconciler가 rebind-origin inflight 파일을 일반 stale inflight처럼 너무 빨리 sweep하지 않도록 보존합니다. recovery/rebind 경로가 아직 참조할 수 있는 inflight 상태를 cleanup이 먼저 지우지 않는 것이 목표입니다.

## 쉬운 설명
rebind-origin inflight는 복구 과정에서 watcher/relay가 다시 붙기 위한 임시 상태입니다. 이전에는 reconcile cleanup이 이 파일을 너무 이르게 지울 수 있었습니다. 이제 해당 상태는 별도 조건으로 보존되어 recovery가 필요한 정보를 잃지 않습니다.

## 개선되는 것
### Fix 1
rebind-origin inflight 파일을 premature cleanup 대상에서 제외합니다.

### Fix 2
reconcile stale cleanup의 조건을 더 명확히 해 recovery path와 충돌하지 않게 합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| rebind-origin inflight가 남아 있음 | sweep이 먼저 삭제 가능 | recovery가 참조할 수 있게 보존 |
| 일반 stale inflight | 기존 cleanup 유지 | cleanup 유지 |
| maintenance docs gate | line count drift 가능 | docs 동기화 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| rebind recovery 진행 중 | inflight 파일 유지 | 복구 안정성 개선 |
| truly stale non-rebind state | cleanup 가능 | 누수 확대 방지 |
| generated docs | PR에서 제외 | upstream 현 구조 존중 |

## 해결한 내용
- `src/reconcile.rs`: rebind-origin inflight cleanup 조건 보강
- `docs/agent-maintenance/change-surfaces.md`: reconcile surface 설명/line count 동기화

## 포트 메모
`kunkunGames/AgentDesk` fork의 rebind-origin cleanup fix를 `itismyfield/AgentDesk:main` 기준으로 선별 포트했습니다. upstream에 없는 generated inventory docs는 되살리지 않았습니다.

## 검증
- `cargo fmt --all --check`
- `./scripts/ci-script-checks.sh`
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo test -p agentdesk --lib reconcile`
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo check --all-targets`