### PR TITLE
Maintenance: bump TLS roots and polish CLI/path handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3644,7 +3644,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3846,7 +3846,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3886,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5815,14 +5815,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -569,7 +569,7 @@ fn check_qwen_settings_files(configured: bool) -> Check {
         );
     }
 
-    let guidance = "Qwen은 settings 없이도 동작할 수 있지만, 모델 picker와 운영 surface를 안정적으로 쓰려면 ~/.qwen/settings.json 또는 <workspace>/.qwen/settings.json 구성을 권장합니다.";
+    let guidance = "Qwen can operate without settings, but for reliable model picker and operational surface usage, configuring ~/.qwen/settings.json or <workspace>/.qwen/settings.json is recommended.";
     if configured {
         Check::warn(
             "provider_qwen_settings",
@@ -643,7 +643,7 @@ fn check_qwen_auth_hints(configured: bool) -> Check {
         ]);
     }
 
-    let guidance = "API key 경로는 project .qwen/.env 우선, 그다음 .env를 확인하세요. Qwen CLI는 env-file을 merge하지 않습니다. 사용량/제한은 숫자를 doctor에 고정하지 말고 DashScope 웹 콘솔 또는 공식 문서를 확인하세요.";
+    let guidance = "Check the API key path in the project .qwen/.env first, then .env. The Qwen CLI does not merge env-files. Check DashScope web console or official documentation for usage/limits instead of hardcoding numbers in doctor.";
     if configured {
         Check::warn(
             "provider_qwen_auth",
@@ -966,7 +966,7 @@ fn check_opencode_mcp_config(configured: bool) -> Check {
             CheckGroup::ProviderRuntime,
             "OpenCode MCP config",
             "memento MCP not visible for OpenCode",
-            "runtime mcp_servers 또는 ~/.config/opencode/opencode.json top-level mcp에 memento 서버를 설정하세요.",
+            "configure the memento server in runtime mcp_servers or the top-level mcp in ~/.config/opencode/opencode.json.",
         )
         .with_expected_actual("memento MCP configured", "memento MCP missing")
         .with_next_steps(vec![
@@ -2964,7 +2964,7 @@ fn check_server_running(snapshot: &HealthSnapshot) -> Check {
                 (
                     "unauthorized",
                     Severity::Error,
-                    "auth token 또는 /api/health/detail 권한을 확인하세요.",
+                    "check the auth token or /api/health/detail permissions.",
                 )
             } else if error.contains("--allow-remote") {
                 (
@@ -3015,7 +3015,7 @@ fn check_runtime_root() -> Check {
             CheckGroup::Core,
             "Runtime Root",
             format!("{} — missing", path.display()),
-            "agentdesk doctor --fix 로 기본 runtime 디렉터리를 생성할 수 있습니다.",
+            "you can create the default runtime directory with agentdesk doctor --fix.",
         )
         .with_path(path.display().to_string())
         .with_expected_actual("runtime root exists", "runtime root missing")
@@ -3025,7 +3025,7 @@ fn check_runtime_root() -> Check {
             CheckGroup::Core,
             "Runtime Root",
             "unable to determine runtime root",
-            "AGENTDESK_ROOT_DIR 또는 기본 ~/.adk/release 경로를 확인하세요.",
+            "check AGENTDESK_ROOT_DIR or the default ~/.adk/release path.",
         )
         .with_expected_actual(
             "runtime root path resolvable",
@@ -3641,7 +3641,7 @@ fn check_service_manager() -> Check {
             CheckGroup::Core,
             "Service Manager",
             "systemd --user — agentdesk-dcserver enabled but inactive",
-            "`systemctl --user status agentdesk-dcserver` 로 상태를 확인하거나 `agentdesk doctor --fix`로 restart를 시도하세요.",
+            "check the status with `systemctl --user status agentdesk-dcserver` or try restarting with `agentdesk doctor --fix`.",
         )
         .with_expected_actual("systemd user service active", "systemd user service enabled but inactive")
         .with_next_steps(vec![
@@ -3684,7 +3684,7 @@ fn check_service_manager() -> Check {
             CheckGroup::Core,
             "Service Manager",
             "Windows service — AgentDeskDcserver installed but not running",
-            "`sc query AgentDeskDcserver` 로 상태를 확인하거나 `agentdesk doctor --fix`로 restart를 시도하세요.",
+            "check the status with `sc query AgentDeskDcserver` or try restarting with `agentdesk doctor --fix`.",
         )
         .with_expected_actual("Windows service running", "Windows service installed but not running")
         .with_next_steps(vec![
@@ -3697,7 +3697,7 @@ fn check_service_manager() -> Check {
             CheckGroup::Core,
             "Service Manager",
             "Windows service — AgentDeskDcserver not installed",
-            "Windows service 또는 수동 실행 방식 중 어떤 배포인지 확인하세요.",
+            "check whether the deployment is a Windows service or a manual execution.",
         )
         .with_expected_actual("Windows service installed", "Windows service not installed")
         .with_next_steps(vec!["sc query AgentDeskDcserver".to_string()])
@@ -3871,7 +3871,7 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
             CheckGroup::Core,
             "PostgreSQL",
             format!("{summary} — failed"),
-            "DATABASE_URL 또는 database 설정값(host/port/dbname/user/password)을 확인하세요.",
+            "check the DATABASE_URL or database configuration values (host/port/dbname/user/password).",
         )
         .with_expected_actual("postgres connection succeeds", error)
         .with_next_steps(vec![
@@ -4086,7 +4086,7 @@ fn check_disk_usage() -> Check {
             CheckGroup::Core,
             "Disk Usage",
             format!("{} — runtime root missing", path.display()),
-            "agentdesk doctor --fix 로 기본 runtime 디렉터리를 생성할 수 있습니다.",
+            "you can create the default runtime directory with agentdesk doctor --fix.",
         )
         .with_path(path.display().to_string())
         .with_expected_actual(
@@ -4208,7 +4208,7 @@ fn check_disk_usage() -> Check {
             CheckGroup::Core,
             "Disk Usage",
             "cannot determine runtime root",
-            "AGENTDESK_ROOT_DIR 또는 기본 ~/.adk/release 경로를 확인하세요.",
+            "check AGENTDESK_ROOT_DIR or the default ~/.adk/release path.",
         )
         .with_expected_actual(
             "runtime root path resolvable",

--- a/src/services/discord/role_map.rs
+++ b/src/services/discord/role_map.rs
@@ -12,12 +12,9 @@ use crate::services::provider::ProviderKind;
 
 /// Expand `~` or `~/` prefix to the user's home directory.
 fn expand_tilde(path: &str) -> String {
-    if let Some(home) = dirs::home_dir() {
-        if path == "~" {
-            return home.display().to_string();
-        }
-        if path.starts_with("~/") {
-            return format!("{}{}", home.display(), &path[1..]);
+    if path == "~" || path.starts_with("~/") {
+        if let Some(expanded) = crate::runtime_layout::expand_user_path(path) {
+            return expanded.to_string_lossy().into_owned();
         }
     }
     path.to_string()


### PR DESCRIPTION
## 목표
작은 안정화 변경을 묶어 포트합니다. TLS 관련 lockfile 버전을 올리고, doctor 진단 메시지를 영어로 정리하며, Discord role-map path expansion을 공용 helper로 통일합니다.

## 쉬운 설명
의존성 lockfile의 TLS/webpki 계열 버전을 최신 patch로 올립니다. CLI doctor 출력의 하드코딩된 한국어 진단을 영어로 바꿔 upstream 사용자에게 더 자연스럽게 보이도록 합니다. `~` path expansion은 기존 동작을 유지하면서 공용 helper를 재사용합니다.

## 개선되는 것
### Fix 1
`Cargo.lock`의 `rustls-webpki`, `webpki-roots` patch 버전을 갱신합니다.

### Fix 2
`doctor` orchestration 메시지를 영어 진단 문구로 통일합니다.

### Fix 3
Discord role-map path config의 tilde expansion 중복 구현을 `runtime_layout::expand_user_path` 재사용으로 줄입니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| TLS root/webpki dependency | 이전 patch lock | 최신 patch lock |
| doctor 진단 출력 | 한국어 하드코딩 메시지 | 영어 메시지 |
| `~/path` role map config | 로컬 helper 직접 구현 | 공용 path helper 재사용 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| path가 `~` 또는 `~/`로 시작 | 공용 helper로 확장 | 기존 동작 유지 |
| path가 일반 문자열 | 원문 반환 | fallback 유지 |
| lockfile-only dependency bump | API 변경 없음 | 낮은 위험 |

## 해결한 내용
- `Cargo.lock`: `rustls-webpki`, `webpki-roots` patch bump
- `src/cli/doctor/orchestrator.rs`: doctor diagnostic text 영어화
- `src/services/discord/role_map.rs`: `expand_user_path` helper 재사용

## 포트 메모
`kunkunGames/AgentDesk` fork의 작은 안정화 커밋 3개를 `itismyfield/AgentDesk:main` 기준으로 묶어 포트했습니다. generated inventory 변경은 upstream 현재 구조에 맞춰 제외했습니다.

## 검증
- `git diff --check upstream/main...HEAD`
- `CARGO_TARGET_DIR=/Users/kunkun/kunkunGames/AgentDesk/target cargo check --all-targets`