### PR TITLE
test(e2e): define agent involvement lanes

### DIFF
--- a/docs/auto-queue-turn-finalization.md
+++ b/docs/auto-queue-turn-finalization.md
@@ -4,6 +4,19 @@ Tracks issue #1586 and subissue #1637. This document inventories the current
 sources of truth for "a turn is finished" before the implementation PRs make
 one canonical finalizer responsible for all downstream completion effects.
 
+## E2E Agent Mode Lane
+
+Auto-queue sandbox preflight must default to a non-live lane. Use
+`agent_mode: none` for static fixture/preflight checks and `agent_mode:
+controlled` when a deterministic finalizer stub drives the transition. These
+lanes must not contact a real provider and must not mutate production cards,
+GitHub branches, Discord sessions, or live queue rows.
+
+Any future live auto-queue smoke must opt in explicitly with `agent_mode:
+real_live` and report `real_provider_contacted: true` plus provider/cell
+identity. Required gates should fail when a scenario declares `controlled` or
+`real_live` but only produces a shallower observed lane.
+
 ## Current Signal Inventory
 
 | Signal | Current producers | Current consumers | Classification |

--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -27,12 +27,30 @@ is in that list.
 
 ```yaml
 id: E-1
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 steps:
   - send_prompt: ...
 assertions:
   - ...
 ```
+
+Every scenario must declare `agent_mode`:
+
+| `agent_mode` | Use when | Relay example |
+| --- | --- | --- |
+| `none` | No AgentDesk agent/provider is contacted; the harness checks local state-machine or replay fixtures only. | `E-24`/`E-25` local fixture replay. These can prove parser/finalization contracts, but cannot satisfy live relay gates. |
+| `controlled` | A deterministic test agent, fake provider, scripted responder, or controlled runtime hook owns completion. | Future hook-backed relay gaps such as forced quiescence timeout or synthetic foreign-active state. |
+| `real_live` | The scenario sends work through a real provider/cell and live Discord/runtime boundary. | Normal relay matrix prompts, direct TUI input, cross-channel `E-11`, and post-deploy relay continuity smoke. |
+
+The driver validates metadata against the scenario shape. A scenario that
+declares `none` but sends a prompt, or declares `real_live` while switching to a
+fixture execution lane, fails before it can produce a misleading green report.
+Gate runners can also pass `--required-agent-mode controlled` or
+`--required-agent-mode real_live`; selected scenarios below that lane fail
+instead of silently downgrading. Machine-readable reports include
+`agent_mode`, `agent_mode_actual`, `provider_identity`, `real_provider_contacted`,
+and `failure_attribution` on each scenario.
 
 Provider-specific scenarios (`E-6` claude `/compact`, `E-7` codex `/compact`)
 narrow the list. TUI-keystroke-only scenarios (`E-4`, `E-10`, `E-12`) include
@@ -132,7 +150,10 @@ scripts/e2e/run_tui_relay.py \
 The driver writes `report.<cell>.json` so an orchestrator that aims all 5 cells
 at one `--output` directory does not overwrite sibling reports. Per-cell lease
 files (`/tmp/agentdesk-e2e-relay.<cell>.lease`) let cells run in parallel from
-separate operator sessions.
+separate operator sessions. The top-level report includes `agent_mode_totals`
+and `real_provider_contacted`; individual scenario rows include the provider,
+runtime, worker agent, channel id, raw failure attribution, and whether a real
+provider was contacted.
 
 Post-deploy relay continuity uses a narrower operational wrapper around the
 same driver:
@@ -151,6 +172,13 @@ The live form adds `--confirm-live` and runs only TUI cells (`claude-tui` or
 boundary. See
 [`docs/runbooks/post-deploy-relay-continuity-smoke.md`](../runbooks/post-deploy-relay-continuity-smoke.md)
 for the full runbook and pass/fail evidence.
+
+Auto-queue and voice harnesses use the same lane vocabulary. The sandbox
+auto-queue preflight defaults to `agent_mode=none` or a controlled finalizer
+because it validates generate/dispatch/slot/entry/run truth, not LLM behavior.
+Deterministic PCM voice E2E should use `agent_mode=controlled`; the opt-in live
+Discord media smoke is the voice `agent_mode=real_live` lane and must say
+whether a real provider was contacted.
 
 Destructive steps (`restart_dcserver`, `kill_pane`, `send_keys_no_enter`,
 `cancel_turn`) are gated by both `--allow-destructive` and

--- a/docs/runbooks/post-deploy-relay-continuity-smoke.md
+++ b/docs/runbooks/post-deploy-relay-continuity-smoke.md
@@ -20,6 +20,9 @@ python3 scripts/e2e/post_deploy_relay_continuity.py --fixture bad-state
 smoke distinguishes local output from Discord relay continuity and catches
 ownerless inflight, relay-dead, stale proof, and orphaned target states.
 
+Offline checks report `agent_mode: none` and `real_provider_contacted: false`.
+They are fixtures only; they must never satisfy a required live relay gate.
+
 ## Live Dry Run
 
 Use dry run before a release deploy to validate config, channel id lookup, and
@@ -34,6 +37,17 @@ python3 scripts/e2e/post_deploy_relay_continuity.py \
 
 The script resolves the `adk-<cell>-e2e` channel id from
 `~/.adk/release/config/agentdesk.yaml` unless `--channel-id` is supplied.
+Dry run declares the planned live lane but reports `agent_mode_actual: none` and
+`real_provider_contacted: false`; it verifies wiring without contacting the TUI
+provider.
+
+## Agent Mode Contract
+
+The live smoke is an explicit `agent_mode: real_live` scenario. The summary and
+wrapped TUI relay report must include the requested lane, observed lane, cell
+identity, provider identity, `real_provider_contacted`, and failure attribution.
+The wrapper rejects live success unless both `E-9` and `E-19` report
+`agent_mode: real_live` and `real_provider_contacted: true`.
 
 ## Live Smoke
 

--- a/docs/voice-e2e-results.md
+++ b/docs/voice-e2e-results.md
@@ -8,6 +8,16 @@
 본문은 시나리오·기대 동작·관찰 포인트·체크박스를 포함하며, 실측 후 결과(통과/실패 +
 짧은 메모)를 직접 기록한다.
 
+## agent_mode lane
+
+- 현재 수동 실측 체크리스트는 실제 Discord voice channel, STT/TTS, 외부 agent 응답을
+  쓰므로 `agent_mode: real_live` 로 취급한다.
+- 결정적 PCM/fixture 기반 voice harness 는 `agent_mode: controlled` 로 기록하고,
+  실제 provider 접촉 없이 미디어 파이프라인만 검증한다.
+- live voice media smoke 는 명시적 opt-in 일 때만 `agent_mode: real_live` 로 실행하며,
+  보고서에는 `agent_mode`, cell/provider 식별자, `real_provider_contacted`, 실패 귀속
+  (Discord media, STT/TTS, provider response, relay/reporting)을 남긴다.
+
 ## 머신/클라이언트 분리 (중요)
 
 ADK voice는 Discord 표준 voice channel을 그대로 사용하므로 **사용자 마이크/스피커는

--- a/scripts/e2e/post_deploy_relay_continuity.py
+++ b/scripts/e2e/post_deploy_relay_continuity.py
@@ -464,6 +464,9 @@ def run_self_check(
     ok = all(check["ok"] or not check["fatal"] for check in checks)
     return {
         "mode": "self-check",
+        "agent_mode": "none",
+        "agent_mode_actual": "none",
+        "real_provider_contacted": False,
         "ok": ok,
         "strict_live": strict_live,
         "checks": checks,
@@ -654,6 +657,8 @@ def validate_driver_report(report: dict[str, Any]) -> list[str]:
     totals = report.get("totals") if isinstance(report.get("totals"), dict) else {}
     if int(totals.get("fail") or 0) > 0:
         violations.append(f"driver reported failed scenario count={totals.get('fail')}")
+    if report.get("real_provider_contacted") is not True:
+        violations.append("driver report did not record real_provider_contacted=true")
 
     scenarios = _scenario_by_id(report)
     for scenario_id in REQUIRED_SCENARIO_IDS:
@@ -661,6 +666,10 @@ def validate_driver_report(report: dict[str, Any]) -> list[str]:
         if not scenario:
             violations.append(f"driver report missing required scenario {scenario_id}")
             continue
+        if scenario.get("agent_mode") != "real_live":
+            violations.append(f"{scenario_id} agent_mode={scenario.get('agent_mode')}")
+        if scenario.get("real_provider_contacted") is not True:
+            violations.append(f"{scenario_id} real_provider_contacted is not true")
         if scenario.get("status") != "pass":
             violations.append(
                 f"{scenario_id} status={scenario.get('status')} reason={scenario.get('reason')}"
@@ -696,6 +705,9 @@ def run_fixture_mode(args: argparse.Namespace) -> int:
     violations = validate_fixture_evidence(evidence)
     result = {
         "mode": "fixture",
+        "agent_mode": "none",
+        "agent_mode_actual": "none",
+        "real_provider_contacted": False,
         "fixture": args.fixture,
         "ok": not violations,
         "violations": violations,
@@ -710,6 +722,9 @@ def run_dry_run(args: argparse.Namespace) -> int:
         _json_dump(
             {
                 "mode": "dry-run",
+                "agent_mode": "real_live",
+                "agent_mode_actual": "none",
+                "real_provider_contacted": False,
                 "ok": False,
                 "self_check": checks,
                 "driver_command": None,
@@ -731,6 +746,15 @@ def run_dry_run(args: argparse.Namespace) -> int:
     )
     result = {
         "mode": "dry-run",
+        "agent_mode": "real_live",
+        "agent_mode_actual": "none",
+        "real_provider_contacted": False,
+        "agent_mode_contract": cell_driver._agent_mode_contract(  # noqa: SLF001
+            declared="real_live",
+            actual="none",
+            dry_run=True,
+            real_provider_contacted=False,
+        ),
         "ok": bool(checks["ok"] and command),
         "self_check": checks,
         "driver_command": command,
@@ -746,6 +770,9 @@ def run_live(args: argparse.Namespace) -> int:
         _json_dump(
             {
                 "mode": "live",
+                "agent_mode": "real_live",
+                "agent_mode_actual": "none",
+                "real_provider_contacted": False,
                 "ok": False,
                 "violations": ["live execution requires --confirm-live"],
             }
@@ -753,7 +780,16 @@ def run_live(args: argparse.Namespace) -> int:
         return 2
     checks = run_self_check(args, strict_live=True)
     if not checks["ok"]:
-        _json_dump({"mode": "live", "ok": False, "self_check": checks})
+        _json_dump(
+            {
+                "mode": "live",
+                "agent_mode": "real_live",
+                "agent_mode_actual": "none",
+                "real_provider_contacted": False,
+                "ok": False,
+                "self_check": checks,
+            }
+        )
         return 2
 
     output_dir = resolve_output_dir(args.output)
@@ -788,8 +824,14 @@ def run_live(args: argparse.Namespace) -> int:
 
     summary = {
         "mode": "live",
+        "agent_mode": "real_live",
+        "agent_mode_actual": "real_live" if (report or {}).get("real_provider_contacted") else "none",
+        "real_provider_contacted": bool((report or {}).get("real_provider_contacted")),
         "ok": not violations,
         "cell": args.cell,
+        "provider": cell_driver.cell_provider(args.cell),
+        "runtime": cell_driver.cell_runtime(args.cell),
+        "provider_identity": cell_driver.provider_identity(args.cell, channel_id),
         "channel_id": channel_id,
         "output": str(output_dir),
         "driver_report": str(report_path),
@@ -807,7 +849,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         if args.list_fixtures:
-            _json_dump({"fixtures": sorted(BUILTIN_FIXTURES)})
+            _json_dump(
+                {
+                    "agent_mode": "none",
+                    "real_provider_contacted": False,
+                    "fixtures": sorted(BUILTIN_FIXTURES),
+                }
+            )
             return 0
         if args.fixture:
             return run_fixture_mode(args)

--- a/scripts/e2e/run_multi_provider_matrix.py
+++ b/scripts/e2e/run_multi_provider_matrix.py
@@ -79,6 +79,12 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=float(os.environ.get("AGENTDESK_E2E_TURN_START_TIMEOUT_S", "180")),
     )
+    parser.add_argument(
+        "--required-agent-mode",
+        choices=cell_driver.AGENT_MODES,
+        default=os.environ.get("AGENTDESK_E2E_REQUIRED_AGENT_MODE"),
+        help="Fail selected scenarios whose declared agent_mode is below this gate.",
+    )
     return parser.parse_args()
 
 
@@ -124,6 +130,7 @@ def load_cross_channel_scenarios(scenarios_dir: Path) -> list[dict[str, Any]]:
         if not isinstance(data.get("cross_channel"), dict):
             raise ValueError(f"{yaml_path} declares cross_channel without config")
         data["__path__"] = str(yaml_path)
+        cell_driver.validate_scenario_agent_mode(data)
         scenarios.append(data)
     return scenarios
 
@@ -183,6 +190,8 @@ def run_cell(
         cmd.extend(["--filter", args.filter])
     if args.dry_run:
         cmd.append("--dry-run")
+    if args.required_agent_mode:
+        cmd.extend(["--required-agent-mode", str(args.required_agent_mode)])
     if args.allow_destructive:
         cmd.append("--allow-destructive")
     if not args.reset_before_each:
@@ -201,10 +210,15 @@ def run_cell(
         "kind": "cell",
         "pass_index": pass_index,
         "cell": cell,
+        "provider": cell_driver.cell_provider(cell),
+        "runtime": cell_driver.cell_runtime(cell),
         "channel_id": channel_id,
+        "provider_identity": cell_driver.provider_identity(cell, channel_id),
         "returncode": proc.returncode,
         "report": str(report_path),
         "totals": (report or {}).get("totals"),
+        "agent_mode_totals": (report or {}).get("agent_mode_totals"),
+        "real_provider_contacted": bool((report or {}).get("real_provider_contacted")),
         "ok": proc.returncode == 0 and bool(report),
     }
 
@@ -265,12 +279,14 @@ def resolve_cross_channel_participants(
                 "name": str(raw_participant.get("name") or cell),
                 "cell": cell,
                 "provider": cell_driver.cell_provider(cell),
+                "runtime": cell_driver.cell_runtime(cell),
                 "channel_id": str(channel_id),
                 "channel_kind": str(
                     raw_participant.get("channel_kind")
                     or cell_driver.cell_channel_kind(cell)
                 ),
                 "handoff_to_agent": cell_driver.cell_default_agent(cell),
+                "provider_identity": cell_driver.provider_identity(cell, str(channel_id)),
                 "workspace_substring": cell_driver.cell_workspace_substring(cell),
                 "marker": str(marker),
                 "prompt": str(prompt),
@@ -555,6 +571,7 @@ def run_cross_channel_scenario(
     pass_index: int,
 ) -> dict[str, Any]:
     scenario_id = str(scenario.get("id"))
+    declared_agent_mode = cell_driver.scenario_agent_mode(scenario)
     result: dict[str, Any] = {
         "kind": "cross_channel",
         "pass_index": pass_index,
@@ -562,20 +579,66 @@ def run_cross_channel_scenario(
         "path": scenario.get("__path__"),
         "status": "skipped",
         "reason": None,
+        "agent_mode": declared_agent_mode,
+        "agent_mode_planned": cell_driver.infer_planned_agent_mode(
+            scenario,
+            declared=declared_agent_mode,
+        ),
+        "agent_mode_actual": "none",
+        "agent_mode_contract": cell_driver._agent_mode_contract(  # noqa: SLF001
+            declared=declared_agent_mode,
+            actual="none",
+            dry_run=bool(args.dry_run),
+            real_provider_contacted=False,
+        ),
+        "real_provider_contacted": False,
+        "failure_attribution": None,
         "participants": [],
         "ok": False,
         "started_at": dt.datetime.now().isoformat(timespec="seconds"),
     }
+
+    gate_violation = cell_driver.required_agent_mode_violation(
+        declared=declared_agent_mode,
+        required=getattr(args, "required_agent_mode", None),
+        scenario_id=scenario_id,
+    )
+    if gate_violation:
+        result["status"] = "fail"
+        result["reason"] = gate_violation
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "agent_mode_gate",
+            gate_violation,
+        )
+        return result
 
     try:
         required_cells = _cross_participants_required_cells(scenario)
     except ValueError as error:
         result["status"] = "fail"
         result["reason"] = str(error)
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "config",
+            str(error),
+        )
         return result
     missing_selected = sorted(required_cells.difference(selected_cells))
     if missing_selected:
         result["reason"] = "requires selected cells: " + ", ".join(missing_selected)
+        observed_gate_violation = cell_driver.required_agent_mode_violation(
+            declared=declared_agent_mode,
+            actual=str(result["agent_mode_actual"]),
+            required=getattr(args, "required_agent_mode", None),
+            scenario_id=scenario_id,
+        )
+        if observed_gate_violation and not args.dry_run:
+            result["status"] = "fail"
+            result["reason"] = observed_gate_violation
+            result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+                "agent_mode_gate",
+                observed_gate_violation,
+            )
+            return result
         result["ok"] = True
         return result
 
@@ -588,11 +651,19 @@ def run_cross_channel_scenario(
     except ValueError as error:
         result["status"] = "fail"
         result["reason"] = str(error)
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "config",
+            str(error),
+        )
         return result
     result["participants"] = [
         {
             "cell": participant["cell"],
+            "provider": participant["provider"],
+            "runtime": participant["runtime"],
             "channel_id": participant["channel_id"],
+            "worker_agent": participant["handoff_to_agent"],
+            "provider_identity": participant["provider_identity"],
             "marker": participant["marker"],
         }
         for participant in participants
@@ -680,6 +751,7 @@ def run_cross_channel_scenario(
                 "message_id": response.get("message_id") or response.get("id"),
             }
 
+        dispatch_errors: list[str] = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(participants)) as executor:
             futures = {
                 executor.submit(_dispatch, participant): participant
@@ -689,13 +761,21 @@ def run_cross_channel_scenario(
                 participant = futures[future]
                 try:
                     dispatch_results.append(future.result())
+                    cell_driver._mark_real_provider_contacted(  # noqa: SLF001
+                        result,
+                        declared_agent_mode=declared_agent_mode,
+                        dry_run=False,
+                    )
                 except Exception as error:  # noqa: BLE001
-                    raise assertions.AssertionError(
-                        "cross-channel dispatch failed "
+                    dispatch_errors.append(
                         f"cell={participant['cell']} channel={participant['channel_id']}: "
                         f"{type(error).__name__}: {error}"
-                    ) from error
+                    )
         result["dispatches"] = sorted(dispatch_results, key=lambda item: item["cell"])
+        if dispatch_errors:
+            raise assertions.AssertionError(
+                "cross-channel dispatch failed " + "; ".join(dispatch_errors)
+            )
 
         wait_timeout_s = float(
             (scenario.get("cross_channel") or {}).get("wait_timeout_s", 240)
@@ -781,7 +861,11 @@ def run_cross_channel_scenario(
             )
             channel_record = {
                 "cell": participant["cell"],
+                "provider": participant["provider"],
+                "runtime": participant["runtime"],
                 "channel_id": participant["channel_id"],
+                "provider_identity": participant["provider_identity"],
+                "real_provider_contacted": True,
                 "relay_count": len(window.messages),
                 "raw_count": len(window.raw_messages),
                 "message_updates": len(window.message_updates),
@@ -813,6 +897,10 @@ def run_cross_channel_scenario(
     except assertions.AssertionError as error:
         result["status"] = "fail"
         result["reason"] = f"assertion: {error}"
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "assertion",
+            str(error),
+        )
         teardown_errors = _send_cross_channel_teardown(
             clients=clients,
             participants=participants,
@@ -824,6 +912,10 @@ def run_cross_channel_scenario(
     except Exception as error:  # noqa: BLE001
         result["status"] = "fail"
         result["reason"] = f"{type(error).__name__}: {error}"
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "exception",
+            str(result["reason"]),
+        )
         teardown_errors = _send_cross_channel_teardown(
             clients=clients,
             participants=participants,
@@ -835,6 +927,20 @@ def run_cross_channel_scenario(
 
     result["completed_at"] = dt.datetime.now().isoformat(timespec="seconds")
     return result
+
+
+def _matrix_agent_mode_totals(results: list[dict[str, Any]]) -> dict[str, int]:
+    totals = {mode: 0 for mode in cell_driver.AGENT_MODES}
+    for result in results:
+        nested = result.get("agent_mode_totals")
+        if isinstance(nested, dict):
+            for mode in totals:
+                totals[mode] += int(nested.get(mode) or 0)
+            continue
+        mode = str(result.get("agent_mode") or "")
+        if mode in totals:
+            totals[mode] += 1
+    return totals
 
 
 def main() -> int:
@@ -891,6 +997,10 @@ def main() -> int:
         "cells": cells,
         "passes": pass_count,
         "cross_channel_scenarios": [str(scenario.get("id")) for scenario in cross_scenarios],
+        "agent_mode_totals": _matrix_agent_mode_totals(results),
+        "real_provider_contacted": any(
+            result.get("real_provider_contacted") is True for result in results
+        ),
         "results": results,
         "ok": all(result["ok"] for result in results),
     }

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -53,6 +53,24 @@ SUPPORTED_CELLS: tuple[str, ...] = (
     "codex-pipe",
     "codex-tui",
 )
+AGENT_MODES: tuple[str, ...] = ("none", "controlled", "real_live")
+AGENT_MODE_RANK = {mode: rank for rank, mode in enumerate(AGENT_MODES)}
+REAL_PROVIDER_STEP_KEYS: tuple[str, ...] = (
+    "send_prompt",
+    "send_provider_hold_prompt",
+    "send_prompts_concurrent",
+    "send_keys",
+)
+CONTROLLED_HARNESS_STEP_KEYS: tuple[str, ...] = (
+    "restart_dcserver",
+    "poison_claude_tui_relay_offset",
+    "capture_session_identity",
+    "assert_session_preserved",
+    "cancel_turn",
+    "assert_health",
+    "kill_pane",
+    "send_keys_no_enter",
+)
 
 IDLE_MAILBOX_STATUSES = {"", "idle", "none"}
 IDLE_RELAY_STALL_STATES = {"", "healthy"}
@@ -80,6 +98,7 @@ REPORT_RECORD_KEYS: tuple[str, ...] = (
     "recent_raw",
     "tmux_key_sequences",
     "direct_input_prompts",
+    "concurrent_prompt_batches",
     "wait_timeouts",
     "provider_hold_prompts",
     "provider_hold_states",
@@ -91,6 +110,13 @@ REPORT_RECORD_KEYS: tuple[str, ...] = (
     "fixture_state",
     "fixture_health",
     "fixture_followup_probes",
+    "agent_mode",
+    "agent_mode_actual",
+    "agent_mode_contract",
+    "provider_identity",
+    "real_provider_contacted",
+    "controlled_harness_evidence",
+    "failure_attribution",
 )
 
 
@@ -100,6 +126,14 @@ class ScenarioStepAssertionError(assertions.AssertionError):
     def __init__(self, message: str, *, record: dict[str, Any]):
         super().__init__(message)
         self.record = record
+
+
+class ConcurrentPromptSendError(assertions.AssertionError):
+    """Concurrent prompt failure that preserves any successful sends."""
+
+    def __init__(self, message: str, *, partial_results: list[dict[str, Any]]):
+        super().__init__(message)
+        self.partial_results = partial_results
 
 
 def parse_args() -> argparse.Namespace:
@@ -192,6 +226,15 @@ def parse_args() -> argparse.Namespace:
         default=float(os.environ.get("AGENTDESK_E2E_TURN_START_TIMEOUT_S", "180")),
         help="How long send_prompt retries transient mailbox-busy turn/start responses.",
     )
+    parser.add_argument(
+        "--required-agent-mode",
+        choices=AGENT_MODES,
+        default=os.environ.get("AGENTDESK_E2E_REQUIRED_AGENT_MODE"),
+        help=(
+            "Fail selected scenarios whose declared agent_mode is shallower than "
+            "this required gate."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -220,6 +263,256 @@ def cell_channel_kind(cell: str) -> str:
 def cell_workspace_substring(cell: str) -> str:
     """Substring tagged onto runtime/jsonl paths to safely target this cell."""
     return f"adk-{cell}-e2e"
+
+
+def normalize_agent_mode(value: Any, *, scenario_id: str | None = None) -> str:
+    mode = str(value or "").strip().lower()
+    if mode not in AGENT_MODE_RANK:
+        label = f" for {scenario_id}" if scenario_id else ""
+        raise ValueError(
+            f"agent_mode{label} must be one of {', '.join(AGENT_MODES)}; got {value!r}"
+        )
+    return mode
+
+
+def scenario_agent_mode(scenario: dict[str, Any]) -> str:
+    return normalize_agent_mode(
+        scenario.get("agent_mode"),
+        scenario_id=str(scenario.get("id") or scenario.get("__path__") or "<unknown>"),
+    )
+
+
+def provider_identity(cell: str, channel_id: str | None = None) -> dict[str, Any]:
+    identity: dict[str, Any] = {
+        "cell": cell,
+        "provider": cell_provider(cell),
+        "runtime": cell_runtime(cell),
+        "worker_agent": cell_default_agent(cell),
+    }
+    if channel_id is not None:
+        identity["channel_id"] = str(channel_id)
+    return identity
+
+
+def _send_keys_sequence_contacts_provider(params: Any) -> bool:
+    if isinstance(params, dict):
+        return bool(params.get("mark_prompt_sent", True))
+    return True
+
+
+def _step_contacts_real_provider(step: dict[str, Any]) -> bool:
+    if any(key in step for key in REAL_PROVIDER_STEP_KEYS):
+        return True
+    if "send_keys_sequence" in step:
+        return _send_keys_sequence_contacts_provider(step["send_keys_sequence"])
+    return False
+
+
+def _controlled_harness_step_evidence(step: dict[str, Any]) -> str | None:
+    if _step_contacts_real_provider(step):
+        return None
+    for key in CONTROLLED_HARNESS_STEP_KEYS:
+        if key in step:
+            return key
+    if "send_keys_sequence" in step:
+        return "send_keys_sequence"
+    return None
+
+
+def scenario_has_controlled_harness_evidence(scenario: dict[str, Any]) -> bool:
+    for step in scenario.get("steps") or []:
+        if isinstance(step, dict) and _controlled_harness_step_evidence(step):
+            return True
+    return False
+
+
+def is_controlled_execution_scenario(scenario: dict[str, Any]) -> bool:
+    execution = str(scenario.get("execution") or "").strip().lower()
+    return execution in {
+        "controlled",
+        "controlled_hook",
+        "controlled_provider",
+        "hook",
+        "scripted",
+    }
+
+
+def infer_planned_agent_mode(
+    scenario: dict[str, Any],
+    *,
+    declared: str | None = None,
+) -> str:
+    if scenario.get("skip_reason") and declared is not None:
+        return declared
+    if is_local_fixture_scenario(scenario):
+        return "none"
+    for step in scenario.get("steps") or []:
+        if isinstance(step, dict) and _step_contacts_real_provider(step):
+            return "real_live"
+    if scenario.get("orchestration") == "cross_channel":
+        return "real_live"
+    if scenario_has_controlled_harness_evidence(scenario):
+        return "controlled"
+    if is_controlled_execution_scenario(scenario):
+        return "controlled"
+    return "none"
+
+
+def validate_scenario_agent_mode(scenario: dict[str, Any]) -> str:
+    declared = scenario_agent_mode(scenario)
+    planned = infer_planned_agent_mode(scenario, declared=declared)
+    if declared != planned:
+        scenario_id = str(scenario.get("id") or scenario.get("__path__") or "<unknown>")
+        raise ValueError(
+            f"{scenario_id} declares agent_mode={declared!r}, but scenario steps "
+            f"plan {planned!r}; update metadata or execution lane"
+        )
+    return declared
+
+
+def required_agent_mode_violation(
+    *,
+    declared: str,
+    actual: str | None = None,
+    required: str | None,
+    scenario_id: str,
+) -> str | None:
+    if not required:
+        return None
+    required_mode = normalize_agent_mode(required, scenario_id=scenario_id)
+    if actual is not None:
+        observed_mode = normalize_agent_mode(actual, scenario_id=scenario_id)
+    else:
+        observed_mode = declared
+    if AGENT_MODE_RANK[observed_mode] < AGENT_MODE_RANK[required_mode]:
+        if actual is not None:
+            return (
+                f"agent_mode gate requires {required_mode}, but {scenario_id} "
+                f"observed agent_mode_actual={observed_mode}"
+            )
+        return (
+            f"agent_mode gate requires {required_mode}, but {scenario_id} "
+            f"declares {declared}"
+        )
+    return None
+
+
+def _apply_observed_required_agent_mode_gate(
+    result: dict[str, Any],
+    *,
+    required: str | None,
+    declared: str,
+    scenario_id: str,
+    record: dict[str, Any] | None = None,
+) -> bool:
+    actual = result.get("agent_mode_actual")
+    if actual is None:
+        return False
+    violation = required_agent_mode_violation(
+        declared=declared,
+        actual=str(actual),
+        required=required,
+        scenario_id=scenario_id,
+    )
+    if not violation:
+        return False
+    result["status"] = "fail"
+    result["reason"] = violation
+    result["failure_attribution"] = _failure_attribution(
+        "agent_mode_gate",
+        violation,
+        record=record,
+    )
+    return True
+
+
+def _agent_mode_contract(
+    *,
+    declared: str,
+    actual: str,
+    dry_run: bool,
+    real_provider_contacted: bool,
+) -> dict[str, Any]:
+    return {
+        "declared": declared,
+        "actual": actual,
+        "dry_run": dry_run,
+        "real_provider_contacted": real_provider_contacted,
+        "satisfied": dry_run or declared == actual,
+    }
+
+
+def _failure_attribution(
+    source: str,
+    reason: str,
+    *,
+    record: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    attribution: dict[str, Any] = {
+        "source": source,
+        "raw_reason": reason,
+    }
+    if record:
+        wait_timeouts = record.get("wait_timeouts")
+        if isinstance(wait_timeouts, list) and wait_timeouts:
+            classifications = [
+                item.get("classification")
+                for item in wait_timeouts
+                if isinstance(item, dict) and item.get("classification")
+            ]
+            if classifications:
+                attribution["wait_timeout_classifications"] = classifications
+        provider_states = record.get("provider_hold_states")
+        if isinstance(provider_states, list) and provider_states:
+            classifications = [
+                item.get("classification")
+                for item in provider_states
+                if isinstance(item, dict) and item.get("classification")
+            ]
+            if classifications:
+                attribution["provider_hold_classifications"] = classifications
+    return attribution
+
+
+def _mark_real_provider_contacted(
+    record: dict[str, Any],
+    *,
+    declared_agent_mode: str,
+    dry_run: bool,
+) -> None:
+    record["real_provider_contacted"] = True
+    record["agent_mode_actual"] = "real_live"
+    record["agent_mode_contract"] = _agent_mode_contract(
+        declared=declared_agent_mode,
+        actual="real_live",
+        dry_run=dry_run,
+        real_provider_contacted=True,
+    )
+
+
+def observed_agent_mode(scenario: dict[str, Any], record: dict[str, Any]) -> str:
+    if record.get("real_provider_contacted"):
+        return "real_live"
+    if record.get("controlled_harness_evidence"):
+        return "controlled"
+    return "none"
+
+
+def _refresh_agent_mode_record(
+    record: dict[str, Any],
+    *,
+    scenario: dict[str, Any],
+    declared_agent_mode: str,
+    dry_run: bool,
+) -> None:
+    actual_mode = observed_agent_mode(scenario, record)
+    record["agent_mode_actual"] = actual_mode
+    record["agent_mode_contract"] = _agent_mode_contract(
+        declared=declared_agent_mode,
+        actual=actual_mode,
+        dry_run=dry_run,
+        real_provider_contacted=bool(record.get("real_provider_contacted")),
+    )
 
 
 def _truncate_text(value: str, *, max_chars: int = 500) -> str:
@@ -300,6 +593,7 @@ def load_scenarios(scenarios_dir: Path, *, cell: str) -> list[dict[str, Any]]:
         if cell not in cells:
             continue
         data["__path__"] = str(yaml_path)
+        validate_scenario_agent_mode(data)
         scenarios.append(data)
     return scenarios
 
@@ -628,6 +922,7 @@ def send_prompts_concurrent(
 
     specs = _normalize_concurrent_prompt_specs(params, channel_id=channel_id, cell=cell)
     results: list[dict[str, Any]] = []
+    failures: list[str] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(specs)) as executor:
         futures = {
             executor.submit(
@@ -643,11 +938,11 @@ def send_prompts_concurrent(
             try:
                 response = future.result()
             except Exception as error:  # noqa: BLE001 - report every failed branch
-                raise assertions.AssertionError(
-                    "send_prompts_concurrent failed "
+                failures.append(
                     f"index={spec['index']} channel={spec['channel_id']}: "
                     f"{type(error).__name__}: {error}"
-                ) from error
+                )
+                continue
             results.append(
                 {
                     "index": spec["index"],
@@ -655,6 +950,11 @@ def send_prompts_concurrent(
                     "message_id": response.get("message_id") or response.get("id"),
                 }
             )
+    if failures:
+        raise ConcurrentPromptSendError(
+            "send_prompts_concurrent failed " + "; ".join(failures),
+            partial_results=sorted(results, key=lambda item: int(item["index"])),
+        )
     return sorted(results, key=lambda item: int(item["index"]))
 
 
@@ -1933,26 +2233,82 @@ def run_scenario(
 ) -> dict[str, Any]:
     scenario_id = str(scenario.get("id"))
     cell = args.cell
+    declared_agent_mode = scenario_agent_mode(scenario)
+    planned_agent_mode = infer_planned_agent_mode(
+        scenario,
+        declared=declared_agent_mode,
+    )
     result: dict[str, Any] = {
         "id": scenario_id,
         "path": scenario.get("__path__"),
         "cell": cell,
+        "provider": cell_provider(cell),
+        "runtime": cell_runtime(cell),
         "channel_id": args.channel_id,
         "status": "skipped",
         "reason": None,
         "started_at": dt.datetime.now().isoformat(timespec="seconds"),
         "assertions": [],
+        "agent_mode": declared_agent_mode,
+        "agent_mode_planned": planned_agent_mode,
+        "agent_mode_actual": "none",
+        "agent_mode_contract": _agent_mode_contract(
+            declared=declared_agent_mode,
+            actual="none",
+            dry_run=bool(args.dry_run),
+            real_provider_contacted=False,
+        ),
+        "provider_identity": provider_identity(cell, args.channel_id),
+        "real_provider_contacted": False,
+        "failure_attribution": None,
     }
 
     target_channel_id = scenario_channel_id(scenario, args)
     if target_channel_id is None:
         result["reason"] = "requires --thread-channel-id or AGENTDESK_E2E_THREAD_CHANNEL_ID"
+        result["failure_attribution"] = _failure_attribution(
+            "config",
+            str(result["reason"]),
+        )
+        if not args.dry_run:
+            _apply_observed_required_agent_mode_gate(
+                result,
+                required=getattr(args, "required_agent_mode", None),
+                declared=declared_agent_mode,
+                scenario_id=scenario_id,
+            )
         return result
     result["channel_id"] = target_channel_id
+    result["provider_identity"] = provider_identity(cell, target_channel_id)
+
+    gate_violation = required_agent_mode_violation(
+        declared=declared_agent_mode,
+        required=getattr(args, "required_agent_mode", None),
+        scenario_id=scenario_id,
+    )
+    if gate_violation:
+        result["status"] = "fail"
+        result["reason"] = gate_violation
+        result["failure_attribution"] = _failure_attribution(
+            "agent_mode_gate",
+            gate_violation,
+        )
+        return result
 
     if scenario.get("skip_reason"):
         result["reason"] = str(scenario["skip_reason"])
         result["acceptance_criteria"] = scenario.get("acceptance_criteria")
+        result["failure_attribution"] = _failure_attribution(
+            "scenario_skip",
+            str(result["reason"]),
+        )
+        if not args.dry_run:
+            _apply_observed_required_agent_mode_gate(
+                result,
+                required=getattr(args, "required_agent_mode", None),
+                declared=declared_agent_mode,
+                scenario_id=scenario_id,
+            )
         return result
 
     destructive = is_destructive(scenario)
@@ -1964,6 +2320,17 @@ def run_scenario(
         result["reason"] = (
             "destructive: requires --allow-destructive AND AGENTDESK_E2E_ALLOW_DESTRUCTIVE=1"
         )
+        result["failure_attribution"] = _failure_attribution(
+            "destructive_gate",
+            str(result["reason"]),
+        )
+        if not args.dry_run:
+            _apply_observed_required_agent_mode_gate(
+                result,
+                required=getattr(args, "required_agent_mode", None),
+                declared=declared_agent_mode,
+                scenario_id=scenario_id,
+            )
         return result
 
     if args.reset_before_each and not args.dry_run and not is_local_fixture_scenario(scenario):
@@ -1990,6 +2357,7 @@ def run_scenario(
         time.sleep(2.0)
 
     try:
+        partial_record_holder: dict[str, Any] = {}
         window = run_one_cell(
             scenario=scenario,
             cell=cell,
@@ -1998,13 +2366,39 @@ def run_scenario(
             run_id=run_id,
             dry_run=args.dry_run,
             args=args,
+            partial_record_sink=partial_record_holder,
         )
         _merge_record_into_result(result, window)
-        result["status"] = "pass"
+        if not args.dry_run and _apply_observed_required_agent_mode_gate(
+            result,
+            required=getattr(args, "required_agent_mode", None),
+            declared=declared_agent_mode,
+            scenario_id=scenario_id,
+            record=window,
+        ):
+            pass
+        elif not args.dry_run and result.get("agent_mode_actual") != declared_agent_mode:
+            result["status"] = "fail"
+            result["reason"] = (
+                "agent_mode contract mismatch: "
+                f"declared={declared_agent_mode} actual={result.get('agent_mode_actual')}"
+            )
+            result["failure_attribution"] = _failure_attribution(
+                "agent_mode_contract",
+                str(result["reason"]),
+                record=window,
+            )
+        else:
+            result["status"] = "pass"
     except ScenarioStepAssertionError as error:
         result["status"] = "fail"
         result["reason"] = f"assertion: {error}"
         _merge_record_into_result(result, error.record)
+        result["failure_attribution"] = _failure_attribution(
+            "assertion",
+            str(error),
+            record=error.record,
+        )
         if not args.dry_run:
             try:
                 send_teardown_marker(
@@ -2021,6 +2415,20 @@ def run_scenario(
     except assertions.AssertionError as error:
         result["status"] = "fail"
         result["reason"] = f"assertion: {error}"
+        partial_record = partial_record_holder.get("record")
+        if isinstance(partial_record, dict):
+            _refresh_agent_mode_record(
+                partial_record,
+                scenario=scenario,
+                declared_agent_mode=declared_agent_mode,
+                dry_run=args.dry_run,
+            )
+            _merge_record_into_result(result, partial_record)
+        result["failure_attribution"] = _failure_attribution(
+            "assertion",
+            str(error),
+            record=partial_record if isinstance(partial_record, dict) else None,
+        )
         if not args.dry_run:
             try:
                 send_teardown_marker(
@@ -2037,6 +2445,20 @@ def run_scenario(
     except Exception as error:  # noqa: BLE001 — surfaced in report
         result["status"] = "fail"
         result["reason"] = f"{type(error).__name__}: {error}"
+        partial_record = partial_record_holder.get("record")
+        if isinstance(partial_record, dict):
+            _refresh_agent_mode_record(
+                partial_record,
+                scenario=scenario,
+                declared_agent_mode=declared_agent_mode,
+                dry_run=args.dry_run,
+            )
+            _merge_record_into_result(result, partial_record)
+        result["failure_attribution"] = _failure_attribution(
+            "exception",
+            str(result["reason"]),
+            record=partial_record if isinstance(partial_record, dict) else None,
+        )
         if not args.dry_run:
             try:
                 send_teardown_marker(
@@ -2064,8 +2486,10 @@ def run_one_cell(
     run_id: str,
     dry_run: bool,
     args: argparse.Namespace,
+    partial_record_sink: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     scenario_id = scenario.get("id")
+    declared_agent_mode = scenario_agent_mode(scenario)
     if is_local_fixture_scenario(scenario):
         return run_local_fixture_scenario(
             scenario=scenario,
@@ -2076,7 +2500,21 @@ def run_one_cell(
         )
 
     setup_marker = f"### E2E SETUP {scenario_id} cell={cell} run={run_id}"
-    record: dict[str, Any] = {"assertions": []}
+    record: dict[str, Any] = {
+        "assertions": [],
+        "agent_mode": declared_agent_mode,
+        "agent_mode_actual": "none",
+        "agent_mode_contract": _agent_mode_contract(
+            declared=declared_agent_mode,
+            actual="none",
+            dry_run=dry_run,
+            real_provider_contacted=False,
+        ),
+        "provider_identity": provider_identity(cell, channel_id),
+        "real_provider_contacted": False,
+    }
+    if partial_record_sink is not None:
+        partial_record_sink["record"] = record
 
     if dry_run:
         print(f"[dry-run] {scenario_id} ({cell}): would send setup → steps → teardown")
@@ -2119,6 +2557,11 @@ def run_one_cell(
     for step in scenario.get("steps") or []:
         if not isinstance(step, dict):
             continue
+        controlled_evidence = _controlled_harness_step_evidence(step)
+        if controlled_evidence:
+            record.setdefault("controlled_harness_evidence", []).append(
+                controlled_evidence
+            )
         if "send_prompt" in step:
             _prepare_first_prompt_window()
             window.mark_prompt_sent()
@@ -2127,6 +2570,11 @@ def run_one_cell(
                 channel_id,
                 last_sent_prompt,
                 channel_kind=cell_channel_kind(cell),
+            )
+            _mark_real_provider_contacted(
+                record,
+                declared_agent_mode=declared_agent_mode,
+                dry_run=dry_run,
             )
             last_turn_identity = turn_identity_from_send_response(
                 response,
@@ -2145,6 +2593,11 @@ def run_one_cell(
                 channel_id,
                 prompt,
                 channel_kind=cell_channel_kind(cell),
+            )
+            _mark_real_provider_contacted(
+                record,
+                declared_agent_mode=declared_agent_mode,
+                dry_run=dry_run,
             )
             last_turn_identity = turn_identity_from_send_response(
                 response,
@@ -2165,11 +2618,31 @@ def run_one_cell(
         elif "send_prompts_concurrent" in step:
             _prepare_first_prompt_window()
             params = step["send_prompts_concurrent"]
-            batch = send_prompts_concurrent(
-                client=client,
-                channel_id=channel_id,
-                cell=cell,
-                params=params,
+            try:
+                batch = send_prompts_concurrent(
+                    client=client,
+                    channel_id=channel_id,
+                    cell=cell,
+                    params=params,
+                )
+            except ConcurrentPromptSendError as error:
+                batch = error.partial_results
+                if batch:
+                    _mark_real_provider_contacted(
+                        record,
+                        declared_agent_mode=declared_agent_mode,
+                        dry_run=dry_run,
+                    )
+                    for _ in batch:
+                        window.mark_prompt_sent()
+                    record.setdefault("concurrent_prompt_batches", []).append(batch)
+                    _update_record_window_snapshot(record, window)
+                    raise ScenarioStepAssertionError(str(error), record=record) from error
+                raise
+            _mark_real_provider_contacted(
+                record,
+                declared_agent_mode=declared_agent_mode,
+                dry_run=dry_run,
             )
             for _ in batch:
                 window.mark_prompt_sent()
@@ -2267,18 +2740,28 @@ def run_one_cell(
                     "wait_for_provider_hold_state requires a preceding prompt send "
                     "with a turn identity"
                 )
-            record.setdefault("provider_hold_states", []).append(
-                wait_for_provider_hold_state(
-                    runtime_root=Path(args.queue_runtime_root),
-                    provider=cell_provider(cell),
-                    channel_id=channel_id,
-                    expected_identity=last_turn_identity,
-                    ok_marker=ok_marker,
-                    late_marker=late_marker,
-                    timeout_s=float(params.get("timeout_s", 180)),
-                    poll_interval_s=float(params.get("poll_interval_s", 1)),
+            try:
+                record.setdefault("provider_hold_states", []).append(
+                    wait_for_provider_hold_state(
+                        runtime_root=Path(args.queue_runtime_root),
+                        provider=cell_provider(cell),
+                        channel_id=channel_id,
+                        expected_identity=last_turn_identity,
+                        ok_marker=ok_marker,
+                        late_marker=late_marker,
+                        timeout_s=float(params.get("timeout_s", 180)),
+                        poll_interval_s=float(params.get("poll_interval_s", 1)),
+                    )
                 )
-            )
+            except assertions.AssertionError as error:
+                _update_record_window_snapshot(record, window)
+                _refresh_agent_mode_record(
+                    record,
+                    scenario=scenario,
+                    declared_agent_mode=declared_agent_mode,
+                    dry_run=dry_run,
+                )
+                raise ScenarioStepAssertionError(str(error), record=record) from error
         elif "restart_dcserver" in step:
             target = args.restart_target_override or (step["restart_dcserver"] or {}).get(
                 "target", "release"
@@ -2374,7 +2857,8 @@ def run_one_cell(
                 raise assertions.AssertionError(
                     f"send_keys_sequence requires a non-empty keys list: {step!r}"
                 )
-            if bool(params.get("mark_prompt_sent", True)):
+            mark_prompt_sent = bool(params.get("mark_prompt_sent", True))
+            if mark_prompt_sent:
                 window.mark_prompt_sent()
             key_args = [str(key) for key in keys]
             last_sent_prompt = (
@@ -2402,6 +2886,12 @@ def run_one_cell(
                     key_interval_s=key_interval_s,
                 )
             )
+            if mark_prompt_sent:
+                _mark_real_provider_contacted(
+                    record,
+                    declared_agent_mode=declared_agent_mode,
+                    dry_run=dry_run,
+                )
             time.sleep(float(params.get("sleep_s", 0.2)))
         elif "send_keys" in step:
             thread_channel_id = channel_id if scenario.get("requires_thread_channel") else None
@@ -2423,6 +2913,11 @@ def run_one_cell(
                 raise assertions.AssertionError(
                     f"tmux submit failed for session {session_name!r}"
                 )
+            _mark_real_provider_contacted(
+                record,
+                declared_agent_mode=declared_agent_mode,
+                dry_run=dry_run,
+            )
         else:
             raise assertions.AssertionError(f"unknown step shape: {step!r}")
 
@@ -2437,20 +2932,34 @@ def run_one_cell(
 
     _update_record_window_snapshot(record, window)
 
-    for assertion_spec in scenario.get("assertions") or []:
-        run_assertion(assertion_spec, window=window, record=record)
-        record["assertions"].append({"spec": assertion_spec, "passed": True})
+    try:
+        for assertion_spec in scenario.get("assertions") or []:
+            run_assertion(assertion_spec, window=window, record=record)
+            record["assertions"].append({"spec": assertion_spec, "passed": True})
 
-    idle_check = assert_cell_idle(
-        base_url=client.base_url,
-        channel_id=channel_id,
-        cell=cell,
-        runtime_root=Path(args.queue_runtime_root),
-    )
-    record["post_scenario_idle"] = idle_check
-    record["assertions"].append(
-        {"spec": {"post_scenario_cell_idle": True}, "passed": True, "details": idle_check}
-    )
+        idle_check = assert_cell_idle(
+            base_url=client.base_url,
+            channel_id=channel_id,
+            cell=cell,
+            runtime_root=Path(args.queue_runtime_root),
+        )
+        record["post_scenario_idle"] = idle_check
+        record["assertions"].append(
+            {
+                "spec": {"post_scenario_cell_idle": True},
+                "passed": True,
+                "details": idle_check,
+            }
+        )
+    except assertions.AssertionError as error:
+        _update_record_window_snapshot(record, window)
+        _refresh_agent_mode_record(
+            record,
+            scenario=scenario,
+            declared_agent_mode=declared_agent_mode,
+            dry_run=dry_run,
+        )
+        raise ScenarioStepAssertionError(str(error), record=record) from error
 
     send_teardown_marker(
         client=client,
@@ -2458,6 +2967,12 @@ def run_one_cell(
         scenario_id=str(scenario_id),
         cell=cell,
         run_id=run_id,
+    )
+    _refresh_agent_mode_record(
+        record,
+        scenario=scenario,
+        declared_agent_mode=declared_agent_mode,
+        dry_run=False,
     )
     return record
 
@@ -2471,10 +2986,21 @@ def run_local_fixture_scenario(
     dry_run: bool,
 ) -> dict[str, Any]:
     scenario_id = str(scenario.get("id"))
+    declared_agent_mode = scenario_agent_mode(scenario)
     record: dict[str, Any] = {
         "assertions": [],
         "local_fixture": True,
         "fixture_steps": [],
+        "agent_mode": declared_agent_mode,
+        "agent_mode_actual": "none",
+        "agent_mode_contract": _agent_mode_contract(
+            declared=declared_agent_mode,
+            actual="none",
+            dry_run=dry_run,
+            real_provider_contacted=False,
+        ),
+        "provider_identity": provider_identity(cell, channel_id),
+        "real_provider_contacted": False,
     }
     if dry_run:
         print(f"[dry-run] {scenario_id} ({cell}): would replay local fixture")
@@ -2893,6 +3419,15 @@ def run_assertion(
         raise assertions.AssertionError(f"unknown assertion: {spec!r}")
 
 
+def agent_mode_totals(results: list[dict[str, Any]]) -> dict[str, int]:
+    totals = {mode: 0 for mode in AGENT_MODES}
+    for result in results:
+        mode = str(result.get("agent_mode") or "")
+        if mode in totals:
+            totals[mode] += 1
+    return totals
+
+
 def main() -> int:
     args = parse_args()
     cell = args.cell
@@ -2935,7 +3470,14 @@ def main() -> int:
     summary = {
         "run_id": run_id,
         "cell": cell,
+        "provider": cell_provider(cell),
+        "runtime": cell_runtime(cell),
         "channel_id": args.channel_id,
+        "provider_identity": provider_identity(cell, args.channel_id),
+        "agent_mode_totals": agent_mode_totals(results),
+        "real_provider_contacted": any(
+            result.get("real_provider_contacted") is True for result in results
+        ),
         "scenarios": results,
         "totals": {
             "pass": sum(1 for r in results if r["status"] == "pass"),
@@ -2943,7 +3485,7 @@ def main() -> int:
             "skipped": sum(1 for r in results if r["status"] == "skipped"),
         },
     }
-    summary_path.write_text(json.dumps(summary, indent=2))
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
     print(f"[e2e] report → {summary_path}")
     return 0 if summary["totals"]["fail"] == 0 else 1
 

--- a/scripts/e2e/tui_relay/test_driver_health.py
+++ b/scripts/e2e/tui_relay/test_driver_health.py
@@ -134,6 +134,196 @@ def _busy_mailbox(channel_id: str = "99", provider: str = "claude") -> dict:
     return mailbox
 
 
+class AgentModeContract(unittest.TestCase):
+    def test_load_scenarios_requires_agent_mode_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "missing.yaml"
+            path.write_text(
+                """
+id: E-X
+cells: [codex-tui]
+steps: []
+assertions: []
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                driver.load_scenarios(Path(tmp), cell="codex-tui")
+
+        self.assertIn("agent_mode", str(ctx.exception))
+
+    def test_load_scenarios_rejects_none_metadata_for_real_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mismatch.yaml"
+            path.write_text(
+                """
+id: E-X
+agent_mode: none
+cells: [codex-tui]
+steps:
+  - send_prompt: "hello"
+assertions: []
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                driver.load_scenarios(Path(tmp), cell="codex-tui")
+
+        self.assertIn("declares agent_mode='none'", str(ctx.exception))
+        self.assertIn("plan 'real_live'", str(ctx.exception))
+
+    def test_required_agent_mode_gate_fails_shallower_scenario(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="controlled",
+        )
+        scenario = {"id": "E-X", "agent_mode": "none", "steps": [], "assertions": []}
+
+        result = driver.run_scenario(
+            scenario,
+            args=args,
+            run_id="run-1",
+            client=FakeClient(),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["failure_attribution"]["source"], "agent_mode_gate")
+
+    def test_required_agent_mode_gate_fails_skipped_scenario_with_no_actual_mode(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+        args = Namespace(
+            cell="claude-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="controlled",
+        )
+        scenario = {
+            "id": "E-16",
+            "agent_mode": "controlled",
+            "skip_reason": "stub until runtime hook exists",
+            "steps": [],
+            "assertions": [],
+        }
+
+        result = driver.run_scenario(
+            scenario,
+            args=args,
+            run_id="run-1",
+            client=FakeClient(),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["agent_mode_actual"], "none")
+        self.assertEqual(result["failure_attribution"]["source"], "agent_mode_gate")
+        self.assertIn("observed agent_mode_actual=none", result["reason"])
+
+    def test_controlled_execution_metadata_without_evidence_records_none_actual_mode(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.next_id = 100
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.next_id += 1
+                return {"id": str(self.next_id)}
+
+            def fetch_messages(self, channel_id, *, after_id=None, limit=100):  # noqa: ARG002
+                return []
+
+        args = Namespace(queue_runtime_root="/tmp/agentdesk-e2e-test-runtime")
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "controlled",
+            "execution": "controlled",
+            "steps": [],
+            "assertions": [],
+        }
+
+        with patch("run_tui_relay.time.sleep"), patch(
+            "run_tui_relay.assert_cell_idle",
+            return_value={"ok": True, "mailbox": "idle"},
+        ):
+            record = driver.run_one_cell(
+                scenario=scenario,
+                cell="codex-tui",
+                channel_id="42",
+                client=FakeClient(),  # type: ignore[arg-type]
+                run_id="run-1",
+                dry_run=False,
+                args=args,
+            )
+
+        self.assertEqual(record["agent_mode_actual"], "none")
+        self.assertFalse(record["real_provider_contacted"])
+        self.assertFalse(record["agent_mode_contract"]["satisfied"])
+
+    def test_controlled_harness_step_records_controlled_actual_mode(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.next_id = 100
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.next_id += 1
+                return {"id": str(self.next_id)}
+
+            def fetch_messages(self, channel_id, *, after_id=None, limit=100):  # noqa: ARG002
+                return []
+
+        args = Namespace(queue_runtime_root="/tmp/agentdesk-e2e-test-runtime")
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "controlled",
+            "execution": "controlled",
+            "steps": [{"assert_health": {}}],
+            "assertions": [],
+        }
+
+        with (
+            patch("run_tui_relay.time.sleep"),
+            patch("run_tui_relay.assert_health", return_value={"status": "healthy"}),
+            patch(
+                "run_tui_relay.assert_cell_idle",
+                return_value={"ok": True, "mailbox": "idle"},
+            ),
+        ):
+            record = driver.run_one_cell(
+                scenario=scenario,
+                cell="codex-tui",
+                channel_id="42",
+                client=FakeClient(),  # type: ignore[arg-type]
+                run_id="run-1",
+                dry_run=False,
+                args=args,
+            )
+
+        self.assertEqual(record["agent_mode_actual"], "controlled")
+        self.assertEqual(record["controlled_harness_evidence"], ["assert_health"])
+        self.assertFalse(record["real_provider_contacted"])
+        self.assertTrue(record["agent_mode_contract"]["satisfied"])
+
+
 class HealthWait(unittest.TestCase):
     def test_wait_for_health_requires_json_healthy_not_just_http_200(self):
         degraded = {
@@ -1322,6 +1512,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-18",
+            "agent_mode": "real_live",
             "steps": [
                 {
                     "send_provider_hold_prompt": {
@@ -1360,6 +1551,8 @@ class ControlFlowPrimitives(unittest.TestCase):
             record["provider_hold_prompts"][0]["turn_identity"]["user_msg_id"],
             "9100000000000000123",
         )
+        self.assertEqual(record["agent_mode_actual"], "real_live")
+        self.assertTrue(record["real_provider_contacted"])
 
     def test_run_one_cell_local_fixture_does_not_touch_client_or_health(self):
         class ForbiddenClient:
@@ -1382,6 +1575,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-25",
+            "agent_mode": "none",
             "execution": "fixture",
             "steps": [
                 {
@@ -1437,6 +1631,8 @@ class ControlFlowPrimitives(unittest.TestCase):
         self.assertEqual(record["relay_count"], 1)
         self.assertEqual(record["post_scenario_idle"]["source"], "local_fixture")
         self.assertTrue(record["fixture_state"]["followup_probe_accepted"])
+        self.assertEqual(record["agent_mode_actual"], "none")
+        self.assertFalse(record["real_provider_contacted"])
 
     def test_run_one_cell_waits_for_hold_state_before_cancel(self):
         class FakeClient:
@@ -1463,6 +1659,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-18",
+            "agent_mode": "real_live",
             "steps": [
                 {
                     "send_provider_hold_prompt": {
@@ -1535,6 +1732,7 @@ class ControlFlowPrimitives(unittest.TestCase):
             ],
         )
         self.assertEqual(record["cancel_turns"], [{"ok": True}])
+        self.assertEqual(record["agent_mode_actual"], "real_live")
         self.assertEqual(
             record["assertions"][0],
             {
@@ -1622,6 +1820,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-X",
+            "agent_mode": "real_live",
             "steps": [
                 {
                     "send_prompts_concurrent": {
@@ -1652,6 +1851,7 @@ class ControlFlowPrimitives(unittest.TestCase):
 
         self.assertEqual(client.max_active, 2)
         self.assertCountEqual(client.sent, ["prompt-a", "prompt-b"])
+        self.assertEqual(record["agent_mode_actual"], "real_live")
         self.assertEqual(
             [item["index"] for item in record["concurrent_prompt_batches"][0]],
             [0, 1],
@@ -1675,6 +1875,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-X",
+            "agent_mode": "real_live",
             "steps": [
                 {
                     "send_keys_sequence": {
@@ -1725,6 +1926,7 @@ class ControlFlowPrimitives(unittest.TestCase):
             record["direct_input_prompts"],
             [{"mode": "send_keys_sequence", "prompt_preview": "final prompt"}],
         )
+        self.assertTrue(record["real_provider_contacted"])
 
     def test_send_keys_sequence_can_pause_between_control_keys(self):
         class FakeClient:
@@ -1744,6 +1946,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-21",
+            "agent_mode": "real_live",
             "steps": [
                 {
                     "send_keys_sequence": {
@@ -1819,6 +2022,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         )
         scenario = {
             "id": "E-21",
+            "agent_mode": "real_live",
             "steps": [
                 {
                     "send_keys_sequence": {
@@ -1914,7 +2118,7 @@ class ScenarioTeardown(unittest.TestCase):
             hard_reset_session_each=False,
             allow_destructive=False,
         )
-        scenario = {"id": "E-18", "steps": [], "assertions": []}
+        scenario = {"id": "E-18", "agent_mode": "real_live", "steps": [], "assertions": []}
         provider_hold_state = {
             "ok_marker": "[E2E:E18:OK]",
             "ok_marker_seen": True,
@@ -1940,6 +2144,16 @@ class ScenarioTeardown(unittest.TestCase):
                 "cancel_turns": [{"ok": True}],
                 "health_assertions": [{"status": "healthy"}],
                 "post_scenario_idle": {"status": "idle"},
+                "agent_mode": "real_live",
+                "agent_mode_actual": "real_live",
+                "real_provider_contacted": True,
+                "agent_mode_contract": {
+                    "declared": "real_live",
+                    "actual": "real_live",
+                    "dry_run": False,
+                    "real_provider_contacted": True,
+                    "satisfied": True,
+                },
             },
         ):
             result = driver.run_scenario(
@@ -1977,13 +2191,16 @@ class ScenarioTeardown(unittest.TestCase):
             hard_reset_session_each=False,
             allow_destructive=False,
         )
-        scenario = {"id": "E-21", "steps": [], "assertions": []}
+        scenario = {"id": "E-21", "agent_mode": "real_live", "steps": [], "assertions": []}
         partial = {
             "assertions": [],
             "relay_count": 1,
             "raw_count": 2,
             "tmux_key_sequences": [{"mode": "per_key", "count": 4}],
             "wait_timeouts": [{"classification": "direct_input_notified_no_tail_observed"}],
+            "agent_mode": "real_live",
+            "agent_mode_actual": "real_live",
+            "real_provider_contacted": True,
         }
 
         with patch(
@@ -2005,6 +2222,434 @@ class ScenarioTeardown(unittest.TestCase):
         self.assertEqual(result["raw_count"], 2)
         self.assertEqual(result["tmux_key_sequences"], partial["tmux_key_sequences"])
         self.assertEqual(result["wait_timeouts"], partial["wait_timeouts"])
+        self.assertEqual(
+            result["failure_attribution"]["wait_timeout_classifications"],
+            ["direct_input_notified_no_tail_observed"],
+        )
+
+    def test_run_scenario_preserves_agent_mode_record_on_final_assertion_failure(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                return {"id": "101"}
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [{"send_prompt": "hello"}],
+            "assertions": [{"text_present": "never observed"}],
+        }
+        client = FakeClient()
+
+        with (
+            patch("run_tui_relay.time.sleep", return_value=None),
+            patch(
+                "run_tui_relay.run_assertion",
+                side_effect=assertions.AssertionError("text missing"),
+            ),
+        ):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertTrue(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "assertion")
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
+
+    def test_run_scenario_preserves_agent_mode_record_on_provider_hold_failure(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                return {"id": "101"}
+
+        args = Namespace(
+            cell="claude-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [
+                {
+                    "send_provider_hold_prompt": {
+                        "ok_marker": "[OK]",
+                        "late_marker": "[LATE]",
+                    }
+                },
+                {
+                    "wait_for_provider_hold_state": {
+                        "ok_marker": "[OK]",
+                        "late_marker": "[LATE]",
+                    }
+                },
+            ],
+            "assertions": [],
+        }
+        client = FakeClient()
+
+        with (
+            patch("run_tui_relay.time.sleep", return_value=None),
+            patch(
+                "run_tui_relay.wait_for_provider_hold_state",
+                side_effect=assertions.AssertionError("provider hold missing"),
+            ),
+        ):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertTrue(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "assertion")
+        self.assertEqual(len(result["provider_hold_prompts"]), 1)
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
+
+    def test_run_scenario_preserves_agent_mode_record_on_post_send_step_assertion(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                return {"id": "101"}
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [{"send_prompt": "hello"}, {"assert_health": {"status": "healthy"}}],
+            "assertions": [],
+        }
+        client = FakeClient()
+
+        with (
+            patch("run_tui_relay.time.sleep", return_value=None),
+            patch(
+                "run_tui_relay.assert_health",
+                side_effect=assertions.AssertionError("health failed"),
+            ),
+        ):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertTrue(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "assertion")
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
+
+    def test_run_scenario_preserves_agent_mode_record_on_post_send_exception(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+                self.fetch_calls = 0
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                self.fetch_calls += 1
+                if self.fetch_calls >= 2:
+                    raise RuntimeError("discord history read failed")
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                return {"id": "101"}
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [{"send_prompt": "hello"}],
+            "assertions": [],
+        }
+        client = FakeClient()
+
+        with patch("run_tui_relay.time.sleep", return_value=None):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertTrue(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "exception")
+        self.assertIn("RuntimeError: discord history read failed", result["reason"])
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
+
+    def test_run_scenario_does_not_mark_real_provider_when_send_prompt_fails(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                raise RuntimeError("dispatch refused before provider contact")
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [{"send_prompt": "hello"}],
+            "assertions": [],
+        }
+        client = FakeClient()
+
+        with patch("run_tui_relay.time.sleep", return_value=None):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertFalse(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "none")
+        self.assertFalse(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "exception")
+        self.assertIn("dispatch refused before provider contact", result["reason"])
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
+
+    def test_run_scenario_does_not_mark_real_provider_when_direct_input_send_fails(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+        args = Namespace(
+            cell="claude-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [{"send_keys": "hello"}],
+            "assertions": [],
+        }
+        client = FakeClient()
+
+        with (
+            patch("run_tui_relay.time.sleep", return_value=None),
+            patch("run_tui_relay.tmux.send_keys", return_value=False),
+        ):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertFalse(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "none")
+        self.assertFalse(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "assertion")
+        self.assertIn("tmux send-keys failed", result["reason"])
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
+
+    def test_run_scenario_preserves_partial_concurrent_send_success(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.control_messages: list[str] = []
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                self.control_messages.append(content)
+                return {"id": str(len(self.control_messages))}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                if content == "fail":
+                    raise RuntimeError("dispatch refused before provider contact")
+                return {"id": "101"}
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_agent_mode="real_live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "real_live",
+            "steps": [{"send_prompts_concurrent": ["ok", "fail"]}],
+            "assertions": [],
+        }
+        client = FakeClient()
+
+        with patch("run_tui_relay.time.sleep", return_value=None):
+            result = driver.run_scenario(
+                scenario,
+                args=args,
+                run_id="run-1",
+                client=client,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertTrue(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["failure_attribution"]["source"], "assertion")
+        self.assertEqual(
+            result["concurrent_prompt_batches"],
+            [[{"index": 0, "channel_id": "42", "message_id": "101"}]],
+        )
+        self.assertIn("send_prompts_concurrent failed", result["reason"])
+        self.assertTrue(
+            any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
+            client.control_messages,
+        )
 
     def test_run_scenario_posts_teardown_when_idle_assertion_fails(self):
         class FakeClient:
@@ -2030,7 +2675,7 @@ class ScenarioTeardown(unittest.TestCase):
             hard_reset_session_each=False,
             allow_destructive=False,
         )
-        scenario = {"id": "E-X", "steps": [], "assertions": []}
+        scenario = {"id": "E-X", "agent_mode": "none", "steps": [], "assertions": []}
         client = FakeClient()
 
         with (

--- a/scripts/e2e/tui_relay/test_matrix_runner.py
+++ b/scripts/e2e/tui_relay/test_matrix_runner.py
@@ -354,6 +354,9 @@ class CrossChannelMatrix(unittest.TestCase):
 
         self.assertEqual(result["status"], "pass")
         self.assertTrue(result["ok"])
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertTrue(result["agent_mode_contract"]["satisfied"])
         self.assertEqual(FakeClient.max_active, 2)
         self.assertIn(
             (
@@ -386,6 +389,79 @@ class CrossChannelMatrix(unittest.TestCase):
             {"marker_absent": {"marker": "[E2E:E11:CC-MARKER]", "surface": "relay"}},
             all_specs,
         )
+
+    def test_cross_channel_dispatch_failure_before_send_does_not_report_provider_contact(self):
+        class FailingClient:
+            def __init__(self, **kwargs):
+                self.base_url = kwargs["base_url"]
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                return {"id": "1"}
+
+            def fetch_messages(self, channel_id, *, limit=50, after_id=None):  # noqa: ARG002
+                return []
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                raise RuntimeError("provider send unavailable")
+
+        args = Namespace(
+            base_url="http://agentdesk.test",
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            reset_before_each=False,
+            turn_start_timeout_s=5,
+        )
+
+        with (
+            patch(
+                "run_multi_provider_matrix.cell_driver.discord.DiscordClient",
+                FailingClient,
+            ),
+            patch(
+                "run_multi_provider_matrix.guard_no_foreign_live_state",
+                return_value={"status": "isolated"},
+            ),
+            patch("run_multi_provider_matrix.time.sleep", return_value=None),
+        ):
+            result = matrix.run_cross_channel_scenario(
+                self.e11,
+                args=args,
+                run_id="run-1",
+                channel_ids=self.channel_ids,
+                selected_cells=["claude-tui", "codex-tui"],
+                pass_index=1,
+            )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertFalse(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "none")
+        self.assertFalse(result["agent_mode_contract"]["satisfied"])
+        self.assertIn("cross-channel dispatch failed", result["reason"])
+
+    def test_cross_channel_required_real_live_fails_missing_selected_cells(self):
+        args = Namespace(
+            base_url="http://agentdesk.test",
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            reset_before_each=False,
+            required_agent_mode="real_live",
+            turn_start_timeout_s=5,
+        )
+
+        result = matrix.run_cross_channel_scenario(
+            self.e11,
+            args=args,
+            run_id="run-1",
+            channel_ids=self.channel_ids,
+            selected_cells=["claude-tui"],
+            pass_index=1,
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["agent_mode_actual"], "none")
+        self.assertEqual(result["failure_attribution"]["source"], "agent_mode_gate")
+        self.assertIn("observed agent_mode_actual=none", result["reason"])
 
     def test_cross_channel_non_leak_fails_on_sibling_marker(self):
         class LeakyClient:

--- a/scripts/e2e/tui_relay/test_post_deploy_relay_continuity.py
+++ b/scripts/e2e/tui_relay/test_post_deploy_relay_continuity.py
@@ -139,16 +139,21 @@ class DriverReportValidation(unittest.TestCase):
         report = {
             "cell": "claude-tui",
             "channel_id": "222",
+            "real_provider_contacted": True,
             "totals": {"pass": 2, "fail": 0, "skipped": 0},
             "scenarios": [
                 {
                     "id": "E-9",
+                    "agent_mode": "real_live",
+                    "real_provider_contacted": True,
                     "status": "pass",
                     "relay_count": 2,
                     "post_scenario_idle": {"status": "idle"},
                 },
                 {
                     "id": "E-19",
+                    "agent_mode": "real_live",
+                    "real_provider_contacted": True,
                     "status": "pass",
                     "post_scenario_idle": {"status": "idle"},
                     "session_preserved": {
@@ -162,16 +167,21 @@ class DriverReportValidation(unittest.TestCase):
 
     def test_driver_report_fails_when_e19_lacks_session_preservation(self):
         report = {
+            "real_provider_contacted": True,
             "totals": {"pass": 2, "fail": 0, "skipped": 0},
             "scenarios": [
                 {
                     "id": "E-9",
+                    "agent_mode": "real_live",
+                    "real_provider_contacted": True,
                     "status": "pass",
                     "relay_count": 2,
                     "post_scenario_idle": {"status": "idle"},
                 },
                 {
                     "id": "E-19",
+                    "agent_mode": "real_live",
+                    "real_provider_contacted": True,
                     "status": "pass",
                     "post_scenario_idle": {"status": "idle"},
                 },

--- a/tests/e2e/tui_relay/scenarios/E-1-single-prompt.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-1-single-prompt.yaml
@@ -1,5 +1,6 @@
 id: E-1
 title: 짧은 단일 프롬프트 → 응답 1회 relay
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-10-stranded-draft.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-10-stranded-draft.yaml
@@ -1,5 +1,6 @@
 id: E-10
 title: composer에 send-keys (Enter 없이) → restart → 일관된 draft 처리 (#2635)
+agent_mode: real_live
 cells: [claude-tui, codex-tui]  # composer send-keys is TUI-specific
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-11-dual-channel-concurrency.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-11-dual-channel-concurrency.yaml
@@ -1,5 +1,6 @@
 id: E-11
 title: cc · cdx 동시 진행, 채널 격리 (#2691 + 7.2)
+agent_mode: real_live
 cells: []  # cross-cell scenario, handled by run_multi_provider_matrix.py
 orchestration: cross_channel
 isolation: required

--- a/tests/e2e/tui_relay/scenarios/E-12-tmux-pane-kill.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-12-tmux-pane-kill.yaml
@@ -1,5 +1,6 @@
 id: E-12
 title: 진행 중 tmux kill-pane → "세션 종료" 1회 알림, hang 0 (9.1)
+agent_mode: real_live
 cells: [claude-tui, codex-tui]  # kill-pane assumes a tmux-hosted TUI
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-13-claude-scheduled-wakeup-monitor.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-13-claude-scheduled-wakeup-monitor.yaml
@@ -1,5 +1,6 @@
 id: E-13
 title: Claude Code scheduled wakeup/monitor 패턴이 깨어난 뒤 최종 출력 relay
+agent_mode: real_live
 cells: [claude-pipe]
 isolation: required
 notes: |

--- a/tests/e2e/tui_relay/scenarios/E-14-claude-tui-thread-stale-reattach.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-14-claude-tui-thread-stale-reattach.yaml
@@ -1,5 +1,6 @@
 id: E-14
 title: Claude TUI thread relay survives stale offset rehydrate after restart
+agent_mode: real_live
 cells: [claude-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
@@ -1,5 +1,6 @@
 id: E-15
 title: 2000자 초과 응답 청크 완전성 (#2838 P0-2) — head→mid→tail 순서 + 중복 0
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 notes: |

--- a/tests/e2e/tui_relay/scenarios/E-16-claude-tui-quiescence-timeout-release.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-16-claude-tui-quiescence-timeout-release.yaml
@@ -1,5 +1,6 @@
 id: E-16
 title: Claude TUI quiescence timeout still releases mailbox
+agent_mode: controlled
 cells: [claude-tui]
 isolation: required
 skip_reason: >

--- a/tests/e2e/tui_relay/scenarios/E-17-foreign-active-restart-guard.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-17-foreign-active-restart-guard.yaml
@@ -1,5 +1,6 @@
 id: E-17
 title: Destructive restart refuses foreign active mailbox
+agent_mode: controlled
 cells: [codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-18-stop-mid-turn-cancel.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-18-stop-mid-turn-cancel.yaml
@@ -1,5 +1,6 @@
 id: E-18
 title: cancel_turn 중단 후 late marker 미전송 보장
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, codex-pipe, codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-19-session-continuity-after-restart.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-19-session-continuity-after-restart.yaml
@@ -1,5 +1,6 @@
 id: E-19
 title: dcserver restart preserves live tmux session identity
+agent_mode: real_live
 cells: [claude-tui, codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-2-three-turns.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-2-three-turns.yaml
@@ -1,5 +1,6 @@
 id: E-2
 title: 연속 3턴 (각 응답 후 다음 프롬프트), 턴 헤더 분리 확인
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-20-same-session-concurrent-dispatch.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-20-same-session-concurrent-dispatch.yaml
@@ -1,5 +1,6 @@
 id: E-20
 title: same-session near-concurrent dispatch returns both markers once
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-21-direct-input-control-strip.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-21-direct-input-control-strip.yaml
@@ -1,5 +1,6 @@
 id: E-21
 title: Direct TUI input C-u clears stale draft and strips control bytes
+agent_mode: real_live
 cells: [claude-tui, codex-tui]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-22-tool-use-text-completeness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-22-tool-use-text-completeness.yaml
@@ -1,5 +1,6 @@
 id: E-22
 title: tool_use 이후 후속 텍스트 head-to-tail 완결성
+agent_mode: real_live
 cells: [claude-pipe, claude-tui]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-23-premature-completion-guard.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-23-premature-completion-guard.yaml
@@ -1,5 +1,6 @@
 id: E-23
 title: 본문 전/본문 없는 completion chrome 회귀 가드
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-24-croncreate-background-fixture.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-24-croncreate-background-fixture.yaml
@@ -1,5 +1,6 @@
 id: E-24
 title: exact CronCreate Background relay fixture
+agent_mode: none
 cells: [claude-pipe]
 execution: fixture
 isolation: local

--- a/tests/e2e/tui_relay/scenarios/E-25-codex-modern-schema-fixture.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-25-codex-modern-schema-fixture.yaml
@@ -1,5 +1,6 @@
 id: E-25
 title: Codex response_item plus task_complete replay fixture
+agent_mode: none
 cells: [codex-pipe, codex-tui]
 execution: fixture
 isolation: local

--- a/tests/e2e/tui_relay/scenarios/E-3-utf8-multiline.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-3-utf8-multiline.yaml
@@ -1,5 +1,6 @@
 id: E-3
 title: 멀티라인 + 이모지 / 한글 / 코드블록 입력 echo
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-4-direct-input-relay.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-4-direct-input-relay.yaml
@@ -1,5 +1,6 @@
 id: E-4
 title: SSH/direct TUI 입력 시 프롬프트 알림 + 응답 1회 relay (#2697/#2683/#2669 positive)
+agent_mode: real_live
 cells: [claude-tui, codex-tui]  # direct keystroke relay assumes TUI host
 isolation: required
 notes: |

--- a/tests/e2e/tui_relay/scenarios/E-5-turn-separation.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-5-turn-separation.yaml
@@ -1,5 +1,6 @@
 id: E-5
 title: 응답 직후 새 프롬프트 → 새 턴 헤더 분리 + inflight cleanup 관측 (#2625)
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-6-compact-recap-once.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-6-compact-recap-once.yaml
@@ -1,5 +1,6 @@
 id: E-6
 title: /compact 후 memory recap이 사용자 메시지로 오인되지 않음 (#2702 + 3.3)
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e]  # /compact memory recap is claude-only
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-7-codex-compact-readiness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-7-codex-compact-readiness.yaml
@@ -1,5 +1,6 @@
 id: E-7
 title: Codex /compact 직후 새 입력 readiness (#2695)
+agent_mode: real_live
 cells: [codex-pipe, codex-tui]  # Codex /compact readiness is codex-only
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-8-restart-between-turns.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-8-restart-between-turns.yaml
@@ -1,5 +1,6 @@
 id: E-8
 title: 응답 완료 → dcserver dev restart → 새 프롬프트 → 새 응답만 emit
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
@@ -1,5 +1,6 @@
 id: E-9
 title: 스트리밍 중 dev 재기동 — sentinel marker 후 restart, 청크 이어 emit, 중복 0
+agent_mode: real_live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 destructive: true


### PR DESCRIPTION
## Summary
- Add explicit agent-mode metadata and reporting for TUI relay E2E scenarios.
- Preserve partial run records across assertion and generic failure paths so real provider contact, diagnostics, and failure attribution survive post-send failures.
- Move real-provider contact marking after successful dispatch/direct-input operations, including concurrent partial-success handling.

Issue: #3803

## Verification
- python3 -m unittest scripts/e2e/tui_relay/test_driver_health.py scripts/e2e/tui_relay/test_matrix_runner.py
- python3 -m unittest discover -s scripts/e2e/tui_relay -p 'test_*.py'\n- python3 -m py_compile scripts/e2e/run_tui_relay.py scripts/e2e/tui_relay/test_driver_health.py scripts/e2e/tui_relay/test_matrix_runner.py\n- python3 scripts/check_agent_maintenance_docs.py (0 errors, existing generated-inventory warning)\n- git diff --check\n\n## Review\n- Fresh xhigh Codex review: VERDICT: CLEAN