### PR TITLE
Guard API docs coverage against mounted routes

### DIFF
--- a/scripts/check_api_docs_coverage.py
+++ b/scripts/check_api_docs_coverage.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = REPO_ROOT / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import generate_inventory_docs as inventory  # noqa: E402
+
+DOCS_RS = REPO_ROOT / "src" / "server" / "routes" / "docs.rs"
+PARAM_RE = re.compile(r"\{[^}/]+\}")
+GLOB_CHARS_RE = re.compile(r"[*?\[\]]")
+
+# Exact mounted routes that intentionally stay out of /api/docs. Keep this
+# dictionary narrow: no globbing, no path-prefix entries, and every reason must
+# explain why callers should not discover the route from the public docs shape.
+UNDOCUMENTED_API_ROUTES: dict[tuple[str, str], str] = {
+    (
+        "POST",
+        "/api/hook/reset-status",
+    ): "Loopback-only hook control-plane mutation for status reconciliation; not an operator-facing API.",
+    (
+        "POST",
+        "/api/hook/skill-usage",
+    ): "Loopback-only hook ingestion endpoint for skill usage telemetry; callers use docs-visible analytics routes instead.",
+    (
+        "DELETE",
+        "/api/hook/session/{sessionKey}",
+    ): "Loopback-only hook session disconnect endpoint with hook-client path casing; not part of the public API docs contract.",
+    (
+        "POST",
+        "/api/internal/escalation/emit",
+    ): "Loopback-only internal escalation emitter under /internal; not discoverable as a public operator route.",
+}
+
+
+@dataclass(frozen=True, order=True)
+class EndpointPair:
+    method: str
+    path: str
+
+    @property
+    def normalized(self) -> "EndpointPair":
+        return EndpointPair(self.method.upper(), normalize_path(self.path))
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    missing: tuple[EndpointPair, ...]
+    stale: tuple[EndpointPair, ...]
+    unused_allowlist: tuple[EndpointPair, ...]
+    allowlist_errors: tuple[str, ...]
+
+    def is_clean(self) -> bool:
+        return not (
+            self.missing
+            or self.stale
+            or self.unused_allowlist
+            or self.allowlist_errors
+        )
+
+
+def normalize_path(path: str) -> str:
+    normalized = PARAM_RE.sub("{}", path.strip())
+    if len(normalized) > 1:
+        normalized = normalized.rstrip("/")
+    return normalized
+
+
+def _parse_simple_rust_string(expr: str) -> str | None:
+    expr = expr.strip()
+    if len(expr) < 2 or not expr.startswith('"') or not expr.endswith('"'):
+        return None
+    return bytes(expr[1:-1], "utf-8").decode("unicode_escape")
+
+
+def _rust_function_body(text: str, fn_name: str) -> str:
+    match = re.search(rf"\bfn\s+{re.escape(fn_name)}\s*\(", text)
+    if match is None:
+        raise RuntimeError(f"could not find function {fn_name}")
+    open_brace = text.find("{", match.end())
+    if open_brace == -1:
+        raise RuntimeError(f"could not find body for function {fn_name}")
+    body, _end = inventory.scan_balanced(
+        text, open_brace, open_char="{", close_char="}"
+    )
+    return body
+
+
+def parse_docs_endpoints(docs_path: Path = DOCS_RS) -> list[EndpointPair]:
+    text = docs_path.read_text(encoding="utf-8")
+    body = _rust_function_body(text, "all_endpoints")
+    entries: list[EndpointPair] = []
+    for match in re.finditer(r"\bep\s*\(", body):
+        args, _end = inventory.extract_call_args(body, match)
+        pieces = inventory.split_top_level(args, maxsplit=3)
+        if len(pieces) < 2:
+            continue
+        method = _parse_simple_rust_string(pieces[0])
+        path = _parse_simple_rust_string(pieces[1])
+        if method is None or path is None:
+            continue
+        entries.append(EndpointPair(method.upper(), path))
+    return entries
+
+
+def collect_mounted_api_endpoints() -> list[EndpointPair]:
+    return [
+        EndpointPair(entry.method.upper(), entry.path)
+        for entry in inventory.collect_mounted_api_route_entries()
+        if entry.path.startswith("/api/")
+    ]
+
+
+def _validate_allowlist(
+    allowlist: dict[tuple[str, str], str],
+    mounted_raw: set[EndpointPair],
+    docs_normalized: set[EndpointPair],
+) -> tuple[tuple[EndpointPair, ...], tuple[str, ...]]:
+    unused: list[EndpointPair] = []
+    errors: list[str] = []
+
+    for (method, path), reason in sorted(allowlist.items()):
+        pair = EndpointPair(method.upper(), path)
+        if method != method.upper():
+            errors.append(f"{method} {path}: method must be uppercase")
+        if not path.startswith("/api/"):
+            errors.append(f"{pair.method} {path}: allowlist path must start with /api/")
+        if GLOB_CHARS_RE.search(method) or GLOB_CHARS_RE.search(path):
+            errors.append(f"{pair.method} {path}: allowlist entries must be exact, not globs")
+        if not reason.strip():
+            errors.append(f"{pair.method} {path}: allowlist reason must be non-empty")
+        if pair not in mounted_raw or pair.normalized in docs_normalized:
+            unused.append(pair)
+
+    return tuple(sorted(unused)), tuple(errors)
+
+
+def build_coverage_report(
+    mounted: list[EndpointPair] | None = None,
+    docs: list[EndpointPair] | None = None,
+    allowlist: dict[tuple[str, str], str] | None = None,
+) -> CoverageReport:
+    if mounted is None:
+        mounted = collect_mounted_api_endpoints()
+    if docs is None:
+        docs = parse_docs_endpoints()
+    if allowlist is None:
+        allowlist = UNDOCUMENTED_API_ROUTES
+
+    mounted_raw = set(mounted)
+    docs_raw = set(docs)
+    docs_normalized = {entry.normalized for entry in docs_raw}
+    mounted_normalized = {entry.normalized for entry in mounted_raw}
+    allowlisted_raw = {EndpointPair(method.upper(), path) for method, path in allowlist}
+
+    missing = tuple(
+        sorted(
+            entry
+            for entry in mounted_raw
+            if entry not in allowlisted_raw and entry.normalized not in docs_normalized
+        )
+    )
+    stale = tuple(
+        sorted(entry for entry in docs_raw if entry.normalized not in mounted_normalized)
+    )
+    unused_allowlist, allowlist_errors = _validate_allowlist(
+        allowlist, mounted_raw, docs_normalized
+    )
+
+    return CoverageReport(
+        missing=missing,
+        stale=stale,
+        unused_allowlist=unused_allowlist,
+        allowlist_errors=allowlist_errors,
+    )
+
+
+def _format_pairs(title: str, pairs: tuple[EndpointPair, ...]) -> list[str]:
+    if not pairs:
+        return []
+    lines = [title]
+    lines.extend(f"  - {pair.method} {pair.path}" for pair in pairs)
+    return lines
+
+
+def format_report(report: CoverageReport) -> str:
+    if report.is_clean():
+        return "api docs coverage check passed"
+
+    lines: list[str] = []
+    lines.extend(
+        _format_pairs("Missing /api/docs entries for mounted routes:", report.missing)
+    )
+    lines.extend(_format_pairs("Stale /api/docs entries not mounted:", report.stale))
+    lines.extend(_format_pairs("Unused allowlist entries:", report.unused_allowlist))
+    if report.allowlist_errors:
+        lines.append("Allowlist errors:")
+        lines.extend(f"  - {error}" for error in report.allowlist_errors)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    report = build_coverage_report()
+    print(format_report(report))
+    return 0 if report.is_clean() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -141,6 +141,10 @@ echo "=== Generate inventory docs (refresh workspace; gate source-of-truth invar
 # [[entry]] tables in scripts/giant_file_registry.toml.
 "$PYTHON" scripts/generate_inventory_docs.py
 
+echo "=== API docs coverage gate (#3719) ==="
+"$PYTHON" scripts/check_api_docs_coverage.py
+"$PYTHON" -m unittest tests.test_api_docs_coverage
+
 echo "=== Agent maintenance freshness gate (warn, #1432; LoC hard-gate, #3036) ==="
 # --warning-only keeps the #1432 freshness/touch rollout non-fatal, while
 # --line-count-gate hard-fails on change-surfaces.md production-LoC drift, ghost

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -1049,6 +1049,8 @@ def parse_route_file(
         decl_line = offset_to_line(text, match.start())
         for method, handler in parse_method_chain(methods_expr):
             resolved = resolve_function_source(handler, by_file, by_name)
+            if resolved is None and "::" not in handler and handler in by_file.get(path, {}):
+                resolved = (path, by_file[path][handler])
             if resolved is None:
                 raise ParseError(f"could not resolve handler source for {handler!r}")
             handler_path, handler_line = resolved
@@ -1065,7 +1067,10 @@ def parse_route_file(
 
 
 def find_function_body(text: str, fn_name: str) -> tuple[str, int]:
-    match = re.search(rf"pub\s+async\s+fn\s+{re.escape(fn_name)}\s*\(", text)
+    match = re.search(
+        rf"(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+{re.escape(fn_name)}\s*\(",
+        text,
+    )
     if match is None:
         raise ParseError(f"could not find function {fn_name}")
     open_brace = text.find("{", match.end())
@@ -1073,6 +1078,96 @@ def find_function_body(text: str, fn_name: str) -> tuple[str, int]:
         raise ParseError(f"could not find body for function {fn_name}")
     body, _ = scan_balanced(text, open_brace, open_char="{", close_char="}")
     return body, open_brace + 1
+
+
+def _router_source_path_from_merge_expr(expr: str, routes_root: Path) -> Path:
+    stripped = expr.strip()
+    domain_match = re.match(
+        r"^(?:(?:crate::server::routes|self)::)?domains::"
+        r"(?P<module>[A-Za-z_][A-Za-z0-9_]*)::router\s*\(",
+        stripped,
+    )
+    if domain_match:
+        source_path = routes_root / "domains" / f"{domain_match.group('module')}.rs"
+    else:
+        top_level_match = re.match(
+            r"^(?:(?:crate::server::routes|self)::)?"
+            r"(?P<module>[A-Za-z_][A-Za-z0-9_]*)::router\s*\(",
+            stripped,
+        )
+        if top_level_match is None:
+            raise ParseError(
+                "unsupported compose_api_router merge expression: "
+                f"{strip_wrapping_whitespace(stripped)!r}"
+            )
+        source_path = routes_root / f"{top_level_match.group('module')}.rs"
+
+    if not source_path.exists():
+        raise ParseError(
+            "compose_api_router merge references missing router source: "
+            f"{rel_posix(source_path) if source_path.is_relative_to(REPO_ROOT) else source_path}"
+        )
+    return source_path
+
+
+def mounted_api_route_source_paths(
+    routes_mod_path: Path | None = None,
+    routes_root: Path | None = None,
+) -> list[Path]:
+    """Return route declaration files merged by ``compose_api_router``.
+
+    ``src/server/mod.rs`` nests the composed API router under ``/api``. The
+    composed router itself is centralized in ``src/server/routes/mod.rs``; parse
+    that merge chain so coverage follows the actual mounted router graph instead
+    of scanning files by convention.
+    """
+
+    if routes_mod_path is None:
+        routes_mod_path = REPO_ROOT / "src" / "server" / "routes" / "mod.rs"
+    if routes_root is None:
+        routes_root = routes_mod_path.parent
+
+    text = read_text(routes_mod_path)
+    body, _offset = find_function_body(text, "compose_api_router")
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for match in re.finditer(r"\.merge\s*\(", body):
+        args, _end = extract_call_args(body, match)
+        pieces = split_top_level(args, maxsplit=1)
+        if len(pieces) != 1:
+            raise ParseError(
+                "expected one router expression in compose_api_router merge: "
+                f"{strip_wrapping_whitespace(args)!r}"
+            )
+        source_path = _router_source_path_from_merge_expr(pieces[0], routes_root)
+        if source_path not in seen:
+            paths.append(source_path)
+            seen.add(source_path)
+
+    if not paths:
+        raise ParseError(f"could not find merged API routers in {rel_posix(routes_mod_path)}")
+    return paths
+
+
+def collect_mounted_api_route_entries(
+    function_paths: list[Path] | None = None,
+    by_file: dict[Path, dict[str, int]] | None = None,
+    by_name: dict[str, list[tuple[Path, int]]] | None = None,
+) -> list[RouteEntry]:
+    if by_file is None or by_name is None:
+        if function_paths is None:
+            function_paths = sorted(
+                path
+                for path in (REPO_ROOT / "src" / "server").rglob("*.rs")
+                if path.is_file() and not is_test_file(path)
+            )
+        by_file, by_name = build_function_index(function_paths)
+
+    route_entries: list[RouteEntry] = []
+    for route_path in mounted_api_route_source_paths():
+        route_entries.extend(parse_route_file(route_path, "/api", by_file, by_name))
+    route_entries.sort(key=lambda entry: (entry.path, entry.method, entry.handler))
+    return route_entries
 
 
 def preceding_comment_block(text: str, offset: int) -> str:
@@ -1370,18 +1465,11 @@ def generated_documents() -> dict[Path, str]:
         for path in (REPO_ROOT / "src" / "server").rglob("*.rs")
         if path.is_file() and not is_test_file(path)
     )
-    route_paths = sorted(
-        path
-        for path in (REPO_ROOT / "src" / "server" / "routes" / "domains").rglob("*.rs")
-        if path.is_file() and not is_test_file(path)
-    )
     by_file, by_name = build_function_index(function_paths)
 
     module_entries = collect_modules()
     giant_registrations = build_giant_registrations(module_entries)
-    route_entries: list[RouteEntry] = []
-    for route_path in route_paths:
-        route_entries.extend(parse_route_file(route_path, "/api", by_file, by_name))
+    route_entries = collect_mounted_api_route_entries(function_paths, by_file, by_name)
     route_entries.extend(
         parse_route_file(REPO_ROOT / "src" / "server" / "mod.rs", "", by_file, by_name)
     )

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -319,7 +319,7 @@ fn canonical_category(category: &str) -> &'static str {
         "dispatches" | "dispatched-sessions" | "internal" | "messages" | "sessions" => "dispatches",
         "auto-queue" | "cron" | "queue" => "queue",
         "routines" => "routines",
-        "analytics" | "auth" | "cluster" | "docs" | "health" | "monitoring" | "stats"
+        "analytics" | "auth" | "cluster" | "docs" | "health" | "monitoring" | "stats" | "v1"
         | "provider-cli" => "ops",
         "discord" | "github" | "github-dashboard" | "meetings" => "integrations",
         "departments" | "memory" | "offices" | "onboarding" | "policies" | "settings"
@@ -486,6 +486,7 @@ fn category_description(category: &str) -> &'static str {
         "settings" => "Settings surfaces, live overrides, precedence, and onboarding contracts.",
         "skills" => "Skill catalog and usage ranking.",
         "stats" => "Aggregate system counters.",
+        "v1" => "Versioned dashboard read models and compatibility settings endpoints.",
         _ => "Miscellaneous API endpoints.",
     }
 }
@@ -5444,6 +5445,178 @@ fn all_endpoints() -> Vec<EndpointDoc> {
                 "local_fallback_hint": "set ADK_FORCE_LOCAL_MEMORY=1 to query/delete only PostgreSQL local_memory fallback rows"
             }),
         ),
+        // #3719 mounted-route coverage: compact docs for routes that were
+        // mounted but absent from the curated /api/docs endpoint list.
+        ep(
+            "GET",
+            "/api/agents/diag/{identifier}",
+            "agents",
+            "Agent diagnostic snapshot by id or role identifier.",
+        )
+        .with_params([(
+            "identifier",
+            path_param("Agent id, role id, or configured agent identifier"),
+        )]),
+        ep(
+            "GET",
+            "/api/analytics/policy-hooks",
+            "analytics",
+            "Policy hook timeout and execution counters.",
+        ),
+        ep(
+            "GET",
+            "/api/github/pr-summary",
+            "github",
+            "Fetch a GitHub PR summary from the AgentDesk cache, with gh CLI fallback on cache miss.",
+        )
+        .with_params([
+            ("repo", query_param("string", true, "Repository in owner/name form")),
+            ("pr", query_param("integer", true, "Pull request number")),
+            (
+                "force_refresh",
+                query_param("boolean", false, "Bypass cached value and refetch"),
+            ),
+            (
+                "expected_head_sha",
+                query_param("string", false, "Use cache only when the head SHA matches"),
+            ),
+        ]),
+        ep(
+            "POST",
+            "/api/github/pr-summary/invalidate",
+            "github",
+            "Invalidate one cached GitHub PR summary entry.",
+        )
+        .with_params([
+            ("repo", body_param("string", true, "Repository in owner/name form")),
+            ("pr", body_param("integer", true, "Pull request number")),
+        ]),
+        ep(
+            "GET",
+            "/api/maintenance/jobs",
+            "ops",
+            "List maintenance job status records from PostgreSQL.",
+        ),
+        ep(
+            "GET",
+            "/api/queue/phase-gates/violations",
+            "auto-queue",
+            "Report pending or active auto-queue entries whose batch phase is ahead of the run phase pointer.",
+        ),
+        ep(
+            "POST",
+            "/api/queue/runs/{id}/entries",
+            "auto-queue",
+            "Append a GitHub issue entry to an existing auto-queue run.",
+        )
+        .with_params([
+            ("id", path_param("Auto-queue run id")),
+            ("issue_number", body_param("integer", true, "GitHub issue number")),
+            ("thread_group", body_param("integer", false, "Optional thread-group override")),
+            ("batch_phase", body_param("integer", false, "Optional batch phase override")),
+        ]),
+        ep(
+            "GET",
+            "/api/round-table-meetings/channels",
+            "meetings",
+            "List Discord channels available to round-table meeting workflows.",
+        ),
+        ep(
+            "POST",
+            "/api/inflight/rebind",
+            "dispatches",
+            "Recover an orphaned live tmux session by rebinding inflight state and respawning its watcher.",
+        ),
+        ep(
+            "POST",
+            "/api/sessions/{session_key}/idle-recap",
+            "sessions",
+            "Trigger an idle-recap card for a resumable dispatched session.",
+        )
+        .with_params([(
+            "session_key",
+            path_param("Dispatched session key to recap"),
+        )]),
+        ep(
+            "GET",
+            "/api/v1/overview",
+            "v1",
+            "Versioned dashboard overview combining health, agents, kanban, dispatch, token, and sparkline summaries.",
+        ),
+        ep(
+            "GET",
+            "/api/v1/agents",
+            "v1",
+            "Versioned dashboard agent list, optionally filtered by officeId.",
+        )
+        .with_params([(
+            "officeId",
+            query_param("string", false, "Optional office id filter"),
+        )]),
+        ep(
+            "GET",
+            "/api/v1/tokens",
+            "v1",
+            "Versioned token usage summary for range or period query windows.",
+        )
+        .with_params([
+            ("range", query_param("string", false, "Usage window such as 7d or 30d")),
+            ("period", query_param("string", false, "Legacy alias for range")),
+        ]),
+        ep(
+            "GET",
+            "/api/v1/kanban",
+            "v1",
+            "Versioned dashboard kanban summary.",
+        ),
+        ep(
+            "GET",
+            "/api/v1/ops/health",
+            "v1",
+            "Versioned operational health payload with bottleneck annotations.",
+        ),
+        ep(
+            "GET",
+            "/api/v1/stream",
+            "v1",
+            "Versioned Server-Sent Events stream with optional last-event-id replay.",
+        ),
+        ep(
+            "GET",
+            "/api/v1/activity",
+            "v1",
+            "Versioned activity feed with limit and cursor pagination.",
+        )
+        .with_params([
+            ("limit", query_param("integer", false, "Maximum activity items")),
+            ("before", query_param("string", false, "Cursor returned by a prior page")),
+        ]),
+        ep(
+            "GET",
+            "/api/v1/achievements",
+            "v1",
+            "Versioned achievement bundle, optionally scoped to an agent.",
+        )
+        .with_params([(
+            "agentId",
+            query_param("string", false, "Optional agent id filter"),
+        )]),
+        ep(
+            "GET",
+            "/api/v1/settings",
+            "v1",
+            "Versioned settings list compatible with the dashboard settings surface.",
+        ),
+        ep(
+            "PATCH",
+            "/api/v1/settings/{key}",
+            "v1",
+            "Patch one versioned settings value using the dashboard-compatible settings contract.",
+        )
+        .with_params([
+            ("key", path_param("Settings key")),
+            ("value", body_param("any", true, "New settings value")),
+        ]),
         // provider-cli safe migration
         ep(
             "GET",

--- a/tests/test_api_docs_coverage.py
+++ b/tests/test_api_docs_coverage.py
@@ -1,0 +1,190 @@
+"""Unit tests for scripts/check_api_docs_coverage.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_api_docs_coverage.py"
+
+_SPEC = importlib.util.spec_from_file_location("check_api_docs_coverage", SCRIPT_PATH)
+CHECKER = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = CHECKER
+_SPEC.loader.exec_module(CHECKER)
+
+
+def pair(method: str, path: str) -> CHECKER.EndpointPair:
+    return CHECKER.EndpointPair(method, path)
+
+
+class ApiDocsCoverageTest(unittest.TestCase):
+    def test_reports_missing_and_stale_pairs(self) -> None:
+        report = CHECKER.build_coverage_report(
+            mounted=[pair("GET", "/api/mounted")],
+            docs=[pair("POST", "/api/stale")],
+            allowlist={},
+        )
+
+        self.assertEqual(report.missing, (pair("GET", "/api/mounted"),))
+        self.assertEqual(report.stale, (pair("POST", "/api/stale"),))
+
+    def test_path_parameter_names_compare_by_shape(self) -> None:
+        report = CHECKER.build_coverage_report(
+            mounted=[pair("GET", "/api/items/{id}")],
+            docs=[pair("GET", "/api/items/{segment}")],
+            allowlist={},
+        )
+
+        self.assertTrue(report.is_clean(), CHECKER.format_report(report))
+
+    def test_allowlist_requires_non_empty_reason(self) -> None:
+        report = CHECKER.build_coverage_report(
+            mounted=[pair("GET", "/api/internal")],
+            docs=[],
+            allowlist={("GET", "/api/internal"): "   "},
+        )
+
+        self.assertIn(
+            "GET /api/internal: allowlist reason must be non-empty",
+            report.allowlist_errors,
+        )
+
+    def test_allowlist_is_exact_and_rejects_globs(self) -> None:
+        report = CHECKER.build_coverage_report(
+            mounted=[pair("GET", "/api/items/{id}")],
+            docs=[],
+            allowlist={
+                ("GET", "/api/items/{segment}"): "wrong parameter name",
+                ("GET", "/api/admin/*"): "too broad",
+            },
+        )
+
+        self.assertEqual(report.missing, (pair("GET", "/api/items/{id}"),))
+        self.assertIn(pair("GET", "/api/items/{segment}"), report.unused_allowlist)
+        self.assertIn(pair("GET", "/api/admin/*"), report.unused_allowlist)
+        self.assertIn(
+            "GET /api/admin/*: allowlist entries must be exact, not globs",
+            report.allowlist_errors,
+        )
+
+    def test_allowlist_entry_becomes_unused_when_docs_cover_route(self) -> None:
+        report = CHECKER.build_coverage_report(
+            mounted=[pair("GET", "/api/internal")],
+            docs=[pair("GET", "/api/internal")],
+            allowlist={("GET", "/api/internal"): "internal-only"},
+        )
+
+        self.assertEqual(report.unused_allowlist, (pair("GET", "/api/internal"),))
+
+    def test_parses_docs_ep_entries(self) -> None:
+        with TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs.rs"
+            docs.write_text(
+                textwrap.dedent(
+                    """
+                    fn ep(method: &'static str, path: &'static str) {}
+
+                    fn all_endpoints() {
+                        vec![
+                            ep(
+                                "GET",
+                                "/api/example/{id}",
+                                "category",
+                                "description",
+                            ),
+                            ep("POST", "/api/other", "category", "description"),
+                        ];
+                    }
+                    """
+                ).lstrip("\n"),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                CHECKER.parse_docs_endpoints(docs),
+                [pair("GET", "/api/example/{id}"), pair("POST", "/api/other")],
+            )
+
+    def test_parser_ignores_ep_entries_outside_all_endpoints(self) -> None:
+        with TemporaryDirectory() as tmp:
+            docs = Path(tmp) / "docs.rs"
+            docs.write_text(
+                textwrap.dedent(
+                    """
+                    fn all_endpoints() {
+                        vec![ep("GET", "/api/documented", "category", "description")];
+                    }
+
+                    #[cfg(test)]
+                    mod tests {
+                        fn helper() {
+                            let _ = ep("POST", "/api/test-only", "category", "description");
+                        }
+                    }
+                    """
+                ).lstrip("\n"),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                CHECKER.parse_docs_endpoints(docs),
+                [pair("GET", "/api/documented")],
+            )
+
+    def test_mounted_route_collection_includes_v1_router(self) -> None:
+        mounted = set(CHECKER.collect_mounted_api_endpoints())
+
+        self.assertIn(pair("GET", "/api/v1/overview"), mounted)
+
+    def test_generated_route_inventory_includes_v1_router(self) -> None:
+        route_inventory = CHECKER.inventory.generated_documents()[
+            CHECKER.inventory.GENERATED_DOCS_DIR / "route-inventory.md"
+        ]
+
+        self.assertIn("| `GET` | `/api/v1/overview` |", route_inventory)
+
+    def test_mounted_route_source_paths_follow_compose_api_router(self) -> None:
+        with TemporaryDirectory() as tmp:
+            routes_root = Path(tmp) / "src" / "server" / "routes"
+            domains_root = routes_root / "domains"
+            domains_root.mkdir(parents=True)
+            (domains_root / "mounted.rs").write_text("", encoding="utf-8")
+            (domains_root / "unmounted.rs").write_text("", encoding="utf-8")
+            (routes_root / "v1.rs").write_text("", encoding="utf-8")
+            routes_mod = routes_root / "mod.rs"
+            routes_mod.write_text(
+                textwrap.dedent(
+                    """
+                    fn compose_api_router(state: AppState) -> ApiRouter {
+                        Router::new()
+                            .merge(domains::mounted::router(state.clone()))
+                            .merge(v1::router(state))
+                    }
+                    """
+                ).lstrip("\n"),
+                encoding="utf-8",
+            )
+
+            source_paths = CHECKER.inventory.mounted_api_route_source_paths(
+                routes_mod, routes_root
+            )
+
+            self.assertEqual(
+                [path.relative_to(routes_root).as_posix() for path in source_paths],
+                ["domains/mounted.rs", "v1.rs"],
+            )
+
+    def test_current_repo_api_docs_coverage_passes(self) -> None:
+        report = CHECKER.build_coverage_report()
+
+        self.assertTrue(report.is_clean(), CHECKER.format_report(report))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python API docs coverage checker that compares mounted API routes with `/api/docs` method/path entries
- derive mounted API route sources from `compose_api_router` merges, including `/api/v1`, instead of scanning route files by convention
- add compact docs for currently mounted but undocumented public routes and keep internal hook routes in an exact allowlist
- wire the checker and unit tests into `scripts/ci-script-checks.sh`

Issue: #3719

## Verification
- `python3 scripts/check_api_docs_coverage.py`
- `python3 -m unittest tests.test_api_docs_coverage`
- `python3 scripts/generate_inventory_docs.py --check`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test --lib docs -- --nocapture --test-threads=1`
- `git diff --check`

## Review
- fresh Codex xhigh review (`Godel`) returned `VERDICT: CLEAN` after the compose-router source derivation fix.
