### PR TITLE
ci(pr): cancel-in-progress=false to stop signal-15 false-failures (#3927)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,11 +14,17 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Collapse rapid re-pushes to the same PR head branch into one run. Only
-  # pull_request/workflow_dispatch events reach here now, so `github.head_ref`
-  # is set for PRs; fall back to `github.ref` for manual dispatch.
+  # Group runs by PR head branch. Only pull_request/workflow_dispatch events
+  # reach here now, so `github.head_ref` is set for PRs; fall back to
+  # `github.ref` for manual dispatch.
   group: ci-pr-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # cancel-in-progress=false: superseded runs finish instead of being
+  # cancelled. Cancelling them makes the `*_required_context` mirrors below
+  # (which run `if: always()` and FAIL CLOSED on a `cancelled` upstream)
+  # surface spurious `terminated by signal 15` / exit-143 required-check
+  # failures, forcing constant re-runs (#3927). Trade-off: extra runner
+  # minutes on rapid re-pushes; branch protection still gates the HEAD commit.
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #3927.

## Confirmed root cause
The intermittent `terminated by signal 15` / exit-143 failures on `Fast check (ubuntu-latest)` and its siblings are **runner cancellations, not timeout expiries**. The failing logs end with `The runner has received a shutdown signal ... canceled`.

`cancel-in-progress: true` in the `ci-pr.yml` concurrency block cancels superseded PR runs whenever a new commit is pushed to the same head branch. The `*_required_context` mirror jobs run `if: always()` and **fail closed** on a `cancelled` upstream, so the cancellation surfaces as a *required-check failure* and forces constant re-runs.

## The approved fix (option 2)
Flip `cancel-in-progress` to `false` so superseded runs **finish** instead of being cancelled.

```diff
-  cancel-in-progress: true
+  cancel-in-progress: false
```
(plus an explanatory comment in the concurrency block so a future "optimization" doesn't revert it.)

## Trade-off & security
- **Trade-off (accepted by maintainer):** extra runner minutes on rapid re-pushes, since superseded runs run to completion.
- **No security regression:** branch protection still gates the HEAD commit; older runs finishing doesn't change which commit is allowed to merge.

## Scope — why only `ci-pr.yml`
Only `ci-pr.yml` carries the fail-closed `*_required_context` mirror pattern, so it is the only workflow changed. Deliberately left as-is:
- `ci-main.yml` — post-merge main CI; superseding older main runs is intended and has no PR required-check impact. No required-context mirrors.
- `ci-macos-trusted.yml` — push/merge_group triggered; no required-context mirrors, so a superseded run does not produce fail-closed required-check failures.
- `main-ci-triage.yml`, `regen-docs.yml`, `ci-nightly.yml` — already `cancel-in-progress: false`.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-pr.yml'))"` → OK
- `python3 scripts/check_agent_maintenance_docs.py` → exit 0
- `python3 scripts/audit_maintainability.py --check` → exit 0 (only pre-existing baseline route-SRP warnings, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)