### PR TITLE
fix(discord): clear recap card on synthetic TUI-direct turns + improve recap layout

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -15,7 +15,7 @@
 | `src/server/worker_registry.rs` | 1256 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
 | `src/services/discord/health/recovery.rs` | 2134 | discord-relay | 2026-10-31 | #3839 |
-| `src/services/discord/idle_recap.rs` | 1201 | discord-relay | 2026-08-31 | #3405 |
+| `src/services/discord/idle_recap.rs` | 1252 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/inflight.rs` | 2802 | discord-relay | 2026-10-31 | #3835 |
 | `src/services/discord/placeholder_sweeper.rs` | 1004 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/recovery_engine.rs` | 3899 | discord-relay | 2026-10-31 | #3834 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -456,7 +456,7 @@
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1093 | 497 | 596 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |
-| `services::discord::idle_recap` | `src/services/discord/idle_recap.rs` | 2335 | 1201 | 1134 | giant-file |
+| `services::discord::idle_recap` | `src/services/discord/idle_recap.rs` | 2407 | 1252 | 1155 | giant-file |
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
@@ -652,7 +652,7 @@
 | `services::discord::tui_direct_abort_marker::deferred_claim` | `src/services/discord/tui_direct_abort_marker/deferred_claim.rs` | 669 | 265 | 404 |  |
 | `services::discord::tui_direct_abort_marker::store` | `src/services/discord/tui_direct_abort_marker/store.rs` | 348 | 348 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 2431 | 1048 | 1383 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 966 | 966 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 995 | 995 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 449 | 213 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 208 | 208 | 0 |  |

--- a/src/services/discord/idle_recap.rs
+++ b/src/services/discord/idle_recap.rs
@@ -441,25 +441,59 @@ pub(crate) fn compose_recap_text(
         .and_then(|output| output.summary.as_deref())
         .and_then(sanitize_recap_line)
     {
-        lines.push(format!("> 요약: {summary}"));
+        // Blank line separates the header block from the summary so the card
+        // reads as distinct sections instead of one cramped quote.
+        lines.push(String::new());
+        lines.push("> 📝 **요약**".to_string());
+        lines.push(format!("> {summary}"));
     }
     if let Some(suggested_reply) = composer
         .and_then(|output| output.suggested_reply.as_deref())
         .and_then(sanitize_recap_line)
     {
-        lines.push(format!("> 추천 답변: {suggested_reply}"));
+        // The suggested reply gets its own labelled block on a separate line so
+        // it is easy to read (and copy) rather than trailing the summary.
+        // `suggested_reply_from_recap_content` parses the line after this label.
+        lines.push(String::new());
+        lines.push("> 💬 **추천 답변**".to_string());
+        lines.push(format!("> {suggested_reply}"));
     }
     lines.join("\n")
 }
 
 pub(crate) fn suggested_reply_from_recap_content(content: &str) -> Option<String> {
-    content.lines().find_map(|line| {
+    // Handles both the legacy inline form (`> 추천 답변: <reply>`) and the
+    // current labelled form (`> 💬 **추천 답변**` on one line, `> <reply>` on
+    // the next). Markdown/emoji decoration around the label is tolerated so the
+    // card layout can change without breaking the `[추천 답변 보내기]` button.
+    let mut lines = content.lines();
+    while let Some(line) = lines.next() {
         let trimmed = line.trim().trim_start_matches('>').trim();
-        trimmed
-            .strip_prefix("추천 답변:")
-            .or_else(|| trimmed.strip_prefix("추천 답변 :"))
-            .and_then(sanitize_recap_line)
-    })
+        let Some(idx) = trimmed.find("추천 답변") else {
+            continue;
+        };
+        // Inline value on the same line as the label (legacy layout).
+        let inline = trimmed[idx + "추천 답변".len()..]
+            .trim_start_matches(|c: char| c == ':' || c == '*' || c.is_whitespace())
+            .trim();
+        if let Some(reply) = sanitize_recap_line(inline) {
+            return Some(reply);
+        }
+        // Label-only line: the reply lives on the next quoted line.
+        if let Some(next) = lines.next() {
+            let next_trimmed = next
+                .trim()
+                .trim_start_matches('>')
+                .trim()
+                .trim_start_matches('*')
+                .trim();
+            if let Some(reply) = sanitize_recap_line(next_trimmed) {
+                return Some(reply);
+            }
+        }
+        return None;
+    }
+    None
 }
 
 fn compose_recap_header(snapshot: &RecapSnapshot, relay_status: RelayIntegrityStatus) -> String {
@@ -1579,11 +1613,20 @@ mod tests {
         let ok = relay_probe_with(RelayIntegrityStatus::Ok);
         let content = compose_recap_text(&snapshot, Some(&composer), &ok);
         assert!(content.contains("relay OK"));
-        assert!(content.contains("> 요약: 작업 요약"));
-        assert!(content.contains("> 추천 답변: 테스트 계속 진행해줘"));
+        // Labelled blocks on their own lines for legibility (the summary and the
+        // suggested reply are separated by blank lines, not crammed together).
+        assert!(content.contains("> 📝 **요약**\n> 작업 요약"));
+        assert!(content.contains("> 💬 **추천 답변**\n> 테스트 계속 진행해줘"));
         assert_eq!(
             suggested_reply_from_recap_content(&content).as_deref(),
             Some("테스트 계속 진행해줘")
+        );
+        // Backward compatibility: the parser still reads the legacy inline form
+        // from cards posted before the layout change.
+        assert_eq!(
+            suggested_reply_from_recap_content("📦 idle\n> 추천 답변: 옛날 형식 답변")
+                .as_deref(),
+            Some("옛날 형식 답변")
         );
         assert!(!content.contains("이어서 진행"));
 

--- a/src/services/discord/idle_recap.rs
+++ b/src/services/discord/idle_recap.rs
@@ -464,20 +464,18 @@ pub(crate) fn compose_recap_text(
 pub(crate) fn suggested_reply_from_recap_content(content: &str) -> Option<String> {
     // Handles both the legacy inline form (`> 추천 답변: <reply>`) and the
     // current labelled form (`> 💬 **추천 답변**` on one line, `> <reply>` on
-    // the next). Markdown/emoji decoration around the label is tolerated so the
-    // card layout can change without breaking the `[추천 답변 보내기]` button.
+    // the next). Decorative emoji/markdown is tolerated around the label, but
+    // incidental mentions of "추천 답변" in summary text are ignored.
     let mut lines = content.lines();
     while let Some(line) = lines.next() {
         let trimmed = line.trim().trim_start_matches('>').trim();
-        let Some(idx) = trimmed.find("추천 답변") else {
-            continue;
-        };
-        // Inline value on the same line as the label (legacy layout).
-        let inline = trimmed[idx + "추천 답변".len()..]
-            .trim_start_matches(|c: char| c == ':' || c == '*' || c.is_whitespace())
-            .trim();
-        if let Some(reply) = sanitize_recap_line(inline) {
+        if let Some(inline) = suggested_reply_inline_value(trimmed)
+            && let Some(reply) = sanitize_recap_line(inline)
+        {
             return Some(reply);
+        }
+        if !suggested_reply_label_is_standalone(trimmed) {
+            continue;
         }
         // Label-only line: the reply lives on the next quoted line.
         if let Some(next) = lines.next() {
@@ -494,6 +492,25 @@ pub(crate) fn suggested_reply_from_recap_content(content: &str) -> Option<String
         return None;
     }
     None
+}
+
+fn suggested_reply_inline_value(line: &str) -> Option<&str> {
+    line.strip_prefix("추천 답변:")
+        .or_else(|| line.strip_prefix("추천 답변 :"))
+}
+
+fn suggested_reply_label_is_standalone(line: &str) -> bool {
+    let normalized = line
+        .chars()
+        .filter(|ch| {
+            !ch.is_whitespace()
+                && !matches!(
+                    ch,
+                    '>' | '*' | '_' | '`' | ':' | '：' | '💬' | '📝' | '📦' | '·' | '-' | '—'
+                )
+        })
+        .collect::<String>();
+    normalized == "추천답변"
 }
 
 fn compose_recap_header(snapshot: &RecapSnapshot, relay_status: RelayIntegrityStatus) -> String {
@@ -1624,9 +1641,21 @@ mod tests {
         // Backward compatibility: the parser still reads the legacy inline form
         // from cards posted before the layout change.
         assert_eq!(
-            suggested_reply_from_recap_content("📦 idle\n> 추천 답변: 옛날 형식 답변")
-                .as_deref(),
+            suggested_reply_from_recap_content("📦 idle\n> 추천 답변: 옛날 형식 답변").as_deref(),
             Some("옛날 형식 답변")
+        );
+        assert_eq!(
+            suggested_reply_from_recap_content(
+                "📦 idle\n> 📝 **요약**\n> 요약 안의 추천 답변 언급은 라벨이 아님\n\n> 💬 **추천 답변**\n> 진짜 답변"
+            )
+            .as_deref(),
+            Some("진짜 답변")
+        );
+        assert_eq!(
+            suggested_reply_from_recap_content(
+                "📦 idle\n> 📝 **요약**\n> 추천 답변 언급만 있고 실제 라벨은 없음"
+            ),
+            None
         );
         assert!(!content.contains("이어서 진행"));
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -399,6 +399,24 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             return;
         }
     };
+    // A TUI-direct prompt has now been observed for this channel. Clear any
+    // stale `📦 … idle N분` recap card immediately — independent of whether the
+    // synthetic turn-start below later succeeds, defers, or ABORTs (#3296).
+    // The active-turn clear inside `claim_tui_direct_synthetic_turn` only runs
+    // once the turn actually starts (`mailbox_try_start_turn`), so a
+    // deferred/aborted synthetic start (e.g. a prior inflight is still live)
+    // used to leave the recap card sitting over an already-engaged channel.
+    // Fire-and-forget compare-and-clear on the captured id (codex R2 P2), so it
+    // never alters this observer's lease/inflight control flow; the active-turn
+    // path keeps its own bump-then-clear for the steady-state case.
+    if let Some(pool) = shared.pg_pool.as_ref().cloned() {
+        super::idle_recap::spawn_clear_captured_idle_recap_for_channel(
+            notify_http.clone(),
+            pool,
+            channel_id.get(),
+        )
+        .await;
+    }
     // #3164 / #750 invariant: the `⏳` MUST be added by the SAME bot identity that
     // later removes it (`remove_reaction_raw` only removes `@me`'s reaction; a
     // different bot leaves the hourglass forever). The note BODY may be any bot

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -327,6 +327,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         );
         return;
     };
+    let recap_provider = ProviderKind::from_str_or_unsupported(&prompt.provider);
     // #3178 (codex P1 lease-overwrite): run the slash-command-control dedupe BEFORE
     // recording ANY external-input lease. The #3153 double-post (raw echo + expanded
     // `<command-*>` wrapper, ~tens-of-ms apart) must not let the SECOND half record a
@@ -399,17 +400,27 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             return;
         }
     };
-    // A TUI-direct prompt has now been observed for this channel. Clear any
-    // stale `📦 … idle N분` recap card immediately — independent of whether the
-    // synthetic turn-start below later succeeds, defers, or ABORTs (#3296).
-    // The active-turn clear inside `claim_tui_direct_synthetic_turn` only runs
-    // once the turn actually starts (`mailbox_try_start_turn`), so a
-    // deferred/aborted synthetic start (e.g. a prior inflight is still live)
-    // used to leave the recap card sitting over an already-engaged channel.
-    // Fire-and-forget compare-and-clear on the captured id (codex R2 P2), so it
-    // never alters this observer's lease/inflight control flow; the active-turn
-    // path keeps its own bump-then-clear for the steady-state case.
+    // A TUI-direct prompt has now been observed for this channel. Bump idle
+    // recap generation before the pre-claim clear so an in-flight recap POST job
+    // cannot persist a stale card after a deferred/local-only/aborted synthetic
+    // start path (#3296, #3878).
     if let Some(pool) = shared.pg_pool.as_ref().cloned() {
+        if let Err(e) = super::idle_recap::bump_turn_generation(
+            &pool,
+            channel_id.get(),
+            &recap_provider,
+            lease.session_key.as_deref(),
+        )
+        .await
+        {
+            tracing::warn!(
+                error = %e,
+                channel_id = channel_id.get(),
+                provider = %recap_provider.as_str(),
+                session_key = lease.session_key.as_deref().unwrap_or(""),
+                "idle_recap: failed to bump turn generation on TUI-direct observation"
+            );
+        }
         super::idle_recap::spawn_clear_captured_idle_recap_for_channel(
             notify_http.clone(),
             pool,


### PR DESCRIPTION
운영자 보고 2건 (#adk-cc) 수정.

## #2 — 합성 TUI-direct 턴에서 recap 카드 미제거
`📦 … idle N분` recap 카드는 `claim_tui_direct_synthetic_turn` 안에서 **턴이 실제 active**가 됐을 때(`mailbox_try_start_turn`)만 지워졌다. 합성 turn-start가 **deferred/ABORT**(#3296, 예: prior inflight이 아직 live)되면 그 clear가 skip돼 라이브 채널 위에 recap 카드가 남았다.
- `relay_observed_prompt`에서 **TUI-direct 프롬프트 관찰 즉시** captured 카드를 clear (normal/deferred/abort 모두 커버).
- fire-and-forget compare-and-clear(codex R2 P2) → 관찰자 lease/inflight 흐름 무영향. active-turn 경로의 bump-then-clear는 그대로 유지.

## #3 — recap 카드 추천답변 시인성 개선
요약/추천답변이 1줄 줄바꿈으로 붙어 있어 가독성이 낮았다.
- `> 📝 **요약**` / `> 💬 **추천 답변**` 라벨 블록 + 값은 다음 줄, 블록 사이 빈 줄.
- `suggested_reply_from_recap_content`를 신규 라벨 레이아웃 + 레거시 인라인(`추천 답변:`) 둘 다 파싱하도록 견고화 → 기존 카드의 `[추천 답변 보내기]` 버튼도 계속 동작.

## Verify
- `cargo check` exit 0
- `cargo test --lib idle_recap` → 40 passed (갱신된 `recap_renders_*` + 레거시 파싱 회귀 포함)
- 2 files: idle_recap.rs, tui_prompt_relay.rs

## Note
릴레이 인접 변경이라 머지 전 codex 적대적 리뷰 권장. 관련 진단: #adk-cdx와 동일한 stuck-inflight(user_msg_id=0)가 #2 증상의 트리거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)