### PR TITLE
Make script checks require Python 3.11

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -244,6 +244,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Python for script checks
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -346,6 +346,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Python for script checks
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -692,6 +692,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Python for script checks
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Large file guard
         shell: bash
         run: |

--- a/docs/ci/release-gates.md
+++ b/docs/ci/release-gates.md
@@ -66,6 +66,12 @@ high_risk_recovery:
 - `scripts/generate_inventory_docs.py --check` 은 `Script checks` job 마지막 단계에서 하드 블록 (ci-main `scripts` step, ci-pr `scripts` step).
 - 이 drift 검증이 red 면 Full/PG/High-risk 와 동일하게 release gate 위반으로 간주한다.
 
+### Script checks Python runtime
+
+- `scripts/ci-script-checks.sh` 는 Python 3.11+ 를 최소 런타임으로 요구한다. 이는 `tomllib` 같은 Python 3.11 표준 라이브러리 사용과 `scripts/audit_maintainability.py` 정책에 맞춘다.
+- CI 의 `Script checks` 계열 job 은 `actions/setup-python` 으로 Python 3.11 을 명시적으로 설치한다.
+- 로컬에서 `python3` 이 3.10 이하이면 `PYTHON=/path/to/python3.11 ./scripts/ci-script-checks.sh` 로 같은 정책을 재현한다. 지원하지 않는 Python 은 check 본문 실행 전에 명확한 오류로 실패해야 한다.
+
 ## 3. High-risk recovery lane test axes
 
 `#1011`/`#974` 감사로그는 release gate 의 high-risk recovery lane 이 아래 **4 축**을 회귀 방지선으로 유지해야 한다고 명시한다. 레거시 SQLite 기반 `src/integration_tests/tests/high_risk_recovery.rs` 시나리오 하네스는 #3035 Phase 1 에서 제거되었으며, PG-only 회귀 보호는 `src/high_risk_recovery.rs` 로 이전된다. 아래 시나리오 매트릭스(`failure_recovery` / `outbox_boundary` / `delayed_worker` / `idle_session_cleanup` 축)는 제거된 레거시 하네스 기준 기록이며 PG 스위트 재매핑은 후속 Phase 에서 진행한다. 축별 대표 시나리오는 [`docs/high-risk-recovery-lane.md`](../high-risk-recovery-lane.md#release-gate-축-매핑) 참고.

--- a/scripts/check_hotfile_ratchet.py
+++ b/scripts/check_hotfile_ratchet.py
@@ -30,8 +30,30 @@ on any missing required entry.
 from __future__ import annotations
 
 import sys
-import tomllib
 from pathlib import Path
+
+MIN_PYTHON = (3, 11)
+
+# Keep this before importing tomllib so unsupported interpreters fail with the
+# repository policy message instead of a raw ModuleNotFoundError.
+if sys.version_info < MIN_PYTHON:
+    version = (
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
+    print(
+        "ERROR: scripts/check_hotfile_ratchet.py requires Python 3.11+ "
+        "for stdlib tomllib; "
+        f"{sys.executable} is Python {version}.",
+        file=sys.stderr,
+    )
+    print(
+        "Run with python3.11+ or set PYTHON=/path/to/python3.11+ when using "
+        "scripts/ci-script-checks.sh.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / "scripts" / "hotfile_ratchet.toml"

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -1,6 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PYTHON="${PYTHON:-python3}"
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "ERROR: AgentDesk script checks require Python 3.11+, but '$PYTHON' was not found." >&2
+  echo "Set PYTHON=/path/to/python3.11+ or put python3.11+ first on PATH." >&2
+  exit 1
+fi
+
+if ! "$PYTHON" - <<'PY'
+import platform
+import sys
+
+if sys.version_info < (3, 11):
+    print(
+        "ERROR: AgentDesk script checks require Python 3.11+; "
+        f"{sys.executable} is Python {platform.python_version()}.",
+        file=sys.stderr,
+    )
+    print(
+        "Set PYTHON=/path/to/python3.11+ or put python3.11+ first on PATH.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+then
+  exit 1
+fi
+
 if command -v shellcheck >/dev/null 2>&1; then
   echo "=== shellcheck scripts ==="
   FAILED=0
@@ -18,16 +46,16 @@ echo "=== PG audit guard ==="
 ./scripts/pg-audit.sh
 
 echo "=== Postgres migration checksum guard ==="
-python3 scripts/check_postgres_migration_checksums.py
+"$PYTHON" scripts/check_postgres_migration_checksums.py
 
 echo "=== State/lint hardening guard ==="
-python3 scripts/audit_state_lint_hardening.py
+"$PYTHON" scripts/audit_state_lint_hardening.py
 
 echo "=== await_holding_lock ratchet guard ==="
-python3 scripts/check_await_holding_lock_ratchet.py
+"$PYTHON" scripts/check_await_holding_lock_ratchet.py
 
 echo "=== Hotfile LOC ratchet guard (#3565) ==="
-python3 scripts/check_hotfile_ratchet.py
+"$PYTHON" scripts/check_hotfile_ratchet.py
 
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
@@ -96,29 +124,30 @@ if [ "$FAIL" -ne 0 ]; then
 fi
 
 echo "=== Portable deployable path lint ==="
-python3 scripts/check-portable-paths.py
-python3 -m unittest \
+"$PYTHON" scripts/check-portable-paths.py
+"$PYTHON" -m unittest \
   tests.test_portable_path_lint \
   tests.test_install_bootstrap_portable \
+  tests.test_script_python_policy \
   tests.test_analyze_prs
 
 echo "=== Generate inventory docs (also gates giant-file registry, #3036) ==="
 # The generator hard-fails (exit 2) on giant-file registry drift: unregistered
 # new giants, ghost registrations left after decomposition, or deadline-less
 # [[entry]] tables in scripts/giant_file_registry.toml.
-python3 scripts/generate_inventory_docs.py
+"$PYTHON" scripts/generate_inventory_docs.py
 
 echo "=== Agent maintenance freshness gate (warn, #1432; LoC hard-gate, #3036) ==="
 # --warning-only keeps the #1432 freshness/touch rollout non-fatal, while
 # --line-count-gate hard-fails on change-surfaces.md production-LoC drift, ghost
 # freeze entries, and decomposition regressions.
-python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate
+"$PYTHON" scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate
 
 echo "=== Agent maintenance freshness tests ==="
-python3 -m unittest tests.test_agent_maintenance_docs
+"$PYTHON" -m unittest tests.test_agent_maintenance_docs
 
 echo "=== Maintainability audit ==="
 mkdir -p target
-python3 scripts/audit_maintainability.py --format yaml > target/maintainability-audit.yaml
-python3 scripts/audit_maintainability.py --check
+"$PYTHON" scripts/audit_maintainability.py --format yaml > target/maintainability-audit.yaml
+"$PYTHON" scripts/audit_maintainability.py --check
 echo "Wrote target/maintainability-audit.yaml"

--- a/tests/test_script_python_policy.py
+++ b/tests/test_script_python_policy.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ScriptPythonPolicyTests(unittest.TestCase):
+    def test_ci_script_checks_declares_python_311_runtime(self) -> None:
+        script = (REPO_ROOT / "scripts" / "ci-script-checks.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('PYTHON="${PYTHON:-python3}"', script)
+        self.assertIn("AgentDesk script checks require Python 3.11+", script)
+        self.assertIn("sys.version_info < (3, 11)", script)
+        self.assertIn('"$PYTHON" scripts/check_hotfile_ratchet.py', script)
+        self.assertIn("tests.test_script_python_policy", script)
+        self.assertIn('"$PYTHON" scripts/audit_maintainability.py --check', script)
+
+    def test_ci_script_checks_fails_before_body_on_unsupported_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_python = Path(tmp) / "python3.10"
+            fake_python.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    echo "ERROR: AgentDesk script checks require Python 3.11+; $0 is Python 3.10.0." >&2
+                    echo "Set PYTHON=/path/to/python3.11+ or put python3.11+ first on PATH." >&2
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_python.chmod(fake_python.stat().st_mode | 0o111)
+
+            result = subprocess.run(
+                ["bash", "scripts/ci-script-checks.sh"],
+                cwd=REPO_ROOT,
+                env={**os.environ, "PYTHON": str(fake_python)},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("require Python 3.11+", result.stderr)
+        self.assertIn("Set PYTHON=/path/to/python3.11+", result.stderr)
+        self.assertNotIn("=== PG audit guard ===", result.stdout)
+
+    def test_hotfile_ratchet_guards_before_tomllib_import(self) -> None:
+        source = (REPO_ROOT / "scripts" / "check_hotfile_ratchet.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("MIN_PYTHON = (3, 11)", source)
+        self.assertLess(
+            source.index("sys.version_info < MIN_PYTHON"),
+            source.index("import tomllib"),
+        )
+        self.assertIn("requires Python 3.11+", source)
+        self.assertIn("for stdlib tomllib", source)
+
+    def test_ci_script_check_jobs_pin_python_311(self) -> None:
+        for rel in (
+            ".github/workflows/ci-main.yml",
+            ".github/workflows/ci-pr.yml",
+            ".github/workflows/ci-nightly.yml",
+        ):
+            with self.subTest(workflow=rel):
+                workflow = (REPO_ROOT / rel).read_text(encoding="utf-8")
+                self.assertIn("Setup Python for script checks", workflow)
+                self.assertIn('python-version: "3.11"', workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Pins script-check CI jobs to Python 3.11.
- Adds an early PYTHON preflight to scripts/ci-script-checks.sh and routes Python checks through that interpreter.
- Makes check_hotfile_ratchet.py fail clearly before stdlib tomllib import on unsupported Python.
- Adds CI-gated tests for the policy and unsupported-Python preflight behavior.

## Validation
- bash -n scripts/ci-script-checks.sh
- /opt/homebrew/bin/python3 -m unittest tests.test_script_python_policy
- /opt/homebrew/bin/python3 -m py_compile tests/test_script_python_policy.py scripts/check_hotfile_ratchet.py
- git diff --check
- Fresh Codex review: VERDICT CLEAN

Issue: #3727