### PR TITLE
[codex] Add policy raw DB capability manifest guard

### DIFF
--- a/docs/generated/policy-db-inventory.md
+++ b/docs/generated/policy-db-inventory.md
@@ -33,11 +33,11 @@ Measured on branch head with the command above (excludes `policies/__tests__/`):
 
 | op | count |
 |---|---|
-| `agentdesk.db.query` (read) | 132 |
-| `agentdesk.db.execute` (mutation) | 63 |
-| **total** | **195** |
+| `agentdesk.db.query` (read) | 127 |
+| `agentdesk.db.execute` (mutation) | 57 |
+| **total** | **184** |
 
-These 195 callsites are spread across 29 policy files under `policies/`. One
+These 184 callsites are spread across 30 policy files under `policies/`. One
 additional callsite lives in `policies/__tests__/` and is excluded from the
 migration debt total.
 
@@ -48,6 +48,10 @@ migration debt total.
   (`setBlockedReason`, `getCardStatus`, `getReworkCardInfo`, `listWaitingForCi`).
   The file now has zero `agentdesk.db.*` callsites and carries
   `// typed-facade-slice:start ci-recovery` / `:end` markers to flag regressions.
+- **Capability-manifest first rollout**: `policies/timeouts/active-monitor.js`,
+  `policies/review-automation.js`, and `policies/merge-automation.js` now have
+  adjacent `*.cap.yaml` manifests in `db.raw_sql.mode: legacy` with pinned
+  `no_silent_growth` baselines.
 - **Next candidates (mutation-heavy)**: `review-automation.js`,
   `merge-automation.js`, `kanban-rules.js`, and the `auto-queue` lib modules
   (`lib/auto-queue-phase-gate.js`, `lib/auto-queue-lifecycle.js`).

--- a/docs/policy-sql-guard.md
+++ b/docs/policy-sql-guard.md
@@ -35,9 +35,16 @@ DB callsites must migrate to a typed facade or carry a
 `legacy-raw-db: policy=<name> capability=<intent> source_event=<hook>` marker
 so audit logs can attribute the capability.
 
-The current audited baseline is 195 unmarked raw DB callsites plus 3 annotated
-escape-hatch callsites. This baseline records the existing trusted-automation
-surface; it is not permission for silent growth.
+The current audited baseline is 184 raw DB callsites across 30 policy files.
+Four nearby `legacy-raw-db` marker comments annotate existing escape-hatch
+callsites. This baseline records the existing trusted-automation surface; it is
+not permission for silent growth.
+
+Static manifest enforcement now runs through
+`scripts/check_policy_db_capabilities.py --no-silent-growth`. The check only
+applies to policies with checked-in `policies/**/*.cap.yaml` manifests. It does
+not change runtime policy execution or `src/engine/sql_guard.rs`; it makes drift
+visible before runtime denial is introduced.
 
 ## Additional Protected Table Candidates
 
@@ -67,6 +74,8 @@ trust: trusted-automation
 source_events:
   - onCardCompleted
   - onTick
+include_files:
+  - policies/lib/merge-notification-dispatcher.js
 db:
   read:
     tables:
@@ -81,6 +90,9 @@ db:
       - task_dispatches
   raw_sql:
     mode: audited
+    capabilities:
+      - merge_candidate_inspection
+      - merge_request_tracking
     markers_required: true
 exec:
   allow:
@@ -100,21 +112,68 @@ session:
 | `policy` | Policy basename without `.js`; must match the file it describes. |
 | `trust` | Must be `trusted-automation` for repo policies. Other trust levels are out of scope until untrusted policy loading exists. |
 | `source_events` | Hook names or scheduler events that exercise the listed capabilities. |
+| `include_files` | Optional repo-relative helper files whose raw DB callsites are runtime-reachable from this policy and should share the manifest baseline. |
 | `db.read.tables` | Tables the policy can read through raw SQL or typed facades. |
 | `db.write.tables` | Tables or table columns the policy can write directly or through typed facades. |
 | `db.write.guarded_targets` | Guarded targets the policy must not mutate through raw SQL. |
-| `db.raw_sql.mode` | `forbidden`, `audited`, or `transitional`. MVP defaults to `audited` for legacy policies. |
+| `db.raw_sql.mode` | `forbidden`, `audited`, `transitional`, or `legacy`. MVP defaults to `audited` for marker-based policies; `legacy` is only for policy-wide transitional access pinned by `no_silent_growth`. |
+| `db.raw_sql.capabilities` | Named raw DB intents accepted for the policy. Marker-based policies must use one of these names in `legacy-raw-db capability=...`; `legacy` mode uses this as the explicit broad raw DB capability. |
 | `db.raw_sql.markers_required` | Whether raw SQL callsites need the `legacy-raw-db` marker. |
+| `db.raw_sql.no_silent_growth.callsites` | Expected `agentdesk.db.query/execute` callsite count for a manifest-enabled legacy policy. |
+| `db.raw_sql.no_silent_growth.fingerprint` | SHA-256 baseline over the manifest-enabled policy's current raw DB callsites. |
 | `exec.allow` | Executable names allowed through the policy exec bridge. |
 | `http.loopback_only` | Must be `true` for policy HTTP calls. |
 | `session.kill` | Whether policy code may request session termination. |
 
+### Static Check Workflow
+
+The CI/script guard is:
+
+```bash
+python3 scripts/check_policy_db_capabilities.py --no-silent-growth \
+  --require-manifest policies/timeouts/active-monitor.cap.yaml \
+  --require-manifest policies/review-automation.cap.yaml \
+  --require-manifest policies/merge-automation.cap.yaml
+```
+
+`scripts/ci-script-checks.sh` runs the guard with those required first-rollout
+manifests and the focused unittest suite.
+For manifest-enabled policies, the check accepts raw DB callsites in two ways:
+
+- A `legacy-raw-db` SQL comment inside the `agentdesk.db.*` call expression
+  includes `policy`, `capability`, and `source_event`; the capability and source
+  event must be declared by the manifest. Keeping the marker inside the SQL
+  string makes the static check and runtime `policy.raw_db_audit` attribution
+  see the same fields.
+- The manifest uses explicit `db.raw_sql.mode: legacy` and its
+  `no_silent_growth` count/fingerprint matches the current callsite set.
+
+To add or intentionally change a manifest-enabled policy's raw DB surface,
+review the policy diff, prefer migrating to a typed facade or adding a
+`legacy-raw-db` marker, then refresh the manifest baseline with:
+
+```bash
+python3 scripts/check_policy_db_capabilities.py --emit-baseline
+python3 scripts/check_policy_db_capabilities.py --no-silent-growth
+```
+
+The first rollout manifests are checked in for:
+
+- `policies/timeouts/active-monitor.cap.yaml`
+- `policies/review-automation.cap.yaml`
+- `policies/merge-automation.cap.yaml`
+
+All three are in `legacy` raw SQL mode with pinned baselines. This prevents
+silent growth in the highest-risk policy files while keeping the runtime guard
+behavior unchanged.
+
 ### Enforcement Plan
 
 1. Add manifests for the highest-risk policies with `db.raw_sql.mode:
-   audited`.
-2. Add a static CI check that each `agentdesk.db.*` callsite maps to a
-   manifest capability and marker.
+   legacy` and `db.raw_sql.no_silent_growth` baselines.
+2. Add a static CI check that each manifest-enabled `agentdesk.db.*` callsite
+   either has a complete `legacy-raw-db` marker or is covered by an explicit
+   legacy raw SQL baseline.
 3. Migrate hot paths to typed facades listed in `docs/policy-typed-facade.md`.
 4. Flip individual policies or slices from `audited` to `forbidden` once typed
    facades cover their required behavior.

--- a/policies/merge-automation.cap.yaml
+++ b/policies/merge-automation.cap.yaml
@@ -1,0 +1,41 @@
+version: 1
+policy: merge-automation
+trust: trusted-automation
+source_events:
+  - onCardTerminal
+  - onTick5min
+include_files:
+  - policies/lib/merge-notification-dispatcher.js
+db:
+  read:
+    tables:
+      - auto_queue_entries
+      - auto_queue_runs
+      - issue_specs
+      - kanban_cards
+      - kv_meta
+      - sessions
+      - task_dispatches
+      - test_phase_runs
+  write:
+    tables:
+      - kanban_cards
+      - kv_meta
+  raw_sql:
+    mode: legacy
+    capabilities:
+      - merge_automation_legacy_raw_db
+    markers_required: false
+    rationale: broad legacy merge automation DB access pinned by no-silent-growth baseline
+    no_silent_growth:
+      callsites: 21
+      fingerprint: sha256:97bc5a54a0815356381d47ed38420291977b41679f59534ed60463f4768bd73c
+exec:
+  allow:
+    - gh
+    - git
+    - tmux
+http:
+  loopback_only: true
+session:
+  kill: false

--- a/policies/review-automation.cap.yaml
+++ b/policies/review-automation.cap.yaml
@@ -1,0 +1,35 @@
+version: 1
+policy: review-automation
+trust: trusted-automation
+source_events:
+  - onReviewEnter
+  - onDispatchCompleted
+  - onReviewVerdict
+db:
+  read:
+    tables:
+      - card_review_state
+      - kanban_cards
+      - kanban_reviews
+      - pipeline_stages
+      - task_dispatches
+  write:
+    tables:
+      - kanban_cards
+  raw_sql:
+    mode: legacy
+    capabilities:
+      - review_lifecycle_legacy_raw_db
+    markers_required: false
+    rationale: broad legacy review lifecycle DB access pinned by no-silent-growth baseline
+    no_silent_growth:
+      callsites: 34
+      fingerprint: sha256:620b153dace9185681b156c6467dc62d28df609bcfa00a4039276c3fbfb7f6f9
+exec:
+  allow:
+    - gh
+    - git
+http:
+  loopback_only: true
+session:
+  kill: false

--- a/policies/timeouts/active-monitor.cap.yaml
+++ b/policies/timeouts/active-monitor.cap.yaml
@@ -1,0 +1,32 @@
+version: 1
+policy: timeouts/active-monitor
+trust: trusted-automation
+source_events:
+  - timeouts.onTick30s
+db:
+  read:
+    tables:
+      - kv_meta
+      - sessions
+      - task_dispatches
+  write:
+    tables:
+      - kv_meta
+      - sessions
+      - session_termination_events
+  raw_sql:
+    mode: legacy
+    capabilities:
+      - active_monitor_legacy_raw_db
+    markers_required: false
+    rationale: broad legacy timeout monitor DB access pinned by no-silent-growth baseline
+    no_silent_growth:
+      callsites: 18
+      fingerprint: sha256:01464111232ee18b4a513d3a77a985067a30cb8322a85af55d669e842a15d21b
+exec:
+  allow:
+    - tmux
+http:
+  loopback_only: true
+session:
+  kill: true

--- a/scripts/check_policy_db_capabilities.py
+++ b/scripts/check_policy_db_capabilities.py
@@ -36,7 +36,7 @@ RAW_DB_METHOD_ALIAS_RE = re.compile(
     rf"""(?:\b(?:var|let|const)\s+)?({IDENT_RE})\s*=\s*{RAW_DB_SURFACE_RE}\s*(?:\.\s*(query|execute)|\[\s*["'](query|execute)["']\s*\])"""
 )
 RAW_DB_METHOD_DESTRUCTURE_RE = re.compile(
-    rf"""\b(?:var|let|const)\s+\{{([^}}]+)\}}\s*=\s*{RAW_DB_SURFACE_RE}\b"""
+    rf"""\b(?:var|let|const)\s+\{{([^}}]+)\}}\s*=\s*{RAW_DB_SURFACE_RE}(?=\s*(?:[;,\)\n]|$))"""
 )
 AGENTDESK_DB_DESTRUCTURE_RE = re.compile(
     rf"""(?:\b(?:var|let|const)\s+)?\{{[^}}]*\bdb\s*(?::\s*({IDENT_RE}))?[^}}]*\}}\s*=\s*agentdesk\b"""

--- a/scripts/check_policy_db_capabilities.py
+++ b/scripts/check_policy_db_capabilities.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Static guard for policy raw-DB capability manifests.
+
+The first rollout slice is intentionally audit-oriented: manifest-enabled
+policies may keep legacy broad raw SQL access, but CI pins the existing
+callsite set so new agentdesk.db.* usage cannot grow silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICIES_ROOT = REPO_ROOT / "policies"
+LEGACY_BROAD_MODES = {"legacy"}
+ALLOWED_RAW_MODES = {"forbidden", "audited", "transitional", *LEGACY_BROAD_MODES}
+RAW_DB_RE = re.compile(r"agentdesk\.db\.(query|execute)\s*\(")
+MARKER_RE = re.compile(r"legacy-raw-db:\s*([^*\n]+)")
+
+
+@dataclasses.dataclass(frozen=True)
+class Callsite:
+    path: Path
+    rel_path: str
+    line: int
+    op: str
+    expression: str
+    marker: dict[str, str]
+
+    @property
+    def fingerprint(self) -> str:
+        canonical = " ".join(self.expression.split())
+        payload = f"{self.rel_path}\0{self.op}\0{canonical}".encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+
+@dataclasses.dataclass(frozen=True)
+class Manifest:
+    path: Path
+    data: dict[str, Any]
+    js_path: Path
+    rel_js_path: str
+    expected_policy: str
+
+    @property
+    def policy(self) -> str:
+        return str(self.data.get("policy", ""))
+
+    @property
+    def raw_sql(self) -> dict[str, Any]:
+        db = self.data.get("db")
+        if not isinstance(db, dict):
+            return {}
+        raw_sql = db.get("raw_sql")
+        return raw_sql if isinstance(raw_sql, dict) else {}
+
+    @property
+    def raw_mode(self) -> str:
+        return str(self.raw_sql.get("mode", "")).strip().lower()
+
+    @property
+    def is_broad_legacy(self) -> bool:
+        return self.raw_mode in LEGACY_BROAD_MODES
+
+    @property
+    def no_silent_growth(self) -> dict[str, Any]:
+        baseline = self.raw_sql.get("no_silent_growth")
+        return baseline if isinstance(baseline, dict) else {}
+
+    @property
+    def raw_capabilities(self) -> list[str]:
+        capabilities = self.raw_sql.get("capabilities")
+        if isinstance(capabilities, list):
+            return [str(capability) for capability in capabilities]
+        return []
+
+
+def parse_scalar(value: str) -> Any:
+    value = value.strip()
+    if value == "":
+        return ""
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if value in {"null", "Null", "~"}:
+        return None
+    if value == "[]":
+        return []
+    if value == "{}":
+        return {}
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def preprocess_yaml(text: str) -> list[tuple[int, str]]:
+    lines: list[tuple[int, str]] = []
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        lines.append((indent, raw.strip()))
+    return lines
+
+
+def parse_yaml_subset(text: str) -> dict[str, Any]:
+    lines = preprocess_yaml(text)
+    if not lines:
+        return {}
+    node, index = parse_yaml_node(lines, 0, lines[0][0])
+    if index != len(lines):
+        raise ValueError(f"Could not parse YAML near line {index + 1}: {lines[index][1]}")
+    if not isinstance(node, dict):
+        raise ValueError("Manifest root must be a mapping")
+    return node
+
+
+def parse_yaml_node(
+    lines: list[tuple[int, str]], index: int, indent: int
+) -> tuple[Any, int]:
+    if index >= len(lines):
+        return {}, index
+    current_indent, content = lines[index]
+    if current_indent < indent:
+        return {}, index
+    if current_indent != indent:
+        raise ValueError(f"Unexpected indentation before: {content}")
+    if content.startswith("- "):
+        return parse_yaml_list(lines, index, indent)
+    return parse_yaml_mapping(lines, index, indent)
+
+
+def parse_yaml_list(
+    lines: list[tuple[int, str]], index: int, indent: int
+) -> tuple[list[Any], int]:
+    result: list[Any] = []
+    while index < len(lines):
+        current_indent, content = lines[index]
+        if current_indent < indent:
+            break
+        if current_indent != indent or not content.startswith("- "):
+            break
+        item = content[2:].strip()
+        index += 1
+        if item == "":
+            child, index = parse_yaml_node(lines, index, indent + 2)
+            result.append(child)
+        elif ":" in item and not item.startswith(("'", '"')):
+            key, value = item.split(":", 1)
+            item_dict: dict[str, Any] = {key.strip(): parse_scalar(value)}
+            if index < len(lines) and lines[index][0] > indent:
+                child, index = parse_yaml_node(lines, index, lines[index][0])
+                if isinstance(child, dict):
+                    item_dict.update(child)
+                else:
+                    raise ValueError("List item mapping child must be a mapping")
+            result.append(item_dict)
+        else:
+            result.append(parse_scalar(item))
+    return result, index
+
+
+def parse_yaml_mapping(
+    lines: list[tuple[int, str]], index: int, indent: int
+) -> tuple[dict[str, Any], int]:
+    result: dict[str, Any] = {}
+    while index < len(lines):
+        current_indent, content = lines[index]
+        if current_indent < indent:
+            break
+        if current_indent != indent or content.startswith("- "):
+            break
+        if ":" not in content:
+            raise ValueError(f"Expected mapping entry, got: {content}")
+        key, value = content.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        index += 1
+        if value:
+            result[key] = parse_scalar(value)
+        elif index < len(lines) and lines[index][0] > indent:
+            child, index = parse_yaml_node(lines, index, lines[index][0])
+            result[key] = child
+        else:
+            result[key] = {}
+    return result, index
+
+
+def parse_marker(marker_text: str) -> dict[str, str]:
+    marker: dict[str, str] = {}
+    for token in shlex.split(marker_text):
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        if key in {"policy_name", "event"}:
+            key = {"policy_name": "policy", "event": "source_event"}[key]
+        marker[key] = value
+    return marker
+
+
+def marker_in_call_expression(expression: str) -> dict[str, str]:
+    literal_text = "\n".join(extract_string_literals(first_call_argument(expression)))
+    matches = MARKER_RE.findall(literal_text)
+    if not matches:
+        return {}
+    return parse_marker(matches[-1])
+
+
+def scan_callsites(path: Path, repo_root: Path = REPO_ROOT) -> list[Callsite]:
+    repo_root = repo_root.resolve()
+    path = (repo_root / path).resolve() if not path.is_absolute() else path.resolve()
+    text = path.read_text(encoding="utf-8")
+    rel_path = path.relative_to(repo_root).as_posix()
+    callsites: list[Callsite] = []
+    for match in RAW_DB_RE.finditer(text):
+        op = match.group(1)
+        expression = extract_call_expression(text, match.start(), match.end() - 1)
+        line = text.count("\n", 0, match.start()) + 1
+        callsites.append(
+            Callsite(
+                path=path,
+                rel_path=rel_path,
+                line=line,
+                op=op,
+                expression=expression,
+                marker=marker_in_call_expression(expression),
+            )
+        )
+    return callsites
+
+
+def first_call_argument(expression: str) -> str:
+    open_paren = expression.find("(")
+    if open_paren < 0:
+        return expression
+    quote: str | None = None
+    comment: str | None = None
+    escaped = False
+    nested = 0
+    i = open_paren + 1
+    while i < len(expression):
+        ch = expression[i]
+        nxt = expression[i + 1] if i + 1 < len(expression) else ""
+        if comment == "line":
+            if ch == "\n":
+                comment = None
+            i += 1
+            continue
+        if comment == "block":
+            if ch == "*" and nxt == "/":
+                comment = None
+                i += 2
+                continue
+            i += 1
+            continue
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            comment = "line"
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            comment = "block"
+            i += 2
+            continue
+        if ch in {"'", '"', "`"}:
+            quote = ch
+            i += 1
+            continue
+        if ch in "([{":
+            nested += 1
+        elif ch in ")]}":
+            if ch == ")" and nested == 0:
+                return expression[open_paren + 1 : i]
+            nested = max(0, nested - 1)
+        elif ch == "," and nested == 0:
+            return expression[open_paren + 1 : i]
+        i += 1
+    return expression[open_paren + 1 :]
+
+
+def extract_string_literals(text: str) -> list[str]:
+    literals: list[str] = []
+    quote: str | None = None
+    comment: str | None = None
+    escaped = False
+    buf: list[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if comment == "line":
+            if ch == "\n":
+                comment = None
+            i += 1
+            continue
+        if comment == "block":
+            if ch == "*" and nxt == "/":
+                comment = None
+                i += 2
+                continue
+            i += 1
+            continue
+        if quote:
+            if escaped:
+                buf.append(ch)
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                literals.append("".join(buf))
+                buf = []
+                quote = None
+            else:
+                buf.append(ch)
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            comment = "line"
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            comment = "block"
+            i += 2
+            continue
+        if ch in {"'", '"', "`"}:
+            quote = ch
+            buf = []
+        i += 1
+    return literals
+
+
+def extract_call_expression(text: str, start: int, open_paren: int) -> str:
+    depth = 0
+    quote: str | None = None
+    comment: str | None = None
+    escaped = False
+    i = open_paren
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if comment == "line":
+            if ch == "\n":
+                comment = None
+            i += 1
+            continue
+        if comment == "block":
+            if ch == "*" and nxt == "/":
+                comment = None
+                i += 2
+                continue
+            i += 1
+            continue
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            comment = "line"
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            comment = "block"
+            i += 2
+            continue
+        if ch in {"'", '"', "`"}:
+            quote = ch
+            i += 1
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+        i += 1
+    raise ValueError(f"Unterminated agentdesk.db call starting near byte {start}")
+
+
+def manifest_policy_from_path(manifest_path: Path, policies_root: Path) -> str:
+    rel = manifest_path.relative_to(policies_root).as_posix()
+    if not rel.endswith(".cap.yaml"):
+        raise ValueError(f"Manifest must end with .cap.yaml: {manifest_path}")
+    return rel[: -len(".cap.yaml")]
+
+
+def load_manifest(path: Path, policies_root: Path, repo_root: Path) -> Manifest:
+    data = parse_yaml_subset(path.read_text(encoding="utf-8"))
+    policy_from_path = manifest_policy_from_path(path, policies_root)
+    js_path = policies_root / f"{policy_from_path}.js"
+    return Manifest(
+        path=path,
+        data=data,
+        js_path=js_path,
+        rel_js_path=js_path.relative_to(repo_root).as_posix(),
+        expected_policy=policy_from_path,
+    )
+
+
+def load_manifests(policies_root: Path, repo_root: Path) -> list[Manifest]:
+    return [
+        load_manifest(path, policies_root, repo_root)
+        for path in sorted(policies_root.rglob("*.cap.yaml"))
+    ]
+
+
+def manifest_scan_paths(manifest: Manifest, repo_root: Path) -> list[Path]:
+    paths = [manifest.js_path]
+    include_files = manifest.data.get("include_files", [])
+    if not isinstance(include_files, list):
+        return paths
+    for include_file in include_files:
+        paths.append(repo_root / str(include_file))
+    return paths
+
+
+def callsite_baseline(callsites: list[Callsite]) -> tuple[int, str]:
+    fingerprints = sorted(callsite.fingerprint for callsite in callsites)
+    payload = json.dumps(fingerprints, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return len(callsites), "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def validate_manifest_shape(manifest: Manifest, repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    if manifest.policy != manifest.expected_policy:
+        errors.append(
+            f"{manifest.path}: policy must be '{manifest.expected_policy}' to match {manifest.rel_js_path}"
+        )
+    if not manifest.path.name.endswith(".cap.yaml"):
+        errors.append(f"{manifest.path}: manifest filename must end with .cap.yaml")
+    if manifest.data.get("version") != 1:
+        errors.append(f"{manifest.path}: version must be 1")
+    if manifest.data.get("trust") != "trusted-automation":
+        errors.append(f"{manifest.path}: trust must be trusted-automation")
+    events = manifest.data.get("source_events")
+    if not isinstance(events, list) or not events or not all(isinstance(e, str) for e in events):
+        errors.append(f"{manifest.path}: source_events must be a non-empty list of strings")
+    include_files = manifest.data.get("include_files", [])
+    if include_files != [] and (
+        not isinstance(include_files, list) or not all(isinstance(p, str) for p in include_files)
+    ):
+        errors.append(f"{manifest.path}: include_files must be a list of repo-relative paths")
+    elif isinstance(include_files, list):
+        for include_file in include_files:
+            include_path = repo_root / include_file
+            if not include_path.exists():
+                errors.append(f"{manifest.path}: include file does not exist: {include_file}")
+    if not manifest.raw_mode:
+        errors.append(f"{manifest.path}: db.raw_sql.mode is required")
+    elif manifest.raw_mode not in ALLOWED_RAW_MODES:
+        errors.append(
+            f"{manifest.path}: db.raw_sql.mode={manifest.raw_mode!r} is not one of "
+            f"{', '.join(sorted(ALLOWED_RAW_MODES))}"
+        )
+    if manifest.raw_mode != "forbidden" and not manifest.raw_capabilities:
+        errors.append(f"{manifest.path}: db.raw_sql.capabilities must declare at least one capability")
+    if not manifest.js_path.exists():
+        errors.append(f"{manifest.path}: described JS policy file does not exist: {manifest.js_path}")
+    return errors
+
+
+def validate_callsites(
+    manifest: Manifest,
+    callsites: list[Callsite],
+    no_silent_growth: bool,
+) -> list[str]:
+    errors: list[str] = []
+    if manifest.raw_mode == "forbidden":
+        for callsite in callsites:
+            errors.append(
+                f"{callsite.rel_path}:{callsite.line}: agentdesk.db.{callsite.op} is not allowed "
+                f"because {manifest.path} sets db.raw_sql.mode=forbidden"
+            )
+        return errors
+    if manifest.is_broad_legacy:
+        if no_silent_growth:
+            expected_count = manifest.no_silent_growth.get("callsites")
+            expected_fingerprint = manifest.no_silent_growth.get("fingerprint")
+            current_count, current_fingerprint = callsite_baseline(callsites)
+            if expected_count != current_count or expected_fingerprint != current_fingerprint:
+                errors.append(
+                    f"{manifest.path}: raw DB baseline drift for {manifest.rel_js_path}; "
+                    f"expected callsites={expected_count} fingerprint={expected_fingerprint}, "
+                    f"got callsites={current_count} fingerprint={current_fingerprint}. "
+                    "Review the diff and update db.raw_sql.no_silent_growth only for intentional changes."
+                )
+        return errors
+
+    for callsite in callsites:
+        marker = callsite.marker
+        missing = [field for field in ("policy", "capability", "source_event") if not marker.get(field)]
+        if missing:
+            errors.append(
+                f"{callsite.rel_path}:{callsite.line}: unmarked agentdesk.db.{callsite.op} "
+                f"for manifest-enabled policy {manifest.policy}; missing {', '.join(missing)}"
+            )
+            continue
+        if marker.get("policy") != manifest.policy:
+            errors.append(
+                f"{callsite.rel_path}:{callsite.line}: legacy-raw-db policy={marker.get('policy')} "
+                f"does not match manifest policy={manifest.policy}"
+            )
+        if marker.get("capability") not in set(manifest.raw_capabilities):
+            errors.append(
+                f"{callsite.rel_path}:{callsite.line}: legacy-raw-db capability={marker.get('capability')} "
+                f"is not declared in {manifest.path}"
+            )
+        events = manifest.data.get("source_events")
+        if isinstance(events, list) and marker.get("source_event") not in set(events):
+            errors.append(
+                f"{callsite.rel_path}:{callsite.line}: legacy-raw-db source_event={marker.get('source_event')} "
+                f"is not declared in {manifest.path}"
+            )
+    return errors
+
+
+def emit_baselines(manifests: list[Manifest], repo_root: Path) -> int:
+    for manifest in manifests:
+        callsites: list[Callsite] = []
+        for path in manifest_scan_paths(manifest, repo_root):
+            callsites.extend(scan_callsites(path, repo_root))
+        count, fingerprint = callsite_baseline(callsites)
+        print(f"{manifest.path.relative_to(repo_root).as_posix()}:")
+        print("  no_silent_growth:")
+        print(f"    callsites: {count}")
+        print(f"    fingerprint: {fingerprint}")
+    return 0
+
+
+def run_check(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root.resolve()
+    policies_root = (repo_root / args.policies_root).resolve()
+    manifests = load_manifests(policies_root, repo_root)
+    manifest_rel_paths = {manifest.path.relative_to(repo_root).as_posix() for manifest in manifests}
+    for required in args.require_manifest:
+        if required not in manifest_rel_paths:
+            print(
+                f"policy DB capability check failed:\n"
+                f"  - required manifest is missing: {required}",
+                file=sys.stderr,
+            )
+            return 1
+    if args.emit_baseline:
+        return emit_baselines(manifests, repo_root)
+    errors: list[str] = []
+    checked_callsites = 0
+    for manifest in manifests:
+        errors.extend(validate_manifest_shape(manifest, repo_root))
+        scan_paths = manifest_scan_paths(manifest, repo_root)
+        if not all(path.exists() for path in scan_paths):
+            continue
+        callsites: list[Callsite] = []
+        for path in scan_paths:
+            callsites.extend(scan_callsites(path, repo_root))
+        checked_callsites += len(callsites)
+        errors.extend(validate_callsites(manifest, callsites, args.no_silent_growth))
+    if errors:
+        print("policy DB capability check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(
+        "policy DB capability check passed: "
+        f"{len(manifests)} manifest(s), {checked_callsites} raw DB callsite(s) checked"
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root. Defaults to the parent of scripts/.",
+    )
+    parser.add_argument(
+        "--policies-root",
+        default="policies",
+        help="Policies directory relative to --repo-root.",
+    )
+    parser.add_argument(
+        "--no-silent-growth",
+        action="store_true",
+        help="Require broad legacy manifests to match their checked-in callsite baseline.",
+    )
+    parser.add_argument(
+        "--emit-baseline",
+        action="store_true",
+        help="Print no_silent_growth baseline snippets for current manifest-enabled policies.",
+    )
+    parser.add_argument(
+        "--require-manifest",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Require a specific manifest path relative to --repo-root. May be repeated.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return run_check(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_policy_db_capabilities.py
+++ b/scripts/check_policy_db_capabilities.py
@@ -23,8 +23,21 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 POLICIES_ROOT = REPO_ROOT / "policies"
 LEGACY_BROAD_MODES = {"legacy"}
 ALLOWED_RAW_MODES = {"forbidden", "audited", "transitional", *LEGACY_BROAD_MODES}
-RAW_DB_RE = re.compile(r"agentdesk\.db\.(query|execute)\s*\(")
+IDENT_RE = r"[A-Za-z_$][A-Za-z0-9_$]*"
+RAW_DB_SURFACE_RE = r"""agentdesk\s*(?:\.\s*db|\[\s*["']db["']\s*\])"""
+RAW_DB_CALL_RE = re.compile(
+    rf"""{RAW_DB_SURFACE_RE}\s*(?:\.\s*(query|execute)|\[\s*["'](query|execute)["']\s*\])\s*\("""
+)
 MARKER_RE = re.compile(r"legacy-raw-db:\s*([^*\n]+)")
+RAW_DB_ALIAS_RE = re.compile(
+    rf"""(?:\b(?:var|let|const)\s+)?({IDENT_RE})\s*=\s*{RAW_DB_SURFACE_RE}(?=\s*(?:[;,\)\n]|$))"""
+)
+RAW_DB_METHOD_ALIAS_RE = re.compile(
+    rf"""(?:\b(?:var|let|const)\s+)?({IDENT_RE})\s*=\s*{RAW_DB_SURFACE_RE}\s*(?:\.\s*(query|execute)|\[\s*["'](query|execute)["']\s*\])"""
+)
+AGENTDESK_DB_DESTRUCTURE_RE = re.compile(
+    rf"""(?:\b(?:var|let|const)\s+)?\{{[^}}]*\bdb\s*(?::\s*({IDENT_RE}))?[^}}]*\}}\s*=\s*agentdesk\b"""
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -221,26 +234,153 @@ def marker_in_call_expression(expression: str) -> dict[str, str]:
     return parse_marker(matches[-1])
 
 
+def mask_js_comments_and_strings(text: str) -> str:
+    masked: list[str] = []
+    comment: str | None = None
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if comment == "line":
+            if ch == "\n":
+                comment = None
+                masked.append(ch)
+            else:
+                masked.append(" ")
+            i += 1
+            continue
+        if comment == "block":
+            if ch == "*" and nxt == "/":
+                comment = None
+                masked.extend("  ")
+                i += 2
+            else:
+                masked.append("\n" if ch == "\n" else " ")
+                i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            comment = "line"
+            masked.extend("  ")
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            comment = "block"
+            masked.extend("  ")
+            i += 2
+            continue
+        if ch in {"'", '"', "`"}:
+            literal, end = read_js_string_literal(text, i)
+            replacement = (
+                literal
+                if literal_value(literal) in {"db", "query", "execute"}
+                else "".join("\n" if c == "\n" else " " for c in literal)
+            )
+            masked.append(replacement)
+            i = end
+            continue
+        masked.append(ch)
+        i += 1
+    return "".join(masked)
+
+
+def read_js_string_literal(text: str, start: int) -> tuple[str, int]:
+    quote = text[start]
+    escaped = False
+    i = start + 1
+    while i < len(text):
+        ch = text[i]
+        if escaped:
+            escaped = False
+        elif ch == "\\":
+            escaped = True
+        elif ch == quote:
+            return text[start : i + 1], i + 1
+        i += 1
+    return text[start:], len(text)
+
+
+def literal_value(literal: str) -> str:
+    if len(literal) < 2:
+        return ""
+    quote = literal[0]
+    if quote not in {"'", '"', "`"} or literal[-1] != quote:
+        return ""
+    value = literal[1:-1]
+    if "\\" in value:
+        return ""
+    return value
+
+
+def raw_db_aliases(masked_text: str) -> dict[str, str | None]:
+    aliases: dict[str, str | None] = {}
+    for match in RAW_DB_ALIAS_RE.finditer(masked_text):
+        aliases[match.group(1)] = None
+    for match in AGENTDESK_DB_DESTRUCTURE_RE.finditer(masked_text):
+        aliases[match.group(1) or "db"] = None
+    for match in RAW_DB_METHOD_ALIAS_RE.finditer(masked_text):
+        aliases[match.group(1)] = match.group(2) or match.group(3)
+    return aliases
+
+
+def alias_call_regex(alias: str) -> re.Pattern[str]:
+    escaped_alias = re.escape(alias)
+    return re.compile(
+        rf"""(?<![.\w$])\b{escaped_alias}\s*(?:\.\s*(query|execute)|\[\s*["'](query|execute)["']\s*\])\s*\("""
+    )
+
+
+def method_alias_call_regex(alias: str) -> re.Pattern[str]:
+    return re.compile(rf"""(?<![.\w$])\b{re.escape(alias)}\s*\(""")
+
+
+def callsite_from_match(
+    text: str,
+    path: Path,
+    rel_path: str,
+    match: re.Match[str],
+    op: str,
+) -> Callsite:
+    expression = extract_call_expression(text, match.start(), match.end() - 1)
+    line = text.count("\n", 0, match.start()) + 1
+    return Callsite(
+        path=path,
+        rel_path=rel_path,
+        line=line,
+        op=op,
+        expression=expression,
+        marker=marker_in_call_expression(expression),
+    )
+
+
 def scan_callsites(path: Path, repo_root: Path = REPO_ROOT) -> list[Callsite]:
     repo_root = repo_root.resolve()
     path = (repo_root / path).resolve() if not path.is_absolute() else path.resolve()
     text = path.read_text(encoding="utf-8")
+    masked_text = mask_js_comments_and_strings(text)
     rel_path = path.relative_to(repo_root).as_posix()
     callsites: list[Callsite] = []
-    for match in RAW_DB_RE.finditer(text):
-        op = match.group(1)
-        expression = extract_call_expression(text, match.start(), match.end() - 1)
-        line = text.count("\n", 0, match.start()) + 1
-        callsites.append(
-            Callsite(
-                path=path,
-                rel_path=rel_path,
-                line=line,
-                op=op,
-                expression=expression,
-                marker=marker_in_call_expression(expression),
-            )
-        )
+    seen: set[tuple[int, int]] = set()
+    for match in RAW_DB_CALL_RE.finditer(masked_text):
+        op = match.group(1) or match.group(2)
+        callsites.append(callsite_from_match(text, path, rel_path, match, op))
+        seen.add((match.start(), match.end()))
+    for alias, method_op in raw_db_aliases(masked_text).items():
+        if method_op:
+            pattern = method_alias_call_regex(alias)
+            for match in pattern.finditer(masked_text):
+                if (match.start(), match.end()) in seen:
+                    continue
+                callsites.append(callsite_from_match(text, path, rel_path, match, method_op))
+                seen.add((match.start(), match.end()))
+            continue
+        pattern = alias_call_regex(alias)
+        for match in pattern.finditer(masked_text):
+            if (match.start(), match.end()) in seen:
+                continue
+            op = match.group(1) or match.group(2)
+            callsites.append(callsite_from_match(text, path, rel_path, match, op))
+            seen.add((match.start(), match.end()))
+    callsites.sort(key=lambda callsite: (callsite.rel_path, callsite.line, callsite.expression))
     return callsites
 
 

--- a/scripts/check_policy_db_capabilities.py
+++ b/scripts/check_policy_db_capabilities.py
@@ -35,6 +35,9 @@ RAW_DB_ALIAS_RE = re.compile(
 RAW_DB_METHOD_ALIAS_RE = re.compile(
     rf"""(?:\b(?:var|let|const)\s+)?({IDENT_RE})\s*=\s*{RAW_DB_SURFACE_RE}\s*(?:\.\s*(query|execute)|\[\s*["'](query|execute)["']\s*\])"""
 )
+RAW_DB_METHOD_DESTRUCTURE_RE = re.compile(
+    rf"""\b(?:var|let|const)\s+\{{([^}}]+)\}}\s*=\s*{RAW_DB_SURFACE_RE}\b"""
+)
 AGENTDESK_DB_DESTRUCTURE_RE = re.compile(
     rf"""(?:\b(?:var|let|const)\s+)?\{{[^}}]*\bdb\s*(?::\s*({IDENT_RE}))?[^}}]*\}}\s*=\s*agentdesk\b"""
 )
@@ -319,6 +322,26 @@ def raw_db_aliases(masked_text: str) -> dict[str, str | None]:
         aliases[match.group(1) or "db"] = None
     for match in RAW_DB_METHOD_ALIAS_RE.finditer(masked_text):
         aliases[match.group(1)] = match.group(2) or match.group(3)
+    for match in RAW_DB_METHOD_DESTRUCTURE_RE.finditer(masked_text):
+        aliases.update(raw_db_method_destructure_aliases(match.group(1)))
+    return aliases
+
+
+def raw_db_method_destructure_aliases(binding_text: str) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for part in binding_text.split(","):
+        binding = part.strip()
+        if not binding:
+            continue
+        if ":" in binding:
+            source, target = binding.split(":", 1)
+            source = source.strip()
+            target = target.strip().split("=", 1)[0].strip()
+        else:
+            source = binding.split("=", 1)[0].strip()
+            target = source
+        if source in {"query", "execute"} and re.fullmatch(IDENT_RE, target):
+            aliases[target] = source
     return aliases
 
 

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -51,6 +51,13 @@ echo "=== Postgres migration checksum guard ==="
 echo "=== State/lint hardening guard ==="
 "$PYTHON" scripts/audit_state_lint_hardening.py
 
+echo "=== Policy DB capability manifest guard (#3734) ==="
+"$PYTHON" scripts/check_policy_db_capabilities.py --no-silent-growth \
+  --require-manifest policies/timeouts/active-monitor.cap.yaml \
+  --require-manifest policies/review-automation.cap.yaml \
+  --require-manifest policies/merge-automation.cap.yaml
+"$PYTHON" -m unittest tests.test_policy_db_capabilities
+
 echo "=== await_holding_lock ratchet guard ==="
 "$PYTHON" scripts/check_await_holding_lock_ratchet.py
 

--- a/tests/test_policy_db_capabilities.py
+++ b/tests/test_policy_db_capabilities.py
@@ -137,6 +137,28 @@ db:
             self.assertEqual(count, 2)
             self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
 
+    def test_legacy_baseline_counts_agentdesk_db_method_destructure_callsites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    const { query, execute: rawExecute } = agentdesk.db;
+    query("SELECT id FROM kanban_cards");
+    rawExecute("DELETE FROM kv_meta WHERE key = ?", ["x"]);
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+
+            self.assertEqual(count, 2)
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
+
     def test_legacy_baseline_rejects_alias_growth_from_zero_literal_callsites(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_policy_db_capabilities.py
+++ b/tests/test_policy_db_capabilities.py
@@ -92,6 +92,80 @@ db:
 
             self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
 
+    def test_legacy_baseline_counts_agentdesk_db_alias_callsites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    var db = agentdesk.db;
+    db.query("SELECT id FROM kanban_cards");
+    db["execute"]("DELETE FROM kv_meta WHERE key = ?", ["x"]);
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+
+            self.assertEqual(count, 2)
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
+
+    def test_legacy_baseline_counts_agentdesk_db_method_alias_callsites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    const query = agentdesk["db"].query;
+    const execute = agentdesk.db["execute"];
+    query("SELECT id FROM kanban_cards");
+    execute("DELETE FROM kv_meta WHERE key = ?", ["x"]);
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+
+            self.assertEqual(count, 2)
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
+
+    def test_legacy_baseline_rejects_alias_growth_from_zero_literal_callsites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    return null;
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+            policy_path.write_text(
+                """module.exports = {
+  onTick: function() {
+    var db = agentdesk.db;
+    return db.query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
     def test_marker_mode_requires_runtime_visible_marker_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_policy_db_capabilities.py
+++ b/tests/test_policy_db_capabilities.py
@@ -159,6 +159,27 @@ db:
             self.assertEqual(count, 2)
             self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
 
+    def test_legacy_baseline_counts_bracket_db_method_destructure_callsites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    const { query } = agentdesk["db"];
+    query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+
+            self.assertEqual(count, 1)
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
+
     def test_legacy_baseline_rejects_alias_growth_from_zero_literal_callsites(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_policy_db_capabilities.py
+++ b/tests/test_policy_db_capabilities.py
@@ -1,0 +1,357 @@
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_policy_db_capabilities as checker
+
+
+class PolicyDbCapabilitiesTest(unittest.TestCase):
+    def write(self, root: Path, rel: str, text: str) -> Path:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def legacy_manifest(self, root: Path, policy: str, callsites: int, fingerprint: str) -> None:
+        self.write(
+            root,
+            f"policies/{policy}.cap.yaml",
+            f"""version: 1
+policy: {policy}
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: legacy
+    capabilities:
+      - legacy_raw_db
+    markers_required: false
+    no_silent_growth:
+      callsites: {callsites}
+      fingerprint: {fingerprint}
+""",
+        )
+
+    def run_checker(self, root: Path, *args: str) -> int:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            return checker.main(["--repo-root", str(root), *args])
+
+    def test_legacy_baseline_accepts_current_callsites(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    return agentdesk.db.query(
+      "SELECT id FROM kanban_cards WHERE id = ?",
+      ["card-1"]
+    );
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
+
+    def test_legacy_baseline_rejects_new_callsite_growth(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            policy_path = self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    agentdesk.db.query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+            )
+            callsites = checker.scan_callsites(policy_path, root)
+            count, fingerprint = checker.callsite_baseline(callsites)
+            self.legacy_manifest(root, "example", count, fingerprint)
+            policy_path.write_text(
+                """module.exports = {
+  onTick: function() {
+    agentdesk.db.query("SELECT id FROM kanban_cards");
+    agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", ["x"]);
+  }
+};
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_marker_mode_requires_runtime_visible_marker_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/marked.js",
+                """module.exports = {
+  onTick: function() {
+    return agentdesk.db.query(
+      "/* legacy-raw-db: policy=marked capability=read_cards source_event=onTick */ " +
+      "SELECT id FROM kanban_cards"
+    );
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/marked.cap.yaml",
+                """version: 1
+policy: marked
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: audited
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 0)
+
+    def test_marker_mode_rejects_static_only_js_comment_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/marked.js",
+                """module.exports = {
+  onTick: function() {
+    /* legacy-raw-db: policy=marked capability=read_cards source_event=onTick */
+    return agentdesk.db.query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/marked.cap.yaml",
+                """version: 1
+policy: marked
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: audited
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_marker_mode_rejects_js_comment_inside_call_expression(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/marked.js",
+                """module.exports = {
+  onTick: function() {
+    return agentdesk.db.query(
+      /* legacy-raw-db: policy=marked capability=read_cards source_event=onTick */
+      "SELECT id FROM kanban_cards"
+    );
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/marked.cap.yaml",
+                """version: 1
+policy: marked
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: audited
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_marker_mode_rejects_marker_in_params_argument(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/marked.js",
+                """module.exports = {
+  onTick: function() {
+    return agentdesk.db.query(
+      "SELECT id FROM kanban_cards WHERE note = ?",
+      ["/* legacy-raw-db: policy=marked capability=read_cards source_event=onTick */"]
+    );
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/marked.cap.yaml",
+                """version: 1
+policy: marked
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: audited
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_marker_mode_rejects_unmarked_callsite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/marked.js",
+                """module.exports = {
+  onTick: function() {
+    return agentdesk.db.query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/marked.cap.yaml",
+                """version: 1
+policy: marked
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: audited
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_forbidden_mode_rejects_any_raw_db_callsite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/forbidden.js",
+                """module.exports = {
+  onTick: function() {
+    /* legacy-raw-db: policy=forbidden capability=read_cards source_event=onTick */
+    return agentdesk.db.query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/forbidden.cap.yaml",
+                """version: 1
+policy: forbidden
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: forbidden
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_unknown_raw_sql_mode_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/bogus.js",
+                """module.exports = {
+  onTick: function() {
+    /* legacy-raw-db: policy=bogus capability=read_cards source_event=onTick */
+    return agentdesk.db.query("SELECT id FROM kanban_cards");
+  }
+};
+""",
+            )
+            self.write(
+                root,
+                "policies/bogus.cap.yaml",
+                """version: 1
+policy: bogus
+trust: trusted-automation
+source_events:
+  - onTick
+db:
+  raw_sql:
+    mode: typo
+    capabilities:
+      - read_cards
+    markers_required: true
+""",
+            )
+
+            self.assertEqual(self.run_checker(root, "--no-silent-growth"), 1)
+
+    def test_required_manifest_missing_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write(
+                root,
+                "policies/example.js",
+                """module.exports = {
+  onTick: function() {
+    return null;
+  }
+};
+""",
+            )
+
+            self.assertEqual(
+                self.run_checker(
+                    root,
+                    "--no-silent-growth",
+                    "--require-manifest",
+                    "policies/example.cap.yaml",
+                ),
+                1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add checked-in capability manifests for `timeouts/active-monitor`, `review-automation`, and `merge-automation`, including the merge notification helper raw DB surface.
- Add `scripts/check_policy_db_capabilities.py` to statically scan manifest-enabled `agentdesk.db.query/execute` callsites, enforce required first-rollout manifests, validate raw SQL modes, and pin no-silent-growth baselines.
- Wire the guard into `scripts/ci-script-checks.sh` and update policy SQL guard/inventory docs.

## Tests
- `cargo fmt --all --check`
- `cargo check --lib` (passes with existing unused-import warnings)
- `/opt/homebrew/bin/python3 scripts/check_policy_db_capabilities.py --no-silent-growth --require-manifest policies/timeouts/active-monitor.cap.yaml --require-manifest policies/review-automation.cap.yaml --require-manifest policies/merge-automation.cap.yaml`
- `/opt/homebrew/bin/python3 -m unittest tests.test_policy_db_capabilities`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`
- Independent review: `VERDICT: CLEAN`

Refs #3734