### PR TITLE
feat(cluster): #3667 sync preferred_intake_node_labels from agentdesk.yaml

### DIFF
--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -2718,6 +2718,7 @@ fn merge_imported_agents(
             keywords: Vec::new(),
             department: None,
             avatar_emoji: agent.avatar_emoji.clone(),
+            preferred_intake_node_labels: None,
         };
 
         if let Some(existing) = config

--- a/src/config.rs
+++ b/src/config.rs
@@ -346,6 +346,14 @@ pub struct AgentDef {
     pub department: Option<String>,
     #[serde(default)]
     pub avatar_emoji: Option<String>,
+    /// Cluster intake node-affinity labels (#3667). When set and non-empty,
+    /// intake for this agent's channels is routed to an online worker node whose
+    /// labels satisfy this list; `Some([])` means no preference (intake stays on
+    /// the leader). `None` (key absent from yaml) leaves any existing DB value
+    /// untouched on sync, so an out-of-band label is never wiped. Maps to the
+    /// `agents.preferred_intake_node_labels` JSONB column.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferred_intake_node_labels: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -655,12 +655,25 @@ async fn upsert_agent_from_config_pg(pool: &PgPool, agent: &AgentDef) -> Result<
     let discord_channel_id = provider_primary.or_else(|| discord_channel_cc.clone());
     let discord_channel_alt = discord_channel_cdx.clone();
 
+    // #3667: config-declared intake node-affinity labels. `None` (key absent
+    // from yaml) binds SQL NULL; the COALESCE then keeps the existing DB value
+    // so an out-of-band label (e.g. ch-td's DB-only `["mac-book"]`, not in yaml)
+    // is never wiped by a routine restart sync. `Some([...])` sets/overwrites it
+    // and `Some([])` explicitly clears it. We reference the bound `$11` (not
+    // EXCLUDED) in the conflict branch so the NULL signal survives the VALUES
+    // COALESCE used to satisfy the NOT NULL column on insert.
+    let preferred_intake_node_labels = agent
+        .preferred_intake_node_labels
+        .as_ref()
+        .map(|labels| serde_json::json!(labels));
+
     sqlx::query(
         "INSERT INTO agents (
             id, name, name_ko, provider, department, avatar_emoji,
-            discord_channel_id, discord_channel_alt, discord_channel_cc, discord_channel_cdx
+            discord_channel_id, discord_channel_alt, discord_channel_cc, discord_channel_cdx,
+            preferred_intake_node_labels
          )
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE($11, '[]'::JSONB))
          ON CONFLICT (id) DO UPDATE
          SET name = EXCLUDED.name,
              name_ko = EXCLUDED.name_ko,
@@ -670,7 +683,9 @@ async fn upsert_agent_from_config_pg(pool: &PgPool, agent: &AgentDef) -> Result<
              discord_channel_id = EXCLUDED.discord_channel_id,
              discord_channel_alt = EXCLUDED.discord_channel_alt,
              discord_channel_cc = EXCLUDED.discord_channel_cc,
-             discord_channel_cdx = EXCLUDED.discord_channel_cdx",
+             discord_channel_cdx = EXCLUDED.discord_channel_cdx,
+             preferred_intake_node_labels =
+                 COALESCE($11, agents.preferred_intake_node_labels)",
     )
     .bind(&agent.id)
     .bind(&agent.name)
@@ -682,6 +697,7 @@ async fn upsert_agent_from_config_pg(pool: &PgPool, agent: &AgentDef) -> Result<
     .bind(discord_channel_alt)
     .bind(discord_channel_cc)
     .bind(discord_channel_cdx)
+    .bind(preferred_intake_node_labels)
     .execute(pool)
     .await
     .map_err(|error| format!("upsert postgres agent {}: {error}", agent.id))?;
@@ -749,7 +765,16 @@ async fn copy_runtime_fields_from_legacy_pg(
              sprite_number = COALESCE(legacy.sprite_number, agents.sprite_number),
              description = COALESCE(legacy.description, agents.description),
              system_prompt = COALESCE(legacy.system_prompt, agents.system_prompt),
-             pipeline_config = COALESCE(legacy.pipeline_config, agents.pipeline_config)
+             pipeline_config = COALESCE(legacy.pipeline_config, agents.pipeline_config),
+             -- #3667: inherit a legacy DB-only intake label only when the
+             -- canonical row has none yet (config-set value wins; the column is
+             -- NOT NULL so a plain COALESCE would clobber it with '[]').
+             preferred_intake_node_labels = CASE
+                 WHEN jsonb_array_length(agents.preferred_intake_node_labels) = 0
+                      AND jsonb_array_length(legacy.preferred_intake_node_labels) > 0
+                     THEN legacy.preferred_intake_node_labels
+                 ELSE agents.preferred_intake_node_labels
+             END
          FROM agents AS legacy
          WHERE legacy.id = $1
            AND agents.id = $2",
@@ -1122,6 +1147,7 @@ mod tests {
         connect_test_pool_and_migrate_config, create_test_database, database_enabled,
         database_summary, health_check, run_test_postgres_sqlx_op_with_timeout,
         runtime_pool_settings, should_yield_for_counters, startup_pool_settings, startup_reseed,
+        sync_agents_from_config_pg,
     };
     use sqlx::Row;
     use std::collections::BTreeMap;
@@ -1239,6 +1265,7 @@ mod tests {
             keywords: Vec::new(),
             department: Some("platform".to_string()),
             avatar_emoji: Some(":gear:".to_string()),
+            preferred_intake_node_labels: None,
         }];
         config
     }
@@ -1561,6 +1588,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sync_agents_writes_and_preserves_preferred_intake_node_labels() {
+        // #3667: config-declared node-affinity labels (`Option<Vec<String>>`)
+        // are synced to the agents.preferred_intake_node_labels JSONB column:
+        //   Some([...]) sets/overwrites, Some([]) clears, None preserves an
+        //   out-of-band value (the ch-td DB-only `["mac-book"]` case, absent
+        //   from yaml).
+        let test_db = TestDatabase::create().await;
+        let mut config = postgres_test_config(&test_db);
+
+        let pool = connect_test_pool_and_migrate_config(
+            &config,
+            "db::postgres intake-label sync test pool",
+        )
+        .await
+        .expect("connect and migrate postgres")
+        .expect("postgres pool");
+
+        let read_labels = |id: &'static str| {
+            let pool = pool.clone();
+            async move {
+                let value: serde_json::Value = sqlx::query_scalar(
+                    "SELECT preferred_intake_node_labels FROM agents WHERE id = $1",
+                )
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .expect("read preferred_intake_node_labels");
+                value
+            }
+        };
+
+        // 1. Config declares Some(["mac-mini"]) -> written verbatim on insert.
+        config.agents[0].preferred_intake_node_labels = Some(vec!["mac-mini".to_string()]);
+        sync_agents_from_config_pg(&pool, &config.agents)
+            .await
+            .expect("sync with labels");
+        assert_eq!(
+            read_labels("pg-agent").await,
+            serde_json::json!(["mac-mini"])
+        );
+
+        // 2. Seed an out-of-band label, then sync with the field ABSENT (None:
+        //    agent in yaml but no key). COALESCE($11=NULL, existing) must
+        //    preserve the existing value instead of wiping it.
+        sqlx::query("UPDATE agents SET preferred_intake_node_labels = $1 WHERE id = $2")
+            .bind(serde_json::json!(["mac-book"]))
+            .bind("pg-agent")
+            .execute(&pool)
+            .await
+            .expect("seed out-of-band label");
+        config.agents[0].preferred_intake_node_labels = None;
+        sync_agents_from_config_pg(&pool, &config.agents)
+            .await
+            .expect("sync with absent field");
+        assert_eq!(
+            read_labels("pg-agent").await,
+            serde_json::json!(["mac-book"]),
+            "absent field (None) must not wipe an out-of-band label"
+        );
+
+        // 3. A non-empty config list is authoritative again on conflict/update.
+        config.agents[0].preferred_intake_node_labels =
+            Some(vec!["mac-mini".to_string(), "release".to_string()]);
+        sync_agents_from_config_pg(&pool, &config.agents)
+            .await
+            .expect("sync overwrite labels");
+        assert_eq!(
+            read_labels("pg-agent").await,
+            serde_json::json!(["mac-mini", "release"])
+        );
+
+        // 4. Some([]) is an explicit clear, distinct from None.
+        config.agents[0].preferred_intake_node_labels = Some(Vec::new());
+        sync_agents_from_config_pg(&pool, &config.agents)
+            .await
+            .expect("sync explicit clear");
+        assert_eq!(
+            read_labels("pg-agent").await,
+            serde_json::json!([]),
+            "Some([]) must explicitly clear the label"
+        );
+
+        close_test_pool(pool, "db::postgres intake-label sync test pool")
+            .await
+            .expect("close postgres pool");
+        test_db.drop().await;
+    }
+
+    #[tokio::test]
     async fn core_status_constraints_reject_invalid_values_and_allow_valid_states() {
         let test_db = TestDatabase::create().await;
         let config = postgres_test_config(&test_db);
@@ -1811,6 +1927,7 @@ mod tests {
             keywords: Vec::new(),
             department: Some("engineering".to_string()),
             avatar_emoji: Some("🛠️".to_string()),
+            preferred_intake_node_labels: None,
         }];
 
         let pool =
@@ -1949,6 +2066,7 @@ mod tests {
                 keywords: Vec::new(),
                 department: Some("engineering".to_string()),
                 avatar_emoji: None,
+                preferred_intake_node_labels: None,
             },
             crate::config::AgentDef {
                 id: "openclaw-maker".to_string(),
@@ -1967,6 +2085,7 @@ mod tests {
                 keywords: Vec::new(),
                 department: Some("legacy".to_string()),
                 avatar_emoji: None,
+                preferred_intake_node_labels: None,
             },
         ];
 

--- a/src/runtime_layout/config_merge.rs
+++ b/src/runtime_layout/config_merge.rs
@@ -315,6 +315,7 @@ fn ensure_config_agent(
         keywords: Vec::new(),
         department: None,
         avatar_emoji: None,
+        preferred_intake_node_labels: None,
     });
     (config.agents.len() - 1, true)
 }

--- a/src/server/routes/voice_config.rs
+++ b/src/server/routes/voice_config.rs
@@ -411,6 +411,7 @@ mod tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 

--- a/src/services/discord/agentdesk_config.rs
+++ b/src/services/discord/agentdesk_config.rs
@@ -128,6 +128,7 @@ pub(crate) fn ensure_agent_setup_config(
         keywords: Vec::new(),
         department: None,
         avatar_emoji: None,
+        preferred_intake_node_labels: None,
     });
 
     if let Err(error) = crate::voice::commands::validate_agent_alias_collisions(&next_agents) {

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -3862,6 +3862,7 @@ mod tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 

--- a/src/services/discord_config_audit.rs
+++ b/src/services/discord_config_audit.rs
@@ -1324,6 +1324,7 @@ mod db_agent_drift_tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 
@@ -1485,6 +1486,7 @@ mod voice_alias_precheck_tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 

--- a/src/services/onboarding/mod.rs
+++ b/src/services/onboarding/mod.rs
@@ -1816,6 +1816,7 @@ fn write_agentdesk_channel_bindings(
                 keywords: Vec::new(),
                 department: None,
                 avatar_emoji: None,
+                preferred_intake_node_labels: None,
             });
             config.agents.len() - 1
         };

--- a/src/services/provider_hosting.rs
+++ b/src/services/provider_hosting.rs
@@ -1040,6 +1040,7 @@ mod tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 
@@ -1066,6 +1067,7 @@ mod tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 }

--- a/src/voice/commands.rs
+++ b/src/voice/commands.rs
@@ -566,6 +566,7 @@ mod tests {
             keywords: Vec::new(),
             department: None,
             avatar_emoji: None,
+            preferred_intake_node_labels: None,
         }
     }
 


### PR DESCRIPTION
Closes #3667 (Phase 1 — durable config binding).

## 문제
롤맵 없는 채널(2268, 6983)을 특정 클러스터 노드에 고정 라우팅하려면 `agents.preferred_intake_node_labels`(JSONB)에 라벨이 있어야 한다. 라우팅 읽기 경로(`intake_router_hook::agent_id_and_preferred_labels` → `intake_routing`)는 이미 동작하지만, `AgentDef`에 필드가 없고 `upsert_agent_from_config_pg`가 그 컬럼을 쓰지 않아 **yaml에서 선언적으로 설정할 경로가 없었다**. (`code-0` DB 바인딩은 sync가 yaml에 없는 DB-only agent를 재시작마다 삭제하므로 durable하지 않음.)

## 변경
- `config::AgentDef`에 `preferred_intake_node_labels: Option<Vec<String>>` 추가.
- `upsert_agent_from_config_pg`가 JSONB 컬럼을 동기화. 바인딩된 `$11`(Option)을 직접 참조:
  - `VALUES(..., COALESCE($11, '[]'::JSONB))` — NOT NULL 충족
  - `ON CONFLICT ... SET preferred_intake_node_labels = COALESCE($11, agents.preferred_intake_node_labels)`
  - **의미론**: `None`(yaml 키 부재)=기존값 보존(out-of-band 라벨 wipe 방지, 예: ch-td의 DB-only `["mac-book"]`), `Some([..])`=설정/덮어쓰기, `Some([])`=명시적 비우기.
- `copy_runtime_fields_from_legacy_pg`가 라벨 보존: canonical이 비어있고 legacy가 비어있지 않을 때만 상속(config-set 값 우선).
- 신규 테스트 `sync_agents_writes_and_preserves_preferred_intake_node_labels` — set/preserve-on-None/overwrite/explicit-clear 4케이스, 실 PG 통과.
- 나머지 파일들은 `AgentDef` 구조체 리터럴에 신규 필드(`None`) 추가(컴파일).

## 검증
- `cargo check --tests` clean, `cargo fmt --check` clean
- 신규 PG 테스트 통과
- codex 적대적 리뷰 2라운드 → **VERDICT CLEAN** (블로커 2건 지적: Vec→Option 의미론, 레거시 복사 누락 → 둘 다 수정)

## 후속 (별도)
- Phase 2(배포): agentdesk.yaml에 `generic-claude-macbook`(2268, `[mac-book]`) / `generic-claude-macmini`(6983, `[mac-mini]`) 등록 + 배포
- Phase 3: 실 메시지 round-trip으로 노드 라우팅 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)