### PR TITLE
fix(discord): render Codex subagent notifications as cards

### DIFF
--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -23,16 +23,13 @@ use crate::services::tui_prompt_dedupe::{
 };
 use tracing::Instrument;
 
-// #3479 rank-5: the pure injected-prompt classification + formatting policy
-// lives in a capped sibling module. Names are re-imported below so the stateful
-// dedupe/bridge call sites in this parent stay byte-identical.
 mod injected_prompt_policy;
 use self::injected_prompt_policy::{
     InjectedPromptClass, classify_injected_prompt, format_slash_command_control_note,
-    format_ssh_direct_prompt_notification, format_system_continuation_note,
-    is_slash_command_control_prompt, is_start_anchored_task_notification,
-    should_suppress_local_only_kind_note_after_continuation, slash_command_control_kind,
-    slash_command_control_prompt_is_caveat_only,
+    format_ssh_direct_prompt_notification, format_subagent_notification_card,
+    format_system_continuation_note, is_slash_command_control_prompt,
+    is_start_anchored_task_notification, should_suppress_local_only_kind_note_after_continuation,
+    slash_command_control_kind, slash_command_control_prompt_is_caveat_only,
 };
 
 // #3479 rank-10: the pure transcript/rollout prompt scanners live in a capped
@@ -523,17 +520,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
              (adding with a different bot would leave an un-removable hourglass)"
         );
     }
-    // #3099 / #3100: a compact/system continuation prologue is NOT a human request —
-    // it renders as a neutral note (no ⏳/anchor/synthetic turn) but must NOT short-
-    // circuit the whole relay (P1): the bridge tail below still relays its assistant
-    // output. #3178: a SlashCommandControl is NO LONGER suppressed — it takes the
-    // active-turn `else` block (anchor + ⏳ + synthetic inflight) so mid-/loop input
-    // queues cleanly. Only SystemContinuation suppresses the lifecycle here.
-    let is_system_continuation = injected_class.suppresses_user_turn_lifecycle();
-    debug_assert!(
-        injected_class.still_delivers_assistant_output(),
-        "every injected class must still deliver assistant output via the bridge tail",
-    );
+    let suppresses_user_turn_lifecycle = injected_class.suppresses_user_turn_lifecycle();
     // #3176: anchor id of THIS turn's synthetic inflight (set only on the anchor-
     // posting branch); the idle-tail drain-wait uses it to identity-pin our own row
     // (no self-deadlock) while still waiting on a genuinely distinct previous turn.
@@ -590,7 +577,20 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         }
         return;
     }
-    if is_system_continuation {
+    if injected_class.is_subagent_notification_event() {
+        let note = format_subagent_notification_card(&prompt.tmux_session_name, &prompt.prompt);
+        if let Err(error) = channel_id.say(&*notify_http, note).await {
+            tracing::warn!(
+                provider = %prompt.provider,
+                channel_id = channel_id.get(),
+                tmux_session_name = %prompt.tmux_session_name,
+                error = %error,
+                "failed to send subagent_notification machine-event card"
+            );
+        }
+        return;
+    }
+    if suppresses_user_turn_lifecycle {
         // #3178 (codex fix): only SystemContinuation reaches here now —
         // SlashCommandControl was removed from `suppresses_user_turn_lifecycle`
         // and takes the active-turn `else` block below.

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -14,9 +14,14 @@ use super::*;
 // so the classifier, formatters, and card parser stay in sync. The parent's
 // glob (`use super::*`) does not re-export these `use`-imported names, so the
 // child module imports them directly to keep the moved bodies byte-identical.
+use serde::Deserialize;
+
 use super::super::tui_task_card::{
     strip_terminal_controls, truncate_chars_ascii as truncate_chars,
 };
+
+const SUBAGENT_NOTIFICATION_PREVIEW_CHARS: usize = 900;
+const SUBAGENT_NOTIFICATION_PREVIEW_LINES: usize = 8;
 
 /// Classification of TUI-injected prompt text. Each class drives different
 /// lifecycle handling: human/task turns get active-turn ownership, continuation
@@ -25,6 +30,7 @@ use super::super::tui_task_card::{
 pub(super) enum InjectedPromptClass {
     HumanTuiDirect,
     TaskNotificationEvent,
+    SubagentNotificationEvent,
     SystemContinuation,
     SlashCommandControl,
 }
@@ -36,23 +42,34 @@ impl InjectedPromptClass {
         matches!(self, InjectedPromptClass::HumanTuiDirect)
     }
 
-    /// Only continuation banners suppress the active-turn lifecycle. Slash
-    /// control echoes are not human turns, but keep the full synthetic lifecycle.
+    /// Neutral machine events suppress the active-turn lifecycle. Slash control
+    /// echoes are not human turns, but keep the full synthetic lifecycle.
     pub(super) fn suppresses_user_turn_lifecycle(self) -> bool {
-        matches!(self, InjectedPromptClass::SystemContinuation)
+        matches!(
+            self,
+            InjectedPromptClass::SystemContinuation
+                | InjectedPromptClass::SubagentNotificationEvent
+        )
     }
 
-    /// Every injected class still delivers provider output via the bridge tail.
+    /// Whether this injected class should keep the provider-output bridge tail.
+    #[cfg(test)]
     pub(super) fn still_delivers_assistant_output(self) -> bool {
-        true
+        !matches!(self, InjectedPromptClass::SubagentNotificationEvent)
+    }
+
+    pub(super) fn is_subagent_notification_event(self) -> bool {
+        matches!(self, InjectedPromptClass::SubagentNotificationEvent)
     }
 }
 
 /// Pure classifier for injected TUI prompt text. Order is load-bearing:
-/// continuation banners win before task notifications and slash-control echoes.
+/// continuation banners win before machine notifications and slash-control echoes.
 pub(super) fn classify_injected_prompt(prompt: &str) -> InjectedPromptClass {
     if is_system_continuation_prompt(prompt) {
         InjectedPromptClass::SystemContinuation
+    } else if is_start_anchored_subagent_notification(prompt) {
+        InjectedPromptClass::SubagentNotificationEvent
     } else if is_task_notification_prompt(prompt) {
         InjectedPromptClass::TaskNotificationEvent
     } else if is_slash_command_control_prompt(prompt) {
@@ -136,6 +153,22 @@ pub(super) fn is_start_anchored_task_notification(prompt: &str) -> bool {
     normalized.starts_with("<task-notification>") || normalized.starts_with("<task-notification ")
 }
 
+/// Detects Codex `<subagent_notification>` envelopes as neutral machine events.
+/// This is deliberately START-ANCHORED: a human prompt that quotes the XML-ish
+/// tag mid-body remains a normal TUI-direct prompt.
+pub(super) fn is_start_anchored_subagent_notification(prompt: &str) -> bool {
+    let normalized = normalized_start_anchored_injection(prompt);
+    normalized.starts_with("<subagent_notification>")
+        || normalized.starts_with("<subagent_notification ")
+}
+
+fn normalized_start_anchored_injection(prompt: &str) -> String {
+    let normalized = strip_terminal_controls(prompt);
+    let normalized = normalized.trim_start();
+    let normalized = strip_leading_injection_wrapper(normalized);
+    normalized.trim_start().to_string()
+}
+
 /// Detects start-anchored compact/session-continuation banners.
 pub(super) fn is_system_continuation_prompt(prompt: &str) -> bool {
     let normalized = strip_terminal_controls(prompt);
@@ -183,6 +216,117 @@ pub(super) fn format_ssh_direct_prompt_notification(
         sanitize_inline_code(tmux_session_name),
         preview,
     )
+}
+
+#[derive(Debug, Deserialize)]
+struct SubagentNotificationEnvelope {
+    status: Option<SubagentNotificationStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SubagentNotificationStatus {
+    completed: Option<String>,
+    failed: Option<String>,
+}
+
+pub(super) fn format_subagent_notification_card(tmux_session_name: &str, prompt: &str) -> String {
+    match parse_subagent_notification(prompt) {
+        Ok(SubagentNotificationRender::Completed(report)) => {
+            format_subagent_notification_report(tmux_session_name, "✅", "completed", &report)
+        }
+        Ok(SubagentNotificationRender::Failed(report)) => {
+            format_subagent_notification_report(tmux_session_name, "❌", "failed", &report)
+        }
+        Ok(SubagentNotificationRender::Unknown) => format!(
+            "📋 Subagent notification (tmux : `{}`) — no completed/failed status",
+            sanitize_inline_code(tmux_session_name),
+        ),
+        Err(_) => format!(
+            "⚠️ Subagent notification (tmux : `{}`) — malformed payload omitted",
+            sanitize_inline_code(tmux_session_name),
+        ),
+    }
+}
+
+enum SubagentNotificationRender {
+    Completed(String),
+    Failed(String),
+    Unknown,
+}
+
+fn parse_subagent_notification(prompt: &str) -> Result<SubagentNotificationRender, ()> {
+    let payload = extract_subagent_notification_payload(prompt)?;
+    let envelope: SubagentNotificationEnvelope = serde_json::from_str(&payload).map_err(|_| ())?;
+    let status = envelope.status.ok_or(())?;
+    if let Some(report) = status.completed.filter(|report| !report.trim().is_empty()) {
+        return Ok(SubagentNotificationRender::Completed(report));
+    }
+    if let Some(report) = status.failed.filter(|report| !report.trim().is_empty()) {
+        return Ok(SubagentNotificationRender::Failed(report));
+    }
+    Ok(SubagentNotificationRender::Unknown)
+}
+
+fn extract_subagent_notification_payload(prompt: &str) -> Result<String, ()> {
+    const OPEN: &str = "<subagent_notification";
+    const CLOSE: &str = "</subagent_notification>";
+
+    let normalized = normalized_start_anchored_injection(prompt);
+    if !normalized.starts_with(OPEN) {
+        return Err(());
+    }
+    let after_open_name = &normalized[OPEN.len()..];
+    let Some(first) = after_open_name.chars().next() else {
+        return Err(());
+    };
+    if first != '>' && !first.is_whitespace() {
+        return Err(());
+    }
+    let open_end = normalized.find('>').ok_or(())? + 1;
+    let after_open = &normalized[open_end..];
+    let close_start = after_open.find(CLOSE).ok_or(())?;
+    Ok(after_open[..close_start].trim().to_string())
+}
+
+fn format_subagent_notification_report(
+    tmux_session_name: &str,
+    icon: &str,
+    status: &str,
+    report: &str,
+) -> String {
+    let preview = subagent_report_preview(report);
+    let mut lines = vec![format!(
+        "{icon} Subagent {status} (tmux : `{}`)",
+        sanitize_inline_code(tmux_session_name),
+    )];
+    if !preview.is_empty() {
+        lines.push(String::new());
+        lines.push(preview);
+    }
+    lines.join("\n")
+}
+
+fn subagent_report_preview(report: &str) -> String {
+    let report = strip_terminal_controls(report);
+    let mut collected: Vec<String> = Vec::new();
+    for line in report.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        collected.push(sanitize_subagent_report_line(line));
+        if collected.len() >= SUBAGENT_NOTIFICATION_PREVIEW_LINES {
+            break;
+        }
+    }
+    truncate_chars(&collected.join("\n"), SUBAGENT_NOTIFICATION_PREVIEW_CHARS)
+}
+
+fn sanitize_subagent_report_line(value: &str) -> String {
+    value
+        .replace('\r', " ")
+        .replace('\n', " ")
+        .replace("```", "` ` `")
 }
 
 /// Canonical command kind for slash-control dedupe and kind-only notes.

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -826,6 +826,107 @@ fn classify_injected_prompt_task_notification_event() {
     );
 }
 
+// #3716: Codex subagent completions arrive as start-anchored
+// `<subagent_notification>{json}</subagent_notification>` envelopes. They are
+// neutral machine events, not human direct prompts.
+#[test]
+fn classify_injected_prompt_subagent_notification_event() {
+    let unwrapped = r#"<subagent_notification>
+{"agent_path":"/tmp/agent","status":{"completed":"Read-only review complete."}}
+</subagent_notification>"#;
+    assert_eq!(
+        classify_injected_prompt(unwrapped),
+        InjectedPromptClass::SubagentNotificationEvent,
+    );
+    assert!(
+        super::injected_prompt_policy::is_start_anchored_subagent_notification(unwrapped),
+        "bare subagent_notification must pass the start-anchored detector"
+    );
+
+    let wrapped = "터미널에 직접 주입된 입력 (tmux : `AgentDesk-codex-adk-cdx`):\n```text\n\
+<subagent_notification>\n{\"status\":{\"completed\":\"done\"}}\n</subagent_notification>\n```";
+    assert_eq!(
+        classify_injected_prompt(wrapped),
+        InjectedPromptClass::SubagentNotificationEvent,
+    );
+    assert!(
+        super::injected_prompt_policy::is_start_anchored_subagent_notification(wrapped),
+        "wrapped subagent_notification must pass after peeling the direct-injection wrapper"
+    );
+
+    let quoted = "please inspect this log line:\n<subagent_notification>{\"status\":{\"completed\":\"x\"}}</subagent_notification>";
+    assert_eq!(
+        classify_injected_prompt(quoted),
+        InjectedPromptClass::HumanTuiDirect,
+        "a human quote of the envelope mid-body must stay a normal direct prompt",
+    );
+    assert!(
+        !super::injected_prompt_policy::is_start_anchored_subagent_notification(quoted),
+        "mid-body quote must not pass the start-anchored detector"
+    );
+}
+
+#[test]
+fn subagent_notification_card_completed_hides_raw_envelope() {
+    let prompt = r#"<subagent_notification>
+{"agent_path":"/tmp/private-agent","status":{"completed":"Read-only review complete.\n\n1. Make /api/docs route-derived.\n2. Resolve generated-doc drift policy."}}
+</subagent_notification>"#;
+
+    let output = format_subagent_notification_card("AgentDesk-codex-adk-cdx", prompt);
+
+    assert!(output.contains("Subagent completed"));
+    assert!(output.contains("Read-only review complete."));
+    assert!(output.contains("1. Make /api/docs route-derived."));
+    assert!(output.contains("(tmux : `AgentDesk-codex-adk-cdx`)"));
+    assert!(!output.contains("터미널에 직접 주입된 입력"));
+    assert!(!output.contains("<subagent_notification>"));
+    assert!(!output.contains("agent_path"));
+    assert!(!output.contains("/tmp/private-agent"));
+    assert!(!output.contains("{\""));
+}
+
+#[test]
+fn subagent_notification_card_failed_hides_raw_envelope() {
+    let prompt = r#"<subagent_notification>{"status":{"failed":"Review failed: missing test coverage."}}</subagent_notification>"#;
+
+    let output = format_subagent_notification_card("tmux`name", prompt);
+
+    assert!(output.contains("Subagent failed"));
+    assert!(output.contains("Review failed: missing test coverage."));
+    assert!(output.contains("(tmux : `tmux'name`)"));
+    assert!(!output.contains("<subagent_notification>"));
+    assert!(!output.contains("{\"status\""));
+}
+
+#[test]
+fn subagent_notification_card_truncates_long_report() {
+    let long_report = "x".repeat(1_200);
+    let prompt = format!(
+        "<subagent_notification>{{\"status\":{{\"completed\":\"{long_report}\"}}}}</subagent_notification>"
+    );
+
+    let output = format_subagent_notification_card("sess", &prompt);
+
+    assert!(output.contains("Subagent completed"));
+    assert!(output.contains("..."));
+    assert!(output.len() < prompt.len());
+}
+
+#[test]
+fn subagent_notification_card_malformed_payload_omits_raw_payload() {
+    let prompt =
+        "<subagent_notification>{not-json agent_path=/tmp/private}</subagent_notification>";
+
+    let output = format_subagent_notification_card("sess", prompt);
+
+    assert!(output.contains("Subagent notification"));
+    assert!(output.contains("malformed payload omitted"));
+    assert!(!output.contains("not-json"));
+    assert!(!output.contains("agent_path"));
+    assert!(!output.contains("/tmp/private"));
+    assert!(!output.contains("<subagent_notification>"));
+}
+
 // #3393 finding 2: the live-panel terminal BRIDGE is gated on a START-ANCHORED
 // check, distinct from the contains-based CARD classifier. A human direct
 // prompt that QUOTES a notification (embedding a LIVE tool-use-id) still earns
@@ -1385,6 +1486,14 @@ fn system_continuation_suppresses_user_turn_but_still_delivers_output() {
         "SystemContinuation must still relay Claude's assistant output (no orphaning)"
     );
     assert!(!cont.is_human_active_turn());
+
+    // A subagent_notification is a terminal machine-event card, not a model
+    // prologue: it suppresses the user-turn lifecycle and does not keep the
+    // provider-output bridge tail.
+    let subagent = InjectedPromptClass::SubagentNotificationEvent;
+    assert!(subagent.suppresses_user_turn_lifecycle());
+    assert!(!subagent.still_delivers_assistant_output());
+    assert!(!subagent.is_human_active_turn());
 
     // Human + task-notification turns keep their user-turn lifecycle AND
     // deliver output.


### PR DESCRIPTION
## Summary

Fixes #3716.

Codex `<subagent_notification>` TUI injections now render as compact Discord machine-event cards instead of raw SSH-direct prompt blocks.

## Changes

- Classify only start-anchored `<subagent_notification>` envelopes as neutral `SubagentNotificationEvent` machine events.
- Parse the JSON envelope defensively and render completed/failed reports as bounded previews.
- Hide raw XML, raw JSON, and `agent_path` from Discord output; malformed payloads get a compact omitted-payload note.
- Keep mid-body human quotes as normal `HumanTuiDirect` prompts.
- Avoid active-turn anchor/⏳/synthetic inflight lifecycle for subagent notification events.

## Validation

- `cargo fmt --check`
- `cargo check --lib`
- `cargo test --lib subagent_notification -- --nocapture`
- `AGENTDESK_ROOT_DIR=$(mktemp -d ...) cargo test --lib services::discord::tui_prompt_relay::tests -- --test-threads=1`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `git diff --check`
- `PYTHON=/Users/itismyfield/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 ./scripts/ci-script-checks.sh`
- Fresh Codex xhigh adversarial review: `VERDICT: CLEAN`

Notes: existing warnings remain for `legacy-sqlite-tests` cfg and pre-existing unused imports.
