### PR TITLE
fix(discord): route reaction control replies through v3

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -431,11 +431,13 @@ src/
 │   │   │   ├── message.rs
 │   │   │   ├── mod.rs
 │   │   │   ├── policy.rs
+│   │   │   ├── reaction_control.rs
 │   │   │   ├── result.rs
 │   │   │   ├── send_api.rs
 │   │   │   ├── send_gate.rs
 │   │   │   ├── send_target.rs
 │   │   │   ├── send_to_agent.rs
+│   │   │   ├── serenity_reference.rs
 │   │   │   ├── transport.rs
 │   │   │   └── turn_output_controller.rs
 │   │   ├── placeholder_live_events/

--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -126,17 +126,19 @@ These callsites already use the unified delivery engine. Rows marked
 | `src/services/discord/gateway.rs:359` (`send_intake_placeholder`) | `placeholder_sends` (intake) | **migrated_v3**. Posts the `"..."` placeholder before a turn via direct v3. Uses `preserve_inline_content().without_idempotency()` to preserve streaming behavior. |
 | `src/services/discord/gateway.rs:377` (`edit_outbound_message`) | `placeholder_sends` (edit) | **migrated_v3**. Encodes edit through `OutboundOperation::Edit`. |
 | `src/services/discord/gateway.rs:400` (`TurnGateway::{send_message, edit_message}`) | turn-bridge messages/edits | **migrated_v3 transitively via gateway**. Used for handoff, rollover freeze, snapshot, stable update, and terminal edit. |
+| `src/services/discord/router/intake_gate.rs` (`send_reaction_control_reply`) | reaction-control lifecycle replies | **migrated_v3**. Short fixed replies for queued-card POST fallback and duplicate stop now use referenced v3 lifecycle notices. Correlation = `intake-reaction-control:<channel_id>:<message_id>`, semantic = `intake-reaction-control:<channel_id>:<message_id>:<reason_key>`. |
 | `src/services/discord/monitoring_status.rs:115` (`deliver_monitoring_status`) | monitoring status | **migrated_v3**. Status banner send + edit with `preserve_inline_content`; edits use `without_idempotency()`. |
 | `src/services/discord/meeting_orchestrator.rs:754, 796` (`meeting_outbound_message` / edit path) | meeting status / cancel / parse-error | **migrated_v3**. Stable meeting dedup metadata plus `OutboundOperation::Edit`. |
 | `src/services/routines/discord_log.rs:486, 531` (`deliver_or_update_discord_summary`) | routine Discord summary | **migrated_v3**. Uses direct v3 send/edit and disables semantic dedupe for repeated summary writes. |
 | `src/integration_tests/discord_flow/scenarios.rs` (removed in #3035 Phase 1) | integration test harness | Mock-Discord roundtrip for §1.2 validation; legacy-sqlite-only harness deleted. |
 | `src/integration_tests/agents_setup_e2e.rs` (removed in #3035 Phase 1) | integration test | Wizard-ready E2E; legacy-sqlite-only harness deleted. |
 
-Total **direct migrated_v3 production families: 11** (`dispatch_outbox`,
+Total **direct migrated_v3 production families: 12** (`dispatch_outbox`,
 `review_notifications`, final dispatch completion summaries, issue
 announcements, monitoring status, meeting notifications, routine Discord
 summaries, CLI text/DM helper, short manual notifications, short manual DM
-notifications, and gateway/turn-bridge placeholder sends/edits).
+notifications, intake reaction-control replies, and gateway/turn-bridge
+placeholder sends/edits).
 
 No production caller uses the removed legacy facade. Verify with
 `git grep -n 'deliver_outbound' -- src/services src/bin tests`.
@@ -168,10 +170,9 @@ interaction tokens or ephemeral visibility.
 | `src/services/discord/commands/meeting_cmd.rs:33, 42, 83, 97` | `/meeting` ACK | excluded |
 | `src/services/discord/commands/text_commands.rs:1239` | text-command running banner | excluded |
 | `src/services/discord/commands/model_picker.rs:60, 132` | `/model` picker | excluded |
-| `src/services/discord/router/intake_gate.rs:258` | reaction-control reply | excluded — reply with reference inside slash interaction |
 | `src/services/discord/router/intake_gate.rs:960, 1071` | "duplicate-queue" + "drain-pending" notices | candidate — these are bot notifications, not interaction tokens. Triage: **low priority**, very short fixed strings, no length risk. |
 
-Total commands-bucket: **62 callsites**, all explicitly excluded.
+Total commands-bucket: **61 callsites**, all explicitly excluded.
 
 #### B.2 File / attachment uploads
 
@@ -273,7 +274,7 @@ button hits the manual outbound API, which is covered under §3.A
    Remove the manual `/api/discord/send` and `/api/discord/send-dm` over-2k compatibility shims
    once v3 can send multipart attachment payloads or explicitly delegate to a
    chunk/attachment transport variant.
-5. **Direct-send candidates (low priority).** §B.1
+5. **Direct-send candidates (low priority).** §B.1 remaining duplicate/drain
    intake-gate notices, §B.4 tmux lifecycle notices, §B.5 router announces.
    Each is a fixed short string; v3 buys consistent dedup keying.
 6. **Out of scope (separate follow-up issues recommended).**
@@ -300,6 +301,12 @@ button hits the manual outbound API, which is covered under §3.A
   `v3_dm_user_target_resolves_before_posting` verifies `OutboundTarget::DmUser`
   resolves before first post and duplicate replay does not resolve the DM
   channel again.
+- `src/services/discord/outbound/delivery.rs`:
+  `v3_referenced_send_preserves_reference_and_dedupes` verifies referenced v3
+  sends preserve the reply target and duplicate replay avoids a second post.
+- `src/services/discord/outbound/reaction_control.rs`:
+  `reaction_control_reply_ids_are_stable_per_message_and_reason` verifies the
+  reaction-control lifecycle replies keep stable correlation and semantic ids.
 - `src/services/discord/turn_bridge/mod.rs`:
   `final_completion_delivery_stays_blocked_until_terminal_message_commits`
   verifies final completion delivery remains blocked until the terminal Discord

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -46,7 +46,6 @@ direct_discord_sends = [
   # announce-token fallback is removed; deliver_outbound currently collapses
   # HTTP status / Discord error code into a string on edit failures.
   "src/services/issue_announcements.rs#direct_discord_sends:c953e696eec38deb",
-  "src/services/discord/router/intake_gate.rs#direct_discord_sends:0a2beaabe9619b4f",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:2bf7e5b93d0fda6b",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:07b7e52940af8eab",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:1cc530214eb6c5d6",

--- a/src/services/discord/outbound/delivery.rs
+++ b/src/services/discord/outbound/delivery.rs
@@ -703,6 +703,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct MockClient {
         posts: Arc<Mutex<Vec<(String, String)>>>,
+        referenced_posts: Arc<Mutex<Vec<(String, String, String, String)>>>,
         dm_resolutions: Arc<Mutex<Vec<String>>>,
         length_failures_remaining: Arc<Mutex<usize>>,
         send_failures_remaining: Arc<Mutex<usize>>,
@@ -729,6 +730,10 @@ mod tests {
 
         fn posts(&self) -> Vec<(String, String)> {
             self.posts.lock().unwrap().clone()
+        }
+
+        fn referenced_posts(&self) -> Vec<(String, String, String, String)> {
+            self.referenced_posts.lock().unwrap().clone()
         }
 
         fn dm_resolutions(&self) -> Vec<String> {
@@ -774,6 +779,25 @@ mod tests {
                 ));
             }
             Ok(format!("msg-{target_channel}-{}", content.chars().count()))
+        }
+
+        async fn post_message_with_reference(
+            &self,
+            target_channel: &str,
+            content: &str,
+            reference_channel: &str,
+            reference_message: &str,
+        ) -> Result<String, DispatchMessagePostError> {
+            self.referenced_posts.lock().unwrap().push((
+                target_channel.to_string(),
+                content.to_string(),
+                reference_channel.to_string(),
+                reference_message.to_string(),
+            ));
+            Ok(format!(
+                "msg-ref-{target_channel}-{reference_channel}-{reference_message}-{}",
+                content.chars().count()
+            ))
         }
 
         async fn resolve_dm_channel(
@@ -889,6 +913,51 @@ mod tests {
             other => panic!("expected duplicate, got {other:?}"),
         }
         assert_eq!(client.posts().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn v3_referenced_send_preserves_reference_and_dedupes() {
+        let client = MockClient::default();
+        let dedup = OutboundDeduper::new();
+        let make = || {
+            DiscordOutboundMessage::new(
+                "intake-reaction-control:123:456",
+                "intake-reaction-control:123:456:already_stopping",
+                "Already stopping...",
+                OutboundTarget::Channel(ChannelId::new(123)),
+                DiscordOutboundPolicy::preserve_inline_content(),
+            )
+            .with_reference(OutboundReferenceContext::reply_to(
+                ChannelId::new(123),
+                poise::serenity_prelude::MessageId::new(456),
+            ))
+        };
+
+        let first = deliver_outbound(&client, &dedup, make(), None).await;
+        assert!(matches!(first, DeliveryResult::Sent { .. }));
+        let second = deliver_outbound(&client, &dedup, make(), None).await;
+
+        match second {
+            DeliveryResult::Duplicate {
+                existing_messages, ..
+            } => {
+                assert_eq!(
+                    existing_messages[0].raw_message_id,
+                    "msg-ref-123-123-456-19"
+                );
+            }
+            other => panic!("expected duplicate, got {other:?}"),
+        }
+        assert!(client.posts().is_empty());
+        assert_eq!(
+            client.referenced_posts(),
+            vec![(
+                "123".to_string(),
+                "Already stopping...".to_string(),
+                "123".to_string(),
+                "456".to_string(),
+            )]
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/outbound/mod.rs
+++ b/src/services/discord/outbound/mod.rs
@@ -13,11 +13,13 @@ pub(in crate::services::discord) mod delivery_record; // #3089 B0
 pub(crate) mod manual_delivery;
 pub(crate) mod message;
 pub(crate) mod policy;
+pub(in crate::services::discord) mod reaction_control;
 pub(crate) mod result;
 pub(crate) mod send_api;
 pub(crate) mod send_gate;
 pub(crate) mod send_target;
 pub(crate) mod send_to_agent;
+pub(in crate::services::discord) mod serenity_reference;
 mod transport;
 pub(in crate::services::discord) mod turn_output_controller; // #3089 A1
 

--- a/src/services/discord/outbound/reaction_control.rs
+++ b/src/services/discord/outbound/reaction_control.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use poise::serenity_prelude as serenity;
+
+use crate::services::discord::SharedData;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) enum ReactionControlReplyReason {
+    QueuedCardPostFailed,
+    AlreadyStopping,
+}
+
+impl ReactionControlReplyReason {
+    fn key(self) -> &'static str {
+        match self {
+            Self::QueuedCardPostFailed => "queued_card_post_failed",
+            Self::AlreadyStopping => "already_stopping",
+        }
+    }
+}
+
+pub(in crate::services::discord) async fn send_reaction_control_reply(
+    ctx: &serenity::Context,
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+    message_id: serenity::MessageId,
+    reason: ReactionControlReplyReason,
+    content: &str,
+) {
+    let (correlation_id, semantic_event_id) =
+        reaction_control_reply_delivery_ids(channel_id, message_id, reason);
+    if let Err(error) = super::serenity_reference::send_referenced_lifecycle_notice(
+        ctx.http.clone(),
+        shared.clone(),
+        channel_id,
+        message_id,
+        content,
+        correlation_id,
+        semantic_event_id,
+    )
+    .await
+    {
+        tracing::warn!(
+            channel_id = channel_id.get(),
+            message_id = message_id.get(),
+            reason = reason.key(),
+            error = %error,
+            "[discord] reaction-control lifecycle notice delivery failed"
+        )
+    }
+}
+
+fn reaction_control_reply_delivery_ids(
+    channel_id: serenity::ChannelId,
+    message_id: serenity::MessageId,
+    reason: ReactionControlReplyReason,
+) -> (String, String) {
+    (
+        format!(
+            "intake-reaction-control:{}:{}",
+            channel_id.get(),
+            message_id.get()
+        ),
+        format!(
+            "intake-reaction-control:{}:{}:{}",
+            channel_id.get(),
+            message_id.get(),
+            reason.key()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReactionControlReplyReason, reaction_control_reply_delivery_ids};
+    use poise::serenity_prelude::{ChannelId, MessageId};
+
+    #[test]
+    fn reaction_control_reply_ids_are_stable_per_message_and_reason() {
+        let channel_id = ChannelId::new(123);
+        let message_id = MessageId::new(456);
+
+        let queued = reaction_control_reply_delivery_ids(
+            channel_id,
+            message_id,
+            ReactionControlReplyReason::QueuedCardPostFailed,
+        );
+        let stopping = reaction_control_reply_delivery_ids(
+            channel_id,
+            message_id,
+            ReactionControlReplyReason::AlreadyStopping,
+        );
+
+        assert_eq!(queued.0, "intake-reaction-control:123:456");
+        assert_eq!(
+            queued.1,
+            "intake-reaction-control:123:456:queued_card_post_failed"
+        );
+        assert_eq!(stopping.0, "intake-reaction-control:123:456");
+        assert_eq!(
+            stopping.1,
+            "intake-reaction-control:123:456:already_stopping"
+        );
+    }
+}

--- a/src/services/discord/outbound/serenity_reference.rs
+++ b/src/services/discord/outbound/serenity_reference.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use poise::serenity_prelude as serenity;
+use serenity::{ChannelId, MessageId};
+
+use crate::services::dispatches::discord_delivery::{
+    DispatchMessagePostError, DispatchMessagePostErrorKind,
+};
+
+use super::delivery::{deliver_outbound, first_raw_message_id};
+use super::message::{DiscordOutboundMessage, OutboundReferenceContext, OutboundTarget};
+use super::policy::DiscordOutboundPolicy;
+use super::result::DeliveryResult;
+use super::{DiscordOutboundClient, shared_outbound_deduper};
+use crate::services::discord::{SharedData, rate_limit_wait};
+
+struct SerenityReferenceOutboundClient {
+    http: Arc<serenity::Http>,
+    shared: Arc<SharedData>,
+}
+
+pub(in crate::services::discord) async fn send_referenced_lifecycle_notice(
+    http: Arc<serenity::Http>,
+    shared: Arc<SharedData>,
+    channel_id: ChannelId,
+    reference_message_id: MessageId,
+    content: &str,
+    correlation_id: String,
+    semantic_event_id: String,
+) -> Result<Option<MessageId>, String> {
+    let client = SerenityReferenceOutboundClient { http, shared };
+    let msg = DiscordOutboundMessage::new(
+        correlation_id,
+        semantic_event_id,
+        content,
+        OutboundTarget::Channel(channel_id),
+        DiscordOutboundPolicy::preserve_inline_content(),
+    )
+    .with_reference(OutboundReferenceContext::reply_to(
+        channel_id,
+        reference_message_id,
+    ));
+    delivery_message_id(deliver_outbound(&client, shared_outbound_deduper(), msg, None).await)
+}
+
+fn delivery_message_id(result: DeliveryResult) -> Result<Option<MessageId>, String> {
+    match result {
+        DeliveryResult::Sent { messages, .. } => first_raw_message_id(&messages)
+            .as_deref()
+            .map(parse_message_id)
+            .transpose(),
+        DeliveryResult::Duplicate {
+            existing_messages, ..
+        } => first_raw_message_id(&existing_messages)
+            .as_deref()
+            .map(parse_message_id)
+            .transpose(),
+        DeliveryResult::Fallback { messages, .. } => first_raw_message_id(&messages)
+            .as_deref()
+            .map(parse_message_id)
+            .transpose(),
+        DeliveryResult::Skip { .. } => Ok(None),
+        DeliveryResult::PermanentFailure { reason } => Err(reason),
+    }
+}
+
+impl DiscordOutboundClient for SerenityReferenceOutboundClient {
+    async fn post_message(
+        &self,
+        target_channel: &str,
+        content: &str,
+    ) -> Result<String, DispatchMessagePostError> {
+        let channel_id = parse_channel_id(target_channel)?;
+        rate_limit_wait(&self.shared, channel_id).await;
+        channel_id
+            .send_message(
+                &self.http,
+                serenity::CreateMessage::new()
+                    .content(content)
+                    .allowed_mentions(super::super::http::relay_allowed_mentions()),
+            )
+            .await
+            .map(|message| message.id.get().to_string())
+            .map_err(dispatch_post_error)
+    }
+
+    async fn post_message_with_reference(
+        &self,
+        target_channel: &str,
+        content: &str,
+        reference_channel: &str,
+        reference_message: &str,
+    ) -> Result<String, DispatchMessagePostError> {
+        let channel_id = parse_channel_id(target_channel)?;
+        let reference_channel_id = parse_channel_id(reference_channel)?;
+        let reference_message_id = parse_message_id(reference_message).map_err(|error| {
+            DispatchMessagePostError::new(DispatchMessagePostErrorKind::Other, error)
+        })?;
+        rate_limit_wait(&self.shared, channel_id).await;
+        channel_id
+            .send_message(
+                &self.http,
+                serenity::CreateMessage::new()
+                    .reference_message(
+                        serenity::MessageReference::from((
+                            reference_channel_id,
+                            reference_message_id,
+                        ))
+                        .fail_if_not_exists(false),
+                    )
+                    .content(content)
+                    .allowed_mentions(super::super::http::relay_allowed_mentions()),
+            )
+            .await
+            .map(|message| message.id.get().to_string())
+            .map_err(dispatch_post_error)
+    }
+}
+
+fn parse_channel_id(raw: &str) -> Result<ChannelId, DispatchMessagePostError> {
+    raw.parse::<u64>().map(ChannelId::new).map_err(|error| {
+        DispatchMessagePostError::new(
+            DispatchMessagePostErrorKind::Other,
+            format!("invalid Discord channel id {raw}: {error}"),
+        )
+    })
+}
+
+fn parse_message_id(raw: &str) -> Result<MessageId, String> {
+    raw.parse::<u64>()
+        .map(MessageId::new)
+        .map_err(|error| format!("invalid Discord message id {raw}: {error}"))
+}
+
+fn dispatch_post_error(error: serenity::Error) -> DispatchMessagePostError {
+    let detail = crate::utils::redact::redact_known_secrets(&error.to_string());
+    let lowered = detail.to_ascii_lowercase();
+    let kind = if detail.contains("BASE_TYPE_MAX_LENGTH")
+        || lowered.contains("2000 or fewer in length")
+        || lowered.contains("length")
+    {
+        DispatchMessagePostErrorKind::MessageTooLong
+    } else {
+        DispatchMessagePostErrorKind::Other
+    };
+    DispatchMessagePostError::new(kind, detail)
+}

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1,3 +1,6 @@
+use super::super::outbound::reaction_control::{
+    ReactionControlReplyReason, send_reaction_control_reply,
+};
 use super::super::*;
 
 mod busy_duplicate_notice;
@@ -800,24 +803,6 @@ pub(super) fn classify_removed_control_reaction(
     }
 }
 
-async fn send_reaction_control_reply(
-    ctx: &serenity::Context,
-    shared: &std::sync::Arc<SharedData>,
-    channel_id: serenity::ChannelId,
-    message_id: serenity::MessageId,
-    content: &str,
-) {
-    rate_limit_wait(shared, channel_id).await;
-    let _ = channel_id
-        .send_message(
-            &ctx.http,
-            serenity::builder::CreateMessage::new()
-                .reference_message((channel_id, message_id))
-                .content(content),
-        )
-        .await;
-}
-
 /// #3009: when a follow-up message is *merged* into the previous queue head
 /// (`MailboxEnqueueOutcome::merged == true`), the head intervention's
 /// `message_id` is rewritten to this follow-up's id while the older ids are
@@ -1268,6 +1253,7 @@ async fn render_visible_queued_ack(
                 &data.shared,
                 channel_id,
                 user_msg_id,
+                ReactionControlReplyReason::QueuedCardPostFailed,
                 "📬 큐에 추가됨 — 카드 표시는 실패했지만 메시지는 큐잉되었습니다.",
             )
             .await;
@@ -1594,6 +1580,7 @@ async fn handle_reaction_remove(
                         &data.shared,
                         channel_id,
                         removed_reaction.message_id,
+                        ReactionControlReplyReason::AlreadyStopping,
                         "Already stopping...",
                     )
                     .await;


### PR DESCRIPTION
Issue: #3731

## Summary
- move intake reaction-control lifecycle replies off the direct-send allowlist into v3 outbound delivery
- add a referenced Serenity outbound client for short lifecycle reply sends with stable correlation/semantic IDs
- document the migration and remove the intake_gate direct-send allowlist entry

## Verification
- cargo fmt --all --check
- cargo check --lib
- cargo test --lib reaction_control_reply -- --nocapture
- cargo test --lib v3_referenced_send_preserves_reference_and_dedupes -- --nocapture
- AGENTDESK_ROOT_DIR=<tmp> cargo test --lib intake_gate -- --nocapture
- /opt/homebrew/bin/python3 scripts/audit_maintainability.py --check
- /opt/homebrew/bin/python3 scripts/generate_inventory_docs.py --check
- PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh
- git diff --check