### PR TITLE
fix(discord): reduce footer-mode status flicker

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -138,10 +138,12 @@
     heartbeat timestamp selection into `watchers/lifecycle_decision.rs` and
     keeps lifecycle below its frozen ratchet; -6 from #3736 removing legacy
     remote-profile restore plumbing while remote SSH is disabled).
-  - `src/services/discord/tmux.rs` (2048 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2033 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
     status/footer stripping in the placeholder suppression decisions;
+    -15 from #3717 footer-only placeholder target preservation plus status-strip
+    helper extraction to `single_message_panel.rs`;
     +4 from #3167: the monitor-auto-turn start passes `ActiveTurnKind::Background`
     so a queued user message can supersede the low-priority monitor/loop turn;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
@@ -1071,10 +1073,11 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6238 lines; production LoC; the BRIDGE
+  - `src/services/discord/turn_bridge/mod.rs` (6234 lines; production LoC; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.
+    #3717 skips status-panel-v2 footer edits when only the spinner frame changes.
     Registered giant-file (#3038 decompose target — see
     `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).
     It surfaced as a giant only after #3028 fixed the prod/test splitter: an

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -579,6 +579,112 @@ pub(in crate::services::discord) fn strip_streaming_footer(
     None
 }
 
+pub(in crate::services::discord) fn same_streaming_footer_except_spinner_tick(
+    previous: &str,
+    next: &str,
+) -> bool {
+    if previous == next {
+        return true;
+    }
+    let Some((previous_body, previous_footer)) = streaming_footer_split(previous) else {
+        return false;
+    };
+    let Some((next_body, next_footer)) = streaming_footer_split(next) else {
+        return false;
+    };
+    previous_body == next_body
+        && normalize_footer_spinner_header(previous_footer)
+            == normalize_footer_spinner_header(next_footer)
+}
+
+pub(in crate::services::discord) fn streaming_footer_text_changed(
+    footer_mode: bool,
+    previous: &str,
+    next: &str,
+) -> bool {
+    previous != next && !(footer_mode && same_streaming_footer_except_spinner_tick(previous, next))
+}
+
+pub(in crate::services::discord) fn streaming_footer_only_surface_was_exposed(
+    text: &str,
+    provider: &super::ProviderKind,
+) -> bool {
+    let trimmed = text.trim();
+    !trimmed.is_empty()
+        && text_has_single_message_footer_surface(trimmed)
+        && strip_streaming_footer(text, provider).is_some_and(|cleaned| cleaned.trim().is_empty())
+}
+
+pub(in crate::services::discord) fn strip_placeholder_terminal_status(
+    text: &str,
+    provider: &super::ProviderKind,
+) -> String {
+    let text = strip_streaming_footer(text, provider).unwrap_or_else(|| text.to_string());
+    strip_inprogress_indicators(&text)
+}
+
+fn strip_inprogress_indicators(body: &str) -> String {
+    let mut lines: Vec<&str> = body
+        .lines()
+        .filter(|line| !is_inprogress_indicator_line(line))
+        .collect();
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+fn is_inprogress_indicator_line(line: &str) -> bool {
+    line.trim_start()
+        .chars()
+        .next()
+        .is_some_and(is_spinner_prefix_char)
+}
+
+fn is_spinner_prefix_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '⠏' | '⠋' | '⠙' | '⠹' | '⠸' | '⠼' | '⠴' | '⠦' | '⠧' | '⠇'
+    )
+}
+
+fn text_has_single_message_footer_surface(text: &str) -> bool {
+    text.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            (!line.is_empty()).then_some(line)
+        })
+        .any(|line| {
+            line.starts_with("Context   ")
+                || line == "Tasks"
+                || line == "Subagents"
+                || line.starts_with("└ ")
+                || (line.contains(" — ") && line.contains("(<t:"))
+        })
+}
+
+fn streaming_footer_split(text: &str) -> Option<(&str, &str)> {
+    if footer_starts_with_spinner(text) {
+        return Some(("", text));
+    }
+    split_footer(text)
+}
+
+fn normalize_footer_spinner_header(footer: &str) -> String {
+    let mut normalized = Vec::new();
+    let mut header_normalized = false;
+    for line in footer.lines() {
+        if !header_normalized && let Some(status) = strip_footer_braille_spinner_prefix(line.trim())
+        {
+            normalized.push(format!("⠿ {status}"));
+            header_normalized = true;
+        } else {
+            normalized.push(line.to_string());
+        }
+    }
+    normalized.join("\n")
+}
+
 fn split_footer(text: &str) -> Option<(&str, &str)> {
     let mut search_end = text.len();
     while let Some(idx) = text[..search_end].rfind("\n\n") {
@@ -879,6 +985,41 @@ mod tests {
         assert!(panel.len() <= super::SINGLE_MESSAGE_PANEL_LIVE_BODY_BUDGET_BYTES);
         assert!(panel.ends_with("\n…") || panel == "…");
         assert!(block.len() > super::SINGLE_MESSAGE_PANEL_LIVE_BODY_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn streaming_footer_semantic_compare_ignores_spinner_tick_only_3717() {
+        let previous =
+            "visible body\n\n⠋ 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let next =
+            "visible body\n\n⠙ 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+
+        assert!(super::same_streaming_footer_except_spinner_tick(
+            previous, next
+        ));
+    }
+
+    #[test]
+    fn streaming_footer_semantic_compare_keeps_body_and_panel_changes_3717() {
+        let previous =
+            "visible body\n\n⠋ 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let body_changed = "visible body plus output\n\n⠙ 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let panel_changed =
+            "visible body\n\n⠙ 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review done";
+        let completed =
+            "visible body\n\n✅ 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+
+        assert!(!super::same_streaming_footer_except_spinner_tick(
+            previous,
+            body_changed
+        ));
+        assert!(!super::same_streaming_footer_except_spinner_tick(
+            previous,
+            panel_changed
+        ));
+        assert!(!super::same_streaming_footer_except_spinner_tick(
+            previous, completed
+        ));
     }
 
     /// #3394: the footer finalization sink must re-balance fence parity. A panel

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -479,43 +479,12 @@ enum SuppressedPlaceholderAction {
     Edit(String),
 }
 
-fn is_spinner_prefix_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '⠏' | '⠋' | '⠙' | '⠹' | '⠸' | '⠼' | '⠴' | '⠦' | '⠧' | '⠇'
-    )
-}
-
-fn is_inprogress_indicator_line(line: &str) -> bool {
-    line.trim_start()
-        .chars()
-        .next()
-        .is_some_and(is_spinner_prefix_char)
-}
-
-fn strip_inprogress_indicators(body: &str) -> String {
-    let mut lines: Vec<&str> = body
-        .lines()
-        .filter(|line| !is_inprogress_indicator_line(line))
-        .collect();
-    while lines.last().is_some_and(|line| line.trim().is_empty()) {
-        lines.pop();
-    }
-    lines.join("\n")
-}
-
-fn strip_placeholder_terminal_status(text: &str, provider: &ProviderKind) -> String {
-    let text = super::single_message_panel::strip_streaming_footer(text, provider)
-        .unwrap_or_else(|| text.to_string());
-    strip_inprogress_indicators(&text)
-}
-
 fn rewrite_placeholder_as_terminal_suppressed(
     text: &str,
     label: &str,
     provider: &ProviderKind,
 ) -> String {
-    let cleaned = strip_placeholder_terminal_status(text, provider);
+    let cleaned = super::single_message_panel::strip_placeholder_terminal_status(text, provider);
     let trimmed = cleaned.trim_end();
     if trimmed.ends_with(label) {
         return trimmed.to_string();
@@ -576,9 +545,10 @@ fn orphan_suppressed_placeholder_action(
 
     let body = reconstructed_inflight_placeholder_body(state);
     let placeholder_was_exposed = state.response_sent_offset > 0
-        || !strip_placeholder_terminal_status(&body, provider)
+        || !super::single_message_panel::strip_placeholder_terminal_status(&body, provider)
             .trim()
-            .is_empty();
+            .is_empty()
+        || super::single_message_panel::streaming_footer_only_surface_was_exposed(&body, provider);
     if !placeholder_was_exposed {
         return SuppressedPlaceholderAction::Delete;
     }
@@ -642,7 +612,7 @@ enum PlaceholderSuppressDecision {
 }
 
 fn strip_placeholder_indicators_for_preserve(text: &str, provider: &ProviderKind) -> String {
-    strip_placeholder_terminal_status(text, provider)
+    super::single_message_panel::strip_placeholder_terminal_status(text, provider)
         .trim_end()
         .to_string()
 }
@@ -678,6 +648,11 @@ fn decide_placeholder_suppression(
                     ),
                 };
             }
+            let footer_only_was_exposed =
+                super::single_message_panel::streaming_footer_only_surface_was_exposed(
+                    ctx.last_edit_text,
+                    ctx.provider,
+                );
             match suppressed_placeholder_action(
                 ctx.placeholder_msg_id.is_some(),
                 ctx.provider,
@@ -686,6 +661,9 @@ fn decide_placeholder_suppression(
             ) {
                 SuppressedPlaceholderAction::None => PlaceholderSuppressDecision::None,
                 SuppressedPlaceholderAction::Delete => PlaceholderSuppressDecision::Delete,
+                SuppressedPlaceholderAction::Edit(content) if footer_only_was_exposed => {
+                    PlaceholderSuppressDecision::Edit(content)
+                }
                 // #3533: this duplicate-relay guard fires because a bridge turn
                 // already owns delivery, so an exposed body was/will be delivered by
                 // it — preserve it (strip the live spinner) instead of stamping
@@ -1030,9 +1008,16 @@ fn suppressed_placeholder_action(
     }
 
     let placeholder_was_exposed = response_sent_offset > 0
-        || !strip_placeholder_terminal_status(last_edit_text, provider)
-            .trim()
-            .is_empty();
+        || !super::single_message_panel::strip_placeholder_terminal_status(
+            last_edit_text,
+            provider,
+        )
+        .trim()
+        .is_empty()
+        || super::single_message_panel::streaming_footer_only_surface_was_exposed(
+            last_edit_text,
+            provider,
+        );
     if placeholder_was_exposed {
         SuppressedPlaceholderAction::Edit(rewrite_placeholder_as_terminal_suppressed(
             last_edit_text,
@@ -1116,23 +1101,25 @@ mod placeholder_suppression_tests {
     }
 
     #[test]
-    fn footer_mode_status_only_placeholder_deletes() {
+    fn footer_mode_status_only_placeholder_edits_to_keep_message_target() {
         let placeholder = footer_only_placeholder();
 
-        assert_eq!(
-            suppressed_placeholder_action(true, &ProviderKind::Claude, 0, &placeholder),
-            SuppressedPlaceholderAction::Delete
-        );
+        let action = suppressed_placeholder_action(true, &ProviderKind::Claude, 0, &placeholder);
+        let SuppressedPlaceholderAction::Edit(content) = action else {
+            panic!("footer-only placeholder should edit instead of deleting its message target");
+        };
+        assert_eq!(content, SUPPRESSED_INTERNAL_LABEL);
     }
 
     #[test]
-    fn completion_footer_only_placeholder_deletes() {
+    fn completion_footer_only_placeholder_edits_to_keep_message_target() {
         let placeholder = completion_footer_only_placeholder();
 
-        assert_eq!(
-            suppressed_placeholder_action(true, &ProviderKind::Claude, 0, &placeholder),
-            SuppressedPlaceholderAction::Delete
-        );
+        let action = suppressed_placeholder_action(true, &ProviderKind::Claude, 0, &placeholder);
+        let SuppressedPlaceholderAction::Edit(content) = action else {
+            panic!("completion-footer-only placeholder should edit instead of deleting");
+        };
+        assert_eq!(content, SUPPRESSED_INTERNAL_LABEL);
     }
 
     #[test]
@@ -1277,15 +1264,17 @@ mod placeholder_suppression_tests {
     }
 
     #[test]
-    fn active_bridge_unexposed_placeholder_still_deletes() {
-        // No body and no sent offset → nothing to preserve; deleting the bare
-        // spinner placeholder is unchanged behavior.
+    fn active_bridge_footer_only_placeholder_edits_to_preserve_target() {
+        // No body and no sent offset still carries a visible single-message
+        // footer. Keep the Discord message id alive so the bridge-owned
+        // completion footer can edit the same target instead of hitting 404.
         let placeholder = footer_only_placeholder();
         let ctx = active_bridge_ctx(&placeholder, 0, false);
-        assert_eq!(
-            decide_placeholder_suppression(&ctx),
-            PlaceholderSuppressDecision::Delete
-        );
+        let PlaceholderSuppressDecision::Edit(content) = decide_placeholder_suppression(&ctx)
+        else {
+            panic!("footer-only active bridge placeholder should edit, not delete");
+        };
+        assert_eq!(content, SUPPRESSED_INTERNAL_LABEL);
     }
 }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::services::discord::InflightTurnState;
+use crate::services::discord::http::{edit_channel_message, send_channel_message};
 use crate::services::discord::outbound::delivery_record as dr; // #3089 B2b
 use crate::services::discord::replace_outcome_policy::watcher_partial_continuation_retry_plan;
 
@@ -1705,15 +1706,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     let indicator = SPINNER[spin_idx % SPINNER.len()];
                     spin_idx += 1;
 
-                    // #3003 single-chokepoint orphan reclaim: reclaim a watcher-created
-                    // external-input v2 panel the moment its turn is abandoned (stopped/
-                    // cancelled → inflight cleared, or a recent turn-stop tombstone).
-                    // Positioned BEFORE every early-`continue` guard below (silent /
-                    // bridge-delivered / inflight-missing / recent-stop) so none can skip
-                    // it — the recurring orphan source. Committed turns null out
-                    // `status_panel_msg_id` at completion, so a finalized panel is safe.
-                    // #3351: reclaim the turn's stuck relay placeholder alongside the
-                    // panel (still-placeholder gated; real responses never deleted).
                     let tick_placeholder_reclaim = watcher_should_reclaim_orphan_turn_placeholder(
                         turn_is_external_input_for_session,
                         placeholder_msg_id,
@@ -2394,49 +2386,47 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         &watcher_provider,
                     );
 
-                    if display_text != last_edit_text {
-                        match placeholder_msg_id {
+                    if crate::services::discord::single_message_panel::streaming_footer_text_changed(
+                        single_message_panel_footer_mode,
+                        &last_edit_text,
+                        &display_text,
+                    ) {
+                        let edit_committed = match placeholder_msg_id {
                             Some(msg_id) => {
-                                // Edit existing placeholder
                                 rate_limit_wait(&shared, channel_id).await;
-                                let _ = crate::services::discord::http::edit_channel_message(
-                                    &http,
-                                    channel_id,
-                                    msg_id,
-                                    &display_text,
-                                )
-                                .await;
+                                edit_channel_message(&http, channel_id, msg_id, &display_text)
+                                    .await
+                                    .is_ok()
                             }
                             None => {
-                                // Create new placeholder
                                 if let Ok(msg) =
-                                    crate::services::discord::http::send_channel_message(
-                                        &http,
-                                        channel_id,
-                                        &display_text,
-                                    )
-                                    .await
+                                    send_channel_message(&http, channel_id, &display_text).await
                                 {
                                     placeholder_msg_id = Some(msg.id);
                                     placeholder_from_restored_inflight = false;
+                                    true
+                                } else {
+                                    false
                                 }
                             }
+                        };
+                        if edit_committed {
+                            last_edit_text = display_text;
+                            persist_watcher_stream_progress(
+                                &watcher_provider,
+                                channel_id,
+                                &tmux_session_name,
+                                turn_identity_for_panel.as_ref(),
+                                placeholder_msg_id,
+                                &full_response,
+                                response_sent_offset,
+                                tool_state.current_tool_line.as_deref(),
+                                tool_state.prev_tool_status.as_deref(),
+                                task_notification_kind,
+                                tool_state.any_tool_used,
+                                tool_state.has_post_tool_text,
+                            );
                         }
-                        last_edit_text = display_text;
-                        persist_watcher_stream_progress(
-                            &watcher_provider,
-                            channel_id,
-                            &tmux_session_name,
-                            turn_identity_for_panel.as_ref(),
-                            placeholder_msg_id,
-                            &full_response,
-                            response_sent_offset,
-                            tool_state.current_tool_line.as_deref(),
-                            tool_state.prev_tool_status.as_deref(),
-                            task_notification_kind,
-                            tool_state.any_tool_used,
-                            tool_state.has_post_tool_text,
-                        );
                     }
                 }
             }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -3467,19 +3467,8 @@ pub(super) fn spawn_turn_bridge(
                                 {
                                     pending_key.message_id = current_msg_id;
                                 }
-                                // #1255 codex round-1 P2: rollover advanced
-                                // `current_msg_id` past the message that owned the
-                                // active long-running placeholder. The old message
-                                // now holds delivered response content; retarget
-                                // the controller onto the new message_id so the
-                                // eventual terminal transition lands on the live
-                                // card instead of overwriting that frozen chunk.
-                                // codex round-2 P2: drop the active pointer if the
-                                // retarget edit fails — otherwise we'd suppress
-                                // streaming with no card visible.
-                                // codex round-4 P2: detach the old key first so
-                                // its `Active` controller entry doesn't linger as
-                                // a non-evictable row in the cap-bounded map.
+                                // #1255: rollover retargets the controller to the
+                                // new message and detaches the old key first.
                                 if let Some((old_key, snapshot, close_trigger, ack_consumed)) =
                                     long_running_placeholder_active.as_ref()
                                 {
@@ -3543,27 +3532,34 @@ pub(super) fn spawn_turn_bridge(
                     &provider,
                 );
 
-                // #1255 codex round-1 P2: while a long-running placeholder owns
-                // `current_msg_id`, the controller is the sole writer. Skipping the
-                // regular streaming edit prevents `stable_display_text` from
-                // overwriting the `🔄 백그라운드 처리 중` card mid-flight.
-                if stable_display_text != last_edit_text
+                if super::single_message_panel::streaming_footer_text_changed(
+                    single_message_panel_footer_mode,
+                    &last_edit_text,
+                    &stable_display_text,
+                )
                     && !done
                     && last_status_edit.elapsed() >= status_interval
                     && long_running_placeholder_active.is_none()
                     && pending_long_running_open_after_state_save.is_none()
                     && pending_long_running_retarget_after_state_save.is_none()
                 {
-                    let _ = gateway
-                        .edit_message(channel_id, current_msg_id, &stable_display_text)
-                        .await;
-                    last_edit_text = stable_display_text;
+                    let edit_ok = TurnGateway::edit_message(
+                        gateway.as_ref(),
+                        channel_id,
+                        current_msg_id,
+                        &stable_display_text,
+                    )
+                    .await
+                    .is_ok();
                     last_status_edit = tokio::time::Instant::now();
-                    inflight_state.current_msg_id = current_msg_id.get();
-                    inflight_state.current_msg_len = last_edit_text.len();
-                    inflight_state.response_sent_offset = response_sent_offset;
-                    inflight_state.full_response = full_response.clone();
-                    state_dirty = true;
+                    if edit_ok {
+                        last_edit_text = stable_display_text;
+                        inflight_state.current_msg_id = current_msg_id.get();
+                        inflight_state.current_msg_len = last_edit_text.len();
+                        inflight_state.response_sent_offset = response_sent_offset;
+                        inflight_state.full_response = full_response.clone();
+                        state_dirty = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Keep footer-only single-message placeholder targets alive by editing them to the suppressed-label state instead of deleting the Discord message id.
- Suppress footer-mode live edits when only the braille spinner frame changes, while still editing on assistant body changes, footer panel changes, completion transitions, and non-footer mode updates.
- Only commit `last_edit_text` / persisted stream progress after Discord edit/send success, so failed writes are retried instead of hidden by spinner-only suppression.
- Move placeholder terminal-status stripping into `single_message_panel.rs` and sync maintenance LoC docs.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --lib`
- `AGENTDESK_ROOT_DIR=$(mktemp -d /tmp/adk-test-root-3717-XXXXXX) cargo test --lib placeholder_suppression_tests -- --nocapture`
- `AGENTDESK_ROOT_DIR=$(mktemp -d /tmp/adk-test-root-3717-XXXXXX) cargo test --lib streaming_footer_semantic_compare -- --nocapture`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`

## Fresh xhigh review
- Hooke: `VERDICT: CLEAN`
- Darwin: `VERDICT: CLEAN`

## Notes
- Existing user/stash changes were reviewed and not mixed into this diff. The relevant stashes are preserved for future relay/rehydration work only.
- Raw `<subagent_notification>` relay leakage reproduced again during this work; that is tracked as a separate follow-up after this #3717 fix.
