### PR TITLE
fix(pipeline): #3868 persist stage backoff, stop silent API drop

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -803,7 +803,7 @@
 | `services::opencode` | `src/services/opencode.rs` | 3125 | 2760 | 365 | giant-file |
 | `services::operator_connectors` | `src/services/operator_connectors.rs` | 477 | 293 | 184 |  |
 | `services::pipeline_override` | `src/services/pipeline_override.rs` | 1001 | 333 | 668 |  |
-| `services::pipeline_routes` | `src/services/pipeline_routes.rs` | 644 | 644 | 0 |  |
+| `services::pipeline_routes` | `src/services/pipeline_routes.rs` | 861 | 670 | 191 |  |
 | `services::platform` | `src/services/platform/mod.rs` | 26 | 26 | 0 |  |
 | `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1483 | 1381 | 102 | giant-file |
 | `services::platform::dump_tool` | `src/services/platform/dump_tool.rs` | 97 | 97 | 0 |  |

--- a/migrations/postgres/0076_pipeline_stages_backoff.sql
+++ b/migrations/postgres/0076_pipeline_stages_backoff.sql
@@ -1,0 +1,20 @@
+-- #3868 P2: persist the pipeline stage `backoff` policy (stop silently dropping it).
+--
+-- The pipeline API (`src/services/pipeline_routes.rs`) has long accepted a
+-- `backoff` field on each stage, validated it against STAGE_BACKOFF_VALUES
+-- (exponential/linear/none), and then **discarded it** — the INSERT never bound
+-- the column and the table had no place to store it. An operator who POSTed
+-- `backoff: exponential` got a 200, but the value vanished on the next GET
+-- (silent data loss). This adds the missing column so the validated value is
+-- actually persisted and round-trips back through the list/GET path.
+--
+-- Additive, nullable, no default and no backfill: existing rows get NULL, which
+-- the API already serializes as `"backoff": null`. `IF NOT EXISTS` keeps the
+-- migration idempotent.
+--
+-- DECLARATIVE-ONLY (see follow-up #3916): persisting `backoff` makes the API's
+-- "forward-compat" promise real, but NO runtime executor reads this column yet —
+-- like `on_failure` / `max_retries`, it is stored config metadata, not enforced
+-- behavior. The retry/backoff executor wiring is tracked by #3916.
+ALTER TABLE pipeline_stages
+  ADD COLUMN IF NOT EXISTS backoff TEXT;

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -390,6 +390,11 @@
       "path": "migrations/postgres/0075_turns_archive.sql",
       "sha256": "e0fe9fff7f70ef331f380f6188d7415b017720c94c827822728733131dce1759",
       "version": 75
+    },
+    {
+      "path": "migrations/postgres/0076_pipeline_stages_backoff.sql",
+      "sha256": "38275062039f5a29a8d5103cc3622e7d348d1273b0e3be780568aa44f624903f",
+      "version": 76
     }
   ],
   "version": 1

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -768,9 +768,9 @@ impl Default for BackoffPolicy {
     }
 }
 
-/// `on_failure` policy for stages (#1082).
-// reason: staged-rollout policy enum retained for config compatibility; the
-// runtime mirror lives in services::pipeline_routes and is not yet wired here.
+/// `on_failure` policy for stages (#1082). DECLARATIVE-ONLY config surface.
+// reason: persisted + validated by services::pipeline_routes, but NOT enforced
+// at runtime — no executor reads on_failure/retry/backoff (follow-up #3916).
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -829,9 +829,9 @@ pub struct TimeoutConfig {
     pub condition: Option<String>,
 }
 
-// reason: #1082 timeout retry/backoff resolution surface retained for staged
-// policy rollout; currently consumed only by the #1082 DoD unit tests, pending
-// wiring into the live timeout executor.
+// reason: #1082 timeout retry/backoff resolution surface. DECLARATIVE-ONLY:
+// consumed only by the #1082 DoD unit tests; NOT wired to any live timeout
+// executor (decide_timeout reads only legacy on_exhaust). Follow-up #3916.
 #[allow(dead_code)]
 impl TimeoutConfig {
     /// Default max_retries when caller did not specify (1, per #1082 DoD).

--- a/src/services/pipeline_routes.rs
+++ b/src/services/pipeline_routes.rs
@@ -13,6 +13,29 @@ pub const STAGE_ON_FAILURE_VALUES: &[&str] =
 /// #1082 -- accepted `backoff` policy values.
 pub const STAGE_BACKOFF_VALUES: &[&str] = &["exponential", "linear", "none"];
 
+/// `replace_stages` upsert. `backoff` ($14) added by #3868 so the validated
+/// value is persisted instead of silently dropped. Column order MUST match the
+/// `.bind(...)` chain in `replace_stages`.
+const INSERT_STAGE_SQL: &str = "INSERT INTO pipeline_stages (
+    repo_id, stage_name, stage_order, trigger_after, entry_skill,
+    timeout_minutes, on_failure, skip_condition, provider, agent_override_id,
+    on_failure_target, max_retries, parallel_with, backoff
+ ) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
+ )";
+
+/// `list_pipeline_stages_pg` projection. `backoff` added by #3868 so it
+/// round-trips back through the list/GET path. Column order MUST match
+/// `pg_stage_row_to_json`.
+const SELECT_STAGES_SQL: &str =
+    "SELECT id, repo_id, stage_name, stage_order, trigger_after, entry_skill,
+        timeout_minutes, on_failure, skip_condition, provider,
+        agent_override_id, on_failure_target, max_retries, parallel_with, backoff
+ FROM pipeline_stages
+ WHERE ($1::text IS NULL OR repo_id = $1)
+   AND ($2::text IS NULL OR agent_override_id = $2)
+ ORDER BY stage_order ASC";
+
 #[derive(Debug)]
 pub enum PipelineRouteError {
     BadRequest { stage: String, error: String },
@@ -33,8 +56,11 @@ pub struct PipelineStageInput {
     pub on_failure: Option<String>,
     pub on_failure_target: Option<String>,
     pub max_retries: Option<i64>,
-    /// #1082 backoff policy. One of STAGE_BACKOFF_VALUES. Not persisted to DB
-    /// in this iteration; accepted for forward-compat in the API payload.
+    /// #1082 backoff policy. One of STAGE_BACKOFF_VALUES. Persisted as
+    /// declarative stage metadata (#3868) so it round-trips through GET, but it
+    /// is **stored, not enforced** — no runtime executor reads it yet (same as
+    /// `on_failure` / `max_retries`). The retry/backoff executor is tracked by
+    /// the follow-up #3916.
     pub backoff: Option<String>,
     pub skip_condition: Option<String>,
     pub parallel_with: Option<String>,
@@ -90,36 +116,29 @@ impl<'a> PipelineRouteService<'a> {
             let on_failure = stage.on_failure.as_deref().unwrap_or("fail");
             let max_retries = stage.max_retries.unwrap_or(0);
 
-            sqlx::query(
-                "INSERT INTO pipeline_stages (
-                    repo_id, stage_name, stage_order, trigger_after, entry_skill,
-                    timeout_minutes, on_failure, skip_condition, provider, agent_override_id,
-                    on_failure_target, max_retries, parallel_with
-                 ) VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
-                 )",
-            )
-            .bind(repo)
-            .bind(&stage.stage_name)
-            .bind(order)
-            .bind(stage.trigger_after.as_deref())
-            .bind(stage.entry_skill.as_deref())
-            .bind(timeout)
-            .bind(on_failure)
-            .bind(stage.skip_condition.as_deref())
-            .bind(stage.provider.as_deref())
-            .bind(stage.agent_override_id.as_deref())
-            .bind(stage.on_failure_target.as_deref())
-            .bind(max_retries)
-            .bind(stage.parallel_with.as_deref())
-            .execute(&mut *tx)
-            .await
-            .map_err(|error| {
-                PipelineRouteError::Database(format!(
-                    "insert stage '{}': {error}",
-                    stage.stage_name
-                ))
-            })?;
+            sqlx::query(INSERT_STAGE_SQL)
+                .bind(repo)
+                .bind(&stage.stage_name)
+                .bind(order)
+                .bind(stage.trigger_after.as_deref())
+                .bind(stage.entry_skill.as_deref())
+                .bind(timeout)
+                .bind(on_failure)
+                .bind(stage.skip_condition.as_deref())
+                .bind(stage.provider.as_deref())
+                .bind(stage.agent_override_id.as_deref())
+                .bind(stage.on_failure_target.as_deref())
+                .bind(max_retries)
+                .bind(stage.parallel_with.as_deref())
+                .bind(normalize_optional(stage.backoff.as_deref()))
+                .execute(&mut *tx)
+                .await
+                .map_err(|error| {
+                    PipelineRouteError::Database(format!(
+                        "insert stage '{}': {error}",
+                        stage.stage_name
+                    ))
+                })?;
         }
 
         tx.commit()
@@ -356,6 +375,13 @@ pub fn validate_on_failure(value: Option<&str>) -> Result<(), String> {
     }
 }
 
+/// Map `None` or an empty/whitespace-only string to `None` so it persists as
+/// SQL NULL (rather than an empty string). Used for the optional `backoff`
+/// column (#3868) so an omitted/blank policy round-trips back as `null`.
+fn normalize_optional(value: Option<&str>) -> Option<&str> {
+    value.filter(|v| !v.trim().is_empty())
+}
+
 /// Validate a stage's `backoff` string.
 pub fn validate_backoff(value: Option<&str>) -> Result<(), String> {
     match value {
@@ -377,7 +403,11 @@ fn validate_pipeline_stages(stages: &[PipelineStageInput]) -> Result<(), Pipelin
                 error,
             });
         }
-        if let Err(error) = validate_backoff(stage.backoff.as_deref()) {
+        // Validate the *normalized* value so a blank/whitespace-only backoff is
+        // treated identically to absent (both persist as NULL), instead of an
+        // empty string passing but "   " erroring — consistent with the INSERT,
+        // which also binds `normalize_optional(stage.backoff)`.
+        if let Err(error) = validate_backoff(normalize_optional(stage.backoff.as_deref())) {
             return Err(PipelineRouteError::BadRequest {
                 stage: stage.stage_name.clone(),
                 error,
@@ -410,6 +440,7 @@ fn stage_json(
     on_failure_target: Option<String>,
     max_retries: Option<i64>,
     parallel_with: Option<String>,
+    backoff: Option<String>,
 ) -> Value {
     json!({
         "id": id,
@@ -427,6 +458,7 @@ fn stage_json(
         "on_failure_target": on_failure_target,
         "max_retries": max_retries,
         "parallel_with": parallel_with,
+        "backoff": backoff,
     })
 }
 
@@ -450,6 +482,7 @@ fn pg_stage_row_to_json(row: &sqlx::postgres::PgRow) -> Result<Value, sqlx::Erro
         row.try_get::<Option<String>, _>("on_failure_target")?,
         max_retries,
         row.try_get::<Option<String>, _>("parallel_with")?,
+        row.try_get::<Option<String>, _>("backoff")?,
     ))
 }
 
@@ -458,20 +491,12 @@ async fn list_pipeline_stages_pg(
     repo: Option<&str>,
     agent_id: Option<&str>,
 ) -> Result<Vec<Value>, PipelineRouteError> {
-    let rows = sqlx::query(
-        "SELECT id, repo_id, stage_name, stage_order, trigger_after, entry_skill,
-                timeout_minutes, on_failure, skip_condition, provider,
-                agent_override_id, on_failure_target, max_retries, parallel_with
-         FROM pipeline_stages
-         WHERE ($1::text IS NULL OR repo_id = $1)
-           AND ($2::text IS NULL OR agent_override_id = $2)
-         ORDER BY stage_order ASC",
-    )
-    .bind(repo)
-    .bind(agent_id)
-    .fetch_all(pool)
-    .await
-    .map_err(|error| PipelineRouteError::Database(format!("query postgres stages: {error}")))?;
+    let rows = sqlx::query(SELECT_STAGES_SQL)
+        .bind(repo)
+        .bind(agent_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|error| PipelineRouteError::Database(format!("query postgres stages: {error}")))?;
 
     rows.into_iter()
         .map(|row| {
@@ -641,4 +666,196 @@ fn source_label(source: table_metadata::Source) -> &'static str {
 
 fn database_error(error: sqlx::Error) -> PipelineRouteError {
     PipelineRouteError::Database(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stage_with_backoff(backoff: Option<&str>) -> PipelineStageInput {
+        PipelineStageInput {
+            stage_name: "build".to_string(),
+            stage_order: Some(1),
+            trigger_after: None,
+            entry_skill: None,
+            provider: None,
+            agent_override_id: None,
+            timeout_minutes: Some(60),
+            on_failure: Some("retry-with-backoff".to_string()),
+            on_failure_target: None,
+            max_retries: Some(2),
+            backoff: backoff.map(str::to_string),
+            skip_condition: None,
+            parallel_with: None,
+        }
+    }
+
+    /// The persistence SQL must carry the `backoff` column on BOTH the write and
+    /// read paths. This is the direct regression guard for the #3868 silent drop
+    /// (INSERT used to omit the column / SELECT used to never read it). The bind
+    /// count must also reach `$14` so the value is actually written.
+    #[test]
+    fn persistence_sql_includes_backoff_column() {
+        assert!(
+            INSERT_STAGE_SQL.contains("backoff"),
+            "INSERT must persist backoff: {INSERT_STAGE_SQL}"
+        );
+        assert!(
+            INSERT_STAGE_SQL.contains("$14"),
+            "INSERT must bind backoff as $14: {INSERT_STAGE_SQL}"
+        );
+        assert!(
+            SELECT_STAGES_SQL.contains("backoff"),
+            "SELECT must read backoff back: {SELECT_STAGES_SQL}"
+        );
+    }
+
+    /// Serialization unit guard: `stage_json` emits the `backoff` it is given
+    /// (this is the JSON the DB row feeds through `pg_stage_row_to_json`). The
+    /// end-to-end DB round-trip is covered by
+    /// `replace_stages_persists_backoff_round_trip_pg`.
+    #[test]
+    fn stage_json_emits_backoff_field() {
+        let value = stage_json(
+            1,
+            Some("repo".to_string()),
+            Some("build".to_string()),
+            1,
+            None,
+            None,
+            60,
+            Some("retry-with-backoff".to_string()),
+            None,
+            None,
+            None,
+            None,
+            Some(2),
+            None,
+            Some("exponential".to_string()),
+        );
+        assert_eq!(value["backoff"], json!("exponential"));
+    }
+
+    /// Absent backoff serializes as JSON null (no spurious default).
+    #[test]
+    fn stage_json_absent_backoff_is_null() {
+        let value = stage_json(
+            1, None, None, 1, None, None, 60, None, None, None, None, None, None, None, None,
+        );
+        assert_eq!(value["backoff"], Value::Null);
+    }
+
+    /// A valid backoff passes validation; an unknown value is rejected as
+    /// BadRequest (the API contract stays intact after persistence wiring).
+    #[test]
+    fn invalid_backoff_is_bad_request() {
+        validate_pipeline_stages(&[stage_with_backoff(Some("exponential"))])
+            .expect("known backoff value should validate");
+        // Blank/whitespace-only is treated like absent (normalized to NULL),
+        // NOT a BadRequest — consistent with the empty-string and None cases.
+        validate_pipeline_stages(&[stage_with_backoff(Some(""))])
+            .expect("empty backoff should validate (normalizes to NULL)");
+        validate_pipeline_stages(&[stage_with_backoff(Some("   "))])
+            .expect("whitespace-only backoff should validate (normalizes to NULL)");
+
+        let err = validate_pipeline_stages(&[stage_with_backoff(Some("bogus"))])
+            .expect_err("unknown backoff value must be rejected");
+        match err {
+            PipelineRouteError::BadRequest { stage, error } => {
+                assert_eq!(stage, "build");
+                assert!(
+                    error.contains("backoff"),
+                    "error should name backoff: {error}"
+                );
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    /// Empty/whitespace backoff normalizes to NULL so it round-trips as `null`
+    /// rather than an empty string; a real value passes through unchanged.
+    #[test]
+    fn normalize_optional_blanks_to_none() {
+        assert_eq!(normalize_optional(None), None);
+        assert_eq!(normalize_optional(Some("")), None);
+        assert_eq!(normalize_optional(Some("   ")), None);
+        assert_eq!(normalize_optional(Some("exponential")), Some("exponential"));
+    }
+
+    /// End-to-end DB round-trip against a real Postgres: write stages via
+    /// `replace_stages` and read them back via `list_stages`, proving the
+    /// `backoff` value actually survives the persistence layer. This is the
+    /// regression test for the #3868 silent drop — it would have FAILED before
+    /// the INSERT/SELECT/column wiring. Skips cleanly when no local Postgres is
+    /// reachable. Also covers absent->null, whitespace-only->NULL, and
+    /// invalid->BadRequest through the same write path.
+    #[tokio::test]
+    async fn replace_stages_persists_backoff_round_trip_pg() {
+        let Some(pg_db) = crate::dispatch::test_support::DispatchPostgresTestDb::try_create(
+            "agentdesk_pipeline_backoff",
+            "pipeline stage backoff persistence",
+        )
+        .await
+        else {
+            return; // no local Postgres available — skip.
+        };
+        let pool = pg_db.connect_and_migrate().await;
+
+        // `pipeline_stages` seeds as `file-canonical` (read-only) in 0019; flip
+        // it to `db` so the API write path is exercised rather than rejected.
+        sqlx::query(
+            "UPDATE db_table_metadata SET source_of_truth = 'db' \
+             WHERE table_name = 'pipeline_stages'",
+        )
+        .execute(&pool)
+        .await
+        .expect("flip pipeline_stages to db source-of-truth");
+
+        let service = PipelineRouteService::new(&pool);
+
+        // (1) A real backoff written via replace_stages reads back identically
+        // through list_stages — the direct #3868 silent-drop guard.
+        let written = service
+            .replace_stages("repo-rt", &[stage_with_backoff(Some("exponential"))])
+            .await
+            .expect("replace_stages with backoff should succeed");
+        assert_eq!(written[0]["backoff"], json!("exponential"));
+        let listed = service
+            .list_stages(Some("repo-rt"), None)
+            .await
+            .expect("list_stages should succeed");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0]["backoff"], json!("exponential"));
+
+        // (2) Absent backoff round-trips as null (no spurious default).
+        let listed = service
+            .replace_stages("repo-rt", &[stage_with_backoff(None)])
+            .await
+            .expect("replace_stages without backoff should succeed");
+        assert_eq!(listed[0]["backoff"], Value::Null);
+
+        // (3) Whitespace-only backoff normalizes to NULL (consistent with
+        // absent/""), neither a BadRequest nor a stored "   ".
+        let listed = service
+            .replace_stages("repo-rt", &[stage_with_backoff(Some("   "))])
+            .await
+            .expect("whitespace-only backoff should normalize to NULL, not error");
+        assert_eq!(listed[0]["backoff"], Value::Null);
+
+        // (4) Invalid backoff is rejected before any write; the prior good row
+        // (NULL from case 3) stays intact (validation precedes the tx).
+        let err = service
+            .replace_stages("repo-rt", &[stage_with_backoff(Some("bogus"))])
+            .await
+            .expect_err("invalid backoff must be rejected");
+        assert!(matches!(err, PipelineRouteError::BadRequest { .. }));
+        let listed = service
+            .list_stages(Some("repo-rt"), None)
+            .await
+            .expect("list_stages should succeed");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0]["backoff"], Value::Null);
+
+        pg_db.drop().await;
+    }
 }


### PR DESCRIPTION
Closes #3868.

## The bug (silent data loss)
The pipeline API has long accepted a `backoff` policy per stage, validated it
against `STAGE_BACKOFF_VALUES` (`exponential`/`linear`/`none`), and then
**silently dropped it**:
- `replace_stages` INSERT bound 13 columns — never `backoff`.
- the list SELECT / `stage_json` / `pg_stage_row_to_json` never read or emitted it.
- `pipeline_stages` had no `backoff` column at all.

Net effect: an operator POSTs `backoff: exponential`, the API returns 200, and
the value is gone on the next GET. The field was documented "Not persisted ...
accepted for forward-compat" — i.e. accepted then thrown away.

## The fix (additive, minimal — AC path B)
Persist `backoff` as declarative metadata so the validated value round-trips:

- **New migration `0076_pipeline_stages_backoff.sql`**:
  `ALTER TABLE pipeline_stages ADD COLUMN IF NOT EXISTS backoff TEXT;` — nullable,
  no default, no backfill, idempotent. Checksum appended to
  `immutable-checksums.json`.
- **`src/services/pipeline_routes.rs`**: bind `backoff` in the INSERT (`$14`),
  read it in the SELECT, emit it from `stage_json` / `pg_stage_row_to_json`.
  Empty/blank normalizes to `NULL` (round-trips as `null`). The INSERT/SELECT
  SQL were extracted into named consts so a unit test guards the `backoff` column
  on both the write and read paths. `validate_backoff` is unchanged.

## Docs honesty
Per the issue's AC ("persist or downgrade to declarative + remove silent drop"),
this also makes the dead typed-policy surface honest:
- `src/pipeline.rs` (comment-only, net-zero LoC): `OnFailurePolicy` and
  `impl TimeoutConfig` are now marked **DECLARATIVE-ONLY — persisted/validated but
  NOT enforced at runtime**. No executor reads `on_failure`/`retry`/`backoff`;
  `decide_timeout` reads only the legacy `on_exhaust` string.
- The API `backoff` doc comment now says stored-not-enforced (same as
  `on_failure` / `max_retries`).

## Deferred (out of #3868 scope)
The real executor — wiring `OnFailurePolicy`/`TimeoutConfig` retry+backoff into
`engine/transition.rs` `decide_timeout` + a backoff-aware timeout sweep + per-card
retry state — is a greenfield epic, not a P2. Tracked by follow-up **#3916**.

## Tests (`pipeline_routes.rs` had none)
- `persistence_sql_includes_backoff_column` — guards the column on INSERT (`$14`)
  and SELECT (kills the silent-drop regression).
- `stage_json_round_trips_backoff` / `stage_json_absent_backoff_is_null`.
- `invalid_backoff_is_bad_request` — contract intact.
- `normalize_optional_blanks_to_none`.
- Existing pipeline FSM/timeout/gate tests stay green (18 passed, 0 failed).

## Invariants
Additive nullable column, ZERO runtime/FSM/relay behavior change, `pipeline.rs`
comment-only (giant baseline untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)