### PR TITLE
fix(discord): sanitize subagent notification relay rollovers

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -140,7 +140,8 @@
     remote-profile restore plumbing while remote SSH is disabled; ±0 from
     #3815 moving direct Codex TUI resume restore helpers into
     `watchers/codex_tui_restore.rs` while adding the restore branch).
-  - `src/services/discord/tmux.rs` (2033 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2039 lines after #2558 dead-code sweep;
+    +6 from #3818 sanitizing restored/orphan subagent-notification placeholders;
     +1 from #3384 restored-seed undelivered-body discard guard;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
     status/footer stripping in the placeholder suppression decisions;
@@ -1217,7 +1218,10 @@
     `turn_finalizer/watcher_backstop.rs` (watcher far-backstop tunables +
     terminal-or-defer verdict pair). Bugfix only outside a
     finalizer-decomposition plan).
-  - `src/services/discord/formatting.rs` (2798 lines; net +0 from #3034 scoped
+  - `src/services/discord/formatting.rs` (2802 lines; #3818 keeps only the
+    placeholder-status subagent-notification summary hook here while moving the
+    shared streaming-rollover predicate to `subagent_notification_card.rs`, so
+    the file stays at its frozen baseline; net +0 from #3034 scoped
     dead-code allows on the `MonitorHandoffReason::InlineTimeout` /
     `MonitorHandoffStatus::Failed` reserved variants — the two added `#[allow]`
     lines were offset by collapsing the adjacent reason comments back to inline

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -10,6 +10,7 @@ use super::{
     DISCORD_MSG_LIMIT, SharedData,
     placeholder_cleanup::{PlaceholderCleanupOutcome, classify_delete_error},
     rate_limit_wait,
+    response_sanitizer::subagent_notification_card,
 };
 use crate::utils::format::tail_with_ellipsis_bytes;
 
@@ -847,9 +848,10 @@ pub(super) fn format_for_discord_with_status_panel(
 mod status_panel_v2_formatter_tests {
     use super::{
         MonitorHandoffReason, MonitorHandoffStatus, build_monitor_handoff_placeholder,
-        build_monitor_handoff_placeholder_with_live_events, build_status_panel_streaming_edit_text,
-        build_streaming_placeholder_text, format_for_discord, format_for_discord_with_provider,
-        format_for_discord_with_status_panel, plan_streaming_rollover,
+        build_monitor_handoff_placeholder_with_live_events, build_placeholder_status_block,
+        build_status_panel_streaming_edit_text, build_streaming_placeholder_text,
+        format_for_discord, format_for_discord_with_provider, format_for_discord_with_status_panel,
+        plan_streaming_rollover,
     };
     use crate::services::provider::ProviderKind;
 
@@ -1068,6 +1070,25 @@ files, and memory recall below as new actionable input.\n\n\
         assert!(!output.contains("<subagent_notification>"));
         assert!(!output.contains("agent_path"));
         assert!(!output.contains("/tmp/private-agent"));
+    }
+
+    #[test]
+    fn placeholder_status_block_summarizes_subagent_notification_3818() {
+        let input = r#"<subagent_notification>
+{"agent_path":"/tmp/private-agent","status":{"completed":"Review complete.\n\nVERDICT: CLEAN"}}
+</subagent_notification>"#;
+
+        let from_full_response = build_placeholder_status_block("⠙", None, None, input);
+        assert!(from_full_response.contains("Subagent completed"));
+        assert!(!from_full_response.contains("<subagent_notification>"));
+        assert!(!from_full_response.contains("agent_path"));
+        assert!(!from_full_response.contains("/tmp/private-agent"));
+
+        let from_current_tool = build_placeholder_status_block("⠙", None, Some(input), "");
+        assert!(from_current_tool.contains("Subagent completed"));
+        assert!(!from_current_tool.contains("<subagent_notification>"));
+        assert!(!from_current_tool.contains("agent_path"));
+        assert!(!from_current_tool.contains("/tmp/private-agent"));
     }
 
     #[test]
@@ -3573,8 +3594,11 @@ pub(super) fn build_placeholder_status_block(
     current_tool_line: Option<&str>,
     full_response: &str,
 ) -> String {
-    let raw_tool_status = resolve_raw_tool_status(current_tool_line, full_response);
-    let tool_status = humanize_tool_status(raw_tool_status);
+    let tool_status =
+        subagent_notification_card::status_summary_from(current_tool_line, full_response)
+            .unwrap_or_else(|| {
+                humanize_tool_status(resolve_raw_tool_status(current_tool_line, full_response))
+            });
     format!("{indicator} {tool_status}")
 }
 

--- a/src/services/discord/subagent_notification_card.rs
+++ b/src/services/discord/subagent_notification_card.rs
@@ -67,6 +67,30 @@ pub(in crate::services::discord) fn sanitize_start_anchored_subagent_notificatio
         .then(|| format_subagent_notification_card(None, input))
 }
 
+pub(in crate::services::discord) fn status_summary(input: &str) -> Option<String> {
+    sanitize_start_anchored_subagent_notification(input).map(|card| {
+        card.lines()
+            .next()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .unwrap_or("Subagent notification")
+            .to_string()
+    })
+}
+
+pub(in crate::services::discord) fn status_summary_from(
+    current_tool_line: Option<&str>,
+    full_response: &str,
+) -> Option<String> {
+    current_tool_line
+        .and_then(status_summary)
+        .or_else(|| status_summary(full_response))
+}
+
+pub(in crate::services::discord) fn streaming_rollover_should_skip(input: &str) -> bool {
+    status_summary(input).is_some()
+}
+
 fn parse(prompt: &str) -> Result<Render, ()> {
     let payload = extract_payload(prompt)?;
     let envelope: Envelope = serde_json::from_str(&payload).map_err(|_| ())?;
@@ -108,7 +132,10 @@ fn normalized_start_anchored_injection(prompt: &str) -> String {
     let normalized = normalized.trim_start();
     let normalized = strip_provider_session_reuse_prologue(normalized).unwrap_or(normalized);
     let normalized = normalized.trim_start();
-    let normalized = strip_leading_user_author_prefix(normalized).unwrap_or(normalized);
+    let normalized =
+        strip_leading_user_author_prefix(normalized).unwrap_or_else(|| normalized.to_string());
+    let normalized = normalized.trim_start();
+    let normalized = super::strip_leading_tui_response_chrome(normalized);
     normalized.trim_start().to_string()
 }
 
@@ -143,11 +170,12 @@ fn provider_reuse_tail<'a>(rest: &'a str, prologue: &str) -> Option<&'a str> {
         .and_then(|tail| tail.strip_prefix("\n\n"))
 }
 
-fn strip_leading_user_author_prefix(text: &str) -> Option<&str> {
+fn strip_leading_user_author_prefix(text: &str) -> Option<String> {
     let rest = text.strip_prefix("[User: ")?;
     let close = rest.find(']')?;
     let tail = rest[close + 1..].trim_start();
-    starts_with_xmlish_tag(tail, "subagent_notification").then_some(tail)
+    let tail = super::strip_leading_tui_response_chrome(tail);
+    starts_with_xmlish_tag(&tail, "subagent_notification").then_some(tail)
 }
 
 fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
@@ -244,6 +272,29 @@ mod tests {
 
         let wrapped = format!("터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n{prefixed}\n```");
         assert!(is_start_anchored_subagent_notification(&wrapped));
+    }
+
+    #[test]
+    fn detects_provider_reuse_tui_chrome_subagent_notifications_3818() {
+        let raw =
+            r#"<subagent_notification>{"status":{"completed":"done"}}</subagent_notification>"#;
+        let prefixed = format!("{RESUMED_PREFIX}No response requested.\n{raw}");
+        assert!(is_start_anchored_subagent_notification(&prefixed));
+        assert!(streaming_rollover_should_skip(&prefixed));
+        assert_eq!(
+            status_summary(&prefixed).as_deref(),
+            Some("✅ Subagent completed")
+        );
+        assert!(
+            sanitize_start_anchored_subagent_notification(&prefixed)
+                .expect("card")
+                .contains("Subagent completed")
+        );
+
+        let user_prefixed = format!(
+            "{RESUMED_PREFIX}[User: 0hbujang (ID: 343742347365974026)] No response requested.\n{raw}"
+        );
+        assert!(is_start_anchored_subagent_notification(&user_prefixed));
     }
 
     #[test]

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -206,6 +206,7 @@ pub(super) fn restored_watcher_turn_from_inflight(
         return None;
     }
 
+    let provider = state.provider_kind()?;
     let response_sent_offset =
         normalize_response_sent_offset(&state.full_response, state.response_sent_offset);
     Some(RestoredWatcherTurn {
@@ -213,7 +214,7 @@ pub(super) fn restored_watcher_turn_from_inflight(
         status_message_id: state.status_message_id.map(MessageId::new),
         response_sent_offset,
         full_response: state.full_response.clone(),
-        last_edit_text: reconstructed_inflight_placeholder_body(state),
+        last_edit_text: reconstructed_inflight_placeholder_body(state, &provider),
         task_notification_kind: state.task_notification_kind,
         finish_mailbox_on_completion,
         injected_prompt_message_id: state.injected_prompt_message_id,
@@ -515,18 +516,23 @@ fn rewrite_placeholder_as_terminal_suppressed(
     }
 }
 
-fn reconstructed_inflight_placeholder_body(state: &super::inflight::InflightTurnState) -> String {
+fn reconstructed_inflight_placeholder_body(
+    state: &super::inflight::InflightTurnState,
+    provider: &ProviderKind,
+) -> String {
     let current_portion = state
         .full_response
         .get(state.response_sent_offset..)
         .unwrap_or("");
+    let current_portion =
+        super::formatting::format_for_discord_with_status_panel(current_portion, provider);
     let status_block = super::formatting::build_placeholder_status_block(
         "⠼",
         state.prev_tool_status.as_deref(),
         state.current_tool_line.as_deref(),
         &state.full_response,
     );
-    build_streaming_placeholder_text(current_portion, &status_block)
+    build_streaming_placeholder_text(&current_portion, &status_block)
 }
 
 fn orphan_suppressed_placeholder_action(
@@ -543,7 +549,7 @@ fn orphan_suppressed_placeholder_action(
         return SuppressedPlaceholderAction::None;
     }
 
-    let body = reconstructed_inflight_placeholder_body(state);
+    let body = reconstructed_inflight_placeholder_body(state, provider);
     let placeholder_was_exposed = state.response_sent_offset > 0
         || !super::single_message_panel::strip_placeholder_terminal_status(&body, provider)
             .trim()
@@ -1069,6 +1075,25 @@ mod placeholder_suppression_tests {
         format!("{body}\n\n{}", completion_footer_block())
     }
 
+    struct RuntimeRootEnvRestore {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for RuntimeRootEnvRestore {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    fn set_runtime_root_for_test(path: &std::path::Path) -> RuntimeRootEnvRestore {
+        let previous = std::env::var_os("AGENTDESK_ROOT_DIR");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", path) };
+        RuntimeRootEnvRestore { previous }
+    }
+
     fn orphan_state(
         full_response: &str,
         response_sent_offset: usize,
@@ -1195,6 +1220,36 @@ mod placeholder_suppression_tests {
             content,
             format!("visible assistant body\n\n{SUPPRESSED_RESTART_LABEL}")
         );
+    }
+
+    #[test]
+    fn orphan_restart_subagent_notification_body_is_sanitized_3818() {
+        let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
+        let tempdir = tempfile::tempdir().expect("temp runtime root");
+        let _env = set_runtime_root_for_test(tempdir.path());
+        let full_response = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+No response requested.\n\
+<subagent_notification>{\"agent_path\":\"/tmp/private-agent\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+        let mut state = orphan_state(full_response, 0);
+        state.provider = ProviderKind::Codex.as_str().to_string();
+
+        let action =
+            orphan_suppressed_placeholder_action(&state, &ProviderKind::Codex, false, TEST_SESSION);
+
+        let SuppressedPlaceholderAction::Edit(content) = action else {
+            panic!("orphan restart subagent body should edit the restart label");
+        };
+        assert!(content.contains("Subagent completed"));
+        assert!(content.contains("Review complete."));
+        assert!(content.ends_with(SUPPRESSED_RESTART_LABEL));
+        assert!(!content.contains("[Provider Session Reuse]"));
+        assert!(!content.contains("No response requested."));
+        assert!(!content.contains("<subagent_notification>"));
+        assert!(!content.contains("agent_path"));
+        assert!(!content.contains("/tmp/private-agent"));
     }
 
     #[test]

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2281,6 +2281,9 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         let Some(msg_id) = placeholder_msg_id else {
                             break;
                         };
+                        if watcher_streaming_rollover_should_skip(current_portion) {
+                            break;
+                        }
                         let Some(plan) = plan_streaming_rollover(current_portion, &status_block)
                         else {
                             break;

--- a/src/services/discord/tmux_watcher/liveness.rs
+++ b/src/services/discord/tmux_watcher/liveness.rs
@@ -93,8 +93,18 @@ pub(super) fn build_watcher_streaming_edit_text(
             provider,
         )
     } else {
-        build_streaming_placeholder_text(current_portion, status_block)
+        let formatted = crate::services::discord::formatting::format_for_discord_with_status_panel(
+            current_portion,
+            provider,
+        );
+        build_streaming_placeholder_text(&formatted, status_block)
     }
+}
+
+pub(super) fn watcher_streaming_rollover_should_skip(current_portion: &str) -> bool {
+    crate::services::discord::response_sanitizer::subagent_notification_card::streaming_rollover_should_skip(
+        current_portion,
+    )
 }
 
 pub(super) fn watcher_should_suppress_streaming_after_bridge_delivery(
@@ -132,6 +142,89 @@ pub(super) fn watcher_fallback_edit_failure_can_delete_original_placeholder(
     // the original message id may already contain partial assistant content.
     // Without a Discord probe proving it is a pure placeholder, preserve it.
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_watcher_streaming_edit_text, watcher_streaming_rollover_should_skip};
+    use crate::services::provider::ProviderKind;
+
+    #[test]
+    fn rollover_skips_subagent_notification_then_sanitizes_edit_3818() {
+        let current_portion = format!(
+            r#"<subagent_notification>
+{{"agent_path":"/tmp/adk-issue-3818-subagent-xml/private-agent","status":{{"completed":"{}"}}}}
+</subagent_notification>"#,
+            "Review complete. ".repeat(220),
+        );
+        let status_block = "⠙ 계속 처리 중";
+        let raw_plan = crate::services::discord::formatting::plan_streaming_rollover(
+            &current_portion,
+            status_block,
+        )
+        .expect("raw notification would otherwise roll over");
+
+        assert!(raw_plan.frozen_chunk.contains("<subagent_notification>"));
+        assert!(watcher_streaming_rollover_should_skip(&current_portion));
+
+        let rendered = build_watcher_streaming_edit_text(
+            false,
+            &current_portion,
+            status_block,
+            &ProviderKind::Codex,
+        );
+        assert!(rendered.contains("Subagent completed"));
+        assert!(!rendered.contains("<subagent_notification>"));
+        assert!(!rendered.contains("</subagent_notification>"));
+        assert!(!rendered.contains("agent_path"));
+        assert!(!rendered.contains("/tmp/adk-issue-3818-subagent-xml"));
+    }
+
+    #[test]
+    fn rollover_skips_tui_chrome_prefixed_subagent_notification_3818() {
+        let current_portion = format!(
+            "No response requested.\n<subagent_notification>\n{{\"agent_path\":\"/tmp/adk-issue-3818-subagent-xml/private-agent\",\"status\":{{\"completed\":\"{}\"}}}}\n</subagent_notification>",
+            "Implementation worker complete. ".repeat(180),
+        );
+
+        assert!(watcher_streaming_rollover_should_skip(&current_portion));
+
+        let rendered = build_watcher_streaming_edit_text(
+            false,
+            &current_portion,
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+        assert!(rendered.contains("Subagent completed"));
+        assert!(!rendered.contains("No response requested."));
+        assert!(!rendered.contains("<subagent_notification>"));
+        assert!(!rendered.contains("</subagent_notification>"));
+        assert!(!rendered.contains("agent_path"));
+        assert!(!rendered.contains("/tmp/adk-issue-3818-subagent-xml"));
+    }
+
+    #[test]
+    fn legacy_streaming_edit_sanitizes_subagent_notification_3818() {
+        let current_portion = r#"<subagent_notification>
+{"agent_path":"/tmp/adk-issue-3818-subagent-xml/review-agent","status":{"completed":"Read-only review complete.\n\nVERDICT: CLEAN"}}
+</subagent_notification>"#;
+
+        let rendered = build_watcher_streaming_edit_text(
+            false,
+            current_portion,
+            "⠙ 계속 처리 중",
+            &ProviderKind::Codex,
+        );
+
+        assert!(rendered.contains("Subagent completed"));
+        assert!(rendered.contains("Read-only review complete."));
+        assert!(rendered.contains("VERDICT: CLEAN"));
+        assert!(rendered.ends_with("⠙ 계속 처리 중"));
+        assert!(!rendered.contains("<subagent_notification>"));
+        assert!(!rendered.contains("</subagent_notification>"));
+        assert!(!rendered.contains("agent_path"));
+        assert!(!rendered.contains("/tmp/adk-issue-3818-subagent-xml"));
+    }
 }
 
 /// #3107: inflight-INDEPENDENT probe — capture the pane right now and classify

--- a/src/services/discord/turn_bridge/streaming_edit_text.rs
+++ b/src/services/discord/turn_bridge/streaming_edit_text.rs
@@ -31,25 +31,8 @@ pub(in crate::services::discord) fn build_turn_bridge_streaming_edit_text(
 pub(in crate::services::discord) fn bridge_streaming_rollover_should_skip(
     current_portion: &str,
 ) -> bool {
-    streaming_subagent_notification_card(current_portion).is_some()
-}
-
-fn streaming_subagent_notification_card(current_portion: &str) -> Option<String> {
-    let direct =
-        crate::services::discord::response_sanitizer::subagent_notification_card::sanitize_start_anchored_subagent_notification(
-            current_portion,
-        );
-    if direct.is_some() {
-        return direct;
-    }
-    let stripped = crate::services::discord::response_sanitizer::strip_leading_tui_response_chrome(
+    super::response_sanitizer::subagent_notification_card::streaming_rollover_should_skip(
         current_portion,
-    );
-    if stripped == current_portion {
-        return None;
-    }
-    crate::services::discord::response_sanitizer::subagent_notification_card::sanitize_start_anchored_subagent_notification(
-        &stripped,
     )
 }
 


### PR DESCRIPTION
## Summary
- Share start-anchored subagent notification detection across streaming rollover and status placeholder paths.
- Sanitize provider-reuse/TUI-chrome-prefixed subagent notification envelopes before watcher/bridge relay edits.
- Sanitize restored watcher/orphan placeholder reconstruction so persisted inflight XML cannot be edited back to Discord.

Issue: #3818

## Verification
- cargo fmt --all --check
- cargo test --lib subagent_notification
- cargo test --lib watcher_streaming_edit
- cargo test --lib streaming_edit_text_tests
- cargo test --lib 3818
- python3 scripts/generate_inventory_docs.py --check
- python3 scripts/check_agent_maintenance_docs.py
- git diff --check

## Review
- Fresh xhigh Codex review round 1: VERDICT: ISSUES; restored/orphan placeholder path found.
- Fresh xhigh Codex review round 2 after fix: VERDICT: CLEAN