### PR TITLE
fix(cluster): gate OpenClaw roster sync to leader

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Agent turn lifecycle is managed by a dedicated orchestration layer (`src/service
 AgentDesk can run multiple release instances against one PostgreSQL control plane. Each node advertises identity, labels, provider capabilities, and node-local MCP health through `worker_nodes`, while PostgreSQL leases prevent duplicate cluster-wide side effects.
 
 - **Leader/worker split** — Each node boots with `cluster.instance_id`, acquires the cluster leader advisory lease when eligible, and records its effective role through `/api/cluster/nodes`.
+- **Agent roster ownership** — In cluster mode, exactly one node should be configured as `cluster.role: leader`; that configured leader owns the destructive config-to-DB agent roster sync. All-`auto` clusters can elect an effective runtime leader, but startup roster sync is intentionally disabled on `auto` nodes so agent edits can appear frozen.
 - **Capability-aware routing** — Dispatch claims compare required labels/providers/MCP health against registered worker capabilities and record routing diagnostics when a node is ineligible.
 - **Lease-backed work claims** — `task_dispatches` and dispatch outbox rows use PG claim owner, expiry, and idempotency fields so multiple nodes do not process the same work item concurrently.
 - **Exclusive resource locks** — `/api/cluster/resource-locks*` serializes node-local resources such as Unreal Editor, MCP endpoints, and project-level test execution.
@@ -367,7 +368,7 @@ database:
 cluster:
   enabled: true
   instance_id: example-main-node   # use a unique value per host, e.g. example-worker-node
-  role: auto                       # auto | leader | worker
+  role: leader                     # auto | leader | worker; set exactly one leader for roster sync
   heartbeat_interval_secs: 10
   lease_ttl_secs: 30
   labels: [example-main, release]

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1370,7 +1370,7 @@
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
   - `src/cli/doctor/orchestrator.rs` (4381 lines).
-  - `src/cli/migrate/apply.rs` (3231 lines; +1 from #3690 AgentDef preferred_intake_node_labels literal).
+  - `src/cli/migrate/apply.rs` (3237 lines; +1 from #3690 AgentDef preferred_intake_node_labels literal; +6 from #3697 OpenClaw --write-db non-leader roster-sync gate).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),
     dcserver.rs (1560)}`.

--- a/docs/agent-maintenance/multinode-two-node-smoke.md
+++ b/docs/agent-maintenance/multinode-two-node-smoke.md
@@ -36,12 +36,12 @@ node --test policies/__tests__/merge-automation.test.js
 Run this only against a release runtime against the shared PostgreSQL instance.
 Do not stop `AgentDesk-*` tmux work sessions unless the operator explicitly asks.
 
-1. Start Mac mini as leader-capable:
+1. Start Mac mini as the configured leader:
 
 ```bash
 AGENTDESK_CLUSTER_ENABLED=true \
 AGENTDESK_CLUSTER_INSTANCE_ID=mac-mini-release \
-AGENTDESK_CLUSTER_ROLE=auto \
+AGENTDESK_CLUSTER_ROLE=leader \
 scripts/deploy-release.sh
 ```
 
@@ -64,6 +64,9 @@ Expected:
 
 - two distinct `worker_nodes` rows
 - exactly one `effective_role=leader`
+- exactly one configured `cluster.role=leader`; all-`auto` clusters can elect a
+  runtime leader but skip destructive config-to-DB agent roster sync, so
+  `agentdesk.yaml` roster edits can remain frozen
 - MacBook/Mac mini capability surfaces differ where expected
 
 4. Verify claim and routing diagnostics:

--- a/docs/openclaw-migrate.md
+++ b/docs/openclaw-migrate.md
@@ -88,7 +88,7 @@ channel binding, bot 설정, 세션까지 함께 이관:
 - `--workspace-root-rewrite OLD=NEW`: 절대 workspace prefix 재작성
 - `--write-org`: `config/org.yaml` 반영
 - `--write-bot-settings`: `config/bot_settings.json` 반영
-- `--write-db`: SQLite upsert 반영
+- `--write-db`: PostgreSQL agent/session import 반영
 - `--with-channel-bindings`: Discord channel binding import 적용
 - `--with-sessions`: 세션 이관 활성화
 - `--snapshot-source`: source tree snapshot 남김
@@ -102,4 +102,5 @@ channel binding, bot 설정, 세션까지 함께 이관:
 - `--resume <import_id>`는 현재 runtime 상태로 role id를 다시 계산하지 않고, audit의 `agent-map.json`에 저장된 source→role 매핑을 그대로 재사용합니다.
 - Windows source에서 넘어온 `C:\...` 또는 `D:/...` workspace 경로는 절대경로로 유지한 뒤, 필요하면 `--workspace-root-rewrite`로 현 환경 경로에 맞춰 바꿔야 합니다.
 - workspace가 없거나 provider 매핑이 불가능한 agent는 audit에는 남지만 apply에서 건너뜁니다.
+- `--write-db`는 config-to-DB agent roster sync를 수행하므로 클러스터에서는 single-node 또는 명시적으로 `cluster.role: leader`인 노드에서만 실행합니다. worker/auto 노드에서는 안전하게 거부됩니다.
 - token/tool policy는 기본적으로 `report` 모드이며, 실제 쓰기 전 dry-run과 audit 결과를 먼저 확인하는 것이 안전합니다.

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -1743,6 +1743,12 @@ fn apply_db_import(
     runtime_root: &Path,
     warnings: &mut Vec<String>,
 ) -> Result<String, String> {
+    if !db::postgres::agent_roster_sync_enabled(config) {
+        return Err(format!(
+            "OpenClaw --write-db imports run the destructive config-to-DB agent roster sync; run this command only on a single-node deployment or the configured cluster leader (cluster.role={}).",
+            config.cluster.role
+        ));
+    }
     fs::create_dir_all(&config.data.dir).map_err(|e| {
         format!(
             "Failed to create data directory '{}': {e}",


### PR DESCRIPTION
## Summary
- Reject OpenClaw `--write-db` imports on cluster worker/auto nodes before filesystem or DB writes, reusing the existing roster-sync owner predicate.
- Document that cluster deployments need exactly one configured `cluster.role: leader` for config-to-DB agent roster sync.
- Update the multinode smoke runbook, OpenClaw migration docs, and maintenance line-count freeze.

Refs #3697

## Verification
- cargo fmt
- cargo test --lib agent_roster_sync_gated_to_leader_or_single_node
- cargo check --bin agentdesk
- python3 scripts/audit_maintainability.py --check
- python3 scripts/generate_inventory_docs.py
- python3 scripts/generate_inventory_docs.py --check
- python3 scripts/check_agent_maintenance_docs.py
- git diff --check

## Review
- Claude Opus adversarial review: VERDICT: CLEAN