### PR TITLE
fix(discord): unwrap user-prefixed subagent notifications

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -896,7 +896,7 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (1625 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1709 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +20 from #3676: Codex rollout user prompts now
     prefer the stable message entry id when present so Codex TUI direct prompt
@@ -907,7 +907,10 @@
     returns `(prompt, Option<uuid>)`, a `relayed_entry_ids_by_tmux` ledger
     (PROMPT_ANCHOR_TTL-purged, ring-capped) + `PromptObservation::SuppressedReplayedEntry`,
     and `observe_prompt_by_tmux_with_entry_id_at` suppress an already-relayed entry
-    re-encountered after a relay-watermark reset / jsonl head rotation BY IDENTITY
+    re-encountered after a relay-watermark reset / jsonl head rotation BY IDENTITY;
+    +84 from #3818: user-prefixed subagent notification machine events now bypass
+    the Discord self-relay duplicate filter after provider-reuse/TUI-chrome
+    wrapper peeling so the sanitizer can render a card instead of raw XML
     (never by inflight/EOF observation), so the idle-transcript scanner cannot mint
     a phantom synthetic inflight; a genuinely new prompt carries a new uuid and is
     never suppressed (#3459/#3303 missed-prompt guard); +37 from #3527: `is_discord_relayed_user_prompt`

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -1074,6 +1074,32 @@ files, and memory recall below as new actionable input.\n\n\
     }
 
     #[test]
+    fn format_for_discord_sanitizes_provider_reuse_chrome_then_user_subagent_3818() {
+        let input = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+No response requested.\n\
+[User: 0hbujang (ID: 343742347365974026)] \
+<subagent_notification>{\"agent_path\":\"/tmp/private-agent\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+
+        let output = format_for_discord_with_provider(input, &ProviderKind::Codex);
+        assert!(output.contains("Subagent completed"));
+        assert!(output.contains("Review complete."));
+        assert!(!output.contains("[Provider Session Reuse]"));
+        assert!(!output.contains("No response requested."));
+        assert!(!output.contains("[User:"));
+        assert!(!output.contains("<subagent_notification>"));
+        assert!(!output.contains("agent_path"));
+        assert!(!output.contains("/tmp/private-agent"));
+
+        let status_panel_output = format_for_discord_with_status_panel(input, &ProviderKind::Codex);
+        assert!(status_panel_output.contains("Subagent completed"));
+        assert!(!status_panel_output.contains("<subagent_notification>"));
+        assert!(!status_panel_output.contains("[User:"));
+    }
+
+    #[test]
     fn placeholder_status_block_summarizes_subagent_notification_3818() {
         let input = r#"<subagent_notification>
 {"agent_path":"/tmp/private-agent","status":{"completed":"Review complete.\n\nVERDICT: CLEAN"}}

--- a/src/services/discord/subagent_notification_card.rs
+++ b/src/services/discord/subagent_notification_card.rs
@@ -127,16 +127,39 @@ fn extract_payload(prompt: &str) -> Result<String, ()> {
 
 fn normalized_start_anchored_injection(prompt: &str) -> String {
     let normalized = strip_terminal_controls(prompt);
-    let normalized = normalized.trim_start();
-    let normalized = strip_leading_injection_wrapper(normalized);
-    let normalized = normalized.trim_start();
-    let normalized = strip_provider_session_reuse_prologue(normalized).unwrap_or(normalized);
-    let normalized = normalized.trim_start();
-    let normalized =
-        strip_leading_user_author_prefix(normalized).unwrap_or_else(|| normalized.to_string());
-    let normalized = normalized.trim_start();
-    let normalized = super::strip_leading_tui_response_chrome(normalized);
-    normalized.trim_start().to_string()
+    let mut current = normalized.trim_start().to_string();
+
+    loop {
+        let before = current.clone();
+
+        let unwrapped = strip_leading_injection_wrapper(&current);
+        if unwrapped != current {
+            current = unwrapped.trim_start().to_string();
+            continue;
+        }
+
+        if let Some(tail) = strip_provider_session_reuse_prologue(&current) {
+            current = tail.trim_start().to_string();
+            continue;
+        }
+
+        let stripped_chrome = super::strip_leading_tui_response_chrome(&current);
+        if stripped_chrome != current {
+            current = stripped_chrome.trim_start().to_string();
+            continue;
+        }
+
+        if let Some(tail) = strip_leading_user_author_prefix(&current) {
+            current = tail.trim_start().to_string();
+            continue;
+        }
+
+        if current == before {
+            break;
+        }
+    }
+
+    current.trim_start().to_string()
 }
 
 fn strip_leading_injection_wrapper(text: &str) -> &str {
@@ -295,6 +318,18 @@ mod tests {
             "{RESUMED_PREFIX}[User: 0hbujang (ID: 343742347365974026)] No response requested.\n{raw}"
         );
         assert!(is_start_anchored_subagent_notification(&user_prefixed));
+
+        let chrome_before_user = format!(
+            "{RESUMED_PREFIX}No response requested.\n[User: 0hbujang (ID: 343742347365974026)] {raw}"
+        );
+        assert!(is_start_anchored_subagent_notification(&chrome_before_user));
+        assert!(streaming_rollover_should_skip(&chrome_before_user));
+        let card = sanitize_start_anchored_subagent_notification(&chrome_before_user)
+            .expect("chrome-before-user subagent card");
+        assert!(card.contains("Subagent completed"));
+        assert!(!card.contains("No response requested."));
+        assert!(!card.contains("[User:"));
+        assert!(!card.contains("<subagent_notification>"));
     }
 
     #[test]

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1705,6 +1705,30 @@ files, and memory recall below as new actionable input.\n\n\
     assert!(!output.contains("agent_path"));
 }
 
+#[test]
+fn classify_provider_reuse_chrome_then_user_prefixed_subagent_3818() {
+    let resumed = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+No response requested.\n\
+[User: 0hbujang (ID: 343742347365974026)] \
+<subagent_notification>{\"agent_path\":\"/tmp/private\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+
+    assert_eq!(
+        classify_injected_prompt(resumed),
+        InjectedPromptClass::SubagentNotificationEvent,
+        "provider reuse + TUI chrome + user prefix must still render as a subagent card, not a raw direct prompt",
+    );
+    let output = format_subagent_notification_card("AgentDesk-codex-adk-cdx", resumed);
+    assert!(output.contains("Subagent completed"));
+    assert!(output.contains("Review complete."));
+    assert!(!output.contains("No response requested."));
+    assert!(!output.contains("[User:"));
+    assert!(!output.contains("<subagent_notification>"));
+    assert!(!output.contains("agent_path"));
+}
+
 // #3100 codex P2: stripping the wrapper is anchored to the START. A human
 // message whose body merely contains/quotes the wrapper marker (not as the
 // leading line) must NOT be unwrapped and must stay a human turn.

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -861,7 +861,8 @@ fn observe_prompt_candidates_by_tmux_inner(
         // prompts → candidates stay empty → `PromptObservation::Ignored`.
         if prompt.is_empty()
             || is_synthetic_tui_user_prompt_for_provider(&provider, prompt)
-            || is_discord_relayed_user_prompt(prompt)
+            || (is_discord_relayed_user_prompt(prompt)
+                && !is_user_prefixed_subagent_notification_machine_event(prompt))
         {
             continue;
         }
@@ -1325,6 +1326,89 @@ fn is_discord_relayed_user_prompt(prompt: &str) -> bool {
         tail = &tail[id_at + "(ID: ".len()..];
     }
     false
+}
+
+fn is_user_prefixed_subagent_notification_machine_event(prompt: &str) -> bool {
+    let mut current = prompt.trim_start();
+    let mut saw_user_prefix = false;
+
+    loop {
+        if let Some(tail) = strip_provider_session_reuse_prologue(current) {
+            current = tail.trim_start();
+            continue;
+        }
+
+        let stripped_chrome = strip_leading_tui_response_chrome(current);
+        if stripped_chrome != current {
+            current = stripped_chrome.trim_start();
+            continue;
+        }
+
+        if let Some(tail) = strip_leading_user_author_prefix(current) {
+            saw_user_prefix = true;
+            current = tail.trim_start();
+            continue;
+        }
+
+        break;
+    }
+
+    saw_user_prefix && starts_with_xmlish_tag(current.trim_start(), "subagent_notification")
+}
+
+fn strip_provider_session_reuse_prologue(normalized: &str) -> Option<&str> {
+    const RESUMED_THREAD_PROLOGUE: &str = "The prior authoritative Discord, role, and tool \
+         instructions already present in this Codex thread still apply. Treat only this turn's \
+         user request, reply context, uploaded files, and memory recall below as new actionable \
+         input.";
+    const FRESH_FORK_PROLOGUE: &str = "The prior authoritative Discord, role, and tool \
+         instructions already issued to this role in the current dcserver lifetime still apply. \
+         Treat only this turn's user request, reply context, uploaded files, and memory recall \
+         below as new actionable input.";
+
+    let rest = normalized
+        .strip_prefix("[Provider Session Reuse]")?
+        .trim_start();
+    provider_reuse_tail(rest, RESUMED_THREAD_PROLOGUE)
+        .or_else(|| provider_reuse_tail(rest, FRESH_FORK_PROLOGUE))
+}
+
+fn provider_reuse_tail<'a>(rest: &'a str, prologue: &str) -> Option<&'a str> {
+    rest.strip_prefix(prologue)
+        .and_then(|tail| tail.strip_prefix("\n\n"))
+}
+
+fn strip_leading_tui_response_chrome(input: &str) -> &str {
+    let mut stripped = input;
+    loop {
+        let trimmed = stripped.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("No response requested.")
+            && (rest.is_empty()
+                || rest.starts_with('\n')
+                || rest.starts_with('\r')
+                || rest.chars().next().is_some_and(|ch| !ch.is_whitespace()))
+        {
+            stripped = rest;
+            continue;
+        }
+        return trimmed;
+    }
+}
+
+fn strip_leading_user_author_prefix(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix("[User: ")?;
+    let close = rest.find(']')?;
+    Some(rest[close + 1..].trim_start())
+}
+
+fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
+    let Some(rest) = text.strip_prefix('<') else {
+        return false;
+    };
+    let Some(rest) = rest.strip_prefix(tag) else {
+        return false;
+    };
+    rest.starts_with('>') || rest.chars().next().is_some_and(char::is_whitespace)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2528,6 +2612,48 @@ mod tests {
             !external_input_relay_lease_present("claude", "tmux-3527", 42),
             "a [User:] relay re-observation must not create an ExternalInput lease (#3527)"
         );
+    }
+
+    #[test]
+    fn observe_publishes_user_prefixed_subagent_notification_machine_event_3818() {
+        // #3818 regression: Codex subagent completions can be wrapped by
+        // Provider Session Reuse and the Discord author prefix before the TUI
+        // observer sees them. The #3527 self-relay filter must not swallow these
+        // terminal machine events, or the card renderer never gets a chance to
+        // hide the raw XML envelope from Discord.
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let prompt = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+[User: 0hbujang (ID: 343742347365974026)] No response requested.\n\
+<subagent_notification>{\"agent_path\":\"/tmp/private\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+
+        assert_eq!(
+            observe_prompt_by_tmux("codex", "tmux-3818", prompt),
+            PromptObservation::PublishedSshDirect,
+            "start-anchored subagent_notification must bypass the [User:] duplicate filter"
+        );
+        assert!(clear_external_input_relay_lease("codex", "tmux-3818", 42));
+
+        let chrome_before_user = "[Provider Session Reuse]\n\
+The prior authoritative Discord, role, and tool instructions already present in this \
+Codex thread still apply. Treat only this turn's user request, reply context, uploaded \
+files, and memory recall below as new actionable input.\n\n\
+No response requested.\n\
+[User: 0hbujang (ID: 343742347365974026)] \
+<subagent_notification>{\"agent_path\":\"/tmp/private\",\"status\":{\"completed\":\"Review complete.\"}}</subagent_notification>";
+        assert_eq!(
+            observe_prompt_by_tmux("codex", "tmux-3818-chrome-first", chrome_before_user),
+            PromptObservation::PublishedSshDirect,
+            "TUI chrome before the Discord author prefix must not re-enable the [User:] duplicate filter"
+        );
+        assert!(clear_external_input_relay_lease(
+            "codex",
+            "tmux-3818-chrome-first",
+            42
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Iteratively peels provider-reuse, TUI chrome, and Discord author wrappers before subagent notification classification.
- Allows user-prefixed subagent machine events through the TUI prompt dedupe filter so the card renderer can sanitize them.
- Adds regression coverage for provider reuse + chrome + `[User:]` wrapper order in formatter, relay classifier, notification card, and dedupe paths.

## Verification
- cargo fmt --all --check
- cargo check --lib
- cargo test --lib subagent_notification -- --nocapture
- cargo test --lib observe_publishes_user_prefixed_subagent_notification_machine_event_3818 -- --nocapture
- cargo test --lib format_for_discord_sanitizes_provider_reuse_chrome_then_user_subagent_3818 -- --nocapture
- cargo test --lib classify_provider_reuse_chrome_then_user_prefixed_subagent_3818 -- --nocapture
- git diff --check

Issue: #3818