### PR TITLE
fix(discord): rehydrate Codex TUI relay bindings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -466,6 +466,7 @@ src/
 │   │   │   ├── jsonl_extract.rs
 │   │   │   ├── output_path_detect.rs
 │   │   │   ├── phase_policy.rs
+│   │   │   ├── rebind_runtime.rs
 │   │   │   ├── state_extractors.rs
 │   │   │   ├── status_panel.rs
 │   │   │   └── terminal_watcher.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -801,12 +801,14 @@
     extracted verbatim from `tui_prompt_relay.rs` — no `shared.`/`http.`/async-IO
     coupling, all items `pub(super)` and re-imported by the parent; below the
     giant-file threshold).
-  - `src/services/discord/tui_prompt_relay/rehydration.rs` (295 prod lines; #3479
+  - `src/services/discord/tui_prompt_relay/rehydration.rs` (648 prod lines; #3479
     rank-10: the Discord-IO/`SharedData`-coupled Claude TUI binding rehydration +
-    dead/orphaned-session eviction pass extracted from `tui_prompt_relay.rs`. Free
-    functions taking `&Arc<SharedData>` explicitly (no captured module state), so
-    the move via `use super::*;` is behavior-identical; the five fns are
-    `pub(super)` and re-imported by the parent; below the giant-file threshold).
+    dead/orphaned-session eviction pass extracted from `tui_prompt_relay.rs`. #3711
+    extends the same rehydrate surface to Codex TUI restart recovery: persist/use
+    rollout markers, reject already-claimed marker paths, and allow markerless
+    cwd-based fallback only when exactly one live markerless Codex TUI session
+    owns that cwd. This file is still below the giant-file threshold, but split
+    before adding another provider/recovery policy cluster).
   - `src/services/discord/tui_prompt_relay/anchor_completion.rs` (213 prod lines;
     #3479 item-2: the live-relay TUI-direct prompt anchor COMPLETION lifecycle
     (`⏳ → ✅`) — the visibility gate, the deferred `⏳`-completion drain decision,
@@ -927,7 +929,10 @@
     marker suppression for stop-control transcript envelopes; +62 from #3304:
     slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3438 lines; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +26 from #3680 relay recovery review hardening; +9 from #3582 stamping
+  - `src/services/discord/recovery_engine.rs` (3433 lines; -5 net from #3711/#3712 extracting rebind runtime/output-path resolution to
+    `recovery_engine/rebind_runtime.rs` while adding direct Codex TUI detection
+    so rebind can rebuild rollout bindings when possible and return 409 instead
+    of synthesizing inert legacy-wrapper inflight rows; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +26 from #3680 relay recovery review hardening; +9 from #3582 stamping
     `set_relay_owner_kind(Watcher)` at the rebind-origin birth site so the
     STALL-WATCHDOG force-clean -> respawn synthetic row (which lands here with
     `existing_inflight = None`) is watcher-owned instead of degrading to
@@ -1003,7 +1008,7 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2730 lines; #3676 moved
+  - `src/services/discord/health/recovery.rs` (2732 lines; +2 from #3711/#3712 mapping direct TUI runtime-binding-unavailable rebind failures to 409 Conflict; #3676 moved
     `tmux_alive_relay_dead` watchdog reattach logic into sibling
     `health/relay_dead_reattach.rs`, leaving recovery.rs with only the
     pre-cleanup hook so final transcript output can be delivered without
@@ -1480,7 +1485,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   support extracted from the route layer; split before adding non-bugfix
   behavior.
 - `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
-  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3011),
+  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3023),
   `src/services/opencode.rs` (2760), `src/services/provider.rs` (1818) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
@@ -1499,15 +1504,20 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   move). #3038 S3 relocates the TUI warm/follow-up hosting cluster into
   `src/services/claude_tui/hosting/` child modules, ratchets claude.rs at 2950
   production LoC, and leaves the #3262 turn-lock machinery in the claude.rs
-  root.)
-- `src/services/codex_tui/rollout_tail.rs` (1772) — Codex TUI rollout tail
+  root. #3711 adds +12 in codex.rs to persist Codex TUI rollout markers when
+  idle relay bindings are registered, so dcserver restart rehydrate has a
+  stable rollout identity.)
+- `src/services/codex_tui/rollout_tail.rs` (1831) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix and the #3343 message-boundary
   separator unified across the streamed `StreamMessage::Text` surface and the
   `final_text` assembly (one shared `push_message_text` boundary writer; the
   newline witness is the single source of truth so the two surfaces mirror);
   +4 from #3676 threading Codex rollout user-message entry ids into TUI prompt
-  dedupe so restart/offset rewind cannot mint duplicate direct-input anchors.
+  dedupe so restart/offset rewind cannot mint duplicate direct-input anchors;
+  +59 from #3711 persisting rollout markers as soon as the live rollout is
+  discovered and adding claimed-rollout candidate selection for restart
+  rehydrate.
 - `src/services/codex_tui/input.rs` (1366) — Codex TUI input readiness
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -533,6 +533,18 @@ fn register_codex_tui_idle_relay_binding(
     tmux_session_name: &str,
     tail_result: &crate::services::codex_tui::rollout_tail::CodexTuiTailResult,
 ) {
+    if let Err(error) = crate::services::codex_tui::session::write_codex_tui_rollout_marker(
+        tmux_session_name,
+        &tail_result.rollout_path,
+        tail_result.session_id.as_deref(),
+    ) {
+        tracing::warn!(
+            tmux_session_name,
+            rollout_path = %tail_result.rollout_path.display(),
+            error,
+            "failed to persist Codex TUI rollout marker; restart rehydrate will fall back to rollout discovery"
+        );
+    }
     crate::services::tui_prompt_dedupe::register_tmux_runtime_binding(
         tmux_session_name,
         codex_tui_idle_relay_binding(tmux_session_name, tail_result),

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -327,6 +327,13 @@ fn tail_latest_rollout_for_cwd_with_handoff_options(
         &mut is_alive,
         options.wait_for_rollout,
     )?;
+    let rollout_session_id =
+        super::rollout_index::read_rollout_session_meta(&rollout_path).and_then(|meta| meta.id);
+    persist_codex_tui_rollout_marker(
+        options.tmux_session_name.as_deref(),
+        &rollout_path,
+        rollout_session_id.as_deref(),
+    );
     tail_rollout_file_until_assistant_response(
         &rollout_path,
         0,
@@ -498,6 +505,11 @@ fn tail_resumed_rollout_for_session_with_handoff_options(
     } else {
         0
     };
+    persist_codex_tui_rollout_marker(
+        options.tmux_session_name.as_deref(),
+        &rollout_path,
+        Some(session_id),
+    );
     let known_session_id = (start_offset > 0).then(|| session_id.to_string());
     tail_rollout_file_until_assistant_response(
         &rollout_path,
@@ -521,6 +533,28 @@ fn tail_resumed_rollout_for_session_with_handoff_options(
         final_offset: outcome.final_offset,
         session_id: outcome.session_id,
     })
+}
+
+fn persist_codex_tui_rollout_marker(
+    tmux_session_name: Option<&str>,
+    rollout_path: &Path,
+    session_id: Option<&str>,
+) {
+    let Some(tmux_session_name) = tmux_session_name else {
+        return;
+    };
+    if let Err(error) = crate::services::codex_tui::session::write_codex_tui_rollout_marker(
+        tmux_session_name,
+        rollout_path,
+        session_id,
+    ) {
+        tracing::warn!(
+            tmux_session_name,
+            rollout_path = %rollout_path.display(),
+            error,
+            "failed to persist Codex TUI rollout marker after transcript discovery"
+        );
+    }
 }
 
 fn wait_for_latest_rollout_for_cwd(
@@ -609,8 +643,29 @@ pub fn latest_rollout_for_cwd_since(
     modified_since: SystemTime,
     sessions_dir: &Path,
 ) -> Option<PathBuf> {
+    rollout_candidates_for_cwd_since(cwd, modified_since, sessions_dir)
+        .into_iter()
+        .next()
+}
+
+pub fn latest_unclaimed_rollout_for_cwd_since(
+    cwd: &Path,
+    modified_since: SystemTime,
+    sessions_dir: &Path,
+    claimed_rollout_paths: &HashSet<PathBuf>,
+) -> Option<PathBuf> {
+    rollout_candidates_for_cwd_since(cwd, modified_since, sessions_dir)
+        .into_iter()
+        .find(|path| !rollout_path_is_claimed(path, claimed_rollout_paths))
+}
+
+pub fn rollout_candidates_for_cwd_since(
+    cwd: &Path,
+    modified_since: SystemTime,
+    sessions_dir: &Path,
+) -> Vec<PathBuf> {
     let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
-    let mut best: Option<(SystemTime, PathBuf)> = None;
+    let mut candidates: Vec<(SystemTime, PathBuf)> = Vec::new();
     for item in super::rollout_index::cached_indexed_rollouts(sessions_dir) {
         if item.modified < modified_since {
             continue;
@@ -623,14 +678,18 @@ pub fn latest_rollout_for_cwd_since(
         if session_cwd != canonical_cwd {
             continue;
         }
-        if best
-            .as_ref()
-            .is_none_or(|(best_modified, _)| item.modified > *best_modified)
-        {
-            best = Some((item.modified, item.path));
-        }
+        candidates.push((item.modified, item.path));
     }
-    best.map(|(_, path)| path)
+    candidates.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+    candidates.into_iter().map(|(_, path)| path).collect()
+}
+
+fn rollout_path_is_claimed(path: &Path, claimed_rollout_paths: &HashSet<PathBuf>) -> bool {
+    if claimed_rollout_paths.contains(path) {
+        return true;
+    }
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    claimed_rollout_paths.contains(&canonical)
 }
 
 /// Find a codex rollout transcript by its session UUID alone, scanning the
@@ -1914,6 +1973,54 @@ mod tests {
         )
         .unwrap();
         path
+    }
+
+    #[test]
+    fn latest_unclaimed_rollout_skips_rollout_claimed_by_another_tui() {
+        let _guard = super::super::rollout_index::lock_cache_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let older = write_rollout(
+            dir.path(),
+            "old/rollout-old.jsonl",
+            "session-old",
+            cwd.path(),
+            "",
+        );
+        let newer = write_rollout(
+            dir.path(),
+            "new/rollout-new.jsonl",
+            "session-new",
+            cwd.path(),
+            "",
+        );
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
+        filetime::set_file_mtime(
+            &older,
+            filetime::FileTime::from_system_time(base + Duration::from_secs(10)),
+        )
+        .unwrap();
+        filetime::set_file_mtime(
+            &newer,
+            filetime::FileTime::from_system_time(base + Duration::from_secs(20)),
+        )
+        .unwrap();
+
+        assert_eq!(
+            latest_rollout_for_cwd_since(cwd.path(), base, dir.path()).as_deref(),
+            Some(newer.as_path()),
+            "precondition: unclaimed lookup chooses the newest rollout"
+        );
+
+        let claimed = [std::fs::canonicalize(&newer).unwrap()]
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            latest_unclaimed_rollout_for_cwd_since(cwd.path(), base, dir.path(), &claimed)
+                .as_deref(),
+            Some(older.as_path()),
+            "rehydrate must not bind two live Codex TUI sessions to the same rollout"
+        );
     }
 
     #[test]

--- a/src/services/codex_tui/session.rs
+++ b/src/services/codex_tui/session.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -30,6 +31,64 @@ impl CodexTuiSessionFiles {
         let _ = std::fs::remove_dir_all(&self.codex_home_path);
         let _ = std::fs::remove_dir_all(&self.legacy_codex_home_path);
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexTuiRolloutMarker {
+    pub rollout_path: PathBuf,
+    pub session_id: Option<String>,
+}
+
+pub fn write_codex_tui_rollout_marker(
+    tmux_session_name: &str,
+    rollout_path: &Path,
+    session_id: Option<&str>,
+) -> Result<(), String> {
+    let tmux_session_name = tmux_session_name.trim();
+    if tmux_session_name.is_empty() {
+        return Ok(());
+    }
+    let path = crate::services::tmux_common::session_temp_path(
+        tmux_session_name,
+        crate::services::tmux_common::CODEX_TUI_ROLLOUT_MARKER_TEMP_EXT,
+    );
+    let value = serde_json::json!({
+        "rollout_path": rollout_path.display().to_string(),
+        "session_id": session_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+    });
+    std::fs::write(&path, format!("{value}\n"))
+        .map_err(|error| format!("failed to write Codex TUI rollout marker: {error}"))
+}
+
+pub fn read_codex_tui_rollout_marker(tmux_session_name: &str) -> Option<CodexTuiRolloutMarker> {
+    let tmux_session_name = tmux_session_name.trim();
+    if tmux_session_name.is_empty() {
+        return None;
+    }
+    let path = crate::services::tmux_common::resolve_session_temp_path(
+        tmux_session_name,
+        crate::services::tmux_common::CODEX_TUI_ROLLOUT_MARKER_TEMP_EXT,
+    )?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(raw.trim()).ok()?;
+    let rollout_path = value
+        .get("rollout_path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)?;
+    let session_id = value
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    Some(CodexTuiRolloutMarker {
+        rollout_path,
+        session_id,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -314,6 +373,26 @@ mod tests {
         assert!(
             !files.legacy_codex_home_path.exists(),
             "cleanup_best_effort must remove the legacy Codex TUI temp home recursively"
+        );
+    }
+
+    #[test]
+    fn codex_tui_rollout_marker_round_trips() {
+        let _lock = lock_test_env();
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvRestore::set_agentdesk_root_and_host(dir.path(), "codex-tui-marker-host");
+        let rollout_path = dir.path().join("rollout-session.jsonl");
+        std::fs::write(&rollout_path, "{}\n").unwrap();
+
+        write_codex_tui_rollout_marker("AgentDesk-codex-marker", &rollout_path, Some("sess-1"))
+            .unwrap();
+
+        assert_eq!(
+            read_codex_tui_rollout_marker("AgentDesk-codex-marker"),
+            Some(CodexTuiRolloutMarker {
+                rollout_path,
+                session_id: Some("sess-1".to_string()),
+            })
         );
     }
 

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1071,12 +1071,34 @@ pub(super) fn rebind_error_status_and_message(
     let status = match err {
         discord::recovery_engine::RebindError::TmuxNotAlive { .. } => "404 Not Found",
         discord::recovery_engine::RebindError::InflightAlreadyExists
-        | discord::recovery_engine::RebindError::StaleOutputPath { .. } => "409 Conflict",
+        | discord::recovery_engine::RebindError::StaleOutputPath { .. }
+        | discord::recovery_engine::RebindError::RuntimeBindingUnavailable { .. } => "409 Conflict",
         discord::recovery_engine::RebindError::ChannelNotBound
         | discord::recovery_engine::RebindError::ChannelNameMissing => "400 Bad Request",
         discord::recovery_engine::RebindError::Internal(_) => "500 Internal Server Error",
     };
     (status, err.to_string())
+}
+
+#[cfg(test)]
+mod rebind_error_status_tests {
+    use super::rebind_error_status_and_message;
+    use crate::services::agent_protocol::RuntimeHandoffKind;
+    use crate::services::discord::recovery_engine::RebindError;
+
+    #[test]
+    fn runtime_binding_unavailable_maps_to_conflict() {
+        let err = RebindError::RuntimeBindingUnavailable {
+            tmux_session: "AgentDesk-codex-adk-cdx".to_string(),
+            runtime_kind: RuntimeHandoffKind::CodexTui,
+        };
+
+        let (status, message) = rebind_error_status_and_message(&err);
+
+        assert_eq!(status, "409 Conflict");
+        assert!(message.contains("codex_tui"));
+        assert!(message.contains("AgentDesk-codex-adk-cdx"));
+    }
 }
 
 /// Self-watchdog: runs on a dedicated OS thread (not tokio) to detect

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -44,6 +44,8 @@ mod terminal_watcher;
 // spawn-cwd derivation) into a leaf module.
 #[path = "recovery_engine/analytics_transcript.rs"]
 mod analytics_transcript;
+#[path = "recovery_engine/rebind_runtime.rs"]
+mod rebind_runtime;
 #[path = "recovery_engine/state_extractors.rs"]
 mod state_extractors;
 
@@ -81,6 +83,7 @@ use self::terminal_watcher::{
 // members (the worktree path/branch/info/git helpers, `recovery_dispatch_id`,
 // `recovery_requires_worktree_context` and `inflight_ready_for_input_without_tui_pane`)
 // stay private to the submodule.
+use self::rebind_runtime::resolve_rebind_runtime_state;
 use self::state_extractors::{
     inflight_or_legacy_tmux_ready_for_input, interrupted_recovery_message, recovery_spawn_adk_cwd,
     recovery_tmux_session_name, restore_recovered_session_worktree,
@@ -3386,6 +3389,13 @@ pub enum RebindError {
     },
     /// Channel is not bound to the requested provider in the role-map. 400.
     ChannelNotBound,
+    /// A direct TUI tmux session was detected, but `/api/inflight/rebind` can
+    /// only respawn wrapper-output watchers. Direct TUI recovery must go
+    /// through the runtime-specific rehydrate/idle relay path instead.
+    RuntimeBindingUnavailable {
+        tmux_session: String,
+        runtime_kind: RuntimeHandoffKind,
+    },
     /// `tmux_session` not provided and no in-memory session supplies a
     /// channel_name — cannot derive the canonical tmux session name. 400.
     ChannelNameMissing,
@@ -3422,6 +3432,14 @@ impl std::fmt::Display for RebindError {
                 )
             }
             Self::ChannelNotBound => write!(f, "channel is not bound for this provider"),
+            Self::RuntimeBindingUnavailable {
+                tmux_session,
+                runtime_kind,
+            } => write!(
+                f,
+                "watcher rebind unavailable for {} tmux session {tmux_session}",
+                runtime_kind.as_str()
+            ),
             Self::ChannelNameMissing => write!(
                 f,
                 "channel name missing — pass tmux_session or pre-register the channel"
@@ -3557,50 +3575,17 @@ pub(crate) async fn rebind_inflight_for_channel(
         return Err(RebindError::ChannelNotBound);
     }
 
-    let (default_output_path, input_fifo) = tmux_runtime_paths(&tmux_session_name);
-    let fallback_output_path = existing_saved_output_path
-        .clone()
-        .unwrap_or_else(|| default_output_path.clone());
-    let (output_path, synthetic_initial_offset) = {
-        #[cfg(unix)]
-        {
-            match detect_live_tmux_output_path(&tmux_session_name, &fallback_output_path) {
-                Ok(Some(detected)) => {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::info!(
-                        "  [{ts}] ♻ rebind adopted live tmux output path for {}: {} -> {} (offset {})",
-                        tmux_session_name,
-                        default_output_path,
-                        detected.path,
-                        detected.initial_offset
-                    );
-                    (detected.path, detected.initial_offset)
-                }
-                Ok(None) => {
-                    let synthetic_initial_offset = std::fs::metadata(&fallback_output_path)
-                        .map(|m| m.len())
-                        .unwrap_or(0);
-                    (fallback_output_path.clone(), synthetic_initial_offset)
-                }
-                Err(stale) => {
-                    return Err(RebindError::StaleOutputPath {
-                        tmux_session: tmux_session_name.clone(),
-                        output_path: fallback_output_path.clone(),
-                        live_fd: stale.fd,
-                        live_inode: stale.inode,
-                        live_path: stale.raw_path,
-                    });
-                }
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            let synthetic_initial_offset = std::fs::metadata(&fallback_output_path)
-                .map(|m| m.len())
-                .unwrap_or(0);
-            (fallback_output_path.clone(), synthetic_initial_offset)
-        }
-    };
+    let runtime_state = resolve_rebind_runtime_state(
+        provider,
+        &tmux_session_name,
+        existing_saved_output_path.as_deref(),
+        existing_session_id.clone(),
+    )?;
+    let output_path = runtime_state.output_path;
+    let synthetic_initial_offset = runtime_state.synthetic_initial_offset;
+    let input_fifo_for_state = runtime_state.input_fifo_path;
+    let runtime_kind_for_state = runtime_state.runtime_kind;
+    let session_id_for_state = runtime_state.session_id;
 
     let initial_offset = if let Some(existing) = existing_inflight.as_ref() {
         let (resume_offset, current_len, truncated) =
@@ -3633,7 +3618,13 @@ pub(crate) async fn rebind_inflight_for_channel(
         let expected_turn_start_offset = existing.turn_start_offset;
         existing.tmux_session_name = Some(tmux_session_name.clone());
         existing.output_path = Some(output_path.clone());
-        existing.input_fifo_path = Some(input_fifo.clone());
+        existing.input_fifo_path = input_fifo_for_state.clone();
+        if let Some(runtime_kind) = runtime_kind_for_state {
+            existing.runtime_kind = Some(runtime_kind);
+        }
+        if session_id_for_state.is_some() {
+            existing.session_id = session_id_for_state.clone();
+        }
         existing.set_relay_owner_kind(super::inflight::RelayOwnerKind::Watcher);
         let save_outcome =
             super::inflight::save_existing_inflight_rebind_adoption_if_matches_identity(
@@ -3673,9 +3664,13 @@ pub(crate) async fn rebind_inflight_for_channel(
             None, // session_id
             Some(tmux_session_name.clone()),
             Some(output_path.clone()),
-            Some(input_fifo.clone()),
+            input_fifo_for_state.clone(),
             initial_offset,
         );
+        state.runtime_kind = runtime_kind_for_state;
+        if session_id_for_state.is_some() {
+            state.session_id = session_id_for_state.clone();
+        }
         state.rebind_origin = true;
         // #2161 Part 2 / #2285 adoption: this synthetic inflight is born when
         // `POST /api/inflight/rebind` adopts a tmux session the operator

--- a/src/services/discord/recovery_engine/rebind_runtime.rs
+++ b/src/services/discord/recovery_engine/rebind_runtime.rs
@@ -1,0 +1,144 @@
+use super::*;
+
+pub(super) struct RebindRuntimeState {
+    pub(super) output_path: String,
+    pub(super) synthetic_initial_offset: u64,
+    pub(super) input_fifo_path: Option<String>,
+    pub(super) runtime_kind: Option<RuntimeHandoffKind>,
+    pub(super) session_id: Option<String>,
+}
+
+pub(super) fn resolve_rebind_runtime_state(
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+    existing_saved_output_path: Option<&str>,
+    existing_session_id: Option<String>,
+) -> Result<RebindRuntimeState, RebindError> {
+    let existing_runtime_binding =
+        crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name);
+    let observed_runtime_kind = crate::services::tmux_common::resolve_tmux_runtime_kind_marker(
+        tmux_session_name,
+    )
+    .or_else(|| {
+        existing_runtime_binding
+            .as_ref()
+            .map(|binding| binding.runtime_kind)
+    });
+    if provider == &ProviderKind::Codex
+        && observed_runtime_kind == Some(RuntimeHandoffKind::CodexTui)
+    {
+        return Err(RebindError::RuntimeBindingUnavailable {
+            tmux_session: tmux_session_name.to_string(),
+            runtime_kind: RuntimeHandoffKind::CodexTui,
+        });
+    }
+
+    let (default_output_path, default_input_fifo) = tmux_runtime_paths(tmux_session_name);
+    let input_fifo_path = Some(default_input_fifo);
+    let runtime_kind = observed_runtime_kind;
+    let session_id = existing_session_id;
+    let fallback_output_path = existing_saved_output_path
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| default_output_path.clone());
+    let (output_path, synthetic_initial_offset) = resolve_output_path_for_rebind(
+        tmux_session_name,
+        &default_output_path,
+        &fallback_output_path,
+    )?;
+
+    Ok(RebindRuntimeState {
+        output_path,
+        synthetic_initial_offset,
+        input_fifo_path,
+        runtime_kind,
+        session_id,
+    })
+}
+
+fn resolve_output_path_for_rebind(
+    tmux_session_name: &str,
+    default_output_path: &str,
+    fallback_output_path: &str,
+) -> Result<(String, u64), RebindError> {
+    #[cfg(unix)]
+    {
+        match detect_live_tmux_output_path(tmux_session_name, fallback_output_path) {
+            Ok(Some(detected)) => {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::info!(
+                    "  [{ts}] ♻ rebind adopted live tmux output path for {}: {} -> {} (offset {})",
+                    tmux_session_name,
+                    default_output_path,
+                    detected.path,
+                    detected.initial_offset
+                );
+                Ok((detected.path, detected.initial_offset))
+            }
+            Ok(None) => Ok((
+                fallback_output_path.to_string(),
+                std::fs::metadata(fallback_output_path)
+                    .map(|m| m.len())
+                    .unwrap_or(0),
+            )),
+            Err(stale) => Err(RebindError::StaleOutputPath {
+                tmux_session: tmux_session_name.to_string(),
+                output_path: fallback_output_path.to_string(),
+                live_fd: stale.fd,
+                live_inode: stale.inode,
+                live_path: stale.raw_path,
+            }),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        Ok((
+            fallback_output_path.to_string(),
+            std::fs::metadata(fallback_output_path)
+                .map(|m| m.len())
+                .unwrap_or(0),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::tui_prompt_dedupe::TuiRuntimeBinding;
+    use std::sync::{Mutex, OnceLock};
+
+    fn test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn direct_codex_tui_rebind_rejects_existing_runtime_binding() {
+        let _guard = test_lock().lock().unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+        let tmux_session_name = "AgentDesk-codex-adk-cdx";
+        crate::services::tui_prompt_dedupe::register_tmux_runtime_binding(
+            tmux_session_name,
+            TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::CodexTui,
+                output_path: "/tmp/codex-rollout.jsonl".to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: Some("019f0111-fc32".to_string()),
+                last_offset: 42,
+                relay_last_offset: None,
+            },
+        );
+
+        let result =
+            resolve_rebind_runtime_state(&ProviderKind::Codex, tmux_session_name, None, None);
+
+        assert!(matches!(
+            result,
+            Err(RebindError::RuntimeBindingUnavailable {
+                runtime_kind: RuntimeHandoffKind::CodexTui,
+                ..
+            })
+        ));
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+    }
+}

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -56,7 +56,8 @@ use self::idle_transcript_scan::{
 mod rehydration;
 #[cfg(unix)]
 use self::rehydration::{
-    rehydrate_existing_claude_tui_bindings, rehydrated_claude_tui_binding_for_tmux_session,
+    rehydrate_existing_claude_tui_bindings, rehydrate_existing_codex_tui_bindings,
+    rehydrated_claude_tui_binding_for_tmux_session,
 };
 // The dead/orphaned-session predicates and the eviction pass are driven in
 // production only transitively (via `rehydrate_existing_claude_tui_bindings`);
@@ -2771,9 +2772,17 @@ fn resolve_idle_relay_transcript(
 
 #[cfg(unix)]
 pub(super) fn resolve_rehydrated_claude_tmux_channel_id(tmux_session_name: &str) -> Option<u64> {
+    resolve_rehydrated_tmux_channel_id(&ProviderKind::Claude, tmux_session_name)
+}
+
+#[cfg(unix)]
+pub(super) fn resolve_rehydrated_tmux_channel_id(
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+) -> Option<u64> {
     let mut matched: Option<u64> = None;
     for binding in super::settings::list_registered_channel_bindings() {
-        if binding.owner_provider != ProviderKind::Claude {
+        if &binding.owner_provider != provider {
             continue;
         }
         let channel_id_text = binding.channel_id.to_string();
@@ -2787,7 +2796,8 @@ pub(super) fn resolve_rehydrated_claude_tmux_channel_id(tmux_session_name: &str)
             segments.push(fallback_name);
         }
         for segment in segments {
-            let Some(candidate_channel_id) = rehydrated_claude_channel_id_for_segment(
+            let Some(candidate_channel_id) = rehydrated_channel_id_for_segment(
+                provider,
                 tmux_session_name,
                 segment,
                 binding.channel_id,
@@ -2797,9 +2807,10 @@ pub(super) fn resolve_rehydrated_claude_tmux_channel_id(tmux_session_name: &str)
             if matched.is_some_and(|existing| existing != candidate_channel_id) {
                 tracing::warn!(
                     tmux_session_name,
+                    provider = provider.as_str(),
                     channel_id = candidate_channel_id,
                     existing_channel_id = matched.unwrap_or_default(),
-                    "Claude TUI rehydrate skipped ambiguous exact session-name match"
+                    "TUI rehydrate skipped ambiguous exact session-name match"
                 );
                 return None;
             }
@@ -2809,20 +2820,35 @@ pub(super) fn resolve_rehydrated_claude_tmux_channel_id(tmux_session_name: &str)
     matched
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, test))]
 fn rehydrated_claude_channel_id_for_segment(
     tmux_session_name: &str,
     segment: &str,
     parent_channel_id: u64,
 ) -> Option<u64> {
-    let base_session_name = ProviderKind::Claude.build_tmux_session_name(segment);
+    rehydrated_channel_id_for_segment(
+        &ProviderKind::Claude,
+        tmux_session_name,
+        segment,
+        parent_channel_id,
+    )
+}
+
+#[cfg(unix)]
+fn rehydrated_channel_id_for_segment(
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+    segment: &str,
+    parent_channel_id: u64,
+) -> Option<u64> {
+    let base_session_name = provider.build_tmux_session_name(segment);
     if base_session_name == tmux_session_name {
         return Some(parent_channel_id);
     }
 
-    let (provider, session_segment) =
+    let (session_provider, session_segment) =
         crate::services::provider::parse_provider_and_channel_from_tmux_name(tmux_session_name)?;
-    if provider != ProviderKind::Claude {
+    if &session_provider != provider {
         return None;
     }
     let (_base_provider, base_segment) =
@@ -2864,8 +2890,27 @@ fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
     super::task_supervisor::spawn_observed("codex_idle_rollout_relay", async move {
         let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let mut active_tails: HashSet<String> = HashSet::new();
+        let mut next_rehydrate = tokio::time::Instant::now();
 
         loop {
+            // #3711: direct Codex TUI tmux sessions survive dcserver restarts,
+            // but their in-memory rollout binding does not.
+            let now = tokio::time::Instant::now();
+            if now >= next_rehydrate {
+                let shared_for_rehydrate = shared.clone();
+                let rehydrate_result = tokio::task::spawn_blocking(move || {
+                    rehydrate_existing_codex_tui_bindings(&shared_for_rehydrate);
+                })
+                .await;
+                if let Err(error) = rehydrate_result {
+                    tracing::warn!(
+                        error = %error,
+                        "Codex TUI binding rehydrate task panicked or was cancelled"
+                    );
+                }
+                next_rehydrate = now + CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL;
+            }
+
             while let Ok(tmux_session_name) = done_rx.try_recv() {
                 active_tails.remove(&tmux_session_name);
             }
@@ -6644,6 +6689,25 @@ mod tests {
             rehydrated_claude_channel_id_for_segment(
                 &tmux_session_name,
                 "adk-cc",
+                parent_channel_id
+            ),
+            Some(thread_id)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_rehydrate_thread_session_resolves_thread_channel_id() {
+        let parent_channel_id = 1479671301387059200;
+        let thread_id = 1504455726595051591_u64;
+        let tmux_session_name =
+            ProviderKind::Codex.build_tmux_session_name(&format!("adk-cdx-t{thread_id}"));
+
+        assert_eq!(
+            rehydrated_channel_id_for_segment(
+                &ProviderKind::Codex,
+                &tmux_session_name,
+                "adk-cdx",
                 parent_channel_id
             ),
             Some(thread_id)

--- a/src/services/discord/tui_prompt_relay/rehydration.rs
+++ b/src/services/discord/tui_prompt_relay/rehydration.rs
@@ -12,6 +12,7 @@
 //! `use self::rehydration::{...}` re-import.
 
 use super::*;
+use std::collections::HashMap;
 
 /// #3105 (codex P1 sub-case B): a tmux session whose dedupe mirror still holds a
 /// stale ClaudeTui binding but which is genuinely dead/orphaned — pane gone AND no
@@ -114,6 +115,45 @@ pub(super) fn evict_dead_orphaned_claude_tui_mirrors(shared: &Arc<SharedData>) {
                 tmux_session_name = %tmux_session_name,
                 provider = "claude",
                 "evicted stale dedupe mirror for dead/orphaned Claude TUI session \
+                 (pane gone, no live watcher); idle relay will no longer re-emit \
+                 per-poll drift/skip warnings for it"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+fn codex_tui_session_is_dead_orphaned(shared: &Arc<SharedData>, tmux_session_name: &str) -> bool {
+    if shared
+        .tmux_watchers
+        .has_live_watcher_handle(tmux_session_name)
+    {
+        return false;
+    }
+    pane_is_confirmed_dead_orphaned(
+        || crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name),
+        || crate::services::tmux_diagnostics::tmux_session_exists(tmux_session_name),
+        DEAD_ORPHANED_PANE_PROBE_SAMPLES,
+        Some(DEAD_ORPHANED_PANE_PROBE_DELAY),
+    )
+}
+
+#[cfg(unix)]
+fn evict_dead_orphaned_codex_tui_mirrors(shared: &Arc<SharedData>) {
+    for (tmux_session_name, _binding) in
+        crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(RuntimeHandoffKind::CodexTui)
+    {
+        if !codex_tui_session_is_dead_orphaned(shared, &tmux_session_name) {
+            continue;
+        }
+        shared
+            .tmux_watchers
+            .clear_restored_owner_for_tmux_session(&tmux_session_name);
+        if crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(&tmux_session_name) {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                provider = "codex",
+                "evicted stale dedupe mirror for dead/orphaned Codex TUI session \
                  (pane gone, no live watcher); idle relay will no longer re-emit \
                  per-poll drift/skip warnings for it"
             );
@@ -265,6 +305,117 @@ pub(super) fn rehydrate_existing_claude_tui_bindings(shared: &Arc<SharedData>) {
 }
 
 #[cfg(unix)]
+pub(super) fn rehydrate_existing_codex_tui_bindings(shared: &Arc<SharedData>) {
+    evict_dead_orphaned_codex_tui_mirrors(shared);
+
+    let mut sessions = match crate::services::platform::tmux::list_session_names() {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            tracing::debug!(error = %error, "Codex TUI binding rehydrate skipped; tmux sessions unavailable");
+            return;
+        }
+    };
+    sessions.sort_by(|left, right| {
+        codex_tui_launch_modified_since(right)
+            .cmp(&codex_tui_launch_modified_since(left))
+            .then_with(|| left.cmp(right))
+    });
+
+    let rehydrate_plan = codex_tui_rehydrate_plan(&sessions);
+    let mut claimed_rollout_paths = claimed_codex_tui_rollout_paths();
+
+    for tmux_session_name in sessions {
+        if !tmux_session_is_codex_tui(&tmux_session_name) {
+            continue;
+        }
+
+        let existing_binding = crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+            &tmux_session_name,
+        );
+        let authoritative_channel =
+            resolve_rehydrated_tmux_channel_id(&ProviderKind::Codex, &tmux_session_name);
+        let Some(channel_id) = authoritative_channel.or_else(|| {
+            crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(&tmux_session_name)
+        }) else {
+            continue;
+        };
+
+        if !crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name) {
+            shared
+                .tmux_watchers
+                .clear_restored_owner_for_tmux_session(&tmux_session_name);
+            if codex_tui_session_is_dead_orphaned(shared, &tmux_session_name)
+                && crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(&tmux_session_name)
+            {
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    provider = "codex",
+                    "evicted stale dedupe mirror for dead/orphaned Codex TUI session \
+                     (listed pane dead, no live watcher)"
+                );
+            }
+            continue;
+        }
+
+        if let Some(authoritative_channel) = authoritative_channel {
+            let repaired = shared.tmux_watchers.restore_owner_channel_for_tmux_session(
+                &tmux_session_name,
+                ChannelId::new(authoritative_channel),
+            );
+            if repaired {
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    channel_id = authoritative_channel,
+                    provider = "codex",
+                    "repaired authoritative tmux-session->channel registry for live Codex TUI session \
+                     (no live watcher slot); idle rollout relay can route again"
+                );
+            }
+        }
+
+        if let Some(existing) = existing_binding.as_ref()
+            && existing.runtime_kind == RuntimeHandoffKind::CodexTui
+            && Path::new(&existing.output_path).exists()
+        {
+            crate::services::tui_prompt_dedupe::register_tmux_channel(
+                &tmux_session_name,
+                channel_id,
+            );
+            claimed_rollout_paths.insert(canonical_rollout_claim_path(Path::new(
+                &existing.output_path,
+            )));
+            continue;
+        }
+
+        let Some(fresh) = rehydrated_codex_tui_binding_for_tmux_session(
+            &tmux_session_name,
+            &claimed_rollout_paths,
+            &rehydrate_plan.reserved_rollout_paths,
+            &rehydrate_plan.duplicate_marker_paths,
+            rehydrate_plan
+                .markerless_fallback_allowed_sessions
+                .contains(&tmux_session_name),
+        ) else {
+            continue;
+        };
+        crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
+            ProviderKind::Codex.as_str(),
+            &tmux_session_name,
+            channel_id,
+            fresh.clone(),
+        );
+        tracing::info!(
+            tmux_session_name = %tmux_session_name,
+            channel_id,
+            rollout_path = %fresh.output_path,
+            last_offset = fresh.last_offset,
+            "rehydrated Codex TUI direct relay binding from live rollout"
+        );
+        claimed_rollout_paths.insert(canonical_rollout_claim_path(Path::new(&fresh.output_path)));
+    }
+}
+
+#[cfg(unix)]
 pub(super) fn rehydrated_claude_tui_binding_for_tmux_session(
     tmux_session_name: &str,
 ) -> Option<crate::services::tui_prompt_dedupe::TuiRuntimeBinding> {
@@ -292,4 +443,548 @@ pub(super) fn rehydrated_claude_tui_binding_for_tmux_session(
         last_offset: start_offset,
         relay_last_offset: None,
     })
+}
+
+#[cfg(unix)]
+fn tmux_session_is_codex_tui(tmux_session_name: &str) -> bool {
+    if crate::services::tmux_common::resolve_tmux_runtime_kind_marker(tmux_session_name)
+        == Some(RuntimeHandoffKind::CodexTui)
+    {
+        return true;
+    }
+    crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name)
+        .is_some_and(|binding| binding.runtime_kind == RuntimeHandoffKind::CodexTui)
+}
+
+#[cfg(unix)]
+fn codex_rollout_session_id(rollout_path: &Path) -> Option<String> {
+    let file = std::fs::File::open(rollout_path).ok()?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut first_line = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut first_line).ok()?;
+    let value: serde_json::Value = serde_json::from_str(first_line.trim()).ok()?;
+    if value.get("type").and_then(serde_json::Value::as_str) != Some("session_meta") {
+        return None;
+    }
+    value
+        .get("payload")
+        .and_then(|payload| payload.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+#[cfg(unix)]
+fn codex_tui_launch_modified_since(tmux_session_name: &str) -> std::time::SystemTime {
+    crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "sh")
+        .and_then(|path| {
+            std::fs::metadata(path)
+                .and_then(|meta| meta.modified())
+                .ok()
+        })
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
+#[cfg(unix)]
+fn canonical_rollout_claim_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(unix)]
+fn claimed_codex_tui_rollout_paths() -> HashSet<PathBuf> {
+    crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(RuntimeHandoffKind::CodexTui)
+        .into_iter()
+        .filter_map(|(_, binding)| {
+            let path = PathBuf::from(binding.output_path);
+            path.exists().then(|| canonical_rollout_claim_path(&path))
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+#[derive(Debug, Default)]
+struct CodexTuiRehydratePlan {
+    reserved_rollout_paths: HashSet<PathBuf>,
+    duplicate_marker_paths: HashSet<PathBuf>,
+    markerless_fallback_allowed_sessions: HashSet<String>,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+struct CodexTuiRehydrateObservation {
+    tmux_session_name: String,
+    live_pane: bool,
+    canonical_cwd: Option<PathBuf>,
+    existing_binding_path: Option<PathBuf>,
+    marker_path: Option<PathBuf>,
+}
+
+#[cfg(unix)]
+fn codex_tui_rehydrate_observations(sessions: &[String]) -> Vec<CodexTuiRehydrateObservation> {
+    let mut observations = Vec::new();
+    for tmux_session_name in sessions {
+        if !tmux_session_is_codex_tui(tmux_session_name) {
+            continue;
+        }
+        let live_pane =
+            crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name);
+        let canonical_cwd = live_pane
+            .then(|| crate::services::platform::tmux::pane_current_path(tmux_session_name))
+            .flatten()
+            .map(PathBuf::from)
+            .map(|cwd| std::fs::canonicalize(&cwd).unwrap_or(cwd));
+        let marker_path =
+            crate::services::codex_tui::session::read_codex_tui_rollout_marker(tmux_session_name)
+                .and_then(|marker| {
+                    marker
+                        .rollout_path
+                        .exists()
+                        .then(|| canonical_rollout_claim_path(&marker.rollout_path))
+                });
+        observations.push(CodexTuiRehydrateObservation {
+            tmux_session_name: tmux_session_name.clone(),
+            live_pane,
+            canonical_cwd,
+            existing_binding_path: codex_tui_existing_valid_binding_path(tmux_session_name),
+            marker_path,
+        });
+    }
+    observations
+}
+
+#[cfg(unix)]
+fn codex_tui_rehydrate_plan(sessions: &[String]) -> CodexTuiRehydratePlan {
+    codex_tui_rehydrate_plan_from_observations(codex_tui_rehydrate_observations(sessions))
+}
+
+#[cfg(unix)]
+fn codex_tui_rehydrate_plan_from_observations(
+    observations: Vec<CodexTuiRehydrateObservation>,
+) -> CodexTuiRehydratePlan {
+    let mut tmux_sessions_by_marker_path: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    for observation in &observations {
+        let Some(marker_path) = observation.marker_path.as_ref() else {
+            continue;
+        };
+        tmux_sessions_by_marker_path
+            .entry(marker_path.clone())
+            .or_default()
+            .push(observation.tmux_session_name.clone());
+    }
+
+    let mut duplicate_marker_paths = HashSet::new();
+    let mut reserved_rollout_paths: HashSet<PathBuf> = observations
+        .iter()
+        .filter_map(|observation| observation.existing_binding_path.clone())
+        .collect();
+    for (marker_path, tmux_sessions) in tmux_sessions_by_marker_path {
+        reserved_rollout_paths.insert(marker_path.clone());
+        if tmux_sessions.len() == 1 {
+            continue;
+        }
+        duplicate_marker_paths.insert(marker_path.clone());
+        tracing::debug!(
+            marker_path = %marker_path.display(),
+            sessions = ?tmux_sessions,
+            "Codex TUI rollout marker path is shared by multiple sessions; treating as markerless ambiguity"
+        );
+    }
+
+    let markerless_cwd_by_tmux = observations
+        .iter()
+        .filter_map(|observation| {
+            codex_tui_observation_needs_markerless_fallback(observation, &duplicate_marker_paths)
+                .then(|| {
+                    observation
+                        .canonical_cwd
+                        .clone()
+                        .map(|cwd| (observation.tmux_session_name.clone(), cwd))
+                })
+                .flatten()
+        })
+        .collect();
+    let markerless_fallback_allowed_sessions =
+        markerless_codex_tui_fallback_allowed_from_cwds(markerless_cwd_by_tmux);
+
+    CodexTuiRehydratePlan {
+        reserved_rollout_paths,
+        duplicate_marker_paths,
+        markerless_fallback_allowed_sessions,
+    }
+}
+
+#[cfg(unix)]
+fn codex_tui_existing_valid_binding_path(tmux_session_name: &str) -> Option<PathBuf> {
+    let binding =
+        crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name)?;
+    if binding.runtime_kind != RuntimeHandoffKind::CodexTui {
+        return None;
+    }
+    let path = PathBuf::from(binding.output_path);
+    path.exists().then(|| canonical_rollout_claim_path(&path))
+}
+
+#[cfg(unix)]
+fn codex_tui_observation_needs_markerless_fallback(
+    observation: &CodexTuiRehydrateObservation,
+    duplicate_marker_paths: &HashSet<PathBuf>,
+) -> bool {
+    if !observation.live_pane || observation.existing_binding_path.is_some() {
+        return false;
+    }
+    match observation.marker_path.as_ref() {
+        Some(marker_path) => duplicate_marker_paths.contains(marker_path),
+        None => true,
+    }
+}
+
+#[cfg(unix)]
+fn markerless_codex_tui_fallback_allowed_from_cwds(
+    markerless_cwd_by_tmux: Vec<(String, PathBuf)>,
+) -> HashSet<String> {
+    let mut sessions_by_cwd: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    for (tmux_session_name, cwd) in markerless_cwd_by_tmux {
+        sessions_by_cwd
+            .entry(cwd)
+            .or_default()
+            .push(tmux_session_name);
+    }
+    let mut allowed = HashSet::new();
+    for (cwd, sessions) in sessions_by_cwd {
+        if sessions.len() == 1 {
+            allowed.insert(sessions[0].clone());
+            continue;
+        }
+        tracing::debug!(
+            cwd = %cwd.display(),
+            session_count = sessions.len(),
+            sessions = ?sessions,
+            "skipping markerless Codex TUI rollout rehydrate fallback for ambiguous same-cwd sessions"
+        );
+    }
+    allowed
+}
+
+#[cfg(unix)]
+fn codex_tui_rehydrated_binding_from_rollout_path(
+    tmux_session_name: &str,
+    rollout_path: &Path,
+    session_id: Option<String>,
+) -> Option<crate::services::tui_prompt_dedupe::TuiRuntimeBinding> {
+    if !rollout_path.exists() {
+        return None;
+    }
+    let start_offset = std::fs::metadata(rollout_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    let relay_output_path =
+        crate::services::tmux_common::session_temp_path(tmux_session_name, "jsonl");
+    let relay_last_offset = std::fs::metadata(&relay_output_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    Some(crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+        runtime_kind: RuntimeHandoffKind::CodexTui,
+        output_path: rollout_path.display().to_string(),
+        relay_output_path: Some(relay_output_path),
+        input_fifo_path: None,
+        session_id: session_id.or_else(|| codex_rollout_session_id(rollout_path)),
+        last_offset: start_offset,
+        relay_last_offset: Some(relay_last_offset),
+    })
+}
+
+#[cfg(unix)]
+#[derive(Debug, PartialEq, Eq)]
+enum CodexTuiMarkerRehydrateDecision {
+    Use {
+        rollout_path: PathBuf,
+        session_id: Option<String>,
+    },
+    TryFallback,
+}
+
+#[cfg(unix)]
+fn codex_tui_marker_rehydrate_decision(
+    marker: &crate::services::codex_tui::session::CodexTuiRolloutMarker,
+    claimed_rollout_paths: &HashSet<PathBuf>,
+    duplicate_marker_paths: &HashSet<PathBuf>,
+) -> CodexTuiMarkerRehydrateDecision {
+    let path = &marker.rollout_path;
+    let claim_path = canonical_rollout_claim_path(path);
+    if path.exists()
+        && !duplicate_marker_paths.contains(&claim_path)
+        && !rollout_path_is_claimed_for_other_session(path, claimed_rollout_paths)
+    {
+        return CodexTuiMarkerRehydrateDecision::Use {
+            rollout_path: path.clone(),
+            session_id: marker.session_id.clone(),
+        };
+    }
+    CodexTuiMarkerRehydrateDecision::TryFallback
+}
+
+#[cfg(unix)]
+pub(in crate::services::discord) fn rehydrated_codex_tui_binding_for_tmux_session(
+    tmux_session_name: &str,
+    claimed_rollout_paths: &HashSet<PathBuf>,
+    reserved_rollout_paths: &HashSet<PathBuf>,
+    duplicate_marker_paths: &HashSet<PathBuf>,
+    allow_markerless_cwd_fallback: bool,
+) -> Option<crate::services::tui_prompt_dedupe::TuiRuntimeBinding> {
+    if !tmux_session_is_codex_tui(tmux_session_name) {
+        return None;
+    }
+    if let Some(marker) =
+        crate::services::codex_tui::session::read_codex_tui_rollout_marker(tmux_session_name)
+    {
+        match codex_tui_marker_rehydrate_decision(
+            &marker,
+            claimed_rollout_paths,
+            duplicate_marker_paths,
+        ) {
+            CodexTuiMarkerRehydrateDecision::Use {
+                rollout_path,
+                session_id,
+            } => {
+                return codex_tui_rehydrated_binding_from_rollout_path(
+                    tmux_session_name,
+                    &rollout_path,
+                    session_id,
+                );
+            }
+            CodexTuiMarkerRehydrateDecision::TryFallback => {}
+        }
+        tracing::debug!(
+            tmux_session_name,
+            rollout_path = %marker.rollout_path.display(),
+            "skipping Codex TUI rehydrate from stale, duplicate, or already-claimed rollout marker; trying markerless fallback if permitted"
+        );
+    }
+    if !allow_markerless_cwd_fallback {
+        tracing::debug!(
+            tmux_session_name,
+            "skipping markerless Codex TUI rollout rehydrate fallback because cwd is ambiguous"
+        );
+        return None;
+    }
+    let cwd = crate::services::platform::tmux::pane_current_path(tmux_session_name)?;
+    let sessions_dir = crate::services::codex_tui::rollout_tail::default_codex_sessions_dir()?;
+    let mut excluded_rollout_paths = reserved_rollout_paths.clone();
+    excluded_rollout_paths.extend(claimed_rollout_paths.iter().cloned());
+    let rollout_path =
+        crate::services::codex_tui::rollout_tail::latest_unclaimed_rollout_for_cwd_since(
+            Path::new(&cwd),
+            codex_tui_launch_modified_since(tmux_session_name),
+            &sessions_dir,
+            &excluded_rollout_paths,
+        )?;
+    codex_tui_rehydrated_binding_from_rollout_path(tmux_session_name, &rollout_path, None)
+}
+
+#[cfg(unix)]
+fn rollout_path_is_claimed_for_other_session(
+    path: &Path,
+    claimed_rollout_paths: &HashSet<PathBuf>,
+) -> bool {
+    claimed_rollout_paths.contains(path)
+        || claimed_rollout_paths.contains(&canonical_rollout_claim_path(path))
+}
+
+#[cfg(all(unix, test))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_rollout_session_id_reads_first_session_meta_line() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout_path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &rollout_path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"019f0111-fc32\"}}\n",
+                "{\"type\":\"event\",\"payload\":{}}\n"
+            ),
+        )
+        .expect("write rollout");
+
+        assert_eq!(
+            codex_rollout_session_id(&rollout_path),
+            Some("019f0111-fc32".to_string())
+        );
+    }
+
+    #[test]
+    fn codex_rollout_session_id_rejects_non_meta_first_line() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout_path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &rollout_path,
+            concat!(
+                "{\"type\":\"event\",\"payload\":{}}\n",
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"late\"}}\n"
+            ),
+        )
+        .expect("write rollout");
+
+        assert_eq!(codex_rollout_session_id(&rollout_path), None);
+    }
+
+    #[test]
+    fn markerless_codex_tui_fallback_rejects_ambiguous_same_cwd_sessions() {
+        let cwd = PathBuf::from("/tmp/agentdesk-shared-cwd");
+        let allowed = markerless_codex_tui_fallback_allowed_from_cwds(vec![
+            ("AgentDesk-codex-a".to_string(), cwd.clone()),
+            ("AgentDesk-codex-b".to_string(), cwd),
+        ]);
+
+        assert!(
+            allowed.is_empty(),
+            "markerless same-cwd sessions have no stable rollout identity; rehydrate must skip rather than cross-wire channels"
+        );
+    }
+
+    #[test]
+    fn markerless_codex_tui_fallback_allows_unambiguous_cwd_sessions() {
+        let allowed = markerless_codex_tui_fallback_allowed_from_cwds(vec![
+            (
+                "AgentDesk-codex-a".to_string(),
+                PathBuf::from("/tmp/agentdesk-cwd-a"),
+            ),
+            (
+                "AgentDesk-codex-b".to_string(),
+                PathBuf::from("/tmp/agentdesk-cwd-b"),
+            ),
+        ]);
+
+        assert_eq!(allowed.len(), 2);
+        assert!(allowed.contains("AgentDesk-codex-a"));
+        assert!(allowed.contains("AgentDesk-codex-b"));
+    }
+
+    fn codex_tui_observation(
+        tmux_session_name: &str,
+        cwd: Option<&str>,
+        existing_binding_path: Option<&str>,
+        marker_path: Option<&str>,
+    ) -> CodexTuiRehydrateObservation {
+        CodexTuiRehydrateObservation {
+            tmux_session_name: tmux_session_name.to_string(),
+            live_pane: cwd.is_some(),
+            canonical_cwd: cwd.map(PathBuf::from),
+            existing_binding_path: existing_binding_path.map(PathBuf::from),
+            marker_path: marker_path.map(PathBuf::from),
+        }
+    }
+
+    #[test]
+    fn codex_tui_marker_rehydrate_decision_uses_valid_marker() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rollout_path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &rollout_path,
+            "{\"type\":\"session_meta\",\"payload\":{}}\n",
+        )
+        .expect("write rollout");
+        let marker = crate::services::codex_tui::session::CodexTuiRolloutMarker {
+            rollout_path: rollout_path.clone(),
+            session_id: Some("sess-1".to_string()),
+        };
+
+        assert_eq!(
+            codex_tui_marker_rehydrate_decision(&marker, &HashSet::new(), &HashSet::new()),
+            CodexTuiMarkerRehydrateDecision::Use {
+                rollout_path,
+                session_id: Some("sess-1".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn codex_tui_marker_rehydrate_decision_falls_back_for_unusable_marker() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let existing_rollout_path = dir.path().join("existing-rollout.jsonl");
+        std::fs::write(
+            &existing_rollout_path,
+            "{\"type\":\"session_meta\",\"payload\":{}}\n",
+        )
+        .expect("write rollout");
+        let stale_marker = crate::services::codex_tui::session::CodexTuiRolloutMarker {
+            rollout_path: dir.path().join("deleted-rollout.jsonl"),
+            session_id: Some("stale".to_string()),
+        };
+        let duplicate_marker = crate::services::codex_tui::session::CodexTuiRolloutMarker {
+            rollout_path: existing_rollout_path.clone(),
+            session_id: Some("duplicate".to_string()),
+        };
+        let claimed_marker = crate::services::codex_tui::session::CodexTuiRolloutMarker {
+            rollout_path: existing_rollout_path.clone(),
+            session_id: Some("claimed".to_string()),
+        };
+        let mut duplicate_marker_paths = HashSet::new();
+        duplicate_marker_paths.insert(canonical_rollout_claim_path(&existing_rollout_path));
+        let mut claimed_rollout_paths = HashSet::new();
+        claimed_rollout_paths.insert(canonical_rollout_claim_path(&existing_rollout_path));
+
+        assert_eq!(
+            codex_tui_marker_rehydrate_decision(&stale_marker, &HashSet::new(), &HashSet::new(),),
+            CodexTuiMarkerRehydrateDecision::TryFallback
+        );
+        assert_eq!(
+            codex_tui_marker_rehydrate_decision(
+                &duplicate_marker,
+                &HashSet::new(),
+                &duplicate_marker_paths,
+            ),
+            CodexTuiMarkerRehydrateDecision::TryFallback
+        );
+        assert_eq!(
+            codex_tui_marker_rehydrate_decision(
+                &claimed_marker,
+                &claimed_rollout_paths,
+                &HashSet::new(),
+            ),
+            CodexTuiMarkerRehydrateDecision::TryFallback
+        );
+    }
+
+    #[test]
+    fn codex_tui_rehydrate_plan_reserves_marker_paths_before_markerless_fallback() {
+        let marker_path = "/tmp/agentdesk-marker-backed-rollout.jsonl";
+        let plan = codex_tui_rehydrate_plan_from_observations(vec![
+            codex_tui_observation("AgentDesk-codex-markerless", Some("/repo"), None, None),
+            codex_tui_observation(
+                "AgentDesk-codex-marker-backed",
+                Some("/repo"),
+                None,
+                Some(marker_path),
+            ),
+        ]);
+
+        assert!(
+            plan.reserved_rollout_paths
+                .contains(&PathBuf::from(marker_path)),
+            "marker-backed rollout must be reserved before markerless cwd fallback runs"
+        );
+        assert!(
+            plan.markerless_fallback_allowed_sessions
+                .contains("AgentDesk-codex-markerless"),
+            "the markerless sibling may fallback, but only after excluding the reserved marker path"
+        );
+    }
+
+    #[test]
+    fn codex_tui_rehydrate_plan_counts_stale_marker_sessions_as_markerless_ambiguity() {
+        let plan = codex_tui_rehydrate_plan_from_observations(vec![
+            codex_tui_observation("AgentDesk-codex-markerless", Some("/repo"), None, None),
+            // A stale marker has no usable rollout path, so it is represented as
+            // live but without `marker_path` and must count against cwd fallback.
+            codex_tui_observation("AgentDesk-codex-stale-marker", Some("/repo"), None, None),
+        ]);
+
+        assert!(
+            plan.markerless_fallback_allowed_sessions.is_empty(),
+            "two live sessions with no usable rollout identity in the same cwd must skip fallback"
+        );
+    }
 }

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -535,6 +535,7 @@ const SESSIONS_SUBDIR: &str = "runtime/sessions";
 pub(crate) const CLAUDE_TUI_HOOK_SETTINGS_TEMP_EXT: &str = "claude-tui-settings.json";
 pub(crate) const CLAUDE_TUI_LAUNCH_SCRIPT_TEMP_EXT: &str = "claude-tui.sh";
 pub(crate) const CODEX_TUI_HOME_TEMP_EXT: &str = "codex-tui-home";
+pub(crate) const CODEX_TUI_ROLLOUT_MARKER_TEMP_EXT: &str = "codex-tui-rollout.json";
 pub(crate) const TMUX_DEAD_MARKER_TEMP_EXT: &str = "pane_dead";
 pub(crate) const TMUX_RUNTIME_KIND_TEMP_EXT: &str = "runtime-kind";
 
@@ -695,6 +696,7 @@ pub fn cleanup_session_temp_files(session_name: &str) {
         TMUX_DEAD_MARKER_TEMP_EXT,
         CLAUDE_TUI_HOOK_SETTINGS_TEMP_EXT,
         CLAUDE_TUI_LAUNCH_SCRIPT_TEMP_EXT,
+        CODEX_TUI_ROLLOUT_MARKER_TEMP_EXT,
     ];
     for ext in EXTS {
         let _ = std::fs::remove_file(session_temp_path(session_name, ext));


### PR DESCRIPTION
## Summary
- Fixes #3711.
- Rehydrates live `codex_tui` tmux sessions from their active Codex rollout after dcserver restart.
- Persists a per-tmux Codex TUI rollout marker as soon as the rollout is discovered, and uses claimed/reserved rollout exclusion during rehydrate so two live Codex TUI sessions cannot bind to the same rollout.
- For markerless pre-PR legacy Codex TUI sessions, cwd-based fallback is allowed only when exactly one live markerless session owns that cwd; ambiguous same-cwd sessions are skipped rather than risk wrong-channel relay.
- Restores tmux-session to channel ownership for live Codex TUI sessions so idle rollout relay can scan again.
- Rejects `/api/inflight/rebind` for direct Codex TUI sessions with `409 Conflict`; that API respawns wrapper-output watchers and cannot safely consume native Codex rollout JSONL.
- Extracts rebind runtime/output-path resolution to `recovery_engine/rebind_runtime.rs` to keep `recovery_engine.rs` below its production LoC ratchet.

## Root Cause
PR #3710 fixed placeholder-only delivery for long TUI-direct responses, but the active #adk-cdx session remained dark because the release restart lost the in-memory `CodexTui` runtime binding. Claude TUI had rehydration; Codex TUI did not. A manual rebind then synthesized a legacy wrapper inflight pointing at non-existent `runtime/sessions/...jsonl` and `.input` paths, which blocked idle rollout relay scans.

## Verification
- `cargo test -q latest_unclaimed_rollout_skips_rollout_claimed_by_another_tui`
- `cargo test -q markerless_codex_tui_fallback`
- `cargo test -q codex_tui_rehydrate_plan`
- `cargo test -q codex_tui_marker_rehydrate_decision`
- `cargo test -q codex_tui_rollout_marker_round_trips`
- `cargo test -q direct_codex_tui_rebind_rejects_existing_runtime_binding`
- `cargo test -q runtime_binding_unavailable_maps_to_conflict`
- `cargo test -q codex_rehydrate_thread_session_resolves_thread_channel_id`
- `cargo test -q codex_rollout_session_id_reads_first_session_meta_line`
- `cargo test -q codex_rollout_session_id_rejects_non_meta_first_line`
- `cargo test -q rehydrate`
- `cargo test -q rebind_error_status_tests`
- `cargo test -q codex_idle_rollout_scan`
- `cargo check -q`
- `./scripts/ci-script-checks.sh`
- `git diff --check`

Note: local Rust commands still print existing repo warnings for `legacy-sqlite-tests` cfg and two unrelated unused imports.
