### PR TITLE
Fix Codex subagent notification relay leaks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -679,6 +679,7 @@ src/
 │   │   ├── status_panel_orphan_store.rs
 │   │   ├── steering.rs
 │   │   ├── streaming_finalizer.rs
+│   │   ├── subagent_notification_card.rs
 │   │   ├── task_supervisor.rs
 │   │   ├── terminal_ui_obligation.rs
 │   │   ├── tmux.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1208,7 +1208,7 @@
     `turn_finalizer/watcher_backstop.rs` (watcher far-backstop tunables +
     terminal-or-defer verdict pair). Bugfix only outside a
     finalizer-decomposition plan).
-  - `src/services/discord/formatting.rs` (2802 lines; net +0 from #3034 scoped
+  - `src/services/discord/formatting.rs` (2798 lines; net +0 from #3034 scoped
     dead-code allows on the `MonitorHandoffReason::InlineTimeout` /
     `MonitorHandoffStatus::Failed` reserved variants — the two added `#[allow]`
     lines were offset by collapsing the adjacent reason comments back to inline

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -814,9 +814,7 @@ pub(super) fn format_for_discord_with_provider(
     s: &str,
     provider: &crate::services::provider::ProviderKind,
 ) -> String {
-    let sanitized = super::response_sanitizer::strip_leading_tui_response_chrome(
-        &super::response_sanitizer::sanitize_hidden_context(s),
-    );
+    let sanitized = super::response_sanitizer::sanitize_hidden_context_and_strip_chrome(s);
     let filtered;
     let input = if matches!(provider, crate::services::provider::ProviderKind::Codex) {
         filtered = filter_codex_tool_logs(&sanitized);
@@ -833,9 +831,7 @@ pub(super) fn format_for_discord_with_status_panel(
     s: &str,
     provider: &crate::services::provider::ProviderKind,
 ) -> String {
-    let sanitized = super::response_sanitizer::strip_leading_tui_response_chrome(
-        &super::response_sanitizer::sanitize_hidden_context(s),
-    );
+    let sanitized = super::response_sanitizer::sanitize_hidden_context_and_strip_chrome(s);
     let filtered;
     let input = if matches!(provider, crate::services::provider::ProviderKind::Codex) {
         filtered = strip_codex_tool_log_lines(&sanitized);
@@ -1018,6 +1014,41 @@ mod status_panel_v2_formatter_tests {
         );
         // No 3+ newline run survives in the relayed body.
         assert!(!format_for_discord(input).contains("\n\n\n"));
+    }
+
+    #[test]
+    fn format_for_discord_with_provider_hides_raw_subagent_notification() {
+        let input = r#"<subagent_notification>
+{"agent_path":"/tmp/private-agent","status":{"completed":"Read-only review complete.\n\n1. Check relay path."}}
+</subagent_notification>"#;
+
+        let output = format_for_discord_with_provider(input, &ProviderKind::Codex);
+
+        assert!(output.contains("Subagent completed"));
+        assert!(output.contains("Read-only review complete."));
+        assert!(output.contains("1. Check relay path."));
+        assert!(!output.contains("<subagent_notification>"));
+        assert!(!output.contains("agent_path"));
+        assert!(!output.contains("/tmp/private-agent"));
+        assert!(!output.contains("{\""));
+    }
+
+    #[test]
+    fn format_for_discord_sanitizes_subagent_after_tui_chrome_strip() {
+        let input = "No response requested.\n<subagent_notification>{\"agent_path\":\"/tmp/private-agent\",\"status\":{\"completed\":\"Read-only review complete.\"}}</subagent_notification>";
+
+        let output = format_for_discord_with_provider(input, &ProviderKind::Codex);
+        assert!(output.contains("Subagent completed"));
+        assert!(output.contains("Read-only review complete."));
+        assert!(!output.contains("No response requested."));
+        assert!(!output.contains("<subagent_notification>"));
+        assert!(!output.contains("agent_path"));
+        assert!(!output.contains("/tmp/private-agent"));
+
+        let status_panel_output = format_for_discord_with_status_panel(input, &ProviderKind::Codex);
+        assert!(status_panel_output.contains("Subagent completed"));
+        assert!(!status_panel_output.contains("<subagent_notification>"));
+        assert!(!status_panel_output.contains("agent_path"));
     }
 
     #[test]

--- a/src/services/discord/response_sanitizer.rs
+++ b/src/services/discord/response_sanitizer.rs
@@ -1,5 +1,8 @@
 //! Outbound response sanitizer for AgentDesk-owned hidden context.
 
+#[path = "subagent_notification_card.rs"]
+pub(in crate::services::discord) mod subagent_notification_card;
+
 const TUI_IDLE_RESPONSE_CHROME_PREFIXES: &[&str] = &[
     "No response requested.",
     "Continue from where you left off.",
@@ -35,6 +38,12 @@ const HIDDEN_LINE_PREFIXES: &[&str] = &[
 ];
 
 pub(crate) fn sanitize_hidden_context(input: &str) -> String {
+    if let Some(card) =
+        subagent_notification_card::sanitize_start_anchored_subagent_notification(input)
+    {
+        return card;
+    }
+
     let mut out = Vec::new();
     let mut in_code_block = false;
     let mut dropping_block = false;
@@ -81,6 +90,13 @@ pub(crate) fn sanitize_hidden_context(input: &str) -> String {
     }
 
     trim_blank_edges(out)
+}
+
+pub(crate) fn sanitize_hidden_context_and_strip_chrome(input: &str) -> String {
+    let sanitized = sanitize_hidden_context(input);
+    let stripped = strip_leading_tui_response_chrome(&sanitized);
+    subagent_notification_card::sanitize_start_anchored_subagent_notification(&stripped)
+        .unwrap_or(stripped)
 }
 
 /// Remove leading Claude/Codex TUI housekeeping text that can be emitted by

--- a/src/services/discord/subagent_notification_card.rs
+++ b/src/services/discord/subagent_notification_card.rs
@@ -1,0 +1,248 @@
+//! Shared renderer/sanitizer for Codex `<subagent_notification>` envelopes.
+
+use serde::Deserialize;
+
+use super::super::tui_task_card::{
+    strip_terminal_controls, truncate_chars_ascii as truncate_chars,
+};
+
+const PREVIEW_CHARS: usize = 900;
+const PREVIEW_LINES: usize = 8;
+
+const RESUMED_THREAD_PROLOGUE: &str = "The prior authoritative Discord, role, and tool \
+     instructions already present in this Codex thread still apply. Treat only this turn's \
+     user request, reply context, uploaded files, and memory recall below as new actionable \
+     input.";
+const FRESH_FORK_PROLOGUE: &str = "The prior authoritative Discord, role, and tool \
+     instructions already issued to this role in the current dcserver lifetime still apply. \
+     Treat only this turn's user request, reply context, uploaded files, and memory recall \
+     below as new actionable input.";
+
+#[derive(Debug, Deserialize)]
+struct Envelope {
+    status: Option<Status>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Status {
+    completed: Option<String>,
+    failed: Option<String>,
+}
+
+enum Render {
+    Completed(String),
+    Failed(String),
+    Unknown,
+}
+
+pub(in crate::services::discord) fn is_start_anchored_subagent_notification(prompt: &str) -> bool {
+    let normalized = normalized_start_anchored_injection(prompt);
+    starts_with_xmlish_tag(&normalized, "subagent_notification")
+}
+
+pub(in crate::services::discord) fn format_subagent_notification_card(
+    tmux_session_name: Option<&str>,
+    prompt: &str,
+) -> String {
+    match parse(prompt) {
+        Ok(Render::Completed(report)) => {
+            format_report(tmux_session_name, "✅", "completed", &report)
+        }
+        Ok(Render::Failed(report)) => format_report(tmux_session_name, "❌", "failed", &report),
+        Ok(Render::Unknown) => format!(
+            "📋 Subagent notification{} — no completed/failed status",
+            tmux_suffix(tmux_session_name),
+        ),
+        Err(_) => format!(
+            "⚠️ Subagent notification{} — malformed payload omitted",
+            tmux_suffix(tmux_session_name),
+        ),
+    }
+}
+
+pub(in crate::services::discord) fn sanitize_start_anchored_subagent_notification(
+    input: &str,
+) -> Option<String> {
+    is_start_anchored_subagent_notification(input)
+        .then(|| format_subagent_notification_card(None, input))
+}
+
+fn parse(prompt: &str) -> Result<Render, ()> {
+    let payload = extract_payload(prompt)?;
+    let envelope: Envelope = serde_json::from_str(&payload).map_err(|_| ())?;
+    let status = envelope.status.ok_or(())?;
+    if let Some(report) = status.completed.filter(|report| !report.trim().is_empty()) {
+        return Ok(Render::Completed(report));
+    }
+    if let Some(report) = status.failed.filter(|report| !report.trim().is_empty()) {
+        return Ok(Render::Failed(report));
+    }
+    Ok(Render::Unknown)
+}
+
+fn extract_payload(prompt: &str) -> Result<String, ()> {
+    const OPEN: &str = "<subagent_notification";
+    const CLOSE: &str = "</subagent_notification>";
+
+    let normalized = normalized_start_anchored_injection(prompt);
+    if !normalized.starts_with(OPEN) {
+        return Err(());
+    }
+    let after_open_name = &normalized[OPEN.len()..];
+    let Some(first) = after_open_name.chars().next() else {
+        return Err(());
+    };
+    if first != '>' && !first.is_whitespace() {
+        return Err(());
+    }
+    let open_end = normalized.find('>').ok_or(())? + 1;
+    let after_open = &normalized[open_end..];
+    let close_start = after_open.find(CLOSE).ok_or(())?;
+    Ok(after_open[..close_start].trim().to_string())
+}
+
+fn normalized_start_anchored_injection(prompt: &str) -> String {
+    let normalized = strip_terminal_controls(prompt);
+    let normalized = normalized.trim_start();
+    let normalized = strip_leading_injection_wrapper(normalized);
+    let normalized = normalized.trim_start();
+    let normalized = strip_provider_session_reuse_prologue(normalized).unwrap_or(normalized);
+    normalized.trim_start().to_string()
+}
+
+fn strip_leading_injection_wrapper(text: &str) -> &str {
+    const WRAPPER_MARKER: &str = "터미널에 직접 주입된 입력";
+    if !text.starts_with(WRAPPER_MARKER) {
+        return text;
+    }
+    let Some(after_wrapper_line) = text.find('\n').map(|idx| &text[idx + 1..]) else {
+        return text;
+    };
+    let trimmed = after_wrapper_line.trim_start_matches(['\r', '\n']);
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        if let Some(idx) = rest.find('\n') {
+            return &rest[idx + 1..];
+        }
+        return after_wrapper_line;
+    }
+    after_wrapper_line
+}
+
+fn strip_provider_session_reuse_prologue(normalized: &str) -> Option<&str> {
+    let rest = normalized
+        .strip_prefix("[Provider Session Reuse]")?
+        .trim_start();
+    provider_reuse_tail(rest, RESUMED_THREAD_PROLOGUE)
+        .or_else(|| provider_reuse_tail(rest, FRESH_FORK_PROLOGUE))
+}
+
+fn provider_reuse_tail<'a>(rest: &'a str, prologue: &str) -> Option<&'a str> {
+    rest.strip_prefix(prologue)
+        .and_then(|tail| tail.strip_prefix("\n\n"))
+}
+
+fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
+    let Some(rest) = text.strip_prefix('<') else {
+        return false;
+    };
+    let Some(rest) = rest.strip_prefix(tag) else {
+        return false;
+    };
+    rest.starts_with('>') || rest.chars().next().is_some_and(char::is_whitespace)
+}
+
+fn format_report(
+    tmux_session_name: Option<&str>,
+    icon: &str,
+    status: &str,
+    report: &str,
+) -> String {
+    let preview = preview(report);
+    let mut lines = vec![format!(
+        "{icon} Subagent {status}{}",
+        tmux_suffix(tmux_session_name),
+    )];
+    if !preview.is_empty() {
+        lines.push(String::new());
+        lines.push(preview);
+    }
+    lines.join("\n")
+}
+
+fn preview(report: &str) -> String {
+    let report = strip_terminal_controls(report);
+    let mut collected: Vec<String> = Vec::new();
+    for line in report.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        collected.push(sanitize_report_line(line));
+        if collected.len() >= PREVIEW_LINES {
+            break;
+        }
+    }
+    truncate_chars(&collected.join("\n"), PREVIEW_CHARS)
+}
+
+fn sanitize_report_line(value: &str) -> String {
+    value
+        .replace('\r', " ")
+        .replace('\n', " ")
+        .replace("```", "` ` `")
+}
+
+fn tmux_suffix(tmux_session_name: Option<&str>) -> String {
+    tmux_session_name
+        .map(|name| format!(" (tmux : `{}`)", sanitize_inline_code(name)))
+        .unwrap_or_default()
+}
+
+fn sanitize_inline_code(value: &str) -> String {
+    value.replace('`', "'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RESUMED_PREFIX: &str = "[Provider Session Reuse]\nThe prior authoritative Discord, role, and tool instructions already present in this Codex thread still apply. Treat only this turn's user request, reply context, uploaded files, and memory recall below as new actionable input.\n\n";
+
+    #[test]
+    fn detects_bare_wrapped_and_provider_reuse_subagent_notifications() {
+        let bare =
+            r#"<subagent_notification>{"status":{"completed":"done"}}</subagent_notification>"#;
+        assert!(is_start_anchored_subagent_notification(bare));
+
+        let wrapped = format!("터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n{bare}\n```");
+        assert!(is_start_anchored_subagent_notification(&wrapped));
+
+        let resumed = format!("{RESUMED_PREFIX}{bare}");
+        assert!(is_start_anchored_subagent_notification(&resumed));
+    }
+
+    #[test]
+    fn human_mid_body_quote_is_not_sanitized() {
+        let quoted = "please inspect this log line:\n<subagent_notification>{\"status\":{\"completed\":\"x\"}}</subagent_notification>";
+        assert!(!is_start_anchored_subagent_notification(quoted));
+        assert!(sanitize_start_anchored_subagent_notification(quoted).is_none());
+    }
+
+    #[test]
+    fn card_hides_raw_envelope_and_agent_path() {
+        let prompt = r#"<subagent_notification>
+{"agent_path":"/tmp/private-agent","status":{"completed":"Read-only review complete.\n\n1. Make /api/docs route-derived."}}
+</subagent_notification>"#;
+
+        let output = format_subagent_notification_card(Some("AgentDesk-codex"), prompt);
+
+        assert!(output.contains("Subagent completed"));
+        assert!(output.contains("Read-only review complete."));
+        assert!(output.contains("1. Make /api/docs route-derived."));
+        assert!(output.contains("(tmux : `AgentDesk-codex`)"));
+        assert!(!output.contains("<subagent_notification>"));
+        assert!(!output.contains("agent_path"));
+        assert!(!output.contains("/tmp/private-agent"));
+        assert!(!output.contains("{\""));
+    }
+}

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -14,14 +14,10 @@ use super::*;
 // so the classifier, formatters, and card parser stay in sync. The parent's
 // glob (`use super::*`) does not re-export these `use`-imported names, so the
 // child module imports them directly to keep the moved bodies byte-identical.
-use serde::Deserialize;
-
+use super::super::response_sanitizer::subagent_notification_card;
 use super::super::tui_task_card::{
     strip_terminal_controls, truncate_chars_ascii as truncate_chars,
 };
-
-const SUBAGENT_NOTIFICATION_PREVIEW_CHARS: usize = 900;
-const SUBAGENT_NOTIFICATION_PREVIEW_LINES: usize = 8;
 
 /// Classification of TUI-injected prompt text. Each class drives different
 /// lifecycle handling: human/task turns get active-turn ownership, continuation
@@ -64,12 +60,13 @@ impl InjectedPromptClass {
 }
 
 /// Pure classifier for injected TUI prompt text. Order is load-bearing:
-/// continuation banners win before machine notifications and slash-control echoes.
+/// start-anchored subagent envelopes win before generic continuation banners
+/// because Provider Session Reuse may wrap the machine-event tail.
 pub(super) fn classify_injected_prompt(prompt: &str) -> InjectedPromptClass {
-    if is_system_continuation_prompt(prompt) {
-        InjectedPromptClass::SystemContinuation
-    } else if is_start_anchored_subagent_notification(prompt) {
+    if is_start_anchored_subagent_notification(prompt) {
         InjectedPromptClass::SubagentNotificationEvent
+    } else if is_system_continuation_prompt(prompt) {
+        InjectedPromptClass::SystemContinuation
     } else if is_task_notification_prompt(prompt) {
         InjectedPromptClass::TaskNotificationEvent
     } else if is_slash_command_control_prompt(prompt) {
@@ -148,8 +145,7 @@ pub(super) fn is_start_anchored_task_notification(prompt: &str) -> bool {
 /// This is deliberately START-ANCHORED: a human prompt that quotes the XML-ish
 /// tag mid-body remains a normal TUI-direct prompt.
 pub(super) fn is_start_anchored_subagent_notification(prompt: &str) -> bool {
-    let normalized = normalized_start_anchored_injection(prompt);
-    starts_with_xmlish_tag(&normalized, "subagent_notification")
+    subagent_notification_card::is_start_anchored_subagent_notification(prompt)
 }
 
 fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
@@ -242,115 +238,8 @@ pub(super) fn format_ssh_direct_prompt_notification(
     )
 }
 
-#[derive(Debug, Deserialize)]
-struct SubagentNotificationEnvelope {
-    status: Option<SubagentNotificationStatus>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SubagentNotificationStatus {
-    completed: Option<String>,
-    failed: Option<String>,
-}
-
 pub(super) fn format_subagent_notification_card(tmux_session_name: &str, prompt: &str) -> String {
-    match parse_subagent_notification(prompt) {
-        Ok(SubagentNotificationRender::Completed(report)) => {
-            format_subagent_notification_report(tmux_session_name, "✅", "completed", &report)
-        }
-        Ok(SubagentNotificationRender::Failed(report)) => {
-            format_subagent_notification_report(tmux_session_name, "❌", "failed", &report)
-        }
-        Ok(SubagentNotificationRender::Unknown) => format!(
-            "📋 Subagent notification (tmux : `{}`) — no completed/failed status",
-            sanitize_inline_code(tmux_session_name),
-        ),
-        Err(_) => format!(
-            "⚠️ Subagent notification (tmux : `{}`) — malformed payload omitted",
-            sanitize_inline_code(tmux_session_name),
-        ),
-    }
-}
-
-enum SubagentNotificationRender {
-    Completed(String),
-    Failed(String),
-    Unknown,
-}
-
-fn parse_subagent_notification(prompt: &str) -> Result<SubagentNotificationRender, ()> {
-    let payload = extract_subagent_notification_payload(prompt)?;
-    let envelope: SubagentNotificationEnvelope = serde_json::from_str(&payload).map_err(|_| ())?;
-    let status = envelope.status.ok_or(())?;
-    if let Some(report) = status.completed.filter(|report| !report.trim().is_empty()) {
-        return Ok(SubagentNotificationRender::Completed(report));
-    }
-    if let Some(report) = status.failed.filter(|report| !report.trim().is_empty()) {
-        return Ok(SubagentNotificationRender::Failed(report));
-    }
-    Ok(SubagentNotificationRender::Unknown)
-}
-
-fn extract_subagent_notification_payload(prompt: &str) -> Result<String, ()> {
-    const OPEN: &str = "<subagent_notification";
-    const CLOSE: &str = "</subagent_notification>";
-
-    let normalized = normalized_start_anchored_injection(prompt);
-    if !normalized.starts_with(OPEN) {
-        return Err(());
-    }
-    let after_open_name = &normalized[OPEN.len()..];
-    let Some(first) = after_open_name.chars().next() else {
-        return Err(());
-    };
-    if first != '>' && !first.is_whitespace() {
-        return Err(());
-    }
-    let open_end = normalized.find('>').ok_or(())? + 1;
-    let after_open = &normalized[open_end..];
-    let close_start = after_open.find(CLOSE).ok_or(())?;
-    Ok(after_open[..close_start].trim().to_string())
-}
-
-fn format_subagent_notification_report(
-    tmux_session_name: &str,
-    icon: &str,
-    status: &str,
-    report: &str,
-) -> String {
-    let preview = subagent_report_preview(report);
-    let mut lines = vec![format!(
-        "{icon} Subagent {status} (tmux : `{}`)",
-        sanitize_inline_code(tmux_session_name),
-    )];
-    if !preview.is_empty() {
-        lines.push(String::new());
-        lines.push(preview);
-    }
-    lines.join("\n")
-}
-
-fn subagent_report_preview(report: &str) -> String {
-    let report = strip_terminal_controls(report);
-    let mut collected: Vec<String> = Vec::new();
-    for line in report.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        collected.push(sanitize_subagent_report_line(line));
-        if collected.len() >= SUBAGENT_NOTIFICATION_PREVIEW_LINES {
-            break;
-        }
-    }
-    truncate_chars(&collected.join("\n"), SUBAGENT_NOTIFICATION_PREVIEW_CHARS)
-}
-
-fn sanitize_subagent_report_line(value: &str) -> String {
-    value
-        .replace('\r', " ")
-        .replace('\n', " ")
-        .replace("```", "` ` `")
+    subagent_notification_card::format_subagent_notification_card(Some(tmux_session_name), prompt)
 }
 
 /// Canonical command kind for slash-control dedupe and kind-only notes.

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1661,6 +1661,28 @@ Codex thread still apply.\n\nThis is a human question about the marker.";
     );
 }
 
+#[test]
+fn classify_injected_prompt_provider_session_reuse_subagent_stays_subagent_event() {
+    let resumed = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+<subagent_notification>{\"agent_path\":\"/tmp/private\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+
+    assert_eq!(
+        classify_injected_prompt(resumed),
+        InjectedPromptClass::SubagentNotificationEvent,
+        "provider-session reuse wrapping must not downgrade subagent notifications to generic continuation events",
+    );
+    let output = format_subagent_notification_card("AgentDesk-codex-adk-cdx", resumed);
+    assert!(output.contains("Subagent completed"));
+    assert!(output.contains("Review complete."));
+    assert!(!output.contains("[Provider Session Reuse]"));
+    assert!(!output.contains("<subagent_notification>"));
+    assert!(!output.contains("agent_path"));
+    assert!(!output.contains("/tmp/private"));
+}
+
 // #3100 codex P2: stripping the wrapper is anchored to the START. A human
 // message whose body merely contains/quotes the wrapper marker (not as the
 // leading line) must NOT be unwrapped and must stay a human turn.

--- a/src/services/discord/turn_bridge/tmux_runtime.rs
+++ b/src/services/discord/turn_bridge/tmux_runtime.rs
@@ -907,9 +907,7 @@ pub(crate) fn tmux_runtime_paths(tmux_session_name: &str) -> (String, String) {
 }
 
 pub(in crate::services::discord) fn stale_inflight_message(saved_response: &str) -> String {
-    let cleaned = crate::services::discord::response_sanitizer::strip_leading_tui_response_chrome(
-        saved_response.trim(),
-    );
+    let cleaned = restart_saved_response_for_discord(saved_response);
     let cleaned = cleaned.trim();
     if cleaned.is_empty() {
         "⚠️ AgentDesk가 재시작되어 진행 중이던 응답을 이어붙이지 못했습니다.".to_string()
@@ -923,9 +921,7 @@ pub(in crate::services::discord) fn handoff_interrupted_message(
     restart_mode: InflightRestartMode,
     saved_response: &str,
 ) -> String {
-    let cleaned = crate::services::discord::response_sanitizer::strip_leading_tui_response_chrome(
-        saved_response.trim(),
-    );
+    let cleaned = restart_saved_response_for_discord(saved_response);
     let cleaned = cleaned.trim();
     match restart_mode {
         InflightRestartMode::DrainRestart => {
@@ -947,6 +943,12 @@ pub(in crate::services::discord) fn handoff_interrupted_message(
     }
 }
 
+fn restart_saved_response_for_discord(saved_response: &str) -> String {
+    crate::services::discord::response_sanitizer::sanitize_hidden_context_and_strip_chrome(
+        saved_response.trim(),
+    )
+}
+
 pub(super) fn is_dcserver_restart_command(input: &str) -> bool {
     let lower = input.to_lowercase();
 
@@ -961,4 +963,56 @@ pub(super) fn is_dcserver_restart_command(input: &str) -> bool {
     lower.contains("launchctl")
         && lower.contains("com.agentdesk.dcserver")
         && (lower.contains("kickstart") || lower.contains("bootstrap") || lower.contains("bootout"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RAW_SUBAGENT: &str = r#"<subagent_notification>
+{"agent_path":"/tmp/private-agent","status":{"completed":"Read-only review complete.\n\n1. Check relay path."}}
+</subagent_notification>"#;
+    const CHROME_RAW_SUBAGENT: &str = "No response requested.\n<subagent_notification>{\"agent_path\":\"/tmp/private-agent\",\"status\":{\"completed\":\"Read-only review complete.\"}}</subagent_notification>";
+
+    #[test]
+    fn stale_inflight_message_hides_raw_subagent_notification() {
+        let message = stale_inflight_message(RAW_SUBAGENT);
+
+        assert!(message.contains("Subagent completed"));
+        assert!(message.contains("Read-only review complete."));
+        assert!(message.contains("[Interrupted by restart]"));
+        assert!(!message.contains("<subagent_notification>"));
+        assert!(!message.contains("agent_path"));
+        assert!(!message.contains("/tmp/private-agent"));
+        assert!(!message.contains("{\""));
+    }
+
+    #[test]
+    fn handoff_interrupted_message_hides_raw_subagent_notification() {
+        let message = handoff_interrupted_message(InflightRestartMode::DrainRestart, RAW_SUBAGENT);
+
+        assert!(message.contains("Subagent completed"));
+        assert!(message.contains("Read-only review complete."));
+        assert!(message.contains("[Restart handoff incomplete]"));
+        assert!(!message.contains("<subagent_notification>"));
+        assert!(!message.contains("agent_path"));
+        assert!(!message.contains("/tmp/private-agent"));
+        assert!(!message.contains("{\""));
+    }
+
+    #[test]
+    fn restart_messages_sanitize_subagent_after_tui_chrome_strip() {
+        let stale = stale_inflight_message(CHROME_RAW_SUBAGENT);
+        assert!(stale.contains("Subagent completed"));
+        assert!(stale.contains("Read-only review complete."));
+        assert!(!stale.contains("No response requested."));
+        assert!(!stale.contains("<subagent_notification>"));
+        assert!(!stale.contains("agent_path"));
+
+        let handoff =
+            handoff_interrupted_message(InflightRestartMode::DrainRestart, CHROME_RAW_SUBAGENT);
+        assert!(handoff.contains("Subagent completed"));
+        assert!(!handoff.contains("<subagent_notification>"));
+        assert!(!handoff.contains("agent_path"));
+    }
 }


### PR DESCRIPTION
## Summary
- Reopen/fix #3716 regression where Codex `<subagent_notification>` payloads can still reach Discord raw after Provider Session Reuse or non-TUI relay paths.
- Move subagent notification parsing/rendering into a shared Discord sanitizer helper, and use it from TUI injected prompt classification plus outbound Discord formatting/restart handoff paths.
- Add a post-TUI-chrome sanitizer pass so `No response requested.` / resume chrome cannot expose a raw envelope after stripping.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --lib`
- `cargo test --lib subagent_notification -- --nocapture`
- `cargo test --lib format_for_discord_sanitizes_subagent_after_tui_chrome_strip -- --nocapture`
- `cargo test --lib restart_messages_sanitize_subagent_after_tui_chrome_strip -- --nocapture`
- `cargo test --lib classify_injected_prompt_provider_session_reuse_subagent_stays_subagent_event -- --nocapture`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`

## Review
- Fresh Codex xhigh adversarial review, final round: `VERDICT: CLEAN`.
