### PR TITLE
test(e2e): add auto-queue sandbox preflight harness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,6 +205,11 @@ src/
 │   │   │   ├── mod.rs
 │   │   │   ├── tuning_aggregate.rs
 │   │   │   └── verdict_route.rs
+│   │   ├── tests/
+│   │   │   ├── preflight_harness/
+│   │   │   │   ├── types.rs
+│   │   │   │   └── validation.rs
+│   │   │   └── auto_queue_preflight_harness_tests.rs
 │   │   ├── agents.rs
 │   │   ├── agents_crud.rs
 │   │   ├── agents_setup.rs

--- a/docs/auto-queue-preflight.md
+++ b/docs/auto-queue-preflight.md
@@ -1,0 +1,45 @@
+# Auto-Queue Sandbox Preflight
+
+Run the MVP fixture-mode preflight for a selected repo/group/pipeline fixture:
+
+```bash
+scripts/e2e/auto-queue-preflight.sh \
+  --fixture tests/fixtures/auto-queue-preflight/basic.json \
+  --report /tmp/agentdesk-auto-queue-preflight.json
+```
+
+The default fixture uses repo `agentdesk/preflight-fixture`, group
+`sandbox-auto-queue`, and pipeline `repo-group-pipeline-fixture-v1`.
+
+The harness starts an in-process API router backed by a temporary PostgreSQL
+database, then exercises:
+
+- `POST /api/queue/generate`
+- `POST /api/queue/dispatch-next`
+- `GET /api/queue/status`
+- `GET /api/queue/history`
+
+Default mode is sandbox-only. It seeds synthetic repo/card/agent rows in the
+temporary database, lets `/api/queue/generate` choose the normal queue shape,
+then requires `/api/queue/dispatch-next` to create a real `task_dispatches` row
+and bind it to the queue entry with a slot index. Fixture kanban-card metadata
+marks the run as `sandbox_preflight=true` with
+`production_mutation_allowed=false`, so the dispatch creation path keeps the
+canonical queue/dispatch state transitions while disabling external side
+effects such as Discord channel validation, fresh worktree creation, and
+dispatch-channel notification outbox rows. The harness then completes the
+created dispatch through `PATCH /api/dispatches/{id}` so the real terminal sync
+path advances `auto_queue_entries` and `auto_queue_runs`. It does not contact
+GitHub, create PR/branch tracking rows, create worktrees, enqueue production
+dispatch-channel notifications, or start live agent sessions.
+
+The JSON report includes the run id, entry ids, dispatch ids, slot ids,
+phase-gate state, repo/group/pipeline identity, terminal statuses, endpoint
+observations, production-safety counters, and raw failure reasons. The harness
+fails on split-brain completion (`task_dispatches.status=completed` while the
+matching queue entry/run did not advance), reserved slots, entries stuck in
+`dispatched`, blocking phase gates without a visible reason, or diagnostics
+that omit correlation ids.
+
+Requirements: the same local PostgreSQL test environment used by the repo's
+Postgres-backed tests (`POSTGRES_TEST_DATABASE_URL_BASE` or `PG*` variables).

--- a/scripts/e2e/auto-queue-preflight.sh
+++ b/scripts/e2e/auto-queue-preflight.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE="${ROOT_DIR}/tests/fixtures/auto-queue-preflight/basic.json"
+REPORT="${TMPDIR:-/tmp}/agentdesk-auto-queue-preflight.json"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/e2e/auto-queue-preflight.sh [--fixture PATH] [--report PATH]
+
+Runs the sandbox fixture-mode auto-queue E2E preflight harness against an
+in-process test API and a temporary PostgreSQL database. Default mode does not
+mutate production GitHub cards, issues, PRs, branches, dispatch channels, or
+live sessions.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fixture)
+      FIXTURE="$2"
+      shift 2
+      ;;
+    --report)
+      REPORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+export AGENTDESK_AUTO_QUEUE_PREFLIGHT_FIXTURE="$FIXTURE"
+export AGENTDESK_AUTO_QUEUE_PREFLIGHT_REPORT="$REPORT"
+
+cd "$ROOT_DIR"
+cargo test --lib auto_queue_preflight_fixture_sandbox_roundtrip -- --ignored
+
+echo "auto-queue preflight report: $REPORT"

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -51,6 +51,10 @@ pub mod termination_events;
 pub mod v1;
 pub mod voice_config;
 
+#[cfg(test)]
+#[path = "tests/auto_queue_preflight_harness_tests.rs"]
+mod auto_queue_preflight_harness_tests;
+
 use axum::{
     Router,
     http::header::CONTENT_TYPE,

--- a/src/server/routes/tests/auto_queue_preflight_harness_tests.rs
+++ b/src/server/routes/tests/auto_queue_preflight_harness_tests.rs
@@ -1,0 +1,846 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Method, Request, StatusCode, header},
+};
+use serde_json::{Value, json};
+use sqlx::{Column, Row};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+use tower::ServiceExt;
+
+#[path = "preflight_harness/types.rs"]
+mod types;
+#[path = "preflight_harness/validation.rs"]
+mod validation;
+
+use self::types::{
+    DispatchSnapshot, EndpointObservation, EntrySnapshot, PreflightFixture, PreflightReport,
+    PreflightSnapshot, SafetyProof, SlotId,
+};
+use self::validation::{
+    apply_snapshot_to_report, validate_history_contains_run, validate_preflight_snapshot,
+};
+
+#[tokio::test]
+#[ignore = "requires a local PostgreSQL test server; run scripts/e2e/auto-queue-preflight.sh"]
+async fn auto_queue_preflight_fixture_sandbox_roundtrip() -> Result<(), String> {
+    let fixture_path = fixture_path_from_env();
+    let report_path = report_path_from_env();
+    let fixture = load_fixture(&fixture_path)
+        .map_err(|error| format!("load fixture {}: {error}", fixture_path.display()))?;
+    let mut report = PreflightReport::new(&fixture);
+
+    if let Err(error) = run_preflight(&fixture, &mut report).await {
+        report.raw_failure_reasons.push(error);
+    }
+
+    write_report(&report_path, &report)
+        .map_err(|error| format!("write preflight report {}: {error}", report_path.display()))?;
+
+    if !report.raw_failure_reasons.is_empty() {
+        return Err(format!(
+            "auto-queue preflight failed; report: {}; failures: {:?}",
+            report_path.display(),
+            report.raw_failure_reasons
+        ));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn auto_queue_preflight_detects_split_brain_completion() {
+    let failures = validate_preflight_snapshot(&PreflightSnapshot {
+        run_id: Some("run-split-brain".to_string()),
+        run_status: Some("active".to_string()),
+        entries: vec![EntrySnapshot {
+            id: "entry-split-brain".to_string(),
+            status: "dispatched".to_string(),
+            dispatch_id: Some("dispatch-split-brain".to_string()),
+            slot_index: Some(0),
+        }],
+        dispatches: vec![DispatchSnapshot {
+            id: "dispatch-split-brain".to_string(),
+            status: "completed".to_string(),
+        }],
+        reserved_slots: Vec::new(),
+        phase_gates: Vec::new(),
+        diagnostics: Vec::new(),
+        safety: SafetyProof::default(),
+    });
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("split-brain")),
+        "expected split-brain failure, got {failures:?}"
+    );
+}
+
+async fn run_preflight(
+    fixture: &PreflightFixture,
+    report: &mut PreflightReport,
+) -> Result<(), String> {
+    if fixture.entries.is_empty() {
+        return Err("fixture must contain at least one entry".to_string());
+    }
+    if fixture.review_mode != "disabled" {
+        return Err("sandbox preflight fixture must use review_mode=disabled".to_string());
+    }
+
+    let db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+    let pool = db.connect_and_migrate_with_max_connections(8).await;
+    seed_fixture(&pool, fixture).await?;
+    let app = build_preflight_app(pool.clone(), fixture)?;
+
+    let generate_body = json!({
+        "repo": fixture.repo,
+        "agent_id": fixture.agent_id,
+        "review_mode": fixture.review_mode,
+        "max_concurrent_threads": fixture.max_concurrent_threads,
+        "force": true,
+        "entries": fixture.entries.iter().map(|entry| {
+            json!({
+                "issue_number": entry.issue_number,
+                "batch_phase": entry.batch_phase.unwrap_or(0),
+                "thread_group": entry.thread_group.unwrap_or(0),
+                "phase_gate_kind": entry.phase_gate_kind,
+            })
+        }).collect::<Vec<_>>(),
+    });
+    let generate = request_json(
+        &app,
+        report,
+        &fixture.auth_token,
+        Method::POST,
+        "/api/queue/generate".to_string(),
+        Some(generate_body),
+    )
+    .await?;
+    let run_id = required_string(&generate, &["run", "id"])?;
+    report.run_id = Some(run_id.clone());
+
+    let generated_entries = load_generated_entries(&pool, &run_id).await?;
+    if generated_entries.is_empty() {
+        return Err(format!(
+            "/api/queue/generate created no entries for fixture {}",
+            fixture.fixture_id
+        ));
+    }
+    report.entry_ids = generated_entries
+        .iter()
+        .map(|entry| entry.entry_id.clone())
+        .collect();
+
+    let dispatch_next = request_json(
+        &app,
+        report,
+        &fixture.auth_token,
+        Method::POST,
+        "/api/queue/dispatch-next".to_string(),
+        Some(json!({ "run_id": run_id, "repo": fixture.repo, "agent_id": fixture.agent_id })),
+    )
+    .await?;
+    if dispatch_next.get("error").is_some() {
+        report.raw_failure_reasons.push(format!(
+            "/api/queue/dispatch-next returned error body: {dispatch_next}"
+        ));
+    }
+    validate_dispatch_next_created_work(&dispatch_next, report);
+    let inflight_entries = load_entry_snapshots(&pool, &report.entry_ids).await?;
+    let dispatch_ids = dispatch_ids_from_entries(&inflight_entries);
+    if dispatch_ids.is_empty() {
+        report.raw_failure_reasons.push(format!(
+            "/api/queue/dispatch-next created no entry-bound dispatches: {dispatch_next}"
+        ));
+    }
+    if !inflight_entries
+        .iter()
+        .any(|entry| entry.slot_index.is_some() && entry.dispatch_id.is_some())
+    {
+        report.raw_failure_reasons.push(format!(
+            "/api/queue/dispatch-next did not record a slot-bound entry: {inflight_entries:?}"
+        ));
+    }
+    report.dispatch_ids = dispatch_ids.clone();
+
+    let status_path = queue_path("/api/queue/status", fixture, Some(20));
+    let status_inflight = request_json(
+        &app,
+        report,
+        &fixture.auth_token,
+        Method::GET,
+        status_path,
+        None,
+    )
+    .await?;
+    report.status_inflight = Some(status_inflight.clone());
+
+    for dispatch_id in &dispatch_ids {
+        request_json(
+            &app,
+            report,
+            &fixture.auth_token,
+            Method::PATCH,
+            format!("/api/dispatches/{dispatch_id}"),
+            Some(json!({
+                "status": "completed",
+                "allowed_from": ["pending", "dispatched"],
+                "result": {
+                    "summary": "sandbox auto-queue preflight fixture completed",
+                    "assistant_message": "sandbox auto-queue preflight fixture completed",
+                    "agent_response_present": true,
+                    "work_outcome": "sandbox_preflight_pass",
+                    "completion_source": "auto_queue_preflight_fixture",
+                    "fixture_id": fixture.fixture_id,
+                    "production_mutation_allowed": false
+                }
+            })),
+        )
+        .await?;
+    }
+
+    let status_final = request_json(
+        &app,
+        report,
+        &fixture.auth_token,
+        Method::GET,
+        queue_path("/api/queue/status", fixture, Some(20)),
+        None,
+    )
+    .await?;
+    report.status_final = Some(status_final.clone());
+
+    let history_final = request_json(
+        &app,
+        report,
+        &fixture.auth_token,
+        Method::GET,
+        queue_path("/api/queue/history", fixture, Some(8)),
+        None,
+    )
+    .await?;
+    report.history_final = Some(history_final.clone());
+
+    let snapshot = load_snapshot(
+        &pool,
+        Some(&run_id),
+        &report.entry_ids,
+        &dispatch_ids,
+        report,
+    )
+    .await?;
+    apply_snapshot_to_report(report, &snapshot);
+    report
+        .raw_failure_reasons
+        .extend(validate_preflight_snapshot(&snapshot));
+    report
+        .raw_failure_reasons
+        .extend(validate_history_contains_run(&history_final, &run_id));
+
+    db.drop().await;
+    Ok(())
+}
+
+fn build_preflight_app(pool: sqlx::PgPool, fixture: &PreflightFixture) -> Result<Router, String> {
+    let mut config = crate::config::Config::default();
+    config.server.host = "127.0.0.1".to_string();
+    config.server.auth_token = Some(fixture.auth_token.clone());
+    config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
+    let engine = crate::engine::PolicyEngine::new_with_pg(&config, Some(pool.clone()))
+        .map_err(|error| format!("create policy engine: {error}"))?;
+    let broadcast_tx = crate::server::ws::new_broadcast();
+    let batch_buffer = crate::server::ws::spawn_batch_flusher(broadcast_tx.clone());
+    let api = crate::server::routes::api_router_with_pg(
+        engine,
+        config,
+        broadcast_tx,
+        batch_buffer,
+        None,
+        Some(pool),
+    );
+    Ok(Router::new().nest("/api", api))
+}
+
+async fn seed_fixture(pool: &sqlx::PgPool, fixture: &PreflightFixture) -> Result<(), String> {
+    let pipeline_config = json!({
+        "fixture_mode": true,
+        "pipeline_id": fixture.pipeline_id,
+        "group": fixture.group,
+        "production_mutation_allowed": false
+    });
+    sqlx::query(
+        "INSERT INTO github_repos (id, display_name, sync_enabled, default_agent_id, pipeline_config)
+         VALUES ($1, $2, FALSE, $3, $4::jsonb)
+         ON CONFLICT (id) DO UPDATE
+         SET display_name = EXCLUDED.display_name,
+             sync_enabled = FALSE,
+             default_agent_id = EXCLUDED.default_agent_id,
+             pipeline_config = EXCLUDED.pipeline_config",
+    )
+    .bind(&fixture.repo)
+    .bind(format!("fixture {}", fixture.repo))
+    .bind(&fixture.agent_id)
+    .bind(pipeline_config.to_string())
+    .execute(pool)
+    .await
+    .map_err(|error| format!("seed fixture repo: {error}"))?;
+
+    sqlx::query(
+        "INSERT INTO agents (
+             id, name, provider, discord_channel_id, discord_channel_cdx,
+             discord_channel_cc, discord_channel_alt, status, pipeline_config
+         )
+         VALUES ($1, $2, 'codex', NULL, NULL, NULL, NULL, 'idle', $3::jsonb)
+         ON CONFLICT (id) DO UPDATE
+         SET name = EXCLUDED.name,
+             provider = EXCLUDED.provider,
+             discord_channel_id = EXCLUDED.discord_channel_id,
+             discord_channel_cdx = EXCLUDED.discord_channel_cdx,
+             discord_channel_cc = EXCLUDED.discord_channel_cc,
+             discord_channel_alt = EXCLUDED.discord_channel_alt,
+             status = EXCLUDED.status,
+             pipeline_config = EXCLUDED.pipeline_config",
+    )
+    .bind(&fixture.agent_id)
+    .bind(
+        fixture
+            .agent_name
+            .as_deref()
+            .unwrap_or("Sandbox Auto Queue Agent"),
+    )
+    .bind(pipeline_config.to_string())
+    .execute(pool)
+    .await
+    .map_err(|error| format!("seed fixture agent: {error}"))?;
+
+    for entry in &fixture.entries {
+        let card_id = fixture_card_id(fixture, entry.issue_number);
+        let metadata = json!({
+            "fixture_mode": true,
+            "sandbox_preflight": true,
+            "fixture_id": fixture.fixture_id,
+            "group": fixture.group,
+            "pipeline_id": fixture.pipeline_id,
+            "production_mutation_allowed": false
+        });
+        sqlx::query(
+            "INSERT INTO kanban_cards (
+                 id, repo_id, title, status, priority, assigned_agent_id,
+                 github_issue_url, github_issue_number, metadata, description
+             )
+             VALUES ($1, $2, $3, 'ready', $4, $5, $6, $7, $8::jsonb, $9)
+             ON CONFLICT (id) DO UPDATE
+             SET repo_id = EXCLUDED.repo_id,
+                 title = EXCLUDED.title,
+                 status = 'ready',
+                 priority = EXCLUDED.priority,
+                 assigned_agent_id = EXCLUDED.assigned_agent_id,
+                 github_issue_url = EXCLUDED.github_issue_url,
+                 github_issue_number = EXCLUDED.github_issue_number,
+                 latest_dispatch_id = NULL,
+                 metadata = EXCLUDED.metadata,
+                 description = EXCLUDED.description",
+        )
+        .bind(card_id)
+        .bind(&fixture.repo)
+        .bind(&entry.title)
+        .bind(&entry.priority)
+        .bind(&fixture.agent_id)
+        .bind(format!(
+            "https://github.com/{}/issues/{}",
+            fixture.repo, entry.issue_number
+        ))
+        .bind(entry.issue_number as i32)
+        .bind(metadata.to_string())
+        .bind(entry.description.as_deref())
+        .execute(pool)
+        .await
+        .map_err(|error| format!("seed fixture card #{}: {error}", entry.issue_number))?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct GeneratedEntryRow {
+    entry_id: String,
+}
+
+async fn load_generated_entries(
+    pool: &sqlx::PgPool,
+    run_id: &str,
+) -> Result<Vec<GeneratedEntryRow>, String> {
+    let rows = sqlx::query(
+        "SELECT id
+         FROM auto_queue_entries
+         WHERE run_id = $1
+         ORDER BY priority_rank ASC, id ASC",
+    )
+    .bind(run_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("load generated entries for run {run_id}: {error}"))?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(GeneratedEntryRow {
+                entry_id: row
+                    .try_get("id")
+                    .map_err(|error| format!("decode generated entry id: {error}"))?,
+            })
+        })
+        .collect()
+}
+
+fn validate_dispatch_next_created_work(dispatch_next: &Value, report: &mut PreflightReport) {
+    let count = dispatch_next
+        .get("count")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let dispatched_count = dispatch_next
+        .get("dispatched")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    if count <= 0 || dispatched_count == 0 {
+        report.raw_failure_reasons.push(format!(
+            "/api/queue/dispatch-next did not activate work: count={count}, dispatched_count={dispatched_count}, body={dispatch_next}"
+        ));
+    }
+}
+
+fn dispatch_ids_from_entries(entries: &[EntrySnapshot]) -> Vec<String> {
+    let mut dispatch_ids = Vec::new();
+    for entry in entries {
+        if let Some(dispatch_id) = entry.dispatch_id.as_ref()
+            && !dispatch_ids.iter().any(|seen| seen == dispatch_id)
+        {
+            dispatch_ids.push(dispatch_id.clone());
+        }
+    }
+    dispatch_ids
+}
+
+async fn request_json(
+    app: &Router,
+    report: &mut PreflightReport,
+    auth_token: &str,
+    method: Method,
+    path: String,
+    body: Option<Value>,
+) -> Result<Value, String> {
+    let mut builder = Request::builder()
+        .method(method.clone())
+        .uri(path.clone())
+        .header(header::AUTHORIZATION, format!("Bearer {auth_token}"));
+    let request_body = match body {
+        Some(value) => {
+            builder = builder.header(header::CONTENT_TYPE, "application/json");
+            Body::from(value.to_string())
+        }
+        None => Body::empty(),
+    };
+    let request = builder
+        .body(request_body)
+        .map_err(|error| format!("build request {method} {path}: {error}"))?;
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .map_err(|error| format!("send request {method} {path}: {error}"))?;
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .map_err(|error| format!("read response {method} {path}: {error}"))?;
+    let body_json = serde_json::from_slice::<Value>(&bytes).unwrap_or_else(|_| {
+        json!({
+            "raw": String::from_utf8_lossy(&bytes).to_string()
+        })
+    });
+    report.endpoint_observations.push(EndpointObservation {
+        method: method.as_str().to_string(),
+        path: path.clone(),
+        status: status.as_u16(),
+        ok: status.is_success(),
+        body: body_json.clone(),
+    });
+    if !status.is_success() {
+        report
+            .raw_failure_reasons
+            .push(format!("{method} {path} returned {status}: {body_json}"));
+    }
+    if status == StatusCode::UNAUTHORIZED {
+        return Err(format!("{method} {path} unauthorized"));
+    }
+    Ok(body_json)
+}
+
+async fn load_snapshot(
+    pool: &sqlx::PgPool,
+    run_id: Option<&str>,
+    entry_ids: &[String],
+    dispatch_ids: &[String],
+    report: &PreflightReport,
+) -> Result<PreflightSnapshot, String> {
+    let run_status = if let Some(run_id) = run_id {
+        sqlx::query_scalar::<_, String>("SELECT status FROM auto_queue_runs WHERE id = $1")
+            .bind(run_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|error| format!("load run status {run_id}: {error}"))?
+    } else {
+        None
+    };
+
+    let entries = load_entry_snapshots(pool, entry_ids).await?;
+    let dispatches = load_dispatch_snapshots(pool, dispatch_ids).await?;
+    let reserved_slots = load_reserved_slots(pool, run_id).await?;
+    let phase_gates = load_phase_gates(pool, run_id).await?;
+    let safety = load_safety_proof(pool).await?;
+    let diagnostics = [
+        report.status_inflight.as_ref(),
+        report.status_final.as_ref(),
+    ]
+    .into_iter()
+    .filter_map(|status| status.and_then(|value| value.get("diagnostics")).cloned())
+    .collect();
+
+    Ok(PreflightSnapshot {
+        run_id: run_id.map(str::to_string),
+        run_status,
+        entries,
+        dispatches,
+        reserved_slots,
+        phase_gates,
+        diagnostics,
+        safety,
+    })
+}
+
+async fn load_entry_snapshots(
+    pool: &sqlx::PgPool,
+    entry_ids: &[String],
+) -> Result<Vec<EntrySnapshot>, String> {
+    let mut entries = Vec::with_capacity(entry_ids.len());
+    for entry_id in entry_ids {
+        let row = sqlx::query(
+            "SELECT id, status, dispatch_id, slot_index::BIGINT AS slot_index
+             FROM auto_queue_entries
+             WHERE id = $1",
+        )
+        .bind(entry_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|error| format!("load entry snapshot {entry_id}: {error}"))?
+        .ok_or_else(|| format!("entry {entry_id} missing from auto_queue_entries"))?;
+        entries.push(EntrySnapshot {
+            id: row
+                .try_get("id")
+                .map_err(|error| format!("decode entry id {entry_id}: {error}"))?,
+            status: row
+                .try_get("status")
+                .map_err(|error| format!("decode entry status {entry_id}: {error}"))?,
+            dispatch_id: row
+                .try_get("dispatch_id")
+                .map_err(|error| format!("decode entry dispatch id {entry_id}: {error}"))?,
+            slot_index: row
+                .try_get("slot_index")
+                .map_err(|error| format!("decode entry slot index {entry_id}: {error}"))?,
+        });
+    }
+    Ok(entries)
+}
+
+async fn load_dispatch_snapshots(
+    pool: &sqlx::PgPool,
+    dispatch_ids: &[String],
+) -> Result<Vec<DispatchSnapshot>, String> {
+    let mut dispatches = Vec::with_capacity(dispatch_ids.len());
+    for dispatch_id in dispatch_ids {
+        let row = sqlx::query("SELECT id, status FROM task_dispatches WHERE id = $1")
+            .bind(dispatch_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|error| format!("load dispatch snapshot {dispatch_id}: {error}"))?
+            .ok_or_else(|| format!("dispatch {dispatch_id} missing from task_dispatches"))?;
+        dispatches.push(DispatchSnapshot {
+            id: row
+                .try_get("id")
+                .map_err(|error| format!("decode dispatch id {dispatch_id}: {error}"))?,
+            status: row
+                .try_get("status")
+                .map_err(|error| format!("decode dispatch status {dispatch_id}: {error}"))?,
+        });
+    }
+    Ok(dispatches)
+}
+
+async fn load_reserved_slots(
+    pool: &sqlx::PgPool,
+    run_id: Option<&str>,
+) -> Result<Vec<SlotId>, String> {
+    let Some(run_id) = run_id else {
+        return Ok(Vec::new());
+    };
+    let rows = sqlx::query(
+        "SELECT agent_id, slot_index::BIGINT AS slot_index
+         FROM auto_queue_slots
+         WHERE assigned_run_id = $1
+         ORDER BY agent_id, slot_index",
+    )
+    .bind(run_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("load reserved slots for run {run_id}: {error}"))?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(SlotId {
+                agent_id: row
+                    .try_get("agent_id")
+                    .map_err(|error| format!("decode slot agent id: {error}"))?,
+                slot_index: row
+                    .try_get("slot_index")
+                    .map_err(|error| format!("decode slot index: {error}"))?,
+            })
+        })
+        .collect()
+}
+
+async fn load_phase_gates(pool: &sqlx::PgPool, run_id: Option<&str>) -> Result<Vec<Value>, String> {
+    let Some(run_id) = run_id else {
+        return Ok(Vec::new());
+    };
+    let rows = sqlx::query(
+        "SELECT id::BIGINT AS id,
+                phase::BIGINT AS phase,
+                status,
+                verdict,
+                dispatch_id,
+                failure_reason
+         FROM auto_queue_phase_gates
+         WHERE run_id = $1
+         ORDER BY phase ASC, id ASC",
+    )
+    .bind(run_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("load phase gates for run {run_id}: {error}"))?;
+
+    rows.into_iter()
+        .map(|row| {
+            let id: i64 = row
+                .try_get("id")
+                .map_err(|error| format!("decode phase gate id: {error}"))?;
+            let phase: i64 = row
+                .try_get("phase")
+                .map_err(|error| format!("decode phase gate phase: {error}"))?;
+            let status: String = row
+                .try_get("status")
+                .map_err(|error| format!("decode phase gate status: {error}"))?;
+            let verdict: Option<String> = row
+                .try_get("verdict")
+                .map_err(|error| format!("decode phase gate verdict: {error}"))?;
+            let dispatch_id: Option<String> = row
+                .try_get("dispatch_id")
+                .map_err(|error| format!("decode phase gate dispatch id: {error}"))?;
+            let failure_reason: Option<String> = row
+                .try_get("failure_reason")
+                .map_err(|error| format!("decode phase gate failure reason: {error}"))?;
+            Ok(json!({
+                "id": id,
+                "phase": phase,
+                "status": status,
+                "verdict": verdict,
+                "dispatch_id": dispatch_id,
+                "failure_reason": failure_reason
+            }))
+        })
+        .collect()
+}
+
+async fn load_safety_proof(pool: &sqlx::PgPool) -> Result<SafetyProof, String> {
+    let message_outbox_rows = load_limited_json_rows(
+        pool,
+        "SELECT id::BIGINT AS id, target, bot, source, status, reason_code, content
+         FROM message_outbox
+         ORDER BY id ASC
+         LIMIT 10",
+    )
+    .await?;
+    let dispatch_outbox_notify_rows = load_limited_json_rows(
+        pool,
+        "SELECT id::BIGINT AS id, dispatch_id, action, status, agent_id, card_id, title
+         FROM dispatch_outbox
+         WHERE action IN ('notify', 'followup')
+         ORDER BY id ASC
+         LIMIT 10",
+    )
+    .await?;
+
+    Ok(SafetyProof {
+        production_card_count: scalar_i64(
+            pool,
+            "SELECT COUNT(*)::BIGINT
+             FROM kanban_cards
+             WHERE COALESCE((metadata->>'sandbox_preflight')::BOOLEAN, FALSE) = FALSE",
+        )
+        .await?,
+        github_pr_tracking_count: scalar_i64(pool, "SELECT COUNT(*)::BIGINT FROM pr_tracking")
+            .await?,
+        live_session_count: scalar_i64(
+            pool,
+            "SELECT COUNT(*)::BIGINT
+             FROM sessions
+             WHERE COALESCE(status, '') NOT IN ('disconnected', 'aborted', 'completed', 'failed', 'cancelled')",
+        )
+        .await?,
+        dispatch_delivery_sent_count: scalar_i64(
+            pool,
+            "SELECT COUNT(*)::BIGINT
+             FROM dispatch_delivery_events
+             WHERE status = 'sent'",
+        )
+        .await?,
+        message_outbox_count: scalar_i64(pool, "SELECT COUNT(*)::BIGINT FROM message_outbox")
+            .await?,
+        message_outbox_rows,
+        dispatch_outbox_notify_count: scalar_i64(
+            pool,
+            "SELECT COUNT(*)::BIGINT
+             FROM dispatch_outbox
+             WHERE action IN ('notify', 'followup')",
+        )
+        .await?,
+        dispatch_outbox_notify_rows,
+        worktree_or_branch_context_count: scalar_i64(
+            pool,
+            "SELECT COUNT(*)::BIGINT
+             FROM task_dispatches
+             WHERE context LIKE '%worktree%'
+                OR context LIKE '%branch%'",
+        )
+        .await?,
+    })
+}
+
+async fn load_limited_json_rows(pool: &sqlx::PgPool, sql: &str) -> Result<Vec<Value>, String> {
+    let rows = sqlx::query(sql)
+        .fetch_all(pool)
+        .await
+        .map_err(|error| format!("load safety detail rows `{sql}`: {error}"))?;
+    rows.into_iter()
+        .map(|row| {
+            let mut map = serde_json::Map::new();
+            for column in row.columns() {
+                let name = column.name();
+                let value = decode_row_value(&row, name)?;
+                map.insert(name.to_string(), value);
+            }
+            Ok(Value::Object(map))
+        })
+        .collect()
+}
+
+fn decode_row_value(row: &sqlx::postgres::PgRow, name: &str) -> Result<Value, String> {
+    if let Ok(value) = row.try_get::<Option<String>, _>(name) {
+        return Ok(value.map(Value::String).unwrap_or(Value::Null));
+    }
+    if let Ok(value) = row.try_get::<Option<i64>, _>(name) {
+        return Ok(value.map(|value| json!(value)).unwrap_or(Value::Null));
+    }
+    Ok(Value::Null)
+}
+
+async fn scalar_i64(pool: &sqlx::PgPool, sql: &str) -> Result<i64, String> {
+    sqlx::query_scalar::<_, i64>(sql)
+        .fetch_one(pool)
+        .await
+        .map_err(|error| format!("run scalar safety query `{sql}`: {error}"))
+}
+
+fn required_string(value: &Value, path: &[&str]) -> Result<String, String> {
+    let mut current = value;
+    for key in path {
+        current = current
+            .get(*key)
+            .ok_or_else(|| format!("missing JSON path {} in {value}", path.join(".")))?;
+    }
+    current
+        .as_str()
+        .filter(|text| !text.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            format!(
+                "JSON path {} is not a non-empty string in {value}",
+                path.join(".")
+            )
+        })
+}
+
+fn queue_path(base: &str, fixture: &PreflightFixture, limit: Option<usize>) -> String {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    serializer.append_pair("repo", &fixture.repo);
+    serializer.append_pair("agent_id", &fixture.agent_id);
+    if let Some(limit) = limit {
+        serializer.append_pair("limit", &limit.to_string());
+    }
+    format!("{base}?{}", serializer.finish())
+}
+
+fn fixture_card_id(fixture: &PreflightFixture, issue_number: i64) -> String {
+    format!(
+        "preflight-card-{}-{issue_number}",
+        sanitize_identifier(&fixture.fixture_id)
+    )
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn load_fixture(path: &Path) -> Result<PreflightFixture, String> {
+    let raw = fs::read_to_string(path).map_err(|error| error.to_string())?;
+    serde_json::from_str(&raw).map_err(|error| error.to_string())
+}
+
+fn fixture_path_from_env() -> PathBuf {
+    env::var("AGENTDESK_AUTO_QUEUE_PREFLIGHT_FIXTURE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/auto-queue-preflight/basic.json")
+        })
+}
+
+fn report_path_from_env() -> PathBuf {
+    env::var("AGENTDESK_AUTO_QUEUE_PREFLIGHT_REPORT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| env::temp_dir().join("agentdesk-auto-queue-preflight.json"))
+}
+
+fn write_report(path: &Path, report: &PreflightReport) -> Result<(), String> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let raw = serde_json::to_vec_pretty(report).map_err(|error| error.to_string())?;
+    fs::write(path, raw).map_err(|error| error.to_string())
+}

--- a/src/server/routes/tests/preflight_harness/types.rs
+++ b/src/server/routes/tests/preflight_harness/types.rs
@@ -1,0 +1,174 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PreflightFixture {
+    pub(crate) fixture_id: String,
+    pub(crate) repo: String,
+    pub(crate) group: String,
+    pub(crate) pipeline_id: String,
+    pub(crate) agent_id: String,
+    #[serde(default)]
+    pub(crate) agent_name: Option<String>,
+    #[serde(default = "default_auth_token")]
+    pub(crate) auth_token: String,
+    #[serde(default = "default_review_mode")]
+    pub(crate) review_mode: String,
+    #[serde(default = "default_max_concurrent_threads")]
+    pub(crate) max_concurrent_threads: i64,
+    pub(crate) entries: Vec<PreflightFixtureEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PreflightFixtureEntry {
+    pub(crate) issue_number: i64,
+    pub(crate) title: String,
+    #[serde(default)]
+    pub(crate) description: Option<String>,
+    #[serde(default = "default_priority")]
+    pub(crate) priority: String,
+    #[serde(default)]
+    pub(crate) batch_phase: Option<i64>,
+    #[serde(default)]
+    pub(crate) thread_group: Option<i64>,
+    #[serde(default = "default_phase_gate_kind")]
+    pub(crate) phase_gate_kind: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct PreflightIdentity {
+    pub(crate) fixture_id: String,
+    pub(crate) repo: String,
+    pub(crate) group: String,
+    pub(crate) pipeline_id: String,
+    pub(crate) agent_id: String,
+    pub(crate) review_mode: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct EndpointObservation {
+    pub(crate) method: String,
+    pub(crate) path: String,
+    pub(crate) status: u16,
+    pub(crate) ok: bool,
+    pub(crate) body: Value,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub(crate) struct SlotId {
+    pub(crate) agent_id: String,
+    pub(crate) slot_index: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct EntryTerminal {
+    pub(crate) id: String,
+    pub(crate) status: String,
+    pub(crate) dispatch_id: Option<String>,
+    pub(crate) slot_index: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct DispatchTerminal {
+    pub(crate) id: String,
+    pub(crate) status: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct TerminalStatus {
+    pub(crate) run_status: Option<String>,
+    pub(crate) entries: Vec<EntryTerminal>,
+    pub(crate) dispatches: Vec<DispatchTerminal>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct SafetyProof {
+    pub(crate) production_card_count: i64,
+    pub(crate) github_pr_tracking_count: i64,
+    pub(crate) live_session_count: i64,
+    pub(crate) dispatch_delivery_sent_count: i64,
+    pub(crate) message_outbox_count: i64,
+    pub(crate) message_outbox_rows: Vec<Value>,
+    pub(crate) dispatch_outbox_notify_count: i64,
+    pub(crate) dispatch_outbox_notify_rows: Vec<Value>,
+    pub(crate) worktree_or_branch_context_count: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct PreflightReport {
+    pub(crate) identity: PreflightIdentity,
+    pub(crate) run_id: Option<String>,
+    pub(crate) entry_ids: Vec<String>,
+    pub(crate) dispatch_ids: Vec<String>,
+    pub(crate) slot_ids: Vec<SlotId>,
+    pub(crate) phase_gate_state: Vec<Value>,
+    pub(crate) terminal_status: TerminalStatus,
+    pub(crate) raw_failure_reasons: Vec<String>,
+    pub(crate) endpoint_observations: Vec<EndpointObservation>,
+    pub(crate) safety: SafetyProof,
+    pub(crate) status_inflight: Option<Value>,
+    pub(crate) status_final: Option<Value>,
+    pub(crate) history_final: Option<Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PreflightSnapshot {
+    pub(crate) run_id: Option<String>,
+    pub(crate) run_status: Option<String>,
+    pub(crate) entries: Vec<EntrySnapshot>,
+    pub(crate) dispatches: Vec<DispatchSnapshot>,
+    pub(crate) reserved_slots: Vec<SlotId>,
+    pub(crate) phase_gates: Vec<Value>,
+    pub(crate) diagnostics: Vec<Value>,
+    pub(crate) safety: SafetyProof,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct EntrySnapshot {
+    pub(crate) id: String,
+    pub(crate) status: String,
+    pub(crate) dispatch_id: Option<String>,
+    pub(crate) slot_index: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DispatchSnapshot {
+    pub(crate) id: String,
+    pub(crate) status: String,
+}
+
+impl PreflightReport {
+    pub(crate) fn new(fixture: &PreflightFixture) -> Self {
+        Self {
+            identity: PreflightIdentity {
+                fixture_id: fixture.fixture_id.clone(),
+                repo: fixture.repo.clone(),
+                group: fixture.group.clone(),
+                pipeline_id: fixture.pipeline_id.clone(),
+                agent_id: fixture.agent_id.clone(),
+                review_mode: fixture.review_mode.clone(),
+            },
+            ..Self::default()
+        }
+    }
+}
+
+fn default_auth_token() -> String {
+    "auto-queue-preflight-token".to_string()
+}
+
+fn default_review_mode() -> String {
+    "disabled".to_string()
+}
+
+fn default_priority() -> String {
+    "high".to_string()
+}
+
+fn default_phase_gate_kind() -> String {
+    "pr-confirm".to_string()
+}
+
+fn default_max_concurrent_threads() -> i64 {
+    1
+}

--- a/src/server/routes/tests/preflight_harness/validation.rs
+++ b/src/server/routes/tests/preflight_harness/validation.rs
@@ -1,0 +1,249 @@
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use super::types::{
+    DispatchTerminal, EntrySnapshot, EntryTerminal, PreflightReport, PreflightSnapshot, SlotId,
+    TerminalStatus,
+};
+
+pub(crate) fn apply_snapshot_to_report(report: &mut PreflightReport, snapshot: &PreflightSnapshot) {
+    report.slot_ids = observed_slot_ids(snapshot);
+    report.phase_gate_state = snapshot.phase_gates.clone();
+    report.terminal_status = TerminalStatus {
+        run_status: snapshot.run_status.clone(),
+        entries: snapshot
+            .entries
+            .iter()
+            .map(|entry| EntryTerminal {
+                id: entry.id.clone(),
+                status: entry.status.clone(),
+                dispatch_id: entry.dispatch_id.clone(),
+                slot_index: entry.slot_index,
+            })
+            .collect(),
+        dispatches: snapshot
+            .dispatches
+            .iter()
+            .map(|dispatch| DispatchTerminal {
+                id: dispatch.id.clone(),
+                status: dispatch.status.clone(),
+            })
+            .collect(),
+    };
+    report.safety = snapshot.safety.clone();
+}
+
+pub(crate) fn validate_preflight_snapshot(snapshot: &PreflightSnapshot) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    for dispatch in &snapshot.dispatches {
+        if dispatch.status != "completed" {
+            continue;
+        }
+        let matching_entries: Vec<&EntrySnapshot> = snapshot
+            .entries
+            .iter()
+            .filter(|entry| entry.dispatch_id.as_deref() == Some(dispatch.id.as_str()))
+            .collect();
+        if matching_entries.is_empty() {
+            failures.push(format!(
+                "split-brain: task_dispatches.status=completed for {} but no matching auto_queue_entries row points at it",
+                dispatch.id
+            ));
+            continue;
+        }
+        for entry in matching_entries {
+            if entry.status != "done" {
+                failures.push(format!(
+                    "split-brain: task_dispatches.status=completed for {} but auto_queue_entries {} stayed {}",
+                    dispatch.id, entry.id, entry.status
+                ));
+            }
+        }
+        if snapshot.run_status.as_deref() != Some("completed") {
+            failures.push(format!(
+                "split-brain: task_dispatches.status=completed for {} but auto_queue_runs {:?} stayed {:?}",
+                dispatch.id, snapshot.run_id, snapshot.run_status
+            ));
+        }
+    }
+
+    for slot in &snapshot.reserved_slots {
+        failures.push(format!(
+            "slot remains reserved after terminal preflight: agent={} slot={}",
+            slot.agent_id, slot.slot_index
+        ));
+    }
+    for entry in &snapshot.entries {
+        if entry.status == "dispatched" {
+            failures.push(format!(
+                "entry stuck dispatched after terminal preflight: {} dispatch={:?}",
+                entry.id, entry.dispatch_id
+            ));
+        }
+    }
+    for gate in &snapshot.phase_gates {
+        let status = gate.get("status").and_then(Value::as_str).unwrap_or("");
+        if matches!(status, "pending" | "failed" | "blocked")
+            && !phase_gate_has_visible_reason(gate)
+        {
+            failures.push(format!(
+                "phase gate blocks without visible reason or correlation: {gate}"
+            ));
+        }
+    }
+    for diagnostics in &snapshot.diagnostics {
+        failures.extend(validate_diagnostics_have_correlation_ids(diagnostics));
+    }
+
+    let safety = &snapshot.safety;
+    if safety.production_card_count != 0 {
+        failures.push(format!(
+            "sandbox preflight touched non-fixture kanban cards: {}",
+            safety.production_card_count
+        ));
+    }
+    if safety.github_pr_tracking_count != 0 {
+        failures.push(format!(
+            "sandbox preflight created PR/branch tracking rows: {}",
+            safety.github_pr_tracking_count
+        ));
+    }
+    if safety.live_session_count != 0 {
+        failures.push(format!(
+            "sandbox preflight left live sessions: {}",
+            safety.live_session_count
+        ));
+    }
+    if safety.dispatch_delivery_sent_count != 0 {
+        failures.push(format!(
+            "sandbox preflight sent dispatch delivery events: {}",
+            safety.dispatch_delivery_sent_count
+        ));
+    }
+    if safety.message_outbox_count != 0 {
+        failures.push(format!(
+            "sandbox preflight wrote dispatch channel messages: {}",
+            safety.message_outbox_count
+        ));
+    }
+    if safety.dispatch_outbox_notify_count != 0 {
+        failures.push(format!(
+            "sandbox preflight enqueued dispatch notifications: {}",
+            safety.dispatch_outbox_notify_count
+        ));
+    }
+    if safety.worktree_or_branch_context_count != 0 {
+        failures.push(format!(
+            "sandbox preflight recorded worktree/branch context: {}",
+            safety.worktree_or_branch_context_count
+        ));
+    }
+
+    failures
+}
+
+pub(crate) fn validate_history_contains_run(history: &Value, run_id: &str) -> Vec<String> {
+    let contains_run = history
+        .get("runs")
+        .and_then(Value::as_array)
+        .is_some_and(|runs| {
+            runs.iter()
+                .any(|run| run.get("id").and_then(Value::as_str) == Some(run_id))
+        });
+    if contains_run {
+        Vec::new()
+    } else {
+        vec![format!(
+            "/api/queue/history did not include terminal preflight run {run_id}: {history}"
+        )]
+    }
+}
+
+fn observed_slot_ids(snapshot: &PreflightSnapshot) -> Vec<SlotId> {
+    let mut slots = snapshot.reserved_slots.clone();
+    let mut seen: BTreeSet<(String, i64)> = slots
+        .iter()
+        .map(|slot| (slot.agent_id.clone(), slot.slot_index))
+        .collect();
+    for entry in &snapshot.entries {
+        if let Some(slot_index) = entry.slot_index {
+            let agent_id = "entry-bound-slot".to_string();
+            if seen.insert((agent_id.clone(), slot_index)) {
+                slots.push(SlotId {
+                    agent_id,
+                    slot_index,
+                });
+            }
+        }
+    }
+    slots
+}
+
+fn phase_gate_has_visible_reason(gate: &Value) -> bool {
+    ["failure_reason", "dispatch_id", "verdict"]
+        .iter()
+        .any(|key| non_empty_json_string(gate.get(*key)))
+}
+
+fn validate_diagnostics_have_correlation_ids(diagnostics: &Value) -> Vec<String> {
+    let mut failures = Vec::new();
+    for diagnostic in diagnostics
+        .get("slot_invariant_violations")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if !non_empty_json_string(diagnostic.get("run_id"))
+            || diagnostic
+                .get("entry_ids")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty)
+            || diagnostic
+                .get("dispatch_ids")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty)
+        {
+            failures.push(format!(
+                "slot invariant diagnostic omits correlation ids: {diagnostic}"
+            ));
+        }
+    }
+    for diagnostic in diagnostics
+        .get("entry_dispatch_delivery_mismatches")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let has_ids = non_empty_json_string(diagnostic.get("run_id"))
+            && non_empty_json_string(diagnostic.get("entry_id"))
+            && non_empty_json_string(diagnostic.get("dispatch_id"))
+            && non_empty_json_string(diagnostic.get("card_id"))
+            && diagnostic.get("slot_index").is_some();
+        if !has_ids {
+            failures.push(format!(
+                "delivery mismatch diagnostic omits correlation ids: {diagnostic}"
+            ));
+        }
+    }
+    for diagnostic in diagnostics
+        .get("run_timeout_overruns")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if !non_empty_json_string(diagnostic.get("run_id")) {
+            failures.push(format!(
+                "timeout diagnostic omits run correlation id: {diagnostic}"
+            ));
+        }
+    }
+    failures
+}
+
+fn non_empty_json_string(value: Option<&Value>) -> bool {
+    value
+        .and_then(Value::as_str)
+        .is_some_and(|text| !text.trim().is_empty())
+}

--- a/src/services/auto_queue/phase_gate.rs
+++ b/src/services/auto_queue/phase_gate.rs
@@ -101,7 +101,8 @@ async fn create_activate_dispatch_pg_inner(
                 latest_dispatch_id,
                 repo_id,
                 assigned_agent_id,
-                github_issue_number::BIGINT AS github_issue_number
+                github_issue_number::BIGINT AS github_issue_number,
+                metadata
          FROM kanban_cards
          WHERE id = $1",
     )
@@ -129,6 +130,11 @@ async fn create_activate_dispatch_pg_inner(
     let github_issue_number: Option<i64> = row
         .try_get("github_issue_number")
         .map_err(|error| format!("decode github_issue_number for {card_id}: {error}"))?;
+    let metadata: Option<serde_json::Value> = row
+        .try_get("metadata")
+        .map_err(|error| format!("decode metadata for {card_id}: {error}"))?;
+    let sandbox_preflight_dispatch =
+        metadata_disables_preflight_external_side_effects(metadata.as_ref());
 
     let agent_exists =
         sqlx::query_scalar::<_, i64>("SELECT COUNT(*)::BIGINT FROM agents WHERE id = $1")
@@ -143,26 +149,30 @@ async fn create_activate_dispatch_pg_inner(
         ));
     }
 
-    let channel_value = crate::db::agents::resolve_agent_dispatch_channel_pg(
-        pool,
-        to_agent_id,
-        Some(dispatch_type),
-    )
-    .await
-    .map_err(|error| {
-        format!("resolve postgres dispatch channel for {to_agent_id} ({dispatch_type}): {error}")
-    })?
-    .map(|value| value.trim().to_string())
-    .filter(|value| !value.is_empty())
-    .ok_or_else(|| {
-        format!(
-            "Cannot create {dispatch_type} dispatch: agent '{to_agent_id}' has no discord channel (card {card_id})"
+    if !sandbox_preflight_dispatch {
+        let channel_value = crate::db::agents::resolve_agent_dispatch_channel_pg(
+            pool,
+            to_agent_id,
+            Some(dispatch_type),
         )
-    })?;
-    if resolve_activate_dispatch_channel_id(&channel_value).is_none() {
-        return Err(format!(
-            "Cannot create {dispatch_type} dispatch: agent '{to_agent_id}' has invalid discord channel '{channel_value}' (card {card_id})"
-        ));
+        .await
+        .map_err(|error| {
+            format!(
+                "resolve postgres dispatch channel for {to_agent_id} ({dispatch_type}): {error}"
+            )
+        })?
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            format!(
+                "Cannot create {dispatch_type} dispatch: agent '{to_agent_id}' has no discord channel (card {card_id})"
+            )
+        })?;
+        if resolve_activate_dispatch_channel_id(&channel_value).is_none() {
+            return Err(format!(
+                "Cannot create {dispatch_type} dispatch: agent '{to_agent_id}' has invalid discord channel '{channel_value}' (card {card_id})"
+            ));
+        }
     }
 
     let effective =
@@ -197,8 +207,18 @@ async fn create_activate_dispatch_pg_inner(
             obj.entry("issue_number".to_string())
                 .or_insert_with(|| json!(issue_number));
         }
+        if sandbox_preflight_dispatch {
+            obj.entry("sandbox_preflight".to_string())
+                .or_insert_with(|| json!(true));
+            obj.entry("fixture_mode".to_string())
+                .or_insert_with(|| json!(true));
+            obj.entry("production_mutation_allowed".to_string())
+                .or_insert_with(|| json!(false));
+        }
     }
-    if crate::dispatch::dispatch_type_requires_fresh_worktree(Some(dispatch_type)) {
+    if !sandbox_preflight_dispatch
+        && crate::dispatch::dispatch_type_requires_fresh_worktree(Some(dispatch_type))
+    {
         let Some((worktree_path, worktree_branch, _, created)) =
             crate::dispatch::ensure_card_worktree(pool, card_id, Some(&context_with_strategy))
                 .await
@@ -493,22 +513,24 @@ async fn create_activate_dispatch_pg_inner(
     .await
     .map_err(|error| format!("insert postgres dispatch event for {dispatch_id}: {error}"))?;
 
-    sqlx::query(
-        "INSERT INTO dispatch_outbox (
-            dispatch_id, action, agent_id, card_id, title, required_capabilities
-         )
-         SELECT $1, 'notify', $2, $3, $4, required_capabilities
-           FROM task_dispatches
-          WHERE id = $1
-         ON CONFLICT DO NOTHING",
-    )
-    .bind(&dispatch_id)
-    .bind(to_agent_id)
-    .bind(card_id)
-    .bind(title)
-    .execute(&mut *tx)
-    .await
-    .map_err(|error| format!("insert postgres dispatch outbox for {dispatch_id}: {error}"))?;
+    if !sandbox_preflight_dispatch {
+        sqlx::query(
+            "INSERT INTO dispatch_outbox (
+                dispatch_id, action, agent_id, card_id, title, required_capabilities
+             )
+             SELECT $1, 'notify', $2, $3, $4, required_capabilities
+               FROM task_dispatches
+              WHERE id = $1
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(&dispatch_id)
+        .bind(to_agent_id)
+        .bind(card_id)
+        .bind(title)
+        .execute(&mut *tx)
+        .await
+        .map_err(|error| format!("insert postgres dispatch outbox for {dispatch_id}: {error}"))?;
+    }
 
     for intent in &decision.intents {
         crate::engine::transition_executor_pg::execute_activate_transition_intent_pg(
@@ -543,4 +565,45 @@ async fn create_activate_dispatch_pg_inner(
         .map_err(|error| format!("commit postgres dispatch {dispatch_id}: {error}"))?;
 
     Ok(dispatch_id)
+}
+
+fn metadata_disables_preflight_external_side_effects(metadata: Option<&serde_json::Value>) -> bool {
+    metadata.is_some_and(|metadata| {
+        metadata
+            .get("sandbox_preflight")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+            && metadata
+                .get("production_mutation_allowed")
+                .and_then(serde_json::Value::as_bool)
+                != Some(true)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::metadata_disables_preflight_external_side_effects;
+
+    #[test]
+    fn sandbox_preflight_metadata_disables_external_side_effects_only_when_safe() {
+        assert!(metadata_disables_preflight_external_side_effects(Some(
+            &serde_json::json!({
+                "sandbox_preflight": true,
+                "production_mutation_allowed": false
+            })
+        )));
+        assert!(!metadata_disables_preflight_external_side_effects(Some(
+            &serde_json::json!({
+                "sandbox_preflight": true,
+                "production_mutation_allowed": true
+            })
+        )));
+        assert!(!metadata_disables_preflight_external_side_effects(Some(
+            &serde_json::json!({
+                "sandbox_preflight": false,
+                "production_mutation_allowed": false
+            })
+        )));
+        assert!(!metadata_disables_preflight_external_side_effects(None));
+    }
 }

--- a/tests/fixtures/auto-queue-preflight/basic.json
+++ b/tests/fixtures/auto-queue-preflight/basic.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "issue-3799-basic",
+  "repo": "agentdesk/preflight-fixture",
+  "group": "sandbox-auto-queue",
+  "pipeline_id": "repo-group-pipeline-fixture-v1",
+  "agent_id": "auto-queue-preflight-agent",
+  "agent_name": "Auto Queue Preflight Agent",
+  "auth_token": "auto-queue-preflight-token",
+  "review_mode": "disabled",
+  "max_concurrent_threads": 1,
+  "entries": [
+    {
+      "issue_number": 3799001,
+      "title": "Fixture: sandbox auto-queue preflight",
+      "description": "Synthetic fixture card used by the sandbox auto-queue preflight harness. It must never map to a production GitHub issue, branch, Discord thread, or live agent session.",
+      "priority": "high",
+      "batch_phase": 0,
+      "thread_group": 0,
+      "phase_gate_kind": "pr-confirm"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds an ignored auto-queue preflight harness and runner for the sandbox queue flow.
- Covers generate -> dispatch-next -> status/history -> completion using a local PostgreSQL fixture.
- Emits a JSON report with endpoint observations, terminal run/entry/dispatch state, failure reasons, and safety counters.
- Splits harness report/validation types into child modules to stay within maintenance ratchets.

## Verification
- cargo fmt --all --check
- cargo check --lib
- cargo test --lib auto_queue_preflight_detects_split_brain_completion -- --nocapture
- scripts/e2e/auto-queue-preflight.sh --fixture tests/fixtures/auto-queue-preflight/basic.json --report /tmp/agentdesk-auto-queue-preflight.json
- python3 scripts/generate_inventory_docs.py
- python3 scripts/check_agent_maintenance_docs.py
- git diff --check

Issue: #3799