### PR TITLE
Resolve remote SSH stub drift

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,12 +131,13 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2324 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2318 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
     construction from the watcher-spawn handle; #3718 moved runtime mtime
     heartbeat timestamp selection into `watchers/lifecycle_decision.rs` and
-    keeps lifecycle below its frozen ratchet).
+    keeps lifecycle below its frozen ratchet; -6 from #3736 removing legacy
+    remote-profile restore plumbing while remote SSH is disabled).
   - `src/services/discord/tmux.rs` (2048 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
@@ -931,7 +932,7 @@
     marker suppression for stop-control transcript envelopes; +62 from #3304:
     slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (3437 lines; -5 net from #3711/#3712 extracting rebind runtime/output-path resolution to
+  - `src/services/discord/recovery_engine.rs` (3424 lines; -5 net from #3711/#3712 extracting rebind runtime/output-path resolution to
     `recovery_engine/rebind_runtime.rs` while adding direct Codex TUI detection
     so rebind can rebuild rollout bindings when possible and return 409 instead
     of synthesizing inert legacy-wrapper inflight rows; +2 from #3668 re-exporting `success_result_end_offset_after_offset` (pub(in discord)) so the relay_recovery F2 tail-answer guard can require terminal success evidence; +24 from f12b09366 backstop missed turn intake (drain-restart ownerless-inflight recovery: phase_policy/relay_recovery/relay_health predicates); +15 from #3610 PR-2 codex r2 Issue-2 storm-guard comment at the committed-branch anchor-repost dispose (passes `tmux_alive = false` so a transient send-new is budget-bounded, not pane-preserved forever; the now-unused liveness probe is dropped); +33 from #3610 PR-2 anchor-repost fallback (flag-gated, default OFF); +26 from #3680 relay recovery review hardening; +9 from #3582 stamping
@@ -997,7 +998,8 @@
     non-#-tag prose-comment compaction in the same root, the cutover body lives in
     the sub-1000-prod-LoC sibling `recovery_paths/controller_cutover.rs`; +4 from
     #3717 guarding completion-footer registry forgets by the exact takeover
-    message id).
+    message id; -13 from #3736 removing legacy remote-profile restore plumbing
+    while remote SSH is disabled).
   - `src/services/discord/relay_recovery.rs` (1006 lines; #3680 split relay
     recovery reattach/self-heal path; new behavior is bugfix-only until a
     follow-up extraction drops it below the giant-file threshold; net -1 from
@@ -1237,7 +1239,7 @@
     `audit_maintainability_config.toml`; the root is no longer a prod giant and
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
-  - `src/services/discord/session_runtime.rs` (1679 lines; -41 from #3591 dead `assistant_turn_count`/`recent_history_context` 메서드 제거 — 100턴/idle 세션 리셋 폐기 연쇄).
+  - `src/services/discord/session_runtime.rs` (1657 lines; -41 from #3591 dead `assistant_turn_count`/`recent_history_context` 메서드 제거 — 100턴/idle 세션 리셋 폐기 연쇄; -22 from #3736 making legacy remote-profile names non-routing/non-path-affecting while remote SSH is disabled).
   - `src/services/discord/voice_barge_in.rs` (2823 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
@@ -1408,7 +1410,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2559 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests; +8 from #3690 AgentDef.preferred_intake_node_labels field + doc; #3683 config hot-reload restart-fingerprint config surface).
+  - `src/config.rs` (2564 lines; +11 from #3573 failure_pause_auto_resume_secs config field; +16 from #3655 DB pool default 12→18 + 2-node-boot sizing-rationale comment; +47 from #3651 DatabaseConfig.foreground_reserve field (best-effort advisory docs) + manual Default impl + default-consistency tests; +8 from #3690 AgentDef.preferred_intake_node_labels field + doc; #3683 config hot-reload restart-fingerprint config surface; #3736 documents the disabled remote-profile compatibility shim).
   - `src/server/mod.rs` (2650 lines; +42 from #3573 auto-resume tick + backoff-race fix; #3628 wires failure→pause producer behind the same knob, net -1 line from comment condensation; #3651 net ~0 — the message_outbox_loop is the foreground headless-delivery drain and must NOT be backpressured, so its earlier backpressure gate was removed during codex review; #3740 adds the boot hook for token-analytics cache prewarm; #3722 removes duplicate startup reseed when callers already completed guarded startup initialization).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1513 lines).

--- a/src/config.rs
+++ b/src/config.rs
@@ -2823,9 +2823,13 @@ pub(crate) fn shared_test_env_lock() -> &'static std::sync::Mutex<()> {
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
 }
 
-/// Compatibility shim: RCC's `config::Settings` is referenced by discord code
-/// for remote_profiles. AgentDesk doesn't have TUI settings, so this returns
-/// an empty struct.
+/// Compatibility shim for legacy provider signatures that still mention
+/// `remote_profiles`.
+///
+/// AgentDesk does not load remote profiles from operator config. `Settings`
+/// intentionally returns an empty list so those signatures cannot be mistaken
+/// for supported remote SSH behavior. Future remote SSH work must use the
+/// #2193 `providers.codex.remote_hosts` contract instead.
 pub struct Settings {
     pub remote_profiles: Vec<crate::services::remote::RemoteProfile>,
 }
@@ -2840,5 +2844,19 @@ impl Settings {
     #[allow(dead_code)]
     pub fn config_dir() -> Option<std::path::PathBuf> {
         runtime_root().map(|root| crate::runtime_layout::config_dir(&root))
+    }
+}
+
+#[cfg(test)]
+mod remote_settings_tests {
+    use super::Settings;
+
+    #[test]
+    fn settings_load_exposes_no_remote_profiles() {
+        let settings = Settings::load();
+        assert!(
+            settings.remote_profiles.is_empty(),
+            "remote profiles are not loaded from AgentDesk config; use the #2193 remote_hosts ADR"
+        );
     }
 }

--- a/src/services/discord/commands/session.rs
+++ b/src/services/discord/commands/session.rs
@@ -26,20 +26,7 @@ pub(in crate::services::discord) async fn cmd_start(
 
     let path_str = path.as_deref().unwrap_or("").trim();
 
-    // Existing remote session state still influences path validation; /start no longer exposes
-    // a user-facing remote selector.
-    let will_be_remote = {
-        let data = ctx.data().shared.core.lock().await;
-        data.sessions
-            .get(&ctx.channel_id())
-            .and_then(|s| s.remote_profile_name.as_ref())
-            .is_some()
-    };
-
-    let canonical_path = if path_str.is_empty() && will_be_remote {
-        // Remote + no path: keep remote-shell default expansion behavior.
-        "~".to_string()
-    } else if path_str.is_empty() {
+    let canonical_path = if path_str.is_empty() {
         // Local + no path: create random workspace directory
         let Some(workspace_dir) = workspace_root() else {
             ctx.say("Error: cannot determine workspace root.").await?;
@@ -58,14 +45,6 @@ pub(in crate::services::discord) async fn cmd_start(
             return Ok(());
         }
         new_dir.display().to_string()
-    } else if will_be_remote {
-        // Remote + path specified: expand tilde only, skip local validation
-        if path_str.starts_with("~/") || path_str == "~" {
-            // Keep tilde as-is for remote (remote shell will expand it)
-            path_str.to_string()
-        } else {
-            path_str.to_string()
-        }
     } else {
         // Local + path specified: expand ~ and validate locally
         let expanded = crate::runtime_layout::expand_user_path(path_str)
@@ -167,6 +146,7 @@ pub(in crate::services::discord) async fn cmd_start(
         session.category_name = cat_name;
         session.last_active = tokio::time::Instant::now();
         session.current_path = Some(effective_path.clone());
+        session.remote_profile_name = None;
 
         // Apply worktree info if created
         session.worktree = worktree_info.clone();
@@ -196,18 +176,15 @@ pub(in crate::services::discord) async fn cmd_start(
 
         // Persist channel → path mapping for auto-restore
         let ch_key = channel_id.get().to_string();
-        let current_remote_for_settings = data
-            .sessions
-            .get(&channel_id)
-            .and_then(|s| s.remote_profile_name.clone());
         drop(data);
 
+        // Remote SSH is disabled by policy (#2193). `/start` is always local and
+        // clears any legacy remote profile key left by older builds.
         save_last_session_runtime(
             ctx.data().shared.pg_pool.as_ref(),
             &ctx.data().shared.token_hash,
             ch_key.parse::<u64>().unwrap_or_default(),
             &canonical_path,
-            current_remote_for_settings.as_deref(),
         );
 
         // Rescan skills with project path to pick up project-level commands

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -192,7 +192,7 @@ use restart_report::flush_restart_reports;
 use router::handle_event;
 use settings::{
     RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings,
-    load_last_remote_profile, load_last_session_path, resolve_role_binding, save_bot_settings,
+    load_last_session_path, resolve_role_binding, save_bot_settings,
     validate_bot_channel_routing_with_provider_channel,
 };
 #[cfg(unix)]

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3,7 +3,7 @@ use super::inflight::optional_message_id;
 use super::recovery_paths::restart::dispose_recovery_relay_outcome;
 use super::recovery_paths::shared::RecoveryRelayOutcome;
 use super::settings::{
-    load_last_remote_profile, load_last_session_path, resolve_role_binding,
+    load_last_session_path, resolve_role_binding,
     validate_bot_channel_routing_with_provider_channel,
 };
 use super::single_message_panel as smp;
@@ -2907,11 +2907,6 @@ pub(super) async fn restore_inflight_turns(
                         continue;
                     }
                 };
-                let saved_remote = load_last_remote_profile(
-                    shared.pg_pool.as_ref(),
-                    &shared.token_hash,
-                    channel_id.get(),
-                );
                 let mut data = shared.core.lock().await;
                 let session = data
                     .sessions
@@ -2924,7 +2919,7 @@ pub(super) async fn restore_inflight_turns(
                         history: Vec::new(),
                         pending_uploads: Vec::new(),
                         cleared: false,
-                        remote_profile_name: saved_remote,
+                        remote_profile_name: None,
                         channel_id: Some(channel_id.get()),
                         channel_name: effective_channel_name.clone(),
                         category_name: None,
@@ -3153,12 +3148,6 @@ pub(super) async fn restore_inflight_turns(
                 continue;
             }
         };
-        let saved_remote = load_last_remote_profile(
-            shared.pg_pool.as_ref(),
-            &shared.token_hash,
-            channel_id.get(),
-        );
-
         let cancel_token = Arc::new(CancelToken::new());
         super::turn_bridge::bind_cancel_token_tmux_runtime(
             provider,
@@ -3180,7 +3169,7 @@ pub(super) async fn restore_inflight_turns(
                     history: Vec::new(),
                     pending_uploads: Vec::new(),
                     cleared: false,
-                    remote_profile_name: saved_remote.clone(),
+                    remote_profile_name: None,
                     channel_id: Some(channel_id.get()),
                     channel_name: channel_name.clone(),
                     category_name: None,
@@ -3197,9 +3186,7 @@ pub(super) async fn restore_inflight_turns(
             if session.channel_name.is_none() {
                 session.channel_name = channel_name.clone();
             }
-            if session.remote_profile_name.is_none() {
-                session.remote_profile_name = saved_remote;
-            }
+            session.remote_profile_name = None;
             restore_recovered_session_worktree(session, &state);
         }
 

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -12,7 +12,10 @@ pub(super) struct DiscordSession {
     pub(super) history: Vec<HistoryItem>,
     pub(super) pending_uploads: Vec<String>,
     pub(super) cleared: bool,
-    /// Remote profile name for SSH execution (None = local)
+    /// Legacy remote profile name slot.
+    ///
+    /// Remote SSH is disabled by policy (#2193), so restored/persisted profile
+    /// names must not influence routing, path validation, or dispatch.
     pub(super) remote_profile_name: Option<String>,
     pub(super) channel_id: Option<u64>,
     pub(super) channel_name: Option<String>,
@@ -26,22 +29,14 @@ pub(super) struct DiscordSession {
     pub(super) born_generation: u64,
 }
 
-pub(super) fn allows_nonlocal_session_path(remote_profile_name: Option<&str>) -> bool {
-    remote_profile_name.is_some_and(|name| !name.trim().is_empty())
-}
-
-pub(super) fn session_path_is_usable(
-    current_path: &str,
-    remote_profile_name: Option<&str>,
-) -> bool {
-    allows_nonlocal_session_path(remote_profile_name) || std::path::Path::new(current_path).is_dir()
+pub(super) fn session_path_is_usable(current_path: &str) -> bool {
+    std::path::Path::new(current_path).is_dir()
 }
 
 pub(super) fn select_restored_session_path(
     configured_path: Option<String>,
     db_cwd: Option<String>,
     yaml_path: Option<String>,
-    remote_profile_name: Option<&str>,
     db_cwd_is_reusable_worktree: bool,
 ) -> Option<String> {
     // #3219: when the channel-scoped DB cwd is the channel's OWN existing managed
@@ -61,17 +56,15 @@ pub(super) fn select_restored_session_path(
     // different repo under the same `worktrees_root` — is NOT elevated and falls
     // through to the configured path below.
     if db_cwd_is_reusable_worktree
-        && let Some(worktree) = db_cwd
-            .as_ref()
-            .filter(|path| session_path_is_usable(path, remote_profile_name))
+        && let Some(worktree) = db_cwd.as_ref().filter(|path| session_path_is_usable(path))
     {
         return Some(worktree.clone());
     }
 
     configured_path
-        .filter(|path| session_path_is_usable(path, remote_profile_name))
-        .or_else(|| db_cwd.filter(|path| session_path_is_usable(path, remote_profile_name)))
-        .or_else(|| yaml_path.filter(|path| session_path_is_usable(path, remote_profile_name)))
+        .filter(|path| session_path_is_usable(path))
+        .or_else(|| db_cwd.filter(|path| session_path_is_usable(path)))
+        .or_else(|| yaml_path.filter(|path| session_path_is_usable(path)))
 }
 
 /// #3219: true when the recovered DB cwd is the channel's own reusable managed
@@ -154,7 +147,7 @@ impl DiscordSession {
     /// If the path is stale (deleted), clear `current_path` and `worktree`, log, and return `None`.
     pub(super) fn validated_path(&mut self, channel_id: impl std::fmt::Display) -> Option<String> {
         let current_path = self.current_path.as_ref()?;
-        if session_path_is_usable(current_path, self.remote_profile_name.as_deref()) {
+        if session_path_is_usable(current_path) {
             return Some(current_path.clone());
         }
         let ts = chrono::Local::now().format("%H:%M:%S");
@@ -660,7 +653,7 @@ pub(super) async fn auto_restore_session_force(
     let is_dm = resolve_is_dm_channel(dm_hint, is_dm);
 
     // Read settings first to get provider and runtime restore metadata.
-    let (last_path, saved_remote, provider) = {
+    let (last_path, provider) = {
         let settings = shared.settings.read().await;
         let provider = settings.provider.clone();
         let configured_path = settings::resolve_workspace(channel_id, restore_ch_name.as_deref())
@@ -672,12 +665,6 @@ pub(super) async fn auto_restore_session_force(
                     None
                 }
             });
-        let saved_remote = load_last_remote_profile(
-            shared.pg_pool.as_ref(),
-            &shared.token_hash,
-            channel_id.get(),
-        );
-
         // Use the effective tmux channel name here so restart recovery keeps
         // looking up the same session key for thread sessions that intentionally
         // use a synthetic "{parent}-t{thread_id}" channel name.
@@ -709,7 +696,7 @@ pub(super) async fn auto_restore_session_force(
         // Only a usable path is honored for install into `session.current_path`.
         let mut db_cwd: Option<String> = restored_cwd
             .map(|r| r.path)
-            .filter(|p| !p.is_empty() && session_path_is_usable(p, saved_remote.as_deref()));
+            .filter(|p| !p.is_empty() && session_path_is_usable(p));
 
         // #3216 GAP 2: reconcile the DB cwd against the live tmux pane. The live
         // pane is the source of truth for where the session actually runs; if the
@@ -726,7 +713,7 @@ pub(super) async fn auto_restore_session_force(
                 .unwrap_or(false);
             let tmux_cwd_is_usable = tmux_cwd
                 .as_deref()
-                .map(|p| session_path_is_usable(p, saved_remote.as_deref()))
+                .map(session_path_is_usable)
                 .unwrap_or(false);
             if let Some(reconciled) = reconcile_recovery_cwd(
                 db_cwd.as_deref(),
@@ -791,11 +778,10 @@ pub(super) async fn auto_restore_session_force(
             configured_path,
             db_cwd,
             persisted_path,
-            saved_remote.as_deref(),
             reusable_worktree,
         );
 
-        (last_path, saved_remote, provider)
+        (last_path, provider)
     };
 
     let mut data = shared.core.lock().await;
@@ -804,9 +790,7 @@ pub(super) async fn auto_restore_session_force(
         session.last_active = tokio::time::Instant::now();
         session.channel_name = restore_ch_name.clone();
         session.category_name = cat_name.clone();
-        if session.remote_profile_name.is_none() {
-            session.remote_profile_name = saved_remote.clone();
-        }
+        session.remote_profile_name = None;
         if session.current_path.is_some() || last_path.is_none() {
             // A pre-existing session (e.g. inserted by restart watcher
             // registration with `current_path` from `sessions.cwd` but
@@ -827,7 +811,7 @@ pub(super) async fn auto_restore_session_force(
     }
 
     if let Some(last_path) = last_path
-        && session_path_is_usable(&last_path, saved_remote.as_deref())
+        && session_path_is_usable(&last_path)
     {
         // Session ID is restored from DB (sessions.claude_session_id column)
         // which is already loaded into DiscordSession.session_id at startup.
@@ -845,7 +829,7 @@ pub(super) async fn auto_restore_session_force(
                 channel_id: Some(channel_id.get()),
                 channel_name: restore_ch_name.clone(),
                 category_name: cat_name.clone(),
-                remote_profile_name: saved_remote.clone(),
+                remote_profile_name: None,
                 last_active: tokio::time::Instant::now(),
                 worktree: None,
                 born_generation: runtime_store::load_generation(),
@@ -854,9 +838,7 @@ pub(super) async fn auto_restore_session_force(
         session.last_active = tokio::time::Instant::now();
         session.channel_name = restore_ch_name.clone();
         session.category_name = cat_name.clone();
-        if session.remote_profile_name.is_none() {
-            session.remote_profile_name = saved_remote.clone();
-        }
+        session.remote_profile_name = None;
         session.current_path = Some(last_path.clone());
         reconstruct_managed_worktree_metadata(session, &provider, channel_id, &last_path);
         drop(data);
@@ -865,11 +847,7 @@ pub(super) async fn auto_restore_session_force(
         let new_skills = scan_skills(&provider, Some(&last_path));
         *shared.skills_cache.write().await = new_skills;
         let ts = chrono::Local::now().format("%H:%M:%S");
-        let remote_info = saved_remote
-            .as_ref()
-            .map(|n| format!(" (remote: {})", n))
-            .unwrap_or_default();
-        tracing::info!("  [{ts}] ↻ Auto-restored session: {last_path}{remote_info}");
+        tracing::info!("  [{ts}] ↻ Auto-restored session: {last_path}");
     }
 }
 
@@ -1685,68 +1663,105 @@ mod select_restored_session_path_tests {
     //! (`db_cwd_is_reusable_worktree`, git-validated against the configured parent
     //! repo); here we verify the selector honors that decision and otherwise
     //! preserves the configured→db_cwd→yaml fallback order unchanged.
-    use super::{db_cwd_is_reusable_worktree, select_restored_session_path};
+    use super::{
+        db_cwd_is_reusable_worktree, select_restored_session_path, session_path_is_usable,
+    };
 
-    const BASE: &str = "/repo/workspaces/agentdesk";
-    const WT: &str = "/repo/worktrees/claude-adk-cc-113822";
+    struct FixturePaths {
+        _root: tempfile::TempDir,
+        base: String,
+        wt: String,
+        yaml: String,
+    }
+
+    fn fixture_paths() -> FixturePaths {
+        let root = tempfile::tempdir().expect("temp root");
+        let base = root.path().join("workspaces").join("agentdesk");
+        let wt = root.path().join("worktrees").join("claude-adk-cc-113822");
+        let yaml = root.path().join("yaml").join("path");
+        std::fs::create_dir_all(&base).expect("base dir");
+        std::fs::create_dir_all(&wt).expect("worktree dir");
+        std::fs::create_dir_all(&yaml).expect("yaml dir");
+        FixturePaths {
+            _root: root,
+            base: base.display().to_string(),
+            wt: wt.display().to_string(),
+            yaml: yaml.display().to_string(),
+        }
+    }
 
     #[test]
     fn reusable_worktree_outranks_configured_base() {
+        let paths = fixture_paths();
         let selected = select_restored_session_path(
-            Some(BASE.into()),
-            Some(WT.into()),
+            Some(paths.base.clone()),
+            Some(paths.wt.clone()),
             None,
-            // remote profile set → session_path_is_usable short-circuits true so
-            // the assertion does not depend on these paths existing on disk.
-            Some("remote"),
             true,
         );
-        assert_eq!(selected.as_deref(), Some(WT));
+        assert_eq!(selected.as_deref(), Some(paths.wt.as_str()));
     }
 
     #[test]
     fn non_reusable_db_cwd_keeps_configured_priority() {
+        let paths = fixture_paths();
         // When the caller's git validation says the worktree is NOT reusable
         // (stale/foreign/relocated/remote), configured base wins as before.
         let selected = select_restored_session_path(
-            Some(BASE.into()),
-            Some(WT.into()),
+            Some(paths.base.clone()),
+            Some(paths.wt.clone()),
             None,
-            Some("remote"),
             false,
         );
-        assert_eq!(selected.as_deref(), Some(BASE));
+        assert_eq!(selected.as_deref(), Some(paths.base.as_str()));
     }
 
     #[test]
     fn falls_back_to_db_cwd_then_yaml_when_no_configured() {
+        let paths = fixture_paths();
         // No configured path: existing fallback order is unchanged regardless of
         // the reusable flag.
         let selected = select_restored_session_path(
             None,
-            Some(WT.into()),
-            Some("/yaml/path".into()),
-            Some("remote"),
+            Some(paths.wt.clone()),
+            Some(paths.yaml.clone()),
             false,
         );
-        assert_eq!(selected.as_deref(), Some(WT));
+        assert_eq!(selected.as_deref(), Some(paths.wt.as_str()));
 
+        let selected = select_restored_session_path(None, None, Some(paths.yaml.clone()), true);
+        assert_eq!(selected.as_deref(), Some(paths.yaml.as_str()));
+    }
+
+    #[test]
+    fn legacy_remote_profile_names_do_not_bypass_local_path_validation() {
+        let missing = "/agentdesk/remote-only/path";
+        assert!(
+            !session_path_is_usable(missing),
+            "remote-profile compatibility names must not make remote-only paths usable"
+        );
         let selected = select_restored_session_path(
+            Some(missing.into()),
+            Some("~/remote-shell-cwd".into()),
             None,
-            None,
-            Some("/yaml/path".into()),
-            Some("remote"),
             true,
         );
-        assert_eq!(selected.as_deref(), Some("/yaml/path"));
+        assert_eq!(
+            selected, None,
+            "restored paths must be real local directories while remote SSH is disabled"
+        );
     }
 
     #[test]
     fn reusable_predicate_requires_configured_and_db_cwd() {
         // No git work here: a missing configured parent or missing db_cwd can
         // never be "reusable" (the full git validation only runs when both exist).
-        assert!(!db_cwd_is_reusable_worktree(None, Some(WT)));
-        assert!(!db_cwd_is_reusable_worktree(Some(BASE), None));
+        let paths = fixture_paths();
+        assert!(!db_cwd_is_reusable_worktree(None, Some(paths.wt.as_str())));
+        assert!(!db_cwd_is_reusable_worktree(
+            Some(paths.base.as_str()),
+            None
+        ));
         assert!(!db_cwd_is_reusable_worktree(None, None));
     }
 }

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -40,9 +40,7 @@ pub(super) use content::{
     load_review_tuning_guidance, load_role_prompt, render_peer_agent_guidance,
 };
 pub(crate) use memory::{memory_settings_for_binding, resolve_memory_settings};
-pub(super) use read::{
-    load_bot_settings, load_last_remote_profile, load_last_session_path, save_last_session_runtime,
-};
+pub(super) use read::{load_bot_settings, load_last_session_path, save_last_session_runtime};
 pub use read::{
     load_discord_bot_launch_configs, resolve_discord_bot_provider, resolve_discord_token_by_hash,
 };

--- a/src/services/discord/settings/read.rs
+++ b/src/services/discord/settings/read.rs
@@ -237,39 +237,21 @@ pub(crate) fn load_last_session_path(
     load_kv_meta_value(pg_pool, &last_session_path_key(token_hash, channel_id))
 }
 
-pub(crate) fn load_last_remote_profile(
-    pg_pool: Option<&sqlx::PgPool>,
-    token_hash: &str,
-    channel_id: u64,
-) -> Option<String> {
-    load_kv_meta_value(pg_pool, &last_remote_profile_key(token_hash, channel_id))
-}
-
 pub(crate) fn save_last_session_runtime(
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
     channel_id: u64,
     current_path: &str,
-    remote_profile_name: Option<&str>,
 ) {
     let session_key = last_session_path_key(token_hash, channel_id);
     let remote_key = last_remote_profile_key(token_hash, channel_id);
-    let remote_value = remote_profile_name
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
+    // Remote SSH is disabled by policy (#2193). Older builds may have persisted
+    // a remote profile key, but runtime saves now delete it so it cannot affect
+    // routing/path validation while the #2193 prerequisites remain unimplemented.
 
     let helper_write_ok =
         crate::services::discord::internal_api::set_kv_value(&session_key, current_path).is_ok()
-            && match remote_value.as_deref() {
-                Some(remote) => {
-                    crate::services::discord::internal_api::set_kv_value(&remote_key, remote)
-                        .is_ok()
-                }
-                None => {
-                    crate::services::discord::internal_api::delete_kv_value(&remote_key).is_ok()
-                }
-            };
+            && crate::services::discord::internal_api::delete_kv_value(&remote_key).is_ok();
     if helper_write_ok {
         return;
     }
@@ -294,27 +276,11 @@ pub(crate) fn save_last_session_runtime(
                 .await
                 .map_err(|error| format!("save {session_key}: {error}"))?;
 
-                match remote_value {
-                    Some(remote) => {
-                        sqlx::query(
-                            "INSERT INTO kv_meta (key, value)
-                             VALUES ($1, $2)
-                             ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value",
-                        )
-                        .bind(&remote_key)
-                        .bind(remote)
-                        .execute(&mut *tx)
-                        .await
-                        .map_err(|error| format!("save {remote_key}: {error}"))?;
-                    }
-                    None => {
-                        sqlx::query("DELETE FROM kv_meta WHERE key = $1")
-                            .bind(&remote_key)
-                            .execute(&mut *tx)
-                            .await
-                            .map_err(|error| format!("delete {remote_key}: {error}"))?;
-                    }
-                }
+                sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+                    .bind(&remote_key)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|error| format!("delete {remote_key}: {error}"))?;
 
                 tx.commit()
                     .await

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -34,8 +34,8 @@ use super::placeholder_live_events::{
     RecentPlaceholderEvent, events_from_json, status_events_from_json,
 };
 use super::settings::{
-    channel_supports_provider, load_last_remote_profile, load_last_session_path,
-    resolve_role_binding, validate_bot_channel_routing_with_provider_channel,
+    channel_supports_provider, load_last_session_path, resolve_role_binding,
+    validate_bot_channel_routing_with_provider_channel,
 };
 use super::tmux_error_detect::{
     detect_provider_overload_message, is_auth_error_message, is_prompt_too_long_message,

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -2625,11 +2625,6 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                 &shared.token_hash,
                 channel_id.get(),
             );
-            let remote_profile = load_last_remote_profile(
-                shared.pg_pool.as_ref(),
-                &shared.token_hash,
-                channel_id.get(),
-            );
             let persisted_session_id = load_restored_provider_session_id(
                 None::<&crate::db::Db>,
                 shared.pg_pool.as_ref(),
@@ -2670,7 +2665,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                         cleared: false,
                         channel_name: Some(channel_name.clone()),
                         category_name: None,
-                        remote_profile_name: remote_profile.clone(),
+                        remote_profile_name: None,
                         channel_id: Some(channel_id.get()),
 
                         last_active: tokio::time::Instant::now(),
@@ -2708,7 +2703,6 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                     configured_path,
                     db_cwd,
                     persisted_path,
-                    remote_profile.as_deref(),
                     reusable_worktree,
                 );
                 if let Some(path) = effective_path {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -125,5 +125,8 @@ pub mod turn_cancel_finalizer;
 pub mod turn_lifecycle;
 pub mod turn_orchestrator;
 
-// Compatibility alias: code referencing services::remote::* uses the stub
+// Compatibility alias only: code referencing `services::remote::*` still
+// compiles, but the target module is disabled per #1606/#2175/#2193. A real
+// `services::remote` must replace `remote_stub` only when the ADR prerequisites
+// in `docs/codex-remote-ssh-policy.md` are satisfied.
 pub use remote_stub as remote;

--- a/src/services/remote_stub.rs
+++ b/src/services/remote_stub.rs
@@ -1,9 +1,15 @@
-//! Stub module providing type definitions formerly in services::remote.
-//! SSH/SFTP functionality is not available in AgentDesk — only types are provided
-//! so that other modules (claude, codex) compile without modification.
+//! Disabled remote SSH compatibility surface.
+//!
+//! #1606 removed user-facing remote execution, #2175 classified Codex remote
+//! direct/tmux as "not allowed now", and #2193 defines the ADR prerequisites
+//! for any future re-enable. Until those follow-ups land, these profile/auth
+//! types exist only so provider signatures can continue to parse old shapes;
+//! they are not a supported runtime configuration surface.
 
 use serde::{Deserialize, Serialize};
 
+/// Parse-compatibility only. Per `docs/codex-remote-ssh-policy.md`, password
+/// and key-file credentials must not authenticate future remote SSH execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RemoteAuth {
     #[serde(rename = "password")]
@@ -16,6 +22,9 @@ pub enum RemoteAuth {
     },
 }
 
+/// Parse-compatibility only. AgentDesk does not load `RemoteProfile` entries
+/// from operator config, and remote dispatch paths must refuse before any SSH
+/// attempt unless the #2193 prerequisites are fully implemented.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteProfile {
     pub name: String,
@@ -34,10 +43,84 @@ fn default_port() -> u16 {
     22
 }
 
-/// Stub — always returns Err. Real implementation requires russh.
+/// Disabled stub — always returns `Err`.
+///
+/// A real implementation must replace this module under the #2193 contract:
+/// ssh-agent auth, strict host allow-list, no password/key-file credentials,
+/// direct SSH only, and cancel-path coverage.
 pub async fn ssh_connect_and_auth(_profile: &RemoteProfile) -> Result<SshConnectionStub, String> {
-    Err("SSH not available in AgentDesk build".to_string())
+    Err("Remote SSH is disabled by policy (#2193); see docs/codex-remote-ssh-policy.md".to_string())
 }
 
 /// Placeholder type returned by ssh_connect_and_auth stub.
+#[derive(Debug)]
 pub struct SshConnectionStub;
+
+#[cfg(test)]
+mod tests {
+    use super::{RemoteAuth, RemoteProfile, ssh_connect_and_auth};
+
+    fn profile_with_auth(auth: RemoteAuth) -> RemoteProfile {
+        RemoteProfile {
+            name: "legacy-profile".to_string(),
+            host: "mac-mini.local".to_string(),
+            port: 22,
+            user: "operator".to_string(),
+            auth,
+            default_path: "/tmp".to_string(),
+            claude_path: None,
+        }
+    }
+
+    #[test]
+    fn password_and_keyfile_auth_parse_for_compatibility_only() {
+        let password: RemoteProfile = serde_json::from_str(
+            r#"{
+                "name": "legacy-password",
+                "host": "mac-mini.local",
+                "user": "operator",
+                "auth": { "password": { "password": "secret" } }
+            }"#,
+        )
+        .expect("legacy password profile should still parse");
+        assert!(matches!(password.auth, RemoteAuth::Password { .. }));
+
+        let key_file: RemoteProfile = serde_json::from_str(
+            r#"{
+                "name": "legacy-key",
+                "host": "mac-mini.local",
+                "user": "operator",
+                "auth": {
+                    "key_file": {
+                        "path": "/Users/operator/.ssh/id_ed25519",
+                        "passphrase": "secret"
+                    }
+                }
+            }"#,
+        )
+        .expect("legacy key-file profile should still parse");
+        assert!(matches!(key_file.auth, RemoteAuth::KeyFile { .. }));
+    }
+
+    #[tokio::test]
+    async fn ssh_connect_stub_refuses_before_auth_for_all_legacy_variants() {
+        for auth in [
+            RemoteAuth::Password {
+                password: "secret".to_string(),
+            },
+            RemoteAuth::KeyFile {
+                path: "/Users/operator/.ssh/id_ed25519".to_string(),
+                passphrase: Some("secret".to_string()),
+            },
+        ] {
+            let err = ssh_connect_and_auth(&profile_with_auth(auth))
+                .await
+                .expect_err("stub must refuse before any auth attempt");
+            assert!(
+                err.contains("disabled by policy"),
+                "unexpected error: {err}"
+            );
+            assert!(err.contains("#2193"), "error must cite ADR issue: {err}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Document `remote_stub`/`services::remote` as a disabled compatibility surface tied to #1606/#2175/#2193.
- Keep legacy `RemoteProfile`/`RemoteAuth` shapes parse-compatible but make SSH connection refusal cite #2193.
- Remove stale persisted `remote_profile_name` effects from path validation, restore selection, `/start`, watcher restore, and recovery restore while deleting legacy remote-profile runtime keys on save.
- Add focused tests for disabled remote auth parsing/refusal, empty remote profile settings, and local-only restore path validation.

Issue: #3736

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --lib`
- `cargo test --lib services::discord::session_runtime::select_restored_session_path_tests -- --nocapture --test-threads=1`
- `cargo test --lib services::remote_stub::tests -- --nocapture --test-threads=1`
- `cargo test --lib config::remote_settings_tests -- --nocapture --test-threads=1`
- `cargo test --lib services::codex::remote_dispatch_gate_tests -- --nocapture --test-threads=1`
- `cargo test --lib services::provider_hosting::tests::codex_remote_ssh_gate -- --nocapture --test-threads=1`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`

## Review
- Fresh Codex xhigh review: initial `VERDICT: ISSUES` on stale persisted `remote_profile_name` path behavior.
- Fresh Codex xhigh re-review after fix: `VERDICT: CLEAN`.
