### PR TITLE
fix(cluster): #3692 gate config→DB agent roster sync to leader only

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1367,7 +1367,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3230 lines).
+  - `src/cli/migrate/apply.rs` (3231 lines; +1 from #3690 AgentDef preferred_intake_node_labels literal).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.
@@ -1390,7 +1390,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2521 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests).
+  - `src/config.rs` (2529 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests; +8 from #3690 AgentDef.preferred_intake_node_labels field + doc).
   - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
@@ -1431,7 +1431,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1116 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests).
+  - `src/db/postgres.rs` (1167 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests; #3690: preferred_intake_node_labels upsert/sync + COALESCE preserve; #3692: `agent_roster_sync_enabled` leader-ownership gate on the roster sync).
   - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads).
@@ -1461,7 +1461,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
-- `src/services/onboarding/mod.rs` (2936),
+- `src/services/onboarding/mod.rs` (2937),
   `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
@@ -1554,7 +1554,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   — the thirteen restart-lifecycle fields — into
   `shared_state::RestartLifecycle`, leaving a single `restart: RestartLifecycle`
   group field on `SharedData` with the type re-exported for surface freeze),
-  `src/services/discord_config_audit.rs` (1273).
+  `src/services/discord_config_audit.rs` (1288; +15 from #3692 leader-ownership gate on the config-audit agent sync path).
 - `src/services/turn_orchestrator.rs` (3089; +3 from #3293 declaring the
   `registry_purge` child module — the non-creating `peek` lookup and the
   operator-gated `remove_idle_entry` purge live in

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -350,8 +350,10 @@ pub async fn startup_reseed(pool: &PgPool, config: &Config) -> Result<(), String
 /// Whether this node should run the destructive config→DB agent roster sync.
 /// True for single-node deployments (cluster disabled) and for the node
 /// explicitly configured as `cluster.role: leader`. Worker/auto nodes return
-/// false so they never clobber the leader-owned shared roster (#3692).
-fn agent_roster_sync_enabled(config: &Config) -> bool {
+/// false so they never clobber the leader-owned shared roster (#3692). Shared
+/// with the config-audit path (`discord_config_audit`), which reaches the same
+/// destructive sync before `startup_reseed` runs.
+pub(crate) fn agent_roster_sync_enabled(config: &Config) -> bool {
     !config.cluster.enabled || config.cluster.role.trim().eq_ignore_ascii_case("leader")
 }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -327,8 +327,32 @@ pub async fn startup_reseed(pool: &PgPool, config: &Config) -> Result<(), String
         register_repo(pool, &repo_id).await?;
     }
 
-    sync_agents_from_config_pg(pool, &config.agents).await?;
+    // #3692: in a cluster, the shared `agents` table is owned by the leader.
+    // `sync_agents_from_config_pg` is destructive (it DELETEs agents absent from
+    // the local config), so if a worker/auto node ran it at boot it would
+    // clobber the leader's roster — each node's startup would fight over the
+    // shared table and the roster would flip-flop per deploy order. Reseed runs
+    // before cluster leadership election, so gate on the configured role: only a
+    // single-node deployment (cluster disabled) or the explicitly-configured
+    // leader owns the roster sync. Workers/auto nodes trust the shared roster.
+    if agent_roster_sync_enabled(config) {
+        sync_agents_from_config_pg(pool, &config.agents).await?;
+    } else {
+        tracing::info!(
+            "[agent-sync] skipping config→DB agent roster sync on non-leader node \
+             (cluster.role={}); the cluster leader owns the shared agents table (#3692)",
+            config.cluster.role
+        );
+    }
     Ok(())
+}
+
+/// Whether this node should run the destructive config→DB agent roster sync.
+/// True for single-node deployments (cluster disabled) and for the node
+/// explicitly configured as `cluster.role: leader`. Worker/auto nodes return
+/// false so they never clobber the leader-owned shared roster (#3692).
+fn agent_roster_sync_enabled(config: &Config) -> bool {
+    !config.cluster.enabled || config.cluster.role.trim().eq_ignore_ascii_case("leader")
 }
 
 pub async fn health_check(pool: &PgPool) -> Result<(), String> {
@@ -1142,12 +1166,12 @@ pub(crate) async fn close_test_pool(pool: PgPool, label: &str) -> Result<(), Str
 #[cfg(test)]
 mod tests {
     use super::{
-        AdvisoryLockLease, POSTGRES_MIGRATOR, STARTUP_PG_ACQUIRE_TIMEOUT_SECS, checksum_hex,
-        clamp_foreground_reserve, close_test_pool, config_database_summary, connect_options,
-        connect_test_pool_and_migrate_config, create_test_database, database_enabled,
-        database_summary, health_check, run_test_postgres_sqlx_op_with_timeout,
-        runtime_pool_settings, should_yield_for_counters, startup_pool_settings, startup_reseed,
-        sync_agents_from_config_pg,
+        AdvisoryLockLease, POSTGRES_MIGRATOR, STARTUP_PG_ACQUIRE_TIMEOUT_SECS,
+        agent_roster_sync_enabled, checksum_hex, clamp_foreground_reserve, close_test_pool,
+        config_database_summary, connect_options, connect_test_pool_and_migrate_config,
+        create_test_database, database_enabled, database_summary, health_check,
+        run_test_postgres_sqlx_op_with_timeout, runtime_pool_settings, should_yield_for_counters,
+        startup_pool_settings, startup_reseed, sync_agents_from_config_pg,
     };
     use sqlx::Row;
     use std::collections::BTreeMap;
@@ -1584,6 +1608,89 @@ mod tests {
             .await
             .expect("close postgres pool");
         assert!(test_db.database_url.contains("agentdesk_pg_"));
+        test_db.drop().await;
+    }
+
+    #[test]
+    fn agent_roster_sync_gated_to_leader_or_single_node() {
+        // #3692: only a single-node deployment or the configured leader owns the
+        // destructive config→DB agent roster sync.
+        let mut config = crate::config::Config::default();
+
+        config.cluster.enabled = false; // single-node: always owns the roster
+        config.cluster.role = "auto".to_string();
+        assert!(agent_roster_sync_enabled(&config));
+
+        config.cluster.enabled = true;
+        for (role, expected) in [
+            ("leader", true),
+            ("Leader", true),
+            ("  leader  ", true),
+            ("worker", false),
+            ("auto", false),
+            ("", false),
+        ] {
+            config.cluster.role = role.to_string();
+            assert_eq!(
+                agent_roster_sync_enabled(&config),
+                expected,
+                "cluster.role={role:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_node_reseed_does_not_clobber_shared_agent_roster() {
+        // #3692: a cluster worker/auto node must NOT run the destructive agent
+        // sync at boot — doing so would delete leader-owned agents from the
+        // shared table and re-add its own, causing roster flip-flop per deploy.
+        let test_db = TestDatabase::create().await;
+        let mut config = postgres_test_config(&test_db);
+
+        let pool = connect_test_pool_and_migrate_config(
+            &config,
+            "db::postgres worker-reseed gating test pool",
+        )
+        .await
+        .expect("connect and migrate postgres")
+        .expect("postgres pool");
+
+        // Simulate a leader-owned agent already present in the shared table.
+        sqlx::query("INSERT INTO agents (id, name, provider) VALUES ($1, $2, $3)")
+            .bind("leader-owned")
+            .bind("Leader Owned")
+            .bind("claude")
+            .execute(&pool)
+            .await
+            .expect("seed leader-owned agent");
+
+        // This node is a cluster worker: reseed must skip the agent sync.
+        config.cluster.enabled = true;
+        config.cluster.role = "worker".to_string();
+        startup_reseed(&pool, &config).await.expect("worker reseed");
+
+        let leader_owned: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM agents WHERE id = 'leader-owned'")
+                .fetch_one(&pool)
+                .await
+                .expect("count leader-owned");
+        assert_eq!(
+            leader_owned, 1,
+            "worker reseed must not delete leader-owned agents"
+        );
+        let own_agent: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM agents WHERE id = 'pg-agent'")
+                .fetch_one(&pool)
+                .await
+                .expect("count pg-agent");
+        assert_eq!(
+            own_agent, 0,
+            "worker reseed must not sync its own config agents into the shared roster"
+        );
+
+        close_test_pool(pool, "db::postgres worker-reseed gating test pool")
+            .await
+            .expect("close postgres pool");
         test_db.drop().await;
     }
 

--- a/src/services/discord_config_audit.rs
+++ b/src/services/discord_config_audit.rs
@@ -661,6 +661,21 @@ fn audit_db_agents(
         return Ok(());
     }
 
+    // #3692: this config-audit sync runs before `startup_reseed`, so it needs the
+    // same leader-ownership gate. Only a single-node deployment or the configured
+    // cluster leader runs the destructive config→DB agent sync. A cluster
+    // worker/auto node reports drift (without warnings — divergence from the
+    // leader-owned roster is expected on a worker) and must not mutate the shared
+    // agents table, otherwise it clobbers the leader's roster.
+    if !crate::db::postgres::agent_roster_sync_enabled(config) {
+        report.actions.push(
+            "skipped DB agent sync on non-leader cluster node; the leader owns the shared agents roster (#3692)"
+                .to_string(),
+        );
+        apply_db_agent_drift(report, pre_sync_drift.without_warnings());
+        return Ok(());
+    }
+
     match sync_db_agents_pg(config, &config.agents) {
         Ok(Some(count)) => {
             report.storage.synced_agents = Some(count);


### PR DESCRIPTION
Closes #3692.

## 문제
클러스터는 단일 공유 Postgres를 쓰는데, **각 노드가 startup마다 자기 `agentdesk.yaml`로 `sync_agents_from_config_pg`를 실행**한다. 이 sync는 파괴적(자기 config에 없는 agent를 DELETE)이라, 노드 간 roster가 다르면 서로의 agent를 지우고 배포 순서에 따라 공유 roster가 **flip-flop**한다. (#3667의 generic agent를 mac-book에만 추가했더니 mac-mini sync가 삭제한 것이 발단.)

## 수정
`startup_reseed`는 cluster leadership 선출 **전**에 실행되므로 런타임 lease로 게이팅 불가 → configured role로 게이팅:
- `agent_roster_sync_enabled(config)` = `!cluster.enabled || cluster.role == "leader"`
- 단일 노드(cluster 비활성) 또는 명시적 `role: leader` 노드만 agent roster sync 실행
- worker/auto 노드는 skip + 로그 표면화 → 공유 roster를 신뢰

pipeline_stages 등 다른 reseed 시드는 upsert-only(비파괴)라 제외. agents sync만 파괴적.

## 테스트
- `agent_roster_sync_gated_to_leader_or_single_node` (단위): disabled→true, leader→true(공백/대소문자 무관), worker/auto/빈문자열→false
- `worker_node_reseed_does_not_clobber_shared_agent_roster` (통합, 실 PG): worker reseed가 leader-owned agent를 삭제하지 않고 자기 config agent도 안 넣음
- 기존 reseed 테스트(cluster 비활성)는 그대로 sync → 회귀 없음
- `cargo check --tests` + `fmt` clean

## 배포 시 주의 (운영)
leader-only 게이팅 후 **리더(mac-book) config가 canonical full roster**가 된다. 현재 mac-book config에 없는 `project-scheduler`/`project-skillmanager`(mac-mini config에만 존재)는 리더 sync가 보존하지 않으므로, 유지하려면 리더 config에 추가해야 한다(별도 운영 결정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)