### PR TITLE
Fix status panel footer ownership flicker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,6 +524,8 @@ src/
 │   │   │   ├── read.rs
 │   │   │   ├── validation.rs
 │   │   │   └── write.rs
+│   │   ├── single_message_panel/
+│   │   │   └── completion_footer_registry.rs
 │   │   ├── tmux_watcher/
 │   │   │   ├── commit_decisions.rs
 │   │   │   ├── completion_gate.rs
@@ -654,6 +656,7 @@ src/
 │   │   ├── relay_health.rs
 │   │   ├── relay_owner_observability.rs
 │   │   ├── relay_recovery.rs
+│   │   ├── relay_recovery_completion_footer.rs
 │   │   ├── replace_outcome_policy.rs
 │   │   ├── response_sanitizer.rs
 │   │   ├── restart_ctrl.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -929,7 +929,7 @@
     marker suppression for stop-control transcript envelopes; +62 from #3304:
     slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3433 lines; -5 net from #3711/#3712 extracting rebind runtime/output-path resolution to
+  - `src/services/discord/recovery_engine.rs` (3437 lines; -5 net from #3711/#3712 extracting rebind runtime/output-path resolution to
     `recovery_engine/rebind_runtime.rs` while adding direct Codex TUI detection
     so rebind can rebuild rollout bindings when possible and return 409 instead
     of synthesizing inert legacy-wrapper inflight rows; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +26 from #3680 relay recovery review hardening; +9 from #3582 stamping
@@ -993,10 +993,13 @@
     short-replace through the unified controller behind a flag (default OFF) — the
     one-arm gate at `relay_recovered_terminal_text_to_placeholder` is offset by
     non-#-tag prose-comment compaction in the same root, the cutover body lives in
-    the sub-1000-prod-LoC sibling `recovery_paths/controller_cutover.rs`).
-  - `src/services/discord/relay_recovery.rs` (1007 lines; #3680 split relay
+    the sub-1000-prod-LoC sibling `recovery_paths/controller_cutover.rs`; +4 from
+    #3717 guarding completion-footer registry forgets by the exact takeover
+    message id).
+  - `src/services/discord/relay_recovery.rs` (1006 lines; #3680 split relay
     recovery reattach/self-heal path; new behavior is bugfix-only until a
-    follow-up extraction drops it below the giant-file threshold).
+    follow-up extraction drops it below the giant-file threshold; net -1 from
+    #3717 moving completion-footer target ownership cleanup to a sibling helper).
   - `src/services/discord/health.rs` (417 prod lines after the #3038 Phase A
     directory decomposition; module root keeps the `HealthRegistry` core +
     re-export surface, and the former monolith body lives in flat

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -6,6 +6,7 @@ use super::settings::{
     load_last_remote_profile, load_last_session_path, resolve_role_binding,
     validate_bot_channel_routing_with_provider_channel,
 };
+use super::single_message_panel as smp;
 use super::turn_bridge::stale_inflight_message;
 use super::*;
 use crate::db::turns::TurnTokenUsage;
@@ -321,10 +322,6 @@ fn should_advance_recovery_dispatch_after_relay(relay_ok: bool) -> bool {
     relay_ok
 }
 
-fn forget_completion_footer_for_recovery_takeover(channel_id: ChannelId) {
-    super::single_message_panel::completion_footer_forget_registered_target(channel_id);
-}
-
 async fn relay_recovery_terminal_notice(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
@@ -357,7 +354,9 @@ pub(in crate::services::discord) async fn relay_recovered_terminal_text_to_place
     placeholder: Option<MessageId>,
     text: &str,
 ) -> RecoveryRelayOutcome {
-    forget_completion_footer_for_recovery_takeover(channel_id);
+    if let Some(placeholder) = placeholder {
+        smp::completion_footer_forget_registered_target_if_message(channel_id, placeholder);
+    }
     let delivery = match placeholder {
         Some(placeholder) => {
             use super::recovery_paths::controller_cutover as cc;
@@ -703,7 +702,11 @@ mod recovery_completion_outcome_tests {
             true,
         );
 
-        super::forget_completion_footer_for_recovery_takeover(channel_id);
+        assert!(
+            super::super::single_message_panel::completion_footer_forget_registered_target_if_message(
+            channel_id,
+            MessageId::new(3_089_301),
+        ));
 
         assert_eq!(
             super::super::single_message_panel::completion_footer_edit_for_registered_target_at(
@@ -714,6 +717,39 @@ mod recovery_completion_outcome_tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn recovery_takeover_keeps_different_completion_footer_target() {
+        let channel_id = ChannelId::new(3_089_211);
+        let shared = super::super::make_shared_data_for_tests();
+        super::super::single_message_panel::completion_footer_forget_registered_target(channel_id);
+        let _ = super::super::single_message_panel::register_completion_footer_target(
+            channel_id,
+            MessageId::new(3_089_311),
+            &ProviderKind::Claude,
+            1_800_000_000,
+            "Final answer",
+            None,
+            true,
+        );
+
+        assert!(
+            !super::super::single_message_panel::completion_footer_forget_registered_target_if_message(
+            channel_id,
+            MessageId::new(3_089_312),
+        ));
+
+        assert!(
+            super::super::single_message_panel::completion_footer_edit_for_registered_target_at(
+                shared.as_ref(),
+                channel_id,
+                "⠸",
+                1_800_000_005,
+            )
+            .is_some()
+        );
+        super::super::single_message_panel::completion_footer_forget_registered_target(channel_id);
     }
 }
 
@@ -3719,7 +3755,12 @@ pub(crate) async fn rebind_inflight_for_channel(
         }
         state
     };
-    forget_completion_footer_for_recovery_takeover(discord_channel_id);
+    if let Some(current_msg_id) = optional_message_id(recovered_state_for_session.current_msg_id) {
+        smp::completion_footer_forget_registered_target_if_message(
+            discord_channel_id,
+            current_msg_id,
+        );
+    }
 
     // Register / refresh the in-memory session so downstream handlers can
     // locate this channel after the rebind.

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -22,6 +22,9 @@ use crate::services::provider::ProviderKind;
 const AUTO_HEAL_WINDOW_SECS: i64 = 600;
 const AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW: u32 = 1;
 
+#[path = "relay_recovery_completion_footer.rs"]
+mod completion_footer;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(in crate::services::discord) enum RelayRecoveryActionKind {
@@ -681,10 +684,6 @@ fn relay_frontier_dead_reattach_owner(decision: &RelayRecoveryDecision) -> Optio
     ))
 }
 
-fn forget_completion_footer_for_relay_recovery(channel_id: ChannelId) {
-    super::single_message_panel::completion_footer_forget_registered_target(channel_id);
-}
-
 fn idle_tmux_repair_ready_for_input(
     provider: &ProviderKind,
     channel_id: u64,
@@ -822,7 +821,7 @@ async fn apply_relay_recovery_decision(
         }
         RelayRecoveryActionKind::ReattachWatcher => {
             let channel = ChannelId::new(decision.channel_id);
-            forget_completion_footer_for_relay_recovery(channel);
+            completion_footer::forget_if_message(channel, decision.affected.bridge_current_msg_id);
             if let Some(tmux_session) = decision.affected.tmux_session.as_deref()
                 && decision.evidence.unread_bytes.unwrap_or(0) == 0
                 && idle_tmux_repair_ready_for_input(provider, decision.channel_id, tmux_session)
@@ -1098,7 +1097,10 @@ mod tests {
             true,
         );
 
-        forget_completion_footer_for_relay_recovery(channel_id);
+        assert!(completion_footer::forget_if_message(
+            channel_id,
+            Some(3_089_303),
+        ));
 
         assert_eq!(
             super::super::single_message_panel::completion_footer_edit_for_registered_target_at(
@@ -1109,6 +1111,38 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn relay_recovery_takeover_keeps_different_completion_footer_target() {
+        let channel_id = ChannelId::new(3_089_213);
+        let shared = super::super::make_shared_data_for_tests();
+        super::super::single_message_panel::completion_footer_forget_registered_target(channel_id);
+        let _ = super::super::single_message_panel::register_completion_footer_target(
+            channel_id,
+            MessageId::new(3_089_313),
+            &ProviderKind::Codex,
+            1_800_000_000,
+            "Final answer",
+            None,
+            true,
+        );
+
+        assert!(!completion_footer::forget_if_message(
+            channel_id,
+            Some(3_089_314),
+        ));
+
+        assert!(
+            super::super::single_message_panel::completion_footer_edit_for_registered_target_at(
+                shared.as_ref(),
+                channel_id,
+                "⠸",
+                1_800_000_005,
+            )
+            .is_some()
+        );
+        super::super::single_message_panel::completion_footer_forget_registered_target(channel_id);
     }
 
     #[test]

--- a/src/services/discord/relay_recovery_completion_footer.rs
+++ b/src/services/discord/relay_recovery_completion_footer.rs
@@ -1,0 +1,9 @@
+use poise::serenity_prelude::{ChannelId, MessageId};
+
+pub(super) fn forget_if_message(channel_id: ChannelId, message_id: Option<u64>) -> bool {
+    message_id.map(MessageId::new).is_some_and(|message_id| {
+        super::super::single_message_panel::completion_footer_forget_registered_target_if_message(
+            channel_id, message_id,
+        )
+    })
+}

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
 
-use poise::serenity_prelude::{ChannelId, MessageId};
+mod completion_footer_registry;
+
+pub(in crate::services::discord) use completion_footer_registry::*;
 
 /// Byte budget for the COMPLETION footer task section (#3089 S3) — the final
 /// turn message keeps a compact task summary. The LIVE streaming panel uses the
@@ -27,32 +28,6 @@ pub(in crate::services::discord) fn single_message_panel_spinner_frame(
     index: usize,
 ) -> &'static str {
     SINGLE_MESSAGE_PANEL_SPINNER_FRAMES[index % SINGLE_MESSAGE_PANEL_SPINNER_FRAMES.len()]
-}
-
-#[derive(Debug, Clone)]
-struct RegisteredCompletionFooter {
-    message_id: MessageId,
-    provider: super::ProviderKind,
-    base_body: String,
-    last_completion_block: Option<String>,
-    registered_at_unix: i64,
-    consecutive_edit_failures: u8,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::services::discord) struct CompletionFooterEdit {
-    pub(in crate::services::discord) message_id: MessageId,
-    pub(in crate::services::discord) text: String,
-    pub(in crate::services::discord) remove_after_edit: bool,
-    completion_block: Option<String>,
-    // #3391: identities of terminal task/subagent slots in `text`; evicted by
-    // slot identity (not line string) once this edit is delivered.
-    delivered_terminal_ids: Vec<super::placeholder_live_events::TerminalSlotId>,
-}
-
-fn completion_footer_registry() -> &'static Mutex<HashMap<u64, RegisteredCompletionFooter>> {
-    static REGISTRY: OnceLock<Mutex<HashMap<u64, RegisteredCompletionFooter>>> = OnceLock::new();
-    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 pub(in crate::services::discord) fn enabled() -> bool {
@@ -208,225 +183,6 @@ pub(in crate::services::discord) fn completion_footer_base_body(
     provider: &super::ProviderKind,
 ) -> String {
     strip_streaming_footer(text, provider).unwrap_or_else(|| text.trim_end().to_string())
-}
-
-pub(in crate::services::discord) fn register_completion_footer_target(
-    channel_id: ChannelId,
-    message_id: MessageId,
-    provider: &super::ProviderKind,
-    registered_at_unix: i64,
-    base_body: &str,
-    completion_block: Option<&str>,
-    has_unfinished_entries: bool,
-) -> Option<CompletionFooterEdit> {
-    let mut guard = completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let previous = guard.remove(&channel_id.get());
-    if has_unfinished_entries {
-        let base_body = completion_footer_base_body(base_body, provider);
-        guard.insert(
-            channel_id.get(),
-            RegisteredCompletionFooter {
-                message_id,
-                provider: provider.clone(),
-                base_body,
-                last_completion_block: completion_block.map(str::to_string),
-                registered_at_unix,
-                consecutive_edit_failures: 0,
-            },
-        );
-    }
-    previous
-        .filter(|target| target.message_id != message_id)
-        .map(supersede_edit_from_registered_target)
-}
-
-pub(in crate::services::discord) fn completion_footer_supersede_registered_target(
-    channel_id: ChannelId,
-) -> Option<CompletionFooterEdit> {
-    completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .remove(&channel_id.get())
-        .map(supersede_edit_from_registered_target)
-}
-
-#[cfg(test)]
-pub(in crate::services::discord) fn completion_footer_registered_failure_count(
-    channel_id: ChannelId,
-) -> Option<u8> {
-    completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(&channel_id.get())
-        .map(|target| target.consecutive_edit_failures)
-}
-
-pub(in crate::services::discord) fn completion_footer_has_registered_target(
-    channel_id: ChannelId,
-) -> bool {
-    completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .contains_key(&channel_id.get())
-}
-
-pub(in crate::services::discord) fn completion_footer_edit_for_registered_target(
-    shared: &super::SharedData,
-    channel_id: ChannelId,
-    indicator: &str,
-) -> Option<CompletionFooterEdit> {
-    completion_footer_edit_for_registered_target_at(
-        shared,
-        channel_id,
-        indicator,
-        chrono::Utc::now().timestamp(),
-    )
-}
-
-pub(in crate::services::discord) fn completion_footer_edit_for_registered_target_at(
-    shared: &super::SharedData,
-    channel_id: ChannelId,
-    indicator: &str,
-    now_unix: i64,
-) -> Option<CompletionFooterEdit> {
-    let target = completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(&channel_id.get())
-        .cloned()?;
-    let idle_expired =
-        completion_footer_idle_animation_expired(target.registered_at_unix, now_unix);
-    let render_indicator = if idle_expired {
-        COMPLETION_FOOTER_IDLE_EXPIRED_INDICATOR
-    } else {
-        indicator
-    };
-    let rendered = shared.ui.placeholder_live_events.render_completion_footer(
-        channel_id,
-        &target.provider,
-        render_indicator,
-    );
-    let completion_block = rendered.block;
-    let text = compose_completion_footer_text(&target.base_body, completion_block.as_deref());
-    if text.trim().is_empty() {
-        if idle_expired {
-            completion_footer_forget_registered_target(channel_id);
-        }
-        return None;
-    }
-    Some(CompletionFooterEdit {
-        message_id: target.message_id,
-        text,
-        remove_after_edit: idle_expired || !rendered.has_unfinished_entries,
-        completion_block,
-        delivered_terminal_ids: rendered.delivered_terminal_ids,
-    })
-}
-
-fn completion_footer_idle_animation_expired(registered_at_unix: i64, now_unix: i64) -> bool {
-    now_unix.saturating_sub(registered_at_unix) >= COMPLETION_FOOTER_MAX_IDLE_ANIMATION_SECS
-}
-
-pub(in crate::services::discord) fn completion_footer_record_edit_result(
-    channel_id: ChannelId,
-    remove_after_edit: bool,
-    edited: bool,
-) {
-    completion_footer_record_edit_result_with_block(channel_id, remove_after_edit, edited, None);
-}
-
-pub(in crate::services::discord) fn completion_footer_record_edit_result_for_edit(
-    shared: &super::SharedData,
-    channel_id: ChannelId,
-    edit: &CompletionFooterEdit,
-    edited: bool,
-) {
-    completion_footer_record_edit_result_with_block(
-        channel_id,
-        edit.remove_after_edit,
-        edited,
-        edit.completion_block.as_deref(),
-    );
-    // #3391: this edit delivered the terminal marks once; evict those slot
-    // identities so the next render (and any #3386 migration footer) drops the
-    // completed task AND subagent entries.
-    if edited {
-        shared
-            .ui
-            .placeholder_live_events
-            .evict_delivered_terminal_footer_tasks(channel_id, &edit.delivered_terminal_ids);
-    }
-}
-
-fn completion_footer_record_edit_result_with_block(
-    channel_id: ChannelId,
-    remove_after_edit: bool,
-    edited: bool,
-    completion_block: Option<&str>,
-) {
-    if remove_after_edit {
-        completion_footer_forget_registered_target(channel_id);
-        return;
-    }
-
-    let mut guard = completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let Some(target) = guard.get_mut(&channel_id.get()) else {
-        return;
-    };
-    if edited {
-        target.consecutive_edit_failures = 0;
-        if let Some(block) = completion_block {
-            target.last_completion_block = Some(block.to_string());
-        }
-        return;
-    }
-    target.consecutive_edit_failures = target.consecutive_edit_failures.saturating_add(1);
-    if target.consecutive_edit_failures >= COMPLETION_FOOTER_MAX_CONSECUTIVE_EDIT_FAILURES {
-        guard.remove(&channel_id.get());
-    }
-}
-
-fn supersede_edit_from_registered_target(
-    target: RegisteredCompletionFooter,
-) -> CompletionFooterEdit {
-    let completion_block = target
-        .last_completion_block
-        .as_deref()
-        .map(freeze_completion_footer_block);
-    let text = compose_completion_footer_text(&target.base_body, completion_block.as_deref());
-    CompletionFooterEdit {
-        message_id: target.message_id,
-        text,
-        remove_after_edit: true,
-        completion_block,
-        // #3391 migration-race rule: a frozen supersede snapshot never counts
-        // as "the once" — it carries only the last delivered block string with
-        // no slot identity. Terminal marks in it were either already evicted by
-        // a confirmed live delivery, or (failed-edit race) render once more on
-        // the new target and evict on that delivery; a ✓ is never lost.
-        delivered_terminal_ids: Vec::new(),
-    }
-}
-
-fn freeze_completion_footer_block(block: &str) -> String {
-    SINGLE_MESSAGE_PANEL_SPINNER_FRAMES
-        .iter()
-        .fold(block.to_string(), |acc, frame| {
-            acc.replace(frame, COMPLETION_FOOTER_IDLE_EXPIRED_INDICATOR)
-        })
-}
-
-pub(in crate::services::discord) fn completion_footer_forget_registered_target(
-    channel_id: ChannelId,
-) {
-    completion_footer_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .remove(&channel_id.get());
 }
 
 fn compose_merged_footer_status_block(indicator: &str, panel_text: &str) -> Option<String> {
@@ -2064,6 +1820,557 @@ mod tests {
 
         super::completion_footer_record_edit_result(channel_id, edit.remove_after_edit, true);
         assert!(super::completion_footer_has_registered_target(channel_id));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn completion_footer_skips_refresh_when_committed_text_is_unchanged_3717() {
+        let channel_id = ChannelId::new(3_717_001);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let now = 1_800_000_000;
+        let _ = super::register_completion_footer_target(
+            channel_id,
+            MessageId::new(3_717_101),
+            &ProviderKind::Claude,
+            now,
+            "Final answer",
+            None,
+            true,
+        );
+
+        let first = super::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠸",
+            now + 1,
+        )
+        .expect("first refresh should edit the footer");
+        assert!(first.text.contains('⠸'));
+        super::completion_footer_record_edit_result_for_edit(
+            shared.as_ref(),
+            channel_id,
+            &first,
+            true,
+        );
+
+        assert_eq!(
+            super::completion_footer_edit_for_registered_target_at(
+                shared.as_ref(),
+                channel_id,
+                "⠸",
+                now + 2,
+            ),
+            None,
+            "same rendered footer text must not issue a redundant Discord edit"
+        );
+
+        let next = super::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠼",
+            now + 3,
+        )
+        .expect("changed spinner frame still edits the stable target");
+        assert_eq!(next.message_id, MessageId::new(3_717_101));
+        assert!(next.text.contains('⠼'));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn duplicate_same_message_registration_preserves_committed_noop_state_3717() {
+        let channel_id = ChannelId::new(3_717_002);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let msg_id = MessageId::new(3_717_102);
+        let now = 1_800_000_000;
+        let _ = super::register_completion_footer_target(
+            channel_id,
+            msg_id,
+            &ProviderKind::Claude,
+            now,
+            "Final answer",
+            None,
+            true,
+        );
+        let first = super::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠸",
+            now + 1,
+        )
+        .expect("first refresh should edit the footer");
+        super::completion_footer_record_edit_result_for_edit(
+            shared.as_ref(),
+            channel_id,
+            &first,
+            true,
+        );
+
+        assert_eq!(
+            super::register_completion_footer_target(
+                channel_id,
+                msg_id,
+                &ProviderKind::Claude,
+                now + 2,
+                "Final answer",
+                first.completion_block.as_deref(),
+                true,
+            ),
+            None,
+            "same message id is a duplicate registration, not a supersede"
+        );
+        assert_eq!(
+            super::completion_footer_edit_for_registered_target_at(
+                shared.as_ref(),
+                channel_id,
+                "⠸",
+                now + 3,
+            ),
+            None,
+            "duplicate registration must not lose the committed-text dedupe state"
+        );
+
+        let changed = super::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠼",
+            now + 4,
+        )
+        .expect("changed content still edits the original stable target");
+        assert_eq!(changed.message_id, msg_id);
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn stale_owner_cannot_refresh_newer_footer_target_3717() {
+        let channel_id = ChannelId::new(3_717_003);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(10, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(11, 1_800_000_010);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_103),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::completion_footer_edit_for_registered_target_at_for_owner(
+                shared.as_ref(),
+                channel_id,
+                Some(old_owner),
+                "⠸",
+                1_800_000_011,
+            ),
+            None,
+            "older owner must not edit the newer registered footer target"
+        );
+
+        let edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(new_owner),
+            "⠸",
+            1_800_000_012,
+        )
+        .expect("registered owner should refresh its target");
+        assert_eq!(edit.message_id, MessageId::new(3_717_103));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn stale_owner_cannot_register_over_newer_footer_target_3717() {
+        let channel_id = ChannelId::new(3_717_007);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(50, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(51, 1_800_000_010);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_108),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::register_completion_footer_target_for_owner(
+                channel_id,
+                MessageId::new(3_717_109),
+                old_owner,
+                &ProviderKind::Claude,
+                old_owner.started_at_unix,
+                "Old answer",
+                None,
+                true,
+            ),
+            None,
+            "older completion must not replace the newer registered footer target"
+        );
+
+        let edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(new_owner),
+            "⠸",
+            1_800_000_011,
+        )
+        .expect("newer target should remain registered after stale register attempt");
+        assert_eq!(edit.message_id, MessageId::new(3_717_108));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn stale_edit_snapshot_is_not_current_after_target_changes_3717() {
+        let channel_id = ChannelId::new(3_717_009);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(70, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(71, 1_800_000_010);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_112),
+            old_owner,
+            &ProviderKind::Claude,
+            old_owner.started_at_unix,
+            "Old answer",
+            None,
+            true,
+        );
+        let old_edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(old_owner),
+            "⠸",
+            1_800_000_001,
+        )
+        .expect("old owner should initially receive an edit");
+        assert!(super::completion_footer_edit_still_registered(
+            channel_id, &old_edit
+        ));
+
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_113),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        assert!(
+            !super::completion_footer_edit_still_registered(channel_id, &old_edit),
+            "refresh callers must skip an edit snapshot after another target registers"
+        );
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn stale_owner_cannot_clear_newer_footer_target_3717() {
+        let channel_id = ChannelId::new(3_717_008);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(60, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(61, 1_800_000_010);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_110),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::register_completion_footer_target_for_owner(
+                channel_id,
+                MessageId::new(3_717_111),
+                old_owner,
+                &ProviderKind::Claude,
+                old_owner.started_at_unix,
+                "Old answer",
+                None,
+                false,
+            ),
+            None,
+            "older no-residual completion must not clear the newer footer target"
+        );
+
+        let edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(new_owner),
+            "⠸",
+            1_800_000_011,
+        )
+        .expect("newer target should remain registered after stale clear attempt");
+        assert_eq!(edit.message_id, MessageId::new(3_717_110));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn stale_edit_result_cannot_remove_newer_footer_target_3717() {
+        let channel_id = ChannelId::new(3_717_004);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(20, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(21, 1_800_000_010);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_104),
+            old_owner,
+            &ProviderKind::Claude,
+            old_owner.started_at_unix,
+            "Old answer",
+            None,
+            true,
+        );
+        let old_edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(old_owner),
+            "⠸",
+            1_800_000_001,
+        )
+        .expect("old owner should initially receive an edit");
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_105),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        let mut stale_remove = old_edit.clone();
+        stale_remove.remove_after_edit = true;
+        super::completion_footer_record_edit_result_for_edit(
+            shared.as_ref(),
+            channel_id,
+            &stale_remove,
+            true,
+        );
+
+        let new_edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(new_owner),
+            "⠼",
+            1_800_000_011,
+        )
+        .expect("stale edit result must not remove the newer target");
+        assert_eq!(new_edit.message_id, MessageId::new(3_717_105));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn older_turn_start_cannot_supersede_newer_footer_target_3717() {
+        let channel_id = ChannelId::new(3_717_005);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(30, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(31, 1_800_000_010);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_106),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::completion_footer_supersede_registered_target_for_owner(
+                channel_id,
+                Some(old_owner)
+            ),
+            None,
+            "older turn-start cleanup must not supersede the newer footer target"
+        );
+        assert!(
+            super::completion_footer_edit_for_registered_target_at_for_owner(
+                shared.as_ref(),
+                channel_id,
+                Some(new_owner),
+                "⠸",
+                1_800_000_011,
+            )
+            .is_some(),
+            "newer target should remain registered after stale supersede attempt"
+        );
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn same_second_lower_snowflake_cannot_supersede_higher_footer_owner_3717() {
+        let channel_id = ChannelId::new(3_717_006);
+        super::completion_footer_forget_registered_target(channel_id);
+        let old_owner = super::CompletionFooterOwner::new(40, 1_800_000_000);
+        let new_owner = super::CompletionFooterOwner::new(41, 1_800_000_000);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_107),
+            new_owner,
+            &ProviderKind::Claude,
+            new_owner.started_at_unix,
+            "New answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::completion_footer_supersede_registered_target_for_owner(
+                channel_id,
+                Some(old_owner)
+            ),
+            None,
+            "same-second stale owner with lower Discord snowflake must not supersede"
+        );
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn same_second_unknown_owner_does_not_block_known_owner_3717() {
+        let channel_id = ChannelId::new(3_717_010);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let unknown_owner = super::CompletionFooterOwner::new(0, 1_800_000_000);
+        let known_owner = super::CompletionFooterOwner::new(81, 1_800_000_000);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_114),
+            unknown_owner,
+            &ProviderKind::Claude,
+            unknown_owner.started_at_unix,
+            "Unknown owner answer",
+            None,
+            true,
+        );
+
+        assert!(
+            super::register_completion_footer_target_for_owner(
+                channel_id,
+                MessageId::new(3_717_115),
+                known_owner,
+                &ProviderKind::Claude,
+                known_owner.started_at_unix,
+                "Known owner answer",
+                None,
+                true,
+            )
+            .is_some(),
+            "same-second user_msg_id=0 owner must not be treated as provably newer"
+        );
+        let edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(known_owner),
+            "⠸",
+            1_800_000_001,
+        )
+        .expect("known owner should replace same-second unknown target");
+        assert_eq!(edit.message_id, MessageId::new(3_717_115));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn same_second_unknown_owner_cannot_register_over_known_owner_3717() {
+        let channel_id = ChannelId::new(3_717_011);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let known_owner = super::CompletionFooterOwner::new(81, 1_800_000_000);
+        let unknown_owner = super::CompletionFooterOwner::new(0, 1_800_000_000);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_116),
+            known_owner,
+            &ProviderKind::Claude,
+            known_owner.started_at_unix,
+            "Known owner answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::register_completion_footer_target_for_owner(
+                channel_id,
+                MessageId::new(3_717_117),
+                unknown_owner,
+                &ProviderKind::Claude,
+                unknown_owner.started_at_unix,
+                "Unknown owner answer",
+                None,
+                true,
+            ),
+            None,
+            "same-second user_msg_id=0 owner must not replace a known owner"
+        );
+        let edit = super::completion_footer_edit_for_registered_target_at_for_owner(
+            shared.as_ref(),
+            channel_id,
+            Some(known_owner),
+            "⠸",
+            1_800_000_001,
+        )
+        .expect("known owner should remain registered");
+        assert_eq!(edit.message_id, MessageId::new(3_717_116));
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    #[test]
+    fn same_second_unknown_owner_cannot_supersede_known_owner_3717() {
+        let channel_id = ChannelId::new(3_717_012);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_subagent(channel_id);
+        let known_owner = super::CompletionFooterOwner::new(82, 1_800_000_000);
+        let unknown_owner = super::CompletionFooterOwner::new(0, 1_800_000_000);
+        let _ = super::register_completion_footer_target_for_owner(
+            channel_id,
+            MessageId::new(3_717_118),
+            known_owner,
+            &ProviderKind::Claude,
+            known_owner.started_at_unix,
+            "Known owner answer",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            super::completion_footer_supersede_registered_target_for_owner(
+                channel_id,
+                Some(unknown_owner)
+            ),
+            None,
+            "same-second user_msg_id=0 owner must not supersede a known owner"
+        );
+        assert!(
+            super::completion_footer_edit_for_registered_target_at_for_owner(
+                shared.as_ref(),
+                channel_id,
+                Some(known_owner),
+                "⠸",
+                1_800_000_001,
+            )
+            .is_some(),
+            "known owner should remain registered after unknown supersede attempt"
+        );
         super::completion_footer_forget_registered_target(channel_id);
     }
 

--- a/src/services/discord/single_message_panel/completion_footer_registry.rs
+++ b/src/services/discord/single_message_panel/completion_footer_registry.rs
@@ -1,0 +1,624 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use poise::serenity_prelude::{ChannelId, MessageId};
+
+use crate::services::discord::{ProviderKind, SharedData, placeholder_live_events::TerminalSlotId};
+
+#[derive(Debug, Clone)]
+struct RegisteredCompletionFooter {
+    message_id: MessageId,
+    owner: CompletionFooterOwner,
+    provider: ProviderKind,
+    base_body: String,
+    last_completion_block: Option<String>,
+    last_committed_text: Option<String>,
+    registered_at_unix: i64,
+    consecutive_edit_failures: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) struct CompletionFooterOwner {
+    pub(in crate::services::discord) user_msg_id: u64,
+    pub(in crate::services::discord) started_at_unix: i64,
+}
+
+impl CompletionFooterOwner {
+    pub(in crate::services::discord) fn new(user_msg_id: u64, started_at_unix: i64) -> Self {
+        Self {
+            user_msg_id,
+            started_at_unix,
+        }
+    }
+
+    #[cfg(test)]
+    fn unknown() -> Self {
+        Self {
+            user_msg_id: 0,
+            started_at_unix: 0,
+        }
+    }
+}
+
+fn completion_footer_owner_is_newer_than(
+    registered: CompletionFooterOwner,
+    takeover: CompletionFooterOwner,
+) -> bool {
+    if registered.started_at_unix != takeover.started_at_unix {
+        return registered.started_at_unix > takeover.started_at_unix;
+    }
+    if registered.user_msg_id == 0 {
+        return false;
+    }
+    takeover.user_msg_id == 0 || registered.user_msg_id > takeover.user_msg_id
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::services::discord) struct CompletionFooterEdit {
+    pub(in crate::services::discord) message_id: MessageId,
+    pub(in crate::services::discord) text: String,
+    pub(in crate::services::discord) remove_after_edit: bool,
+    owner: CompletionFooterOwner,
+    pub(in crate::services::discord) completion_block: Option<String>,
+    // #3391: identities of terminal task/subagent slots in `text`; evicted by
+    // slot identity (not line string) once this edit is delivered.
+    pub(in crate::services::discord) delivered_terminal_ids: Vec<TerminalSlotId>,
+}
+
+fn completion_footer_registry() -> &'static Mutex<HashMap<u64, RegisteredCompletionFooter>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<u64, RegisteredCompletionFooter>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn register_completion_footer_target(
+    channel_id: ChannelId,
+    message_id: MessageId,
+    provider: &ProviderKind,
+    registered_at_unix: i64,
+    base_body: &str,
+    completion_block: Option<&str>,
+    has_unfinished_entries: bool,
+) -> Option<CompletionFooterEdit> {
+    register_completion_footer_target_for_owner(
+        channel_id,
+        message_id,
+        CompletionFooterOwner::unknown(),
+        provider,
+        registered_at_unix,
+        base_body,
+        completion_block,
+        has_unfinished_entries,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::services::discord) fn register_completion_footer_target_for_owner(
+    channel_id: ChannelId,
+    message_id: MessageId,
+    owner: CompletionFooterOwner,
+    provider: &ProviderKind,
+    registered_at_unix: i64,
+    base_body: &str,
+    completion_block: Option<&str>,
+    has_unfinished_entries: bool,
+) -> Option<CompletionFooterEdit> {
+    let mut guard = completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let previous = guard.remove(&channel_id.get());
+    if let Some(target) = previous.as_ref()
+        && target.message_id != message_id
+        && completion_footer_owner_is_newer_than(target.owner, owner)
+    {
+        tracing::warn!(
+            target: "agentdesk.discord.single_message_panel",
+            event = "completion_footer_register_skipped",
+            channel_id = channel_id.get(),
+            old_message_id = target.message_id.get(),
+            attempted_message_id = message_id.get(),
+            registered_owner_user_msg_id = target.owner.user_msg_id,
+            registered_owner_started_at_unix = target.owner.started_at_unix,
+            attempted_owner_user_msg_id = owner.user_msg_id,
+            attempted_owner_started_at_unix = owner.started_at_unix,
+            provider = ?target.provider,
+            reason = if has_unfinished_entries {
+                "newer_target_already_registered"
+            } else {
+                "newer_target_clear_skipped"
+            },
+            "completion footer target registration skipped because a newer target is registered"
+        );
+        guard.insert(channel_id.get(), target.clone());
+        return None;
+    }
+    if has_unfinished_entries {
+        let base_body = super::completion_footer_base_body(base_body, provider);
+        let owner = previous
+            .as_ref()
+            .filter(|target| target.message_id == message_id)
+            .map(|target| target.owner)
+            .unwrap_or(owner);
+        let last_committed_text = previous
+            .as_ref()
+            .filter(|target| target.message_id == message_id)
+            .and_then(|target| target.last_committed_text.clone());
+        let registered_at_unix = previous
+            .as_ref()
+            .filter(|target| target.message_id == message_id)
+            .map(|target| target.registered_at_unix)
+            .unwrap_or(registered_at_unix);
+        let consecutive_edit_failures = previous
+            .as_ref()
+            .filter(|target| target.message_id == message_id)
+            .map(|target| target.consecutive_edit_failures)
+            .unwrap_or(0);
+        if let Some(target) = previous.as_ref() {
+            if target.message_id == message_id {
+                tracing::debug!(
+                    target: "agentdesk.discord.single_message_panel",
+                    event = "completion_footer_target_duplicate_discarded",
+                    channel_id = channel_id.get(),
+                    message_id = message_id.get(),
+                    owner_user_msg_id = owner.user_msg_id,
+                    owner_started_at_unix = owner.started_at_unix,
+                    provider = ?provider,
+                    reason = "same_message_re_registered",
+                    "completion footer kept existing edit target"
+                );
+            } else {
+                tracing::info!(
+                    target: "agentdesk.discord.single_message_panel",
+                    event = "completion_footer_target_changed",
+                    channel_id = channel_id.get(),
+                    old_message_id = target.message_id.get(),
+                    new_message_id = message_id.get(),
+                    old_owner_user_msg_id = target.owner.user_msg_id,
+                    old_owner_started_at_unix = target.owner.started_at_unix,
+                    new_owner_user_msg_id = owner.user_msg_id,
+                    new_owner_started_at_unix = owner.started_at_unix,
+                    provider = ?provider,
+                    reason = "new_message_registered",
+                    "completion footer edit target changed"
+                );
+            }
+        } else {
+            tracing::debug!(
+                target: "agentdesk.discord.single_message_panel",
+                event = "completion_footer_target_registered",
+                channel_id = channel_id.get(),
+                message_id = message_id.get(),
+                owner_user_msg_id = owner.user_msg_id,
+                owner_started_at_unix = owner.started_at_unix,
+                provider = ?provider,
+                reason = "new_target",
+                "completion footer edit target registered"
+            );
+        }
+        guard.insert(
+            channel_id.get(),
+            RegisteredCompletionFooter {
+                message_id,
+                owner,
+                provider: provider.clone(),
+                base_body,
+                last_completion_block: completion_block.map(str::to_string),
+                last_committed_text,
+                registered_at_unix,
+                consecutive_edit_failures,
+            },
+        );
+    } else if let Some(target) = previous.as_ref() {
+        tracing::debug!(
+            target: "agentdesk.discord.single_message_panel",
+            event = "completion_footer_target_cleared",
+            channel_id = channel_id.get(),
+            old_message_id = target.message_id.get(),
+            old_owner_user_msg_id = target.owner.user_msg_id,
+            old_owner_started_at_unix = target.owner.started_at_unix,
+            provider = ?target.provider,
+            reason = "no_unfinished_entries",
+            "completion footer target cleared"
+        );
+    }
+    previous
+        .filter(|target| target.message_id != message_id)
+        .map(supersede_edit_from_registered_target)
+}
+
+pub(in crate::services::discord) fn completion_footer_supersede_registered_target_for_owner(
+    channel_id: ChannelId,
+    takeover_owner: Option<CompletionFooterOwner>,
+) -> Option<CompletionFooterEdit> {
+    let mut guard = completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let target = guard.get(&channel_id.get())?.clone();
+    if let Some(owner) = takeover_owner
+        && completion_footer_owner_is_newer_than(target.owner, owner)
+    {
+        tracing::warn!(
+            target: "agentdesk.discord.single_message_panel",
+            event = "completion_footer_supersede_skipped",
+            channel_id = channel_id.get(),
+            old_message_id = target.message_id.get(),
+            old_owner_user_msg_id = target.owner.user_msg_id,
+            old_owner_started_at_unix = target.owner.started_at_unix,
+            new_owner_user_msg_id = owner.user_msg_id,
+            new_owner_started_at_unix = owner.started_at_unix,
+            provider = ?target.provider,
+            reason = "newer_target_already_registered",
+            "completion footer supersede skipped because a newer target is registered"
+        );
+        return None;
+    }
+    let target = guard.remove(&channel_id.get())?;
+    tracing::info!(
+        target: "agentdesk.discord.single_message_panel",
+        event = "completion_footer_target_superseded",
+        channel_id = channel_id.get(),
+        old_message_id = target.message_id.get(),
+        old_owner_user_msg_id = target.owner.user_msg_id,
+        old_owner_started_at_unix = target.owner.started_at_unix,
+        new_owner_user_msg_id = takeover_owner.map(|owner| owner.user_msg_id),
+        new_owner_started_at_unix = takeover_owner.map(|owner| owner.started_at_unix),
+        provider = ?target.provider,
+        reason = "explicit_supersede",
+        "completion footer edit target superseded"
+    );
+    Some(supersede_edit_from_registered_target(target))
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn completion_footer_registered_failure_count(
+    channel_id: ChannelId,
+) -> Option<u8> {
+    completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&channel_id.get())
+        .map(|target| target.consecutive_edit_failures)
+}
+
+pub(in crate::services::discord) fn completion_footer_has_registered_target(
+    channel_id: ChannelId,
+) -> bool {
+    completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .contains_key(&channel_id.get())
+}
+
+pub(in crate::services::discord) fn completion_footer_edit_for_registered_target(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    indicator: &str,
+) -> Option<CompletionFooterEdit> {
+    completion_footer_edit_for_registered_target_at(
+        shared,
+        channel_id,
+        indicator,
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+pub(in crate::services::discord) fn completion_footer_edit_for_registered_target_for_owner(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    owner: CompletionFooterOwner,
+    indicator: &str,
+) -> Option<CompletionFooterEdit> {
+    completion_footer_edit_for_registered_target_at_for_owner(
+        shared,
+        channel_id,
+        Some(owner),
+        indicator,
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+pub(in crate::services::discord) fn completion_footer_edit_for_registered_target_at(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    indicator: &str,
+    now_unix: i64,
+) -> Option<CompletionFooterEdit> {
+    completion_footer_edit_for_registered_target_at_for_owner(
+        shared, channel_id, None, indicator, now_unix,
+    )
+}
+
+pub(in crate::services::discord) fn completion_footer_edit_for_registered_target_at_for_owner(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    owner: Option<CompletionFooterOwner>,
+    indicator: &str,
+    now_unix: i64,
+) -> Option<CompletionFooterEdit> {
+    let target = completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&channel_id.get())
+        .cloned()?;
+    if let Some(expected) = owner
+        && target.owner != expected
+    {
+        tracing::warn!(
+            target: "agentdesk.discord.single_message_panel",
+            event = "completion_footer_edit_skipped",
+            channel_id = channel_id.get(),
+            message_id = target.message_id.get(),
+            registered_owner_user_msg_id = target.owner.user_msg_id,
+            registered_owner_started_at_unix = target.owner.started_at_unix,
+            expected_owner_user_msg_id = expected.user_msg_id,
+            expected_owner_started_at_unix = expected.started_at_unix,
+            provider = ?target.provider,
+            reason = "owner_mismatch",
+            "completion footer edit skipped because caller does not own the target"
+        );
+        return None;
+    }
+    let idle_expired =
+        completion_footer_idle_animation_expired(target.registered_at_unix, now_unix);
+    let render_indicator = if idle_expired {
+        super::COMPLETION_FOOTER_IDLE_EXPIRED_INDICATOR
+    } else {
+        indicator
+    };
+    let rendered = shared.ui.placeholder_live_events.render_completion_footer(
+        channel_id,
+        &target.provider,
+        render_indicator,
+    );
+    let completion_block = rendered.block;
+    let text =
+        super::compose_completion_footer_text(&target.base_body, completion_block.as_deref());
+    let remove_after_edit = idle_expired || !rendered.has_unfinished_entries;
+    if text.trim().is_empty() {
+        if idle_expired {
+            completion_footer_forget_registered_target_if_identity(
+                channel_id,
+                target.message_id,
+                target.owner,
+            );
+        }
+        return None;
+    }
+    if target.last_committed_text.as_deref() == Some(text.as_str()) {
+        tracing::debug!(
+            target: "agentdesk.discord.single_message_panel",
+            event = "completion_footer_edit_skipped",
+            channel_id = channel_id.get(),
+            message_id = target.message_id.get(),
+            owner_user_msg_id = target.owner.user_msg_id,
+            owner_started_at_unix = target.owner.started_at_unix,
+            provider = ?target.provider,
+            reason = "unchanged_text",
+            "completion footer edit skipped because rendered text is unchanged"
+        );
+        if remove_after_edit {
+            completion_footer_forget_registered_target_if_identity(
+                channel_id,
+                target.message_id,
+                target.owner,
+            );
+        }
+        return None;
+    }
+    Some(CompletionFooterEdit {
+        message_id: target.message_id,
+        text,
+        remove_after_edit,
+        owner: target.owner,
+        completion_block,
+        delivered_terminal_ids: rendered.delivered_terminal_ids,
+    })
+}
+
+pub(in crate::services::discord) fn completion_footer_edit_still_registered(
+    channel_id: ChannelId,
+    edit: &CompletionFooterEdit,
+) -> bool {
+    completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&channel_id.get())
+        .is_some_and(|target| target.message_id == edit.message_id && target.owner == edit.owner)
+}
+
+fn completion_footer_idle_animation_expired(registered_at_unix: i64, now_unix: i64) -> bool {
+    now_unix.saturating_sub(registered_at_unix) >= super::COMPLETION_FOOTER_MAX_IDLE_ANIMATION_SECS
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn completion_footer_record_edit_result(
+    channel_id: ChannelId,
+    remove_after_edit: bool,
+    edited: bool,
+) {
+    completion_footer_record_edit_result_with_block(
+        channel_id,
+        remove_after_edit,
+        edited,
+        None,
+        None,
+        None,
+    );
+}
+
+pub(in crate::services::discord) fn completion_footer_record_committed_text_result_for_owner(
+    channel_id: ChannelId,
+    message_id: MessageId,
+    owner: CompletionFooterOwner,
+    remove_after_edit: bool,
+    edited: bool,
+    committed_text: &str,
+    completion_block: Option<&str>,
+) -> bool {
+    completion_footer_record_edit_result_with_block(
+        channel_id,
+        remove_after_edit,
+        edited,
+        completion_block,
+        Some(committed_text),
+        Some((message_id, owner)),
+    )
+}
+
+pub(in crate::services::discord) fn completion_footer_record_edit_result_for_edit(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    edit: &CompletionFooterEdit,
+    edited: bool,
+) -> bool {
+    let recorded = completion_footer_record_edit_result_with_block(
+        channel_id,
+        edit.remove_after_edit,
+        edited,
+        edit.completion_block.as_deref(),
+        Some(&edit.text),
+        Some((edit.message_id, edit.owner)),
+    );
+    // #3391: this edit delivered the terminal marks once; evict those slot
+    // identities so the next render (and any #3386 migration footer) drops the
+    // completed task AND subagent entries.
+    if edited && recorded {
+        shared
+            .ui
+            .placeholder_live_events
+            .evict_delivered_terminal_footer_tasks(channel_id, &edit.delivered_terminal_ids);
+    }
+    recorded
+}
+
+fn completion_footer_record_edit_result_with_block(
+    channel_id: ChannelId,
+    remove_after_edit: bool,
+    edited: bool,
+    completion_block: Option<&str>,
+    committed_text: Option<&str>,
+    guard_identity: Option<(MessageId, CompletionFooterOwner)>,
+) -> bool {
+    let mut guard = completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(target) = guard.get_mut(&channel_id.get()) else {
+        return false;
+    };
+    if let Some((message_id, owner)) = guard_identity {
+        if target.message_id != message_id || target.owner != owner {
+            tracing::warn!(
+                target: "agentdesk.discord.single_message_panel",
+                event = "completion_footer_edit_result_skipped",
+                channel_id = channel_id.get(),
+                edit_message_id = message_id.get(),
+                registered_message_id = target.message_id.get(),
+                edit_owner_user_msg_id = owner.user_msg_id,
+                edit_owner_started_at_unix = owner.started_at_unix,
+                registered_owner_user_msg_id = target.owner.user_msg_id,
+                registered_owner_started_at_unix = target.owner.started_at_unix,
+                provider = ?target.provider,
+                reason = "owner_or_message_mismatch",
+                "completion footer edit result ignored because registry target changed"
+            );
+            return false;
+        }
+    }
+
+    if remove_after_edit {
+        guard.remove(&channel_id.get());
+        return true;
+    }
+    if edited {
+        target.consecutive_edit_failures = 0;
+        if let Some(block) = completion_block {
+            target.last_completion_block = Some(block.to_string());
+        }
+        if let Some(text) = committed_text {
+            target.last_committed_text = Some(text.to_string());
+        }
+        return true;
+    }
+    target.consecutive_edit_failures = target.consecutive_edit_failures.saturating_add(1);
+    if target.consecutive_edit_failures >= super::COMPLETION_FOOTER_MAX_CONSECUTIVE_EDIT_FAILURES {
+        guard.remove(&channel_id.get());
+    }
+    true
+}
+
+fn supersede_edit_from_registered_target(
+    target: RegisteredCompletionFooter,
+) -> CompletionFooterEdit {
+    let completion_block = target
+        .last_completion_block
+        .as_deref()
+        .map(freeze_completion_footer_block);
+    let text =
+        super::compose_completion_footer_text(&target.base_body, completion_block.as_deref());
+    CompletionFooterEdit {
+        message_id: target.message_id,
+        text,
+        remove_after_edit: true,
+        owner: target.owner,
+        completion_block,
+        // #3391 migration-race rule: a frozen supersede snapshot never counts
+        // as "the once" — it carries only the last delivered block string with
+        // no slot identity. Terminal marks in it were either already evicted by
+        // a confirmed live delivery, or (failed-edit race) render once more on
+        // the new target and evict on that delivery; a ✓ is never lost.
+        delivered_terminal_ids: Vec::new(),
+    }
+}
+
+fn freeze_completion_footer_block(block: &str) -> String {
+    super::SINGLE_MESSAGE_PANEL_SPINNER_FRAMES
+        .iter()
+        .fold(block.to_string(), |acc, frame| {
+            acc.replace(frame, super::COMPLETION_FOOTER_IDLE_EXPIRED_INDICATOR)
+        })
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn completion_footer_forget_registered_target(
+    channel_id: ChannelId,
+) {
+    completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&channel_id.get());
+}
+
+pub(in crate::services::discord) fn completion_footer_forget_registered_target_if_message(
+    channel_id: ChannelId,
+    message_id: MessageId,
+) -> bool {
+    let mut guard = completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !guard
+        .get(&channel_id.get())
+        .is_some_and(|target| target.message_id == message_id)
+    {
+        return false;
+    }
+    guard.remove(&channel_id.get());
+    true
+}
+
+fn completion_footer_forget_registered_target_if_identity(
+    channel_id: ChannelId,
+    message_id: MessageId,
+    owner: CompletionFooterOwner,
+) -> bool {
+    let mut guard = completion_footer_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !guard
+        .get(&channel_id.get())
+        .is_some_and(|target| target.message_id == message_id && target.owner == owner)
+    {
+        return false;
+    }
+    guard.remove(&channel_id.get());
+    true
+}

--- a/src/services/discord/tmux_restart_handoff.rs
+++ b/src/services/discord/tmux_restart_handoff.rs
@@ -122,8 +122,13 @@ fn restart_handoff_notice_target(
     RestartHandoffNoticeTarget::Edit(state.current_msg_id)
 }
 
-fn forget_completion_footer_for_restart_handoff(channel_id: ChannelId) {
-    super::single_message_panel::completion_footer_forget_registered_target(channel_id);
+fn forget_completion_footer_for_restart_handoff(
+    channel_id: ChannelId,
+    message_id: serenity::MessageId,
+) -> bool {
+    super::single_message_panel::completion_footer_forget_registered_target_if_message(
+        channel_id, message_id,
+    )
 }
 
 pub(super) fn resolve_dispatched_thread_dispatch_from_db(
@@ -276,13 +281,14 @@ pub(super) async fn start_restart_handoff_from_state(
     best_response: &str,
 ) -> bool {
     let stale_text = super::turn_bridge::stale_inflight_message(best_response);
-    forget_completion_footer_for_restart_handoff(channel_id);
     match restart_handoff_notice_target(&state) {
         RestartHandoffNoticeTarget::Edit(current_msg_id) => {
+            let current_msg_id = serenity::MessageId::new(current_msg_id);
+            forget_completion_footer_for_restart_handoff(channel_id, current_msg_id);
             let relay_ok = super::formatting::replace_long_message_raw(
                 http,
                 channel_id,
-                serenity::MessageId::new(current_msg_id),
+                current_msg_id,
                 &stale_text,
                 shared,
             )
@@ -540,7 +546,10 @@ mod notice_target_tests {
             true,
         );
 
-        super::forget_completion_footer_for_restart_handoff(channel_id);
+        assert!(super::forget_completion_footer_for_restart_handoff(
+            channel_id,
+            MessageId::new(3_089_302),
+        ));
 
         assert_eq!(
             super::super::single_message_panel::completion_footer_edit_for_registered_target_at(
@@ -551,5 +560,37 @@ mod notice_target_tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn restart_handoff_keeps_different_completion_footer_target() {
+        let channel_id = ChannelId::new(3_089_212);
+        let shared = super::super::make_shared_data_for_tests();
+        super::super::single_message_panel::completion_footer_forget_registered_target(channel_id);
+        let _ = super::super::single_message_panel::register_completion_footer_target(
+            channel_id,
+            MessageId::new(3_089_312),
+            &ProviderKind::Codex,
+            1_800_000_000,
+            "Final answer",
+            None,
+            true,
+        );
+
+        assert!(!super::forget_completion_footer_for_restart_handoff(
+            channel_id,
+            MessageId::new(3_089_313),
+        ));
+
+        assert!(
+            super::super::single_message_panel::completion_footer_edit_for_registered_target_at(
+                shared.as_ref(),
+                channel_id,
+                "⠸",
+                1_800_000_005,
+            )
+            .is_some()
+        );
+        super::super::single_message_panel::completion_footer_forget_registered_target(channel_id);
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1025,6 +1025,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             .as_ref()
             .filter(|state| state.tmux_session_name.as_deref() == Some(tmux_session_name.as_str()))
             .map(crate::services::discord::inflight::InflightTurnIdentity::from_state);
+        let (status_panel_started_at, footer_owner) =
+            make_owner_now(turn_identity_for_panel.as_ref());
         // #3003 P2: rehydrate a watcher-owned persisted panel id while the row
         // still exists; footer mode intentionally has no separate panel handle.
         if !single_message_panel_footer_mode
@@ -1047,7 +1049,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             && (shared.ui.placeholder_live_events_enabled || shared.ui.status_panel_v2_enabled)
         {
             if single_message_panel_footer_mode {
-                supersede_watcher_registered_completion_footer(&http, &shared, channel_id).await;
+                supersede_watcher_footer(&http, &shared, channel_id, footer_owner).await;
                 shared
                     .ui
                     .placeholder_live_events
@@ -1057,7 +1059,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             }
         }
         let mut last_status_panel_text = String::new();
-        let status_panel_started_at = chrono::Utc::now().timestamp();
         let mut last_edit_text = stream_seed.last_edit_text;
         let mut response_sent_offset = stream_seed.response_sent_offset;
         let finish_mailbox_on_completion = stream_seed.finish_mailbox_on_completion;
@@ -1075,7 +1076,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // #1009: 1-shot tracker for the monitor-auto-turn preamble hint so the
         // hint text is emitted exactly once per watcher turn frame.
         let mut monitor_auto_turn_preamble_injected = false;
-
         // Process any complete lines we already have
         let initial_buffer_len = all_data.len();
         observe_qwen_user_prompts_in_buffer(&all_data, &watcher_provider, &tmux_session_name);

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -2,6 +2,26 @@
 
 use super::*;
 
+pub(super) fn make_owner(
+    identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
+    started_at_unix: i64,
+) -> crate::services::discord::single_message_panel::CompletionFooterOwner {
+    crate::services::discord::single_message_panel::CompletionFooterOwner::new(
+        identity.map(|identity| identity.user_msg_id).unwrap_or(0),
+        started_at_unix,
+    )
+}
+
+pub(super) fn make_owner_now(
+    identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
+) -> (
+    i64,
+    crate::services::discord::single_message_panel::CompletionFooterOwner,
+) {
+    let started_at_unix = chrono::Utc::now().timestamp();
+    (started_at_unix, make_owner(identity, started_at_unix))
+}
+
 pub(super) fn watcher_single_message_panel_footer_enabled(status_panel_v2_enabled: bool) -> bool {
     footer_mode_enabled(
         crate::services::discord::single_message_panel_enabled(),
@@ -212,6 +232,7 @@ pub(super) async fn complete_watcher_single_message_completion_footer(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
     terminal_msg_id: Option<serenity::MessageId>,
+    owner: crate::services::discord::single_message_panel::CompletionFooterOwner,
     provider: &ProviderKind,
     _started_at_unix: i64,
     terminal_text: &str,
@@ -230,9 +251,10 @@ pub(super) async fn complete_watcher_single_message_completion_footer(
         return true;
     };
     if let Some(edit) =
-        crate::services::discord::single_message_panel::register_completion_footer_target(
+        crate::services::discord::single_message_panel::register_completion_footer_target_for_owner(
             channel_id,
             msg_id,
+            owner,
             provider,
             chrono::Utc::now().timestamp(),
             terminal_text,
@@ -283,15 +305,20 @@ pub(super) async fn complete_watcher_single_message_completion_footer(
             false
         }
     };
-    crate::services::discord::single_message_panel::completion_footer_record_edit_result(
+    let recorded =
+        crate::services::discord::single_message_panel::completion_footer_record_committed_text_result_for_owner(
         channel_id,
+        msg_id,
+        owner,
         !rendered.has_unfinished_entries,
         edited,
+        &finalized,
+        rendered.block.as_deref(),
     );
     // #3391: the finalize edit delivered this render's terminal marks once;
     // evict those slot identities so subsequent footer renders (incl. #3386
     // migration) drop the completed task AND subagent entries.
-    if edited {
+    if edited && recorded {
         shared
             .ui
             .placeholder_live_events
@@ -300,14 +327,16 @@ pub(super) async fn complete_watcher_single_message_completion_footer(
     edited
 }
 
-pub(super) async fn supersede_watcher_registered_completion_footer(
+pub(super) async fn supersede_watcher_footer(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
+    owner: crate::services::discord::single_message_panel::CompletionFooterOwner,
 ) -> bool {
     let Some(edit) =
-        crate::services::discord::single_message_panel::completion_footer_supersede_registered_target(
+        crate::services::discord::single_message_panel::completion_footer_supersede_registered_target_for_owner(
             channel_id,
+            Some(owner),
         )
     else {
         return false;
@@ -350,6 +379,11 @@ pub(super) async fn refresh_watcher_registered_completion_footer(
         return false;
     };
     rate_limit_wait(shared, channel_id).await;
+    if !crate::services::discord::single_message_panel::completion_footer_edit_still_registered(
+        channel_id, &edit,
+    ) {
+        return false;
+    }
     let edited = match crate::services::discord::http::edit_channel_message(
         http,
         channel_id,
@@ -403,6 +437,10 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
                 text: last_edit_text.to_string(),
             });
         let target = terminal_target.or(fallback_target);
+        let owner = crate::services::discord::single_message_panel::CompletionFooterOwner::new(
+            status_panel_completion_user_msg_id.unwrap_or(0),
+            started_at_unix,
+        );
         let indicator =
             crate::services::discord::single_message_panel::single_message_panel_spinner_frame(
                 *spin_idx,
@@ -413,6 +451,7 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
             shared,
             channel_id,
             target.as_ref().map(|target| target.msg_id),
+            owner,
             provider,
             started_at_unix,
             target

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1357,12 +1357,12 @@ pub(super) fn spawn_turn_bridge(
             bool, // ack_consumed
         )> = None;
         let mut active_background_child_session_ids: Vec<i64> = Vec::new();
+        let (status_panel_started_at, footer_owner) = make_owner_now(user_msg_id);
         let single_message_panel_footer_mode =
             bridge_single_message_panel_footer_enabled(shared_owned.ui.status_panel_v2_enabled);
         if shared_owned.ui.placeholder_live_events_enabled || shared_owned.ui.status_panel_v2_enabled {
             if single_message_panel_footer_mode {
-                supersede_bridge_registered_completion_footer(shared_owned.as_ref(), channel_id)
-                    .await;
+                supersede_bridge_footer(shared_owned.as_ref(), channel_id, footer_owner).await;
                 shared_owned
                     .ui
                     .placeholder_live_events
@@ -1585,7 +1585,6 @@ pub(super) fn spawn_turn_bridge(
         let mut last_status_panel_text = String::new();
         let mut status_panel_dirty = shared_owned.ui.status_panel_v2_enabled;
         let mut last_status_panel_edit = tokio::time::Instant::now() - status_interval;
-        let status_panel_started_at = chrono::Utc::now().timestamp();
         let turn_start = std::time::Instant::now();
 
         maybe_create_bridge_separate_status_panel_response(
@@ -2444,9 +2443,10 @@ pub(super) fn spawn_turn_bridge(
                                         spin_idx,
                                     );
                                 spin_idx = spin_idx.wrapping_add(1);
-                                refresh_bridge_registered_completion_footer(
+                                refresh_bridge_footer(
                                     shared_owned.as_ref(),
                                     channel_id,
+                                    footer_owner,
                                     indicator,
                                 )
                                 .await;
@@ -3388,16 +3388,16 @@ pub(super) fn spawn_turn_bridge(
                 && status_panel_dirty
                 && last_status_panel_edit.elapsed() >= status_interval
             {
-                refresh_bridge_registered_completion_footer(
+                refresh_bridge_footer(
                     shared_owned.as_ref(),
                     channel_id,
+                    footer_owner,
                     indicator,
                 )
                 .await;
                 last_status_panel_edit = tokio::time::Instant::now();
                 status_panel_dirty = false;
             }
-
             if !watcher_owns_assistant_relay && !standby_relay_owns_output {
                 loop {
                     let current_portion =

--- a/src/services/discord/turn_bridge/single_message_footer.rs
+++ b/src/services/discord/turn_bridge/single_message_footer.rs
@@ -2,6 +2,23 @@
 
 use super::*;
 
+pub(super) fn make_owner(
+    user_msg_id: Option<MessageId>,
+    started_at_unix: i64,
+) -> super::single_message_panel::CompletionFooterOwner {
+    super::single_message_panel::CompletionFooterOwner::new(
+        user_msg_id.map(|id| id.get()).unwrap_or(0),
+        started_at_unix,
+    )
+}
+
+pub(super) fn make_owner_now(
+    user_msg_id: Option<MessageId>,
+) -> (i64, super::single_message_panel::CompletionFooterOwner) {
+    let started_at_unix = chrono::Utc::now().timestamp();
+    (started_at_unix, make_owner(user_msg_id, started_at_unix))
+}
+
 pub(super) fn bridge_single_message_panel_footer_enabled(status_panel_v2_enabled: bool) -> bool {
     super::single_message_panel::footer_mode_enabled(
         crate::services::discord::single_message_panel_enabled(),
@@ -175,6 +192,7 @@ pub(super) async fn complete_bridge_single_message_completion_footer(
     shared: &SharedData,
     channel_id: ChannelId,
     terminal_msg_id: MessageId,
+    owner: super::single_message_panel::CompletionFooterOwner,
     provider: &ProviderKind,
     _started_at_unix: i64,
     terminal_text: &str,
@@ -189,9 +207,10 @@ pub(super) async fn complete_bridge_single_message_completion_footer(
         .ui
         .placeholder_live_events
         .render_completion_footer(channel_id, provider, indicator);
-    if let Some(edit) = super::single_message_panel::register_completion_footer_target(
+    if let Some(edit) = super::single_message_panel::register_completion_footer_target_for_owner(
         channel_id,
         terminal_msg_id,
+        owner,
         provider,
         chrono::Utc::now().timestamp(),
         terminal_text,
@@ -235,15 +254,20 @@ pub(super) async fn complete_bridge_single_message_completion_footer(
             false
         }
     };
-    super::single_message_panel::completion_footer_record_edit_result(
-        channel_id,
-        !rendered.has_unfinished_entries,
-        edited,
-    );
+    let recorded =
+        super::single_message_panel::completion_footer_record_committed_text_result_for_owner(
+            channel_id,
+            terminal_msg_id,
+            owner,
+            !rendered.has_unfinished_entries,
+            edited,
+            &finalized,
+            rendered.block.as_deref(),
+        );
     // #3391: the finalize edit delivered this render's terminal marks once;
     // evict those slot identities so subsequent footer renders (incl. #3386
     // migration) drop the completed task AND subagent entries.
-    if edited {
+    if edited && recorded {
         shared
             .ui
             .placeholder_live_events
@@ -252,12 +276,16 @@ pub(super) async fn complete_bridge_single_message_completion_footer(
     edited
 }
 
-pub(super) async fn supersede_bridge_registered_completion_footer(
+pub(super) async fn supersede_bridge_footer(
     shared: &SharedData,
     channel_id: ChannelId,
+    owner: super::single_message_panel::CompletionFooterOwner,
 ) -> bool {
     let Some(edit) =
-        super::single_message_panel::completion_footer_supersede_registered_target(channel_id)
+        super::single_message_panel::completion_footer_supersede_registered_target_for_owner(
+            channel_id,
+            Some(owner),
+        )
     else {
         return false;
     };
@@ -275,16 +303,22 @@ pub(super) async fn supersede_bridge_registered_completion_footer(
     }
 }
 
-pub(super) async fn refresh_bridge_registered_completion_footer(
+pub(super) async fn refresh_bridge_footer(
     shared: &SharedData,
     channel_id: ChannelId,
+    owner: super::single_message_panel::CompletionFooterOwner,
     indicator: &str,
 ) -> bool {
-    let Some(edit) = super::single_message_panel::completion_footer_edit_for_registered_target(
-        shared, channel_id, indicator,
-    ) else {
+    let Some(edit) =
+        super::single_message_panel::completion_footer_edit_for_registered_target_for_owner(
+            shared, channel_id, owner, indicator,
+        )
+    else {
         return false;
     };
+    if !super::single_message_panel::completion_footer_edit_still_registered(channel_id, &edit) {
+        return false;
+    }
     let edited = match edit_bridge_completion_footer(
         shared,
         channel_id,
@@ -346,12 +380,17 @@ pub(super) async fn complete_bridge_terminal_footer_or_status_panel<G: TurnGatew
         return true;
     }
     if single_message_panel_footer_mode {
+        let owner = super::single_message_panel::CompletionFooterOwner::new(
+            this_turn_user_msg_id,
+            started_at_unix,
+        );
         return match terminal_text {
             Some(text) => {
                 complete_bridge_single_message_completion_footer(
                     shared,
                     channel_id,
                     current_msg_id,
+                    owner,
                     provider,
                     started_at_unix,
                     text,


### PR DESCRIPTION
## Summary
- Move completion-footer registry state into a dedicated module and track each footer target with an owner tuple (`user_msg_id`, `started_at_unix`).
- Make turn bridge and tmux watcher footer refreshes owner-aware, skip stale owners, re-check registry identity before HTTP edits, and apply edit results atomically.
- Guard recovery / relay recovery / restart handoff cleanup so they only forget the exact message they are taking over, preserving newer footer targets.
- Preserve status-panel maintenance ratchets by extracting relay recovery footer cleanup to a sibling helper and updating maintenance docs.

## Verification
- `cargo fmt --check`
- `cargo test --lib 3717 -- --nocapture` (12 tests)
- `cargo test --lib recovery_takeover_keeps_different -- --nocapture`
- `cargo test --lib relay_recovery_takeover_keeps_different -- --nocapture`
- `cargo test --lib restart_handoff_keeps_different -- --nocapture`
- `cargo test --lib single_message_panel -- --nocapture` (71 tests)
- `cargo check --lib`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `git diff --check`
- `PYTHON=/Users/itismyfield/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 ./scripts/ci-script-checks.sh`

## Review
- Fresh xhigh Codex review: `VERDICT: CLEAN`
