### PR TITLE
fix(discord): keep headless DM terminal delivery bridge-owned

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1059,7 +1059,7 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6234 lines; production LoC; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6235 lines; production LoC; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -4058,6 +4058,7 @@ pub(super) fn spawn_turn_bridge(
             adk_session_key.as_deref(),
             turn_id.as_str(),
             current_msg_id.get(),
+            can_chain_locally,
             tmux_last_offset,
             response_unsent,
             &mut inflight_state,

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -76,6 +76,22 @@ pub(super) fn bridge_should_hand_off_busy_turn_to_watcher(
         && live_watcher_registered
 }
 
+/// A synthetic-headless bridge turn has no real Discord placeholder for the
+/// watcher to edit. If the bridge already holds terminal text, keep ownership on
+/// the bridge so it can run the headless outbox delivery path instead of
+/// promoting the turn to watcher-only ownership with zero relay progress.
+pub(super) fn headless_terminal_delivery_should_stay_on_bridge(
+    can_chain_locally: bool,
+    current_msg_id: u64,
+    response_pending_bytes: usize,
+    response_pending_trimmed_empty: bool,
+) -> bool {
+    !can_chain_locally
+        && super::super::is_synthetic_headless_message_id_raw(current_msg_id)
+        && response_pending_bytes > 0
+        && !response_pending_trimmed_empty
+}
+
 /// #3268 FIX 1 (codex blocker): true ONLY for a GENUINELY-LIVE watcher = a
 /// handle is present AND it is neither cancelled NOR heartbeat-stale.
 ///
@@ -310,6 +326,7 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
     session_key: Option<&str>,
     turn_id: &str,
     current_msg_id: u64,
+    can_chain_locally: bool,
     tmux_last_offset: Option<u64>,
     response_unsent: &str,
     inflight_state: &mut InflightTurnState,
@@ -326,6 +343,23 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
         genuinely_live_watcher_for_relay(&shared_owned.tmux_watchers, watcher_owner_channel_id),
     ) && let Some(watcher) = shared_owned.tmux_watchers.get(&watcher_owner_channel_id)
     {
+        if headless_terminal_delivery_should_stay_on_bridge(
+            can_chain_locally,
+            current_msg_id,
+            response_unsent.len(),
+            response_unsent.trim().is_empty(),
+        ) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = channel_id.get(),
+                watcher_owner_channel = watcher_owner_channel_id.get(),
+                current_msg_id,
+                response_pending_bytes = response_unsent.len(),
+                "  [{ts}] 👁 #3704: quiescence timeout with headless terminal text pending — bridge keeps delivery ownership instead of handing off to watcher"
+            );
+            return;
+        }
         // #3277 (Defect A): a turn whose JSONL terminator is ALREADY on disk
         // (and whose transcript grew past the turn start) has nothing left for
         // the watcher to relay — handing it off parks the watcher at EOF and
@@ -663,6 +697,33 @@ mod tests {
         assert_eq!(
             post_gate_handoff_pending_response_visibility_kind(12, true),
             None
+        );
+    }
+
+    #[test]
+    fn headless_terminal_delivery_stays_on_bridge_truth_table() {
+        let synthetic_id = super::super::SYNTHETIC_HEADLESS_MESSAGE_ID_FLOOR + 42;
+        assert!(headless_terminal_delivery_should_stay_on_bridge(
+            false,
+            synthetic_id,
+            128,
+            false,
+        ));
+        assert!(
+            !headless_terminal_delivery_should_stay_on_bridge(false, synthetic_id, 0, false),
+            "no pending response means no bridge-owned terminal delivery to protect"
+        );
+        assert!(
+            !headless_terminal_delivery_should_stay_on_bridge(false, synthetic_id, 128, true),
+            "whitespace-only pending response should not block watcher handoff"
+        );
+        assert!(
+            !headless_terminal_delivery_should_stay_on_bridge(true, synthetic_id, 128, false),
+            "live Discord turns can still use the existing watcher handoff path"
+        );
+        assert!(
+            !headless_terminal_delivery_should_stay_on_bridge(false, 42, 128, false),
+            "real Discord placeholders are not the headless outbox path"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3704.

Headless DM routine turns can now keep bridge ownership of terminal assistant text when the TUI quiescence gate times out. This prevents a final response from being promoted to watcher-only relay ownership with `response_sent_offset = 0`, where the bridge skips direct delivery and the watcher may relay zero bytes.

## Root Cause

The 요회장 probe incident produced valid final assistant text, but the bridge timed out waiting for TUI quiescence and handed the turn to the tmux watcher. The bridge then logged `tmux watcher owns assistant relay; bridge skipped direct response delivery`, while observability showed `full_response_len > 0`, `response_sent_offset = 0`, and `dispatch_ok = false`. The watcher later surfaced as `tmux_alive_relay_dead`, so no DM was sent.

## Changes

- Add a narrow guard for synthetic-headless terminal responses with non-empty pending text.
- Keep those turns bridge-owned so the existing `enqueue_headless_delivery` terminal path runs.
- Preserve live Discord watcher handoff behavior by requiring `!can_chain_locally` and a synthetic headless message id.
- Add a truth-table unit test for the new guard.

## Review

- `claude -p` review round on the rebased patch: `VERDICT CLEAN`.
- Findings were Info-only and non-blocking.

## Validation

- `cargo fmt`
- `cargo test watcher_handoff --lib`
- `cargo check`
- `git diff --check`

Existing warnings remain unrelated: `legacy-sqlite-tests` cfg warnings and pre-existing unused imports.
