### PR TITLE
fix(discord): clear abandoned pending-start queue gate

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2511,7 +2511,7 @@ fn idle_queue_snapshot_has_kickable_backlog(
         // finalize before claiming. Do NOT kick normal queued work in the
         // meantime — that would re-introduce the very turn-interleave this fix
         // serializes away.
-        && !tui_direct_pending_start::pending_synthetic_start_present(
+        && !tui_direct_pending_start::pending_synthetic_start_blocks_idle_kickoff(
             provider.as_str(),
             channel_id.get(),
         )

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -322,7 +322,7 @@ mod presleep_tests {
     // this sync scope and never span an await, so no await_holding_lock allow is
     // needed (#3034 ratchet stays frozen at its baseline).
     #[test]
-    fn abandoned_presence_clear_releases_idle_queue_gate_but_keeps_durable_record() {
+    fn abandoned_presence_auto_reconcile_releases_idle_queue_gate_but_keeps_durable_record() {
         let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
         let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let tmp = tempfile::tempdir().expect("temp runtime root");
@@ -348,27 +348,24 @@ mod presleep_tests {
 
             let record = pending_record(&provider, channel_id);
             super::super::tui_direct_pending_start::persist(&record).unwrap();
-            let snapshot = mailbox_snapshot(&shared, channel_id).await;
             assert!(
-                !idle_queue_snapshot_has_kickable_backlog(
-                    &shared,
-                    &provider,
-                    channel_id,
-                    &snapshot
-                ),
-                "pending synthetic-start presence must block the idle queue before the #3333 clear"
-            );
-
-            assert!(
-                super::super::tui_direct_pending_start::clear_abandoned_synthetic_start_presence(
+                super::super::tui_direct_pending_start::pending_synthetic_start_present(
                     provider.as_str(),
                     channel_id.get(),
                 ),
-                "the abandoned durable record should allow presence-only clearing"
+                "the retained pending-start presence starts out blocking the idle queue"
             );
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
             assert!(
                 idle_queue_snapshot_has_kickable_backlog(&shared, &provider, channel_id, &snapshot),
-                "after presence-only clear, the queued item is kickable by the final one-shot drain"
+                "#3691: abandoned retry-exhausted presence must self-clear so the queued item is kickable"
+            );
+            assert!(
+                !super::super::tui_direct_pending_start::pending_synthetic_start_present(
+                    provider.as_str(),
+                    channel_id.get(),
+                ),
+                "#3691: only the in-memory presence is cleared"
             );
             assert!(
                 super::super::tui_direct_pending_start::pending_synthetic_start_abandoned(

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -273,6 +273,24 @@ pub(super) fn pending_synthetic_start_present(provider: &str, channel_id: u64) -
         > 0
 }
 
+pub(super) fn pending_synthetic_start_blocks_idle_kickoff(provider: &str, channel_id: u64) -> bool {
+    if !pending_synthetic_start_present(provider, channel_id) {
+        return false;
+    }
+
+    if clear_abandoned_synthetic_start_presence(provider, channel_id) {
+        tracing::warn!(
+            provider,
+            channel_id,
+            issue = "#3691",
+            "idle queue gate cleared abandoned TUI-direct pending-start presence; durable record retained for restart retry"
+        );
+        return false;
+    }
+
+    true
+}
+
 /// Re-mark a record present during restart restore. [`load_all`] reads the
 /// durable store but does not touch the in-memory index; this restores the gate
 /// state before the respawned worker's first poll. The worker's terminal


### PR DESCRIPTION
## Summary
- Fixes issue #3691 by reconciling retry-exhausted TUI-direct pending-start presence inside the idle queue gate.
- Keeps the durable pending-start record for restart retry, but clears the abandoned in-memory presence so queued user messages can kick off without dcserver restart.
- Adds a regression test proving the idle queue predicate self-clears abandoned presence while preserving the durable record.

## Safety
- `clear_abandoned_synthetic_start_presence` rechecks under the reconcile lock and refuses to clear while an active pending-start worker exists.
- No durable record delete is added; successful claim/delete and restart retry semantics stay unchanged.
- Existing watcher no-inflight suppression remains active for live pending-start workers.

## Verification
- `cargo fmt --check`
- `cargo test --lib abandoned_presence_auto_reconcile_releases_idle_queue_gate_but_keeps_durable_record`
- `cargo test --lib claim_false_exhausted_still_retains_record`
- `cargo check --lib`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py`
- Cross-model adversarial review (`gpt-5.5`): `VERDICT: CLEAN`
