### PR TITLE
ci: bound self-hosted macOS job with timeout-minutes (#3867)

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -152,6 +152,12 @@ jobs:
     # ever moved under an org, switch back to the `group:`+`labels:` form and
     # set MACOS_RUNNER_GROUP.
     runs-on: ${{ fromJSON(needs.resolve_macos_runner.outputs.labels) }}
+    # Self-hosted runners do NOT inherit GitHub's auto-cancellation, so without
+    # an explicit bound a hung cargo link/deadlocked test could hold the shared
+    # production Mac mini up to the 6h hard max (see #3867, #3658). Cap the job
+    # at 45 min — comfortably above observed cold-sccache build+test durations
+    # while still freeing the host for the live control plane on a stall.
+    timeout-minutes: 45
     steps:
       - name: Trusted event / runner sanity check
         shell: bash


### PR DESCRIPTION
## Problem
The `macos_self_hosted` job in `.github/workflows/ci-macos-trusted.yml` had **no `timeout-minutes`** (job at :146, `cargo check --all-targets` at :229 and the multi-target `cargo test` block at :231-239). Self-hosted runners do **not** inherit GitHub's automatic job cancellation, so the only upper bound was the 6h hard max. Because this runner shares the production Mac mini (live release dcserver + production Postgres, #3658), a deadlocked test or stuck `cargo` link could hold the host for up to 6h, starving the live control plane (CPU/RAM/sccache contention, potential OOM).

## Fix
Add a job-level `timeout-minutes: 45` to `macos_self_hosted`, matching the timeout convention used by the hosted ubuntu jobs (e.g. `ci-pr.yml:503` uses `timeout-minutes: 15` at step level). An explanatory comment references #3867/#3658.

## Bound chosen
**45 minutes** (upper end of the 30-45 min range proposed in the issue).

## Why
45 min sits comfortably above the self-hosted job's observed cold-sccache build + multi-target test duration, so it should not false-fail legitimate builds, while still being an ~8x reduction from the 6h hard max — freeing the shared production host quickly when a build genuinely hangs. The hosted `macos_hosted` job already runs on GitHub-hosted runners (which inherit auto-cancellation and are not the prod host), so this change is scoped to the self-hosted job per the issue.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML OK
- `actionlint` → exit 0 (no findings)
- YAML-only change; no Rust/cargo touched. Pre-existing agent-maintenance doc line-count warnings are unrelated to this change (confirmed identical on pristine origin/main).

Closes #3867

🤖 Generated with [Claude Code](https://claude.com/claude-code)