### PR TITLE
Guard Postgres startup with advisory lock

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1409,7 +1409,7 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2559 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests; +8 from #3690 AgentDef.preferred_intake_node_labels field + doc; #3683 config hot-reload restart-fingerprint config surface).
-  - `src/server/mod.rs` (2641 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review; #3740 adds the boot hook for token-analytics cache prewarm).
+  - `src/server/mod.rs` (2650 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review; #3740 adds the boot hook for token-analytics cache prewarm; #3722 removes duplicate startup reseed when callers already completed guarded startup initialization).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).
   - `src/reconcile.rs` (1868 lines; #3685 rebind-origin stale-inflight
@@ -1450,7 +1450,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1167 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests; #3690: preferred_intake_node_labels upsert/sync + COALESCE preserve; #3692: `agent_roster_sync_enabled` leader-ownership gate on the roster sync).
+  - `src/db/postgres.rs` (1280 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests; #3690: preferred_intake_node_labels upsert/sync + COALESCE preserve; #3692: `agent_roster_sync_enabled` leader-ownership gate on the roster sync; #3722 adds the bounded startup advisory lock wrapper plus concurrency coverage for migration/config-audit/reseed startup sections).
   - `src/db/dispatched_sessions.rs` (1628 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads; #3693: +2 to

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1372,50 +1372,42 @@ pub fn handle_dcserver(token: Option<String>) {
             }
         }
 
-        let discord_pg_pool = match crate::db::postgres::connect_and_migrate(&ad_config).await {
+        let discord_pg_pool = match crate::db::postgres::connect(&ad_config).await {
             Ok(Some(pool)) => {
-                if let Some(root) = runtime_root.as_ref() {
-                    match crate::services::discord_config_audit::load_runtime_config(root)
-                        .and_then(|loaded| {
-                            crate::services::discord_config_audit::audit_and_reconcile_config_only(
-                                root,
-                                loaded.config,
-                                loaded.path,
-                                loaded.existed,
-                                &legacy_scan,
-                                false,
-                            )
-                        })
-                    {
-                        Ok(outcome) => {
-                            ad_config = outcome.config;
-                        }
-                        Err(error) => {
-                            eprintln!(
-                                "  ✖ Config audit after PostgreSQL migration failed: {error}"
-                            );
-                            std::process::exit(1);
-                        }
-                    }
-                }
-                let startup_pg_pool =
-                    match crate::db::postgres::connect_for_startup(&ad_config).await {
-                        Ok(pool) => pool,
-                        Err(error) => {
-                            eprintln!(
-                                "  ⚠ PostgreSQL warmup pool unavailable: {error} — falling back to runtime pool"
-                            );
-                            None
-                        }
-                    };
-                let startup_pool = startup_pg_pool.as_ref().unwrap_or(&pool);
                 if let Err(error) =
-                    crate::db::postgres::startup_reseed(startup_pool, &ad_config).await
+                    crate::db::postgres::with_startup_advisory_lock(&pool, || async {
+                        crate::db::postgres::migrate(&pool).await?;
+                        if let Some(root) = runtime_root.as_ref() {
+                            match crate::services::discord_config_audit::load_runtime_config(root)
+                                .and_then(|loaded| {
+                                    crate::services::discord_config_audit::audit_and_reconcile_config_only(
+                                        root,
+                                        loaded.config,
+                                        loaded.path,
+                                        loaded.existed,
+                                        &legacy_scan,
+                                        false,
+                                    )
+                                })
+                            {
+                                Ok(outcome) => {
+                                    ad_config = outcome.config;
+                                }
+                                Err(error) => {
+                                    return Err(format!(
+                                        "Config audit after PostgreSQL migration failed: {error}"
+                                    ));
+                                }
+                            }
+                        }
+                        crate::db::postgres::startup_reseed_with_warmup_pool(&pool, &ad_config)
+                            .await
+                    })
+                    .await
                 {
-                    eprintln!("  ✖ PostgreSQL startup reseed failed: {error}");
+                    eprintln!("  ✖ PostgreSQL startup initialization failed: {error}");
                     std::process::exit(1);
                 }
-                drop(startup_pg_pool);
                 pool
             }
             Ok(None) => {
@@ -1423,7 +1415,7 @@ pub fn handle_dcserver(token: Option<String>) {
                 std::process::exit(1);
             }
             Err(error) => {
-                eprintln!("  ✖ PostgreSQL connect/migrate failed: {error}");
+                eprintln!("  ✖ PostgreSQL connect failed: {error}");
                 std::process::exit(1);
             }
         };

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -163,20 +163,49 @@ async fn build_app_state(with_health_registry: bool) -> Result<AppState, String>
         }
     };
 
-    let mut config = if let Some(root) = runtime_root.as_ref() {
-        crate::services::discord_config_audit::audit_and_reconcile_config_only(
+    let crate::services::discord_config_audit::LoadedRuntimeConfig {
+        mut config,
+        path: loaded_path,
+        existed: loaded_existed,
+    } = loaded;
+    if let Some(root) = runtime_root
+        .as_ref()
+        .filter(|_| !crate::db::postgres::database_enabled(&config))
+    {
+        config = crate::services::discord_config_audit::audit_and_reconcile_config_only(
             root,
-            loaded.config,
-            loaded.path,
-            loaded.existed,
+            config,
+            loaded_path,
+            loaded_existed,
             &legacy_scan,
             false,
         )
         .map_err(|e| format!("audit runtime config: {e}"))?
-        .config
-    } else {
-        loaded.config
-    };
+        .config;
+    }
+
+    let pg_pool = crate::db::postgres::connect(&config).await?;
+    if let Some(pool) = pg_pool.as_ref() {
+        crate::db::postgres::with_startup_advisory_lock(pool, || async {
+            crate::db::postgres::migrate(pool).await?;
+            if let Some(root) = runtime_root.as_ref() {
+                let loaded = crate::services::discord_config_audit::load_runtime_config(root)
+                    .map_err(|e| format!("reload runtime config after pg migration: {e}"))?;
+                config = crate::services::discord_config_audit::audit_and_reconcile_config_only(
+                    root,
+                    loaded.config,
+                    loaded.path,
+                    loaded.existed,
+                    &legacy_scan,
+                    false,
+                )
+                .map_err(|e| format!("persist runtime config audit after pg migration: {e}"))?
+                .config;
+            }
+            crate::db::postgres::startup_reseed_with_warmup_pool(pool, &config).await
+        })
+        .await?;
+    }
 
     let pipeline_path = config.policies.dir.join("default-pipeline.yaml");
     if pipeline_path.exists() {
@@ -192,27 +221,6 @@ async fn build_app_state(with_health_registry: bool) -> Result<AppState, String>
         }
     } else {
         crate::pipeline::ensure_loaded();
-    }
-
-    let pg_pool = crate::db::postgres::connect_and_migrate(&config).await?;
-    if let Some(root) = runtime_root.as_ref() {
-        let loaded = crate::services::discord_config_audit::load_runtime_config(root)
-            .map_err(|e| format!("reload runtime config after pg migration: {e}"))?;
-        config = crate::services::discord_config_audit::audit_and_reconcile_config_only(
-            root,
-            loaded.config,
-            loaded.path,
-            loaded.existed,
-            &legacy_scan,
-            false,
-        )
-        .map_err(|e| format!("persist runtime config audit after pg migration: {e}"))?
-        .config;
-    }
-    if let Some(pool) = pg_pool.as_ref() {
-        crate::db::postgres::startup_reseed(pool, &config)
-            .await
-            .map_err(|e| format!("startup reseed: {e}"))?;
     }
     crate::pipeline::refresh_override_health_report(pg_pool.as_ref()).await;
     crate::services::termination_audit::init_audit_db(pg_pool.clone());

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use sqlx::Connection;
 use sqlx::migrate::Migrator;
@@ -17,6 +18,10 @@ const DEFAULT_PG_ACQUIRE_TIMEOUT_SECS: u64 = 3;
 const STARTUP_PG_ACQUIRE_TIMEOUT_SECS: u64 = 60;
 const DEFAULT_PG_IDLE_TIMEOUT_SECS: u64 = 5 * 60;
 const DEFAULT_PG_MAX_LIFETIME_SECS: u64 = 30 * 60;
+const STARTUP_INITIALIZATION_ADVISORY_LOCK_ID: i64 = 3_722_000_001;
+const STARTUP_INITIALIZATION_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+const STARTUP_INITIALIZATION_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(250);
+const STARTUP_INITIALIZATION_LOCK_LOG_INTERVAL: Duration = Duration::from_secs(5);
 
 /// #3651: process-global count of runtime-pool connections reserved for
 /// foreground turn ingestion. Set once when the runtime pool is built
@@ -296,7 +301,7 @@ pub async fn connect_and_migrate(config: &Config) -> Result<Option<PgPool>, Stri
     let Some(pool) = connect(config).await? else {
         return Ok(None);
     };
-    migrate(&pool).await?;
+    with_startup_advisory_lock(&pool, || async { migrate(&pool).await }).await?;
     Ok(Some(pool))
 }
 
@@ -306,6 +311,95 @@ pub async fn migrate(pool: &PgPool) -> Result<(), String> {
         .await
         .map_err(|error| format!("run postgres migrations: {error}"))?;
     Ok(())
+}
+
+async fn acquire_startup_advisory_lock(pool: &PgPool) -> Result<AdvisoryLockLease, String> {
+    let started = Instant::now();
+    let mut last_wait_log = started
+        .checked_sub(STARTUP_INITIALIZATION_LOCK_LOG_INTERVAL)
+        .unwrap_or(started);
+
+    loop {
+        match AdvisoryLockLease::try_acquire(
+            pool,
+            STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+            "postgres startup initialization",
+        )
+        .await?
+        {
+            Some(lease) => {
+                tracing::info!(
+                    lock_id = STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+                    wait_ms = started.elapsed().as_millis() as u64,
+                    "[startup] acquired postgres startup advisory lock"
+                );
+                return Ok(lease);
+            }
+            None => {
+                let elapsed = started.elapsed();
+                if elapsed >= STARTUP_INITIALIZATION_LOCK_WAIT_TIMEOUT {
+                    return Err(format!(
+                        "postgres startup initialization advisory lock {} unavailable after {}s",
+                        STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+                        elapsed.as_secs()
+                    ));
+                }
+
+                if last_wait_log.elapsed() >= STARTUP_INITIALIZATION_LOCK_LOG_INTERVAL {
+                    tracing::warn!(
+                        lock_id = STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+                        waited_ms = elapsed.as_millis() as u64,
+                        timeout_ms = STARTUP_INITIALIZATION_LOCK_WAIT_TIMEOUT.as_millis() as u64,
+                        "[startup] waiting for postgres startup advisory lock"
+                    );
+                    last_wait_log = Instant::now();
+                }
+
+                tokio::time::sleep(STARTUP_INITIALIZATION_LOCK_RETRY_INTERVAL).await;
+            }
+        }
+    }
+}
+
+pub async fn with_startup_advisory_lock<T, F, Fut>(pool: &PgPool, operation: F) -> Result<T, String>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, String>>,
+{
+    let started = Instant::now();
+    let lease = acquire_startup_advisory_lock(pool).await?;
+    let result = operation().await;
+    let release_result = lease.unlock().await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+
+    match (result, release_result) {
+        (Ok(value), Ok(())) => {
+            tracing::info!(
+                lock_id = STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+                elapsed_ms,
+                "[startup] released postgres startup advisory lock"
+            );
+            Ok(value)
+        }
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Ok(())) => {
+            tracing::info!(
+                lock_id = STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+                elapsed_ms,
+                "[startup] released postgres startup advisory lock after failed startup mutation"
+            );
+            Err(error)
+        }
+        (Err(error), Err(unlock_error)) => {
+            tracing::warn!(
+                lock_id = STARTUP_INITIALIZATION_ADVISORY_LOCK_ID,
+                elapsed_ms,
+                unlock_error,
+                "[startup] failed to explicitly release postgres startup advisory lock after startup mutation error"
+            );
+            Err(error)
+        }
+    }
 }
 
 pub async fn startup_reseed(pool: &PgPool, config: &Config) -> Result<(), String> {
@@ -344,6 +438,25 @@ pub async fn startup_reseed(pool: &PgPool, config: &Config) -> Result<(), String
             config.cluster.role
         );
     }
+    Ok(())
+}
+
+pub async fn startup_reseed_with_warmup_pool(
+    runtime_pool: &PgPool,
+    config: &Config,
+) -> Result<(), String> {
+    let startup_pg_pool = match connect_for_startup(config).await {
+        Ok(pool) => pool,
+        Err(error) => {
+            tracing::warn!(
+                "[startup] postgres warmup pool unavailable; falling back to runtime pool: {error}"
+            );
+            None
+        }
+    };
+    let startup_pool = startup_pg_pool.as_ref().unwrap_or(runtime_pool);
+    startup_reseed(startup_pool, config).await?;
+    drop(startup_pg_pool);
     Ok(())
 }
 
@@ -1174,10 +1287,16 @@ mod tests {
         create_test_database, database_enabled, database_summary, health_check,
         run_test_postgres_sqlx_op_with_timeout, runtime_pool_settings, should_yield_for_counters,
         startup_pool_settings, startup_reseed, sync_agents_from_config_pg,
+        with_startup_advisory_lock,
     };
     use sqlx::Row;
     use std::collections::BTreeMap;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use std::time::Duration;
+    use tokio::sync::{Mutex, Notify};
 
     struct TestDatabase {
         admin_url: String,
@@ -2455,6 +2574,105 @@ mod tests {
             .await
             .expect("close pool B");
         close_test_pool(pool_a, "db::postgres advisory lock pool A")
+            .await
+            .expect("close pool A");
+        test_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn postgres_startup_advisory_lock_serializes_concurrent_startup_sections() {
+        let test_db = TestDatabase::create().await;
+        let config = postgres_test_config(&test_db);
+
+        let pool_a =
+            connect_test_pool_and_migrate_config(&config, "db::postgres startup lock test pool A")
+                .await
+                .expect("connect and migrate postgres pool A")
+                .expect("postgres pool A");
+        let pool_b =
+            connect_test_pool_and_migrate_config(&config, "db::postgres startup lock test pool B")
+                .await
+                .expect("connect and migrate postgres pool B")
+                .expect("postgres pool B");
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let events = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let first_entered = Arc::new(Notify::new());
+        let release_first = Arc::new(Notify::new());
+
+        let pool_a_task = pool_a.clone();
+        let active_a = Arc::clone(&active);
+        let max_active_a = Arc::clone(&max_active);
+        let events_a = Arc::clone(&events);
+        let first_entered_a = Arc::clone(&first_entered);
+        let release_first_a = Arc::clone(&release_first);
+        let config_a = config.clone();
+        let first = tokio::spawn(async move {
+            with_startup_advisory_lock(&pool_a_task, || async {
+                let now = active_a.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active_a.fetch_max(now, Ordering::SeqCst);
+                events_a.lock().await.push("first-enter");
+                first_entered_a.notify_one();
+                release_first_a.notified().await;
+                startup_reseed(&pool_a_task, &config_a).await?;
+                events_a.lock().await.push("first-exit");
+                active_a.fetch_sub(1, Ordering::SeqCst);
+                Ok(())
+            })
+            .await
+        });
+
+        first_entered.notified().await;
+
+        let pool_b_task = pool_b.clone();
+        let active_b = Arc::clone(&active);
+        let max_active_b = Arc::clone(&max_active);
+        let events_b = Arc::clone(&events);
+        let config_b = config.clone();
+        let second = tokio::spawn(async move {
+            with_startup_advisory_lock(&pool_b_task, || async {
+                let now = active_b.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active_b.fetch_max(now, Ordering::SeqCst);
+                events_b.lock().await.push("second-enter");
+                startup_reseed(&pool_b_task, &config_b).await?;
+                active_b.fetch_sub(1, Ordering::SeqCst);
+                Ok(())
+            })
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            active.load(Ordering::SeqCst),
+            1,
+            "the second startup section must wait while the first lock holder is active"
+        );
+
+        release_first.notify_one();
+        first
+            .await
+            .expect("first startup task joins")
+            .expect("first startup lock section");
+        second
+            .await
+            .expect("second startup task joins")
+            .expect("second startup lock section");
+
+        assert_eq!(
+            max_active.load(Ordering::SeqCst),
+            1,
+            "startup lock must prevent overlapping startup mutation sections"
+        );
+        assert_eq!(
+            events.lock().await.as_slice(),
+            ["first-enter", "first-exit", "second-enter"]
+        );
+
+        close_test_pool(pool_b, "db::postgres startup lock pool B")
+            .await
+            .expect("close pool B");
+        close_test_pool(pool_a, "db::postgres startup lock pool A")
             .await
             .expect("close pool A");
         test_db.drop().await;

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -14,29 +14,38 @@ async fn launch_server(state: crate::bootstrap::BootstrapState) -> Result<()> {
         tracing::info!("Pipeline loaded: {}", pipeline_path.display());
     }
 
-    let pg_pool = crate::db::postgres::connect_and_migrate(&config)
+    let pg_pool = crate::db::postgres::connect(&config)
         .await
         .map_err(anyhow::Error::msg)
         .context("Failed to init PostgreSQL")?;
 
-    if let Some(root) = crate::config::runtime_root().as_ref() {
-        let legacy_scan = crate::services::discord_config_audit::scan_legacy_sources(root);
-        let loaded =
-            crate::services::discord_config_audit::load_runtime_config(root).map_err(|error| {
-                anyhow::anyhow!("Failed to reload config after PG migration: {error}")
-            })?;
-        config = crate::services::discord_config_audit::audit_and_reconcile_config_only(
-            root,
-            loaded.config,
-            loaded.path,
-            loaded.existed,
-            &legacy_scan,
-            false,
-        )
-        .map_err(|error| {
-            anyhow::anyhow!("Failed to persist config audit after PG migration: {error}")
-        })?
-        .config;
+    if let Some(pool) = pg_pool.as_ref() {
+        crate::db::postgres::with_startup_advisory_lock(pool, || async {
+            crate::db::postgres::migrate(pool).await?;
+            if let Some(root) = crate::config::runtime_root().as_ref() {
+                let legacy_scan = crate::services::discord_config_audit::scan_legacy_sources(root);
+                let loaded = crate::services::discord_config_audit::load_runtime_config(root)
+                    .map_err(|error| {
+                        format!("Failed to reload config after PG migration: {error}")
+                    })?;
+                config = crate::services::discord_config_audit::audit_and_reconcile_config_only(
+                    root,
+                    loaded.config,
+                    loaded.path,
+                    loaded.existed,
+                    &legacy_scan,
+                    false,
+                )
+                .map_err(|error| {
+                    format!("Failed to persist config audit after PG migration: {error}")
+                })?
+                .config;
+            }
+            crate::db::postgres::startup_reseed_with_warmup_pool(pool, &config).await
+        })
+        .await
+        .map_err(anyhow::Error::msg)
+        .context("Failed to init PostgreSQL")?;
     }
     crate::services::provider_hosting::install_provider_hosting_config(&config);
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -280,17 +280,33 @@ pub(crate) async fn run(
         config.config_hot_reload,
     );
     let pg_pool = match pg_pool {
+        // Callers that provide a runtime pool have already completed the
+        // startup migrate/config-audit/reseed sequence under the startup lock.
         Some(pool) => Some(pool),
-        None => crate::db::postgres::connect_and_migrate(&config)
-            .await
-            .map_err(anyhow::Error::msg)?,
+        None => {
+            let pool = crate::db::postgres::connect(&config)
+                .await
+                .map_err(anyhow::Error::msg)?;
+            if let Some(pool_ref) = pool.as_ref() {
+                crate::db::postgres::with_startup_advisory_lock(pool_ref, || async {
+                    crate::db::postgres::migrate(pool_ref).await?;
+                    crate::db::postgres::startup_reseed_with_warmup_pool(pool_ref, &config).await
+                })
+                .await
+                .map_err(anyhow::Error::msg)?;
+            }
+            pool
+        }
     };
+    if pg_pool.is_none() {
+        anyhow::bail!("PostgreSQL is required for AgentDesk server runtime");
+    }
     let startup_pg_pool = if pg_pool.is_some() {
         match crate::db::postgres::connect_for_startup(&config).await {
             Ok(pool) => pool,
             Err(error) => {
                 tracing::warn!(
-                    "[startup] postgres warmup pool unavailable; falling back to runtime pool: {error}"
+                    "[startup] postgres warmup pool unavailable for boot reconcile; falling back to runtime pool: {error}"
                 );
                 None
             }
@@ -298,13 +314,6 @@ pub(crate) async fn run(
     } else {
         None
     };
-    if let Some(pool) = startup_pg_pool.as_ref().or(pg_pool.as_ref()) {
-        crate::db::postgres::startup_reseed(pool, &config)
-            .await
-            .map_err(anyhow::Error::msg)?;
-    } else {
-        anyhow::bail!("PostgreSQL is required for AgentDesk server runtime");
-    }
     if let Some(pool) = pg_pool.as_ref() {
         // #1309: publish the runtime PG pool so cancel-tombstone helpers
         // called from contexts without a SharedData / PgPool argument


### PR DESCRIPTION
## Summary

- Add a bounded PostgreSQL startup advisory-lock helper and use it for startup migration/reseed paths.
- Hold the lock across migration, config audit, and startup reseed in launch, dcserver, direct, and server-owned fallback startup.
- Avoid duplicate `server::run` reseed when callers already pass an initialized runtime pool.
- Add a live-PG concurrency regression test proving startup sections serialize while running reseed work.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --lib`
- `cargo test --lib postgres_startup_advisory_lock_serializes_concurrent_startup_sections -- --nocapture --test-threads=1`
- `cargo test --lib postgres_advisory_lock_lease -- --nocapture --test-threads=1`
- `cargo test --lib startup_reseed -- --nocapture --test-threads=1`
- `cargo test --lib worker_node_reseed_does_not_clobber_shared_agent_roster -- --nocapture --test-threads=1`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`

## Review

- Fresh Codex xhigh adversarial review: first round found `direct` config audit still outside the lock; fixed.
- Fresh Codex xhigh re-review: `VERDICT: CLEAN`.
