### PR TITLE
fix(discord): finalize inflight + dequeue after OOB deadlock-manager leak recovery (#3925)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1031,7 +1031,14 @@
     children (`send_target`, `send_gate`, `send_api`, `manual_delivery`) to
     `outbound/` while preserving the `health::` re-export API; #1879
     snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2134 lines; #3872 removes
+  - `src/services/discord/health/recovery.rs` (2223 lines; +89 from #3925
+    finalizing the inflight turn-state after the out-of-band deadlock-manager leak
+    recovery (`maybe_recover_completed_stale_leak`) delivers a completed answer —
+    routing the recovered terminal through `finish_recovered_turn_mailbox` (mailbox
+    token release + gated `global_active` decrement + idle-queue kickoff) and an
+    identity-guarded inflight clear (`clear_recovered_leak_inflight`), so a
+    relay-broken turn no longer pins the session to a phantom in-progress turn that
+    queues new messages forever; #3872 removes
     visible continuation markers from long-message split paths and adds legacy-prefix
     recovery compatibility (+3 after review fix); -598 from #3839 moving
     pure stall-watchdog decisions to `health/recovery/watchdog_decisions.rs`

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -15,7 +15,7 @@
 | `src/server/maintenance.rs` | 1014 | server-runtime | 2026-10-31 | #3909 |
 | `src/server/worker_registry.rs` | 1267 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
-| `src/services/discord/health/recovery.rs` | 2134 | discord-relay | 2026-10-31 | #3839 |
+| `src/services/discord/health/recovery.rs` | 2223 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1252 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/inflight.rs` | 3068 | discord-relay | 2026-10-31 | #3835 |
 | `src/services/discord/placeholder_sweeper.rs` | 1014 | discord-relay | 2026-08-31 | #3405 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -444,7 +444,7 @@
 | `services::discord::health::headless_turn` | `src/services/discord/health/headless_turn.rs` | 369 | 369 | 0 |  |
 | `services::discord::health::mailbox` | `src/services/discord/health/mailbox.rs` | 111 | 111 | 0 |  |
 | `services::discord::health::provider_probe` | `src/services/discord/health/provider_probe.rs` | 246 | 193 | 53 |  |
-| `services::discord::health::recovery` | `src/services/discord/health/recovery.rs` | 3380 | 2134 | 1246 | giant-file |
+| `services::discord::health::recovery` | `src/services/discord/health/recovery.rs` | 3611 | 2223 | 1388 | giant-file |
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 289 | 289 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -2143,7 +2143,238 @@ async fn maybe_recover_completed_stale_leak(
         true,
         Some(delivery_detail),
     );
+
+    // #3925: finalize the turn the SAME way normal completion does. The relay
+    // broke mid-turn, so this turn's own finalizer never ran — both the inflight
+    // row AND the in-memory mailbox active-turn token were left "in progress".
+    // We have now delivered the completed answer out-of-band (reaching here only
+    // on FULL delivery — every partial/retryable path returned earlier), so the
+    // turn is genuinely done. Previously this path only advanced
+    // `response_sent_offset` and returned, leaving the session pinned to a phantom
+    // in-progress turn: the intake gate (`mailbox_has_live_active_turn_or_cleanup_stale_proof`)
+    // kept queueing every new message with "앞선 턴 진행 중" and no completion event
+    // ever fired to dequeue them → permanent dead session (#3925).
+    //
+    // Mirror the startup recovery branches (`recovery_engine.rs`
+    // completed_during_downtime / output_completed): route the recovered terminal
+    // through the single-authority finalizer (`finish_recovered_turn_mailbox` →
+    // `mailbox_finish_turn` token release + gated `global_active` decrement +
+    // idle-queue kickoff), then clear the inflight row under its identity guard.
+    super::super::recovery_engine::finish_recovered_turn_mailbox(
+        shared,
+        provider,
+        channel_id,
+        "leak_recovery_oob_completion",
+    )
+    .await;
+    // Identity-guarded clear so a turn that started in the narrow window after the
+    // mailbox token released (the kickoff above drains the queue on a spawned task)
+    // is never clobbered — the helper re-reads the fresh on-disk row under its
+    // flock before deleting (#3860 RMW discipline).
+    let inflight_clear_outcome = clear_recovered_leak_inflight(provider, channel_id, &state);
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider.as_str(),
+        channel_id.get(),
+        state.dispatch_id.as_deref(),
+        state.session_key.as_deref(),
+        turn_id.as_deref(),
+        "leak_recovery_finalized_inflight",
+        serde_json::json!({
+            "guarded_clear_outcome": format!("{inflight_clear_outcome:?}"),
+            "user_msg_id": state.user_msg_id,
+            "byte_end": end,
+        }),
+    );
     true
+}
+
+/// #3925: finalize the inflight turn-state for a turn whose completed answer was
+/// just delivered out-of-band by [`maybe_recover_completed_stale_leak`]. Mirrors
+/// the identity-guarded clear the normal turn-completion path uses
+/// (`turn_finalizer::do_finalize` step A / the startup recovery branches): a real
+/// `user_msg_id` clears via `clear_inflight_state_if_matches` (a newer turn's row
+/// yields `UserMsgMismatch` and is preserved); a zero-id-owned recovery /
+/// TUI-direct turn clears its own zero-id row via the zero-owned guard.
+fn clear_recovered_leak_inflight(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    state: &discord::inflight::InflightTurnState,
+) -> discord::inflight::GuardedClearOutcome {
+    let Some(root) = discord::inflight::inflight_runtime_root() else {
+        return discord::inflight::GuardedClearOutcome::Missing;
+    };
+    clear_recovered_leak_inflight_in_root(&root, provider, channel_id, state)
+}
+
+/// Root-explicit variant of [`clear_recovered_leak_inflight`] for hermetic unit
+/// tests (mirrors inflight.rs's own `_in_root` test convention).
+fn clear_recovered_leak_inflight_in_root(
+    root: &std::path::Path,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    state: &discord::inflight::InflightTurnState,
+) -> discord::inflight::GuardedClearOutcome {
+    if state.user_msg_id != 0 {
+        discord::inflight::clear_inflight_state_if_matches_in_root(
+            root,
+            provider,
+            channel_id.get(),
+            state.user_msg_id,
+        )
+    } else {
+        discord::inflight::clear_inflight_state_if_matches_zero_owned_in_root(
+            root,
+            provider,
+            channel_id.get(),
+        )
+    }
+}
+
+/// #3925 — hermetic tests pinning that the OOB deadlock-manager leak recovery
+/// finalizes the inflight turn-state after delivering the completed answer, so an
+/// idle session stops queueing new messages forever. Uses TempDir + the `_in_root`
+/// clear path (no env / SharedData), mirroring inflight.rs's own test convention.
+#[cfg(test)]
+mod leak_recovery_inflight_finalize_tests {
+    use super::clear_recovered_leak_inflight_in_root;
+    use crate::services::discord::inflight::{GuardedClearOutcome, InflightTurnState};
+    use crate::services::provider::ProviderKind;
+    use poise::serenity_prelude::ChannelId;
+
+    fn leak_inflight_state(
+        provider: &ProviderKind,
+        channel_id: u64,
+        user_msg_id: u64,
+    ) -> InflightTurnState {
+        serde_json::from_value(serde_json::json!({
+            "version": 9,
+            "provider": provider.as_str(),
+            "channel_id": channel_id,
+            "channel_name": "adk-cc",
+            "request_owner_user_id": 7,
+            "user_msg_id": user_msg_id,
+            "current_msg_id": user_msg_id + 1,
+            "current_msg_len": 0,
+            "user_text": "prompt",
+            "source": "text",
+            "session_id": "session",
+            "tmux_session_name": "AgentDesk-claude-adk-cc",
+            "output_path": "/tmp/claude-transcript.jsonl",
+            "input_fifo_path": null,
+            "last_offset": 0,
+            "full_response": "recovered answer body",
+            "response_sent_offset": 0,
+            "relay_owner_kind": "watcher",
+            "started_at": "2026-01-01 00:00:00",
+            "updated_at": "2026-01-01 00:00:00"
+        }))
+        .expect("leak inflight state")
+    }
+
+    fn seed_leak_inflight(
+        root: &std::path::Path,
+        provider: &ProviderKind,
+        channel_id: u64,
+        user_msg_id: u64,
+    ) -> InflightTurnState {
+        let state = leak_inflight_state(provider, channel_id, user_msg_id);
+        let provider_dir = root.join(provider.as_str());
+        std::fs::create_dir_all(&provider_dir).expect("create provider dir");
+        let path = provider_dir.join(format!("{channel_id}.json"));
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&state).expect("serialize"),
+        )
+        .expect("seed inflight row");
+        state
+    }
+
+    fn row_path(
+        root: &std::path::Path,
+        provider: &ProviderKind,
+        channel_id: u64,
+    ) -> std::path::PathBuf {
+        root.join(provider.as_str())
+            .join(format!("{channel_id}.json"))
+    }
+
+    /// The fix: after the OOB recovery delivers the completed answer, the inflight
+    /// row that pinned the phantom in-progress turn is cleared, so the intake gate
+    /// stops queueing new messages and the deferred kickoff can dequeue.
+    #[test]
+    fn oob_leak_recovery_clears_inflight_so_queue_can_drain() {
+        let temp = tempfile::tempdir().expect("temp root");
+        let provider = ProviderKind::Claude;
+        let channel_id = 4242u64;
+        let state = seed_leak_inflight(temp.path(), &provider, channel_id, 9001);
+        assert!(
+            row_path(temp.path(), &provider, channel_id).exists(),
+            "precondition: the inflight row exists and would gate intake-queueing"
+        );
+
+        let outcome = clear_recovered_leak_inflight_in_root(
+            temp.path(),
+            &provider,
+            ChannelId::new(channel_id),
+            &state,
+        );
+
+        assert_eq!(
+            outcome,
+            GuardedClearOutcome::Cleared,
+            "OOB recovery must finalize (clear) the inflight turn-state (#3925)"
+        );
+        assert!(
+            !row_path(temp.path(), &provider, channel_id).exists(),
+            "the phantom in-progress inflight row must be removed so the session returns to idle"
+        );
+    }
+
+    /// #3860: the guarded clear must NOT clobber a NEWER turn that wrote this
+    /// channel's row in the window after the mailbox token released.
+    #[test]
+    fn oob_leak_recovery_preserves_a_newer_turns_inflight() {
+        let temp = tempfile::tempdir().expect("temp root");
+        let provider = ProviderKind::Claude;
+        let channel_id = 4242u64;
+        // On disk: a NEWER turn's row.
+        seed_leak_inflight(temp.path(), &provider, channel_id, 12345);
+        // The recovered (older) turn carries a different user_msg_id.
+        let recovered = leak_inflight_state(&provider, channel_id, 9001);
+
+        let outcome = clear_recovered_leak_inflight_in_root(
+            temp.path(),
+            &provider,
+            ChannelId::new(channel_id),
+            &recovered,
+        );
+
+        assert_eq!(outcome, GuardedClearOutcome::UserMsgMismatch);
+        assert!(
+            row_path(temp.path(), &provider, channel_id).exists(),
+            "a newer turn's inflight row must be preserved (#3860)"
+        );
+    }
+
+    /// A zero-id-owned recovery / TUI-direct turn (its on-disk `user_msg_id` is 0)
+    /// must still finalize its own row via the zero-owned guard.
+    #[test]
+    fn oob_leak_recovery_clears_zero_id_owned_inflight() {
+        let temp = tempfile::tempdir().expect("temp root");
+        let provider = ProviderKind::Claude;
+        let channel_id = 7007u64;
+        let state = seed_leak_inflight(temp.path(), &provider, channel_id, 0);
+
+        let outcome = clear_recovered_leak_inflight_in_root(
+            temp.path(),
+            &provider,
+            ChannelId::new(channel_id),
+            &state,
+        );
+
+        assert_eq!(outcome, GuardedClearOutcome::Cleared);
+        assert!(!row_path(temp.path(), &provider, channel_id).exists());
+    }
 }
 
 /// #1446 — pure-helper tests for the stall-watchdog decision logic.


### PR DESCRIPTION
## Root cause

After a relay break strands a turn's completed answer, the stall watchdog's out-of-band recovery `maybe_recover_completed_stale_leak` (`src/services/discord/health/recovery.rs:1780`) delivers the answer (edit placeholder / send continuation chunks), then **only advances `response_sent_offset` and returns** (`recovery.rs:2089-2146`) — it deliberately preserves the inflight row and never finalizes the turn.

The normal turn-completion path (`turn_finalizer::do_finalize`) and the startup recovery branches (`recovery_engine.rs` completed_during_downtime / output_completed) both finalize via `finish_recovered_turn_mailbox` + `clear_inflight_state`. This OOB path skipped all of it, so:

- the inflight row stayed on disk, and
- the in-memory mailbox active-turn token stayed held,

leaving the session pinned to a **phantom in-progress turn**. The intake gate `mailbox_has_live_active_turn_or_cleanup_stale_proof` (`router/intake_gate/stale_turn.rs:234`) keyed off the live mailbox token and kept queueing every new message with `📬 메시지 대기 중 / 사유: 앞선 턴 진행 중`. Because the turn already completed out-of-band, **no completion event ever fired to dequeue them** → permanent dead session (manual `/stop` or `/restart` required).

## The OOB-recovery cleanup gap

`maybe_recover_completed_stale_leak` returns `true` at `recovery.rs:2146` after only the offset bump. A scan of the whole function body for `clear_inflight | finish_recovered | mailbox_finish | drain | kickoff` matched nothing. The `#2427-D` "safety net" inflight-cleanup signal lives in `complete_recovery_visible_turn`, which this path never calls — so neither it nor any other cleanup fired.

## The fix (mirrors normal completion precisely)

After a **full** out-of-band delivery (every partial/retryable path returns earlier), mirror what the startup recovery branches do:

1. `recovery_engine::finish_recovered_turn_mailbox(...)` — routes the recovered terminal through the single-authority finalizer (`FinalizeContext::monitor`): `mailbox_finish_turn` token release + gated `global_active` decrement + idle-queue kickoff. No re-delivery, no visible-UI re-emit.
2. `clear_recovered_leak_inflight(...)` — identity-guarded inflight clear: `clear_inflight_state_if_matches` for a real `user_msg_id`, `clear_inflight_state_if_matches_zero_owned` for a zero-id-owned recovery / TUI-direct turn. The guard re-reads the fresh on-disk row under its flock (**#3860 RMW**) so a turn that started in the narrow window after the token released is never clobbered (a newer row yields `UserMsgMismatch` and is preserved).

This is the same finalize+clear pair the startup branches use; it does not invent a divergent path.

## Invariant

A turn result delivered out-of-band (deadlock leak recovery) or after a mid-turn relay break **must** finalize the inflight turn-state and trigger the intake-queue dequeue, so an idle session never holds queued messages behind a phantom in-progress turn.

## Tests (new, hermetic — TempDir + `_in_root`)

- `oob_leak_recovery_clears_inflight_so_queue_can_drain` — real-id row is cleared (`Cleared`) and removed after OOB recovery.
- `oob_leak_recovery_preserves_a_newer_turns_inflight` — #3860: a newer turn's row is preserved (`UserMsgMismatch`).
- `oob_leak_recovery_clears_zero_id_owned_inflight` — zero-id-owned recovery turn clears its own row.

## Gate results

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check --lib` | clean (only pre-existing warnings in untouched files) |
| `cargo test --lib inflight` (clean root) | 287 passed, 0 failed (incl. 3 new) |
| `cargo test --lib health::recovery` / `recovery_engine::` | 33 / 75 passed |
| `generate_inventory_docs.py` | regenerated + committed |
| `check_agent_maintenance_docs.py` | freshness check passed |
| `check_hotfile_ratchet.py` | exit 0 |
| `audit_maintainability.py --check` | exit 0 (recovery.rs 2223 < 2736 baseline) |
| clippy (touched files) | clean |

## Scope safety

Only `src/services/discord/health/recovery.rs` (+ regenerated docs) touched. No #3016 hotfile (`turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, `turn_finalizer*`) and no concurrent-track file (`status_panel.rs`, voice) modified — `finish_recovered_turn_mailbox` and the inflight clear helpers are **called**, not edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)