### PR TITLE
Expose Discord bot token reload endpoint

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1337,10 +1337,11 @@
     relocated the `require_explicit_bearer_token` /
     `resolve_requesting_agent_id_with_pg` auth/identity helpers to
     `crate::services::kanban`).
-  - `src/server/routes/docs.rs` (5956 lines; +40 from #3556 documenting
+  - `src/server/routes/docs.rs` (5997 production lines; +40 from #3556 documenting
     the agent-to-agent turn-trigger handoff endpoint `/api/agents/{id}/handoff`
     paired example + 409 conflict error example + curl; +16 documenting the
-    `expect_reply` reply-expectation param on /message and /handoff).
+    `expect_reply` reply-expectation param on /message and /handoff; +41 from
+    #3750 documenting `/api/discord/bot-tokens/reload`).
   - `src/server/routes/escalation.rs` (1376 lines).
   - `src/server/routes/meetings.rs` (1266 lines; SQL extracted to `src/db/meetings.rs` in #3570 slice 1).
   - `src/server/routes/review_verdict/decision_route.rs` was decomposed in

--- a/docs/health-port-unification-checklist.md
+++ b/docs/health-port-unification-checklist.md
@@ -6,6 +6,8 @@ AgentDesk prompt/skill/memory assets should follow these rules after the `/api/d
 - [x] Use the active `server.port` value for local API calls such as `http://127.0.0.1:<port>/api/discord/send`.
 - [x] Do not reference `AGENTDESK_HEALTH_PORT`; the separate health listener no longer exists.
 - [x] Use `credential/announce_bot_token` and `credential/notify_bot_token` as the bot-token source for agent-to-agent routing.
+- [x] Use `POST /api/discord/bot-tokens/reload` after rotating `credential/announce_bot_token` or `credential/notify_bot_token`; each bot response has a `status` such as `reloaded` or `missing_or_invalid` plus a `previous_client_kept` boolean without exposing token material.
+- [x] Treat provider runtime bot tokens as restart-scoped: `SharedData.cached_bot_token` is a `OnceCell`, so this reload endpoint does not rotate gateway/provider bots until dcserver restarts.
 - [x] Treat `/api/health`, `/api/discord/send`, and `/api/discord/send-dm` as endpoints on the same axum server.
 
 ## Verification (2026-03-23)

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1271,6 +1271,47 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         .with_curl("curl -X POST http://localhost:8787/api/discord/send -H 'Content-Type: application/json' -d '{\"target\":\"channel:1473922824350601297\",\"content\":\"hello\",\"source\":\"system\",\"bot\":\"notify\"}'"),
         ep(
             "POST",
+            "/api/discord/bot-tokens/reload",
+            "discord",
+            "Reload announce/notify Discord utility bot tokens",
+        )
+        .with_example(
+            json!({}),
+            json!({
+                "ok": true,
+                "status": "reloaded",
+                "report": {
+                    "announce": {
+                        "bot": "announce",
+                        "credential": "credential/announce_bot_token",
+                        "status": "reloaded",
+                        "reloaded": true,
+                        "previous_client_kept": false,
+                        "user_id_cache_invalidated": true
+                    },
+                    "notify": {
+                        "bot": "notify",
+                        "credential": "credential/notify_bot_token",
+                        "status": "reloaded",
+                        "reloaded": true,
+                        "previous_client_kept": false,
+                        "user_id_cache_invalidated": true
+                    },
+                    "runtime_root_available": true,
+                    "any_reloaded": true,
+                    "utility_bot_user_ids_invalidated": true,
+                    "provider_cached_bot_token_scope": "announce/notify HealthRegistry clients are reloaded; provider runtime SharedData.cached_bot_token is restart-only"
+                }
+            }),
+        )
+        .with_error_example(
+            403,
+            json!({}),
+            json!({"ok": false, "error": "auth_token required for non-loopback host"}),
+        )
+        .with_curl("curl -X POST http://127.0.0.1:8787/api/discord/bot-tokens/reload"),
+        ep(
+            "POST",
             "/api/discord/send-to-agent",
             "discord",
             "Send a Discord message by agent role_id",

--- a/src/server/routes/domains/ops.rs
+++ b/src/server/routes/domains/ops.rs
@@ -30,6 +30,10 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
             )
             .route("/discord/send", post(health_api::send_handler))
             .route(
+                "/discord/bot-tokens/reload",
+                post(health_api::reload_discord_bot_tokens_handler),
+            )
+            .route(
                 "/discord/send-to-agent",
                 post(health_api::send_to_agent_handler),
             )

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -1684,6 +1684,70 @@ pub async fn send_handler(
     (status, Json(json)).into_response()
 }
 
+/// POST /api/discord/bot-tokens/reload — reload announce/notify REST clients.
+///
+/// This only rotates the utility bots backed by `HealthRegistry`
+/// (`credential/announce_bot_token`, `credential/notify_bot_token`). Provider
+/// runtime gateway token caches are `OnceCell`s and still require a dcserver
+/// restart; the response reports that scope explicitly.
+///
+/// See `send_handler` for the rationale on the mandatory
+/// `ConnectInfo<SocketAddr>` extractor and non-loopback Bearer requirement.
+pub async fn reload_discord_bot_tokens_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    if !discord_control_endpoints_allowed(&state.config, Some(peer_addr), &headers) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"ok": false, "error": "auth_token required for non-loopback host"})),
+        )
+            .into_response();
+    }
+
+    let Some(ref registry) = state.health_registry else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"ok": false, "error": "Discord not available (standalone mode)"})),
+        )
+            .into_response();
+    };
+
+    let report = registry.reload_bot_tokens().await;
+    let status = if !report.runtime_root_available {
+        "runtime_root_unavailable"
+    } else if report.any_reloaded {
+        "reloaded"
+    } else if report.announce.previous_client_kept || report.notify.previous_client_kept {
+        "kept_previous_no_valid_credentials"
+    } else {
+        "no_valid_credentials_loaded"
+    };
+    tracing::info!(
+        status,
+        announce = ?report.announce.status,
+        notify = ?report.notify.status,
+        utility_bot_user_ids_invalidated = report.utility_bot_user_ids_invalidated,
+        "operator-triggered Discord utility bot token reload completed"
+    );
+
+    let http_status = if report.runtime_root_available {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        http_status,
+        Json(serde_json::json!({
+            "ok": report.any_reloaded,
+            "status": status,
+            "report": report,
+        })),
+    )
+        .into_response()
+}
+
 /// POST /api/inflight/rebind — #896 orphan recovery endpoint.
 ///
 /// Rebinds a live tmux session to a freshly-created inflight state and
@@ -1806,10 +1870,11 @@ mod tests {
         public_health_json, registry_purge_decision, stale_mailbox_repair_applied,
     };
     use axum::{
-        body::Body,
+        body::{Body, to_bytes},
         http::{HeaderMap, Request, StatusCode, header::AUTHORIZATION},
     };
     use serde_json::json;
+    use std::{path::Path, sync::Arc, sync::MutexGuard};
     use tower::ServiceExt;
 
     fn empty_headers() -> HeaderMap {
@@ -1887,24 +1952,76 @@ mod tests {
     }
 
     fn test_api_router_with_config(config: crate::config::Config) -> axum::Router {
+        test_api_router_with_config_and_registry(config, None)
+    }
+
+    fn test_api_router_with_config_and_registry(
+        config: crate::config::Config,
+        health_registry: Option<Arc<crate::services::discord::health::HealthRegistry>>,
+    ) -> axum::Router {
         let mut engine_config = crate::config::Config::default();
         engine_config.policies.hot_reload = false;
         let engine = crate::engine::PolicyEngine::new(&engine_config).unwrap();
         let tx = crate::server::ws::new_broadcast();
         let buf = crate::server::ws::spawn_batch_flusher(tx.clone());
-        crate::server::routes::api_router_with_pg(engine, config, tx, buf, None, None)
+        crate::server::routes::api_router_with_pg(engine, config, tx, buf, health_registry, None)
     }
 
     fn control_request(peer: &str) -> Request<Body> {
+        control_request_for("/discord/send", peer, r#"{"content":"hello"}"#)
+    }
+
+    fn reload_bot_tokens_request(peer: &str) -> Request<Body> {
+        control_request_for("/discord/bot-tokens/reload", peer, "")
+    }
+
+    fn control_request_for(uri: &str, peer: &str, body: &str) -> Request<Body> {
         let mut request = Request::builder()
             .method("POST")
-            .uri("/discord/send")
-            .body(Body::from(r#"{"content":"hello"}"#))
+            .uri(uri)
+            .body(Body::from(body.to_string()))
             .unwrap();
         request.extensions_mut().insert(axum::extract::ConnectInfo(
             peer.parse::<std::net::SocketAddr>().unwrap(),
         ));
         request
+    }
+
+    struct EnvVarGuard {
+        key: String,
+        previous_value: Option<std::ffi::OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &str, path: &Path) -> Self {
+            let lock = crate::config::shared_test_env_lock()
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let previous_value = std::env::var_os(key);
+            unsafe { std::env::set_var(key, path) };
+            Self {
+                key: key.to_string(),
+                previous_value,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous_value {
+                Some(value) => unsafe { std::env::set_var(&self.key, value) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    fn write_test_bot_token(root: &Path, bot_name: &str, token: &str) {
+        crate::runtime_layout::ensure_credential_layout(root).unwrap();
+        let path = crate::runtime_layout::credential_token_path(root, bot_name);
+        crate::utils::secret_file::write_secret_file(&path, format!("{token}\n"))
+            .expect("write test bot token");
     }
 
     #[tokio::test]
@@ -1980,6 +2097,73 @@ mod tests {
         let response = app.oneshot(control_request("10.0.0.5:8791")).await.unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn discord_bot_token_reload_router_rejects_non_loopback_auth_token_without_bearer() {
+        let mut config = crate::config::Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        config.server.auth_token = Some("secret".to_string());
+        let app = test_api_router_with_config(config);
+
+        let response = app
+            .oneshot(reload_bot_tokens_request("10.0.0.5:8791"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn discord_bot_token_reload_router_rejects_non_loopback_without_auth_token() {
+        let mut config = crate::config::Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        let app = test_api_router_with_config(config);
+
+        let response = app
+            .oneshot(reload_bot_tokens_request("10.0.0.5:8791"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn discord_bot_token_reload_router_reports_success_without_exposing_tokens() {
+        let runtime_root = tempfile::tempdir().expect("temp runtime root");
+        let _env = EnvVarGuard::set_path("AGENTDESK_ROOT_DIR", runtime_root.path());
+        write_test_bot_token(runtime_root.path(), "announce", "announce-token");
+        write_test_bot_token(runtime_root.path(), "notify", "notify-token");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        runtime.block_on(async {
+            let mut config = crate::config::Config::default();
+            config.server.host = "0.0.0.0".to_string();
+            let registry = Arc::new(crate::services::discord::health::HealthRegistry::new());
+            let app = test_api_router_with_config_and_registry(config, Some(registry));
+
+            let response = app
+                .oneshot(reload_bot_tokens_request("127.0.0.1:8791"))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+            assert_eq!(body["ok"], true);
+            assert_eq!(body["status"], "reloaded");
+            assert_eq!(body["report"]["announce"]["status"], "reloaded");
+            assert_eq!(body["report"]["notify"]["status"], "reloaded");
+            assert_eq!(
+                body["report"]["provider_cached_bot_token_scope"],
+                "announce/notify HealthRegistry clients are reloaded; provider runtime SharedData.cached_bot_token is restart-only"
+            );
+            assert!(!String::from_utf8_lossy(&bytes).contains("announce-token"));
+            assert!(!String::from_utf8_lossy(&bytes).contains("notify-token"));
+        });
     }
 
     #[test]

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -1,7 +1,11 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::Instant;
 
 use poise::serenity_prelude as serenity;
+use serde::Serialize;
 use serenity::ChannelId;
 
 use super::SharedData;
@@ -77,6 +81,34 @@ pub(super) struct ProviderEntry {
     pub(super) shared: Arc<SharedData>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotTokenReloadStatus {
+    Reloaded,
+    MissingOrInvalid,
+    RuntimeRootUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BotTokenReloadEntry {
+    pub bot: &'static str,
+    pub credential: &'static str,
+    pub status: BotTokenReloadStatus,
+    pub reloaded: bool,
+    pub previous_client_kept: bool,
+    pub user_id_cache_invalidated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BotTokenReloadReport {
+    pub announce: BotTokenReloadEntry,
+    pub notify: BotTokenReloadEntry,
+    pub runtime_root_available: bool,
+    pub any_reloaded: bool,
+    pub utility_bot_user_ids_invalidated: bool,
+    pub provider_cached_bot_token_scope: &'static str,
+}
+
 /// Registry that providers register with so the unified axum API can query all of them.
 /// Also holds Discord HTTP clients for agent-to-agent message routing.
 pub struct HealthRegistry {
@@ -95,13 +127,15 @@ pub struct HealthRegistry {
     /// Dedicated HTTP client for the announce bot (agent-to-agent routing).
     /// This bot's messages are accepted by all agents' allowed_bot_ids.
     announce_http: tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
-    /// Cached Discord user id for the announce bot.
-    announce_user_id: tokio::sync::Mutex<Option<u64>>,
+    /// Cached Discord user id for the announce bot, paired with the token generation.
+    announce_user_id: tokio::sync::Mutex<Option<(u64, u64)>>,
+    announce_token_generation: AtomicU64,
     /// Dedicated HTTP client for the notify bot (info-only notifications).
     /// Agents do NOT process notify bot messages — use for non-actionable alerts.
     notify_http: tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
-    /// Cached Discord user id for the notify bot.
-    notify_user_id: tokio::sync::Mutex<Option<u64>>,
+    /// Cached Discord user id for the notify bot, paired with the token generation.
+    notify_user_id: tokio::sync::Mutex<Option<(u64, u64)>>,
+    notify_token_generation: AtomicU64,
 }
 
 impl HealthRegistry {
@@ -113,8 +147,10 @@ impl HealthRegistry {
             discord_http: tokio::sync::Mutex::new(Vec::new()),
             announce_http: tokio::sync::Mutex::new(None),
             announce_user_id: tokio::sync::Mutex::new(None),
+            announce_token_generation: AtomicU64::new(0),
             notify_http: tokio::sync::Mutex::new(None),
             notify_user_id: tokio::sync::Mutex::new(None),
+            notify_token_generation: AtomicU64::new(0),
         }
     }
 
@@ -328,89 +364,392 @@ impl HealthRegistry {
     /// and the cached user ids are cleared so the next call to
     /// `utility_bot_user_id` re-derives them against the new token.
     ///
-    /// Returns a tuple `(announce_loaded, notify_loaded)` so callers can
-    /// surface a clean status. Tokens that fail [`crate::credential::is_valid_bot_name`]
-    /// or whose credential file is absent leave the corresponding HTTP slot
-    /// untouched (caller can decide whether to treat that as an error).
-    // #3034: operator-triggered token-rotation entry point (#2047 Finding 11);
-    // not yet wired to an HTTP/CLI route. Keep the rotation API live.
-    #[allow(dead_code)]
-    pub async fn reload_bot_tokens(&self) -> (bool, bool) {
+    /// Returns a structured report so operator surfaces can distinguish
+    /// "reloaded", "credential missing/invalid, kept prior client", and
+    /// "runtime root unavailable" without ever exposing token material.
+    pub async fn reload_bot_tokens(&self) -> BotTokenReloadReport {
         self.reload_bot_tokens_inner(true).await
     }
 
-    async fn reload_bot_tokens_inner(&self, rotation: bool) -> (bool, bool) {
-        let mut announce_loaded = false;
-        let mut notify_loaded = false;
-        if super::runtime_store::agentdesk_root().is_some() {
-            for (bot_name, http_field, user_id_field, loaded_flag) in [
-                (
+    async fn reload_bot_tokens_inner(&self, rotation: bool) -> BotTokenReloadReport {
+        let runtime_root_available = super::runtime_store::agentdesk_root().is_some();
+        let (announce, notify) = if runtime_root_available {
+            (
+                self.reload_utility_bot_token(
                     "announce",
+                    "credential/announce_bot_token",
                     &self.announce_http,
                     &self.announce_user_id,
-                    &mut announce_loaded,
-                ),
-                (
+                    &self.announce_token_generation,
+                    rotation,
+                )
+                .await,
+                self.reload_utility_bot_token(
                     "notify",
+                    "credential/notify_bot_token",
                     &self.notify_http,
                     &self.notify_user_id,
-                    &mut notify_loaded,
-                ),
-            ] {
-                if let Some(token) = crate::credential::read_bot_token(bot_name) {
-                    let http = Arc::new(serenity::Http::new(&format!("Bot {token}")));
-                    *http_field.lock().await = Some(http);
-                    // Invalidate the cached user-id so the next utility call
-                    // re-resolves it via the rotated token; otherwise a stale
-                    // id from a revoked bot account could leak into routing.
-                    *user_id_field.lock().await = None;
-                    *loaded_flag = true;
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    let emoji = if bot_name == "announce" {
-                        "📢"
-                    } else {
-                        "🔔"
-                    };
-                    let action = if rotation { "reloaded" } else { "loaded" };
-                    tracing::info!(
-                        "  [{ts}] {emoji} {bot_name} bot {action} for /api/discord/send routing"
-                    );
-                } else if rotation {
-                    tracing::warn!(
-                        bot = bot_name,
-                        "reload_bot_tokens: credential file missing or invalid; keeping previous client"
-                    );
-                }
+                    &self.notify_token_generation,
+                    rotation,
+                )
+                .await,
+            )
+        } else {
+            let announce = self
+                .runtime_root_unavailable_reload_entry(
+                    "announce",
+                    "credential/announce_bot_token",
+                    &self.announce_http,
+                )
+                .await;
+            let notify = self
+                .runtime_root_unavailable_reload_entry(
+                    "notify",
+                    "credential/notify_bot_token",
+                    &self.notify_http,
+                )
+                .await;
+            if rotation {
+                tracing::warn!(
+                    "reload_bot_tokens called before agentdesk runtime root is initialised"
+                );
             }
-        } else if rotation {
-            tracing::warn!("reload_bot_tokens called before agentdesk runtime root is initialised");
+            (announce, notify)
+        };
+
+        BotTokenReloadReport {
+            runtime_root_available,
+            any_reloaded: announce.reloaded || notify.reloaded,
+            utility_bot_user_ids_invalidated: announce.user_id_cache_invalidated
+                || notify.user_id_cache_invalidated,
+            provider_cached_bot_token_scope: "announce/notify HealthRegistry clients are reloaded; provider runtime SharedData.cached_bot_token is restart-only",
+            announce,
+            notify,
         }
-        (announce_loaded, notify_loaded)
+    }
+
+    async fn reload_utility_bot_token(
+        &self,
+        bot_name: &'static str,
+        credential: &'static str,
+        http_field: &tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
+        user_id_field: &tokio::sync::Mutex<Option<(u64, u64)>>,
+        token_generation: &AtomicU64,
+        rotation: bool,
+    ) -> BotTokenReloadEntry {
+        if let Some(token) = crate::credential::read_bot_token(bot_name) {
+            let http = Arc::new(serenity::Http::new(&format!("Bot {token}")));
+            *http_field.lock().await = Some(http);
+            // Invalidate the cached user-id so the next utility call re-resolves
+            // it via the rotated token; otherwise a stale id from a revoked bot
+            // account could leak into routing.
+            let mut user_id = user_id_field.lock().await;
+            *user_id = None;
+            token_generation.fetch_add(1, Ordering::SeqCst);
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            let emoji = if bot_name == "announce" {
+                "📢"
+            } else {
+                "🔔"
+            };
+            let action = if rotation { "reloaded" } else { "loaded" };
+            tracing::info!(
+                "  [{ts}] {emoji} {bot_name} bot {action} for /api/discord/send routing"
+            );
+            return BotTokenReloadEntry {
+                bot: bot_name,
+                credential,
+                status: BotTokenReloadStatus::Reloaded,
+                reloaded: true,
+                previous_client_kept: false,
+                user_id_cache_invalidated: true,
+            };
+        }
+
+        let previous_client_kept = http_field.lock().await.is_some();
+        if rotation {
+            tracing::warn!(
+                bot = bot_name,
+                "reload_bot_tokens: credential file missing or invalid; keeping previous client"
+            );
+        }
+        BotTokenReloadEntry {
+            bot: bot_name,
+            credential,
+            status: BotTokenReloadStatus::MissingOrInvalid,
+            reloaded: false,
+            previous_client_kept,
+            user_id_cache_invalidated: false,
+        }
+    }
+
+    async fn runtime_root_unavailable_reload_entry(
+        &self,
+        bot_name: &'static str,
+        credential: &'static str,
+        http_field: &tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
+    ) -> BotTokenReloadEntry {
+        BotTokenReloadEntry {
+            bot: bot_name,
+            credential,
+            status: BotTokenReloadStatus::RuntimeRootUnavailable,
+            reloaded: false,
+            previous_client_kept: http_field.lock().await.is_some(),
+            user_id_cache_invalidated: false,
+        }
     }
 
     pub async fn utility_bot_user_id(&self, bot_name: &str) -> Option<u64> {
         match bot_name {
             "announce" => {
-                if let Some(id) = *self.announce_user_id.lock().await {
-                    return Some(id);
-                }
-                let http = { self.announce_http.lock().await.clone()? };
-                let user = http.get_current_user().await.ok()?;
-                let id = user.id.get();
-                *self.announce_user_id.lock().await = Some(id);
-                Some(id)
+                Self::utility_bot_user_id_from(
+                    &self.announce_http,
+                    &self.announce_user_id,
+                    &self.announce_token_generation,
+                )
+                .await
             }
             "notify" => {
-                if let Some(id) = *self.notify_user_id.lock().await {
-                    return Some(id);
-                }
-                let http = { self.notify_http.lock().await.clone()? };
-                let user = http.get_current_user().await.ok()?;
-                let id = user.id.get();
-                *self.notify_user_id.lock().await = Some(id);
-                Some(id)
+                Self::utility_bot_user_id_from(
+                    &self.notify_http,
+                    &self.notify_user_id,
+                    &self.notify_token_generation,
+                )
+                .await
             }
             _ => None,
         }
+    }
+
+    async fn utility_bot_user_id_from(
+        http_field: &tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
+        user_id_field: &tokio::sync::Mutex<Option<(u64, u64)>>,
+        token_generation: &AtomicU64,
+    ) -> Option<u64> {
+        for _ in 0..3 {
+            let current_generation = token_generation.load(Ordering::SeqCst);
+            if let Some((id, cached_generation)) = *user_id_field.lock().await
+                && cached_generation == current_generation
+            {
+                return Some(id);
+            }
+            let http = http_field.lock().await.clone()?;
+            let observed_generation = token_generation.load(Ordering::SeqCst);
+            let user = match http.get_current_user().await {
+                Ok(user) => user,
+                Err(_) => {
+                    if Self::utility_bot_http_matches_current(http_field, &http).await {
+                        return None;
+                    }
+                    continue;
+                }
+            };
+            let id = user.id.get();
+            if Self::cache_utility_bot_user_id_if_current(
+                http_field,
+                user_id_field,
+                token_generation,
+                observed_generation,
+                &http,
+                id,
+            )
+            .await
+            {
+                return Some(id);
+            }
+        }
+        None
+    }
+
+    async fn utility_bot_http_matches_current(
+        http_field: &tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
+        expected_http: &Arc<serenity::Http>,
+    ) -> bool {
+        http_field
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, expected_http))
+    }
+
+    async fn cache_utility_bot_user_id_if_current(
+        http_field: &tokio::sync::Mutex<Option<Arc<serenity::Http>>>,
+        user_id_field: &tokio::sync::Mutex<Option<(u64, u64)>>,
+        token_generation: &AtomicU64,
+        expected_generation: u64,
+        expected_http: &Arc<serenity::Http>,
+        id: u64,
+    ) -> bool {
+        if token_generation.load(Ordering::SeqCst) != expected_generation {
+            return false;
+        }
+        if !Self::utility_bot_http_matches_current(http_field, expected_http).await {
+            return false;
+        }
+        let mut cached_user_id = user_id_field.lock().await;
+        if token_generation.load(Ordering::SeqCst) != expected_generation {
+            return false;
+        }
+        if cached_user_id
+            .as_ref()
+            .is_none_or(|(_, cached_generation)| *cached_generation != expected_generation)
+        {
+            *cached_user_id = Some((id, expected_generation));
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{path::Path, sync::MutexGuard};
+    use tempfile::TempDir;
+
+    struct EnvVarGuard {
+        key: String,
+        previous_value: Option<std::ffi::OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &str, path: &Path) -> Self {
+            let lock = crate::config::shared_test_env_lock()
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let previous_value = std::env::var_os(key);
+            unsafe { std::env::set_var(key, path) };
+            Self {
+                key: key.to_string(),
+                previous_value,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous_value {
+                Some(value) => unsafe { std::env::set_var(&self.key, value) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    fn write_test_bot_token(root: &Path, bot_name: &str, token: &str) {
+        crate::runtime_layout::ensure_credential_layout(root).unwrap();
+        let path = crate::runtime_layout::credential_token_path(root, bot_name);
+        crate::utils::secret_file::write_secret_file(&path, format!("{token}\n"))
+            .expect("write test bot token");
+    }
+
+    #[test]
+    fn reload_bot_tokens_reports_success_and_invalidates_user_id_cache() {
+        let temp = TempDir::new().expect("temp runtime root");
+        let _env = EnvVarGuard::set_path("AGENTDESK_ROOT_DIR", temp.path());
+        write_test_bot_token(temp.path(), "announce", "announce-token");
+        write_test_bot_token(temp.path(), "notify", "notify-token");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        runtime.block_on(async {
+            let registry = HealthRegistry::new();
+            *registry.announce_user_id.lock().await = Some((11, 0));
+            *registry.notify_user_id.lock().await = Some((22, 0));
+
+            let report = registry.reload_bot_tokens().await;
+
+            assert!(report.runtime_root_available);
+            assert!(report.any_reloaded);
+            assert!(report.utility_bot_user_ids_invalidated);
+            assert_eq!(report.announce.status, BotTokenReloadStatus::Reloaded);
+            assert!(report.announce.reloaded);
+            assert!(report.announce.user_id_cache_invalidated);
+            assert_eq!(*registry.announce_user_id.lock().await, None);
+            assert_eq!(report.notify.status, BotTokenReloadStatus::Reloaded);
+            assert!(report.notify.reloaded);
+            assert!(report.notify.user_id_cache_invalidated);
+            assert_eq!(*registry.notify_user_id.lock().await, None);
+            assert!(resolve_bot_http(&registry, "announce").await.is_ok());
+            assert!(resolve_bot_http(&registry, "notify").await.is_ok());
+        });
+    }
+
+    #[test]
+    fn reload_bot_tokens_keeps_previous_client_when_credential_is_missing() {
+        let temp = TempDir::new().expect("temp runtime root");
+        let _env = EnvVarGuard::set_path("AGENTDESK_ROOT_DIR", temp.path());
+        write_test_bot_token(temp.path(), "announce", "announce-token");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        runtime.block_on(async {
+            let registry = HealthRegistry::new();
+            let first = registry.reload_bot_tokens().await;
+            assert_eq!(first.announce.status, BotTokenReloadStatus::Reloaded);
+            assert!(resolve_bot_http(&registry, "announce").await.is_ok());
+
+            std::fs::remove_file(crate::runtime_layout::credential_token_path(
+                temp.path(),
+                "announce",
+            ))
+            .expect("remove announce token");
+            let second = registry.reload_bot_tokens().await;
+
+            assert_eq!(
+                second.announce.status,
+                BotTokenReloadStatus::MissingOrInvalid
+            );
+            assert!(!second.announce.reloaded);
+            assert!(second.announce.previous_client_kept);
+            assert!(resolve_bot_http(&registry, "announce").await.is_ok());
+        });
+    }
+
+    #[tokio::test]
+    async fn utility_bot_user_id_cache_rejects_stale_http_after_reload() {
+        let registry = HealthRegistry::new();
+        let old_http = Arc::new(serenity::Http::new("Bot old-token"));
+        let new_http = Arc::new(serenity::Http::new("Bot new-token"));
+
+        *registry.announce_http.lock().await = Some(old_http.clone());
+        let old_generation = registry.announce_token_generation.load(Ordering::SeqCst);
+        assert!(
+            HealthRegistry::cache_utility_bot_user_id_if_current(
+                &registry.announce_http,
+                &registry.announce_user_id,
+                &registry.announce_token_generation,
+                old_generation,
+                &old_http,
+                11,
+            )
+            .await
+        );
+        assert_eq!(
+            *registry.announce_user_id.lock().await,
+            Some((11, old_generation))
+        );
+
+        registry
+            .announce_token_generation
+            .fetch_add(1, Ordering::SeqCst);
+        *registry.announce_http.lock().await = Some(new_http);
+        *registry.announce_user_id.lock().await = None;
+        assert!(
+            !HealthRegistry::cache_utility_bot_user_id_if_current(
+                &registry.announce_http,
+                &registry.announce_user_id,
+                &registry.announce_token_generation,
+                old_generation,
+                &old_http,
+                22,
+            )
+            .await
+        );
+        assert_eq!(*registry.announce_user_id.lock().await, None);
     }
 }


### PR DESCRIPTION
## Summary
- add protected `POST /api/discord/bot-tokens/reload` for announce/notify utility bot token reload
- return a structured per-bot report for reloaded, missing/invalid, kept-previous, and user-id cache invalidation state without exposing tokens
- guard utility bot user-id caches with per-bot token generations plus HTTP Arc identity checks so reload races cannot re-cache stale bot ids
- document the reload scope and provider `SharedData.cached_bot_token` restart-only boundary

Fixes #3750

## Verification
- `cargo fmt --check`
- `cargo test --lib reload_bot_tokens -- --nocapture`
- `cargo test --lib utility_bot_user_id_cache_rejects_stale_http_after_reload -- --nocapture`
- `cargo test --lib discord_bot_token_reload_router -- --nocapture`
- `cargo check --lib`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `git diff --check`
- `PYTHON=/Users/itismyfield/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 ./scripts/ci-script-checks.sh`

## Review
- Fresh Codex xhigh review: Erdos, `VERDICT: CLEAN`
