### PR TITLE
Fix provider system injection classification

### DIFF
--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -124,33 +124,24 @@ pub(super) fn strip_leading_local_command_caveat(text: &str) -> (&str, bool) {
 }
 
 /// Detects the `<task-notification>` auto-turn tag injected by Claude Code /
-/// Codex when a background task reaches a terminal state. Deliberately
-/// CONTAINS-based: the CARD render must fire even for a human prompt that quotes
-/// a notification (it is still classified + rendered, never lost). The terminal
-/// BRIDGE uses the stricter `is_start_anchored_task_notification` instead.
+/// Codex when a background task reaches a terminal state. Start-anchored after
+/// the same normalization used by the terminal bridge, so a human prompt that
+/// quotes the tag mid-body remains a normal direct prompt (#3730).
 pub(super) fn is_task_notification_prompt(prompt: &str) -> bool {
-    let trimmed = prompt.trim_start();
-    // Skip a leading terminal-control prefix some injectors prepend before the
-    // tag (strip_terminal_controls is applied for display, not classification).
-    let normalized = strip_terminal_controls(trimmed);
-    let normalized = normalized.trim_start();
-    normalized.contains("<task-notification>") || normalized.contains("<task-notification ")
+    is_start_anchored_task_notification(prompt)
 }
 
 /// #3393 finding 2: START-ANCHORED gate for the live-panel terminal BRIDGE only.
 /// A REAL machine `<task-notification>` user-record begins with the tag after the
 /// shared normalization pipeline (strip_terminal_controls → trim →
 /// strip_leading_injection_wrapper → trim, mirroring #3100/#3388). A human direct
-/// prompt that merely QUOTES a notification mid-message keeps its CARD render (the
-/// contains-based classifier) but must NOT push terminal StatusEvents — combined
-/// with finding 1's id requirement this closes the false-close attack where a
-/// quoted live tool-use-id would otherwise finalize a real running slot.
+/// prompt that merely QUOTES a notification mid-message must NOT push terminal
+/// StatusEvents — combined with finding 1's id requirement this closes the
+/// false-close attack where a quoted live tool-use-id would otherwise finalize a
+/// real running slot.
 pub(super) fn is_start_anchored_task_notification(prompt: &str) -> bool {
-    let normalized = strip_terminal_controls(prompt);
-    let normalized = normalized.trim_start();
-    let normalized = strip_leading_injection_wrapper(normalized);
-    let normalized = normalized.trim_start();
-    normalized.starts_with("<task-notification>") || normalized.starts_with("<task-notification ")
+    let normalized = normalized_start_anchored_injection(prompt);
+    starts_with_xmlish_tag(&normalized, "task-notification")
 }
 
 /// Detects Codex `<subagent_notification>` envelopes as neutral machine events.
@@ -158,8 +149,17 @@ pub(super) fn is_start_anchored_task_notification(prompt: &str) -> bool {
 /// tag mid-body remains a normal TUI-direct prompt.
 pub(super) fn is_start_anchored_subagent_notification(prompt: &str) -> bool {
     let normalized = normalized_start_anchored_injection(prompt);
-    normalized.starts_with("<subagent_notification>")
-        || normalized.starts_with("<subagent_notification ")
+    starts_with_xmlish_tag(&normalized, "subagent_notification")
+}
+
+fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
+    let Some(rest) = text.strip_prefix('<') else {
+        return false;
+    };
+    let Some(rest) = rest.strip_prefix(tag) else {
+        return false;
+    };
+    rest.starts_with('>') || rest.chars().next().is_some_and(char::is_whitespace)
 }
 
 fn normalized_start_anchored_injection(prompt: &str) -> String {
@@ -182,6 +182,30 @@ pub(super) fn is_system_continuation_prompt(prompt: &str) -> bool {
     SYSTEM_CONTINUATION_OPENINGS
         .iter()
         .any(|opening| normalized.starts_with(opening))
+        || is_provider_session_reuse_marker(normalized)
+}
+
+fn is_provider_session_reuse_marker(normalized: &str) -> bool {
+    const RESUMED_THREAD_PROLOGUE: &str = "The prior authoritative Discord, role, and tool \
+         instructions already present in this Codex thread still apply. Treat only this turn's \
+         user request, reply context, uploaded files, and memory recall below as new actionable \
+         input.";
+    const FRESH_FORK_PROLOGUE: &str = "The prior authoritative Discord, role, and tool \
+         instructions already issued to this role in the current dcserver lifetime still apply. \
+         Treat only this turn's user request, reply context, uploaded files, and memory recall \
+         below as new actionable input.";
+
+    let Some(rest) = normalized.strip_prefix("[Provider Session Reuse]") else {
+        return false;
+    };
+    let rest = rest.trim_start();
+    provider_reuse_prologue_has_prompt_tail(rest, RESUMED_THREAD_PROLOGUE)
+        || provider_reuse_prologue_has_prompt_tail(rest, FRESH_FORK_PROLOGUE)
+}
+
+fn provider_reuse_prologue_has_prompt_tail(rest: &str, prologue: &str) -> bool {
+    rest.strip_prefix(prologue)
+        .is_some_and(|tail| tail.starts_with("\n\n"))
 }
 
 /// Removes a leading SSH-direct wrapper line/fence; mid-body quotes are untouched.

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -800,10 +800,9 @@ fn classify_injected_prompt_human_direct_input() {
 // injected message id, so it is classified distinctly from human input.
 #[test]
 fn classify_injected_prompt_task_notification_event() {
+    let bare = "<task-notification><status>completed</status><task_id>codex-background-event</task_id></task-notification>";
     assert_eq!(
-        classify_injected_prompt(
-            "<task-notification><status>completed</status><task_id>codex-background-event</task_id></task-notification>"
-        ),
+        classify_injected_prompt(bare),
         InjectedPromptClass::TaskNotificationEvent,
     );
     // Tolerates a leading terminal-control prefix some injectors prepend.
@@ -818,12 +817,35 @@ fn classify_injected_prompt_task_notification_event() {
         classify_injected_prompt("<task-notification kind=\"background\"></task-notification>"),
         InjectedPromptClass::TaskNotificationEvent,
     );
-    assert!(
-        !classify_injected_prompt(
-            "<task-notification><status>completed</status></task-notification>"
-        )
-        .is_human_active_turn()
+    assert_eq!(
+        classify_injected_prompt("<task-notification\nkind=\"background\"></task-notification>"),
+        InjectedPromptClass::TaskNotificationEvent,
+        "task-notification detection must accept newline attribute boundaries",
     );
+    assert_eq!(
+        classify_injected_prompt("<task-notification\tkind=\"background\"></task-notification>"),
+        InjectedPromptClass::TaskNotificationEvent,
+        "task-notification detection must accept tab attribute boundaries",
+    );
+    let wrapped = format!("터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n{bare}\n```");
+    assert_eq!(
+        classify_injected_prompt(&wrapped),
+        InjectedPromptClass::TaskNotificationEvent,
+        "wrapped task notification must classify after peeling the direct-injection wrapper",
+    );
+    let quoted = "please inspect this log line:\n\
+<task-notification><status>completed</status></task-notification>";
+    assert_eq!(
+        classify_injected_prompt(quoted),
+        InjectedPromptClass::HumanTuiDirect,
+        "a human quote of the tag mid-body must stay a normal direct prompt",
+    );
+    assert_eq!(
+        classify_injected_prompt("<task-notification-extra></task-notification-extra>"),
+        InjectedPromptClass::HumanTuiDirect,
+        "task-notification detection must honor tag boundaries",
+    );
+    assert!(!classify_injected_prompt(bare).is_human_active_turn());
 }
 
 // #3716: Codex subagent completions arrive as start-anchored
@@ -852,6 +874,24 @@ fn classify_injected_prompt_subagent_notification_event() {
     assert!(
         super::injected_prompt_policy::is_start_anchored_subagent_notification(wrapped),
         "wrapped subagent_notification must pass after peeling the direct-injection wrapper"
+    );
+
+    let newline_attr = "<subagent_notification\nkind=\"worker\">{\"status\":{\"completed\":\"done\"}}</subagent_notification>";
+    assert_eq!(
+        classify_injected_prompt(newline_attr),
+        InjectedPromptClass::SubagentNotificationEvent,
+        "subagent_notification detection must accept newline attribute boundaries",
+    );
+    let tab_attr = "<subagent_notification\tkind=\"worker\">{\"status\":{\"completed\":\"done\"}}</subagent_notification>";
+    assert_eq!(
+        classify_injected_prompt(tab_attr),
+        InjectedPromptClass::SubagentNotificationEvent,
+        "subagent_notification detection must accept tab attribute boundaries",
+    );
+    assert_eq!(
+        classify_injected_prompt("<subagent_notification_extra>{}</subagent_notification_extra>"),
+        InjectedPromptClass::HumanTuiDirect,
+        "subagent_notification detection must honor tag boundaries",
     );
 
     let quoted = "please inspect this log line:\n<subagent_notification>{\"status\":{\"completed\":\"x\"}}</subagent_notification>";
@@ -927,12 +967,12 @@ fn subagent_notification_card_malformed_payload_omits_raw_payload() {
     assert!(!output.contains("<subagent_notification>"));
 }
 
-// #3393 finding 2: the live-panel terminal BRIDGE is gated on a START-ANCHORED
-// check, distinct from the contains-based CARD classifier. A human direct
-// prompt that QUOTES a notification (embedding a LIVE tool-use-id) still earns
-// its card but must NOT push terminal StatusEvents — so a quoted id cannot
-// false-close a real running slot. A bare real-shape record (incl. a leading
-// injection-wrapper round-trip) still bridges.
+// #3393/#3730: the live-panel terminal BRIDGE and system-event classifier are
+// both gated on a START-ANCHORED check. A human direct prompt that QUOTES a
+// notification (embedding a LIVE tool-use-id) must stay a human prompt and must
+// not push terminal StatusEvents — so a quoted id cannot false-close a real
+// running slot. A bare real-shape record (incl. a leading injection-wrapper
+// round-trip) still bridges.
 #[test]
 fn bridge_guard_is_start_anchored_not_contains() {
     // Human prompt quoting a notification mid-message, with a LIVE tool-use-id
@@ -945,11 +985,10 @@ fn bridge_guard_is_start_anchored_not_contains() {
         !is_start_anchored_task_notification(quoted),
         "a mid-message quoted notification must NOT pass the bridge guard"
     );
-    // …yet the contains-based classifier still routes it to the CARD (the
-    // card behavior is preserved; only the terminal bridge is suppressed).
     assert_eq!(
         classify_injected_prompt(quoted),
-        InjectedPromptClass::TaskNotificationEvent,
+        InjectedPromptClass::HumanTuiDirect,
+        "a mid-message quoted notification must not classify as a system event",
     );
 
     // A bare, start-anchored real-shape record bridges.
@@ -1580,6 +1619,48 @@ fn classify_injected_prompt_wrapped_continuation_is_continuation() {
     );
 }
 
+// #3730: provider-session reuse prompts are machine/system injections. They
+// compact repeated authoritative Discord/role/tool instructions and must render
+// as neutral continuation notes, not raw direct-input blocks.
+#[test]
+fn classify_injected_prompt_provider_session_reuse_is_continuation() {
+    let resumed = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n[User: 0hbujang] ok";
+    assert_eq!(
+        classify_injected_prompt(resumed),
+        InjectedPromptClass::SystemContinuation,
+    );
+
+    let fresh_fork = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already issued to this \
+role in the current dcserver lifetime still apply. Treat only this turn's user request, \
+reply context, uploaded files, and memory recall below as new actionable input.\n\n[User: x]";
+    assert_eq!(
+        classify_injected_prompt(fresh_fork),
+        InjectedPromptClass::SystemContinuation,
+    );
+
+    let wrapped = format!(
+        "터미널에 직접 주입된 입력 (tmux : `AgentDesk-codex-adk-cdx`):\n```text\n{resumed}\n```"
+    );
+    assert_eq!(
+        classify_injected_prompt(&wrapped),
+        InjectedPromptClass::SystemContinuation,
+        "wrapped provider reuse marker must classify after peeling the direct-injection wrapper",
+    );
+
+    let truncated_prologue = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply.\n\nThis is a human question about the marker.";
+    assert_eq!(
+        classify_injected_prompt(truncated_prologue),
+        InjectedPromptClass::HumanTuiDirect,
+        "provider reuse detection must require the full generated prologue, not just the first sentence",
+    );
+}
+
 // #3100 codex P2: stripping the wrapper is anchored to the START. A human
 // message whose body merely contains/quotes the wrapper marker (not as the
 // leading line) must NOT be unwrapped and must stay a human turn.
@@ -1601,6 +1682,14 @@ fn classify_injected_prompt_wrapper_quoted_mid_body_is_not_continuation() {
     assert_eq!(
         classify_injected_prompt(wrapped_human),
         InjectedPromptClass::HumanTuiDirect,
+    );
+
+    let quoted_reuse = "Why did the prompt include [Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this Codex thread still apply?";
+    assert_eq!(
+        classify_injected_prompt(quoted_reuse),
+        InjectedPromptClass::HumanTuiDirect,
+        "provider reuse detection must stay start-anchored to avoid swallowing human questions",
     );
 }
 


### PR DESCRIPTION
## Summary

Addresses #3730.

Provider/system injected prompts now share stricter typed classification before Discord rendering:

- Classify `<task-notification>` with the same start-anchored normalization used by the live-panel bridge, so human mid-body quotes stay direct input.
- Reuse one XML-ish tag boundary helper for task and subagent notifications: `>` or any whitespace after the tag name, while rejecting similarly named tags.
- Classify `[Provider Session Reuse]` only when it matches the full generated canonical prologue plus the blank-line prompt delimiter.
- Add regression coverage for wrapped/unwrapped system events, newline/tab tag attributes, quoted tags/markers, and truncated provider-reuse text.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check --lib`
- `cargo test --lib classify_injected_prompt_task_notification_event -- --nocapture`
- `cargo test --lib classify_injected_prompt_subagent_notification_event -- --nocapture`
- `cargo test --lib classify_injected_prompt_provider_session_reuse_is_continuation -- --nocapture`
- `AGENTDESK_ROOT_DIR=$(mktemp -d /tmp/adk3730-relay-tests.XXXXXX) cargo test --lib services::discord::tui_prompt_relay::tests -- --test-threads=1`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `PYTHON=/Users/itismyfield/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 ./scripts/ci-script-checks.sh`
- Fresh Codex xhigh adversarial review: `VERDICT: CLEAN`

Notes: existing warnings remain for `legacy-sqlite-tests` cfg and pre-existing unused imports.
