### PR TITLE
Centralize Discord intake queue commit side effects

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -498,6 +498,7 @@ src/
 │   │   │   ├── authorization.rs
 │   │   │   ├── dispatch_trigger.rs
 │   │   │   ├── intake_gate.rs
+│   │   │   ├── intake_queue_transaction.rs
 │   │   │   ├── message_handler.rs
 │   │   │   ├── mod.rs
 │   │   │   ├── response_format.rs
@@ -629,6 +630,7 @@ src/
 │   │   ├── dispatch_policy.rs
 │   │   ├── formatting.rs
 │   │   ├── gateway.rs
+│   │   ├── gateway_voice_queue.rs
 │   │   ├── health.rs
 │   │   ├── http.rs
 │   │   ├── idle_detector.rs

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -343,6 +343,33 @@ impl CatchUpScanStats {
     }
 }
 
+fn catch_up_enqueue_accepted(outcome: &MailboxEnqueueOutcome) -> bool {
+    outcome.enqueued && outcome.persistence_error.is_none()
+}
+
+fn log_catch_up_enqueue_not_accepted(
+    phase: &'static str,
+    channel_id: ChannelId,
+    message_id: MessageId,
+    outcome: &MailboxEnqueueOutcome,
+) {
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    let refusal = outcome
+        .refusal_reason
+        .map(|reason| reason.as_str())
+        .unwrap_or("none");
+    let persistence_error = outcome.persistence_error.as_deref().unwrap_or("none");
+    tracing::warn!(
+        "  [{ts}] ⚠ catch-up {phase}: message {} in channel {} was not committed to queue (enqueued={} merged={} refusal={} persistence_error={})",
+        message_id,
+        channel_id,
+        outcome.enqueued,
+        outcome.merged,
+        refusal,
+        persistence_error
+    );
+}
+
 /// Plain inputs to the catch-up filter, decoupled from `serenity::Message` so
 /// we can unit test the regression scenario without a Discord runtime.
 #[derive(Debug, Clone)]
@@ -662,13 +689,12 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 );
                 break;
             }
-            stats.record(outcome);
             if outcome != CatchUpClassification::Recover {
+                stats.record(outcome);
                 continue;
             }
 
-            reaction_cleanup::cleanup_recovered_catch_up_hourglass(http, channel_id, msg.id).await;
-            mailbox_enqueue_intervention(
+            let enqueue = mailbox_enqueue_intervention(
                 shared,
                 provider,
                 channel_id,
@@ -691,6 +717,13 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 },
             )
             .await;
+            if !catch_up_enqueue_accepted(&enqueue) {
+                log_catch_up_enqueue_not_accepted("phase1", channel_id, msg.id, &enqueue);
+                continue;
+            }
+
+            stats.record(CatchUpClassification::Recover);
+            reaction_cleanup::cleanup_recovered_catch_up_hourglass(http, channel_id, msg.id).await;
             // Track the newest actually-recovered message for checkpoint
             let mid = msg.id.get();
             if max_recovered_id.map(|m| mid > m).unwrap_or(true) {
@@ -873,7 +906,7 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 continue;
             }
 
-            mailbox_enqueue_intervention(
+            let enqueue = mailbox_enqueue_intervention(
                 shared,
                 provider,
                 channel_id,
@@ -896,6 +929,11 @@ pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
                 },
             )
             .await;
+            if !catch_up_enqueue_accepted(&enqueue) {
+                log_catch_up_enqueue_not_accepted("phase2", channel_id, msg.id, &enqueue);
+                continue;
+            }
+
             existing_ids.insert(mid);
             phase2_checkpoint = Some(phase2_checkpoint.map_or(mid, |saved| saved.max(mid)));
             channel_recovered += 1;
@@ -925,7 +963,7 @@ mod catch_up_recovery_tests {
     use super::{
         CATCH_UP_RECENT_MAX_PAGES, CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate,
         CatchUpClassification, CatchUpFetchMode, CatchUpMessageView, ChannelId, ProviderKind,
-        catch_up_fetch_mode_for_scan, classify_catch_up_message,
+        catch_up_enqueue_accepted, catch_up_fetch_mode_for_scan, classify_catch_up_message,
         insert_configured_catch_up_candidate, parse_catch_up_scan_pace,
         should_fetch_older_recent_page, should_pace_before_scan,
     };
@@ -1166,5 +1204,34 @@ mod catch_up_recovery_tests {
             catch_up_fetch_mode_for_scan(&candidate, None, None),
             CatchUpFetchMode::After(_)
         ));
+    }
+
+    #[test]
+    fn enqueue_acceptance_requires_queue_success_without_persistence_error() {
+        let accepted = super::super::MailboxEnqueueOutcome {
+            enqueued: true,
+            merged: false,
+            refusal_reason: None,
+            persistence_error: None,
+        };
+        assert!(catch_up_enqueue_accepted(&accepted));
+
+        let refused = super::super::MailboxEnqueueOutcome {
+            enqueued: false,
+            merged: false,
+            refusal_reason: Some(
+                crate::services::turn_orchestrator::EnqueueRefusalReason::SourceIdAlreadyQueued,
+            ),
+            persistence_error: None,
+        };
+        assert!(!catch_up_enqueue_accepted(&refused));
+
+        let persistence_failed = super::super::MailboxEnqueueOutcome {
+            enqueued: true,
+            merged: false,
+            refusal_reason: None,
+            persistence_error: Some("disk unavailable".to_string()),
+        };
+        assert!(!catch_up_enqueue_accepted(&persistence_failed));
     }
 }

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use poise::serenity_prelude as serenity;
 use serenity::{ChannelId, MessageId, UserId};
 
+use super::gateway_voice_queue::queued_intervention_request_owner;
 use super::outbound::delivery::{deliver_outbound, first_raw_message_id};
 use super::outbound::message::{
     DiscordOutboundMessage, OutboundOperation, OutboundReferenceContext, OutboundTarget,
@@ -772,16 +773,12 @@ impl TurnGateway for DiscordGateway {
                 shared: &self.shared,
                 token: &live_turn.token,
             };
-            // #2266: if the queued intervention carries a voice-transcript
-            // announcement (race-loss enqueue from `handle_text_message`),
+            // #2266 compatibility: older queued interventions may already
+            // carry a voice-transcript accepted-replay payload. If present,
             // reinsert it into the per-process `voice::announce_meta` store
-            // keyed by the intervention's HEAD `message_id` so the
-            // downstream `handle_text_message` `take()` (line ~2261)
-            // recovers the full transcript framing instead of degrading to
-            // plain text. The original entry was consumed by the active
-            // turn that won the race; this in-flight handoff is what makes
-            // the queued path self-contained against the 30s in-memory TTL.
-            let has_embedded_voice_announcement = intervention.voice_announcement.is_some();
+            // keyed by the intervention's HEAD `message_id`. New queue commits
+            // strip that payload and rely on the readable announcement text to
+            // resolve and claim the durable row at dispatch time.
             if let Some(announcement) = intervention.voice_announcement.as_ref() {
                 crate::voice::announce_meta::global_store()
                     .insert_accepted_replay(intervention.message_id, announcement.clone());
@@ -796,12 +793,13 @@ impl TurnGateway for DiscordGateway {
             // owner). Non-voice queued items kept the legacy behavior of
             // routing via the live-turn owner so the user attribution does
             // not silently swap mid-chain; we only override the
-            // request_owner when the intervention is voice-tagged.
-            let dispatch_request_owner = if has_embedded_voice_announcement {
-                intervention.author_id
-            } else {
-                live_turn.request_owner
-            };
+            // request_owner when the intervention is voice-tagged. New queue
+            // commits deliberately avoid embedding the full voice payload; the
+            // readable announce text still needs the announce-bot author so
+            // `handle_text_message` can resolve and claim the durable row at
+            // processing time.
+            let dispatch_request_owner =
+                queued_intervention_request_owner(intervention, live_turn.request_owner);
             if !intervention.pending_uploads.is_empty() {
                 let mut data = self.shared.core.lock().await;
                 if let Some(session) = data.sessions.get_mut(&channel_id) {

--- a/src/services/discord/gateway_voice_queue.rs
+++ b/src/services/discord/gateway_voice_queue.rs
@@ -1,0 +1,92 @@
+use poise::serenity_prelude::UserId;
+
+use super::Intervention;
+
+pub(super) fn queued_intervention_request_owner(
+    intervention: &Intervention,
+    fallback_request_owner: UserId,
+) -> UserId {
+    if intervention.voice_announcement.is_some()
+        || crate::voice::prompt::is_readable_voice_transcript_announcement(&intervention.text)
+    {
+        intervention.author_id
+    } else {
+        fallback_request_owner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::InterventionMode;
+    use poise::serenity_prelude::MessageId;
+    use std::time::Instant;
+
+    fn queued_intervention(
+        author_id: u64,
+        text: &str,
+        voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
+    ) -> Intervention {
+        Intervention {
+            author_id: UserId::new(author_id),
+            author_is_bot: true,
+            message_id: MessageId::new(50_001),
+            source_message_ids: vec![MessageId::new(50_001)],
+            text: text.to_string(),
+            mode: InterventionMode::Soft,
+            created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
+            pending_uploads: Vec::new(),
+            voice_announcement,
+        }
+    }
+
+    fn voice_announcement() -> crate::voice::prompt::VoiceTranscriptAnnouncement {
+        crate::voice::prompt::VoiceTranscriptAnnouncement {
+            transcript: "상태 알려줘".to_string(),
+            user_id: "42".to_string(),
+            utterance_id: "utt-gateway-owner".to_string(),
+            language: "ko-KR".to_string(),
+            verbose_progress: true,
+            started_at: Some("2026-06-28T22:00:00+09:00".to_string()),
+            completed_at: Some("2026-06-28T22:00:01+09:00".to_string()),
+            samples_written: Some(48_000),
+            control_channel_id: Some(300),
+            stt_mode: Some("file".to_string()),
+            stt_latency_ms: Some(120),
+        }
+    }
+
+    #[test]
+    fn uses_author_for_embedded_or_readable_voice_metadata() {
+        let fallback = UserId::new(7);
+        let announce_bot = UserId::new(88);
+        let embedded = queued_intervention(
+            announce_bot.get(),
+            "plain fallback",
+            Some(voice_announcement()),
+        );
+        assert_eq!(
+            queued_intervention_request_owner(&embedded, fallback),
+            announce_bot
+        );
+
+        let readable = queued_intervention(
+            announce_bot.get(),
+            "🎙️ \"상태 알려줘\"\n||ADK_VOICE_ANNOUNCE_REF key=voice:1:300:utt-gateway-owner::announce:generation:1||",
+            None,
+        );
+        assert_eq!(
+            queued_intervention_request_owner(&readable, fallback),
+            announce_bot
+        );
+
+        let normal = queued_intervention(announce_bot.get(), "not a voice announcement", None);
+        assert_eq!(
+            queued_intervention_request_owner(&normal, fallback),
+            fallback
+        );
+    }
+}

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -10,6 +10,7 @@ mod discord_io;
 mod dispatch_policy;
 pub(crate) mod formatting;
 mod gateway;
+mod gateway_voice_queue;
 pub(crate) mod health;
 pub(crate) mod http;
 mod idle_detector;
@@ -3833,14 +3834,12 @@ pub(super) async fn kickoff_idle_queues(
             shared,
             token,
         };
-        // #2266: kickoff_idle_queues is the other queued-dispatch entrypoint
-        // alongside `DiscordGateway::dispatch_queued_turn`. It is reached by
-        // `schedule_deferred_idle_queue_kickoff` from the very same race-loss
-        // branch that embeds the voice payload into the queued Intervention,
-        // so we must reinsert the announcement into the per-process store
-        // before re-entering `handle_text_message`. Without this hook the
-        // race-loss path that takes the idle-kickoff branch would still
-        // degrade to plain text.
+        // #2266 compatibility: kickoff_idle_queues is the other queued-dispatch
+        // entrypoint alongside `DiscordGateway::dispatch_queued_turn`. Older
+        // queued interventions may still carry a voice accepted-replay payload,
+        // so reinsert it before re-entering `handle_text_message`. New queue
+        // commits strip that payload and let dispatch claim the durable row
+        // from the readable announcement text.
         if let Some(announcement) = intervention.voice_announcement.as_ref() {
             crate::voice::announce_meta::global_store()
                 .insert_accepted_replay(intervention.message_id, announcement.clone());

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -2,6 +2,11 @@ use super::super::outbound::reaction_control::{
     ReactionControlReplyReason, send_reaction_control_reply,
 };
 use super::super::*;
+use super::intake_queue_transaction::{
+    IntakeQueueAuthorClass, IntakeQueueCommitEffects, IntakeQueueCommitOptions,
+    IntakeQueueCommitSource, IntakeQueuePendingReactionPolicy, SoftInterventionCommitRequest,
+    SoftInterventionSpec, commit_soft_intervention_transaction,
+};
 
 mod busy_duplicate_notice;
 mod node_override_routing;
@@ -243,119 +248,12 @@ async fn resolve_voice_transcript_announcement_for_intake(
     }
 }
 
-async fn claim_voice_transcript_announcement_for_queue(
-    data: &Data,
-    channel_id: serenity::ChannelId,
-    message_id: serenity::MessageId,
-    voice_announcement: &Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
-    context: &'static str,
-) -> bool {
-    if voice_announcement.is_none() {
-        return true;
-    }
-    let Some(pool) = data.shared.pg_pool.as_ref() else {
-        return true;
-    };
-    match crate::voice::announce_meta::mark_voice_announcement_durable_consumed(pool, message_id)
-        .await
-    {
-        Ok(true) => true,
-        Ok(false) => {
-            tracing::info!(
-                channel_id = channel_id.get(),
-                message_id = message_id.get(),
-                context,
-                "voice transcript announcement durable metadata already claimed before queue accept"
-            );
-            false
-        }
-        Err(error) => {
-            tracing::warn!(
-                error = %error,
-                channel_id = channel_id.get(),
-                message_id = message_id.get(),
-                context,
-                "voice transcript announcement durable metadata claim failed before queue accept"
-            );
-            false
-        }
-    }
-}
-
-fn build_soft_intervention(
-    author_id: serenity::UserId,
-    author_is_bot: bool,
-    message_id: serenity::MessageId,
-    text: &str,
-    reply_context: Option<String>,
-    has_reply_boundary: bool,
-    merge_consecutive: bool,
-    pending_uploads: Vec<String>,
-    // #2266: when the intake-gate sees a voice-transcript announcement and
-    // chooses to enqueue it (busy active turn, thread guard, dispatch
-    // collision, drain mode, reconcile gate), the per-process
-    // `voice::announce_meta` store entry can expire before the queued turn
-    // runs (30s TTL vs. arbitrary queue dwell). Carrying the announcement
-    // inside the Intervention keeps the queued payload self-contained so
-    // every queued-dispatch entrypoint can reinsert it into the store and
-    // recover the voice-transcript framing.
-    voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
-) -> Intervention {
-    Intervention {
-        author_id,
-        author_is_bot,
-        message_id,
-        source_message_ids: vec![message_id],
-        text: text.to_string(),
-        mode: InterventionMode::Soft,
-        created_at: Instant::now(),
-        reply_context,
-        has_reply_boundary,
-        merge_consecutive,
-        pending_uploads,
-        voice_announcement,
-    }
-}
-
-async fn enqueue_soft_intervention(
-    data: &Data,
-    channel_id: serenity::ChannelId,
-    author_id: serenity::UserId,
-    author_is_bot: bool,
-    message_id: serenity::MessageId,
-    text: &str,
-    reply_context: Option<String>,
-    has_reply_boundary: bool,
-    merge_consecutive: bool,
-    pending_uploads: Vec<String>,
-    // #2266: pass-through for the voice-transcript payload (see
-    // `build_soft_intervention` doc-comment).
-    voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
-) -> super::super::MailboxEnqueueOutcome {
-    mailbox_enqueue_intervention(
-        &data.shared,
-        &data.provider,
-        channel_id,
-        build_soft_intervention(
-            author_id,
-            author_is_bot,
-            message_id,
-            text,
-            reply_context,
-            has_reply_boundary,
-            merge_consecutive,
-            pending_uploads,
-            voice_announcement,
-        ),
-    )
-    .await
-}
-
 /// Pick the queue-pending reaction emoji based on the enqueue outcome.
 /// Standalone queue head entries get `📬`; merged-into-previous entries get
 /// `➕` so users can tell merged from standalone at a glance (#1190 follow-up).
+#[cfg(test)]
 pub(super) fn queue_pending_reaction_for(outcome: super::super::MailboxEnqueueOutcome) -> char {
-    if outcome.merged { '➕' } else { '📬' }
+    super::intake_queue_transaction::queue_pending_reaction_for(&outcome)
 }
 
 /// #3182: add the queue-pending reaction (📬 standalone / ➕ merged) and
@@ -403,6 +301,61 @@ async fn add_queue_pending_reaction_self_healing(
             channel_id,
             user_msg_id
         );
+    }
+}
+
+struct IntakeGateQueueEffects<'a> {
+    ctx: &'a serenity::Context,
+    data: &'a Data,
+}
+
+#[async_trait::async_trait]
+impl IntakeQueueCommitEffects for IntakeGateQueueEffects<'_> {
+    async fn enqueue_soft_intervention(
+        &mut self,
+        intervention: SoftInterventionSpec,
+    ) -> super::super::MailboxEnqueueOutcome {
+        let channel_id = intervention.channel_id;
+        mailbox_enqueue_intervention(
+            &self.data.shared,
+            &self.data.provider,
+            channel_id,
+            intervention.into_intervention(),
+        )
+        .await
+    }
+
+    async fn apply_pending_reaction(
+        &mut self,
+        channel_id: serenity::ChannelId,
+        message_id: serenity::MessageId,
+        emoji: char,
+    ) {
+        add_queue_pending_reaction_self_healing(self.ctx, self.data, channel_id, message_id, emoji)
+            .await;
+    }
+
+    fn advance_checkpoint(
+        &mut self,
+        channel_id: serenity::ChannelId,
+        message_id: serenity::MessageId,
+    ) -> u64 {
+        super::super::advance_last_message_checkpoint(
+            &self.data.shared,
+            &self.data.provider,
+            channel_id,
+            message_id,
+        )
+    }
+
+    async fn schedule_idle_kickoff(&mut self) -> usize {
+        super::super::kickoff_idle_queues(
+            self.ctx,
+            &self.data.shared,
+            &self.data.token,
+            &self.data.provider,
+        )
+        .await
     }
 }
 
@@ -1900,13 +1853,15 @@ pub(in crate::services::discord) async fn handle_event(
                 .unwrap_or(channel_id);
             let settings_snapshot = { data.shared.settings.read().await.clone() };
             // #2266: resolve the voice-transcript payload ONCE at the
-            // intake-gate so we can both (a) cheaply classify the message and
-            // (b) embed the full announcement in any queued Intervention we
-            // construct on the busy-channel/thread-guard/drain-mode paths
-            // below. Resolution is non-consuming: local store, durable PG row,
-            // then a short pending-key wait for the gateway-before-send-response
-            // race. Legacy hidden metadata is deliberately not trusted here;
-            // the durable/ref path is the authority for new runtime routing.
+            // intake-gate so queue commits can classify voice messages and
+            // keep them as standalone queue entries. The transaction helper
+            // strips the accepted-replay payload before enqueue; the eventual
+            // dispatch re-resolves and claims the durable row from the readable
+            // announcement text. Resolution is non-consuming: local store,
+            // durable PG row, then a short pending-key wait for the
+            // gateway-before-send-response race. Legacy hidden metadata is
+            // deliberately not trusted here; the durable/ref path is the
+            // authority for new runtime routing.
             let resolved_voice_announcement = resolve_voice_transcript_announcement_for_intake(
                 data.shared.pg_pool.as_ref(),
                 channel_id,
@@ -2333,55 +2288,35 @@ pub(in crate::services::discord) async fn handle_event(
                                 channel_id,
                                 thread_id
                             );
-                            if !claim_voice_transcript_announcement_for_queue(
-                                data,
-                                channel_id,
-                                new_message.id,
-                                &resolved_voice_announcement,
-                                "thread_guard_queue",
-                            )
-                            .await
-                            {
-                                return Ok(());
-                            }
-                            let outcome = enqueue_soft_intervention(
-                                data,
-                                channel_id,
-                                user_id,
-                                new_message.author.bot,
-                                new_message.id,
-                                text,
-                                None,
-                                false,
-                                false,
-                                upload_records.clone(),
-                                // #2266: thread-guard queue path — embed the
-                                // voice payload so the eventual queued
-                                // dispatch can reinsert it into the store
-                                // even if the >30s TTL expires first.
-                                resolved_voice_announcement.clone(),
-                            )
-                            .await;
-                            add_queue_pending_reaction_self_healing(
-                                ctx,
-                                data,
-                                channel_id,
-                                new_message.id,
-                                queue_pending_reaction_for(outcome),
+                            let mut queue_effects = IntakeGateQueueEffects { ctx, data };
+                            let _commit = commit_soft_intervention_transaction(
+                                &mut queue_effects,
+                                SoftInterventionCommitRequest {
+                                    source: IntakeQueueCommitSource::ThreadGuard,
+                                    author_class: IntakeQueueAuthorClass::from_flags(
+                                        new_message.author.bot,
+                                        is_allowed_bot,
+                                    ),
+                                    intervention: SoftInterventionSpec {
+                                        channel_id,
+                                        author_id: user_id,
+                                        author_is_bot: new_message.author.bot,
+                                        message_id: new_message.id,
+                                        text: text.to_string(),
+                                        reply_context: None,
+                                        has_reply_boundary: false,
+                                        merge_consecutive: false,
+                                        pending_uploads: upload_records.clone(),
+                                        // #2266: thread-guard queue path —
+                                        // pass resolved voice metadata only so
+                                        // the transaction can detect voice and
+                                        // enqueue standalone readable text.
+                                        voice_announcement: resolved_voice_announcement.clone(),
+                                    },
+                                    options: IntakeQueueCommitOptions::default(),
+                                },
                             )
                             .await;
-                            // #2044 F12: use monotonic checkpoint helper
-                            // so this hot intake path matches the cancel
-                            // reaction path
-                            // (`mod.rs:advance_last_message_checkpoint`)
-                            // and never regresses the per-channel
-                            // last-processed id.
-                            super::super::advance_last_message_checkpoint(
-                                &data.shared,
-                                &data.provider,
-                                channel_id,
-                                new_message.id,
-                            );
                             return Ok(());
                         }
                     } else {
@@ -2404,43 +2339,41 @@ pub(in crate::services::discord) async fn handle_event(
                 )
                 .await
                 {
-                    let outcome = enqueue_soft_intervention(
-                        data,
-                        channel_id,
-                        user_id,
-                        new_message.author.bot,
-                        new_message.id,
-                        text,
-                        None,
-                        false,
-                        false,
-                        upload_records.clone(),
-                        // #2266: DISPATCH: collision guard — DISPATCH messages
-                        // never carry voice transcripts, so this is always
-                        // None. Explicit for clarity / future audits.
-                        None,
+                    let mut queue_effects = IntakeGateQueueEffects { ctx, data };
+                    let commit = commit_soft_intervention_transaction(
+                        &mut queue_effects,
+                        SoftInterventionCommitRequest {
+                            source: IntakeQueueCommitSource::DispatchGuard,
+                            author_class: IntakeQueueAuthorClass::from_flags(
+                                new_message.author.bot,
+                                is_allowed_bot,
+                            ),
+                            intervention: SoftInterventionSpec {
+                                channel_id,
+                                author_id: user_id,
+                                author_is_bot: new_message.author.bot,
+                                message_id: new_message.id,
+                                text: text.to_string(),
+                                reply_context: None,
+                                has_reply_boundary: false,
+                                merge_consecutive: false,
+                                pending_uploads: upload_records.clone(),
+                                // #2266: DISPATCH: collision guard — DISPATCH messages
+                                // never carry voice transcripts, so this is always
+                                // None. Explicit for clarity / future audits.
+                                voice_announcement: None,
+                            },
+                            options: IntakeQueueCommitOptions::default(),
+                        },
                     )
                     .await;
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::info!(
-                        "  [{ts}] 📬 DISPATCH-GUARD: queued dispatch message in channel {} (active turn in progress)",
-                        channel_id
-                    );
-                    add_queue_pending_reaction_self_healing(
-                        ctx,
-                        data,
-                        channel_id,
-                        new_message.id,
-                        queue_pending_reaction_for(outcome),
-                    )
-                    .await;
-                    // #2044 F12: monotonic checkpoint (see comment above).
-                    super::super::advance_last_message_checkpoint(
-                        &data.shared,
-                        &data.provider,
-                        channel_id,
-                        new_message.id,
-                    );
+                    if commit.accepted() {
+                        tracing::info!(
+                            "  [{ts}] 📬 DISPATCH-GUARD: queued dispatch message in channel {} (active turn in progress)",
+                            channel_id
+                        );
+                    }
                     return Ok(());
                 }
                 // No active turn — fall through to normal processing below
@@ -2454,44 +2387,54 @@ pub(in crate::services::discord) async fn handle_event(
             )
             .await
             {
-                if !claim_voice_transcript_announcement_for_queue(
-                    data,
-                    channel_id,
-                    new_message.id,
-                    &resolved_voice_announcement,
-                    "busy_active_turn_queue",
-                )
-                .await
-                {
-                    return Ok(());
-                }
-                let outcome = enqueue_soft_intervention(
-                    data,
-                    channel_id,
-                    user_id,
-                    new_message.author.bot,
-                    new_message.id,
-                    text,
-                    reply_context.clone(),
-                    has_reply_boundary,
-                    merge_consecutive,
-                    upload_records.clone(),
-                    // #2266: main busy-active-turn queue path — voice transcripts that
-                    // arrive while a previous turn is running flow through here. Embed the
-                    // announcement so the queued dispatch reinserts it into the store even
-                    // if the >30s in-memory TTL expires first.
-                    resolved_voice_announcement.clone(),
-                )
-                .await;
                 let is_shutting_down = data
                     .shared
                     .restart
                     .shutting_down
                     .load(std::sync::atomic::Ordering::Relaxed);
+                let mut queue_effects = IntakeGateQueueEffects { ctx, data };
+                let commit = commit_soft_intervention_transaction(
+                    &mut queue_effects,
+                    SoftInterventionCommitRequest {
+                        source: IntakeQueueCommitSource::BusyActiveTurn,
+                        author_class: IntakeQueueAuthorClass::from_flags(
+                            new_message.author.bot,
+                            is_allowed_bot,
+                        ),
+                        intervention: SoftInterventionSpec {
+                            channel_id,
+                            author_id: user_id,
+                            author_is_bot: new_message.author.bot,
+                            message_id: new_message.id,
+                            text: text.to_string(),
+                            reply_context: reply_context.clone(),
+                            has_reply_boundary,
+                            merge_consecutive,
+                            pending_uploads: upload_records.clone(),
+                            // #2266: main busy-active-turn queue path — voice transcripts that
+                            // arrive while a previous turn is running flow through here. Embed the
+                            // announcement so the queued dispatch reinserts it into the store even
+                            // if the >30s in-memory TTL expires first.
+                            voice_announcement: resolved_voice_announcement.clone(),
+                        },
+                        options: IntakeQueueCommitOptions::default(),
+                    },
+                )
+                .await;
 
-                if !outcome.enqueued {
+                if !commit.accepted() {
+                    if commit.failed() {
+                        rate_limit_wait(&data.shared, channel_id).await;
+                        let _ = channel_id
+                            .say(
+                                &ctx.http,
+                                "⚠️ 메시지 큐 저장 중 오류가 감지되어 접수 표시를 생략했어.",
+                            )
+                            .await;
+                        return Ok(());
+                    }
                     if busy_duplicate_notice::silence_if_already_queued(
-                        outcome.refusal_reason,
+                        commit.refusal_reason(),
                         new_message.id,
                         channel_id,
                     ) {
@@ -2511,31 +2454,12 @@ pub(in crate::services::discord) async fn handle_event(
                         channel_id,
                         new_message.id,
                         text,
-                        outcome.merged,
+                        commit.merged(),
                     )
                     .await;
                 }
 
-                // React 📬 (standalone queue head) or ➕ (merged into previous
-                // head), self-healing against the #3182 late-add race (see
-                // `add_queue_pending_reaction_self_healing`).
-                add_queue_pending_reaction_self_healing(
-                    ctx,
-                    data,
-                    channel_id,
-                    new_message.id,
-                    queue_pending_reaction_for(outcome),
-                )
-                .await;
-
-                // Checkpoint: message successfully queued (#2044 F12 — monotonic).
-                super::super::advance_last_message_checkpoint(
-                    &data.shared,
-                    &data.provider,
-                    channel_id,
-                    new_message.id,
-                );
-                if is_shutting_down {
+                if is_shutting_down && commit.checkpoint_advanced() {
                     let ids: std::collections::HashMap<u64, u64> = data
                         .shared
                         .last_message_ids
@@ -2554,41 +2478,38 @@ pub(in crate::services::discord) async fn handle_event(
                 .reconcile_done
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
-                if !claim_voice_transcript_announcement_for_queue(
-                    data,
-                    channel_id,
-                    new_message.id,
-                    &resolved_voice_announcement,
-                    "reconcile_gate_queue",
-                )
-                .await
-                {
-                    return Ok(());
-                }
-                let _ = enqueue_soft_intervention(
-                    data,
-                    channel_id,
-                    user_id,
-                    new_message.author.bot,
-                    new_message.id,
-                    text,
-                    reply_context.clone(),
-                    has_reply_boundary,
-                    merge_consecutive,
-                    upload_records.clone(),
-                    // #2266: reconcile gate — startup-recovery queue path. Voice transcripts
-                    // that arrive before recovery completes need the embedded payload too.
-                    resolved_voice_announcement.clone(),
+                let mut queue_effects = IntakeGateQueueEffects { ctx, data };
+                let _commit = commit_soft_intervention_transaction(
+                    &mut queue_effects,
+                    SoftInterventionCommitRequest {
+                        source: IntakeQueueCommitSource::ReconcileGate,
+                        author_class: IntakeQueueAuthorClass::from_flags(
+                            new_message.author.bot,
+                            is_allowed_bot,
+                        ),
+                        intervention: SoftInterventionSpec {
+                            channel_id,
+                            author_id: user_id,
+                            author_is_bot: new_message.author.bot,
+                            message_id: new_message.id,
+                            text: text.to_string(),
+                            reply_context: reply_context.clone(),
+                            has_reply_boundary,
+                            merge_consecutive,
+                            pending_uploads: upload_records.clone(),
+                            // #2266: reconcile gate — startup-recovery queue
+                            // path. Resolved voice metadata makes this a
+                            // standalone queued voice entry; durable claim
+                            // remains deferred to dispatch.
+                            voice_announcement: resolved_voice_announcement.clone(),
+                        },
+                        options: IntakeQueueCommitOptions {
+                            pending_reaction: IntakeQueuePendingReactionPolicy::Static('🔄'),
+                            ..IntakeQueueCommitOptions::default()
+                        },
+                    },
                 )
                 .await;
-                // Checkpoint: track last processed message (#2044 F12 — monotonic).
-                super::super::advance_last_message_checkpoint(
-                    &data.shared,
-                    &data.provider,
-                    channel_id,
-                    new_message.id,
-                );
-                formatting::add_reaction_raw(&ctx.http, channel_id, new_message.id, '🔄').await;
                 return Ok(());
             }
 
@@ -2606,59 +2527,49 @@ pub(in crate::services::discord) async fn handle_event(
                     .shutting_down
                     .load(std::sync::atomic::Ordering::Relaxed);
 
-                if !claim_voice_transcript_announcement_for_queue(
-                    data,
-                    channel_id,
-                    new_message.id,
-                    &resolved_voice_announcement,
-                    "drain_mode_queue",
-                )
-                .await
-                {
-                    return Ok(());
-                }
-                let outcome = enqueue_soft_intervention(
-                    data,
-                    channel_id,
-                    user_id,
-                    new_message.author.bot,
-                    new_message.id,
-                    text,
-                    reply_context.clone(),
-                    has_reply_boundary,
-                    merge_consecutive,
-                    upload_records.clone(),
-                    // #2266: drain-mode queue path (restart pending) — pass the embedded voice
-                    // payload so the post-restart dispatch path can reinsert it into the store.
-                    resolved_voice_announcement.clone(),
+                let mut queue_effects = IntakeGateQueueEffects { ctx, data };
+                let commit = commit_soft_intervention_transaction(
+                    &mut queue_effects,
+                    SoftInterventionCommitRequest {
+                        source: IntakeQueueCommitSource::DrainMode,
+                        author_class: IntakeQueueAuthorClass::from_flags(
+                            new_message.author.bot,
+                            is_allowed_bot,
+                        ),
+                        intervention: SoftInterventionSpec {
+                            channel_id,
+                            author_id: user_id,
+                            author_is_bot: new_message.author.bot,
+                            message_id: new_message.id,
+                            text: text.to_string(),
+                            reply_context: reply_context.clone(),
+                            has_reply_boundary,
+                            merge_consecutive,
+                            pending_uploads: upload_records.clone(),
+                            // #2266: drain-mode queue path (restart pending) —
+                            // pass resolved voice metadata so the transaction
+                            // keeps readable voice text standalone.
+                            voice_announcement: resolved_voice_announcement.clone(),
+                        },
+                        options: IntakeQueueCommitOptions::default(),
+                    },
                 )
                 .await;
 
                 let ts = chrono::Local::now().format("%H:%M:%S");
+                if !commit.accepted() {
+                    tracing::info!(
+                        "  [{ts}] ⏸ DRAIN: message from [{user_name}] in channel {} was not accepted into restart queue",
+                        channel_id
+                    );
+                    return Ok(());
+                }
                 tracing::info!(
                     "  [{ts}] ⏸ DRAIN: queued message from [{user_name}] in channel {} (restart pending)",
                     channel_id
                 );
 
-                // React 📬 (standalone) or ➕ (merged into previous queue head).
-                add_queue_pending_reaction_self_healing(
-                    ctx,
-                    data,
-                    channel_id,
-                    new_message.id,
-                    queue_pending_reaction_for(outcome),
-                )
-                .await;
-
-                // Checkpoint: message successfully queued in drain mode (#2044 F12 — monotonic).
-                super::super::advance_last_message_checkpoint(
-                    &data.shared,
-                    &data.provider,
-                    channel_id,
-                    new_message.id,
-                );
-
-                if is_shutting_down {
+                if is_shutting_down && commit.checkpoint_advanced() {
                     // Persist checkpoint to disk immediately during shutdown
                     let ids: std::collections::HashMap<u64, u64> = data
                         .shared
@@ -2692,69 +2603,53 @@ pub(in crate::services::discord) async fn handle_event(
                 if has_active_turn || !has_pending_backlog {
                     None
                 } else {
-                    if !claim_voice_transcript_announcement_for_queue(
-                        data,
-                        channel_id,
-                        new_message.id,
-                        &resolved_voice_announcement,
-                        "idle_backlog_queue",
-                    )
-                    .await
-                    {
-                        return Ok(());
-                    }
+                    let mut queue_effects = IntakeGateQueueEffects { ctx, data };
                     Some(
-                        enqueue_soft_intervention(
-                            data,
-                            channel_id,
-                            user_id,
-                            new_message.author.bot,
-                            new_message.id,
-                            text,
-                            reply_context.clone(),
-                            has_reply_boundary,
-                            merge_consecutive,
-                            upload_records.clone(),
-                            // #2266: queued-behind-idle-backlog path —
-                            // FIFO ordering keeps voice transcripts behind
-                            // pre-existing queue items, so embed the
-                            // payload for the eventual dispatch reinsert.
-                            resolved_voice_announcement.clone(),
+                        commit_soft_intervention_transaction(
+                            &mut queue_effects,
+                            SoftInterventionCommitRequest {
+                                source: IntakeQueueCommitSource::IdleBacklog,
+                                author_class: IntakeQueueAuthorClass::from_flags(
+                                    new_message.author.bot,
+                                    is_allowed_bot,
+                                ),
+                                intervention: SoftInterventionSpec {
+                                    channel_id,
+                                    author_id: user_id,
+                                    author_is_bot: new_message.author.bot,
+                                    message_id: new_message.id,
+                                    text: text.to_string(),
+                                    reply_context: reply_context.clone(),
+                                    has_reply_boundary,
+                                    merge_consecutive,
+                                    pending_uploads: upload_records.clone(),
+                                    // #2266: queued-behind-idle-backlog path —
+                                    // FIFO ordering keeps voice transcripts behind
+                                    // pre-existing queue items; the transaction
+                                    // keeps voice text standalone and defers the
+                                    // durable claim until dispatch.
+                                    voice_announcement: resolved_voice_announcement.clone(),
+                                },
+                                options: IntakeQueueCommitOptions::idle_backlog(),
+                            },
                         )
                         .await,
                     )
                 }
             };
-            if let Some(outcome) = queued_behind_idle_backlog {
+            if let Some(commit) = queued_behind_idle_backlog {
                 let ts = chrono::Local::now().format("%H:%M:%S");
-                if outcome.enqueued {
+                if commit.accepted() {
                     tracing::info!(
                         "  [{ts}] 📬 IDLE-QUEUE: queued message from [{user_name}] in channel {} behind pending backlog",
                         channel_id
                     );
-                    add_queue_pending_reaction_self_healing(
-                        ctx,
-                        data,
-                        channel_id,
-                        new_message.id,
-                        queue_pending_reaction_for(outcome),
-                    )
-                    .await;
-                    // #2044 F12: monotonic checkpoint helper.
-                    super::super::advance_last_message_checkpoint(
-                        &data.shared,
-                        &data.provider,
-                        channel_id,
-                        new_message.id,
-                    );
                 } else {
                     tracing::info!(
-                        "  [{ts}] ↪ IDLE-QUEUE: duplicate message from [{user_name}] already pending in channel {}",
+                        "  [{ts}] ↪ IDLE-QUEUE: message from [{user_name}] was not accepted into channel {} backlog",
                         channel_id
                     );
                 }
-                super::super::kickoff_idle_queues(ctx, &data.shared, &data.token, &data.provider)
-                    .await;
                 return Ok(());
             }
 

--- a/src/services/discord/router/intake_queue_transaction.rs
+++ b/src/services/discord/router/intake_queue_transaction.rs
@@ -1,0 +1,823 @@
+use std::time::Instant;
+
+use async_trait::async_trait;
+use poise::serenity_prelude as serenity;
+
+use super::super::{Intervention, InterventionMode, MailboxEnqueueOutcome};
+use crate::services::turn_orchestrator::EnqueueRefusalReason;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IntakeQueueCommitSource {
+    BusyActiveTurn,
+    ThreadGuard,
+    DispatchGuard,
+    ReconcileGate,
+    DrainMode,
+    IdleBacklog,
+}
+
+impl IntakeQueueCommitSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::BusyActiveTurn => "busy_active_turn",
+            Self::ThreadGuard => "thread_guard",
+            Self::DispatchGuard => "dispatch_guard",
+            Self::ReconcileGate => "reconcile_gate",
+            Self::DrainMode => "drain_mode",
+            Self::IdleBacklog => "idle_backlog",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IntakeQueueAuthorClass {
+    Human,
+    AllowedBot,
+    OtherBot,
+}
+
+impl IntakeQueueAuthorClass {
+    pub(super) fn from_flags(author_is_bot: bool, is_allowed_bot: bool) -> Self {
+        if is_allowed_bot {
+            Self::AllowedBot
+        } else if author_is_bot {
+            Self::OtherBot
+        } else {
+            Self::Human
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::AllowedBot => "allowed_bot",
+            Self::OtherBot => "other_bot",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IntakeQueueIdleKickoffPolicy {
+    Never,
+    AlwaysAfterAttempt,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IntakeQueuePendingReactionPolicy {
+    QueueState,
+    Static(char),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct IntakeQueueCommitOptions {
+    pub(super) pending_reaction: IntakeQueuePendingReactionPolicy,
+    pub(super) advance_checkpoint: bool,
+    pub(super) idle_kickoff: IntakeQueueIdleKickoffPolicy,
+}
+
+impl IntakeQueueCommitOptions {
+    pub(super) fn idle_backlog() -> Self {
+        Self {
+            idle_kickoff: IntakeQueueIdleKickoffPolicy::AlwaysAfterAttempt,
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for IntakeQueueCommitOptions {
+    fn default() -> Self {
+        Self {
+            pending_reaction: IntakeQueuePendingReactionPolicy::QueueState,
+            advance_checkpoint: true,
+            idle_kickoff: IntakeQueueIdleKickoffPolicy::Never,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SoftInterventionSpec {
+    pub(super) channel_id: serenity::ChannelId,
+    pub(super) author_id: serenity::UserId,
+    pub(super) author_is_bot: bool,
+    pub(super) message_id: serenity::MessageId,
+    pub(super) text: String,
+    pub(super) reply_context: Option<String>,
+    pub(super) has_reply_boundary: bool,
+    pub(super) merge_consecutive: bool,
+    pub(super) pending_uploads: Vec<String>,
+    pub(super) voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
+}
+
+impl SoftInterventionSpec {
+    pub(super) fn into_intervention(self) -> Intervention {
+        Intervention {
+            author_id: self.author_id,
+            author_is_bot: self.author_is_bot,
+            message_id: self.message_id,
+            source_message_ids: vec![self.message_id],
+            text: self.text,
+            mode: InterventionMode::Soft,
+            created_at: Instant::now(),
+            reply_context: self.reply_context,
+            has_reply_boundary: self.has_reply_boundary,
+            merge_consecutive: self.merge_consecutive,
+            pending_uploads: self.pending_uploads,
+            voice_announcement: self.voice_announcement,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SoftInterventionCommitRequest {
+    pub(super) source: IntakeQueueCommitSource,
+    pub(super) author_class: IntakeQueueAuthorClass,
+    pub(super) intervention: SoftInterventionSpec,
+    pub(super) options: IntakeQueueCommitOptions,
+}
+
+impl SoftInterventionCommitRequest {
+    fn channel_id(&self) -> serenity::ChannelId {
+        self.intervention.channel_id
+    }
+
+    fn message_id(&self) -> serenity::MessageId {
+        self.intervention.message_id
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IntakeQueueCommittedStep {
+    MailboxEnqueued,
+    PendingReactionApplied,
+    CheckpointAdvanced,
+    IdleKickoffScheduled,
+}
+
+impl IntakeQueueCommittedStep {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::MailboxEnqueued => "mailbox_enqueued",
+            Self::PendingReactionApplied => "pending_reaction_applied",
+            Self::CheckpointAdvanced => "checkpoint_advanced",
+            Self::IdleKickoffScheduled => "idle_kickoff_scheduled",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PendingReactionSkipReason {
+    Disabled,
+    Refused,
+    Failed,
+}
+
+impl PendingReactionSkipReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Refused => "refused",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PendingReactionDecision {
+    Apply(char),
+    Skip(PendingReactionSkipReason),
+}
+
+impl PendingReactionDecision {
+    fn as_log_value(self) -> String {
+        match self {
+            Self::Apply(emoji) => format!("apply:{emoji}"),
+            Self::Skip(reason) => format!("skip:{}", reason.as_str()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum IntakeQueueCommitStatus {
+    Enqueued {
+        merged: bool,
+    },
+    Refused {
+        reason: Option<EnqueueRefusalReason>,
+    },
+    Failed {
+        error: String,
+    },
+}
+
+impl IntakeQueueCommitStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Enqueued { .. } => "enqueued",
+            Self::Refused { .. } => "refused",
+            Self::Failed { .. } => "failed",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct IntakeQueueCommitOutcome {
+    pub(super) channel_id: serenity::ChannelId,
+    pub(super) message_id: serenity::MessageId,
+    pub(super) source: IntakeQueueCommitSource,
+    pub(super) author_class: IntakeQueueAuthorClass,
+    pub(super) status: IntakeQueueCommitStatus,
+    pub(super) mailbox_outcome: MailboxEnqueueOutcome,
+    pub(super) pending_reaction: PendingReactionDecision,
+    pub(super) committed_steps: Vec<IntakeQueueCommittedStep>,
+    pub(super) checkpoint_advanced_to: Option<u64>,
+    pub(super) idle_kickoff_started_count: Option<usize>,
+}
+
+impl IntakeQueueCommitOutcome {
+    pub(super) fn accepted(&self) -> bool {
+        matches!(self.status, IntakeQueueCommitStatus::Enqueued { .. })
+    }
+
+    pub(super) fn failed(&self) -> bool {
+        matches!(self.status, IntakeQueueCommitStatus::Failed { .. })
+    }
+
+    pub(super) fn merged(&self) -> bool {
+        matches!(
+            self.status,
+            IntakeQueueCommitStatus::Enqueued { merged: true }
+        )
+    }
+
+    pub(super) fn refusal_reason(&self) -> Option<EnqueueRefusalReason> {
+        match self.status {
+            IntakeQueueCommitStatus::Refused { reason } => reason,
+            _ => None,
+        }
+    }
+
+    pub(super) fn checkpoint_advanced(&self) -> bool {
+        self.checkpoint_advanced_to.is_some()
+    }
+
+    fn committed_steps_log_value(&self) -> String {
+        if self.committed_steps.is_empty() {
+            return "none".to_string();
+        }
+        self.committed_steps
+            .iter()
+            .map(|step| step.as_str())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+#[async_trait]
+pub(super) trait IntakeQueueCommitEffects {
+    async fn enqueue_soft_intervention(
+        &mut self,
+        intervention: SoftInterventionSpec,
+    ) -> MailboxEnqueueOutcome;
+
+    async fn apply_pending_reaction(
+        &mut self,
+        channel_id: serenity::ChannelId,
+        message_id: serenity::MessageId,
+        emoji: char,
+    );
+
+    fn advance_checkpoint(
+        &mut self,
+        channel_id: serenity::ChannelId,
+        message_id: serenity::MessageId,
+    ) -> u64;
+
+    async fn schedule_idle_kickoff(&mut self) -> usize;
+}
+
+pub(super) fn queue_pending_reaction_for(outcome: &MailboxEnqueueOutcome) -> char {
+    if outcome.merged { '➕' } else { '📬' }
+}
+
+pub(super) async fn commit_soft_intervention_transaction<E>(
+    effects: &mut E,
+    request: SoftInterventionCommitRequest,
+) -> IntakeQueueCommitOutcome
+where
+    E: IntakeQueueCommitEffects,
+{
+    let channel_id = request.channel_id();
+    let message_id = request.message_id();
+    let source = request.source;
+    let author_class = request.author_class;
+    let options = request.options;
+    let has_voice_announcement = request.intervention.voice_announcement.is_some();
+    let mut intervention = request.intervention;
+    if has_voice_announcement {
+        // Do not expose a queued item that can be replayed as already accepted
+        // before the durable one-shot claim runs. The queued dispatch path
+        // re-enters handle_text_message with the original readable announce
+        // text, which resolves and consumes the durable PG row at processing
+        // time. Keeping voice items standalone preserves message-id ownership
+        // and avoids mixing two voice prompts into one queue head.
+        intervention.voice_announcement = None;
+        intervention.merge_consecutive = false;
+    }
+    let mailbox_outcome = effects.enqueue_soft_intervention(intervention).await;
+
+    let status = classify_mailbox_outcome(&mailbox_outcome);
+    let mut outcome = IntakeQueueCommitOutcome {
+        channel_id,
+        message_id,
+        source,
+        author_class,
+        status,
+        mailbox_outcome,
+        pending_reaction: PendingReactionDecision::Skip(PendingReactionSkipReason::Disabled),
+        committed_steps: Vec::new(),
+        checkpoint_advanced_to: None,
+        idle_kickoff_started_count: None,
+    };
+
+    if outcome.mailbox_outcome.enqueued {
+        outcome
+            .committed_steps
+            .push(IntakeQueueCommittedStep::MailboxEnqueued);
+    }
+
+    match outcome.status {
+        IntakeQueueCommitStatus::Enqueued { .. } => {
+            match options.pending_reaction {
+                IntakeQueuePendingReactionPolicy::QueueState => {
+                    let emoji = queue_pending_reaction_for(&outcome.mailbox_outcome);
+                    outcome.pending_reaction = PendingReactionDecision::Apply(emoji);
+                    effects
+                        .apply_pending_reaction(channel_id, message_id, emoji)
+                        .await;
+                    outcome
+                        .committed_steps
+                        .push(IntakeQueueCommittedStep::PendingReactionApplied);
+                }
+                IntakeQueuePendingReactionPolicy::Static(emoji) => {
+                    outcome.pending_reaction = PendingReactionDecision::Apply(emoji);
+                    effects
+                        .apply_pending_reaction(channel_id, message_id, emoji)
+                        .await;
+                    outcome
+                        .committed_steps
+                        .push(IntakeQueueCommittedStep::PendingReactionApplied);
+                }
+            }
+
+            if options.advance_checkpoint {
+                let checkpoint = effects.advance_checkpoint(channel_id, message_id);
+                outcome.checkpoint_advanced_to = Some(checkpoint);
+                outcome
+                    .committed_steps
+                    .push(IntakeQueueCommittedStep::CheckpointAdvanced);
+            }
+        }
+        IntakeQueueCommitStatus::Refused { .. } => {
+            outcome.pending_reaction =
+                PendingReactionDecision::Skip(PendingReactionSkipReason::Refused);
+        }
+        IntakeQueueCommitStatus::Failed { .. } => {
+            outcome.pending_reaction =
+                PendingReactionDecision::Skip(PendingReactionSkipReason::Failed);
+        }
+    }
+
+    let should_schedule_idle_kickoff = match options.idle_kickoff {
+        IntakeQueueIdleKickoffPolicy::Never => false,
+        IntakeQueueIdleKickoffPolicy::AlwaysAfterAttempt => true,
+    };
+    if should_schedule_idle_kickoff {
+        let started = effects.schedule_idle_kickoff().await;
+        outcome.idle_kickoff_started_count = Some(started);
+        outcome
+            .committed_steps
+            .push(IntakeQueueCommittedStep::IdleKickoffScheduled);
+    }
+
+    log_commit_outcome(&outcome);
+    outcome
+}
+
+fn classify_mailbox_outcome(outcome: &MailboxEnqueueOutcome) -> IntakeQueueCommitStatus {
+    if let Some(error) = outcome.persistence_error.as_ref() {
+        return IntakeQueueCommitStatus::Failed {
+            error: error.clone(),
+        };
+    }
+    if outcome.enqueued {
+        IntakeQueueCommitStatus::Enqueued {
+            merged: outcome.merged,
+        }
+    } else {
+        IntakeQueueCommitStatus::Refused {
+            reason: outcome.refusal_reason,
+        }
+    }
+}
+
+fn log_commit_outcome(outcome: &IntakeQueueCommitOutcome) {
+    let committed_steps = outcome.committed_steps_log_value();
+    let pending_reaction = outcome.pending_reaction.as_log_value();
+    let refusal_reason = outcome
+        .refusal_reason()
+        .map(EnqueueRefusalReason::as_str)
+        .unwrap_or("none");
+    let persistence_error = outcome
+        .mailbox_outcome
+        .persistence_error
+        .as_deref()
+        .unwrap_or("none");
+
+    match outcome.status {
+        IntakeQueueCommitStatus::Failed { .. } => {
+            tracing::warn!(
+                channel_id = outcome.channel_id.get(),
+                message_id = outcome.message_id.get(),
+                source = outcome.source.as_str(),
+                author_class = outcome.author_class.as_str(),
+                outcome = outcome.status.as_str(),
+                committed_steps = committed_steps.as_str(),
+                pending_reaction = pending_reaction.as_str(),
+                refusal_reason,
+                persistence_error,
+                "discord intake queue transaction finished with failed commit"
+            );
+        }
+        _ => {
+            tracing::info!(
+                channel_id = outcome.channel_id.get(),
+                message_id = outcome.message_id.get(),
+                source = outcome.source.as_str(),
+                author_class = outcome.author_class.as_str(),
+                outcome = outcome.status.as_str(),
+                committed_steps = committed_steps.as_str(),
+                pending_reaction = pending_reaction.as_str(),
+                refusal_reason,
+                persistence_error,
+                "discord intake queue transaction committed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeEffects {
+        enqueue_outcome: MailboxEnqueueOutcome,
+        enqueued_specs: Vec<SoftInterventionSpec>,
+        reactions: Vec<(serenity::ChannelId, serenity::MessageId, char)>,
+        checkpoints: Vec<(serenity::ChannelId, serenity::MessageId)>,
+        idle_kickoffs: usize,
+    }
+
+    impl Default for FakeEffects {
+        fn default() -> Self {
+            Self {
+                enqueue_outcome: MailboxEnqueueOutcome::default(),
+                enqueued_specs: Vec::new(),
+                reactions: Vec::new(),
+                checkpoints: Vec::new(),
+                idle_kickoffs: 0,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl IntakeQueueCommitEffects for FakeEffects {
+        async fn enqueue_soft_intervention(
+            &mut self,
+            intervention: SoftInterventionSpec,
+        ) -> MailboxEnqueueOutcome {
+            self.enqueued_specs.push(intervention);
+            self.enqueue_outcome.clone()
+        }
+
+        async fn apply_pending_reaction(
+            &mut self,
+            channel_id: serenity::ChannelId,
+            message_id: serenity::MessageId,
+            emoji: char,
+        ) {
+            self.reactions.push((channel_id, message_id, emoji));
+        }
+
+        fn advance_checkpoint(
+            &mut self,
+            channel_id: serenity::ChannelId,
+            message_id: serenity::MessageId,
+        ) -> u64 {
+            self.checkpoints.push((channel_id, message_id));
+            message_id.get()
+        }
+
+        async fn schedule_idle_kickoff(&mut self) -> usize {
+            self.idle_kickoffs += 1;
+            self.idle_kickoffs
+        }
+    }
+
+    fn request(options: IntakeQueueCommitOptions) -> SoftInterventionCommitRequest {
+        SoftInterventionCommitRequest {
+            source: IntakeQueueCommitSource::BusyActiveTurn,
+            author_class: IntakeQueueAuthorClass::Human,
+            intervention: SoftInterventionSpec {
+                channel_id: serenity::ChannelId::new(42),
+                author_id: serenity::UserId::new(7),
+                author_is_bot: false,
+                message_id: serenity::MessageId::new(100),
+                text: "hello".to_string(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: true,
+                pending_uploads: Vec::new(),
+                voice_announcement: None,
+            },
+            options,
+        }
+    }
+
+    fn voice_announcement() -> crate::voice::prompt::VoiceTranscriptAnnouncement {
+        crate::voice::prompt::VoiceTranscriptAnnouncement {
+            transcript: "상태 알려줘".to_string(),
+            user_id: "42".to_string(),
+            utterance_id: "utt-3724".to_string(),
+            language: "ko-KR".to_string(),
+            verbose_progress: true,
+            started_at: Some("2026-06-28T22:00:00+09:00".to_string()),
+            completed_at: Some("2026-06-28T22:00:01+09:00".to_string()),
+            samples_written: Some(48_000),
+            control_channel_id: Some(300),
+            stt_mode: Some("file".to_string()),
+            stt_latency_ms: Some(120),
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_commit_applies_reaction_and_advances_checkpoint() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: false,
+                refusal_reason: None,
+                persistence_error: None,
+            },
+            ..FakeEffects::default()
+        };
+
+        let outcome =
+            commit_soft_intervention_transaction(&mut effects, request(Default::default())).await;
+
+        assert!(outcome.accepted());
+        assert_eq!(
+            outcome.pending_reaction,
+            PendingReactionDecision::Apply('📬')
+        );
+        assert_eq!(
+            effects.reactions,
+            vec![(
+                serenity::ChannelId::new(42),
+                serenity::MessageId::new(100),
+                '📬'
+            )]
+        );
+        assert_eq!(
+            effects.checkpoints,
+            vec![(serenity::ChannelId::new(42), serenity::MessageId::new(100))]
+        );
+        assert_eq!(
+            outcome.committed_steps,
+            vec![
+                IntakeQueueCommittedStep::MailboxEnqueued,
+                IntakeQueueCommittedStep::PendingReactionApplied,
+                IntakeQueueCommittedStep::CheckpointAdvanced,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn accepted_commit_can_apply_static_reaction() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: false,
+                refusal_reason: None,
+                persistence_error: None,
+            },
+            ..FakeEffects::default()
+        };
+        let mut options = IntakeQueueCommitOptions::default();
+        options.pending_reaction = IntakeQueuePendingReactionPolicy::Static('🔄');
+
+        let outcome = commit_soft_intervention_transaction(&mut effects, request(options)).await;
+
+        assert!(outcome.accepted());
+        assert_eq!(
+            outcome.pending_reaction,
+            PendingReactionDecision::Apply('🔄')
+        );
+        assert_eq!(
+            effects.reactions,
+            vec![(
+                serenity::ChannelId::new(42),
+                serenity::MessageId::new(100),
+                '🔄'
+            )]
+        );
+        assert_eq!(
+            effects.checkpoints,
+            vec![(serenity::ChannelId::new(42), serenity::MessageId::new(100))]
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_refusal_does_not_apply_accepted_reaction_or_checkpoint() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: false,
+                merged: false,
+                refusal_reason: Some(EnqueueRefusalReason::SourceIdAlreadyQueued),
+                persistence_error: None,
+            },
+            ..FakeEffects::default()
+        };
+
+        let outcome =
+            commit_soft_intervention_transaction(&mut effects, request(Default::default())).await;
+
+        assert!(!outcome.accepted());
+        assert_eq!(
+            outcome.refusal_reason(),
+            Some(EnqueueRefusalReason::SourceIdAlreadyQueued)
+        );
+        assert_eq!(
+            outcome.pending_reaction,
+            PendingReactionDecision::Skip(PendingReactionSkipReason::Refused)
+        );
+        assert!(effects.reactions.is_empty());
+        assert!(effects.checkpoints.is_empty());
+        assert!(outcome.committed_steps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn persistence_failure_does_not_emit_misleading_reaction_or_checkpoint() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: false,
+                refusal_reason: None,
+                persistence_error: Some("disk unavailable".to_string()),
+            },
+            ..FakeEffects::default()
+        };
+
+        let outcome =
+            commit_soft_intervention_transaction(&mut effects, request(Default::default())).await;
+
+        assert!(outcome.failed());
+        assert!(effects.reactions.is_empty());
+        assert!(effects.checkpoints.is_empty());
+        assert_eq!(
+            outcome.committed_steps,
+            vec![IntakeQueueCommittedStep::MailboxEnqueued]
+        );
+    }
+
+    #[tokio::test]
+    async fn voice_commit_defers_durable_claim_until_dispatch() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: false,
+                refusal_reason: None,
+                persistence_error: None,
+            },
+            ..FakeEffects::default()
+        };
+        let mut req = request(Default::default());
+        req.intervention.voice_announcement = Some(voice_announcement());
+
+        let outcome = commit_soft_intervention_transaction(&mut effects, req).await;
+
+        assert!(outcome.accepted());
+        assert_eq!(effects.enqueued_specs.len(), 1);
+        assert!(effects.enqueued_specs[0].voice_announcement.is_none());
+        assert!(
+            !effects.enqueued_specs[0].merge_consecutive,
+            "queued voice announcements stay standalone so dispatch can resolve the durable row by the head message id"
+        );
+        assert_eq!(
+            outcome.pending_reaction,
+            PendingReactionDecision::Apply('📬')
+        );
+        assert_eq!(
+            effects.reactions,
+            vec![(
+                serenity::ChannelId::new(42),
+                serenity::MessageId::new(100),
+                '📬'
+            )]
+        );
+        assert_eq!(
+            effects.checkpoints,
+            vec![(serenity::ChannelId::new(42), serenity::MessageId::new(100))]
+        );
+        assert_eq!(
+            outcome.committed_steps,
+            vec![
+                IntakeQueueCommittedStep::MailboxEnqueued,
+                IntakeQueueCommittedStep::PendingReactionApplied,
+                IntakeQueueCommittedStep::CheckpointAdvanced,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn voice_persistence_failure_never_exposes_accepted_replay_payload() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: false,
+                refusal_reason: None,
+                persistence_error: Some("disk unavailable".to_string()),
+            },
+            ..FakeEffects::default()
+        };
+        let mut req = request(Default::default());
+        req.intervention.voice_announcement = Some(voice_announcement());
+
+        let outcome = commit_soft_intervention_transaction(&mut effects, req).await;
+
+        assert!(outcome.failed());
+        assert_eq!(effects.enqueued_specs.len(), 1);
+        assert!(effects.enqueued_specs[0].voice_announcement.is_none());
+        assert!(effects.reactions.is_empty());
+        assert!(effects.checkpoints.is_empty());
+        assert_eq!(
+            outcome.committed_steps,
+            vec![IntakeQueueCommittedStep::MailboxEnqueued]
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_backlog_commit_schedules_kickoff_after_accept() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: true,
+                refusal_reason: None,
+                persistence_error: None,
+            },
+            ..FakeEffects::default()
+        };
+        let mut req = request(IntakeQueueCommitOptions::idle_backlog());
+        req.source = IntakeQueueCommitSource::IdleBacklog;
+
+        let outcome = commit_soft_intervention_transaction(&mut effects, req).await;
+
+        assert!(outcome.accepted());
+        assert_eq!(
+            outcome.pending_reaction,
+            PendingReactionDecision::Apply('➕')
+        );
+        assert_eq!(effects.idle_kickoffs, 1);
+        assert_eq!(outcome.idle_kickoff_started_count, Some(1));
+        assert!(
+            outcome
+                .committed_steps
+                .contains(&IntakeQueueCommittedStep::IdleKickoffScheduled)
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_backlog_refusal_still_kicks_existing_backlog_without_reaction_or_checkpoint() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: false,
+                merged: false,
+                refusal_reason: Some(EnqueueRefusalReason::LastItemDedup),
+                persistence_error: None,
+            },
+            ..FakeEffects::default()
+        };
+        let mut req = request(IntakeQueueCommitOptions::idle_backlog());
+        req.source = IntakeQueueCommitSource::IdleBacklog;
+
+        let outcome = commit_soft_intervention_transaction(&mut effects, req).await;
+
+        assert!(!outcome.accepted());
+        assert!(effects.reactions.is_empty());
+        assert!(effects.checkpoints.is_empty());
+        assert_eq!(effects.idle_kickoffs, 1);
+        assert_eq!(
+            outcome.committed_steps,
+            vec![IntakeQueueCommittedStep::IdleKickoffScheduled]
+        );
+    }
+}

--- a/src/services/discord/router/mod.rs
+++ b/src/services/discord/router/mod.rs
@@ -1,6 +1,7 @@
 mod authorization;
 mod dispatch_trigger;
 mod intake_gate;
+mod intake_queue_transaction;
 mod message_handler;
 mod response_format;
 mod thread_binding;


### PR DESCRIPTION
## Summary

- Add `intake_queue_transaction` to centralize Discord intake enqueue side effects and structured commit outcomes.
- Route busy/race-loss/thread guard/reconcile/drain/idle-backlog and catch-up enqueue paths through the shared helper so reactions, checkpoints, and idle kickoff follow the accepted enqueue result.
- Strip queued voice accepted-replay payloads before enqueue, keep voice entries standalone, and resolve/claim durable voice metadata at dispatch time with gateway request-owner handling for readable voice announcements.

## Verification

- Fresh xhigh Codex review: `VERDICT: CLEAN`
- `cargo test --lib intake_queue_transaction`
- `cargo test --lib uses_author_for_embedded_or_readable_voice_metadata`
- `cargo test --lib catch_up_recovery_tests`
- `AGENTDESK_ROOT_DIR=$(mktemp -d /tmp/adk-3724-router.XXXXXX) cargo test --lib router::`
- `cargo check --lib`
- `cargo fmt --all --check`
- `PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh`
- `git diff --check`

## Issue

Refs #3724
