### PR TITLE
Expose bot-token reload restart scopes

### DIFF
--- a/docs/health-port-unification-checklist.md
+++ b/docs/health-port-unification-checklist.md
@@ -6,9 +6,47 @@ AgentDesk prompt/skill/memory assets should follow these rules after the `/api/d
 - [x] Use the active `server.port` value for local API calls such as `http://127.0.0.1:<port>/api/discord/send`.
 - [x] Do not reference `AGENTDESK_HEALTH_PORT`; the separate health listener no longer exists.
 - [x] Use `credential/announce_bot_token` and `credential/notify_bot_token` as the bot-token source for agent-to-agent routing.
-- [x] Use `POST /api/discord/bot-tokens/reload` after rotating `credential/announce_bot_token` or `credential/notify_bot_token`; each bot response has a `status` such as `reloaded` or `missing_or_invalid` plus a `previous_client_kept` boolean without exposing token material.
-- [x] Treat provider runtime bot tokens as restart-scoped: `SharedData.cached_bot_token` is a `OnceCell`, so this reload endpoint does not rotate gateway/provider bots until dcserver restarts.
+- [x] Use `POST /api/discord/bot-tokens/reload` after rotating `credential/announce_bot_token` or `credential/notify_bot_token`; each bot response has a `status` such as `reloaded` or `missing_or_invalid` plus a `previous_client_kept` boolean without exposing token material. The response includes `report.scopes.utility_rest_clients.restart_required=false`.
+- [x] Treat provider runtime bot tokens as restart-scoped: `SharedData.cached_bot_token` is a `OnceCell`, so this reload endpoint does not rotate gateway/provider bots until dcserver restarts. Check `report.scopes.provider_runtime_cached_token.restart_required=true`, `report.scopes.provider_gateway_session.restart_required=true`, or `/api/health/detail` `bot_token_reload_scopes.*.restart_required`.
 - [x] Treat `/api/health`, `/api/discord/send`, and `/api/discord/send-dm` as endpoints on the same axum server.
+
+## Bot Token Rotation Procedure
+
+Utility bot rotation (`announce` / `notify`):
+
+1. Write the new token to `credential/announce_bot_token` and/or `credential/notify_bot_token` in the active AgentDesk runtime root.
+2. Reload the utility REST clients from the dcserver host:
+
+   ```bash
+   curl -fsS -X POST http://127.0.0.1:8791/api/discord/bot-tokens/reload | jq .
+   ```
+
+   For a non-loopback caller, include the configured API bearer token:
+
+   ```bash
+   curl -fsS -X POST http://<host>:8791/api/discord/bot-tokens/reload \
+     -H "Authorization: Bearer $AGENTDESK_API_TOKEN" | jq .
+   ```
+
+3. Confirm `report.announce.status` and/or `report.notify.status` is `reloaded`. If a rotated utility credential reports `missing_or_invalid`, fix the file and call the endpoint again. Do not paste token values into logs or issue comments.
+
+Provider runtime / gateway bot rotation:
+
+1. Update the provider bot token source: `discord.bots.<name>.token` in `config/agentdesk.yaml` or `credential/<name>_bot_token`.
+2. Call the reload endpoint only to refresh utility clients and to confirm the runtime scope status. It will continue to report `provider_runtime_cached_token.restart_required=true` and `provider_gateway_session.restart_required=true`.
+3. Restart dcserver after active turns have drained:
+
+   ```bash
+   agentdesk restart-dcserver
+   ```
+
+4. Verify the post-restart diagnostic surface:
+
+   ```bash
+   curl -fsS http://127.0.0.1:8791/api/health/detail | jq '.bot_token_reload_scopes'
+   ```
+
+   The provider runtime and gateway scopes still report `restart_required=true` as a capability statement: future provider-token rotations require another dcserver restart.
 
 ## Verification (2026-03-23)
 

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1352,6 +1352,32 @@ fn all_endpoints() -> Vec<EndpointDoc> {
                     "runtime_root_available": true,
                     "any_reloaded": true,
                     "utility_bot_user_ids_invalidated": true,
+                    "scopes": {
+                        "utility_rest_clients": {
+                            "scope": "utility_rest_clients",
+                            "status": "reload_supported",
+                            "live_reload_supported": true,
+                            "restart_required": false,
+                            "token_source": "credential/announce_bot_token and credential/notify_bot_token",
+                            "detail": "POST /api/discord/bot-tokens/reload rebuilds announce/notify HealthRegistry REST clients in place."
+                        },
+                        "provider_runtime_cached_token": {
+                            "scope": "provider_runtime_cached_token",
+                            "status": "restart_required",
+                            "live_reload_supported": false,
+                            "restart_required": true,
+                            "token_source": "discord.bots.<name>.token or credential/<name>_bot_token selected at provider runtime startup",
+                            "detail": "SharedData.cached_bot_token is a OnceCell per provider runtime, so rotated provider REST fallback credentials are not adopted until dcserver restarts."
+                        },
+                        "provider_gateway_session": {
+                            "scope": "provider_gateway_session",
+                            "status": "restart_required",
+                            "live_reload_supported": false,
+                            "restart_required": true,
+                            "token_source": "discord.bots.<name>.token or credential/<name>_bot_token selected at provider runtime startup",
+                            "detail": "Discord gateway sessions are created by provider runtimes at startup; reconnecting them with a rotated token requires a dcserver restart."
+                        }
+                    },
                     "provider_cached_bot_token_scope": "announce/notify HealthRegistry clients are reloaded; provider runtime SharedData.cached_bot_token is restart-only"
                 }
             }),

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -1467,7 +1467,7 @@ pub async fn send_handler(
 /// This only rotates the utility bots backed by `HealthRegistry`
 /// (`credential/announce_bot_token`, `credential/notify_bot_token`). Provider
 /// runtime gateway token caches are `OnceCell`s and still require a dcserver
-/// restart; the response reports that scope explicitly.
+/// restart; the response reports each reload scope explicitly.
 ///
 /// See `send_handler` for the rationale on the mandatory
 /// `ConnectInfo<SocketAddr>` extractor and non-loopback Bearer requirement.
@@ -2006,12 +2006,113 @@ mod tests {
             assert_eq!(body["report"]["announce"]["status"], "reloaded");
             assert_eq!(body["report"]["notify"]["status"], "reloaded");
             assert_eq!(
+                body["report"]["scopes"]["utility_rest_clients"]["status"],
+                "reload_supported"
+            );
+            assert_eq!(
+                body["report"]["scopes"]["utility_rest_clients"]["restart_required"],
+                false
+            );
+            assert_eq!(
+                body["report"]["scopes"]["provider_runtime_cached_token"]["status"],
+                "restart_required"
+            );
+            assert_eq!(
+                body["report"]["scopes"]["provider_runtime_cached_token"]["restart_required"],
+                true
+            );
+            assert_eq!(
+                body["report"]["scopes"]["provider_gateway_session"]["status"],
+                "restart_required"
+            );
+            assert_eq!(
+                body["report"]["scopes"]["provider_gateway_session"]["restart_required"],
+                true
+            );
+            assert_eq!(
                 body["report"]["provider_cached_bot_token_scope"],
                 "announce/notify HealthRegistry clients are reloaded; provider runtime SharedData.cached_bot_token is restart-only"
             );
             assert!(!String::from_utf8_lossy(&bytes).contains("announce-token"));
             assert!(!String::from_utf8_lossy(&bytes).contains("notify-token"));
         });
+    }
+
+    #[test]
+    fn discord_bot_token_reload_router_reports_missing_or_invalid_credentials() {
+        let runtime_root = tempfile::tempdir().expect("temp runtime root");
+        let _env = EnvVarGuard::set_path("AGENTDESK_ROOT_DIR", runtime_root.path());
+        crate::runtime_layout::ensure_credential_layout(runtime_root.path()).unwrap();
+        let notify_path =
+            crate::runtime_layout::credential_token_path(runtime_root.path(), "notify");
+        crate::utils::secret_file::write_secret_file(&notify_path, "   \n")
+            .expect("write invalid notify token");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        runtime.block_on(async {
+            let mut config = crate::config::Config::default();
+            config.server.host = "0.0.0.0".to_string();
+            let registry = Arc::new(crate::services::discord::health::HealthRegistry::new());
+            let app = test_api_router_with_config_and_registry(config, Some(registry));
+
+            let response = app
+                .oneshot(reload_bot_tokens_request("127.0.0.1:8791"))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+            assert_eq!(body["ok"], false);
+            assert_eq!(body["status"], "no_valid_credentials_loaded");
+            assert_eq!(body["report"]["announce"]["status"], "missing_or_invalid");
+            assert_eq!(body["report"]["announce"]["previous_client_kept"], false);
+            assert_eq!(body["report"]["notify"]["status"], "missing_or_invalid");
+            assert_eq!(body["report"]["notify"]["previous_client_kept"], false);
+            assert_eq!(
+                body["report"]["scopes"]["provider_runtime_cached_token"]["restart_required"],
+                true
+            );
+            let response_text = String::from_utf8_lossy(&bytes);
+            assert!(!response_text.contains("announce-token"));
+            assert!(!response_text.contains("notify-token"));
+        });
+    }
+
+    #[tokio::test]
+    async fn health_detail_reports_provider_runtime_bot_token_restart_required() {
+        let mut config = crate::config::Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        let registry = Arc::new(crate::services::discord::health::HealthRegistry::new());
+        let app = test_api_router_with_config_and_registry(config, Some(registry));
+
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("/health/detail")
+            .body(Body::empty())
+            .unwrap();
+        request.extensions_mut().insert(axum::extract::ConnectInfo(
+            "127.0.0.1:8791".parse::<std::net::SocketAddr>().unwrap(),
+        ));
+        let response = app.oneshot(request).await.unwrap();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(
+            body["bot_token_reload_scopes"]["provider_runtime_cached_token"]["status"],
+            "restart_required"
+        );
+        assert_eq!(
+            body["bot_token_reload_scopes"]["provider_runtime_cached_token"]["restart_required"],
+            true
+        );
+        assert_eq!(
+            body["bot_token_reload_scopes"]["provider_gateway_session"]["restart_required"],
+            true
+        );
     }
 
     #[test]

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -89,6 +89,30 @@ pub enum BotTokenReloadStatus {
     RuntimeRootUnavailable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BotTokenReloadScopeStatus {
+    ReloadSupported,
+    RestartRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BotTokenReloadScope {
+    pub scope: &'static str,
+    pub status: BotTokenReloadScopeStatus,
+    pub live_reload_supported: bool,
+    pub restart_required: bool,
+    pub token_source: &'static str,
+    pub detail: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BotTokenReloadScopes {
+    pub utility_rest_clients: BotTokenReloadScope,
+    pub provider_runtime_cached_token: BotTokenReloadScope,
+    pub provider_gateway_session: BotTokenReloadScope,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BotTokenReloadEntry {
     pub bot: &'static str,
@@ -106,7 +130,37 @@ pub struct BotTokenReloadReport {
     pub runtime_root_available: bool,
     pub any_reloaded: bool,
     pub utility_bot_user_ids_invalidated: bool,
+    pub scopes: BotTokenReloadScopes,
     pub provider_cached_bot_token_scope: &'static str,
+}
+
+pub fn bot_token_reload_scopes() -> BotTokenReloadScopes {
+    BotTokenReloadScopes {
+        utility_rest_clients: BotTokenReloadScope {
+            scope: "utility_rest_clients",
+            status: BotTokenReloadScopeStatus::ReloadSupported,
+            live_reload_supported: true,
+            restart_required: false,
+            token_source: "credential/announce_bot_token and credential/notify_bot_token",
+            detail: "POST /api/discord/bot-tokens/reload rebuilds announce/notify HealthRegistry REST clients in place.",
+        },
+        provider_runtime_cached_token: BotTokenReloadScope {
+            scope: "provider_runtime_cached_token",
+            status: BotTokenReloadScopeStatus::RestartRequired,
+            live_reload_supported: false,
+            restart_required: true,
+            token_source: "discord.bots.<name>.token or credential/<name>_bot_token selected at provider runtime startup",
+            detail: "SharedData.cached_bot_token is a OnceCell per provider runtime, so rotated provider REST fallback credentials are not adopted until dcserver restarts.",
+        },
+        provider_gateway_session: BotTokenReloadScope {
+            scope: "provider_gateway_session",
+            status: BotTokenReloadScopeStatus::RestartRequired,
+            live_reload_supported: false,
+            restart_required: true,
+            token_source: "discord.bots.<name>.token or credential/<name>_bot_token selected at provider runtime startup",
+            detail: "Discord gateway sessions are created by provider runtimes at startup; reconnecting them with a rotated token requires a dcserver restart.",
+        },
+    }
 }
 
 /// Registry that providers register with so the unified axum API can query all of them.
@@ -422,6 +476,7 @@ impl HealthRegistry {
             any_reloaded: announce.reloaded || notify.reloaded,
             utility_bot_user_ids_invalidated: announce.user_id_cache_invalidated
                 || notify.user_id_cache_invalidated,
+            scopes: bot_token_reload_scopes(),
             provider_cached_bot_token_scope: "announce/notify HealthRegistry clients are reloaded; provider runtime SharedData.cached_bot_token is restart-only",
             announce,
             notify,

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -1,11 +1,11 @@
 use poise::serenity_prelude::ChannelId;
 use serde::Serialize;
 
-use super::HealthRegistry;
 use super::mailbox::MailboxHealthSnapshot;
 use super::provider_probe::{self, ProviderHealthSnapshot};
 use super::redaction;
 use super::session_enrichment::SessionEnrichment;
+use super::{BotTokenReloadScopes, HealthRegistry, bot_token_reload_scopes};
 use crate::services::discord;
 use crate::services::discord::SharedData;
 use crate::services::discord::relay_health::{
@@ -138,6 +138,7 @@ pub struct DiscordHealthSnapshot {
     queue_depth: usize,
     watcher_count: usize,
     recovery_duration: f64,
+    bot_token_reload_scopes: BotTokenReloadScopes,
     degraded_reasons: Vec<String>,
     providers: Vec<ProviderHealthSnapshot>,
     mailboxes: Vec<MailboxHealthSnapshot>,
@@ -763,6 +764,7 @@ async fn build_health_snapshot_with_options(
         queue_depth,
         watcher_count,
         recovery_duration,
+        bot_token_reload_scopes: bot_token_reload_scopes(),
         degraded_reasons,
         providers: provider_entries,
         mailboxes: mailbox_entries,


### PR DESCRIPTION
Issue: #3793

## Summary
- Add machine-readable bot-token reload scope reporting to `/api/discord/bot-tokens/reload`.
- Mark utility REST clients as live-reloadable while provider runtime cached token and provider gateway session are explicit `restart_required` scopes.
- Surface the same capability status in `/api/health/detail` and API docs.
- Update operator docs with separate utility reload and provider/gateway restart procedures.

## Verification
- `cargo fmt`
- `cargo test reload_bot_tokens`
- `cargo test bot_token_reload`
- `cargo test health_detail_reports_provider_runtime_bot_token_restart_required`
- `cargo check --all-targets`
- `python3 scripts/check_agent_maintenance_docs.py --line-count-gate`
- `python3 scripts/audit_maintainability.py --check`
- `git diff --check`
- fresh Codex xhigh review: `VERDICT: CLEAN`

## Notes
- Provider runtime/gateway live reload remains intentionally unsupported in this PR; the operator-visible behavior is now explicit instead of ambiguous.
- The scope status is capability/status reporting, not token-change detection.