### PR TITLE
Enforce caller-class source labels for discord send

### DIFF
--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1253,15 +1253,23 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ("message", body_param("string", false, "Alias for content")),
             (
                 "source",
-                body_param("string", false, "Known agent role_id or internal source; defaults to system"),
+                body_param("string", false, "Source label allowed for the caller class: CLI uses agentdesk-cli/operator, dashboard uses dashboard or an agent role_id, and internal labels such as system/headless_turn require a loopback internal caller"),
             ),
             (
                 "bot",
                 body_param("string", false, "Delivery bot: announce (default) or notify"),
             ),
+            (
+                "X-AgentDesk-Source",
+                header_param(
+                    "string",
+                    false,
+                    "Caller class attestation: cli, dashboard, or loopback/internal",
+                ),
+            ),
         ])
         .with_example(
-            json!({"body": {"target": "channel:1473922824350601297", "content": "hello", "source": "system", "bot": "notify"}}),
+            json!({"body": {"target": "channel:1473922824350601297", "content": "hello", "source": "operator", "bot": "notify"}}),
             json!({"ok": true, "message_id": "1500000000000000000"}),
         )
         .with_error_example(
@@ -1269,7 +1277,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             json!({"body": {"target": "channel:1473922824350601297"}}),
             json!({"error": "content is required", "ok": false}),
         )
-        .with_curl("curl -X POST http://localhost:8787/api/discord/send -H 'Content-Type: application/json' -d '{\"target\":\"channel:1473922824350601297\",\"content\":\"hello\",\"source\":\"system\",\"bot\":\"notify\"}'"),
+        .with_curl("curl -X POST http://localhost:8787/api/discord/send -H 'Content-Type: application/json' -H 'X-AgentDesk-Source: cli' -d '{\"target\":\"channel:1473922824350601297\",\"content\":\"hello\",\"source\":\"operator\",\"bot\":\"notify\"}'"),
         ep(
             "POST",
             "/api/discord/bot-tokens/reload",
@@ -6606,6 +6614,7 @@ mod tests {
             "message",
             "source",
             "bot",
+            "X-AgentDesk-Source",
         ] {
             assert!(
                 send.params.contains_key(param),
@@ -6633,7 +6642,12 @@ mod tests {
             .request["body"];
         assert_eq!(example_body["target"], "channel:1473922824350601297");
         assert_eq!(example_body["content"], "hello");
-        assert_eq!(example_body["source"], "system");
+        assert_eq!(example_body["source"], "operator");
+        assert!(
+            send.curl_example
+                .expect("send docs must include a curl example")
+                .contains("X-AgentDesk-Source: cli")
+        );
     }
 
     #[test]

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -21,6 +21,7 @@ use crate::services::provider::ProviderKind;
 use super::AppState;
 
 const OUTBOX_AGE_DEGRADED_SECS: i64 = 60;
+const X_AGENTDESK_SOURCE: &str = "x-agentdesk-source";
 const ACTIVE_SESSION_AUDIT_QUERY: &str =
     "SELECT session_key, provider, status, active_dispatch_id, last_heartbeat,
                 thread_channel_id, channel_id
@@ -155,6 +156,26 @@ fn discord_control_endpoints_allowed(
     }
 
     bearer_token_matches(config, headers)
+}
+
+fn discord_send_caller_class(
+    peer_addr: SocketAddr,
+    headers: &HeaderMap,
+) -> health::SendCallerClass {
+    let source_header = headers.get(X_AGENTDESK_SOURCE);
+    let header_class = source_header
+        .and_then(|value| value.to_str().ok())
+        .and_then(health::SendCallerClass::from_header);
+    match header_class {
+        Some(health::SendCallerClass::LoopbackInternal) if peer_addr.ip().is_loopback() => {
+            health::SendCallerClass::LoopbackInternal
+        }
+        Some(health::SendCallerClass::LoopbackInternal) => health::SendCallerClass::Unknown,
+        Some(class) => class,
+        None if source_header.is_some() => health::SendCallerClass::Unknown,
+        None if peer_addr.ip().is_loopback() => health::SendCallerClass::LoopbackInternal,
+        None => health::SendCallerClass::Unknown,
+    }
 }
 
 /// Build combined DB + Discord provider health.
@@ -1676,8 +1697,19 @@ pub async fn send_handler(
     };
 
     let body_str = String::from_utf8_lossy(&body);
-    let (status_str, response_body) =
-        health::handle_send(registry, None, state.pg_pool_ref(), &body_str).await;
+    let caller_class = discord_send_caller_class(peer_addr, &headers);
+    let (status_str, response_body) = if caller_class == health::SendCallerClass::LoopbackInternal {
+        health::handle_send(registry, None, state.pg_pool_ref(), &body_str).await
+    } else {
+        crate::services::discord::outbound::send_api::handle_send_with_caller(
+            registry,
+            None,
+            state.pg_pool_ref(),
+            &body_str,
+            caller_class,
+        )
+        .await
+    };
     let status = parse_status_code(status_str);
     let json: serde_json::Value =
         serde_json::from_str(&response_body).unwrap_or(serde_json::json!({"error": "internal"}));
@@ -1867,7 +1899,8 @@ pub async fn senddm_handler(
 mod tests {
     use super::{
         ACTIVE_SESSION_AUDIT_QUERY, RegistryPurgeDecision, discord_control_endpoints_allowed,
-        public_health_json, registry_purge_decision, stale_mailbox_repair_applied,
+        discord_send_caller_class, public_health_json, registry_purge_decision,
+        stale_mailbox_repair_applied,
     };
     use axum::{
         body::{Body, to_bytes},
@@ -1889,6 +1922,12 @@ mod tests {
                 .parse()
                 .expect("valid bearer header"),
         );
+        headers
+    }
+
+    fn source_headers(source: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-agentdesk-source", source.parse().expect("valid source"));
         headers
     }
 
@@ -1949,6 +1988,45 @@ mod tests {
             Some("10.0.0.5:8791".parse().unwrap()),
             &bearer_headers("wrong")
         ));
+    }
+
+    #[test]
+    fn discord_send_caller_class_uses_header_when_present() {
+        use crate::services::discord::health::SendCallerClass;
+
+        let loopback = "127.0.0.1:8791".parse().unwrap();
+        let remote = "10.0.0.5:8791".parse().unwrap();
+
+        assert_eq!(
+            discord_send_caller_class(loopback, &source_headers("cli")),
+            SendCallerClass::Cli
+        );
+        assert_eq!(
+            discord_send_caller_class(loopback, &source_headers("dashboard")),
+            SendCallerClass::Dashboard
+        );
+        assert_eq!(
+            discord_send_caller_class(loopback, &source_headers("not-a-caller-class")),
+            SendCallerClass::Unknown
+        );
+        assert_eq!(
+            discord_send_caller_class(remote, &source_headers("internal")),
+            SendCallerClass::Unknown
+        );
+    }
+
+    #[test]
+    fn discord_send_caller_class_keeps_headerless_loopback_compatibility() {
+        use crate::services::discord::health::SendCallerClass;
+
+        assert_eq!(
+            discord_send_caller_class("127.0.0.1:8791".parse().unwrap(), &empty_headers()),
+            SendCallerClass::LoopbackInternal
+        );
+        assert_eq!(
+            discord_send_caller_class("10.0.0.5:8791".parse().unwrap(), &empty_headers()),
+            SendCallerClass::Unknown
+        );
     }
 
     fn test_api_router_with_config(config: crate::config::Config) -> axum::Router {
@@ -2086,6 +2164,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn discord_send_router_applies_explicit_cli_source_gate_on_loopback() {
+        let mut config = crate::config::Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        let registry = Arc::new(crate::services::discord::health::HealthRegistry::new());
+        let app = test_api_router_with_config_and_registry(config, Some(registry));
+
+        let mut request = control_request_for(
+            "/discord/send",
+            "127.0.0.1:8791",
+            r#"{"target":"channel:999999999999999999","content":"hello","source":"system"}"#,
+        );
+        request
+            .headers_mut()
+            .insert("x-agentdesk-source", "cli".parse().unwrap());
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["error"], "source not allowed for this caller");
     }
 
     #[tokio::test]

--- a/src/services/discord/outbound/send_api.rs
+++ b/src/services/discord/outbound/send_api.rs
@@ -9,7 +9,7 @@ use super::manual_delivery::{
     ManualDeliveryOutcome, ManualOutboundDeliveryId, SerenityManualOutboundClient,
     deliver_manual_dm_notification, is_reserved_voice_correlation_namespace,
 };
-use super::send_gate::send_message_with_backends_and_delivery_id;
+use super::send_gate::{SendCallerClass, send_message_with_backends_and_delivery_id_for_caller};
 use crate::db::Db;
 use crate::services::discord::health::{HealthRegistry, resolve_bot_http};
 use crate::services::discord::outbound::shared_outbound_deduper;
@@ -19,6 +19,23 @@ pub async fn handle_send<'a>(
     sqlite: Option<&Db>,
     pg_pool: Option<&PgPool>,
     body: &str,
+) -> (&'a str, String) {
+    handle_send_with_caller(
+        registry,
+        sqlite,
+        pg_pool,
+        body,
+        SendCallerClass::LoopbackInternal,
+    )
+    .await
+}
+
+pub async fn handle_send_with_caller<'a>(
+    registry: &HealthRegistry,
+    sqlite: Option<&Db>,
+    pg_pool: Option<&PgPool>,
+    body: &str,
+    caller_class: SendCallerClass,
 ) -> (&'a str, String) {
     let Ok(json) = serde_json::from_str::<serde_json::Value>(body) else {
         return (
@@ -79,7 +96,7 @@ pub async fn handle_send<'a>(
         );
     }
 
-    send_message_with_backends_and_delivery_id(
+    send_message_with_backends_and_delivery_id_for_caller(
         registry,
         sqlite,
         pg_pool,
@@ -89,6 +106,7 @@ pub async fn handle_send<'a>(
         bot,
         summary,
         delivery_id,
+        caller_class,
     )
     .await
 }
@@ -406,11 +424,65 @@ mod handle_send_contract_tests {
     //! directory decomposition. All expectations capture current behavior
     //! as-is (no seam; empty `HealthRegistry`).
 
-    use crate::services::discord::health::HealthRegistry;
+    use crate::services::discord::health::{HealthRegistry, SendCallerClass};
 
-    use super::handle_send;
+    use super::{handle_send, handle_send_with_caller};
 
-    #[tokio::test]
+    struct TestRuntimeRoot {
+        previous_root: Option<std::ffi::OsString>,
+        _temp: tempfile::TempDir,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl TestRuntimeRoot {
+        fn new() -> Self {
+            let lock = crate::config::shared_test_env_lock()
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let previous_root = std::env::var_os("AGENTDESK_ROOT_DIR");
+            let temp = tempfile::tempdir().expect("temp runtime root"); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+            unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+            Self {
+                previous_root,
+                _temp: temp,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for TestRuntimeRoot {
+        fn drop(&mut self) {
+            match &self.previous_root {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    async fn assert_source_gate_body(
+        caller_class: SendCallerClass,
+        source: &str,
+        expected_status: &str,
+        expected_error: &str,
+    ) {
+        let _runtime_root = TestRuntimeRoot::new();
+        let registry = HealthRegistry::new();
+        let body = serde_json::json!({
+            "target": "channel:999999999999999999",
+            "content": "hi",
+            "source": source,
+        })
+        .to_string();
+
+        let (status, body) =
+            handle_send_with_caller(&registry, None, None, &body, caller_class).await;
+        assert_eq!(status, expected_status);
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap(); // agentdesk-audit: allow-unwrap — test response JSON should parse
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["error"], expected_error);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn invalid_json_body_is_a_400_with_pinned_body() {
         let registry = HealthRegistry::new();
         let (status, body) = handle_send(&registry, None, None, "not json").await;
@@ -418,8 +490,9 @@ mod handle_send_contract_tests {
         assert_eq!(body, r#"{"ok":false,"error":"invalid JSON"}"#);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn missing_content_is_a_400_with_pinned_body() {
+        let _runtime_root = TestRuntimeRoot::new();
         let registry = HealthRegistry::new();
         let (status, body) =
             handle_send(&registry, None, None, r#"{"target":"channel:123"}"#).await;
@@ -427,8 +500,9 @@ mod handle_send_contract_tests {
         assert_eq!(body, r#"{"ok":false,"error":"content is required"}"#);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn missing_target_is_a_400_invalid_target() {
+        let _runtime_root = TestRuntimeRoot::new();
         let registry = HealthRegistry::new();
         let (status, body) = handle_send(&registry, None, None, r#"{"content":"hi"}"#).await;
         assert_eq!(status, "400 Bad Request");
@@ -440,8 +514,9 @@ mod handle_send_contract_tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn channel_id_fallback_reaches_target_resolution_like_explicit_target() {
+        let _runtime_root = TestRuntimeRoot::new();
         let registry = HealthRegistry::new();
         // Legacy `channel_id` (numeric, no `channel:` prefix) must be accepted
         // via the fallback + prefixing path and produce the exact same
@@ -470,5 +545,62 @@ mod handle_send_contract_tests {
             fallback_body,
             r#"{"ok":false,"error":"channel not in role-map"}"#
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cli_caller_can_use_cli_sources_but_not_system() {
+        assert_source_gate_body(
+            SendCallerClass::Cli,
+            "agentdesk-cli",
+            "403 Forbidden",
+            "channel not in role-map",
+        )
+        .await;
+        assert_source_gate_body(
+            SendCallerClass::Cli,
+            "operator",
+            "403 Forbidden",
+            "channel not in role-map",
+        )
+        .await;
+        assert_source_gate_body(
+            SendCallerClass::Cli,
+            "system",
+            "403 Forbidden",
+            "source not allowed for this caller",
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dashboard_unknown_and_loopback_use_caller_specific_source_gate() {
+        assert_source_gate_body(
+            SendCallerClass::Dashboard,
+            "dashboard",
+            "403 Forbidden",
+            "channel not in role-map",
+        )
+        .await;
+        assert_source_gate_body(
+            SendCallerClass::Dashboard,
+            "headless_turn",
+            "403 Forbidden",
+            "source not allowed for this caller",
+        )
+        .await;
+        assert_source_gate_body(
+            SendCallerClass::Unknown,
+            "slo_alerter",
+            "403 Forbidden",
+            "source not allowed for this caller",
+        )
+        .await;
+        assert_source_gate_body(
+            SendCallerClass::LoopbackInternal,
+            "headless_turn",
+            "403 Forbidden",
+            "channel not in role-map",
+        )
+        .await;
     }
 }

--- a/src/services/discord/outbound/send_gate.rs
+++ b/src/services/discord/outbound/send_gate.rs
@@ -52,7 +52,7 @@ pub(crate) async fn send_message_with_backends_and_delivery_id(
     summary: Option<&str>,
     delivery_id: Option<ManualOutboundDeliveryId<'_>>,
 ) -> (&'static str, String) {
-    send_message_with_backends_and_delivery_options(
+    send_message_with_backends_and_delivery_options_for_caller(
         registry,
         db,
         pg_pool,
@@ -63,6 +63,35 @@ pub(crate) async fn send_message_with_backends_and_delivery_id(
         summary,
         delivery_id,
         ManualOutboundOptions::default(),
+        SendCallerClass::LoopbackInternal,
+    )
+    .await
+}
+
+pub(crate) async fn send_message_with_backends_and_delivery_id_for_caller(
+    registry: &HealthRegistry,
+    db: Option<&Db>,
+    pg_pool: Option<&PgPool>,
+    target: &str,
+    content: &str,
+    source: &str,
+    bot: &str,
+    summary: Option<&str>,
+    delivery_id: Option<ManualOutboundDeliveryId<'_>>,
+    caller_class: SendCallerClass,
+) -> (&'static str, String) {
+    send_message_with_backends_and_delivery_options_for_caller(
+        registry,
+        db,
+        pg_pool,
+        target,
+        content,
+        source,
+        bot,
+        summary,
+        delivery_id,
+        ManualOutboundOptions::default(),
+        caller_class,
     )
     .await
 }
@@ -104,6 +133,35 @@ pub(crate) async fn send_message_with_backends_and_delivery_options(
     delivery_id: Option<ManualOutboundDeliveryId<'_>>,
     options: ManualOutboundOptions,
 ) -> (&'static str, String) {
+    send_message_with_backends_and_delivery_options_for_caller(
+        registry,
+        db,
+        pg_pool,
+        target,
+        content,
+        source,
+        bot,
+        summary,
+        delivery_id,
+        options,
+        SendCallerClass::LoopbackInternal,
+    )
+    .await
+}
+
+async fn send_message_with_backends_and_delivery_options_for_caller(
+    registry: &HealthRegistry,
+    db: Option<&Db>,
+    pg_pool: Option<&PgPool>,
+    target: &str,
+    content: &str,
+    source: &str,
+    bot: &str,
+    summary: Option<&str>,
+    delivery_id: Option<ManualOutboundDeliveryId<'_>>,
+    options: ManualOutboundOptions,
+    caller_class: SendCallerClass,
+) -> (&'static str, String) {
     if content.is_empty() {
         return (
             "400 Bad Request",
@@ -141,10 +199,16 @@ pub(crate) async fn send_message_with_backends_and_delivery_options(
     // response body. That made enumerating the whitelist trivial and gave a
     // log-injection assist. The full label is preserved in `tracing::warn!`
     // for operators.
-    if !is_allowed_send_source(source) {
+    let source_allowed = if caller_class == SendCallerClass::LoopbackInternal {
+        is_allowed_send_source(source)
+    } else {
+        is_allowed_send_source_for(source, caller_class)
+    };
+    if !source_allowed {
         tracing::warn!(
             source,
             bot,
+            caller_class = ?caller_class,
             "/api/discord/send rejected: source label not allowed for caller class"
         );
         return (
@@ -235,7 +299,7 @@ pub(crate) async fn send_message_with_backends_and_delivery_options(
         }
         if !authorized
             && options.allow_unbound_internal_channel
-            && is_allowed_send_source(source)
+            && is_allowed_send_source_for(source, caller_class)
             && target.trim_start().starts_with("channel:")
             && target_channel_accessible
         {
@@ -305,6 +369,12 @@ pub enum SendCallerClass {
     /// most restrictive bucket.
     #[allow(dead_code)]
     Unknown,
+}
+
+impl Default for SendCallerClass {
+    fn default() -> Self {
+        Self::LoopbackInternal
+    }
 }
 
 impl SendCallerClass {
@@ -425,6 +495,47 @@ mod send_source_tests {
     }
 
     #[test]
+    fn dashboard_can_use_dashboard_or_known_agent_role_labels() {
+        assert!(is_allowed_send_source_for(
+            "dashboard",
+            SendCallerClass::Dashboard
+        ));
+
+        let _lock = crate::config::shared_test_env_lock().lock().unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+        let temp = tempfile::tempdir().unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+        std::fs::create_dir_all(temp.path().join("config")).unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+        std::fs::write(
+            temp.path().join("config/agentdesk.yaml"),
+            r#"
+server: {}
+agents:
+  - id: project-agentdesk
+    name: AgentDesk
+    provider: codex
+    channels:
+      codex:
+        id: "123"
+        prompt_file: "/tmp/project-agentdesk.md"
+        workspace: "/tmp"
+        provider: codex
+"#,
+        )
+        .unwrap(); // agentdesk-audit: allow-unwrap — test setup in #[cfg(test)] mod
+        let previous_root = std::env::var_os("AGENTDESK_ROOT_DIR");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        assert!(is_allowed_send_source_for(
+            "project-agentdesk",
+            SendCallerClass::Dashboard
+        ));
+
+        match previous_root {
+            Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+            None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+        }
+    }
+
+    #[test]
     fn unknown_caller_class_only_allows_known_agents() {
         // Without a verified caller class we still let messages through when
         // the source matches a registered agent role id (the agent identity
@@ -466,6 +577,7 @@ mod send_source_tests {
         std::fs::write(
             temp.path().join("config/agentdesk.yaml"),
             r#"
+server: {}
 discord:
   dm_default_agent: family-counsel
 agents:


### PR DESCRIPTION
## Summary
- Wire `/api/discord/send` caller-class inference from `X-AgentDesk-Source` and peer address into the send API path.
- Keep trusted loopback/internal compatibility on the existing in-process/default send wrappers.
- Update `/api/docs` examples to use public-safe CLI source labeling.

Fixes #3745

## Tests
- `cargo fmt --all --check`
- `cargo test --lib send_source_tests`
- `cargo test --lib handle_send_contract_tests`
- `cargo test --lib discord_send_caller_class`
- `cargo test --lib discord_send_router_applies_explicit_cli_source_gate_on_loopback`
- `cargo test --lib discord_send_docs_include_canonical_fields_and_legacy_aliases`
- `cargo check --lib`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`