### PR TITLE
test(e2e): separate relay live coverage classes

### DIFF
--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -28,6 +28,7 @@ is in that list.
 ```yaml
 id: E-1
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 steps:
   - send_prompt: ...
@@ -43,6 +44,21 @@ Every scenario must declare `agent_mode`:
 | `controlled` | A deterministic test agent, fake provider, scripted responder, or controlled runtime hook owns completion. | Future hook-backed relay gaps such as forced quiescence timeout or synthetic foreign-active state. |
 | `real_live` | The scenario sends work through a real provider/cell and live Discord/runtime boundary. | Normal relay matrix prompts, direct TUI input, cross-channel `E-11`, and post-deploy relay continuity smoke. |
 
+Every scenario must also declare `coverage_class`:
+
+| `coverage_class` | Use when | Gate behavior |
+| --- | --- | --- |
+| `live` | The row exercises the live Discord/runtime/provider path, or a controlled production-parser/hook path that is allowed to count as live coverage while `agent_mode` records whether a real provider was contacted. | Can satisfy `--required-coverage-class live` if its actual class remains live. |
+| `fixture` | The row replays deterministic local data without Discord, tmux, dcserver, or provider contact. | Useful parser/finalization coverage, but fails `--required-coverage-class live`. |
+| `unsupported-known-gap` | The row is a machine-readable gap placeholder with `skip_reason` and acceptance criteria. | Excluded from green live-gate claims and fails `--required-coverage-class live`. |
+
+`agent_mode` and `coverage_class` are independent axes. A future safe
+production-parser injection can be `agent_mode: controlled` and
+`coverage_class: live`; a local replay remains `agent_mode: none` and
+`coverage_class: fixture`. Gate runners can pass `--required-coverage-class live`
+to make selected fixture or known-gap rows fail instead of being counted as live
+confidence.
+
 The driver validates metadata against the scenario shape. A scenario that
 declares `none` but sends a prompt, or declares `real_live` while switching to a
 fixture execution lane, fails before it can produce a misleading green report.
@@ -50,7 +66,8 @@ Gate runners can also pass `--required-agent-mode controlled` or
 `--required-agent-mode real_live`; selected scenarios below that lane fail
 instead of silently downgrading. Machine-readable reports include
 `agent_mode`, `agent_mode_actual`, `provider_identity`, `real_provider_contacted`,
-and `failure_attribution` on each scenario.
+`coverage_class`, `coverage_class_actual`, `run_id`, and `failure_attribution`
+on each scenario.
 
 Provider-specific scenarios (`E-6` claude `/compact`, `E-7` codex `/compact`)
 narrow the list. TUI-keystroke-only scenarios (`E-4`, `E-10`, `E-12`) include
@@ -84,7 +101,10 @@ they run through the YAML harness without Discord, tmux, or live dcserver state.
 result-text relay plus clean finalization. `E-25` replays modern Codex
 `response_item` plus `event_msg/task_complete` frames and asserts final text
 relay, task-complete finalization, follow-up readiness, and no stale
-health/queue degradation.
+health/queue degradation. `E-26` through `E-29` are explicit
+`unsupported-known-gap` rows for live coverage not yet implemented: exact
+CronCreate live creation, Codex modern-schema production-parser/live stream,
+Codex live tool-command coverage, and `claude-e` tool-use-to-text completeness.
 
 ## #2943 Scenario Coverage And Gaps
 
@@ -105,21 +125,19 @@ Covered P0/P1 backlog items:
 
 Remaining exact gaps:
 
-- Exact `CronCreate` live creation is still not claimed by `E-24`: the harness
-  now has deterministic local replay for the exact `CronCreate`/`Background`
-  classification and relay contract, but it does not create a live cron job.
-- Codex modern-schema live injection is still not claimed by `E-25`: the harness
-  now has fixture-level replay for `response_item` + `event_msg/task_complete`
-  frames, but normal Codex cells still provide only indirect live coverage.
-- Live tool-command coverage is not claimed for `codex-pipe` or `codex-tui`:
-  those worker roles cannot execute shell/tool commands in the E2E scenario
-  contract. Codex relay coverage for modern completion frames remains in
-  deterministic fixture `E-25`.
-- `tool_use->text completeness` for `claude-e` is not claimed by `E-22`: the
-  scenario relies on `wait_for_provider_hold_state`, and there is no current
-  local/non-live fixture proving `claude-e` persists the same
-  `any_tool_used=true` and `has_post_tool_text=false` inflight witness before
-  post-tool text. Follow-up needed before adding `claude-e` to `E-22`.
+- Exact `CronCreate` live creation is still not claimed by `E-24`; `E-26` is
+  the `unsupported-known-gap` row for the live CronCreate creation/background
+  notification/finalization lane.
+- Codex modern-schema live or production-parser injection is still not claimed
+  by `E-25`; `E-27` is the `unsupported-known-gap` row for the safe parser
+  injection or real runtime stream lane.
+- Live tool-command coverage is not claimed for `codex-pipe` or `codex-tui`;
+  `E-28` is the `unsupported-known-gap` row because those worker roles cannot
+  execute shell/tool commands in the current E2E contract.
+- `tool_use->text completeness` for `claude-e` is not claimed by `E-22`; `E-29`
+  is the `unsupported-known-gap` row until the harness has a live witness or
+  fixture proving the same `any_tool_used=true` and
+  `has_post_tool_text=false` inflight state before post-tool text.
 
 ## Driver
 
@@ -144,6 +162,7 @@ scripts/e2e/run_tui_relay.py \
     [--scenarios tests/e2e/tui_relay/scenarios] \
     [--filter E-1,E-5] \
     [--output out/e2e/tui_relay/<run-id>] \
+    [--required-coverage-class live] \
     [--dry-run]
 ```
 
@@ -151,9 +170,10 @@ The driver writes `report.<cell>.json` so an orchestrator that aims all 5 cells
 at one `--output` directory does not overwrite sibling reports. Per-cell lease
 files (`/tmp/agentdesk-e2e-relay.<cell>.lease`) let cells run in parallel from
 separate operator sessions. The top-level report includes `agent_mode_totals`
-and `real_provider_contacted`; individual scenario rows include the provider,
-runtime, worker agent, channel id, raw failure attribution, and whether a real
-provider was contacted.
+`coverage_class_totals`, `coverage_class_violations`, and
+`real_provider_contacted`; individual scenario rows include the provider,
+runtime, worker agent, channel id, run id, raw failure attribution,
+`coverage_class_actual`, and whether a real provider was contacted.
 
 Post-deploy relay continuity uses a narrower operational wrapper around the
 same driver:
@@ -178,7 +198,11 @@ auto-queue preflight defaults to `agent_mode=none` or a controlled finalizer
 because it validates generate/dispatch/slot/entry/run truth, not LLM behavior.
 Deterministic PCM voice E2E should use `agent_mode=controlled`; the opt-in live
 Discord media smoke is the voice `agent_mode=real_live` lane and must say
-whether a real provider was contacted.
+whether a real provider was contacted. The live media runner is
+`scripts/e2e/run_voice_live_media_smoke.py`; it fails closed unless explicit
+test guild/channel ids, an AgentDesk bot id, a separate speaker bot token, and
+live-safety confirmation env vars are set. Its report separates Discord media,
+STT/TTS, provider response, cleanup, and reporting failures.
 
 Destructive steps (`restart_dcserver`, `kill_pane`, `send_keys_no_enter`,
 `cancel_turn`) are gated by both `--allow-destructive` and

--- a/scripts/e2e/run_multi_provider_matrix.py
+++ b/scripts/e2e/run_multi_provider_matrix.py
@@ -85,6 +85,12 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("AGENTDESK_E2E_REQUIRED_AGENT_MODE"),
         help="Fail selected scenarios whose declared agent_mode is below this gate.",
     )
+    parser.add_argument(
+        "--required-coverage-class",
+        choices=cell_driver.COVERAGE_CLASSES,
+        default=os.environ.get("AGENTDESK_E2E_REQUIRED_COVERAGE_CLASS"),
+        help="Fail selected scenarios whose declared coverage_class is below this gate.",
+    )
     return parser.parse_args()
 
 
@@ -131,6 +137,7 @@ def load_cross_channel_scenarios(scenarios_dir: Path) -> list[dict[str, Any]]:
             raise ValueError(f"{yaml_path} declares cross_channel without config")
         data["__path__"] = str(yaml_path)
         cell_driver.validate_scenario_agent_mode(data)
+        cell_driver.validate_scenario_coverage_class(data)
         scenarios.append(data)
     return scenarios
 
@@ -192,6 +199,8 @@ def run_cell(
         cmd.append("--dry-run")
     if args.required_agent_mode:
         cmd.extend(["--required-agent-mode", str(args.required_agent_mode)])
+    if args.required_coverage_class:
+        cmd.extend(["--required-coverage-class", str(args.required_coverage_class)])
     if args.allow_destructive:
         cmd.append("--allow-destructive")
     if not args.reset_before_each:
@@ -218,6 +227,8 @@ def run_cell(
         "report": str(report_path),
         "totals": (report or {}).get("totals"),
         "agent_mode_totals": (report or {}).get("agent_mode_totals"),
+        "coverage_class_totals": (report or {}).get("coverage_class_totals"),
+        "coverage_class_violations": (report or {}).get("coverage_class_violations"),
         "real_provider_contacted": bool((report or {}).get("real_provider_contacted")),
         "ok": proc.returncode == 0 and bool(report),
     }
@@ -572,11 +583,18 @@ def run_cross_channel_scenario(
 ) -> dict[str, Any]:
     scenario_id = str(scenario.get("id"))
     declared_agent_mode = cell_driver.scenario_agent_mode(scenario)
+    declared_coverage_class = cell_driver.scenario_coverage_class(scenario)
+    initial_coverage_actual = cell_driver._initial_coverage_class_actual(  # noqa: SLF001
+        scenario,
+        declared=declared_coverage_class,
+        dry_run=bool(args.dry_run),
+    )
     result: dict[str, Any] = {
         "kind": "cross_channel",
         "pass_index": pass_index,
         "id": scenario_id,
         "path": scenario.get("__path__"),
+        "run_id": run_id,
         "status": "skipped",
         "reason": None,
         "agent_mode": declared_agent_mode,
@@ -590,6 +608,17 @@ def run_cross_channel_scenario(
             actual="none",
             dry_run=bool(args.dry_run),
             real_provider_contacted=False,
+        ),
+        "coverage_class": declared_coverage_class,
+        "coverage_class_planned": cell_driver.infer_planned_coverage_class(
+            scenario,
+            declared=declared_coverage_class,
+        ),
+        "coverage_class_actual": initial_coverage_actual,
+        "coverage_class_contract": cell_driver._coverage_class_contract(  # noqa: SLF001
+            declared=declared_coverage_class,
+            actual=initial_coverage_actual,
+            dry_run=bool(args.dry_run),
         ),
         "real_provider_contacted": False,
         "failure_attribution": None,
@@ -609,6 +638,20 @@ def run_cross_channel_scenario(
         result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
             "agent_mode_gate",
             gate_violation,
+        )
+        return result
+
+    coverage_gate_violation = cell_driver.required_coverage_class_violation(
+        declared=declared_coverage_class,
+        required=getattr(args, "required_coverage_class", None),
+        scenario_id=scenario_id,
+    )
+    if coverage_gate_violation:
+        result["status"] = "fail"
+        result["reason"] = coverage_gate_violation
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "coverage_class_gate",
+            coverage_gate_violation,
         )
         return result
 
@@ -637,6 +680,20 @@ def run_cross_channel_scenario(
             result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
                 "agent_mode_gate",
                 observed_gate_violation,
+            )
+            return result
+        observed_coverage_gate_violation = cell_driver.required_coverage_class_violation(
+            declared=declared_coverage_class,
+            actual=str(result["coverage_class_actual"]),
+            required=getattr(args, "required_coverage_class", None),
+            scenario_id=scenario_id,
+        )
+        if observed_coverage_gate_violation and not args.dry_run:
+            result["status"] = "fail"
+            result["reason"] = observed_coverage_gate_violation
+            result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+                "coverage_class_gate",
+                observed_coverage_gate_violation,
             )
             return result
         result["ok"] = True
@@ -678,6 +735,12 @@ def run_cross_channel_scenario(
             )
         )
         result["status"] = "pass"
+        result["coverage_class_actual"] = "live"
+        result["coverage_class_contract"] = cell_driver._coverage_class_contract(  # noqa: SLF001
+            declared=declared_coverage_class,
+            actual="live",
+            dry_run=bool(args.dry_run),
+        )
         result["ok"] = True
         result["completed_at"] = dt.datetime.now().isoformat(timespec="seconds")
         return result
@@ -893,6 +956,12 @@ def run_cross_channel_scenario(
         if teardown_errors:
             result["teardown_errors"] = teardown_errors
         result["status"] = "pass"
+        result["coverage_class_actual"] = "live"
+        result["coverage_class_contract"] = cell_driver._coverage_class_contract(  # noqa: SLF001
+            declared=declared_coverage_class,
+            actual="live",
+            dry_run=False,
+        )
         result["ok"] = True
     except assertions.AssertionError as error:
         result["status"] = "fail"
@@ -941,6 +1010,48 @@ def _matrix_agent_mode_totals(results: list[dict[str, Any]]) -> dict[str, int]:
         if mode in totals:
             totals[mode] += 1
     return totals
+
+
+def _matrix_coverage_class_totals(results: list[dict[str, Any]]) -> dict[str, int]:
+    totals = {coverage: 0 for coverage in cell_driver.COVERAGE_CLASSES}
+    for result in results:
+        nested = result.get("coverage_class_totals")
+        if isinstance(nested, dict):
+            for coverage in totals:
+                totals[coverage] += int(nested.get(coverage) or 0)
+            continue
+        coverage = str(result.get("coverage_class") or "")
+        if coverage in totals:
+            totals[coverage] += 1
+    return totals
+
+
+def _matrix_coverage_class_violations(
+    results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    for result in results:
+        nested = result.get("coverage_class_violations")
+        if isinstance(nested, list):
+            violations.extend(item for item in nested if isinstance(item, dict))
+        attribution = result.get("failure_attribution")
+        if not isinstance(attribution, dict):
+            continue
+        if attribution.get("source") != "coverage_class_gate":
+            continue
+        violations.append(
+            {
+                "kind": result.get("kind"),
+                "id": result.get("id"),
+                "cell": result.get("cell"),
+                "provider": result.get("provider"),
+                "runtime": result.get("runtime"),
+                "coverage_class": result.get("coverage_class"),
+                "coverage_class_actual": result.get("coverage_class_actual"),
+                "reason": result.get("reason"),
+            }
+        )
+    return violations
 
 
 def main() -> int:
@@ -998,6 +1109,8 @@ def main() -> int:
         "passes": pass_count,
         "cross_channel_scenarios": [str(scenario.get("id")) for scenario in cross_scenarios],
         "agent_mode_totals": _matrix_agent_mode_totals(results),
+        "coverage_class_totals": _matrix_coverage_class_totals(results),
+        "coverage_class_violations": _matrix_coverage_class_violations(results),
         "real_provider_contacted": any(
             result.get("real_provider_contacted") is True for result in results
         ),

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -55,6 +55,12 @@ SUPPORTED_CELLS: tuple[str, ...] = (
 )
 AGENT_MODES: tuple[str, ...] = ("none", "controlled", "real_live")
 AGENT_MODE_RANK = {mode: rank for rank, mode in enumerate(AGENT_MODES)}
+COVERAGE_CLASSES: tuple[str, ...] = ("live", "fixture", "unsupported-known-gap")
+COVERAGE_CLASS_RANK = {
+    "unsupported-known-gap": 0,
+    "fixture": 1,
+    "live": 2,
+}
 REAL_PROVIDER_STEP_KEYS: tuple[str, ...] = (
     "send_prompt",
     "send_provider_hold_prompt",
@@ -113,6 +119,9 @@ REPORT_RECORD_KEYS: tuple[str, ...] = (
     "agent_mode",
     "agent_mode_actual",
     "agent_mode_contract",
+    "coverage_class",
+    "coverage_class_actual",
+    "coverage_class_contract",
     "provider_identity",
     "real_provider_contacted",
     "controlled_harness_evidence",
@@ -235,6 +244,15 @@ def parse_args() -> argparse.Namespace:
             "this required gate."
         ),
     )
+    parser.add_argument(
+        "--required-coverage-class",
+        choices=COVERAGE_CLASSES,
+        default=os.environ.get("AGENTDESK_E2E_REQUIRED_COVERAGE_CLASS"),
+        help=(
+            "Fail selected scenarios whose coverage_class is shallower than "
+            "this required gate, e.g. live."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -280,6 +298,39 @@ def scenario_agent_mode(scenario: dict[str, Any]) -> str:
         scenario.get("agent_mode"),
         scenario_id=str(scenario.get("id") or scenario.get("__path__") or "<unknown>"),
     )
+
+
+def normalize_coverage_class(value: Any, *, scenario_id: str | None = None) -> str:
+    coverage = str(value or "").strip().lower()
+    if coverage not in COVERAGE_CLASS_RANK:
+        label = f" for {scenario_id}" if scenario_id else ""
+        raise ValueError(
+            f"coverage_class{label} must be one of "
+            f"{', '.join(COVERAGE_CLASSES)}; got {value!r}"
+        )
+    return coverage
+
+
+def infer_planned_coverage_class(
+    scenario: dict[str, Any],
+    *,
+    declared: str | None = None,
+) -> str:
+    if scenario.get("skip_reason") and declared is not None:
+        return declared
+    if is_local_fixture_scenario(scenario):
+        return "fixture"
+    agent_mode = str(scenario.get("agent_mode") or "").strip().lower()
+    if agent_mode == "none":
+        return "fixture"
+    return "live"
+
+
+def scenario_coverage_class(scenario: dict[str, Any]) -> str:
+    scenario_id = str(scenario.get("id") or scenario.get("__path__") or "<unknown>")
+    if "coverage_class" not in scenario:
+        return infer_planned_coverage_class(scenario)
+    return normalize_coverage_class(scenario.get("coverage_class"), scenario_id=scenario_id)
 
 
 def provider_identity(cell: str, channel_id: str | None = None) -> dict[str, Any]:
@@ -370,6 +421,25 @@ def validate_scenario_agent_mode(scenario: dict[str, Any]) -> str:
     return declared
 
 
+def validate_scenario_coverage_class(scenario: dict[str, Any]) -> str:
+    scenario_id = str(scenario.get("id") or scenario.get("__path__") or "<unknown>")
+    if "coverage_class" not in scenario:
+        raise ValueError(f"{scenario_id} must declare coverage_class")
+    declared = scenario_coverage_class(scenario)
+    if declared == "unsupported-known-gap" and not scenario.get("skip_reason"):
+        raise ValueError(
+            f"{scenario_id} declares coverage_class='unsupported-known-gap' "
+            "without skip_reason"
+        )
+    planned = infer_planned_coverage_class(scenario, declared=declared)
+    if declared != planned:
+        raise ValueError(
+            f"{scenario_id} declares coverage_class={declared!r}, but scenario "
+            f"steps plan {planned!r}; update metadata or execution lane"
+        )
+    return declared
+
+
 def required_agent_mode_violation(
     *,
     declared: str,
@@ -392,6 +462,33 @@ def required_agent_mode_violation(
             )
         return (
             f"agent_mode gate requires {required_mode}, but {scenario_id} "
+            f"declares {declared}"
+        )
+    return None
+
+
+def required_coverage_class_violation(
+    *,
+    declared: str,
+    actual: str | None = None,
+    required: str | None,
+    scenario_id: str,
+) -> str | None:
+    if not required:
+        return None
+    required_class = normalize_coverage_class(required, scenario_id=scenario_id)
+    if actual is not None:
+        observed_class = normalize_coverage_class(actual, scenario_id=scenario_id)
+    else:
+        observed_class = declared
+    if COVERAGE_CLASS_RANK[observed_class] < COVERAGE_CLASS_RANK[required_class]:
+        if actual is not None:
+            return (
+                f"coverage_class gate requires {required_class}, but {scenario_id} "
+                f"observed coverage_class_actual={observed_class}"
+            )
+        return (
+            f"coverage_class gate requires {required_class}, but {scenario_id} "
             f"declares {declared}"
         )
     return None
@@ -426,6 +523,35 @@ def _apply_observed_required_agent_mode_gate(
     return True
 
 
+def _apply_observed_required_coverage_class_gate(
+    result: dict[str, Any],
+    *,
+    required: str | None,
+    declared: str,
+    scenario_id: str,
+    record: dict[str, Any] | None = None,
+) -> bool:
+    actual = result.get("coverage_class_actual")
+    if actual is None:
+        return False
+    violation = required_coverage_class_violation(
+        declared=declared,
+        actual=str(actual),
+        required=required,
+        scenario_id=scenario_id,
+    )
+    if not violation:
+        return False
+    result["status"] = "fail"
+    result["reason"] = violation
+    result["failure_attribution"] = _failure_attribution(
+        "coverage_class_gate",
+        violation,
+        record=record,
+    )
+    return True
+
+
 def _agent_mode_contract(
     *,
     declared: str,
@@ -440,6 +566,35 @@ def _agent_mode_contract(
         "real_provider_contacted": real_provider_contacted,
         "satisfied": dry_run or declared == actual,
     }
+
+
+def _coverage_class_contract(
+    *,
+    declared: str,
+    actual: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    return {
+        "declared": declared,
+        "actual": actual,
+        "dry_run": dry_run,
+        "satisfied": dry_run or declared == actual,
+    }
+
+
+def _initial_coverage_class_actual(
+    scenario: dict[str, Any],
+    *,
+    declared: str,
+    dry_run: bool,
+) -> str:
+    if dry_run:
+        return declared
+    if is_local_fixture_scenario(scenario):
+        return "fixture"
+    if declared == "unsupported-known-gap":
+        return "unsupported-known-gap"
+    return "unsupported-known-gap"
 
 
 def _failure_attribution(
@@ -488,6 +643,14 @@ def _mark_real_provider_contacted(
         dry_run=dry_run,
         real_provider_contacted=True,
     )
+    declared_coverage_class = record.get("coverage_class")
+    if declared_coverage_class:
+        record["coverage_class_actual"] = "live"
+        record["coverage_class_contract"] = _coverage_class_contract(
+            declared=str(declared_coverage_class),
+            actual="live",
+            dry_run=dry_run,
+        )
 
 
 def observed_agent_mode(scenario: dict[str, Any], record: dict[str, Any]) -> str:
@@ -512,6 +675,40 @@ def _refresh_agent_mode_record(
         actual=actual_mode,
         dry_run=dry_run,
         real_provider_contacted=bool(record.get("real_provider_contacted")),
+    )
+
+
+def observed_coverage_class(
+    scenario: dict[str, Any],
+    record: dict[str, Any],
+    *,
+    dry_run: bool,
+) -> str:
+    declared = scenario_coverage_class(scenario)
+    if dry_run:
+        return declared
+    if record.get("local_fixture") or is_local_fixture_scenario(scenario):
+        return "fixture"
+    if declared == "unsupported-known-gap":
+        return "unsupported-known-gap"
+    if record.get("real_provider_contacted") or record.get("controlled_harness_evidence"):
+        return "live"
+    return "unsupported-known-gap"
+
+
+def _refresh_coverage_class_record(
+    record: dict[str, Any],
+    *,
+    scenario: dict[str, Any],
+    declared_coverage_class: str,
+    dry_run: bool,
+) -> None:
+    actual_class = observed_coverage_class(scenario, record, dry_run=dry_run)
+    record["coverage_class_actual"] = actual_class
+    record["coverage_class_contract"] = _coverage_class_contract(
+        declared=declared_coverage_class,
+        actual=actual_class,
+        dry_run=dry_run,
     )
 
 
@@ -594,6 +791,7 @@ def load_scenarios(scenarios_dir: Path, *, cell: str) -> list[dict[str, Any]]:
             continue
         data["__path__"] = str(yaml_path)
         validate_scenario_agent_mode(data)
+        validate_scenario_coverage_class(data)
         scenarios.append(data)
     return scenarios
 
@@ -2238,9 +2436,20 @@ def run_scenario(
         scenario,
         declared=declared_agent_mode,
     )
+    declared_coverage_class = scenario_coverage_class(scenario)
+    planned_coverage_class = infer_planned_coverage_class(
+        scenario,
+        declared=declared_coverage_class,
+    )
+    initial_coverage_actual = _initial_coverage_class_actual(
+        scenario,
+        declared=declared_coverage_class,
+        dry_run=bool(args.dry_run),
+    )
     result: dict[str, Any] = {
         "id": scenario_id,
         "path": scenario.get("__path__"),
+        "run_id": run_id,
         "cell": cell,
         "provider": cell_provider(cell),
         "runtime": cell_runtime(cell),
@@ -2257,6 +2466,14 @@ def run_scenario(
             actual="none",
             dry_run=bool(args.dry_run),
             real_provider_contacted=False,
+        ),
+        "coverage_class": declared_coverage_class,
+        "coverage_class_planned": planned_coverage_class,
+        "coverage_class_actual": initial_coverage_actual,
+        "coverage_class_contract": _coverage_class_contract(
+            declared=declared_coverage_class,
+            actual=initial_coverage_actual,
+            dry_run=bool(args.dry_run),
         ),
         "provider_identity": provider_identity(cell, args.channel_id),
         "real_provider_contacted": False,
@@ -2277,6 +2494,12 @@ def run_scenario(
                 declared=declared_agent_mode,
                 scenario_id=scenario_id,
             )
+            _apply_observed_required_coverage_class_gate(
+                result,
+                required=getattr(args, "required_coverage_class", None),
+                declared=declared_coverage_class,
+                scenario_id=scenario_id,
+            )
         return result
     result["channel_id"] = target_channel_id
     result["provider_identity"] = provider_identity(cell, target_channel_id)
@@ -2295,6 +2518,20 @@ def run_scenario(
         )
         return result
 
+    coverage_gate_violation = required_coverage_class_violation(
+        declared=declared_coverage_class,
+        required=getattr(args, "required_coverage_class", None),
+        scenario_id=scenario_id,
+    )
+    if coverage_gate_violation:
+        result["status"] = "fail"
+        result["reason"] = coverage_gate_violation
+        result["failure_attribution"] = _failure_attribution(
+            "coverage_class_gate",
+            coverage_gate_violation,
+        )
+        return result
+
     if scenario.get("skip_reason"):
         result["reason"] = str(scenario["skip_reason"])
         result["acceptance_criteria"] = scenario.get("acceptance_criteria")
@@ -2307,6 +2544,12 @@ def run_scenario(
                 result,
                 required=getattr(args, "required_agent_mode", None),
                 declared=declared_agent_mode,
+                scenario_id=scenario_id,
+            )
+            _apply_observed_required_coverage_class_gate(
+                result,
+                required=getattr(args, "required_coverage_class", None),
+                declared=declared_coverage_class,
                 scenario_id=scenario_id,
             )
         return result
@@ -2329,6 +2572,12 @@ def run_scenario(
                 result,
                 required=getattr(args, "required_agent_mode", None),
                 declared=declared_agent_mode,
+                scenario_id=scenario_id,
+            )
+            _apply_observed_required_coverage_class_gate(
+                result,
+                required=getattr(args, "required_coverage_class", None),
+                declared=declared_coverage_class,
                 scenario_id=scenario_id,
             )
         return result
@@ -2377,6 +2626,14 @@ def run_scenario(
             record=window,
         ):
             pass
+        elif not args.dry_run and _apply_observed_required_coverage_class_gate(
+            result,
+            required=getattr(args, "required_coverage_class", None),
+            declared=declared_coverage_class,
+            scenario_id=scenario_id,
+            record=window,
+        ):
+            pass
         elif not args.dry_run and result.get("agent_mode_actual") != declared_agent_mode:
             result["status"] = "fail"
             result["reason"] = (
@@ -2385,6 +2642,21 @@ def run_scenario(
             )
             result["failure_attribution"] = _failure_attribution(
                 "agent_mode_contract",
+                str(result["reason"]),
+                record=window,
+            )
+        elif (
+            not args.dry_run
+            and result.get("coverage_class_actual") != declared_coverage_class
+        ):
+            result["status"] = "fail"
+            result["reason"] = (
+                "coverage_class contract mismatch: "
+                f"declared={declared_coverage_class} "
+                f"actual={result.get('coverage_class_actual')}"
+            )
+            result["failure_attribution"] = _failure_attribution(
+                "coverage_class_contract",
                 str(result["reason"]),
                 record=window,
             )
@@ -2423,6 +2695,12 @@ def run_scenario(
                 declared_agent_mode=declared_agent_mode,
                 dry_run=args.dry_run,
             )
+            _refresh_coverage_class_record(
+                partial_record,
+                scenario=scenario,
+                declared_coverage_class=declared_coverage_class,
+                dry_run=args.dry_run,
+            )
             _merge_record_into_result(result, partial_record)
         result["failure_attribution"] = _failure_attribution(
             "assertion",
@@ -2451,6 +2729,12 @@ def run_scenario(
                 partial_record,
                 scenario=scenario,
                 declared_agent_mode=declared_agent_mode,
+                dry_run=args.dry_run,
+            )
+            _refresh_coverage_class_record(
+                partial_record,
+                scenario=scenario,
+                declared_coverage_class=declared_coverage_class,
                 dry_run=args.dry_run,
             )
             _merge_record_into_result(result, partial_record)
@@ -2490,6 +2774,7 @@ def run_one_cell(
 ) -> dict[str, Any]:
     scenario_id = scenario.get("id")
     declared_agent_mode = scenario_agent_mode(scenario)
+    declared_coverage_class = scenario_coverage_class(scenario)
     if is_local_fixture_scenario(scenario):
         return run_local_fixture_scenario(
             scenario=scenario,
@@ -2509,6 +2794,21 @@ def run_one_cell(
             actual="none",
             dry_run=dry_run,
             real_provider_contacted=False,
+        ),
+        "coverage_class": declared_coverage_class,
+        "coverage_class_actual": _initial_coverage_class_actual(
+            scenario,
+            declared=declared_coverage_class,
+            dry_run=dry_run,
+        ),
+        "coverage_class_contract": _coverage_class_contract(
+            declared=declared_coverage_class,
+            actual=_initial_coverage_class_actual(
+                scenario,
+                declared=declared_coverage_class,
+                dry_run=dry_run,
+            ),
+            dry_run=dry_run,
         ),
         "provider_identity": provider_identity(cell, channel_id),
         "real_provider_contacted": False,
@@ -2761,6 +3061,12 @@ def run_one_cell(
                     declared_agent_mode=declared_agent_mode,
                     dry_run=dry_run,
                 )
+                _refresh_coverage_class_record(
+                    record,
+                    scenario=scenario,
+                    declared_coverage_class=declared_coverage_class,
+                    dry_run=dry_run,
+                )
                 raise ScenarioStepAssertionError(str(error), record=record) from error
         elif "restart_dcserver" in step:
             target = args.restart_target_override or (step["restart_dcserver"] or {}).get(
@@ -2959,6 +3265,12 @@ def run_one_cell(
             declared_agent_mode=declared_agent_mode,
             dry_run=dry_run,
         )
+        _refresh_coverage_class_record(
+            record,
+            scenario=scenario,
+            declared_coverage_class=declared_coverage_class,
+            dry_run=dry_run,
+        )
         raise ScenarioStepAssertionError(str(error), record=record) from error
 
     send_teardown_marker(
@@ -2974,6 +3286,12 @@ def run_one_cell(
         declared_agent_mode=declared_agent_mode,
         dry_run=False,
     )
+    _refresh_coverage_class_record(
+        record,
+        scenario=scenario,
+        declared_coverage_class=declared_coverage_class,
+        dry_run=False,
+    )
     return record
 
 
@@ -2987,6 +3305,7 @@ def run_local_fixture_scenario(
 ) -> dict[str, Any]:
     scenario_id = str(scenario.get("id"))
     declared_agent_mode = scenario_agent_mode(scenario)
+    declared_coverage_class = scenario_coverage_class(scenario)
     record: dict[str, Any] = {
         "assertions": [],
         "local_fixture": True,
@@ -2998,6 +3317,13 @@ def run_local_fixture_scenario(
             actual="none",
             dry_run=dry_run,
             real_provider_contacted=False,
+        ),
+        "coverage_class": declared_coverage_class,
+        "coverage_class_actual": "fixture",
+        "coverage_class_contract": _coverage_class_contract(
+            declared=declared_coverage_class,
+            actual="fixture",
+            dry_run=dry_run,
         ),
         "provider_identity": provider_identity(cell, channel_id),
         "real_provider_contacted": False,
@@ -3428,6 +3754,37 @@ def agent_mode_totals(results: list[dict[str, Any]]) -> dict[str, int]:
     return totals
 
 
+def coverage_class_totals(results: list[dict[str, Any]]) -> dict[str, int]:
+    totals = {coverage: 0 for coverage in COVERAGE_CLASSES}
+    for result in results:
+        coverage = str(result.get("coverage_class") or "")
+        if coverage in totals:
+            totals[coverage] += 1
+    return totals
+
+
+def coverage_class_violations(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    for result in results:
+        attribution = result.get("failure_attribution")
+        if not isinstance(attribution, dict):
+            continue
+        if attribution.get("source") != "coverage_class_gate":
+            continue
+        violations.append(
+            {
+                "id": result.get("id"),
+                "cell": result.get("cell"),
+                "provider": result.get("provider"),
+                "runtime": result.get("runtime"),
+                "coverage_class": result.get("coverage_class"),
+                "coverage_class_actual": result.get("coverage_class_actual"),
+                "reason": result.get("reason"),
+            }
+        )
+    return violations
+
+
 def main() -> int:
     args = parse_args()
     cell = args.cell
@@ -3475,6 +3832,8 @@ def main() -> int:
         "channel_id": args.channel_id,
         "provider_identity": provider_identity(cell, args.channel_id),
         "agent_mode_totals": agent_mode_totals(results),
+        "coverage_class_totals": coverage_class_totals(results),
+        "coverage_class_violations": coverage_class_violations(results),
         "real_provider_contacted": any(
             result.get("real_provider_contacted") is True for result in results
         ),

--- a/scripts/e2e/tui_relay/test_cell_resolution.py
+++ b/scripts/e2e/tui_relay/test_cell_resolution.py
@@ -365,6 +365,7 @@ class ScenarioFilter(unittest.TestCase):
                 self.assertIn("E-24", ids)
                 e24 = next(s for s in scenarios if s.get("id") == "E-24")
                 self.assertEqual(e24.get("execution"), "fixture")
+                self.assertEqual(e24.get("coverage_class"), "fixture")
                 self.assertIn(
                     {
                         "fixture_task_notification": {
@@ -387,6 +388,7 @@ class ScenarioFilter(unittest.TestCase):
                 self.assertIn("E-25", ids)
                 e25 = next(s for s in scenarios if s.get("id") == "E-25")
                 self.assertEqual(e25.get("execution"), "fixture")
+                self.assertEqual(e25.get("coverage_class"), "fixture")
                 self.assertIn(
                     {
                         "fixture_task_complete_finalized": {
@@ -399,6 +401,28 @@ class ScenarioFilter(unittest.TestCase):
                 self.assertTrue(driver.is_local_fixture_scenario(e25))
             else:
                 self.assertNotIn("E-25", ids)
+
+    def test_known_gap_rows_are_machine_readable_and_non_live(self):
+        expected = {
+            "E-26": {"claude-pipe"},
+            "E-27": {"codex-pipe", "codex-tui"},
+            "E-28": {"codex-pipe", "codex-tui"},
+            "E-29": {"claude-e"},
+        }
+        for cell in driver.SUPPORTED_CELLS:
+            scenarios = driver.load_scenarios(self.scenarios_dir, cell=cell)
+            by_id = {str(s.get("id")): s for s in scenarios}
+            for scenario_id, cells in expected.items():
+                if cell in cells:
+                    scenario = by_id[scenario_id]
+                    self.assertEqual(
+                        scenario.get("coverage_class"),
+                        "unsupported-known-gap",
+                    )
+                    self.assertIn("skip_reason", scenario)
+                    self.assertIn("acceptance_criteria", scenario)
+                else:
+                    self.assertNotIn(scenario_id, by_id)
 
     def test_e11_excluded_everywhere(self):
         for cell in driver.SUPPORTED_CELLS:

--- a/scripts/e2e/tui_relay/test_driver_health.py
+++ b/scripts/e2e/tui_relay/test_driver_health.py
@@ -174,6 +174,52 @@ assertions: []
         self.assertIn("declares agent_mode='none'", str(ctx.exception))
         self.assertIn("plan 'real_live'", str(ctx.exception))
 
+    def test_load_scenarios_requires_coverage_class_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "missing-coverage.yaml"
+            path.write_text(
+                """
+id: E-X
+agent_mode: real_live
+cells: [codex-tui]
+steps:
+  - send_prompt: "hello"
+assertions: []
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                driver.load_scenarios(Path(tmp), cell="codex-tui")
+
+        self.assertIn("coverage_class", str(ctx.exception))
+
+    def test_load_scenarios_rejects_live_coverage_for_fixture_lane(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mismatch-coverage.yaml"
+            path.write_text(
+                """
+id: E-X
+agent_mode: none
+coverage_class: live
+cells: [codex-tui]
+execution: fixture
+steps:
+  - replay_fixture:
+      kind: codex_modern_schema
+      provider: codex
+      frames: []
+assertions: []
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                driver.load_scenarios(Path(tmp), cell="codex-tui")
+
+        self.assertIn("declares coverage_class='live'", str(ctx.exception))
+        self.assertIn("plan 'fixture'", str(ctx.exception))
+
     def test_required_agent_mode_gate_fails_shallower_scenario(self):
         class FakeClient:
             base_url = "http://agentdesk.test"
@@ -200,6 +246,42 @@ assertions: []
 
         self.assertEqual(result["status"], "fail")
         self.assertEqual(result["failure_attribution"]["source"], "agent_mode_gate")
+
+    def test_required_coverage_class_gate_fails_fixture_scenario(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+        args = Namespace(
+            cell="codex-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            reset_before_each=False,
+            dry_run=True,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            hard_reset_session_each=False,
+            allow_destructive=False,
+            required_coverage_class="live",
+        )
+        scenario = {
+            "id": "E-X",
+            "agent_mode": "none",
+            "coverage_class": "fixture",
+            "execution": "fixture",
+            "steps": [],
+            "assertions": [],
+        }
+
+        result = driver.run_scenario(
+            scenario,
+            args=args,
+            run_id="run-1",
+            client=FakeClient(),  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["coverage_class"], "fixture")
+        self.assertEqual(result["failure_attribution"]["source"], "coverage_class_gate")
+        self.assertIn("declares fixture", result["reason"])
 
     def test_required_agent_mode_gate_fails_skipped_scenario_with_no_actual_mode(self):
         class FakeClient:
@@ -1576,6 +1658,7 @@ class ControlFlowPrimitives(unittest.TestCase):
         scenario = {
             "id": "E-25",
             "agent_mode": "none",
+            "coverage_class": "fixture",
             "execution": "fixture",
             "steps": [
                 {
@@ -1632,6 +1715,8 @@ class ControlFlowPrimitives(unittest.TestCase):
         self.assertEqual(record["post_scenario_idle"]["source"], "local_fixture")
         self.assertTrue(record["fixture_state"]["followup_probe_accepted"])
         self.assertEqual(record["agent_mode_actual"], "none")
+        self.assertEqual(record["coverage_class_actual"], "fixture")
+        self.assertTrue(record["coverage_class_contract"]["satisfied"])
         self.assertFalse(record["real_provider_contacted"])
 
     def test_run_one_cell_waits_for_hold_state_before_cancel(self):
@@ -2118,7 +2203,13 @@ class ScenarioTeardown(unittest.TestCase):
             hard_reset_session_each=False,
             allow_destructive=False,
         )
-        scenario = {"id": "E-18", "agent_mode": "real_live", "steps": [], "assertions": []}
+        scenario = {
+            "id": "E-18",
+            "agent_mode": "real_live",
+            "coverage_class": "live",
+            "steps": [],
+            "assertions": [],
+        }
         provider_hold_state = {
             "ok_marker": "[E2E:E18:OK]",
             "ok_marker_seen": True,
@@ -2152,6 +2243,14 @@ class ScenarioTeardown(unittest.TestCase):
                     "actual": "real_live",
                     "dry_run": False,
                     "real_provider_contacted": True,
+                    "satisfied": True,
+                },
+                "coverage_class": "live",
+                "coverage_class_actual": "live",
+                "coverage_class_contract": {
+                    "declared": "live",
+                    "actual": "live",
+                    "dry_run": False,
                     "satisfied": True,
                 },
             },

--- a/scripts/e2e/tui_relay/test_matrix_runner.py
+++ b/scripts/e2e/tui_relay/test_matrix_runner.py
@@ -66,6 +66,98 @@ agents:
         ):
             self.assertTrue(matrix.parse_args().reset_before_each)
 
+    def test_run_cell_passes_required_coverage_class_to_driver(self):
+        args = Namespace(
+            base_url="http://agentdesk.test",
+            scenarios="tests/e2e/tui_relay/scenarios",
+            filter="E-25",
+            dry_run=True,
+            required_agent_mode=None,
+            required_coverage_class="live",
+            allow_destructive=False,
+            reset_before_each=True,
+            hard_reset_session_each=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            turn_start_timeout_s=5,
+        )
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd, check=False, text=True):  # noqa: ARG001
+            captured["cmd"] = list(cmd)
+            out_index = cmd.index("--output") + 1
+            report_dir = Path(cmd[out_index])
+            report_dir.mkdir(parents=True, exist_ok=True)
+            (report_dir / "report.codex-tui.json").write_text(
+                """
+{
+  "totals": {"pass": 0, "fail": 1, "skipped": 0},
+  "agent_mode_totals": {"none": 1, "controlled": 0, "real_live": 0},
+  "coverage_class_totals": {"live": 0, "fixture": 1, "unsupported-known-gap": 0},
+  "coverage_class_violations": [
+    {"id": "E-25", "cell": "codex-tui", "coverage_class": "fixture"}
+  ],
+  "real_provider_contacted": false
+}
+""",
+                encoding="utf-8",
+            )
+            return Namespace(returncode=1)
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "run_multi_provider_matrix.subprocess.run",
+            side_effect=fake_run,
+        ):
+            result = matrix.run_cell(
+                cell="codex-tui",
+                channel_id="555",
+                args=args,
+                output_dir=Path(tmp),
+                pass_index=1,
+            )
+
+        self.assertIn("--required-coverage-class", captured["cmd"])
+        self.assertIn("live", captured["cmd"])
+        self.assertEqual(
+            result["coverage_class_totals"],
+            {"live": 0, "fixture": 1, "unsupported-known-gap": 0},
+        )
+        self.assertEqual(result["coverage_class_violations"][0]["id"], "E-25")
+
+    def test_matrix_coverage_totals_and_violations_aggregate_nested_reports(self):
+        results = [
+            {
+                "kind": "cell",
+                "coverage_class_totals": {
+                    "live": 2,
+                    "fixture": 1,
+                    "unsupported-known-gap": 0,
+                },
+                "coverage_class_violations": [
+                    {"id": "E-24", "cell": "claude-pipe"}
+                ],
+            },
+            {
+                "kind": "cross_channel",
+                "id": "E-11",
+                "coverage_class": "live",
+            },
+            {
+                "kind": "cross_channel",
+                "id": "E-X",
+                "coverage_class": "unsupported-known-gap",
+                "coverage_class_actual": "unsupported-known-gap",
+                "failure_attribution": {"source": "coverage_class_gate"},
+                "reason": "coverage_class gate requires live",
+            },
+        ]
+
+        self.assertEqual(
+            matrix._matrix_coverage_class_totals(results),  # noqa: SLF001
+            {"live": 3, "fixture": 1, "unsupported-known-gap": 1},
+        )
+        violations = matrix._matrix_coverage_class_violations(results)  # noqa: SLF001
+        self.assertEqual([item["id"] for item in violations], ["E-24", "E-X"])
+
 
 def _relay_msg(msg_id: int, content: str) -> dict:
     return {
@@ -357,6 +449,8 @@ class CrossChannelMatrix(unittest.TestCase):
         self.assertTrue(result["real_provider_contacted"])
         self.assertEqual(result["agent_mode_actual"], "real_live")
         self.assertTrue(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["coverage_class_actual"], "live")
+        self.assertTrue(result["coverage_class_contract"]["satisfied"])
         self.assertEqual(FakeClient.max_active, 2)
         self.assertIn(
             (
@@ -436,6 +530,8 @@ class CrossChannelMatrix(unittest.TestCase):
         self.assertFalse(result["real_provider_contacted"])
         self.assertEqual(result["agent_mode_actual"], "none")
         self.assertFalse(result["agent_mode_contract"]["satisfied"])
+        self.assertEqual(result["coverage_class_actual"], "unsupported-known-gap")
+        self.assertFalse(result["coverage_class_contract"]["satisfied"])
         self.assertIn("cross-channel dispatch failed", result["reason"])
 
     def test_cross_channel_required_real_live_fails_missing_selected_cells(self):
@@ -462,6 +558,34 @@ class CrossChannelMatrix(unittest.TestCase):
         self.assertEqual(result["agent_mode_actual"], "none")
         self.assertEqual(result["failure_attribution"]["source"], "agent_mode_gate")
         self.assertIn("observed agent_mode_actual=none", result["reason"])
+
+    def test_cross_channel_required_live_coverage_fails_known_gap_row(self):
+        scenario = dict(self.e11)
+        scenario["id"] = "E-X"
+        scenario["coverage_class"] = "unsupported-known-gap"
+        scenario["skip_reason"] = "known gap"
+        args = Namespace(
+            base_url="http://agentdesk.test",
+            dry_run=True,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            reset_before_each=False,
+            required_coverage_class="live",
+            turn_start_timeout_s=5,
+        )
+
+        result = matrix.run_cross_channel_scenario(
+            scenario,
+            args=args,
+            run_id="run-1",
+            channel_ids=self.channel_ids,
+            selected_cells=["claude-tui", "codex-tui"],
+            pass_index=1,
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["failure_attribution"]["source"], "coverage_class_gate")
+        self.assertIn("declares unsupported-known-gap", result["reason"])
 
     def test_cross_channel_non_leak_fails_on_sibling_marker(self):
         class LeakyClient:

--- a/tests/e2e/tui_relay/scenarios/E-1-single-prompt.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-1-single-prompt.yaml
@@ -1,6 +1,7 @@
 id: E-1
 title: 짧은 단일 프롬프트 → 응답 1회 relay
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-10-stranded-draft.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-10-stranded-draft.yaml
@@ -1,6 +1,7 @@
 id: E-10
 title: composer에 send-keys (Enter 없이) → restart → 일관된 draft 처리 (#2635)
 agent_mode: real_live
+coverage_class: live
 cells: [claude-tui, codex-tui]  # composer send-keys is TUI-specific
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-11-dual-channel-concurrency.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-11-dual-channel-concurrency.yaml
@@ -1,6 +1,7 @@
 id: E-11
 title: cc · cdx 동시 진행, 채널 격리 (#2691 + 7.2)
 agent_mode: real_live
+coverage_class: live
 cells: []  # cross-cell scenario, handled by run_multi_provider_matrix.py
 orchestration: cross_channel
 isolation: required

--- a/tests/e2e/tui_relay/scenarios/E-12-tmux-pane-kill.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-12-tmux-pane-kill.yaml
@@ -1,6 +1,7 @@
 id: E-12
 title: 진행 중 tmux kill-pane → "세션 종료" 1회 알림, hang 0 (9.1)
 agent_mode: real_live
+coverage_class: live
 cells: [claude-tui, codex-tui]  # kill-pane assumes a tmux-hosted TUI
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-13-claude-scheduled-wakeup-monitor.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-13-claude-scheduled-wakeup-monitor.yaml
@@ -1,6 +1,7 @@
 id: E-13
 title: Claude Code scheduled wakeup/monitor 패턴이 깨어난 뒤 최종 출력 relay
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe]
 isolation: required
 notes: |

--- a/tests/e2e/tui_relay/scenarios/E-14-claude-tui-thread-stale-reattach.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-14-claude-tui-thread-stale-reattach.yaml
@@ -1,6 +1,7 @@
 id: E-14
 title: Claude TUI thread relay survives stale offset rehydrate after restart
 agent_mode: real_live
+coverage_class: live
 cells: [claude-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-15-long-response-chunk-completeness.yaml
@@ -1,6 +1,7 @@
 id: E-15
 title: 2000자 초과 응답 청크 완전성 (#2838 P0-2) — head→mid→tail 순서 + 중복 0
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 notes: |

--- a/tests/e2e/tui_relay/scenarios/E-16-claude-tui-quiescence-timeout-release.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-16-claude-tui-quiescence-timeout-release.yaml
@@ -1,6 +1,7 @@
 id: E-16
 title: Claude TUI quiescence timeout still releases mailbox
 agent_mode: controlled
+coverage_class: unsupported-known-gap
 cells: [claude-tui]
 isolation: required
 skip_reason: >

--- a/tests/e2e/tui_relay/scenarios/E-17-foreign-active-restart-guard.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-17-foreign-active-restart-guard.yaml
@@ -1,6 +1,7 @@
 id: E-17
 title: Destructive restart refuses foreign active mailbox
 agent_mode: controlled
+coverage_class: unsupported-known-gap
 cells: [codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-18-stop-mid-turn-cancel.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-18-stop-mid-turn-cancel.yaml
@@ -1,6 +1,7 @@
 id: E-18
 title: cancel_turn 중단 후 late marker 미전송 보장
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, codex-pipe, codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-19-session-continuity-after-restart.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-19-session-continuity-after-restart.yaml
@@ -1,6 +1,7 @@
 id: E-19
 title: dcserver restart preserves live tmux session identity
 agent_mode: real_live
+coverage_class: live
 cells: [claude-tui, codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-2-three-turns.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-2-three-turns.yaml
@@ -1,6 +1,7 @@
 id: E-2
 title: 연속 3턴 (각 응답 후 다음 프롬프트), 턴 헤더 분리 확인
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-20-same-session-concurrent-dispatch.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-20-same-session-concurrent-dispatch.yaml
@@ -1,6 +1,7 @@
 id: E-20
 title: same-session near-concurrent dispatch returns both markers once
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-21-direct-input-control-strip.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-21-direct-input-control-strip.yaml
@@ -1,6 +1,7 @@
 id: E-21
 title: Direct TUI input C-u clears stale draft and strips control bytes
 agent_mode: real_live
+coverage_class: live
 cells: [claude-tui, codex-tui]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-22-tool-use-text-completeness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-22-tool-use-text-completeness.yaml
@@ -1,6 +1,7 @@
 id: E-22
 title: tool_use 이후 후속 텍스트 head-to-tail 완결성
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-23-premature-completion-guard.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-23-premature-completion-guard.yaml
@@ -1,6 +1,7 @@
 id: E-23
 title: 본문 전/본문 없는 completion chrome 회귀 가드
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e]
 isolation: required
 acceptance_criteria:

--- a/tests/e2e/tui_relay/scenarios/E-24-croncreate-background-fixture.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-24-croncreate-background-fixture.yaml
@@ -1,6 +1,7 @@
 id: E-24
 title: exact CronCreate Background relay fixture
 agent_mode: none
+coverage_class: fixture
 cells: [claude-pipe]
 execution: fixture
 isolation: local

--- a/tests/e2e/tui_relay/scenarios/E-25-codex-modern-schema-fixture.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-25-codex-modern-schema-fixture.yaml
@@ -1,6 +1,7 @@
 id: E-25
 title: Codex response_item plus task_complete replay fixture
 agent_mode: none
+coverage_class: fixture
 cells: [codex-pipe, codex-tui]
 execution: fixture
 isolation: local

--- a/tests/e2e/tui_relay/scenarios/E-26-croncreate-live-known-gap.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-26-croncreate-live-known-gap.yaml
@@ -1,0 +1,17 @@
+id: E-26
+title: exact CronCreate live creation known gap
+agent_mode: real_live
+coverage_class: unsupported-known-gap
+cells: [claude-pipe]
+isolation: required
+skip_reason: >
+  Known gap for #3798: E-24 proves the exact CronCreate/Background relay shape
+  through deterministic local fixture replay, but the matrix does not yet create
+  a live CronCreate job and observe the resulting background task notification
+  through the live Discord/runtime/provider boundary.
+acceptance_criteria:
+  - Create a live CronCreate job from the tested cell.
+  - Observe the background task notification through production relay handling.
+  - Relay result.result text and finalize without stale queue or health state.
+steps: []
+assertions: []

--- a/tests/e2e/tui_relay/scenarios/E-27-codex-modern-schema-live-known-gap.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-27-codex-modern-schema-live-known-gap.yaml
@@ -1,0 +1,17 @@
+id: E-27
+title: Codex modern-schema production parser known gap
+agent_mode: controlled
+coverage_class: unsupported-known-gap
+cells: [codex-pipe, codex-tui]
+isolation: required
+skip_reason: >
+  Known gap for #3798: E-25 proves Codex response_item plus
+  event_msg/task_complete finalization through deterministic fixture replay, but
+  the matrix does not yet drive a real Codex runtime stream or a controlled safe
+  injection point that passes through the production event parser.
+acceptance_criteria:
+  - Exercise response_item and event_msg/task_complete frames through the production parser.
+  - Relay the task_complete final body with head-to-tail completeness.
+  - Prove follow-up readiness after finalization.
+steps: []
+assertions: []

--- a/tests/e2e/tui_relay/scenarios/E-28-codex-live-tool-command-known-gap.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-28-codex-live-tool-command-known-gap.yaml
@@ -1,0 +1,17 @@
+id: E-28
+title: Codex live tool-command coverage known gap
+agent_mode: real_live
+coverage_class: unsupported-known-gap
+cells: [codex-pipe, codex-tui]
+isolation: required
+skip_reason: >
+  Known gap for #3798: Codex relay cells currently provide live text and
+  lifecycle coverage, but their E2E worker role does not execute live shell or
+  tool commands. Tool-command completeness therefore cannot be counted as a
+  green live lane for codex-pipe or codex-tui.
+acceptance_criteria:
+  - Execute a live Codex tool-command path or supported command fixture.
+  - Observe provider/tool state through production relay handling.
+  - Assert final text completeness and clean post-turn readiness.
+steps: []
+assertions: []

--- a/tests/e2e/tui_relay/scenarios/E-29-claude-e-tool-use-known-gap.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-29-claude-e-tool-use-known-gap.yaml
@@ -1,0 +1,17 @@
+id: E-29
+title: claude-e tool-use-to-text completeness known gap
+agent_mode: real_live
+coverage_class: unsupported-known-gap
+cells: [claude-e]
+isolation: required
+skip_reason: >
+  Known gap for #3798: E-22 covers tool_use-to-text completeness for
+  relay-backed Claude pipe/TUI cells via wait_for_provider_hold_state, but
+  claude-e does not yet have a live witness or fixture proving the same
+  any_tool_used and has_post_tool_text inflight state before post-tool text.
+acceptance_criteria:
+  - Produce a claude-e tool-use witness equivalent to wait_for_provider_hold_state.
+  - Relay the post-tool head/middle/tail body in order without truncation.
+  - Keep completion chrome after the user-visible body.
+steps: []
+assertions: []

--- a/tests/e2e/tui_relay/scenarios/E-3-utf8-multiline.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-3-utf8-multiline.yaml
@@ -1,6 +1,7 @@
 id: E-3
 title: 멀티라인 + 이모지 / 한글 / 코드블록 입력 echo
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-4-direct-input-relay.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-4-direct-input-relay.yaml
@@ -1,6 +1,7 @@
 id: E-4
 title: SSH/direct TUI 입력 시 프롬프트 알림 + 응답 1회 relay (#2697/#2683/#2669 positive)
 agent_mode: real_live
+coverage_class: live
 cells: [claude-tui, codex-tui]  # direct keystroke relay assumes TUI host
 isolation: required
 notes: |

--- a/tests/e2e/tui_relay/scenarios/E-5-turn-separation.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-5-turn-separation.yaml
@@ -1,6 +1,7 @@
 id: E-5
 title: 응답 직후 새 프롬프트 → 새 턴 헤더 분리 + inflight cleanup 관측 (#2625)
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-6-compact-recap-once.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-6-compact-recap-once.yaml
@@ -1,6 +1,7 @@
 id: E-6
 title: /compact 후 memory recap이 사용자 메시지로 오인되지 않음 (#2702 + 3.3)
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e]  # /compact memory recap is claude-only
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-7-codex-compact-readiness.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-7-codex-compact-readiness.yaml
@@ -1,6 +1,7 @@
 id: E-7
 title: Codex /compact 직후 새 입력 readiness (#2695)
 agent_mode: real_live
+coverage_class: live
 cells: [codex-pipe, codex-tui]  # Codex /compact readiness is codex-only
 isolation: required
 steps:

--- a/tests/e2e/tui_relay/scenarios/E-8-restart-between-turns.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-8-restart-between-turns.yaml
@@ -1,6 +1,7 @@
 id: E-8
 title: 응답 완료 → dcserver dev restart → 새 프롬프트 → 새 응답만 emit
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 destructive: true

--- a/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-9-restart-mid-stream.yaml
@@ -1,6 +1,7 @@
 id: E-9
 title: 스트리밍 중 dev 재기동 — sentinel marker 후 restart, 청크 이어 emit, 중복 0
 agent_mode: real_live
+coverage_class: live
 cells: [claude-pipe, claude-tui, claude-e, codex-pipe, codex-tui]
 isolation: required
 destructive: true


### PR DESCRIPTION
Refs #3798

## Summary
- Add explicit relay E2E `coverage_class` metadata: `live`, `fixture`, and `unsupported-known-gap`.
- Add `--required-coverage-class` gates to the single-cell driver and matrix runner, with machine-readable `coverage_class_actual`, totals, and violations in reports.
- Mark E-24/E-25 as fixture coverage and add E-26 through E-29 as explicit known-gap rows for the remaining live claims.
- Update docs/tests so `agent_mode` and `coverage_class` stay separate lanes.

## Validation
- `python3 -m unittest discover scripts/e2e/tui_relay -p 'test_*.py'`
- `python3 scripts/e2e/run_multi_provider_matrix.py --dry-run --cells claude-pipe,codex-tui --filter E-24,E-25 --output /tmp/adk-matrix-classification`
- `python3 scripts/e2e/run_multi_provider_matrix.py --dry-run --cells claude-pipe,codex-tui --filter E-24,E-25 --required-coverage-class live --output /tmp/adk-matrix-live-gate` exited 1 as expected: E-24 and E-25 fail because they declare `coverage_class: fixture`.
- `python3 scripts/generate_inventory_docs.py && python3 scripts/check_agent_maintenance_docs.py`
- `git diff --check`
- `cargo fmt --check`
- `cargo check --lib` passed with existing unused-import warnings.

## Coordination Notes
- Fetched and rebased onto latest `origin/main` before pushing.
- PR #3830 is still open and also edits `docs/e2e/multi-provider-e2e.md`; this PR preserves its voice live media smoke paragraph text while adding #3798 `coverage_class` schema/reporting content above and around the relay matrix sections. If #3830 merges first, this file should be reviewed for logical doc overlap.
- Did not touch #3016 hotfiles: `turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, or `turn_finalizer.rs`.
