### PR TITLE
Preserve Discord semantic relay boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -675,6 +675,7 @@ src/
 │   │   ├── role_map.rs
 │   │   ├── runtime_bootstrap.rs
 │   │   ├── runtime_store.rs
+│   │   ├── semantic_boundaries.rs
 │   │   ├── session_identity.rs
 │   │   ├── session_relay_sink.rs
 │   │   ├── session_runtime.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1218,10 +1218,14 @@
     `turn_finalizer/watcher_backstop.rs` (watcher far-backstop tunables +
     terminal-or-defer verdict pair). Bugfix only outside a
     finalizer-decomposition plan).
-  - `src/services/discord/formatting.rs` (2802 lines; #3818 keeps only the
-    placeholder-status subagent-notification summary hook here while moving the
-    shared streaming-rollover predicate to `subagent_notification_card.rs`, so
-    the file stays at its frozen baseline; net +0 from #3034 scoped
+  - `src/services/discord/formatting.rs` (2801 lines; #3807 wires semantic
+    sentence-boundary callsites here while keeping the shared helper in
+    `semantic_boundaries.rs`, so the frozen giant stays below baseline;
+    worker-local presentation logic only, no relay ownership/lease change.
+    #3818 keeps only the placeholder-status subagent-notification summary hook
+    here while moving the shared streaming-rollover predicate to
+    `subagent_notification_card.rs`. Historical freeze notes: net +0 from #3034
+    scoped
     dead-code allows on the `MonitorHandoffReason::InlineTimeout` /
     `MonitorHandoffStatus::Failed` reserved variants — the two added `#[allow]`
     lines were offset by collapsing the adjacent reason comments back to inline

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1016,7 +1016,8 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2729 lines; -3 from #3795
+  - `src/services/discord/health/recovery.rs` (2731 lines; +2 from #3807 applying
+    compact continuation context to stale-leak recovery split delivery; -3 from #3795
     routing session-key tail fallback through `SessionIdentity`; +2 from #3711/#3712 mapping direct TUI runtime-binding-unavailable rebind failures to 409 Conflict; #3676 moved
     `tmux_alive_relay_dead` watchdog reattach logic into sibling
     `health/relay_dead_reattach.rs`, leaving recovery.rs with only the
@@ -1219,8 +1220,8 @@
     terminal-or-defer verdict pair). Bugfix only outside a
     finalizer-decomposition plan).
   - `src/services/discord/formatting.rs` (2801 lines; #3807 wires semantic
-    sentence-boundary callsites here while keeping the shared helper in
-    `semantic_boundaries.rs`, so the frozen giant stays below baseline;
+    sentence-boundary callsites while keeping the shared boundary classifier
+    and compact continuation-context helper in `semantic_boundaries.rs`;
     worker-local presentation logic only, no relay ownership/lease change.
     #3818 keeps only the placeholder-status subagent-notification summary hook
     here while moving the shared streaming-rollover predicate to

--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -35,6 +35,8 @@ Last refreshed: 2026-06-16 (against `main` @ `8ec7336e32eb6ef89e1143fab2543f2fc6
 >
 > Last refreshed: 2026-06-28 (#3751 — `InflightTurnState` still carries `watcher_owner_channel_id` for same-binary fast reads, but the mixed-binary-safe source of restart recovery is the separate `discord_delivery_owner_context` sidecar stored under the delivery channel. `recovery_paths/restart.rs::try_recover_anchor_repost` first resolves that sidecar delivery-channel → watcher-owner mapping, falls back to the inflight field / `state.channel_id` for legacy rows, and rejects shared-owner stale anchors whose recorded `panel_channel_id` does not match the recovered delivery channel or whose range starts at/after the row's `last_offset`. `logical_channel_id` remains a thread-parent axis and is explicitly not used for delivery-record lookup. The repost target still comes from recorded `panel_channel_id`; stale-generation and `MessageGone` guards are unchanged).
 >
+> Last refreshed: 2026-06-29 (#3807 — manual notification over-limit chunk delivery now wraps `split_message` output with compact continuation context markers, matching the other long-message split paths. This is still the existing compatibility chunk shim in `outbound/manual_delivery.rs`; no v3 outbound API shape, dedup writer, attachment policy, or direct-send inventory category changed).
+>
 > Companion docs: [`docs/discord-outbound-remaining-producers.md`](../discord-outbound-remaining-producers.md) (#1175 closure), [`docs/source-of-truth.md`](../source-of-truth.md).
 
 This is the single source of truth for "where is each Discord outbound callsite
@@ -319,6 +321,9 @@ button hits the manual outbound API, which is covered under §3.A
   `api_send_rejects_user_supplied_voice_delivery_id_namespace` verifies manual
   `/api/discord/send` callers cannot forge the reserved `voice:` correlation
   namespace used by voice announce delivery ids.
+- `src/services/discord/outbound/manual_delivery.rs`:
+  #3807 keeps the manual over-limit notification path on the compatibility
+  chunk shim while adding compact continuation context to each split message.
 
 ## 6. Guardrail proposal (DoD #4)
 

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -1252,7 +1252,8 @@ files, and memory recall below as new actionable input.\n\n\
     mod a0_characterization_tests {
         use super::super::super::semantic_boundaries::semantic_sentence_split_boundary;
         use super::super::{
-            DISCORD_MSG_LIMIT, plan_streaming_rollover, split_message, streaming_split_boundary,
+            DISCORD_MSG_LIMIT, long_message_reply_builders, plan_streaming_rollover, split_message,
+            streaming_split_boundary,
         };
 
         // -------------------------------------------------------------------
@@ -1360,6 +1361,20 @@ files, and memory recall below as new actionable input.\n\n\
                 chunks[1].starts_with("```rust\n"),
                 "next chunk re-opens the fence with the same language tag"
             );
+        }
+
+        #[test]
+        fn a0_long_message_reply_builders_add_compact_continuation_context() {
+            let body = "a".repeat(2500);
+            let replies = long_message_reply_builders(&body);
+            assert_eq!(replies.len(), 2);
+            let first = replies[0].content.as_ref().expect("first content");
+            let second = replies[1].content.as_ref().expect("second content");
+
+            assert!(first.starts_with("[1/2]\n"));
+            assert!(second.starts_with("[2/2]\n"));
+            assert!(first.len() <= DISCORD_MSG_LIMIT);
+            assert!(second.len() <= DISCORD_MSG_LIMIT);
         }
 
         // -------------------------------------------------------------------
@@ -1734,7 +1749,7 @@ pub(super) async fn send_long_message_ctx(ctx: Context<'_>, text: &str) -> Resul
         return Ok(());
     }
 
-    let chunks = split_message(text);
+    let chunks = super::semantic_boundaries::add_continuation_context(split_message(text));
     let total = chunks.len();
     for (i, chunk) in chunks.iter().enumerate() {
         tracing::debug!(
@@ -1763,7 +1778,7 @@ pub(in crate::services::discord) fn long_message_reply_builders(
         return vec![poise::CreateReply::default().content(text.to_string())];
     }
 
-    split_message(text)
+    super::semantic_boundaries::add_continuation_context(split_message(text))
         .into_iter()
         .map(|chunk| poise::CreateReply::default().content(chunk))
         .collect()
@@ -1862,7 +1877,7 @@ pub(in crate::services::discord) async fn send_long_message_raw_with_reference(
         }
     }
 
-    let chunks = split_message(text);
+    let chunks = super::semantic_boundaries::add_continuation_context(split_message(text));
     let total = chunks.len();
     // #3082 part B: hold the per-channel answer-flush barrier for the whole
     // multi-chunk send so a queued-turn notice POST cannot interleave between
@@ -1942,7 +1957,7 @@ pub(super) async fn send_long_message_raw_with_rollback(
     shared: &Arc<SharedData>,
 ) -> Result<Vec<MessageId>, Error> {
     let payload_byte_len = text.len();
-    let chunks = split_message(text);
+    let chunks = super::semantic_boundaries::add_continuation_context(split_message(text));
     let total = chunks.len();
     let rollback_key = replace_continuation_rollback_key(channel_id, rollback_anchor_msg_id);
 
@@ -2227,7 +2242,7 @@ pub(super) async fn replace_long_message_raw_with_outcome(
     shared: &Arc<SharedData>,
 ) -> Result<ReplaceLongMessageOutcome, Error> {
     let payload_byte_len = text.len();
-    let chunks = split_message(text);
+    let chunks = super::semantic_boundaries::add_continuation_context(split_message(text));
     let total = chunks.len();
     let Some(first_chunk) = chunks.first() else {
         tracing::debug!(

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -301,6 +301,7 @@ pub(super) fn streaming_split_boundary(text: &str, max_len: usize) -> Option<usi
 
     let preferred = paragraph_split
         .or(newline_split)
+        .or_else(|| super::semantic_boundaries::semantic_sentence_split_boundary(window))
         .or(whitespace_split)
         .unwrap_or(safe_end);
     let split_at = if preferred < safe_end / 2 {
@@ -1249,6 +1250,7 @@ files, and memory recall below as new actionable input.\n\n\
     // `#[cfg(test)] mod` block => ZERO production LoC under the ratchet
     // (formatting.rs baseline 2802 stays unchanged).
     mod a0_characterization_tests {
+        use super::super::super::semantic_boundaries::semantic_sentence_split_boundary;
         use super::super::{
             DISCORD_MSG_LIMIT, plan_streaming_rollover, split_message, streaming_split_boundary,
         };
@@ -1313,6 +1315,22 @@ files, and memory recall below as new actionable input.\n\n\
                 chunks[1], tail,
                 "the boundary newline is stripped from the next chunk head"
             );
+        }
+
+        #[test]
+        fn a0_split_message_uses_semantic_sentence_boundary_when_no_newline_exists() {
+            let head = format!("{}확인합니다.", "a".repeat(1480));
+            let tail = format!("`NullRHI`{}", "b".repeat(1000));
+            let body = format!("{head}{tail}");
+            let chunks = split_message(&body);
+
+            assert_eq!(chunks.len(), 2);
+            assert_eq!(
+                chunks[0], head,
+                "newline-free prose should split at a sentence boundary before hard-splitting"
+            );
+            assert_eq!(chunks[1], tail);
+            assert_eq!(format!("{}{}", chunks[0], chunks[1]), body);
         }
 
         #[test]
@@ -1423,6 +1441,51 @@ files, and memory recall below as new actionable input.\n\n\
                 streaming_split_boundary(&body, 50),
                 Some(31),
                 "single newline wins over a later space"
+            );
+        }
+
+        #[test]
+        fn a0_streaming_split_boundary_sentence_beats_a_later_space() {
+            let head = format!("{}확인합니다.", "x".repeat(20));
+            let body = format!("{}{} {}", head, "y".repeat(5), "z".repeat(100));
+            assert_eq!(
+                streaming_split_boundary(&body, 50),
+                Some(head.len()),
+                "sentence boundary wins over a later whitespace split"
+            );
+        }
+
+        #[test]
+        fn a0_semantic_sentence_split_boundary_skips_markdown_continuations_and_code_fences() {
+            assert_eq!(
+                semantic_sentence_split_boundary("확인합니다.`NullRHI`"),
+                Some("확인합니다.".len()),
+                "inline-code follow-up after Korean sentence is a readable split point"
+            );
+            assert_eq!(
+                semantic_sentence_split_boundary("- item. more text"),
+                None,
+                "list items keep their existing markdown continuation behavior"
+            );
+            assert_eq!(
+                semantic_sentence_split_boundary("| Col | value."),
+                None,
+                "table-like lines keep their existing markdown continuation behavior"
+            );
+            assert_eq!(
+                semantic_sentence_split_boundary("version 1.2"),
+                None,
+                "decimal points are not sentence boundaries"
+            );
+            assert_eq!(
+                semantic_sentence_split_boundary("config.yaml"),
+                None,
+                "single-token file extensions are not sentence boundaries"
+            );
+            assert_eq!(
+                semantic_sentence_split_boundary("```text\nDone.\n```"),
+                None,
+                "code-fence content must not be sentence-split"
             );
         }
 
@@ -2928,10 +2991,8 @@ pub(super) fn split_message(text: &str) -> Vec<String> {
         // back to a hard split at `safe_end` (or skip the orphan newline when
         // `safe_end` is also 0 due to a multi-byte char on the boundary).
         let safe_end = floor_char_boundary(remaining, effective_limit);
-        let (mut split_at, mut boundary_kind) = match remaining[..safe_end].rfind('\n') {
-            Some(idx) => (idx, "newline"),
-            None => (safe_end, "hard"),
-        };
+        let (mut split_at, mut boundary_kind) =
+            super::semantic_boundaries::message_split_boundary(remaining, safe_end);
         if split_at == 0 {
             if safe_end > 0 {
                 split_at = safe_end;

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -1250,7 +1250,9 @@ files, and memory recall below as new actionable input.\n\n\
     // `#[cfg(test)] mod` block => ZERO production LoC under the ratchet
     // (formatting.rs baseline 2802 stays unchanged).
     mod a0_characterization_tests {
-        use super::super::super::semantic_boundaries::semantic_sentence_split_boundary;
+        use super::super::super::semantic_boundaries::{
+            message_split_boundary, semantic_sentence_split_boundary,
+        };
         use super::super::{
             DISCORD_MSG_LIMIT, long_message_reply_builders, plan_streaming_rollover, split_message,
             streaming_split_boundary,
@@ -1476,6 +1478,17 @@ files, and memory recall below as new actionable input.\n\n\
                 semantic_sentence_split_boundary("확인합니다.`NullRHI`"),
                 Some("확인합니다.".len()),
                 "inline-code follow-up after Korean sentence is a readable split point"
+            );
+            assert_eq!(
+                semantic_sentence_split_boundary("Use `foo.bar` in config"),
+                None,
+                "inline code punctuation is not a sentence split point"
+            );
+            let code_window = "println!(\"done.\"); keep streaming inside fence";
+            assert_eq!(
+                message_split_boundary(code_window, code_window.len(), true),
+                (code_window.len(), "hard"),
+                "already-open code fences must not use semantic sentence splits"
             );
             assert_eq!(
                 semantic_sentence_split_boundary("- item. more text"),
@@ -3007,7 +3020,7 @@ pub(super) fn split_message(text: &str) -> Vec<String> {
         // `safe_end` is also 0 due to a multi-byte char on the boundary).
         let safe_end = floor_char_boundary(remaining, effective_limit);
         let (mut split_at, mut boundary_kind) =
-            super::semantic_boundaries::message_split_boundary(remaining, safe_end);
+            super::semantic_boundaries::message_split_boundary(remaining, safe_end, in_code_block);
         if split_at == 0 {
             if safe_end > 0 {
                 split_at = safe_end;

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -40,7 +40,9 @@ pub(super) trait TurnGateway: Send + Sync {
         content: &'a str,
     ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
         Box::pin(async move {
-            let chunks = formatting::split_message(content);
+            let chunks = super::semantic_boundaries::add_continuation_context(
+                formatting::split_message(content),
+            );
             if chunks.is_empty() {
                 return Ok(Vec::new());
             }
@@ -885,7 +887,9 @@ impl TurnGateway for HeadlessGateway {
         content: &'a str,
     ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
         Box::pin(async move {
-            let chunks = formatting::split_message(content);
+            let chunks = super::semantic_boundaries::add_continuation_context(
+                formatting::split_message(content),
+            );
             let count = chunks.len().max(1);
             Ok((0..count).map(|_| next_headless_message_id()).collect())
         })

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -1118,7 +1118,15 @@ mod tests {
         let sent = gateway.sent.lock().expect("sent lock");
         assert_eq!(
             sent.iter()
-                .map(|(_, chunk)| chunk.as_str())
+                .map(|(_, chunk)| {
+                    chunk
+                        .split_once('\n')
+                        .filter(|(prefix, _)| {
+                            prefix.starts_with('[') && prefix.ends_with(']') && prefix.contains('/')
+                        })
+                        .map(|(_, body)| body)
+                        .unwrap_or(chunk.as_str())
+                })
                 .collect::<String>(),
             body
         );

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -2428,7 +2428,9 @@ async fn maybe_recover_completed_stale_leak(
     // Discord's 2000). For multi-chunk recovery we first consult the durable
     // per-chunk ledger. Legacy/pre-ledger retries can still derive a prefix
     // from live Discord state, then seed the ledger before continuing.
-    let chunks = discord::formatting::split_message(&delivery_text);
+    let chunks = discord::semantic_boundaries::add_continuation_context(
+        discord::formatting::split_message(&delivery_text),
+    );
     if chunks.is_empty() {
         return false;
     }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -60,6 +60,7 @@ pub(crate) mod restart_report;
 mod role_map;
 mod router;
 mod runtime_bootstrap;
+pub(in crate::services::discord) mod semantic_boundaries;
 // #1446 stall-deadlock recovery: shared post-clear bookkeeping for the THREAD-GUARD
 // + stall-watchdog cleanup paths so neither leaks `global_active` / cancel tokens.
 pub mod runtime_store;

--- a/src/services/discord/outbound/manual_delivery.rs
+++ b/src/services/discord/outbound/manual_delivery.rs
@@ -20,6 +20,7 @@ use crate::services::discord::outbound::{
     DISCORD_HARD_LIMIT_CHARS, DISCORD_SAFE_LIMIT_CHARS, DiscordOutboundClient, OutboundDedupClaim,
     OutboundDedupReservation, OutboundDedupWait, OutboundDeduper,
 };
+use crate::services::discord::semantic_boundaries::add_continuation_context;
 use crate::services::dispatches::discord_delivery::{
     DispatchMessagePostError, DispatchMessagePostErrorKind,
 };
@@ -568,7 +569,7 @@ async fn deliver_chunked_manual_notification<C: ManualOutboundClient>(
     content: &str,
 ) -> Result<ManualDeliveryOutcome, DispatchMessagePostError> {
     let mut last_message_id = None;
-    for chunk in split_message(content) {
+    for chunk in add_continuation_context(split_message(content)) {
         let message_id = client.post_message(channel_id, &chunk).await?;
         last_message_id = Some(message_id);
     }

--- a/src/services/discord/semantic_boundaries.rs
+++ b/src/services/discord/semantic_boundaries.rs
@@ -22,15 +22,79 @@ fn semantic_terminal_boundary_allowed(line: &str, idx: usize, ch: char) -> bool 
         return false;
     }
 
-    let token_before_dot = line[..idx].rsplit(char::is_whitespace).next().unwrap_or("");
     if before.is_some_and(|ch| ch.is_ascii_alphanumeric())
-        && after.is_some_and(|ch| ch.is_ascii_lowercase())
-        && !has_hangul(token_before_dot)
+        && extension_join_candidate(line, idx, &line[idx + ch.len_utf8()..])
     {
         return false;
     }
 
     true
+}
+
+fn token_before_dot(line: &str, dot_idx: usize) -> &str {
+    line[..dot_idx]
+        .rsplit(|ch: char| ch.is_whitespace() || matches!(ch, '`' | '(' | '[' | '{' | '/' | '\\'))
+        .next()
+        .unwrap_or("")
+}
+
+fn leading_extension_token(text: &str) -> &str {
+    let trimmed = text.trim_start();
+    let end = trimmed
+        .char_indices()
+        .find(|(_, ch)| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')))
+        .map(|(idx, _)| idx)
+        .unwrap_or(trimmed.len());
+    &trimmed[..end]
+}
+
+fn common_extension_token(token: &str) -> bool {
+    matches!(
+        token,
+        "bash"
+            | "css"
+            | "csv"
+            | "db"
+            | "env"
+            | "gif"
+            | "html"
+            | "jpeg"
+            | "jpg"
+            | "js"
+            | "json"
+            | "jsx"
+            | "lock"
+            | "log"
+            | "md"
+            | "pdf"
+            | "png"
+            | "py"
+            | "rs"
+            | "scss"
+            | "sh"
+            | "sql"
+            | "sqlite"
+            | "svg"
+            | "toml"
+            | "ts"
+            | "tsx"
+            | "txt"
+            | "webp"
+            | "xml"
+            | "yaml"
+            | "yml"
+            | "zsh"
+    )
+}
+
+fn extension_join_candidate(line: &str, dot_idx: usize, incoming: &str) -> bool {
+    let before = token_before_dot(line, dot_idx);
+    let extension = leading_extension_token(incoming);
+    !before.is_empty() && !has_hangul(before) && common_extension_token(extension)
+}
+
+fn inline_code_span_open(line: &str) -> bool {
+    line.chars().filter(|ch| *ch == '`').count() % 2 == 1
 }
 
 fn markdown_continuation_head(text: &str) -> bool {
@@ -93,6 +157,35 @@ pub(in crate::services::discord) fn message_split_boundary(
     }
 }
 
+fn continuation_context_prefix(index: usize, total: usize) -> String {
+    let full = format!("[{}/{}]\n", index + 1, total);
+    if full.len() <= 10 {
+        return full;
+    }
+    let partial = format!("[{}]\n", index + 1);
+    if partial.len() <= 10 {
+        partial
+    } else {
+        "[+]\n".to_string()
+    }
+}
+
+pub(in crate::services::discord) fn add_continuation_context(chunks: Vec<String>) -> Vec<String> {
+    if chunks.len() <= 1 {
+        return chunks;
+    }
+    let total = chunks.len();
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(index, chunk)| {
+            let prefix = continuation_context_prefix(index, total);
+            debug_assert!(prefix.len() <= 10);
+            format!("{prefix}{chunk}")
+        })
+        .collect()
+}
+
 pub(in crate::services::discord) fn semantic_chunk_separator_needed(
     prefix: &str,
     incoming: &str,
@@ -110,6 +203,9 @@ pub(in crate::services::discord) fn semantic_chunk_separator_needed(
 
     let tail_line = prefix.rsplit('\n').next().unwrap_or(prefix).trim_end();
     if markdown_continuation_tail(tail_line) {
+        return false;
+    }
+    if inline_code_span_open(tail_line) {
         return false;
     }
 
@@ -132,9 +228,7 @@ pub(in crate::services::discord) fn semantic_chunk_separator_needed(
             return false;
         }
         if before.is_some_and(|ch| ch.is_ascii_alphanumeric())
-            && next.is_some_and(|ch| ch.is_ascii_lowercase())
-            && !has_hangul(tail_line)
-            && !tail_line.chars().any(char::is_whitespace)
+            && extension_join_candidate(tail_line, last_idx, incoming)
         {
             return false;
         }

--- a/src/services/discord/semantic_boundaries.rs
+++ b/src/services/discord/semantic_boundaries.rs
@@ -1,0 +1,144 @@
+fn line_starts_code_fence(line: &str) -> bool {
+    line.trim_start().starts_with("```")
+}
+
+fn has_hangul(text: &str) -> bool {
+    text.chars()
+        .any(|ch| ('\u{ac00}'..='\u{d7a3}').contains(&ch))
+}
+
+fn semantic_terminal_char(ch: char) -> bool {
+    matches!(ch, '.' | '!' | '?' | '…' | '。' | '！' | '？')
+}
+
+fn semantic_terminal_boundary_allowed(line: &str, idx: usize, ch: char) -> bool {
+    if ch != '.' {
+        return true;
+    }
+
+    let before = line[..idx].chars().rev().find(|ch| !ch.is_whitespace());
+    let after = line[idx + ch.len_utf8()..].chars().next();
+    if before.is_some_and(|ch| ch.is_ascii_digit()) && after.is_some_and(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+
+    let token_before_dot = line[..idx].rsplit(char::is_whitespace).next().unwrap_or("");
+    if before.is_some_and(|ch| ch.is_ascii_alphanumeric())
+        && after.is_some_and(|ch| ch.is_ascii_lowercase())
+        && !has_hangul(token_before_dot)
+    {
+        return false;
+    }
+
+    true
+}
+
+fn markdown_continuation_head(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("|")
+        || trimmed.starts_with("- ")
+        || trimmed.starts_with("* ")
+        || trimmed.starts_with("+ ")
+        || trimmed.starts_with("> ")
+        || trimmed
+            .chars()
+            .next()
+            .is_some_and(|ch| matches!(ch, ')' | ']' | '}' | ',' | ';' | ':'))
+}
+
+fn markdown_continuation_tail(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("|")
+        || trimmed.starts_with("- ")
+        || trimmed.starts_with("* ")
+        || trimmed.starts_with("+ ")
+        || trimmed.starts_with("> ")
+}
+
+pub(in crate::services::discord) fn semantic_sentence_split_boundary(text: &str) -> Option<usize> {
+    let mut in_code_block = false;
+    let mut offset = 0;
+    let mut boundary = None;
+
+    for segment in text.split_inclusive('\n') {
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        let fence_line = line_starts_code_fence(line);
+        if !in_code_block && !fence_line && !markdown_continuation_tail(line) {
+            for (idx, ch) in line.char_indices() {
+                if semantic_terminal_char(ch) && semantic_terminal_boundary_allowed(line, idx, ch) {
+                    boundary = Some(offset + idx + ch.len_utf8());
+                }
+            }
+        }
+        if fence_line {
+            in_code_block = !in_code_block;
+        }
+        offset += segment.len();
+    }
+
+    boundary
+}
+
+pub(in crate::services::discord) fn message_split_boundary(
+    remaining: &str,
+    safe_end: usize,
+) -> (usize, &'static str) {
+    let window = &remaining[..safe_end];
+    if let Some(idx) = window.rfind('\n') {
+        (idx, "newline")
+    } else if let Some(idx) = semantic_sentence_split_boundary(window) {
+        (idx, "semantic")
+    } else {
+        (safe_end, "hard")
+    }
+}
+
+pub(in crate::services::discord) fn semantic_chunk_separator_needed(
+    prefix: &str,
+    incoming: &str,
+) -> bool {
+    if prefix.is_empty()
+        || incoming.is_empty()
+        || prefix.chars().last().is_some_and(char::is_whitespace)
+        || incoming.chars().next().is_some_and(char::is_whitespace)
+    {
+        return false;
+    }
+    if markdown_continuation_head(incoming) {
+        return false;
+    }
+
+    let tail_line = prefix.rsplit('\n').next().unwrap_or(prefix).trim_end();
+    if markdown_continuation_tail(tail_line) {
+        return false;
+    }
+
+    let Some((last_idx, last)) = tail_line.char_indices().next_back() else {
+        return false;
+    };
+    if !semantic_terminal_char(last) {
+        return false;
+    }
+
+    let next = incoming.chars().next();
+    if last == '.' {
+        let before = tail_line[..last_idx]
+            .chars()
+            .rev()
+            .find(|ch| !ch.is_whitespace());
+        if before.is_some_and(|ch| ch.is_ascii_digit())
+            && next.is_some_and(|ch| ch.is_ascii_digit())
+        {
+            return false;
+        }
+        if before.is_some_and(|ch| ch.is_ascii_alphanumeric())
+            && next.is_some_and(|ch| ch.is_ascii_lowercase())
+            && !has_hangul(tail_line)
+            && !tail_line.chars().any(char::is_whitespace)
+        {
+            return false;
+        }
+    }
+
+    true
+}

--- a/src/services/discord/semantic_boundaries.rs
+++ b/src/services/discord/semantic_boundaries.rs
@@ -160,8 +160,8 @@ fn markdown_continuation_tail(line: &str) -> bool {
         || trimmed.starts_with("> ")
 }
 
-pub(in crate::services::discord) fn semantic_sentence_split_boundary(text: &str) -> Option<usize> {
-    let mut in_code_block = false;
+fn semantic_sentence_split_boundary_from(text: &str, starts_in_code_block: bool) -> Option<usize> {
+    let mut in_code_block = starts_in_code_block;
     let mut offset = 0;
     let mut boundary = None;
 
@@ -169,8 +169,14 @@ pub(in crate::services::discord) fn semantic_sentence_split_boundary(text: &str)
         let line = segment.strip_suffix('\n').unwrap_or(segment);
         let fence_line = line_starts_code_fence(line);
         if !in_code_block && !fence_line && !markdown_continuation_tail(line) {
+            let mut in_inline_code = false;
             for (idx, ch) in line.char_indices() {
-                if semantic_terminal_char(ch) && semantic_terminal_boundary_allowed(line, idx, ch) {
+                if ch == '`' {
+                    in_inline_code = !in_inline_code;
+                } else if !in_inline_code
+                    && semantic_terminal_char(ch)
+                    && semantic_terminal_boundary_allowed(line, idx, ch)
+                {
                     boundary = Some(offset + idx + ch.len_utf8());
                 }
             }
@@ -184,14 +190,19 @@ pub(in crate::services::discord) fn semantic_sentence_split_boundary(text: &str)
     boundary
 }
 
+pub(in crate::services::discord) fn semantic_sentence_split_boundary(text: &str) -> Option<usize> {
+    semantic_sentence_split_boundary_from(text, false)
+}
+
 pub(in crate::services::discord) fn message_split_boundary(
     remaining: &str,
     safe_end: usize,
+    starts_in_code_block: bool,
 ) -> (usize, &'static str) {
     let window = &remaining[..safe_end];
     if let Some(idx) = window.rfind('\n') {
         (idx, "newline")
-    } else if let Some(idx) = semantic_sentence_split_boundary(window) {
+    } else if let Some(idx) = semantic_sentence_split_boundary_from(window, starts_in_code_block) {
         (idx, "semantic")
     } else {
         (safe_end, "hard")

--- a/src/services/discord/semantic_boundaries.rs
+++ b/src/services/discord/semantic_boundaries.rs
@@ -48,6 +48,13 @@ fn leading_extension_token(text: &str) -> &str {
     &trimmed[..end]
 }
 
+fn incoming_extension_token_and_rest(text: &str) -> (&str, &str) {
+    let trimmed = text.trim_start();
+    let token = leading_extension_token(trimmed);
+    let rest = &trimmed[token.len()..];
+    (token, rest)
+}
+
 fn common_extension_token(token: &str) -> bool {
     matches!(
         token,
@@ -87,10 +94,44 @@ fn common_extension_token(token: &str) -> bool {
     )
 }
 
+fn likely_file_stem_token(token: &str) -> bool {
+    token
+        .chars()
+        .any(|ch| ch.is_ascii_digit() || matches!(ch, '_' | '-' | '.'))
+        || matches!(
+            token.to_ascii_lowercase().as_str(),
+            "app"
+                | "cargo"
+                | "changelog"
+                | "client"
+                | "config"
+                | "defaults"
+                | "dockerfile"
+                | "index"
+                | "lib"
+                | "license"
+                | "main"
+                | "makefile"
+                | "mod"
+                | "package"
+                | "readme"
+                | "requirements"
+                | "schema"
+                | "server"
+                | "settings"
+                | "test"
+                | "tests"
+                | "tsconfig"
+        )
+}
+
 fn extension_join_candidate(line: &str, dot_idx: usize, incoming: &str) -> bool {
     let before = token_before_dot(line, dot_idx);
-    let extension = leading_extension_token(incoming);
-    !before.is_empty() && !has_hangul(before) && common_extension_token(extension)
+    let (extension, rest) = incoming_extension_token_and_rest(incoming);
+    !before.is_empty()
+        && !has_hangul(before)
+        && common_extension_token(extension)
+        && (rest.trim().is_empty() || likely_file_stem_token(before))
 }
 
 fn inline_code_span_open(line: &str) -> bool {

--- a/src/services/discord/turn_bridge/chunk_compose.rs
+++ b/src/services/discord/turn_bridge/chunk_compose.rs
@@ -27,6 +27,14 @@ pub(super) fn streamed_text_inside_open_code_fence(full_response: &str) -> bool 
 pub(super) fn append_streamed_text_chunk(full_response: &mut String, content: &str) {
     if full_response.ends_with("\n\n") && !streamed_text_inside_open_code_fence(full_response) {
         full_response.push_str(content.trim_start_matches('\n'));
+    } else if !streamed_text_inside_open_code_fence(full_response)
+        && super::super::semantic_boundaries::semantic_chunk_separator_needed(
+            full_response,
+            content,
+        )
+    {
+        full_response.push_str("\n\n");
+        full_response.push_str(content);
     } else {
         full_response.push_str(content);
     }

--- a/src/services/discord/turn_bridge/chunk_compose_tests.rs
+++ b/src/services/discord/turn_bridge/chunk_compose_tests.rs
@@ -126,3 +126,51 @@ fn closed_code_fence_then_boundary_normalizes() {
     append_streamed_text_chunk(&mut full_response, "\n\nafter");
     assert_eq!(full_response, "```\ncode\n```\n\nafter");
 }
+
+#[test]
+fn semantic_sentence_boundary_separates_glued_korean_progress_chunks() {
+    let mut inline_code = String::from("확인하겠습니다.");
+    append_streamed_text_chunk(&mut inline_code, "`NullRHI`");
+    assert_eq!(inline_code, "확인하겠습니다.\n\n`NullRHI`");
+
+    let mut identifier = String::from("보겠습니다.");
+    append_streamed_text_chunk(&mut identifier, "Monolith는");
+    assert_eq!(identifier, "보겠습니다.\n\nMonolith는");
+
+    let mut lower = String::from("완료.");
+    append_streamed_text_chunk(&mut lower, "local");
+    assert_eq!(lower, "완료.\n\nlocal");
+}
+
+#[test]
+fn semantic_sentence_boundary_separates_ascii_status_chunks() {
+    let mut full_response = String::from("Review complete.");
+    append_streamed_text_chunk(&mut full_response, "VERDICT: CLEAN");
+    assert_eq!(full_response, "Review complete.\n\nVERDICT: CLEAN");
+}
+
+#[test]
+fn semantic_sentence_boundary_avoids_decimal_and_single_token_extension_splits() {
+    let mut decimal = String::from("version 1.");
+    append_streamed_text_chunk(&mut decimal, "2");
+    assert_eq!(decimal, "version 1.2");
+
+    let mut file = String::from("config.");
+    append_streamed_text_chunk(&mut file, "yaml");
+    assert_eq!(file, "config.yaml");
+}
+
+#[test]
+fn semantic_sentence_boundary_does_not_touch_lists_tables_or_open_fences() {
+    let mut list = String::from("- item.");
+    append_streamed_text_chunk(&mut list, "- next");
+    assert_eq!(list, "- item.- next");
+
+    let mut table = String::from("| Col |");
+    append_streamed_text_chunk(&mut table, "| Next |");
+    assert_eq!(table, "| Col || Next |");
+
+    let mut fence = String::from("```text\ncomplete.\n");
+    append_streamed_text_chunk(&mut fence, "VERDICT");
+    assert_eq!(fence, "```text\ncomplete.\nVERDICT");
+}

--- a/src/services/discord/turn_bridge/chunk_compose_tests.rs
+++ b/src/services/discord/turn_bridge/chunk_compose_tests.rs
@@ -147,6 +147,10 @@ fn semantic_sentence_boundary_separates_ascii_status_chunks() {
     let mut full_response = String::from("Review complete.");
     append_streamed_text_chunk(&mut full_response, "VERDICT: CLEAN");
     assert_eq!(full_response, "Review complete.\n\nVERDICT: CLEAN");
+
+    let mut prose = String::from("Review complete.");
+    append_streamed_text_chunk(&mut prose, "log follows");
+    assert_eq!(prose, "Review complete.\n\nlog follows");
 }
 
 #[test]

--- a/src/services/discord/turn_bridge/chunk_compose_tests.rs
+++ b/src/services/discord/turn_bridge/chunk_compose_tests.rs
@@ -158,6 +158,17 @@ fn semantic_sentence_boundary_avoids_decimal_and_single_token_extension_splits()
     let mut file = String::from("config.");
     append_streamed_text_chunk(&mut file, "yaml");
     assert_eq!(file, "config.yaml");
+
+    let mut prose_file = String::from("Open config.");
+    append_streamed_text_chunk(&mut prose_file, "yaml");
+    assert_eq!(prose_file, "Open config.yaml");
+}
+
+#[test]
+fn semantic_sentence_boundary_avoids_open_inline_code_splits() {
+    let mut inline_code = String::from("Use `done.");
+    append_streamed_text_chunk(&mut inline_code, "` now");
+    assert_eq!(inline_code, "Use `done.` now");
 }
 
 #[test]

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -663,6 +663,7 @@ mod tests {
     use crate::services::discord::formatting;
     use crate::services::discord::formatting::ReplaceLongMessageOutcome;
     use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
+    use crate::services::discord::semantic_boundaries::add_continuation_context;
     use crate::services::provider::ProviderKind;
     use poise::serenity_prelude::{ChannelId, MessageId};
     use std::sync::{Arc, Mutex};
@@ -692,7 +693,7 @@ mod tests {
             let sent_chunks = self.sent_chunks.clone();
             let fail_after_sent_chunks = self.fail_after_sent_chunks;
             Box::pin(async move {
-                let chunks = formatting::split_message(content);
+                let chunks = add_continuation_context(formatting::split_message(content));
                 let mut message_ids = Vec::new();
                 for (index, chunk) in chunks.iter().enumerate() {
                     sent_chunks


### PR DESCRIPTION
Issue: #3807

## Summary
- Add a shared Discord semantic boundary helper for sentence-safe relay splits and streamed chunk joins.
- Use semantic boundaries in streaming rollover and 2000-byte message chunking when newline/paragraph boundaries are unavailable.
- Separate glued streamed progress/final chunks after safe sentence terminals while preserving code fences, lists, tables, decimals, and file-token extensions.
- Keep `formatting.rs` below the frozen giant-file baseline by extracting the helper to `semantic_boundaries.rs`.

## Local verification
- `cargo fmt --all --check`
- `cargo test --lib a0_`
- `cargo test --lib chunk_compose`
- `cargo check --lib`
- `python3 scripts/check_agent_maintenance_docs.py`
- `PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh`
- `git diff --check`
