### PR TITLE
fix(claude_tui): fail fast on MCP-auth cold-boot welcome screen (#3889)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1560,7 +1560,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1182) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (2963), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (2969), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3049),
   `src/services/opencode.rs` (2760), `src/services/provider.rs` (1613) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
@@ -1604,13 +1604,17 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1765) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1930) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:
   startup-dialog auto-dismiss and keeping the follow-up readiness wait alive
   while the prior turn streams; +20 from #3637 centralizing post-paste error
-  cleanup and making draft clearing cancel-agnostic.)
+  cleanup and making draft clearing cancel-agnostic. # #3889 +165: detect the
+  MCP-authentication-required cold-boot welcome screen during readiness and fail
+  fast with an actionable, non-timeout reason instead of false-submitting then
+  blind-waiting/retrying the full timeout; gate every ready-return path —
+  including the recorded-turn idle-transcript fallbacks — on the MCP-auth check.)
 - `src/services/memory/memento.rs` (1893).
 - `src/services/dispatched_sessions.rs` (1550) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -76,8 +76,8 @@
 | `src/services/auto_queue.rs` | 1546 |
 | `src/services/auto_queue/activate_command.rs` | 1506 |
 | `src/services/auto_queue/cancel_run.rs` | 1032 |
-| `src/services/claude.rs` | 2963 |
-| `src/services/claude_tui/input.rs` | 1765 |
+| `src/services/claude.rs` | 2969 |
+| `src/services/claude_tui/input.rs` | 1930 |
 | `src/services/codex.rs` | 3049 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1366 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -349,7 +349,7 @@
 | `services::auto_queue::view_admin_routes` | `src/services/auto_queue/view_admin_routes.rs` | 730 | 730 | 0 |  |
 | `services::automation_candidate_contract` | `src/services/automation_candidate_contract.rs` | 127 | 87 | 40 |  |
 | `services::automation_candidate_materializer` | `src/services/automation_candidate_materializer.rs` | 844 | 844 | 0 |  |
-| `services::claude` | `src/services/claude.rs` | 4087 | 2963 | 1124 | giant-file |
+| `services::claude` | `src/services/claude.rs` | 4099 | 2969 | 1130 | giant-file |
 | `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 428 | 248 | 180 |  |
 | `services::claude_e` | `src/services/claude_e/mod.rs` | 18 | 18 | 0 |  |
 | `services::claude_e::cancellation` | `src/services/claude_e/cancellation.rs` | 3 | 3 | 0 |  |
@@ -364,7 +364,7 @@
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
-| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3048 | 1765 | 1283 | giant-file |
+| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3356 | 1930 | 1426 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 576 | 446 | 130 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 431 | 180 | 251 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
@@ -868,7 +868,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 533 | 506 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 223 | 223 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 1566 | 943 | 623 |  |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 1720 | 991 | 729 |  |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 241 | 241 | 0 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 720 | 677 | 43 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 100 | 100 | 0 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -20,7 +20,10 @@
 # #3038 execute_streaming S3: lowered claude.rs 3989 -> 2950 by moving the
 # TUI warm/follow-up hosting helpers into claude_tui/hosting/ child modules.
 # #3262 turn-lock acquisition/state/tests intentionally remain in claude.rs root.
-"src/services/claude.rs" = 2963
+# #3889 +6 (2963 -> 2969): the fresh-prompt retry guard explicitly never retries
+# the terminal MCP-auth cold-boot error (1 LoC) plus its rationale comment; this
+# bounds the retry storm and is the live consumer of `is_mcp_auth_required_error`.
+"src/services/claude.rs" = 2969
 # #3034 batch-8: the dead_code lint went live for the discord tree; the two
 # test-only `#[allow(dead_code)]` attributes on
 # `watcher_inflight_is_external_input_for_session` / the lease alias add +2 and

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2162,7 +2162,13 @@ fn run_claude_tui_fresh_turn_with_ready_retry(
 
 #[cfg(unix)]
 fn should_retry_claude_tui_fresh_prompt_ready(error: &str, attempt: usize) -> bool {
-    crate::services::claude_tui::input::is_prompt_ready_timeout_error(error)
+    // #3889: a cold-boot stranded on the MCP-authentication-required welcome
+    // screen is a terminal, operator-actionable condition — retrying just reboots
+    // into the same blocked screen and burns another readiness window. It is
+    // already a distinct (non-timeout) error, but guard it explicitly so the
+    // retry loop can never re-enter it even if classification shifts.
+    !crate::services::claude_tui::input::is_mcp_auth_required_error(error)
+        && crate::services::claude_tui::input::is_prompt_ready_timeout_error(error)
         && attempt < CLAUDE_TUI_FRESH_PROMPT_MAX_READY_ATTEMPTS
 }
 
@@ -3572,6 +3578,12 @@ mod local_tmux_lifecycle_tests {
         ));
         assert!(!should_retry_claude_tui_fresh_prompt_ready(
             "claude tui session died before prompt input was ready",
+            1
+        ));
+        // #3889: the terminal MCP-authentication block must never be retried —
+        // rebooting just lands on the same blocked welcome screen.
+        assert!(!should_retry_claude_tui_fresh_prompt_ready(
+            "claude tui blocked on MCP server authentication: the Claude Code cold-boot welcome screen is waiting on MCP server authentication and is silently dropping prompt submissions; run /mcp in tmux session 'AgentDesk-ch-ad' to authenticate the server, then resend",
             1
         ));
     }

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -39,6 +39,14 @@ const PROMPT_DRAFT_CLEANUP_CANCEL_TOKEN: Option<&CancelToken> = None;
 const SELECTOR_OPEN_TIMEOUT: Duration = Duration::from_secs(5);
 const PROMPT_READY_TIMEOUT_ERROR_PREFIX: &str = "timeout waiting for claude tui";
 pub const PROMPT_READY_CANCELLED_ERROR: &str = "claude tui prompt readiness wait cancelled";
+/// #3889: distinct, NON-timeout error prefix returned when a cold-boot lands on
+/// the MCP-authentication-required welcome screen. Kept separate from the
+/// readiness-timeout prefix so the fresh-prompt retry loop does not treat it as a
+/// transient timeout and reboot straight back into the same blocked screen.
+const PROMPT_READY_MCP_AUTH_ERROR_PREFIX: &str = "claude tui blocked on MCP server authentication";
+/// Settle delay before re-capturing to confirm an observed MCP-auth cold-boot
+/// banner is a stable blocking state and not a single half-rendered boot frame.
+const PROMPT_READY_MCP_AUTH_CONFIRM_SETTLE: Duration = Duration::from_millis(400);
 /// Cap on auto-dismiss key presses for Claude startup dialogs (resume-from-
 /// summary picker, workspace trust) per readiness wait. Startup can stack at
 /// most two dialogs back to back; if the pane still shows a dialog after this
@@ -332,6 +340,16 @@ pub fn send_followup_prompt(
 
 pub fn is_prompt_ready_timeout_error(error: &str) -> bool {
     error.starts_with(PROMPT_READY_TIMEOUT_ERROR_PREFIX)
+}
+
+/// True for the distinct, NON-timeout error `wait_for_prompt_ready` returns when
+/// a Claude Code cold-boot is stranded on the MCP-authentication-required welcome
+/// screen (#3889). Held apart from `is_prompt_ready_timeout_error` so the
+/// fresh-prompt retry loop does NOT treat it as a transient readiness timeout and
+/// re-boot into the same blocked screen; the caller instead surfaces the
+/// actionable `run /mcp` reason to the operator and stops looping.
+pub fn is_mcp_auth_required_error(error: &str) -> bool {
+    error.starts_with(PROMPT_READY_MCP_AUTH_ERROR_PREFIX)
 }
 
 pub fn is_prompt_ready_cancelled_error(error: &str) -> bool {
@@ -953,6 +971,23 @@ fn wait_for_prompt_ready_inner(
     let timeout = readiness.timeout();
     let start = Instant::now();
 
+    // #3889: a fresh cold-boot can land on the MCP-authentication-required
+    // welcome screen, which paints composer chrome (so it reads READY) yet
+    // silently drops every prompt submission until the operator runs `/mcp`.
+    // Detect it up front and fail fast with an actionable, non-timeout reason
+    // instead of blind-waiting the full readiness timeout and then rebooting
+    // into the same blocked screen. Scoped to FreshTurn (the cold-boot case);
+    // the kind-agnostic polling-loop check below is the safety net for both
+    // kinds. The check only re-captures when the banner is actually present, so
+    // a healthy fresh boot pays just one extra capture.
+    if matches!(readiness, PromptReadinessKind::FreshTurn) {
+        let snapshot = prompt_readiness_snapshot(session_name);
+        if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)? {
+            log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
+            return Err(mcp_auth_required_error_message(session_name));
+        }
+    }
+
     // #tui-hook-ttl-buffer (REQ-006): consult the in-memory hook registry as an
     // additive event source for an early Stop that landed before this wait
     // began. The global `prompt_ready_notify()` used by the fast path below is
@@ -991,7 +1026,12 @@ fn wait_for_prompt_ready_inner(
         );
     }
 
-    if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path) {
+    // #3889: even an idle transcript must not confirm ready while the live pane
+    // is stranded on the MCP-auth welcome screen (short-circuit keeps the pane
+    // capture off the non-idle hot path).
+    if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path)
+        && pane_not_mcp_auth_blocked(session_name)
+    {
         tracing::info!(
             tmux_session_name = session_name,
             readiness = readiness.label(),
@@ -1064,7 +1104,11 @@ fn wait_for_prompt_ready_inner(
             );
             return Ok(());
         }
-        if transcript_idle_confirms_prompt_ready(&snapshot, transcript_path) {
+        // #3889: gate the idle-transcript fallback on the MCP-auth check too —
+        // we already hold the post-event snapshot, so this is free.
+        if !snapshot_indicates_mcp_auth_block(&snapshot)
+            && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
+        {
             check_prompt_cancel(cancel_token)?;
             let drained_buffered_stop = claude_registry_stop_already_buffered(session_name);
             tracing::info!(
@@ -1277,7 +1321,13 @@ fn wait_for_prompt_ready_polling(
     let mut active_turn_extension_logged = false;
     loop {
         check_prompt_cancel(cancel_token)?;
-        if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path) {
+        // #3889: idle transcript alone must not confirm ready while the pane is
+        // stranded on the MCP-auth welcome screen (short-circuit keeps the pane
+        // capture off the non-idle poll cadence). When it IS blocked this falls
+        // through to the snapshot + auth fail-fast just below.
+        if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path)
+            && pane_not_mcp_auth_blocked(session_name)
+        {
             tracing::info!(
                 tmux_session_name = session_name,
                 readiness = readiness.label(),
@@ -1288,6 +1338,16 @@ fn wait_for_prompt_ready_polling(
         }
         let snapshot = prompt_readiness_snapshot(session_name);
         check_prompt_cancel(cancel_token)?;
+        // #3889: bail out of the wait the moment the pane is confirmed stranded
+        // on the MCP-authentication-required cold-boot welcome screen. This must
+        // precede the ready check because that screen's composer chrome would
+        // otherwise read as ready (`prompt_marker_confirms_prompt_ready` already
+        // refuses it, but failing fast here surfaces the actionable reason and
+        // avoids burning the rest of the timeout).
+        if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)? {
+            log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
+            return Err(mcp_auth_required_error_message(session_name));
+        }
         if prompt_marker_confirms_prompt_ready(&snapshot) {
             return Ok(());
         }
@@ -1334,7 +1394,12 @@ fn wait_for_prompt_ready_polling(
                 }
             }
         }
-        if transcript_idle_confirms_prompt_ready(&snapshot, transcript_path) {
+        // #3889: gate the idle-transcript fallback on the MCP-auth check (the
+        // snapshot is already in hand). The auth fail-fast above normally returns
+        // first, so this is belt-and-suspenders for any future reordering.
+        if !snapshot_indicates_mcp_auth_block(&snapshot)
+            && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
+        {
             tracing::info!(
                 tmux_session_name = session_name,
                 readiness = readiness.label(),
@@ -1474,7 +1539,76 @@ fn pane_looks_ready_for_prompt(pane: &str) -> bool {
 }
 
 fn prompt_marker_confirms_prompt_ready(snapshot: &PromptReadinessSnapshot) -> bool {
-    snapshot.prompt_marker_detected && !snapshot.prompt_draft_detected
+    snapshot.prompt_marker_detected
+        && !snapshot.prompt_draft_detected
+        // #3889: the MCP-authentication-required cold-boot welcome screen paints
+        // composer chrome that otherwise reads as ready, but Claude Code drops
+        // submissions into it. Never confirm ready while that banner is up — in
+        // any path (fast-path pre/post snapshot, buffered-Stop, or polling).
+        && !snapshot_indicates_mcp_auth_block(snapshot)
+}
+
+/// Whether the snapshot's captured pane shows the MCP-authentication-required
+/// cold-boot welcome banner (`⚠ N MCP server(s) need authentication · run
+/// /mcp`). Derived from `pane_tail`, which always includes the bottom chrome
+/// where the warning renders (just above the composer); a blind capture
+/// (`capture_available == false`) can claim nothing and reports `false`.
+fn snapshot_indicates_mcp_auth_block(snapshot: &PromptReadinessSnapshot) -> bool {
+    snapshot.capture_available
+        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_mcp_auth_required(
+            &snapshot.pane_tail,
+        )
+}
+
+/// #3889 (Codex review #3931 [2]): a ready-return path that relies on transcript
+/// idleness — NOT a live pane marker — must still refuse to confirm ready when
+/// the pane is stranded on the MCP-authentication-required cold-boot welcome
+/// screen. Otherwise a stale idle transcript from a prior run (reachable via the
+/// #3880 A2 recorded-turn fast path) lets the prompt submit into a dead screen,
+/// bypassing the marker-path gate entirely.
+///
+/// Captures the pane to verify. Callers MUST gate this behind the transcript-idle
+/// check via short-circuit `&&` so the steady-state polling cadence pays no extra
+/// capture — the snapshot is taken only at the confirm boundary. A blind capture
+/// cannot assert a block, so it reports "not blocked".
+fn pane_not_mcp_auth_blocked(session_name: &str) -> bool {
+    !snapshot_indicates_mcp_auth_block(&prompt_readiness_snapshot(session_name))
+}
+
+/// Actionable, NON-timeout error for a cold-boot stranded on the
+/// MCP-authentication-required welcome screen. The `run /mcp` remediation is
+/// embedded so the reason reaches the operator verbatim instead of a generic
+/// "transport error".
+fn mcp_auth_required_error_message(session_name: &str) -> String {
+    format!(
+        "{PROMPT_READY_MCP_AUTH_ERROR_PREFIX}: the Claude Code cold-boot welcome screen is waiting on MCP server authentication and is silently dropping prompt submissions; run /mcp in tmux session '{session_name}' to authenticate the server, then resend"
+    )
+}
+
+/// Detect — and CONFIRM across a short settle re-capture — that the pane is
+/// stranded on the MCP-authentication-required cold-boot welcome screen.
+///
+/// Returns the confirming snapshot when the block is stable so the caller can
+/// fail fast with an actionable reason. Returns `Ok(None)` when the banner is
+/// absent, or when it was a transient half-rendered boot frame that cleared on
+/// the re-capture (so a session still coming up is never aborted). Cancellation
+/// during the settle propagates via `?`.
+fn confirm_mcp_auth_block(
+    session_name: &str,
+    cancel_token: Option<&CancelToken>,
+    first: &PromptReadinessSnapshot,
+) -> Result<Option<PromptReadinessSnapshot>, String> {
+    if !snapshot_indicates_mcp_auth_block(first) {
+        return Ok(None);
+    }
+    std::thread::sleep(PROMPT_READY_MCP_AUTH_CONFIRM_SETTLE);
+    check_prompt_cancel(cancel_token)?;
+    let confirm = prompt_readiness_snapshot(session_name);
+    if snapshot_indicates_mcp_auth_block(&confirm) {
+        Ok(Some(confirm))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Truthful root-cause attribution for a prompt-readiness timeout, derived from
@@ -1700,6 +1834,37 @@ fn log_prompt_ready_timeout(
             snapshot.prompt_marker_detected,
             snapshot.prompt_draft_detected,
             snapshot.tmux_pane_alive && !snapshot.prompt_marker_detected,
+            snapshot.tmux_pane_alive,
+            snapshot.capture_available,
+            snapshot.pane_tail
+        ),
+    );
+}
+
+/// #3889: record the confirmed MCP-auth cold-boot block. Logs the full pane tail
+/// (which carries the welcome box + warning banner) to `claude_tui.log` so the
+/// failure is diagnosable from a forensics file, not just a first-line WARN.
+fn log_prompt_ready_mcp_auth_block(
+    session_name: &str,
+    readiness: PromptReadinessKind,
+    snapshot: &PromptReadinessSnapshot,
+) {
+    tracing::warn!(
+        tmux_session_name = session_name,
+        readiness = readiness.label(),
+        prompt_marker_detected = snapshot.prompt_marker_detected,
+        prompt_draft_detected = snapshot.prompt_draft_detected,
+        tmux_pane_alive = snapshot.tmux_pane_alive,
+        capture_available = snapshot.capture_available,
+        pane_tail = %snapshot.pane_tail,
+        "claude_tui cold-boot stranded on MCP server authentication welcome screen; failing fast with an actionable reason instead of blind-waiting the readiness timeout"
+    );
+    crate::services::claude::debug_log_to(
+        "claude_tui.log",
+        &format!(
+            "prompt readiness mcp-auth block session={} readiness={} tmux_pane_alive={} capture_available={} pane_tail:\n{}",
+            session_name,
+            readiness.label(),
             snapshot.tmux_pane_alive,
             snapshot.capture_available,
             snapshot.pane_tail
@@ -2197,6 +2362,91 @@ mod tests {
         assert!(!prompt_marker_confirms_prompt_ready(&snapshot));
     }
 
+    // #3889: the MCP-authentication-required cold-boot welcome screen paints
+    // composer chrome that the legacy readiness predicate reads as ready, yet
+    // Claude Code drops every submission into it. The readiness gate must refuse
+    // such a snapshot as ready-to-submit (so we never false-submit and then
+    // blind-wait/retry), while a genuine empty composer still confirms ready.
+    #[test]
+    fn mcp_auth_cold_boot_welcome_is_not_ready_but_normal_composer_is() {
+        let mcp_auth_pane = "\
+╭─── Claude Code v2.1.195 ───────────────────────────╮
+│            Welcome back 오부장!                    │
+│   Opus 4.8 (1M context) · Claude Max               │
+╰────────────────────────────────────────────────────
+
+ ⚠ 1 MCP server needs authentication · run /mcp
+
+────────────────────────────────────────────────────
+❯ [Pasted text #1 +59 lines]
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+
+        // Marker/draft signals as the live snapshot would compute them on this
+        // pane (composer chrome ⇒ marker true, draft folded into idle chrome ⇒
+        // draft false): without the gate this is the exact false-ready that made
+        // the fresh turn submit into a dead screen.
+        let blocked = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: mcp_auth_pane.to_string(),
+        };
+        assert!(snapshot_indicates_mcp_auth_block(&blocked));
+        assert!(
+            !prompt_marker_confirms_prompt_ready(&blocked),
+            "MCP-auth cold-boot welcome screen must not be classified ready-to-submit"
+        );
+
+        // A genuine, connected, empty composer is unaffected and still ready.
+        let ready = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "\
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on"
+                .to_string(),
+        };
+        assert!(!snapshot_indicates_mcp_auth_block(&ready));
+        assert!(
+            prompt_marker_confirms_prompt_ready(&ready),
+            "a normal empty composer must still confirm ready"
+        );
+
+        // A blind capture cannot assert the banner is present, so it must not be
+        // flagged as auth-blocked (the unavailable-capture path owns that case).
+        let blind = PromptReadinessSnapshot {
+            capture_available: false,
+            pane_tail: "<capture unavailable>".to_string(),
+            ..blocked.clone()
+        };
+        assert!(!snapshot_indicates_mcp_auth_block(&blind));
+    }
+
+    // #3889: the MCP-auth fail-fast error must be a DISTINCT, non-timeout error
+    // so the fresh-prompt retry loop does not treat it as a transient timeout and
+    // reboot straight back into the same blocked screen.
+    #[test]
+    fn mcp_auth_required_error_is_distinct_from_timeout() {
+        let error = mcp_auth_required_error_message("AgentDesk-ch-ad");
+        assert!(is_mcp_auth_required_error(&error));
+        assert!(
+            !is_prompt_ready_timeout_error(&error),
+            "MCP-auth error must not be misread as a readiness timeout (which would retry it)"
+        );
+        assert!(error.contains("run /mcp"), "reason must be actionable");
+
+        // A real readiness timeout is not an MCP-auth error.
+        let timeout = format!("{PROMPT_READY_TIMEOUT_ERROR_PREFIX} fresh prompt input readiness");
+        assert!(is_prompt_ready_timeout_error(&timeout));
+        assert!(!is_mcp_auth_required_error(&timeout));
+    }
+
     #[test]
     fn prompt_submit_retries_only_when_live_pane_still_has_draft() {
         let draft_snapshot = PromptReadinessSnapshot {
@@ -2484,6 +2734,64 @@ line 13";
             &snapshot,
             Some(file.path())
         ));
+    }
+
+    // Codex review #3931 [2] (under-block): the transcript-idle fallback paths
+    // must also honour the MCP-auth gate. A recorded-turn (idle) transcript +
+    // an MCP-auth welcome pane must NOT confirm ready, even though the
+    // transcript-idle predicate ALONE accepts the composer-chrome pane — a
+    // normal recorded-turn idle pane (no welcome banner) still does.
+    #[test]
+    fn idle_transcript_fallback_is_gated_on_mcp_auth_block() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{"type":"system","subtype":"turn_duration","sessionId":"s"}"#,
+        )
+        .unwrap();
+
+        let blocked = PromptReadinessSnapshot {
+            prompt_marker_detected: false,
+            prompt_draft_detected: true,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "\
+ \u{26a0} 1 MCP server needs authentication \u{b7} run /mcp
+────────────────────────────────────────────────────
+\u{276f} [Pasted text #1 +59 lines]
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on"
+                .to_string(),
+        };
+        // Precondition: the transcript-idle predicate alone accepts the
+        // composer-chrome welcome pane (this is exactly why the gate is needed).
+        assert!(transcript_idle_confirms_prompt_ready(
+            &blocked,
+            Some(file.path())
+        ));
+        assert!(snapshot_indicates_mcp_auth_block(&blocked));
+        // The gate the fallback paths apply (`!block && idle`) refuses it.
+        assert!(
+            !(!snapshot_indicates_mcp_auth_block(&blocked)
+                && transcript_idle_confirms_prompt_ready(&blocked, Some(file.path()))),
+            "MCP-auth welcome pane must not confirm ready via the idle-transcript fallback"
+        );
+
+        // No regression: a normal recorded-turn idle pane (no welcome banner)
+        // still confirms ready through the same gate.
+        let ready = PromptReadinessSnapshot {
+            prompt_marker_detected: false,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "status footer without prompt glyph".to_string(),
+        };
+        assert!(!snapshot_indicates_mcp_auth_block(&ready));
+        assert!(
+            !snapshot_indicates_mcp_auth_block(&ready)
+                && transcript_idle_confirms_prompt_ready(&ready, Some(file.path())),
+            "a normal recorded-turn idle pane must still confirm ready (no regression)"
+        );
     }
 
     #[test]

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -8,6 +8,11 @@ use crate::services::tmux_diagnostics::clear_tmux_exit_reason;
 const CLAUDE_TUI_READY_SCAN_LINES: usize = 12;
 const CLAUDE_TUI_ACTIVE_SCAN_LINES: usize = 24;
 const CLAUDE_TUI_DRAFT_SCAN_LINES: usize = 36;
+/// Recent non-empty pane lines scanned for the MCP-authentication-required
+/// cold-boot banner. The warning renders just above the composer on a fresh
+/// boot, so a modest tail window captures it reliably while keeping older
+/// scrollback that merely mentions "authentication" from false-positiving.
+const CLAUDE_TUI_MCP_AUTH_SCAN_LINES: usize = 16;
 const CLAUDE_TUI_READY_BANNER: &str = "Ready for input (type message + Enter)";
 const CLAUDE_TUI_PROMPT_MARKER: &str = "\u{276f}";
 
@@ -387,6 +392,48 @@ pub(crate) fn tmux_capture_indicates_claude_tui_idle_suggestion(capture: &str) -
             ))
         })
         .unwrap_or(false)
+}
+
+/// True for the Claude Code cold-boot banner reporting one or more MCP servers
+/// still need authentication, e.g. `⚠ 1 MCP server needs authentication · run
+/// /mcp`. The banner paints on the post-launch welcome screen (commonly when a
+/// remote SSE server failed to authenticate), which still renders normal
+/// composer chrome — so `..._ready_for_input` reads it as READY even though
+/// Claude Code silently drops every submission until `/mcp` is run. The
+/// claude_tui readiness gate uses this to refuse that false-ready and fail fast
+/// with an actionable reason instead of blind-waiting/retrying (#3889).
+pub(crate) fn tmux_capture_indicates_claude_tui_mcp_auth_required(capture: &str) -> bool {
+    let non_empty = capture
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>();
+    let start = non_empty
+        .len()
+        .saturating_sub(CLAUDE_TUI_MCP_AUTH_SCAN_LINES);
+    non_empty[start..]
+        .iter()
+        .any(|line| line_is_mcp_auth_required_warning(line))
+}
+
+/// One pane line is the MCP-auth-needed warning only when it is Claude Code's
+/// system warning banner — **anchored to the `⚠` glyph** (`⚠ N MCP server(s)
+/// need authentication · run /mcp`) AND naming MCP + authentication + (`need` |
+/// `run /mcp`). The `⚠` anchor is load-bearing: assistant/tool transcript output
+/// (lines beginning `⏺`/`✻`, or continuation prose) can say "The MCP server needs
+/// authentication; run /mcp ..." above a perfectly ready composer, so token
+/// presence alone must NOT match — only the chrome glyph the system banner
+/// carries does (#3889 Codex review [1]).
+fn line_is_mcp_auth_required_warning(line: &str) -> bool {
+    let trimmed = trim_prompt_line(line);
+    // Anchor to the system warning banner glyph (U+26A0). `starts_with` matches
+    // regardless of a trailing emoji variation selector (`⚠️`, U+FE0F).
+    if !trimmed.starts_with('\u{26a0}') {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    lower.contains("mcp")
+        && lower.contains("authentic")
+        && (lower.contains("need") || lower.contains("run /mcp"))
 }
 
 fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
@@ -1018,6 +1065,113 @@ Claude Code v2.1.141
   CLAUDE.md: 1, MCP: 2 │ Tools: 0 done";
 
         assert!(!tmux_capture_indicates_claude_tui_selector_open(pane));
+    }
+}
+
+#[cfg(test)]
+mod mcp_auth_required_tests {
+    use super::*;
+
+    /// The exact fresh-boot screen from #3889: a welcome box, the
+    /// `⚠ N MCP server needs authentication · run /mcp` warning, and a composer
+    /// that paints the usual separator + bypass-permissions footer. The composer
+    /// chrome means `..._ready_for_input` reads this as READY, so the dedicated
+    /// MCP-auth detector is what keeps the readiness gate from false-submitting
+    /// into it.
+    #[test]
+    fn detects_cold_boot_mcp_auth_welcome_screen() {
+        let pane = "\
+╭─── Claude Code v2.1.195 ───────────────────────────╮
+│            Welcome back 오부장!                    │
+│   Opus 4.8 (1M context) · Claude Max               │
+│   ~/.adk/release/workspaces/ch-ad                  │
+╰────────────────────────────────────────────────────
+
+ ⚠ 1 MCP server needs authentication · run /mcp
+
+────────────────────────────────────────────────────
+❯ [Pasted text #1 +59 lines]
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+
+        // The composer chrome makes the legacy readiness predicate read READY...
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(pane));
+        // ...but the MCP-auth detector flags it so the readiness gate refuses it.
+        assert!(tmux_capture_indicates_claude_tui_mcp_auth_required(pane));
+    }
+
+    /// Plural copy (`N MCP servers need authentication`) must still match.
+    #[test]
+    fn detects_plural_servers_need_authentication() {
+        let pane = "\
+ ⚠ 2 MCP servers need authentication · run /mcp
+────────────────────────────────────────────────────
+❯
+  🤖 Opus(H) │ 0% │ MCP: 3 │ ⏵⏵ bypass permissions on";
+
+        assert!(tmux_capture_indicates_claude_tui_mcp_auth_required(pane));
+    }
+
+    /// A genuinely ready, empty composer with all MCP servers connected must NOT
+    /// be flagged — the footer mentions `MCP: 2` but never "authentication".
+    #[test]
+    fn ignores_normal_ready_composer_with_connected_mcp() {
+        let pane = "\
+Claude Code v2.1.195
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(pane));
+        assert!(!tmux_capture_indicates_claude_tui_mcp_auth_required(pane));
+    }
+
+    /// Prose that mentions only one of the tokens (e.g. an assistant message
+    /// talking about MCP, or about authentication generally) must not trip the
+    /// detector — all of MCP + authentication + (need | run /mcp) are required.
+    #[test]
+    fn ignores_partial_token_prose() {
+        let mcp_only = "⏺ I configured the MCP server list in settings.";
+        assert!(!tmux_capture_indicates_claude_tui_mcp_auth_required(
+            mcp_only
+        ));
+
+        let auth_only = "⏺ The API needs authentication via a bearer token.";
+        assert!(!tmux_capture_indicates_claude_tui_mcp_auth_required(
+            auth_only
+        ));
+    }
+
+    /// Codex review #3931 [1] (over-block regression): an assistant transcript
+    /// line that contains ALL the tokens (`mcp` + `authentication` + `run /mcp`)
+    /// but sits as `⏺` output above a genuinely ready composer must NOT be
+    /// classified as MCP-auth-blocked — only the system `⚠` warning banner is.
+    #[test]
+    fn ignores_assistant_prose_with_all_tokens_above_ready_composer() {
+        let pane = "\
+Claude Code v2.1.195
+⏺ The MCP server needs authentication; run /mcp to reconnect it, then retry.
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+
+        // The composer is genuinely ready...
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(pane));
+        // ...and the all-token assistant prose above it must not block it.
+        assert!(!tmux_capture_indicates_claude_tui_mcp_auth_required(pane));
+
+        // The real system banner with the same tokens IS blocked — the `⚠`
+        // chrome glyph is the only difference.
+        let banner = "\
+Claude Code v2.1.195
+ ⚠ 1 MCP server needs authentication · run /mcp
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 0% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+        assert!(tmux_capture_indicates_claude_tui_mcp_auth_required(banner));
     }
 }
 


### PR DESCRIPTION
Closes #3889.

## Root cause
A fresh-turn cold-boot that lands on the Claude Code welcome screen while an MCP server still needs authentication (`⚠ N MCP server needs authentication · run /mcp`) renders the normal composer chrome (a `─` separator + the `⏵⏵ bypass permissions on` footer). `tmux_capture_indicates_claude_tui_ready_for_input` therefore classified it as **READY**, AgentDesk "submitted" the prompt into a dead screen, no transcript ever appeared, and the caller blind-waited the full 120s readiness/transcript timeout — then rebooted straight back into the same blocked screen (effectively infinite cold-boot retry), surfaced to the user only as a generic "transport error".

The welcome/MCP-auth screen was **not distinguished from a ready composer anywhere in the readiness path**.

## Fix (scoped to claude_tui readiness + tmux_common classification)
- **`src/services/tmux_common.rs`** — new positive detector `tmux_capture_indicates_claude_tui_mcp_auth_required` for the cold-boot MCP-auth banner. The existing `ready_for_input` predicate is deliberately left unchanged so other consumers (watcher/relay) are not perturbed.
- **`src/services/claude_tui/input.rs`** —
  - `prompt_marker_confirms_prompt_ready` now refuses the banner in **every** ready path (fast-path pre/post snapshot, buffered-Stop, polling), so the false-ready can never submit.
  - **Fail fast** — up front for `FreshTurn` and as a kind-agnostic safety net in the polling loop — with a **distinct, NON-timeout, actionable** error (`PROMPT_READY_MCP_AUTH_ERROR_PREFIX`) that names `run /mcp`. The block is confirmed across a short settle re-capture so a half-rendered boot frame can't abort a healthy boot. The full pane tail is logged to `claude_tui.log` for forensics.
  - New `is_mcp_auth_required_error` predicate so callers can classify the condition.
- **`src/services/claude.rs`** — the fresh-prompt retry loop explicitly never retries the terminal MCP-auth error (already non-timeout; the guard makes intent self-documenting), bounding the within-turn retry storm.

Builds on #3880 (A1 literal-settle + A2 recorded-turn gate) — does not revert it.

## How the infinite retry is now bounded
- Per turn: the auth error is **distinct from a readiness timeout**, so `should_retry_claude_tui_fresh_prompt_ready` returns false → it returns immediately instead of looping 120s × N.
- Per attempt: fails in <1s (cancel-token path) / ≤ event-budget (no-cancel path) instead of 120s blind wait, and surfaces `run /mcp` so the operator can self-resolve and stop the cross-message loop.

## Tests
- `tmux_common::mcp_auth_required_tests` — detects the synthetic welcome+auth capture (and plural copy); ignores a normal connected composer and partial-token prose.
- `claude_tui::input::tests::mcp_auth_cold_boot_welcome_is_not_ready_but_normal_composer_is` — the auth capture is NOT ready-to-submit; a normal empty composer still IS; blind capture is not flagged.
- `claude_tui::input::tests::mcp_auth_required_error_is_distinct_from_timeout`.
- `claude::...::fresh_tui_prompt_retry_is_limited_to_readiness_timeouts` — extended: the MCP-auth error is never retried.

## Gates
- `cargo fmt --check` clean; `cargo check --lib` clean.
- `cargo test --lib claude_tui` (280) / `tmux_common` (42) / `claude` (41) green.
- `clippy --lib` clean on touched files.
- inventory regen + agent-maintenance freshness check passed.
- `check_hotfile_ratchet.py` exit 0; `audit_maintainability.py --check` exit 0.

No #3016 hotfile (turn_bridge/mod.rs, tmux_watcher.rs, session_relay_sink.rs, turn_finalizer*) or voice/routines/server file was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)