### PR TITLE
fix(voice): wire voice.thresholds.speech_start_db into STT gate + reconcile default (#3912)

### DIFF
--- a/agentdesk.example.yaml
+++ b/agentdesk.example.yaml
@@ -129,12 +129,12 @@ voice:
       # edge-tts rate argument, e.g. +0%, -10%, +15%.
       rate: "+0%"
   thresholds:
-    # dBFS threshold that marks the start of speech.
-    speech_start_db: -45.0
-    # dBFS threshold below which speech is considered ended.
-    speech_end_db: -55.0
-    # dBFS threshold used while listening for wake words.
-    wake_word_db: -50.0
+    # Mean-volume floor (dBFS) for the STT speech-vs-silence gate: utterances
+    # whose mean volume is below this (and whose peak is below the internal
+    # -12 dB max floor) are treated as silence and skipped before whisper.
+    # Lower it to transcribe quieter speech; raise it to drop more background
+    # noise. This is the effective gate default.
+    speech_start_db: -35.0
   idle:
     # Silence after a PCM burst before closing the current segment file.
     segment_idle_ms: 2200

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -900,7 +900,7 @@
 | `voice::barge_in` | `src/voice/barge_in.rs` | 937 | 592 | 345 |  |
 | `voice::cancel_tombstone` | `src/voice/cancel_tombstone.rs` | 201 | 131 | 70 |  |
 | `voice::commands` | `src/voice/commands.rs` | 839 | 541 | 298 |  |
-| `voice::config` | `src/voice/config.rs` | 595 | 372 | 223 |  |
+| `voice::config` | `src/voice/config.rs` | 601 | 379 | 222 |  |
 | `voice::flight` | `src/voice/flight.rs` | 252 | 138 | 114 |  |
 | `voice::metrics` | `src/voice/metrics.rs` | 377 | 275 | 102 |  |
 | `voice::progress` | `src/voice/progress.rs` | 448 | 353 | 95 |  |
@@ -909,7 +909,7 @@
 | `voice::runtime_boundary` | `src/voice/runtime_boundary.rs` | 281 | 212 | 69 |  |
 | `voice::runtime_process` | `src/voice/runtime_process.rs` | 217 | 158 | 59 |  |
 | `voice::sanitizer` | `src/voice/sanitizer.rs` | 328 | 247 | 81 |  |
-| `voice::stt` | `src/voice/stt.rs` | 1215 | 964 | 251 |  |
+| `voice::stt` | `src/voice/stt.rs` | 1276 | 971 | 305 |  |
 | `voice::stt_streaming` | `src/voice/stt_streaming.rs` | 293 | 185 | 108 |  |
 | `voice::tts` | `src/voice/tts/mod.rs` | 939 | 557 | 382 |  |
 | `voice::tts::chunks` | `src/voice/tts/chunks.rs` | 387 | 270 | 117 |  |

--- a/src/voice/config.rs
+++ b/src/voice/config.rs
@@ -332,20 +332,27 @@ impl Default for VoiceBargeInConfig {
     }
 }
 
+/// dBFS thresholds for the voice STT speech-vs-silence gate.
+///
+/// `speech_start_db` is the mean-volume floor below which an incoming utterance
+/// is treated as silence/noise and skipped before whisper. It is wired into the
+/// ffmpeg `volumedetect` gate via [`SttConfig::speech_start_db`](super::stt);
+/// its default MUST stay in sync with the effective gate default so that
+/// config-default == gate-default (see the `speech_start_db_default_matches_*`
+/// test in `stt.rs`).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
 pub(crate) struct VoiceDbThresholds {
     pub speech_start_db: f32,
-    pub speech_end_db: f32,
-    pub wake_word_db: f32,
 }
 
 impl Default for VoiceDbThresholds {
     fn default() -> Self {
         Self {
-            speech_start_db: -45.0,
-            speech_end_db: -55.0,
-            wake_word_db: -50.0,
+            // Matches the previously-effective hardcoded stt low-volume gate
+            // (`LOW_VOLUME_MEAN_DB`); reconciled from the old documented -45.0
+            // default which never reached the gate (#3912).
+            speech_start_db: -35.0,
         }
     }
 }
@@ -454,7 +461,6 @@ spoken_result:
             PathBuf::from("~/.adk/voice/transcripts")
         );
         assert_eq!(config.thresholds.speech_start_db, -42.5);
-        assert_eq!(config.thresholds.speech_end_db, -55.0);
         assert_eq!(config.stt, VoiceSttConfig::default());
         assert_eq!(config.tts.backend, VoiceTtsBackendKind::Edge);
         assert_eq!(config.tts.edge.command, DEFAULT_EDGE_TTS_COMMAND);

--- a/src/voice/stt.rs
+++ b/src/voice/stt.rs
@@ -25,8 +25,10 @@ const STT_TIMEOUT: Duration = Duration::from_secs(120);
 const EMPTY_RETRY_DELAY: Duration = Duration::from_millis(300);
 
 // Volume gating (ffmpeg `volumedetect` thresholds, in dBFS).
-// Utterances below BOTH thresholds are treated as silence/noise and skipped.
-const LOW_VOLUME_MEAN_DB: f32 = -35.0;
+// An utterance is treated as silence/noise (and skipped before whisper) only
+// when BOTH its mean volume is below the configured mean floor
+// (`SttConfig::speech_start_db`, sourced from `voice.thresholds.speech_start_db`)
+// AND its peak volume is below `LOW_VOLUME_MAX_DB`.
 const LOW_VOLUME_MAX_DB: f32 = -12.0;
 
 // whisper-cli decoding thresholds passed via CLI flags.
@@ -38,7 +40,7 @@ const WHISPER_ENTROPY_THRESHOLD: &str = "2.2";
 /// `-lpt` log-probability threshold: decoder fallback trigger when avg logprob falls below this.
 const WHISPER_LOGPROB_THRESHOLD: &str = "-0.8";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SttConfig {
     pub(crate) ffmpeg_command: String,
     pub(crate) whisper_command: String,
@@ -46,6 +48,10 @@ pub(crate) struct SttConfig {
     pub(crate) language: String,
     pub(crate) temp_dir: PathBuf,
     pub(crate) timeout: Duration,
+    /// Mean-volume floor (dBFS) for the low-volume silence gate, sourced from
+    /// `voice.thresholds.speech_start_db` (#3912). Utterances whose mean volume
+    /// is below this (and whose peak is below `LOW_VOLUME_MAX_DB`) are skipped.
+    pub(crate) speech_start_db: f32,
     pub(crate) stream_overlap: StreamingOverlapConfig,
 }
 
@@ -58,6 +64,7 @@ impl SttConfig {
             language: config.stt.language.clone(),
             temp_dir: expand_tilde(&config.audio.temp_dir),
             timeout: STT_TIMEOUT,
+            speech_start_db: config.thresholds.speech_start_db,
             stream_overlap: StreamingOverlapConfig {
                 sample_rate_hz: WHISPER_STREAM_SAMPLE_RATE_HZ,
                 step_ms: config.stt.stream.step_ms,
@@ -218,7 +225,7 @@ impl SttRuntime {
             );
             return Ok(false);
         };
-        Ok(levels.mean_db < LOW_VOLUME_MEAN_DB && levels.max_db < LOW_VOLUME_MAX_DB)
+        Ok(levels.mean_db < self.config.speech_start_db && levels.max_db < LOW_VOLUME_MAX_DB)
     }
 
     async fn convert_for_whisper(&self, wav_path: &Path, output_path: &Path) -> Result<()> {
@@ -976,6 +983,7 @@ mod tests {
             language: "ko".to_string(),
             temp_dir,
             timeout: Duration::from_secs(5),
+            speech_start_db: -35.0,
             stream_overlap: StreamingOverlapConfig {
                 sample_rate_hz: 1_000,
                 step_ms: 4,
@@ -1051,6 +1059,59 @@ mod tests {
         assert_eq!(
             *invocations.lock().unwrap(),
             vec![SttCommandKind::VolumeDetect]
+        );
+    }
+
+    /// Regression guard for #3912: `voice.thresholds.speech_start_db` must
+    /// actually reach the low-volume gate. With the same audio levels, only the
+    /// configured threshold differs, and the gate decision must flip — proving
+    /// the config value is live rather than a no-op.
+    #[tokio::test]
+    async fn speech_start_db_threshold_is_wired_into_low_volume_gate() {
+        let temp = tempfile::tempdir().unwrap();
+        let wav = temp.path().join("clip.wav");
+        // ffmpeg volumedetect reports mean -38 dB, peak -20 dB (peak is below the
+        // -12 dB max floor, so the silence decision hinges on the mean threshold).
+        let runner: SttCommandRunner = Arc::new(move |_invocation| {
+            Box::pin(async move {
+                Ok(SttCommandOutput {
+                    stderr: b"mean_volume: -38.0 dB\nmax_volume: -20.0 dB".to_vec(),
+                    stdout: Vec::new(),
+                })
+            })
+        });
+
+        // Strict floor (-45): mean -38 is *above* -45 -> treated as speech.
+        let mut strict = test_config(temp.path().to_path_buf());
+        strict.speech_start_db = -45.0;
+        let strict_runtime = SttRuntime::with_runner(strict, runner.clone());
+        assert!(
+            !strict_runtime.is_low_volume_utterance(&wav).await.unwrap(),
+            "mean -38 dB must NOT be gated as silence when speech_start_db is -45"
+        );
+
+        // Permissive floor (-35): mean -38 is *below* -35 -> treated as silence.
+        let mut permissive = test_config(temp.path().to_path_buf());
+        permissive.speech_start_db = -35.0;
+        let permissive_runtime = SttRuntime::with_runner(permissive, runner);
+        assert!(
+            permissive_runtime
+                .is_low_volume_utterance(&wav)
+                .await
+                .unwrap(),
+            "mean -38 dB MUST be gated as silence when speech_start_db is -35"
+        );
+    }
+
+    /// #3912: the config default must equal the effective gate default so that
+    /// the documented `voice.thresholds.speech_start_db` matches real behavior.
+    #[test]
+    fn speech_start_db_default_matches_effective_low_volume_gate() {
+        assert_eq!(VoiceConfig::default().thresholds.speech_start_db, -35.0);
+        assert_eq!(
+            SttConfig::from_voice_config(&VoiceConfig::default()).speech_start_db,
+            -35.0,
+            "config default must reach the gate unchanged (config-default == gate-default)"
         );
     }
 


### PR DESCRIPTION
Closes #3912.

## Root cause
`voice.thresholds` was **dead config**. `config.rs` parsed/deserialized `speech_start_db` / `speech_end_db` / `wake_word_db` (`src/voice/config.rs:335-351`) but **nothing read them outside config.rs** (grep-verified). The actual STT speech-vs-silence gate used a hardcoded constant `LOW_VOLUME_MEAN_DB = -35.0` (`src/voice/stt.rs:29`, consumed at `is_low_volume_utterance`, old line 221). So:

- **No-op:** operators tuning `voice.thresholds.speech_start_db` in `agentdesk.yaml` got **zero effect**.
- **Default mismatch (실게이트 불일치):** config/docs advertised `-45.0`, but the live gate was fixed at `-35.0`.

## Which fields were dead
- `speech_start_db` — had a *real* but **disconnected** gate (the stt low-volume mean floor).
- `speech_end_db`, `wake_word_db` — **truly vestigial**: no runtime gate consumes an end-of-speech or wake-word dB threshold (segmentation is idle-time based via `voice.idle`; wake detection is text-based).

## Fix (wire the live one, remove the dead two)
1. **Wire** `speech_start_db` into the gate: `SttConfig` now carries `speech_start_db` (sourced from `config.thresholds.speech_start_db` in `from_voice_config`), and `is_low_volume_utterance` reads `self.config.speech_start_db` instead of the hardcoded const. The YAML key is now **live**.
2. **Reconcile the default:** `VoiceDbThresholds::speech_start_db` default `-45.0 → -35.0` to match the previously-effective gate value. **config-default == gate-default**, and the default audible/gating behavior is **unchanged** (no retune).
3. **Remove** the two vestigial fields (`speech_end_db`, `wake_word_db`) from the struct + `agentdesk.example.yaml`. No `deny_unknown_fields`, so existing YAML keys are silently ignored (they were no-ops anyway). No dead keys remain.

The `-12 dB` peak floor (`LOW_VOLUME_MAX_DB`) stays an internal constant — no config field maps to it, and adding one would be scope creep.

## New tests (`src/voice/stt.rs`)
- `speech_start_db_threshold_is_wired_into_low_volume_gate` — same audio levels, only the configured threshold differs, gate decision **flips** (proves it's no longer a no-op; would fail under the old hardcoded gate).
- `speech_start_db_default_matches_effective_low_volume_gate` — pins `config-default == effective gate default (-35.0)`.

## Gates (CARGO_BUILD_JOBS=5)
- `cargo fmt --check` clean
- `cargo check --lib` clean (pre-existing warnings only, untouched files)
- `cargo test --lib voice` — all voice config/stt tests pass incl. the 2 new ones. (One unrelated failure, `voice_barge_in::...background_handoff_stop...`, is a pre-existing #3293 test-isolation flake in `voice_barge_in.rs` — confirmed identical failure on clean origin/main with this branch's changes stashed; that file is untouched here.)
- `generate_inventory_docs.py` → only `module-inventory.md` line-count refresh (committed); `check_agent_maintenance_docs.py` → "freshness check passed"
- `check_hotfile_ratchet.py` exit 0
- `audit_maintainability.py --check` exit 0
- clippy clean on touched files

## Scope
Touched only `src/voice/config.rs`, `src/voice/stt.rs`, `agentdesk.example.yaml` (+ generated `module-inventory.md`). Did **not** touch `inflight.rs` (#3925), `status_panel.rs` (#3920), `voice/metrics.rs`, the `voice_barge_in` feed/reap logic (#3910), or #3016 hotfiles. No behavior change for the default config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)