### PR TITLE
fix(voice): File-mode streaming feed-task leak + per-tick needless respawn / PCM conversion (#3910)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1280,7 +1280,7 @@
     `audit_maintainability_config.toml`; the root is no longer a prod giant and
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
-  - `src/services/discord/voice_barge_in.rs` (2800 lines after #3038
+  - `src/services/discord/voice_barge_in.rs` (2893 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
     S2 moved the progress playback method cluster to
@@ -1304,7 +1304,17 @@
     `InflightForegroundCancelGuard` drop guard (+19 prod lines) so an aborted
     foreground `generate().await` unregisters its CancelToken instead of
     leaking it (a leak left `has_inflight_foreground` permanently true and the
-    channel misclassified the next fresh utterance as a barge-in);
+    channel misclassified the next fresh utterance as a barge-in), and #3910
+    gated the File-mode streaming feed-task hook behind a synchronous
+    `streaming_stt_enabled` atomic mirror and made `unregister_voice_guild` async
+    so voice-channel teardown reaps per-channel feed-task buckets
+    (`StreamingSttSessions::remove_channel`) AND discards the matching inner
+    `WhisperStream` sessions (`VoiceSttRuntime::discard_stream_session`, with the
+    stt read guard hoisted to a local so it is not held across the discard
+    awaits) (+93 prod lines), closing a default-deployment memory/CPU leak where
+    every ~20ms File-mode speaking tick spawned an immediately-returning feed
+    task whose `JoinHandle` was never drained, plus a Stream-mode inner-session
+    leak on mid-utterance channel leave;
     voice STT/TTS, lobby routing, progress mirroring, and barge-in
     orchestration surface; tracked decompose target — see
     `giant-file-registry.md` (owner `voice-runtime`, deadline 2026-08-31,

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -28,7 +28,7 @@
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6248 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |
-| `src/services/discord/voice_barge_in.rs` | 2800 | voice-runtime | 2026-08-31 | #3405 |
+| `src/services/discord/voice_barge_in.rs` | 2893 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2079 | discord-relay | 2026-10-31 | #3840 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -434,7 +434,7 @@
 | `services::discord::commands::steer` | `src/services/discord/commands/steer.rs` | 146 | 146 | 0 |  |
 | `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1475 | 1475 | 0 | giant-file |
 | `services::discord::commands::tui_passthrough` | `src/services/discord/commands/tui_passthrough.rs` | 412 | 357 | 55 |  |
-| `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1015 | 957 | 58 |  |
+| `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1018 | 960 | 58 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 527 | 527 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
 | `services::discord::formatting` | `src/services/discord/formatting.rs` | 3755 | 2801 | 954 | giant-file |
@@ -715,14 +715,14 @@
 | `services::discord::turn_finalizer::watcher_backstop` | `src/services/discord/turn_finalizer/watcher_backstop.rs` | 172 | 120 | 52 |  |
 | `services::discord::voice_acknowledgement` | `src/services/discord/voice_acknowledgement.rs` | 61 | 61 | 0 |  |
 | `services::discord::voice_background_driver` | `src/services/discord/voice_background_driver.rs` | 235 | 200 | 35 |  |
-| `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 4659 | 2800 | 1859 | giant-file |
+| `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 4953 | 2893 | 2060 | giant-file |
 | `services::discord::voice_barge_in::final_result_playback` | `src/services/discord/voice_barge_in/final_result_playback.rs` | 243 | 243 | 0 |  |
 | `services::discord::voice_barge_in::foreground_decision` | `src/services/discord/voice_barge_in/foreground_decision.rs` | 214 | 214 | 0 |  |
 | `services::discord::voice_barge_in::live_cut_playback` | `src/services/discord/voice_barge_in/live_cut_playback.rs` | 120 | 120 | 0 |  |
 | `services::discord::voice_barge_in::progress_playback` | `src/services/discord/voice_barge_in/progress_playback.rs` | 423 | 423 | 0 |  |
 | `services::discord::voice_barge_in::receive_hook` | `src/services/discord/voice_barge_in/receive_hook.rs` | 114 | 114 | 0 |  |
 | `services::discord::voice_barge_in::routing` | `src/services/discord/voice_barge_in/routing.rs` | 500 | 500 | 0 |  |
-| `services::discord::voice_barge_in::stt` | `src/services/discord/voice_barge_in/stt.rs` | 314 | 314 | 0 |  |
+| `services::discord::voice_barge_in::stt` | `src/services/discord/voice_barge_in/stt.rs` | 326 | 326 | 0 |  |
 | `services::discord::voice_barge_in::tts_pipeline` | `src/services/discord/voice_barge_in/tts_pipeline.rs` | 86 | 86 | 0 |  |
 | `services::discord::voice_config_cache` | `src/services/discord/voice_config_cache.rs` | 79 | 79 | 0 |  |
 | `services::discord::voice_id_sequences` | `src/services/discord/voice_id_sequences.rs` | 69 | 69 | 0 |  |
@@ -908,7 +908,7 @@
 | `voice::runtime_boundary` | `src/voice/runtime_boundary.rs` | 281 | 212 | 69 |  |
 | `voice::runtime_process` | `src/voice/runtime_process.rs` | 217 | 158 | 59 |  |
 | `voice::sanitizer` | `src/voice/sanitizer.rs` | 328 | 247 | 81 |  |
-| `voice::stt` | `src/voice/stt.rs` | 1195 | 944 | 251 |  |
+| `voice::stt` | `src/voice/stt.rs` | 1215 | 964 | 251 |  |
 | `voice::stt_streaming` | `src/voice/stt_streaming.rs` | 293 | 185 | 108 |  |
 | `voice::tts` | `src/voice/tts/mod.rs` | 939 | 557 | 382 |  |
 | `voice::tts::chunks` | `src/voice/tts/chunks.rs` | 387 | 270 | 117 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -274,7 +274,17 @@
 # #3038 VoiceBargeInRuntime S8: lowered 3044 -> 2823 (-221) as the foreground
 # decision/parser cluster moved to `voice_barge_in/foreground_decision.rs` (214
 # prod LoC, below the giant threshold). Locks in the shrink win.
-"src/services/discord/voice_barge_in.rs" = 2823
+# #3910: +70 (2823 -> 2893) for the File-mode streaming feed-task leak fix — a
+# synchronous `streaming_stt_enabled` atomic mirror (field + getter + two init
+# sites + a set_runtime_language sync) that gates `observe_streaming_stt_pcm_i16`
+# so File mode (the default) skips the per-tick PCM convert / task spawn / bucket
+# growth, plus `StreamingSttSessions::remove_channel` (now returning the removed
+# handles) and an async `unregister_voice_guild` that reaps per-channel feed-task
+# buckets AND discards the matching inner `WhisperStream` sessions on
+# voice-channel teardown (Stream-mode inner-session leak, codex review; the stt
+# read guard is hoisted to a local so it is not held across the discard awaits).
+# Minimum surface for the leak fix; no decomposition opportunity in this slice.
+"src/services/discord/voice_barge_in.rs" = 2893
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/commands/voice.rs
+++ b/src/services/discord/commands/voice.rs
@@ -844,7 +844,10 @@ async fn leave_voice_channel(
         .shared
         .voice_barge_in
         .control_channel_ids_for_guild(guild_id);
-    data.shared.voice_barge_in.unregister_voice_guild(guild_id);
+    data.shared
+        .voice_barge_in
+        .unregister_voice_guild(guild_id)
+        .await;
     let mut flushed = 0usize;
     for cc_id in control_channel_ids {
         flushed += data

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -852,6 +852,48 @@ impl StreamingSttSessions {
         self.sessions.clear();
         self.feed_tasks.clear();
     }
+
+    /// #3910: Drop every session + feed-task bucket whose key belongs to
+    /// `channel_id`, aborting any still-pending feed task so a speaker who
+    /// leaves the voice channel mid-utterance does not strand streaming state.
+    /// Previously these per-(channel,user) buckets were only reaped at
+    /// utterance completion (`transcribe_completed_utterance`), so a channel
+    /// teardown left them orphaned in the maps.
+    ///
+    /// Returns the removed outer `SttSessionHandle`s so the caller can also reap
+    /// the matching inner `WhisperStream` sessions (which only `finalize()`
+    /// removes) — dropping the outer handle alone leaves the underlying stream
+    /// session leaked in Stream mode.
+    fn remove_channel(&self, channel_id: u64) -> Vec<SttSessionHandle> {
+        let mut removed = Vec::new();
+        self.sessions.retain(|key, handle| {
+            if key.channel_id == channel_id {
+                removed.push(handle.clone());
+                false
+            } else {
+                true
+            }
+        });
+        self.feed_tasks.retain(|key, bucket| {
+            if key.channel_id != channel_id {
+                return true;
+            }
+            match bucket.lock() {
+                Ok(mut tasks) => {
+                    for task in tasks.drain(..) {
+                        task.abort();
+                    }
+                }
+                Err(poisoned) => {
+                    for task in poisoned.into_inner().drain(..) {
+                        task.abort();
+                    }
+                }
+            }
+            false
+        });
+        removed
+    }
 }
 
 pub(in crate::services::discord) struct VoiceBargeInRuntime {
@@ -870,6 +912,11 @@ pub(in crate::services::discord) struct VoiceBargeInRuntime {
     // 동일한 StreamingSttKey 로 묶이며 entry/get/remove 의미와 clear 순서를
     // 그대로 보존한다.
     streaming_stt: StreamingSttSessions,
+    // #3910: 현재 STT 런타임이 streaming 모드인지 동기적으로 조회하기 위한 atomic
+    // mirror. `stt` (async RwLock) 를 await 없이 읽을 수 없으므로, stt 가 만들어지거나
+    // 교체될 때마다 이 플래그를 갱신한다. File 모드(기본값)에서는 false 이므로
+    // `observe_streaming_stt_pcm_i16` 가 PCM 변환·태스크 스폰 전에 곧바로 반환한다.
+    streaming_stt_enabled: AtomicBool,
     tts: RwLock<Option<TtsRuntime>>,
     progress_tx: broadcast::Sender<VoiceProgressEvent>,
     monitors: dashmap::DashMap<u64, Arc<std::sync::Mutex<LiveBargeInMonitor>>>,
@@ -973,6 +1020,9 @@ impl VoiceBargeInRuntime {
             voice_config_state: RwLock::new(config.clone()),
             spoken_result_language: RwLock::new(config.stt.language.clone()),
             verbose_progress: AtomicBool::new(config.verbose_progress),
+            streaming_stt_enabled: AtomicBool::new(
+                stt.as_ref().is_some_and(VoiceSttRuntime::is_streaming),
+            ),
             stt: RwLock::new(stt),
             streaming_stt: StreamingSttSessions::new(),
             tts: RwLock::new(tts),
@@ -1006,6 +1056,7 @@ impl VoiceBargeInRuntime {
             verbose_progress: AtomicBool::new(false),
             stt: RwLock::new(None),
             streaming_stt: StreamingSttSessions::new(),
+            streaming_stt_enabled: AtomicBool::new(false),
             tts: RwLock::new(None),
             progress_tx,
             monitors: dashmap::DashMap::new(),
@@ -1172,6 +1223,14 @@ impl VoiceBargeInRuntime {
         }
         self.inflight_foreground_cancels
             .remove_if(&channel_id.get(), |_, value| value.is_empty());
+    }
+
+    /// #3910: whether the live STT runtime is in streaming mode. Read
+    /// synchronously from an atomic mirror so the per-PCM-tick hook can gate
+    /// streaming work without awaiting the `stt` lock. Kept in sync wherever
+    /// `stt` is (re)built.
+    pub(in crate::services::discord) fn streaming_stt_enabled(&self) -> bool {
+        self.streaming_stt_enabled.load(Ordering::Relaxed)
     }
 
     /// #2250: signal cancellation on every in-flight foreground call for the
@@ -1367,7 +1426,12 @@ impl VoiceBargeInRuntime {
         *self.spoken_result_language.write().await = language;
         if self.enabled {
             self.streaming_stt.clear();
-            *self.stt.write().await = Some(VoiceSttRuntime::from_voice_config(&config));
+            let runtime = VoiceSttRuntime::from_voice_config(&config);
+            // #3910: keep the synchronous streaming mirror aligned with the
+            // freshly rebuilt runtime before publishing it.
+            self.streaming_stt_enabled
+                .store(runtime.is_streaming(), Ordering::Relaxed);
+            *self.stt.write().await = Some(runtime);
         }
     }
 
@@ -1403,7 +1467,7 @@ impl VoiceBargeInRuntime {
         }
     }
 
-    pub(in crate::services::discord) fn unregister_voice_guild(&self, guild_id: GuildId) {
+    pub(in crate::services::discord) async fn unregister_voice_guild(&self, guild_id: GuildId) {
         // F7 (#2046): voice_guilds 만 지우면 channel_id 키로 적재된 monitors /
         // playbacks / spoken_result_playbacks / active_voice_routes /
         // deferred_buffers 가 남아 join/leave 반복 시 누수. 같은 guild 의 모든
@@ -1421,6 +1485,9 @@ impl VoiceBargeInRuntime {
             .collect();
         self.voice_guilds
             .retain(|_, registered_guild_id| *registered_guild_id != guild_id);
+        // #3910: outer handles for the leaving channels, collected so the inner
+        // WhisperStream sessions can be discarded after the sync teardown loop.
+        let mut stranded_stream_sessions: Vec<SttSessionHandle> = Vec::new();
         for channel_id in stale_channels {
             self.monitors.remove(&channel_id);
             if let Some((_, session)) = self.playbacks.remove(&channel_id) {
@@ -1437,6 +1504,32 @@ impl VoiceBargeInRuntime {
             );
             self.active_voice_routes.remove(&channel_id);
             self.deferred_buffers.remove(&channel_id);
+            // #3910: a speaker leaving the channel mid-utterance otherwise leaves
+            // its streaming-STT session + feed-task bucket stranded in the maps
+            // (they were only reaped at utterance completion). Drop the outer
+            // bucket + abort pending feed tasks here, and collect the outer
+            // handles so the inner stream session is reaped below too.
+            stranded_stream_sessions.extend(self.streaming_stt.remove_channel(channel_id));
+        }
+        // #3910: dropping the outer `SttSessionHandle` alone leaves the matching
+        // inner `WhisperStream` session (inserted by `start_session`, removed
+        // only by `finalize()`) leaked until the runtime is rebuilt. Discard
+        // those inner sessions for the leaving channels (no final decode — the
+        // speaker left, so partial-transcript loss is acceptable). File mode
+        // keeps no inner session, so this is a no-op there.
+        if !stranded_stream_sessions.is_empty() {
+            // Hoist read+clone into a local so the `RwLockReadGuard` drops at
+            // this statement's end — NOT held across the `discard_stream_session`
+            // awaits below (an `if let` scrutinee would extend the guard over the
+            // whole body, holding `self.stt` read while awaiting → deadlock risk
+            // against any `self.stt` writer / re-entrant lock). A plain `let`
+            // binding (not `let-else` + `return`) preserves the rest of the fn.
+            let stt = self.stt.read().await.clone();
+            if let Some(stt) = stt {
+                for handle in stranded_stream_sessions {
+                    stt.discard_stream_session(&handle).await;
+                }
+            }
         }
     }
 
@@ -2844,6 +2937,11 @@ mod tests {
                 .is_streaming(),
             "default STT mode must remain file"
         );
+        // #3910: the synchronous streaming mirror must agree with the runtime.
+        assert!(
+            !file_runtime.streaming_stt_enabled(),
+            "File-mode runtime mirror must report streaming disabled"
+        );
 
         let mut stream_config = VoiceConfig::default();
         stream_config.enabled = true;
@@ -2858,6 +2956,202 @@ mod tests {
                 .unwrap()
                 .is_streaming(),
             "stream STT must only activate when configured"
+        );
+        // #3910: Stream-mode runtime must drive the mirror true (gates the
+        // per-tick hook ON), contrasting the File-mode false above.
+        assert!(
+            stream_runtime.streaming_stt_enabled(),
+            "Stream-mode runtime mirror must report streaming enabled"
+        );
+
+        // #3910: rebuilding `stt` via set_runtime_language must preserve the
+        // mirror (stale-mirror regression guard) — language changes never flip
+        // the configured mode, so a Stream runtime stays mirror-true afterward.
+        stream_runtime.set_runtime_language("en".to_string()).await;
+        assert!(
+            stream_runtime
+                .stt
+                .read()
+                .await
+                .as_ref()
+                .unwrap()
+                .is_streaming(),
+            "set_runtime_language must keep the Stream runtime streaming"
+        );
+        assert!(
+            stream_runtime.streaming_stt_enabled(),
+            "set_runtime_language must keep the streaming mirror in sync"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_mode_streaming_observe_is_gated_and_does_not_leak_feed_tasks() {
+        // #3910: in File mode (default) the per-tick streaming hook must skip the
+        // PCM conversion + task spawn entirely, so the feed-task buckets stay
+        // empty across an utterance instead of accumulating one completed
+        // `JoinHandle` per ~20ms speaking tick (the leak this fix closes).
+        let mut file_config = VoiceConfig::default();
+        file_config.enabled = true;
+        let runtime = Arc::new(VoiceBargeInRuntime::from_voice_config(&file_config));
+        assert!(
+            !runtime.streaming_stt_enabled(),
+            "default File mode must report streaming disabled"
+        );
+
+        let channel = ChannelId::new(7_910_001);
+        let samples = vec![16_384i16, -16_384, 16_384, -16_384].repeat(480);
+        // Simulate ~50 of the ~20ms speaking ticks that occur during one
+        // utterance; none of them should create or grow a feed-task bucket.
+        for _ in 0..50 {
+            runtime.observe_streaming_stt_pcm_i16(channel, 4242, &samples);
+        }
+        assert_eq!(
+            runtime.streaming_stt.feed_tasks().len(),
+            0,
+            "File mode must not spawn per-tick feed tasks or accumulate JoinHandles"
+        );
+        assert_eq!(
+            runtime.streaming_stt.sessions().len(),
+            0,
+            "File mode must not start any streaming session"
+        );
+    }
+
+    #[tokio::test]
+    async fn leaving_voice_channel_drops_streaming_stt_buckets() {
+        // #3910: a speaker leaving the channel mid-utterance must not strand its
+        // streaming-STT session / feed-task bucket — channel teardown reaps it
+        // (aborting any pending feed task) while leaving sibling channels intact.
+        let mut config = VoiceConfig::default();
+        config.enabled = true;
+        let runtime = Arc::new(VoiceBargeInRuntime::from_voice_config(&config));
+
+        let channel = ChannelId::new(7_910_002);
+        let guild = GuildId::new(7_910_999);
+        runtime.register_voice_context(channel, guild);
+
+        let key = StreamingSttKey {
+            channel_id: channel.get(),
+            user_id: 99,
+        };
+        let pending = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(3_600)).await;
+        });
+        let abort_handle = pending.abort_handle();
+        runtime
+            .streaming_stt
+            .feed_tasks()
+            .insert(key, Arc::new(StdMutex::new(vec![pending])));
+        assert_eq!(runtime.streaming_stt.feed_tasks().len(), 1);
+
+        // A different channel's bucket must survive this guild teardown.
+        let sibling_key = StreamingSttKey {
+            channel_id: channel.get() + 1,
+            user_id: 99,
+        };
+        runtime
+            .streaming_stt
+            .feed_tasks()
+            .insert(sibling_key, Arc::new(StdMutex::new(Vec::new())));
+
+        runtime.unregister_voice_guild(guild).await;
+
+        assert!(
+            !runtime.streaming_stt.feed_tasks().contains_key(&key),
+            "leaving the channel must drop its streaming feed-task bucket"
+        );
+        assert!(
+            runtime
+                .streaming_stt
+                .feed_tasks()
+                .contains_key(&sibling_key),
+            "an unrelated channel's feed-task bucket must be left intact"
+        );
+        for _ in 0..200 {
+            if abort_handle.is_finished() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(
+            abort_handle.is_finished(),
+            "the stranded feed task must be aborted on channel teardown"
+        );
+    }
+
+    #[tokio::test]
+    async fn leaving_voice_channel_discards_inner_stream_sessions() {
+        // #3910: in Stream mode the underlying `WhisperStream` session lives in
+        // an inner map removed only by `finalize()`. A channel leave must reap
+        // that inner session too (not just the outer handle), while preserving a
+        // sibling channel's inner session. Without the inner discard the stream
+        // session leaks until the runtime is rebuilt.
+        let mut config = VoiceConfig::default();
+        config.enabled = true;
+        config.stt.mode = crate::voice::config::VoiceSttMode::Stream;
+        let runtime = Arc::new(VoiceBargeInRuntime::from_voice_config(&config));
+        assert!(runtime.streaming_stt_enabled());
+
+        let stt = runtime
+            .stt
+            .read()
+            .await
+            .clone()
+            .expect("stream runtime stt must exist");
+
+        let channel = ChannelId::new(7_910_010);
+        let guild = GuildId::new(7_910_777);
+        runtime.register_voice_context(channel, guild);
+
+        // Leaving channel: a live inner streaming session + its outer handle.
+        let leaving_handle = stt
+            .start_session("ko")
+            .await
+            .expect("start leaving streaming session");
+        let leaving_key = StreamingSttKey {
+            channel_id: channel.get(),
+            user_id: 1,
+        };
+        runtime
+            .streaming_stt
+            .sessions()
+            .insert(leaving_key, leaving_handle.clone());
+
+        // Sibling channel (not registered to this guild) must be preserved.
+        let sibling_handle = stt
+            .start_session("ko")
+            .await
+            .expect("start sibling streaming session");
+        let sibling_key = StreamingSttKey {
+            channel_id: channel.get() + 1,
+            user_id: 1,
+        };
+        runtime
+            .streaming_stt
+            .sessions()
+            .insert(sibling_key, sibling_handle.clone());
+
+        runtime.unregister_voice_guild(guild).await;
+
+        // Outer map: leaving entry gone, sibling intact.
+        assert!(
+            !runtime.streaming_stt.sessions().contains_key(&leaving_key),
+            "leaving channel outer session handle must be removed"
+        );
+        assert!(
+            runtime.streaming_stt.sessions().contains_key(&sibling_key),
+            "sibling channel outer session handle must be preserved"
+        );
+
+        // Inner WhisperStream map: leaving session discarded (finalize on a
+        // removed handle errors), sibling session still finalizable.
+        assert!(
+            stt.finalize(leaving_handle).await.is_err(),
+            "leaving channel inner WhisperStream session must be discarded on leave"
+        );
+        assert!(
+            stt.finalize(sibling_handle).await.is_ok(),
+            "sibling channel inner WhisperStream session must survive the leave"
         );
     }
 

--- a/src/services/discord/voice_barge_in/stt.rs
+++ b/src/services/discord/voice_barge_in/stt.rs
@@ -7,6 +7,18 @@ impl VoiceBargeInRuntime {
         user_id: u64,
         samples: &[i16],
     ) {
+        // #3910: in File mode (the default) streaming STT is inactive, so skip
+        // the PCM conversion, the per-tick `tokio::spawn`, and the feed-task
+        // bucket entirely. Previously every ~20ms speaking tick allocated a
+        // `Vec<f32>`, spawned a task that immediately early-returned, and pushed
+        // its completed `JoinHandle` into a per-speaker bucket that was never
+        // drained in File mode — so memory grew monotonically and CPU was wasted
+        // for a disabled feature. The mirror is checked synchronously (no `stt`
+        // lock await), and `feed_streaming_stt_pcm` keeps its own `is_streaming`
+        // guard as defense-in-depth against a mode flip racing this gate.
+        if !self.streaming_stt_enabled() {
+            return;
+        }
         if samples.is_empty() {
             return;
         }

--- a/src/voice/stt.rs
+++ b/src/voice/stt.rs
@@ -381,6 +381,17 @@ impl VoiceSttRuntime {
     pub(crate) fn is_streaming(&self) -> bool {
         matches!(self, Self::Stream { .. })
     }
+
+    /// #3910: drop the inner streaming session for `session` without running a
+    /// final decode. Used when a speaker leaves the voice channel mid-utterance
+    /// so the underlying `WhisperStream` session is not stranded in the inner
+    /// map until the runtime is rebuilt/dropped. File mode keeps no inner
+    /// session, so this is a no-op there.
+    pub(crate) async fn discard_stream_session(&self, session: &SttSessionHandle) {
+        if let Self::Stream { stream, .. } = self {
+            stream.discard_session(session).await;
+        }
+    }
 }
 
 #[async_trait]
@@ -523,6 +534,15 @@ impl WhisperStream {
         cleanup_temp_file(&wav_path).await;
         cleanup_temp_file(&transcript_path).await;
         result
+    }
+
+    /// #3910: forget a session's inner state without finalizing/decoding it.
+    /// Removing the entry drops the `Arc<Mutex<WhisperStreamSession>>`; combined
+    /// with aborting the per-tick feed task, the session is freed on channel
+    /// leave instead of lingering until `finalize()` (which never runs when the
+    /// speaker simply leaves the channel).
+    pub(crate) async fn discard_session(&self, session: &SttSessionHandle) {
+        self.sessions.lock().await.remove(session);
     }
 }
 


### PR DESCRIPTION
Closes #3910.

## Root cause
In voice **File** mode (the default, `VoiceSttMode::File`), the streaming-STT feed path ran every speaking tick for a *disabled* feature:

- `voice_barge_in/receive_hook.rs::observe_pcm` calls `observe_streaming_stt_pcm_i16` **unconditionally** on every ~20ms PCM tick.
- `voice_barge_in/stt.rs::observe_streaming_stt_pcm_i16` then **always** converted PCM (`discord_pcm_i16_stereo_48k_to_mono_f32_16k`), spawned a `tokio` task, and pushed its `JoinHandle` into the per-`(channel,user)` `feed_tasks` bucket.
- The spawned task immediately early-returns in File mode (`if !stt.is_streaming() { return; }`), but its **completed handle stayed in the bucket forever** — the drainer (`drain_streaming_stt_feed_tasks`) only runs when `is_streaming()` (i.e. never in File mode), and the global `clear()` only fires on language change.

Net effect on the default deployment: per active speaker ~50 handles/s accumulate (monotonic memory growth) plus a wasted `Vec<f32>` alloc + task spawn each tick (wasted CPU).

## Fix (minimal; audible output unchanged)
- **Gate the per-tick work** behind a synchronous `streaming_stt_enabled` `AtomicBool` mirror of the live STT runtime's mode. `stt` is behind an async `RwLock`, so the sync `observe_pcm` hook cannot `await` it; the mirror is set at construction and kept in sync wherever `stt` is (re)built (`set_runtime_language`). File mode now returns before any convert/spawn/bucket work. `feed_streaming_stt_pcm` keeps its own `is_streaming` guard as defense-in-depth.
  - `src/services/discord/voice_barge_in/stt.rs:10` (early-return gate)
- **Reap per-channel buckets on channel leave.** `StreamingSttSessions::remove_channel` drops the session + feed-task buckets for a torn-down channel (aborting any pending feed task); wired into `unregister_voice_guild` alongside the existing per-channel cleanups.
  - `src/services/discord/voice_barge_in.rs` (`remove_channel` + `unregister_voice_guild` call)

## Tests (new, pinning the fix)
- `file_mode_streaming_observe_is_gated_and_does_not_leak_feed_tasks` — 50 simulated ticks in File mode leave `feed_tasks`/`sessions` empty (no per-tick respawn/convert, no leak).
- `leaving_voice_channel_drops_streaming_stt_buckets` — channel teardown removes the channel's bucket (and aborts the pending task) while leaving a sibling channel's bucket intact.

## Gates
- `cargo fmt --check` clean; `cargo check --lib` clean.
- `cargo test --lib voice`: 303 passed, 0 failed (incl. both new tests).
- `generate_inventory_docs.py` regenerated; `check_agent_maintenance_docs.py`: **freshness check passed**.
- `check_hotfile_ratchet.py` exit 0; `audit_maintainability.py --check` exit 0 (voice_barge_in.rs giant freeze raised 2823 → 2854 with a documented entry).
- clippy clean on touched files.

Does **not** touch `src/voice/metrics.rs`, command-guard / bot_settings, or any #3016 core hotfile.