### PR TITLE
chore(cli): remove deprecated postgres-cutover importer (#3874 part A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,8 +666,9 @@ agentdesk api GET /api/health                    # Public safe health summary
 agentdesk api GET /api/health/detail             # Authenticated/local detailed health
 agentdesk deploy                                 # Build workspace + promote to release
 agentdesk migrate openclaw <ARGS>                # Import OpenClaw durable state
-# `migrate postgres-cutover` is retired (production cutover landed 2026-04-19); the
-# subcommand is parsed but returns an error so help/scripts don't break. Do not run it.
+# `migrate postgres-cutover` was retired (production cutover landed 2026-04-19) and the
+# subcommand has been removed. Restore src/cli/migrate/postgres_cutover.rs from history
+# for an explicitly approved emergency re-cutover.
 agentdesk provider-cli <SUBCOMMAND>              # Provider CLI safe-migration ops (status/plan/upgrade/canary/promote/rollback/cleanup/run/resume/smoke)
 
 # Process wrappers (internal — invoked by tmux session lifecycle)

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -53,7 +53,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 21 | 21 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1047 | 979 | 68 |  |
+| `cli::args` | `src/cli/args.rs` | 1037 | 969 | 68 |  |
 | `cli::client` | `src/cli/client.rs` | 2563 | 2378 | 185 | giant-file |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1627 | 1627 | 0 | giant-file |
 | `cli::direct` | `src/cli/direct.rs` | 1813 | 1813 | 0 | giant-file |
@@ -65,14 +65,14 @@
 | `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 4498 | 4381 | 117 | giant-file |
 | `cli::doctor::startup` | `src/cli/doctor/startup.rs` | 623 | 553 | 70 |  |
 | `cli::init` | `src/cli/init.rs` | 1520 | 1444 | 76 | giant-file |
-| `cli::migrate` | `src/cli/migrate.rs` | 346 | 346 | 0 |  |
+| `cli::migrate` | `src/cli/migrate.rs` | 317 | 317 | 0 |  |
 | `cli::migrate::apply` | `src/cli/migrate/apply.rs` | 3237 | 3237 | 0 | giant-file |
 | `cli::migrate::plan` | `src/cli/migrate/plan.rs` | 1513 | 1513 | 0 | giant-file |
 | `cli::migrate::source` | `src/cli/migrate/source.rs` | 1612 | 1612 | 0 | giant-file |
 | `cli::monitoring` | `src/cli/monitoring.rs` | 123 | 123 | 0 |  |
 | `cli::provider_cli` | `src/cli/provider_cli/mod.rs` | 1039 | 1039 | 0 | giant-file |
 | `cli::query` | `src/cli/query.rs` | 462 | 379 | 83 |  |
-| `cli::run` | `src/cli/run.rs` | 667 | 667 | 0 |  |
+| `cli::run` | `src/cli/run.rs` | 663 | 663 | 0 |  |
 | `cli::utils` | `src/cli/utils.rs` | 581 | 473 | 108 |  |
 | `compat` | `src/compat/mod.rs` | 39 | 39 | 0 |  |
 | `compat::legacy_db_paths` | `src/compat/legacy_db_paths.rs` | 12 | 12 | 0 |  |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -876,8 +876,6 @@ pub(crate) struct DispatchArgs {
 pub(crate) enum MigrateAction {
     /// Import OpenClaw durable state into AgentDesk
     Openclaw(super::migrate::OpenClawMigrateArgs),
-    /// Cut over SQLite history into PostgreSQL and verify live state is drained
-    PostgresCutover(super::migrate::PostgresCutoverArgs),
 }
 
 #[derive(Subcommand)]
@@ -936,14 +934,6 @@ pub(crate) enum ParseOutcome {
 }
 
 fn rewrite_legacy_args(mut args: Vec<String>) -> Vec<String> {
-    if args.get(1).map(String::as_str) == Some("--cutover-pg") {
-        let mut rewritten = Vec::with_capacity(args.len() + 1);
-        rewritten.push(args.remove(0));
-        rewritten.push("migrate".to_string());
-        rewritten.push("postgres-cutover".to_string());
-        rewritten.extend(args.into_iter().skip(1));
-        return rewritten;
-    }
     if args.get(1).map(String::as_str) == Some("--emit-launchd-plist") {
         let mut rewritten = Vec::with_capacity(args.len() + 1);
         rewritten.push(args.remove(0));

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -13,35 +13,6 @@ use apply::apply_import_plan;
 use plan::build_import_plan;
 use source::resolve_source_root;
 
-#[derive(Clone, Debug, Args)]
-pub struct PostgresCutoverArgs {
-    /// Preview counts and blockers without writing files or importing into PostgreSQL
-    #[arg(long)]
-    pub dry_run: bool,
-    /// Optional directory for JSONL archive snapshots
-    #[arg(long = "archive-dir", value_name = "PATH")]
-    pub archive_dir: Option<String>,
-    /// Skip PostgreSQL import and only report/export the SQLite history.
-    #[arg(long)]
-    pub skip_pg_import: bool,
-    /// Acknowledge and proceed even when SQLite still has unsent message_outbox rows.
-    #[arg(long = "allow-unsent-messages")]
-    pub allow_unsent_messages: bool,
-    /// Override the runtime-active safety check for archive-only cutover.
-    #[arg(long = "allow-runtime-active")]
-    pub allow_runtime_active: bool,
-}
-
-#[deprecated(
-    note = "production cutover completed on 2026-04-19; the legacy SQLite-to-PostgreSQL cutover implementation is intentionally retired from normal builds."
-)]
-pub async fn cmd_migrate_postgres_cutover(_args: PostgresCutoverArgs) -> Result<(), String> {
-    Err(
-        "postgres-cutover is retired: production cutover completed on 2026-04-19, and the legacy SQLite-to-PostgreSQL importer is no longer compiled into AgentDesk. Restore src/cli/migrate/postgres_cutover.rs from history for an explicitly approved emergency re-cutover."
-            .to_string(),
-    )
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ToolPolicyMode {
     Report,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -553,10 +553,6 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
         }
         Commands::Migrate { action } => exit_for_cli(match action {
             MigrateAction::Openclaw(args) => super::migrate::cmd_migrate_openclaw(args),
-            #[allow(deprecated)]
-            MigrateAction::PostgresCutover(args) => {
-                super::direct::run_async(super::migrate::cmd_migrate_postgres_cutover(args))
-            }
         }),
         Commands::ProviderCli(args) => exit_for_cli(super::provider_cli::cmd_provider_cli(args)),
         Commands::Show { action } => exit_for_cli(handle_show(action)),


### PR DESCRIPTION
## Summary
**PR-A of the #3874 dead-code split** (the parallel-safe, `cli/*`-only half).

The production SQLite→PostgreSQL cutover landed 2026-04-19 (#3034/#3035). The legacy importer was already retired behind a `#[deprecated]` error-returning stub. This PR removes the dead CLI surface entirely. **Pure dead-code removal — zero behavior change.**

## Scope (this PR — `cli/*` only)
- `src/cli/migrate.rs` — delete `PostgresCutoverArgs` struct + `cmd_migrate_postgres_cutover()`.
- `src/cli/args.rs` — drop the `PostgresCutover` variant from `MigrateAction`, and the `--cutover-pg` → `migrate postgres-cutover` legacy-arg rewrite block in `rewrite_legacy_args()` (without the subcommand it would rewrite to a non-existent target).
- `src/cli/run.rs` — drop the `MigrateAction::PostgresCutover` dispatch arm.
- `README.md` — update the migrate cheat-sheet note (subcommand is now removed, not merely parsed-and-erroring).
- `docs/generated/module-inventory.md` — regenerated `cli::args`/`cli::migrate`/`cli::run` row line counts (inventory gate).

`migrate openclaw` and every other subcommand are untouched.

## Deferred to PR-B (NOT in this PR)
The `Db` alias / `DisabledDbBackend` / `memento_feedback_stats.rs` removal (design §A–C) necessarily edits the #3016 **core hotfiles** `turn_bridge/mod.rs` and `tmux_watcher.rs`, so it **must serialize after the Lane1 (#3859) hotfile window**. Those files are byte-identical to `origin/main` in this PR.

## Gate results (toolchain pinned 1.94.1, `CARGO_BUILD_JOBS=5`)
- `cargo fmt --check` — **PASS** (clean).
- `cargo check --lib --bins` — **PASS** (Finished).
- `cargo clippy --workspace --all-targets --all-features -- -W clippy::all` (repo's authoritative `just lint` gate) — **PASS, exit 0**. The stricter `-D warnings` variant (`just lint-strict`) is the repo's documented "Expected-failing zero-warning target" and fails only on **pre-existing baseline debt in files this PR does not touch**; this PR introduces no new clippy finding (no `cli/*` file appears in clippy output).
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` — **PASS** ("agent-maintenance freshness check passed"); unrelated inventory drift (control.rs, idle_recap_interaction.rs) reverted to keep the PR scoped to `cli/*`.
- `check_hotfile_ratchet.py` — **PASS, exit 0**.
- `audit_maintainability.py --check` — **PASS, exit 0** (incl. the "Legacy SQLite references" hard gate: count 0).
- CLI smoke: `agentdesk migrate --help` lists only `openclaw`/`help` — **no `postgres-cutover`**; `--cutover-pg` is now an unrecognized argument.
- `cargo test --lib` test targets compile; no test references the removed symbols.

Closes part A of #3874. **Do not merge before review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)