### PR TITLE
Migrate active-monitor raw DB access to timeout facade

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,6 +144,7 @@ src/
 │   │   ├── review_automation_ops.rs
 │   │   ├── review_ops.rs
 │   │   ├── runtime_ops.rs
+│   │   ├── timeouts_ops.rs
 │   │   └── turn_ops.rs
 │   ├── hooks.rs
 │   ├── intent.rs

--- a/docs/generated/policy-db-inventory.md
+++ b/docs/generated/policy-db-inventory.md
@@ -33,11 +33,11 @@ Measured on branch head with the command above (excludes `policies/__tests__/`):
 
 | op | count |
 |---|---|
-| `agentdesk.db.query` (read) | 127 |
-| `agentdesk.db.execute` (mutation) | 57 |
-| **total** | **184** |
+| `agentdesk.db.query` (read) | 120 |
+| `agentdesk.db.execute` (mutation) | 46 |
+| **total** | **166** |
 
-These 184 callsites are spread across 30 policy files under `policies/`. One
+These 166 callsites are spread across 29 policy files under `policies/`. One
 additional callsite lives in `policies/__tests__/` and is excluded from the
 migration debt total.
 
@@ -48,10 +48,13 @@ migration debt total.
   (`setBlockedReason`, `getCardStatus`, `getReworkCardInfo`, `listWaitingForCi`).
   The file now has zero `agentdesk.db.*` callsites and carries
   `// typed-facade-slice:start ci-recovery` / `:end` markers to flag regressions.
-- **Capability-manifest first rollout**: `policies/timeouts/active-monitor.js`,
-  `policies/review-automation.js`, and `policies/merge-automation.js` now have
-  adjacent `*.cap.yaml` manifests in `db.raw_sql.mode: legacy` with pinned
-  `no_silent_growth` baselines.
+- **Active-monitor slice**: `policies/timeouts/active-monitor.js` Section I
+  moved 18 raw-DB callsites (7 reads, 11 mutations) behind
+  `agentdesk.timeouts.*` and `agentdesk.kv.*`. Its adjacent capability
+  manifest now sets `db.raw_sql.mode: forbidden`.
+- **Capability-manifest first rollout**: `policies/review-automation.js` and
+  `policies/merge-automation.js` still have adjacent `*.cap.yaml` manifests in
+  `db.raw_sql.mode: legacy` with pinned `no_silent_growth` baselines.
 - **Next candidates (mutation-heavy)**: `review-automation.js`,
   `merge-automation.js`, `kanban-rules.js`, and the `auto-queue` lib modules
   (`lib/auto-queue-phase-gate.js`, `lib/auto-queue-lifecycle.js`).

--- a/docs/policy-sql-guard.md
+++ b/docs/policy-sql-guard.md
@@ -35,7 +35,7 @@ DB callsites must migrate to a typed facade or carry a
 `legacy-raw-db: policy=<name> capability=<intent> source_event=<hook>` marker
 so audit logs can attribute the capability.
 
-The current audited baseline is 184 raw DB callsites across 30 policy files.
+The current audited baseline is 166 raw DB callsites across 29 policy files.
 Four nearby `legacy-raw-db` marker comments annotate existing escape-hatch
 callsites. This baseline records the existing trusted-automation surface; it is
 not permission for silent growth.
@@ -163,9 +163,12 @@ The first rollout manifests are checked in for:
 - `policies/review-automation.cap.yaml`
 - `policies/merge-automation.cap.yaml`
 
-All three are in `legacy` raw SQL mode with pinned baselines. This prevents
-silent growth in the highest-risk policy files while keeping the runtime guard
-behavior unchanged.
+`review-automation` and `merge-automation` remain in `legacy` raw SQL mode with
+pinned baselines. `timeouts/active-monitor` has been migrated to typed timeout
+facades and now uses `forbidden` raw SQL mode, so any new `agentdesk.db.*`
+callsite in that file fails the static check. This prevents silent growth in
+the highest-risk policy files while keeping the runtime guard behavior
+unchanged.
 
 ### Enforcement Plan
 

--- a/docs/policy-typed-facade.md
+++ b/docs/policy-typed-facade.md
@@ -29,6 +29,14 @@ Current typed facade entrypoints:
 | `agentdesk.kanban` | `setReviewStatus(card_id, status, opts)` | Updates the review status without raw `kanban_cards.review_status` UPDATEs. |
 | `agentdesk.queue` | `status()` | Returns typed queue and outbox counts without exposing raw queue tables to JS. |
 | `agentdesk.autoQueue` | `updateEntryStatus(entry_id, status, source, opts)` | Updates `auto_queue_entries` status cleanly, logging the transition. |
+| `agentdesk.timeouts` | `clearDeadlockCountersForFreshSessions(stale_scan_minutes)` | Deletes stale `deadlock_check:*` markers for active sessions with fresh heartbeats. |
+| `agentdesk.timeouts` | `listStaleWorkingSessions(grace_minutes)` | Returns stale `turn_active`/`working` sessions plus active dispatch status for safe stale-session recovery. |
+| `agentdesk.timeouts` | `listDeadlockCandidates(stale_scan_minutes, limit)` | Returns bounded stale session candidates ordered by heartbeat without exposing session SQL to JS. |
+| `agentdesk.timeouts` | `markSessionIdle(session_key, opts)` | Transitions a stale active session to `idle`, optionally clearing `active_dispatch_id`. |
+| `agentdesk.timeouts` | `getDispatchType(dispatch_id)` | Returns a dispatch type or `null` for review-hang targeting. |
+| `agentdesk.timeouts` | `recordDeadlockTermination(payload)` | Inserts the deadlock-policy termination audit row with fixed component/reason fields. |
+| `agentdesk.timeouts` | `cleanupDeadlockCountersForInactiveSessions()` | Deletes `deadlock_check:*` markers whose sessions are no longer active. |
+| `agentdesk.timeouts` | `cleanupDeadlockHistoryBefore(cutoff_ms)` | Deletes old `deadlock_history:*` markers by timestamp suffix. |
 | `agentdesk.dispatch` | `create(...)` | Existing typed command, retained as-is. |
 | `agentdesk.kv` | `get/set/delete(...)` | Existing typed KV facade, preferred over `kv_meta` SQL. |
 
@@ -53,6 +61,7 @@ Other scalar columns keep the same shape as `query`; the difference is limited t
 - Prefer `agentdesk.cards.list(...)` over ad hoc `SELECT ... FROM kanban_cards`.
 - Prefer `agentdesk.cards.assign(...)` and `agentdesk.cards.setPriority(...)` over direct `UPDATE kanban_cards`.
 - Prefer `agentdesk.review.entryContext(...)` and `agentdesk.review.recordEntry(...)` for review round planning over ad hoc `task_dispatches`/`kanban_cards.review_round` SQL.
+- Prefer `agentdesk.timeouts.*` for active-monitor stale-session scans, session idle transitions, deadlock cleanup, dispatch-type lookups, and termination audits.
 - Prefer `agentdesk.kv.*` over `kv_meta` SQL.
 - Keep `agentdesk.db.*` for gaps, debugging, or transitional policy code only.
 
@@ -76,6 +85,20 @@ Other scalar columns keep the same shape as `query`; the difference is limited t
 
 The migrated slice covers `onReviewEnter` and its round-planning logic. A static test blocks any future `agentdesk.db.*` reintroduction inside that slice.
 
+`policies/timeouts/active-monitor.js` now routes Section I deadlock monitoring through:
+
+- `agentdesk.timeouts.clearDeadlockCountersForFreshSessions`
+- `agentdesk.timeouts.listStaleWorkingSessions`
+- `agentdesk.timeouts.listDeadlockCandidates`
+- `agentdesk.timeouts.markSessionIdle`
+- `agentdesk.timeouts.getDispatchType`
+- `agentdesk.timeouts.recordDeadlockTermination`
+- `agentdesk.timeouts.cleanupDeadlockCountersForInactiveSessions`
+- `agentdesk.timeouts.cleanupDeadlockHistoryBefore`
+- `agentdesk.kv.get/set/delete`
+
+The active-monitor policy capability manifest sets `db.raw_sql.mode=forbidden`, so static capability checks fail if `agentdesk.db.*` is reintroduced in that file.
+
 ## Backlog
 
 Typed-facade gaps are tracked as explicit follow-up slices instead of silent exceptions:
@@ -84,6 +107,6 @@ Typed-facade gaps are tracked as explicit follow-up slices instead of silent exc
 | --- | --- | --- |
 | `policies/review-automation.js` | verdict handling, pipeline-stage lookup, PR tracking card reads | typed review outcome + pipeline stage query facade |
 | `policies/kanban-rules.js` | preflight helpers, dispatch-completion reads, metadata merge helpers | typed preflight facade + card metadata patch facade |
-| `policies/timeouts.js` | stale dispatch/session scans, kv cleanup, long-turn alert queries | typed timeout scan facade + kv sweep facade |
+| `policies/timeouts.js` | remaining stale dispatch/orphan/long-turn alert queries outside active-monitor Section I | typed timeout scan facade + kv sweep facade |
 
 These slices remain allowed to use `agentdesk.db.*` until they are migrated and individually placed behind the same enforcement pattern.

--- a/policies/__tests__/support/harness.js
+++ b/policies/__tests__/support/harness.js
@@ -136,6 +136,14 @@ function createAgentdeskMock(options) {
     autoQueueResumes: [],
     autoQueueSavedPhaseGates: [],
     autoQueueClearedPhaseGates: [],
+    timeoutClearFreshCounterCalls: [],
+    timeoutStaleWorkingScans: [],
+    timeoutDeadlockCandidateScans: [],
+    timeoutMarkSessionIdleCalls: [],
+    timeoutDispatchTypeLookups: [],
+    timeoutTerminationRecords: [],
+    timeoutInactiveCounterCleanups: 0,
+    timeoutHistoryCleanupCalls: [],
     retrospectiveCalls: [],
     runtimeSignals: [],
     httpPosts: [],
@@ -149,6 +157,7 @@ function createAgentdeskMock(options) {
   const dbQuery = settings.dbQuery || (() => []);
   const dbExecute = settings.dbExecute || (() => ({ changes: 1 }));
   const exec = settings.exec || (() => "");
+  const timeouts = settings.timeouts || {};
   const cards = settings.cards || {};
   const counterChannels = settings.counterChannels || {};
   const primaryChannels = settings.primaryChannels || {};
@@ -308,6 +317,67 @@ function createAgentdeskMock(options) {
         return null;
       },
       refreshInventoryDocs() {}
+    },
+    timeouts: {
+      clearDeadlockCountersForFreshSessions(staleScanMinutes) {
+        state.timeoutClearFreshCounterCalls.push({ staleScanMinutes });
+        if (typeof timeouts.clearDeadlockCountersForFreshSessions === "function") {
+          return clone(timeouts.clearDeadlockCountersForFreshSessions(staleScanMinutes, state));
+        }
+        return { ok: true, deleted: 0 };
+      },
+      listStaleWorkingSessions(graceMinutes) {
+        state.timeoutStaleWorkingScans.push({ graceMinutes });
+        if (typeof timeouts.listStaleWorkingSessions === "function") {
+          return clone(timeouts.listStaleWorkingSessions(graceMinutes, state));
+        }
+        return clone(timeouts.staleWorkingSessions || []);
+      },
+      listDeadlockCandidates(staleScanMinutes, limit) {
+        state.timeoutDeadlockCandidateScans.push({ staleScanMinutes, limit });
+        if (typeof timeouts.listDeadlockCandidates === "function") {
+          return clone(timeouts.listDeadlockCandidates(staleScanMinutes, limit, state));
+        }
+        return clone(timeouts.deadlockCandidates || []);
+      },
+      markSessionIdle(sessionKey, optionsArg) {
+        state.timeoutMarkSessionIdleCalls.push({ sessionKey, options: clone(optionsArg || {}) });
+        if (typeof timeouts.markSessionIdle === "function") {
+          return clone(timeouts.markSessionIdle(sessionKey, optionsArg || {}, state));
+        }
+        return { ok: true, rows_affected: 1 };
+      },
+      getDispatchType(dispatchId) {
+        state.timeoutDispatchTypeLookups.push({ dispatchId });
+        if (typeof timeouts.getDispatchType === "function") {
+          return timeouts.getDispatchType(dispatchId, state);
+        }
+        if (timeouts.dispatchTypes && Object.prototype.hasOwnProperty.call(timeouts.dispatchTypes, dispatchId)) {
+          return timeouts.dispatchTypes[dispatchId];
+        }
+        return null;
+      },
+      recordDeadlockTermination(payload) {
+        state.timeoutTerminationRecords.push(clone(payload || {}));
+        if (typeof timeouts.recordDeadlockTermination === "function") {
+          return clone(timeouts.recordDeadlockTermination(payload || {}, state));
+        }
+        return { ok: true, rows_affected: 1 };
+      },
+      cleanupDeadlockCountersForInactiveSessions() {
+        state.timeoutInactiveCounterCleanups += 1;
+        if (typeof timeouts.cleanupDeadlockCountersForInactiveSessions === "function") {
+          return clone(timeouts.cleanupDeadlockCountersForInactiveSessions(state));
+        }
+        return { ok: true, deleted: 0 };
+      },
+      cleanupDeadlockHistoryBefore(cutoffMs) {
+        state.timeoutHistoryCleanupCalls.push({ cutoffMs });
+        if (typeof timeouts.cleanupDeadlockHistoryBefore === "function") {
+          return clone(timeouts.cleanupDeadlockHistoryBefore(cutoffMs, state));
+        }
+        return { ok: true, deleted: 0 };
+      }
     },
     http: {
       post(url, body) {

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -578,6 +578,25 @@ test("timeouts active monitor module checks tmux live panes exactly", () => {
   assert.equal(policy._tmuxHasLivePane("AgentDesk-codex-project-agentdesk"), true);
 });
 
+test("timeouts active monitor deadlock section uses typed timeout facade", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    timeouts: {
+      staleWorkingSessions: [],
+      deadlockCandidates: []
+    }
+  });
+
+  policy._section_I();
+
+  assert.equal(state.queries.length, 0);
+  assert.equal(state.executions.length, 0);
+  assert.deepEqual(toPlain(state.timeoutClearFreshCounterCalls), [{ staleScanMinutes: 30 }]);
+  assert.deepEqual(toPlain(state.timeoutStaleWorkingScans), [{ graceMinutes: 10 }]);
+  assert.deepEqual(toPlain(state.timeoutDeadlockCandidateScans), [{ staleScanMinutes: 30, limit: 50 }]);
+  assert.equal(state.timeoutInactiveCounterCleanups, 1);
+  assert.equal(state.timeoutHistoryCleanupCalls.length, 1);
+});
+
 test("timeouts active monitor module treats synthetic reattach placeholders as absent", () => {
   const sessionKey = "provider:AgentDesk-codex-project-agentdesk";
   const { policy, state } = loadPolicy("policies/timeouts.js", {
@@ -598,35 +617,16 @@ test("timeouts active monitor module treats synthetic reattach placeholders as a
         updated_at: timestampMinutesAgo(95)
       }
     ],
-    dbQuery: createSqlRouter([
-      {
-        match: "DELETE FROM kv_meta WHERE key IN",
-        result: []
-      },
-      {
-        match: "SELECT session_key FROM sessions WHERE status IN ('turn_active', 'working') AND last_heartbeat < datetime('now', '-10 minutes')",
-        result: []
-      },
-      {
-        match: "SELECT session_key, agent_id, active_dispatch_id, last_heartbeat FROM sessions WHERE status IN ('turn_active', 'working')",
-        result: [
-          {
-            session_key: sessionKey,
-            agent_id: "agent-1",
-            active_dispatch_id: "dispatch-1",
-            last_heartbeat: "2026-04-29 10:00:00"
-          }
-        ]
-      },
-      {
-        match: "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_check:%'",
-        result: []
-      },
-      {
-        match: "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_history:%'",
-        result: []
-      }
-    ]),
+    timeouts: {
+      deadlockCandidates: [
+        {
+          session_key: sessionKey,
+          agent_id: "agent-1",
+          active_dispatch_id: "dispatch-1",
+          last_heartbeat: "2026-04-29 10:00:00"
+        }
+      ]
+    },
     exec() {
       return "0\n";
     }
@@ -636,9 +636,9 @@ test("timeouts active monitor module treats synthetic reattach placeholders as a
 
   assert.equal(state.deadlockAlerts.length, 0);
   assert.equal(state.httpPosts.length, 0);
-  assert.match(state.executions[1].sql, /SET status = 'idle'/);
-  assert.deepEqual(toPlain(state.executions[1].params), [sessionKey]);
-  assert.deepEqual(toPlain(state.executions[2].params), ["deadlock_check:" + sessionKey]);
+  assert.deepEqual(toPlain(state.timeoutMarkSessionIdleCalls), [
+    { sessionKey, options: { clear_active_dispatch_id: false } }
+  ]);
 });
 
 test("timeouts active monitor opt-in review hang recovery retries stale review dispatches", () => {
@@ -663,34 +663,19 @@ test("timeouts active monitor opt-in review hang recovery retries stale review d
         dispatch_id: "dispatch-review-1"
       }
     ],
-    dbQuery: createSqlRouter([
-      { match: "DELETE FROM kv_meta WHERE key IN", result: [] },
-      {
-        match: "SELECT session_key FROM sessions WHERE status IN ('turn_active', 'working') AND last_heartbeat < datetime('now', '-10 minutes')",
-        result: []
-      },
-      {
-        match: "SELECT session_key, agent_id, active_dispatch_id, last_heartbeat FROM sessions WHERE status IN ('turn_active', 'working')",
-        result: [
-          {
-            session_key: sessionKey,
-            agent_id: "agent-review",
-            active_dispatch_id: "dispatch-review-1",
-            last_heartbeat: timestampMinutesAgo(16)
-          }
-        ]
-      },
-      {
-        match: "SELECT dispatch_type FROM task_dispatches WHERE id = ?",
-        result: [{ dispatch_type: "review" }]
-      },
-      {
-        match: "SELECT value FROM kv_meta WHERE key = ?",
-        result: [{ value: JSON.stringify({ count: 1, ts: previousCheck }) }]
-      },
-      { match: "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_check:%'", result: [] },
-      { match: "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_history:%'", result: [] }
-    ]),
+    timeouts: {
+      deadlockCandidates: [
+        {
+          session_key: sessionKey,
+          agent_id: "agent-review",
+          active_dispatch_id: "dispatch-review-1",
+          last_heartbeat: timestampMinutesAgo(16)
+        }
+      ],
+      dispatchTypes: {
+        "dispatch-review-1": "review"
+      }
+    },
     exec() {
       return "0\n";
     },
@@ -703,6 +688,7 @@ test("timeouts active monitor opt-in review hang recovery retries stale review d
       };
     }
   });
+  state.kv.set("deadlock_check:" + sessionKey, JSON.stringify({ count: 1, ts: previousCheck }));
 
   policy._section_I();
 
@@ -715,6 +701,8 @@ test("timeouts active monitor opt-in review hang recovery retries stale review d
   assert.match(state.httpPosts[0].body.reason, /review hang timeout/);
   assert.equal(state.deadlockAlerts.length, 1);
   assert.match(state.deadlockAlerts[0].message, /재디스패치 완료/);
+  assert.equal(state.timeoutTerminationRecords.length, 1);
+  assert.equal(state.timeoutTerminationRecords[0].session_key, sessionKey);
 });
 
 test("timeouts active monitor review fast path leaves non-review sessions on the normal threshold", () => {
@@ -725,30 +713,19 @@ test("timeouts active monitor review fast path leaves non-review sessions on the
       review_hang_auto_recovery_enabled: true,
       review_hang_auto_recovery_stale_min: 15
     },
-    dbQuery: createSqlRouter([
-      { match: "DELETE FROM kv_meta WHERE key IN", result: [] },
-      {
-        match: "SELECT session_key FROM sessions WHERE status IN ('turn_active', 'working') AND last_heartbeat < datetime('now', '-10 minutes')",
-        result: []
-      },
-      {
-        match: "SELECT session_key, agent_id, active_dispatch_id, last_heartbeat FROM sessions WHERE status IN ('turn_active', 'working')",
-        result: [
-          {
-            session_key: sessionKey,
-            agent_id: "agent-impl",
-            active_dispatch_id: "dispatch-impl-1",
-            last_heartbeat: timestampMinutesAgo(16)
-          }
-        ]
-      },
-      {
-        match: "SELECT dispatch_type FROM task_dispatches WHERE id = ?",
-        result: [{ dispatch_type: "implementation" }]
-      },
-      { match: "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_check:%'", result: [] },
-      { match: "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_history:%'", result: [] }
-    ]),
+    timeouts: {
+      deadlockCandidates: [
+        {
+          session_key: sessionKey,
+          agent_id: "agent-impl",
+          active_dispatch_id: "dispatch-impl-1",
+          last_heartbeat: timestampMinutesAgo(16)
+        }
+      ],
+      dispatchTypes: {
+        "dispatch-impl-1": "implementation"
+      }
+    },
     exec() {
       throw new Error("non-review session under 30 minutes should not probe tmux");
     }

--- a/policies/timeouts/active-monitor.cap.yaml
+++ b/policies/timeouts/active-monitor.cap.yaml
@@ -15,14 +15,8 @@ db:
       - sessions
       - session_termination_events
   raw_sql:
-    mode: legacy
-    capabilities:
-      - active_monitor_legacy_raw_db
-    markers_required: false
-    rationale: broad legacy timeout monitor DB access pinned by no-silent-growth baseline
-    no_silent_growth:
-      callsites: 18
-      fingerprint: sha256:01464111232ee18b4a513d3a77a985067a30cb8322a85af55d669e842a15d21b
+    mode: forbidden
+    rationale: active monitor session/deadlock DB access is mediated by agentdesk.timeouts.* and agentdesk.kv.*
 exec:
   allow:
     - tmux

--- a/policies/timeouts/active-monitor.js
+++ b/policies/timeouts/active-monitor.js
@@ -42,11 +42,7 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
   function reviewDispatchType(dispatchId) {
     if (!dispatchId) return null;
     try {
-      var rows = agentdesk.db.query(
-        "SELECT dispatch_type FROM task_dispatches WHERE id = ?",
-        [dispatchId]
-      );
-      return rows.length > 0 ? rows[0].dispatch_type : null;
+      return agentdesk.timeouts.getDispatchType(dispatchId);
     } catch (e) {
       agentdesk.log.warn("[deadlock] Failed to inspect dispatch type for " + dispatchId + ": " + e);
       return null;
@@ -84,22 +80,13 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
       var iInProgress = agentdesk.pipeline.nextGatedTarget(iInitial, iCfg);
 
       // 먼저: heartbeat가 신선한 working 세션의 카운터를 리셋 (비연속 스톨 누적 방지)
-      agentdesk.db.execute(
-        "DELETE FROM kv_meta WHERE key IN (" +
-        "SELECT 'deadlock_check:' || session_key FROM sessions " +
-        "WHERE status IN ('turn_active', 'working') " +
-        "AND last_heartbeat >= datetime('now', '-" + STALE_SCAN_MINUTES + " minutes')" +
-        ")"
-      );
+      agentdesk.timeouts.clearDeadlockCountersForFreshSessions(STALE_SCAN_MINUTES);
 
       // Fix stale working sessions: if status=working but no inflight file exists,
       // the turn has ended but DB wasn't updated. Fix to idle.
       // #219: Increased grace period from 3min to 10min — agents running long tool
       // calls (cargo build, subagents) may not send heartbeats for several minutes.
-      var staleWorkingSessions = agentdesk.db.query(
-        "SELECT session_key FROM sessions WHERE status IN ('turn_active', 'working') " +
-        "AND last_heartbeat < datetime('now', '-10 minutes')"
-      );
+      var staleWorkingSessions = agentdesk.timeouts.listStaleWorkingSessions(10);
       for (var sw = 0; sw < staleWorkingSessions.length; sw++) {
         var swKey = staleWorkingSessions[sw].session_key;
         var tmuxName = (swKey || "").split(":").pop();
@@ -119,15 +106,10 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
           // Without this, the dispatch stays "pending" as an orphan and gets
           // re-delivered or auto-completed, causing the failure loop.
           try {
-            var swSessInfo = agentdesk.db.query(
-              "SELECT active_dispatch_id FROM sessions WHERE session_key = ?", [swKey]
-            );
-            if (swSessInfo.length > 0 && swSessInfo[0].active_dispatch_id) {
-              var swDispId = swSessInfo[0].active_dispatch_id;
-              var swDispStatus = agentdesk.db.query(
-                "SELECT status FROM task_dispatches WHERE id = ?", [swDispId]
-              );
-              if (swDispStatus.length > 0 && (swDispStatus[0].status === "pending" || swDispStatus[0].status === "dispatched")) {
+            if (staleWorkingSessions[sw].active_dispatch_id) {
+              var swDispId = staleWorkingSessions[sw].active_dispatch_id;
+              var swDispStatus = staleWorkingSessions[sw].active_dispatch_status;
+              if (swDispStatus === "pending" || swDispStatus === "dispatched") {
                 agentdesk.dispatch.markFailed(swDispId, "Stale working session recovery — no active tmux session after 10min");
                 agentdesk.log.warn("[deadlock] Failed stale dispatch " + swDispId + " for session " + swKey);
               }
@@ -135,25 +117,14 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
           } catch(dispErr) {
             agentdesk.log.warn("[deadlock] Failed to mark dispatch for " + swKey + ": " + dispErr);
           }
-          agentdesk.db.execute(
-            "UPDATE sessions " +
-            "SET status = 'idle', active_dispatch_id = NULL, last_heartbeat = datetime('now') " +
-            "WHERE session_key = ? AND status IN ('turn_active', 'working')",
-            [swKey]
-          );
+          agentdesk.timeouts.markSessionIdle(swKey, { clear_active_dispatch_id: true });
           agentdesk.log.info("[deadlock] Fixed stale working session → idle: " + swKey);
         }
       }
 
       // 데드락 의심 세션: sessions.last_heartbeat 기반 판별
       // deadlock-manager 자신의 세션은 제외 (자기 자신을 오탐하는 무한 루프 방지)
-      var staleSessions = agentdesk.db.query(
-        "SELECT session_key, agent_id, active_dispatch_id, last_heartbeat " +
-        "FROM sessions WHERE status IN ('turn_active', 'working') " +
-        "AND session_key NOT LIKE '%deadlock-manager%' " +
-        "AND last_heartbeat < datetime('now', '-" + STALE_SCAN_MINUTES + " minutes') " +
-        "ORDER BY last_heartbeat ASC LIMIT 50"
-      );
+      var staleSessions = agentdesk.timeouts.listDeadlockCandidates(STALE_SCAN_MINUTES, 50);
       for (var dl = 0; dl < staleSessions.length; dl++) {
         var sess = staleSessions[dl];
         var deadlockKey = "deadlock_check:" + sess.session_key;
@@ -176,7 +147,7 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
         // Recent terminal output is the authoritative signal for "normal progress".
         // A live pane alone is not enough — hung tools can leave a pane alive forever.
         if (tmuxAlive && inflightProgress.recent && !inflightProgress.max_turn_reached) {
-          agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [deadlockKey]);
+          agentdesk.kv.delete(deadlockKey);
           var extendMin = sessionDeadlockMinutes;
           if (inflightProgress.turn_age_min !== null) {
             extendMin = Math.min(
@@ -213,31 +184,24 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
         // 활성 턴(inflight)이 없는 working 세션은 idle로 전환하고 스킵
         // (턴 완료 후 세션 상태가 working으로 남은 stale 케이스)
         if (!tmuxAlive || (!inflightProgress.channel_id && !inflightProgress.recent)) {
-          agentdesk.db.execute(
-            "UPDATE sessions " +
-            "SET status = 'idle', last_heartbeat = datetime('now') " +
-            "WHERE session_key = ? AND status IN ('turn_active', 'working')",
-            [sess.session_key]
-          );
-          agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [deadlockKey]);
+          agentdesk.timeouts.markSessionIdle(sess.session_key, { clear_active_dispatch_id: false });
+          agentdesk.kv.delete(deadlockKey);
           agentdesk.log.info("[deadlock] Stale working session → idle (no active turn): " + sess.session_key);
           continue;
         }
 
         // Check extension count + last check timestamp
-        var extRecord = agentdesk.db.query(
-          "SELECT value FROM kv_meta WHERE key = ?", [deadlockKey]
-        );
+        var extValue = agentdesk.kv.get(deadlockKey);
         var extensions = 0;
         var lastCheckAt = 0;
-        if (extRecord.length > 0) {
+        if (extValue) {
           try {
-            var parsed = JSON.parse(extRecord[0].value);
+            var parsed = JSON.parse(extValue);
             extensions = parsed.count || 0;
             lastCheckAt = parsed.ts || 0;
           } catch(e) {
             // 기존 형식(숫자만) 마이그레이션
-            extensions = parseInt(extRecord[0].value) || 0;
+            extensions = parseInt(extValue) || 0;
           }
         }
 
@@ -317,37 +281,35 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
               " turn_age_min=" + (inflightProgress.turn_age_min === null ? "null" : Math.round(inflightProgress.turn_age_min)) +
               " kill_ok=" + (!!forceKillResp.tmux_killed) +
               " inflight_cleared=" + (!!forceKillResp.inflight_cleared);
-            agentdesk.db.execute(
-              "INSERT INTO session_termination_events (session_key, dispatch_id, killer_component, reason_code, reason_text, probe_snapshot, tmux_alive) VALUES (?, ?, ?, ?, ?, ?, ?)",
-              [sess.session_key, sess.active_dispatch_id || null, "deadlock_policy", "deadlock_timeout",
-               timeoutLabel + " — " + (redispatched ? "redispatched" : "cancelled"), probeInfo, tmuxAlive ? 1 : 0]
-            );
+            agentdesk.timeouts.recordDeadlockTermination({
+              session_key: sess.session_key,
+              dispatch_id: sess.active_dispatch_id || null,
+              reason_text: timeoutLabel + " — " + (redispatched ? "redispatched" : "cancelled"),
+              probe_snapshot: probeInfo,
+              tmux_alive: !!tmuxAlive
+            });
           } catch (e) { /* fire-and-forget */ }
 
           // 6) 이력 기록 (legacy)
-          agentdesk.db.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?, ?)",
-            ["deadlock_history:" + sess.session_key + ":" + Date.now(),
-             JSON.stringify({
-               session_key: sess.session_key,
-               agent_id: sess.agent_id,
-               dispatch_id: sess.active_dispatch_id,
-               retry_dispatch_id: forceKillResp.retry_dispatch_id || null,
-               extensions: extensions,
-               action: redispatched ? "force_cancel_and_redispatch" : "force_cancel_only",
-               ts: new Date().toISOString()
-             })]
+          agentdesk.kv.set(
+            "deadlock_history:" + sess.session_key + ":" + Date.now(),
+            JSON.stringify({
+              session_key: sess.session_key,
+              agent_id: sess.agent_id,
+              dispatch_id: sess.active_dispatch_id,
+              retry_dispatch_id: forceKillResp.retry_dispatch_id || null,
+              extensions: extensions,
+              action: redispatched ? "force_cancel_and_redispatch" : "force_cancel_only",
+              ts: new Date().toISOString()
+            })
           );
 
           // 카운터 삭제 (다음 세션은 새 카운터)
-          agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [deadlockKey]);
+          agentdesk.kv.delete(deadlockKey);
 
         } else {
           // ── 데드락 의심: 카운터 증가 (타임스탬프 포함, last_heartbeat 인위적 덮어쓰기 없음) ──
-          agentdesk.db.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?, ?)",
-            [deadlockKey, JSON.stringify({ count: extensions + 1, ts: nowMs })]
-          );
+          agentdesk.kv.set(deadlockKey, JSON.stringify({ count: extensions + 1, ts: nowMs }));
           agentdesk.log.warn("[deadlock] Session " + sess.session_key +
             " — heartbeat stale " + sessionDeadlockMinutes + "min. Extension " +
             (extensions + 1) + "/" + sessionMaxExtensions);
@@ -360,24 +322,10 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
       }
 
       // Clean up deadlock counters for sessions no longer working
-      agentdesk.db.execute(
-        "DELETE FROM kv_meta WHERE key LIKE 'deadlock_check:%' AND " +
-        "REPLACE(key, 'deadlock_check:', '') NOT IN (" +
-        "  SELECT session_key FROM sessions WHERE status IN ('turn_active', 'working')" +
-        ")"
-      );
+      agentdesk.timeouts.cleanupDeadlockCountersForInactiveSessions();
 
       // Clean up old deadlock history entries (7일 이상)
-      var historyKeys = agentdesk.db.query(
-        "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_history:%'"
-      );
       var sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      for (var hk = 0; hk < historyKeys.length; hk++) {
-        var parts = historyKeys[hk].key.split(":");
-        var ts = parseInt(parts[parts.length - 1], 10);
-        if (ts && ts < sevenDaysAgo) {
-          agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [historyKeys[hk].key]);
-        }
-      }
+      agentdesk.timeouts.cleanupDeadlockHistoryBefore(sevenDaysAgo);
     };
 };

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -24,6 +24,7 @@ mod queue_ops;
 mod review_automation_ops;
 mod review_ops;
 mod runtime_ops;
+mod timeouts_ops;
 pub(crate) mod turn_ops;
 
 pub(crate) use db_ops::execute_policy_sql;
@@ -83,6 +84,7 @@ fn register_globals_pg_only(
     pipeline_ops::register_pipeline_ops(ctx, pg_pool.clone())?;
     dm_reply_ops::register_dm_reply_ops(ctx, pg_pool.clone())?;
     agent_ops::register_agent_ops(ctx, pg_pool.clone())?;
+    timeouts_ops::register_timeouts_ops(ctx, pg_pool.clone())?;
     turn_ops::register_turn_ops(ctx, pg_pool)?;
 
     Ok(())

--- a/src/engine/ops/timeouts_ops.rs
+++ b/src/engine/ops/timeouts_ops.rs
@@ -1,0 +1,529 @@
+use chrono::{DateTime, Utc};
+use rquickjs::{Ctx, Function, Object, Result as JsResult};
+use serde::Deserialize;
+use serde_json::json;
+use sqlx::{PgPool, Row as SqlxRow};
+
+// ── Timeout policy typed facade (#3733) ─────────────────────────────
+//
+// Replaces raw session/deadlock DB access in policies/timeouts/active-monitor.js
+// with narrow domain operations. Per-key deadlock marker values still use the
+// existing agentdesk.kv facade.
+
+pub(super) fn register_timeouts_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
+    let ad: Object<'js> = ctx.globals().get("agentdesk")?;
+    let obj = Object::new(ctx.clone())?;
+
+    let pg_clear_fresh = pg_pool.clone();
+    obj.set(
+        "__clearDeadlockCountersForFreshSessionsRaw",
+        Function::new(ctx.clone(), move |stale_scan_minutes: i32| -> String {
+            clear_deadlock_counters_for_fresh_sessions_raw(
+                pg_clear_fresh.as_ref(),
+                stale_scan_minutes,
+            )
+        })?,
+    )?;
+
+    let pg_stale_working = pg_pool.clone();
+    obj.set(
+        "__listStaleWorkingSessionsRaw",
+        Function::new(ctx.clone(), move |grace_minutes: i32| -> String {
+            list_stale_working_sessions_raw(pg_stale_working.as_ref(), grace_minutes)
+        })?,
+    )?;
+
+    let pg_candidates = pg_pool.clone();
+    obj.set(
+        "__listDeadlockCandidatesRaw",
+        Function::new(
+            ctx.clone(),
+            move |stale_scan_minutes: i32, limit: i32| -> String {
+                list_deadlock_candidates_raw(pg_candidates.as_ref(), stale_scan_minutes, limit)
+            },
+        )?,
+    )?;
+
+    let pg_mark_idle = pg_pool.clone();
+    obj.set(
+        "__markSessionIdleRaw",
+        Function::new(
+            ctx.clone(),
+            move |session_key: String, clear_active_dispatch_id: bool| -> String {
+                mark_session_idle_raw(
+                    pg_mark_idle.as_ref(),
+                    &session_key,
+                    clear_active_dispatch_id,
+                )
+            },
+        )?,
+    )?;
+
+    let pg_dispatch_type = pg_pool.clone();
+    obj.set(
+        "__getDispatchTypeRaw",
+        Function::new(ctx.clone(), move |dispatch_id: String| -> String {
+            get_dispatch_type_raw(pg_dispatch_type.as_ref(), &dispatch_id)
+        })?,
+    )?;
+
+    let pg_record = pg_pool.clone();
+    obj.set(
+        "__recordDeadlockTerminationRaw",
+        Function::new(ctx.clone(), move |payload_json: String| -> String {
+            record_deadlock_termination_raw(pg_record.as_ref(), &payload_json)
+        })?,
+    )?;
+
+    let pg_cleanup_counters = pg_pool.clone();
+    obj.set(
+        "__cleanupDeadlockCountersForInactiveSessionsRaw",
+        Function::new(ctx.clone(), move || -> String {
+            cleanup_deadlock_counters_for_inactive_sessions_raw(pg_cleanup_counters.as_ref())
+        })?,
+    )?;
+
+    let pg_cleanup_history = pg_pool;
+    obj.set(
+        "__cleanupDeadlockHistoryBeforeRaw",
+        Function::new(ctx.clone(), move |cutoff_ms: i64| -> String {
+            cleanup_deadlock_history_before_raw(pg_cleanup_history.as_ref(), cutoff_ms)
+        })?,
+    )?;
+
+    ad.set("timeouts", obj)?;
+
+    ctx.eval::<(), _>(
+        r#"
+        (function() {
+            function unwrap(result) {
+                if (result.error) throw new Error(result.error);
+                return result;
+            }
+            agentdesk.timeouts.clearDeadlockCountersForFreshSessions = function(staleScanMinutes) {
+                return unwrap(JSON.parse(agentdesk.timeouts.__clearDeadlockCountersForFreshSessionsRaw(staleScanMinutes)));
+            };
+            agentdesk.timeouts.listStaleWorkingSessions = function(graceMinutes) {
+                var result = unwrap(JSON.parse(agentdesk.timeouts.__listStaleWorkingSessionsRaw(graceMinutes)));
+                return result.sessions || [];
+            };
+            agentdesk.timeouts.listDeadlockCandidates = function(staleScanMinutes, limit) {
+                var result = unwrap(JSON.parse(agentdesk.timeouts.__listDeadlockCandidatesRaw(staleScanMinutes, limit || 50)));
+                return result.sessions || [];
+            };
+            agentdesk.timeouts.markSessionIdle = function(sessionKey, opts) {
+                opts = opts || {};
+                return unwrap(JSON.parse(agentdesk.timeouts.__markSessionIdleRaw(
+                    sessionKey || "",
+                    !!opts.clear_active_dispatch_id
+                )));
+            };
+            agentdesk.timeouts.getDispatchType = function(dispatchId) {
+                if (!dispatchId) return null;
+                var result = unwrap(JSON.parse(agentdesk.timeouts.__getDispatchTypeRaw(dispatchId || "")));
+                return result.dispatch_type || null;
+            };
+            agentdesk.timeouts.recordDeadlockTermination = function(payload) {
+                return unwrap(JSON.parse(agentdesk.timeouts.__recordDeadlockTerminationRaw(JSON.stringify(payload || {}))));
+            };
+            agentdesk.timeouts.cleanupDeadlockCountersForInactiveSessions = function() {
+                return unwrap(JSON.parse(agentdesk.timeouts.__cleanupDeadlockCountersForInactiveSessionsRaw()));
+            };
+            agentdesk.timeouts.cleanupDeadlockHistoryBefore = function(cutoffMs) {
+                return unwrap(JSON.parse(agentdesk.timeouts.__cleanupDeadlockHistoryBeforeRaw(cutoffMs || 0)));
+            };
+        })();
+        "#,
+    )?;
+
+    Ok(())
+}
+
+fn unavailable() -> String {
+    json!({ "error": "postgres backend is required for agentdesk.timeouts" }).to_string()
+}
+
+fn valid_minutes(value: i32, field: &str) -> Result<i32, String> {
+    if !(1..=24 * 60).contains(&value) {
+        return Err(format!("{field} must be between 1 and 1440 minutes"));
+    }
+    Ok(value)
+}
+
+fn valid_limit(value: i32, field: &str) -> Result<i32, String> {
+    if !(1..=500).contains(&value) {
+        return Err(format!("{field} must be between 1 and 500"));
+    }
+    Ok(value)
+}
+
+fn valid_session_key(session_key: &str) -> Result<String, String> {
+    let trimmed = session_key.trim();
+    if trimmed.is_empty() {
+        return Err("session_key is required".to_string());
+    }
+    Ok(trimmed.to_string())
+}
+
+fn valid_cutoff_ms(cutoff_ms: i64) -> Result<i64, String> {
+    if cutoff_ms <= 0 {
+        return Err("cutoff_ms must be positive".to_string());
+    }
+    Ok(cutoff_ms)
+}
+
+fn format_ts(value: Option<DateTime<Utc>>) -> serde_json::Value {
+    match value {
+        Some(value) => json!(value.format("%Y-%m-%d %H:%M:%S").to_string()),
+        None => serde_json::Value::Null,
+    }
+}
+
+fn clear_deadlock_counters_for_fresh_sessions_raw(
+    pg_pool: Option<&PgPool>,
+    stale_scan_minutes: i32,
+) -> String {
+    let minutes = match valid_minutes(stale_scan_minutes, "stale_scan_minutes") {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows_affected = sqlx::query(
+                "DELETE FROM kv_meta
+                 WHERE key IN (
+                    SELECT 'deadlock_check:' || session_key
+                    FROM sessions
+                    WHERE status IN ('turn_active', 'working')
+                      AND last_heartbeat >= NOW() - ($1::int * INTERVAL '1 minute')
+                 )",
+            )
+            .bind(minutes)
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("clear fresh-session deadlock counters: {error}"))?
+            .rows_affected();
+            Ok(json!({ "ok": true, "deleted": rows_affected }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn list_stale_working_sessions_raw(pg_pool: Option<&PgPool>, grace_minutes: i32) -> String {
+    let minutes = match valid_minutes(grace_minutes, "grace_minutes") {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows = sqlx::query(
+                "SELECT s.session_key,
+                        s.active_dispatch_id,
+                        td.status AS active_dispatch_status
+                 FROM sessions s
+                 LEFT JOIN task_dispatches td ON td.id = s.active_dispatch_id
+                 WHERE s.status IN ('turn_active', 'working')
+                   AND s.last_heartbeat < NOW() - ($1::int * INTERVAL '1 minute')
+                 ORDER BY s.last_heartbeat ASC",
+            )
+            .bind(minutes)
+            .fetch_all(&bridge_pool)
+            .await
+            .map_err(|error| format!("list stale working sessions: {error}"))?;
+
+            let sessions = rows
+                .into_iter()
+                .map(|row| {
+                    json!({
+                        "session_key": row.try_get::<Option<String>, _>("session_key").ok().flatten(),
+                        "active_dispatch_id": row.try_get::<Option<String>, _>("active_dispatch_id").ok().flatten(),
+                        "active_dispatch_status": row.try_get::<Option<String>, _>("active_dispatch_status").ok().flatten()
+                    })
+                })
+                .collect::<Vec<_>>();
+            Ok(json!({ "sessions": sessions }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn list_deadlock_candidates_raw(
+    pg_pool: Option<&PgPool>,
+    stale_scan_minutes: i32,
+    limit: i32,
+) -> String {
+    let minutes = match valid_minutes(stale_scan_minutes, "stale_scan_minutes") {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let limit = match valid_limit(limit, "limit") {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows = sqlx::query(
+                "SELECT session_key,
+                        agent_id,
+                        active_dispatch_id,
+                        last_heartbeat
+                 FROM sessions
+                 WHERE status IN ('turn_active', 'working')
+                   AND session_key NOT LIKE '%deadlock-manager%'
+                   AND last_heartbeat < NOW() - ($1::int * INTERVAL '1 minute')
+                 ORDER BY last_heartbeat ASC
+                 LIMIT $2",
+            )
+            .bind(minutes)
+            .bind(limit)
+            .fetch_all(&bridge_pool)
+            .await
+            .map_err(|error| format!("list deadlock candidates: {error}"))?;
+
+            let sessions = rows
+                .into_iter()
+                .map(|row| {
+                    let last_heartbeat =
+                        row.try_get::<Option<DateTime<Utc>>, _>("last_heartbeat")
+                            .ok()
+                            .flatten();
+                    json!({
+                        "session_key": row.try_get::<Option<String>, _>("session_key").ok().flatten(),
+                        "agent_id": row.try_get::<Option<String>, _>("agent_id").ok().flatten(),
+                        "active_dispatch_id": row.try_get::<Option<String>, _>("active_dispatch_id").ok().flatten(),
+                        "last_heartbeat": format_ts(last_heartbeat)
+                    })
+                })
+                .collect::<Vec<_>>();
+            Ok(json!({ "sessions": sessions }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn mark_session_idle_raw(
+    pg_pool: Option<&PgPool>,
+    session_key: &str,
+    clear_active_dispatch_id: bool,
+) -> String {
+    let session_key = match valid_session_key(session_key) {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows_affected = sqlx::query(
+                "UPDATE sessions
+                 SET status = 'idle',
+                     active_dispatch_id = CASE WHEN $2 THEN NULL ELSE active_dispatch_id END,
+                     last_heartbeat = NOW()
+                 WHERE session_key = $1
+                   AND status IN ('turn_active', 'working')",
+            )
+            .bind(&session_key)
+            .bind(clear_active_dispatch_id)
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("mark session idle {session_key}: {error}"))?
+            .rows_affected();
+            Ok(json!({ "ok": true, "rows_affected": rows_affected }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn get_dispatch_type_raw(pg_pool: Option<&PgPool>, dispatch_id: &str) -> String {
+    let dispatch_id = dispatch_id.trim().to_string();
+    if dispatch_id.is_empty() {
+        return json!({ "dispatch_type": null }).to_string();
+    }
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let dispatch_type = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT dispatch_type FROM task_dispatches WHERE id = $1",
+            )
+            .bind(&dispatch_id)
+            .fetch_optional(&bridge_pool)
+            .await
+            .map_err(|error| format!("load dispatch type {dispatch_id}: {error}"))?
+            .flatten();
+            Ok(json!({ "dispatch_type": dispatch_type }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+#[derive(Deserialize)]
+struct DeadlockTerminationPayload {
+    session_key: String,
+    dispatch_id: Option<String>,
+    reason_text: Option<String>,
+    probe_snapshot: Option<String>,
+    tmux_alive: bool,
+}
+
+fn record_deadlock_termination_raw(pg_pool: Option<&PgPool>, payload_json: &str) -> String {
+    let payload: DeadlockTerminationPayload = match serde_json::from_str(payload_json) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return json!({ "error": format!("invalid deadlock termination payload: {error}") })
+                .to_string();
+        }
+    };
+    let session_key = match valid_session_key(&payload.session_key) {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let dispatch_id = payload.dispatch_id.and_then(|value| {
+        let trimmed = value.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows_affected = sqlx::query(
+                "INSERT INTO session_termination_events
+                 (session_key, dispatch_id, killer_component, reason_code, reason_text, probe_snapshot, tmux_alive)
+                 VALUES ($1, $2, 'deadlock_policy', 'deadlock_timeout', $3, $4, $5)",
+            )
+            .bind(&session_key)
+            .bind(dispatch_id)
+            .bind(payload.reason_text)
+            .bind(payload.probe_snapshot)
+            .bind(if payload.tmux_alive { 1_i32 } else { 0_i32 })
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("record deadlock termination {session_key}: {error}"))?
+            .rows_affected();
+            Ok(json!({ "ok": true, "rows_affected": rows_affected }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn cleanup_deadlock_counters_for_inactive_sessions_raw(pg_pool: Option<&PgPool>) -> String {
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows_affected = sqlx::query(
+                "DELETE FROM kv_meta
+                 WHERE key LIKE 'deadlock_check:%'
+                   AND REPLACE(key, 'deadlock_check:', '') NOT IN (
+                      SELECT session_key
+                      FROM sessions
+                      WHERE status IN ('turn_active', 'working')
+                   )",
+            )
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("cleanup inactive deadlock counters: {error}"))?
+            .rows_affected();
+            Ok(json!({ "ok": true, "deleted": rows_affected }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+fn cleanup_deadlock_history_before_raw(pg_pool: Option<&PgPool>, cutoff_ms: i64) -> String {
+    let cutoff_ms = match valid_cutoff_ms(cutoff_ms) {
+        Ok(value) => value,
+        Err(error) => return json!({ "error": error }).to_string(),
+    };
+    let Some(pool) = pg_pool else {
+        return unavailable();
+    };
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let rows_affected = sqlx::query(
+                "DELETE FROM kv_meta
+                 WHERE key LIKE 'deadlock_history:%'
+                   AND regexp_replace(key, '^.*:', '') ~ '^[0-9]+$'
+                   AND regexp_replace(key, '^.*:', '')::bigint < $1",
+            )
+            .bind(cutoff_ms)
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("cleanup deadlock history before {cutoff_ms}: {error}"))?
+            .rows_affected();
+            Ok(json!({ "ok": true, "deleted": rows_affected }).to_string())
+        },
+        |error| json!({ "error": error }).to_string(),
+    ) {
+        Ok(result) => result,
+        Err(raw) => crate::engine::ops::ensure_js_error_json(raw),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_rejects_out_of_range_minutes() {
+        assert!(valid_minutes(0, "m").is_err());
+        assert!(valid_minutes(1441, "m").is_err());
+        assert_eq!(valid_minutes(30, "m").unwrap(), 30);
+    }
+
+    #[test]
+    fn validation_rejects_empty_session_key() {
+        assert!(valid_session_key("").is_err());
+        assert!(valid_session_key("  ").is_err());
+        assert_eq!(
+            valid_session_key(" provider:tmux ").unwrap(),
+            "provider:tmux"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a typed Rust agentdesk.timeouts facade for active-monitor stale session scans, idle transitions, deadlock cleanup, dispatch-type lookup, and termination audit insert
- migrate policies/timeouts/active-monitor.js off direct agentdesk.db.* calls, using agentdesk.timeouts.* plus agentdesk.kv.*
- flip active-monitor capability manifest to db.raw_sql.mode=forbidden and refresh policy raw-DB inventory counts from 184 to 166

## Verification
- node --test policies/__tests__/timeouts.test.js
- npm run test:policies
- python3 -m unittest tests/test_policy_db_capabilities.py
- python3 scripts/check_policy_db_capabilities.py --no-silent-growth
- PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh
- cargo fmt --check
- git diff --check
- cargo check --lib
- cargo test --lib engine::ops::timeouts_ops::tests

Fixes #3733