### PR TITLE
Retry dead-frontier relay reattach once

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -656,6 +656,7 @@ src/
 │   │   ├── relay_health.rs
 │   │   ├── relay_owner_observability.rs
 │   │   ├── relay_recovery.rs
+│   │   ├── relay_recovery_auto_heal_attempts.rs
 │   │   ├── relay_recovery_completion_footer.rs
 │   │   ├── replace_outcome_policy.rs
 │   │   ├── response_sanitizer.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1002,10 +1002,6 @@
     #3717 guarding completion-footer registry forgets by the exact takeover
     message id; -13 from #3736 removing legacy remote-profile restore plumbing
     while remote SSH is disabled).
-  - `src/services/discord/relay_recovery.rs` (1006 lines; #3680 split relay
-    recovery reattach/self-heal path; new behavior is bugfix-only until a
-    follow-up extraction drops it below the giant-file threshold; net -1 from
-    #3717 moving completion-footer target ownership cleanup to a sibling helper).
   - `src/services/discord/health.rs` (417 prod lines after the #3038 Phase A
     directory decomposition; module root keeps the `HealthRegistry` core +
     re-export surface, and the former monolith body lives in flat

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -479,7 +479,9 @@
 # boot path) so a freshly-restarted live watcher is never false-classified as dead.
 # Tests live in the excluded `rebind_origin_reap_tests` module.
 "src/services/discord/inflight.rs" = 3138 # #3680 relay recovery review hardening / adoption guards
-"src/services/discord/relay_recovery.rs" = 1008 # #3680 ownerless relay recovery reattach
+# #3779 extracted relay-recovery auto-heal attempt accounting to a sibling
+# module, dropping relay_recovery.rs below the prod-giant threshold; the ratchet
+# entry is retired instead of raising the baseline.
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -323,16 +323,10 @@ owner = "discord-relay"
 deadline = "2026-08-31"
 decompose_issue = "#3405"
 
-[[entry]]
-# Crossed the 1000-prod-LoC threshold in #3680: relay recovery gained the
-# bounded watcher-reattach planner/apply guards for ownerless inflight recovery
-# and multi-runtime channel ownership. Keep future relay recovery orchestration
-# growth honest; split action planning/apply execution into child modules once
-# the reattach lifecycle stabilizes.
-file = "src/services/discord/relay_recovery.rs"
-owner = "discord-relay"
-deadline = "2026-08-31"
-decompose_issue = "#3405"
+# NOTE: src/services/discord/relay_recovery.rs previously had an [[entry]] here;
+# #3779 extracted auto-heal attempt accounting into a sibling module, dropping
+# the root below the prod-giant threshold. Its entry and ratchet baseline are
+# removed to avoid a ghost registration.
 
 [[entry]]
 # Crossed the 1000-prod-LoC threshold in #3739: worker-local LoopOwned Tokio

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -4,9 +4,8 @@
 //! classifier into an operator-facing decision, and only applies local,
 //! idempotent cleanup when the evidence is strong enough.
 
-use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex, OnceLock};
 
 use poise::serenity_prelude::ChannelId;
 use serde::Serialize;
@@ -19,11 +18,18 @@ use super::{
 };
 use crate::services::provider::ProviderKind;
 
-const AUTO_HEAL_WINDOW_SECS: i64 = 600;
-const AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW: u32 = 1;
-
+#[path = "relay_recovery_auto_heal_attempts.rs"]
+mod auto_heal_attempts;
 #[path = "relay_recovery_completion_footer.rs"]
 mod completion_footer;
+
+#[cfg(test)]
+use auto_heal_attempts::clear_auto_heal_attempts_for_tests;
+use auto_heal_attempts::{
+    AUTO_HEAL_DEAD_FRONTIER_REATTACH_MAX_ATTEMPTS_PER_WINDOW,
+    AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW, AUTO_HEAL_WINDOW_SECS, auto_heal_key,
+    max_attempts_per_window_for_snapshot, remaining_auto_heal_attempts, reserve_auto_heal_attempt,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -203,56 +209,6 @@ impl RelayRecoveryError {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-struct AttemptWindow {
-    window_start_ms: i64,
-    attempts: u32,
-}
-
-fn auto_heal_attempts() -> &'static Mutex<HashMap<String, AttemptWindow>> {
-    static ATTEMPTS: OnceLock<Mutex<HashMap<String, AttemptWindow>>> = OnceLock::new();
-    // Short-lived process memory guard only; persistence across restarts is out
-    // of scope for this bounded local auto-heal limiter.
-    ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn auto_heal_key(provider: &str, channel_id: u64, action: RelayRecoveryActionKind) -> String {
-    format!("{}:{}:{}", provider, channel_id, action.as_str())
-}
-
-fn remaining_auto_heal_attempts(key: &str, now_ms: i64) -> u32 {
-    let mut attempts = auto_heal_attempts()
-        .lock()
-        .expect("relay recovery attempt map poisoned");
-    let Some(window) = attempts.get_mut(key) else {
-        return AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW;
-    };
-    if now_ms.saturating_sub(window.window_start_ms) >= AUTO_HEAL_WINDOW_SECS * 1000 {
-        attempts.remove(key);
-        return AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW;
-    }
-    AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW.saturating_sub(window.attempts)
-}
-
-fn reserve_auto_heal_attempt(key: &str, now_ms: i64) -> Result<u32, &'static str> {
-    let mut attempts = auto_heal_attempts()
-        .lock()
-        .expect("relay recovery attempt map poisoned");
-    let window = attempts.entry(key.to_string()).or_insert(AttemptWindow {
-        window_start_ms: now_ms,
-        attempts: 0,
-    });
-    if now_ms.saturating_sub(window.window_start_ms) >= AUTO_HEAL_WINDOW_SECS * 1000 {
-        window.window_start_ms = now_ms;
-        window.attempts = 0;
-    }
-    if window.attempts >= AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW {
-        return Err("auto_heal_rate_limited");
-    }
-    window.attempts += 1;
-    Ok(AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW.saturating_sub(window.attempts))
-}
-
 fn is_agentdesk_tmux_session(tmux_session: Option<&str>) -> bool {
     tmux_session.is_some_and(|session| session.starts_with("AgentDesk-"))
 }
@@ -341,12 +297,13 @@ fn auto_heal_metadata(
     now_ms: i64,
 ) -> RelayRecoveryAutoHeal {
     let key = auto_heal_key(&snapshot.provider, snapshot.channel_id, action);
+    let max_attempts_per_window = max_attempts_per_window_for_snapshot(snapshot, action);
     RelayRecoveryAutoHeal {
         eligible,
         bounded: true,
-        max_attempts_per_window: AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW,
+        max_attempts_per_window,
         window_secs: AUTO_HEAL_WINDOW_SECS,
-        remaining_attempts: remaining_auto_heal_attempts(&key, now_ms),
+        remaining_attempts: remaining_auto_heal_attempts(&key, now_ms, max_attempts_per_window),
         skipped_reason,
     }
 }
@@ -588,7 +545,7 @@ async fn apply_relay_recovery_plan(
     }
 
     let key = auto_heal_key(&decision.provider, decision.channel_id, decision.action);
-    match reserve_auto_heal_attempt(&key, now_ms) {
+    match reserve_auto_heal_attempt(&key, now_ms, decision.auto_heal.max_attempts_per_window) {
         Ok(remaining) => {
             decision.auto_heal.remaining_attempts = remaining;
         }
@@ -997,14 +954,6 @@ fn trace_relay_recovery_skipped(
 }
 
 #[cfg(test)]
-fn clear_auto_heal_attempts_for_tests() {
-    auto_heal_attempts()
-        .lock()
-        .expect("relay recovery attempt map poisoned")
-        .clear();
-}
-
-#[cfg(test)]
 mod tests {
     use super::super::relay_health::RelayStallClassifier;
     use super::*;
@@ -1166,7 +1115,7 @@ mod tests {
         assert_eq!(decision.affected.thread_channel_id, Some(99));
         assert_eq!(
             decision.auto_heal.remaining_attempts,
-            AUTO_HEAL_MAX_ATTEMPTS_PER_WINDOW
+            AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW
         );
     }
 
@@ -1520,15 +1469,85 @@ mod tests {
             RelayRecoveryActionKind::ClearOrphanPendingToken,
         );
 
-        assert_eq!(reserve_auto_heal_attempt(&key, 1_000), Ok(0));
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 2_000),
+            reserve_auto_heal_attempt(&key, 1_000, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW),
+            Ok(0)
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 2_000, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW),
             Err("auto_heal_rate_limited")
         );
         assert_eq!(
-            reserve_auto_heal_attempt(&key, 1_000 + AUTO_HEAL_WINDOW_SECS * 1000),
+            reserve_auto_heal_attempt(
+                &key,
+                1_000 + AUTO_HEAL_WINDOW_SECS * 1000,
+                AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW
+            ),
             Ok(0)
         );
+    }
+
+    #[tokio::test]
+    async fn dead_frontier_reattach_gets_one_bounded_retry_only() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let snapshot = RelayHealthSnapshot {
+            provider: "codex".to_string(),
+            channel_id: 3_779_001,
+            active_turn: RelayActiveTurn::Foreground,
+            tmux_session: Some("AgentDesk-codex-retry-dead-frontier".to_string()),
+            tmux_alive: Some(true),
+            watcher_attached: true,
+            watcher_owner_channel_id: Some(3_779_001),
+            watcher_owns_live_relay: true,
+            bridge_inflight_present: true,
+            mailbox_has_cancel_token: true,
+            mailbox_active_user_msg_id: Some(3_779_101),
+            last_capture_offset: Some(2_048),
+            last_relay_offset: 0,
+            unread_bytes: Some(2_048),
+            desynced: true,
+            ..snapshot()
+        };
+        let decision = plan_relay_recovery(&snapshot, RelayStallState::TmuxAliveRelayDead, 1_000);
+        let key = auto_heal_key(&decision.provider, decision.channel_id, decision.action);
+
+        assert_eq!(decision.action, RelayRecoveryActionKind::ReattachWatcher);
+        assert!(decision.auto_heal.eligible);
+        assert_eq!(
+            decision.auto_heal.max_attempts_per_window,
+            AUTO_HEAL_DEAD_FRONTIER_REATTACH_MAX_ATTEMPTS_PER_WINDOW
+        );
+        assert_eq!(decision.auto_heal.remaining_attempts, 2);
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 1_000, decision.auto_heal.max_attempts_per_window),
+            Ok(1)
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 2_000, decision.auto_heal.max_attempts_per_window),
+            Ok(0),
+            "a still-dead relay frontier gets one bounded non-destructive reattach retry"
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 3_000, decision.auto_heal.max_attempts_per_window),
+            Err("auto_heal_rate_limited")
+        );
+
+        let progressed = plan_relay_recovery(
+            &RelayHealthSnapshot {
+                last_relay_ts_ms: Some(2_500),
+                last_relay_offset: 512,
+                unread_bytes: Some(1_536),
+                ..snapshot
+            },
+            RelayStallState::TmuxAliveRelayDead,
+            3_000,
+        );
+        assert_eq!(
+            progressed.auto_heal.max_attempts_per_window, AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW,
+            "once the relay frontier advances, reattach returns to the default limiter"
+        );
+        assert_eq!(progressed.auto_heal.remaining_attempts, 0);
     }
 
     #[tokio::test]

--- a/src/services/discord/relay_recovery_auto_heal_attempts.rs
+++ b/src/services/discord/relay_recovery_auto_heal_attempts.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use super::{RelayRecoveryActionKind, is_agentdesk_tmux_session};
+use crate::services::discord::relay_health::RelayHealthSnapshot;
+
+pub(super) const AUTO_HEAL_WINDOW_SECS: i64 = 600;
+pub(super) const AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW: u32 = 1;
+pub(super) const AUTO_HEAL_DEAD_FRONTIER_REATTACH_MAX_ATTEMPTS_PER_WINDOW: u32 = 2;
+
+#[derive(Clone, Copy, Debug)]
+struct AttemptWindow {
+    window_start_ms: i64,
+    attempts: u32,
+}
+
+fn auto_heal_attempts() -> &'static Mutex<HashMap<String, AttemptWindow>> {
+    static ATTEMPTS: OnceLock<Mutex<HashMap<String, AttemptWindow>>> = OnceLock::new();
+    // Short-lived process memory guard only; persistence across restarts is out
+    // of scope for this bounded local auto-heal limiter.
+    ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(super) fn auto_heal_key(
+    provider: &str,
+    channel_id: u64,
+    action: RelayRecoveryActionKind,
+) -> String {
+    format!("{}:{}:{}", provider, channel_id, action.as_str())
+}
+
+pub(super) fn remaining_auto_heal_attempts(
+    key: &str,
+    now_ms: i64,
+    max_attempts_per_window: u32,
+) -> u32 {
+    let mut attempts = auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned");
+    let Some(window) = attempts.get_mut(key) else {
+        return max_attempts_per_window;
+    };
+    if now_ms.saturating_sub(window.window_start_ms) >= AUTO_HEAL_WINDOW_SECS * 1000 {
+        attempts.remove(key);
+        return max_attempts_per_window;
+    }
+    max_attempts_per_window.saturating_sub(window.attempts)
+}
+
+pub(super) fn reserve_auto_heal_attempt(
+    key: &str,
+    now_ms: i64,
+    max_attempts_per_window: u32,
+) -> Result<u32, &'static str> {
+    let mut attempts = auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned");
+    let window = attempts.entry(key.to_string()).or_insert(AttemptWindow {
+        window_start_ms: now_ms,
+        attempts: 0,
+    });
+    if now_ms.saturating_sub(window.window_start_ms) >= AUTO_HEAL_WINDOW_SECS * 1000 {
+        window.window_start_ms = now_ms;
+        window.attempts = 0;
+    }
+    if window.attempts >= max_attempts_per_window {
+        return Err("auto_heal_rate_limited");
+    }
+    window.attempts += 1;
+    Ok(max_attempts_per_window.saturating_sub(window.attempts))
+}
+
+pub(super) fn max_attempts_per_window_for_snapshot(
+    snapshot: &RelayHealthSnapshot,
+    action: RelayRecoveryActionKind,
+) -> u32 {
+    if action == RelayRecoveryActionKind::ReattachWatcher
+        && is_agentdesk_tmux_session(snapshot.tmux_session.as_deref())
+        && snapshot.relay_frontier_never_advanced_with_unread_tail()
+    {
+        return AUTO_HEAL_DEAD_FRONTIER_REATTACH_MAX_ATTEMPTS_PER_WINDOW;
+    }
+    AUTO_HEAL_DEFAULT_MAX_ATTEMPTS_PER_WINDOW
+}
+
+#[cfg(test)]
+pub(super) fn clear_auto_heal_attempts_for_tests() {
+    auto_heal_attempts()
+        .lock()
+        .expect("relay recovery attempt map poisoned")
+        .clear();
+}


### PR DESCRIPTION
## Summary
- Fixes #3779.
- Keeps the default auto-heal limiter at one attempt per 600s window.
- Allows only `ReattachWatcher` on an AgentDesk dead relay frontier to get one bounded retry while `last_relay_offset=0`, no relay timestamp exists, and unread/capture tail evidence remains.
- Leaves destructive recovery actions such as orphan pending-token cleanup on the existing one-attempt limiter.

## Verification
- `cargo fmt --check`
- `cargo test relay_recovery --lib`
- `cargo check --lib`
- `python3 scripts/check_agent_maintenance_docs.py` returned 0 errors, 1 existing warning about missing generated module inventory
- `python3 scripts/generate_inventory_docs.py --check` reports existing generated docs drift; not changed in this scoped PR per warning-only generated-doc policy

## Runtime evidence
- Release logs showed channel `1479430394431668336` auto-healed as `reattached_watcher`, then stayed in `tmux_alive_relay_dead` with `last_relay_offset=0` and growing unread tail while subsequent non-destructive reattach attempts were rate-limited.