### PR TITLE
fix(discord): remove false-positive tmux-death "session ended" notice (#3898)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,7 +131,7 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2111 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2079 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
     construction from the watcher-spawn handle; #3718 moved runtime mtime
@@ -141,7 +141,10 @@
     #3815 moving direct Codex TUI resume restore helpers into
     `watchers/codex_tui_restore.rs` while adding the restore branch; -207 from
     #3840 moving heartbeat/activity helpers into
-    `watchers/lifecycle/activity.rs`).
+    `watchers/lifecycle/activity.rs`; -32 from #3898 removing the false-positive
+    "session ended … start a new session" tmux-death notice and its
+    `should_send_session_ended_notice`/`session_ended_notice`/
+    `TmuxDeathLifecycleDecision` plumbing).
   - `src/services/discord/tmux.rs` (1477 lines; +14 from current inventory
     refresh after the relay split stack landed; after #2558 dead-code sweep;
     +6 from #3818 sanitizing restored/orphan subagent-notification placeholders;

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -29,7 +29,7 @@
 | `src/services/discord/turn_bridge/mod.rs` | 6248 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |
 | `src/services/discord/voice_barge_in.rs` | 2800 | voice-runtime | 2026-08-31 | #3405 |
-| `src/services/discord/watchers/lifecycle.rs` | 2111 | discord-relay | 2026-10-31 | #3840 |
+| `src/services/discord/watchers/lifecycle.rs` | 2079 | discord-relay | 2026-10-31 | #3840 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -728,7 +728,7 @@
 | `services::discord::voice_routing` | `src/services/discord/voice_routing.rs` | 163 | 138 | 25 |  |
 | `services::discord::voice_sensitivity` | `src/services/discord/voice_sensitivity.rs` | 113 | 113 | 0 |  |
 | `services::discord::watchers::codex_tui_restore` | `src/services/discord/watchers/codex_tui_restore.rs` | 178 | 146 | 32 |  |
-| `services::discord::watchers::lifecycle` | `src/services/discord/watchers/lifecycle.rs` | 2834 | 2111 | 723 | giant-file |
+| `services::discord::watchers::lifecycle` | `src/services/discord/watchers/lifecycle.rs` | 2869 | 2079 | 790 | giant-file |
 | `services::discord::watchers::lifecycle::activity` | `src/services/discord/watchers/lifecycle/activity.rs` | 219 | 219 | 0 |  |
 | `services::discord::watchers::lifecycle_decision` | `src/services/discord/watchers/lifecycle_decision.rs` | 363 | 212 | 151 |  |
 | `services::discord_config_audit` | `src/services/discord_config_audit.rs` | 1600 | 1288 | 312 | giant-file |

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -501,7 +501,25 @@ pub(super) fn cancel_suppression_applies_to_watcher_death(
     cancel_induced_candidate && !terminal_delivery_observed
 }
 
-pub(super) fn should_send_session_ended_notice(
+/// #3898 — whether a watcher-observed tmux death should attempt the
+/// resume-aborted restart handoff (`resume_aborted_restart_turn`). This is the
+/// ONLY user-facing lifecycle signal for a genuinely abnormal mid-turn pane
+/// crash: the turn was aborted *before* terminal delivery and the pane did not
+/// exit through a normal-completion path (`turn completed` / `exit:0` /
+/// `routine fresh`).
+///
+/// The legacy "session ended: tmux pane exited. Send a new message to start a
+/// new session." Discord notice (removed in #3898) is intentionally NOT
+/// reinstated here. It was both noise and factually wrong:
+/// - It required `terminal_delivery_observed`, so it never covered a genuine
+///   mid-turn crash — that case routes to the restart handoff below, not to a
+///   notice. The only deaths it actually fired on were delivered-then-idle /
+///   cleanup / force-kill teardowns that left no normal-completion marker,
+///   i.e. normal idle exits (false positive).
+/// - A pane death does NOT start a fresh session: the DB `claude_session_id`
+///   persists and the next message resumes the conversation with `--resume`,
+///   so "start a new session" was incorrect for every death that reached it.
+pub(super) fn tmux_death_should_attempt_restart_handoff(
     cancel_induced: bool,
     prompt_too_long_killed: bool,
     terminal_delivery_observed: bool,
@@ -509,39 +527,8 @@ pub(super) fn should_send_session_ended_notice(
 ) -> bool {
     !cancel_induced
         && !prompt_too_long_killed
-        && terminal_delivery_observed
+        && !terminal_delivery_observed
         && !is_normal_completion
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct TmuxDeathLifecycleDecision {
-    pub(super) cancel_induced: bool,
-    pub(super) send_session_ended_notice: bool,
-}
-
-pub(super) fn tmux_death_lifecycle_decision(
-    cancel_induced_candidate: bool,
-    prompt_too_long_killed: bool,
-    terminal_delivery_observed: bool,
-    is_normal_completion: bool,
-) -> TmuxDeathLifecycleDecision {
-    let cancel_induced = cancel_suppression_applies_to_watcher_death(
-        cancel_induced_candidate,
-        terminal_delivery_observed,
-    );
-    TmuxDeathLifecycleDecision {
-        cancel_induced,
-        send_session_ended_notice: should_send_session_ended_notice(
-            cancel_induced,
-            prompt_too_long_killed,
-            terminal_delivery_observed,
-            is_normal_completion,
-        ),
-    }
-}
-
-pub(super) fn session_ended_notice() -> &'static str {
-    "session ended: tmux pane exited. Send a new message to start a new session."
 }
 
 pub(super) async fn handle_tmux_watcher_observed_death(
@@ -593,14 +580,25 @@ pub(super) async fn handle_tmux_watcher_observed_death(
         shared.pg_pool.as_ref(),
     )
     .await;
-    let decision = tmux_death_lifecycle_decision(
+    let cancel_induced = cancel_suppression_applies_to_watcher_death(
         cancel_induced_candidate,
+        terminal_delivery_observed,
+    );
+    // #3898 — the legacy "session ended … start a new session" Discord notice was
+    // removed. It false-fired on normal idle / cleanup / force-kill teardown
+    // (no `turn completed` / `exit:0` / `routine fresh` marker → classified
+    // abnormal) and was factually wrong (a pane death resumes via `--resume`, it
+    // does not start a fresh session). The genuine mid-turn crash signal is the
+    // restart handoff below; cancel suppression is still computed because it
+    // gates that handoff. `is_normal_completion` already folds in the exit-reason
+    // normal-completion check (`tmux_death_is_normal_completion`), so it is the
+    // single source of truth for the restart-handoff suppression.
+    let attempt_restart_handoff = tmux_death_should_attempt_restart_handoff(
+        cancel_induced,
         prompt_too_long_killed,
         terminal_delivery_observed,
         is_normal_completion,
     );
-    let cancel_induced = decision.cancel_induced;
-    let send_session_ended_notice = decision.send_session_ended_notice;
     if cancel_induced {
         tracing::info!(
             "  [{ts}] 👁 tmux session {tmux_session_name} ended after recent cancel/turn-stop, skipping lifecycle notification + restart handoff"
@@ -608,10 +606,6 @@ pub(super) async fn handle_tmux_watcher_observed_death(
     } else if cancel_induced_candidate {
         tracing::info!(
             "  [{ts}] 👁 tmux session {tmux_session_name} ended after a relayed terminal turn; ignoring stale cancel/turn-stop suppression"
-        );
-    } else if send_session_ended_notice {
-        tracing::info!(
-            "  [{ts}] 👁 tmux session {tmux_session_name} ended without normal completion, sending session-ended notice"
         );
     } else if !is_normal_completion {
         tracing::info!(
@@ -622,36 +616,10 @@ pub(super) async fn handle_tmux_watcher_observed_death(
             "  [{ts}] 👁 tmux session {tmux_session_name} ended after normal completion, skipping lifecycle notification"
         );
     }
-    if !cancel_induced && !prompt_too_long_killed && !terminal_delivery_observed {
-        // Suppress warning for normal dispatch completion — not an error.
-        let suppress_restart = is_normal_completion
-            || reason_short
-                .as_deref()
-                .is_some_and(tmux_exit_reason_is_normal_completion);
-        if !suppress_restart {
-            let _ = resume_aborted_restart_turn(
-                channel_id,
-                http,
-                shared,
-                tmux_session_name,
-                output_path,
-            )
-            .await;
-        }
-    }
-    if send_session_ended_notice {
-        rate_limit_wait(shared, channel_id).await;
-        if let Err(error) = crate::services::discord::http::send_channel_message(
-            http,
-            channel_id,
-            session_ended_notice(),
-        )
-        .await
-        {
-            tracing::warn!(
-                "  [{ts}] ⚠ tmux session {tmux_session_name} ended but session-ended notice send failed: {error}"
-            );
-        }
+    if attempt_restart_handoff {
+        let _ =
+            resume_aborted_restart_turn(channel_id, http, shared, tmux_session_name, output_path)
+                .await;
     }
 }
 
@@ -866,6 +834,73 @@ mod tests {
             turn_delivered: Arc::new(AtomicBool::new(false)),
             last_heartbeat_ts_ms: Arc::new(AtomicI64::new(tmux_watcher_now_ms())),
         }
+    }
+
+    // #3898 — cancel suppression is the surviving gate that protects the restart
+    // handoff (and previously gated the now-removed "session ended" notice).
+    #[test]
+    fn cancel_suppression_only_applies_before_terminal_delivery() {
+        // A cancel/turn-stop candidate that died before delivering its turn is
+        // suppressed (no restart handoff; historically no notice either).
+        assert!(cancel_suppression_applies_to_watcher_death(true, false));
+        // Once a terminal turn was delivered, a later pane death is a real
+        // lifecycle event for that turn — stale cancel suppression must NOT apply.
+        assert!(!cancel_suppression_applies_to_watcher_death(true, true));
+        // No cancel candidate → never suppressed.
+        assert!(!cancel_suppression_applies_to_watcher_death(false, false));
+        assert!(!cancel_suppression_applies_to_watcher_death(false, true));
+    }
+
+    // #3898 — the false-positive fix. A tmux pane that exits *after* delivering
+    // its turn (normal idle / cleanup / force-kill, which leave no
+    // normal-completion marker → `is_normal_completion == false`) must NOT
+    // surface any lifecycle signal: the removed notice never fires, and the
+    // restart handoff is gated off by `terminal_delivery_observed`. This is the
+    // noise the issue reported — a normal idle exit emitting a spurious notice.
+    #[test]
+    fn delivered_then_idle_death_surfaces_no_lifecycle_signal() {
+        let cancel_induced = cancel_suppression_applies_to_watcher_death(false, true);
+        assert!(!cancel_induced);
+        // Even with an "abnormal" exit reason (no normal-completion marker), a
+        // delivered turn means this is a normal idle/cleanup/force-kill teardown.
+        assert!(!tmux_death_should_attempt_restart_handoff(
+            cancel_induced,
+            /* prompt_too_long_killed */ false,
+            /* terminal_delivery_observed */ true,
+            /* is_normal_completion */ false,
+        ));
+        // The same holds when the pane DID exit through a normal-completion path.
+        assert!(!tmux_death_should_attempt_restart_handoff(
+            cancel_induced,
+            false,
+            true,
+            true,
+        ));
+    }
+
+    // #3898 — a genuinely abnormal mid-turn pane crash (turn aborted BEFORE
+    // terminal delivery, no normal-completion marker) STILL surfaces a signal:
+    // the resume-aborted restart handoff fires. This is the case the removed
+    // notice never covered (it required `terminal_delivery_observed`), so
+    // removing the notice does not lose any genuine-crash signal.
+    #[test]
+    fn genuine_mid_turn_crash_triggers_restart_handoff() {
+        assert!(tmux_death_should_attempt_restart_handoff(
+            /* cancel_induced */ false, /* prompt_too_long_killed */ false,
+            /* terminal_delivery_observed */ false, /* is_normal_completion */ false,
+        ));
+        // Suppressed when the user canceled the turn themselves …
+        assert!(!tmux_death_should_attempt_restart_handoff(
+            true, false, false, false
+        ));
+        // … when the prompt-too-long teardown already handled it …
+        assert!(!tmux_death_should_attempt_restart_handoff(
+            false, true, false, false
+        ));
+        // … or when the pane exited through a normal-completion path.
+        assert!(!tmux_death_should_attempt_restart_handoff(
+            false, false, false, true
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3898.

## Problem
The Discord notice `session ended: tmux pane exited. Send a new message to start a new session.` had two defects:

1. **False positive on normal idle exit.** Emit gate was `terminal_delivery_observed && !is_normal_completion`, and `is_normal_completion` (`tmux_diagnostics.rs::tmux_exit_reason_is_normal_completion`) only recognizes the `turn completed` / `exit:0` / `routine fresh` exit-reason markers. Idle-cleanup / force-kill leave no such marker → classified abnormal → notice fired on a perfectly normal idle teardown (pure noise).
2. **Factually wrong.** A pane death does **not** start a fresh session: the DB `claude_session_id` persists and the next message resumes the conversation via `--resume`. "start a new session" was incorrect.

## Root cause / key insight
The notice gate **required `terminal_delivery_observed == true`**. So a genuinely abnormal *mid-turn* pane crash (no delivery yet) **never routed to the notice at all** — that case is handled by the separate `resume_aborted_restart_turn` handoff. The only deaths that actually reached the notice were *delivered-then-died* teardowns, i.e. normal idle / cleanup / force-kill. There was therefore no legitimate trigger left for the notice, so per the issue's resolution it is **removed entirely** (fixes both the false positive and the factual error in one stroke).

## Change (all in `src/services/discord/watchers/lifecycle.rs`)
- Removed the Discord send block, `session_ended_notice()`, `should_send_session_ended_notice()`, the `TmuxDeathLifecycleDecision` struct + `tmux_death_lifecycle_decision()` wrapper, and the misleading "sending session-ended notice" log branch.
- **Preserved** the genuine-crash signal: the restart-handoff gate is extracted into the pure, unit-tested `tmux_death_should_attempt_restart_handoff(...)` and called at the same site. This is behaviour-identical — `is_normal_completion` already folds in the exit-reason normal-completion check (`tmux_death_is_normal_completion`), so dropping the redundant `reason_short` recheck (`suppress_restart == is_normal_completion`) is a no-op.
- **Preserved** cancel-suppression (`cancel_suppression_applies_to_watcher_death`) — it still gates the restart handoff.
- `exit_reason` classification in `tmux_diagnostics.rs` is left unchanged (per issue scope).

## Tests (new)
- `cancel_suppression_only_applies_before_terminal_delivery` — cancel suppression preserved.
- `delivered_then_idle_death_surfaces_no_lifecycle_signal` — normal idle/cleanup/force-kill (delivered, no normal-completion marker) surfaces **no** lifecycle signal (the false-positive fix).
- `genuine_mid_turn_crash_triggers_restart_handoff` — a genuine abnormal mid-turn crash (aborted before delivery) **still** surfaces the restart handoff.

## Gates
- `cargo fmt --check`: clean
- `cargo check --lib`: clean (only pre-existing warnings in other files)
- new tests: 3 passed
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: freshness check passed (giant-file freeze synced 2111→2079)
- `check_hotfile_ratchet.py`: exit 0
- `audit_maintainability.py --check`: exit 0
- `clippy`: clean on touched files

**Conflict avoidance:** `src/services/claude.rs` was NOT touched (concurrent track #3889 / PR #3931). No #3016 hotfile (turn_bridge/mod.rs, tmux_watcher.rs, session_relay_sink.rs, turn_finalizer*, inflight.rs, etc.), voice, routines, or status-panel touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)