### PR TITLE
fix(db): add retention for turn_lifecycle_events/skill_usage/turns (#3865)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -765,7 +765,7 @@
 | `services::long_turn_watchdog` | `src/services/long_turn_watchdog.rs` | 321 | 233 | 88 |  |
 | `services::maintenance` | `src/services/maintenance/mod.rs` | 331 | 331 | 0 |  |
 | `services::maintenance::jobs` | `src/services/maintenance/jobs/mod.rs` | 162 | 162 | 0 |  |
-| `services::maintenance::jobs::db_retention` | `src/services/maintenance/jobs/db_retention.rs` | 806 | 577 | 229 |  |
+| `services::maintenance::jobs::db_retention` | `src/services/maintenance/jobs/db_retention.rs` | 998 | 599 | 399 |  |
 | `services::maintenance::jobs::hang_dump_cleanup` | `src/services/maintenance/jobs/hang_dump_cleanup.rs` | 125 | 125 | 0 |  |
 | `services::maintenance::jobs::memento_consolidation` | `src/services/maintenance/jobs/memento_consolidation.rs` | 301 | 301 | 0 |  |
 | `services::maintenance::jobs::target_sweep` | `src/services/maintenance/jobs/target_sweep.rs` | 200 | 200 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -765,7 +765,7 @@
 | `services::long_turn_watchdog` | `src/services/long_turn_watchdog.rs` | 321 | 233 | 88 |  |
 | `services::maintenance` | `src/services/maintenance/mod.rs` | 331 | 331 | 0 |  |
 | `services::maintenance::jobs` | `src/services/maintenance/jobs/mod.rs` | 162 | 162 | 0 |  |
-| `services::maintenance::jobs::db_retention` | `src/services/maintenance/jobs/db_retention.rs` | 397 | 397 | 0 |  |
+| `services::maintenance::jobs::db_retention` | `src/services/maintenance/jobs/db_retention.rs` | 806 | 577 | 229 |  |
 | `services::maintenance::jobs::hang_dump_cleanup` | `src/services/maintenance/jobs/hang_dump_cleanup.rs` | 125 | 125 | 0 |  |
 | `services::maintenance::jobs::memento_consolidation` | `src/services/maintenance/jobs/memento_consolidation.rs` | 301 | 301 | 0 |  |
 | `services::maintenance::jobs::target_sweep` | `src/services/maintenance/jobs/target_sweep.rs` | 200 | 200 | 0 |  |

--- a/docs/storage-retention.md
+++ b/docs/storage-retention.md
@@ -57,6 +57,9 @@ Each row is a (vector × action × job) tuple. If a vector is not in this table,
 | PG `agent_quality_event`                  | 90 days                                     | Monthly aggregate insert into summary table, then `DELETE`   | `storage.db_retention`            | Weekly   |
 | PG `session_transcripts`                  | 90 days                                     | Copy to archive table, then `DELETE`                         | `storage.db_retention`            | Weekly   |
 | PG `task_dispatches`                      | 90 days                                     | Monthly aggregate insert, then `DELETE`                      | `storage.db_retention`            | Weekly   |
+| PG `turn_lifecycle_events`                | 30 days                                     | `DELETE` (on `created_at`)                                   | `storage.db_retention`            | Weekly   |
+| PG `skill_usage`                          | 90 days                                     | `DELETE` (on `used_at`)                                      | `storage.db_retention`            | Weekly   |
+| PG `turns`                                | 90 days                                     | Copy to `turns_archive` table, then `DELETE` (on `finished_at`) | `storage.db_retention`            | Weekly   |
 | PG `prompt_manifest_layers`               | 30 days                                     | `UPDATE full_content = NULL, is_truncated = TRUE` (preserves hashes) | `storage.prompt_manifest_retention`| Daily    |
 | PG `kanban_cards`                         | **Forever**                                 | None — intentional permanent history                         | —                                 | —        |
 | `dcserver.stdout.log`                         | 100 MB × 10 files by default            | Internal dcserver tracing writer rotates before append; launchd stdout/stderr are bootstrap-only | Built into `logging.rs` startup    | Continuous |

--- a/migrations/postgres/0075_turns_archive.sql
+++ b/migrations/postgres/0075_turns_archive.sql
@@ -1,0 +1,41 @@
+-- #3865 DB retention: archive side table for `turns`.
+--
+-- The weekly `services::maintenance::jobs::db_retention` job applies a
+-- 90-day archive-then-delete policy to `turns` (token/cost analytics), mirroring
+-- the `session_transcripts` → `session_transcripts_archive` flow in 0016. Old
+-- rows are copied here (idempotently, via WHERE NOT EXISTS) before being deleted
+-- from the hot table, so historical token/cost totals stay queryable while the
+-- INSERT-only `turns` table stays bounded.
+--
+-- No DDL is needed for `turn_lifecycle_events` or `skill_usage`: those follow a
+-- plain time-window DELETE on their existing `created_at` / `used_at` columns
+-- (already indexed by 0037 and 0062).
+
+-- Archive table for `turns`. Mirrors the source columns and appends
+-- `archived_at` to record when the retention sweep relocated each row.
+CREATE TABLE IF NOT EXISTS turns_archive (
+    turn_id             TEXT PRIMARY KEY,
+    session_key         TEXT,
+    thread_id           TEXT,
+    thread_title        TEXT,
+    channel_id          TEXT NOT NULL,
+    agent_id            TEXT,
+    provider            TEXT,
+    session_id          TEXT,
+    dispatch_id         TEXT,
+    started_at          TIMESTAMPTZ NOT NULL,
+    finished_at         TIMESTAMPTZ NOT NULL,
+    duration_ms         INTEGER,
+    input_tokens        INTEGER NOT NULL DEFAULT 0,
+    cache_create_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+    output_tokens       INTEGER NOT NULL DEFAULT 0,
+    created_at          TIMESTAMPTZ,
+    archived_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_turns_archive_finished_at
+    ON turns_archive(finished_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_turns_archive_session_key
+    ON turns_archive(session_key);

--- a/migrations/postgres/0075_turns_archive.sql
+++ b/migrations/postgres/0075_turns_archive.sql
@@ -1,4 +1,4 @@
--- #3865 DB retention: archive side table for `turns`.
+-- #3865 DB retention: archive side table + scan index for `turns`.
 --
 -- The weekly `services::maintenance::jobs::db_retention` job applies a
 -- 90-day archive-then-delete policy to `turns` (token/cost analytics), mirroring
@@ -11,8 +11,12 @@
 -- plain time-window DELETE on their existing `created_at` / `used_at` columns
 -- (already indexed by 0037 and 0062).
 
--- Archive table for `turns`. Mirrors the source columns and appends
--- `archived_at` to record when the retention sweep relocated each row.
+-- Archive table for `turns`. Mirrors the source columns *as they stand after
+-- 0008_int4_to_bigint_audit.sql* — `duration_ms` and the four token columns were
+-- widened from INTEGER to BIGINT there, so they MUST be BIGINT here too. An
+-- INTEGER archive column would overflow (and fail the whole retention pass) the
+-- first time a valid >INT32 source value is archived. `archived_at` records when
+-- the retention sweep relocated each row.
 CREATE TABLE IF NOT EXISTS turns_archive (
     turn_id             TEXT PRIMARY KEY,
     session_key         TEXT,
@@ -25,11 +29,11 @@ CREATE TABLE IF NOT EXISTS turns_archive (
     dispatch_id         TEXT,
     started_at          TIMESTAMPTZ NOT NULL,
     finished_at         TIMESTAMPTZ NOT NULL,
-    duration_ms         INTEGER,
-    input_tokens        INTEGER NOT NULL DEFAULT 0,
-    cache_create_tokens INTEGER NOT NULL DEFAULT 0,
-    cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
-    output_tokens       INTEGER NOT NULL DEFAULT 0,
+    duration_ms         BIGINT,
+    input_tokens        BIGINT NOT NULL DEFAULT 0,
+    cache_create_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens   BIGINT NOT NULL DEFAULT 0,
+    output_tokens       BIGINT NOT NULL DEFAULT 0,
     created_at          TIMESTAMPTZ,
     archived_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -39,3 +43,14 @@ CREATE INDEX IF NOT EXISTS idx_turns_archive_finished_at
 
 CREATE INDEX IF NOT EXISTS idx_turns_archive_session_key
     ON turns_archive(session_key);
+
+-- Scan index on the source `turns` table. The retention archive/delete predicate
+-- filters on `turns.finished_at`, which previously had no index — every weekly
+-- pass full-scanned this high-frequency table. Non-concurrent CREATE INDEX is
+-- intentional and follows the repo convention: sqlx's Migrator wraps each
+-- migration file in its own transaction (no migration here uses the
+-- `-- no-transaction` opt-out), so CREATE INDEX CONCURRENTLY is forbidden. The
+-- brief SHARE lock on this single-host Mac mini deployment is acceptable for a
+-- one-time build on an append-mostly table (mirrors the lock notes in 0055/0071).
+CREATE INDEX IF NOT EXISTS idx_turns_finished_at
+    ON turns(finished_at DESC);

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -388,7 +388,7 @@
     },
     {
       "path": "migrations/postgres/0075_turns_archive.sql",
-      "sha256": "70aabbc0dfb0242c9e19c067f6bfb2a3cd4093fbda6f4230555d2878d5120167",
+      "sha256": "e0fe9fff7f70ef331f380f6188d7415b017720c94c827822728733131dce1759",
       "version": 75
     }
   ],

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -385,6 +385,11 @@
       "path": "migrations/postgres/0074_local_memory.sql",
       "sha256": "1e246fa4115fc7be5150e0f9b695501fe23061cf9be660aa986becf1ef98ee19",
       "version": 74
+    },
+    {
+      "path": "migrations/postgres/0075_turns_archive.sql",
+      "sha256": "70aabbc0dfb0242c9e19c067f6bfb2a3cd4093fbda6f4230555d2878d5120167",
+      "version": 75
     }
   ],
   "version": 1

--- a/src/services/maintenance/jobs/db_retention.rs
+++ b/src/services/maintenance/jobs/db_retention.rs
@@ -1,14 +1,17 @@
-//! DB retention job (#1093 / 909-4).
+//! DB retention job (#1093 / 909-4; extended in #3865).
 //!
-//! Five retention policies across the AgentDesk postgres backbone:
+//! Eight retention policies across the AgentDesk postgres backbone:
 //!
-//! | Table                  | Retention | Strategy                          |
-//! |------------------------|-----------|-----------------------------------|
-//! | `agent_quality_event`  | 90 days   | Monthly aggregate, then DELETE    |
-//! | `session_transcripts`  | 90 days   | Archive-table copy, then DELETE   |
-//! | `message_outbox` (sent)| 7 days    | DELETE                            |
-//! | `auto_queue_entries`   | 30 days   | DELETE (status='completed')       |
-//! | `task_dispatches`      | 90 days   | Monthly aggregate, then DELETE    |
+//! | Table                    | Retention | Strategy                          |
+//! |--------------------------|-----------|-----------------------------------|
+//! | `agent_quality_event`    | 90 days   | Monthly aggregate, then DELETE    |
+//! | `session_transcripts`    | 90 days   | Archive-table copy, then DELETE   |
+//! | `message_outbox` (sent)  | 7 days    | DELETE                            |
+//! | `auto_queue_entries`     | 30 days   | DELETE (status='completed')       |
+//! | `task_dispatches`        | 90 days   | Monthly aggregate, then DELETE    |
+//! | `turn_lifecycle_events`  | 30 days   | DELETE (on `created_at`)          |
+//! | `skill_usage`            | 90 days   | DELETE (on `used_at`)             |
+//! | `turns`                  | 90 days   | Archive-table copy, then DELETE   |
 //!
 //! `kanban_cards` is explicitly **not** touched — done cards are permanent
 //! history. See `docs/source-of-truth.md` §retention for the policy rationale.
@@ -36,8 +39,9 @@ pub struct TableReport {
     pub rows_affected: i64,
 }
 
-/// Full report for one run of [`db_retention_job`]. Five table entries plus
-/// any aggregate-write entries (turn_analytics, task_dispatches).
+/// Full report for one run of [`db_retention_job`]. Eight table entries plus
+/// any aggregate-write / archive-write entries (turn_analytics, task_dispatches,
+/// session_transcripts_archive, turns_archive).
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct RetentionReport {
     pub dry_run: bool,
@@ -78,13 +82,18 @@ const TRANSCRIPT_RETENTION_DAYS: i32 = 90;
 const OUTBOX_RETENTION_DAYS: i32 = 7;
 const AUTO_QUEUE_RETENTION_DAYS: i32 = 30;
 const DISPATCH_RETENTION_DAYS: i32 = 90;
+// #3865 — three INSERT-only tables with no prior prune. These named windows are
+// the configurable retention boundaries for the policies added below.
+const TURN_LIFECYCLE_RETENTION_DAYS: i32 = 30; // pure operational telemetry, highest volume (multi-row/turn)
+const SKILL_USAGE_RETENTION_DAYS: i32 = 90; // dashboard analytics (used_at DESC fast-path)
+const TURNS_RETENTION_DAYS: i32 = 90; // token/cost analytics → archive before delete
 
 /// Run the full retention pass. Returns a per-table report. When
 /// `dry_run = true` no DML is executed — only SELECT COUNT(*) probes.
 pub async fn db_retention_job(pool: &PgPool, dry_run: bool) -> Result<RetentionReport> {
     let mut report = RetentionReport {
         dry_run,
-        tables: Vec::with_capacity(8),
+        tables: Vec::with_capacity(12),
     };
 
     // 1. turn analytics (agent_quality_event).
@@ -97,6 +106,12 @@ pub async fn db_retention_job(pool: &PgPool, dry_run: bool) -> Result<RetentionR
     retain_auto_queue_entries(pool, dry_run, &mut report).await?;
     // 5. task_dispatches.
     retain_task_dispatches(pool, dry_run, &mut report).await?;
+    // 6. turn_lifecycle_events (time-window DELETE on created_at). #3865
+    retain_turn_lifecycle_events(pool, dry_run, &mut report).await?;
+    // 7. skill_usage (time-window DELETE on used_at). #3865
+    retain_skill_usage(pool, dry_run, &mut report).await?;
+    // 8. turns (archive-then-delete on finished_at). #3865
+    retain_turns(pool, dry_run, &mut report).await?;
 
     tracing::info!(
         dry_run,
@@ -394,4 +409,398 @@ async fn retain_task_dispatches(
         rows_affected: del.rows_affected() as i64,
     });
     Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 6. turn_lifecycle_events: delete telemetry rows older than 30 days. #3865
+//
+// Pure operational telemetry (multiple rows per turn) with no downstream
+// aggregate — a plain time-window DELETE on the indexed `created_at` column.
+// ─────────────────────────────────────────────────────────────────────────
+async fn retain_turn_lifecycle_events(
+    pool: &PgPool,
+    dry_run: bool,
+    report: &mut RetentionReport,
+) -> Result<()> {
+    if dry_run {
+        let would = sqlx::query(
+            "SELECT COUNT(*)::BIGINT AS n FROM turn_lifecycle_events \
+             WHERE created_at < NOW() - ($1::INT || ' days')::INTERVAL",
+        )
+        .bind(TURN_LIFECYCLE_RETENTION_DAYS)
+        .fetch_one(pool)
+        .await?;
+        let n: i64 = would.try_get("n").unwrap_or(0);
+        report.push(TableReport {
+            table_name: "turn_lifecycle_events",
+            action: "delete_would",
+            rows_affected: n,
+        });
+        return Ok(());
+    }
+
+    let del = sqlx::query(
+        "DELETE FROM turn_lifecycle_events \
+         WHERE created_at < NOW() - ($1::INT || ' days')::INTERVAL",
+    )
+    .bind(TURN_LIFECYCLE_RETENTION_DAYS)
+    .execute(pool)
+    .await?;
+    report.push(TableReport {
+        table_name: "turn_lifecycle_events",
+        action: "delete",
+        rows_affected: del.rows_affected() as i64,
+    });
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 7. skill_usage: delete usage rows older than 90 days. #3865
+//
+// `used_at` is nullable (DEFAULT NOW()); rows are never inserted with NULL, but
+// the `used_at IS NOT NULL` guard mirrors the message_outbox `sent_at` guard so
+// a stray NULL is retained rather than mis-windowed.
+// ─────────────────────────────────────────────────────────────────────────
+async fn retain_skill_usage(
+    pool: &PgPool,
+    dry_run: bool,
+    report: &mut RetentionReport,
+) -> Result<()> {
+    if dry_run {
+        let would = sqlx::query(
+            "SELECT COUNT(*)::BIGINT AS n FROM skill_usage \
+             WHERE used_at IS NOT NULL \
+               AND used_at < NOW() - ($1::INT || ' days')::INTERVAL",
+        )
+        .bind(SKILL_USAGE_RETENTION_DAYS)
+        .fetch_one(pool)
+        .await?;
+        let n: i64 = would.try_get("n").unwrap_or(0);
+        report.push(TableReport {
+            table_name: "skill_usage",
+            action: "delete_would",
+            rows_affected: n,
+        });
+        return Ok(());
+    }
+
+    let del = sqlx::query(
+        "DELETE FROM skill_usage \
+         WHERE used_at IS NOT NULL \
+           AND used_at < NOW() - ($1::INT || ' days')::INTERVAL",
+    )
+    .bind(SKILL_USAGE_RETENTION_DAYS)
+    .execute(pool)
+    .await?;
+    report.push(TableReport {
+        table_name: "skill_usage",
+        action: "delete",
+        rows_affected: del.rows_affected() as i64,
+    });
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 8. turns: archive-then-delete on finished_at older than 90 days. #3865
+//
+// Mirrors `retain_session_transcripts`: copy into `turns_archive` (idempotent
+// via WHERE NOT EXISTS) so historical token/cost totals stay queryable, then
+// DELETE from the hot table. `finished_at` is NOT NULL → no NULL edge cases.
+// ─────────────────────────────────────────────────────────────────────────
+async fn retain_turns(pool: &PgPool, dry_run: bool, report: &mut RetentionReport) -> Result<()> {
+    if dry_run {
+        let would = sqlx::query(
+            "SELECT COUNT(*)::BIGINT AS n FROM turns \
+             WHERE finished_at < NOW() - ($1::INT || ' days')::INTERVAL",
+        )
+        .bind(TURNS_RETENTION_DAYS)
+        .fetch_one(pool)
+        .await?;
+        let n: i64 = would.try_get("n").unwrap_or(0);
+        report.push(TableReport {
+            table_name: "turns",
+            action: "archive_would",
+            rows_affected: n,
+        });
+        return Ok(());
+    }
+
+    // INSERT … SELECT … WHERE NOT EXISTS keeps re-runs idempotent.
+    let archived = sqlx::query(
+        "INSERT INTO turns_archive \
+             (turn_id, session_key, thread_id, thread_title, channel_id, agent_id, \
+              provider, session_id, dispatch_id, started_at, finished_at, duration_ms, \
+              input_tokens, cache_create_tokens, cache_read_tokens, output_tokens, created_at) \
+         SELECT t.turn_id, t.session_key, t.thread_id, t.thread_title, t.channel_id, \
+                t.agent_id, t.provider, t.session_id, t.dispatch_id, t.started_at, \
+                t.finished_at, t.duration_ms, t.input_tokens, t.cache_create_tokens, \
+                t.cache_read_tokens, t.output_tokens, t.created_at \
+         FROM turns t \
+         WHERE t.finished_at < NOW() - ($1::INT || ' days')::INTERVAL \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM turns_archive a WHERE a.turn_id = t.turn_id \
+           )",
+    )
+    .bind(TURNS_RETENTION_DAYS)
+    .execute(pool)
+    .await?;
+    report.push(TableReport {
+        table_name: "turns_archive",
+        action: "insert",
+        rows_affected: archived.rows_affected() as i64,
+    });
+
+    let del = sqlx::query(
+        "DELETE FROM turns \
+         WHERE finished_at < NOW() - ($1::INT || ' days')::INTERVAL",
+    )
+    .bind(TURNS_RETENTION_DAYS)
+    .execute(pool)
+    .await?;
+    report.push(TableReport {
+        table_name: "turns",
+        action: "delete",
+        rows_affected: del.rows_affected() as i64,
+    });
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #3865 — regression coverage for the three new retention policies.
+//
+// Uses the shared `DispatchPostgresTestDb` harness (same pattern as
+// `engine::ops::kanban_ops` tests): create an ephemeral DB, run all migrations
+// (incl. 0075_turns_archive), seed one stale + one fresh row per table, run the
+// job, and assert old rows are pruned, fresh rows survive, `turns` rows are
+// archived, the report is shaped correctly, dry-run is a no-op, and re-runs are
+// idempotent. Skipped automatically when no local Postgres is reachable.
+// ─────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn count(pool: &PgPool, sql: &str) -> i64 {
+        sqlx::query(sql)
+            .fetch_one(pool)
+            .await
+            .unwrap_or_else(|err| panic!("count query `{sql}`: {err}"))
+            .try_get::<i64, _>("n")
+            .unwrap_or(0)
+    }
+
+    /// Seed one stale row (older than the policy window) and one fresh row in
+    /// each of the three tables. `stale_days` puts the stale row safely past
+    /// the largest (90d) window.
+    async fn seed_fixtures(pool: &PgPool, stale_days: i32) {
+        // turn_lifecycle_events: stale + fresh.
+        for (turn_id, age) in [("tle-old", stale_days), ("tle-new", 0)] {
+            sqlx::query(
+                "INSERT INTO turn_lifecycle_events \
+                     (turn_id, channel_id, kind, severity, summary, created_at) \
+                 VALUES ($1, 'chan', 'turn_start', 'info', 'seed', \
+                         NOW() - ($2::INT || ' days')::INTERVAL)",
+            )
+            .bind(turn_id)
+            .bind(age)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|err| panic!("seed turn_lifecycle_events {turn_id}: {err}"));
+        }
+
+        // skill_usage: stale + fresh.
+        for (skill_id, age) in [("sk-old", stale_days), ("sk-new", 0)] {
+            sqlx::query(
+                "INSERT INTO skill_usage (skill_id, agent_id, session_key, used_at) \
+                 VALUES ($1, 'agent', 'sess', NOW() - ($2::INT || ' days')::INTERVAL)",
+            )
+            .bind(skill_id)
+            .bind(age)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|err| panic!("seed skill_usage {skill_id}: {err}"));
+        }
+
+        // turns: stale + fresh (windowed on finished_at).
+        for (turn_id, age) in [("turn-old", stale_days), ("turn-new", 0)] {
+            sqlx::query(
+                "INSERT INTO turns \
+                     (turn_id, channel_id, started_at, finished_at, input_tokens, output_tokens) \
+                 VALUES ($1, 'chan', \
+                         NOW() - ($2::INT || ' days')::INTERVAL, \
+                         NOW() - ($2::INT || ' days')::INTERVAL, 10, 20)",
+            )
+            .bind(turn_id)
+            .bind(age)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|err| panic!("seed turns {turn_id}: {err}"));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn db_retention_prunes_old_rows_archives_turns_and_is_idempotent() {
+        let db = crate::dispatch::test_support::DispatchPostgresTestDb::create(
+            "agentdesk_db_retention_3865",
+            "db_retention #3865 lifecycle/skill_usage/turns coverage",
+        )
+        .await;
+        let pool = db.connect_and_migrate().await;
+
+        // 91 days is past every policy window (max is 90d).
+        seed_fixtures(&pool, 91).await;
+
+        // ── Dry-run is a no-op: nothing deleted, would-counts == 1 each. ──
+        let dry = db_retention_job(&pool, true)
+            .await
+            .expect("dry-run retention pass");
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turn_lifecycle_events"
+            )
+            .await,
+            2,
+            "dry-run must not delete turn_lifecycle_events rows"
+        );
+        assert_eq!(
+            count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM skill_usage").await,
+            2,
+            "dry-run must not delete skill_usage rows"
+        );
+        assert_eq!(
+            count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM turns").await,
+            2,
+            "dry-run must not delete turns rows"
+        );
+        assert_eq!(
+            count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM turns_archive").await,
+            0,
+            "dry-run must not archive turns rows"
+        );
+        assert_eq!(
+            dry.get("turn_lifecycle_events", "delete_would")
+                .map(|t| t.rows_affected),
+            Some(1)
+        );
+        assert_eq!(
+            dry.get("skill_usage", "delete_would")
+                .map(|t| t.rows_affected),
+            Some(1)
+        );
+        assert_eq!(
+            dry.get("turns", "archive_would").map(|t| t.rows_affected),
+            Some(1)
+        );
+
+        // ── Live run: old rows pruned, fresh rows kept, turn archived. ──
+        let report = db_retention_job(&pool, false)
+            .await
+            .expect("live retention pass");
+
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turn_lifecycle_events"
+            )
+            .await,
+            1,
+            "stale turn_lifecycle_events row must be deleted"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turn_lifecycle_events WHERE turn_id = 'tle-new'"
+            )
+            .await,
+            1,
+            "fresh turn_lifecycle_events row must survive"
+        );
+
+        assert_eq!(
+            count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM skill_usage").await,
+            1,
+            "stale skill_usage row must be deleted"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM skill_usage WHERE skill_id = 'sk-new'"
+            )
+            .await,
+            1,
+            "fresh skill_usage row must survive"
+        );
+
+        assert_eq!(
+            count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM turns").await,
+            1,
+            "stale turns row must be deleted"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turns WHERE turn_id = 'turn-new'"
+            )
+            .await,
+            1,
+            "fresh turns row must survive"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turns_archive WHERE turn_id = 'turn-old'"
+            )
+            .await,
+            1,
+            "stale turns row must be copied into turns_archive before deletion"
+        );
+
+        // Report entries reflect the new policies.
+        assert_eq!(
+            report
+                .get("turn_lifecycle_events", "delete")
+                .map(|t| t.rows_affected),
+            Some(1)
+        );
+        assert_eq!(
+            report.get("skill_usage", "delete").map(|t| t.rows_affected),
+            Some(1)
+        );
+        assert_eq!(
+            report
+                .get("turns_archive", "insert")
+                .map(|t| t.rows_affected),
+            Some(1)
+        );
+        assert_eq!(
+            report.get("turns", "delete").map(|t| t.rows_affected),
+            Some(1)
+        );
+
+        // ── Idempotency: a second run deletes nothing new and creates no
+        //    duplicate archive rows (NOT EXISTS guard). ──
+        let rerun = db_retention_job(&pool, false)
+            .await
+            .expect("second retention pass");
+        assert_eq!(
+            rerun
+                .get("turns_archive", "insert")
+                .map(|t| t.rows_affected),
+            Some(0),
+            "re-run must not duplicate turns_archive rows"
+        );
+        assert_eq!(
+            rerun.get("turns", "delete").map(|t| t.rows_affected),
+            Some(0),
+            "re-run must delete no additional turns rows"
+        );
+        assert_eq!(
+            count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM turns_archive").await,
+            1,
+            "turns_archive must hold exactly one row after a double run"
+        );
+
+        pool.close().await;
+        db.drop().await;
+    }
 }

--- a/src/services/maintenance/jobs/db_retention.rs
+++ b/src/services/maintenance/jobs/db_retention.rs
@@ -503,9 +503,21 @@ async fn retain_skill_usage(
 // ─────────────────────────────────────────────────────────────────────────
 // 8. turns: archive-then-delete on finished_at older than 90 days. #3865
 //
-// Mirrors `retain_session_transcripts`: copy into `turns_archive` (idempotent
-// via WHERE NOT EXISTS) so historical token/cost totals stay queryable, then
-// DELETE from the hot table. `finished_at` is NOT NULL → no NULL edge cases.
+// Like `retain_session_transcripts` this copies into `turns_archive` (idempotent
+// via WHERE NOT EXISTS) before deleting, but `turns` is high-value token/cost
+// data so the two steps are hardened against an archive-less delete:
+//
+//   * Both statements run inside ONE transaction. Postgres `NOW()` resolves to
+//     `transaction_timestamp()`, which is fixed for the life of the transaction,
+//     so the archive and delete predicates share the *identical* cutoff — a row
+//     can never cross the 90-day boundary between the two steps. (This is
+//     stronger than computing the cutoff app-side, which would add DB/app clock
+//     skew.)
+//   * The DELETE carries an `EXISTS (… turns_archive …)` guard, so it can only
+//     remove rows that are already in the archive — a delete-without-archive is
+//     impossible even if the reasoning above were ever violated.
+//
+// `finished_at` is NOT NULL → no NULL edge cases.
 // ─────────────────────────────────────────────────────────────────────────
 async fn retain_turns(pool: &PgPool, dry_run: bool, report: &mut RetentionReport) -> Result<()> {
     if dry_run {
@@ -525,6 +537,8 @@ async fn retain_turns(pool: &PgPool, dry_run: bool, report: &mut RetentionReport
         return Ok(());
     }
 
+    let mut tx = pool.begin().await?;
+
     // INSERT … SELECT … WHERE NOT EXISTS keeps re-runs idempotent.
     let archived = sqlx::query(
         "INSERT INTO turns_archive \
@@ -542,7 +556,7 @@ async fn retain_turns(pool: &PgPool, dry_run: bool, report: &mut RetentionReport
            )",
     )
     .bind(TURNS_RETENTION_DAYS)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     report.push(TableReport {
         table_name: "turns_archive",
@@ -550,18 +564,26 @@ async fn retain_turns(pool: &PgPool, dry_run: bool, report: &mut RetentionReport
         rows_affected: archived.rows_affected() as i64,
     });
 
+    // EXISTS guard: only delete rows that are already archived. Combined with the
+    // shared transaction cutoff, every old row was archived by the INSERT above,
+    // so this deletes exactly the archived set and nothing more.
     let del = sqlx::query(
-        "DELETE FROM turns \
-         WHERE finished_at < NOW() - ($1::INT || ' days')::INTERVAL",
+        "DELETE FROM turns t \
+         WHERE t.finished_at < NOW() - ($1::INT || ' days')::INTERVAL \
+           AND EXISTS ( \
+               SELECT 1 FROM turns_archive a WHERE a.turn_id = t.turn_id \
+           )",
     )
     .bind(TURNS_RETENTION_DAYS)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     report.push(TableReport {
         table_name: "turns",
         action: "delete",
         rows_affected: del.rows_affected() as i64,
     });
+
+    tx.commit().await?;
     Ok(())
 }
 
@@ -579,6 +601,12 @@ async fn retain_turns(pool: &PgPool, dry_run: bool, report: &mut RetentionReport
 mod tests {
     use super::*;
 
+    /// Token value larger than INT32::MAX (2_147_483_647). The `turns` token
+    /// columns were widened to BIGINT in 0008; the stale row carries this so the
+    /// archive copy exercises BIGINT fidelity (an INTEGER archive column would
+    /// overflow here and fail the whole pass — guards #3865 review finding #1).
+    const BIG_TOKENS: i64 = 3_000_000_000;
+
     async fn count(pool: &PgPool, sql: &str) -> i64 {
         sqlx::query(sql)
             .fetch_one(pool)
@@ -588,9 +616,28 @@ mod tests {
             .unwrap_or(0)
     }
 
+    /// Insert one `turns` row windowed on `finished_at`, with explicit BIGINT
+    /// token/duration values so archive fidelity can be asserted.
+    async fn seed_turn(pool: &PgPool, turn_id: &str, age_days: i32, tokens: i64) {
+        sqlx::query(
+            "INSERT INTO turns \
+                 (turn_id, channel_id, started_at, finished_at, duration_ms, \
+                  input_tokens, cache_create_tokens, cache_read_tokens, output_tokens) \
+             VALUES ($1, 'chan', \
+                     NOW() - ($2::INT || ' days')::INTERVAL, \
+                     NOW() - ($2::INT || ' days')::INTERVAL, $3, $3, $3, $3, $3)",
+        )
+        .bind(turn_id)
+        .bind(age_days)
+        .bind(tokens)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|err| panic!("seed turns {turn_id}: {err}"));
+    }
+
     /// Seed one stale row (older than the policy window) and one fresh row in
     /// each of the three tables. `stale_days` puts the stale row safely past
-    /// the largest (90d) window.
+    /// the largest (90d) window. The stale `turns` row carries [`BIG_TOKENS`].
     async fn seed_fixtures(pool: &PgPool, stale_days: i32) {
         // turn_lifecycle_events: stale + fresh.
         for (turn_id, age) in [("tle-old", stale_days), ("tle-new", 0)] {
@@ -620,21 +667,9 @@ mod tests {
             .unwrap_or_else(|err| panic!("seed skill_usage {skill_id}: {err}"));
         }
 
-        // turns: stale + fresh (windowed on finished_at).
-        for (turn_id, age) in [("turn-old", stale_days), ("turn-new", 0)] {
-            sqlx::query(
-                "INSERT INTO turns \
-                     (turn_id, channel_id, started_at, finished_at, input_tokens, output_tokens) \
-                 VALUES ($1, 'chan', \
-                         NOW() - ($2::INT || ' days')::INTERVAL, \
-                         NOW() - ($2::INT || ' days')::INTERVAL, 10, 20)",
-            )
-            .bind(turn_id)
-            .bind(age)
-            .execute(pool)
-            .await
-            .unwrap_or_else(|err| panic!("seed turns {turn_id}: {err}"));
-        }
+        // turns: stale (>INT32 tokens) + fresh (windowed on finished_at).
+        seed_turn(pool, "turn-old", stale_days, BIG_TOKENS).await;
+        seed_turn(pool, "turn-new", 0, 20).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -755,6 +790,20 @@ mod tests {
             "stale turns row must be copied into turns_archive before deletion"
         );
 
+        // BIGINT fidelity: the >INT32 token/duration values survive the archive
+        // copy intact (an INTEGER archive column would have overflowed).
+        let archived_tokens: i64 =
+            sqlx::query("SELECT input_tokens AS n FROM turns_archive WHERE turn_id = 'turn-old'")
+                .fetch_one(&pool)
+                .await
+                .expect("read archived input_tokens")
+                .try_get::<i64, _>("n")
+                .expect("input_tokens is BIGINT");
+        assert_eq!(
+            archived_tokens, BIG_TOKENS,
+            "archived input_tokens must preserve the >INT32 value without overflow"
+        );
+
         // Report entries reflect the new policies.
         assert_eq!(
             report
@@ -798,6 +847,149 @@ mod tests {
             count(&pool, "SELECT COUNT(*)::BIGINT AS n FROM turns_archive").await,
             1,
             "turns_archive must hold exactly one row after a double run"
+        );
+
+        pool.close().await;
+        db.drop().await;
+    }
+
+    /// The `used_at IS NOT NULL` guard must keep rows whose timestamp is NULL —
+    /// a NULL `used_at` is never older-than the window, so it survives.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn db_retention_keeps_skill_usage_rows_with_null_used_at() {
+        let db = crate::dispatch::test_support::DispatchPostgresTestDb::create(
+            "agentdesk_db_retention_3865_nullusedat",
+            "db_retention #3865 NULL used_at survival",
+        )
+        .await;
+        let pool = db.connect_and_migrate().await;
+
+        // NULL used_at (must survive), stale (must delete), fresh (must keep).
+        sqlx::query("INSERT INTO skill_usage (skill_id, used_at) VALUES ('sk-null', NULL)")
+            .execute(&pool)
+            .await
+            .expect("seed NULL used_at row");
+        sqlx::query(
+            "INSERT INTO skill_usage (skill_id, used_at) \
+             VALUES ('sk-stale', NOW() - INTERVAL '120 days')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed stale row");
+        sqlx::query("INSERT INTO skill_usage (skill_id, used_at) VALUES ('sk-fresh', NOW())")
+            .execute(&pool)
+            .await
+            .expect("seed fresh row");
+
+        db_retention_job(&pool, false)
+            .await
+            .expect("retention pass");
+
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM skill_usage WHERE skill_id = 'sk-null'"
+            )
+            .await,
+            1,
+            "NULL used_at row must never be deleted by the time-window prune"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM skill_usage WHERE skill_id = 'sk-stale'"
+            )
+            .await,
+            0,
+            "stale skill_usage row must be deleted"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM skill_usage WHERE skill_id = 'sk-fresh'"
+            )
+            .await,
+            1,
+            "fresh skill_usage row must survive"
+        );
+
+        pool.close().await;
+        db.drop().await;
+    }
+
+    /// The `turns` window is strict (`finished_at < cutoff`): a row just inside
+    /// the 90d window survives, a row just outside is archived then deleted, and
+    /// the archived row count always equals the deleted row count (no
+    /// delete-without-archive), including on a re-run.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn db_retention_turns_window_is_strict_with_no_archive_less_delete() {
+        let db = crate::dispatch::test_support::DispatchPostgresTestDb::create(
+            "agentdesk_db_retention_3865_boundary",
+            "db_retention #3865 turns strict boundary + atomic archive",
+        )
+        .await;
+        let pool = db.connect_and_migrate().await;
+
+        // 2-hour margins absorb the ms-level drift between seed and job NOW().
+        // inside: 89d22h old → younger than 90d → kept.
+        sqlx::query(
+            "INSERT INTO turns (turn_id, channel_id, started_at, finished_at) \
+             VALUES ('turn-inside', 'chan', NOW(), NOW() - (INTERVAL '90 days' - INTERVAL '2 hours'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed inside-window turn");
+        // outside: 90d02h old → older than 90d → archived + deleted.
+        sqlx::query(
+            "INSERT INTO turns (turn_id, channel_id, started_at, finished_at) \
+             VALUES ('turn-outside', 'chan', NOW(), NOW() - (INTERVAL '90 days' + INTERVAL '2 hours'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed outside-window turn");
+
+        let report = db_retention_job(&pool, false)
+            .await
+            .expect("retention pass");
+
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turns WHERE turn_id = 'turn-inside'"
+            )
+            .await,
+            1,
+            "row just inside the 90d window must survive (strict `<`)"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turns WHERE turn_id = 'turn-outside'"
+            )
+            .await,
+            0,
+            "row just outside the window must be deleted"
+        );
+        assert_eq!(
+            count(
+                &pool,
+                "SELECT COUNT(*)::BIGINT AS n FROM turns_archive WHERE turn_id = 'turn-outside'"
+            )
+            .await,
+            1,
+            "the deleted row must have been archived first"
+        );
+
+        // Archive insert count == delete count: no delete-without-archive.
+        let archived = report
+            .get("turns_archive", "insert")
+            .map(|t| t.rows_affected);
+        let deleted = report.get("turns", "delete").map(|t| t.rows_affected);
+        assert_eq!(archived, Some(1));
+        assert_eq!(deleted, Some(1));
+        assert_eq!(
+            archived, deleted,
+            "every deleted turns row must be archived in the same pass"
         );
 
         pool.close().await;


### PR DESCRIPTION
Closes #3865.

## Problem
The weekly `db_retention` job (`src/services/maintenance/jobs/db_retention.rs`) pruned only **5** tables. Three high-frequency, INSERT-only tables had **no `DELETE` anywhere in `src/`**, so they grew unbounded and compounded the shared-host Postgres pressure tracked in #3658:

- `turn_lifecycle_events` — multiple rows per turn (`observability/turn_lifecycle.rs`)
- `skill_usage` — one row per Skill call (`turn_bridge/skill_usage.rs`, `server/routes/hooks.rs`)
- `turns` — one row per completed turn (`db/turns.rs`)

## Change
Extends the existing per-table `retain_*` pattern with three new policies (verbatim shape of `retain_message_outbox` / `retain_session_transcripts` — no refactor of existing functions):

| Table | Window | Strategy |
|-------|--------|----------|
| `turn_lifecycle_events` | 30d | time-window `DELETE` on `created_at` |
| `skill_usage` | 90d | time-window `DELETE` on `used_at` (NULL-guarded) |
| `turns` | 90d | archive-then-delete on `finished_at` |

Window boundaries are named `const … RETENTION_DAYS: i32` values bound as `$1` — the configurable retention boundaries the acceptance criteria require, matching the existing 5 policies.

### New migration — `0075_turns_archive.sql`
Creates `turns_archive` mirroring `turns` columns + `archived_at`, modeled on `session_transcripts_archive` (migration 0016). **No DDL on the source tables** — `turn_lifecycle_events` / `skill_usage` already have the needed timestamp columns and indexes (0037 / 0062). Registered in `immutable-checksums.json`.

## Invariants
- **Idempotent archive-then-delete**: `turns` rows are copied into `turns_archive` via `INSERT … SELECT … WHERE NOT EXISTS`, then deleted — re-runs insert 0 duplicates and delete 0 extra rows.
- **Dry-run executes zero DML**: every `DELETE` becomes a `SELECT COUNT(*)` probe; the report carries `delete_would` / `archive_would` counts.
- **`finished_at` is `NOT NULL`** → no NULL edge cases for the `turns` boundary.
- `total_deleted()` / `summary()` already cover the new `delete` / `insert` / `delete_would` / `archive_would` actions (archive `insert` excluded from the deleted total).

## Tests
Adds a `#[cfg(test)] mod tests` PG regression test using `DispatchPostgresTestDb` (pattern from `engine/ops/kanban_ops.rs`). It seeds one stale (91d) + one fresh row in each of the three tables and asserts:
- dry-run leaves all rows and returns `*_would` counts = 1;
- live run prunes the stale rows, keeps the fresh rows, copies the stale `turns` row into `turns_archive`, and reports the right entries;
- a second live run inserts 0 archive duplicates and deletes 0 extra rows (idempotency).

Also updates the `docs/storage-retention.md` retention matrix (3 rows) and the module doc table.

## Gate results (run locally in the worktree)
- `cargo fmt --check` — clean
- `cargo check --lib` — clean (only pre-existing unrelated warnings)
- `cargo test --lib db_retention` — **1 passed** (local Postgres reachable; the test ran for real)
- `check_postgres_migration_checksums.py` — passed (78 migrations protected; 0075 registered)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` — "agent-maintenance freshness check passed"
- `check_hotfile_ratchet.py` — exit 0 (db_retention.rs not ratcheted)
- `audit_maintainability.py --check` — exit 0 (db_retention.rs is 577 production LoC, under the 1000 giant threshold → no giant baseline entry needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)