### PR TITLE
Stabilize CI postgres service startup

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -14,6 +14,7 @@ env:
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: 10G
   SCCACHE_GHA_ENABLED: "true"
+  POSTGRES_SERVICE_IMAGE: ${{ vars.AGENTDESK_POSTGRES_SERVICE_IMAGE }}
 
 jobs:
   changes:
@@ -120,20 +121,6 @@ jobs:
   postgres:
     name: PostgreSQL tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -145,6 +132,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -175,6 +165,10 @@ jobs:
         timeout-minutes: 15
         run: just test-postgres
 
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -184,20 +178,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.high_risk_recovery == 'true'
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -209,6 +189,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -231,6 +214,10 @@ jobs:
 
       - name: High-risk recovery lane
         run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -14,6 +14,7 @@ env:
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: 10G
   SCCACHE_GHA_ENABLED: "true"
+  POSTGRES_SERVICE_IMAGE: ${{ vars.AGENTDESK_POSTGRES_SERVICE_IMAGE }}
 
 jobs:
   dashboard:
@@ -164,20 +165,6 @@ jobs:
   postgres_full:
     name: PostgreSQL full tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -189,6 +176,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -217,6 +207,10 @@ jobs:
         timeout-minutes: 15
         run: cargo test _pg_ -- --nocapture --test-threads=1
 
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -224,20 +218,6 @@ jobs:
   multinode_regression:
     name: Multinode regression lane
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -249,6 +229,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -281,6 +264,10 @@ jobs:
       - name: Merge gate policy invariants
         run: node --test policies/__tests__/merge-automation.test.js
 
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -288,20 +275,6 @@ jobs:
   high_risk_recovery_full:
     name: High-risk recovery full
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -313,6 +286,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -335,6 +311,10 @@ jobs:
 
       - name: High-risk recovery lane
         run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,6 +25,7 @@ env:
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: 10G
   SCCACHE_GHA_ENABLED: "true"
+  POSTGRES_SERVICE_IMAGE: ${{ vars.AGENTDESK_POSTGRES_SERVICE_IMAGE }}
 
 jobs:
   changes:
@@ -87,6 +88,7 @@ jobs:
               - '.github/workflows/**'
               - 'justfile'
               - 'migrations/**'
+              - 'scripts/ci/postgres-service.sh'
               - 'src/db/**'
               - 'src/dispatch/**'
               - 'src/engine/**'
@@ -458,20 +460,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.pg_db == 'true' && needs.changes.outputs.ci_relax_safe != 'true'
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -483,6 +471,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -513,6 +504,10 @@ jobs:
         timeout-minutes: 15
         run: just test-postgres
 
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -522,20 +517,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.high_risk_recovery == 'true' && needs.changes.outputs.ci_relax_safe != 'true'
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
@@ -547,6 +528,9 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL service
+        run: ./scripts/ci/postgres-service.sh start
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -569,6 +553,10 @@ jobs:
 
       - name: High-risk recovery lane
         run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
+
+      - name: Stop PostgreSQL service
+        if: always()
+        run: ./scripts/ci/postgres-service.sh stop
 
       - name: sccache stats
         if: always()

--- a/docs/ci/postgres-service-image.md
+++ b/docs/ci/postgres-service-image.md
@@ -1,0 +1,19 @@
+# PostgreSQL CI Service Image
+
+GitHub Actions Postgres lanes start their database through
+`scripts/ci/postgres-service.sh` instead of workflow-level `services:`.
+Workflow services pull the container image before any repository step can run,
+so registry slowness or rate limits fail the job without retry context.
+
+The script owns the shared policy:
+
+- `POSTGRES_SERVICE_IMAGE` selects the image. Workflows map this from the
+  optional repository/org variable `AGENTDESK_POSTGRES_SERVICE_IMAGE`.
+- If the variable is unset, the script defaults to `postgres:17`.
+- `POSTGRES_SERVICE_PULL_ATTEMPTS` controls pull retry count and defaults to 3.
+- Startup waits for `pg_isready` and prints container logs before failing.
+
+Use `AGENTDESK_POSTGRES_SERVICE_IMAGE` when the project needs to pin a mirror or
+registry cache without editing every workflow. Image pull failures are reported
+as CI service infrastructure errors; test failures after the database is ready
+remain ordinary AgentDesk test failures.

--- a/scripts/ci/postgres-service.sh
+++ b/scripts/ci/postgres-service.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-start}"
+image="${POSTGRES_SERVICE_IMAGE:-postgres:17}"
+container="${POSTGRES_SERVICE_CONTAINER:-agentdesk-postgres}"
+port="${POSTGRES_SERVICE_PORT:-5432}"
+password="${POSTGRES_SERVICE_PASSWORD:-postgres}"
+pull_attempts="${POSTGRES_SERVICE_PULL_ATTEMPTS:-3}"
+ready_timeout="${POSTGRES_SERVICE_READY_TIMEOUT_SECS:-60}"
+
+log() {
+  printf '[postgres-service] %s\n' "$*"
+}
+
+gha_error() {
+  local title="$1"
+  local message="$2"
+  printf '::error title=%s::%s\n' "$title" "$message"
+}
+
+is_positive_int() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+require_positive_int() {
+  local name="$1"
+  local value="$2"
+
+  if ! is_positive_int "$value"; then
+    gha_error "Invalid Postgres service configuration" "${name} must be a positive integer; got '${value}'."
+    exit 64
+  fi
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    gha_error "Docker unavailable" "Postgres CI service requires docker on the runner."
+    exit 69
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    gha_error "Docker daemon unavailable" "Postgres CI service could not contact the docker daemon."
+    exit 69
+  fi
+}
+
+pull_image() {
+  local attempt=1
+  local delay=5
+
+  while (( attempt <= pull_attempts )); do
+    log "pulling ${image} (attempt ${attempt}/${pull_attempts})"
+    if docker pull "$image"; then
+      return 0
+    fi
+
+    if (( attempt < pull_attempts )); then
+      log "image pull failed; retrying in ${delay}s"
+      sleep "$delay"
+      delay=$((delay * 2))
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  gha_error \
+    "Postgres service image pull failed" \
+    "Unable to pull ${image} after ${pull_attempts} attempts. This is CI runner/image registry infrastructure, not an AgentDesk test failure."
+  return 70
+}
+
+start_container() {
+  local container_id
+
+  docker rm -f "$container" >/dev/null 2>&1 || true
+
+  log "starting ${container} from ${image} on 127.0.0.1:${port}"
+  if ! container_id="$(
+    docker run \
+      --detach \
+      --name "$container" \
+      --env POSTGRES_USER=postgres \
+      --env POSTGRES_PASSWORD="$password" \
+      --env POSTGRES_DB=postgres \
+      --publish "127.0.0.1:${port}:5432" \
+      "$image"
+  )"; then
+    gha_error \
+      "Postgres service container start failed" \
+      "Unable to start ${container} from ${image}. This is CI service startup infrastructure, not an AgentDesk test failure."
+    return 71
+  fi
+
+  log "started container ${container_id}"
+}
+
+wait_until_ready() {
+  local elapsed=0
+
+  while ! docker exec "$container" pg_isready -U postgres -d postgres >/dev/null 2>&1; do
+    if (( elapsed >= ready_timeout )); then
+      log "container logs from failed startup:"
+      docker logs "$container" || true
+      gha_error \
+        "Postgres service startup failed" \
+        "Container ${container} from ${image} did not become ready within ${ready_timeout}s. This is CI service startup infrastructure, not an AgentDesk test failure."
+      return 71
+    fi
+
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  log "Postgres is ready"
+}
+
+start_service() {
+  require_positive_int POSTGRES_SERVICE_PULL_ATTEMPTS "$pull_attempts"
+  require_positive_int POSTGRES_SERVICE_READY_TIMEOUT_SECS "$ready_timeout"
+  require_docker
+  pull_image
+  start_container
+  wait_until_ready
+}
+
+stop_service() {
+  if ! command -v docker >/dev/null 2>&1; then
+    log "docker unavailable; skipping cleanup"
+    return 0
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    log "docker daemon unavailable; skipping cleanup"
+    return 0
+  fi
+
+  log "stopping ${container}"
+  docker rm -f "$container" >/dev/null 2>&1 || true
+}
+
+case "$command" in
+  start)
+    start_service
+    ;;
+  stop)
+    stop_service
+    ;;
+  *)
+    echo "Usage: $0 {start|stop}" >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Replace workflow-level GitHub Actions PostgreSQL services with a shared `scripts/ci/postgres-service.sh` launcher.
- Add pull retry, explicit image-pull/container-start/readiness diagnostics, and cleanup for PR/main/nightly PostgreSQL lanes.
- Centralize image selection behind `POSTGRES_SERVICE_IMAGE`, mapped from optional `AGENTDESK_POSTGRES_SERVICE_IMAGE`, with docs for mirror/cache rollout.
- Add the new service script to the PR `pg_db` path filter so script-only changes still run PostgreSQL CI.

Closes #3726

## Verification
- `bash -n scripts/ci/postgres-service.sh`
- `shellcheck -S warning scripts/ci/postgres-service.sh`
- `git diff --check`
- `actionlint .github/workflows/ci-pr.yml .github/workflows/ci-main.yml .github/workflows/ci-nightly.yml`
- `PYTHON=/Users/itismyfield/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 ./scripts/ci-script-checks.sh`
- Fresh Codex xhigh adversarial review: `VERDICT: CLEAN`

Local Docker daemon is unavailable in this worktree environment, so real container startup is verified by GitHub Actions on this PR.