### PR TITLE
fix(discord): default Claude follow-up requeue on

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -577,6 +577,7 @@ src/
 │   │   │   ├── chunk_compose_tests.rs
 │   │   │   ├── completion_guard.rs
 │   │   │   ├── context_window.rs
+│   │   │   ├── followup_requeue.rs
 │   │   │   ├── headless_delivery.rs
 │   │   │   ├── memory_lifecycle.rs
 │   │   │   ├── mod.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1069,13 +1069,15 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6238 lines; production LoC; +4
+  - `src/services/discord/turn_bridge/mod.rs` (6233 lines; production LoC; +4
     from #3751 stamping the delivery-record owner channel into inflight state
     before cross-channel restart recovery reads durable anchors; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
     turn loop. #3479 extracted the task/session-panel line rendering +
     active-placeholder-card helpers into the `panel_lifecycle.rs` leaf.
     #3717 skips status-panel-v2 footer edits when only the spinner frame changes.
+    #3752 extracted the Claude TUI follow-up pre-submit requeue side effect into
+    `followup_requeue.rs`.
     Registered giant-file (#3038 decompose target — see
     `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).
     It surfaced as a giant only after #3028 fixed the prod/test splitter: an

--- a/docs/claude-e-rollout/operator-guide.md
+++ b/docs/claude-e-rollout/operator-guide.md
@@ -24,6 +24,19 @@ Channels with no explicit `runtime` inherit the provider-level value;
 provider with no explicit `runtime` falls back to the legacy
 `tui_hosting` boolean.
 
+## Claude TUI follow-up retry boundary
+
+Claude TUI warm follow-ups are automatically requeued by default when the
+failure is proven to be a pre-submit busy timeout: the readiness wait timed out
+before AgentDesk sent the prompt into the pane. That path is safe to retry
+because the provider never received the follow-up text. Set
+`AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE=0` (also accepts `false`, `off`, `no`,
+`disable`, or `disabled`) only as an emergency opt-out.
+
+Do not auto-requeue post-submit or ambiguous failures as a fresh prompt. Once
+the prompt may have reached the pane, retrying can double-send user input; those
+paths must keep the existing terminal/finalize or manual-recovery behavior.
+
 ## Live toggle
 
 1. Edit either

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -84,19 +84,87 @@ pub(crate) fn with_claude_tui_session_turn_lock<R>(
     f()
 }
 
-/// Opt-in (default OFF) via env `AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE=1`: when
-/// set, a claude TUI warm follow-up that hits the PRE-submit busy-timeout
-/// surfaces a retryable error so the turn bridge re-queues the inflight message
-/// instead of dropping it. The timeout is pre-submit (the prompt was never sent
-/// to the pane), so the retry cannot double-send. Off by default pending live
-/// validation of the race-path queue dynamics.
+const CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV: &str = "AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE";
+
+/// Default ON; set `AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE` to `0`, `false`,
+/// `off`, `no`, `disable`, or `disabled` for emergency opt-out.
 pub(crate) fn claude_tui_followup_requeue_enabled() -> bool {
-    std::env::var("AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE")
-        .map(|value| {
-            let value = value.trim();
-            value == "1" || value.eq_ignore_ascii_case("true")
-        })
-        .unwrap_or(false)
+    let Ok(value) = std::env::var(CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV) else {
+        return true;
+    };
+    !matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "0" | "false" | "off" | "no" | "disable" | "disabled"
+    )
+}
+
+#[cfg(test)]
+mod claude_tui_followup_requeue_flag_tests {
+    use super::*;
+
+    struct EnvRestore {
+        previous: Option<String>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => unsafe {
+                    std::env::set_var(CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV);
+                },
+            }
+        }
+    }
+
+    fn with_requeue_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .expect("shared test env lock poisoned");
+        let _restore = EnvRestore {
+            previous: std::env::var(CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV).ok(),
+        };
+        match value {
+            Some(value) => unsafe {
+                std::env::set_var(CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV, value);
+            },
+            None => unsafe {
+                std::env::remove_var(CLAUDE_TUI_FOLLOWUP_REQUEUE_ENV);
+            },
+        }
+        f()
+    }
+
+    #[test]
+    fn followup_requeue_defaults_on_when_env_is_unset() {
+        with_requeue_env(None, || assert!(claude_tui_followup_requeue_enabled()));
+    }
+
+    #[test]
+    fn followup_requeue_respects_emergency_opt_out_values() {
+        for value in ["0", "false", "FALSE", "off", "no", "disable", "disabled"] {
+            with_requeue_env(Some(value), || {
+                assert!(
+                    !claude_tui_followup_requeue_enabled(),
+                    "{value} should disable follow-up requeue"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn followup_requeue_keeps_legacy_opt_in_and_invalid_values_enabled() {
+        for value in ["1", "true", "TRUE", "on", "yes", "unexpected"] {
+            with_requeue_env(Some(value), || {
+                assert!(
+                    claude_tui_followup_requeue_enabled(),
+                    "{value} should leave follow-up requeue enabled"
+                );
+            });
+        }
+    }
 }
 
 /// Resolve the path to the claude binary.

--- a/src/services/claude_tui/hosting/followup_support.rs
+++ b/src/services/claude_tui/hosting/followup_support.rs
@@ -8,6 +8,8 @@ use crate::services::provider::{CancelToken, cancel_requested};
 const CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS: usize = 2;
 #[cfg(unix)]
 const CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE: &str = "⚠ Claude TUI가 아직 이전 터미널 턴을 처리 중이라 이 메시지를 주입하지 않았습니다. 현재 응답이 끝난 뒤 다시 보내 주세요.";
+#[cfg(unix)]
+const CLAUDE_TUI_BUSY_FOLLOWUP_REQUEUE_NOTICE: &str = "📬 Claude TUI가 아직 이전 터미널 턴을 처리 중이라 이 메시지를 바로 주입하지 못했습니다. 현재 응답이 끝나면 자동으로 다시 제출되도록 재시도 큐에 넣습니다.";
 
 #[cfg(unix)]
 pub(crate) fn emit_claude_tui_zero_harvest(
@@ -46,6 +48,7 @@ pub(super) fn emit_claude_tui_busy_followup_notice(
     sender: &Sender<StreamMessage>,
     tmux_session_name: &str,
     snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+    requeue_for_retry: bool,
 ) {
     tracing::warn!(
         tmux_session_name,
@@ -67,13 +70,90 @@ pub(super) fn emit_claude_tui_busy_followup_notice(
         snapshot.capture_available,
         snapshot.pane_tail
     ));
+    let notice = if requeue_for_retry {
+        CLAUDE_TUI_BUSY_FOLLOWUP_REQUEUE_NOTICE
+    } else {
+        CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE
+    };
     let _ = sender.send(StreamMessage::Text {
-        content: CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE.to_string(),
+        content: notice.to_string(),
     });
-    let _ = sender.send(StreamMessage::Done {
-        result: String::new(),
-        session_id: None,
-    });
+    if !requeue_for_retry {
+        let _ = sender.send(StreamMessage::Done {
+            result: String::new(),
+            session_id: None,
+        });
+    }
+}
+
+#[cfg(all(test, unix))]
+mod busy_followup_notice_tests {
+    use super::*;
+
+    fn busy_snapshot() -> crate::services::claude_tui::input::PromptReadinessSnapshot {
+        crate::services::claude_tui::input::PromptReadinessSnapshot {
+            prompt_marker_detected: false,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "Thinking...".to_string(),
+        }
+    }
+
+    fn emitted_text(requeue_for_retry: bool) -> String {
+        let (tx, rx) = std::sync::mpsc::channel();
+        emit_claude_tui_busy_followup_notice(
+            &tx,
+            "AgentDesk-claude-test",
+            &busy_snapshot(),
+            requeue_for_retry,
+        );
+        match rx.recv().expect("notice text") {
+            StreamMessage::Text { content } => content,
+            other => panic!("expected text notice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn busy_followup_notice_reports_automatic_retry_when_requeue_is_enabled() {
+        let text = emitted_text(true);
+        assert!(text.contains("자동으로 다시 제출"));
+        assert!(text.contains("재시도 큐"));
+    }
+
+    #[test]
+    fn busy_followup_notice_reports_manual_resend_when_requeue_is_disabled() {
+        let text = emitted_text(false);
+        assert!(text.contains("다시 보내 주세요"));
+    }
+
+    #[test]
+    fn busy_followup_notice_leaves_terminal_frame_to_retry_error_when_requeue_is_enabled() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        emit_claude_tui_busy_followup_notice(&tx, "AgentDesk-claude-test", &busy_snapshot(), true);
+        assert!(matches!(
+            rx.recv().expect("notice text"),
+            StreamMessage::Text { .. }
+        ));
+        assert!(
+            rx.try_recv().is_err(),
+            "automatic-retry path must not emit Done before the retryable Error reaches the bridge"
+        );
+    }
+
+    #[test]
+    fn busy_followup_notice_keeps_legacy_done_when_requeue_is_disabled() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        emit_claude_tui_busy_followup_notice(&tx, "AgentDesk-claude-test", &busy_snapshot(), false);
+        assert!(matches!(
+            rx.recv().expect("notice text"),
+            StreamMessage::Text { .. }
+        ));
+        assert!(matches!(
+            rx.recv().expect("legacy done"),
+            StreamMessage::Done { .. }
+        ));
+    }
 }
 
 #[cfg(unix)]

--- a/src/services/claude_tui/hosting/warm_followup.rs
+++ b/src/services/claude_tui/hosting/warm_followup.rs
@@ -360,10 +360,12 @@ fn run_claude_tui_warm_followup_submit_and_stream(
                     crate::services::claude_tui::input::prompt_readiness_snapshot(
                         tmux_session_name,
                     );
+                let requeue_for_retry = claude_tui_followup_wait_error_requeue_for_retry(&err);
                 emit_claude_tui_busy_followup_notice(
                     &sender,
                     tmux_session_name,
                     &post_wait_snapshot,
+                    requeue_for_retry,
                 );
                 log_producer_exit(
                     "tui_warm_followup_busy_pre_submit",
@@ -382,7 +384,7 @@ fn run_claude_tui_warm_followup_submit_and_stream(
                         "initial_busy_snapshot_prompt_draft_detected": snapshot.prompt_draft_detected,
                         "wait_outcome": if timed_out { "timeout" } else { "error" },
                         "wait_error": err.clone(),
-                        "requeue_for_retry": crate::services::claude::claude_tui_followup_requeue_enabled(),
+                        "requeue_for_retry": requeue_for_retry,
                     }),
                 );
                 // The busy-timeout is PRE-submit: the prompt was never sent to
@@ -390,7 +392,7 @@ fn run_claude_tui_warm_followup_submit_and_stream(
                 // When requeue is enabled, surface it as a retryable error so the
                 // turn bridge re-queues the inflight message (it holds owner/
                 // msg_id/text); otherwise keep the legacy drop-with-busy-notice.
-                if crate::services::claude::claude_tui_followup_requeue_enabled() {
+                if requeue_for_retry {
                     return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(err));
                 }
                 return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
@@ -595,6 +597,69 @@ fn run_claude_tui_warm_followup_submit_and_stream(
         }
     }
     ClaudeTuiWarmFollowupSubmitOutcome::FallThroughRecreate
+}
+
+fn claude_tui_followup_wait_error_requeue_for_retry(error: &str) -> bool {
+    crate::services::claude_tui::input::is_prompt_ready_timeout_error(error)
+        && crate::services::claude::claude_tui_followup_requeue_enabled()
+}
+
+#[cfg(test)]
+mod followup_wait_error_requeue_tests {
+    use super::*;
+
+    const FOLLOWUP_REQUEUE_ENV: &str = "AGENTDESK_CLAUDE_TUI_FOLLOWUP_REQUEUE";
+
+    struct EnvRestore {
+        previous: Option<String>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => unsafe { std::env::set_var(FOLLOWUP_REQUEUE_ENV, value) },
+                None => unsafe { std::env::remove_var(FOLLOWUP_REQUEUE_ENV) },
+            }
+        }
+    }
+
+    fn with_followup_requeue_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .expect("shared test env lock poisoned");
+        let _restore = EnvRestore {
+            previous: std::env::var(FOLLOWUP_REQUEUE_ENV).ok(),
+        };
+        match value {
+            Some(value) => unsafe { std::env::set_var(FOLLOWUP_REQUEUE_ENV, value) },
+            None => unsafe { std::env::remove_var(FOLLOWUP_REQUEUE_ENV) },
+        }
+        f()
+    }
+
+    #[test]
+    fn followup_wait_requeue_requires_timeout_error() {
+        with_followup_requeue_env(None, || {
+            assert!(claude_tui_followup_wait_error_requeue_for_retry(
+                "timeout waiting for claude tui follow-up prompt input readiness after 45s"
+            ));
+            assert!(!claude_tui_followup_wait_error_requeue_for_retry(
+                "unexpected prompt wait error"
+            ));
+            assert!(!claude_tui_followup_wait_error_requeue_for_retry(
+                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR
+            ));
+        });
+    }
+
+    #[test]
+    fn followup_wait_requeue_respects_emergency_opt_out() {
+        with_followup_requeue_env(Some("0"), || {
+            assert!(!claude_tui_followup_wait_error_requeue_for_retry(
+                "timeout waiting for claude tui follow-up prompt input readiness after 45s"
+            ));
+        });
+    }
 }
 
 /// Attempt a warm follow-up against an existing live Claude TUI tmux session.

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3326,11 +3326,10 @@ pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_
     provider: &ProviderKind,
     channel_id: ChannelId,
     inflight_state: &InflightTurnState,
-) {
-    let request_owner_user_id = inflight_state.request_owner_user_id;
+) -> MailboxEnqueueOutcome {
     let user_msg_id = inflight_state.user_msg_id;
     if user_msg_id == 0 || inflight_state.user_text.trim().is_empty() {
-        return;
+        return MailboxEnqueueOutcome::default();
     }
     let message_id = MessageId::new(user_msg_id);
     // FIX #6 (Codex P2): rebuild the retry Intervention from the persisted
@@ -3339,7 +3338,7 @@ pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_
     // context, attachments, and voice metadata. Legacy rows (pre-v9) default
     // these to None/empty/false, matching the previous behavior exactly.
     let intervention = Intervention {
-        author_id: UserId::new(request_owner_user_id),
+        author_id: UserId::new(inflight_state.request_owner_user_id),
         author_is_bot: false,
         message_id,
         source_message_ids: vec![message_id],
@@ -3352,7 +3351,147 @@ pub(in crate::services::discord) async fn mailbox_requeue_inflight_for_followup_
         pending_uploads: inflight_state.followup_pending_uploads.clone(),
         voice_announcement: inflight_state.followup_voice_announcement.clone(),
     };
-    let _ = mailbox_enqueue_intervention(shared, provider, channel_id, intervention).await;
+    mailbox_enqueue_intervention(shared, provider, channel_id, intervention).await
+}
+
+#[cfg(test)]
+mod followup_retry_requeue_tests {
+    use super::*;
+
+    const AGENTDESK_ROOT_DIR_ENV: &str = "AGENTDESK_ROOT_DIR";
+
+    struct EnvGuard {
+        previous: Option<String>,
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, value) },
+                None => unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) },
+            }
+        }
+    }
+
+    fn followup_inflight(channel_id: ChannelId, user_msg_id: MessageId) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id.get(),
+            Some("adk-cc".to_string()),
+            42,
+            user_msg_id.get(),
+            user_msg_id.get() + 1,
+            "please continue".to_string(),
+            Some("session-3752".to_string()),
+            Some("AgentDesk-claude-3752".to_string()),
+            Some("/tmp/agentdesk-3752.jsonl".to_string()),
+            None,
+            0,
+        );
+        state.set_followup_requeue_context(
+            Some("reply context".to_string()),
+            true,
+            false,
+            vec!["attachment-a".to_string(), "attachment-b".to_string()],
+            None,
+        );
+        state
+    }
+
+    #[test]
+    fn pre_submit_requeue_preserves_context_and_returns_enqueue_outcome() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .expect("shared env lock poisoned");
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard {
+            previous: std::env::var(AGENTDESK_ROOT_DIR_ENV).ok(),
+        };
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path()) };
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let shared = make_shared_data_for_tests();
+            let provider = ProviderKind::Claude;
+            let channel_id = ChannelId::new(3_752_001);
+            let user_msg_id = MessageId::new(3_752_101);
+            let state = followup_inflight(channel_id, user_msg_id);
+
+            let outcome =
+                mailbox_requeue_inflight_for_followup_retry(&shared, &provider, channel_id, &state)
+                    .await;
+
+            assert!(outcome.enqueued);
+            assert!(!outcome.merged);
+            assert_eq!(outcome.refusal_reason, None);
+            assert_eq!(outcome.persistence_error, None);
+
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
+            assert_eq!(snapshot.intervention_queue.len(), 1);
+            let intervention = &snapshot.intervention_queue[0];
+            assert_eq!(intervention.author_id, UserId::new(42));
+            assert_eq!(intervention.message_id, user_msg_id);
+            assert_eq!(intervention.source_message_ids, vec![user_msg_id]);
+            assert_eq!(intervention.text, "please continue");
+            assert_eq!(intervention.reply_context.as_deref(), Some("reply context"));
+            assert!(intervention.has_reply_boundary);
+            assert!(!intervention.merge_consecutive);
+            assert_eq!(
+                intervention.pending_uploads,
+                vec!["attachment-a".to_string(), "attachment-b".to_string()]
+            );
+            assert!(intervention.voice_announcement.is_none());
+        });
+    }
+
+    #[test]
+    fn pre_submit_requeue_reports_duplicate_refusal_outcome() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .expect("shared env lock poisoned");
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard {
+            previous: std::env::var(AGENTDESK_ROOT_DIR_ENV).ok(),
+        };
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path()) };
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let shared = make_shared_data_for_tests();
+            let provider = ProviderKind::Claude;
+            let channel_id = ChannelId::new(3_752_002);
+            let user_msg_id = MessageId::new(3_752_102);
+            let state = followup_inflight(channel_id, user_msg_id);
+
+            let first =
+                mailbox_requeue_inflight_for_followup_retry(&shared, &provider, channel_id, &state)
+                    .await;
+            let second =
+                mailbox_requeue_inflight_for_followup_retry(&shared, &provider, channel_id, &state)
+                    .await;
+
+            assert!(first.enqueued);
+            assert!(!second.enqueued);
+            assert_eq!(
+                second.refusal_reason,
+                Some(
+                    crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued
+                )
+            );
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
+            assert_eq!(
+                snapshot.intervention_queue.len(),
+                1,
+                "duplicate pre-submit requeue must not create a second queued prompt"
+            );
+        });
+    }
 }
 
 async fn mailbox_cancel_soft_intervention(

--- a/src/services/discord/recovery_paths/restart.rs
+++ b/src/services/discord/recovery_paths/restart.rs
@@ -674,6 +674,7 @@ mod tests {
         state
     }
 
+    #[cfg(unix)]
     fn touch_generation_marker(tmux_session_name: &str) -> i64 {
         let generation_path =
             crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
@@ -684,6 +685,7 @@ mod tests {
         crate::services::discord::tmux::read_generation_file_mtime_ns(tmux_session_name)
     }
 
+    #[cfg(unix)]
     fn write_current_generation_anchor(
         provider: &ProviderKind,
         channel_id: u64,
@@ -841,6 +843,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn anchor_record_lookup_uses_sidecar_owner_when_inflight_field_missing() {
         let _lock = crate::config::shared_test_env_lock()
@@ -884,6 +887,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn anchor_selection_falls_back_when_stale_sidecar_anchor_is_absent() {
         let _lock = crate::config::shared_test_env_lock()
@@ -923,6 +927,7 @@ mod tests {
         assert_eq!(anchor.panel_msg_id, 999);
     }
 
+    #[cfg(unix)]
     #[test]
     fn anchor_selection_keeps_legacy_candidate_when_sidecar_anchor_also_matches() {
         let _lock = crate::config::shared_test_env_lock()

--- a/src/services/discord/turn_bridge/followup_requeue.rs
+++ b/src/services/discord/turn_bridge/followup_requeue.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+pub(super) async fn requeue_claude_tui_followup_pre_submit_timeout(
+    shared_owned: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    inflight_state: &InflightTurnState,
+    dispatch_id: Option<&str>,
+    adk_session_key: Option<&str>,
+    turn_id: &str,
+) {
+    let requeue_outcome = super::super::mailbox_requeue_inflight_for_followup_retry(
+        shared_owned,
+        provider,
+        channel_id,
+        inflight_state,
+    )
+    .await;
+    let requeue_refusal_reason = requeue_outcome.refusal_reason.map(|reason| reason.as_str());
+    tracing::info!(
+        provider = %provider.as_str(),
+        channel = channel_id.get(),
+        user_msg_id = inflight_state.user_msg_id,
+        requeue_enqueued = requeue_outcome.enqueued,
+        requeue_merged = requeue_outcome.merged,
+        requeue_refusal_reason = requeue_refusal_reason.unwrap_or("none"),
+        requeue_persistence_error = requeue_outcome.persistence_error.as_deref().unwrap_or("none"),
+        "claude_tui follow-up pre-submit timeout: requeue attempt completed"
+    );
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider.as_str(),
+        channel_id.get(),
+        dispatch_id,
+        adk_session_key,
+        Some(turn_id),
+        "claude_tui_followup_pre_submit_requeue",
+        serde_json::json!({
+            "user_msg_id": inflight_state.user_msg_id,
+            "requeue_enqueued": requeue_outcome.enqueued,
+            "requeue_merged": requeue_outcome.merged,
+            "requeue_refusal_reason": requeue_refusal_reason,
+            "requeue_persistence_error": requeue_outcome.persistence_error,
+        }),
+    );
+
+    let retry_present_or_accepted = requeue_outcome.enqueued
+        || matches!(
+            requeue_outcome.refusal_reason,
+            Some(
+                crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued
+                    | crate::services::turn_orchestrator::EnqueueRefusalReason::LastItemDedup
+            )
+        );
+    if retry_present_or_accepted {
+        super::super::schedule_deferred_idle_queue_kickoff(
+            shared_owned.clone(),
+            provider.clone(),
+            channel_id,
+            "claude_tui_followup_requeue_inflight",
+        );
+    }
+}

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -2,6 +2,7 @@ mod cancel_finalize_policy;
 mod chunk_compose;
 mod completion_guard;
 mod context_window;
+mod followup_requeue;
 mod headless_delivery;
 mod memory_lifecycle;
 mod output_lifecycle;
@@ -82,8 +83,8 @@ pub(in crate::services::discord) use status_panel::{
     complete_status_panel_v2_with_http, normalize_status_panel_message_id,
 };
 pub(super) use streaming_edit_text::{
-    bridge_pre_submission_tui_prompt_error, bridge_tui_transport_error_should_skip_quiescence,
-    build_turn_bridge_streaming_edit_text,
+    CLAUDE_TUI_FOLLOWUP_REQUEUE_DELIVERY_NOTICE, bridge_claude_tui_followup_requeue_prompt_error,
+    bridge_tui_transport_error_should_skip_quiescence, build_turn_bridge_streaming_edit_text,
 };
 pub(super) use task_notification_lifecycle::{
     close_all_tracked_background_children, close_next_tracked_background_child,
@@ -3854,6 +3855,18 @@ pub(super) fn spawn_turn_bridge(
             tracing::warn!("  [{ts}] ⚠ invalid API_FRICTION marker: {error}");
         }
 
+        let claude_tui_followup_pre_submit_requeue_candidate =
+            crate::services::claude::claude_tui_followup_requeue_enabled()
+                && bridge_claude_tui_followup_requeue_prompt_error(
+                    &provider,
+                    inflight_state.runtime_kind,
+                    &full_response,
+                );
+        if claude_tui_followup_pre_submit_requeue_candidate {
+            full_response = CLAUDE_TUI_FOLLOWUP_REQUEUE_DELIVERY_NOTICE.to_string();
+            inflight_state.full_response = full_response.clone();
+        }
+
         let is_prompt_too_long = full_response.contains("__prompt too long__");
         let review_dispatch_warning = if !cancelled && !is_prompt_too_long {
             guard_review_dispatch_completion(
@@ -5609,12 +5622,13 @@ pub(super) fn spawn_turn_bridge(
             // the two gate sites.
             #[cfg(unix)]
             {
-                let tui_transport_error_skip_gate = transport_error
-                    && bridge_tui_transport_error_should_skip_quiescence(
+                let tui_transport_error_skip_gate = claude_tui_followup_pre_submit_requeue_candidate
+                    || (transport_error
+                        && bridge_tui_transport_error_should_skip_quiescence(
                         &provider,
                         inflight_state.runtime_kind,
                         &full_response,
-                    );
+                        ));
                 let bridge_gate_outcome = if terminal_delivery_committed
                     && !preserve_inflight_for_cleanup_retry
                     && !tui_transport_error_skip_gate
@@ -5643,36 +5657,17 @@ pub(super) fn spawn_turn_bridge(
                             "TUI transport error was already delivered; skipping quiescence gate so inflight cleanup can complete"
                         );
                     }
-                    if crate::services::claude::claude_tui_followup_requeue_enabled()
-                        && bridge_pre_submission_tui_prompt_error(&provider, &full_response)
-                    {
-                        // The follow-up never delivered its prompt (pre-submit
-                        // busy-timeout), so re-queue the inflight message to the
-                        // back of the mailbox for a retry instead of dropping it.
-                        super::mailbox_requeue_inflight_for_followup_retry(
+                    if claude_tui_followup_pre_submit_requeue_candidate {
+                        followup_requeue::requeue_claude_tui_followup_pre_submit_timeout(
                             &shared_owned,
                             &provider,
                             channel_id,
                             &inflight_state,
+                            dispatch_id.as_deref(),
+                            adk_session_key.as_deref(),
+                            turn_id.as_str(),
                         )
                         .await;
-                        tracing::info!(
-                            provider = %provider.as_str(),
-                            channel = channel_id.get(),
-                            user_msg_id = inflight_state.user_msg_id,
-                            "claude_tui follow-up pre-submit timeout: re-queued inflight message for retry"
-                        );
-                        // The bridge has already finalized the active turn and
-                        // computed its drain decision before this requeue runs, so
-                        // without an explicit kickoff the re-queued retry would sit
-                        // idle until unrelated activity pokes the mailbox. Schedule a
-                        // deferred idle-queue kickoff so it drains once the pane frees.
-                        super::schedule_deferred_idle_queue_kickoff(
-                            shared_owned.clone(),
-                            provider.clone(),
-                            channel_id,
-                            "claude_tui_followup_requeue_inflight",
-                        );
                     }
                     super::tmux::TuiCompletionGateOutcome::NotGated
                 };

--- a/src/services/discord/turn_bridge/streaming_edit_text.rs
+++ b/src/services/discord/turn_bridge/streaming_edit_text.rs
@@ -50,6 +50,32 @@ pub(in crate::services::discord) fn bridge_pre_submission_tui_prompt_error(
     }
 }
 
+pub(in crate::services::discord) const CLAUDE_TUI_FOLLOWUP_REQUEUE_DELIVERY_NOTICE: &str = "📬 Claude TUI가 아직 이전 터미널 턴을 처리 중이라 이 메시지를 바로 주입하지 못했습니다. 현재 응답이 끝나면 자동으로 다시 제출되도록 재시도 큐에 넣습니다.";
+
+pub(in crate::services::discord) fn bridge_claude_tui_followup_requeue_prompt_error(
+    provider: &ProviderKind,
+    runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
+    full_response: &str,
+) -> bool {
+    if !matches!(provider, ProviderKind::Claude)
+        || !matches!(
+            runtime_kind,
+            Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui)
+        )
+    {
+        return false;
+    }
+    let Some(error_text) = full_response
+        .trim_start()
+        .strip_prefix("Error:")
+        .map(str::trim_start)
+    else {
+        return false;
+    };
+    crate::services::claude_tui::input::is_prompt_ready_timeout_error(error_text)
+        && error_text.contains("follow-up prompt input readiness")
+}
+
 pub(in crate::services::discord) fn bridge_tui_transport_error_should_skip_quiescence(
     provider: &ProviderKind,
     runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
@@ -128,6 +154,7 @@ mod streaming_edit_text_tests {
 #[cfg(test)]
 mod pre_submission_tui_prompt_error_tests {
     use super::*;
+    use crate::services::agent_protocol::RuntimeHandoffKind;
 
     #[test]
     fn classifier_matches_wrapped_readiness_errors() {
@@ -150,9 +177,59 @@ mod pre_submission_tui_prompt_error_tests {
     }
 
     #[test]
-    fn tui_transport_errors_skip_quiescence_only_for_matching_tui_runtime() {
-        use crate::services::agent_protocol::RuntimeHandoffKind;
+    fn followup_requeue_classifier_only_accepts_claude_tui_followup_readiness_timeouts() {
+        let followup = "Error: timeout waiting for claude tui follow-up prompt input readiness after 45s; reason=prompt_marker_not_detected; previous_tui_turn_still_running=true; prompt_marker_detected=false; prompt_draft_detected=false; capture_available=true";
+        assert!(bridge_claude_tui_followup_requeue_prompt_error(
+            &ProviderKind::Claude,
+            Some(RuntimeHandoffKind::ClaudeTui),
+            followup
+        ));
 
+        for response in [
+            "Error: timeout waiting for claude tui fresh prompt input readiness after 120s; fresh prompt readiness attempts exhausted (3 attempts)",
+            "Error: timeout waiting for codex tui prompt input readiness after 8s",
+            "Error: claude tui session died after prompt submit",
+        ] {
+            assert!(
+                !bridge_claude_tui_followup_requeue_prompt_error(
+                    &ProviderKind::Claude,
+                    Some(RuntimeHandoffKind::ClaudeTui),
+                    response
+                ),
+                "{response} must not enter the Claude follow-up requeue path"
+            );
+        }
+
+        assert!(!bridge_claude_tui_followup_requeue_prompt_error(
+            &ProviderKind::Codex,
+            Some(RuntimeHandoffKind::CodexTui),
+            followup
+        ));
+        assert!(!bridge_claude_tui_followup_requeue_prompt_error(
+            &ProviderKind::Claude,
+            None,
+            followup
+        ));
+        assert!(CLAUDE_TUI_FOLLOWUP_REQUEUE_DELIVERY_NOTICE.contains("재시도 큐"));
+    }
+
+    #[test]
+    fn classifier_rejects_post_submit_and_ambiguous_tui_errors() {
+        for response in [
+            "Error: claude tui session died after prompt submit",
+            "Error: claude tui prompt submit confirmation unavailable after 3 retries; capture_available=false",
+            "Error: claude tui prompt submit left draft after 3 enter retries; prompt_marker_detected=true; prompt_draft_detected=true; capture_available=true",
+            "Error: Timeout waiting for output file",
+        ] {
+            assert!(
+                !bridge_pre_submission_tui_prompt_error(&ProviderKind::Claude, response),
+                "{response} must not be retried as a fresh prompt"
+            );
+        }
+    }
+
+    #[test]
+    fn tui_transport_errors_skip_quiescence_only_for_matching_tui_runtime() {
         assert!(bridge_tui_transport_error_should_skip_quiescence(
             &ProviderKind::Claude,
             Some(RuntimeHandoffKind::ClaudeTui),


### PR DESCRIPTION
## Summary
- Promote Claude TUI follow-up pre-submit requeue to default-on with emergency opt-out values.
- Scope auto-requeue to ClaudeTui follow-up prompt-readiness timeouts only, not Codex or fresh startup timeouts.
- Preserve retry payload context and surface requeue accepted/refused/deduped outcome logs/lifecycle events.
- Pin the visible busy notice to automatic retry when requeue is active and avoid sending `Done` before the retryable error reaches the bridge.
- Document the retry boundary and non-requeue post-submit/ambiguous failure rule.

Closes #3752

## Verification
- `cargo test --lib claude_tui_followup_requeue -- --nocapture`
- `cargo test --lib busy_followup_notice -- --nocapture`
- `cargo test --lib pre_submission_tui_prompt_error -- --nocapture`
- `cargo test --lib pre_submit_requeue -- --nocapture`
- `cargo test --lib classifier_rejects_post_submit -- --nocapture`
- `cargo test --lib prompt_ready_timeout_clears_only_retryable_followup_drafts -- --nocapture`
- `cargo test --lib claude_busy_followup_defers_to_queue_without_readiness_poll -- --nocapture`
- `AGENTDESK_ROOT_DIR=$(mktemp -d) cargo test --lib followup_requeue_context_round_trips_and_defaults_when_absent -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_agent_maintenance_docs.py` (0 errors, existing module-inventory warning)
- `cargo check --lib`
- `just check` not run: `just` is not installed in this environment.

## Review
- Fresh Codex xhigh review: initial review found 2 issues; both fixed.
- Fresh Codex xhigh re-review: `VERDICT: CLEAN`.
