### PR TITLE
fix(discord): preserve relay across restart and final tail

### DIFF
--- a/src/services/discord/health/relay_dead_reattach.rs
+++ b/src/services/discord/health/relay_dead_reattach.rs
@@ -8,22 +8,6 @@ use crate::services::discord::relay_health::RelayStallState;
 use crate::services::discord::{self, SharedData};
 use crate::services::provider::ProviderKind;
 
-fn outbound_activity_is_recent(
-    last_outbound_activity_ms: Option<i64>,
-    now_unix_secs: i64,
-    threshold_secs: u64,
-) -> bool {
-    let Some(last_outbound_activity_ms) = last_outbound_activity_ms else {
-        return false;
-    };
-    let now_ms = now_unix_secs.saturating_mul(1000);
-    if last_outbound_activity_ms >= now_ms {
-        return true;
-    }
-    let age_ms = now_ms.saturating_sub(last_outbound_activity_ms) as u64;
-    age_ms < threshold_secs.saturating_mul(1000)
-}
-
 fn should_reattach_relay_dead_watcher(
     snapshot: &WatcherStateSnapshot,
     channel_id: ChannelId,
@@ -35,11 +19,6 @@ fn should_reattach_relay_dead_watcher(
         || !snapshot.attached
         || snapshot.watcher_owner_channel_id != Some(channel_id.get())
         || snapshot.tmux_session_alive != Some(true)
-        || outbound_activity_is_recent(
-            snapshot.relay_health.last_outbound_activity_ms,
-            now_unix_secs,
-            recovery::STALL_WATCHDOG_THRESHOLD_SECS,
-        )
     {
         return false;
     }
@@ -215,7 +194,6 @@ mod tests {
                 fresh_activity,
                 boot,
             ),
-            ("fresh outbound", fresh_outbound, stale_activity, boot),
             (
                 "post-restart grace",
                 snapshot(&stale),
@@ -234,5 +212,15 @@ mod tests {
                 "{name}"
             );
         }
+        assert!(
+            should_reattach_relay_dead_watcher(
+                &fresh_outbound,
+                ChannelId::new(42),
+                stale_activity,
+                now,
+                boot,
+            ),
+            "recent outbound activity must not block non-destructive watcher reattach"
+        );
     }
 }

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -132,6 +132,7 @@ pub(super) struct StallWatchdogLivenessEvidence {
     pub(super) pane_offset_advanced_age_secs: Option<u64>,
     pub(super) transcript_mtime_age_secs: Option<u64>,
     pub(super) runtime_activity_age_secs: Option<u64>,
+    pub(super) outbound_activity_age_secs: Option<u64>,
     pub(super) background_synthetic_activity_age_secs: Option<u64>,
     pub(super) background_synthetic_kind: Option<String>,
 }
@@ -147,6 +148,9 @@ impl StallWatchdogLivenessEvidence {
         }
         if is_recent_age(self.runtime_activity_age_secs, freshness_secs) {
             reasons.push("runtime_activity_mtime_recent");
+        }
+        if is_recent_age(self.outbound_activity_age_secs, freshness_secs) {
+            reasons.push("outbound_activity_recent");
         }
         if is_recent_age(self.background_synthetic_activity_age_secs, freshness_secs) {
             reasons.push("background_synthetic_activity_recent");
@@ -375,6 +379,7 @@ pub(super) fn log_stall_watchdog_liveness_deferred(
         pane_offset_advanced_age_secs = ?decision.evidence.pane_offset_advanced_age_secs,
         transcript_mtime_age_secs = ?decision.evidence.transcript_mtime_age_secs,
         runtime_activity_age_secs = ?decision.evidence.runtime_activity_age_secs,
+        outbound_activity_age_secs = ?decision.evidence.outbound_activity_age_secs,
         background_synthetic_activity_age_secs = ?decision.evidence.background_synthetic_activity_age_secs,
         background_synthetic_kind = ?decision.evidence.background_synthetic_kind,
         deferral_count = ?decision.deferral_count(),
@@ -438,6 +443,7 @@ pub(super) fn log_stall_watchdog_force_cleanup_judgment(
         liveness_reasons = liveness_reasons,
         liveness_no_evidence = no_evidence,
         liveness_absolute_backstop_reached = absolute_backstop_reached,
+        outbound_activity_age_secs = ?decision.map(|decision| decision.evidence.outbound_activity_age_secs),
         deferral_count = ?decision.and_then(StallWatchdogLivenessDecision::deferral_count),
         max_deferrals = decision.map(|decision| decision.max_deferrals).unwrap_or(0),
         "  [{ts}] ⚡ STALL-WATCHDOG: forced cleanup for desynced channel {}",
@@ -500,6 +506,10 @@ impl StallWatchdogLivenessEvidence {
             pane_offset_advanced_age_secs,
             transcript_mtime_age_secs: transcript_mtime_age_secs(inflight, now_unix_secs),
             runtime_activity_age_secs: runtime_activity_age_secs(snapshot, now_unix_secs),
+            outbound_activity_age_secs: unix_millis_age_secs(
+                snapshot.relay_health.last_outbound_activity_ms,
+                now_unix_secs,
+            ),
             background_synthetic_activity_age_secs: background_synthetic
                 .as_ref()
                 .map(|(_, age)| *age),
@@ -938,6 +948,42 @@ mod tests {
             StallWatchdogLivenessAction::ProceedNoEvidence
         );
         assert!(!decision.should_defer());
+    }
+
+    #[test]
+    fn recent_outbound_activity_defers_cleanup() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3373);
+        let tmux_session = "AgentDesk-codex-outbound-liveness";
+        let _root = isolated_runtime_root();
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let now = chrono::Utc::now().timestamp();
+        let mut snap = snapshot(channel.get(), tmux_session, None);
+        snap.relay_health.last_outbound_activity_ms = Some((now - 60) * 1000);
+        let mut inflight = inflight_with_output(channel.get(), tmux_session, None);
+        inflight.updated_at = "2026-06-12 00:00:00".to_string();
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+            Some(0),
+        );
+
+        assert_eq!(
+            decision.action,
+            StallWatchdogLivenessAction::Defer { deferral_count: 1 }
+        );
+        assert_eq!(
+            decision
+                .evidence
+                .reason_codes_csv(STALL_WATCHDOG_POSITIVE_LIVENESS_SECS),
+            "outbound_activity_recent"
+        );
     }
 
     #[test]

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -73,7 +73,7 @@ pub(super) use self::jsonl_extract::{
 // `TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD`) are only used inside the submodule and
 // stay private to it.
 use self::terminal_watcher::{
-    output_has_bytes_after_offset, recovery_watcher_start_offset,
+    output_has_bytes_after_offset, recovery_watcher_start_offset_for_state,
     terminal_success_output_drained_for_recovery,
 };
 // #3479 item-2: re-import the inflight-state derivation helpers used by the root
@@ -1751,7 +1751,7 @@ pub(super) async fn restore_inflight_turns(
                         crate::services::tmux_common::session_temp_path(tmux_session_name, "jsonl");
                     if std::fs::metadata(&output_path).is_ok() {
                         let (initial_offset, current_len, truncated) =
-                            recovery_watcher_start_offset(&output_path, state.last_offset);
+                            recovery_watcher_start_offset_for_state(&output_path, &state);
                         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                         let paused = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                         let resume_offset = std::sync::Arc::new(std::sync::Mutex::new(None::<u64>));
@@ -2948,7 +2948,7 @@ pub(super) async fn restore_inflight_turns(
             // Immediately spawn watcher to avoid race condition.
             if std::fs::metadata(&output_path).is_ok() {
                 let (initial_offset, current_len, truncated) =
-                    recovery_watcher_start_offset(&output_path, state.last_offset);
+                    recovery_watcher_start_offset_for_state(&output_path, &state);
                 let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 let paused = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 let resume_offset = std::sync::Arc::new(std::sync::Mutex::new(None::<u64>));
@@ -3604,7 +3604,7 @@ pub(crate) async fn rebind_inflight_for_channel(
 
     let initial_offset = if let Some(existing) = existing_inflight.as_ref() {
         let (resume_offset, current_len, truncated) =
-            recovery_watcher_start_offset(&output_path, existing.last_offset);
+            recovery_watcher_start_offset_for_state(&output_path, existing);
         if truncated {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(

--- a/src/services/discord/recovery_engine/terminal_watcher.rs
+++ b/src/services/discord/recovery_engine/terminal_watcher.rs
@@ -124,14 +124,72 @@ fn jsonl_tail_contains_terminal_end_sentinel(output_path: &str) -> bool {
 pub(super) fn recovery_watcher_start_offset(
     output_path: &str,
     saved_last_offset: u64,
+    turn_start_offset: Option<u64>,
 ) -> (u64, u64, bool) {
     let current_len = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
-    if current_len >= saved_last_offset {
-        (saved_last_offset, current_len, false)
+    let resume_floor = turn_start_offset.unwrap_or(0);
+    let desired_offset = saved_last_offset.max(resume_floor);
+    if current_len >= desired_offset {
+        (desired_offset, current_len, false)
     } else {
         // The output file was recreated or truncated while dcserver was down.
         // Resume from the beginning of the new file so we do not skip the
         // entire restarted session output.
         (0, current_len, true)
+    }
+}
+
+pub(super) fn recovery_watcher_start_offset_for_state(
+    output_path: &str,
+    state: &crate::services::discord::inflight::InflightTurnState,
+) -> (u64, u64, bool) {
+    recovery_watcher_start_offset(output_path, state.last_offset, state.turn_start_offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recovery_watcher_start_offset;
+    use std::io::Write;
+
+    fn temp_file_with_len(len: usize) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(&vec![b'x'; len]).expect("write temp file");
+        file
+    }
+
+    #[test]
+    fn recovery_start_offset_uses_turn_start_floor_when_last_offset_is_zero() {
+        let file = temp_file_with_len(2_000);
+
+        let (offset, current_len, truncated) =
+            recovery_watcher_start_offset(file.path().to_str().unwrap(), 0, Some(1_250));
+
+        assert_eq!(offset, 1_250);
+        assert_eq!(current_len, 2_000);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn recovery_start_offset_prefers_newer_saved_last_offset() {
+        let file = temp_file_with_len(2_000);
+
+        let (offset, current_len, truncated) =
+            recovery_watcher_start_offset(file.path().to_str().unwrap(), 1_600, Some(1_250));
+
+        assert_eq!(offset, 1_600);
+        assert_eq!(current_len, 2_000);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn recovery_start_offset_rewinds_only_when_output_truncated_below_floor() {
+        let file = temp_file_with_len(900);
+
+        let (offset, current_len, truncated) =
+            recovery_watcher_start_offset(file.path().to_str().unwrap(), 0, Some(1_250));
+
+        assert_eq!(offset, 0);
+        assert_eq!(current_len, 900);
+        assert!(truncated);
     }
 }

--- a/src/services/discord/turn_bridge/context_window.rs
+++ b/src/services/discord/turn_bridge/context_window.rs
@@ -20,16 +20,18 @@ pub(super) fn resolve_done_response(
     if any_tool_used && !has_post_tool_text {
         return Some(result.to_string());
     }
-    if done_result_supersedes_streamed_tail(full_response, result) {
+    if done_result_supersedes_streamed_partial(full_response, result) {
         return Some(result.to_string());
     }
     None
 }
 
-fn done_result_supersedes_streamed_tail(full_response: &str, result: &str) -> bool {
+fn done_result_supersedes_streamed_partial(full_response: &str, result: &str) -> bool {
     let streamed = full_response.trim();
     let terminal = result.trim();
-    !streamed.is_empty() && terminal.len() > streamed.len() && terminal.ends_with(streamed)
+    !streamed.is_empty()
+        && terminal.len() > streamed.len()
+        && (terminal.ends_with(streamed) || terminal.starts_with(streamed))
 }
 
 pub(super) fn total_context_tokens(
@@ -106,6 +108,16 @@ mod tests {
         let terminal_body = "[E2E:E15:BEGIN]\nE15-LINE-001\nE15-LINE-002\nE15-LINE-150\nE15-LINE-151\n[E2E:E15:END]";
 
         let resolved = resolve_done_response(streamed_tail, terminal_body, false, false);
+
+        assert_eq!(resolved, Some(terminal_body.to_string()));
+    }
+
+    #[test]
+    fn done_uses_terminal_result_when_streamed_response_is_prefix_missing_tail() {
+        let streamed_prefix = "probe 품질 검토 결과, 현재 관측된 기준으로는";
+        let terminal_body = "probe 품질 검토 결과, 현재 관측된 기준으로는 실패입니다";
+
+        let resolved = resolve_done_response(streamed_prefix, terminal_body, false, false);
 
         assert_eq!(resolved, Some(terminal_body.to_string()));
     }

--- a/src/services/discord/turn_bridge/response_delivery.rs
+++ b/src/services/discord/turn_bridge/response_delivery.rs
@@ -72,3 +72,37 @@ pub(super) fn done_result_requires_full_terminal_replay(
         && !result.trim().is_empty()
         && full_response.trim() == result.trim()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        done_result_requires_full_terminal_replay, terminal_delivery_response_after_offset,
+    };
+    use crate::services::discord::DISCORD_MSG_LIMIT;
+
+    #[test]
+    fn terminal_delivery_after_rollover_includes_authoritative_tail() {
+        let frozen_prefix = "probe 품질 검토 결과, 현재 관측된 ";
+        let terminal_body = format!("{frozen_prefix}기준으로는 실패입니다");
+
+        let delivered_tail =
+            terminal_delivery_response_after_offset(&terminal_body, frozen_prefix.len(), None);
+
+        assert_eq!(delivered_tail, "기준으로는 실패입니다");
+    }
+
+    #[test]
+    fn long_authoritative_done_after_rollover_replays_full_body() {
+        let frozen_prefix = "probe 품질 ".repeat(220);
+        let terminal_tail = "기준으로는 실패입니다";
+        let terminal_body = format!("{frozen_prefix}{terminal_tail}");
+        assert!(terminal_body.len() > DISCORD_MSG_LIMIT);
+
+        assert!(done_result_requires_full_terminal_replay(
+            &terminal_body,
+            &terminal_body,
+            frozen_prefix.len(),
+            true,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- keep restart/recovery watchers from rewinding before the persisted turn_start_offset when last_offset is zero
- treat recent outbound activity as live watchdog evidence and allow non-destructive relay-dead watcher reattach before force-clean
- replace streamed partial text with the authoritative Done result when the streamed text is a prefix missing the final tail

Fixes #3706
Fixes #3707

## Validation
- cargo fmt
- cargo test --lib recovery_start_offset
- cargo test --lib done_uses_terminal_result_when_streamed_response_is_prefix_missing_tail
- cargo test --lib authoritative
- cargo test --lib relay_dead_watcher_reattach
- cargo test --lib recent_outbound_activity_defers_cleanup
- cargo check
- claude -p review: VERDICT CLEAN