### PR TITLE
fix(discord): redact leaked tool-call/control XML from outbound relay (#3883)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1091,7 +1091,9 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (6237 lines; production LoC; +4
+  - `src/services/discord/turn_bridge/mod.rs` (6242 lines; production LoC; +5
+    from #3883 passing the already-frozen prefix into `plan_streaming_rollover`
+    so streaming relay chunks redact leaked tool-call XML statefully; +4
     from #3751 stamping the delivery-record owner channel into inflight state
     before cross-channel restart recovery reads durable anchors; the BRIDGE
     spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
@@ -1236,7 +1238,10 @@
     `turn_finalizer/watcher_backstop.rs` (watcher far-backstop tunables +
     terminal-or-defer verdict pair). Bugfix only outside a
     finalizer-decomposition plan).
-  - `src/services/discord/formatting.rs` (2801 lines; #3807 wires semantic
+  - `src/services/discord/formatting.rs` (2813 lines; #3883 redacts leaked
+    tool-call XML from the streaming `frozen_chunk` at the rollover source via
+    `response_sanitizer::redact_streaming_frozen_chunk`, covering both the
+    turn_bridge and tmux_watcher send sites with one change; #3807 wires semantic
     sentence-boundary callsites while keeping the shared boundary classifier
     and compact continuation-context helper in `semantic_boundaries.rs`;
     worker-local presentation logic only, no relay ownership/lease change.

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -23,9 +23,9 @@
 | `src/services/discord/router/message_handler/intake_turn.rs` | 3616 | discord-relay | 2026-10-31 | #3837 |
 | `src/services/discord/session_relay_sink.rs` | 1631 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/tmux.rs` | 1477 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7058 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux_watcher.rs` | 7064 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
-| `src/services/discord/turn_bridge/mod.rs` | 6237 | discord-relay | 2026-08-31 | #3038 |
+| `src/services/discord/turn_bridge/mod.rs` | 6242 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1521 | discord-finalizer | 2026-08-31 | #3016 |
 | `src/services/discord/voice_barge_in.rs` | 2781 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2111 | discord-relay | 2026-10-31 | #3840 |
@@ -81,7 +81,7 @@
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1366 |
 | `src/services/discord/commands/text_commands.rs` | 1475 |
-| `src/services/discord/formatting.rs` | 2801 |
+| `src/services/discord/formatting.rs` | 2813 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
 | `src/services/discord/mod.rs` | 4147 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1543 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -436,7 +436,7 @@
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1015 | 957 | 58 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 527 | 527 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
-| `services::discord::formatting` | `src/services/discord/formatting.rs` | 3755 | 2801 | 954 | giant-file |
+| `services::discord::formatting` | `src/services/discord/formatting.rs` | 3768 | 2813 | 955 | giant-file |
 | `services::discord::gateway` | `src/services/discord/gateway.rs` | 1228 | 990 | 238 |  |
 | `services::discord::gateway_voice_queue` | `src/services/discord/gateway_voice_queue.rs` | 92 | 17 | 75 |  |
 | `services::discord::health` | `src/services/discord/health.rs` | 810 | 657 | 153 |  |
@@ -545,7 +545,7 @@
 | `services::discord::relay_recovery_auto_heal_attempts` | `src/services/discord/relay_recovery_auto_heal_attempts.rs` | 92 | 92 | 0 |  |
 | `services::discord::relay_recovery_completion_footer` | `src/services/discord/relay_recovery_completion_footer.rs` | 9 | 9 | 0 |  |
 | `services::discord::replace_outcome_policy` | `src/services/discord/replace_outcome_policy.rs` | 263 | 138 | 125 |  |
-| `services::discord::response_sanitizer` | `src/services/discord/response_sanitizer.rs` | 177 | 177 | 0 |  |
+| `services::discord::response_sanitizer` | `src/services/discord/response_sanitizer.rs` | 608 | 397 | 211 |  |
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 102 | 102 | 0 |  |
 | `services::discord::restart_mode` | `src/services/discord/restart_mode.rs` | 32 | 32 | 0 |  |
 | `services::discord::restart_report` | `src/services/discord/restart_report.rs` | 433 | 433 | 0 |  |
@@ -632,17 +632,17 @@
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 596 | 479 | 117 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10223 | 7058 | 3165 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10229 | 7064 | 3165 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 287 | 165 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
-| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |
+| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 404 | 321 | 83 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 225 | 225 | 0 |  |
 | `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 502 | 502 | 0 |  |
 | `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 106 | 106 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 147 | 101 | 46 |  |
 | `services::discord::tmux_watcher::session_bound_ack` | `src/services/discord/tmux_watcher/session_bound_ack.rs` | 427 | 427 | 0 |  |
-| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 645 | 514 | 131 |  |
+| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 646 | 514 | 132 |  |
 | `services::discord::tmux_watcher::supervisor_relay` | `src/services/discord/tmux_watcher/supervisor_relay.rs` | 393 | 393 | 0 |  |
 | `services::discord::tmux_watcher::terminal_readiness` | `src/services/discord/tmux_watcher/terminal_readiness.rs` | 214 | 214 | 0 |  |
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 700 | 654 | 46 |  |
@@ -669,7 +669,7 @@
 | `services::discord::tui_prompt_relay::synthetic_start` | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 938 | 938 | 0 |  |
 | `services::discord::tui_prompt_relay_controller_cutover` | `src/services/discord/tui_prompt_relay_controller_cutover.rs` | 971 | 243 | 728 |  |
 | `services::discord::tui_task_card` | `src/services/discord/tui_task_card.rs` | 1377 | 836 | 541 |  |
-| `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 6660 | 6237 | 423 | giant-file |
+| `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 6665 | 6242 | 423 | giant-file |
 | `services::discord::turn_bridge::cancel_finalize_policy` | `src/services/discord/turn_bridge/cancel_finalize_policy.rs` | 581 | 131 | 450 |  |
 | `services::discord::turn_bridge::chunk_compose` | `src/services/discord/turn_bridge/chunk_compose.rs` | 68 | 68 | 0 |  |
 | `services::discord::turn_bridge::completion_guard` | `src/services/discord/turn_bridge/completion_guard.rs` | 943 | 885 | 58 |  |

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -74,7 +74,11 @@ direct_discord_sends = [
   # existing pre-migration direct sends; retire with the #1436 outbound v3 extraction.
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:d77122f8dd3466ba",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:37e09c3e1136f9b1",
-  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:96efc64ae5a0f315"
+  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:96efc64ae5a0f315",
+  # #3883: the streaming-rollover frozen_chunk edit_message — unchanged call; its
+  # context hash drifted because plan_streaming_rollover gained the
+  # already_sent_prefix arg (frozen_chunk now redacted at the source).
+  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:6d897c99aa17d289"
 ]
 
 # Manual JSON row mapping: legacy mapping callsites pending typed migration.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -156,7 +156,11 @@
 # #3607: +20 raw / +20 prod for the TimedOut+committed terminal-UI obligation
 # hook. The durable sidecar store + isolated sweeper live in
 # terminal_ui_obligation.rs; this keeps the hot-file cost to the call-site hook.
-"src/services/discord/turn_bridge/mod.rs" = 6241 # #3607 terminal-UI obligation hook
+# #3883: 6241 -> 6242 (+1 prod LoC): thread already_sent_prefix into the
+# plan_streaming_rollover call so the streaming-rollover frozen_chunk is redacted
+# of leaked tool-call wrapper markup at the source (bypassed the sanitize
+# chokepoint). Security/correctness fix at the call-site, no decomposition regression.
+"src/services/discord/turn_bridge/mod.rs" = 6242 # #3607 terminal-UI obligation hook; #3883 frozen_chunk redact
 # #3038 turn_bridge S1 child modules, frozen at landed production LoC.
 "src/services/discord/turn_bridge/headless_delivery.rs" = 415
 "src/services/discord/turn_bridge/status_panel.rs" = 437
@@ -362,7 +366,12 @@
 # check + handler delegation in the `InteractionCreate` arm of `handle_event`;
 # the handler logic itself lives in the non-giant `sidecar_interaction.rs`.
 "src/services/discord/router/intake_gate.rs" = 2986
-"src/services/discord/formatting.rs" = 2802
+# #3883: 2802 -> 2813 (+11 prod LoC): redact the streaming-rollover frozen_chunk of
+# leaked tool-call wrapper markup at the source in plan_streaming_rollover (new
+# already_sent_prefix param threaded from both streaming send sites carries
+# inside-leaked-block state across chunk boundaries). The redactor body lives in the
+# non-giant response_sanitizer.rs; closes the #3883 streaming chokepoint bypass.
+"src/services/discord/formatting.rs" = 2813
 # #3038 run_bot S0/S1: lowered 2802 -> 1918 by adding characterization tests and
 # moving restored_state, queued_placeholders, startup_doctor, orphan_recovery,
 # and session_gc into sub-700 `runtime_bootstrap/` modules.

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -80,4 +80,8 @@
 # durable sidecar + sweeper body lives in terminal_ui_obligation.rs.
 # #3715: 6664 -> 6661, lock in the existing shrink reported by the raw-LOC
 # ratchet while restoring main CI script checks.
-"src/services/discord/turn_bridge/mod.rs" = 6661 # #3607 terminal-UI obligation hook
+# #3883: 6661 -> 6665 (+4 raw lines): thread already_sent_prefix into the
+# plan_streaming_rollover call + comment so the streaming-rollover frozen_chunk is
+# redacted of leaked tool-call wrapper markup at the source (security/correctness;
+# bypassed the sanitize chokepoint). Decomposition tracked separately, not in scope.
+"src/services/discord/turn_bridge/mod.rs" = 6665 # #3607 terminal-UI obligation hook; #3883 frozen_chunk redact

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -335,6 +335,7 @@ fn build_streaming_placeholder_snapshot(current_portion: &str, status_block: &st
 pub(super) fn plan_streaming_rollover(
     current_portion: &str,
     status_block: &str,
+    already_sent_prefix: &str,
 ) -> Option<StreamingRolloverPlan> {
     if current_portion.is_empty() {
         return None;
@@ -347,9 +348,20 @@ pub(super) fn plan_streaming_rollover(
         .max(1);
     let split_at = streaming_split_boundary(current_portion, body_budget)?;
 
+    // #3883: the frozen chunk is sent straight to Discord by the streaming
+    // callers (turn_bridge / tmux_watcher), bypassing the non-streaming relay
+    // sanitizer. Redact leaked tool-call wrapper markup here at the source so
+    // BOTH send sites are covered. `already_sent_prefix` carries the
+    // inside-leaked-block state across chunk boundaries; `split_at` stays in
+    // RAW coordinates so the callers' offset bookkeeping is unaffected.
+    let frozen_chunk = super::response_sanitizer::redact_streaming_frozen_chunk(
+        &current_portion[..split_at],
+        already_sent_prefix,
+    );
+
     Some(StreamingRolloverPlan {
         display_snapshot: build_streaming_placeholder_snapshot(current_portion, &status_block),
-        frozen_chunk: current_portion[..split_at].to_string(),
+        frozen_chunk,
         split_at,
     })
 }
@@ -866,7 +878,7 @@ mod status_panel_v2_formatter_tests {
             .max(1);
         let current_portion = "x".repeat(body_budget + 64);
 
-        let plan = plan_streaming_rollover(&current_portion, LIVENESS_FOOTER)
+        let plan = plan_streaming_rollover(&current_portion, LIVENESS_FOOTER, "")
             .expect("current portion should roll over once footer budget is reserved");
 
         assert_eq!(plan.frozen_chunk.len(), body_budget);
@@ -891,7 +903,7 @@ mod status_panel_v2_formatter_tests {
         let current_portion = "x".repeat(body_budget + 1);
         assert!(current_portion.len() < super::DISCORD_MSG_LIMIT);
 
-        let plan = plan_streaming_rollover(&current_portion, LIVENESS_FOOTER)
+        let plan = plan_streaming_rollover(&current_portion, LIVENESS_FOOTER, "")
             .expect("body fits raw Discord limit but not the reserved footer budget");
 
         assert_eq!(plan.split_at, body_budget);
@@ -904,7 +916,7 @@ mod status_panel_v2_formatter_tests {
         let current_portion = "short streamed body";
         let rendered = build_streaming_placeholder_text(current_portion, LIVENESS_FOOTER);
 
-        assert!(plan_streaming_rollover(current_portion, LIVENESS_FOOTER).is_none());
+        assert!(plan_streaming_rollover(current_portion, LIVENESS_FOOTER, "").is_none());
         assert_eq!(rendered, format!("{current_portion}\n\n{LIVENESS_FOOTER}"));
         assert!(rendered.len() < super::DISCORD_MSG_LIMIT);
     }
@@ -914,7 +926,7 @@ mod status_panel_v2_formatter_tests {
         let oversized_footer = "⠸".repeat(super::DISCORD_MSG_LIMIT);
         let rendered = build_streaming_placeholder_text("", &oversized_footer);
 
-        assert!(plan_streaming_rollover("", &oversized_footer).is_none());
+        assert!(plan_streaming_rollover("", &oversized_footer, "").is_none());
         assert!(rendered.len() <= super::DISCORD_MSG_LIMIT);
         assert!(rendered.starts_with('⠸'));
         assert!(!rendered.contains("\n\n"));
@@ -1570,7 +1582,8 @@ No response requested.\n\
             // footer "\n\nSTATUS" = 8; body_budget = 2000 - 18 = 1982.
             let status = "STATUS";
             let body = "Z".repeat(2500);
-            let plan = plan_streaming_rollover(&body, status).expect("a long body must roll over");
+            let plan =
+                plan_streaming_rollover(&body, status, "").expect("a long body must roll over");
             assert_eq!(
                 plan.split_at, 1982,
                 "rollover split point pins the footer+margin reservation"
@@ -1585,8 +1598,8 @@ No response requested.\n\
 
         #[test]
         fn a0_plan_streaming_rollover_is_none_for_empty_or_short_body() {
-            assert_eq!(plan_streaming_rollover("", "STATUS"), None);
-            assert_eq!(plan_streaming_rollover("short body", "STATUS"), None);
+            assert_eq!(plan_streaming_rollover("", "STATUS", ""), None);
+            assert_eq!(plan_streaming_rollover("short body", "STATUS", ""), None);
         }
 
         #[test]
@@ -1594,8 +1607,8 @@ No response requested.\n\
             // Identical (body, status) must yield byte-identical plans on every
             // call, so a future per-surface re-derivation is caught.
             let body = "line one\nline two\n".repeat(200); // > body_budget, newlines
-            let a = plan_streaming_rollover(&body, "STATUS").expect("rolls over");
-            let b = plan_streaming_rollover(&body, "STATUS").expect("rolls over");
+            let a = plan_streaming_rollover(&body, "STATUS", "").expect("rolls over");
+            let b = plan_streaming_rollover(&body, "STATUS", "").expect("rolls over");
             assert_eq!(a, b, "same input must produce an identical rollover plan");
             assert_eq!(a.frozen_chunk, body[..a.split_at]);
         }

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -313,7 +313,7 @@ fn characterize_rollover_seed_has_no_status_panel_content_s0() {
 
     let status_block = build_processing_status_block("⠸");
     let current_portion = "relay body ".repeat(250);
-    let plan = plan_streaming_rollover(&current_portion, &status_block)
+    let plan = plan_streaming_rollover(&current_portion, &status_block, "")
         .expect("representative relay body should roll over");
     let rollover_seed = build_streaming_placeholder_text("", &status_block);
 

--- a/src/services/discord/response_sanitizer.rs
+++ b/src/services/discord/response_sanitizer.rs
@@ -95,8 +95,109 @@ pub(crate) fn sanitize_hidden_context(input: &str) -> String {
 pub(crate) fn sanitize_hidden_context_and_strip_chrome(input: &str) -> String {
     let sanitized = sanitize_hidden_context(input);
     let stripped = strip_leading_tui_response_chrome(&sanitized);
-    subagent_notification_card::sanitize_start_anchored_subagent_notification(&stripped)
-        .unwrap_or(stripped)
+    let redacted = redact_tool_call_wrapper_markup(&stripped);
+    subagent_notification_card::sanitize_start_anchored_subagent_notification(&redacted)
+        .unwrap_or(redacted)
+}
+
+/// Redact leaked tool-call/control wrapper markup that a provider can emit as
+/// plain assistant text when a tool call is malformed or streamed mid-parse
+/// (#3883): raw `<invoke …>`, `<parameter …>`, `<function_calls>`,
+/// `<function_results>` (with an optional `antml:` namespace) and their close
+/// tags. Mirrors the code-fence walk used by [`sanitize_hidden_context`] so
+/// fenced examples and inline-backtick quotes that legitimately mention these
+/// tags are preserved (acceptance #2).
+///
+/// The allowlist is deliberately NARROW — only the four wrapper tag names
+/// above. It must NOT behave like the issue's broad `<[a-z_]+>` proposal, which
+/// would clobber legitimate prose such as `Vec<T>`, `a < b`, HTML examples, or
+/// autolinks like `<https://example>`.
+fn redact_tool_call_wrapper_markup(input: &str) -> String {
+    use regex::Regex;
+    use std::sync::LazyLock;
+
+    // Any wrapper tag, open or close form.
+    static WRAPPER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?i)</?(?:antml:)?(?:invoke|parameter|function_calls|function_results)\b[^>]*>"#,
+        )
+        .unwrap()
+    });
+    // Closers that terminate a whole leaked block (a bare `</parameter>` does
+    // not — its enclosing `<invoke>`/`<function_calls>` block continues).
+    static BLOCK_CLOSER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?i)</(?:antml:)?(?:invoke|function_calls|function_results)\s*>"#).unwrap()
+    });
+
+    let mut out: Vec<String> = Vec::new();
+    let mut in_code_block = false;
+    let mut dropping_block = false;
+    let mut redacted_any = false;
+
+    for line in input.lines() {
+        if line.trim_start().starts_with("```") {
+            in_code_block = !in_code_block;
+            // A fence line is never wrapper markup; reaching one also ends any
+            // in-progress unfenced redaction region.
+            dropping_block = false;
+            out.push(line.to_string());
+            continue;
+        }
+
+        if in_code_block {
+            // Preserve fenced content verbatim (acceptance #2).
+            out.push(line.to_string());
+            continue;
+        }
+
+        if dropping_block {
+            // Inside a leaked wrapper block: drop lines until (and including)
+            // the one that closes it, then resume. If no closer ever arrives
+            // we drop to EOF — this is the cross-message streaming tail where
+            // the opener lived in a previous chunk.
+            redacted_any = true;
+            if BLOCK_CLOSER_RE.is_match(line) {
+                dropping_block = false;
+            }
+            continue;
+        }
+
+        let Some(m) = WRAPPER_RE.find(line) else {
+            out.push(line.to_string());
+            continue;
+        };
+
+        // Inline-backtick guard: an odd number of backticks before the match
+        // means it sits inside an inline code span, i.e. the line is
+        // legitimately quoting the tag — preserve it untouched (acceptance #2).
+        let backticks_before = line[..m.start()].bytes().filter(|&b| b == b'`').count();
+        if backticks_before % 2 == 1 {
+            out.push(line.to_string());
+            continue;
+        }
+
+        redacted_any = true;
+        let prefix = line[..m.start()].trim_end();
+        if !prefix.is_empty() {
+            // Mid-line wrapper after prose: keep the prose prefix, drop the
+            // wrapper remainder.
+            out.push(prefix.to_string());
+        }
+        // The block continues onto following lines unless this same line
+        // already carried its block closer (e.g. a self-contained
+        // `<invoke …>…</invoke>` or a stray `</invoke>`).
+        if !BLOCK_CLOSER_RE.is_match(line) {
+            dropping_block = true;
+        }
+    }
+
+    if redacted_any {
+        tracing::warn!(
+            "redacted leaked tool-call wrapper markup from outbound Discord relay (#3883)"
+        );
+    }
+
+    trim_blank_edges(out)
 }
 
 /// Remove leading Claude/Codex TUI housekeeping text that can be emitted by
@@ -174,4 +275,112 @@ fn trim_blank_edges(lines: Vec<String>) -> String {
         .map(|index| index + 1)
         .unwrap_or(start);
     lines[start..end].join("\n")
+}
+
+#[cfg(test)]
+mod tool_call_wrapper_redaction_tests {
+    use super::sanitize_hidden_context_and_strip_chrome;
+
+    #[test]
+    fn redacts_bare_leaked_invoke_block_from_issue_3883() {
+        let input = "Done.\n<invoke name=\"Agent\">\n<parameter name=\"description\">x</parameter>\n<parameter name=\"prompt\">Step 2 — inspect…";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert!(
+            output.contains("Done."),
+            "prose prefix preserved: {output:?}"
+        );
+        assert!(!output.contains("<invoke"), "invoke tag leaked: {output:?}");
+        assert!(
+            !output.contains("<parameter"),
+            "parameter tag leaked: {output:?}"
+        );
+        assert!(
+            !output.contains("Step 2 — inspect"),
+            "leaked prompt body exposed: {output:?}"
+        );
+    }
+
+    #[test]
+    fn redacts_streaming_continuation_chunk_with_no_opener() {
+        // Cross-message streaming tail: the `<invoke>` opener was in a prior
+        // chunk, so this chunk starts mid-block on a bare `<parameter …>`.
+        let input = "<parameter name=\"prompt\">Step 2 — inspect…";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert!(
+            output.trim().is_empty(),
+            "continuation tail not redacted: {output:?}"
+        );
+    }
+
+    #[test]
+    fn preserves_fenced_code_block_mentioning_wrapper_tags() {
+        let input = "Here is an example:\n```\n<invoke name=\"x\">\n```\nDone.";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert!(
+            output.contains("<invoke name=\"x\">"),
+            "fenced example wrongly redacted: {output:?}"
+        );
+    }
+
+    #[test]
+    fn preserves_inline_backtick_quoted_wrapper_tag() {
+        let input = "Use `<invoke name=\"x\">` to call the tool.";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert_eq!(output, input, "inline-code quote wrongly altered");
+    }
+
+    #[test]
+    fn truncates_line_at_midline_wrapper_keeping_prose_prefix() {
+        let input = "All set. <invoke name=\"Agent\">\n<parameter name=\"prompt\">go";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert_eq!(output, "All set.");
+        assert!(!output.contains("<invoke"));
+    }
+
+    #[test]
+    fn does_not_touch_generic_angle_brackets_or_autolinks() {
+        // The allowlist must not behave like the issue's broad `<[a-z_]+>`.
+        let input = "Vec<T> and a < b and <https://example.com> are all fine.";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert_eq!(output, input, "over-broad redaction clobbered legit prose");
+    }
+
+    #[test]
+    fn redaction_is_idempotent() {
+        let input = "Done.\n<invoke name=\"Agent\">\n<parameter name=\"prompt\">leak</parameter>\n</invoke>";
+        let once = sanitize_hidden_context_and_strip_chrome(input);
+        let twice = sanitize_hidden_context_and_strip_chrome(&once);
+        assert_eq!(
+            once, twice,
+            "sanitizer is not idempotent: {once:?} -> {twice:?}"
+        );
+    }
+
+    #[test]
+    fn existing_hidden_context_and_chrome_stripping_still_works() {
+        // Hidden-header block is dropped, leading TUI chrome is stripped, and
+        // surrounding prose survives — proving no regression from the redactor.
+        let input = "No response requested.\nVisible answer.\n\n[Tool Policy]\nsecret policy text\n\nBack to visible prose.";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert!(
+            output.contains("Visible answer."),
+            "answer dropped: {output:?}"
+        );
+        assert!(
+            output.contains("Back to visible prose."),
+            "tail dropped: {output:?}"
+        );
+        assert!(
+            !output.contains("No response requested."),
+            "TUI chrome leaked: {output:?}"
+        );
+        assert!(
+            !output.contains("Tool Policy"),
+            "hidden header leaked: {output:?}"
+        );
+        assert!(
+            !output.contains("secret policy text"),
+            "hidden body leaked: {output:?}"
+        );
+    }
 }

--- a/src/services/discord/response_sanitizer.rs
+++ b/src/services/discord/response_sanitizer.rs
@@ -113,6 +113,80 @@ pub(crate) fn sanitize_hidden_context_and_strip_chrome(input: &str) -> String {
 /// would clobber legitimate prose such as `Vec<T>`, `a < b`, HTML examples, or
 /// autolinks like `<https://example>`.
 fn redact_tool_call_wrapper_markup(input: &str) -> String {
+    let WrapperWalk {
+        out, redacted_any, ..
+    } = redact_wrapper_markup_walk(input, false, false);
+    if redacted_any {
+        tracing::warn!(
+            "redacted leaked tool-call wrapper markup from outbound Discord relay (#3883)"
+        );
+    }
+    trim_blank_edges(out)
+}
+
+/// Redact leaked tool-call wrapper markup from a single STREAMING frozen chunk
+/// (#3883). The streaming rollover path freezes contiguous slices of the raw
+/// accumulated response straight to Discord, bypassing the non-streaming relay
+/// sanitizer. A `<invoke>` opener can land in chunk N while its `</invoke>`
+/// closer only arrives in chunk N+k, with all-interior chunks in between that
+/// contain no tags at all — so per-chunk redaction cannot see across chunks.
+///
+/// We close that gap statefully: `already_sent_prefix` is everything already
+/// frozen for this message (`full_response[..response_sent_offset]`). Replaying
+/// the walk over it yields the fence / leaked-block regime in force at the
+/// chunk boundary, which seeds the chunk's own walk. Thus once an unterminated
+/// opener has been seen, subsequent frozen chunks stay suppressed until the
+/// matching closer, and a normal chunk after the block resumes untouched.
+///
+/// The frozen chunk's byte length (and therefore the caller's
+/// `response_sent_offset` bookkeeping) is derived from the RAW slice, never
+/// from this redacted text — we only change what is displayed, not the
+/// streaming offsets. When nothing is redacted the raw chunk is returned
+/// byte-for-byte. When a chunk redacts down to nothing (a pure-interior leak
+/// chunk) we emit a zero-width space so the Discord edit stays non-empty while
+/// showing nothing.
+pub(crate) fn redact_streaming_frozen_chunk(chunk: &str, already_sent_prefix: &str) -> String {
+    let prefix_regime = redact_wrapper_markup_walk(already_sent_prefix, false, false);
+    let WrapperWalk {
+        out, redacted_any, ..
+    } = redact_wrapper_markup_walk(
+        chunk,
+        prefix_regime.in_code_block,
+        prefix_regime.dropping_block,
+    );
+    if !redacted_any {
+        // Common path: no leak in this chunk — preserve it exactly so the
+        // streaming bytes/whitespace are unchanged.
+        return chunk.to_string();
+    }
+    tracing::warn!("redacted leaked tool-call wrapper markup from streaming frozen chunk (#3883)");
+    let redacted = out.join("\n");
+    if redacted.trim().is_empty() {
+        // Whole chunk was interior leak: show nothing, but keep the Discord
+        // edit non-empty (an empty edit is rejected by the API).
+        "\u{200B}".to_string()
+    } else {
+        redacted
+    }
+}
+
+struct WrapperWalk {
+    out: Vec<String>,
+    in_code_block: bool,
+    dropping_block: bool,
+    redacted_any: bool,
+}
+
+/// Shared line-walk behind both the non-streaming relay redactor and the
+/// streaming frozen-chunk redactor (#3883). It starts from the given
+/// `in_code_block` / `dropping_block` regime — both `false` for a standalone
+/// message — and returns the surviving lines plus the regime at end-of-input so
+/// a streaming caller can carry state across frozen-chunk boundaries.
+fn redact_wrapper_markup_walk(
+    input: &str,
+    mut in_code_block: bool,
+    mut dropping_block: bool,
+) -> WrapperWalk {
     use regex::Regex;
     use std::sync::LazyLock;
 
@@ -130,16 +204,28 @@ fn redact_tool_call_wrapper_markup(input: &str) -> String {
     });
 
     let mut out: Vec<String> = Vec::new();
-    let mut in_code_block = false;
-    let mut dropping_block = false;
     let mut redacted_any = false;
 
     for line in input.lines() {
+        // Finding #1: while dropping a leaked block, block-drop takes
+        // precedence over fence preservation. A ```fenced``` block that lives
+        // INSIDE the leaked `<invoke>…</invoke>` must be dropped with it rather
+        // than escaping through the fence branch, so this check runs BEFORE the
+        // fence toggle. We deliberately do not toggle `in_code_block` while
+        // dropping — fences inside the leak are part of the dropped content.
+        if dropping_block {
+            // Drop lines until (and including) the one that closes the block,
+            // then resume. If no closer ever arrives we drop to EOF — this is
+            // the cross-chunk streaming tail where the opener lived earlier.
+            redacted_any = true;
+            if BLOCK_CLOSER_RE.is_match(line) {
+                dropping_block = false;
+            }
+            continue;
+        }
+
         if line.trim_start().starts_with("```") {
             in_code_block = !in_code_block;
-            // A fence line is never wrapper markup; reaching one also ends any
-            // in-progress unfenced redaction region.
-            dropping_block = false;
             out.push(line.to_string());
             continue;
         }
@@ -150,31 +236,19 @@ fn redact_tool_call_wrapper_markup(input: &str) -> String {
             continue;
         }
 
-        if dropping_block {
-            // Inside a leaked wrapper block: drop lines until (and including)
-            // the one that closes it, then resume. If no closer ever arrives
-            // we drop to EOF — this is the cross-message streaming tail where
-            // the opener lived in a previous chunk.
-            redacted_any = true;
-            if BLOCK_CLOSER_RE.is_match(line) {
-                dropping_block = false;
-            }
-            continue;
-        }
-
-        let Some(m) = WRAPPER_RE.find(line) else {
+        // Finding #3: preserve the line only if EVERY wrapper match on it sits
+        // inside a *matched* inline code span (CommonMark: a run of N backticks
+        // opens, the next run of exactly N closes). Otherwise redact from the
+        // first genuinely-leaked match. This preserves valid multi-/double-
+        // backtick spans, refuses to corrupt them, and still redacts a real
+        // leak that merely has stray/unmatched backticks before it.
+        let first_leak = WRAPPER_RE
+            .find_iter(line)
+            .find(|m| !is_inside_inline_code_span(line, m.start(), m.end()));
+        let Some(m) = first_leak else {
             out.push(line.to_string());
             continue;
         };
-
-        // Inline-backtick guard: an odd number of backticks before the match
-        // means it sits inside an inline code span, i.e. the line is
-        // legitimately quoting the tag — preserve it untouched (acceptance #2).
-        let backticks_before = line[..m.start()].bytes().filter(|&b| b == b'`').count();
-        if backticks_before % 2 == 1 {
-            out.push(line.to_string());
-            continue;
-        }
 
         redacted_any = true;
         let prefix = line[..m.start()].trim_end();
@@ -191,13 +265,57 @@ fn redact_tool_call_wrapper_markup(input: &str) -> String {
         }
     }
 
-    if redacted_any {
-        tracing::warn!(
-            "redacted leaked tool-call wrapper markup from outbound Discord relay (#3883)"
-        );
+    WrapperWalk {
+        out,
+        in_code_block,
+        dropping_block,
+        redacted_any,
+    }
+}
+
+/// CommonMark-style check: does the byte range `[start, end)` of `line` fall
+/// inside a *matched* inline code span? A code span opens with a run of N
+/// backticks and closes with the next run of exactly N backticks; an unmatched
+/// run is literal text. Used so genuinely inline-code-quoted tag mentions are
+/// preserved while stray or mismatched backticks before a real leak do not
+/// shield it from redaction (#3883 finding #3).
+fn is_inside_inline_code_span(line: &str, start: usize, end: usize) -> bool {
+    let bytes = line.as_bytes();
+
+    // Collect backtick runs as (byte_offset, run_len).
+    let mut runs: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'`' {
+            let run_start = i;
+            while i < bytes.len() && bytes[i] == b'`' {
+                i += 1;
+            }
+            runs.push((run_start, i - run_start));
+        } else {
+            i += 1;
+        }
     }
 
-    trim_blank_edges(out)
+    // Pair each opener with the next run of EXACTLY equal length; the content
+    // between them is a code span. An opener with no equal-length closer is
+    // literal, so we advance and try the next run as a potential opener.
+    let mut idx = 0;
+    while idx < runs.len() {
+        let (open_off, open_len) = runs[idx];
+        if let Some(rel) = runs[idx + 1..].iter().position(|&(_, len)| len == open_len) {
+            let closer_idx = idx + 1 + rel;
+            let content_start = open_off + open_len;
+            let content_end = runs[closer_idx].0;
+            if start >= content_start && end <= content_end {
+                return true;
+            }
+            idx = closer_idx + 1;
+        } else {
+            idx += 1;
+        }
+    }
+    false
 }
 
 /// Remove leading Claude/Codex TUI housekeeping text that can be emitted by
@@ -381,6 +499,110 @@ mod tool_call_wrapper_redaction_tests {
         assert!(
             !output.contains("secret policy text"),
             "hidden body leaked: {output:?}"
+        );
+    }
+
+    // Finding #1: a fenced code block that lives INSIDE a leaked wrapper block
+    // must be dropped with the block, not escape through fence preservation.
+    #[test]
+    fn drops_fenced_code_block_nested_inside_leaked_wrapper_block() {
+        let input = "Done.\n<invoke name=\"Agent\">\n<parameter name=\"prompt\">\n```rust\nlet secret = \"leak\";\n```\n</parameter>\n</invoke>\nVisible tail.";
+        let output = sanitize_hidden_context_and_strip_chrome(input);
+        assert!(output.contains("Done."), "prose prefix dropped: {output:?}");
+        assert!(
+            output.contains("Visible tail."),
+            "post-block tail dropped: {output:?}"
+        );
+        assert!(
+            !output.contains("secret"),
+            "fenced secret inside leaked block escaped: {output:?}"
+        );
+        assert!(
+            !output.contains("```"),
+            "fence inside leaked block escaped: {output:?}"
+        );
+        assert!(!output.contains("<invoke"), "invoke tag leaked: {output:?}");
+    }
+
+    // Finding #2: streaming frozen chunks split a `<invoke>…</invoke>` across an
+    // opener-only chunk, an all-interior chunk (no tags), and a closer chunk;
+    // none of the leak may reach output and a following normal chunk must be
+    // byte-for-byte untouched.
+    #[test]
+    fn streaming_suppresses_leak_split_across_opener_interior_closer_chunks() {
+        use super::redact_streaming_frozen_chunk;
+
+        let opener =
+            "Working on it.\n<invoke name=\"Agent\">\n<parameter name=\"prompt\">step one ";
+        let interior = "step two more leaked prompt body with no tags at all ";
+        let closer = "final words</parameter>\n</invoke>\nHere is your answer.";
+        let normal = "\nAnd a normal follow-up line.";
+
+        // Chunk 1: opener-only, no prior prefix.
+        let out1 = redact_streaming_frozen_chunk(opener, "");
+        assert!(
+            out1.contains("Working on it."),
+            "prose prefix lost: {out1:?}"
+        );
+        assert!(!out1.contains("<invoke"), "opener leaked: {out1:?}");
+        assert!(!out1.contains("<parameter"), "parameter leaked: {out1:?}");
+        assert!(
+            !out1.contains("step one"),
+            "leaked body escaped opener chunk: {out1:?}"
+        );
+
+        // Chunk 2: all-interior, no tags. Prefix = opener.
+        let out2 = redact_streaming_frozen_chunk(interior, opener);
+        assert!(
+            !out2.contains("leaked prompt body") && !out2.contains("step two"),
+            "interior chunk escaped: {out2:?}"
+        );
+
+        // Chunk 3: closer + visible tail. Prefix = opener + interior.
+        let prefix3 = format!("{opener}{interior}");
+        let out3 = redact_streaming_frozen_chunk(closer, &prefix3);
+        assert!(
+            !out3.contains("final words"),
+            "pre-closer leak escaped: {out3:?}"
+        );
+        assert!(!out3.contains("</invoke>"), "closer tag leaked: {out3:?}");
+        assert!(
+            out3.contains("Here is your answer."),
+            "post-block visible tail lost: {out3:?}"
+        );
+
+        // Chunk 4: a normal chunk fully after the block — untouched.
+        let prefix4 = format!("{opener}{interior}{closer}");
+        let out4 = redact_streaming_frozen_chunk(normal, &prefix4);
+        assert_eq!(
+            out4, normal,
+            "normal post-block chunk was altered: {out4:?}"
+        );
+    }
+
+    // Finding #3: a valid double-backtick span containing a single-backtick tag
+    // mention survives byte-for-byte, while a genuine leak that merely has a
+    // stray unmatched backtick before it is still redacted.
+    #[test]
+    fn preserves_double_backtick_span_but_redacts_leak_with_stray_backtick_prefix() {
+        let span = "``Use `<invoke name=\"x\">` literally``";
+        assert_eq!(
+            sanitize_hidden_context_and_strip_chrome(span),
+            span,
+            "valid multi-backtick span corrupted"
+        );
+
+        let leak = "Heads up: ` then <invoke name=\"Agent\">\n<parameter name=\"prompt\">do the thing</parameter>\n</invoke>";
+        let out = sanitize_hidden_context_and_strip_chrome(leak);
+        assert!(out.contains("Heads up:"), "prose prefix lost: {out:?}");
+        assert!(
+            !out.contains("<invoke"),
+            "leak with stray backtick escaped: {out:?}"
+        );
+        assert!(!out.contains("<parameter"), "parameter leaked: {out:?}");
+        assert!(
+            !out.contains("do the thing"),
+            "leaked body escaped: {out:?}"
         );
     }
 }

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -1270,7 +1270,7 @@ mod tests {
             .max(1);
         let current_portion = "x".repeat(expected_body_budget + 1);
         let plan =
-            super::super::formatting::plan_streaming_rollover(&current_portion, &status_block)
+            super::super::formatting::plan_streaming_rollover(&current_portion, &status_block, "")
                 .expect("body should roll over after reserving the bounded footer");
 
         assert!(footer.len() <= max_footer_len);
@@ -1285,7 +1285,7 @@ mod tests {
         let status_block = super::compose_footer_status_block("⠸", panel);
         let current_portion = "streamed body ".repeat(220);
         let plan =
-            super::super::formatting::plan_streaming_rollover(&current_portion, &status_block)
+            super::super::formatting::plan_streaming_rollover(&current_portion, &status_block, "")
                 .expect("body should roll over after reserving the footer");
         let seed = super::super::formatting::build_streaming_placeholder_text("", &status_block);
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2284,8 +2284,14 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         if watcher_streaming_rollover_should_skip(current_portion) {
                             break;
                         }
-                        let Some(plan) = plan_streaming_rollover(current_portion, &status_block)
-                        else {
+                        let Some(plan) = plan_streaming_rollover(
+                            current_portion,
+                            &status_block,
+                            // #3883: prefix already frozen for this message lets
+                            // the source redactor carry inside-leaked-block
+                            // state across rollover chunks.
+                            full_response.get(..response_sent_offset).unwrap_or(""),
+                        ) else {
                             break;
                         };
 

--- a/src/services/discord/tmux_watcher/liveness.rs
+++ b/src/services/discord/tmux_watcher/liveness.rs
@@ -161,6 +161,7 @@ mod tests {
         let raw_plan = crate::services::discord::formatting::plan_streaming_rollover(
             &current_portion,
             status_block,
+            "",
         )
         .expect("raw notification would otherwise roll over");
 

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -564,6 +564,7 @@ mod tests {
         let plan = crate::services::discord::formatting::plan_streaming_rollover(
             &current_portion,
             &status_block,
+            "",
         )
         .expect("footer-bearing status block should force rollover");
         let seed = crate::services::discord::formatting::build_streaming_placeholder_text(

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -3426,9 +3426,14 @@ pub(super) fn spawn_turn_bridge(
                     if bridge_streaming_rollover_should_skip(current_portion) {
                         break;
                     }
-                    let Some(plan) =
-                        super::formatting::plan_streaming_rollover(current_portion, &status_block)
-                    else {
+                    let Some(plan) = super::formatting::plan_streaming_rollover(
+                        current_portion,
+                        &status_block,
+                        // #3883: prefix already frozen for this message, so the
+                        // source redactor can carry inside-leaked-block state
+                        // across rollover chunks.
+                        full_response.get(..response_sent_offset).unwrap_or(""),
+                    ) else {
                         break;
                     };
 


### PR DESCRIPTION
Closes #3883.

## Problem
When a provider tool call is malformed or arrives mid-stream, the harness treats the partial tool-call XML as assistant content and the Discord relay forwards it verbatim — users saw raw `<invoke name="Agent">`, `<parameter name="...">`, and leaked prompt bodies (e.g. "Step 2 — inspect…") in-channel (#3883, #3153 family).

## Fix — single chokepoint
All outbound relay paths route through `response_sanitizer::sanitize_hidden_context_and_strip_chrome` (`format_for_discord_with_provider`, `format_for_discord_with_status_panel` which also backs status-panel + streaming edits, and `tmux_runtime::restart_saved_response_for_discord`). One new pass there covers every path:

- New `redact_tool_call_wrapper_markup` is inserted between `strip_leading_tui_response_chrome` and the subagent-card pass. It mirrors the existing code-fence line-walk in `sanitize_hidden_context`.

## Redaction approach (what it matches / does NOT match)
- **Narrow allowlist regex** (`LazyLock<Regex>`, mirroring `formatting.rs`): `(?i)</?(?:antml:)?(?:invoke|parameter|function_calls|function_results)\b[^>]*>` — only the four real wrapper tag names, optional `antml:` namespace, open or close form.
- Deliberately **NOT** the issue's broad `<[a-z_]+>` proposal — that would clobber `Vec<T>`, `a < b`, HTML examples, and autolinks `<https://x>`.
- Behavior: a bare/anchored wrapper token drops its whole block (to the block closer `</invoke>` / `</function_calls>` / `</function_results>`, or to EOF for a streaming tail whose opener was in a prior chunk); a mid-line token truncates to the prose prefix and drops the remainder.
- **False-positive guards (preserve legit prose):** fenced code blocks pass through verbatim; an odd backtick count before a match (inline code span) preserves the line untouched. A bare `</parameter>` is intentionally not a block closer (its enclosing block continues).
- **Idempotent.** Emits `tracing::warn!` on redaction for observability (no user-visible reminder text, no metrics.rs change).

## Tests (8 new, end-to-end through the chokepoint)
bare leaked `<invoke>` block redacted; streaming continuation chunk (no opener) cleaned; fenced example preserved; inline-backtick quote preserved; mid-line truncation keeps prose prefix; over-broad guard (`Vec<T>`/`a < b`/autolink) untouched; idempotence; and an existing hidden-context + TUI-chrome regression case.

## Gate results
- `cargo fmt --check`: clean
- `cargo check --lib`: clean (only pre-existing unused-import warnings in unrelated files)
- `cargo test --lib services::discord::response_sanitizer`: `test result: ok. 13 passed; 0 failed; 0 ignored`
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: `agent-maintenance freshness check passed`

## Doc-sync note
Regenerated `module-inventory.md` / `giant-file-registry.md`. The freshness gate was **already red on main** (committed inventory was stale/inconsistent with source). Per the maintenance workflow, synced four pre-existing freeze-entry counts in `change-surfaces.md` to the freshly-generated production values — `tmux.rs` 1463→1477, `recovery_engine.rs` 3424→3899, `inflight.rs` 2686→2802, `rollout_tail.rs` 1270→1276 — so the gate is green. These four are unrelated to the sanitizer change (surfaced only by the required regen). `multinode-transition.md` was not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)