### PR TITLE
Fix Codex TUI restart adoption

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -617,6 +617,7 @@ src/
 │   │   │   ├── stt.rs
 │   │   │   └── tts_pipeline.rs
 │   │   ├── watchers/
+│   │   │   ├── codex_tui_restore.rs
 │   │   │   ├── lifecycle.rs
 │   │   │   └── lifecycle_decision.rs
 │   │   ├── adk_session.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -137,7 +137,9 @@
     construction from the watcher-spawn handle; #3718 moved runtime mtime
     heartbeat timestamp selection into `watchers/lifecycle_decision.rs` and
     keeps lifecycle below its frozen ratchet; -6 from #3736 removing legacy
-    remote-profile restore plumbing while remote SSH is disabled).
+    remote-profile restore plumbing while remote SSH is disabled; ±0 from
+    #3815 moving direct Codex TUI resume restore helpers into
+    `watchers/codex_tui_restore.rs` while adding the restore branch).
   - `src/services/discord/tmux.rs` (2033 lines after #2558 dead-code sweep;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -307,6 +307,12 @@ pub async fn agent_diag(
     let task_notification_kind = inflight
         .as_ref()
         .and_then(|state| state.task_notification_kind.clone());
+    let tmux_relay_adoption = tmux_relay_adoption_json(
+        session.provider.as_deref(),
+        tmux_name.as_deref(),
+        session.thread_channel_id.as_deref(),
+        watcher_snapshot_json.as_ref(),
+    );
 
     (
         StatusCode::OK,
@@ -329,6 +335,7 @@ pub async fn agent_diag(
             "oldest_child_spawned_at": oldest_child_spawned_at,
             "children": child_inventory,
             "tui_prompt_readiness": tui_prompt_readiness,
+            "tmux_relay_adoption": tmux_relay_adoption,
             // #tui-hook-ttl-buffer (TSK-P1-003 surfaced early per the missing
             // output-schema contract): additive, process-global snapshot of the
             // in-memory hook registry. New top-level field — existing diag
@@ -423,6 +430,145 @@ fn tui_prompt_readiness_json(
     _tmux_name: Option<&str>,
     _cwd: Option<&str>,
     _provider_session_id: Option<&str>,
+) -> Option<Value> {
+    None
+}
+
+#[cfg(unix)]
+fn tmux_relay_adoption_json(
+    provider: Option<&str>,
+    tmux_name: Option<&str>,
+    channel_id: Option<&str>,
+    watcher_snapshot: Option<&Value>,
+) -> Option<Value> {
+    let tmux_name = tmux_name.map(str::trim).filter(|value| !value.is_empty())?;
+    let pane_liveness = crate::services::tmux_diagnostics::tmux_session_pane_liveness(tmux_name);
+    let tmux_session_exists = crate::services::tmux_diagnostics::tmux_session_exists(tmux_name);
+    let watcher_attached = watcher_snapshot
+        .and_then(|value| value.get("attached"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let watcher_tmux_session = watcher_snapshot
+        .and_then(|value| value.get("tmux_session"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let watcher_tmux_matches = watcher_tmux_session.as_deref() == Some(tmux_name);
+    let watcher_owner_channel_id = watcher_snapshot
+        .and_then(|value| value.get("watcher_owner_channel_id"))
+        .and_then(Value::as_u64);
+    let parsed_channel_id = channel_id.and_then(|value| value.trim().parse::<u64>().ok());
+    let dead_marker_path = crate::services::tmux_common::session_dead_marker_path(tmux_name);
+    let state = classify_tmux_relay_adoption_state(
+        pane_liveness,
+        tmux_session_exists,
+        watcher_attached,
+        watcher_tmux_matches,
+    );
+    let pane_liveness_label = match pane_liveness {
+        crate::services::platform::tmux::PaneLiveness::Live => "live",
+        crate::services::platform::tmux::PaneLiveness::DeadOrAbsent => "dead_or_absent",
+        crate::services::platform::tmux::PaneLiveness::ProbeError => "probe_error",
+    };
+
+    Some(json!({
+        "state": state,
+        "provider": provider.unwrap_or(""),
+        "channel_id": parsed_channel_id,
+        "tmux_session": tmux_name,
+        "tmux_session_exists": tmux_session_exists,
+        "tmux_pane_liveness": pane_liveness_label,
+        "tmux_pane_alive": matches!(
+            pane_liveness,
+            crate::services::platform::tmux::PaneLiveness::Live
+        ),
+        "stale_dead_marker_present": FsPath::new(&dead_marker_path).exists(),
+        "watcher_attached": watcher_attached,
+        "watcher_tmux_session": watcher_tmux_session,
+        "watcher_tmux_matches": watcher_tmux_matches,
+        "watcher_owner_channel_id": watcher_owner_channel_id,
+    }))
+}
+
+#[cfg(unix)]
+fn classify_tmux_relay_adoption_state(
+    pane_liveness: crate::services::platform::tmux::PaneLiveness,
+    tmux_session_exists: bool,
+    watcher_attached: bool,
+    watcher_tmux_matches: bool,
+) -> &'static str {
+    match pane_liveness {
+        crate::services::platform::tmux::PaneLiveness::ProbeError => "unknown",
+        crate::services::platform::tmux::PaneLiveness::DeadOrAbsent if !tmux_session_exists => {
+            "no_tmux"
+        }
+        crate::services::platform::tmux::PaneLiveness::DeadOrAbsent => "tmux_dead_or_absent",
+        crate::services::platform::tmux::PaneLiveness::Live => {
+            if watcher_attached && watcher_tmux_matches {
+                "adopted"
+            } else {
+                "tmux_live_not_adopted"
+            }
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tmux_relay_adoption_state_tests {
+    use crate::services::platform::tmux::PaneLiveness;
+
+    #[test]
+    fn live_tmux_without_matching_watcher_is_reported_as_not_adopted() {
+        assert_eq!(
+            super::classify_tmux_relay_adoption_state(PaneLiveness::Live, true, false, false),
+            "tmux_live_not_adopted"
+        );
+        assert_eq!(
+            super::classify_tmux_relay_adoption_state(PaneLiveness::Live, true, true, false),
+            "tmux_live_not_adopted"
+        );
+    }
+
+    #[test]
+    fn live_tmux_with_matching_watcher_is_adopted() {
+        assert_eq!(
+            super::classify_tmux_relay_adoption_state(PaneLiveness::Live, true, true, true),
+            "adopted"
+        );
+    }
+
+    #[test]
+    fn absent_and_probe_error_states_are_distinct() {
+        assert_eq!(
+            super::classify_tmux_relay_adoption_state(
+                PaneLiveness::DeadOrAbsent,
+                false,
+                false,
+                false,
+            ),
+            "no_tmux"
+        );
+        assert_eq!(
+            super::classify_tmux_relay_adoption_state(
+                PaneLiveness::DeadOrAbsent,
+                true,
+                false,
+                false,
+            ),
+            "tmux_dead_or_absent"
+        );
+        assert_eq!(
+            super::classify_tmux_relay_adoption_state(PaneLiveness::ProbeError, true, false, false,),
+            "unknown"
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn tmux_relay_adoption_json(
+    _provider: Option<&str>,
+    _tmux_name: Option<&str>,
+    _channel_id: Option<&str>,
+    _watcher_snapshot: Option<&Value>,
 ) -> Option<Value> {
     None
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -50,7 +50,7 @@ use self::idle_transcript_scan::{
 // behavior-identical; the names are re-imported here so the parent's call sites
 // (and the test module) stay byte-identical.
 #[cfg(unix)]
-mod rehydration;
+pub(in crate::services::discord) mod rehydration;
 #[cfg(unix)]
 use self::rehydration::{
     codex_tui_rehydrated_binding_from_rollout_path, rehydrate_existing_claude_tui_bindings,

--- a/src/services/discord/watchers/codex_tui_restore.rs
+++ b/src/services/discord/watchers/codex_tui_restore.rs
@@ -1,0 +1,178 @@
+use poise::serenity_prelude::ChannelId;
+
+#[derive(Debug)]
+pub(super) struct DirectResumeFallback {
+    output_path: String,
+    #[cfg(unix)]
+    binding: crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+}
+
+impl DirectResumeFallback {
+    pub(super) fn output_path(&self) -> &str {
+        &self.output_path
+    }
+}
+
+/// #2795 — for codex_tui sessions whose AgentDesk-side relay JSONL does not
+/// exist on disk, look up the actual codex rollout transcript by the
+/// inflight `session_id`. Returns `None` when the inflight is absent, is not
+/// a codex_tui handoff, lacks a session_id, or no rollout matches.
+pub(super) fn rollout_fallback_for_session(
+    provider: &crate::services::provider::ProviderKind,
+    channel_id: ChannelId,
+) -> Option<String> {
+    if *provider != crate::services::provider::ProviderKind::Codex {
+        return None;
+    }
+    let state =
+        crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())?;
+    if !matches!(
+        state.runtime_kind,
+        Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui)
+    ) {
+        return None;
+    }
+    let session_id = state.session_id.as_deref()?;
+    let rollout = crate::services::codex_tui::rollout_tail::find_rollout_by_session_id(session_id)?;
+    Some(rollout.display().to_string())
+}
+
+/// #3815 — dcserver restart recovery must also adopt legacy/direct Codex TUI
+/// panes that were launched as `codex resume <session-id>` instead of through
+/// the current ADK-managed marker path. Those panes can survive deploys with no
+/// AgentDesk JSONL/FIFO/marker files, so the normal restore path used to skip
+/// them as "no output file" even while tmux was live.
+pub(super) fn rollout_fallback_for_live_direct_resume(
+    provider: &crate::services::provider::ProviderKind,
+    tmux_session_name: &str,
+    _channel_id: ChannelId,
+) -> Option<DirectResumeFallback> {
+    #[cfg(not(unix))]
+    {
+        let _ = (provider, tmux_session_name);
+        return None;
+    }
+
+    #[cfg(unix)]
+    {
+        if *provider != crate::services::provider::ProviderKind::Codex {
+            return None;
+        }
+        let session_id = codex_resume_session_id_from_tmux_pane(tmux_session_name)?;
+        let rollout =
+            crate::services::codex_tui::rollout_tail::find_rollout_by_session_id(&session_id)?;
+        let binding = crate::services::discord::tui_prompt_relay::rehydration::codex_tui_rehydrated_binding_from_rollout_path(
+            tmux_session_name,
+            &rollout,
+            Some(session_id),
+        )?;
+        Some(DirectResumeFallback {
+            output_path: rollout.display().to_string(),
+            binding,
+        })
+    }
+}
+
+pub(super) fn commit_live_direct_resume_fallback(
+    tmux_session_name: &str,
+    channel_id: ChannelId,
+    fallback: DirectResumeFallback,
+) {
+    #[cfg(not(unix))]
+    {
+        let _ = (tmux_session_name, channel_id, fallback);
+    }
+
+    #[cfg(unix)]
+    {
+        crate::services::tmux_common::write_tmux_runtime_kind_marker(
+            tmux_session_name,
+            crate::services::agent_protocol::RuntimeHandoffKind::CodexTui,
+        )
+        .ok();
+        crate::services::tui_prompt_dedupe::register_rehydrated_tmux_runtime_binding(
+            crate::services::provider::ProviderKind::Codex.as_str(),
+            tmux_session_name,
+            channel_id.get(),
+            fallback.binding,
+        );
+    }
+}
+
+fn codex_resume_session_id_from_tmux_pane(tmux_session_name: &str) -> Option<String> {
+    let pane_pid = crate::services::platform::tmux::pane_pid(tmux_session_name)?;
+    let process_args = crate::services::platform::tmux::read_process_args(pane_pid)?;
+    codex_resume_session_id_from_process_args(&process_args)
+}
+
+fn codex_resume_session_id_from_process_args(process_args: &str) -> Option<String> {
+    let mut saw_codex_binary = false;
+    let mut saw_exec_before_resume = false;
+    let mut after_resume = false;
+    for raw in process_args.split_whitespace() {
+        let token = raw.trim_matches(|ch| ch == '\'' || ch == '"' || ch == ',');
+        let token_lower = token.to_ascii_lowercase();
+        let token_leaf = token_lower
+            .rsplit('/')
+            .next()
+            .unwrap_or(token_lower.as_str());
+
+        if token_leaf.contains("codex-tmux-wrapper") {
+            return None;
+        }
+        if crate::services::cluster::session_matcher::detect_provider_from_pane_command(token)
+            == Some(crate::services::provider::ProviderKind::Codex)
+        {
+            saw_codex_binary = true;
+            continue;
+        }
+        if token == "exec" && !after_resume {
+            saw_exec_before_resume = true;
+            continue;
+        }
+        if token == "resume" && saw_codex_binary && !saw_exec_before_resume {
+            after_resume = true;
+            continue;
+        }
+        if !after_resume {
+            continue;
+        }
+        if uuid::Uuid::parse_str(token).is_ok() {
+            return Some(token.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod codex_direct_resume_args_tests {
+    #[test]
+    fn extracts_resume_session_id_from_direct_codex_pane_args() {
+        let args = "/opt/homebrew/bin/node /opt/homebrew/bin/codex resume \
+            019e660d-4859-7522-9cee-8ba7c4e7c743 \
+            --dangerously-bypass-hook-trust";
+
+        assert_eq!(
+            super::codex_resume_session_id_from_process_args(args).as_deref(),
+            Some("019e660d-4859-7522-9cee-8ba7c4e7c743")
+        );
+    }
+
+    #[test]
+    fn ignores_wrapper_and_exec_shapes() {
+        assert_eq!(
+            super::codex_resume_session_id_from_process_args(
+                "/usr/local/bin/agentdesk codex-tmux-wrapper resume \
+                 019e660d-4859-7522-9cee-8ba7c4e7c743"
+            ),
+            None
+        );
+        assert_eq!(
+            super::codex_resume_session_id_from_process_args(
+                "/opt/homebrew/bin/codex exec resume \
+                 019e660d-4859-7522-9cee-8ba7c4e7c743"
+            ),
+            None
+        );
+    }
+}

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::services::discord::watcher_lifecycle_decision::runtime_activity_heartbeat_at;
 
+#[path = "codex_tui_restore.rs"]
+mod codex_restore;
+
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum LivenessProbeOutcome {
     /// No dead marker observed; the tmux pane liveness check answered.
@@ -15,29 +18,6 @@ pub(super) enum LivenessProbeOutcome {
     StaleMarkerClearAndAlive,
     /// Dead marker present and the pane really is gone — honour the marker.
     MarkerHonoredDead,
-}
-
-/// #2795 — for codex_tui sessions whose AgentDesk-side relay JSONL does not
-/// exist on disk, look up the actual codex rollout transcript by the
-/// inflight `session_id`. Returns `None` when the inflight is absent, is not
-/// a codex_tui handoff, lacks a session_id, or no rollout matches.
-fn codex_tui_rollout_fallback_for_session(
-    provider: &crate::services::provider::ProviderKind,
-    channel_id: serenity::model::id::ChannelId,
-) -> Option<String> {
-    if *provider != crate::services::provider::ProviderKind::Codex {
-        return None;
-    }
-    let state = super::super::inflight::load_inflight_state(provider, channel_id.get())?;
-    if !matches!(
-        state.runtime_kind,
-        Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui)
-    ) {
-        return None;
-    }
-    let session_id = state.session_id.as_deref()?;
-    let rollout = crate::services::codex_tui::rollout_tail::find_rollout_by_session_id(session_id)?;
-    Some(rollout.display().to_string())
 }
 
 /// #2853 — for claude_tui sessions whose AgentDesk-side relay JSONL never lands
@@ -2269,6 +2249,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
         session_name: String,
         initial_offset: u64,
         restored_turn: Option<RestoredWatcherTurn>,
+        codex_direct_resume_fallback: Option<codex_restore::DirectResumeFallback>,
     }
 
     // Dead sessions that need DB cleanup (idle status report + tmux kill)
@@ -2418,12 +2399,13 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
         );
 
         let mut selected_claude_tui_fallback_transcript: Option<std::path::PathBuf> = None;
+        let mut codex_direct_resume_fallback = None;
         let output_path =
             match crate::services::tmux_common::resolve_session_temp_path(session_name, "jsonl") {
                 Some(path) => path,
                 None => {
                     if let Some(path) =
-                        codex_tui_rollout_fallback_for_session(&provider, *channel_id)
+                        codex_restore::rollout_fallback_for_session(&provider, *channel_id)
                     {
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::info!(
@@ -2432,6 +2414,16 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                             path
                         );
                         path
+                    } else if let Some(path) =
+                        codex_restore::rollout_fallback_for_live_direct_resume(
+                            &provider,
+                            session_name,
+                            *channel_id,
+                        )
+                    {
+                        let output_path = path.output_path().to_string();
+                        codex_direct_resume_fallback = Some(path);
+                        output_path
                     } else if let Some(path) = claude_tui_transcript_fallback_path(
                         &provider,
                         session_name,
@@ -2542,7 +2534,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             );
         }
 
-        if !tmux_session_has_live_pane(session_name) {
+        if !probe_tmux_session_liveness(session_name).await {
             let ts = chrono::Local::now().format("%H:%M:%S");
             if let Some(diag) = build_tmux_death_diagnostic(session_name, Some(&output_path)) {
                 tracing::info!(
@@ -2609,6 +2601,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             session_name: session_name.to_string(),
             initial_offset,
             restored_turn,
+            codex_direct_resume_fallback,
         });
         if let Some(path) = selected_claude_tui_fallback_transcript {
             restore_claimed_claude_tui_transcripts.insert(path);
@@ -2768,6 +2761,13 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                 pw.session_name
             );
             continue;
+        }
+        if let Some(fallback) = pw.codex_direct_resume_fallback {
+            codex_restore::commit_live_direct_resume_fallback(
+                &pw.session_name,
+                pw.channel_id,
+                fallback,
+            );
         }
 
         let ts = chrono::Local::now().format("%H:%M:%S");


### PR DESCRIPTION
Issue: #3815

## Summary
- Re-adopt live direct `codex resume <session-id>` tmux panes during watcher restart recovery when normal AgentDesk JSONL runtime files are missing.
- Keep the direct-resume fallback pure until watcher ownership is successfully claimed, then commit the Codex TUI marker and rehydrated runtime binding.
- Expose `tmux_relay_adoption` in `agent_diag` so live tmux sessions that are not adopted are visible instead of silent.
- Move Codex TUI rollout/restore helpers out of `lifecycle.rs` and update maintenance docs.

## Verification
- `cargo fmt --all --check`
- `cargo test --lib codex_direct_resume_args -- --nocapture`
- `cargo test --lib tmux_relay_adoption_state -- --nocapture`
- `cargo check --lib`
- `python3 scripts/generate_inventory_docs.py --check`
- `python3 scripts/check_agent_maintenance_docs.py`
- `PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh`
- `git diff --check`
- fresh Codex xhigh adversarial re-review: `VERDICT: CLEAN`

## Residual Risk
- Full restart-path E2E coverage is still missing for the exact live direct-resume recovery scenario; this PR adds unit coverage and diag visibility for the regression surface.