### PR TITLE
Compact Discord Recent status output

### DIFF
--- a/src/services/discord/placeholder_live_events/background_task_events.rs
+++ b/src/services/discord/placeholder_live_events/background_task_events.rs
@@ -16,7 +16,7 @@ pub(super) fn slots_enabled_by_footer_flag() -> bool {
 pub(super) fn start_event_from_bash_tool_use(
     name: &str,
     value: &Value,
-    args_summary: Option<String>,
+    _args_summary: Option<String>,
     tool_use_id: Option<&str>,
     footer_mode_enabled: bool,
 ) -> Option<StatusEvent> {
@@ -25,7 +25,7 @@ pub(super) fn start_event_from_bash_tool_use(
     }
     Some(StatusEvent::BackgroundTaskStart {
         name: name.to_string(),
-        summary: task_summary(value).or(args_summary)?,
+        summary: task_summary(value).unwrap_or_else(|| "Bash".to_string()),
         tool_use_id: clean_tool_use_id(tool_use_id)?,
     })
 }
@@ -100,7 +100,7 @@ fn run_in_background(value: &Value) -> bool {
 }
 
 fn task_summary(value: &Value) -> Option<String> {
-    ["description", "desc", "command"]
+    ["description", "desc"]
         .into_iter()
         .find_map(|key| value.get(key).and_then(Value::as_str))
         .map(normalize_summary)

--- a/src/services/discord/placeholder_live_events/common.rs
+++ b/src/services/discord/placeholder_live_events/common.rs
@@ -10,6 +10,7 @@ pub(super) const EVENT_LINE_MAX_CHARS: usize = 100;
 // line. Compact single-line panel cells (Tasks/Subagents) are unaffected — they
 // keep using `normalize_summary` (first line only).
 pub(super) const RECENT_EVENT_MAX_LINES: usize = 4;
+#[cfg(test)]
 pub(super) const EVENT_BLOCK_MAX_CHARS: usize = 1500;
 // Status panels are sent as plain message content, so they must stay under
 // Discord's 2000-character content ceiling rather than the 4096-char embed limit.
@@ -24,6 +25,7 @@ pub(super) const SESSION_PANEL_LINE_MAX_CHARS: usize = 100;
 pub(super) const TASK_PANEL_LINE_MAX_CHARS: usize = 140;
 pub(super) const CONTEXT_PANEL_LINE_MAX_CHARS: usize = 120;
 
+#[cfg(test)]
 pub(super) fn sanitize_for_code_fence(raw: &str) -> String {
     raw.replace('`', "")
 }

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -29,6 +29,8 @@ use common::CHANNEL_EVENT_CAPACITY;
 pub(in crate::services::discord) use completion_footer::TerminalSlotId;
 use completion_footer::{CompletionFooterRender, render_completion_footer};
 use context_panel::ContextPanelSnapshot;
+use recent_events::render_compact_events;
+#[cfg(test)]
 use recent_events::render_events;
 use session_panel::SessionPanelSnapshot;
 use status_panel::{CompletedKind, DerivedStatus, StatusPanelState, render_status_panel};
@@ -45,8 +47,7 @@ use status_panel::{render_recent_section_header, truncate_status_panel_sections}
 
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
-    status_events_from_task_notification_with_tool_use_id,
-    status_events_from_task_notification_xml, status_events_from_tool_result_with_id,
+    status_events_from_task_notification_with_tool_use_id, status_events_from_tool_result_with_id,
     status_events_from_tool_use_with_id,
 };
 // #3034: the bare (no-id) variants are consumed only by the `tests` submodule
@@ -162,6 +163,19 @@ impl PlaceholderLiveEvents {
         &self,
         channel_id: ChannelId,
     ) -> Option<String> {
+        self.render_compact_block(channel_id)
+    }
+
+    fn render_compact_block(&self, channel_id: ChannelId) -> Option<String> {
+        let entry = self.by_channel.get(&channel_id)?;
+        let guard = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        render_compact_events(guard.iter())
+    }
+
+    #[cfg(test)]
+    fn render_raw_block_for_tests(&self, channel_id: ChannelId) -> Option<String> {
         let entry = self.by_channel.get(&channel_id)?;
         let guard = entry
             .lock()

--- a/src/services/discord/placeholder_live_events/recent_events.rs
+++ b/src/services/discord/placeholder_live_events/recent_events.rs
@@ -1,10 +1,13 @@
 use serde_json::Value;
 
 use super::super::formatting::format_tool_input;
+#[cfg(test)]
 use super::common::{
-    EVENT_BLOCK_MAX_CHARS, EVENT_LINE_MAX_CHARS, EVENT_RENDER_LIMIT, first_content_line,
-    is_harness_task_tool_name, is_internal_tool_error, normalize_summary_multiline,
-    sanitize_for_code_fence, tool_prefix, truncate_chars, value_to_compact_string,
+    EVENT_BLOCK_MAX_CHARS, EVENT_LINE_MAX_CHARS, sanitize_for_code_fence, truncate_chars,
+};
+use super::common::{
+    EVENT_RENDER_LIMIT, first_content_line, is_harness_task_tool_name, is_internal_tool_error,
+    normalize_summary_multiline, tool_prefix, value_to_compact_string,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -74,6 +77,7 @@ impl RecentPlaceholderEvent {
         })
     }
 
+    #[cfg(test)]
     pub(super) fn render_line(&self) -> String {
         // #3477 item 1: the summary may span several lines. Put the prefix on the
         // first line and indent the continuation lines so the entry stays visually
@@ -95,6 +99,18 @@ impl RecentPlaceholderEvent {
             out.push_str(&cont);
         }
         out
+    }
+
+    fn compact_bucket(&self) -> (&str, &'static str) {
+        let action = match self.prefix.as_str() {
+            "[tool error]" => "오류",
+            "[background]" => "백그라운드",
+            "[Monitor]" => "monitor",
+            "[Task]" => "작업",
+            "[system]" => "시스템",
+            _ => "실행",
+        };
+        (self.prefix.as_str(), action)
     }
 }
 
@@ -234,6 +250,7 @@ fn tool_result_content(block: &Value) -> String {
         .join("\n")
 }
 
+#[cfg(test)]
 pub(super) fn render_events<'a>(
     events: impl DoubleEndedIterator<Item = &'a RecentPlaceholderEvent>,
 ) -> Option<String> {
@@ -262,4 +279,43 @@ pub(super) fn render_events<'a>(
     }
     lines.reverse();
     Some(format!("```text\n{}\n```", lines.join("\n")))
+}
+
+pub(super) fn render_compact_events<'a>(
+    events: impl DoubleEndedIterator<Item = &'a RecentPlaceholderEvent>,
+) -> Option<String> {
+    let mut buckets: Vec<(String, &'static str, usize)> = Vec::new();
+    for event in events.rev().take(EVENT_RENDER_LIMIT) {
+        let (prefix, action) = event.compact_bucket();
+        if let Some((_, _, count)) =
+            buckets
+                .iter_mut()
+                .find(|(existing_prefix, existing_action, _)| {
+                    existing_prefix == prefix && *existing_action == action
+                })
+        {
+            *count += 1;
+            continue;
+        }
+        buckets.push((prefix.to_string(), action, 1));
+    }
+    if buckets.is_empty() {
+        return None;
+    }
+
+    buckets.reverse();
+    Some(
+        buckets
+            .into_iter()
+            .map(|(prefix, action, count)| {
+                let suffix = if count > 1 {
+                    format!(" · {count}회")
+                } else {
+                    String::new()
+                };
+                format!("• {prefix} {action}{suffix}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -627,8 +627,8 @@ fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
 
 /// Builds [`StatusEvent::SubagentActivity`] events for a nested subagent record,
 /// one per tool_use block, keyed by the parent Task id so the panel updates the
-/// owning slot's recent line (same `[Tool] args` summary) — a long background
-/// subagent surfaces its step, not an opaque "running".
+/// owning slot's recent line with the tool class. Raw nested tool arguments stay
+/// in transcript/log retrieval paths, not normal Discord relay panels.
 fn subagent_activity_status_events(value: &Value, parent_id: String) -> Vec<StatusEvent> {
     let blocks: Vec<(&str, String)> = match value.get("type").and_then(Value::as_str) {
         Some("assistant") => value
@@ -670,18 +670,11 @@ fn subagent_activity_status_events(value: &Value, parent_id: String) -> Vec<Stat
         .collect()
 }
 
-/// Formats a subagent's tool step into a compact activity line, e.g.
-/// `[Bash] cargo test`. Falls back to the bare tool label when no args summary
-/// is available. Returns `None` only when the tool name is unusable.
-fn subagent_activity_line(name: &str, input: &str) -> Option<String> {
+/// Formats a subagent's tool step into a compact activity line such as `[Bash]`.
+/// Returns `None` only when the tool name is unusable.
+fn subagent_activity_line(name: &str, _input: &str) -> Option<String> {
     use super::common::tool_prefix;
-    let args = format_tool_input(name, input);
-    let args = args.trim();
-    let line = if args.is_empty() {
-        tool_prefix(name)
-    } else {
-        format!("{} {}", tool_prefix(name), args)
-    };
+    let line = tool_prefix(name);
     let line = normalize_summary(&line);
     (!line.trim().is_empty()).then_some(truncate_chars(&line, EVENT_LINE_MAX_CHARS))
 }

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -613,12 +613,8 @@ fn render_derived_status(status: &DerivedStatus) -> String {
         DerivedStatus::Completed {
             kind: CompletedKind::Foreground,
         } => "✅ **응답 완료**".to_string(),
-        DerivedStatus::ToolRunning { name, summary } => {
-            let mut rendered = tool_prefix(name);
-            if let Some(summary) = summary.as_deref().filter(|value| !value.trim().is_empty()) {
-                rendered.push(' ');
-                rendered.push_str(&escape_status_panel_markdown(&normalize_summary(summary)));
-            }
+        DerivedStatus::ToolRunning { name, summary: _ } => {
+            let rendered = tool_prefix(name);
             format!("🔧 도구 실행 중 ({})", truncate_chars(&rendered, 140))
         }
         DerivedStatus::SubagentRunning { desc } => {

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -223,7 +223,7 @@ pub(super) fn render_task_tool_slot(slot: &TaskToolSlot) -> String {
         detail_parts.push(escape_status_panel_markdown(task_id));
     }
     if let Some(summary) = slot.summary.as_deref() {
-        if slot.task_id.as_deref() != Some(summary) {
+        if slot.task_id.as_deref() != Some(summary) && summary != label {
             detail_parts.push(escape_status_panel_markdown(summary));
         }
     }

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4,14 +4,13 @@ use super::super::formatting::{
     redact_sensitive_for_placeholder,
 };
 use super::common::{
-    EVENT_BLOCK_MAX_CHARS, EVENT_LINE_MAX_CHARS, EVENT_RENDER_LIMIT, STATUS_PANEL_MAX_CHARS,
-    STATUS_PANEL_TASK_LIMIT,
+    EVENT_BLOCK_MAX_CHARS, EVENT_LINE_MAX_CHARS, STATUS_PANEL_MAX_CHARS, STATUS_PANEL_TASK_LIMIT,
 };
 use super::*;
 use serde_json::json;
 
 #[test]
-fn render_block_keeps_newest_events_under_limit() {
+fn render_block_compacts_newest_events_under_limit() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(42);
     for idx in 0..25 {
@@ -23,14 +22,32 @@ fn render_block_keeps_newest_events_under_limit() {
     }
 
     let block = events.render_block(channel_id).unwrap();
-    assert!(block.starts_with("```text\n"));
-    assert!(block.ends_with("\n```"));
     assert!(block.chars().count() <= EVENT_BLOCK_MAX_CHARS);
     let live_lines = block
         .lines()
-        .filter(|line| line.starts_with("[Bash]"))
+        .filter(|line| line.starts_with("• [Bash]"))
         .collect::<Vec<_>>();
-    assert_eq!(live_lines.len(), EVENT_RENDER_LIMIT);
+    assert_eq!(live_lines.len(), 1);
+    assert!(block.contains("5회"));
+    assert!(!block.contains("echo 24"));
+}
+
+#[test]
+fn raw_debug_block_keeps_newest_events_under_limit() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(43);
+    for idx in 0..25 {
+        events.push_event(
+            channel_id,
+            RecentPlaceholderEvent::tool_use("Bash", &format!(r#"{{"command":"echo {idx}"}}"#))
+                .unwrap(),
+        );
+    }
+
+    let block = events.render_raw_block_for_tests(channel_id).unwrap();
+    assert!(block.starts_with("```text\n"));
+    assert!(block.ends_with("\n```"));
+    assert!(block.chars().count() <= EVENT_BLOCK_MAX_CHARS);
     assert!(!block.contains("echo 19"));
     assert!(block.contains("echo 24"));
 }
@@ -101,7 +118,7 @@ fn monitor_handoff_live_events_stays_under_description_limit_with_long_command()
         );
     }
 
-    let block = events.render_block(channel_id).unwrap();
+    let block = events.render_raw_block_for_tests(channel_id).unwrap();
     let live_lines = block
         .lines()
         .filter(|line| line.starts_with("[Bash]"))
@@ -116,6 +133,7 @@ fn monitor_handoff_live_events_stays_under_description_limit_with_long_command()
     assert!(!block.contains("secret-token"));
     assert!(!block.contains("api_key=secret"));
 
+    let compact_block = events.render_block(channel_id).unwrap();
     let rendered = build_monitor_handoff_placeholder_with_live_events(
         MonitorHandoffStatus::Active,
         MonitorHandoffReason::AsyncDispatch,
@@ -126,7 +144,7 @@ fn monitor_handoff_live_events_stays_under_description_limit_with_long_command()
         Some(&"context ".repeat(200)),
         Some(&"request ".repeat(200)),
         Some(&"progress ".repeat(200)),
-        Some(&block),
+        Some(&compact_block),
     );
 
     assert!(
@@ -135,7 +153,9 @@ fn monitor_handoff_live_events_stays_under_description_limit_with_long_command()
         rendered.len()
     );
     assert!(rendered.contains("[Bash]"));
-    assert!(rendered.contains("```text"));
+    assert!(!rendered.contains("```text"));
+    assert!(!rendered.contains("secret-token"));
+    assert!(!rendered.contains("api_key=secret"));
 }
 
 #[test]
@@ -240,7 +260,39 @@ fn status_panel_renders_derived_tool_state_under_limit() {
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(rendered.contains("도구 실행 중"));
     assert!(rendered.contains("[Bash]"));
+    assert!(
+        !rendered.contains("cargo test"),
+        "status header should show the tool class, not raw command text: {rendered}"
+    );
     assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
+}
+
+#[test]
+fn status_panel_recent_compacts_raw_command_details() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(78);
+    let raw_command = "cargo test --lib placeholder_live_events -- --nocapture";
+    let tool_args = json!({"command": raw_command}).to_string();
+    events.push_status_events(channel_id, status_events_from_tool_use("Bash", &tool_args));
+    events.push_event(
+        channel_id,
+        RecentPlaceholderEvent::tool_use("Bash", &tool_args).unwrap(),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(rendered.contains("🖥️ Recent"));
+    assert!(rendered.contains("• [Bash] 실행"));
+    assert!(!rendered.contains("```text"));
+    assert!(
+        !rendered.contains(raw_command),
+        "normal status panel must not render raw command detail: {rendered}"
+    );
+
+    let raw_debug_block = events.render_raw_block_for_tests(channel_id).unwrap();
+    assert!(
+        raw_debug_block.contains(raw_command),
+        "explicit debug render keeps raw detail available outside the normal status panel"
+    );
 }
 
 #[test]
@@ -257,7 +309,7 @@ fn characterize_rollover_seed_has_no_status_panel_content_s0() {
     let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(panel.contains("도구 실행 중"));
     assert!(panel.contains("[Bash]"));
-    assert!(panel.contains("cargo test --lib placeholder_live_events"));
+    assert!(!panel.contains("cargo test --lib placeholder_live_events"));
 
     let status_block = build_processing_status_block("⠸");
     let current_portion = "relay body ".repeat(250);
@@ -2700,6 +2752,37 @@ fn background_bash_slots_are_footer_flag_gated() {
 }
 
 #[test]
+fn background_bash_command_only_slot_hides_raw_command_3806() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_806_002);
+    let raw_command = "codex exec --skip-git-repo-check -m gpt-5.5";
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": raw_command,
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_raw_command_hidden"),
+            true,
+        ),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(rendered.contains("Tasks"));
+    assert!(
+        rendered.contains("└ Bash"),
+        "background Bash class should remain visible: {rendered}"
+    );
+    assert!(
+        !rendered.contains(raw_command),
+        "background Bash slot must not leak raw command detail: {rendered}"
+    );
+}
+
+#[test]
 fn background_bash_task_slots_trim_to_task_limit() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_089_106);
@@ -2972,9 +3055,9 @@ fn status_panel_pairs_subagent_by_tool_use_id_despite_interleaving() {
 }
 
 // Live subagent activity: a nested subagent record carries the launching Task's
-// id as a top-level `parent_tool_use_id`. Its tool step must surface on the
-// owning subagent slot (`└ type desc — [Tool] args`), not the panel header, so a
-// long (background) subagent is not an opaque "running".
+// id as a top-level `parent_tool_use_id`. Its tool class must surface on the
+// owning subagent slot (`└ type desc — [Tool]`), not the panel header, so a long
+// background subagent is not opaque while raw tool args stay out of the panel.
 #[test]
 fn status_panel_shows_live_subagent_activity_by_parent_id() {
     let events = PlaceholderLiveEvents::default();
@@ -3007,8 +3090,12 @@ fn status_panel_shows_live_subagent_activity_by_parent_id() {
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(rendered.contains("general-purpose Audit logs"));
     assert!(
-        rendered.contains("[Bash]") && rendered.contains("grep ERROR app.log"),
+        rendered.contains("[Bash]"),
         "subagent activity line missing, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("grep ERROR app.log"),
+        "subagent activity must not leak raw command args, got: {rendered}"
     );
     // Nested activity must NOT turn the panel header into a foreground tool run.
     assert!(
@@ -3162,6 +3249,10 @@ fn status_panel_background_subagent_shows_live_activity_while_running() {
     assert!(
         rendered.contains("[WebSearch]"),
         "background subagent live activity missing, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("rust async"),
+        "background subagent activity must not leak raw query args, got: {rendered}"
     );
     // Still running — no completion marker yet.
     assert!(
@@ -5941,8 +6032,12 @@ fn status_panel_late_batch_after_completion_keeps_recent_block() {
         "a fresh late batch racing TurnCompleted must not be blanked: {late}"
     );
     assert!(
-        late.contains("LATE_BATCH"),
-        "late content must render: {late}"
+        late.contains("• [Bash] 실행"),
+        "late compact activity must render without raw command text: {late}"
+    );
+    assert!(
+        !late.contains("LATE_BATCH"),
+        "raw late command leaked: {late}"
     );
 }
 

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -8,13 +8,13 @@ pub(in crate::services::discord) use completion_footer_registry::*;
 /// turn message keeps a compact task summary. The LIVE streaming panel uses the
 /// larger `SINGLE_MESSAGE_PANEL_LIVE_BODY_BUDGET_BYTES` below.
 pub(in crate::services::discord) const SINGLE_MESSAGE_PANEL_FOOTER_BUDGET_BYTES: usize = 600;
-/// #3497: byte budget for the LIVE single-message footer panel BODY (🖥️ Recent
-/// terminal block + Tasks/Subagents/Context; excludes the spinner/status header).
-/// Larger than the completion budget so a terminal-heavy turn shows the full
-/// Recent block during streaming instead of a truncated/dropped one. The relay
-/// body auto-uses the remaining message space (`DISCORD_MSG_LIMIT − footer_len −
-/// margin`) and rolls over when longer, so commentary is preserved across
-/// messages rather than starving the terminal panel.
+/// #3497: byte budget for the LIVE single-message footer panel BODY (Recent +
+/// Tasks/Subagents/Context; excludes the spinner/status header). Normal Recent
+/// output is compact after #3806, but the footer clamp still handles legacy or
+/// debug-shaped fenced Recent sections as whole blocks. The relay body auto-uses
+/// the remaining message space (`DISCORD_MSG_LIMIT − footer_len − margin`) and
+/// rolls over when longer, so commentary is preserved across messages rather
+/// than starving the terminal panel.
 pub(in crate::services::discord) const SINGLE_MESSAGE_PANEL_LIVE_BODY_BUDGET_BYTES: usize = 1200;
 pub(in crate::services::discord) const SINGLE_MESSAGE_PANEL_SPINNER_FRAMES: &[&str] =
     &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -1022,9 +1022,9 @@ mod tests {
         ));
     }
 
-    /// #3394: the footer finalization sink must re-balance fence parity. A panel
-    /// whose fenced Recent block is chopped by the 600-byte body clamp must not
-    /// emit a dangling ``` for Discord to render as literal text.
+    /// #3394: the footer finalization sink must re-balance fence parity. A
+    /// legacy/debug-shaped fenced Recent block chopped by the body clamp must
+    /// not emit a dangling ``` for Discord to render as literal text.
     #[test]
     fn footer_status_block_repairs_dangling_fence_after_clamp_3394() {
         let panel = format!(
@@ -1042,10 +1042,11 @@ mod tests {
         assert!(!block.contains("```text") || fences >= 2);
     }
 
-    /// #3495: when the 600-byte panel clamp severs the fenced 🖥️ Recent block,
-    /// the WHOLE section (header + fence + body) is dropped — Discord must never
-    /// see a bare `🖥️ Recent` header with no terminal body (the intermittent
-    /// "터미널 칸이 사라짐" symptom). When the block fits, it is preserved intact.
+    /// #3495: when the panel clamp severs a legacy/debug-shaped fenced 🖥️ Recent
+    /// block, the WHOLE section (header + fence + body) is dropped — Discord
+    /// must never see a bare `🖥️ Recent` header with no terminal body (the
+    /// intermittent "터미널 칸이 사라짐" symptom). When the block fits, it is
+    /// preserved intact.
     #[test]
     fn footer_panel_clamp_drops_severed_recent_section_3495() {
         // Small leading line so the cut lands inside the Recent section: the


### PR DESCRIPTION
## Summary
- Render normal Discord Recent blocks as compact activity buckets instead of fenced raw command output.
- Keep ToolRunning, subagent activity, and command-only background Bash status compact so raw command/query args stay out of ordinary relay panels.
- Preserve explicit raw debug rendering for tests/diagnostics and update footer clamp comments for legacy/debug-shaped fenced Recent input.

## Issue
- Addresses #3806

## Verification
- cargo fmt --all --check
- cargo test --lib placeholder_live_events -- --nocapture (160 passed)
- cargo check --lib (success; existing unrelated unused-import warnings only)
- python3 scripts/generate_inventory_docs.py --check
- python3 scripts/check_agent_maintenance_docs.py
- PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh
- git diff --check
- Fresh Codex xhigh adversarial review: VERDICT: CLEAN
