### PR TITLE
Centralize GitHub issue creation side effects

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -834,6 +834,7 @@ src/
 │   ├── envelope_dedup.rs
 │   ├── escalation_settings.rs
 │   ├── gemini.rs
+│   ├── github_issue_creation.rs
 │   ├── issue_announcements.rs
 │   ├── kanban.rs
 │   ├── kanban_cards.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1353,7 +1353,7 @@
     `expect_reply` reply-expectation param on /message and /handoff; +41 from
     #3750 documenting `/api/discord/bot-tokens/reload`).
   - `src/server/routes/escalation.rs` (1376 lines).
-  - `src/server/routes/meetings.rs` (1266 lines; SQL extracted to `src/db/meetings.rs` in #3570 slice 1).
+  - `src/server/routes/meetings.rs` (1290 lines; SQL extracted to `src/db/meetings.rs` in #3570 slice 1; +24 from #3742 explicit shared GitHub-only issue creation outcomes).
   - `src/server/routes/review_verdict/decision_route.rs` was decomposed in
     #3038 slice 1 and S1-relocated into a 26-line route shim delegating to
     `src/services/review_decision.rs` plus sub-1000-line service modules under

--- a/src/server/routes/github.rs
+++ b/src/server/routes/github.rs
@@ -5,12 +5,16 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::json;
-use sqlx::{PgPool, Row};
+use sqlx::Row;
 use std::collections::BTreeSet;
 
 use super::AppState;
-use crate::db::kanban::{IssueCardUpsert, upsert_card_from_issue_pg};
 use crate::github;
+use crate::services::github_issue_creation::{
+    GitHubIssueCreateRequest, IssueAnnouncementSync, IssueAnnouncementSyncOptions,
+    IssueCreationError, KanbanCardSync, KanbanCardSyncOptions,
+    create_github_issue_with_side_effects, resolve_known_agent_id_pg,
+};
 
 // ── Body types ─────────────────────────────────────────────────
 
@@ -95,27 +99,6 @@ fn issue_metadata_json(labels: &[String], block_on_issue_numbers: &[i64]) -> Opt
         }
         Some(serde_json::Value::Object(metadata).to_string())
     }
-}
-
-async fn resolve_known_agent_id_pg(
-    pool: &PgPool,
-    agent_id: Option<&str>,
-) -> Result<Option<String>, String> {
-    let Some(agent_id) = agent_id.and_then(trim_non_empty) else {
-        return Ok(None);
-    };
-
-    let exists = sqlx::query_scalar::<_, String>("SELECT id FROM agents WHERE id = $1 LIMIT 1")
-        .bind(&agent_id)
-        .fetch_optional(pool)
-        .await
-        .map_err(|error| format!("resolve agent {agent_id}: {error}"))?;
-
-    if exists.is_none() {
-        tracing::warn!("[issues] ignoring unknown assignee '{agent_id}' for linked kanban card");
-    }
-
-    Ok(exists)
 }
 
 fn resolve_issue_repo(input: &str) -> Result<String, String> {
@@ -444,158 +427,46 @@ pub async fn create_issue(
         .map(|agent_id| vec![format!("agent:{agent_id}")])
         .unwrap_or_default();
 
-    if !github::gh_available() {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "gh CLI is not available on this system"})),
-        );
-    }
+    let issue_create_request = GitHubIssueCreateRequest::new(
+        "api_github_issues_create",
+        repo.clone(),
+        title.clone(),
+        issue_body.clone(),
+    )
+    .with_labels(applied_labels.clone())
+    .with_kanban(KanbanCardSync::enabled(KanbanCardSyncOptions {
+        agent_id: body.agent_id.as_deref().and_then(trim_non_empty),
+        metadata_json: issue_metadata_json(&applied_labels, &block_on_issue_numbers),
+        status_on_create: Some("backlog".to_string()),
+    }))
+    .with_announcement(IssueAnnouncementSync::enabled(
+        IssueAnnouncementSyncOptions {
+            agent_id: body.agent_id.as_deref().and_then(trim_non_empty),
+            announcement_channel_id: body
+                .announcement_channel_id
+                .as_deref()
+                .and_then(trim_non_empty),
+            complete_if_closed: true,
+        },
+    ));
 
-    match github::create_issue_with_labels(&repo, &title, &issue_body, &applied_labels).await {
-        Ok(created) => {
-            let metadata_json = issue_metadata_json(&applied_labels, &block_on_issue_numbers);
-            let (kanban_card_id, kanban_card_sync_error) = if let Some(pool) = state.pg_pool_ref() {
-                let assigned_agent_id = match resolve_known_agent_id_pg(
-                    pool,
-                    body.agent_id.as_deref(),
-                )
-                .await
-                {
-                    Ok(agent_id) => agent_id,
-                    Err(error) => {
-                        tracing::error!(
-                            "[issues] created GitHub issue {}#{} but failed to resolve assignee: {}",
-                            repo,
-                            created.number,
-                            error
-                        );
-                        return (
-                            StatusCode::CREATED,
-                            Json(json!({
-                                "issue": {
-                                    "number": created.number,
-                                    "url": created.url,
-                                    "repo": repo,
-                                },
-                                "kanban_card_id": serde_json::Value::Null,
-                                "kanban_card_sync_error": error,
-                                "applied_labels": applied_labels,
-                                "block_on": block_on_issue_numbers,
-                                "issue_format_version": ISSUE_FORMAT_VERSION,
-                                // deprecated alias kept for transition; remove after clients migrate
-                                "pmd_format_version": ISSUE_FORMAT_VERSION,
-                            })),
-                        );
-                    }
-                };
-                match upsert_card_from_issue_pg(
-                    pool,
-                    IssueCardUpsert {
-                        repo_id: repo.clone(),
-                        issue_number: created.number,
-                        issue_url: Some(created.url.clone()),
-                        title: title.clone(),
-                        description: Some(issue_body.clone()),
-                        priority: None,
-                        assigned_agent_id,
-                        metadata_json: metadata_json.clone(),
-                        status_on_create: Some("backlog".to_string()),
-                    },
-                )
-                .await
-                {
-                    Ok(upserted) => (Some(upserted.card_id), None),
-                    Err(error) => {
-                        tracing::error!(
-                            "[issues] created GitHub issue {}#{} but failed to sync kanban card: {}",
-                            repo,
-                            created.number,
-                            error
-                        );
-                        (None, Some(error))
-                    }
-                }
-            } else {
-                (None, Some("postgres pool unavailable".to_string()))
-            };
-            let (announcement_channel_id, announcement_message_id, announcement_sync_error) =
-                if let Some(pool) = state.pg_pool_ref() {
-                    match crate::services::issue_announcements::create_issue_announcement_pg(
-                        pool,
-                        crate::services::issue_announcements::IssueAnnouncementCreate {
-                            repo: repo.clone(),
-                            issue_number: created.number,
-                            issue_url: created.url.clone(),
-                            title: title.clone(),
-                            agent_id: body.agent_id.as_deref().and_then(trim_non_empty),
-                            announcement_channel_id: body
-                                .announcement_channel_id
-                                .as_deref()
-                                .and_then(trim_non_empty),
-                        },
-                    )
-                    .await
-                    {
-                        Ok(Some(announcement)) => {
-                            if matches!(
-                                github::issue_state(&repo, created.number).as_deref(),
-                                Ok("CLOSED")
-                            ) {
-                                if let Err(error) =
-                                    crate::services::issue_announcements::complete_issue_announcement_pg(
-                                        pool,
-                                        crate::services::issue_announcements::IssueCompletionEvent {
-                                            repo: repo.clone(),
-                                            issue_number: created.number,
-                                            title: Some(title.clone()),
-                                            kind: crate::services::issue_announcements::IssueCompletionKind::Closed,
-                                            pr_number: None,
-                                            pr_url: None,
-                                        },
-                                    )
-                                    .await
-                                {
-                                    tracing::warn!(
-                                        "[issues] immediate completion announcement edit failed for {}#{}: {}",
-                                        repo,
-                                        created.number,
-                                        error
-                                    );
-                                }
-                            }
-                            (
-                                Some(announcement.channel_id),
-                                Some(announcement.message_id),
-                                None,
-                            )
-                        }
-                        Ok(None) => (None, None, None),
-                        Err(error) => {
-                            tracing::warn!(
-                                "[issues] created GitHub issue {}#{} but failed to announce: {}",
-                                repo,
-                                created.number,
-                                error
-                            );
-                            (None, None, Some(error))
-                        }
-                    }
-                } else if body.announcement_channel_id.as_ref().is_some() {
-                    (
-                        None,
-                        None,
-                        Some("postgres pool unavailable for issue announcement".to_string()),
-                    )
-                } else {
-                    (None, None, None)
-                };
+    match create_github_issue_with_side_effects(state.pg_pool_ref(), issue_create_request).await {
+        Ok(result) => {
+            let issue = result.issue;
+            let kanban = result.kanban;
+            let announcement = result.announcement;
+            let kanban_card_id = kanban.card_id.clone();
+            let kanban_card_sync_error = kanban.error.clone();
+            let announcement_channel_id = announcement.channel_id.clone();
+            let announcement_message_id = announcement.message_id.clone();
+            let announcement_sync_error = announcement.error.clone();
 
             (
                 StatusCode::CREATED,
                 Json(json!({
                     "issue": {
-                        "number": created.number,
-                        "url": created.url,
+                        "number": issue.number,
+                        "url": issue.url,
                         "repo": repo,
                     },
                     "kanban_card_id": kanban_card_id,
@@ -603,15 +474,23 @@ pub async fn create_issue(
                     "announcement_channel_id": announcement_channel_id,
                     "announcement_message_id": announcement_message_id,
                     "announcement_sync_error": announcement_sync_error,
-                    "applied_labels": applied_labels,
+                    "applied_labels": result.applied_labels,
                     "block_on": block_on_issue_numbers,
+                    "issue_creation_origin": result.origin,
+                    "issue_creation_mode": result.mode,
+                    "kanban_card_sync": kanban,
+                    "announcement_sync": announcement,
                     "issue_format_version": ISSUE_FORMAT_VERSION,
                     // deprecated alias kept for transition; remove after clients migrate
                     "pmd_format_version": ISSUE_FORMAT_VERSION,
                 })),
             )
         }
-        Err(error) => (
+        Err(IssueCreationError::GhUnavailable) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "gh CLI is not available on this system"})),
+        ),
+        Err(IssueCreationError::GitHub(error)) => (
             StatusCode::BAD_GATEWAY,
             Json(json!({"error": format!("gh issue create failed: {error}")})),
         ),

--- a/src/server/routes/github.rs
+++ b/src/server/routes/github.rs
@@ -500,7 +500,30 @@ pub async fn create_issue(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::sync::Arc;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
 
     fn test_state() -> AppState {
         let config = crate::config::Config::default();
@@ -533,6 +556,54 @@ mod tests {
             announcement_channel_id: None,
             dry_run: None,
         }
+    }
+
+    fn fake_gh_path(dir: &std::path::Path) -> std::path::PathBuf {
+        #[cfg(windows)]
+        {
+            dir.join("gh.ps1")
+        }
+        #[cfg(not(windows))]
+        {
+            dir.join("gh")
+        }
+    }
+
+    fn install_fake_gh(dir: &std::path::Path, fail_create: bool) -> std::path::PathBuf {
+        let path = fake_gh_path(dir);
+        #[cfg(windows)]
+        let script = if fail_create {
+            r#"
+param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Rest)
+if ($Rest[0] -eq "--version") { Write-Output "gh version 2.0.0"; exit 0 }
+if ($Rest[0] -eq "issue" -and $Rest[1] -eq "create") { Write-Error "boom"; exit 7 }
+Write-Error "unexpected gh args: $Rest"; exit 2
+"#
+        } else {
+            r#"
+param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Rest)
+if ($Rest[0] -eq "--version") { Write-Output "gh version 2.0.0"; exit 0 }
+if ($Rest[0] -eq "issue" -and $Rest[1] -eq "create") { Write-Output "https://github.com/itismyfield/AgentDesk/issues/4242"; exit 0 }
+Write-Error "unexpected gh args: $Rest"; exit 2
+"#
+        };
+        #[cfg(not(windows))]
+        let script = if fail_create {
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'gh version 2.0.0'; exit 0; fi\nif [ \"$1\" = \"issue\" ] && [ \"$2\" = \"create\" ]; then echo 'boom' >&2; exit 7; fi\necho \"unexpected gh args: $*\" >&2\nexit 2\n"
+        } else {
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'gh version 2.0.0'; exit 0; fi\nif [ \"$1\" = \"issue\" ] && [ \"$2\" = \"create\" ]; then echo 'https://github.com/itismyfield/AgentDesk/issues/4242'; exit 0; fi\necho \"unexpected gh args: $*\" >&2\nexit 2\n"
+        };
+        std::fs::write(&path, script).expect("write fake gh script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&path)
+                .expect("stat fake gh")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&path, permissions).expect("chmod fake gh");
+        }
+        path
     }
 
     #[tokio::test]
@@ -619,6 +690,79 @@ mod tests {
                 .as_str()
                 .is_some_and(|message| message.contains("unsupported reserved issue-create")),
             "non-dry-run unsupported fields must fail as a contract error: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_issue_non_dry_run_maps_shared_service_success_response() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .expect("shared env lock");
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let fake_gh = install_fake_gh(temp.path(), false);
+        let _gh_guard = EnvVarGuard::set("AGENTDESK_GH_PATH", &fake_gh);
+        let mut body = base_issue_body();
+        body.agent_id = Some("project-agentdesk".to_string());
+        body.block_on = Some(vec![7, 42]);
+
+        let (status, Json(response)) = create_issue(State(test_state()), Json(body)).await;
+
+        assert_eq!(status, StatusCode::CREATED, "{response}");
+        assert_eq!(response["issue"]["number"], json!(4242));
+        assert_eq!(
+            response["issue"]["url"],
+            json!("https://github.com/itismyfield/AgentDesk/issues/4242")
+        );
+        assert_eq!(
+            response["applied_labels"],
+            json!(["agent:project-agentdesk"])
+        );
+        assert_eq!(response["block_on"], json!([7, 42]));
+        assert_eq!(
+            response["issue_creation_origin"],
+            json!("api_github_issues_create")
+        );
+        assert_eq!(response["issue_creation_mode"], json!("standard"));
+        assert_eq!(
+            response["kanban_card_sync_error"],
+            json!("postgres pool unavailable")
+        );
+        assert_eq!(response["kanban_card_sync"]["enabled"], json!(true));
+        assert_eq!(response["announcement_sync"]["enabled"], json!(true));
+        assert_eq!(
+            response["announcement_sync"]["error"],
+            json!("postgres pool unavailable for issue announcement")
+        );
+        assert_eq!(
+            response["announcement_sync_error"],
+            json!("postgres pool unavailable for issue announcement")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_issue_non_dry_run_maps_shared_service_github_failure() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .expect("shared env lock");
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let fake_gh = install_fake_gh(temp.path(), true);
+        let _gh_guard = EnvVarGuard::set("AGENTDESK_GH_PATH", &fake_gh);
+
+        let (status, Json(response)) =
+            create_issue(State(test_state()), Json(base_issue_body())).await;
+
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert!(
+            response["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("gh issue create failed")),
+            "shared service GitHub errors must map to BAD_GATEWAY: {response}"
+        );
+        assert!(
+            response["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("boom")),
+            "fake gh stderr should be preserved in the route error: {response}"
         );
     }
 }

--- a/src/server/routes/meetings.rs
+++ b/src/server/routes/meetings.rs
@@ -20,6 +20,9 @@ use crate::db::meetings::{
 };
 use crate::services::discord::meeting_artifact_store::UpsertMeetingBody;
 use crate::services::discord::{health, meeting, settings};
+use crate::services::github_issue_creation::{
+    GitHubIssueCreateRequest, create_github_issue_with_side_effects,
+};
 use crate::services::provider::ProviderKind;
 
 // ── Body types ─────────────────────────────────────────────────
@@ -780,18 +783,39 @@ pub async fn create_issues(
             String::new()
         };
 
-        // Use the shared async/timeout-bounded GitHub helper so this route
-        // does not block the Tokio worker on a direct gh subprocess call.
-        match crate::github::create_issue(&repo, title, &body_text).await {
-            Ok(issue) => {
-                let url = issue.url;
+        let issue_create_request = GitHubIssueCreateRequest::github_only(
+            "meeting_issue_creation",
+            repo.clone(),
+            title.to_string(),
+            body_text.clone(),
+            "meeting issue creation stores issue_url in meeting metadata and intentionally skips kanban/announcement sync",
+        );
+
+        match create_github_issue_with_side_effects(Some(pool), issue_create_request).await {
+            Ok(result) => {
+                let issue_number = result.issue.number;
+                let url = result.issue.url.clone();
+                let kanban_card_sync = result.kanban.clone();
+                let announcement_sync = result.announcement.clone();
                 // Store result
                 let _ = store_issue_url_pg(pool, &id, &key, &url).await;
-                results.push(json!({"key": key, "title": title, "assignee": "", "ok": true, "issue_url": url, "attempted_at": chrono::Utc::now().timestamp()}));
+                results.push(json!({
+                    "key": key,
+                    "title": title,
+                    "assignee": "",
+                    "ok": true,
+                    "issue_url": url,
+                    "issue_number": issue_number,
+                    "issue_creation_origin": result.origin,
+                    "issue_creation_mode": result.mode.as_str(),
+                    "kanban_card_sync": kanban_card_sync,
+                    "announcement_sync": announcement_sync,
+                    "attempted_at": chrono::Utc::now().timestamp()
+                }));
                 created += 1;
             }
             Err(error) => {
-                results.push(json!({"key": key, "title": title, "assignee": "", "ok": false, "error": error, "attempted_at": chrono::Utc::now().timestamp()}));
+                results.push(json!({"key": key, "title": title, "assignee": "", "ok": false, "error": error.to_string(), "attempted_at": chrono::Utc::now().timestamp()}));
                 failed += 1;
             }
         }

--- a/src/services/api_friction/issues.rs
+++ b/src/services/api_friction/issues.rs
@@ -7,6 +7,10 @@ use super::patterns::{
     load_pattern_candidates_pg,
 };
 use crate::github::CreatedIssue;
+use crate::services::github_issue_creation::{
+    GitHubIssueCreateRequest, GitHubIssueCreationResult, IssueAnnouncementSyncOutcome,
+    IssueCreationMode, KanbanCardSyncOutcome, create_github_issue_with_side_effects,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub(crate) struct ProcessedApiFrictionIssue {
@@ -17,6 +21,9 @@ pub(crate) struct ProcessedApiFrictionIssue {
     pub event_count: usize,
     pub issue_number: i64,
     pub issue_url: String,
+    pub issue_creation_mode: IssueCreationMode,
+    pub kanban_card_sync: KanbanCardSyncOutcome,
+    pub announcement_sync: IssueAnnouncementSyncOutcome,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
@@ -95,14 +102,24 @@ async fn process_pattern_issue_pg(
     let issue_title = issue_title(&pattern);
     let issue_body = build_issue_body_pg(pg_pool, &pattern).await?;
 
-    match crate::github::create_issue(&pattern.repo_id, &issue_title, &issue_body).await {
-        Ok(issue) => {
-            upsert_created_issue_pg(pg_pool, &pattern, &issue_title, &issue_body, &issue).await?;
+    let issue_create_request = GitHubIssueCreateRequest::github_only(
+        "api_friction_issue_processing",
+        pattern.repo_id.clone(),
+        issue_title.clone(),
+        issue_body.clone(),
+        "API-friction issue processing persists issue_url in api_friction_issues and intentionally skips kanban/announcement sync",
+    );
+
+    match create_github_issue_with_side_effects(Some(pg_pool), issue_create_request).await {
+        Ok(result) => {
+            upsert_created_issue_pg(pg_pool, &pattern, &issue_title, &issue_body, &result.issue)
+                .await?;
             Ok(ApiFrictionPatternProcessResult::Created(processed_issue(
-                &pattern, issue,
+                &pattern, result,
             )))
         }
         Err(error) => {
+            let error = error.to_string();
             record_issue_creation_failure_pg(pg_pool, &pattern, &issue_title, &issue_body, &error)
                 .await?;
             Ok(ApiFrictionPatternProcessResult::Failed(pattern_failure(
@@ -222,7 +239,11 @@ fn event_count_i32(event_count: usize) -> Result<i32, String> {
         .map_err(|_| format!("api_friction event_count exceeds postgres integer: {event_count}"))
 }
 
-fn processed_issue(pattern: &ApiFrictionPattern, issue: CreatedIssue) -> ProcessedApiFrictionIssue {
+fn processed_issue(
+    pattern: &ApiFrictionPattern,
+    result: GitHubIssueCreationResult,
+) -> ProcessedApiFrictionIssue {
+    let issue = result.issue;
     ProcessedApiFrictionIssue {
         fingerprint: pattern.fingerprint.clone(),
         endpoint: pattern.endpoint.clone(),
@@ -231,6 +252,9 @@ fn processed_issue(pattern: &ApiFrictionPattern, issue: CreatedIssue) -> Process
         event_count: pattern.event_count,
         issue_number: issue.number,
         issue_url: issue.url,
+        issue_creation_mode: result.mode,
+        kanban_card_sync: result.kanban,
+        announcement_sync: result.announcement,
     }
 }
 

--- a/src/services/github_issue_creation.rs
+++ b/src/services/github_issue_creation.rs
@@ -1,0 +1,617 @@
+use serde::Serialize;
+use sqlx::PgPool;
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::db::kanban::{IssueCardUpsert, upsert_card_from_issue_pg};
+use crate::github::{self, CreatedIssue};
+use crate::services::issue_announcements::{
+    IssueAnnouncementCreate, IssueAnnouncementCreated, IssueCompletionEvent, IssueCompletionKind,
+    complete_issue_announcement_pg, create_issue_announcement_pg,
+};
+
+type IssueCreatorFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<CreatedIssue, String>> + Send + 'a>>;
+
+trait IssueCreator: Send + Sync {
+    fn gh_available(&self) -> bool;
+
+    fn create_issue<'a>(&'a self, request: &'a GitHubIssueCreateRequest) -> IssueCreatorFuture<'a>;
+}
+
+#[derive(Debug, Default)]
+struct GhCliIssueCreator;
+
+impl IssueCreator for GhCliIssueCreator {
+    fn gh_available(&self) -> bool {
+        github::gh_available()
+    }
+
+    fn create_issue<'a>(&'a self, request: &'a GitHubIssueCreateRequest) -> IssueCreatorFuture<'a> {
+        Box::pin(async move {
+            if request.labels.is_empty() {
+                github::create_issue(&request.repo, &request.title, &request.body).await
+            } else {
+                github::create_issue_with_labels(
+                    &request.repo,
+                    &request.title,
+                    &request.body,
+                    &request.labels,
+                )
+                .await
+            }
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueCreationMode {
+    Standard,
+    GithubOnly,
+}
+
+impl IssueCreationMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::GithubOnly => "github_only",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GitHubIssueCreateRequest {
+    pub origin: String,
+    pub mode: IssueCreationMode,
+    pub repo: String,
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub kanban: KanbanCardSync,
+    pub announcement: IssueAnnouncementSync,
+}
+
+impl GitHubIssueCreateRequest {
+    pub fn new(
+        origin: impl Into<String>,
+        repo: impl Into<String>,
+        title: impl Into<String>,
+        body: impl Into<String>,
+    ) -> Self {
+        Self {
+            origin: origin.into(),
+            mode: IssueCreationMode::Standard,
+            repo: repo.into(),
+            title: title.into(),
+            body: body.into(),
+            labels: Vec::new(),
+            kanban: KanbanCardSync::disabled("kanban sync not configured"),
+            announcement: IssueAnnouncementSync::disabled("announcement sync not configured"),
+        }
+    }
+
+    pub fn github_only(
+        origin: impl Into<String>,
+        repo: impl Into<String>,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        let reason = reason.into();
+        Self {
+            origin: origin.into(),
+            mode: IssueCreationMode::GithubOnly,
+            repo: repo.into(),
+            title: title.into(),
+            body: body.into(),
+            labels: Vec::new(),
+            kanban: KanbanCardSync::disabled(reason.clone()),
+            announcement: IssueAnnouncementSync::disabled(reason),
+        }
+    }
+
+    pub fn with_labels(mut self, labels: Vec<String>) -> Self {
+        self.labels = normalize_labels(&labels);
+        self
+    }
+
+    pub fn with_kanban(mut self, kanban: KanbanCardSync) -> Self {
+        self.kanban = kanban;
+        self
+    }
+
+    pub fn with_announcement(mut self, announcement: IssueAnnouncementSync) -> Self {
+        self.announcement = announcement;
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KanbanCardSync {
+    Enabled(KanbanCardSyncOptions),
+    Disabled { reason: String },
+}
+
+impl KanbanCardSync {
+    pub fn enabled(options: KanbanCardSyncOptions) -> Self {
+        Self::Enabled(options)
+    }
+
+    pub fn disabled(reason: impl Into<String>) -> Self {
+        Self::Disabled {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct KanbanCardSyncOptions {
+    pub agent_id: Option<String>,
+    pub metadata_json: Option<String>,
+    pub status_on_create: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IssueAnnouncementSync {
+    Enabled(IssueAnnouncementSyncOptions),
+    Disabled { reason: String },
+}
+
+impl IssueAnnouncementSync {
+    pub fn enabled(options: IssueAnnouncementSyncOptions) -> Self {
+        Self::Enabled(options)
+    }
+
+    pub fn disabled(reason: impl Into<String>) -> Self {
+        Self::Disabled {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IssueAnnouncementSyncOptions {
+    pub agent_id: Option<String>,
+    pub announcement_channel_id: Option<String>,
+    pub complete_if_closed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct KanbanCardSyncOutcome {
+    pub enabled: bool,
+    pub card_id: Option<String>,
+    pub created: Option<bool>,
+    pub error: Option<String>,
+    pub skipped_reason: Option<String>,
+}
+
+impl KanbanCardSyncOutcome {
+    fn synced(created: crate::db::kanban::IssueCardUpsertResult) -> Self {
+        Self {
+            enabled: true,
+            card_id: Some(created.card_id),
+            created: Some(created.created),
+            error: None,
+            skipped_reason: None,
+        }
+    }
+
+    fn failed(error: impl Into<String>) -> Self {
+        Self {
+            enabled: true,
+            card_id: None,
+            created: None,
+            error: Some(error.into()),
+            skipped_reason: None,
+        }
+    }
+
+    fn skipped(reason: impl Into<String>) -> Self {
+        Self {
+            enabled: false,
+            card_id: None,
+            created: None,
+            error: None,
+            skipped_reason: Some(reason.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct IssueAnnouncementSyncOutcome {
+    pub enabled: bool,
+    pub channel_id: Option<String>,
+    pub message_id: Option<String>,
+    pub error: Option<String>,
+    pub skipped_reason: Option<String>,
+}
+
+impl IssueAnnouncementSyncOutcome {
+    fn synced(created: IssueAnnouncementCreated) -> Self {
+        Self {
+            enabled: true,
+            channel_id: Some(created.channel_id),
+            message_id: Some(created.message_id),
+            error: None,
+            skipped_reason: None,
+        }
+    }
+
+    fn failed(error: impl Into<String>) -> Self {
+        Self {
+            enabled: true,
+            channel_id: None,
+            message_id: None,
+            error: Some(error.into()),
+            skipped_reason: None,
+        }
+    }
+
+    fn skipped(reason: impl Into<String>) -> Self {
+        Self {
+            enabled: false,
+            channel_id: None,
+            message_id: None,
+            error: None,
+            skipped_reason: Some(reason.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GitHubIssueCreationResult {
+    pub origin: String,
+    pub mode: IssueCreationMode,
+    pub issue: CreatedIssue,
+    pub applied_labels: Vec<String>,
+    pub kanban: KanbanCardSyncOutcome,
+    pub announcement: IssueAnnouncementSyncOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IssueCreationError {
+    GhUnavailable,
+    GitHub(String),
+}
+
+impl std::fmt::Display for IssueCreationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GhUnavailable => f.write_str("gh CLI is not available on this system"),
+            Self::GitHub(error) => write!(f, "gh issue create failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for IssueCreationError {}
+
+pub async fn create_github_issue_with_side_effects(
+    pool: Option<&PgPool>,
+    request: GitHubIssueCreateRequest,
+) -> Result<GitHubIssueCreationResult, IssueCreationError> {
+    let creator = GhCliIssueCreator;
+    create_github_issue_with_creator(pool, request, &creator).await
+}
+
+async fn create_github_issue_with_creator(
+    pool: Option<&PgPool>,
+    mut request: GitHubIssueCreateRequest,
+    creator: &dyn IssueCreator,
+) -> Result<GitHubIssueCreationResult, IssueCreationError> {
+    if !creator.gh_available() {
+        return Err(IssueCreationError::GhUnavailable);
+    }
+
+    request.labels = normalize_labels(&request.labels);
+    let issue = creator
+        .create_issue(&request)
+        .await
+        .map_err(IssueCreationError::GitHub)?;
+
+    let kanban = sync_kanban_card(pool, &request, &issue).await;
+    let announcement = sync_issue_announcement(pool, &request, &issue).await;
+
+    Ok(GitHubIssueCreationResult {
+        origin: request.origin,
+        mode: request.mode,
+        issue,
+        applied_labels: request.labels,
+        kanban,
+        announcement,
+    })
+}
+
+async fn sync_kanban_card(
+    pool: Option<&PgPool>,
+    request: &GitHubIssueCreateRequest,
+    issue: &CreatedIssue,
+) -> KanbanCardSyncOutcome {
+    let options = match &request.kanban {
+        KanbanCardSync::Enabled(options) => options,
+        KanbanCardSync::Disabled { reason } => {
+            tracing::info!(
+                "[issues] created GitHub-only issue {}#{} from {}: kanban sync disabled: {}",
+                request.repo,
+                issue.number,
+                request.origin,
+                reason
+            );
+            return KanbanCardSyncOutcome::skipped(reason.clone());
+        }
+    };
+
+    let Some(pool) = pool else {
+        return KanbanCardSyncOutcome::failed("postgres pool unavailable");
+    };
+
+    let assigned_agent_id = match resolve_known_agent_id_pg(pool, options.agent_id.as_deref()).await
+    {
+        Ok(agent_id) => agent_id,
+        Err(error) => {
+            tracing::error!(
+                "[issues] created GitHub issue {}#{} but failed to resolve assignee: {}",
+                request.repo,
+                issue.number,
+                error
+            );
+            return KanbanCardSyncOutcome::failed(error);
+        }
+    };
+
+    match upsert_card_from_issue_pg(
+        pool,
+        IssueCardUpsert {
+            repo_id: request.repo.clone(),
+            issue_number: issue.number,
+            issue_url: Some(issue.url.clone()),
+            title: request.title.clone(),
+            description: Some(request.body.clone()),
+            priority: None,
+            assigned_agent_id,
+            metadata_json: options.metadata_json.clone(),
+            status_on_create: options.status_on_create.clone(),
+        },
+    )
+    .await
+    {
+        Ok(upserted) => KanbanCardSyncOutcome::synced(upserted),
+        Err(error) => {
+            tracing::error!(
+                "[issues] created GitHub issue {}#{} but failed to sync kanban card: {}",
+                request.repo,
+                issue.number,
+                error
+            );
+            KanbanCardSyncOutcome::failed(error)
+        }
+    }
+}
+
+async fn sync_issue_announcement(
+    pool: Option<&PgPool>,
+    request: &GitHubIssueCreateRequest,
+    issue: &CreatedIssue,
+) -> IssueAnnouncementSyncOutcome {
+    let options = match &request.announcement {
+        IssueAnnouncementSync::Enabled(options) => options,
+        IssueAnnouncementSync::Disabled { reason } => {
+            tracing::info!(
+                "[issues] created GitHub-only issue {}#{} from {}: announcement sync disabled: {}",
+                request.repo,
+                issue.number,
+                request.origin,
+                reason
+            );
+            return IssueAnnouncementSyncOutcome::skipped(reason.clone());
+        }
+    };
+
+    let Some(pool) = pool else {
+        if options
+            .agent_id
+            .as_deref()
+            .and_then(trim_non_empty)
+            .is_some()
+            || options
+                .announcement_channel_id
+                .as_deref()
+                .and_then(trim_non_empty)
+                .is_some()
+        {
+            return IssueAnnouncementSyncOutcome::failed(
+                "postgres pool unavailable for issue announcement",
+            );
+        }
+        return IssueAnnouncementSyncOutcome::skipped("no announcement target configured");
+    };
+
+    match create_issue_announcement_pg(
+        pool,
+        IssueAnnouncementCreate {
+            repo: request.repo.clone(),
+            issue_number: issue.number,
+            issue_url: issue.url.clone(),
+            title: request.title.clone(),
+            agent_id: options.agent_id.as_deref().and_then(trim_non_empty),
+            announcement_channel_id: options
+                .announcement_channel_id
+                .as_deref()
+                .and_then(trim_non_empty),
+        },
+    )
+    .await
+    {
+        Ok(Some(announcement)) => {
+            if options.complete_if_closed
+                && matches!(
+                    github::issue_state(&request.repo, issue.number).as_deref(),
+                    Ok("CLOSED")
+                )
+            {
+                if let Err(error) = complete_issue_announcement_pg(
+                    pool,
+                    IssueCompletionEvent {
+                        repo: request.repo.clone(),
+                        issue_number: issue.number,
+                        title: Some(request.title.clone()),
+                        kind: IssueCompletionKind::Closed,
+                        pr_number: None,
+                        pr_url: None,
+                    },
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "[issues] immediate completion announcement edit failed for {}#{}: {}",
+                        request.repo,
+                        issue.number,
+                        error
+                    );
+                }
+            }
+            IssueAnnouncementSyncOutcome::synced(announcement)
+        }
+        Ok(None) => IssueAnnouncementSyncOutcome::skipped("no announcement channel resolved"),
+        Err(error) => {
+            tracing::warn!(
+                "[issues] created GitHub issue {}#{} but failed to announce: {}",
+                request.repo,
+                issue.number,
+                error
+            );
+            IssueAnnouncementSyncOutcome::failed(error)
+        }
+    }
+}
+
+pub(crate) async fn resolve_known_agent_id_pg(
+    pool: &PgPool,
+    agent_id: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(agent_id) = agent_id.and_then(trim_non_empty) else {
+        return Ok(None);
+    };
+
+    let exists = sqlx::query_scalar::<_, String>("SELECT id FROM agents WHERE id = $1 LIMIT 1")
+        .bind(&agent_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|error| format!("resolve agent {agent_id}: {error}"))?;
+
+    if exists.is_none() {
+        tracing::warn!("[issues] ignoring unknown assignee '{agent_id}' for linked kanban card");
+    }
+
+    Ok(exists)
+}
+
+fn normalize_labels(labels: &[String]) -> Vec<String> {
+    labels
+        .iter()
+        .filter_map(|label| trim_non_empty(label))
+        .collect()
+}
+
+fn trim_non_empty(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct FakeIssueCreator {
+        available: bool,
+        issue: CreatedIssue,
+    }
+
+    impl IssueCreator for FakeIssueCreator {
+        fn gh_available(&self) -> bool {
+            self.available
+        }
+
+        fn create_issue<'a>(
+            &'a self,
+            _request: &'a GitHubIssueCreateRequest,
+        ) -> IssueCreatorFuture<'a> {
+            Box::pin(async move { Ok(self.issue.clone()) })
+        }
+    }
+
+    fn fake_creator() -> FakeIssueCreator {
+        FakeIssueCreator {
+            available: true,
+            issue: CreatedIssue {
+                number: 3742,
+                url: "https://github.com/itismyfield/AgentDesk/issues/3742".to_string(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn standard_creation_reports_enabled_sync_outcomes_without_live_github() {
+        let request = GitHubIssueCreateRequest::new(
+            "api_github_issues_create",
+            "itismyfield/AgentDesk",
+            "Centralize issue creation",
+            "body",
+        )
+        .with_labels(vec![" agent:td ".to_string(), String::new()])
+        .with_kanban(KanbanCardSync::enabled(KanbanCardSyncOptions {
+            agent_id: Some("td".to_string()),
+            metadata_json: Some(r#"{"depends_on":[1]}"#.to_string()),
+            status_on_create: Some("backlog".to_string()),
+        }))
+        .with_announcement(IssueAnnouncementSync::enabled(
+            IssueAnnouncementSyncOptions {
+                agent_id: Some("td".to_string()),
+                announcement_channel_id: Some("123".to_string()),
+                complete_if_closed: true,
+            },
+        ));
+
+        let result = create_github_issue_with_creator(None, request, &fake_creator())
+            .await
+            .expect("fake issue creation should succeed");
+
+        assert_eq!(result.mode, IssueCreationMode::Standard);
+        assert_eq!(result.applied_labels, vec!["agent:td"]);
+        assert_eq!(result.issue.number, 3742);
+        assert_eq!(result.kanban.enabled, true);
+        assert_eq!(
+            result.kanban.error.as_deref(),
+            Some("postgres pool unavailable")
+        );
+        assert_eq!(result.announcement.enabled, true);
+        assert_eq!(
+            result.announcement.error.as_deref(),
+            Some("postgres pool unavailable for issue announcement")
+        );
+    }
+
+    #[tokio::test]
+    async fn github_only_creation_skips_route_specific_side_effects_explicitly() {
+        let reason = "meeting issue creation stores issue_url locally and intentionally skips sync";
+        let request = GitHubIssueCreateRequest::github_only(
+            "meeting_issue_creation",
+            "itismyfield/AgentDesk",
+            "Meeting action item",
+            "body",
+            reason,
+        );
+
+        let result = create_github_issue_with_creator(None, request, &fake_creator())
+            .await
+            .expect("fake issue creation should succeed");
+
+        assert_eq!(result.mode, IssueCreationMode::GithubOnly);
+        assert!(result.applied_labels.is_empty());
+        assert_eq!(result.kanban.enabled, false);
+        assert_eq!(result.kanban.skipped_reason.as_deref(), Some(reason));
+        assert_eq!(result.announcement.enabled, false);
+        assert_eq!(result.announcement.skipped_reason.as_deref(), Some(reason));
+    }
+}

--- a/src/services/github_issue_creation.rs
+++ b/src/services/github_issue_creation.rs
@@ -525,7 +525,7 @@ mod tests {
     #[derive(Debug)]
     struct FakeIssueCreator {
         available: bool,
-        issue: CreatedIssue,
+        result: Result<CreatedIssue, String>,
     }
 
     impl IssueCreator for FakeIssueCreator {
@@ -537,17 +537,34 @@ mod tests {
             &'a self,
             _request: &'a GitHubIssueCreateRequest,
         ) -> IssueCreatorFuture<'a> {
-            Box::pin(async move { Ok(self.issue.clone()) })
+            Box::pin(async move { self.result.clone() })
         }
     }
 
     fn fake_creator() -> FakeIssueCreator {
         FakeIssueCreator {
             available: true,
-            issue: CreatedIssue {
+            result: Ok(CreatedIssue {
                 number: 3742,
                 url: "https://github.com/itismyfield/AgentDesk/issues/3742".to_string(),
-            },
+            }),
+        }
+    }
+
+    fn fake_creator_unavailable() -> FakeIssueCreator {
+        FakeIssueCreator {
+            available: false,
+            result: Ok(CreatedIssue {
+                number: 1,
+                url: "https://github.com/itismyfield/AgentDesk/issues/1".to_string(),
+            }),
+        }
+    }
+
+    fn fake_creator_failure(error: impl Into<String>) -> FakeIssueCreator {
+        FakeIssueCreator {
+            available: true,
+            result: Err(error.into()),
         }
     }
 
@@ -613,5 +630,53 @@ mod tests {
         assert_eq!(result.kanban.skipped_reason.as_deref(), Some(reason));
         assert_eq!(result.announcement.enabled, false);
         assert_eq!(result.announcement.skipped_reason.as_deref(), Some(reason));
+    }
+
+    #[tokio::test]
+    async fn gh_unavailable_short_circuits_before_side_effects() {
+        let request = GitHubIssueCreateRequest::new(
+            "api_github_issues_create",
+            "itismyfield/AgentDesk",
+            "Centralize issue creation",
+            "body",
+        )
+        .with_kanban(KanbanCardSync::enabled(KanbanCardSyncOptions::default()))
+        .with_announcement(IssueAnnouncementSync::enabled(
+            IssueAnnouncementSyncOptions {
+                agent_id: None,
+                announcement_channel_id: Some("123".to_string()),
+                complete_if_closed: true,
+            },
+        ));
+
+        let error = create_github_issue_with_creator(None, request, &fake_creator_unavailable())
+            .await
+            .expect_err("unavailable gh must fail before sync side effects");
+
+        assert_eq!(error, IssueCreationError::GhUnavailable);
+    }
+
+    #[tokio::test]
+    async fn gh_create_failure_is_reported_without_sync_side_effects() {
+        let request = GitHubIssueCreateRequest::new(
+            "api_github_issues_create",
+            "itismyfield/AgentDesk",
+            "Centralize issue creation",
+            "body",
+        )
+        .with_kanban(KanbanCardSync::enabled(KanbanCardSyncOptions::default()))
+        .with_announcement(IssueAnnouncementSync::enabled(
+            IssueAnnouncementSyncOptions {
+                agent_id: None,
+                announcement_channel_id: Some("123".to_string()),
+                complete_if_closed: true,
+            },
+        ));
+
+        let error = create_github_issue_with_creator(None, request, &fake_creator_failure("boom"))
+            .await
+            .expect_err("gh create failure must map to the shared GitHub error");
+
+        assert_eq!(error, IssueCreationError::GitHub("boom".to_string()));
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -41,6 +41,7 @@ pub mod envelope_dedup;
 pub mod escalation_settings;
 pub mod gemini;
 pub mod git;
+pub mod github_issue_creation;
 pub mod issue_announcements;
 pub mod kanban;
 pub mod kanban_cards;


### PR DESCRIPTION
## Summary
- add a shared `services::github_issue_creation` pipeline for GitHub issue creation, labels, kanban sync, and announcement sync
- route `/api/github/issues/create` through the standard shared path while preserving existing top-level response fields
- route meeting and API-friction issue creation through explicit GitHub-only options with observable skipped sync outcomes
- refresh generated architecture inventory and the meetings route maintenance freeze entry

## Tests
- `cargo fmt --all --check`
- `cargo test --lib github_issue_creation -- --nocapture`
- `cargo test --lib server::routes::github::tests -- --nocapture`
- `cargo check --lib` (passes; existing unrelated unused-import warnings in Discord modules remain)
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`

Refs #3742
