### PR TITLE
Fix idle kill runtime activity contract

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,10 +131,12 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2330 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2324 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
-    construction from the watcher-spawn handle).
+    construction from the watcher-spawn handle; #3718 moved runtime mtime
+    heartbeat timestamp selection into `watchers/lifecycle_decision.rs` and
+    keeps lifecycle below its frozen ratchet).
   - `src/services/discord/tmux.rs` (2048 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
@@ -1449,10 +1451,11 @@
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
   - `src/db/postgres.rs` (1167 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests; #3690: preferred_intake_node_labels upsert/sync + COALESCE preserve; #3692: `agent_roster_sync_enabled` leader-ownership gate on the roster sync).
-  - `src/db/dispatched_sessions.rs` (1621 lines; dispatched session
+  - `src/db/dispatched_sessions.rs` (1628 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads; #3693: +2 to
-    include `cwd` in provider resume selector lookup).
+    include `cwd` in provider resume selector lookup; #3718 makes runtime
+    activity heartbeat refresh monotonic via `GREATEST`).
   - `src/db/session_transcripts.rs` is a retained PG-cleanup surface (now below
     the giant-file threshold; bugfix only).
   - `src/db/prompt_manifests/` (directory, refactored).
@@ -1480,7 +1483,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
 - `src/services/onboarding/mod.rs` (2937),
-  `src/services/dispatched_sessions.rs` (1441), and
+  `src/services/dispatched_sessions.rs` (1546), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
@@ -1533,13 +1536,15 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   while the prior turn streams; +20 from #3637 centralizing post-paste error
   cleanup and making draft clearing cancel-agnostic.)
 - `src/services/memory/memento.rs` (1893).
-- `src/services/dispatched_sessions.rs` (1441) — dispatched session domain
+- `src/services/dispatched_sessions.rs` (1546) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database
   callsites, but the module itself is now giant-file territory; split focused
   helpers before adding non-bugfix behavior. (+5 from #3169 exposing the idle-
   kill `latest_runtime_activity_unix_nanos` jsonl-mtime probe to the stall-
   watchdog liveness guard; +47 from #3693 making kill-tmux's `resumable` claim
-  match Claude TUI transcript-backed resume semantics.)
+  match Claude TUI transcript-backed resume semantics; +105 from #3718 making
+  idle-kill skip active-dispatch sessions, use runtime output age as the
+  live-activity guard anchor, and log kill/skip timing decisions.)
 - `src/services/settings.rs` (1114) — settings domain service extracted from
   the route layer in #1519. Keep follow-up changes bugfix-only unless the file
   is split further.

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -1013,9 +1013,39 @@ test("timeouts idle-kill module calls kill-tmux API for expired idle sessions", 
   assert.match(state.httpPosts[0].body.reason, /idle 6시간 초과/);
   assert.equal(state.httpPosts[0].body.minimum_idle_minutes, 360);
   const idleSql = state.queries.map((q) => q.sql).join("\n");
-  assert.match(idleSql, /turn_lifecycle_events/);
-  assert.match(idleSql, /GREATEST\(COALESCE\(s\.last_heartbeat, s\.created_at\)/);
+  assert.match(idleSql, /COALESCE\(s\.last_heartbeat, s\.created_at\) AS last_seen_at/);
+  assert.doesNotMatch(idleSql, /turn_lifecycle_events/);
+  assert.doesNotMatch(idleSql, /active_dispatch_id IS NOT NULL/);
   assert.match(state.logs.info.join("\n"), /idle kill: agent-idle-1/);
+});
+
+test("timeouts idle-kill module leaves active-dispatch sessions to dispatch cleanup", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { server_port: 8791 },
+    dbQuery: createSqlRouter([
+      { match: "SELECT id, name, name_ko, discord_channel_id, discord_channel_alt, discord_channel_cc, discord_channel_cdx FROM agents", result: [] },
+      { match: "FROM sessions WHERE provider IN ('claude', 'codex', 'qwen') AND (agent_id IS NULL OR TRIM(agent_id) = '')", result: [] },
+      {
+        match(sql) {
+          return sql.includes("WHERE status = 'idle'") &&
+            sql.includes("active_dispatch_id IS NULL") &&
+            sql.includes("INTERVAL '6 hours'");
+        },
+        result: []
+      }
+    ]),
+    httpPost() {
+      throw new Error("active-dispatch idle rows must not call kill-tmux");
+    }
+  });
+
+  policy._section_O();
+
+  assert.equal(state.httpPosts.length, 0);
+  assert.doesNotMatch(
+    state.queries.map((q) => q.sql).join("\n"),
+    /active_dispatch_id IS NOT NULL/
+  );
 });
 
 test("timeouts idle-kill module does not let zombie (already-gone tmux) rows starve live idle sessions (#2861)", () => {

--- a/policies/timeouts/idle-kill.js
+++ b/policies/timeouts/idle-kill.js
@@ -56,22 +56,8 @@ module.exports = function attachIdleKill(timeouts, helpers) {
       var mainChannelSqlGuard =
         "AND thread_channel_id IS NULL " +
         "AND session_key !~ '-t[0-9]{15,}(-dev)?$' ";
-      var recentLifecycleWindowExpr = "NOW() - INTERVAL '24 hours'";
-      var latestChannelLifecycleAtExpr =
-        "(SELECT tle_channel.created_at FROM turn_lifecycle_events tle_channel " +
-        "WHERE NULLIF(BTRIM(COALESCE(s.channel_id, '')), '') IS NOT NULL " +
-        "AND tle_channel.channel_id = s.channel_id " +
-        "AND tle_channel.created_at >= " + recentLifecycleWindowExpr + " " +
-        "ORDER BY tle_channel.created_at DESC LIMIT 1)";
-      var latestSessionLifecycleAtExpr =
-        "(SELECT tle_session.created_at FROM turn_lifecycle_events tle_session " +
-        "WHERE tle_session.session_key = s.session_key " +
-        "AND tle_session.created_at >= " + recentLifecycleWindowExpr + " " +
-        "ORDER BY tle_session.created_at DESC LIMIT 1)";
       var effectiveLastSeenJoin =
-        "CROSS JOIN LATERAL (SELECT GREATEST(COALESCE(s.last_heartbeat, s.created_at), " +
-        "COALESCE(" + latestChannelLifecycleAtExpr + ", TIMESTAMPTZ 'epoch'), " +
-        "COALESCE(" + latestSessionLifecycleAtExpr + ", TIMESTAMPTZ 'epoch')) AS last_seen_at) latest ";
+        "CROSS JOIN LATERAL (SELECT COALESCE(s.last_heartbeat, s.created_at) AS last_seen_at) latest ";
       var idleSessions = agentdesk.db.query(
         "SELECT s.session_key, s.agent_id, s.provider, s.active_dispatch_id, s.thread_channel_id, latest.last_seen_at " +
         "FROM sessions s " +
@@ -83,17 +69,6 @@ module.exports = function attachIdleKill(timeouts, helpers) {
         "AND latest.last_seen_at < NOW() - INTERVAL '6 hours' " +
         "ORDER BY latest.last_seen_at ASC LIMIT 50"
       );
-      var safetySessions = agentdesk.db.query(
-        "SELECT s.session_key, s.agent_id, s.provider, s.active_dispatch_id, s.thread_channel_id, latest.last_seen_at " +
-        "FROM sessions s " +
-        effectiveLastSeenJoin +
-        "WHERE status = 'idle' " +
-        "AND provider IN ('claude', 'codex', 'qwen') " +
-        "AND active_dispatch_id IS NOT NULL " +
-        mainChannelSqlGuard +
-        "AND latest.last_seen_at < NOW() - INTERVAL '24 hours' " +
-        "ORDER BY latest.last_seen_at ASC LIMIT 50"
-      );
 
       // Defense-in-depth: client-side filter catches anything the SQL guard
       // missed (e.g. helper logic evolves with new session_key shapes).
@@ -102,7 +77,6 @@ module.exports = function attachIdleKill(timeouts, helpers) {
           && !parseSessionThreadId(s.session_key, s.provider);
       }
       idleSessions = idleSessions.filter(isMainChannelSession);
-      safetySessions = safetySessions.filter(isMainChannelSession);
 
       function formatIdleDuration(idleMin) {
         if (idleMin >= 60 * 24) {
@@ -175,6 +149,14 @@ module.exports = function attachIdleKill(timeouts, helpers) {
             continue;
           }
 
+          if (killResp.skipped_active_dispatch_guard) {
+            agentdesk.log.warn(
+              "[idle-kill] kill-tmux refused active-dispatch session for " + s.session_key +
+              " (not counted toward budget; dispatch cleanup owns this case)"
+            );
+            continue;
+          }
+
           if (!killResp.tmux_killed) {
             // tmux WAS alive but `tmux kill-session` failed — a genuine failure,
             // not a zombie. Count it toward the budget so a stuck-but-live
@@ -199,7 +181,6 @@ module.exports = function attachIdleKill(timeouts, helpers) {
         }
       }
 
-      killTmuxIdleSessions(safetySessions, 1440, "idle 24시간 경과 (safety TTL)", 2);
       killTmuxIdleSessions(idleSessions, 360, "idle 6시간 경과 (active_dispatch_id 없음)", 3);
     };
 };

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -1635,11 +1635,18 @@ pub(crate) async fn refresh_session_heartbeat_by_key_to_unix_nanos_pg(
     let Some(activity_at) = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, nanos) else {
         return false;
     };
-    match sqlx::query("UPDATE sessions SET last_heartbeat = $2 WHERE session_key = $1")
-        .bind(session_key)
-        .bind(activity_at)
-        .execute(pool)
-        .await
+    match sqlx::query(
+        "UPDATE sessions
+         SET last_heartbeat = GREATEST(
+             COALESCE(last_heartbeat, TIMESTAMPTZ 'epoch'),
+             $2
+         )
+         WHERE session_key = $1",
+    )
+    .bind(session_key)
+    .bind(activity_at)
+    .execute(pool)
+    .await
     {
         Ok(result) => result.rows_affected() > 0,
         Err(error) => {

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::services::discord::watcher_lifecycle_decision::runtime_activity_heartbeat_at;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum LivenessProbeOutcome {
@@ -1432,16 +1433,14 @@ pub(in crate::services::discord) fn refresh_session_heartbeat_from_tmux_output_d
     if let Some(pg_pool) = pg_pool {
         let provider_name = provider.as_str().to_string();
         let thread_channel_id = thread_channel_id.map(|value| value.to_string());
+        let activity_at = runtime_activity_heartbeat_at(tmux_session_name, chrono::Utc::now());
         return crate::utils::async_bridge::block_on_pg_result(
             pg_pool,
             move |pool| async move {
-                let updated = sqlx::query(
-                    "UPDATE sessions
-                     SET last_heartbeat = NOW()
-                     WHERE session_key = $1 OR session_key = $2",
-                )
+                let updated = sqlx::query("UPDATE sessions SET last_heartbeat = GREATEST(COALESCE(last_heartbeat, TIMESTAMPTZ 'epoch'), $3) WHERE session_key = $1 OR session_key = $2")
                 .bind(&session_keys[0])
                 .bind(&session_keys[1])
+                .bind(activity_at)
                 .execute(&pool)
                 .await
                 .map_err(|error| format!("refresh pg watcher heartbeat by session key: {error}"))?
@@ -1459,15 +1458,10 @@ pub(in crate::services::discord) fn refresh_session_heartbeat_from_tmux_output_d
                         rows_affected: 0,
                     });
                 };
-                let updated = sqlx::query(
-                    "UPDATE sessions
-                     SET last_heartbeat = NOW()
-                     WHERE provider = $1
-                       AND thread_channel_id = $2
-                       AND status IN ('idle', 'working')",
-                )
+                let updated = sqlx::query("UPDATE sessions SET last_heartbeat = GREATEST(COALESCE(last_heartbeat, TIMESTAMPTZ 'epoch'), $3) WHERE provider = $1 AND thread_channel_id = $2 AND status IN ('idle', 'working')")
                 .bind(&provider_name)
                 .bind(&thread_channel_id)
+                .bind(activity_at)
                 .execute(&pool)
                 .await
                 .map_err(|error| {

--- a/src/services/discord/watchers/lifecycle_decision.rs
+++ b/src/services/discord/watchers/lifecycle_decision.rs
@@ -191,6 +191,25 @@ pub(super) fn should_resume_watcher_after_turn(
     !defer_watcher_resume && !(has_local_queued_turns && can_chain_locally)
 }
 
+fn datetime_from_unix_nanos(unix_nanos: i64) -> Option<chrono::DateTime<chrono::Utc>> {
+    if unix_nanos <= 0 {
+        return None;
+    }
+    let secs = unix_nanos.div_euclid(1_000_000_000);
+    let nanos = unix_nanos.rem_euclid(1_000_000_000) as u32;
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs, nanos)
+}
+
+pub(in crate::services::discord) fn runtime_activity_heartbeat_at(
+    tmux_session_name: &str,
+    fallback_now: chrono::DateTime<chrono::Utc>,
+) -> chrono::DateTime<chrono::Utc> {
+    datetime_from_unix_nanos(
+        crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(tmux_session_name),
+    )
+    .unwrap_or(fallback_now)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,5 +325,39 @@ mod tests {
         assert!(!should_flush_post_terminal_success_continuation(
             true, false, true, "   "
         ));
+    }
+
+    #[test]
+    fn watcher_activity_heartbeat_uses_runtime_output_mtime() {
+        let tmux_name = format!("AgentDesk-claude-heartbeat-{}", uuid::Uuid::new_v4());
+        let output_path = std::path::PathBuf::from(
+            crate::services::tmux_common::session_temp_path(&tmux_name, "jsonl"),
+        );
+        std::fs::write(&output_path, b"{\"event\":\"output\"}\n").expect("write runtime output");
+        let output_time = filetime::FileTime::from_unix_time(1_700_000_123, 456_000_000);
+        filetime::set_file_mtime(&output_path, output_time).expect("set runtime output mtime");
+        let fallback_now =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_010_000, 0).unwrap();
+
+        let activity_at = runtime_activity_heartbeat_at(&tmux_name, fallback_now);
+
+        assert_eq!(activity_at.timestamp(), 1_700_000_123);
+        assert_eq!(activity_at.timestamp_subsec_nanos(), 456_000_000);
+        let _ = std::fs::remove_file(output_path);
+    }
+
+    #[test]
+    fn watcher_activity_heartbeat_falls_back_to_now_without_runtime_output() {
+        let tmux_name = format!(
+            "AgentDesk-claude-heartbeat-missing-{}",
+            uuid::Uuid::new_v4()
+        );
+        let fallback_now =
+            chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_020_000, 0).unwrap();
+
+        assert_eq!(
+            runtime_activity_heartbeat_at(&tmux_name, fallback_now),
+            fallback_now
+        );
     }
 }

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -1241,6 +1241,7 @@ async fn kill_tmux_session_impl(
                     &target,
                     session_key,
                     reason,
+                    minimum_idle_minutes,
                 )
                 .await;
             }
@@ -1255,6 +1256,47 @@ async fn kill_tmux_session_impl(
     let effective_provider_name = provider_name.or(session_provider.as_deref());
 
     let tmux_was_alive = crate::services::platform::tmux::has_session(&tmux_name);
+    let reason_is_idle_cleanup = reason_is_idle_cleanup_reason(reason);
+    let mut idle_decision_last_seen_nanos = None;
+    let mut idle_decision_runtime_activity_nanos = None;
+    let mut idle_decision_runtime_activity_age_minutes = None;
+
+    if should_skip_idle_cleanup_for_active_dispatch(active_dispatch_id.as_deref(), reason) {
+        let last_seen_nanos =
+            dispatched_sessions_db::session_last_seen_unix_nanos_pg(pool, session_key)
+                .await
+                .unwrap_or(0);
+        let runtime_activity_nanos = latest_runtime_activity_unix_nanos(&tmux_name);
+        let runtime_activity_age_minutes =
+            runtime_activity_age_minutes(runtime_activity_nanos, now_unix_nanos());
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            session_key,
+            tmux_session = %tmux_name,
+            active_dispatch_id = ?active_dispatch_id,
+            last_seen_unix_nanos = last_seen_nanos,
+            runtime_activity_unix_nanos = runtime_activity_nanos,
+            runtime_activity_age_minutes,
+            minimum_idle_minutes,
+            reason,
+            decision = "skip_active_dispatch",
+            "  [{ts}] 🛡 kill-tmux: SKIPPED idle cleanup — active dispatch is still attached, dispatch cleanup owns this session (#3718).",
+        );
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "tmux_killed": false,
+                "tmux_was_alive": tmux_was_alive,
+                "tmux_session_name": tmux_name,
+                "session_row_preserved": true,
+                "skipped_active_dispatch_guard": true,
+                "runtime_activity_age_minutes": runtime_activity_age_minutes,
+                "minimum_idle_minutes": minimum_idle_minutes,
+                "active_dispatch_id": active_dispatch_id,
+            })),
+        );
+    }
 
     // #3053: live-activity guard. idle-kill selects on COALESCE(last_heartbeat,
     // created_at); if the matching heartbeat path silently missed this row,
@@ -1265,25 +1307,24 @@ async fn kill_tmux_session_impl(
     // refresh the heartbeat and SKIP the kill so the next idle-kill tick no
     // longer selects it. Forced/explicit reasons are not affected — this guard
     // only fires for the idle-cleanup reason shape and a live tmux.
-    let reason_is_idle_cleanup = reason.contains("idle") || reason.contains("자동 정리");
     if tmux_was_alive && reason_is_idle_cleanup && active_dispatch_id.is_none() {
         let last_seen_nanos =
             dispatched_sessions_db::session_last_seen_unix_nanos_pg(pool, session_key)
                 .await
                 .unwrap_or(0);
         let runtime_activity_nanos = latest_runtime_activity_unix_nanos(&tmux_name);
+        let now_nanos = now_unix_nanos();
         let runtime_activity_age_minutes =
-            runtime_activity_age_minutes(runtime_activity_nanos, now_unix_nanos());
-        let runtime_activity_still_within_idle_threshold =
-            match (runtime_activity_age_minutes, minimum_idle_minutes) {
-                (Some(age), Some(threshold)) => age < threshold,
-                (Some(_), None) => true,
-                _ => false,
-            };
-        if runtime_activity_nanos > 0
-            && runtime_activity_nanos > last_seen_nanos
-            && runtime_activity_still_within_idle_threshold
-        {
+            runtime_activity_age_minutes(runtime_activity_nanos, now_nanos);
+        idle_decision_last_seen_nanos = Some(last_seen_nanos);
+        idle_decision_runtime_activity_nanos = Some(runtime_activity_nanos);
+        idle_decision_runtime_activity_age_minutes = runtime_activity_age_minutes;
+        if should_skip_idle_kill_for_live_runtime_activity(
+            last_seen_nanos,
+            runtime_activity_nanos,
+            now_nanos,
+            minimum_idle_minutes,
+        ) {
             let refreshed =
                 dispatched_sessions_db::refresh_session_heartbeat_by_key_to_unix_nanos_pg(
                     pool,
@@ -1300,6 +1341,8 @@ async fn kill_tmux_session_impl(
                 runtime_activity_age_minutes,
                 minimum_idle_minutes,
                 heartbeat_refreshed = refreshed,
+                reason,
+                decision = "skip_live_output",
                 "  [{ts}] 🛡 kill-tmux: SKIPPED idle kill — runtime activity newer than last_heartbeat and still within idle threshold, session is live (#3053). Heartbeat refreshed to runtime activity.",
             );
             return (
@@ -1414,6 +1457,38 @@ async fn kill_tmux_session_impl(
         );
     }
 
+    if reason_is_idle_cleanup {
+        if idle_decision_last_seen_nanos.is_none() {
+            idle_decision_last_seen_nanos = Some(
+                dispatched_sessions_db::session_last_seen_unix_nanos_pg(pool, session_key)
+                    .await
+                    .unwrap_or(0),
+            );
+        }
+        if idle_decision_runtime_activity_nanos.is_none() {
+            let runtime_activity_nanos = latest_runtime_activity_unix_nanos(&tmux_name);
+            idle_decision_runtime_activity_nanos = Some(runtime_activity_nanos);
+            idle_decision_runtime_activity_age_minutes =
+                runtime_activity_age_minutes(runtime_activity_nanos, now_unix_nanos());
+        }
+        tracing::info!(
+            session_key,
+            tmux_session = %tmux_name,
+            tmux_killed,
+            tmux_was_alive,
+            session_row_disconnected,
+            resumable,
+            active_dispatch_id = ?active_dispatch_id,
+            last_seen_unix_nanos = idle_decision_last_seen_nanos,
+            runtime_activity_unix_nanos = idle_decision_runtime_activity_nanos,
+            runtime_activity_age_minutes = idle_decision_runtime_activity_age_minutes,
+            minimum_idle_minutes,
+            reason,
+            decision = "kill_idle",
+            "kill-tmux: idle cleanup decision (#3718)"
+        );
+    }
+
     (
         StatusCode::OK,
         Json(json!({
@@ -1429,6 +1504,10 @@ async fn kill_tmux_session_impl(
     )
 }
 
+fn reason_is_idle_cleanup_reason(reason: &str) -> bool {
+    reason.contains("idle") || reason.contains("자동 정리")
+}
+
 fn runtime_activity_age_minutes(runtime_activity_nanos: i64, now_nanos: i64) -> Option<u64> {
     if runtime_activity_nanos <= 0 {
         return None;
@@ -1439,11 +1518,38 @@ fn runtime_activity_age_minutes(runtime_activity_nanos: i64, now_nanos: i64) -> 
     Some(((now_nanos - runtime_activity_nanos) / 60_000_000_000) as u64)
 }
 
+fn should_skip_idle_kill_for_live_runtime_activity(
+    last_seen_nanos: i64,
+    runtime_activity_nanos: i64,
+    now_nanos: i64,
+    minimum_idle_minutes: Option<u64>,
+) -> bool {
+    if runtime_activity_nanos <= 0 || runtime_activity_nanos <= last_seen_nanos {
+        return false;
+    }
+    match (
+        runtime_activity_age_minutes(runtime_activity_nanos, now_nanos),
+        minimum_idle_minutes,
+    ) {
+        (Some(age), Some(threshold)) => age < threshold,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+fn should_skip_idle_cleanup_for_active_dispatch(
+    active_dispatch_id: Option<&str>,
+    reason: &str,
+) -> bool {
+    active_dispatch_id.is_some() && reason_is_idle_cleanup_reason(reason)
+}
+
 #[cfg(test)]
 mod kill_tmux_resume_tests {
     use super::{
         latest_runtime_activity_unix_nanos, provider_resume_selector_is_effective_with_claude_home,
-        runtime_activity_age_minutes,
+        runtime_activity_age_minutes, should_skip_idle_cleanup_for_active_dispatch,
+        should_skip_idle_kill_for_live_runtime_activity,
     };
     use crate::db::dispatched_sessions::ProviderSessionIds;
 
@@ -1508,6 +1614,56 @@ mod kill_tmux_resume_tests {
             runtime_activity_age_minutes(465 * minute, 465 * minute),
             Some(0)
         );
+    }
+
+    #[test]
+    fn idle_kill_guard_uses_runtime_output_age_not_turn_age() {
+        let minute = 60_000_000_000i64;
+        let now = 1_000 * minute;
+        let old_db_last_seen = 10 * minute;
+        let recent_runtime_output = now - 5 * minute;
+        let stale_runtime_output = now - 400 * minute;
+
+        assert!(should_skip_idle_kill_for_live_runtime_activity(
+            old_db_last_seen,
+            recent_runtime_output,
+            now,
+            Some(360),
+        ));
+        assert!(!should_skip_idle_kill_for_live_runtime_activity(
+            old_db_last_seen,
+            stale_runtime_output,
+            now,
+            Some(360),
+        ));
+        assert!(!should_skip_idle_kill_for_live_runtime_activity(
+            recent_runtime_output,
+            recent_runtime_output,
+            now,
+            Some(360),
+        ));
+        assert!(!should_skip_idle_kill_for_live_runtime_activity(
+            old_db_last_seen,
+            0,
+            now,
+            Some(360),
+        ));
+    }
+
+    #[test]
+    fn idle_cleanup_reason_does_not_kill_active_dispatch_tmux() {
+        assert!(should_skip_idle_cleanup_for_active_dispatch(
+            Some("dispatch-123"),
+            "idle 24시간 초과 — 자동 정리",
+        ));
+        assert!(!should_skip_idle_cleanup_for_active_dispatch(
+            Some("dispatch-123"),
+            "operator requested tmux reset",
+        ));
+        assert!(!should_skip_idle_cleanup_for_active_dispatch(
+            None,
+            "idle 24시간 초과 — 자동 정리",
+        ));
     }
 
     #[test]

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -214,6 +214,7 @@ pub(crate) async fn forward_kill_tmux(
     target: &ForwardTarget,
     session_key: &str,
     reason: &str,
+    minimum_idle_minutes: Option<u64>,
 ) -> (StatusCode, Json<Value>) {
     let url = format!(
         "{}/api/sessions/{}/kill-tmux",
@@ -223,7 +224,9 @@ pub(crate) async fn forward_kill_tmux(
     let request = apply_node_headers(
         state,
         target,
-        client().post(url).json(&json!({ "reason": reason })),
+        client()
+            .post(url)
+            .json(&json!({ "reason": reason, "minimum_idle_minutes": minimum_idle_minutes })),
     );
     forward_json_response(request, "kill-tmux", target).await
 }


### PR DESCRIPTION
## Summary
- Anchor idle-kill candidate selection to `sessions.last_heartbeat` / `created_at` only, removing turn lifecycle events from the idle timestamp.
- Persist watcher-observed output heartbeats using runtime output mtime and monotonic `GREATEST` updates.
- Refuse idle cleanup for active-dispatch sessions in both policy and kill-tmux, preserve `minimum_idle_minutes` across node forwarding, and add structured timing logs for skip/kill decisions.
- Update idle-kill policy/Rust unit coverage and AgentDesk maintenance freeze docs.

## Validation
- `node --test policies/__tests__/timeouts.test.js`
- `cargo check --lib`
- `cargo test --lib kill_tmux_resume_tests -- --nocapture`
- `cargo test --lib watcher_activity_heartbeat -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `PYTHON=/opt/homebrew/bin/python3.14 scripts/ci-script-checks.sh`

## Review
- Fresh Codex xhigh review: initial ISSUES addressed, re-review `VERDICT: CLEAN`.

Issue: #3718