### PR TITLE
fix(security): validate /api/reviews/verdict commit (#3863)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -279,11 +279,11 @@
 | `server::routes::queue_api` | `src/server/routes/queue_api.rs` | 439 | 390 | 49 |  |
 | `server::routes::receipt` | `src/server/routes/receipt.rs` | 815 | 502 | 313 |  |
 | `server::routes::resume` | `src/server/routes/resume.rs` | 1260 | 1260 | 0 | giant-file |
-| `server::routes::review_verdict` | `src/server/routes/review_verdict/mod.rs` | 11 | 11 | 0 |  |
+| `server::routes::review_verdict` | `src/server/routes/review_verdict/mod.rs` | 14 | 14 | 0 |  |
 | `server::routes::review_verdict::decision_route` | `src/server/routes/review_verdict/decision_route.rs` | 26 | 26 | 0 |  |
 | `server::routes::review_verdict::tuning_aggregate` | `src/server/routes/review_verdict/tuning_aggregate.rs` | 14 | 14 | 0 |  |
-| `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 593 | 593 | 0 |  |
-| `server::routes::reviews` | `src/server/routes/reviews.rs` | 624 | 624 | 0 |  |
+| `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 705 | 641 | 64 |  |
+| `server::routes::reviews` | `src/server/routes/reviews.rs` | 760 | 671 | 89 |  |
 | `server::routes::routines` | `src/server/routes/routines.rs` | 1039 | 854 | 185 |  |
 | `server::routes::session_activity` | `src/server/routes/session_activity.rs` | 13 | 13 | 0 |  |
 | `server::routes::settings` | `src/server/routes/settings.rs` | 93 | 93 | 0 |  |

--- a/src/server/routes/review_verdict/mod.rs
+++ b/src/server/routes/review_verdict/mod.rs
@@ -5,6 +5,9 @@ mod verdict_route;
 pub(crate) use crate::services::review_decision::spawn_aggregate_if_needed_with_pg;
 pub use decision_route::submit_review_decision;
 pub use tuning_aggregate::aggregate_review_tuning;
+// #3863: single source of truth for the commit-SHA guard. The recovery route in
+// `super::reviews` reuses this exact predicate instead of copy-pasting the regex.
+pub(crate) use verdict_route::is_valid_commit_sha;
 pub use verdict_route::submit_verdict;
 // #3037: review loopback request DTOs (`ReviewDecisionBody`, `SubmitVerdictBody`)
 // were relocated to `crate::services::review_decision`; all consumers reference

--- a/src/server/routes/review_verdict/verdict_route.rs
+++ b/src/server/routes/review_verdict/verdict_route.rs
@@ -47,7 +47,7 @@ fn request_suppresses_followup_outbox(headers: &HeaderMap) -> bool {
 /// segments and let the caller create/empty-truncate arbitrary files outside
 /// `runtime/review_passed/`. Rejecting `/`, `\`, `..`, NUL, uppercase, and
 /// non-hex characters keeps the resulting path a direct child of that dir.
-fn is_valid_commit_sha(commit: &str) -> bool {
+pub(crate) fn is_valid_commit_sha(commit: &str) -> bool {
     let len = commit.len();
     (7..=64).contains(&len)
         && commit

--- a/src/server/routes/review_verdict/verdict_route.rs
+++ b/src/server/routes/review_verdict/verdict_route.rs
@@ -38,14 +38,32 @@ fn request_suppresses_followup_outbox(headers: &HeaderMap) -> bool {
     }
 }
 
+/// Validate that `commit` is a bare lowercase hex git object name
+/// (`^[0-9a-f]{7,64}$`) so it can be safely used as a marker file name.
+///
+/// #3863: `commit` is attacker-influenceable (request body / loopback reviewer
+/// agent ingesting PR/issue text = prompt-injection vector). Without this guard
+/// `Path::join` would honour an absolute path (discarding the base dir) or `..`
+/// segments and let the caller create/empty-truncate arbitrary files outside
+/// `runtime/review_passed/`. Rejecting `/`, `\`, `..`, NUL, uppercase, and
+/// non-hex characters keeps the resulting path a direct child of that dir.
+fn is_valid_commit_sha(commit: &str) -> bool {
+    let len = commit.len();
+    (7..=64).contains(&len)
+        && commit
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+}
+
 /// Write a review-passed marker file for the reviewed commit.
 /// `deploy-release.sh` checks this before allowing release deploy.
 ///
 /// When `reviewed_commit` is provided, stamp that exact commit (the one that
 /// was actually reviewed). Falls back to current HEAD for backwards compat.
-/// Returns `Err` only when HOME directory cannot be resolved (environment
-/// misconfiguration).  Git or filesystem failures are logged but not fatal
-/// — the marker is best-effort when commit is not explicitly provided.
+/// Returns `Err` when HOME directory cannot be resolved (environment
+/// misconfiguration) or when the resolved commit is not a valid SHA (#3863).
+/// Git or filesystem failures are logged but not fatal — the marker is
+/// best-effort when commit is not explicitly provided.
 fn stamp_review_passed_marker(reviewed_commit: Option<&str>) -> Result<(), String> {
     let commit = if let Some(c) = reviewed_commit {
         c.to_string()
@@ -62,6 +80,14 @@ fn stamp_review_passed_marker(reviewed_commit: Option<&str>) -> Result<(), Strin
             }
         }
     };
+    // #3863: defense-in-depth — never let a non-SHA value reach `Path::join`,
+    // regardless of whether it came from the request body, the stored
+    // dispatch context, or `git rev-parse HEAD`.
+    if !is_valid_commit_sha(&commit) {
+        return Err(format!(
+            "refusing to stamp review marker for non-SHA commit (must match ^[0-9a-f]{{7,64}}$)"
+        ));
+    }
     let root = crate::config::runtime_root().ok_or_else(|| {
         "runtime root not found; set AGENTDESK_ROOT_DIR or ensure HOME exists".to_string()
     })?;
@@ -374,6 +400,23 @@ pub async fn submit_verdict(
 
         // C: Validate reviewed commit — the dispatch context stores the HEAD that was
         //    actually sent for review. Reject mismatched commits to prevent arbitrary SHA injection.
+        //
+        // #3863: `body.commit` is attacker-influenceable, so (1) reject any
+        // value that is not a bare lowercase git SHA with 400 before it can
+        // reach the filesystem, and (2) never trust it as the authoritative
+        // marker target — the server-stored `reviewed_commit` (or, when absent,
+        // server-derived HEAD) is the only source the deploy gate honours.
+        if let Some(submitted) = body.commit.as_deref()
+            && !is_valid_commit_sha(submitted)
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "commit must be a lowercase git SHA matching ^[0-9a-f]{7,64}$"
+                })),
+            );
+        }
+
         let stored_reviewed_commit: Option<String> = dispatch_context
             .get("reviewed_commit")
             .and_then(|v| v.as_str())
@@ -396,8 +439,12 @@ pub async fn submit_verdict(
             }
             // body.commit is None → use stored reviewed_commit (no HEAD fallback)
             (None, stored) => stored.clone(),
-            // No stored commit (legacy dispatch) → accept body.commit as-is
-            (submitted, None) => submitted.clone(),
+            // #3863: legacy dispatch without a stored `reviewed_commit` must NOT
+            // let the caller forge the deploy-gate marker via `body.commit`.
+            // Fall back to the server-derived HEAD (None → HEAD in
+            // `stamp_review_passed_marker`) so the marker can only ever name a
+            // commit the server itself observed.
+            (_, None) => None,
         }
     };
 
@@ -590,4 +637,69 @@ pub async fn submit_verdict(
             "card_id": card_id,
         })),
     )
+}
+
+#[cfg(test)]
+mod commit_validation_tests {
+    use super::{is_valid_commit_sha, stamp_review_passed_marker};
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(!is_valid_commit_sha("../../etc/x"));
+        assert!(!is_valid_commit_sha("../review_passed/forged"));
+        assert!(!is_valid_commit_sha("a/b"));
+        assert!(!is_valid_commit_sha("a\\b"));
+    }
+
+    #[test]
+    fn rejects_absolute_paths() {
+        assert!(!is_valid_commit_sha("/etc/passwd"));
+        assert!(!is_valid_commit_sha(
+            "/Users/x/Library/LaunchAgents/y.plist"
+        ));
+    }
+
+    #[test]
+    fn rejects_uppercase_and_non_hex() {
+        // Uppercase hex must be rejected (^[0-9a-f] is lowercase-only).
+        assert!(!is_valid_commit_sha("ABCDEF0"));
+        assert!(!is_valid_commit_sha("DEADBEEF"));
+        // Non-hex letters / metacharacters.
+        assert!(!is_valid_commit_sha("zzzzzzz"));
+        assert!(!is_valid_commit_sha("abc123g"));
+        assert!(!is_valid_commit_sha("abcdef0\0"));
+        assert!(!is_valid_commit_sha("abc def"));
+    }
+
+    #[test]
+    fn rejects_empty_and_out_of_range_lengths() {
+        assert!(!is_valid_commit_sha(""));
+        // Below the 7-char minimum (abbreviated SHA floor).
+        assert!(!is_valid_commit_sha("abc123"));
+        // Above the 64-char maximum (SHA-256 ceiling).
+        assert!(!is_valid_commit_sha(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn accepts_valid_lowercase_sha() {
+        // Abbreviated (7) and full SHA-1 (40) and SHA-256 (64) bounds.
+        assert!(is_valid_commit_sha("0123abc"));
+        assert!(is_valid_commit_sha(
+            "1234567890abcdef1234567890abcdef12345678"
+        ));
+        assert!(is_valid_commit_sha(&"a".repeat(64)));
+    }
+
+    #[test]
+    fn stamp_marker_refuses_non_sha_commit() {
+        // Defense-in-depth: even if a bad value bypasses the route guard, the
+        // stamping helper must never hand it to `Path::join`.
+        let err = stamp_review_passed_marker(Some("../../etc/x"))
+            .expect_err("non-SHA commit must be rejected");
+        assert!(err.contains("non-SHA"), "unexpected error: {err}");
+
+        let err = stamp_review_passed_marker(Some("/etc/passwd"))
+            .expect_err("absolute path must be rejected");
+        assert!(err.contains("non-SHA"), "unexpected error: {err}");
+    }
 }

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -10,6 +10,9 @@ use sqlx::Row;
 use crate::services as services_layer;
 
 use super::AppState;
+// #3863: reuse the verdict route's hardened SHA guard so the recovery route
+// cannot record a forged `reviewed_commit` marker for an arbitrary commit.
+use super::review_verdict::is_valid_commit_sha;
 
 // ── Body types ─────────────────────────────────────────────────
 
@@ -43,6 +46,23 @@ struct ReviewRecoveryDispatch {
 
 fn validate_review_decision(decision: &str) -> bool {
     decision == "accept" || decision == "reject"
+}
+
+/// #3863: reject a non-SHA recovery `target_commit` before it is persisted as the
+/// `reviewed_commit` deploy-gate marker. Pure (no I/O) so the recovery route can
+/// reject as early as possible — before any Postgres transaction or marker
+/// write — and so the guard is unit-testable without a live database. Shares the
+/// `is_valid_commit_sha` predicate with the verdict route (single source of
+/// truth), keeping the same HTTP 400 error shape for an invalid commit.
+fn validate_recovery_target_commit(commit: &str) -> Result<(), (StatusCode, String)> {
+    if is_valid_commit_sha(commit) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::BAD_REQUEST,
+            "target_commit must be a lowercase git SHA matching ^[0-9a-f]{7,64}$".to_string(),
+        ))
+    }
 }
 
 fn trimmed_optional(value: Option<String>) -> Option<String> {
@@ -210,6 +230,14 @@ async fn recover_review_target_pg(
     let reason = trimmed_optional(body.reason)
         .unwrap_or_else(|| "manual review target recovery".to_string());
 
+    // #3863: `target_commit` is attacker-influenceable (request body) and is
+    // persisted as the `reviewed_commit` deploy-gate marker below. Reject any
+    // non-SHA value with 400 before any Postgres read/write so a forged
+    // "review passed" marker can never be recorded for an arbitrary commit.
+    if let Some(commit) = requested_commit.as_deref() {
+        validate_recovery_target_commit(commit)?;
+    }
+
     let dispatch =
         load_review_recovery_dispatch_pg(pool, dispatch_id.as_deref(), card_id.as_deref())
             .await
@@ -287,6 +315,13 @@ async fn recover_review_target_pg(
             ),
         ));
     }
+
+    // #3863: defense-in-depth — re-validate the resolved `target_commit` right
+    // before it is written into the dispatch context as the `reviewed_commit`
+    // marker, regardless of source (request body, inferred worktree HEAD, or
+    // stored dispatch context). Mirrors the verdict route's belt-and-suspenders
+    // check in `stamp_review_passed_marker`.
+    validate_recovery_target_commit(&target_commit)?;
 
     let previous_context = dispatch.context.clone();
     context_obj.insert("reviewed_commit".to_string(), json!(target_commit));
@@ -620,5 +655,57 @@ pub async fn trigger_rework(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("{e}")})),
         ),
+    }
+}
+
+#[cfg(test)]
+mod recovery_commit_validation_tests {
+    //! #3863: the /api/reviews/recovery route must apply the same SHA guard the
+    //! verdict route uses, so a forged "review passed" marker cannot be recorded
+    //! for an arbitrary `target_commit`.
+    use super::{is_valid_commit_sha, validate_recovery_target_commit};
+    use axum::http::StatusCode;
+
+    #[test]
+    fn accepts_valid_lowercase_sha() {
+        // Abbreviated (7), full SHA-1 (40), and SHA-256 (64) bounds are accepted.
+        assert!(validate_recovery_target_commit("0123abc").is_ok());
+        assert!(
+            validate_recovery_target_commit("1234567890abcdef1234567890abcdef12345678").is_ok()
+        );
+        assert!(validate_recovery_target_commit(&"a".repeat(64)).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_target_commit_with_400_and_no_marker() {
+        // Uppercase, too-short, non-hex, and path-traversal inputs must all be
+        // rejected with HTTP 400. The guard returns `Err` before the route
+        // reaches `pool.begin()`, so no `reviewed_commit` marker is ever
+        // persisted (no db/fs write happens on the rejection path).
+        for bad in [
+            "ABCDEF0",                 // uppercase hex
+            "abc123",                  // below the 7-char floor
+            "zzzzzzz",                 // non-hex letters
+            "../../etc",               // path traversal
+            "../review_passed/forged", // marker-forgery attempt
+            "/etc/passwd",             // absolute path
+        ] {
+            let err = validate_recovery_target_commit(bad)
+                .expect_err("non-SHA target_commit must be rejected");
+            assert_eq!(err.0, StatusCode::BAD_REQUEST, "input: {bad}");
+            assert!(
+                err.1.contains("^[0-9a-f]{7,64}$"),
+                "input: {bad}, msg: {}",
+                err.1
+            );
+        }
+    }
+
+    #[test]
+    fn shares_predicate_with_verdict_route() {
+        // The recovery guard is backed by the same `is_valid_commit_sha`
+        // predicate the verdict route hardened in #3863 (single source of truth).
+        assert!(is_valid_commit_sha("0123abc"));
+        assert!(!is_valid_commit_sha("../../etc"));
     }
 }

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -271,6 +271,17 @@ async fn recover_review_target_pg(
             )
         })?;
 
+    // #3863 (codex re-review): validate the RESOLVED `target_commit` from EVERY
+    // source — request body, inferred worktree HEAD, or stored dispatch context
+    // (`reviewed_commit`) — immediately after resolution and BEFORE any git/shell
+    // use. The early body-check above only covers a body-supplied value; when the
+    // body omits `target_commit`, a poisoned stored/HEAD value (e.g.
+    // `--output=/tmp/x`) would otherwise reach `commit_belongs_to_card_issue_pg`
+    // below and be passed to `git log` as an argument (argument injection →
+    // filesystem write) before the later re-validation runs. This guard closes
+    // the resolved-before-git-log window for all sources.
+    validate_recovery_target_commit(&target_commit)?;
+
     if let Some(path) = worktree_path.as_deref() {
         let head = worktree_head(path).map_err(|error| (StatusCode::BAD_REQUEST, error))?;
         if head != target_commit {
@@ -707,5 +718,43 @@ mod recovery_commit_validation_tests {
         // predicate the verdict route hardened in #3863 (single source of truth).
         assert!(is_valid_commit_sha("0123abc"));
         assert!(!is_valid_commit_sha("../../etc"));
+    }
+
+    #[test]
+    fn rejects_resolved_commit_from_stored_context_or_head_before_git() {
+        // #3863 (codex re-review): when `body.target_commit` is ABSENT, the
+        // recovery handler resolves `target_commit` from the inferred worktree
+        // HEAD or the stored dispatch context (`reviewed_commit`) — sources the
+        // early body-check does NOT cover. `recover_review_target_pg` applies
+        // `validate_recovery_target_commit(&target_commit)?` to that RESOLVED
+        // value immediately after the
+        // `requested_commit.or(inferred_worktree_commit).or(existing_commit)`
+        // binding and BEFORE the first git/shell use,
+        // `commit_belongs_to_card_issue_pg`, which runs `git log <commit>`
+        // (commit passed as a positional argument with no `--` separator).
+        //
+        // Structural guarantee: because the guard returns `Err((400, _))` first,
+        // a poisoned stored/HEAD value never reaches that `git log` call, so the
+        // argument-injection vector (e.g. `git log … --output=/tmp/x` writing an
+        // arbitrary file) cannot fire. The full handler needs a live PgPool, so
+        // — like the existing recovery tests — we assert the guard predicate on
+        // the exact poisoned values an attacker could plant in a stored context
+        // or have a worktree HEAD resolve to.
+        for poisoned in [
+            "--output=/tmp/x",            // git log --output= → arbitrary file write
+            "--upload-pack=/tmp/evil.sh", // option/command injection
+            "--no-such-flag",             // any leading-dash option is rejected
+            "../../etc",                  // path traversal
+            "../review_passed/forged",    // marker-forgery attempt
+        ] {
+            let err = validate_recovery_target_commit(poisoned)
+                .expect_err("poisoned resolved target_commit must be rejected pre-git");
+            assert_eq!(err.0, StatusCode::BAD_REQUEST, "input: {poisoned}");
+            assert!(
+                err.1.contains("^[0-9a-f]{7,64}$"),
+                "input: {poisoned}, msg: {}",
+                err.1
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem (#3863, P0)
`POST /api/reviews/verdict` stamped the deploy-gate marker via `std::fs::write(dir.join(&commit), "")` with an **unvalidated** `commit`:
- `Path::join` honours an absolute path (discarding `runtime/review_passed/`) and `..` segments → arbitrary file create / empty-truncate writable by the dcserver user (config, launchd plist, …).
- The **legacy dispatch** arm `(submitted, None) => submitted.clone()` accepted `body.commit` verbatim → a loopback caller (on-host reviewer agent ingesting PR/issue text = prompt-injection vector) could forge a `review_passed/<arbitrary SHA>` marker and bypass the cross-provider review gate.

## Fix
- Add `is_valid_commit_sha` (`^[0-9a-f]{7,64}$`, lowercase-only) reusing the `credential.rs` allowlist idiom.
- Reject a non-conforming `body.commit` with **400** before any FS access.
- `stamp_review_passed_marker` re-validates the resolved commit (body / stored context / `git HEAD`) as defense-in-depth and returns `Err` (→ rollback) rather than touching `Path::join`.
- Harden the legacy arm: a dispatch without a server-stored `reviewed_commit` no longer trusts `body.commit`; it falls back to the server-derived HEAD, so the marker can only ever name a commit the server itself observed. Forgery path closed.

## Scope guard
- Did **not** touch `src/server/routes/mod.rs` (owned by #3870). Changes limited to the verdict route + maintenance docs.

## Tests
`server::routes::review_verdict::verdict_route::commit_validation_tests` (6, all pass): reject `../../etc/x`, `../review_passed/forged`, absolute paths, uppercase/non-hex, NUL, empty, out-of-range lengths; accept valid lowercase SHAs (7/40/64); `stamp_review_passed_marker` refuses non-SHA inputs.

## CI gates
- `cargo fmt --check` clean.
- `cargo check --lib` clean (pre-existing warnings only).
- `cargo test --lib server::routes::review_verdict::verdict_route` → 6 passed.
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → "agent-maintenance freshness check passed". Regeneration also refreshed pre-existing stale generated inventory (tmux/recovery_engine/inflight/rollout_tail freeze entries synced to module-inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)