### PR TITLE
Prewarm and single-flight token analytics cache

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1403,7 +1403,7 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2559 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests; +8 from #3690 AgentDef.preferred_intake_node_labels field + doc; #3683 config hot-reload restart-fingerprint config surface).
-  - `src/server/mod.rs` (2640 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review).
+  - `src/server/mod.rs` (2641 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review; #3740 adds the boot hook for token-analytics cache prewarm).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1868 lines; #3685 rebind-origin stale-inflight

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -388,6 +388,7 @@ pub(crate) async fn run(
     );
     worker_registry.run_boot_only_steps().await?;
     worker_registry.start_after_boot_reconcile()?;
+    routes::receipt::spawn_token_analytics_cache_prewarm();
 
     // Resolve dashboard dist path relative to runtime root or binary location
     let dashboard_dir = crate::cli::agentdesk_runtime_root()

--- a/src/server/routes/home_metrics.rs
+++ b/src/server/routes/home_metrics.rs
@@ -92,29 +92,30 @@ pub async fn home_kpi_trends(
     )
     .await;
 
-    let (tokens_values, cost_values) = match analytics_data.as_deref() {
-        Some(data) => {
-            let mut by_day: BTreeMap<String, (u64, f64)> = BTreeMap::new();
-            for day in &data.daily {
-                by_day.insert(day.date.clone(), (day.total_tokens, day.cost));
+    let (tokens_values, cost_values) =
+        match analytics_data.as_ref().map(|result| result.data.as_ref()) {
+            Some(data) => {
+                let mut by_day: BTreeMap<String, (u64, f64)> = BTreeMap::new();
+                for day in &data.daily {
+                    by_day.insert(day.date.clone(), (day.total_tokens, day.cost));
+                }
+                let tokens = date_keys
+                    .iter()
+                    .map(|d| by_day.get(d).map(|(t, _)| *t).unwrap_or(0))
+                    .map(|v| json!(v))
+                    .collect::<Vec<_>>();
+                let costs = date_keys
+                    .iter()
+                    .map(|d| by_day.get(d).map(|(_, c)| *c).unwrap_or(0.0))
+                    .map(|v| json!(v))
+                    .collect::<Vec<_>>();
+                (tokens, costs)
             }
-            let tokens = date_keys
-                .iter()
-                .map(|d| by_day.get(d).map(|(t, _)| *t).unwrap_or(0))
-                .map(|v| json!(v))
-                .collect::<Vec<_>>();
-            let costs = date_keys
-                .iter()
-                .map(|d| by_day.get(d).map(|(_, c)| *c).unwrap_or(0.0))
-                .map(|v| json!(v))
-                .collect::<Vec<_>>();
-            (tokens, costs)
-        }
-        None => (
-            vec![json!(0); date_keys.len()],
-            vec![json!(0.0); date_keys.len()],
-        ),
-    };
+            None => (
+                vec![json!(0); date_keys.len()],
+                vec![json!(0.0); date_keys.len()],
+            ),
+        };
 
     // ── In-progress (daily dispatch count from PG) ────────────────────────
     let in_progress_values = collect_in_progress_trend_pg(pool, &date_keys).await;

--- a/src/server/routes/receipt.rs
+++ b/src/server/routes/receipt.rs
@@ -8,8 +8,12 @@ use chrono::{Datelike, Local, TimeZone};
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{
+    Arc, Mutex, OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::{Duration as StdDuration, Instant};
+use tokio::sync::Mutex as AsyncMutex;
 
 use super::AppState;
 use crate::receipt;
@@ -26,8 +30,9 @@ pub struct TokenAnalyticsQuery {
     period: Option<String>,
     /// When true, bypass the in-process cache and re-scan disk. Set by the
     /// dashboard's explicit Refresh button so manual refreshes always see
-    /// the freshest possible numbers.
-    fresh: Option<bool>,
+    /// the freshest possible numbers. Accepts `fresh=1` as emitted by the
+    /// dashboard Refresh button, plus common boolean spellings.
+    fresh: Option<String>,
 }
 
 /// In-process cache for the heavy token-analytics computation. Each call to
@@ -46,13 +51,62 @@ const TOKEN_ANALYTICS_CACHE_TTL: StdDuration = StdDuration::from_secs(30);
 
 struct CachedAnalytics {
     cached_at: Instant,
+    refresh_generation: u64,
     data: Arc<receipt::TokenAnalyticsData>,
 }
 
 static TOKEN_ANALYTICS_CACHE: OnceLock<Mutex<HashMap<String, CachedAnalytics>>> = OnceLock::new();
+static TOKEN_ANALYTICS_REFRESH_GENERATION: AtomicU64 = AtomicU64::new(0);
 
 fn token_analytics_cache() -> &'static Mutex<HashMap<String, CachedAnalytics>> {
     TOKEN_ANALYTICS_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+struct TokenAnalyticsCollectLocks {
+    seven_day: AsyncMutex<()>,
+    thirty_day: AsyncMutex<()>,
+    ninety_day: AsyncMutex<()>,
+}
+
+static TOKEN_ANALYTICS_COLLECT_LOCKS: OnceLock<TokenAnalyticsCollectLocks> = OnceLock::new();
+
+fn token_analytics_collect_locks() -> &'static TokenAnalyticsCollectLocks {
+    TOKEN_ANALYTICS_COLLECT_LOCKS.get_or_init(|| TokenAnalyticsCollectLocks {
+        seven_day: AsyncMutex::new(()),
+        thirty_day: AsyncMutex::new(()),
+        ninety_day: AsyncMutex::new(()),
+    })
+}
+
+fn token_analytics_collect_lock(period: &str) -> &'static AsyncMutex<()> {
+    let locks = token_analytics_collect_locks();
+    match period {
+        "7d" => &locks.seven_day,
+        "90d" => &locks.ninety_day,
+        _ => &locks.thirty_day,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TokenAnalyticsCacheState {
+    Hit,
+    Miss,
+    Bypass,
+}
+
+impl TokenAnalyticsCacheState {
+    fn as_header_value(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Miss => "miss",
+            Self::Bypass => "bypass",
+        }
+    }
+}
+
+pub(crate) struct TokenAnalyticsCacheResult {
+    pub(crate) data: Arc<receipt::TokenAnalyticsData>,
+    pub(crate) cache_state: TokenAnalyticsCacheState,
 }
 
 fn read_cached_token_analytics(period: &str) -> Option<Arc<receipt::TokenAnalyticsData>> {
@@ -64,12 +118,44 @@ fn read_cached_token_analytics(period: &str) -> Option<Arc<receipt::TokenAnalyti
     Some(Arc::clone(&entry.data))
 }
 
-fn write_cached_token_analytics(period: &str, data: Arc<receipt::TokenAnalyticsData>) {
+fn cached_token_analytics_refresh_generation(period: &str) -> u64 {
+    token_analytics_cache()
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(period).map(|entry| entry.refresh_generation))
+        .unwrap_or(0)
+}
+
+fn read_cached_token_analytics_refreshed_after(
+    period: &str,
+    refresh_generation: u64,
+) -> Option<Arc<receipt::TokenAnalyticsData>> {
+    let cache = token_analytics_cache().lock().ok()?;
+    let entry = cache.get(period)?;
+    if entry.refresh_generation <= refresh_generation
+        || entry.cached_at.elapsed() > TOKEN_ANALYTICS_CACHE_TTL
+    {
+        return None;
+    }
+    Some(Arc::clone(&entry.data))
+}
+
+fn write_cached_token_analytics(
+    period: &str,
+    data: Arc<receipt::TokenAnalyticsData>,
+    refreshed: bool,
+) {
     if let Ok(mut cache) = token_analytics_cache().lock() {
+        let refresh_generation = if refreshed {
+            TOKEN_ANALYTICS_REFRESH_GENERATION.fetch_add(1, Ordering::Relaxed) + 1
+        } else {
+            0
+        };
         cache.insert(
             period.to_string(),
             CachedAnalytics {
                 cached_at: Instant::now(),
+                refresh_generation,
                 data,
             },
         );
@@ -81,6 +167,12 @@ fn write_cached_token_analytics(period: &str, data: Arc<receipt::TokenAnalyticsD
 /// dashboard's first paint pays at most one ~9 s scan per period instead of
 /// one per endpoint (#1303).
 ///
+/// Cache misses are single-flighted per canonical period. If `/api/home/kpi-trends`
+/// and `/api/token-analytics` miss concurrently, one request performs the scan
+/// while the other waits, rechecks the cache, and reuses the result. The first
+/// explicit `fresh=1` request also scans, but concurrent refreshes for the same
+/// period coalesce behind the period lock and reuse the new cache write.
+///
 /// Returns `None` only when the blocking task panics; the caller is expected
 /// to surface a graceful fallback (empty arrays + warn log) rather than 5xx.
 pub(crate) async fn cached_or_collect_token_analytics(
@@ -88,10 +180,77 @@ pub(crate) async fn cached_or_collect_token_analytics(
     days: i64,
     label: &str,
     now: chrono::DateTime<chrono::Utc>,
-) -> Option<Arc<receipt::TokenAnalyticsData>> {
+) -> Option<TokenAnalyticsCacheResult> {
     if let Some(cached) = read_cached_token_analytics(period_id) {
-        return Some(cached);
+        return Some(TokenAnalyticsCacheResult {
+            data: cached,
+            cache_state: TokenAnalyticsCacheState::Hit,
+        });
     }
+    collect_token_analytics_with_lock(period_id, days, label, now, false).await
+}
+
+async fn collect_token_analytics_with_lock(
+    period_id: &str,
+    days: i64,
+    label: &str,
+    now: chrono::DateTime<chrono::Utc>,
+    bypass_cache: bool,
+) -> Option<TokenAnalyticsCacheResult> {
+    collect_token_analytics_with_lock_using(
+        period_id,
+        days,
+        label,
+        now,
+        bypass_cache,
+        |start, now, label_owned, period_owned| {
+            receipt::collect_token_analytics(start, now, &label_owned, &period_owned)
+        },
+    )
+    .await
+}
+
+async fn collect_token_analytics_with_lock_using<Collect>(
+    period_id: &str,
+    days: i64,
+    label: &str,
+    now: chrono::DateTime<chrono::Utc>,
+    bypass_cache: bool,
+    collect: Collect,
+) -> Option<TokenAnalyticsCacheResult>
+where
+    Collect: FnOnce(
+            chrono::DateTime<chrono::Utc>,
+            chrono::DateTime<chrono::Utc>,
+            String,
+            String,
+        ) -> receipt::TokenAnalyticsData
+        + Send
+        + 'static,
+{
+    let refresh_generation_before_wait = if bypass_cache {
+        cached_token_analytics_refresh_generation(period_id)
+    } else {
+        0
+    };
+    let _guard = token_analytics_collect_lock(period_id).lock().await;
+
+    let cached = if bypass_cache {
+        read_cached_token_analytics_refreshed_after(period_id, refresh_generation_before_wait)
+    } else {
+        read_cached_token_analytics(period_id)
+    };
+    if let Some(cached) = cached {
+        return Some(TokenAnalyticsCacheResult {
+            data: cached,
+            cache_state: if bypass_cache {
+                TokenAnalyticsCacheState::Bypass
+            } else {
+                TokenAnalyticsCacheState::Hit
+            },
+        });
+    }
+
     let local_now = now.with_timezone(&Local);
     let start_date = local_now.date_naive() - chrono::Duration::days(days.saturating_sub(1));
     let start = Local
@@ -101,38 +260,49 @@ pub(crate) async fn cached_or_collect_token_analytics(
         .unwrap_or_else(|| now - chrono::Duration::days(days));
     let label_owned = label.to_string();
     let period_owned = period_id.to_string();
-    let data = match tokio::task::spawn_blocking(move || {
-        receipt::collect_token_analytics(start, now, &label_owned, &period_owned)
+    let data =
+        match tokio::task::spawn_blocking(move || collect(start, now, label_owned, period_owned))
+            .await
+        {
+            Ok(data) => Arc::new(data),
+            Err(error) => {
+                tracing::warn!(period = period_id, error = %error, "token-analytics scan failed");
+                return None;
+            }
+        };
+    write_cached_token_analytics(period_id, Arc::clone(&data), bypass_cache);
+    Some(TokenAnalyticsCacheResult {
+        data,
+        cache_state: if bypass_cache {
+            TokenAnalyticsCacheState::Bypass
+        } else {
+            TokenAnalyticsCacheState::Miss
+        },
     })
-    .await
-    {
-        Ok(data) => Arc::new(data),
-        Err(error) => {
-            tracing::warn!(period = period_id, error = %error, "token-analytics scan failed");
-            return None;
-        }
-    };
-    write_cached_token_analytics(period_id, Arc::clone(&data));
-    Some(data)
+}
+
+/// Spawn a detached post-boot prewarm for the token-analytics in-process cache.
+/// This is intentionally best-effort: the server starts accepting requests
+/// without waiting for filesystem scans, and the single-flight cache path below
+/// still protects first requests if they beat the prewarm.
+pub(crate) fn spawn_token_analytics_cache_prewarm() {
+    tokio::spawn(async {
+        tokio::time::sleep(StdDuration::from_secs(2)).await;
+        prewarm_token_analytics_cache().await;
+    });
 }
 
 /// Pre-warm the token-analytics in-process cache for every period the
 /// dashboard requests on first paint. The first home/stats visit on a fresh
 /// dcserver previously paid the ~9s filesystem scan synchronously while the
-/// user watched a placeholder; with this prewarm running off a detached
-/// `tokio::spawn` shortly after boot, the cache is already populated before
-/// the user lands on /home, so the first request hits the 30s in-process
-/// cache and returns in single-digit ms.
+/// user watched a placeholder; the detached boot hook now calls this shortly
+/// after boot, and concurrent first requests share the same single-flight
+/// collector if they arrive before the prewarm completes.
 ///
 /// We deliberately stagger periods so the three blocking scans don't pile up
 /// onto the same blocking pool slot at the same moment, and we tolerate
 /// individual failures so a transient parse error in one period doesn't
 /// kill the prewarm for the others.
-// reason: boot-time token-analytics cache prewarm entry point. The detached
-// `tokio::spawn` boot hook described above is not currently wired, so the lib
-// build flags it as dead; retained as a ready entry point rather than silently
-// dropping the prewarm capability. See #3034.
-#[allow(dead_code)]
 pub async fn prewarm_token_analytics_cache() {
     for period in ["7d", "30d", "90d"] {
         let (days, label) = match period {
@@ -141,33 +311,22 @@ pub async fn prewarm_token_analytics_cache() {
             _ => (30_i64, "Last 30 Days"),
         };
         let now = chrono::Utc::now();
-        let local_now = now.with_timezone(&Local);
-        let start_date = local_now.date_naive() - chrono::Duration::days(days.saturating_sub(1));
-        let start = Local
-            .from_local_datetime(&start_date.and_hms_opt(0, 0, 0).unwrap())
-            .single()
-            .map(|dt| dt.with_timezone(&chrono::Utc))
-            .unwrap_or_else(|| now - chrono::Duration::days(days));
-        let label_owned = label.to_string();
-        let period_owned = period.to_string();
         let started = Instant::now();
-        let data = match tokio::task::spawn_blocking(move || {
-            receipt::collect_token_analytics(start, now, &label_owned, &period_owned)
-        })
-        .await
-        {
-            Ok(data) => data,
-            Err(error) => {
-                tracing::warn!(period, error = %error, "token-analytics prewarm failed");
+        match cached_or_collect_token_analytics(period, days, label, now).await {
+            Some(result) => {
+                tracing::info!(
+                    period,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    cache_state = result.cache_state.as_header_value(),
+                    "token-analytics prewarm done"
+                );
+            }
+            None => {
+                tracing::warn!(period, "token-analytics prewarm failed");
                 continue;
             }
-        };
-        write_cached_token_analytics(period, Arc::new(data));
-        tracing::info!(
-            period,
-            elapsed_ms = started.elapsed().as_millis(),
-            "token-analytics prewarm done"
-        );
+        }
+        tokio::time::sleep(StdDuration::from_millis(250)).await;
     }
 }
 
@@ -257,9 +416,8 @@ pub async fn get_token_analytics(
 ) -> Response {
     let started = Instant::now();
     let period = params.period.as_deref().unwrap_or("30d");
-    let bypass_cache = params.fresh.unwrap_or(false);
+    let bypass_cache = parse_token_analytics_fresh_param(params.fresh.as_deref());
     let now = chrono::Utc::now();
-    let local_now = now.with_timezone(&Local);
 
     let (days, label, period_id) = match period {
         "7d" => (7_i64, "Last 7 Days", "7d"),
@@ -267,35 +425,18 @@ pub async fn get_token_analytics(
         _ => (30_i64, "Last 30 Days", "30d"),
     };
 
-    if !bypass_cache {
-        if let Some(cached) = read_cached_token_analytics(period_id) {
+    let result = match if bypass_cache {
+        collect_token_analytics_with_lock(period_id, days, label, now, true).await
+    } else {
+        cached_or_collect_token_analytics(period_id, days, label, now).await
+    } {
+        Some(result) => result,
+        None => {
             let elapsed_ms = started.elapsed().as_millis();
-            tracing::debug!(period = period_id, elapsed_ms, "token-analytics cache hit");
-            return build_token_analytics_response(&cached, period_id, elapsed_ms, "hit");
-        }
-    }
-
-    let start_date = local_now.date_naive() - chrono::Duration::days(days.saturating_sub(1));
-    let start = Local
-        .from_local_datetime(&start_date.and_hms_opt(0, 0, 0).unwrap())
-        .single()
-        .map(|dt| dt.with_timezone(&chrono::Utc))
-        .unwrap_or_else(|| now - chrono::Duration::days(days));
-
-    let label_owned = label.to_string();
-    let period_owned = period_id.to_string();
-    let data = match tokio::task::spawn_blocking(move || {
-        receipt::collect_token_analytics(start, now, &label_owned, &period_owned)
-    })
-    .await
-    {
-        Ok(d) => d,
-        Err(e) => {
-            let elapsed_ms = started.elapsed().as_millis();
-            tracing::warn!(period = period_id, elapsed_ms, error = %e, "token-analytics failed");
+            tracing::warn!(period = period_id, elapsed_ms, "token-analytics failed");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("collection failed: {e}")})),
+                Json(json!({"error": "collection failed"})),
             )
                 .into_response();
         }
@@ -305,14 +446,16 @@ pub async fn get_token_analytics(
     tracing::info!(
         period = period_id,
         elapsed_ms,
-        bypass_cache,
+        cache_state = result.cache_state.as_header_value(),
         "token-analytics responded"
     );
 
-    let arc_data = Arc::new(data);
-    write_cached_token_analytics(period_id, Arc::clone(&arc_data));
-    let cache_state = if bypass_cache { "bypass" } else { "miss" };
-    build_token_analytics_response(&arc_data, period_id, elapsed_ms, cache_state)
+    build_token_analytics_response(
+        &result.data,
+        period_id,
+        elapsed_ms,
+        result.cache_state.as_header_value(),
+    )
 }
 
 fn build_token_analytics_response(
@@ -345,4 +488,328 @@ fn build_token_analytics_response(
         HeaderValue::from_static(cache_state),
     );
     response
+}
+
+fn parse_token_analytics_fresh_param(value: Option<&str>) -> bool {
+    matches!(
+        value
+            .map(str::trim)
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref(),
+        Some("1" | "true" | "yes" | "y" | "on")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::receipt::{ReceiptData, ReceiptStats, TokenAnalyticsData, TokenAnalyticsSummary};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TEST_PERIOD_SUFFIX: AtomicUsize = AtomicUsize::new(0);
+
+    fn empty_receipt_data(label: &str) -> ReceiptData {
+        ReceiptData {
+            period_label: label.to_string(),
+            period_start: "2026-01-01T00:00:00Z".to_string(),
+            period_end: "2026-01-01T00:00:00Z".to_string(),
+            models: Vec::new(),
+            subtotal: 0.0,
+            cache_discount: 0.0,
+            total: 0.0,
+            stats: ReceiptStats {
+                total_messages: 0,
+                total_sessions: 0,
+                per_provider: HashMap::new(),
+                per_provider_agents: HashMap::new(),
+            },
+            providers: Vec::new(),
+            agents: Vec::new(),
+        }
+    }
+
+    fn empty_token_analytics_data(period: &str) -> TokenAnalyticsData {
+        TokenAnalyticsData {
+            period: period.to_string(),
+            period_label: "Test Period".to_string(),
+            days: 1,
+            generated_at: "2026-01-01T00:00:00Z".to_string(),
+            summary: TokenAnalyticsSummary {
+                total_tokens: 0,
+                total_cost: 0.0,
+                cache_discount: 0.0,
+                total_messages: 0,
+                total_sessions: 0,
+                active_days: 0,
+                average_daily_tokens: 0,
+                peak_day: None,
+            },
+            receipt: empty_receipt_data("Test Period"),
+            daily: Vec::new(),
+            heatmap: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn token_analytics_cache_state_header_values_are_stable() {
+        assert_eq!(TokenAnalyticsCacheState::Hit.as_header_value(), "hit");
+        assert_eq!(TokenAnalyticsCacheState::Miss.as_header_value(), "miss");
+        assert_eq!(TokenAnalyticsCacheState::Bypass.as_header_value(), "bypass");
+    }
+
+    #[test]
+    fn token_analytics_fresh_param_accepts_dashboard_refresh_shape() {
+        assert!(parse_token_analytics_fresh_param(Some("1")));
+        assert!(parse_token_analytics_fresh_param(Some("true")));
+        assert!(parse_token_analytics_fresh_param(Some("YES")));
+        assert!(!parse_token_analytics_fresh_param(None));
+        assert!(!parse_token_analytics_fresh_param(Some("0")));
+        assert!(!parse_token_analytics_fresh_param(Some("false")));
+    }
+
+    #[test]
+    fn token_analytics_response_sets_cache_and_period_headers() {
+        let data = empty_token_analytics_data("30d");
+        let response = build_token_analytics_response(
+            &data,
+            "30d",
+            123,
+            TokenAnalyticsCacheState::Hit.as_header_value(),
+        );
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("X-Token-Analytics-Period")
+                .and_then(|value| value.to_str().ok()),
+            Some("30d")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("X-Response-Time-Ms")
+                .and_then(|value| value.to_str().ok()),
+            Some("123")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("X-Token-Analytics-Cache")
+                .and_then(|value| value.to_str().ok()),
+            Some("hit")
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_token_analytics_misses_are_single_flighted() {
+        let suffix = TEST_PERIOD_SUFFIX.fetch_add(1, Ordering::SeqCst);
+        let period = format!("test-single-flight-{suffix}");
+        let collect_count = Arc::new(AtomicUsize::new(0));
+        let now = chrono::Utc::now();
+
+        let first_count = Arc::clone(&collect_count);
+        let first = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            false,
+            move |_start, _now, _label, period| {
+                first_count.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(StdDuration::from_millis(50));
+                empty_token_analytics_data(&period)
+            },
+        );
+
+        let second_count = Arc::clone(&collect_count);
+        let second = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            false,
+            move |_start, _now, _label, period| {
+                second_count.fetch_add(1, Ordering::SeqCst);
+                empty_token_analytics_data(&period)
+            },
+        );
+
+        let (first_result, second_result) = tokio::join!(first, second);
+
+        assert_eq!(
+            collect_count.load(Ordering::SeqCst),
+            1,
+            "the second concurrent miss should reuse the first collector's cache write"
+        );
+        let first_state = first_result.expect("first result").cache_state;
+        let second_state = second_result.expect("second result").cache_state;
+        assert!(
+            matches!(first_state, TokenAnalyticsCacheState::Miss)
+                || matches!(second_state, TokenAnalyticsCacheState::Miss)
+        );
+        assert!(
+            matches!(first_state, TokenAnalyticsCacheState::Hit)
+                || matches!(second_state, TokenAnalyticsCacheState::Hit)
+        );
+    }
+
+    #[tokio::test]
+    async fn token_analytics_refresh_ignores_preexisting_cache() {
+        let suffix = TEST_PERIOD_SUFFIX.fetch_add(1, Ordering::SeqCst);
+        let period = format!("test-refresh-bypass-existing-{suffix}");
+        let collect_count = Arc::new(AtomicUsize::new(0));
+        let now = chrono::Utc::now();
+
+        let first_count = Arc::clone(&collect_count);
+        let first = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            false,
+            move |_start, _now, _label, period| {
+                first_count.fetch_add(1, Ordering::SeqCst);
+                let mut data = empty_token_analytics_data(&period);
+                data.generated_at = "initial-cache".to_string();
+                data
+            },
+        )
+        .await
+        .expect("initial result");
+
+        assert_eq!(first.cache_state, TokenAnalyticsCacheState::Miss);
+        assert_eq!(first.data.generated_at, "initial-cache");
+
+        let refresh_count = Arc::clone(&collect_count);
+        let refresh = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            true,
+            move |_start, _now, _label, period| {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+                let mut data = empty_token_analytics_data(&period);
+                data.generated_at = "manual-refresh".to_string();
+                data
+            },
+        )
+        .await
+        .expect("refresh result");
+
+        assert_eq!(
+            collect_count.load(Ordering::SeqCst),
+            2,
+            "manual refresh should bypass cache entries written before it began waiting"
+        );
+        assert_eq!(refresh.cache_state, TokenAnalyticsCacheState::Bypass);
+        assert_eq!(refresh.data.generated_at, "manual-refresh");
+    }
+
+    #[tokio::test]
+    async fn token_analytics_refresh_does_not_reuse_concurrent_normal_miss() {
+        let suffix = TEST_PERIOD_SUFFIX.fetch_add(1, Ordering::SeqCst);
+        let period = format!("test-refresh-skips-normal-miss-{suffix}");
+        let collect_count = Arc::new(AtomicUsize::new(0));
+        let now = chrono::Utc::now();
+
+        let first_count = Arc::clone(&collect_count);
+        let normal_miss = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            false,
+            move |_start, _now, _label, period| {
+                first_count.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(StdDuration::from_millis(50));
+                let mut data = empty_token_analytics_data(&period);
+                data.generated_at = "normal-miss".to_string();
+                data
+            },
+        );
+
+        let refresh_count = Arc::clone(&collect_count);
+        let manual_refresh = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            true,
+            move |_start, _now, _label, period| {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+                let mut data = empty_token_analytics_data(&period);
+                data.generated_at = "manual-refresh".to_string();
+                data
+            },
+        );
+
+        let (normal_result, refresh_result) = tokio::join!(normal_miss, manual_refresh);
+
+        assert_eq!(
+            collect_count.load(Ordering::SeqCst),
+            2,
+            "manual refresh should not reuse a cache entry written by a normal miss or prewarm"
+        );
+        assert_eq!(
+            normal_result.expect("normal miss result").cache_state,
+            TokenAnalyticsCacheState::Miss
+        );
+        let refresh = refresh_result.expect("refresh result");
+        assert_eq!(refresh.cache_state, TokenAnalyticsCacheState::Bypass);
+        assert_eq!(refresh.data.generated_at, "manual-refresh");
+    }
+
+    #[tokio::test]
+    async fn concurrent_token_analytics_refreshes_are_coalesced() {
+        let suffix = TEST_PERIOD_SUFFIX.fetch_add(1, Ordering::SeqCst);
+        let period = format!("test-refresh-single-flight-{suffix}");
+        let collect_count = Arc::new(AtomicUsize::new(0));
+        let now = chrono::Utc::now();
+
+        let first_count = Arc::clone(&collect_count);
+        let first = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            true,
+            move |_start, _now, _label, period| {
+                first_count.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(StdDuration::from_millis(50));
+                empty_token_analytics_data(&period)
+            },
+        );
+
+        let second_count = Arc::clone(&collect_count);
+        let second = collect_token_analytics_with_lock_using(
+            &period,
+            1,
+            "Test Period",
+            now,
+            true,
+            move |_start, _now, _label, period| {
+                second_count.fetch_add(1, Ordering::SeqCst);
+                empty_token_analytics_data(&period)
+            },
+        );
+
+        let (first_result, second_result) = tokio::join!(first, second);
+
+        assert_eq!(
+            collect_count.load(Ordering::SeqCst),
+            1,
+            "concurrent manual refreshes should share the first refresh scan"
+        );
+        assert_eq!(
+            first_result.expect("first result").cache_state,
+            TokenAnalyticsCacheState::Bypass
+        );
+        assert_eq!(
+            second_result.expect("second result").cache_state,
+            TokenAnalyticsCacheState::Bypass
+        );
+    }
 }


### PR DESCRIPTION
Issue: #3740

Summary:
- Added a boot-time best-effort token analytics cache prewarm.
- Shared token analytics cache collection between the token analytics route and home KPI route to avoid duplicate first-load scans.
- Added fresh=1 parsing for dashboard refresh, with manual refresh bypassing pre-existing cache while coalescing concurrent fresh refreshes only.
- Documented the touched server surface in agent maintenance notes.

Validation:
- cargo fmt --check
- cargo test --lib token_analytics -- --nocapture
- cargo check --lib
- python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate
- git diff --check

Review:
- Fresh Codex adversarial review found and rechecked refresh cache races. Final verdict: VERDICT CLEAN
