### PR TITLE
fix(discord): silence catch-up duplicate notice

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -472,6 +472,8 @@ src/
 │   │   │   ├── restart.rs
 │   │   │   └── shared.rs
 │   │   ├── router/
+│   │   │   ├── intake_gate/
+│   │   │   │   └── busy_duplicate_notice.rs
 │   │   │   ├── message_handler/
 │   │   │   │   ├── attachments.rs
 │   │   │   │   ├── control.rs

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 
+mod busy_duplicate_notice;
+
 pub(in crate::services::discord) fn should_process_turn_message(
     kind: serenity::model::channel::MessageType,
 ) -> bool {
@@ -2477,6 +2479,13 @@ pub(in crate::services::discord) async fn handle_event(
                     .load(std::sync::atomic::Ordering::Relaxed);
 
                 if !outcome.enqueued {
+                    if busy_duplicate_notice::silence_if_already_queued(
+                        outcome.refusal_reason,
+                        new_message.id,
+                        channel_id,
+                    ) {
+                        return Ok(());
+                    }
                     rate_limit_wait(&data.shared, channel_id).await;
                     let _ = channel_id
                         .say(&ctx.http, "↪ 같은 메시지가 방금 이미 큐잉되어서 무시했어.")

--- a/src/services/discord/router/intake_gate/busy_duplicate_notice.rs
+++ b/src/services/discord/router/intake_gate/busy_duplicate_notice.rs
@@ -1,0 +1,48 @@
+use crate::services::turn_orchestrator::EnqueueRefusalReason;
+use std::fmt::Display;
+
+pub(super) fn silence_if_already_queued(
+    reason: Option<EnqueueRefusalReason>,
+    message_id: impl Display,
+    channel_id: impl Display,
+) -> bool {
+    if !should_silence(reason) {
+        return false;
+    }
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::info!(
+        reason = reason.map(|reason| reason.as_str()),
+        "  [{ts}] ↪ BUSY-QUEUE: silently ignored already-queued source message {message_id} in channel {channel_id}"
+    );
+    true
+}
+
+fn should_silence(reason: Option<EnqueueRefusalReason>) -> bool {
+    matches!(reason, Some(EnqueueRefusalReason::SourceIdAlreadyQueued))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn silences_already_queued_source_id_duplicate_notice() {
+        assert!(should_silence(Some(
+            EnqueueRefusalReason::SourceIdAlreadyQueued
+        )));
+    }
+
+    #[test]
+    fn keeps_recent_resend_duplicate_notice_visible() {
+        assert!(!should_silence(Some(EnqueueRefusalReason::LastItemDedup)));
+    }
+
+    #[test]
+    fn keeps_queue_error_notice_visible() {
+        assert!(!should_silence(Some(
+            EnqueueRefusalReason::ActorUnreachable
+        )));
+        assert!(!should_silence(Some(EnqueueRefusalReason::MailboxClosed)));
+        assert!(!should_silence(None));
+    }
+}


### PR DESCRIPTION
## Summary
- Suppress the busy-turn duplicate notice only when the mailbox refuses a source id that is already queued.
- Preserve the existing Korean duplicate notice for actual rapid resend dedup and queue errors.
- Add a small helper module and regenerate ARCHITECTURE.md.

Refs #3694

## Verification
- cargo fmt
- cargo test --lib busy_duplicate_notice
- cargo test --lib enqueue_refusal_reason_tests
- cargo check --lib
- python3 scripts/audit_maintainability.py --check
- python3 scripts/generate_inventory_docs.py
- python3 scripts/generate_inventory_docs.py --check
- python3 scripts/check_agent_maintenance_docs.py
- git diff --check

## Review
- Claude Opus adversarial review: VERDICT: CLEAN