### PR TITLE
Clarify generated docs drift policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,12 @@ deprecated_note: "Legacy architecture/config references are retained for context
 
 ## 모듈 상세
 
-드리프트가 잦은 사실값은 generated docs를 source of truth로 관리한다. 아래 파일들은 `python3 scripts/generate_inventory_docs.py`로 갱신되며, CI가 stale 상태를 실패로 처리한다.
+드리프트가 잦은 사실값은 generated docs를 source of truth로 관리한다. 아래
+파일들은 `python3 scripts/generate_inventory_docs.py`로 갱신된다. 일반 PR의
+generated markdown freshness drift는 warning-only이며, 정기 `Regen inventory
+docs` workflow가 누적 drift를 maintenance PR로 갱신한다. 단, giant-file
+registry 불일치나 필수 metadata 누락처럼 generator가 검증하는 유지보수
+invariant 위반은 별도의 hard gate다.
 
 - [Module inventory](generated/module-inventory.md)
 - [Route inventory](generated/route-inventory.md)

--- a/docs/ci/release-gates.md
+++ b/docs/ci/release-gates.md
@@ -63,8 +63,24 @@ high_risk_recovery:
 
 ### Generated docs / architecture drift
 
-- `scripts/generate_inventory_docs.py --check` 은 `Script checks` job 마지막 단계에서 하드 블록 (ci-main `scripts` step, ci-pr `scripts` step).
-- 이 drift 검증이 red 면 Full/PG/High-risk 와 동일하게 release gate 위반으로 간주한다.
+- Ordinary generated markdown freshness drift is **warning-only** for PR work.
+  Stale `ARCHITECTURE.md` or `docs/generated/**` output is not equivalent to
+  Full/PG/High-risk release-gate failure unless the PR is itself changing the
+  generator, generated report wording, or the maintainability invariant that the
+  report represents.
+- `ci-pr.yml` and `ci-main.yml` run `scripts/ci-script-checks.sh`, which invokes
+  `scripts/generate_inventory_docs.py` in the CI workspace. That command may
+  update generated markdown locally for downstream checks, but generic markdown
+  freshness drift is not the hard gate. The hard failures are the generator's
+  source-of-truth invariants, such as giant-file registry drift, missing
+  metadata, parse errors, or other explicitly coded maintainability errors.
+- `ci-nightly.yml` runs `scripts/generate_inventory_docs.py --check` as
+  `Generated docs drift (warn)` and emits a GitHub warning when inventory docs
+  are stale.
+- `.github/workflows/regen-docs.yml` owns the scheduled refresh path. It runs
+  weekly, commits regenerated `ARCHITECTURE.md` / `docs/generated/**` output to a
+  maintenance branch, and opens a reviewable PR. This keeps generated docs useful
+  without forcing unrelated feature/fix PRs to carry mechanical report churn.
 
 ### Script checks Python runtime
 

--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -7,14 +7,25 @@ about the generated report or its generator.
 
 ## Current Policy
 
-- PR CI in `.github/workflows/ci-pr.yml` treats inventory-doc drift from
-  `python3 scripts/generate_inventory_docs.py --check` as warning-only. The
-  warning points contributors to the weekly refresh workflow or to a local
-  regeneration command.
+- PR CI in `.github/workflows/ci-pr.yml` does not hard-block solely on
+  inventory-doc markdown freshness drift.
+- `ci-pr.yml` and `ci-main.yml` run `scripts/ci-script-checks.sh`, which calls
+  `python3 scripts/generate_inventory_docs.py` in the CI workspace. That keeps
+  downstream maintainability checks on the current generated view, but generic
+  committed markdown freshness drift is not the hard failure and does not need
+  to be committed in unrelated PRs.
+- `ci-nightly.yml` runs `Generated docs drift (warn)` with
+  `python3 scripts/generate_inventory_docs.py --check` so accumulated drift is
+  visible without blocking ordinary PRs. That warning points contributors to
+  the weekly refresh workflow or to a local regeneration command.
 - `python3 scripts/audit_maintainability.py --check` is still allowed to fail
   for configured hard or baseline maintainability gates. The warning-only drift
   policy applies to the committed markdown report freshness, not to new
   maintainability violations.
+- `scripts/generate_inventory_docs.py` is still allowed to hard-fail on
+  source-of-truth invariants such as giant-file registry drift, missing required
+  registry metadata, or top-level architecture map parse errors. Those are not
+  generic generated-doc markdown freshness failures.
 - Do not re-introduce a hard PR gate solely because generated docs drifted.
 
 ## Rationale

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -131,7 +131,11 @@ echo "=== Portable deployable path lint ==="
   tests.test_script_python_policy \
   tests.test_analyze_prs
 
-echo "=== Generate inventory docs (also gates giant-file registry, #3036) ==="
+echo "=== Generate inventory docs (refresh workspace; gate source-of-truth invariants, #3036) ==="
+# Generic committed markdown freshness drift is warning-only for ordinary PRs
+# and is refreshed by the weekly regen-docs workflow. This CI invocation writes
+# the current generated view into the workspace so the checks below compare
+# against current source facts.
 # The generator hard-fails (exit 2) on giant-file registry drift: unregistered
 # new giants, ghost registrations left after decomposition, or deadline-less
 # [[entry]] tables in scripts/giant_file_registry.toml.


### PR DESCRIPTION
## Summary
- align release-gate docs with the warning-only generated markdown drift policy
- document the difference between generated markdown freshness and hard source-of-truth invariants
- clarify script-check comments so CI workspace regeneration is not described as a generic markdown drift hard gate
- update architecture docs to point contributors to the scheduled regen workflow

Fixes #3720

## Verification
- `bash -n scripts/ci-script-checks.sh`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `git diff --check`
- `PYTHON=/Users/itismyfield/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 ./scripts/ci-script-checks.sh`

## Review
- Fresh Codex xhigh review: Boyle, `VERDICT: CLEAN`
