### PR TITLE
fix(discord): sanitize subagent streaming notifications

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1069,7 +1069,7 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6233 lines; production LoC; +4
+  - `src/services/discord/turn_bridge/mod.rs` (6237 lines; production LoC; +4
     from #3751 stamping the delivery-record owner channel into inflight state
     before cross-channel restart recovery reads durable anchors; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
@@ -1078,6 +1078,9 @@
     #3717 skips status-panel-v2 footer edits when only the spinner frame changes.
     #3752 extracted the Claude TUI follow-up pre-submit requeue side effect into
     `followup_requeue.rs`.
+    #3777 skips streaming rollover for start-anchored Codex subagent
+    notifications so live edits render the shared card instead of freezing raw
+    XML/JSON chunks.
     Registered giant-file (#3038 decompose target — see
     `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).
     It surfaced as a giant only after #3028 fixed the prod/test splitter: an

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -84,7 +84,8 @@ pub(in crate::services::discord) use status_panel::{
 };
 pub(super) use streaming_edit_text::{
     CLAUDE_TUI_FOLLOWUP_REQUEUE_DELIVERY_NOTICE, bridge_claude_tui_followup_requeue_prompt_error,
-    bridge_tui_transport_error_should_skip_quiescence, build_turn_bridge_streaming_edit_text,
+    bridge_streaming_rollover_should_skip, bridge_tui_transport_error_should_skip_quiescence,
+    build_turn_bridge_streaming_edit_text,
 };
 pub(super) use task_notification_lifecycle::{
     close_all_tracked_background_children, close_next_tracked_background_child,
@@ -3422,6 +3423,9 @@ pub(super) fn spawn_turn_bridge(
                         current_tool_line.as_deref(),
                         &full_response,
                     );
+                    if bridge_streaming_rollover_should_skip(current_portion) {
+                        break;
+                    }
                     let Some(plan) =
                         super::formatting::plan_streaming_rollover(current_portion, &status_block)
                     else {

--- a/src/services/discord/turn_bridge/streaming_edit_text.rs
+++ b/src/services/discord/turn_bridge/streaming_edit_text.rs
@@ -24,8 +24,46 @@ pub(in crate::services::discord) fn build_turn_bridge_streaming_edit_text(
             provider,
         )
     } else {
-        super::formatting::build_streaming_placeholder_text(current_portion, status_block)
+        build_provider_streaming_placeholder_text(current_portion, status_block, provider)
     }
+}
+
+pub(in crate::services::discord) fn bridge_streaming_rollover_should_skip(
+    current_portion: &str,
+) -> bool {
+    streaming_subagent_notification_card(current_portion).is_some()
+}
+
+fn streaming_subagent_notification_card(current_portion: &str) -> Option<String> {
+    let direct =
+        crate::services::discord::response_sanitizer::subagent_notification_card::sanitize_start_anchored_subagent_notification(
+            current_portion,
+        );
+    if direct.is_some() {
+        return direct;
+    }
+    let stripped = crate::services::discord::response_sanitizer::strip_leading_tui_response_chrome(
+        current_portion,
+    );
+    if stripped == current_portion {
+        return None;
+    }
+    crate::services::discord::response_sanitizer::subagent_notification_card::sanitize_start_anchored_subagent_notification(
+        &stripped,
+    )
+}
+
+fn build_provider_streaming_placeholder_text(
+    current_portion: &str,
+    status_block: &str,
+    provider: &ProviderKind,
+) -> String {
+    if current_portion.is_empty() {
+        return super::formatting::build_streaming_placeholder_text("", status_block);
+    }
+    let formatted =
+        super::formatting::format_for_discord_with_status_panel(current_portion, provider);
+    super::formatting::build_streaming_placeholder_text(&formatted, status_block)
 }
 
 pub(in crate::services::discord) fn bridge_pre_submission_tui_prompt_error(
@@ -140,6 +178,72 @@ mod streaming_edit_text_tests {
         );
 
         assert_eq!(rendered, "Partial answer\n\n⠙ 계속 처리 중");
+    }
+
+    #[test]
+    fn legacy_streaming_edit_sanitizes_subagent_notification_3777() {
+        let current_portion = r#"<subagent_notification>
+{"agent_path":"/tmp/agent","status":{"completed":"Read-only review complete.\n\nVERDICT: CLEAN"}}
+</subagent_notification>"#;
+        let rendered = build_turn_bridge_streaming_edit_text(
+            false,
+            current_portion,
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+
+        assert!(rendered.contains("Subagent completed"));
+        assert!(rendered.contains("Read-only review complete."));
+        assert!(rendered.contains("VERDICT: CLEAN"));
+        assert!(rendered.ends_with("⠙ 계속 처리 중"));
+        assert!(!rendered.contains("<subagent_notification>"));
+        assert!(!rendered.contains("agent_path"));
+        assert!(!rendered.contains("/tmp/agent"));
+    }
+
+    #[test]
+    fn rollover_skips_start_anchored_subagent_notification_3777() {
+        let current_portion = format!(
+            r#"<subagent_notification>
+{{"agent_path":"/tmp/agent","status":{{"completed":"{}"}}}}
+</subagent_notification>"#,
+            "x".repeat(2400),
+        );
+
+        assert!(bridge_streaming_rollover_should_skip(&current_portion));
+
+        let rendered = build_turn_bridge_streaming_edit_text(
+            false,
+            &current_portion,
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+        assert!(rendered.contains("Subagent completed"));
+        assert!(!rendered.contains("<subagent_notification>"));
+        assert!(!rendered.contains("agent_path"));
+        assert!(rendered.len() <= 2000);
+    }
+
+    #[test]
+    fn rollover_skips_chrome_prefixed_subagent_notification_3777() {
+        let current_portion = format!(
+            "No response requested.\n<subagent_notification>\n{{\"agent_path\":\"/tmp/agent\",\"status\":{{\"completed\":\"{}\"}}}}\n</subagent_notification>",
+            "x".repeat(2400),
+        );
+
+        assert!(bridge_streaming_rollover_should_skip(&current_portion));
+
+        let rendered = build_turn_bridge_streaming_edit_text(
+            false,
+            &current_portion,
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+        assert!(rendered.contains("Subagent completed"));
+        assert!(!rendered.contains("No response requested."));
+        assert!(!rendered.contains("<subagent_notification>"));
+        assert!(!rendered.contains("agent_path"));
+        assert!(rendered.len() <= 2000);
     }
 
     #[test]


### PR DESCRIPTION
Issue: #3777

## Summary
- sanitize legacy turn-bridge streaming edits through the existing provider/status-panel formatter so start-anchored Codex subagent envelopes render as the shared card instead of raw XML/JSON
- skip streaming rollover for start-anchored subagent notifications so raw envelopes are not frozen into partial chunks
- update change-surface freeze notes for the turn_bridge touch

## Verification
- cargo fmt --all --check
- cargo check --lib
- cargo test --lib 3777 -- --nocapture
- /opt/homebrew/bin/python3 scripts/generate_inventory_docs.py --check
- /opt/homebrew/bin/python3 scripts/check_agent_maintenance_docs.py
- /opt/homebrew/bin/python3 scripts/audit_maintainability.py --check
- PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh
- git diff --check