### PR TITLE
docs(discord): #3862 anchor-repost — track rollout, keep default-OFF pending idempotency hardening (#3918)

### DIFF
--- a/src/services/discord/recovery_paths/shared.rs
+++ b/src/services/discord/recovery_paths/shared.rs
@@ -187,7 +187,22 @@ pub(in crate::services::discord) fn disposition_reason_code(
 
 /// #3610 PR-2: gate for the recovery anchor-repost fallback (`AGENTDESK_RECOVERY_ANCHOR_REPOST`).
 ///
-/// DEFAULT OFF — a dark deploy. When OFF this is the outermost guard of
+/// DEFAULT OFF — intentionally gated, with a tracked rollout plan (#3862 / #3918).
+/// The #3607/#3610 committed-then-gone fallback is fully wired and storm-guarded
+/// (G1–G5 + the transient send-new budget bound in `unrecoverable_relay_disposition`),
+/// but a naked default-ON flip is BLOCKED on two send-new idempotency gaps that only
+/// surface once this path is live (tracked in #3918):
+///   1. a successful send-new is not durably idempotent — a crash (or a silently
+///      failing `inflight::clear_inflight_state`, whose `bool` is ignored) after
+///      Discord accepts the new message lets the next restart re-post the same
+///      answer, and `Delivered` is not budget-counted, so the duplicate is unbounded;
+///   2. a multi-chunk send-new partial failure leaves earlier chunks posted with no
+///      rollback (`formatting::send_long_message_raw`, not the existing
+///      `send_long_message_raw_with_rollback`), so the budget-bounded retry re-sends
+///      the whole body and duplicates them.
+/// Activation criteria + rollout live in #3918; until they are met this stays OFF.
+/// The env var remains a staging opt-in ("1"/"true") for verification under those
+/// guards. When OFF this is the outermost guard of
 /// [`super::restart::try_recover_anchor_repost`], which short-circuits to `None`
 /// before reading any record / probing / relaying, so the recovery loop is a
 /// byte-for-byte no-op (the committed-branch call site is skipped entirely).


### PR DESCRIPTION
Resolves #3862 via its acceptance-criteria option 2 (explicit rollout-tracking issue + criteria). Tracking issue: #3918.

## TL;DR — direction change after adversarial review
This PR originally flipped `recovery_anchor_repost_enabled()` to **default-ON** to un-dark the #3607/#3610 committed-then-gone data-loss fallback. Adversarial review of that flip surfaced **two send-new idempotency gaps that only become reachable once the path is live** — neither covered or tested by the existing storm guards (G1–G5 + the transient send-new budget bound). A naked flip is therefore **blocked**. This PR is re-scoped to a **doc-only, behavior-byte-identical** change: it keeps the gate **default-OFF** and documents the deferred rollout + the two hardening criteria, with #3918 tracking the work. This satisfies #3862's complaint (the fix was permanently dark with no tracking issue/criteria) without shipping an unverified, potentially-unbounded duplicate-repost activation.

## The two blockers (verified against code on `origin/main`)
**1. send-new is not durably idempotent — unbounded duplicate risk.**
`try_recover_anchor_repost` sends a NEW message (`relay_recovered_terminal_text_to_placeholder(.., None, ..)` → `send_long_message_raw`) and relies on a post-send `clear_inflight_state` whose `bool` return is **ignored** (`recovery_paths/restart.rs:107`); the durable anchor is never repointed. `unrecoverable_relay_disposition` maps `Delivered` → `FinishAndClear` with **no attempt bump**, so a crash (or silent clear-failure) after Discord accepts the new message lets the next restart re-post the same answer — **unbounded** (budget never counts `Delivered`).

**2. multi-chunk send-new partial failure duplicates posted chunks.**
The send-new path uses `formatting::send_long_message_raw`, which on a mid-chunk failure returns `Err` leaving earlier chunks posted (`formatting.rs:1972-1985`) with no rollback; the budget-bounded retry re-sends the whole body. A drop-in `send_long_message_raw_with_rollback` exists but returns `Vec<MessageId>` + needs a rollback key, so wiring it through the giant-baselined `recovery_engine.rs` is non-trivial.

## Why defer instead of harden in this PR
A correct fix is **separate-subsystem-scale**: durable repost idempotency (a per-turn `anchor_reposted` marker / anchor repoint) + budget-on-`Delivered` + `clear_inflight_state` failure handling, plus rollback wiring through the giant-baselined `recovery_engine.rs`. A naive bump-before-send mitigation would risk **double-counting against the existing `PreserveAndCount` bump → premature force-clear → re-introducing the #3607 data loss**. Rushing recovery-path correctness here is the higher risk. Per #3862's AC (which explicitly accepts a tracking issue + criteria) and the safety-first call, the hardening is tracked in #3918 and gated ahead of any default-ON flip.

## What this PR actually changes
- `src/services/discord/recovery_paths/shared.rs`: doc comment on `recovery_anchor_repost_enabled()` rewritten from "DEFAULT OFF — a dark deploy" to the documented deferred-rollout plan referencing #3862/#3918 and both hardening gates. **Gate logic unchanged** — still default-OFF, env `AGENTDESK_RECOVERY_ANCHOR_REPOST` `"1"`/`"true"` = staging opt-in. No runtime behavior change.

## Gate results (CARGO_BUILD_JOBS=5)
- `cargo fmt --check` — clean ✅
- `cargo check --lib` — clean ✅ (warnings pre-existing, none in shared.rs)
- `cargo test --lib recovery_paths::shared` — 13 passed; 0 failed ✅ (incl. storm-guard tests `committed_repost_transient_is_budget_bounded_no_infinite_preserve` + `pane_alive_row_is_never_budget_cleared`)
- `check_agent_maintenance_docs.py` — "freshness check passed" ✅
- `check_hotfile_ratchet.py` — exit 0 ✅
- `audit_maintainability.py --check` — exit 0 ✅

## #3794 co-merge note
Still file-disjoint / parallel-safe with #3794 (`shared.rs` only; migration doc untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)