### PR TITLE
Steward: strengthen PR hygiene tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 - [ ] **Duplicate PR guard:** I have checked for overlapping open PRs before creating this PR (especially for generated refresh work).
 - [ ] **No-change verification:** If this PR claims no change, I have verified it modifies zero files using `gh pr view --json files`. (If an unavoidable no-change PR is opened, its body lists the exact overlapping PR numbers and branches).
 - [ ] **Stale branch cleanup:** I am not salvaging a stale broad branch in-place. Instead, I am closing stale branches and recreating clean branches from main.
-- [ ] **Scratch file cleanup:** I have run `git status` or a changed-file audit to ensure no ad-hoc scratch files (e.g. `plan.md`) or unrelated test scripts are included in this PR.
+- [ ] **Scratch file cleanup:** I have run `git status` or a changed-file audit to ensure no ad-hoc scratch files (e.g. `plan.md`, `pr-body.md`) or unrelated test scripts (e.g. `.sh`, `.sql`) are included in this PR.
 
 ## Dashboard / UI checklist
 - [ ] **시안에 없는 기존 기능을 임의로 삭제하지 않았다.** Reference 시안(redesign reference)에서 빠진 위젯·필터·탭이라도 기존 dashboard에 있던 기능은 사용자 명시 제거 요청 없이 삭제하지 않는다. 시안의 톤·간격·타이포에 맞춰 확장하거나 별도 sub-issue로 분리한다. (관련 결정: #1254 audit, 2026-04-15 결정 기록)

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -4,7 +4,7 @@
 - **Duplicate Checks:** Before starting work, check open PRs for duplicates. If your generated inventory refresh or PR overlaps with existing open PRs, stop and report a no-change overlap.
 - **Strict No-Change Verification:** A "no-change" report MUST have exactly zero changed files. Verify using `gh pr view --json files`. If a PR claims "no change" but modifies files (e.g. migrations, routines), it is unsafe. If an empty no-change PR is unavoidably created, its body must explicitly list the exact overlapping PR numbers and branches.
 - **Stale Branch Cleanup:** Treat low-signal or stale broad branches as queue debt. Explicitly close or recommend closing stale broad branches rather than attempting to salvage them in place. A no-change result should NOT become a PR unless it explicitly changes a queue-hygiene artifact.
-- **Clean Workspace (Scratch Files):** When using tools that generate scratch files or creating ad-hoc test scripts (e.g., `test_*.rs`, `plan.md`), always run a final changed-file audit (e.g. `git status`) before committing to ensure stray artifacts are not accidentally included, preventing repository pollution.
+- **Clean Workspace (Scratch Files):** When using tools that generate scratch files or creating ad-hoc test scripts (e.g., `test_*.rs`, `test.sh`, `plan.md`, `pr-body.md`), always run a final changed-file audit (e.g. `git status`) before committing to ensure stray artifacts are not accidentally included, preventing repository pollution. Do not commit scratch PR body files such as `pr-body.md`; put PR text directly in the GitHub PR body.
 
 ## PR Body Requirements
 Every PR must include:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1367,7 +1367,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3230 lines).
+  - `src/cli/migrate/apply.rs` (3231 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.
@@ -1390,7 +1390,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2529 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
@@ -1431,7 +1431,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
+  - `src/db/postgres.rs` (1141 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).
@@ -1461,7 +1461,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
-- `src/services/onboarding/mod.rs` (2936),
+- `src/services/onboarding/mod.rs` (2937),
   `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -74,10 +74,13 @@ def has_non_empty_body_field(body, labels, *, allow_none=False, stop_at_field_la
                 # Next field label is a boundary whether or not it carries a
                 # value: an empty `- Risk:` must not borrow the value of a
                 # following populated field (e.g. `- Rollback notes: revert`).
-                if stop_at_field_labels and _is_top_level_field_label(next_line):
+                is_field_label = _is_top_level_field_label(next_line)
+                if stop_at_field_labels and is_field_label:
                     break
                 if _meaningful_field_value(commentless, allow_none=allow_none):
                     return True
+                if is_field_label:
+                    continue
                 break
     return False
 
@@ -131,7 +134,7 @@ def has_overlap_reference(body):
     pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
     overlap_context = re.compile(r"(?i)\b(?:overlaps?|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
     negated_overlap_context = re.compile(r"(?i)\b(?:non[- ]?overlapp?ing|non[- ]?overlap|not overlapping|not overlap|does not overlap)\b")
-    branch_ref = re.compile(r"(?i)\b(?:branch(?:es)?|head(?: ref)?|ref)\s*[:=-]?\s*`?([A-Za-z0-9][A-Za-z0-9._/-]*)`?")
+    branch_ref = re.compile(r"(?i)\b(?:branch(?:es)?|head(?:\s+ref)?|ref)\b\s*[:=-]?\s*`?([A-Za-z0-9][A-Za-z0-9._/-]*)`?")
     overlap_detail_field = re.compile(r"(?i)^(?:[-*]\s*)?(?:pr|pull request|branch(?:es)?|head(?: ref)?|ref)\s*:")
     in_overlap_block = False
     block_has_pr = False
@@ -144,7 +147,7 @@ def has_overlap_reference(body):
         if negated_overlap_context.search(stripped):
             continue
 
-        is_boundary = stripped.startswith("#") or _is_top_level_field_label(line)
+        is_boundary = _is_markdown_heading(line) or _is_top_level_field_label(line)
         is_overlap_detail = bool(overlap_detail_field.search(stripped))
         if is_boundary and not (in_overlap_block and is_overlap_detail):
             if in_overlap_block and block_has_pr and block_has_branch:

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -53,6 +53,10 @@ def _is_top_level_field_label(line):
         return False
     return re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", line.strip(), re.I)
 
+def _meaningful_branch_ref(value):
+    normalized = value.strip().strip("`").strip(".,;:)]}")
+    return _meaningful_field_value(normalized)
+
 def has_non_empty_body_field(body, labels, *, allow_none=False, stop_at_field_labels=True):
     for label in labels:
         pattern = re.compile(
@@ -133,7 +137,7 @@ def has_scratch_file_cleanup_ack(body):
 def has_overlap_reference(body):
     pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
     overlap_context = re.compile(r"(?i)\b(?:overlaps?|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
-    negated_overlap_context = re.compile(r"(?i)\b(?:non[- ]?overlapp?ing|non[- ]?overlap|not overlapping|not overlap|does not overlap)\b")
+    negated_overlap_context = re.compile(r"(?i)\b(?:non[- ]?overlapp?ing|non[- ]?overlap|not overlapping|not overlap|does not overlap|no overlapping|no overlap)\b")
     branch_ref = re.compile(r"(?i)\b(?:branch(?:es)?|head(?:\s+ref)?|ref)\b\s*[:=-]?\s*`?([A-Za-z0-9][A-Za-z0-9._/-]*)`?")
     overlap_detail_field = re.compile(r"(?i)^(?:[-*]\s*)?(?:pr|pull request|branch(?:es)?|head(?: ref)?|ref)\s*:")
     in_overlap_block = False
@@ -161,7 +165,10 @@ def has_overlap_reference(body):
             continue
 
         block_has_pr = block_has_pr or bool(pr_ref.search(stripped))
-        block_has_branch = block_has_branch or bool(branch_ref.search(stripped))
+        block_has_branch = block_has_branch or any(
+            _meaningful_branch_ref(match.group(1))
+            for match in branch_ref.finditer(stripped)
+        )
         if block_has_pr and block_has_branch:
             return True
 

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -176,7 +176,10 @@ def is_scratch_file_path(path):
     }
     if path in root_scratch_files:
         return True
-    return bool(re.match(r"^(?:scratch|scratchpad|test_scratch)[._-].+\.(?:md|txt|sh|sql|rs)$", path))
+    return bool(
+        re.match(r"^(?:scratch|scratchpad|test_scratch)[._-].+\.(?:md|txt|sh|sql|rs)$", path)
+        or re.match(r"^test_[A-Za-z0-9._-]+\.rs$", path)
+    )
 
 def main():
     repo = _detect_repo()

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -51,7 +51,7 @@ def _is_markdown_heading(line):
 def _is_top_level_field_label(line):
     if line[:1] in {" ", "\t"}:
         return False
-    return re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", line.strip(), re.I)
+    return re.match(r"^(?:[-*]\s*)?(?:\*\*)?[a-z0-9 /_-]+\s*:(?:\*\*)?(?:\s.*)?$", line.strip(), re.I)
 
 def _meaningful_branch_ref(value):
     normalized = value.strip().strip("`").strip(".,;:)]}")
@@ -60,7 +60,7 @@ def _meaningful_branch_ref(value):
 def has_non_empty_body_field(body, labels, *, allow_none=False, stop_at_field_labels=True):
     for label in labels:
         pattern = re.compile(
-            rf"(?im)^[ \t]*(?:[-*][ \t]*)?(?:#{{1,6}}[ \t]*)?{re.escape(label)}(?:[ \t]*:[ \t]*(.*)|[ \t]*)$"
+            rf"(?im)^[ \t]*(?:[-*][ \t]*)?(?:#{{1,6}}[ \t]*)?(?:\*\*)?{re.escape(label)}(?:[ \t]*:(?:\*\*)?[ \t]*(.*)|(?:\*\*)?[ \t]*)$"
         )
         for match in pattern.finditer(body):
             if _meaningful_field_value(match.group(1) or "", allow_none=allow_none):
@@ -136,7 +136,7 @@ def has_scratch_file_cleanup_ack(body):
 
 def has_overlap_reference(body):
     pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
-    overlap_context = re.compile(r"(?i)\b(?:overlaps?|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
+    overlap_context = re.compile(r"(?i)\b(?:overlaps?|overlapping|duplicates?|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
     negated_overlap_context = re.compile(r"(?i)\b(?:non[- ]?overlapp?ing|non[- ]?overlap|not overlapping|not overlap|does not overlap|no overlapping|no overlap)\b")
     branch_ref = re.compile(r"(?i)\b(?:branch(?:es)?|head(?:\s+ref)?|ref)\b\s*[:=-]?\s*`?([A-Za-z0-9][A-Za-z0-9._/-]*)`?")
     overlap_detail_field = re.compile(r"(?i)^(?:[-*]\s*)?(?:pr|pull request|branch(?:es)?|head(?: ref)?|ref)\s*:")
@@ -148,17 +148,18 @@ def has_overlap_reference(body):
         stripped = line.strip()
         if not stripped:
             continue
-        if negated_overlap_context.search(stripped):
-            continue
 
         is_boundary = _is_markdown_heading(line) or _is_top_level_field_label(line)
         is_overlap_detail = bool(overlap_detail_field.search(stripped))
+        is_negated_overlap = bool(negated_overlap_context.search(stripped))
         if is_boundary and not (in_overlap_block and is_overlap_detail):
             if in_overlap_block and block_has_pr and block_has_branch:
                 return True
-            in_overlap_block = bool(overlap_context.search(stripped))
+            in_overlap_block = bool(overlap_context.search(stripped)) and not is_negated_overlap
             block_has_pr = False
             block_has_branch = False
+        if is_negated_overlap:
+            continue
 
         line_has_context = in_overlap_block or bool(overlap_context.search(stripped))
         if not line_has_context:
@@ -254,11 +255,15 @@ def main():
             print("  [!] MISSING SCRATCH FILE CLEANUP CHECK: PR body lacks a completed scratch file cleanup acknowledgement.")
         if not has_non_empty_body_field(body, ["verification commands and results", "verification"]):
             print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
-        if not has_non_empty_body_field(body, ["skipped checks with reasons", "skipped checks"], allow_none=True):
+        if not has_non_empty_body_field(
+            body,
+            ["skipped checks and reasons", "skipped checks with reasons", "skipped checks"],
+            allow_none=True,
+        ):
             print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
-        if not has_non_empty_body_field(body, ["risk", "risk assessment"]):
+        if not has_non_empty_body_field(body, ["risk and rollback notes", "risk", "risk assessment"]):
             print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")
-        if not has_non_empty_body_field(body, ["rollback notes", "rollback"]):
+        if not has_non_empty_body_field(body, ["risk and rollback notes", "rollback notes", "rollback"]):
             print("  [!] MISSING ROLLBACK NOTES: PR body fails to mention 'rollback notes'.")
 
         # 2026-05-13 lesson: treat low-signal or stale broad branches as queue debt

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -124,28 +124,37 @@ def has_scratch_file_cleanup_ack(body):
 
 def has_overlap_reference(body):
     pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
-    overlap_context = re.compile(r"(?i)\b(?:overlap|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
-    branch_token = re.compile(r"`?[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._/-]*`?")
+    overlap_context = re.compile(r"(?i)\b(?:overlaps?|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
+    branch_ref = re.compile(r"(?i)\b(?:branch(?:es)?|head(?: ref)?|ref)\s*[:=-]?\s*`?([A-Za-z0-9][A-Za-z0-9._/-]*)`?")
+    overlap_detail_field = re.compile(r"(?i)^(?:[-*]\s*)?(?:pr|pull request|branch(?:es)?|head(?: ref)?|ref)\s*:")
     in_overlap_block = False
+    block_has_pr = False
+    block_has_branch = False
 
     for line in body.splitlines():
         stripped = line.strip()
         if not stripped:
             continue
 
-        if stripped.startswith("#"):
+        is_boundary = stripped.startswith("#") or _is_top_level_field_label(line)
+        is_overlap_detail = bool(overlap_detail_field.search(stripped))
+        if is_boundary and not (in_overlap_block and is_overlap_detail):
+            if in_overlap_block and block_has_pr and block_has_branch:
+                return True
             in_overlap_block = bool(overlap_context.search(stripped))
-        elif _is_top_level_field_label(line):
-            in_overlap_block = bool(overlap_context.search(stripped))
+            block_has_pr = False
+            block_has_branch = False
 
-        if (
-            pr_ref.search(stripped)
-            and branch_token.search(stripped)
-            and (in_overlap_block or overlap_context.search(stripped))
-        ):
+        line_has_context = in_overlap_block or bool(overlap_context.search(stripped))
+        if not line_has_context:
+            continue
+
+        block_has_pr = block_has_pr or bool(pr_ref.search(stripped))
+        block_has_branch = block_has_branch or bool(branch_ref.search(stripped))
+        if block_has_pr and block_has_branch:
             return True
 
-    return False
+    return in_overlap_block and block_has_pr and block_has_branch
 
 def has_template_summary(body):
     return has_non_empty_body_field(body, ["summary"], stop_at_field_labels=False)

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -48,7 +48,7 @@ def _is_top_level_field_label(line):
         return False
     return re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", line.strip(), re.I)
 
-def has_non_empty_body_field(body, labels, *, allow_none=False):
+def has_non_empty_body_field(body, labels, *, allow_none=False, stop_at_field_labels=True):
     for label in labels:
         pattern = re.compile(
             rf"(?im)^[ \t]*(?:[-*][ \t]*)?(?:#{{1,6}}[ \t]*)?{re.escape(label)}(?:[ \t]*:[ \t]*(.*)|[ \t]*)$"
@@ -69,7 +69,7 @@ def has_non_empty_body_field(body, labels, *, allow_none=False):
                 # Next field label is a boundary whether or not it carries a
                 # value: an empty `- Risk:` must not borrow the value of a
                 # following populated field (e.g. `- Rollback notes: revert`).
-                if _is_top_level_field_label(next_line):
+                if stop_at_field_labels and _is_top_level_field_label(next_line):
                     break
                 if _meaningful_field_value(commentless, allow_none=allow_none):
                     return True
@@ -125,6 +125,7 @@ def has_scratch_file_cleanup_ack(body):
 def has_overlap_reference(body):
     pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
     overlap_context = re.compile(r"(?i)\b(?:overlap|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
+    branch_token = re.compile(r"`?[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._/-]*`?")
     in_overlap_block = False
 
     for line in body.splitlines():
@@ -137,13 +138,17 @@ def has_overlap_reference(body):
         elif _is_top_level_field_label(line):
             in_overlap_block = bool(overlap_context.search(stripped))
 
-        if pr_ref.search(stripped) and (in_overlap_block or overlap_context.search(stripped)):
+        if (
+            pr_ref.search(stripped)
+            and branch_token.search(stripped)
+            and (in_overlap_block or overlap_context.search(stripped))
+        ):
             return True
 
     return False
 
 def has_template_summary(body):
-    return has_non_empty_body_field(body, ["summary"])
+    return has_non_empty_body_field(body, ["summary"], stop_at_field_labels=False)
 
 def is_scratch_file_path(path):
     if not path or "/" in path:
@@ -207,7 +212,7 @@ def main():
             print("  [!] MISSING PRIMARY FILES: PR body lacks the required 'Primary files' field.")
         if not has_non_empty_body_field(body, ["queue hygiene invariant"]):
             print("  [!] MISSING QUEUE HYGIENE INVARIANT: PR body lacks the required 'Queue hygiene invariant' field.")
-        if not has_non_empty_body_field(body, ["related prs/issues checked", "related prs"]):
+        if not has_non_empty_body_field(body, ["related prs/issues checked", "related prs/issues", "related prs"]):
             print("  [!] MISSING RELATED PRS: PR body lacks the required 'Related PRs/issues checked' field.")
         if not has_non_empty_body_field(body, ["why this is non-overlapping", "non-overlapping reason"]):
             print("  [!] MISSING NON-OVERLAPPING REASON: PR body lacks the required 'Why this is non-overlapping' field.")

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -80,6 +80,42 @@ def has_duplicate_guard_ack(body):
         ],
     )
 
+def has_no_change_verification_ack(body):
+    if re.search(r"(?im)^[ \t]*[-*][ \t]*\[[xX]\][ \t]*\*\*no-change verification:\*\*", body):
+        return True
+    return has_non_empty_body_field(
+        body,
+        [
+            "no-change verification",
+            "no change verification",
+        ],
+    )
+
+def has_stale_branch_cleanup_ack(body):
+    if re.search(r"(?im)^[ \t]*[-*][ \t]*\[[xX]\][ \t]*\*\*stale branch cleanup:\*\*", body):
+        return True
+    return has_non_empty_body_field(
+        body,
+        [
+            "stale branch cleanup",
+            "stale-branch cleanup",
+        ],
+    )
+
+def has_scratch_file_cleanup_ack(body):
+    if re.search(r"(?im)^[ \t]*[-*][ \t]*\[[xX]\][ \t]*\*\*scratch file cleanup:\*\*", body):
+        return True
+    return has_non_empty_body_field(
+        body,
+        [
+            "scratch file cleanup",
+            "scratch-file cleanup",
+        ],
+    )
+
+def has_overlap_reference(body):
+    return bool(re.search(r"(?i)(?:#[0-9]+|github\.com/[^/]+/[^/]+/pull/[0-9]+)", body))
+
 def main():
     repo = _detect_repo()
     print("Fetching PRs...")
@@ -108,13 +144,31 @@ def main():
         print(f"\n# {num} - {title}")
 
         # Check PR hygiene requirements
+        if not has_non_empty_body_field(body, ["what changed"]):
+            print("  [!] MISSING WHAT CHANGED: PR body lacks a required 'What changed' description.")
+        if not has_non_empty_body_field(body, ["why"]):
+            print("  [!] MISSING WHY: PR body lacks a required 'Why' description.")
         if "workfingerprint" not in normalized_body:
             print("  [!] MISSING FINGERPRINT: PR body lacks the required 'WorkFingerprint' section.")
+        if not has_non_empty_body_field(body, ["agent"]):
+            print("  [!] MISSING AGENT: PR body lacks the required 'Agent' field.")
+        if not has_non_empty_body_field(body, ["boundary"]):
+            print("  [!] MISSING BOUNDARY: PR body lacks the required 'Boundary' field.")
+        if not has_non_empty_body_field(body, ["primary files"]):
+            print("  [!] MISSING PRIMARY FILES: PR body lacks the required 'Primary files' field.")
+        if not has_non_empty_body_field(body, ["queue hygiene invariant"]):
+            print("  [!] MISSING QUEUE HYGIENE INVARIANT: PR body lacks the required 'Queue hygiene invariant' field.")
+        if not has_non_empty_body_field(body, ["related prs/issues checked", "related prs"]):
+            print("  [!] MISSING RELATED PRS: PR body lacks the required 'Related PRs/issues checked' field.")
+        if not has_non_empty_body_field(body, ["why this is non-overlapping", "non-overlapping reason"]):
+            print("  [!] MISSING NON-OVERLAPPING REASON: PR body lacks the required 'Why this is non-overlapping' field.")
         if not has_duplicate_guard_ack(body):
             print("  [!] MISSING OVERLAP CHECK: PR body lacks a completed duplicate/overlap guard acknowledgement.")
-        if "verification" not in normalized_body:
+        if not has_scratch_file_cleanup_ack(body):
+            print("  [!] MISSING SCRATCH FILE CLEANUP CHECK: PR body lacks a completed scratch file cleanup acknowledgement.")
+        if not has_non_empty_body_field(body, ["verification commands and results", "verification"]):
             print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
-        if "skipped checks" not in normalized_body:
+        if not has_non_empty_body_field(body, ["skipped checks with reasons", "skipped checks"]):
             print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
         if not has_non_empty_body_field(body, ["risk", "risk assessment"]):
             print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")
@@ -128,21 +182,41 @@ def main():
         stat, _ = run(f"gh pr diff {num} --repo {repo} --stat")
         print(f"Stat:\n{stat}")
 
+        # PR files
+        files_json, _ = run(f"gh pr view {num} --repo {repo} --json files")
+        files_data = {}
+        try:
+            if files_json:
+                files_data = json.loads(files_json)
+        except Exception:
+            pass
+
+        # Scratch file detection
+        if files_data.get("files") is not None:
+            scratch_files = []
+            for f in files_data["files"]:
+                path = f.get("path", "")
+                if path in ["pr-body.md", "plan.md"] or path.endswith((".sh", ".sql")):
+                    scratch_files.append(path)
+            if scratch_files:
+                print(f"  [!] SCRATCH FILE DETECTED: PR includes scratch files like pr-body.md, plan.md, or test scripts ({', '.join(scratch_files)}).")
+
         if is_stale:
             print(f"  [!] STALE BRANCH: Head commit is > 14 days old. Treat as queue debt. Close or recommend closing instead of salvaging in place.")
+            if not has_stale_branch_cleanup_ack(body):
+                print("  [!] MISSING STALE BRANCH CLEANUP CHECK: PR body lacks a completed stale branch cleanup acknowledgement.")
 
         # PR #214/#215 lesson: no-change PRs must have 0 changed files
         if "no-change" in title.lower():
-            files_json, _ = run(f"gh pr view {num} --repo {repo} --json files")
-            try:
-                files_data = json.loads(files_json)
-                if files_data.get("files") is not None:
-                    if len(files_data["files"]) > 0:
-                        print(f"  [!] UNSAFE NO-CHANGE PR: Title claims no-change but modifies {len(files_data['files'])} files.")
-                    else:
-                        print(f"  [i] EMPTY NO-CHANGE PR: No changed files. If no durable queue-hygiene artifact is changed, it is a close candidate (report only).")
-            except Exception:
-                pass
+            if not has_no_change_verification_ack(body):
+                print("  [!] MISSING NO-CHANGE VERIFICATION CHECK: PR body lacks a completed no-change verification acknowledgement.")
+            if files_data.get("files") is not None:
+                if len(files_data["files"]) > 0:
+                    print(f"  [!] UNSAFE NO-CHANGE PR: Title claims no-change but modifies {len(files_data['files'])} files.")
+                else:
+                    print(f"  [i] EMPTY NO-CHANGE PR: No changed files. If no durable queue-hygiene artifact is changed, it is a close candidate (report only).")
+                    if not has_overlap_reference(body):
+                        print("  [!] MISSING OVERLAP REFERENCE: Empty no-change PR body must explicitly list the exact overlapping PR numbers and branches.")
 
         # PR #199/#200/#201 lesson: check for multiple inventory refreshes
         if "inventory" in title.lower() and "refresh" in title.lower():

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -38,10 +38,15 @@ def _strip_html_comments(value):
 
 def _meaningful_field_value(value, *, allow_none=False):
     normalized = _strip_html_comments(value).strip().strip("-–—").strip()
+    if re.match(r"(?i)^[a-z0-9 /_-]+\s*:\s*$", normalized):
+        return False
     placeholders = {"n/a", "todo", "tbd", "na"}
     if not allow_none:
         placeholders.add("none")
     return bool(normalized) and normalized.casefold() not in placeholders
+
+def _is_markdown_heading(line):
+    return bool(re.match(r"^[ \t]{0,3}#{1,6}[ \t]+\S", line))
 
 def _is_top_level_field_label(line):
     if line[:1] in {" ", "\t"}:
@@ -64,7 +69,7 @@ def has_non_empty_body_field(body, labels, *, allow_none=False, stop_at_field_la
                 commentless = _strip_html_comments(stripped).strip()
                 if not commentless:
                     continue
-                if stripped.startswith("#"):
+                if _is_markdown_heading(next_line):
                     break
                 # Next field label is a boundary whether or not it carries a
                 # value: an empty `- Risk:` must not borrow the value of a
@@ -125,6 +130,7 @@ def has_scratch_file_cleanup_ack(body):
 def has_overlap_reference(body):
     pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
     overlap_context = re.compile(r"(?i)\b(?:overlaps?|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
+    negated_overlap_context = re.compile(r"(?i)\b(?:non[- ]?overlapp?ing|non[- ]?overlap|not overlapping|not overlap|does not overlap)\b")
     branch_ref = re.compile(r"(?i)\b(?:branch(?:es)?|head(?: ref)?|ref)\s*[:=-]?\s*`?([A-Za-z0-9][A-Za-z0-9._/-]*)`?")
     overlap_detail_field = re.compile(r"(?i)^(?:[-*]\s*)?(?:pr|pull request|branch(?:es)?|head(?: ref)?|ref)\s*:")
     in_overlap_block = False
@@ -134,6 +140,8 @@ def has_overlap_reference(body):
     for line in body.splitlines():
         stripped = line.strip()
         if not stripped:
+            continue
+        if negated_overlap_context.search(stripped):
             continue
 
         is_boundary = stripped.startswith("#") or _is_top_level_field_label(line)
@@ -167,8 +175,10 @@ def is_scratch_file_path(path):
         "plan.md",
         "plan.txt",
         "scratch.md",
+        "scratch.sh",
         "scratch.txt",
         "scratchpad.md",
+        "scratchpad.sh",
         "scratchpad.txt",
         "test.sh",
         "test.sql",

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -33,27 +33,36 @@ def head_commit_timestamp(pr, repo):
         return None
     return parse_github_timestamp(timestamp)
 
-def _meaningful_field_value(value):
-    normalized = value.strip().strip("-–—").strip()
-    return bool(normalized) and normalized.casefold() not in {"n/a", "none", "todo", "tbd", "na"}
+def _strip_html_comments(value):
+    return re.sub(r"<!--.*?-->", "", value, flags=re.S)
+
+def _meaningful_field_value(value, *, allow_none=False):
+    normalized = _strip_html_comments(value).strip().strip("-–—").strip()
+    placeholders = {"n/a", "todo", "tbd", "na"}
+    if not allow_none:
+        placeholders.add("none")
+    return bool(normalized) and normalized.casefold() not in placeholders
 
 def _is_top_level_field_label(line):
     if line[:1] in {" ", "\t"}:
         return False
     return re.match(r"^(?:[-*]\s*)?[a-z0-9 /_-]+\s*:(?:\s.*)?$", line.strip(), re.I)
 
-def has_non_empty_body_field(body, labels):
+def has_non_empty_body_field(body, labels, *, allow_none=False):
     for label in labels:
         pattern = re.compile(
             rf"(?im)^[ \t]*(?:[-*][ \t]*)?(?:#{{1,6}}[ \t]*)?{re.escape(label)}(?:[ \t]*:[ \t]*(.*)|[ \t]*)$"
         )
         for match in pattern.finditer(body):
-            if _meaningful_field_value(match.group(1) or ""):
+            if _meaningful_field_value(match.group(1) or "", allow_none=allow_none):
                 return True
 
             for next_line in body[match.end():].splitlines():
                 stripped = next_line.strip()
                 if not stripped:
+                    continue
+                commentless = _strip_html_comments(stripped).strip()
+                if not commentless:
                     continue
                 if stripped.startswith("#"):
                     break
@@ -62,7 +71,7 @@ def has_non_empty_body_field(body, labels):
                 # following populated field (e.g. `- Rollback notes: revert`).
                 if _is_top_level_field_label(next_line):
                     break
-                if _meaningful_field_value(stripped):
+                if _meaningful_field_value(commentless, allow_none=allow_none):
                     return True
                 break
     return False
@@ -114,7 +123,24 @@ def has_scratch_file_cleanup_ack(body):
     )
 
 def has_overlap_reference(body):
-    return bool(re.search(r"(?i)(?:#[0-9]+|github\.com/[^/]+/[^/]+/pull/[0-9]+)", body))
+    pr_ref = re.compile(r"(?i)(?:#[0-9]+|github\.com/[^/\s]+/[^/\s]+/pull/[0-9]+)")
+    overlap_context = re.compile(r"(?i)\b(?:overlap|overlapping|duplicate|supersed(?:e|ed|es|ing)?|replaces?|same scope)\b")
+    in_overlap_block = False
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if stripped.startswith("#"):
+            in_overlap_block = bool(overlap_context.search(stripped))
+        elif _is_top_level_field_label(line):
+            in_overlap_block = bool(overlap_context.search(stripped))
+
+        if pr_ref.search(stripped) and (in_overlap_block or overlap_context.search(stripped)):
+            return True
+
+    return False
 
 def has_template_summary(body):
     return has_non_empty_body_field(body, ["summary"])
@@ -191,7 +217,7 @@ def main():
             print("  [!] MISSING SCRATCH FILE CLEANUP CHECK: PR body lacks a completed scratch file cleanup acknowledgement.")
         if not has_non_empty_body_field(body, ["verification commands and results", "verification"]):
             print("  [!] MISSING VERIFICATION: PR body lacks the required 'verification' commands and results.")
-        if not has_non_empty_body_field(body, ["skipped checks with reasons", "skipped checks"]):
+        if not has_non_empty_body_field(body, ["skipped checks with reasons", "skipped checks"], allow_none=True):
             print("  [!] MISSING SKIPPED CHECKS: PR body fails to mention 'skipped checks' with reasons.")
         if not has_non_empty_body_field(body, ["risk", "risk assessment"]):
             print("  [!] MISSING RISK: PR body fails to mention 'risk' assessment.")

--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -116,6 +116,28 @@ def has_scratch_file_cleanup_ack(body):
 def has_overlap_reference(body):
     return bool(re.search(r"(?i)(?:#[0-9]+|github\.com/[^/]+/[^/]+/pull/[0-9]+)", body))
 
+def has_template_summary(body):
+    return has_non_empty_body_field(body, ["summary"])
+
+def is_scratch_file_path(path):
+    if not path or "/" in path:
+        return False
+    root_scratch_files = {
+        "pr-body.md",
+        "plan.md",
+        "plan.txt",
+        "scratch.md",
+        "scratch.txt",
+        "scratchpad.md",
+        "scratchpad.txt",
+        "test.sh",
+        "test.sql",
+        "test_scratch.rs",
+    }
+    if path in root_scratch_files:
+        return True
+    return bool(re.match(r"^(?:scratch|scratchpad|test_scratch)[._-].+\.(?:md|txt|sh|sql|rs)$", path))
+
 def main():
     repo = _detect_repo()
     print("Fetching PRs...")
@@ -144,9 +166,10 @@ def main():
         print(f"\n# {num} - {title}")
 
         # Check PR hygiene requirements
-        if not has_non_empty_body_field(body, ["what changed"]):
+        summary_satisfies_change_context = has_template_summary(body)
+        if not has_non_empty_body_field(body, ["what changed"]) and not summary_satisfies_change_context:
             print("  [!] MISSING WHAT CHANGED: PR body lacks a required 'What changed' description.")
-        if not has_non_empty_body_field(body, ["why"]):
+        if not has_non_empty_body_field(body, ["why"]) and not summary_satisfies_change_context:
             print("  [!] MISSING WHY: PR body lacks a required 'Why' description.")
         if "workfingerprint" not in normalized_body:
             print("  [!] MISSING FINGERPRINT: PR body lacks the required 'WorkFingerprint' section.")
@@ -196,7 +219,7 @@ def main():
             scratch_files = []
             for f in files_data["files"]:
                 path = f.get("path", "")
-                if path in ["pr-body.md", "plan.md"] or path.endswith((".sh", ".sql")):
+                if is_scratch_file_path(path):
                     scratch_files.append(path)
             if scratch_files:
                 print(f"  [!] SCRATCH FILE DETECTED: PR includes scratch files like pr-body.md, plan.md, or test scripts ({', '.join(scratch_files)}).")

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -31,8 +31,6 @@ route_srp_violations = [
 # fail the hard gate because they produce different keys.
 direct_discord_sends = [
   "src/services/discord/commands/model_picker.rs#direct_discord_sends:9cf1f42bcb8abe4f",
-  "src/services/discord/commands/skill.rs#direct_discord_sends:1e8d329a7b6eeefe",
-  "src/services/discord/commands/skill.rs#direct_discord_sends:192ce5dcdad6764f",
   "src/services/discord/commands/text_commands.rs#direct_discord_sends:db5444d305a41f96",
   "src/services/discord/commands/text_commands.rs#direct_discord_sends:e1dff75fe79e7d70",
   "src/services/discord/discord_io.rs#direct_discord_sends:2f398342de1e7cd7",
@@ -56,7 +54,6 @@ direct_discord_sends = [
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:edafac97f164fd68",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:b4849c24f5cb7d09",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:1c6f6dcd93167903",
-  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9b9526b38f0691a8",
   # #3560: footer-mode migration reconcile — edits a pre-default-ON *separate*
   # status panel to a migration notice before dropping its handle (behaviorally
   # the same direct resume-notice edit already allowlisted in mod.rs; extracted

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -52,7 +52,7 @@ for scratch_file in scratch[._-]*.sh scratchpad[._-]*.sh test_scratch[._-]*.sh; 
     FAIL=1
   fi
 done
-for scratch_file in scratch[._-]*.md scratchpad[._-]*.md test_scratch[._-]*.md scratch[._-]*.txt scratchpad[._-]*.txt test_scratch[._-]*.txt scratch[._-]*.rs scratchpad[._-]*.rs test_scratch[._-]*.rs; do
+for scratch_file in scratch[._-]*.md scratchpad[._-]*.md test_scratch[._-]*.md scratch[._-]*.txt scratchpad[._-]*.txt test_scratch[._-]*.txt scratch[._-]*.rs scratchpad[._-]*.rs test_scratch[._-]*.rs test_*.rs; do
   if [ -f "$scratch_file" ]; then
     echo "ERROR: Scratch file detected in repository root: $scratch_file"
     FAIL=1

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -34,7 +34,7 @@ echo "=== CI runner hardening guard ==="
 
 echo "=== Scratch file guard ==="
 FAIL=0
-for scratch_file in plan.md scratch.md scratch.txt scratchpad.md scratchpad.txt test_scratch.rs plan.txt; do
+for scratch_file in plan.md scratch.md scratch.txt scratchpad.md scratchpad.txt test_scratch.rs plan.txt pr-body.md test.sh; do
   if [ -f "$scratch_file" ]; then
     echo "ERROR: Scratch file detected in repository root: $scratch_file"
     FAIL=1

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -52,6 +52,12 @@ for scratch_file in scratch[._-]*.sh scratchpad[._-]*.sh test_scratch[._-]*.sh; 
     FAIL=1
   fi
 done
+for scratch_file in scratch[._-]*.md scratchpad[._-]*.md test_scratch[._-]*.md scratch[._-]*.txt scratchpad[._-]*.txt test_scratch[._-]*.txt scratch[._-]*.rs scratchpad[._-]*.rs test_scratch[._-]*.rs; do
+  if [ -f "$scratch_file" ]; then
+    echo "ERROR: Scratch file detected in repository root: $scratch_file"
+    FAIL=1
+  fi
+done
 if [ "$FAIL" -ne 0 ]; then
   exit "$FAIL"
 fi

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -46,6 +46,12 @@ for scratch_file in scratch.sql scratchpad.sql scratch[._-]*.sql scratchpad[._-]
     FAIL=1
   fi
 done
+for scratch_file in scratch[._-]*.sh scratchpad[._-]*.sh test_scratch[._-]*.sh; do
+  if [ -f "$scratch_file" ]; then
+    echo "ERROR: Scratch shell file detected in repository root: $scratch_file"
+    FAIL=1
+  fi
+done
 if [ "$FAIL" -ne 0 ]; then
   exit "$FAIL"
 fi

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -34,7 +34,7 @@ echo "=== CI runner hardening guard ==="
 
 echo "=== Scratch file guard ==="
 FAIL=0
-for scratch_file in plan.md scratch.md scratch.txt scratchpad.md scratchpad.txt test_scratch.rs plan.txt pr-body.md test.sh test.sql; do
+for scratch_file in plan.md scratch.md scratch.txt scratch.sh scratchpad.md scratchpad.txt scratchpad.sh test_scratch.rs plan.txt pr-body.md test.sh test.sql; do
   if [ -f "$scratch_file" ]; then
     echo "ERROR: Scratch file detected in repository root: $scratch_file"
     FAIL=1

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -34,9 +34,15 @@ echo "=== CI runner hardening guard ==="
 
 echo "=== Scratch file guard ==="
 FAIL=0
-for scratch_file in plan.md scratch.md scratch.txt scratchpad.md scratchpad.txt test_scratch.rs plan.txt pr-body.md test.sh; do
+for scratch_file in plan.md scratch.md scratch.txt scratchpad.md scratchpad.txt test_scratch.rs plan.txt pr-body.md test.sh test.sql; do
   if [ -f "$scratch_file" ]; then
     echo "ERROR: Scratch file detected in repository root: $scratch_file"
+    FAIL=1
+  fi
+done
+for scratch_file in scratch.sql scratchpad.sql scratch[._-]*.sql scratchpad[._-]*.sql test_scratch[._-]*.sql; do
+  if [ -f "$scratch_file" ]; then
+    echo "ERROR: Scratch SQL file detected in repository root: $scratch_file"
     FAIL=1
   fi
 done

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -1398,6 +1398,7 @@ def generated_documents() -> dict[Path, str]:
 
 def write_documents(documents: dict[Path, str], check: bool) -> int:
     stale_paths: list[Path] = []
+    wrote_files = False
     for path, content in documents.items():
         if check:
             current = path.read_text(encoding="utf-8") if path.exists() else None
@@ -1423,6 +1424,7 @@ def write_documents(documents: dict[Path, str], check: bool) -> int:
         if current != content:
             path.write_text(content, encoding="utf-8")
             print(f"wrote {rel_posix(path)}")
+            wrote_files = True
         else:
             print(f"unchanged {rel_posix(path)}")
 
@@ -1430,6 +1432,10 @@ def write_documents(documents: dict[Path, str], check: bool) -> int:
         print("")
         print("generated docs are stale; rerun `python3 scripts/generate_inventory_docs.py`")
         return 1
+
+    if wrote_files:
+        print("\nNOTE: Generated inventory changed. Check for existing open PRs to avoid duplicate inventory refreshes.")
+
     return 0
 
 

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -64,6 +64,30 @@ Update analyzer hygiene checks.
             )
         )
 
+    def test_bolded_field_label_counts_as_populated(self):
+        body = "- **Agent:** Codex"
+
+        self.assertTrue(has_non_empty_body_field(body, ["agent"]))
+
+    def test_skipped_checks_and_reasons_label_allows_none(self):
+        body = "- Skipped checks and reasons: none"
+
+        self.assertTrue(
+            has_non_empty_body_field(
+                body,
+                ["skipped checks and reasons", "skipped checks with reasons", "skipped checks"],
+                allow_none=True,
+            )
+        )
+
+    def test_combined_risk_and_rollback_notes_counts_for_both(self):
+        body = "- Risk and rollback notes: low risk; revert this PR."
+
+        self.assertTrue(has_non_empty_body_field(body, ["risk and rollback notes", "risk"]))
+        self.assertTrue(
+            has_non_empty_body_field(body, ["risk and rollback notes", "rollback notes"])
+        )
+
     def test_multiline_field_value_stops_at_next_field_label(self):
         body = """
 - Risk:
@@ -212,6 +236,10 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
         body = "This no-change PR overlaps #1234 on branch inventory-refresh."
         self.assertTrue(has_overlap_reference(body))
 
+    def test_duplicate_plural_wording_with_branch_is_reference(self):
+        body = "This no-change PR duplicates #1234 on branch feature/foo."
+        self.assertTrue(has_overlap_reference(body))
+
     def test_pull_url_without_branch_is_not_overlap_reference(self):
         body = "Overlap with https://github.com/owner/repo/pull/5678."
         self.assertFalse(has_overlap_reference(body))
@@ -259,6 +287,16 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
     def test_no_overlap_wording_is_not_overlap_evidence(self):
         body = """
 - Duplicate/overlap check: checked #123 on branch feature/foo; no overlap found
+"""
+
+        self.assertFalse(has_overlap_reference(body))
+
+    def test_negated_boundary_resets_incomplete_overlap_block(self):
+        body = """
+- Duplicate/overlap check:
+  - PR: #123
+- Why this is non-overlapping:
+  #123 on branch feature/foo
 """
 
         self.assertFalse(has_overlap_reference(body))

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -203,6 +203,11 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
         body = "This is a no-change PR overlapping with #1234."
         self.assertFalse(has_overlap_reference(body))
 
+    def test_ref_prefix_inside_word_is_not_branch_reference(self):
+        body = "Overlap with #1234; refreshed docs only."
+
+        self.assertFalse(has_overlap_reference(body))
+
     def test_plural_overlap_wording_with_branch_is_reference(self):
         body = "This no-change PR overlaps #1234 on branch inventory-refresh."
         self.assertTrue(has_overlap_reference(body))
@@ -223,6 +228,14 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
         body = """
 - Duplicate/overlap check:
   - #1234 on branch codex/same-scope covers this no-change PR.
+"""
+
+        self.assertTrue(has_overlap_reference(body))
+
+    def test_overlap_reference_accepts_bare_issue_ref_line_inside_overlap_block(self):
+        body = """
+- Duplicate/overlap check:
+  #1234 on branch codex/same-scope
 """
 
         self.assertTrue(has_overlap_reference(body))
@@ -277,6 +290,16 @@ Update analyzer hygiene checks to match the current template.
 ## Summary
 
 - Tests: add analyzer coverage.
+"""
+
+        self.assertTrue(has_template_summary(body))
+
+    def test_multiline_labelled_summary_bullet_counts_as_change_context(self):
+        body = """
+## Summary
+
+- Tests:
+  Add analyzer coverage.
 """
 
         self.assertTrue(has_template_summary(body))

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -267,6 +267,7 @@ class PrAnalyzerScratchPathTests(unittest.TestCase):
         self.assertTrue(is_scratch_file_path("pr-body.md"))
         self.assertTrue(is_scratch_file_path("test.sh"))
         self.assertTrue(is_scratch_file_path("scratch-check.sql"))
+        self.assertTrue(is_scratch_file_path("test_cli.rs"))
 
     def test_checked_in_scripts_and_migrations_are_not_scratch(self):
         self.assertFalse(is_scratch_file_path("scripts/deploy-release.sh"))
@@ -292,6 +293,7 @@ class CiScriptScratchGuardTests(unittest.TestCase):
         self.assertIn("scratch[._-]*.md", script)
         self.assertIn("scratchpad[._-]*.txt", script)
         self.assertIn("test_scratch[._-]*.rs", script)
+        self.assertIn("test_*.rs", script)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -256,6 +256,22 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
 
         self.assertFalse(has_overlap_reference(body))
 
+    def test_no_overlap_wording_is_not_overlap_evidence(self):
+        body = """
+- Duplicate/overlap check: checked #123 on branch feature/foo; no overlap found
+"""
+
+        self.assertFalse(has_overlap_reference(body))
+
+    def test_placeholder_branch_value_is_not_overlap_reference(self):
+        body = """
+- Duplicate/overlap check:
+  - PR: #1234
+  - Branch: none
+"""
+
+        self.assertFalse(has_overlap_reference(body))
+
 
 class PrAnalyzerTemplateSummaryTests(unittest.TestCase):
     def test_populated_template_summary_counts_as_change_context(self):

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -1,6 +1,13 @@
 import unittest
 
-from scripts.analyze_prs import has_duplicate_guard_ack, has_non_empty_body_field
+from scripts.analyze_prs import (
+    has_duplicate_guard_ack,
+    has_non_empty_body_field,
+    has_no_change_verification_ack,
+    has_stale_branch_cleanup_ack,
+    has_scratch_file_cleanup_ack,
+    has_overlap_reference,
+)
 
 
 class PrAnalyzerBodyFieldTests(unittest.TestCase):
@@ -68,6 +75,70 @@ class PrAnalyzerDuplicateGuardTests(unittest.TestCase):
 
         self.assertFalse(has_duplicate_guard_ack(body))
 
+
+class PrAnalyzerNoChangeVerificationGuardTests(unittest.TestCase):
+    def test_unchecked_template_no_change_guard_is_not_acknowledgement(self):
+        body = "- [ ] **No-change verification:** If this PR claims no change..."
+
+        self.assertFalse(has_no_change_verification_ack(body))
+
+    def test_checked_template_no_change_guard_is_acknowledgement(self):
+        body = "- [x] **No-change verification:** If this PR claims no change..."
+
+        self.assertTrue(has_no_change_verification_ack(body))
+
+    def test_filled_no_change_field_is_acknowledgement(self):
+        body = "- no-change verification: checked using gh pr view --json files"
+
+        self.assertTrue(has_no_change_verification_ack(body))
+
+
+class PrAnalyzerStaleBranchCleanupGuardTests(unittest.TestCase):
+    def test_unchecked_template_stale_branch_guard_is_not_acknowledgement(self):
+        body = "- [ ] **Stale branch cleanup:** I am not salvaging a stale broad branch in-place."
+
+        self.assertFalse(has_stale_branch_cleanup_ack(body))
+
+    def test_checked_template_stale_branch_guard_is_acknowledgement(self):
+        body = "- [x] **Stale branch cleanup:** I am not salvaging a stale broad branch in-place."
+
+        self.assertTrue(has_stale_branch_cleanup_ack(body))
+
+    def test_filled_stale_branch_field_is_acknowledgement(self):
+        body = "- stale branch cleanup: closed stale branch and recreated."
+
+        self.assertTrue(has_stale_branch_cleanup_ack(body))
+
+
+class PrAnalyzerScratchFileCleanupGuardTests(unittest.TestCase):
+    def test_unchecked_template_scratch_file_guard_is_not_acknowledgement(self):
+        body = "- [ ] **Scratch file cleanup:** I have run `git status`..."
+
+        self.assertFalse(has_scratch_file_cleanup_ack(body))
+
+    def test_checked_template_scratch_file_guard_is_acknowledgement(self):
+        body = "- [X] **Scratch file cleanup:** I have run `git status`..."
+
+        self.assertTrue(has_scratch_file_cleanup_ack(body))
+
+    def test_filled_scratch_file_field_is_acknowledgement(self):
+        body = "- scratch file cleanup: ran git diff --check and git status."
+
+        self.assertTrue(has_scratch_file_cleanup_ack(body))
+
+
+class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
+    def test_overlap_reference_with_hash(self):
+        body = "This is a no-change PR overlapping with #1234."
+        self.assertTrue(has_overlap_reference(body))
+
+    def test_overlap_reference_with_url(self):
+        body = "Overlap with https://github.com/owner/repo/pull/5678."
+        self.assertTrue(has_overlap_reference(body))
+
+    def test_missing_overlap_reference(self):
+        body = "This is a no-change PR but lacks exact PR numbers."
+        self.assertFalse(has_overlap_reference(body))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -190,6 +190,14 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
         body = "This is a no-change PR overlapping with #1234."
         self.assertFalse(has_overlap_reference(body))
 
+    def test_plural_overlap_wording_with_branch_is_reference(self):
+        body = "This no-change PR overlaps #1234 on branch inventory-refresh."
+        self.assertTrue(has_overlap_reference(body))
+
+    def test_pull_url_without_branch_is_not_overlap_reference(self):
+        body = "Overlap with https://github.com/owner/repo/pull/5678."
+        self.assertFalse(has_overlap_reference(body))
+
     def test_generic_template_issue_references_are_not_overlap_references(self):
         body = """
 - Dashboard checklist issue references: #1254 / #1251
@@ -202,6 +210,15 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
         body = """
 - Duplicate/overlap check:
   - #1234 on branch codex/same-scope covers this no-change PR.
+"""
+
+        self.assertTrue(has_overlap_reference(body))
+
+    def test_overlap_reference_accepts_split_pr_and_branch_lines(self):
+        body = """
+- Duplicate/overlap check:
+  - PR: #1234
+  - Branch: codex/same-scope
 """
 
         self.assertTrue(has_overlap_reference(body))
@@ -268,6 +285,13 @@ class CiScriptScratchGuardTests(unittest.TestCase):
 
         self.assertIn("scratch[._-]*.sh", script)
         self.assertIn("scratchpad[._-]*.sh", script)
+
+    def test_ci_guard_includes_analyzer_md_txt_rs_scratch_globs(self):
+        script = Path("scripts/ci-script-checks.sh").read_text()
+
+        self.assertIn("scratch[._-]*.md", script)
+        self.assertIn("scratchpad[._-]*.txt", script)
+        self.assertIn("test_scratch[._-]*.rs", script)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -7,6 +7,8 @@ from scripts.analyze_prs import (
     has_stale_branch_cleanup_ack,
     has_scratch_file_cleanup_ack,
     has_overlap_reference,
+    has_template_summary,
+    is_scratch_file_path,
 )
 
 
@@ -139,6 +141,37 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
     def test_missing_overlap_reference(self):
         body = "This is a no-change PR but lacks exact PR numbers."
         self.assertFalse(has_overlap_reference(body))
+
+
+class PrAnalyzerTemplateSummaryTests(unittest.TestCase):
+    def test_populated_template_summary_counts_as_change_context(self):
+        body = """
+## Summary
+
+Update analyzer hygiene checks to match the current template.
+"""
+
+        self.assertTrue(has_template_summary(body))
+
+    def test_empty_template_summary_is_not_change_context(self):
+        body = """
+## Summary
+
+## Test plan
+"""
+
+        self.assertFalse(has_template_summary(body))
+
+
+class PrAnalyzerScratchPathTests(unittest.TestCase):
+    def test_root_scratch_files_are_flagged(self):
+        self.assertTrue(is_scratch_file_path("pr-body.md"))
+        self.assertTrue(is_scratch_file_path("test.sh"))
+        self.assertTrue(is_scratch_file_path("scratch-check.sql"))
+
+    def test_checked_in_scripts_and_migrations_are_not_scratch(self):
+        self.assertFalse(is_scratch_file_path("scripts/deploy-release.sh"))
+        self.assertFalse(is_scratch_file_path("migrations/postgres/001_init.sql"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -96,6 +96,19 @@ Update analyzer hygiene checks.
             )
         )
 
+    def test_related_prs_issues_allows_bare_issue_ref_value(self):
+        body = """
+- Related PRs/issues checked:
+  #1234
+"""
+
+        self.assertTrue(
+            has_non_empty_body_field(
+                body,
+                ["related prs/issues checked", "related prs/issues", "related prs"],
+            )
+        )
+
 
 class PrAnalyzerDuplicateGuardTests(unittest.TestCase):
     def test_unchecked_template_duplicate_guard_is_not_acknowledgement(self):
@@ -223,6 +236,13 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
 
         self.assertTrue(has_overlap_reference(body))
 
+    def test_non_overlapping_reason_is_not_overlap_evidence(self):
+        body = """
+- Why this is non-overlapping: not overlapping with #1234 on branch feature/foo
+"""
+
+        self.assertFalse(has_overlap_reference(body))
+
 
 class PrAnalyzerTemplateSummaryTests(unittest.TestCase):
     def test_populated_template_summary_counts_as_change_context(self):
@@ -261,11 +281,23 @@ Update analyzer hygiene checks to match the current template.
 
         self.assertTrue(has_template_summary(body))
 
+    def test_empty_summary_field_labels_are_not_change_context(self):
+        body = """
+## Summary
+
+- What changed:
+- Why:
+"""
+
+        self.assertFalse(has_template_summary(body))
+
 
 class PrAnalyzerScratchPathTests(unittest.TestCase):
     def test_root_scratch_files_are_flagged(self):
         self.assertTrue(is_scratch_file_path("pr-body.md"))
         self.assertTrue(is_scratch_file_path("test.sh"))
+        self.assertTrue(is_scratch_file_path("scratch.sh"))
+        self.assertTrue(is_scratch_file_path("scratchpad.sh"))
         self.assertTrue(is_scratch_file_path("scratch-check.sql"))
         self.assertTrue(is_scratch_file_path("test_cli.rs"))
 
@@ -284,6 +316,8 @@ class CiScriptScratchGuardTests(unittest.TestCase):
     def test_ci_guard_includes_root_shell_scratch_globs(self):
         script = Path("scripts/ci-script-checks.sh").read_text()
 
+        self.assertIn("scratch.sh", script)
+        self.assertIn("scratchpad.sh", script)
         self.assertIn("scratch[._-]*.sh", script)
         self.assertIn("scratchpad[._-]*.sh", script)
 

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from scripts.analyze_prs import (
     has_duplicate_guard_ack,
@@ -29,6 +30,39 @@ class PrAnalyzerBodyFieldTests(unittest.TestCase):
 
         self.assertFalse(has_non_empty_body_field(body, ["risk", "risk assessment"]))
         self.assertFalse(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
+
+    def test_html_comment_placeholder_is_not_meaningful_field_content(self):
+        body = """
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+"""
+
+        self.assertFalse(has_non_empty_body_field(body, ["summary"]))
+
+    def test_html_comment_before_real_content_does_not_hide_content(self):
+        body = """
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+Update analyzer hygiene checks.
+"""
+
+        self.assertTrue(has_non_empty_body_field(body, ["summary"]))
+
+    def test_allow_none_is_limited_to_explicit_callers(self):
+        body = "- Skipped checks with reasons: none"
+        labels = ["skipped checks with reasons", "skipped checks"]
+
+        self.assertFalse(has_non_empty_body_field(body, labels))
+        self.assertTrue(has_non_empty_body_field(body, labels, allow_none=True))
+        self.assertFalse(
+            has_non_empty_body_field(
+                "- Skipped checks with reasons: n/a",
+                labels,
+                allow_none=True,
+            )
+        )
 
     def test_multiline_field_value_stops_at_next_field_label(self):
         body = """
@@ -142,6 +176,22 @@ class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
         body = "This is a no-change PR but lacks exact PR numbers."
         self.assertFalse(has_overlap_reference(body))
 
+    def test_generic_template_issue_references_are_not_overlap_references(self):
+        body = """
+- Dashboard checklist issue references: #1254 / #1251
+- Related PRs/issues checked: #9999
+"""
+
+        self.assertFalse(has_overlap_reference(body))
+
+    def test_overlap_reference_inside_overlap_field(self):
+        body = """
+- Duplicate/overlap check:
+  - #1234 on branch codex/same-scope covers this no-change PR.
+"""
+
+        self.assertTrue(has_overlap_reference(body))
+
 
 class PrAnalyzerTemplateSummaryTests(unittest.TestCase):
     def test_populated_template_summary_counts_as_change_context(self):
@@ -162,6 +212,15 @@ Update analyzer hygiene checks to match the current template.
 
         self.assertFalse(has_template_summary(body))
 
+    def test_html_comment_template_summary_is_not_change_context(self):
+        body = """
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+"""
+
+        self.assertFalse(has_template_summary(body))
+
 
 class PrAnalyzerScratchPathTests(unittest.TestCase):
     def test_root_scratch_files_are_flagged(self):
@@ -172,6 +231,14 @@ class PrAnalyzerScratchPathTests(unittest.TestCase):
     def test_checked_in_scripts_and_migrations_are_not_scratch(self):
         self.assertFalse(is_scratch_file_path("scripts/deploy-release.sh"))
         self.assertFalse(is_scratch_file_path("migrations/postgres/001_init.sql"))
+
+
+class CiScriptScratchGuardTests(unittest.TestCase):
+    def test_ci_guard_includes_root_sql_scratch_files(self):
+        script = Path("scripts/ci-script-checks.sh").read_text()
+
+        self.assertIn("test.sql", script)
+        self.assertIn("scratch[._-]*.sql", script)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -86,6 +86,16 @@ Update analyzer hygiene checks.
         self.assertTrue(has_non_empty_body_field(body, ["risk", "risk assessment"]))
         self.assertTrue(has_non_empty_body_field(body, ["rollback notes", "rollback"]))
 
+    def test_related_prs_issues_label_alias_is_populated(self):
+        body = "- Related PRs/issues: checked #123"
+
+        self.assertTrue(
+            has_non_empty_body_field(
+                body,
+                ["related prs/issues checked", "related prs/issues", "related prs"],
+            )
+        )
+
 
 class PrAnalyzerDuplicateGuardTests(unittest.TestCase):
     def test_unchecked_template_duplicate_guard_is_not_acknowledgement(self):
@@ -164,16 +174,20 @@ class PrAnalyzerScratchFileCleanupGuardTests(unittest.TestCase):
 
 
 class PrAnalyzerOverlapReferenceTests(unittest.TestCase):
-    def test_overlap_reference_with_hash(self):
-        body = "This is a no-change PR overlapping with #1234."
+    def test_overlap_reference_with_hash_and_branch(self):
+        body = "This is a no-change PR overlapping with #1234 on branch codex/same-scope."
         self.assertTrue(has_overlap_reference(body))
 
-    def test_overlap_reference_with_url(self):
-        body = "Overlap with https://github.com/owner/repo/pull/5678."
+    def test_overlap_reference_with_url_and_branch(self):
+        body = "Overlap with https://github.com/owner/repo/pull/5678 on branch feature/replacement."
         self.assertTrue(has_overlap_reference(body))
 
     def test_missing_overlap_reference(self):
         body = "This is a no-change PR but lacks exact PR numbers."
+        self.assertFalse(has_overlap_reference(body))
+
+    def test_pr_number_without_branch_is_not_overlap_reference(self):
+        body = "This is a no-change PR overlapping with #1234."
         self.assertFalse(has_overlap_reference(body))
 
     def test_generic_template_issue_references_are_not_overlap_references(self):
@@ -221,6 +235,15 @@ Update analyzer hygiene checks to match the current template.
 
         self.assertFalse(has_template_summary(body))
 
+    def test_colon_prefixed_summary_bullet_counts_as_change_context(self):
+        body = """
+## Summary
+
+- Tests: add analyzer coverage.
+"""
+
+        self.assertTrue(has_template_summary(body))
+
 
 class PrAnalyzerScratchPathTests(unittest.TestCase):
     def test_root_scratch_files_are_flagged(self):
@@ -239,6 +262,12 @@ class CiScriptScratchGuardTests(unittest.TestCase):
 
         self.assertIn("test.sql", script)
         self.assertIn("scratch[._-]*.sql", script)
+
+    def test_ci_guard_includes_root_shell_scratch_globs(self):
+        script = Path("scripts/ci-script-checks.sh").read_text()
+
+        self.assertIn("scratch[._-]*.sh", script)
+        self.assertIn("scratchpad[._-]*.sh", script)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 목표
PR 분석/검증 tooling이 scratch 파일, queue hygiene, no-change overlap, verification/body 필드 누락을 더 정확하게 잡도록 강화합니다. 동시에 현재 PR template과 정상 checked-in script/migration 변경에서 발생할 수 있는 false positive를 줄입니다.

## 쉬운 설명
PR을 올릴 때 흔히 섞이는 임시 파일과 비어 있는 검증 문구를 더 잘 탐지합니다. 현재 template의 `Summary` 섹션은 유효한 변경 설명으로 인정해 불필요한 경고를 줄였습니다. `scripts/*.sh`나 `migrations/*.sql`처럼 실제 repository 파일은 scratch 파일로 오인하지 않습니다. no-change PR의 overlap 증거는 실제 중복 PR과 branch가 있을 때만 인정합니다.

## 개선되는 것
### Fix 1
`analyze_prs.py`가 queue hygiene checklist, no-change overlap, verification/body hygiene 필드를 검증합니다.

### Fix 2
root scratch-file guard에 `pr-body.md`, `test.sh`, root SQL/shell/Rust scratch pattern을 추가해 agent scratch artifact가 섞이는 것을 방지합니다.

### Fix 3
중복 inventory refresh 가능성을 generator 출력에서 더 눈에 띄게 경고합니다.

### Fix 4
template-compliant `## Summary`를 변경 설명으로 인정하고, scratch detection을 root/ad-hoc 파일명으로 제한해 정상 script/migration 변경의 false positive를 막습니다.

### Fix 5
no-change overlap parser가 `no overlap`/`no overlapping` 같은 부정 문구와 `Branch: none` 같은 placeholder branch 값을 overlap evidence로 인정하지 않도록 막습니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| no-change PR이 파일을 수정함 | 제목만 보고 누락 가능 | 변경 파일 수를 보고 경고 |
| PR body가 template Summary만 채움 | What changed/Why 누락 경고 | Summary가 채워져 있으면 통과 |
| `scripts/deploy-release.sh` 변경 | scratch로 오탐 가능 | 정상 checked-in script로 허용 |
| `pr-body.md`가 root에 남음 | guard 누락 | CI script scratch guard로 탐지 |
| `no overlap found` 또는 `Branch: none` | overlap reference로 오인 가능 | `MISSING OVERLAP REFERENCE` 유지 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 일반 PR 분석 | 기존 분석 유지 + 추가 경고 | 안전 |
| template Summary 기반 PR | 불필요한 What/Why 경고 생략 | 오탐 감소 |
| no-change duplicate check가 실제 overlap을 찾지 못함 | branch placeholder/부정 문구는 evidence 제외 | 안전 |

## 해결한 내용
- `scripts/analyze_prs.py`: PR body/queue/no-change/verification hygiene 검사 강화, Summary 허용, scratch path 판정 제한, no-change overlap parser의 negation/placeholder branch 처리 보강
- `tests/test_analyze_prs.py`: 신규 hygiene 검사, false-positive 방지, no-overlap/placeholder branch 회귀 테스트 추가
- `.github/PULL_REQUEST_TEMPLATE.md`, `TEST_PLAN.md`: scratch-file/verification 문구 정리
- `scripts/ci-script-checks.sh`: root scratch-file guard 확장
- `scripts/generate_inventory_docs.py`: 중복 inventory PR 경고 출력 보강
- `scripts/audit_allowlist.toml`: stale allowlist entry 제거

## 포트 메모
`kunkunGames/AgentDesk` fork의 steward/gatekeeper tooling 변경을 upstream 현재 구조에 맞춰 포트했습니다. clean CI에서 ignored generated docs 때문에 실패할 수 있는 generated-docs `--check` hard-gate 전환은 제외했습니다.

## 검증
- `python3 -m unittest tests/test_analyze_prs.py` (47 passed)
- `./scripts/ci-script-checks.sh` (passed; advisory ratchet/SRP baseline notes only)
- `git diff --check`
