### PR TITLE
fix(discord): SIGTERM 큐 복원 레이스 — actor 내부 merge로 라이브 메시지 유실 차단 (#3864)

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -83,7 +83,7 @@
 | `src/services/discord/commands/text_commands.rs` | 1475 |
 | `src/services/discord/formatting.rs` | 2801 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
-| `src/services/discord/mod.rs` | 4147 |
+| `src/services/discord/mod.rs` | 4153 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1543 |
 | `src/services/discord_config_audit.rs` | 1288 |
 | `src/services/dispatched_sessions.rs` | 1550 |
@@ -101,5 +101,5 @@
 | `src/services/routines/store.rs` | 3453 |
 | `src/services/settings.rs` | 1114 |
 | `src/services/tui_prompt_dedupe.rs` | 1709 |
-| `src/services/turn_orchestrator.rs` | 3089 |
+| `src/services/turn_orchestrator.rs` | 3184 |
 | `src/voice/receiver.rs` | 1052 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -394,7 +394,7 @@
 | `services::codex_tui::rollout_tail` | `src/services/codex_tui/rollout_tail.rs` | 4201 | 1276 | 2925 | giant-file |
 | `services::codex_tui::rollout_tail::parser` | `src/services/codex_tui/rollout_tail/parser.rs` | 405 | 405 | 0 |  |
 | `services::codex_tui::session` | `src/services/codex_tui/session.rs` | 800 | 316 | 484 |  |
-| `services::discord` | `src/services/discord/mod.rs` | 5135 | 4147 | 988 | giant-file |
+| `services::discord` | `src/services/discord/mod.rs` | 5141 | 4153 | 988 | giant-file |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 980 | 854 | 126 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 929 | 575 | 354 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1058 | 957 | 101 |  |
@@ -405,7 +405,7 @@
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 120 | 120 | 0 |  |
 | `services::discord::commands::command_policy` | `src/services/discord/commands/command_policy.rs` | 221 | 209 | 12 |  |
 | `services::discord::commands::config` | `src/services/discord/commands/config.rs` | 1224 | 956 | 268 |  |
-| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 778 | 748 | 30 |  |
+| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 840 | 782 | 58 |  |
 | `services::discord::commands::diagnostics` | `src/services/discord/commands/diagnostics/mod.rs` | 389 | 389 | 0 |  |
 | `services::discord::commands::diagnostics::reports` | `src/services/discord/commands/diagnostics/reports.rs` | 677 | 651 | 26 |  |
 | `services::discord::commands::fast_mode` | `src/services/discord/commands/fast_mode.rs` | 82 | 82 | 0 |  |
@@ -460,7 +460,7 @@
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
-| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 457 | 423 | 34 |  |
+| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 7339 | 2802 | 4537 | giant-file |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
@@ -584,8 +584,8 @@
 | `services::discord::runtime_bootstrap::intake` | `src/services/discord/runtime_bootstrap/intake.rs` | 83 | 83 | 0 |  |
 | `services::discord::runtime_bootstrap::orphan_recovery` | `src/services/discord/runtime_bootstrap/orphan_recovery.rs` | 337 | 337 | 0 |  |
 | `services::discord::runtime_bootstrap::queued_placeholders` | `src/services/discord/runtime_bootstrap/queued_placeholders.rs` | 193 | 193 | 0 |  |
-| `services::discord::runtime_bootstrap::recovery_flush` | `src/services/discord/runtime_bootstrap/recovery_flush.rs` | 366 | 366 | 0 |  |
-| `services::discord::runtime_bootstrap::restored_state` | `src/services/discord/runtime_bootstrap/restored_state.rs` | 124 | 124 | 0 |  |
+| `services::discord::runtime_bootstrap::recovery_flush` | `src/services/discord/runtime_bootstrap/recovery_flush.rs` | 387 | 387 | 0 |  |
+| `services::discord::runtime_bootstrap::restored_state` | `src/services/discord/runtime_bootstrap/restored_state.rs` | 93 | 93 | 0 |  |
 | `services::discord::runtime_bootstrap::session_gc` | `src/services/discord/runtime_bootstrap/session_gc.rs` | 180 | 102 | 78 |  |
 | `services::discord::runtime_bootstrap::shared_data` | `src/services/discord/runtime_bootstrap/shared_data.rs` | 245 | 245 | 0 |  |
 | `services::discord::runtime_bootstrap::shutdown` | `src/services/discord/runtime_bootstrap/shutdown.rs` | 209 | 209 | 0 |  |
@@ -874,7 +874,7 @@
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |
 | `services::turn_lifecycle` | `src/services/turn_lifecycle.rs` | 564 | 436 | 128 |  |
-| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5123 | 3089 | 2034 | giant-file |
+| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5464 | 3184 | 2280 | giant-file |
 | `services::turn_orchestrator::registry_purge` | `src/services/turn_orchestrator/registry_purge.rs` | 816 | 293 | 523 |  |
 | `supervisor` | `src/supervisor/mod.rs` | 1045 | 916 | 129 |  |
 | `ui` | `src/ui/mod.rs` | 1 | 1 | 0 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -197,7 +197,11 @@
 # the module inventory surface while shrinking `tui_prompt_relay.rs` below the
 # giant threshold; refresh the frozen parent-module count so script checks reflect
 # current main.
-"src/services/discord/mod.rs" = 4147
+# #3864 (P1 data-loss): swap the now-dead `mailbox_replace_queue` wrapper for the
+# new in-actor `mailbox_merge_restored_queue_items` wrapper (restore now merges
+# inside the mailbox actor instead of a racy out-of-actor snapshot->replace).
+# Net +6 prod LoC. 4147 -> 4153.
+"src/services/discord/mod.rs" = 4153
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).
@@ -342,7 +346,15 @@
 # `TryStartTurn` guard — the enum/state/loop can only live in the root)
 # are offset by #2374 actor-arm comment dedup in the same root, so the
 # frozen baseline stays at 3089 (no raise; #3028 ratchet).
-"src/services/turn_orchestrator.rs" = 3089
+# #3864 (P1 data-loss): move the SIGTERM queue-restore merge INSIDE the mailbox
+# actor so a live reconcile-window enqueue can no longer be overwritten. Adds the
+# `intervention_dedup_ids` helper + thorough (source_message_ids) dedup in
+# `hydrate_pending_queue_into_state`, plus the `MergeRestoredQueueItems` actor
+# message (variant + handle method + handler arm) with race-explanation comments.
+# Also gates the now-test-only `ReplaceQueue` blind-overwrite path behind
+# `#[cfg(test)]` (+ justification comments). Test functions are excluded from the
+# count. +95 prod LoC. 3089 -> 3184.
+"src/services/turn_orchestrator.rs" = 3184
 # #3034 batch-8: +1 for a test-only `#[allow(dead_code)]` on
 # `thread_guard_inflight_is_stale` (#1446 Layer-2 classifier, pinned by tests).
 # #3038 S1: +2 (2958 -> 2960) for the two mechanical `.queued_placeholders` ->

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3664,19 +3664,25 @@ async fn mailbox_clear_channel(
     result
 }
 
-async fn mailbox_replace_queue(
+/// #3864: in-actor merge of SIGTERM-restored disk queue items into the live
+/// mailbox queue. Replaces the out-of-actor snapshot→build→`replace_queue`
+/// read-modify-write the startup restore path used, which silently lost any
+/// live reconcile-window `Enqueue` landing between its snapshot and its
+/// replace. The actor reads, dedups, front-inserts and persists in one
+/// serialized step (cf. `mailbox_hydrate_pending_queue_from_disk`, #1683).
+async fn mailbox_merge_restored_queue_items(
     shared: &SharedData,
     provider: &ProviderKind,
     channel_id: ChannelId,
-    queue: Vec<Intervention>,
-) {
+    items: Vec<Intervention>,
+) -> HydratePendingQueueResult {
     shared
         .mailbox(channel_id)
-        .replace_queue(
-            queue,
+        .merge_restored_queue_items(
+            items,
             queue_persistence_context(shared, provider, channel_id),
         )
-        .await;
+        .await
 }
 
 /// #1683: actor-local disk -> in-memory hydration helper. The mailbox

--- a/src/services/discord/runtime_bootstrap/recovery_flush.rs
+++ b/src/services/discord/runtime_bootstrap/recovery_flush.rs
@@ -85,6 +85,7 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                 let mut skipped_unowned = 0usize;
                 let mut skipped_sender = 0usize;
                 let mut skipped_duplicate = 0usize;
+                let mut skipped_persist_error = 0usize;
                 for (channel_id, items) in restored_queues {
                     if !matches!(
                         resolve_runtime_channel_binding_status(&http_for_tmux, channel_id).await,
@@ -93,38 +94,58 @@ pub(super) fn run_bot_spawn_recovery_and_flush_restart_reports(
                         skipped_unowned += items.len();
                         continue;
                     }
-                    let snapshot = mailbox_snapshot(&shared_for_tmux2, channel_id).await;
-                    let mut existing_ids = queued_message_ids(&snapshot);
-                    let mut queue = snapshot.intervention_queue;
+                    // #3864: the sender filter is stateless, so it stays
+                    // out-of-actor; collect the allowed items here. The merge
+                    // into the live queue (dedup + front-insert + persist) then
+                    // happens INSIDE the mailbox actor in one serialized step,
+                    // so a live reconcile-window `Enqueue` can no longer be lost
+                    // between an out-of-actor snapshot and a blind replace.
+                    let mut allowed_items: Vec<Intervention> = Vec::with_capacity(items.len());
                     for item in items {
-                        if !super::is_allowed_turn_sender(
+                        if super::is_allowed_turn_sender(
                             &allowed_bot_ids_for_restore,
                             announce_bot_id_for_restore,
                             item.author_id.get(),
                             item.author_is_bot,
                             &item.text,
                         ) {
-                            skipped_sender += 1;
-                            continue;
-                        }
-                        if enqueue_restored_intervention(&mut existing_ids, &mut queue, item) {
-                            added += 1;
+                            allowed_items.push(item);
                         } else {
-                            skipped_duplicate += 1;
+                            skipped_sender += 1;
                         }
                     }
-                    mailbox_replace_queue(
+                    let allowed_count = allowed_items.len();
+                    if allowed_count == 0 {
+                        continue;
+                    }
+                    let result = mailbox_merge_restored_queue_items(
                         &shared_for_tmux2,
                         &provider_for_restore,
                         channel_id,
-                        queue,
+                        allowed_items,
                     )
                     .await;
+                    if let Some(error) = result.persistence_error {
+                        // Merge-persist failed → the actor rolled the in-memory
+                        // queue back. The live reconcile-window enqueue survives
+                        // (it was persisted by its own `Enqueue` and lives in the
+                        // rolled-back-to previous queue). Surface the failure;
+                        // don't miscount the restored items as duplicates.
+                        skipped_persist_error += allowed_count;
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] 📋 FLUSH: persist failed merging {allowed_count} restored queue item(s) for channel {channel_id}: {error}"
+                        );
+                    } else {
+                        added += result.absorbed;
+                        skipped_duplicate += allowed_count - result.absorbed;
+                    }
                 }
-                let skipped = skipped_unowned + skipped_sender + skipped_duplicate;
+                let skipped =
+                    skipped_unowned + skipped_sender + skipped_duplicate + skipped_persist_error;
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
-                    "  [{ts}] 📋 FLUSH: restored {added} pending queue item(s) from disk (skipped {skipped}: unowned={skipped_unowned}, sender={skipped_sender}, duplicate={skipped_duplicate})"
+                    "  [{ts}] 📋 FLUSH: restored {added} pending queue item(s) from disk (skipped {skipped}: unowned={skipped_unowned}, sender={skipped_sender}, duplicate={skipped_duplicate}, persist_error={skipped_persist_error})"
                 );
             }
 

--- a/src/services/discord/runtime_bootstrap/restored_state.rs
+++ b/src/services/discord/runtime_bootstrap/restored_state.rs
@@ -91,34 +91,3 @@ pub(super) fn bootstrap_session_reset_pending_channels(
     }
     set
 }
-
-pub(super) fn restored_intervention_message_ids(item: &Intervention) -> Vec<u64> {
-    let mut item_ids: Vec<u64> = item.source_message_ids.iter().map(|id| id.get()).collect();
-    if item_ids.is_empty() {
-        item_ids.push(item.message_id.get());
-    } else if !item_ids.contains(&item.message_id.get()) {
-        item_ids.push(item.message_id.get());
-    }
-    item_ids
-}
-
-pub(super) fn enqueue_restored_intervention(
-    existing_ids: &mut std::collections::HashSet<u64>,
-    queue: &mut Vec<Intervention>,
-    item: Intervention,
-) -> bool {
-    let item_ids = restored_intervention_message_ids(&item);
-    // Persisted merged queue items may represent multiple source messages. If startup
-    // catch-up already recovered only some of them, dropping the whole item would lose
-    // the unseen messages because the merged text is no longer separable.
-    if item_ids
-        .iter()
-        .all(|message_id| existing_ids.contains(message_id))
-    {
-        return false;
-    }
-
-    existing_ids.extend(item_ids);
-    queue.push(item);
-    true
-}

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -1455,6 +1455,12 @@ impl ChannelMailboxHandle {
         .await
     }
 
+    // #3864: test-only queue-seeding helper. Production startup restore moved
+    // to `merge_restored_queue_items` (the in-actor merge), so `ReplaceQueue`'s
+    // blind overwrite — the source of the lost-enqueue race — has NO production
+    // caller anymore and is gated to test builds. Test modules still use it to
+    // seed a channel queue directly.
+    #[cfg(test)]
     pub(crate) async fn replace_queue(
         &self,
         queue: Vec<Intervention>,
@@ -1478,6 +1484,29 @@ impl ChannelMailboxHandle {
     ) -> HydratePendingQueueResult {
         self.request(
             |reply| ChannelMailboxMsg::HydratePendingQueueFromDisk { persistence, reply },
+            HydratePendingQueueResult::default(),
+        )
+        .await
+    }
+
+    /// #3864: in-actor merge of SIGTERM-restored disk items into the live
+    /// queue. Mirrors `hydrate_pending_queue_from_disk`, but the caller
+    /// supplies the items it already loaded and sender-filtered (the
+    /// sender check is stateless, so it stays out-of-actor); the actor then
+    /// dedups, front-inserts and persists in one serialized step. Replaces
+    /// the out-of-actor snapshot→build→`replace_queue` RMW that silently
+    /// dropped any live `Enqueue` landing between its two round-trips.
+    pub(crate) async fn merge_restored_queue_items(
+        &self,
+        items: Vec<Intervention>,
+        persistence: QueuePersistenceContext,
+    ) -> HydratePendingQueueResult {
+        self.request(
+            |reply| ChannelMailboxMsg::MergeRestoredQueueItems {
+                items,
+                persistence,
+                reply,
+            },
             HydratePendingQueueResult::default(),
         )
         .await
@@ -1988,12 +2017,30 @@ enum ChannelMailboxMsg {
         clear_cancelled_active_anchor: bool,
         reply: oneshot::Sender<PurgeQueueResult>,
     },
+    /// #3864: blind queue overwrite. Production restore now uses
+    /// `MergeRestoredQueueItems` (in-actor, race-immune); `ReplaceQueue` has no
+    /// production caller and survives ONLY as a `#[cfg(test)]` queue-seeding
+    /// primitive used across the queue / turn_finalizer / turn_orchestrator
+    /// test modules.
+    #[cfg(test)]
     ReplaceQueue {
         queue: Vec<Intervention>,
         persistence: QueuePersistenceContext,
         reply: oneshot::Sender<()>,
     },
     HydratePendingQueueFromDisk {
+        persistence: QueuePersistenceContext,
+        reply: oneshot::Sender<HydratePendingQueueResult>,
+    },
+    /// #3864: merge SIGTERM-restored disk queue items into the LIVE queue
+    /// inside the actor, in one serialized step. Unlike `ReplaceQueue` — a
+    /// blind overwrite that loses any `Enqueue` landing between an
+    /// out-of-actor snapshot and the replace — this reads, dedups,
+    /// front-inserts and persists atomically, so a live reconcile-window
+    /// enqueue can never be dropped (same race-immunity as
+    /// `HydratePendingQueueFromDisk`, #1683).
+    MergeRestoredQueueItems {
+        items: Vec<Intervention>,
         persistence: QueuePersistenceContext,
         reply: oneshot::Sender<HydratePendingQueueResult>,
     },
@@ -2136,6 +2183,20 @@ fn persist_queue_or_restore(
     }
 }
 
+/// #3864: the full set of message ids an intervention represents — every
+/// `source_message_ids` entry (a merged queue item may carry several), plus its
+/// own `message_id` when not already among them. Dedup must treat an incoming
+/// item as a duplicate ONLY when EVERY one of these ids is already queued;
+/// otherwise a merged item whose text is no longer separable would silently
+/// drop the source messages startup catch-up has not yet recovered.
+fn intervention_dedup_ids(item: &Intervention) -> Vec<MessageId> {
+    let mut ids: Vec<MessageId> = item.source_message_ids.clone();
+    if !ids.contains(&item.message_id) {
+        ids.push(item.message_id);
+    }
+    ids
+}
+
 fn hydrate_pending_queue_into_state(
     state: &mut ChannelMailboxState,
     channel_id: ChannelId,
@@ -2145,18 +2206,29 @@ fn hydrate_pending_queue_into_state(
 ) -> HydratePendingQueueResult {
     state.last_persistence = Some(persistence.clone());
     let previous_queue = state.intervention_queue.clone();
+    // #3864: seed the seen-set with the FULL id set of every live queue item
+    // (message_id + source_message_ids), not just message_id, so a restored
+    // merged item that overlaps a live item on any source id is recognized as
+    // a duplicate. Strictly strengthens the prior message_id-only dedup; the
+    // existing disk-hydrate callers only ever pass single-source items, for
+    // which this is identical behavior.
     let mut existing_ids: HashSet<MessageId> = state
         .intervention_queue
         .iter()
-        .map(|item| item.message_id)
+        .flat_map(intervention_dedup_ids)
         .collect();
     let mut absorbed = 0usize;
     // Walk in reverse so repeated `insert(0, …)` ends up with disk
     // items in their original order.
     for item in disk_items.into_iter().rev() {
-        if !existing_ids.insert(item.message_id) {
+        let item_ids = intervention_dedup_ids(&item);
+        // Skip ONLY when every id the item represents is already queued. A
+        // merged item is dropped whole solely if all of its source messages
+        // are present; otherwise the unseen ones would be lost.
+        if item_ids.iter().all(|id| existing_ids.contains(id)) {
             continue;
         }
+        existing_ids.extend(item_ids);
         state.intervention_queue.insert(0, item);
         absorbed += 1;
     }
@@ -3060,6 +3132,7 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                         cleared_active_anchor,
                     });
                 }
+                #[cfg(test)]
                 ChannelMailboxMsg::ReplaceQueue {
                     queue,
                     persistence,
@@ -3086,6 +3159,28 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                         &mut state,
                         channel_id,
                         &persistence,
+                    );
+                    let _ = reply.send(result);
+                }
+                ChannelMailboxMsg::MergeRestoredQueueItems {
+                    items,
+                    persistence,
+                    reply,
+                } => {
+                    // #3864: merge SIGTERM-restored disk items into the live
+                    // queue in ONE serialized actor step (read + dedup-merge +
+                    // persist). Immune to the lost-enqueue race the old
+                    // out-of-actor snapshot→build→`ReplaceQueue` RMW suffered:
+                    // a live reconcile-window `Enqueue` is serialized before
+                    // or after this merge, never overwritten by it. override =
+                    // None — dispatch_role_overrides are restored separately,
+                    // before the restore loop (see recovery_flush).
+                    let result = hydrate_pending_queue_into_state(
+                        &mut state,
+                        channel_id,
+                        items,
+                        persistence,
+                        None,
                     );
                     let _ = reply.send(result);
                 }
@@ -3215,10 +3310,35 @@ mod actor_hydrate_regression_tests {
         }
     }
 
+    fn make_intervention_with_sources(
+        message_id: u64,
+        source_ids: &[u64],
+        text: &str,
+        created_at: Instant,
+    ) -> Intervention {
+        Intervention {
+            source_message_ids: source_ids.iter().copied().map(MessageId::new).collect(),
+            ..make_intervention(message_id, text, created_at)
+        }
+    }
+
     fn lock_test_env() -> MutexGuard<'static, ()> {
         TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Drive an async body to completion on a fresh current-thread runtime.
+    /// Used by the env-locked queue tests so the `lock_test_env()` guard is
+    /// held across a *synchronous* `block_on` rather than across an `.await` —
+    /// keeping the global `AGENTDESK_ROOT_DIR` env stable for the duration
+    /// WITHOUT a `#[allow(clippy::await_holding_lock)]` site (#3034 ratchet).
+    fn run_async<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(fut)
     }
 
     #[test]
@@ -3292,6 +3412,247 @@ mod actor_hydrate_regression_tests {
         );
         assert_eq!(hydrate.queue_len_after, 0);
         assert!(handle.snapshot().await.intervention_queue.is_empty());
+    }
+
+    /// #3864 PRIMARY regression: a live reconcile-window `Enqueue` that lands
+    /// before the SIGTERM restore merge must be PRESERVED, not overwritten.
+    /// The old out-of-actor snapshot→build→`ReplaceQueue` RMW blind-replaced
+    /// the queue and silently dropped the live message from BOTH memory and
+    /// disk; the in-actor merge front-inserts the restored item ahead of the
+    /// live one and persists both atomically.
+    ///
+    /// Sync test driving the actor via `run_async`/`block_on` so the env lock
+    /// guard is not held across an `.await` (no await_holding_lock site).
+    #[test]
+    fn merge_restored_items_preserves_concurrent_live_enqueue() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let token_hash = "merge-restored-preserves-live";
+            let channel_id = ChannelId::new(3864001);
+            let registry = ChannelMailboxRegistry::default();
+            let handle = registry.handle(channel_id);
+            let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+
+            // Live reconcile-window message B lands first (actor `Enqueue`).
+            let live = handle
+                .enqueue(
+                    make_intervention(200, "live-during-reconcile", Instant::now()),
+                    persistence.clone(),
+                )
+                .await;
+            assert!(live.enqueued, "live reconcile-window enqueue must succeed");
+
+            // SIGTERM-restored item A is merged AFTER (loaded out-of-actor,
+            // handed to the actor as items). It must NOT clobber the live B.
+            let result = handle
+                .merge_restored_queue_items(
+                    vec![make_intervention(
+                        100,
+                        "restored-from-sigterm",
+                        Instant::now(),
+                    )],
+                    persistence.clone(),
+                )
+                .await;
+            assert_eq!(result.absorbed, 1, "restored item A is absorbed");
+            assert_eq!(result.queue_len_after, 2);
+            assert!(result.persistence_error.is_none());
+
+            // In memory: [A, B] — restored (older) front-inserted ahead of live.
+            let queue = handle.snapshot().await.intervention_queue;
+            let ids: Vec<u64> = queue.iter().map(|i| i.message_id.get()).collect();
+            assert_eq!(
+                ids,
+                vec![100, 200],
+                "merge must keep the live enqueue and front-insert the restored item"
+            );
+
+            // On disk: the same [A, B] (the old ReplaceQueue would persist only [A]).
+            let (disk, _override) = load_channel_pending_queue(&provider, token_hash, channel_id);
+            let disk_ids: Vec<u64> = disk.iter().map(|i| i.message_id.get()).collect();
+            assert_eq!(
+                disk_ids,
+                vec![100, 200],
+                "both the restored and the live item must be durably persisted"
+            );
+        });
+    }
+
+    /// #3864 order: multiple restored items keep their original order and are
+    /// all front-inserted ahead of the (newer) live queue item.
+    #[test]
+    fn merge_restored_items_front_inserts_in_order_ahead_of_live() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let token_hash = "merge-restored-order";
+            let channel_id = ChannelId::new(3864002);
+            let registry = ChannelMailboxRegistry::default();
+            let handle = registry.handle(channel_id);
+            let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+
+            handle
+                .enqueue(
+                    make_intervention(300, "live", Instant::now()),
+                    persistence.clone(),
+                )
+                .await;
+            let result = handle
+                .merge_restored_queue_items(
+                    vec![
+                        make_intervention(100, "restored-older", Instant::now()),
+                        make_intervention(200, "restored-newer", Instant::now()),
+                    ],
+                    persistence.clone(),
+                )
+                .await;
+            assert_eq!(result.absorbed, 2);
+            let ids: Vec<u64> = handle
+                .snapshot()
+                .await
+                .intervention_queue
+                .iter()
+                .map(|i| i.message_id.get())
+                .collect();
+            assert_eq!(
+                ids,
+                vec![100, 200, 300],
+                "restored items keep order and sit ahead of the live item"
+            );
+        });
+    }
+
+    /// #3864 thorough dedup: a restored item whose ids are fully covered by a
+    /// live queued item's `source_message_ids` is skipped. The old
+    /// `message_id`-only dedup would re-add it (its `message_id` is NOT a live
+    /// head `message_id`, only a live SOURCE id), creating a duplicate.
+    #[test]
+    fn merge_restored_items_skips_overlapping_source_ids() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let token_hash = "merge-restored-dedup";
+            let channel_id = ChannelId::new(3864003);
+            let registry = ChannelMailboxRegistry::default();
+            let handle = registry.handle(channel_id);
+            let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+
+            // Live queue holds a MERGED item: head message_id 300, source {300, 301}.
+            handle
+                .replace_queue(
+                    vec![make_intervention_with_sources(
+                        300,
+                        &[300, 301],
+                        "live-merged",
+                        Instant::now(),
+                    )],
+                    persistence.clone(),
+                )
+                .await;
+
+            // Restored item carries head message_id 301 (a live SOURCE id, not a
+            // live head id) with source {301} — fully covered by the live item.
+            let result = handle
+                .merge_restored_queue_items(
+                    vec![make_intervention_with_sources(
+                        301,
+                        &[301],
+                        "restored-duplicate",
+                        Instant::now(),
+                    )],
+                    persistence.clone(),
+                )
+                .await;
+            assert_eq!(
+                result.absorbed, 0,
+                "restored item fully covered by a live item's source ids must be skipped"
+            );
+            let queue = handle.snapshot().await.intervention_queue;
+            assert_eq!(queue.len(), 1, "no duplicate must be inserted");
+            assert_eq!(queue[0].message_id.get(), 300);
+        });
+    }
+
+    /// #3864 persist-failure rollback: when the merge's durable persist fails,
+    /// the actor rolls the in-memory queue back. The live enqueue survives (it
+    /// was persisted by its own `Enqueue` and lives in the rolled-back-to
+    /// previous queue), and the failure is surfaced via `persistence_error`
+    /// instead of being silently dropped.
+    #[cfg(unix)]
+    #[test]
+    fn merge_restored_items_persist_failure_rolls_back_and_keeps_live() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        run_async(async {
+            let provider = ProviderKind::Claude;
+            let token_hash = "merge-restored-persist-fail";
+            let channel_id = ChannelId::new(3864004);
+            let registry = ChannelMailboxRegistry::default();
+            let handle = registry.handle(channel_id);
+            let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+
+            // Live message B persists successfully (dir writable).
+            let live = handle
+                .enqueue(
+                    make_intervention(200, "live", Instant::now()),
+                    persistence.clone(),
+                )
+                .await;
+            assert!(live.enqueued);
+            let path = queue_file_path(tmp.path(), &provider, token_hash, channel_id);
+            assert!(path.exists());
+            let dir = path.parent().unwrap().to_path_buf();
+
+            // Make the channel's persistence dir read-only so the merge's atomic
+            // write (tmp create + rename) fails.
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+            let result = handle
+                .merge_restored_queue_items(
+                    vec![make_intervention(100, "restored", Instant::now())],
+                    persistence.clone(),
+                )
+                .await;
+            // Restore perms before any assertion can early-return (and before drop).
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+            assert!(
+                result.persistence_error.is_some(),
+                "merge persist failure must be surfaced"
+            );
+            assert_eq!(result.absorbed, 0, "rolled back → nothing absorbed");
+
+            // In memory: rolled back to just the live B (restored A dropped).
+            let ids: Vec<u64> = handle
+                .snapshot()
+                .await
+                .intervention_queue
+                .iter()
+                .map(|i| i.message_id.get())
+                .collect();
+            assert_eq!(ids, vec![200], "rollback keeps the live enqueue");
+
+            // On disk: still the live B only (atomic write never clobbered it).
+            let (disk, _override) = load_channel_pending_queue(&provider, token_hash, channel_id);
+            let disk_ids: Vec<u64> = disk.iter().map(|i| i.message_id.get()).collect();
+            assert_eq!(disk_ids, vec![200], "live enqueue stays durably persisted");
+        });
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #3864 (P1, data-loss).

## The race
SIGTERM 후 재시작 시 persist된 pending 큐 복원이 **mailbox actor 밖에서** read-modify-write를 두 번의 actor round-trip에 걸쳐 수행했다:

- `recovery_flush.rs`: `mailbox_snapshot()` (round-trip #1, 라이브 큐 읽기) → stale snapshot으로 queue 구성 → `mailbox_replace_queue()` (round-trip #2, 쓰기).
- `turn_orchestrator.rs` `ReplaceQueue` 핸들러: `state.intervention_queue = queue` **blind overwrite + durable persist**.

`mark_reconcile_complete`는 복원 루프 종료 후에야 호출되므로, 그동안 ReconcileGate가 라이브 사용자 메시지를 `🔄`로 ack하고 actor `Enqueue`로 적재한다. actor 직렬화 순서는 `Snapshot → (live) Enqueue → ReplaceQueue`. 마지막 `ReplaceQueue`가 방금 적재된 라이브 메시지를 **메모리·디스크 양쪽에서** 덮어쓴다 → 사용자는 큐됨 ack를 봤지만 그 턴은 **영영 미발송**되는 조용한 영구 유실.

## The fix — in-actor merge (reuses #1683)
바로 다음 arm인 `HydratePendingQueueFromDisk`(#1683)가 이미 actor 내부에서 디스크를 읽고 merge하여 이 레이스를 회피한다. 동일 패턴으로 통일했다:

- **stateless sender-filter는 actor 밖에 유지** (라이브 상태 불필요), 허용 항목만 수집.
- 새 actor 메시지 **`MergeRestoredQueueItems`** 가 라이브 큐 읽기 + dedup + front-insert + persist를 **단일 직렬화 스텝**으로 수행. 중간에 끼어든 `Enqueue`는 merge 앞/뒤로 직렬화될 뿐 절대 덮어쓰이지 않는다.

### 변경
- `turn_orchestrator.rs`
  - `hydrate_pending_queue_into_state` dedup을 `message_id` 단독 → **full id set (`message_id` + `source_message_ids`)** 로 강화 (기존 `enqueue_restored_intervention` 의미와 동일; single-source 항목엔 동작 불변이라 기존 hydrate 콜러 안전).
  - 새 `MergeRestoredQueueItems` 메시지 + `ChannelMailboxHandle::merge_restored_queue_items` + 핸들러 arm (override=None, 기존 `HydratePendingQueueResult` 재사용).
  - 더 이상 프로덕션 콜러가 없는 `ReplaceQueue` blind-overwrite 경로를 `#[cfg(test)]`로 게이트 (테스트 큐 시딩 전용으로만 잔존).
- `discord/mod.rs`: `mailbox_merge_restored_queue_items` 래퍼 추가, 죽은 `mailbox_replace_queue` 제거.
- `recovery_flush.rs`: snapshot→build→replace → sender-filter → in-actor merge; 결과에서 added/skipped 도출, persist 실패를 로그로 표면화 (`persist_error` 카운터 추가).
- `restored_state.rs`: 유일 콜러가 사라진 `enqueue_restored_intervention` / `restored_intervention_message_ids` 삭제 (clippy dead_code).

## 보존된 불변식
sender 필터 · 채널 ownership skip · thorough dedup(incl. `source_message_ids`) · durable persist+rollback · `dispatch_role_override` 복원(루프 전, 그대로) · older-before-newer 순서 · **핵심 원자성(read+merge+persist 단일 actor 스텝)**. merge-persist 실패 시 in-memory rollback해도 라이브 메시지는 자신의 `Enqueue`로 이미 persist되어 `previous_queue`에 남으므로 보존된다.

## 테스트 (actor-level regression)
모두 sync `block_on`으로 작성해 `await_holding_lock` ratchet(34)을 유지:
- **`merge_restored_items_preserves_concurrent_live_enqueue`**: `Enqueue(B)` → `Merge([A])` 후 최종 큐 == `[A,B]` (메모리 **및** 디스크). 구 `ReplaceQueue` 경로라면 B 유실.
- **`...front_inserts_in_order_ahead_of_live`**: 복원 항목 순서 유지 + 라이브 앞에 삽입.
- **`...skips_overlapping_source_ids`**: 라이브 항목의 `source_message_ids`에 덮인 복원 항목 skip (구 message_id-only dedup이면 중복 삽입).
- **`...persist_failure_rolls_back_and_keeps_live`**: persist 강제 실패 시 rollback, `persistence_error` 표면화, 라이브 B 잔존.
- 기존 `actor_hydrate_regression_tests` 재실행 (회귀 없음).

## CI 게이트 (giant-file baseline bumps)
- `src/services/discord/mod.rs` 4147 → **4153** (+6 prod LoC).
- `src/services/turn_orchestrator.rs` 3089 → **3184** (+95 prod LoC; 테스트 코드 제외).
정당화 주석 포함, `audit_maintainability.py --check` exit 0.

> 참고: 로컬 toolchain(rust-1.94.1)의 `clippy --all-targets -- -D warnings`는 main에도 존재하는 사전 lint 부채(unused import, MutexGuard-across-await, useless_vec 등 ~25건)로 실패하지만, **본 PR이 추가한 lint는 0건**이며 Cargo.toml `[lints.clippy]` 하드 게이트(`await_holding_lock` 등)는 모두 통과한다.
> 또한 mandated `generate_inventory_docs.py` 재생성이 main의 사전 doc drift(`control.rs`, `idle_recap_interaction.rs` 라인수)도 함께 최신화했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
