### PR TITLE
Move dispatch thread reuse persistence into service

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -718,6 +718,7 @@ src/
 │   │   ├── outbox_queue.rs
 │   │   ├── outbox_route.rs
 │   │   ├── routing_constraint.rs
+│   │   ├── thread_reuse.rs
 │   │   └── wait_queue.rs
 │   ├── git/
 │   │   ├── branch_resolver.rs

--- a/docs/generated/maintainability-audit.md
+++ b/docs/generated/maintainability-audit.md
@@ -4,21 +4,23 @@
 
 > Drift policy: see [docs/generated/README.md](README.md#generated-docs-drift-policy).
 
-Automated audit of giant files, route SRP violations, direct Discord sends, manual JSON row mapping, limit/days clamp duplication, git subprocess callsites, legacy SQLite references, source-of-truth alias writes, and namespace size caps. See `scripts/audit_maintainability.py` (#1282).
+Automated audit of giant files, route SRP violations, direct Discord sends, service-to-server backflow, manual JSON row mapping, limit/days clamp duplication, git subprocess callsites, legacy SQLite references, source-of-truth alias writes, and namespace size caps. See `scripts/audit_maintainability.py` (#1282).
 
-Hard-gating is **enabled** for 6 checks: `giant_files`, `namespace_size_caps`, `direct_discord_sends`, `git_subprocess_callsites`, `legacy_sqlite_refs`, `source_of_truth_alias_writes`.
+Hard-gating is **enabled** for 8 checks: `giant_files`, `giant_file_ratchet`, `namespace_size_caps`, `direct_discord_sends`, `manual_json_row_mapping`, `git_subprocess_callsites`, `legacy_sqlite_refs`, `source_of_truth_alias_writes`.
 
-Baseline no-regression gates are **enabled** for 1 checks: `route_srp_violations`.
+Baseline no-regression gates are **enabled** for 2 checks: `route_srp_violations`, `service_server_backflow`.
 
 ## Summary
 
 | Rule | Hits | Hard gate | Baseline gate |
 |---|---:|:--:|:--:|
 | `giant_files` | 0 | YES | no |
+| `giant_file_ratchet` | 0 | YES | no |
 | `namespace_size_caps` | 0 | YES | no |
-| `route_srp_violations` | 16 | no | YES |
+| `route_srp_violations` | 11 | no | YES |
+| `service_server_backflow` | 0 | no | YES |
 | `direct_discord_sends` | 0 | YES | no |
-| `manual_json_row_mapping` | 0 | no | no |
+| `manual_json_row_mapping` | 0 | YES | no |
 | `limit_clamp_duplication` | 0 | no | no |
 | `git_subprocess_callsites` | 0 | YES | no |
 | `legacy_sqlite_refs` | 0 | YES | no |
@@ -27,6 +29,12 @@ Baseline no-regression gates are **enabled** for 1 checks: `route_srp_violations
 ## Giant files (`giant_files`)
 
 Production Rust files in src/ with >= 1000 lines that are not listed in docs/agent-maintenance/change-surfaces.md.
+
+_No findings._
+
+## Giant file re-inflation ratchet (`giant_file_ratchet`)
+
+Production giants listed in scripts/audit_maintainability_giant_baseline.toml must not exceed their frozen production-LoC baseline.
 
 _No findings._
 
@@ -42,22 +50,23 @@ Files under src/server/routes/ that mix raw SQL, json!() shaping, and crate::ser
 
 | Severity | File | Line | Message |
 |---|---|---:|---|
-| warn | `src/server/routes/agents.rs` |  | route file mixes SQL (10), json!() (72), and crate::services calls (16) |
-| warn | `src/server/routes/agents_crud.rs` |  | route file mixes SQL (40), json!() (73), and crate::services calls (6) |
+| warn | `src/server/routes/agents_crud.rs` |  | route file mixes SQL (40), json!() (77), and crate::services calls (7) |
 | warn | `src/server/routes/agents_setup.rs` |  | route file mixes SQL (7), json!() (12), and crate::services calls (2) |
 | warn | `src/server/routes/cron_api.rs` |  | route file mixes SQL (2), json!() (12), and crate::services calls (1) |
-| warn | `src/server/routes/dispatches/thread_reuse.rs` |  | route file mixes SQL (36), json!() (19), and crate::services calls (1) |
-| warn | `src/server/routes/escalation.rs` |  | route file mixes SQL (44), json!() (38), and crate::services calls (3) |
-| warn | `src/server/routes/github.rs` |  | route file mixes SQL (8), json!() (27), and crate::services calls (5) |
-| warn | `src/server/routes/health_api.rs` |  | route file mixes SQL (20), json!() (64), and crate::services calls (6) |
-| warn | `src/server/routes/meetings.rs` |  | route file mixes SQL (68), json!() (70), and crate::services calls (3) |
-| warn | `src/server/routes/memory_api.rs` |  | route file mixes SQL (8), json!() (15), and crate::services calls (8) |
-| warn | `src/server/routes/pipeline.rs` |  | route file mixes SQL (8), json!() (19), and crate::services calls (4) |
-| warn | `src/server/routes/provider_cli_api.rs` |  | route file mixes SQL (5), json!() (12), and crate::services calls (30) |
-| warn | `src/server/routes/queue_api.rs` |  | route file mixes SQL (4), json!() (15), and crate::services calls (5) |
-| warn | `src/server/routes/review_verdict/decision_route.rs` |  | route file mixes SQL (44), json!() (22), and crate::services calls (1) |
-| warn | `src/server/routes/review_verdict/verdict_route.rs` |  | route file mixes SQL (5), json!() (19), and crate::services calls (4) |
-| warn | `src/server/routes/stats.rs` |  | route file mixes SQL (32), json!() (9), and crate::services calls (1) |
+| warn | `src/server/routes/escalation.rs` |  | route file mixes SQL (24), json!() (24), and crate::services calls (3) |
+| warn | `src/server/routes/github.rs` |  | route file mixes SQL (8), json!() (34), and crate::services calls (5) |
+| warn | `src/server/routes/health_api.rs` |  | route file mixes SQL (30), json!() (106), and crate::services calls (17) |
+| warn | `src/server/routes/memory_api.rs` |  | route file mixes SQL (17), json!() (18), and crate::services calls (7) |
+| warn | `src/server/routes/provider_cli_api.rs` |  | route file mixes SQL (3), json!() (12), and crate::services calls (6) |
+| warn | `src/server/routes/queue_api.rs` |  | route file mixes SQL (4), json!() (15), and crate::services calls (3) |
+| warn | `src/server/routes/review_verdict/verdict_route.rs` |  | route file mixes SQL (5), json!() (19), and crate::services calls (5) |
+| warn | `src/server/routes/stats.rs` |  | route file mixes SQL (32), json!() (10), and crate::services calls (2) |
+
+## Service/server backflow (`service_server_backflow`)
+
+Files under src/services/ that reference crate::server or super::server server-layer modules.
+
+_No findings._
 
 ## Direct Discord send/edit (`direct_discord_sends`)
 

--- a/scripts/audit_maintainability/baselines/route_srp.json
+++ b/scripts/audit_maintainability/baselines/route_srp.json
@@ -2,12 +2,9 @@
   "schema_version": 1,
   "rule": "route_srp_violations",
   "description": "No-regression baseline for route files that still mix raw SQL, json!() shaping, and crate::services calls.",
-  "captured_at": "2026-05-12",
-  "total_count": 15,
+  "captured_at": "2026-06-28",
+  "total_count": 11,
   "files": {
-    "src/server/routes/agents.rs": {
-      "count": 1
-    },
     "src/server/routes/agents_crud.rs": {
       "count": 1
     },
@@ -15,9 +12,6 @@
       "count": 1
     },
     "src/server/routes/cron_api.rs": {
-      "count": 1
-    },
-    "src/server/routes/dispatches/thread_reuse.rs": {
       "count": 1
     },
     "src/server/routes/escalation.rs": {
@@ -29,13 +23,7 @@
     "src/server/routes/health_api.rs": {
       "count": 1
     },
-    "src/server/routes/meetings.rs": {
-      "count": 1
-    },
     "src/server/routes/memory_api.rs": {
-      "count": 1
-    },
-    "src/server/routes/pipeline.rs": {
       "count": 1
     },
     "src/server/routes/provider_cli_api.rs": {

--- a/src/server/routes/dispatches/thread_reuse.rs
+++ b/src/server/routes/dispatches/thread_reuse.rs
@@ -1,27 +1,41 @@
 //! Axum route handlers for dispatch thread linking and lookup.
 //!
-//! The Postgres/Discord-API thread-reuse helpers were relocated to
-//! `crate::services::dispatches::discord_delivery` (#3037) so the service layer
-//! no longer reaches back into the route layer. These handlers consume those
-//! relocated helpers.
+//! Thread-reuse persistence and lookup decisions live in
+//! `crate::services::dispatches::thread_reuse`; these handlers keep the HTTP
+//! boundary focused on extraction, validation, and response conversion.
 
 use axum::{
     Json,
     extract::{Query, State},
     http::StatusCode,
 };
-use serde_json::json;
-use sqlx::Row as SqlxRow;
+use serde_json::{Value, json};
 
-use crate::db::agents::{resolve_agent_counter_model_channel_pg, resolve_agent_primary_channel_pg};
 use crate::server::routes::AppState;
 use crate::services::dispatches::LinkDispatchThreadBody;
-use crate::services::dispatches::discord_delivery::{
-    get_mapped_thread_for_channel_pg, get_thread_for_channel_pg,
-    set_thread_for_channel_map_only_pg, set_thread_for_channel_pg,
+use crate::services::dispatches::thread_reuse::{
+    DispatchThreadReuseError, LinkDispatchThreadInput, get_card_thread_pg,
+    get_pending_dispatch_for_thread_pg, link_dispatch_thread_pg,
 };
 
-use super::parse_channel_id;
+fn postgres_pool_unavailable() -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({"error": "postgres pool unavailable"})),
+    )
+}
+
+fn thread_reuse_error_response(error: DispatchThreadReuseError) -> (StatusCode, Json<Value>) {
+    match error {
+        DispatchThreadReuseError::NotFound(message) => {
+            (StatusCode::NOT_FOUND, Json(json!({"error": message})))
+        }
+        DispatchThreadReuseError::Internal(message) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": message})),
+        ),
+    }
+}
 
 // ── Route handlers ────────────────────────────────────────────
 /// POST /api/internal/link-dispatch-thread
@@ -30,131 +44,22 @@ use super::parse_channel_id;
 pub async fn link_dispatch_thread(
     State(state): State<AppState>,
     Json(body): Json<LinkDispatchThreadBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> (StatusCode, Json<Value>) {
     let Some(pool) = state.pg_pool_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+        return postgres_pool_unavailable();
     };
 
-    let dispatch_row = match sqlx::query(
-        "SELECT kanban_card_id, dispatch_type, to_agent_id
-         FROM task_dispatches
-         WHERE id = $1",
-    )
-    .bind(&body.dispatch_id)
-    .fetch_optional(pool)
-    .await
-    {
-        Ok(row) => row,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            );
-        }
+    let input = LinkDispatchThreadInput {
+        dispatch_id: body.dispatch_id,
+        thread_id: body.thread_id,
+        channel_id: body.channel_id,
     };
-
-    match dispatch_row {
-        Some(row) => {
-            let cid: String = match row.try_get("kanban_card_id") {
-                Ok(value) => value,
-                Err(error) => {
-                    tracing::warn!(%error, "[dispatch] failed to read kanban_card_id from row");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": error.to_string() })),
-                    );
-                }
-            };
-            let dispatch_type: Option<String> = row.try_get("dispatch_type").ok().flatten();
-            let to_agent_id: String = match row.try_get("to_agent_id") {
-                Ok(value) => value,
-                Err(error) => {
-                    tracing::warn!(%error, "[dispatch] failed to read to_agent_id from row");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": error.to_string() })),
-                    );
-                }
-            };
-
-            if let Err(error) = sqlx::query(
-                "UPDATE task_dispatches
-                 SET thread_id = $1,
-                     updated_at = NOW()
-                 WHERE id = $2",
-            )
-            .bind(&body.thread_id)
-            .bind(&body.dispatch_id)
-            .execute(pool)
-            .await
-            {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("{error}")})),
-                );
-            }
-
-            let save_result = if let Some(ref ch_id) = body.channel_id {
-                if let Ok(ch_num) = ch_id.parse::<u64>() {
-                    let counter_channel =
-                        resolve_agent_counter_model_channel_pg(pool, &to_agent_id)
-                            .await
-                            .ok()
-                            .flatten()
-                            .and_then(|value| parse_channel_id(&value));
-                    let is_counter_model_thread =
-                        super::use_counter_model_channel(dispatch_type.as_deref())
-                            && counter_channel == Some(ch_num);
-                    if is_counter_model_thread {
-                        set_thread_for_channel_map_only_pg(pool, &cid, ch_num, &body.thread_id)
-                            .await
-                    } else {
-                        set_thread_for_channel_pg(pool, &cid, ch_num, &body.thread_id).await
-                    }
-                } else {
-                    sqlx::query(
-                        "UPDATE kanban_cards
-                         SET active_thread_id = $1,
-                             updated_at = NOW()
-                         WHERE id = $2",
-                    )
-                    .bind(&body.thread_id)
-                    .bind(&cid)
-                    .execute(pool)
-                    .await
-                    .map(|_| ())
-                    .map_err(|error| format!("{error}"))
-                }
-            } else {
-                sqlx::query(
-                    "UPDATE kanban_cards
-                     SET active_thread_id = $1,
-                         updated_at = NOW()
-                     WHERE id = $2",
-                )
-                .bind(&body.thread_id)
-                .bind(&cid)
-                .execute(pool)
-                .await
-                .map(|_| ())
-                .map_err(|error| format!("{error}"))
-            };
-
-            match save_result {
-                Ok(()) => (StatusCode::OK, Json(json!({"ok": true, "card_id": cid}))),
-                Err(error) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": error})),
-                ),
-            }
-        }
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "dispatch not found"})),
+    match link_dispatch_thread_pg(pool, input).await {
+        Ok(outcome) => (
+            StatusCode::OK,
+            Json(json!({"ok": true, "card_id": outcome.card_id})),
         ),
+        Err(error) => thread_reuse_error_response(error),
     }
 }
 
@@ -163,7 +68,7 @@ pub async fn link_dispatch_thread(
 pub async fn get_card_thread(
     State(state): State<AppState>,
     Query(params): Query<std::collections::HashMap<String, String>>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> (StatusCode, Json<Value>) {
     let dispatch_id = match params.get("dispatch_id") {
         Some(id) => id,
         None => {
@@ -175,143 +80,29 @@ pub async fn get_card_thread(
     };
 
     let Some(pool) = state.pg_pool_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+        return postgres_pool_unavailable();
     };
 
-    let result = match sqlx::query(
-        "SELECT kc.id AS card_id,
-                kc.title AS card_title,
-                kc.github_issue_url AS github_issue_url,
-                kc.github_issue_number::BIGINT AS github_issue_number,
-                kc.description AS issue_body,
-                kc.deferred_dod_json::text AS deferred_dod_json,
-                kc.active_thread_id AS legacy_thread_id,
-                td.dispatch_type AS dispatch_type,
-                td.title AS dispatch_title,
-                td.to_agent_id AS dispatch_agent_id,
-                td.context AS dispatch_context
-         FROM task_dispatches td
-         JOIN kanban_cards kc ON kc.id = td.kanban_card_id
-         WHERE td.id = $1",
-    )
-    .bind(dispatch_id)
-    .fetch_optional(pool)
-    .await
-    {
-        Ok(row) => row,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            );
-        }
-    };
-
-    match result {
-        Some(row) => {
-            let card_id: String = match row.try_get("card_id") {
-                Ok(value) => value,
-                Err(error) => {
-                    tracing::warn!(%error, "[dispatch] failed to read card_id from row");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": error.to_string() })),
-                    );
-                }
-            };
-            let card_title: String = match row.try_get("card_title") {
-                Ok(value) => value,
-                Err(error) => {
-                    tracing::warn!(%error, "[dispatch] failed to read card_title from row");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": error.to_string() })),
-                    );
-                }
-            };
-            let github_issue_url: Option<String> = row.try_get("github_issue_url").ok().flatten();
-            let github_issue_number: Option<i64> =
-                row.try_get("github_issue_number").ok().flatten();
-            let issue_body: Option<String> = row.try_get("issue_body").ok().flatten();
-            let deferred_dod_json: Option<String> = row.try_get("deferred_dod_json").ok().flatten();
-            let dispatch_type: Option<String> = row.try_get("dispatch_type").ok().flatten();
-            let dispatch_title: Option<String> = row.try_get("dispatch_title").ok().flatten();
-            let to_agent_id: String = match row.try_get("dispatch_agent_id") {
-                Ok(value) => value,
-                Err(error) => {
-                    tracing::warn!(%error, "[dispatch] failed to read dispatch_agent_id from row");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({ "error": error.to_string() })),
-                    );
-                }
-            };
-            let dispatch_context: Option<String> = row.try_get("dispatch_context").ok().flatten();
-
-            let primary_channel = resolve_agent_primary_channel_pg(pool, &to_agent_id)
-                .await
-                .ok()
-                .flatten();
-            let counter_model_channel = resolve_agent_counter_model_channel_pg(pool, &to_agent_id)
-                .await
-                .ok()
-                .flatten();
-            // Determine target channel for this dispatch type
-            let use_alt = super::use_counter_model_channel(dispatch_type.as_deref());
-            let target_channel = if use_alt {
-                counter_model_channel.as_deref()
-            } else {
-                primary_channel.as_deref()
-            };
-            // Look up channel-specific thread
-            let thread_id = if let Some(ch_num) = target_channel.and_then(parse_channel_id) {
-                let lookup_result = if use_alt {
-                    get_mapped_thread_for_channel_pg(pool, &card_id, ch_num).await
-                } else {
-                    get_thread_for_channel_pg(pool, &card_id, ch_num).await
-                };
-                match lookup_result {
-                    Ok(thread_id) => thread_id,
-                    Err(error) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(json!({"error": error})),
-                        );
-                    }
-                }
-            } else {
-                None
-            };
-            let deferred_dod = deferred_dod_json
-                .as_deref()
-                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
-
-            (
-                StatusCode::OK,
-                Json(json!({
-                    "card_id": card_id,
-                    "card_title": card_title,
-                    "github_issue_url": github_issue_url,
-                    "github_issue_number": github_issue_number,
-                    "issue_body": issue_body,
-                    "deferred_dod": deferred_dod,
-                    "active_thread_id": thread_id,
-                    "dispatch_type": dispatch_type,
-                    "dispatch_title": dispatch_title,
-                    "discord_channel_id": primary_channel,
-                    "discord_channel_alt": counter_model_channel,
-                    "discord_channel_target": target_channel,
-                    "dispatch_context": dispatch_context,
-                })),
-            )
-        }
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "dispatch not found"})),
+    match get_card_thread_pg(pool, dispatch_id).await {
+        Ok(outcome) => (
+            StatusCode::OK,
+            Json(json!({
+                "card_id": outcome.card_id,
+                "card_title": outcome.card_title,
+                "github_issue_url": outcome.github_issue_url,
+                "github_issue_number": outcome.github_issue_number,
+                "issue_body": outcome.issue_body,
+                "deferred_dod": outcome.deferred_dod,
+                "active_thread_id": outcome.active_thread_id,
+                "dispatch_type": outcome.dispatch_type,
+                "dispatch_title": outcome.dispatch_title,
+                "discord_channel_id": outcome.discord_channel_id,
+                "discord_channel_alt": outcome.discord_channel_alt,
+                "discord_channel_target": outcome.discord_channel_target,
+                "dispatch_context": outcome.dispatch_context,
+            })),
         ),
+        Err(error) => thread_reuse_error_response(error),
     }
 }
 
@@ -324,7 +115,7 @@ pub async fn get_card_thread(
 pub async fn get_pending_dispatch_for_thread(
     State(state): State<AppState>,
     Query(params): Query<std::collections::HashMap<String, String>>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> (StatusCode, Json<Value>) {
     let thread_id = match params.get("thread_id") {
         Some(id) => id,
         None => {
@@ -336,47 +127,15 @@ pub async fn get_pending_dispatch_for_thread(
     };
 
     let Some(pool) = state.pg_pool_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+        return postgres_pool_unavailable();
     };
 
-    let dispatch_id = match sqlx::query_scalar::<_, String>(
-        "SELECT td.id
-         FROM task_dispatches td
-         JOIN kanban_cards kc ON kc.id = td.kanban_card_id
-         WHERE td.status IN ('pending', 'dispatched')
-           AND (
-             td.thread_id = $1
-             OR kc.active_thread_id = $1
-             OR EXISTS(
-               SELECT 1
-               FROM jsonb_each_text(COALESCE(kc.channel_thread_map, '{}'::jsonb)) AS entry(key, value)
-               WHERE entry.value = $1
-             )
-           )
-         ORDER BY td.created_at DESC
-         LIMIT 1",
-    )
-    .bind(thread_id)
-    .fetch_optional(pool)
-    .await
-    {
-        Ok(dispatch_id) => dispatch_id,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            );
-        }
-    };
-
-    match dispatch_id {
-        Some(id) => (StatusCode::OK, Json(json!({"dispatch_id": id}))),
-        None => (
+    match get_pending_dispatch_for_thread_pg(pool, thread_id).await {
+        Ok(Some(id)) => (StatusCode::OK, Json(json!({"dispatch_id": id}))),
+        Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(json!({"error": "no pending dispatch for thread"})),
         ),
+        Err(error) => thread_reuse_error_response(error),
     }
 }

--- a/src/services/dispatches/mod.rs
+++ b/src/services/dispatches/mod.rs
@@ -9,6 +9,7 @@ use crate::services::service_error::{ErrorCode, ServiceError, ServiceResult};
 // migrated from `crate::services::discord_delivery` (the flat path is kept
 // as a re-export in `services/mod.rs` for compatibility).
 pub(crate) mod discord_delivery;
+pub(crate) mod thread_reuse;
 
 // #1730: Claim-owner capability matching and routing diagnostics semantics
 // live in the service layer; DB modules only select/mark/persist.

--- a/src/services/dispatches/thread_reuse.rs
+++ b/src/services/dispatches/thread_reuse.rs
@@ -1,0 +1,408 @@
+//! Dispatch thread-reuse persistence and lookup service.
+//!
+//! The Axum route layer owns request extraction and HTTP response mapping; this
+//! module owns the Postgres reads/writes and the channel-selection rules that
+//! decide how dispatch threads are persisted and looked up.
+
+use serde_json::Value;
+use sqlx::{PgPool, Row as SqlxRow};
+
+use crate::db::agents::{resolve_agent_counter_model_channel_pg, resolve_agent_primary_channel_pg};
+use crate::services::dispatches::discord_delivery::{
+    get_mapped_thread_for_channel_pg, get_thread_for_channel_pg,
+    set_thread_for_channel_map_only_pg, set_thread_for_channel_pg,
+};
+use crate::services::dispatches::outbox_route::{parse_channel_id, use_counter_model_channel};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LinkDispatchThreadInput {
+    pub dispatch_id: String,
+    pub thread_id: String,
+    pub channel_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LinkDispatchThreadOutcome {
+    pub card_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CardThreadLookupOutcome {
+    pub card_id: String,
+    pub card_title: String,
+    pub github_issue_url: Option<String>,
+    pub github_issue_number: Option<i64>,
+    pub issue_body: Option<String>,
+    pub deferred_dod: Option<Value>,
+    pub active_thread_id: Option<String>,
+    pub dispatch_type: Option<String>,
+    pub dispatch_title: Option<String>,
+    pub discord_channel_id: Option<String>,
+    pub discord_channel_alt: Option<String>,
+    pub discord_channel_target: Option<String>,
+    pub dispatch_context: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DispatchThreadReuseError {
+    NotFound(&'static str),
+    Internal(String),
+}
+
+impl std::fmt::Display for DispatchThreadReuseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(message) => formatter.write_str(message),
+            Self::Internal(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DispatchThreadReuseError {}
+
+impl From<sqlx::Error> for DispatchThreadReuseError {
+    fn from(error: sqlx::Error) -> Self {
+        Self::Internal(error.to_string())
+    }
+}
+
+impl From<String> for DispatchThreadReuseError {
+    fn from(error: String) -> Self {
+        Self::Internal(error)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinkThreadPersistence {
+    LegacyActiveThread,
+    ChannelMapAndActive(u64),
+    ChannelMapOnly(u64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CardThreadLookupPlan {
+    None,
+    ChannelWithLegacyFallback(u64),
+    ChannelMapOnly(u64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CardThreadChannelSelection {
+    target_channel: Option<String>,
+    lookup_plan: CardThreadLookupPlan,
+}
+
+pub(crate) async fn link_dispatch_thread_pg(
+    pool: &PgPool,
+    input: LinkDispatchThreadInput,
+) -> Result<LinkDispatchThreadOutcome, DispatchThreadReuseError> {
+    let dispatch_row = sqlx::query(
+        "SELECT kanban_card_id, dispatch_type, to_agent_id
+         FROM task_dispatches
+         WHERE id = $1",
+    )
+    .bind(&input.dispatch_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some(row) = dispatch_row else {
+        return Err(DispatchThreadReuseError::NotFound("dispatch not found"));
+    };
+
+    let card_id: String = read_required_string(&row, "kanban_card_id")?;
+    let dispatch_type: Option<String> = row.try_get("dispatch_type").ok().flatten();
+    let to_agent_id: String = read_required_string(&row, "to_agent_id")?;
+
+    sqlx::query(
+        "UPDATE task_dispatches
+         SET thread_id = $1,
+             updated_at = NOW()
+         WHERE id = $2",
+    )
+    .bind(&input.thread_id)
+    .bind(&input.dispatch_id)
+    .execute(pool)
+    .await?;
+
+    let counter_model_channel = if input
+        .channel_id
+        .as_deref()
+        .and_then(|value| value.parse::<u64>().ok())
+        .is_some()
+    {
+        resolve_agent_counter_model_channel_pg(pool, &to_agent_id)
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+    match classify_link_thread_persistence(
+        input.channel_id.as_deref(),
+        dispatch_type.as_deref(),
+        counter_model_channel.as_deref(),
+    ) {
+        LinkThreadPersistence::LegacyActiveThread => {
+            set_card_active_thread_pg(pool, &card_id, &input.thread_id).await?;
+        }
+        LinkThreadPersistence::ChannelMapAndActive(channel_id) => {
+            set_thread_for_channel_pg(pool, &card_id, channel_id, &input.thread_id).await?;
+        }
+        LinkThreadPersistence::ChannelMapOnly(channel_id) => {
+            set_thread_for_channel_map_only_pg(pool, &card_id, channel_id, &input.thread_id)
+                .await?;
+        }
+    }
+
+    Ok(LinkDispatchThreadOutcome { card_id })
+}
+
+pub(crate) async fn get_card_thread_pg(
+    pool: &PgPool,
+    dispatch_id: &str,
+) -> Result<CardThreadLookupOutcome, DispatchThreadReuseError> {
+    let row = sqlx::query(
+        "SELECT kc.id AS card_id,
+                kc.title AS card_title,
+                kc.github_issue_url AS github_issue_url,
+                kc.github_issue_number::BIGINT AS github_issue_number,
+                kc.description AS issue_body,
+                kc.deferred_dod_json::text AS deferred_dod_json,
+                td.dispatch_type AS dispatch_type,
+                td.title AS dispatch_title,
+                td.to_agent_id AS dispatch_agent_id,
+                td.context AS dispatch_context
+         FROM task_dispatches td
+         JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+         WHERE td.id = $1",
+    )
+    .bind(dispatch_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some(row) = row else {
+        return Err(DispatchThreadReuseError::NotFound("dispatch not found"));
+    };
+
+    let card_id: String = read_required_string(&row, "card_id")?;
+    let card_title: String = read_required_string(&row, "card_title")?;
+    let github_issue_url: Option<String> = row.try_get("github_issue_url").ok().flatten();
+    let github_issue_number: Option<i64> = row.try_get("github_issue_number").ok().flatten();
+    let issue_body: Option<String> = row.try_get("issue_body").ok().flatten();
+    let deferred_dod_json: Option<String> = row.try_get("deferred_dod_json").ok().flatten();
+    let dispatch_type: Option<String> = row.try_get("dispatch_type").ok().flatten();
+    let dispatch_title: Option<String> = row.try_get("dispatch_title").ok().flatten();
+    let to_agent_id: String = read_required_string(&row, "dispatch_agent_id")?;
+    let dispatch_context: Option<String> = row.try_get("dispatch_context").ok().flatten();
+
+    let primary_channel = resolve_agent_primary_channel_pg(pool, &to_agent_id)
+        .await
+        .ok()
+        .flatten();
+    let counter_model_channel = resolve_agent_counter_model_channel_pg(pool, &to_agent_id)
+        .await
+        .ok()
+        .flatten();
+    let selection = select_card_thread_channel(
+        dispatch_type.as_deref(),
+        primary_channel.as_deref(),
+        counter_model_channel.as_deref(),
+    );
+    let active_thread_id = match selection.lookup_plan {
+        CardThreadLookupPlan::None => None,
+        CardThreadLookupPlan::ChannelWithLegacyFallback(channel_id) => {
+            get_thread_for_channel_pg(pool, &card_id, channel_id).await?
+        }
+        CardThreadLookupPlan::ChannelMapOnly(channel_id) => {
+            get_mapped_thread_for_channel_pg(pool, &card_id, channel_id).await?
+        }
+    };
+    let deferred_dod = deferred_dod_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok());
+
+    Ok(CardThreadLookupOutcome {
+        card_id,
+        card_title,
+        github_issue_url,
+        github_issue_number,
+        issue_body,
+        deferred_dod,
+        active_thread_id,
+        dispatch_type,
+        dispatch_title,
+        discord_channel_id: primary_channel,
+        discord_channel_alt: counter_model_channel,
+        discord_channel_target: selection.target_channel,
+        dispatch_context,
+    })
+}
+
+pub(crate) async fn get_pending_dispatch_for_thread_pg(
+    pool: &PgPool,
+    thread_id: &str,
+) -> Result<Option<String>, DispatchThreadReuseError> {
+    let dispatch_id = sqlx::query_scalar::<_, String>(
+        "SELECT td.id
+         FROM task_dispatches td
+         JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+         WHERE td.status IN ('pending', 'dispatched')
+           AND (
+             td.thread_id = $1
+             OR kc.active_thread_id = $1
+             OR EXISTS(
+               SELECT 1
+               FROM jsonb_each_text(COALESCE(kc.channel_thread_map, '{}'::jsonb)) AS entry(key, value)
+               WHERE entry.value = $1
+             )
+           )
+         ORDER BY td.created_at DESC
+         LIMIT 1",
+    )
+    .bind(thread_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(dispatch_id)
+}
+
+fn classify_link_thread_persistence(
+    channel_id: Option<&str>,
+    dispatch_type: Option<&str>,
+    counter_model_channel: Option<&str>,
+) -> LinkThreadPersistence {
+    let Some(channel_id) = channel_id else {
+        return LinkThreadPersistence::LegacyActiveThread;
+    };
+    let Ok(channel_id) = channel_id.parse::<u64>() else {
+        return LinkThreadPersistence::LegacyActiveThread;
+    };
+
+    let counter_model_channel = counter_model_channel.and_then(parse_channel_id);
+    if use_counter_model_channel(dispatch_type) && counter_model_channel == Some(channel_id) {
+        LinkThreadPersistence::ChannelMapOnly(channel_id)
+    } else {
+        LinkThreadPersistence::ChannelMapAndActive(channel_id)
+    }
+}
+
+fn select_card_thread_channel(
+    dispatch_type: Option<&str>,
+    primary_channel: Option<&str>,
+    counter_model_channel: Option<&str>,
+) -> CardThreadChannelSelection {
+    let use_counter_model = use_counter_model_channel(dispatch_type);
+    let target_channel = if use_counter_model {
+        counter_model_channel
+    } else {
+        primary_channel
+    };
+    let lookup_plan = match (use_counter_model, target_channel.and_then(parse_channel_id)) {
+        (_, None) => CardThreadLookupPlan::None,
+        (true, Some(channel_id)) => CardThreadLookupPlan::ChannelMapOnly(channel_id),
+        (false, Some(channel_id)) => CardThreadLookupPlan::ChannelWithLegacyFallback(channel_id),
+    };
+
+    CardThreadChannelSelection {
+        target_channel: target_channel.map(str::to_string),
+        lookup_plan,
+    }
+}
+
+async fn set_card_active_thread_pg(
+    pool: &PgPool,
+    card_id: &str,
+    thread_id: &str,
+) -> Result<(), DispatchThreadReuseError> {
+    sqlx::query(
+        "UPDATE kanban_cards
+         SET active_thread_id = $1,
+             updated_at = NOW()
+         WHERE id = $2",
+    )
+    .bind(thread_id)
+    .bind(card_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+fn read_required_string(
+    row: &sqlx::postgres::PgRow,
+    column: &'static str,
+) -> Result<String, DispatchThreadReuseError> {
+    row.try_get::<String, _>(column).map_err(|error| {
+        tracing::warn!(%error, column, "[dispatch] failed to read required thread-reuse row column");
+        DispatchThreadReuseError::Internal(error.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_counter_model_dispatch_on_counter_channel_updates_map_only() {
+        assert_eq!(
+            classify_link_thread_persistence(Some("123"), Some("review"), Some("123"),),
+            LinkThreadPersistence::ChannelMapOnly(123)
+        );
+    }
+
+    #[test]
+    fn link_primary_or_non_counter_channel_updates_map_and_active_thread() {
+        assert_eq!(
+            classify_link_thread_persistence(Some("456"), Some("review"), Some("123"),),
+            LinkThreadPersistence::ChannelMapAndActive(456)
+        );
+        assert_eq!(
+            classify_link_thread_persistence(Some("123"), Some("implementation"), Some("123"),),
+            LinkThreadPersistence::ChannelMapAndActive(123)
+        );
+    }
+
+    #[test]
+    fn link_missing_or_non_numeric_channel_preserves_legacy_active_thread_write() {
+        assert_eq!(
+            classify_link_thread_persistence(None, Some("review"), Some("123"),),
+            LinkThreadPersistence::LegacyActiveThread
+        );
+        assert_eq!(
+            classify_link_thread_persistence(Some("counter-model"), Some("review"), Some("123"),),
+            LinkThreadPersistence::LegacyActiveThread
+        );
+    }
+
+    #[test]
+    fn card_thread_lookup_uses_counter_map_without_legacy_fallback() {
+        assert_eq!(
+            select_card_thread_channel(Some("plan-review"), Some("111"), Some("222"),),
+            CardThreadChannelSelection {
+                target_channel: Some("222".to_string()),
+                lookup_plan: CardThreadLookupPlan::ChannelMapOnly(222),
+            }
+        );
+    }
+
+    #[test]
+    fn card_thread_lookup_uses_primary_channel_with_legacy_fallback() {
+        assert_eq!(
+            select_card_thread_channel(Some("review-decision"), Some("111"), Some("222"),),
+            CardThreadChannelSelection {
+                target_channel: Some("111".to_string()),
+                lookup_plan: CardThreadLookupPlan::ChannelWithLegacyFallback(111),
+            }
+        );
+    }
+
+    #[test]
+    fn card_thread_lookup_preserves_unparseable_target_in_outcome() {
+        assert_eq!(
+            select_card_thread_channel(Some("review"), Some("111"), Some("not-a-channel"),),
+            CardThreadChannelSelection {
+                target_channel: Some("not-a-channel".to_string()),
+                lookup_plan: CardThreadLookupPlan::None,
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Move dispatch/thread reuse row reads, writes, and channel selection into `services::dispatches::thread_reuse`.
- Keep `src/server/routes/dispatches/thread_reuse.rs` as HTTP extraction/validation/JSON mapping with compatible response keys.
- Add service-level tests for counter-model map-only behavior, primary map+active behavior, legacy invalid-channel behavior, and card-thread lookup selection.
- Refresh route-SRP audit baseline/report so the `thread_reuse.rs` finding is removed.

Issue: #3735

## Tests
- `cargo fmt --all --check`
- `cargo test --lib services::dispatches::thread_reuse`
- `cargo check --lib` (passes; repo still emits existing unused-import warnings outside this change)
- `python3 scripts/audit_maintainability.py --check`
- `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh`
- `git diff --check HEAD~1..HEAD`
- `rg` sanity check confirming no direct SQL query callsites remain in `src/server/routes/dispatches/thread_reuse.rs`