### PR TITLE
chore(db): remove orphaned LEGACY_AGENT_PREFIX dead const (#3874)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -82,7 +82,7 @@
 | `crate` | `src/main.rs` | 7 | 7 | 0 |  |
 | `credential` | `src/credential.rs` | 212 | 59 | 153 |  |
 | `db` | `src/db/mod.rs` | 68 | 68 | 0 |  |
-| `db::agents` | `src/db/agents.rs` | 415 | 254 | 161 |  |
+| `db::agents` | `src/db/agents.rs` | 410 | 249 | 161 |  |
 | `db::auto_queue` | `src/db/auto_queue/mod.rs` | 21 | 21 | 0 |  |
 | `db::auto_queue::claim` | `src/db/auto_queue/claim.rs` | 734 | 734 | 0 |  |
 | `db::auto_queue::consultation` | `src/db/auto_queue/consultation.rs` | 112 | 112 | 0 |  |

--- a/src/db/agents.rs
+++ b/src/db/agents.rs
@@ -5,11 +5,6 @@ use sqlx::{PgPool, Row as SqlxRow};
 
 use crate::services::provider::ProviderKind;
 
-// reason: used only by the removed SQLite-only agent alias path below; the
-// production copy lives in db/postgres.rs. See #3034 / #3035.
-#[allow(dead_code)]
-const LEGACY_AGENT_PREFIX: &str = "openclaw-";
-
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AgentChannelBindings {
     pub provider: Option<String>,


### PR DESCRIPTION
## Summary
Post SQLite→Postgres cutover dead-code cleanup for #3874, **db subtree only**.

Removes the orphaned `LEGACY_AGENT_PREFIX` constant in `src/db/agents.rs` — a `#[allow(dead_code)]` remnant of the removed SQLite-only agent-alias path (#3034/#3035). Pure maintainability, **zero behavior change**.

## What was removed + proof it was dead
- `src/db/agents.rs:8-11` — the 2-line `// reason: ...` comment + `#[allow(dead_code)]` + `const LEGACY_AGENT_PREFIX: &str = "openclaw-";`
  - **Proof dead:** `grep -rn LEGACY_AGENT_PREFIX` shows the `agents.rs` copy had **zero references** — only the declaration. The *live* copy lives in `src/db/postgres.rs:16` (used at `:759`/`:762`) and is unaffected. The const carried its own comment confirming it was "used only by the removed SQLite-only agent alias path."
  - Test `db::postgres::tests::postgres_startup_reseed_preserves_configured_legacy_openclaw_agent_id` still passes — it exercises the live postgres.rs copy, confirming nothing depended on the removed const.
- `docs/generated/module-inventory.md` — regenerated; reflects `db::agents` 415→410 lines.

## Deferred — #3016-gated (PR-B), per issue owner
The issue's headline target (`DisabledDbBackend` + `Db` alias) is **NOT removable in the db subtree** and is intentionally deferred:
- `DisabledDbBackend`'s fake-rusqlite scaffolding (`DisabledDbError`/`DisabledDbConnection`/`DisabledDbRow` + impls in `db/mod.rs`) is **not actually dead** — it has a live compile-time caller, `services::message_outbox::enqueue_lifecycle_notification_sqlite` (reached via `Option<&Db>`, always `None` at runtime but compiled). That file is outside the db subtree.
- `type Db = Arc<DisabledDbBackend>` is threaded through many files **including #3016 hotfiles** (`turn_bridge/mod.rs`, `tmux_watcher.rs`) via `Option<&Db>` params (e.g. `session_transcripts::persist_turn_db`, `memento_feedback_stats::upsert_turn_stat`).
- Per the issue owner's comment, the `Db` alias removal is **PR-B**, deferred to the Lane1 (#3859) hotfile window; this issue closes when PR-B lands. PR-A (#3919) already removed the deprecated importer.

## Scope confirmation
Touched files: `src/db/agents.rs`, `docs/generated/module-inventory.md`. **No** operational-data / migration / live-DB file, **no** #3016 hotfile (turn_bridge/tmux_watcher/session_relay_sink/turn_finalizer), and **no** concurrent-track file (inflight.rs / status_panel.rs / voice) was touched.

## Gates (CARGO_BUILD_JOBS=5)
- `cargo fmt --check` ✅
- `cargo check --lib` ✅ (no errors; only pre-existing warnings)
- `cargo test --lib db::` ✅ 179 passed, 0 failed
- `generate_inventory_docs.py` ✅ (module-inventory.md committed) · `check_agent_maintenance_docs.py` ✅ "freshness check passed"
- `check_hotfile_ratchet.py` ✅ exit 0 · `audit_maintainability.py --check` ✅ hard_gate count 0
- `cargo clippy --lib` ✅ clean (no agents.rs findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)