### PR TITLE
Fix idle cleanup activity and resumable reporting

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1435,9 +1435,10 @@
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
   - `src/db/postgres.rs` (1167 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests; #3690: preferred_intake_node_labels upsert/sync + COALESCE preserve; #3692: `agent_roster_sync_enabled` leader-ownership gate on the roster sync).
-  - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
+  - `src/db/dispatched_sessions.rs` (1612 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
-    durable-truth accessor the idle-relay drift self-heal reads).
+    durable-truth accessor the idle-relay drift self-heal reads; #3693: +2 to
+    include `cwd` in provider resume selector lookup).
   - `src/db/session_transcripts.rs` is a retained PG-cleanup surface (now below
     the giant-file threshold; bugfix only).
   - `src/db/prompt_manifests/` (directory, refactored).
@@ -1465,7 +1466,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
 - `src/services/onboarding/mod.rs` (2937),
-  `src/services/dispatched_sessions.rs` (1328), and
+  `src/services/dispatched_sessions.rs` (1375), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
@@ -1513,12 +1514,13 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   while the prior turn streams; +20 from #3637 centralizing post-paste error
   cleanup and making draft clearing cancel-agnostic.)
 - `src/services/memory/memento.rs` (1893).
-- `src/services/dispatched_sessions.rs` (1328) — dispatched session domain
+- `src/services/dispatched_sessions.rs` (1375) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database
   callsites, but the module itself is now giant-file territory; split focused
   helpers before adding non-bugfix behavior. (+5 from #3169 exposing the idle-
   kill `latest_runtime_activity_unix_nanos` jsonl-mtime probe to the stall-
-  watchdog liveness guard.)
+  watchdog liveness guard; +47 from #3693 making kill-tmux's `resumable` claim
+  match Claude TUI transcript-backed resume semantics.)
 - `src/services/settings.rs` (1114) — settings domain service extracted from
   the route layer in #1519. Keep follow-up changes bugfix-only unless the file
   is split further.

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -990,7 +990,7 @@ test("timeouts idle-kill module calls kill-tmux API for expired idle sessions", 
             provider: "codex",
             active_dispatch_id: null,
             thread_channel_id: null,
-            last_seen_at: "2000-01-01 00:00:00"
+            last_seen_at: timestampMinutesAgo(370)
           }
         ]
       },
@@ -1013,6 +1013,10 @@ test("timeouts idle-kill module calls kill-tmux API for expired idle sessions", 
   assert.equal(state.httpPosts.length, 1);
   assert.match(state.httpPosts[0].url, /\/api\/sessions\/provider%3AAgentDesk-codex-project-agentdesk\/kill-tmux$/);
   assert.equal(state.httpPosts[0].body.retry, undefined);
+  assert.match(state.httpPosts[0].body.reason, /idle 6시간 초과/);
+  const idleSql = state.queries.map((q) => q.sql).join("\n");
+  assert.match(idleSql, /turn_lifecycle_events/);
+  assert.match(idleSql, /GREATEST\(COALESCE\(s\.last_heartbeat, s\.created_at\)/);
   assert.match(state.logs.info.join("\n"), /idle kill: agent-idle-1/);
 });
 
@@ -1082,6 +1086,47 @@ test("timeouts idle-kill module does not let zombie (already-gone tmux) rows sta
   // The live row was reached and actually killed.
   assert.ok(state.httpPosts.some((p) => p.url.includes("live-4")));
   assert.match(state.logs.info.join("\n"), /Killed idle tmux .*live-4/);
+});
+
+test("timeouts idle-kill module does not count live-activity guard skips toward budget", () => {
+  const guardKeys = [
+    "provider:AgentDesk-claude-guard-1",
+    "provider:AgentDesk-claude-guard-2",
+    "provider:AgentDesk-claude-guard-3"
+  ];
+  const liveKey = "provider:AgentDesk-claude-live-after-guard";
+  function row(session_key) {
+    return {
+      session_key,
+      agent_id: null,
+      provider: "claude",
+      active_dispatch_id: null,
+      thread_channel_id: null,
+      last_seen_at: "2000-01-01 00:00:00"
+    };
+  }
+
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { server_port: 8791 },
+    dbQuery: createSqlRouter([
+      { match: "SELECT id, name, name_ko, discord_channel_id, discord_channel_alt, discord_channel_cc, discord_channel_cdx FROM agents", result: [] },
+      { match: "FROM sessions WHERE provider IN ('claude', 'codex', 'qwen') AND (agent_id IS NULL OR TRIM(agent_id) = '')", result: [] },
+      { match: (sql) => sql.includes("WHERE status = 'idle'") && sql.includes("active_dispatch_id IS NULL") && sql.includes("INTERVAL '6 hours'"), result: [...guardKeys.map(row), row(liveKey)] },
+      { match: (sql) => sql.includes("WHERE status = 'idle'") && sql.includes("active_dispatch_id IS NOT NULL") && sql.includes("INTERVAL '24 hours'"), result: [] }
+    ]),
+    httpPost(url) {
+      return url.includes("live-after-guard")
+        ? { ok: true, tmux_was_alive: true, tmux_killed: true }
+        : { ok: true, tmux_was_alive: true, tmux_killed: false, skipped_live_activity_guard: true };
+    }
+  });
+
+  policy._section_O();
+
+  assert.equal(state.httpPosts.length, 4);
+  assert.ok(state.httpPosts.some((p) => p.url.includes("live-after-guard")));
+  assert.match(state.logs.info.join("\n"), /skipped live activity guard/);
+  assert.doesNotMatch(state.logs.error.join("\n"), /tmux was alive but kill failed/);
 });
 
 test("timeouts idle-kill module counts genuine kill failures (tmux alive but kill failed) toward budget", () => {

--- a/policies/timeouts/idle-kill.js
+++ b/policies/timeouts/idle-kill.js
@@ -56,27 +56,43 @@ module.exports = function attachIdleKill(timeouts, helpers) {
       var mainChannelSqlGuard =
         "AND thread_channel_id IS NULL " +
         "AND session_key !~ '-t[0-9]{15,}(-dev)?$' ";
+      var recentLifecycleWindowExpr = "NOW() - INTERVAL '24 hours'";
+      var latestChannelLifecycleAtExpr =
+        "(SELECT tle_channel.created_at FROM turn_lifecycle_events tle_channel " +
+        "WHERE NULLIF(BTRIM(COALESCE(s.channel_id, '')), '') IS NOT NULL " +
+        "AND tle_channel.channel_id = s.channel_id " +
+        "AND tle_channel.created_at >= " + recentLifecycleWindowExpr + " " +
+        "ORDER BY tle_channel.created_at DESC LIMIT 1)";
+      var latestSessionLifecycleAtExpr =
+        "(SELECT tle_session.created_at FROM turn_lifecycle_events tle_session " +
+        "WHERE tle_session.session_key = s.session_key " +
+        "AND tle_session.created_at >= " + recentLifecycleWindowExpr + " " +
+        "ORDER BY tle_session.created_at DESC LIMIT 1)";
+      var effectiveLastSeenJoin =
+        "CROSS JOIN LATERAL (SELECT GREATEST(COALESCE(s.last_heartbeat, s.created_at), " +
+        "COALESCE(" + latestChannelLifecycleAtExpr + ", TIMESTAMPTZ 'epoch'), " +
+        "COALESCE(" + latestSessionLifecycleAtExpr + ", TIMESTAMPTZ 'epoch')) AS last_seen_at) latest ";
       var idleSessions = agentdesk.db.query(
-        "SELECT session_key, agent_id, provider, active_dispatch_id, thread_channel_id, " +
-        "COALESCE(last_heartbeat, created_at) AS last_seen_at " +
-        "FROM sessions " +
+        "SELECT s.session_key, s.agent_id, s.provider, s.active_dispatch_id, s.thread_channel_id, latest.last_seen_at " +
+        "FROM sessions s " +
+        effectiveLastSeenJoin +
         "WHERE status = 'idle' " +
         "AND provider IN ('claude', 'codex', 'qwen') " +
         "AND active_dispatch_id IS NULL " +
         mainChannelSqlGuard +
-        "AND COALESCE(last_heartbeat, created_at) < NOW() - INTERVAL '6 hours' " +
-        "ORDER BY COALESCE(last_heartbeat, created_at) ASC LIMIT 50"
+        "AND latest.last_seen_at < NOW() - INTERVAL '6 hours' " +
+        "ORDER BY latest.last_seen_at ASC LIMIT 50"
       );
       var safetySessions = agentdesk.db.query(
-        "SELECT session_key, agent_id, provider, active_dispatch_id, thread_channel_id, " +
-        "COALESCE(last_heartbeat, created_at) AS last_seen_at " +
-        "FROM sessions " +
+        "SELECT s.session_key, s.agent_id, s.provider, s.active_dispatch_id, s.thread_channel_id, latest.last_seen_at " +
+        "FROM sessions s " +
+        effectiveLastSeenJoin +
         "WHERE status = 'idle' " +
         "AND provider IN ('claude', 'codex', 'qwen') " +
         "AND active_dispatch_id IS NOT NULL " +
         mainChannelSqlGuard +
-        "AND COALESCE(last_heartbeat, created_at) < NOW() - INTERVAL '24 hours' " +
-        "ORDER BY COALESCE(last_heartbeat, created_at) ASC LIMIT 50"
+        "AND latest.last_seen_at < NOW() - INTERVAL '24 hours' " +
+        "ORDER BY latest.last_seen_at ASC LIMIT 50"
       );
 
       // Defense-in-depth: client-side filter catches anything the SQL guard
@@ -144,6 +160,14 @@ module.exports = function attachIdleKill(timeouts, helpers) {
             agentdesk.log.warn(
               "[idle-kill] kill-tmux: tmux already gone for " + s.session_key +
               " (reconciled=" + (killResp.session_row_disconnected === true) + ", not counted toward budget)"
+            );
+            continue;
+          }
+
+          if (killResp.skipped_live_activity_guard) {
+            agentdesk.log.info(
+              "[idle-kill] kill-tmux skipped live activity guard for " + s.session_key +
+              " (heartbeat refreshed, not counted toward budget)"
             );
             continue;
           }

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -1864,6 +1864,7 @@ pub(crate) struct DeleteSessionResult {
 pub(crate) struct ProviderSessionIds {
     pub(crate) claude_session_id: Option<String>,
     pub(crate) raw_provider_session_id: Option<String>,
+    pub(crate) cwd: Option<String>,
 }
 
 pub(crate) struct UpdateSessionParams<'a> {
@@ -2000,7 +2001,7 @@ pub(crate) async fn load_provider_session_ids_pg(
 ) -> Result<Option<ProviderSessionIds>, String> {
     let result = if let Some(provider) = provider {
         sqlx::query(
-            "SELECT claude_session_id, raw_provider_session_id
+            "SELECT claude_session_id, raw_provider_session_id, cwd
              FROM sessions
              WHERE session_key = $1 AND provider = $2",
         )
@@ -2010,7 +2011,7 @@ pub(crate) async fn load_provider_session_ids_pg(
         .await
     } else {
         sqlx::query(
-            "SELECT claude_session_id, raw_provider_session_id
+            "SELECT claude_session_id, raw_provider_session_id, cwd
              FROM sessions
              WHERE session_key = $1",
         )
@@ -2024,6 +2025,7 @@ pub(crate) async fn load_provider_session_ids_pg(
         Ok(ProviderSessionIds {
             claude_session_id: row.try_get("claude_session_id")?,
             raw_provider_session_id: row.try_get("raw_provider_session_id")?,
+            cwd: row.try_get("cwd")?,
         })
     })
     .transpose()

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -1086,6 +1086,62 @@ pub(crate) fn latest_runtime_activity_unix_nanos(tmux_session_name: &str) -> i64
     latest
 }
 
+fn selected_provider_resume_selector(
+    ids: &dispatched_sessions_db::ProviderSessionIds,
+) -> Option<&str> {
+    ids.claude_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            ids.raw_provider_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+}
+
+fn provider_is_claude(provider_name: Option<&str>) -> bool {
+    provider_name.is_some_and(|provider| provider.eq_ignore_ascii_case("claude"))
+}
+
+fn provider_resume_selector_is_effective(
+    provider_name: Option<&str>,
+    ids: &dispatched_sessions_db::ProviderSessionIds,
+) -> bool {
+    provider_resume_selector_is_effective_with_claude_home(provider_name, ids, None)
+}
+
+fn provider_resume_selector_is_effective_with_claude_home(
+    provider_name: Option<&str>,
+    ids: &dispatched_sessions_db::ProviderSessionIds,
+    claude_home: Option<&std::path::Path>,
+) -> bool {
+    let Some(selector) = selected_provider_resume_selector(ids) else {
+        return false;
+    };
+
+    if !provider_is_claude(provider_name) {
+        return true;
+    }
+
+    let Some(cwd) = ids
+        .cwd
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+
+    crate::services::claude_tui::transcript_tail::claude_transcript_path(
+        std::path::Path::new(cwd),
+        selector,
+        claude_home,
+    )
+    .is_ok_and(|path| path.exists())
+}
+
 async fn kill_tmux_session_impl(
     state: &AppState,
     headers: &HeaderMap,
@@ -1114,7 +1170,7 @@ async fn kill_tmux_session_impl(
             Json(json!({"error": "postgres pool unavailable"})),
         );
     };
-    let (active_dispatch_id, _agent_id, _runtime_channel_id, _session_provider, owner_instance_id) =
+    let (active_dispatch_id, _agent_id, _runtime_channel_id, session_provider, owner_instance_id) =
         match dispatched_sessions_db::load_force_kill_session_pg(pool, session_key, provider_name)
             .await
         {
@@ -1159,6 +1215,7 @@ async fn kill_tmux_session_impl(
             }
         }
     }
+    let effective_provider_name = provider_name.or(session_provider.as_deref());
 
     let tmux_was_alive = crate::services::platform::tmux::has_session(&tmux_name);
 
@@ -1213,31 +1270,19 @@ async fn kill_tmux_session_impl(
         false
     };
 
-    // #3052: a tmux-only idle cleanup must not silently claim "preserved for
-    // resume". Verify the provider resume selector is actually present in the
-    // DB row before logging that claim. Either selector column
-    // (claude_session_id namespaced selector or raw_provider_session_id native
-    // fallback) is sufficient for provider-native resume.
+    // #3052/#3693: a tmux-only idle cleanup must not silently claim
+    // "preserved for resume". For Claude TUI, selector presence alone is not
+    // enough: the next launch only resumes when the selected UUID has a
+    // transcript under the persisted cwd; otherwise it forces a fresh UUID.
+    // Non-Claude providers keep the existing selector-presence contract.
     let resumable = match dispatched_sessions_db::load_provider_session_ids_pg(
         pool,
         session_key,
-        provider_name,
+        effective_provider_name,
     )
     .await
     {
-        Ok(Some(ids)) => {
-            let has_claude_selector = ids
-                .claude_session_id
-                .as_deref()
-                .map(|value| !value.is_empty())
-                .unwrap_or(false);
-            let has_raw_selector = ids
-                .raw_provider_session_id
-                .as_deref()
-                .map(|value| !value.is_empty())
-                .unwrap_or(false);
-            has_claude_selector || has_raw_selector
-        }
+        Ok(Some(ids)) => provider_resume_selector_is_effective(effective_provider_name, &ids),
         Ok(None) => false,
         Err(error) => {
             tracing::warn!(
@@ -1260,7 +1305,7 @@ async fn kill_tmux_session_impl(
         );
     } else {
         tracing::info!(
-            "  [{ts}] ✂ kill-tmux: session={}, tmux_killed={}, tmux_was_alive={}, active_dispatch_id={:?} (DB row retained but no provider selector present, resumable=false)",
+            "  [{ts}] ✂ kill-tmux: session={}, tmux_killed={}, tmux_was_alive={}, active_dispatch_id={:?} (DB row retained but no effective provider resume selector present, resumable=false)",
             session_key,
             tmux_killed,
             tmux_was_alive,
@@ -1322,7 +1367,88 @@ async fn kill_tmux_session_impl(
             "tmux_session_name": tmux_name,
             "session_row_preserved": true,
             "session_row_disconnected": session_row_disconnected,
+            "resumable": resumable,
             "active_dispatch_id": active_dispatch_id,
         })),
     )
+}
+
+#[cfg(test)]
+mod kill_tmux_resume_tests {
+    use super::provider_resume_selector_is_effective_with_claude_home;
+    use crate::db::dispatched_sessions::ProviderSessionIds;
+
+    fn ids(
+        claude_session_id: Option<&str>,
+        raw_provider_session_id: Option<&str>,
+        cwd: Option<&std::path::Path>,
+    ) -> ProviderSessionIds {
+        ProviderSessionIds {
+            claude_session_id: claude_session_id.map(str::to_string),
+            raw_provider_session_id: raw_provider_session_id.map(str::to_string),
+            cwd: cwd.map(|path| path.display().to_string()),
+        }
+    }
+
+    #[test]
+    fn claude_resumable_requires_existing_transcript_for_selected_selector() {
+        let cwd = tempfile::tempdir().expect("cwd tempdir");
+        let claude_home = tempfile::tempdir().expect("claude home tempdir");
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let transcript_path = crate::services::claude_tui::transcript_tail::claude_transcript_path(
+            cwd.path(),
+            &session_id,
+            Some(claude_home.path()),
+        )
+        .expect("transcript path");
+
+        std::fs::create_dir_all(transcript_path.parent().expect("transcript parent"))
+            .expect("create transcript parent");
+        std::fs::write(&transcript_path, b"{}\n").expect("write transcript");
+
+        let ids = ids(Some(&session_id), None, Some(cwd.path()));
+        assert!(provider_resume_selector_is_effective_with_claude_home(
+            Some("claude"),
+            &ids,
+            Some(claude_home.path()),
+        ));
+    }
+
+    #[test]
+    fn claude_resumable_rejects_missing_transcript_or_cwd() {
+        let cwd = tempfile::tempdir().expect("cwd tempdir");
+        let claude_home = tempfile::tempdir().expect("claude home tempdir");
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        let missing_transcript = ids(Some(&session_id), None, Some(cwd.path()));
+        assert!(!provider_resume_selector_is_effective_with_claude_home(
+            Some("claude"),
+            &missing_transcript,
+            Some(claude_home.path()),
+        ));
+
+        let missing_cwd = ids(Some(&session_id), None, None);
+        assert!(!provider_resume_selector_is_effective_with_claude_home(
+            Some("claude"),
+            &missing_cwd,
+            Some(claude_home.path()),
+        ));
+    }
+
+    #[test]
+    fn non_claude_resumable_uses_existing_selector_presence_contract() {
+        let codex_ids = ids(None, Some("codex-selector"), None);
+        assert!(provider_resume_selector_is_effective_with_claude_home(
+            Some("codex"),
+            &codex_ids,
+            None,
+        ));
+
+        let no_selector = ids(None, Some("   "), None);
+        assert!(!provider_resume_selector_is_effective_with_claude_home(
+            Some("codex"),
+            &no_selector,
+            None,
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- Make idle-kill compute `last_seen_at` from session heartbeat plus recent durable turn lifecycle activity, so the kill reason and selection use the same effective activity timestamp.
- Treat `/kill-tmux` live-activity guard skips as uncounted budget skips, not kill failures.
- Make `kill-tmux` `resumable` reporting provider-aware: Claude now requires a persisted cwd and an existing selected transcript; non-Claude providers keep selector-presence semantics.
- Sync giant-file freeze docs for the scoped bugfix growth.

## Verification
- `node --test policies/__tests__/timeouts.test.js`
- `cargo test --lib kill_tmux_resume_tests`
- `cargo test --lib tmux_only_kill_preserves_resume_selectors`
- `cargo check --lib`
- `cargo fmt --check`
- `python3 scripts/audit_maintainability.py --check`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `python3 scripts/check_postgres_migration_checksums.py`
- `git diff --check`

## Review
- Opus adversarial review: `VERDICT: CLEAN`

Closes #3693