### PR TITLE
fix(discord): ignore Claude stop interrupt prompt

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -792,6 +792,8 @@ src/
 │   │   └── terminal_usage.rs
 │   ├── slo/
 │   │   └── mod.rs
+│   ├── tui_prompt_dedupe/
+│   │   └── synthetic_prompt.rs
 │   ├── turn_orchestrator/
 │   │   └── registry_purge.rs
 │   ├── agent_protocol.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -886,7 +886,7 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (1633 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1625 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +20 from #3676: Codex rollout user prompts now
     prefer the stable message entry id when present so Codex TUI direct prompt
@@ -922,7 +922,10 @@
     atomic read, closing the present/generation TOCTOU) plus its dedicated accessor unit
     test; the watcher-snapshot no-clobber regression test is retained, rewritten to take
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
-    +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
+    -8 from #3695: moved the synthetic TUI user prompt filter into
+    `tui_prompt_dedupe/synthetic_prompt.rs` while adding exact Claude interrupt
+    marker suppression for stop-control transcript envelopes; +62 from #3304:
+    slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
   - `src/services/discord/recovery_engine.rs` (3412 lines; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +9 from #3582 stamping
     `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -8,6 +8,12 @@ use tokio::sync::broadcast;
 use crate::services::agent_protocol::RuntimeHandoffKind;
 use chrono::{DateTime, Utc};
 
+mod synthetic_prompt;
+use self::synthetic_prompt::{
+    is_synthetic_tui_user_prompt_for_provider, reject_synthetic_claude_user_prompt,
+    reject_synthetic_tui_user_prompt,
+};
+
 const PENDING_PROMPT_TTL: Duration = Duration::from_secs(10);
 const RECENT_OBSERVED_TTL: Duration = Duration::from_secs(30);
 const SESSION_MAPPING_TTL: Duration = Duration::from_secs(24 * 60 * 60);
@@ -854,7 +860,7 @@ fn observe_prompt_candidates_by_tmux_inner(
         // never publishes a spurious SSH-direct turn. Treated like other synthetic
         // prompts → candidates stay empty → `PromptObservation::Ignored`.
         if prompt.is_empty()
-            || is_synthetic_tui_user_prompt(prompt)
+            || is_synthetic_tui_user_prompt_for_provider(&provider, prompt)
             || is_discord_relayed_user_prompt(prompt)
         {
             continue;
@@ -1257,7 +1263,7 @@ pub fn extract_claude_transcript_user_prompt_with_entry_id(
     {
         return None;
     }
-    let prompt = reject_synthetic_tui_user_prompt(extract_message_content_text(message)?)?;
+    let prompt = reject_synthetic_claude_user_prompt(extract_message_content_text(message)?)?;
     let entry_id = extract_claude_transcript_entry_id(json, message);
     Some((prompt, entry_id))
 }
@@ -1289,20 +1295,6 @@ pub fn extract_qwen_jsonl_user_prompt(json: &Value) -> Option<String> {
         return None;
     }
     reject_synthetic_tui_user_prompt(extract_message_content_text(message)?)
-}
-
-fn reject_synthetic_tui_user_prompt(prompt: String) -> Option<String> {
-    (!is_synthetic_tui_user_prompt(&prompt)).then_some(prompt)
-}
-
-fn is_synthetic_tui_user_prompt(prompt: &str) -> bool {
-    let prompt = prompt.trim();
-    if prompt.starts_with("<environment_context>") && prompt.ends_with("</environment_context>") {
-        return true;
-    }
-    prompt.starts_with("[Shared Agent Knowledge]\n")
-        || prompt.starts_with("[Proactive Memory Guidance]\n")
-        || prompt == "No response requested."
 }
 
 /// #3527: `[User: <author> (ID: <digits>)] …` is AgentDesk's OWN Discord→TUI
@@ -2833,6 +2825,50 @@ mod tests {
     }
 
     #[test]
+    fn ignores_claude_interrupt_marker_without_relay_lease() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-stop", "[Request interrupted by user]"),
+            PromptObservation::Ignored
+        );
+        assert!(
+            !external_input_relay_lease_present("claude", "tmux-stop", 42),
+            "a stop-control transcript marker must not create an SSH-direct relay lease"
+        );
+    }
+
+    #[test]
+    fn interrupt_marker_filter_is_claude_scoped_for_direct_observation() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let marker = "[Request interrupted by user]";
+
+        assert_eq!(
+            observe_prompt_by_tmux("codex", "tmux-codex-stop-text", marker),
+            PromptObservation::PublishedSshDirect,
+            "Codex direct input with the same text remains a user prompt"
+        );
+        assert!(clear_external_input_relay_lease(
+            "codex",
+            "tmux-codex-stop-text",
+            42
+        ));
+
+        assert_eq!(
+            observe_prompt_by_tmux("qwen", "tmux-qwen-stop-text", marker),
+            PromptObservation::PublishedSshDirect,
+            "Qwen direct input with the same text remains a user prompt"
+        );
+        assert!(clear_external_input_relay_lease(
+            "qwen",
+            "tmux-qwen-stop-text",
+            42
+        ));
+    }
+
+    #[test]
     fn external_input_relay_lease_can_be_bound_to_channel_after_observation() {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_state();
@@ -3049,6 +3085,42 @@ mod tests {
     }
 
     #[test]
+    fn codex_and_qwen_keep_claude_interrupt_text_as_user_prompt() {
+        let marker = "[Request interrupted by user]";
+        let codex_json = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": marker
+                    }
+                ]
+            }
+        });
+        let qwen_json = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": marker }
+                ]
+            }
+        });
+
+        assert_eq!(
+            extract_codex_rollout_user_prompt(&codex_json).as_deref(),
+            Some(marker)
+        );
+        assert_eq!(
+            extract_qwen_jsonl_user_prompt(&qwen_json).as_deref(),
+            Some(marker)
+        );
+    }
+
+    #[test]
     fn extracts_claude_transcript_user_message_text() {
         let json = serde_json::json!({
             "type": "user",
@@ -3153,6 +3225,49 @@ mod tests {
         });
 
         assert_eq!(extract_claude_transcript_user_prompt(&json), None);
+    }
+
+    #[test]
+    fn ignores_claude_transcript_interrupt_marker_user_message_text() {
+        for marker in [
+            "[Request interrupted by user]",
+            "[Request interrupted by user for tool use]",
+        ] {
+            let json = serde_json::json!({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        { "type": "text", "text": marker }
+                    ]
+                },
+                "sessionId": "sess-tui",
+            });
+
+            assert_eq!(
+                extract_claude_transcript_user_prompt(&json),
+                None,
+                "interrupt marker {marker:?} is control output, not external input"
+            );
+        }
+
+        let user_prompt = "[Request interrupted by user story idea]";
+        let json = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": user_prompt }
+                ]
+            },
+            "sessionId": "sess-tui",
+        });
+
+        assert_eq!(
+            extract_claude_transcript_user_prompt(&json).as_deref(),
+            Some(user_prompt),
+            "nearby human text must not be filtered by prefix"
+        );
     }
 
     #[test]

--- a/src/services/tui_prompt_dedupe/synthetic_prompt.rs
+++ b/src/services/tui_prompt_dedupe/synthetic_prompt.rs
@@ -1,0 +1,34 @@
+pub(super) fn reject_synthetic_tui_user_prompt(prompt: String) -> Option<String> {
+    (!is_synthetic_tui_user_prompt(&prompt)).then_some(prompt)
+}
+
+pub(super) fn reject_synthetic_claude_user_prompt(prompt: String) -> Option<String> {
+    (!is_synthetic_tui_user_prompt_for_provider("claude", &prompt)).then_some(prompt)
+}
+
+const CLAUDE_INTERRUPT_USER_PROMPT_MARKERS: [&str; 2] = [
+    "[Request interrupted by user]",
+    "[Request interrupted by user for tool use]",
+];
+
+fn is_synthetic_tui_user_prompt(prompt: &str) -> bool {
+    let prompt = prompt.trim();
+    if prompt.starts_with("<environment_context>") && prompt.ends_with("</environment_context>") {
+        return true;
+    }
+    prompt.starts_with("[Shared Agent Knowledge]\n")
+        || prompt.starts_with("[Proactive Memory Guidance]\n")
+        || prompt == "No response requested."
+}
+
+pub(super) fn is_synthetic_tui_user_prompt_for_provider(provider: &str, prompt: &str) -> bool {
+    if is_synthetic_tui_user_prompt(prompt) {
+        return true;
+    }
+    provider.trim().eq_ignore_ascii_case("claude") && is_claude_interrupt_marker(prompt)
+}
+
+fn is_claude_interrupt_marker(prompt: &str) -> bool {
+    let prompt = prompt.trim();
+    CLAUDE_INTERRUPT_USER_PROMPT_MARKERS.contains(&prompt)
+}


### PR DESCRIPTION
## Summary
- suppress exact Claude stop-control transcript markers (`[Request interrupted by user]` and tool-use variant) before idle relay creates an SSH-direct prompt anchor
- keep the filter provider-scoped so Codex/Qwen can still submit the same text as a real prompt
- move synthetic TUI prompt predicates into a small helper module and update change-surface inventory docs

Fixes #3695

## Verification
- cargo fmt
- cargo test --lib tui_prompt_dedupe
- cargo test tui_prompt_dedupe
- cargo test tui_turn_state::tests::claude_interrupt
- cargo test idle_transcript_scan
- cargo check --lib
- python3 scripts/audit_maintainability.py --check
- python3 scripts/check_agent_maintenance_docs.py
- python3 scripts/generate_inventory_docs.py --check
- git diff --check
- adversarial Codex review: VERDICT CLEAN
