### PR TITLE
Track dispatch delivery cutover authority state

### DIFF
--- a/docs/design/dispatch-delivery-events.md
+++ b/docs/design/dispatch-delivery-events.md
@@ -4,7 +4,9 @@ Source issue: #1791
 
 Epic: #1790
 
-Last refreshed: 2026-05-08
+Last refreshed: 2026-06-28
+
+Current tracker: #3747
 
 ## Background
 
@@ -34,7 +36,19 @@ make that state queryable without changing first-step delivery behavior.
 ## Current rollout state
 
 The legacy `kv_meta` markers remain the authoritative reservation and
-finalization guard until the cutover go/no-go issue #1952 passes. However,
+finalization guard until a future cutover GO decision lands. The current open
+tracker for the remaining typed-authority work is #3747.
+
+The historical tracking issues should not be interpreted as a completed typed
+cutover:
+
+- #1952 is closed because it produced the 2026-05-08 NO-GO decision report.
+  That issue completed the go/no-go exercise; it did not approve typed
+  authority.
+- #1864 is closed as historical cleanup tracking, but the cleanup remains
+  blocked by the NO-GO decision. Removing or weakening the legacy guard requires
+  a new GO decision under #3747 or a successor issue.
+
 `dispatch_delivery_events` is no longer write-only shadow data. The current
 guard reads typed rows to:
 
@@ -47,8 +61,23 @@ guard reads typed rows to:
 That means operators should use the typed table for delivery diagnosis during
 rollout while still treating `kv_meta` as the source of truth for whether the
 legacy guard has reserved or finalized a notification. Full typed-table
-authority remains incomplete until #1952 approves cutover; legacy guard removal
-stays deferred to follow-up issue #1864.
+authority remains incomplete until #3747 or a successor tracker records a future
+GO decision.
+
+## Runtime and operator source of truth
+
+Until the future GO decision:
+
+| State | Current source of truth | Typed-table role |
+| ----- | ----------------------- | ---------------- |
+| In-flight reservation | `kv_meta['dispatch_reserving:{dispatch_id}']` | Diagnostic/shadow row; typed active reservations are read to avoid duplicate sends during rollout but do not replace the legacy marker. |
+| Final delivery dedupe | `kv_meta['dispatch_notified:{dispatch_id}']` | Diagnostic, typed-read, duplicate metadata, API/dashboard, and reconciliation state. |
+| Cutover readiness | #3747 plus the latest cutover report | Evidence source only; not runtime authority. |
+
+Operators should diagnose delivery through `dispatch_delivery_events`, the
+delivery-events API, and the dashboard panel, but should treat `kv_meta` as the
+authoritative reservation/finalization guard until a future GO changes this
+contract.
 
 ## Non-Goals
 
@@ -204,12 +233,21 @@ Dashboard surfaces:
 
 ## Cutover Criteria
 
-The typed table can become authoritative only after all of these are true:
+The next GO checklist for #3747 or a successor tracker must pass all of these
+items before the typed table can become authoritative:
 
-- Dual-write has run in release for at least seven days or 500 dispatch
-  notification attempts, whichever comes later.
-- Reconciliation reports zero `kv_meta` versus typed-table mismatches for
-  `dispatch_reserving:*` and `dispatch_notified:*` over the cutover window.
+- Release soak duration: dual-write/shadow mode has run in release for at least
+  seven full KST days after the relevant reconciliation, API/dashboard, rollback,
+  recovery, and replay surfaces are available in that release.
+- Dispatch volume: the same observation window includes at least 500 new
+  dispatch notification attempts. If seven days elapse before 500 attempts, keep
+  soaking until both thresholds pass.
+- Mismatch window: reconciliation reports zero `kv_meta` versus typed-table
+  mismatches for `dispatch_reserving:*` and `dispatch_notified:*` inside the
+  cutover observation window, or every in-window mismatch is tied to a concrete
+  dispatch id and explicitly justified. Legacy pre-shadow history may be
+  excluded only when the event or key can be shown to predate the shadow-write
+  window; cumulative `missing_typed` counts are not sufficient by themselves.
 - Recovery tests prove that expired reservations can be retried without
   duplicate Discord posts.
 - Duplicate replay tests prove that the typed active unique key returns the
@@ -219,18 +257,32 @@ The typed table can become authoritative only after all of these are true:
 - `GET /api/dispatches/{id}/events` and the Kanban detail delivery-events panel
   have been deployed in release long enough for operators to use them during at
   least one real dispatch incident or routine verification pass.
-- The rollout has an explicit rollback: re-enable `kv_meta` as the authority and
-  ignore typed read decisions without deleting typed rows.
+- Rollback sign-off: the rollback runbook has explicit reviewer sign-off for the
+  GO attempt and says how to re-enable `kv_meta` as the authority and ignore
+  typed read decisions without deleting typed rows.
+- Post-cutover shadow window: after a GO flips typed authority, keep legacy
+  `kv_meta` shadow writes for one full release before starting any cleanup that
+  removes the legacy guard.
+- Tests pin the selected authority mode. Before GO, guard tests must assert that
+  bare `kv_meta` reservation/finalization markers still block sends even when
+  typed shadow rows are missing. A typed-authority cutover PR must update those
+  tests in the same change that flips runtime authority.
 
 Once those criteria pass, switch runtime reads and dedupe claims to
 `dispatch_delivery_events`, keep shadow `kv_meta` writes for one release, then
-remove the legacy guard in follow-up issue #1864.
+track legacy guard removal in the active cutover tracker or a successor cleanup
+issue. The closed #1864 issue is a historical reference, not current approval to
+remove the guard.
 
 ## Cutover Decision Log
 
 | Date       | Decision | Report                                                                                                      | Notes                                                                                                                                                                                         |
 | ---------- | -------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-05-08 | NO-GO    | [dispatch-delivery-events-cutover-2026-05-08.md](../reports/dispatch-delivery-events-cutover-2026-05-08.md) | Release snapshot had 188 typed events, 1099 cumulative reconciliation mismatches, and no seven-day post-prerequisite soak. Keep the legacy reservation/finalization path; do not start #1864. |
+
+As of 2026-06-28, #3747 is the single current open tracker for the remaining
+typed-authority cutover work. #1952 and #1864 are closed historical issues and
+must not be used to infer that typed authority completed.
 
 Rollback procedure for a future typed-authority cutover:
 [dispatch-delivery-cutover-rollback.md](../runbooks/dispatch-delivery-cutover-rollback.md).

--- a/docs/reports/dispatch-delivery-events-cutover-2026-05-08.md
+++ b/docs/reports/dispatch-delivery-events-cutover-2026-05-08.md
@@ -2,9 +2,32 @@
 
 Source issue: #1952
 
+Current tracker: #3747
+
 Decision: NO-GO
 
 All observation times are KST.
+
+## Tracking Status
+
+#1952 is closed because this report completed the requested go/no-go exercise
+and recorded a NO-GO decision. The closure does not mean typed
+`dispatch_delivery_events` authority was approved.
+
+#1864 is also closed, but the legacy guard cleanup it described remains blocked
+by this NO-GO decision. The current open tracking issue for the remaining
+typed-authority cutover work is #3747. Do not remove or weaken the legacy
+`kv_meta` guard based on the closed state of #1952 or #1864.
+
+Current runtime source of truth:
+
+- `kv_meta['dispatch_reserving:{dispatch_id}']` is authoritative for in-flight
+  reservation.
+- `kv_meta['dispatch_notified:{dispatch_id}']` is authoritative for final
+  delivery dedupe.
+- `dispatch_delivery_events` is diagnostic, typed-read, shadow-write,
+  duplicate-metadata, API/dashboard, and reconciliation state until a future GO
+  decision changes the authority contract.
 
 ## Evidence Sources
 
@@ -127,10 +150,17 @@ finalization path in place, with typed delivery rows retained for audit,
 reconciliation, dashboard display, and duplicate metadata where already
 supported.
 
-#1864 remains blocked. It should not start until a future GO report confirms:
+#1864 cleanup remains blocked even though the historical GitHub issue is closed.
+The current tracker for the next GO attempt is #3747. Legacy guard removal
+should not start until a future GO report confirms:
 
-- seven full KST days of release dual-write observation;
-- at least 500 typed delivery events;
-- zero cutover-window mismatches, or every mismatch fully justified;
-- rollback runbook reviewer sign-off;
-- one release has passed after the typed-authority cutover.
+- seven full KST days of release dual-write observation after all prerequisite
+  surfaces are present;
+- at least 500 typed delivery events in the same cutover observation window;
+- zero cutover-window mismatches, or every in-window mismatch tied to a concrete
+  dispatch id and fully justified;
+- justified exclusion of legacy pre-shadow history from the cutover-window
+  mismatch count;
+- rollback runbook reviewer sign-off for the GO attempt;
+- one full release of post-cutover `kv_meta` shadow writes after the
+  typed-authority cutover.

--- a/docs/runbooks/dispatch-delivery-cutover-rollback.md
+++ b/docs/runbooks/dispatch-delivery-cutover-rollback.md
@@ -2,7 +2,9 @@
 
 Source issue: #1952
 
-Last refreshed: 2026-05-08
+Current tracker: #3747
+
+Last refreshed: 2026-06-28
 
 ## Scope
 
@@ -11,7 +13,13 @@ dedupe authority from the legacy `kv_meta` reservation/finalization path to a
 fully typed `dispatch_delivery_events` claim path.
 
 The current 2026-05-08 decision is NO-GO, so this runbook is documentation for a
-future cutover, not an instruction to change production today.
+future cutover, not an instruction to change production today. Until #3747 or a
+successor tracker records GO, runtime source of truth remains:
+
+- `kv_meta['dispatch_reserving:{dispatch_id}']` for in-flight reservation;
+- `kv_meta['dispatch_notified:{dispatch_id}']` for final delivery dedupe;
+- `dispatch_delivery_events` for diagnostic, typed-read, shadow-write,
+  duplicate-metadata, API/dashboard, and reconciliation state.
 
 ## Rollback Goal
 
@@ -31,12 +39,13 @@ without deleting or rewriting typed delivery rows:
   reconciliation drift after that cutover.
 - The release process can deploy a rollback commit through
   `scripts/deploy-release.sh`.
-- No follow-up cleanup that deletes legacy guard support, especially #1864, has
-  been released.
+- No follow-up cleanup that deletes legacy guard support has been released.
+  The closed #1864 issue is historical cleanup tracking, not current approval to
+  remove the guard.
 
 ## Immediate Containment
 
-1. Stop the roll-forward sequence. Do not start #1864.
+1. Stop the roll-forward sequence. Do not remove legacy guard support.
 2. Capture the current reconciliation snapshot:
 
    ```bash
@@ -126,11 +135,17 @@ Then send or observe one routine dispatch and confirm:
 
 Only retry typed authority after all of these are true:
 
-- release dual-write has at least seven full KST days of observation;
-- at least 500 typed dispatch delivery events have been recorded;
-- every mismatch in the cutover window is zero or explicitly justified;
-- this runbook has one reviewer sign-off;
-- #1864 remains blocked until one post-cutover release passes.
+- release dual-write has at least seven full KST days of observation after all
+  prerequisite surfaces are deployed;
+- at least 500 typed dispatch delivery events have been recorded in the same
+  cutover observation window;
+- every mismatch in the cutover window is zero or tied to a concrete dispatch id
+  and explicitly justified;
+- legacy pre-shadow history is excluded from the cutover-window mismatch count
+  only when the event or key can be shown to predate shadow writes;
+- this runbook has one reviewer sign-off for the GO attempt;
+- legacy `kv_meta` shadow writes remain enabled for one full release after typed
+  authority flips, and cleanup starts only after that post-cutover release.
 
 ## Sign-Off
 

--- a/src/services/dispatches/discord_delivery/guard.rs
+++ b/src/services/dispatches/discord_delivery/guard.rs
@@ -502,6 +502,56 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn kv_meta_markers_remain_authoritative_when_typed_shadow_missing() {
+        let pg_db = create_test_pg_db().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        let notified_dispatch_id = "dispatch-kv-notified-authority";
+        seed_dispatch(&pool, notified_dispatch_id).await;
+        sqlx::query("INSERT INTO kv_meta (key, value) VALUES ($1, $2)")
+            .bind(notified_key(notified_dispatch_id))
+            .bind(notified_dispatch_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert!(
+            !claim_dispatch_delivery_guard(Some(&pool), notified_dispatch_id)
+                .await
+                .unwrap(),
+            "kv_meta notified marker must block sends without a typed shadow row"
+        );
+        assert_eq!(delivery_event_count(&pool, notified_dispatch_id).await, 0);
+
+        let reserving_dispatch_id = "dispatch-kv-reserving-authority";
+        seed_dispatch(&pool, reserving_dispatch_id).await;
+        sqlx::query(
+            "INSERT INTO kv_meta (key, value, expires_at)
+             VALUES ($1, $2, NOW() + INTERVAL '5 minutes')",
+        )
+        .bind(reserving_key(reserving_dispatch_id))
+        .bind(reserving_dispatch_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            !claim_dispatch_delivery_guard(Some(&pool), reserving_dispatch_id)
+                .await
+                .unwrap(),
+            "kv_meta reservation marker must block sends without a typed shadow row"
+        );
+        assert_eq!(
+            kv_meta_count(&pool, &reserving_key(reserving_dispatch_id)).await,
+            1
+        );
+        assert_eq!(delivery_event_count(&pool, reserving_dispatch_id).await, 0);
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
     #[test]
     fn delivery_result_status_maps_to_event_status() {
         let skipped = DispatchNotifyDeliveryResult::success(


### PR DESCRIPTION
## Summary

- Marks #3747 as the current open tracker for the remaining dispatch_delivery_events typed-authority cutover work.
- Explains why closed historical issues #1952 and #1864 do not mean typed authority completed.
- Documents the current source of truth: kv_meta remains authoritative for reservation/finalization; dispatch_delivery_events remains diagnostic/typed-read/shadow state until a future GO.
- Adds the next GO checklist details for soak duration, dispatch count, mismatch-window handling, rollback sign-off, and one-release post-cutover shadow writes.
- Adds a guard test that pins bare kv_meta reservation/notified markers as authoritative when typed shadow rows are missing.

Refs #3747

## Tests

- `cargo fmt --all --check`
- `cargo test -p agentdesk services::dispatches::discord_delivery::guard::tests -- --nocapture`
- `cargo check --lib` (passes with existing unused-import warnings in `placeholder_live_events/mod.rs` and `router/mod.rs`)
- `python3 scripts/check_agent_maintenance_docs.py` (0 errors, 1 warning: missing/empty generated module inventory)
- `python3 scripts/generate_inventory_docs.py --check` (fails because generated inventory docs are stale/missing: module, giant-file, route, worker inventories; not regenerated because they are outside this issue's owned write scope)
