### PR TITLE
Timeouts policy: reduce long-turn cleanup work and use cards facade

### DIFF
--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -193,6 +193,15 @@ test("timeouts requested sweep skips scope-assessment side-path even when overdu
 test("timeouts reconcile fallback does not advance a completed scope-assessment (#3605)", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     config: { pm_decision_gate_enabled: true },
+    cards: {
+      "card-scope-r": {
+        id: "card-scope-r",
+        status: "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-1",
+        deferred_dod_json: null
+      }
+    },
     dbQuery: createSqlRouter([
       {
         match: "SELECT key, value FROM kv_meta WHERE key LIKE 'reconcile_dispatch:%'",
@@ -213,18 +222,7 @@ test("timeouts reconcile fallback does not advance a completed scope-assessment 
           }
         ]
       },
-      {
-        match: "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
-        result: [
-          {
-            id: "card-scope-r",
-            status: "requested",
-            priority: "medium",
-            assigned_agent_id: "agent-1",
-            deferred_dod_json: null
-          }
-        ]
-      },
+
       {
         // #3605 (T2): the fallback now records scope_depth via the shared
         // recorder, which reads the card metadata first.
@@ -267,6 +265,15 @@ test("timeouts reconcile fallback does not advance a completed scope-assessment 
 test("timeouts reconcile fallback applies full fallback for an unparsable scope-assessment (#3605)", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     config: { pm_decision_gate_enabled: true },
+    cards: {
+      "card-scope-fb": {
+        id: "card-scope-fb",
+        status: "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-1",
+        deferred_dod_json: null
+      }
+    },
     dbQuery: createSqlRouter([
       {
         match: "SELECT key, value FROM kv_meta WHERE key LIKE 'reconcile_dispatch:%'",
@@ -287,18 +294,7 @@ test("timeouts reconcile fallback applies full fallback for an unparsable scope-
           }
         ]
       },
-      {
-        match: "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
-        result: [
-          {
-            id: "card-scope-fb",
-            status: "requested",
-            priority: "medium",
-            assigned_agent_id: "agent-1",
-            deferred_dod_json: null
-          }
-        ]
-      },
+
       {
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
         result: [{ metadata: "{}" }]
@@ -329,6 +325,15 @@ test("timeouts reconcile fallback gates depth flow when an auto-queue entry is l
   // was dropped.
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     config: { pm_decision_gate_enabled: true },
+    cards: {
+      "card-scope-g": {
+        id: "card-scope-g",
+        status: "requested",
+        priority: "medium",
+        assigned_agent_id: "agent-1",
+        deferred_dod_json: null
+      }
+    },
     dbQuery: createSqlRouter([
       {
         match: "SELECT key, value FROM kv_meta WHERE key LIKE 'reconcile_dispatch:%'",
@@ -349,18 +354,7 @@ test("timeouts reconcile fallback gates depth flow when an auto-queue entry is l
           }
         ]
       },
-      {
-        match: "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
-        result: [
-          {
-            id: "card-scope-g",
-            status: "requested",
-            priority: "medium",
-            assigned_agent_id: "agent-1",
-            deferred_dod_json: null
-          }
-        ]
-      },
+
       {
         match: "SELECT metadata FROM kanban_cards WHERE id = ?",
         result: [{ metadata: JSON.stringify({ scope_depth: "direct", scope_assessment_status: "completed" }) }]

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -821,7 +821,6 @@ test("timeouts long turn monitor module alerts every 30-minute threshold", () =>
         result: []
       },
       { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'", result: [] },
-      { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_alert:%'", result: [] }
     ])
   });
 
@@ -856,15 +855,19 @@ test("timeouts long turn monitor module skips synthetic reattach placeholders", 
     ],
     dbQuery: createSqlRouter([
       { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'", result: [] },
-      { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_alert:%'", result: [] },
       { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_watchdog_extension:%'", result: [] }
     ])
   });
 
   policy._section_L();
 
+  // Synthetic placeholders never trigger alerts or tier writes…
   assert.equal(state.deadlockAlerts.length, 0);
-  assert.equal(state.executions.length, 0);
+  // …but the cleanup pass still runs and the bulk alert-key DELETE must execute.
+  const bulkAlertDeletes = state.executions.filter((execution) =>
+    /DELETE FROM kv_meta WHERE key LIKE 'long_turn_alert:%'/.test(execution.sql)
+  );
+  assert.equal(bulkAlertDeletes.length, 1);
 });
 
 test("timeouts long turn monitor module skips repeated 30-minute threshold", () => {

--- a/policies/timeouts/long-turn-monitor.js
+++ b/policies/timeouts/long-turn-monitor.js
@@ -162,10 +162,8 @@ module.exports = function attachLongTurnMonitor(timeouts, helpers) {
           }
         }
         // Also clean up old cooldown keys
-        var oldKeys = agentdesk.db.query("SELECT key FROM kv_meta WHERE key LIKE 'long_turn_alert:%'");
-        for (var ok = 0; ok < oldKeys.length; ok++) {
-          agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [oldKeys[ok].key]);
-        }
+        agentdesk.db.execute("DELETE FROM kv_meta WHERE key LIKE 'long_turn_alert:%'");
+
         var extensionKeys = agentdesk.db.query("SELECT key FROM kv_meta WHERE key LIKE 'long_turn_watchdog_extension:%'");
         for (var ek = 0; ek < extensionKeys.length; ek++) {
           var eParts = extensionKeys[ek].key.split(":");

--- a/policies/timeouts/reconciliation.js
+++ b/policies/timeouts/reconciliation.js
@@ -68,12 +68,8 @@ module.exports = function attachReconciliation(timeouts, helpers) {
           continue;
         }
         // 2. For completed dispatches, replay kanban-rules onDispatchCompleted logic
-        var cards = agentdesk.db.query(
-          "SELECT id, status, priority, assigned_agent_id, deferred_dod_json FROM kanban_cards WHERE id = ?",
-          [di.kanban_card_id]
-        );
-        if (cards.length === 0) continue;
-        var card = cards[0];
+        var card = agentdesk.cards.get(di.kanban_card_id);
+        if (!card) continue;
         var rCfg = agentdesk.pipeline.resolveForCard(card.id);
         var rInitial = agentdesk.pipeline.kickoffState(rCfg);
         var rInProgress = agentdesk.pipeline.nextGatedTarget(rInitial, rCfg);
@@ -166,10 +162,14 @@ module.exports = function attachReconciliation(timeouts, helpers) {
           // Format: { items: ["task1", "task2"], verified: ["task1"] }
           if (card.deferred_dod_json) {
             try {
-              var dod = JSON.parse(card.deferred_dod_json);
-              var items = dod.items || [];
-              var verified = dod.verified || [];
-              if (items.length > 0) {
+              var dod = typeof card.deferred_dod_json === "string"
+                ? JSON.parse(card.deferred_dod_json)
+                : card.deferred_dod_json;
+              var items = dod && Array.isArray(dod.items) ? dod.items : [];
+              var verified = dod && Array.isArray(dod.verified)
+                ? dod.verified
+                : (dod && typeof dod.verified === "undefined" ? [] : null);
+              if (items.length > 0 && verified) {
                 var unverified = 0;
                 for (var di2 = 0; di2 < items.length; di2++) {
                   if (verified.indexOf(items[di2]) === -1) unverified++;


### PR DESCRIPTION
## 목표
Timeouts policy의 long-turn cleanup 비용을 줄이고, reconciliation 경로가 card 조회를 typed facade로 통일하도록 포트합니다.

## 쉬운 설명
long-turn alert 키를 하나씩 지우던 흐름을 bulk delete로 줄였습니다. Timeout reconciliation은 raw card access 대신 `agentdesk.cards.get` facade를 사용해 같은 계약을 따릅니다. 기존 timeout 동작은 유지하면서 policy 코드가 더 적은 작업으로 같은 결정을 하도록 정리했습니다.

## 개선되는 것
### Fix 1
long-turn alert cleanup에서 반복 delete 호출을 bulk delete로 줄입니다.

### Fix 2
timeouts reconciliation의 card 조회를 `agentdesk.cards.get` facade로 전환합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 오래된 long-turn alert cleanup | 키별 delete 반복 | bulk delete로 정리 |
| reconciliation card 조회 | policy 내부 접근 경로 혼재 | typed facade 사용 |
| vacuous long-turn 테스트 | 의미 없는 pass 가능 | 실제 cleanup 동작 검증 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 삭제할 alert 키가 없음 | no-op 유지 | 안전 |
| facade card missing | 기존 fallback/skip 계약 유지 | timeout flow 보존 |
| 여러 policy tests 동시 실행 | 176개 통과 | 회귀 없음 |

## 해결한 내용
- `policies/timeouts/long-turn-monitor.js`: long-turn alert key cleanup 최적화
- `policies/timeouts/reconciliation.js`: cards facade 기반 조회로 전환
- `policies/__tests__/timeouts.test.js`: bulk cleanup과 facade path 테스트 갱신

## 포트 메모
`kunkunGames/AgentDesk` fork의 timeouts policy 성능/정확성 변경 중 서로 관련 있는 두 커밋을 `itismyfield/AgentDesk:main` 기준으로 묶어 포트했습니다.

## 검증
- `npm run test:policies -- policies/__tests__/timeouts.test.js` (176 passed)