### PR TITLE
fix(discord): sanitize user-prefixed subagent notifications

### DIFF
--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -1052,6 +1052,25 @@ mod status_panel_v2_formatter_tests {
     }
 
     #[test]
+    fn format_for_discord_sanitizes_provider_reuse_user_prefixed_subagent_3777() {
+        let input = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+[User: 0hbujang (ID: 343742347365974026)] \
+<subagent_notification>{\"agent_path\":\"/tmp/private-agent\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+
+        let output = format_for_discord_with_provider(input, &ProviderKind::Codex);
+        assert!(output.contains("Subagent completed"));
+        assert!(output.contains("Review complete."));
+        assert!(!output.contains("[Provider Session Reuse]"));
+        assert!(!output.contains("[User:"));
+        assert!(!output.contains("<subagent_notification>"));
+        assert!(!output.contains("agent_path"));
+        assert!(!output.contains("/tmp/private-agent"));
+    }
+
+    #[test]
     fn format_for_discord_preserves_blank_lines_inside_code_block_3475() {
         // #3475 acceptance: the blank-line collapse must NOT touch code block
         // contents, so relayed code/tool output keeps its intentional spacing.

--- a/src/services/discord/subagent_notification_card.rs
+++ b/src/services/discord/subagent_notification_card.rs
@@ -107,6 +107,8 @@ fn normalized_start_anchored_injection(prompt: &str) -> String {
     let normalized = strip_leading_injection_wrapper(normalized);
     let normalized = normalized.trim_start();
     let normalized = strip_provider_session_reuse_prologue(normalized).unwrap_or(normalized);
+    let normalized = normalized.trim_start();
+    let normalized = strip_leading_user_author_prefix(normalized).unwrap_or(normalized);
     normalized.trim_start().to_string()
 }
 
@@ -139,6 +141,13 @@ fn strip_provider_session_reuse_prologue(normalized: &str) -> Option<&str> {
 fn provider_reuse_tail<'a>(rest: &'a str, prologue: &str) -> Option<&'a str> {
     rest.strip_prefix(prologue)
         .and_then(|tail| tail.strip_prefix("\n\n"))
+}
+
+fn strip_leading_user_author_prefix(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix("[User: ")?;
+    let close = rest.find(']')?;
+    let tail = rest[close + 1..].trim_start();
+    starts_with_xmlish_tag(tail, "subagent_notification").then_some(tail)
 }
 
 fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
@@ -222,10 +231,30 @@ mod tests {
     }
 
     #[test]
+    fn detects_provider_reuse_user_prefixed_subagent_notifications_3777() {
+        let raw =
+            r#"<subagent_notification>{"status":{"completed":"done"}}</subagent_notification>"#;
+        let prefixed = format!("{RESUMED_PREFIX}[User: 0hbujang (ID: 343742347365974026)] {raw}");
+        assert!(is_start_anchored_subagent_notification(&prefixed));
+        assert!(
+            sanitize_start_anchored_subagent_notification(&prefixed)
+                .expect("card")
+                .contains("Subagent completed")
+        );
+
+        let wrapped = format!("터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n{prefixed}\n```");
+        assert!(is_start_anchored_subagent_notification(&wrapped));
+    }
+
+    #[test]
     fn human_mid_body_quote_is_not_sanitized() {
         let quoted = "please inspect this log line:\n<subagent_notification>{\"status\":{\"completed\":\"x\"}}</subagent_notification>";
         assert!(!is_start_anchored_subagent_notification(quoted));
         assert!(sanitize_start_anchored_subagent_notification(quoted).is_none());
+
+        let prefixed_human = "[User: 0hbujang] please inspect this log line:\n<subagent_notification>{\"status\":{\"completed\":\"x\"}}</subagent_notification>";
+        assert!(!is_start_anchored_subagent_notification(prefixed_human));
+        assert!(sanitize_start_anchored_subagent_notification(prefixed_human).is_none());
     }
 
     #[test]

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1683,6 +1683,28 @@ files, and memory recall below as new actionable input.\n\n\
     assert!(!output.contains("/tmp/private"));
 }
 
+#[test]
+fn classify_provider_reuse_user_prefixed_subagent_stays_subagent_event_3777() {
+    let resumed = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+[User: 0hbujang (ID: 343742347365974026)] \
+<subagent_notification>{\"agent_path\":\"/tmp/private\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+
+    assert_eq!(
+        classify_injected_prompt(resumed),
+        InjectedPromptClass::SubagentNotificationEvent,
+        "provider-session reuse user prefix must not hide subagent machine events",
+    );
+    let output = format_subagent_notification_card("AgentDesk-codex-adk-cdx", resumed);
+    assert!(output.contains("Subagent completed"));
+    assert!(output.contains("Review complete."));
+    assert!(!output.contains("[User:"));
+    assert!(!output.contains("<subagent_notification>"));
+    assert!(!output.contains("agent_path"));
+}
+
 // #3100 codex P2: stripping the wrapper is anchored to the START. A human
 // message whose body merely contains/quotes the wrapper marker (not as the
 // leading line) must NOT be unwrapped and must stay a human turn.


### PR DESCRIPTION
## Summary
- Normalize provider-session reuse prompts whose actionable tail is `[User: ...] <subagent_notification>...` so they render through the shared subagent notification card.
- Keep the prefix stripping gated on the tail immediately starting with a real `subagent_notification` tag to avoid swallowing human prose/debug quotes.
- Add focused coverage for the generic Discord formatter and TUI prompt classification path.

## Verification
- `cargo test --lib 3777 -- --nocapture`
- `cargo test --lib subagent_notification_card -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --lib` (passes with existing unrelated unused-import warnings)
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`
- Fresh xhigh review Heisenberg: `VERDICT: CLEAN`
- Fresh xhigh review Nash: `VERDICT: CLEAN`

## Notes
- Does not apply existing stashes wholesale; current #3777 patch only touches the observed user-prefixed provider-session wrapper shape.
- Follow-up for #3777.