### PR TITLE
fix(discord): surface background Agent subagents on status panel (#3920)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -512,9 +512,9 @@
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
-| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 693 | 693 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 674 | 674 | 0 |  |
-| `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 370 | 195 | 175 |  |
+| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 700 | 700 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 688 | 688 | 0 |  |
+| `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 445 | 270 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 348 | 348 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 207 | 112 | 95 |  |

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -539,6 +539,13 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                 .get("is_error")
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
+            // #3920: a successful async Agent launch ack keeps its slot alive as a
+            // background subagent across turns (it is NOT a completion).
+            if let Some(events) =
+                super::subagent_rollout::async_launch_promote_events(value, blocks, idx, is_error)
+            {
+                return events;
+            }
 
             // This block's OWN aggregate (batched case), keyed by THIS block's
             // tool_use_id; else the legacy record-level aggregate on the first

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -165,25 +165,39 @@ impl StatusPanelState {
                 tool_use_id,
                 background,
             } => {
-                let desc = desc
-                    .filter(|value| !value.trim().is_empty())
-                    .unwrap_or_else(|| "subagent".to_string());
-                let subagent_type = subagent_type
-                    .filter(|value| !value.trim().is_empty())
-                    .unwrap_or_else(|| "Task".to_string());
+                // #3920: keep "was a real value provided?" BEFORE defaulting, so a
+                // background-promotion re-affirmation (an async launch ack carries
+                // no desc/type) never overwrites the launching slot's real
+                // description with the `subagent`/`Task` placeholders.
+                let provided_desc = desc.filter(|value| !value.trim().is_empty());
+                let provided_type = subagent_type.filter(|value| !value.trim().is_empty());
+                // A background `SubagentStart` re-affirms (and #3920: PROMOTES) the
+                // still-running slot for this tool-use id. Matching ANY unfinished
+                // slot — not only an already-background one — lets an async/
+                // `run_in_background` Agent launch (whose async-ness is known only
+                // from the launch-ack `toolUseResult`, not the tool INPUT) flip its
+                // foreground-looking slot to a background subagent. That keeps it
+                // alive across turn-boundary resets like a Bash `run_in_background`
+                // task, instead of being dropped a turn later (#3920).
                 if background
                     && let Some(id) = tool_use_id.as_deref().filter(|id| !id.trim().is_empty())
                     && let Some(slot) = self.subagents.iter_mut().rev().find(|slot| {
-                        slot.background
-                            && slot.finished.is_none()
-                            && slot.tool_use_id.as_deref() == Some(id)
+                        slot.finished.is_none() && slot.tool_use_id.as_deref() == Some(id)
                     })
                 {
-                    slot.subagent_type = subagent_type;
-                    slot.desc = desc.clone();
-                    self.status = DerivedStatus::SubagentRunning { desc };
+                    slot.background = true;
+                    if let Some(subagent_type) = provided_type {
+                        slot.subagent_type = subagent_type;
+                    }
+                    if let Some(desc) = provided_desc {
+                        slot.desc = desc;
+                    }
+                    let running_desc = slot.desc.clone();
+                    self.status = DerivedStatus::SubagentRunning { desc: running_desc };
                     return;
                 }
+                let desc = provided_desc.unwrap_or_else(|| "subagent".to_string());
+                let subagent_type = provided_type.unwrap_or_else(|| "Task".to_string());
                 let ordinal = take_slot_ordinal(&mut self.next_slot_ordinal);
                 self.subagents.push(SubagentSlot {
                     subagent_type,

--- a/src/services/discord/placeholder_live_events/subagent_rollout.rs
+++ b/src/services/discord/placeholder_live_events/subagent_rollout.rs
@@ -26,7 +26,7 @@
 use chrono::DateTime;
 use serde_json::Value;
 
-use crate::services::agent_protocol::SubagentSummary;
+use crate::services::agent_protocol::{StatusEvent, SubagentSummary};
 
 /// Extracts the TUI summary from a parent-transcript `tool_result` record's
 /// top-level `toolUseResult` object. Returns `(summary, agent_id)` when the
@@ -79,6 +79,81 @@ pub(super) fn summary_from_tool_use_result(
         return None;
     }
     Some((summary, agent_id))
+}
+
+/// #3920: `true` when a parent-transcript `tool_result`/`user` record (or a
+/// batched per-block `tool_result`) is an ASYNC subagent LAUNCH acknowledgment
+/// — `toolUseResult.isAsync == true` or `toolUseResult.status == "async_launched"`.
+///
+/// A launch ack is NOT a completion: the launched Agent subagent keeps running
+/// detached and OUTLIVES the launching turn. The async-ness is only knowable
+/// from this launch-ack `toolUseResult` (modern async `Agent` launches do not
+/// carry `run_in_background` in the tool INPUT), so the status panel uses this to
+/// promote the subagent's slot to a background subagent and keep it alive across
+/// turn-boundary resets — the same lifetime a Bash `run_in_background` task gets.
+pub(super) fn tool_use_result_is_async_launch(value: &Value) -> bool {
+    value
+        .get("toolUseResult")
+        .and_then(Value::as_object)
+        .is_some_and(|result| {
+            result.get("isAsync").and_then(Value::as_bool) == Some(true)
+                || result.get("status").and_then(Value::as_str) == Some("async_launched")
+        })
+}
+
+/// #3920: background-promotion [`StatusEvent`]s for a `user`-record `tool_result`
+/// block (`blocks[idx]`) that is a SUCCESSFUL async/background Agent launch ack —
+/// either its OWN `toolUseResult` is async (batched per-block shape) or the
+/// RECORD-level `toolUseResult` is async and this is the first id-bearing block
+/// (legacy single-subagent shape). Such an ack is NOT a completion: the subagent
+/// keeps running detached and outlives the launching turn, so the panel re-affirms
+/// its slot as `background: true` (keyed by the block's tool-use id). That keeps
+/// it alive across turn-boundary resets, parity with a Bash `run_in_background`
+/// task; without it the foreground-looking slot is dropped a turn later (the
+/// #3920 root cause). A FAILED launch returns `None` — the agent never started.
+pub(super) fn async_launch_promote_events(
+    value: &Value,
+    blocks: &[Value],
+    idx: usize,
+    is_error: bool,
+) -> Option<Vec<StatusEvent>> {
+    let block = blocks.get(idx)?;
+    if is_error {
+        return None;
+    }
+    let is_async_launch = tool_use_result_is_async_launch(block)
+        || (tool_use_result_is_async_launch(value)
+            && Some(idx) == first_idful_tool_result_idx(blocks));
+    if !is_async_launch {
+        return None;
+    }
+    let tool_use_id = block
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+    Some(vec![
+        StatusEvent::ToolEnd { success: true },
+        StatusEvent::SubagentStart {
+            subagent_type: None,
+            desc: None,
+            tool_use_id,
+            background: true,
+        },
+    ])
+}
+
+/// First id-bearing `tool_result` block — the owner of any RECORD-level
+/// `toolUseResult` aggregate (legacy single-subagent shape).
+fn first_idful_tool_result_idx(blocks: &[Value]) -> Option<usize> {
+    blocks.iter().position(|block| {
+        block.get("type").and_then(Value::as_str) == Some("tool_result")
+            && block
+                .get("tool_use_id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| !id.trim().is_empty())
+    })
 }
 
 /// Core, IO-free rollout parser. Parses a `subagents/agent-<id>.jsonl` rollout

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -3720,6 +3720,141 @@ fn status_events_json_async_launch_ack_does_not_close_background_subagent() {
     );
 }
 
+// #3920: a modern async `Agent` launch carries NO `run_in_background` in the
+// tool INPUT — its async-ness is known only from the launch-ack `toolUseResult`
+// (`isAsync`/`status: async_launched`). The slot therefore starts foreground
+// (`background: false`); before #3920 it was dropped at the very next turn
+// boundary, so a long-running background Agent subagent spawned in a prior turn
+// never showed on the status panel (only Bash `run_in_background` tasks did).
+// The launch-ack must PROMOTE the slot to a background subagent so it SURVIVES
+// turn-boundary resets and stays observable for parallel-work monitoring.
+#[test]
+fn status_panel_async_agent_subagent_survives_turn_boundary_after_launch_ack() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_920_001);
+
+    // Spawning turn: Agent tool_use WITHOUT `run_in_background` → foreground slot.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Agent",
+            &json!({
+                "subagent_type": "general-purpose",
+                "description": "Implement #3897 r4"
+            })
+            .to_string(),
+            Some("toolu_agent_3897"),
+        ),
+    );
+
+    // The async launch-ack (record-level `isAsync`/`async_launched`, no
+    // accounting) arrives as a `user` record on the watcher/json path.
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_agent_3897",
+                    "is_error": false
+                }]
+            },
+            "toolUseResult": {
+                "isAsync": true,
+                "status": "async_launched",
+                "agentId": "aee5241a0000000",
+                "description": "Implement #3897 r4",
+                "prompt": "...",
+                "outputFile": "...",
+                "canReadOutputFile": true
+            }
+        })),
+    );
+
+    let spawning = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(spawning.contains("Subagents"));
+    assert!(
+        spawning.contains("general-purpose Implement #3897 r4"),
+        "async Agent subagent should render during the spawning turn: {spawning}"
+    );
+
+    // Turn boundary: the next turn resets per-turn content, preserving only
+    // unfinished BACKGROUND residuals (#3386). The promoted slot must survive.
+    events.clear_channel_preserving_footer_residuals(channel_id);
+
+    let next_turn = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_300);
+    let line = next_turn
+        .lines()
+        .find(|line| line.contains("general-purpose Implement #3897 r4"))
+        .unwrap_or_else(|| {
+            panic!("background Agent subagent must survive the turn boundary: {next_turn}")
+        });
+    assert!(
+        next_turn.contains("Subagents"),
+        "the carried background subagent must still render under Subagents: {next_turn}"
+    );
+    assert!(
+        !line.contains('✓') && !line.contains('✗') && !line.contains("Done ("),
+        "the carried background subagent is still running (no terminal marker): {line}"
+    );
+}
+
+// #3920: surfacing the carried background subagent must NOT introduce
+// per-render nondeterminism — the panel text stays byte-identical across
+// heartbeat ticks when no status change occurred (#3477/#3812 invariant).
+#[test]
+fn status_panel_carried_background_subagent_is_heartbeat_stable() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_920_002);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Agent",
+            &json!({ "subagent_type": "Explore", "description": "Audit #3864" }).to_string(),
+            Some("toolu_agent_3864"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_agent_3864",
+                    "is_error": false
+                }]
+            },
+            "toolUseResult": { "isAsync": true, "status": "async_launched", "agentId": "a106f023" }
+        })),
+    );
+    events.clear_channel_preserving_footer_residuals(channel_id);
+
+    let first = events.render_status_panel_with_heartbeat(
+        channel_id,
+        &ProviderKind::Claude,
+        1_700_000_000,
+        1_700_000_005,
+    );
+    let second = events.render_status_panel_with_heartbeat(
+        channel_id,
+        &ProviderKind::Claude,
+        1_700_000_000,
+        1_700_000_090,
+    );
+
+    assert!(
+        first.contains("Explore Audit #3864"),
+        "carried background subagent should render: {first}"
+    );
+    assert_eq!(
+        first, second,
+        "panel text must be byte-identical across heartbeat ticks with no status change"
+    );
+}
+
 #[test]
 fn status_panel_async_completion_with_accounting_still_finalizes_subagent() {
     let events = PlaceholderLiveEvents::default();


### PR DESCRIPTION
Closes #3920.

## Root cause
The Discord status panel set a subagent slot's `background` flag **only** from the tool **INPUT** `run_in_background` (`status_events.rs`, the `is_task_tool` arm at the old line ~87-104). Modern async **`Agent`** launches do **not** carry `run_in_background` in the input — their async-ness is known only from the launch-ack `toolUseResult` (`isAsync` / `status: "async_launched"`, the exact fields `subagent_rollout.rs` already parses).

So async Agent subagents got `background: false`, were treated as foreground, and were dropped at the **very next turn boundary** — `reset_turn_content_preserving_unfinished_footer_residuals` (`status_panel.rs:117-144`) keeps only `is_unfinished_background()` slots. Bash `run_in_background` tasks (which DO set the input flag) survived; long-running Agent subagents spawned in prior turns vanished. That is exactly the issue's symptom (panel showed only `Bash run_in_background`, never the parallel implement/rework Agent subagents).

## Fix (status panel only)
- **`subagent_rollout.rs`**: `tool_use_result_is_async_launch` + `async_launch_promote_events` — for a *successful* async launch ack, emits a `SubagentStart { background: true }` re-affirmation keyed by the block's tool-use id (record-level legacy shape attributed to the first id-bearing block; batched per-block shape detected on the block; a failed launch is left alone).
- **`status_events.rs`** (`user_status_events`): short-circuits an async launch-ack block into that promotion instead of the foreground `ToolEnd`-only path.
- **`status_panel.rs`** (`SubagentStart` apply): a background re-affirmation now **PROMOTES any still-unfinished slot** for that id to `background: true` (previously matched only already-background slots), preserving the slot's real desc/type. The promoted slot then survives turn-boundary resets like a Bash background task and renders under the existing **`Subagents`** section (already distinct from the Bash `Tasks` section, labeled with agent type + description).

When the async agent genuinely finishes (terminal `subagent` notification or a `toolUseResult` with accounting), the existing path finalizes it ✓ — the standard background-subagent lifecycle the `background` flag was designed for.

## Heartbeat stability (#3477 / #3812)
No per-render nondeterminism is introduced — the carried subagent renders from stable slot state only; no server-side elapsed timers. The panel text stays byte-identical across heartbeat ticks with no status change (pinned by a new test).

## Scope / safety
- Only `src/services/discord/placeholder_live_events/*` (+ regenerated `docs/generated/module-inventory.md`).
- No `turn_bridge` / `tmux_watcher` / `session_relay_sink` / `turn_finalizer` (#3016 hotfiles) touched; no `inflight.rs` (#3925) or voice (#3912) files touched.
- `status_events.rs` kept at the 700-LoC namespace cap by housing the new logic in `subagent_rollout.rs`.
- Confidence line (#3812) untouched and still passing.

## Follow-up (out of scope)
The per-turn `pendingBackgroundAgentCount` snapshot (`system{turn_duration}`, currently parsed-but-dropped in `stream_line.rs`) would also let the panel show a count for agents it never saw start (e.g. across a dcserver restart). Plumbing it needs out-of-scope `stream_line.rs` + `turn_bridge` changes — left as a follow-up.

## Tests / gates
New tests: `status_panel_async_agent_subagent_survives_turn_boundary_after_launch_ack` (core bug — async Agent subagent now persists past the turn boundary), `status_panel_carried_background_subagent_is_heartbeat_stable`.

- `cargo fmt --check` ✅
- `cargo check --lib` ✅
- `cargo test --lib placeholder_live_events` → 192 passed, 0 failed ✅
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → "freshness check passed" ✅
- `check_hotfile_ratchet.py` exit 0 ✅
- `audit_maintainability.py --check` exit 0 ✅
- clippy clean on touched files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)