### PR TITLE
Fix session key identity parsing

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1013,7 +1013,8 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2732 lines; +2 from #3711/#3712 mapping direct TUI runtime-binding-unavailable rebind failures to 409 Conflict; #3676 moved
+  - `src/services/discord/health/recovery.rs` (2729 lines; -3 from #3795
+    routing session-key tail fallback through `SessionIdentity`; +2 from #3711/#3712 mapping direct TUI runtime-binding-unavailable rebind failures to 409 Conflict; #3676 moved
     `tmux_alive_relay_dead` watchdog reattach logic into sibling
     `health/relay_dead_reattach.rs`, leaving recovery.rs with only the
     pre-cleanup hook so final transcript output can be delivered without
@@ -1460,11 +1461,12 @@
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
   - `src/db/postgres.rs` (1280 lines; #3651: the `FOREGROUND_RESERVE` process-global, the `background_should_yield` backpressure predicate + pure `should_yield_for_counters` helper, the `clamp_foreground_reserve` helper that keeps the background budget >= 1 for small `pool_max` configs, reserve install+clamp in `connect`, and the predicate + clamp unit tests; #3690: preferred_intake_node_labels upsert/sync + COALESCE preserve; #3692: `agent_roster_sync_enabled` leader-ownership gate on the roster sync; #3722 adds the bounded startup advisory lock wrapper plus concurrency coverage for migration/config-audit/reseed startup sections).
-  - `src/db/dispatched_sessions.rs` (1628 lines; dispatched session
+  - `src/db/dispatched_sessions.rs` (1627 lines; dispatched session
     persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
     durable-truth accessor the idle-relay drift self-heal reads; #3693: +2 to
     include `cwd` in provider resume selector lookup; #3718 makes runtime
-    activity heartbeat refresh monotonic via `GREATEST`).
+    activity heartbeat refresh monotonic via `GREATEST`; -1 from #3795 using
+    the central `SessionIdentity` tmux-tail helper).
   - `src/db/session_transcripts.rs` is a retained PG-cleanup surface (now below
     the giant-file threshold; bugfix only).
   - `src/db/prompt_manifests/` (directory, refactored).
@@ -1492,7 +1494,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
 - `src/services/onboarding/mod.rs` (2937),
-  `src/services/dispatched_sessions.rs` (1546), and
+  `src/services/dispatched_sessions.rs` (1550), and
   `src/services/settings.rs` (1114) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
@@ -1547,7 +1549,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   while the prior turn streams; +20 from #3637 centralizing post-paste error
   cleanup and making draft clearing cancel-agnostic.)
 - `src/services/memory/memento.rs` (1893).
-- `src/services/dispatched_sessions.rs` (1546) — dispatched session domain
+- `src/services/dispatched_sessions.rs` (1550) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database
   callsites, but the module itself is now giant-file territory; split focused
   helpers before adding non-bugfix behavior. (+5 from #3169 exposing the idle-
@@ -1555,7 +1557,9 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   watchdog liveness guard; +47 from #3693 making kill-tmux's `resumable` claim
   match Claude TUI transcript-backed resume semantics; +105 from #3718 making
   idle-kill skip active-dispatch sessions, use runtime output age as the
-  live-activity guard anchor, and log kill/skip timing decisions.)
+  live-activity guard anchor, and log kill/skip timing decisions; +4 from #3795
+  replacing inline session-key split errors with central `SessionIdentity`
+  helper calls and explicit legacy/namespaced error messages.)
 - `src/services/settings.rs` (1114) — settings domain service extracted from
   the route layer in #1519. Keep follow-up changes bugfix-only unless the file
   is split further.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,7 +364,7 @@ CREATE TABLE task_dispatches (
 -- 세션 (기존 PCD dispatched_sessions 유지)
 CREATE TABLE sessions (
   id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-  session_key         TEXT UNIQUE,         -- hostname:tmux-session
+  session_key         TEXT UNIQUE,         -- legacy host:tmux or namespaced provider/token/host:tmux
   agent_id            TEXT REFERENCES agents(id),
   provider            TEXT DEFAULT 'claude',
   status              TEXT DEFAULT 'disconnected',

--- a/docs/recovery-paths.md
+++ b/docs/recovery-paths.md
@@ -125,9 +125,10 @@ All three paths parse the same session-key shapes. Parsing is centralised in
 - legacy: `<host>:<tmux_name>`
 - namespaced: `<provider>/<token_hash>/<host>:<tmux_name>`
 
-Existing scattered `split_once(':')` call sites
-(`services/queue.rs`, `server/routes/session_activity.rs`, etc.) continue to
-compile — they are slated for migration in follow-up cleanups.
+Production session-key call sites that need host/tmux identity route through
+`SessionIdentity::parse` or its `tmux_name_from_session_key` wrapper. Remaining
+raw colon splitting uses are non-session string parsing, the parser
+implementation itself, or explicitly out-of-scope compatibility surfaces.
 
 ## Inflight Cleanup SSoT
 
@@ -162,8 +163,6 @@ lane (`docs/high-risk-recovery-lane.md`).
 Tracked under #1074 follow-ups:
 
 - Mechanical split of `recovery_engine.rs` into the three path modules.
-- Migrate remaining inline `split_once(':')` sites to
-  `session_identity::SessionIdentity::parse`.
 - Move `reregister_active_turn_from_inflight` and
   `rebind_inflight_for_channel` helpers into `recovery::runtime` and
   `recovery::manual_rebind` respectively, leaving `recovery_engine.rs` as a

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -5,6 +5,7 @@ use crate::db::agents::resolve_agent_channel_for_provider_pg;
 use crate::db::session_agent_resolution::{
     normalize_thread_channel_id, parse_thread_channel_id_from_session_key,
 };
+use crate::services::discord::session_identity::tmux_name_from_session_key;
 use crate::services::session_activity::SessionActivityResolver;
 
 pub(crate) async fn load_dispatch_thread_id_pg(pool: &PgPool, dispatch_id: &str) -> Option<String> {
@@ -789,9 +790,7 @@ pub(crate) async fn list_dispatched_sessions_pg(
 }
 
 fn tmux_session_name_from_session_key(session_key: Option<&str>) -> Option<String> {
-    let (_, tmux_session) = session_key?.split_once(':')?;
-    let tmux_session = tmux_session.trim();
-    (!tmux_session.is_empty()).then(|| tmux_session.to_string())
+    tmux_name_from_session_key(session_key?)
 }
 
 #[cfg(test)]

--- a/src/db/session_agent_resolution.rs
+++ b/src/db/session_agent_resolution.rs
@@ -1,6 +1,7 @@
 use sqlx::{PgPool, Row as SqlxRow};
 
 use crate::db::agents::AgentChannelBindings;
+use crate::services::discord::session_identity::SessionIdentity;
 use crate::services::provider::parse_provider_and_channel_from_tmux_name;
 
 pub(crate) fn parse_thread_channel_name(channel_name: &str) -> Option<(&str, &str)> {
@@ -14,10 +15,8 @@ pub(crate) fn parse_thread_channel_name(channel_name: &str) -> Option<(&str, &st
 }
 
 pub(crate) fn parse_channel_name_from_session_key(session_key: &str) -> Option<String> {
-    // Session keys can be plain `host:tmux-name` or namespaced
-    // `provider/token-hash/host:tmux-name`; the tmux session name is always the final segment.
-    let (_, tmux_name) = session_key.rsplit_once(':')?;
-    let (_, channel_name) = parse_provider_and_channel_from_tmux_name(tmux_name)?;
+    let identity = SessionIdentity::parse(session_key)?;
+    let (_, channel_name) = parse_provider_and_channel_from_tmux_name(&identity.tmux_name)?;
     Some(channel_name)
 }
 
@@ -275,4 +274,31 @@ pub(crate) async fn resolve_agent_id_for_session_pg(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_channel_name_from_session_key, parse_thread_channel_id_from_session_key};
+
+    #[test]
+    fn parses_channel_name_from_namespaced_session_key() {
+        assert_eq!(
+            parse_channel_name_from_session_key(
+                "codex/hash123/mac-mini:AgentDesk-codex-adk-cdx-t1500628371829428350"
+            )
+            .as_deref(),
+            Some("adk-cdx-t1500628371829428350")
+        );
+    }
+
+    #[test]
+    fn parses_thread_channel_id_from_namespaced_session_key() {
+        assert_eq!(
+            parse_thread_channel_id_from_session_key(
+                "codex/hash123/mac-mini:AgentDesk-codex-adk-cdx-t1500628371829428350"
+            )
+            .as_deref(),
+            Some("1500628371829428350")
+        );
+    }
 }

--- a/src/engine/ops/exec_ops.rs
+++ b/src/engine/ops/exec_ops.rs
@@ -1,3 +1,4 @@
+use crate::services::discord::session_identity::tmux_name_from_session_key;
 use crate::services::process::{configure_child_process_group, wait_with_output_timeout};
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
 use std::ffi::OsStr;
@@ -311,11 +312,11 @@ pub(super) fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
         rquickjs::Function::new(
             ctx.clone(),
             |session_key: String, command: String| -> String {
-                // session_key may be "hostname:tmux_name"
-                let tmux_name = session_key
-                    .split_once(':')
-                    .map(|(_, name)| name)
-                    .unwrap_or(&session_key);
+                // session_key may be legacy `host:tmux` or namespaced
+                // `provider/token/host:tmux`; raw tmux names remain accepted
+                // for policy compatibility.
+                let tmux_name =
+                    tmux_name_from_session_key(&session_key).unwrap_or_else(|| session_key.clone());
                 // #2378/#2404: enforce the current JS eval's bridge-op
                 // deadline for the tmux child itself. The zero-budget branch
                 // preserves the previous preflight behavior, while positive
@@ -329,12 +330,12 @@ pub(super) fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
                 };
                 let send_result = match tmux_timeout {
                     Some(timeout) => crate::services::platform::tmux::send_keys_timeout(
-                        tmux_name,
+                        &tmux_name,
                         &[&command, "Enter"],
                         timeout,
                     ),
                     None => {
-                        crate::services::platform::tmux::send_keys(tmux_name, &[&command, "Enter"])
+                        crate::services::platform::tmux::send_keys(&tmux_name, &[&command, "Enter"])
                     }
                 };
                 match send_result {
@@ -361,12 +362,11 @@ pub(super) fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
     session_obj.set(
         "kill",
         rquickjs::Function::new(ctx.clone(), |session_key: String| -> String {
-            // session_key is "hostname:tmux_name"; tmux interprets colon as
-            // session:window separator, so extract only the tmux_name part.
-            let tmux_name = session_key
-                .split_once(':')
-                .map(|(_, name)| name)
-                .unwrap_or(&session_key);
+            // session_key may be legacy `host:tmux` or namespaced
+            // `provider/token/host:tmux`; tmux interprets colon as a
+            // session:window separator, so extract only the tmux name.
+            let tmux_name =
+                tmux_name_from_session_key(&session_key).unwrap_or_else(|| session_key.clone());
             // #2378/#2404: keep the existing zero-deadline short-circuit, and
             // use any positive remaining deadline as the timeout for the tmux
             // kill child. The audit record stays after the preflight so it is
@@ -378,7 +378,7 @@ pub(super) fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
                 }
             };
             crate::services::termination_audit::record_termination_for_tmux(
-                tmux_name,
+                &tmux_name,
                 None,
                 "policy_engine",
                 "session_kill_api",
@@ -387,12 +387,12 @@ pub(super) fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
             );
             let kill_result = match tmux_timeout {
                 Some(timeout) => crate::services::platform::tmux::kill_session_output_timeout(
-                    tmux_name,
+                    &tmux_name,
                     "force-kill via agentdesk.session.kill()",
                     timeout,
                 ),
                 None => crate::services::platform::tmux::kill_session_output(
-                    tmux_name,
+                    &tmux_name,
                     "force-kill via agentdesk.session.kill()",
                 )
                 .map_err(|error| error.to_string()),

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -944,7 +944,7 @@ pub async fn stop_agent_turn(
     }
 
     let session_key = session.session_key.clone();
-    let tmux_name = session_key.split(':').next_back().unwrap_or(&session_key);
+    let tmux_name = extract_tmux_name(&session_key).unwrap_or_else(|| session_key.clone());
     let lifecycle = stop_turn_preserving_queue(
         state.health_registry.as_deref(),
         &TurnLifecycleTarget {
@@ -954,7 +954,7 @@ pub async fn stop_agent_turn(
                 .as_deref()
                 .and_then(|value| value.parse::<u64>().ok())
                 .map(poise::serenity_prelude::ChannelId::new),
-            tmux_name: tmux_name.to_string(),
+            tmux_name: tmux_name.clone(),
         },
         &format!("사용자가 {id} 에이전트 턴 수동 중단 (POST /api/agents/{id}/turn/stop)"),
     )

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -3753,7 +3753,12 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             "Kill only the tmux process for an idle session while preserving the session row and provider resume metadata.",
         )
         .with_params([
-            ("session_key", path_param("Session key in host:tmux_name form")),
+            (
+                "session_key",
+                path_param(
+                    "Session key in legacy host:tmux_name or namespaced provider/token/host:tmux_name form",
+                ),
+            ),
             (
                 "reason",
                 body_param(
@@ -3765,7 +3770,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         ])
         .with_example(
             json!({
-                "path": {"session_key": "provider:AgentDesk-claude-adk-cc"},
+                "path": {"session_key": "claude/hash123/mac-mini:AgentDesk-claude-adk-cc"},
                 "body": {"reason": "idle 6시간 초과 — 자동 정리"}
             }),
             json!({

--- a/src/server/routes/idle_recap.rs
+++ b/src/server/routes/idle_recap.rs
@@ -158,7 +158,7 @@ async fn run_idle_recap_post_job(
     // timeout). Both legs degrade gracefully to "no summary" — the card
     // still ships its token / idle header in that case.
     let scrollback = match idle_recap::tmux_session_name_from_key(&session_key) {
-        Some(name) => idle_recap::capture_tmux_scrollback(name).await,
+        Some(name) => idle_recap::capture_tmux_scrollback(&name).await,
         None => None,
     };
     // Fallback for runtimes without a live tmux pane (notably `claude-e`,

--- a/src/services/agents/turn.rs
+++ b/src/services/agents/turn.rs
@@ -361,11 +361,7 @@ pub async fn list_agent_turn_history_pg_json(
 }
 
 pub fn extract_tmux_name(session_key: &str) -> Option<String> {
-    session_key
-        .split_once(':')
-        .map(|(_, tmux_name)| tmux_name.trim())
-        .filter(|tmux_name| !tmux_name.is_empty())
-        .map(str::to_string)
+    crate::services::discord::session_identity::tmux_name_from_session_key(session_key)
 }
 
 fn ansi_escape_re() -> &'static Regex {

--- a/src/services/auto_queue/runtime.rs
+++ b/src/services/auto_queue/runtime.rs
@@ -7,6 +7,7 @@ use crate::db::auto_queue::slot_predicate::{
     DispatchSlotPolarity, active_dispatch_on_slot_predicate,
 };
 use crate::services::discord::health::HealthRegistry;
+use crate::services::discord::session_identity::tmux_name_from_session_key;
 
 #[derive(Debug, Clone)]
 struct RuntimeSlotClearTarget {
@@ -93,9 +94,9 @@ async fn build_slot_clear_target_pg(
             .filter(|value| !value.trim().is_empty())
             .or_else(|| {
                 session_key.as_deref().and_then(|key| {
-                    key.split_once(':').and_then(|(_, tmux_name)| {
+                    tmux_name_from_session_key(key).and_then(|tmux_name| {
                         crate::services::provider::parse_provider_and_channel_from_tmux_name(
-                            tmux_name,
+                            &tmux_name,
                         )
                         .map(|(provider, _)| provider.as_str().to_string())
                     })

--- a/src/services/cluster/session_discovery.rs
+++ b/src/services/cluster/session_discovery.rs
@@ -56,6 +56,7 @@ use super::session_matcher::{
     match_session_detailed,
 };
 use super::session_registry::{RegistryChange, SessionRegistry, global_session_registry};
+use crate::services::discord::session_identity::tmux_name_from_session_key;
 use crate::services::platform::tmux::{EnumeratedSession, list_sessions_with_pane_command};
 use crate::services::provider::{ProviderKind, parse_provider_and_channel_from_tmux_name};
 
@@ -351,9 +352,9 @@ fn normalize_nonempty(value: Option<&str>) -> Option<String> {
 
 fn tmux_name_and_segment_from_session_key(
     session_key: &str,
-) -> Option<(&str, ProviderKind, String)> {
-    let (_, tmux_name) = session_key.rsplit_once(':')?;
-    let (provider, tmux_segment) = parse_provider_and_channel_from_tmux_name(tmux_name)?;
+) -> Option<(String, ProviderKind, String)> {
+    let tmux_name = tmux_name_from_session_key(session_key)?;
+    let (provider, tmux_segment) = parse_provider_and_channel_from_tmux_name(&tmux_name)?;
     Some((tmux_name, provider, tmux_segment))
 }
 
@@ -362,7 +363,7 @@ fn live_tmux_segment_from_session_key(
     live_session_names: &HashSet<String>,
 ) -> Option<(ProviderKind, String)> {
     let (tmux_name, provider, tmux_segment) = tmux_name_and_segment_from_session_key(session_key)?;
-    if !live_session_names.contains(tmux_name) {
+    if !live_session_names.contains(&tmux_name) {
         tracing::debug!(
             session_key = %session_key,
             tmux_name = %tmux_name,

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -7,6 +7,7 @@ use poise::serenity_prelude::{self as serenity, ChannelId, MessageId};
 use serde::Serialize;
 
 use crate::services::discord::relay_health::{RelayActiveTurn, RelayStallState};
+use crate::services::discord::session_identity::tmux_name_from_session_key;
 use crate::services::discord::{self as discord, SharedData};
 use crate::services::provider::{CancelToken, ProviderKind};
 
@@ -871,11 +872,7 @@ pub async fn clear_provider_channel_runtime(
             .get(&channel_id)
             .and_then(|session| session.channel_name.as_ref())
             .map(|channel_name| provider.build_tmux_session_name(channel_name))
-            .or_else(|| {
-                session_key
-                    .and_then(|key| key.split_once(':'))
-                    .map(|(_, tmux_name)| tmux_name.to_string())
-            })
+            .or_else(|| session_key.and_then(tmux_name_from_session_key))
     };
 
     let cleared = discord::mailbox_clear_channel(&shared, &provider, channel_id).await;

--- a/src/services/discord/idle_recap.rs
+++ b/src/services/discord/idle_recap.rs
@@ -859,11 +859,8 @@ pub(in crate::services::discord) async fn spawn_clear_captured_idle_recap_for_ch
 
 /// Extract `tmux_session_name` from a session_key — the part after the last
 /// `:`. Mirrors `parseSessionTmuxName` from `policies/lib/timeouts-helpers.js`.
-pub(crate) fn tmux_session_name_from_key(session_key: &str) -> Option<&str> {
-    session_key
-        .rsplit_once(':')
-        .map(|(_, name)| name)
-        .filter(|s| !s.is_empty())
+pub(crate) fn tmux_session_name_from_key(session_key: &str) -> Option<String> {
+    crate::services::discord::session_identity::tmux_name_from_session_key(session_key)
 }
 
 /// #3146 Part 1 (codex clear/post race): does this channel currently have an

--- a/src/services/discord/runtime_bootstrap/session_gc.rs
+++ b/src/services/discord/runtime_bootstrap/session_gc.rs
@@ -45,7 +45,7 @@ async fn reap_orphan_thread_tmux(deleted_keys: &[String]) -> usize {
                     continue;
                 };
                 if crate::services::platform::tmux::kill_session(
-                    tmux_name,
+                    &tmux_name,
                     "stale thread session GC — DB row removed",
                 ) {
                     killed += 1;
@@ -64,21 +64,21 @@ async fn reap_orphan_thread_tmux(deleted_keys: &[String]) -> usize {
 }
 
 #[cfg(unix)]
-fn deleted_thread_tmux_reap_candidate<'a>(
-    session_key: &'a str,
+fn deleted_thread_tmux_reap_candidate(
+    session_key: &str,
     current_owner_marker: &str,
     belongs_to_current_runtime: impl Fn(&str, &str) -> bool,
     has_session: impl Fn(&str) -> bool,
-) -> Option<&'a str> {
-    // session_key format is `hostname:tmux_name`.
-    let (_, tmux_name) = session_key.split_once(':')?;
+) -> Option<String> {
+    let tmux_name =
+        crate::services::discord::session_identity::tmux_name_from_session_key(session_key)?;
     let (_, channel_name) =
-        crate::services::provider::parse_provider_and_channel_from_tmux_name(tmux_name)?;
+        crate::services::provider::parse_provider_and_channel_from_tmux_name(&tmux_name)?;
     crate::services::discord::adk_session::parse_thread_channel_id_from_name(&channel_name)?;
-    if !belongs_to_current_runtime(tmux_name, current_owner_marker) {
+    if !belongs_to_current_runtime(&tmux_name, current_owner_marker) {
         return None;
     }
-    if !has_session(tmux_name) {
+    if !has_session(&tmux_name) {
         return None;
     }
     Some(tmux_name)
@@ -110,7 +110,16 @@ mod thread_session_gc_tests {
                 &belongs_to_current_runtime,
                 &has_session,
             ),
-            Some(owned_thread)
+            Some(owned_thread.to_string())
+        );
+        assert_eq!(
+            deleted_thread_tmux_reap_candidate(
+                &format!("codex/hash123/host:{owned_thread}"),
+                marker,
+                &belongs_to_current_runtime,
+                &has_session,
+            ),
+            Some(owned_thread.to_string())
         );
         assert_eq!(
             deleted_thread_tmux_reap_candidate(

--- a/src/services/discord/session_identity.rs
+++ b/src/services/discord/session_identity.rs
@@ -25,10 +25,10 @@
 //!
 //! This module consolidates the **parse** half into one unit-tested surface.
 //! The **build** half already lives in `ProviderKind::build_tmux_session_name`
-//! and `adk_session::build_namespaced_session_key`; those stay put. Existing
-//! call sites can migrate to [`SessionIdentity::parse`] opportunistically —
-//! the old inline `split_once(':')` patterns remain equivalent until each
-//! site is touched.
+//! and `adk_session::build_namespaced_session_key`; those stay put. Production
+//! call sites that parse session keys should route through
+//! [`SessionIdentity::parse`] or [`tmux_name_from_session_key`], leaving raw
+//! colon splitting only for this parser or non-session string formats.
 //!
 //! See `docs/recovery-paths.md` for the broader recovery-module SSoT plan.
 
@@ -62,26 +62,43 @@ impl SessionIdentity {
             return None;
         }
 
-        // Split on the FIRST `:` — everything before is the host (or the
-        // provider/token/host triple), everything after is the tmux name.
-        let (prefix, tmux_raw) = trimmed.split_once(':')?;
+        // Split on the LAST `:` for compatibility with old provider/channel
+        // prefixes such as `claude:<channel_id>:<tmux>`. The canonical forms
+        // still have exactly one colon.
+        let (prefix, tmux_raw) = trimmed.rsplit_once(':')?;
         let tmux_name = tmux_raw.trim();
         if tmux_name.is_empty() {
             return None;
         }
 
-        // `prefix` has 0 or 2 '/' separators. 0 = legacy `host`;
-        // 2 = namespaced `provider/token/host`.
+        // `prefix` has 0 or 2 '/' separators for canonical keys. Legacy audit
+        // rows also used `host/alias:tmux`; preserve that by taking the final
+        // slash segment as the host unless the prefix starts with a known
+        // provider and is therefore a malformed namespaced key.
         let prefix_parts: Vec<&str> = prefix.splitn(3, '/').collect();
         let (host, provider_from_key, token_hash, namespaced) = match prefix_parts.as_slice() {
-            [provider, token, host_part] if !provider.is_empty() && !token.is_empty() => (
-                host_part.trim().to_string(),
-                Some((*provider).to_string()),
-                Some((*token).to_string()),
-                true,
+            [provider, token, host_part] if ProviderKind::from_str(provider).is_some() => {
+                if provider.is_empty() || token.is_empty() || host_part.trim().is_empty() {
+                    return None;
+                }
+                (
+                    host_part.trim().to_string(),
+                    Some((*provider).to_string()),
+                    Some((*token).to_string()),
+                    true,
+                )
+            }
+            [provider, ..]
+                if ProviderKind::from_str(provider).is_some() && prefix.contains('/') =>
+            {
+                return None;
+            }
+            _ => (
+                prefix.rsplit('/').next()?.trim().to_string(),
+                None,
+                None,
+                false,
             ),
-            [host_only] => (host_only.trim().to_string(), None, None, false),
-            _ => return None,
         };
 
         if host.is_empty() {
@@ -116,12 +133,82 @@ impl SessionIdentity {
 /// Extract just the tmux session name from a session key in either form.
 ///
 /// Convenience wrapper around [`SessionIdentity::parse`] for call sites that
-/// only need the tmux tail. Previously duplicated across
-/// `services/queue.rs`, `server/routes/agents.rs`, `db/session_agent_resolution.rs`,
-/// and `server/routes/dispatched_sessions.rs`. New code should prefer this.
-// #3034: deliberate consolidation helper ("new code should prefer this"); no
-// live caller has migrated yet. Kept as the canonical session-key tail parser.
-#[allow(dead_code)]
+/// only need the tmux tail. New code should prefer this over ad hoc separator
+/// parsing.
 pub fn tmux_name_from_session_key(session_key: &str) -> Option<String> {
     SessionIdentity::parse(session_key).map(|id| id.tmux_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SessionIdentity, tmux_name_from_session_key};
+
+    #[test]
+    fn parses_legacy_session_key() {
+        let identity = SessionIdentity::parse(" mac-mini:AgentDesk-codex-adk-cdx ").unwrap();
+
+        assert!(!identity.namespaced);
+        assert_eq!(identity.provider_from_key, None);
+        assert_eq!(identity.token_hash, None);
+        assert_eq!(identity.host, "mac-mini");
+        assert_eq!(identity.tmux_name, "AgentDesk-codex-adk-cdx");
+        assert_eq!(identity.legacy_key(), "mac-mini:AgentDesk-codex-adk-cdx");
+    }
+
+    #[test]
+    fn parses_namespaced_session_key() {
+        let identity =
+            SessionIdentity::parse("codex/hash123/mac-mini:AgentDesk-codex-adk-cdx-t123").unwrap();
+
+        assert!(identity.namespaced);
+        assert_eq!(identity.provider_from_key.as_deref(), Some("codex"));
+        assert_eq!(identity.token_hash.as_deref(), Some("hash123"));
+        assert_eq!(identity.host, "mac-mini");
+        assert_eq!(identity.tmux_name, "AgentDesk-codex-adk-cdx-t123");
+        assert_eq!(
+            identity.legacy_key(),
+            "mac-mini:AgentDesk-codex-adk-cdx-t123"
+        );
+        assert_eq!(
+            tmux_name_from_session_key("codex/hash123/mac-mini:AgentDesk-codex-adk-cdx-t123")
+                .as_deref(),
+            Some("AgentDesk-codex-adk-cdx-t123")
+        );
+    }
+
+    #[test]
+    fn legacy_parser_preserves_last_colon_tail_and_host_aliases() {
+        let multi_colon = SessionIdentity::parse(
+            "claude:1473922824350601297:agentdesk-claude-channel-1473922824350601297",
+        )
+        .unwrap();
+        assert!(!multi_colon.namespaced);
+        assert_eq!(multi_colon.host, "claude:1473922824350601297");
+        assert_eq!(
+            multi_colon.tmux_name,
+            "agentdesk-claude-channel-1473922824350601297"
+        );
+        assert_eq!(
+            tmux_name_from_session_key(
+                "claude:1473922824350601297:agentdesk-claude-channel-1473922824350601297"
+            )
+            .as_deref(),
+            Some("agentdesk-claude-channel-1473922824350601297")
+        );
+
+        let host_alias = SessionIdentity::parse("remote-host/farbox:codex-1234").unwrap();
+        assert!(!host_alias.namespaced);
+        assert_eq!(host_alias.host, "farbox");
+        assert_eq!(host_alias.tmux_name, "codex-1234");
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_parts() {
+        assert!(SessionIdentity::parse("").is_none());
+        assert!(SessionIdentity::parse("mac-mini").is_none());
+        assert!(SessionIdentity::parse(":AgentDesk-codex-adk-cdx").is_none());
+        assert!(SessionIdentity::parse("mac-mini: ").is_none());
+        assert!(SessionIdentity::parse("codex//mac-mini:AgentDesk-codex-adk-cdx").is_none());
+        assert!(SessionIdentity::parse("codex/hash123/:AgentDesk-codex-adk-cdx").is_none());
+    }
 }

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -7,6 +7,7 @@ use crate::db::session_agent_resolution::{
 use crate::db::session_status::{
     is_live_status, is_user_wait_status, normalize_incoming_session_status,
 };
+use crate::services::discord::session_identity::tmux_name_from_session_key;
 use crate::services::provider::ProviderKind;
 use crate::services::turn_lifecycle::{TurnLifecycleTarget, force_kill_turn};
 use axum::{
@@ -620,13 +621,14 @@ async fn force_kill_session_impl_with_reason_and_forwarding(
 ) -> (StatusCode, Json<serde_json::Value>) {
     let session_key = session_key;
 
-    // Parse tmux session name from session_key (format: "hostname:tmux_name")
-    let tmux_name = match session_key.split_once(':') {
-        Some((_, name)) => name.to_string(),
+    let tmux_name = match tmux_name_from_session_key(session_key) {
+        Some(name) => name,
         None => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(json!({"error": "invalid session_key format — expected hostname:tmux_name"})),
+                Json(
+                    json!({"error": "invalid session_key format — expected legacy host:tmux or namespaced provider/token/host:tmux"}),
+                ),
             );
         }
     };
@@ -885,8 +887,9 @@ const FORCE_KILL_RETRY_LIMIT: i64 = 5;
 ///
 /// #1067: Skill promotion for watch-agent-turn. Returns the latest N lines of
 /// the tmux pane bound to the session identified by the numeric session id
-/// (`sessions.id`). Reads the session row to derive `hostname:tmux_name` from
-/// `session_key`, then shells out via [`crate::services::platform::tmux::capture_pane`].
+/// (`sessions.id`). Reads the session row to derive the tmux name from a
+/// legacy or namespaced `session_key`, then shells out via
+/// [`crate::services::platform::tmux::capture_pane`].
 pub async fn tmux_output(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -951,15 +954,14 @@ pub async fn tmux_output(
         }
     }
 
-    // session_key format: "hostname:tmux_name"
-    let tmux_name = match session_key.split_once(':') {
-        Some((_, name)) if !name.is_empty() => name.to_string(),
+    let tmux_name = match tmux_name_from_session_key(&session_key) {
+        Some(name) => name,
         _ => {
             return (
                 StatusCode::CONFLICT,
                 Json(json!({
                     "error": format!(
-                        "session #{id} session_key does not follow hostname:tmux_name format"
+                        "session #{id} session_key does not follow legacy host:tmux or namespaced provider/token/host:tmux format"
                     ),
                     "session_id": id,
                     "session_key": session_key,
@@ -1185,12 +1187,14 @@ async fn kill_tmux_session_impl(
     reason: &str,
     minimum_idle_minutes: Option<u64>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let tmux_name = match session_key.split_once(':') {
-        Some((_, name)) => name.to_string(),
+    let tmux_name = match tmux_name_from_session_key(session_key) {
+        Some(name) => name,
         None => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(json!({"error": "invalid session_key format — expected hostname:tmux_name"})),
+                Json(
+                    json!({"error": "invalid session_key format — expected legacy host:tmux or namespaced provider/token/host:tmux"}),
+                ),
             );
         }
     };

--- a/src/services/queue.rs
+++ b/src/services/queue.rs
@@ -4,6 +4,7 @@ use serde_json::{Value, json};
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::services::discord::health::HealthRegistry;
+use crate::services::discord::session_identity::{SessionIdentity, tmux_name_from_session_key};
 use crate::services::provider::ProviderKind;
 use crate::services::service_error::{ErrorCode, ServiceError, ServiceResult};
 use crate::services::turn_lifecycle::{
@@ -77,7 +78,7 @@ async fn force_purge_channel_mailbox(
             provider, channel_id,
         );
     let token_hash = session_key
-        .and_then(crate::services::discord::session_identity::SessionIdentity::parse)
+        .and_then(SessionIdentity::parse)
         .and_then(|identity| identity.token_hash)
         .unwrap_or_else(|| format!("force-purge-channel-{}", channel_id.get()));
     let Some(handle) =
@@ -244,12 +245,8 @@ impl QueueService {
                         .as_deref()
                         .and_then(|channel_id| channel_id.parse::<u64>().ok())
                         .map(ChannelId::new);
-                    let tmux_name = active_turn
-                        .session_key
-                        .split(':')
-                        .next_back()
-                        .unwrap_or_default()
-                        .to_string();
+                    let tmux_name = tmux_name_from_session_key(&active_turn.session_key)
+                        .unwrap_or_else(|| active_turn.session_key.clone());
                     let target = TurnLifecycleTarget {
                         provider: provider_kind,
                         channel_id: parsed_channel_id,
@@ -515,9 +512,10 @@ impl QueueService {
 
         let tmux_name = session_key
             .as_deref()
-            .and_then(|session_key| session_key.split(':').next_back())
-            .unwrap_or_default()
-            .to_string();
+            .map(|session_key| {
+                tmux_name_from_session_key(session_key).unwrap_or_else(|| session_key.to_string())
+            })
+            .unwrap_or_default();
         let target = TurnLifecycleTarget {
             provider: provider_kind,
             channel_id: parsed_channel_id,

--- a/src/services/session_activity.rs
+++ b/src/services/session_activity.rs
@@ -7,6 +7,7 @@ use crate::db::session_status::{
     AWAITING_BG, AWAITING_USER, DISCONNECTED, IDLE, is_active_status, is_bg_wait_status,
     is_terminal_status, is_user_wait_status, normalize_session_status,
 };
+use crate::services::discord::session_identity::SessionIdentity;
 
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::tmux_session_has_live_pane;
@@ -239,13 +240,9 @@ where
 }
 
 fn parse_session_key(session_key: &str) -> Option<(String, String)> {
-    let (host_prefix, tmux_name) = session_key.split_once(':')?;
-    let host = host_prefix.rsplit('/').next().and_then(normalize_host)?;
-    let tmux_name = tmux_name.trim();
-    if tmux_name.is_empty() {
-        return None;
-    }
-    Some((host, tmux_name.to_string()))
+    let identity = SessionIdentity::parse(session_key)?;
+    let host = normalize_host(&identity.host)?;
+    Some((host, identity.tmux_name))
 }
 
 fn normalize_host(host: &str) -> Option<String> {
@@ -336,5 +333,24 @@ mod tests {
         );
         assert!(!state.is_working);
         assert!(resolver.tmux_live_cache.is_empty());
+    }
+
+    #[test]
+    fn parse_session_key_accepts_namespaced_keys() {
+        assert_eq!(
+            parse_session_key("codex/hash123/LocalBox.local:AgentDesk-codex-adk-cdx"),
+            Some((
+                "localbox".to_string(),
+                "AgentDesk-codex-adk-cdx".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_session_key_preserves_legacy_host_alias_keys() {
+        assert_eq!(
+            parse_session_key("remote-host/LocalBox.local:codex-1234"),
+            Some(("localbox".to_string(), "codex-1234".to_string()))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- centralize legacy/namespaced session-key tmux parsing through SessionIdentity and tmux_name_from_session_key
- migrate stop, kill, queue, idle recap, recovery, and session lookup call sites away from ad hoc colon splitting
- preserve legacy last-colon and host-alias behavior with focused tests and update docs/API text

## Verification
- cargo fmt --all --check
- cargo check --lib
- cargo test --lib session_identity -- --nocapture
- cargo test --lib session_activity -- --nocapture
- cargo test --lib session_agent_resolution -- --nocapture
- cargo test --lib tmux_session_name_from_session_key -- --nocapture
- cargo test --lib thread_session_gc -- --nocapture
- python3 scripts/generate_inventory_docs.py --check
- python3 scripts/check_agent_maintenance_docs.py
- /opt/homebrew/bin/python3 scripts/audit_maintainability.py --check
- PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh
- git diff --check

## Review
- fresh Codex xhigh adversarial review: VERDICT CLEAN

Closes #3795