### PR TITLE
test(e2e): close relay E-16/E-17 live regression gaps (#3797)

### DIFF
--- a/docs/e2e/multi-provider-e2e.md
+++ b/docs/e2e/multi-provider-e2e.md
@@ -41,8 +41,8 @@ Every scenario must declare `agent_mode`:
 | `agent_mode` | Use when | Relay example |
 | --- | --- | --- |
 | `none` | No AgentDesk agent/provider is contacted; the harness checks local state-machine or replay fixtures only. | `E-24`/`E-25` local fixture replay. These can prove parser/finalization contracts, but cannot satisfy live relay gates. |
-| `controlled` | A deterministic test agent, fake provider, scripted responder, or controlled runtime hook owns completion. | Future hook-backed relay gaps such as forced quiescence timeout or synthetic foreign-active state. |
-| `real_live` | The scenario sends work through a real provider/cell and live Discord/runtime boundary. | Normal relay matrix prompts, direct TUI input, cross-channel `E-11`, and post-deploy relay continuity smoke. |
+| `controlled` | A deterministic test agent, fake provider, scripted responder, or controlled runtime hook owns completion. | Future fake-provider / production-parser injection. A deterministic forced quiescence timeout would also land here once a runtime hook exists. |
+| `real_live` | The scenario sends work through a real provider/cell and live Discord/runtime boundary. | Normal relay matrix prompts, direct TUI input, cross-channel `E-11`, restart-guard `E-17`, the `E-16` completion-quiescence release window, and post-deploy relay continuity smoke. |
 
 Every scenario must also declare `coverage_class`:
 
@@ -76,10 +76,29 @@ scheduled wakeup/monitor path: the first turn must call `ScheduleWakeup`, and
 the automatic wake turn must relay `[E2E:E13:WAKE]` to Discord. It intentionally
 runs only on `claude-pipe`; `claude-tui` and `claude-e` keep normal relay
 coverage because this matrix does not create a persistent Claude Code wake
-session for those cells. `E-16` and `E-17` are #2935 regression stubs: they are
-loaded by the relevant cells but skipped until the runtime/orchestrator exposes
-hooks to force Claude TUI completion-quiescence timeout and to hold a foreign
-active mailbox during a destructive restart attempt. `E-18` is an executable
+session for those cells. `E-16` and `E-17` close the #2935 live regression gap
+(#3797). `E-16` is an executable `claude-tui` `real_live`/`live` scenario: it
+delivers a first response and then sends a second prompt immediately at the
+first response marker — the completion-quiescence release window after delivery
+(`TUI_COMPLETION_QUIESCENCE_TIMEOUT`, the 3s const in
+`src/services/discord/tmux.rs`) — and proves the second prompt starts and replies
+without an indefinite queued placeholder. Deterministically *forcing* the 3s gate
+would need a production hook, so `E-16` exercises the natural release window on
+the live relay path; the always-on post-scenario idle invariant
+(`assert_cell_idle` → `post_scenario_idle.mailbox_idle_evidence`) captures the
+`/api/health/detail` proof that the tested mailbox returned to idle
+(`agent_turn_status=idle`, `queue_depth=0`, no cancel token, no inflight state, no
+active user message, no stale queued placeholder/pending callback). `E-17` is an
+orchestrator-owned restart-guard scenario (`cells: []`,
+`orchestration: foreign_active_restart_guard`, run by
+`run_multi_provider_matrix.py`): it holds a foreign `claude-tui` turn active via
+the provider-hold witness, waits until `/api/health/detail` surfaces that mailbox
+busy, then attempts a `codex-tui` destructive restart and proves the harness
+refuses before restart while naming the foreign mailbox evidence. SAFETY: `E-17`
+drives only the restart-refusal guard (`_guard_no_foreign_active_turns`) and never
+invokes the real restart/kickstart, so even a regressed guard cannot harm
+unrelated active production work; the foreign hold is released (`cancel_turn`) and
+both channels asserted idle on teardown. `E-18` is an executable
 but destructive-gated `cancel_turn` stop-mid-turn scenario for relay-backed
 pipe/TUI cells; it uses the provider hold witness primitive and omits
 `claude-e` because the stop/cancel path under test is relay-backed lifecycle.
@@ -90,7 +109,8 @@ serialization while asserting both markers arrive once. `E-21` covers TUI
 direct input with an actual `C-u` key sequence: a stale draft marker is typed,
 cleared, and then the real prompt must relay with a complete head-to-tail body
 while the stale marker and terminal controls stay absent. `E-11`
-(cross-cell concurrency) is `cells: []` — the orchestrator owns that scenario.
+(cross-cell concurrency) and `E-17` (foreign-active restart guard) are both
+`cells: []` — the orchestrator owns those scenarios.
 `E-22` covers tool-use to text completeness for Claude relay-backed pipe/TUI
 cells by waiting for a current-turn provider hold witness after a real tool call
 and then asserting the post-tool body remains complete. `E-23` is the dedicated
@@ -122,6 +142,11 @@ Covered P0/P1 backlog items:
 - `direct-input body_complete + control-byte strip`: `E-21`, TUI cells.
 - `codex modern schema turn completeness + follow-up readiness`: `E-25`,
   deterministic local fixture replay for Codex cells.
+- `completion-quiescence release after delivery` (#2935): `E-16`, `claude-tui`,
+  immediate follow-up after the first response marker plus the idle invariant.
+- `foreign-active destructive restart refusal` (#2935): `E-17`, orchestrator-owned
+  hold of a foreign `claude-tui` mailbox while a `codex-tui` restart is attempted
+  (guard-only, no real restart).
 
 Remaining exact gaps:
 

--- a/scripts/e2e/run_multi_provider_matrix.py
+++ b/scripts/e2e/run_multi_provider_matrix.py
@@ -142,6 +142,31 @@ def load_cross_channel_scenarios(scenarios_dir: Path) -> list[dict[str, Any]]:
     return scenarios
 
 
+def load_restart_guard_scenarios(scenarios_dir: Path) -> list[dict[str, Any]]:
+    """Load E-17-style foreign-active restart-guard orchestration scenarios.
+
+    Like cross-channel scenarios these are orchestrator-owned (``cells: []``); the
+    single-cell driver never runs them. The matrix holds a foreign provider turn
+    active and then drives the harness restart-refusal guard for a second cell.
+    """
+
+    scenarios: list[dict[str, Any]] = []
+    for yaml_path in sorted(scenarios_dir.glob("*.yaml")):
+        with yaml_path.open("r", encoding="utf-8") as fp:
+            data = yaml.safe_load(fp)
+        if not isinstance(data, dict):
+            raise ValueError(f"{yaml_path} did not parse to a mapping")
+        if data.get("orchestration") != "foreign_active_restart_guard":
+            continue
+        if not isinstance(data.get("restart_guard"), dict):
+            raise ValueError(f"{yaml_path} declares foreign_active_restart_guard without config")
+        data["__path__"] = str(yaml_path)
+        cell_driver.validate_scenario_agent_mode(data)
+        cell_driver.validate_scenario_coverage_class(data)
+        scenarios.append(data)
+    return scenarios
+
+
 def parse_cells(raw: str) -> list[str]:
     cells = [cell.strip() for cell in raw.split(",") if cell.strip()]
     unknown = [cell for cell in cells if cell not in DEFAULT_CELLS]
@@ -998,6 +1023,505 @@ def run_cross_channel_scenario(
     return result
 
 
+def _restart_guard_config(scenario: dict[str, Any]) -> dict[str, Any]:
+    config = scenario.get("restart_guard")
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"{scenario.get('__path__') or scenario.get('id')} restart_guard must be a mapping"
+        )
+    for role in ("foreign_hold", "restart_attempt"):
+        if not isinstance(config.get(role), dict):
+            raise ValueError(
+                f"{scenario.get('id')} restart_guard.{role} must be a mapping"
+            )
+    return config
+
+
+def _restart_guard_required_cells(scenario: dict[str, Any]) -> set[str]:
+    config = _restart_guard_config(scenario)
+    cells: set[str] = set()
+    for role in ("foreign_hold", "restart_attempt"):
+        cell = str(config[role].get("cell") or "")
+        if cell not in DEFAULT_CELLS:
+            raise ValueError(
+                f"{scenario.get('id')} restart_guard.{role} has bad cell {cell!r}"
+            )
+        cells.add(cell)
+    if len(cells) < 2:
+        raise ValueError(
+            f"{scenario.get('id')} restart_guard.foreign_hold and restart_attempt "
+            "must name different cells"
+        )
+    return cells
+
+
+def resolve_restart_guard_roles(
+    scenario: dict[str, Any],
+    *,
+    channel_ids: dict[str, str],
+    selected_cells: list[str],
+) -> dict[str, dict[str, Any]]:
+    config = _restart_guard_config(scenario)
+    required_cells = _restart_guard_required_cells(scenario)
+    missing_selected = sorted(required_cells.difference(selected_cells))
+    if missing_selected:
+        raise ValueError(
+            "restart-guard scenario requires selected cells: "
+            + ", ".join(missing_selected)
+        )
+    roles: dict[str, dict[str, Any]] = {}
+    for role in ("foreign_hold", "restart_attempt"):
+        raw = config[role]
+        cell = str(raw["cell"])
+        channel_id = channel_ids.get(cell)
+        if not channel_id:
+            raise ValueError(f"configured e2e channel id missing for cell {cell!r}")
+        roles[role] = {
+            "role": role,
+            "cell": cell,
+            "provider": cell_driver.cell_provider(cell),
+            "runtime": cell_driver.cell_runtime(cell),
+            "channel_id": str(channel_id),
+            "channel_kind": str(
+                raw.get("channel_kind") or cell_driver.cell_channel_kind(cell)
+            ),
+            "handoff_to_agent": cell_driver.cell_default_agent(cell),
+            "workspace_substring": cell_driver.cell_workspace_substring(cell),
+            "provider_identity": cell_driver.provider_identity(cell, str(channel_id)),
+            "config": raw,
+        }
+    return roles
+
+
+def _wait_for_foreign_mailbox_busy(
+    *,
+    base_url: str,
+    channel_id: str,
+    provider: str,
+    timeout_s: float,
+    poll_interval_s: float,
+) -> dict[str, Any]:
+    """Poll /api/health/detail until the held foreign mailbox reports busy.
+
+    Bridges the durable provider-hold witness (an on-disk inflight row) to the
+    /api/health/detail mailbox evidence the restart guard actually inspects, so
+    the guard check that follows is deterministic rather than racing the snapshot.
+    """
+
+    deadline = time.monotonic() + max(timeout_s, 0.0)
+    last_error: str | None = None
+    last_reasons: list[str] = []
+    while True:
+        try:
+            detail = cell_driver._read_health_detail(base_url)  # noqa: SLF001
+            mailboxes = detail.get("mailboxes")
+            if isinstance(mailboxes, list):
+                for mailbox in mailboxes:
+                    if not isinstance(mailbox, dict):
+                        continue
+                    if cell_driver._mailbox_channel_id(mailbox) != str(channel_id):  # noqa: SLF001
+                        continue
+                    if cell_driver._mailbox_provider(mailbox) != provider:  # noqa: SLF001
+                        continue
+                    reasons = cell_driver._mailbox_busy_reasons(mailbox)  # noqa: SLF001
+                    last_reasons = reasons
+                    if reasons:
+                        return {
+                            "channel_id": str(channel_id),
+                            "provider": provider,
+                            "busy_reasons": reasons,
+                            "mailbox": cell_driver._mailbox_debug_summary(mailbox),  # noqa: SLF001
+                        }
+            last_error = None
+        except Exception as error:  # noqa: BLE001 - poll through transient health errors
+            last_error = f"{type(error).__name__}: {error}"
+        if time.monotonic() >= deadline:
+            raise assertions.AssertionError(
+                f"foreign mailbox provider={provider} channel={channel_id} never reported "
+                f"busy within {timeout_s}s; last_reasons={last_reasons or '<none>'}; "
+                f"last_error={last_error or '<none>'}"
+            )
+        time.sleep(poll_interval_s)
+
+
+def run_foreign_active_restart_guard_scenario(
+    scenario: dict[str, Any],
+    *,
+    args: argparse.Namespace,
+    run_id: str,
+    channel_ids: dict[str, str],
+    selected_cells: list[str],
+    pass_index: int,
+) -> dict[str, Any]:
+    """Hold a foreign provider turn active, then prove the restart guard refuses.
+
+    SAFETY: this orchestration never calls ``restart_dcserver_for_e2e`` and never
+    kickstarts dcserver. It drives only ``_guard_no_foreign_active_turns`` — the
+    "refuses before restart" half of the restart path — so even a regressed guard
+    cannot trigger a real restart that harms unrelated active production work.
+    """
+
+    scenario_id = str(scenario.get("id"))
+    declared_agent_mode = cell_driver.scenario_agent_mode(scenario)
+    declared_coverage_class = cell_driver.scenario_coverage_class(scenario)
+    initial_coverage_actual = cell_driver._initial_coverage_class_actual(  # noqa: SLF001
+        scenario,
+        declared=declared_coverage_class,
+        dry_run=bool(args.dry_run),
+    )
+    result: dict[str, Any] = {
+        "kind": "foreign_active_restart_guard",
+        "pass_index": pass_index,
+        "id": scenario_id,
+        "path": scenario.get("__path__"),
+        "run_id": run_id,
+        "status": "skipped",
+        "reason": None,
+        "agent_mode": declared_agent_mode,
+        "agent_mode_planned": cell_driver.infer_planned_agent_mode(
+            scenario,
+            declared=declared_agent_mode,
+        ),
+        "agent_mode_actual": "none",
+        "agent_mode_contract": cell_driver._agent_mode_contract(  # noqa: SLF001
+            declared=declared_agent_mode,
+            actual="none",
+            dry_run=bool(args.dry_run),
+            real_provider_contacted=False,
+        ),
+        "coverage_class": declared_coverage_class,
+        "coverage_class_planned": cell_driver.infer_planned_coverage_class(
+            scenario,
+            declared=declared_coverage_class,
+        ),
+        "coverage_class_actual": initial_coverage_actual,
+        "coverage_class_contract": cell_driver._coverage_class_contract(  # noqa: SLF001
+            declared=declared_coverage_class,
+            actual=initial_coverage_actual,
+            dry_run=bool(args.dry_run),
+        ),
+        "real_provider_contacted": False,
+        "failure_attribution": None,
+        "roles": [],
+        "destructive": True,
+        "ok": False,
+        "started_at": dt.datetime.now().isoformat(timespec="seconds"),
+    }
+
+    gate_violation = cell_driver.required_agent_mode_violation(
+        declared=declared_agent_mode,
+        required=getattr(args, "required_agent_mode", None),
+        scenario_id=scenario_id,
+    )
+    if gate_violation:
+        result["status"] = "fail"
+        result["reason"] = gate_violation
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "agent_mode_gate",
+            gate_violation,
+        )
+        return result
+
+    coverage_gate_violation = cell_driver.required_coverage_class_violation(
+        declared=declared_coverage_class,
+        required=getattr(args, "required_coverage_class", None),
+        scenario_id=scenario_id,
+    )
+    if coverage_gate_violation:
+        result["status"] = "fail"
+        result["reason"] = coverage_gate_violation
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "coverage_class_gate",
+            coverage_gate_violation,
+        )
+        return result
+
+    try:
+        required_cells = _restart_guard_required_cells(scenario)
+    except ValueError as error:
+        result["status"] = "fail"
+        result["reason"] = str(error)
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "config",
+            str(error),
+        )
+        return result
+
+    missing_selected = sorted(required_cells.difference(selected_cells))
+    if missing_selected:
+        result["reason"] = "requires selected cells: " + ", ".join(missing_selected)
+        observed_gate_violation = cell_driver.required_agent_mode_violation(
+            declared=declared_agent_mode,
+            actual=str(result["agent_mode_actual"]),
+            required=getattr(args, "required_agent_mode", None),
+            scenario_id=scenario_id,
+        )
+        if observed_gate_violation and not args.dry_run:
+            result["status"] = "fail"
+            result["reason"] = observed_gate_violation
+            result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+                "agent_mode_gate",
+                observed_gate_violation,
+            )
+            return result
+        observed_coverage_gate_violation = cell_driver.required_coverage_class_violation(
+            declared=declared_coverage_class,
+            actual=str(result["coverage_class_actual"]),
+            required=getattr(args, "required_coverage_class", None),
+            scenario_id=scenario_id,
+        )
+        if observed_coverage_gate_violation and not args.dry_run:
+            result["status"] = "fail"
+            result["reason"] = observed_coverage_gate_violation
+            result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+                "coverage_class_gate",
+                observed_coverage_gate_violation,
+            )
+            return result
+        result["ok"] = True
+        return result
+
+    if bool(scenario.get("destructive")) and not (
+        getattr(args, "allow_destructive", False)
+        and os.environ.get("AGENTDESK_E2E_ALLOW_DESTRUCTIVE") == "1"
+    ):
+        result["status"] = "skipped"
+        result["reason"] = (
+            "destructive: requires --allow-destructive AND AGENTDESK_E2E_ALLOW_DESTRUCTIVE=1"
+        )
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "destructive_gate",
+            str(result["reason"]),
+        )
+        if not args.dry_run:
+            observed_coverage_gate_violation = (
+                cell_driver.required_coverage_class_violation(
+                    declared=declared_coverage_class,
+                    actual=str(result["coverage_class_actual"]),
+                    required=getattr(args, "required_coverage_class", None),
+                    scenario_id=scenario_id,
+                )
+            )
+            if observed_coverage_gate_violation:
+                result["status"] = "fail"
+                result["reason"] = observed_coverage_gate_violation
+                result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+                    "coverage_class_gate",
+                    observed_coverage_gate_violation,
+                )
+                return result
+        result["ok"] = True
+        return result
+
+    try:
+        roles = resolve_restart_guard_roles(
+            scenario,
+            channel_ids=channel_ids,
+            selected_cells=selected_cells,
+        )
+    except ValueError as error:
+        result["status"] = "fail"
+        result["reason"] = str(error)
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "config",
+            str(error),
+        )
+        return result
+
+    foreign = roles["foreign_hold"]
+    attempt = roles["restart_attempt"]
+    result["roles"] = [
+        {
+            "role": role["role"],
+            "cell": role["cell"],
+            "provider": role["provider"],
+            "runtime": role["runtime"],
+            "channel_id": role["channel_id"],
+            "provider_identity": role["provider_identity"],
+        }
+        for role in (foreign, attempt)
+    ]
+
+    if args.dry_run:
+        print(
+            f"[matrix] dry-run restart-guard {scenario_id}: hold "
+            f"{foreign['cell']}->{foreign['channel_id']} active, attempt restart on "
+            f"{attempt['cell']}->{attempt['channel_id']} (guard-only, no restart)"
+        )
+        result["status"] = "pass"
+        result["coverage_class_actual"] = "live"
+        result["coverage_class_contract"] = cell_driver._coverage_class_contract(  # noqa: SLF001
+            declared=declared_coverage_class,
+            actual="live",
+            dry_run=bool(args.dry_run),
+        )
+        result["ok"] = True
+        result["completed_at"] = dt.datetime.now().isoformat(timespec="seconds")
+        return result
+
+    runtime_root = Path(args.queue_runtime_root)
+    hold_cfg = foreign["config"]
+    ok_marker = str(hold_cfg.get("ok_marker") or "[E2E:E17:HOLD-OK]")
+    late_marker = str(hold_cfg.get("late_marker") or "[E2E:E17:HOLD-LATE]")
+    foreign_label = f"{foreign['provider']}:{foreign['channel_id']}"
+    foreign_client = cell_driver.discord.DiscordClient(
+        base_url=args.base_url,
+        timeout_s=args.turn_start_timeout_s,
+        handoff_to_agent=foreign["handoff_to_agent"],
+        handoff_from_agent="adk-e2e-orchestrator",
+    )
+    hold_released = False
+
+    try:
+        if args.reset_before_each:
+            result["resets"] = [
+                cell_driver.reset_channel_state(
+                    base_url=args.base_url,
+                    channel_id=role["channel_id"],
+                    runtime_root=runtime_root,
+                    provider=role["provider"],
+                )
+                for role in (foreign, attempt)
+            ]
+            time.sleep(2.0)
+
+        hold_prompt = cell_driver.build_provider_hold_prompt(
+            {
+                "ok_marker": ok_marker,
+                "late_marker": late_marker,
+                "hold_seconds": int(
+                    hold_cfg.get("hold_seconds", cell_driver.DEFAULT_PROVIDER_HOLD_SECONDS)
+                ),
+            },
+            scenario_id=scenario_id,
+        )
+        send_response = foreign_client.send_prompt(
+            foreign["channel_id"],
+            hold_prompt,
+            channel_kind=foreign["channel_kind"],
+        )
+        cell_driver._mark_real_provider_contacted(  # noqa: SLF001
+            result,
+            declared_agent_mode=declared_agent_mode,
+            dry_run=False,
+        )
+        turn_identity = cell_driver.turn_identity_from_send_response(
+            send_response,
+            channel_id=foreign["channel_id"],
+        )
+
+        # Deterministic witness that the foreign turn is genuinely held active.
+        result["foreign_hold_state"] = cell_driver.wait_for_provider_hold_state(
+            runtime_root=runtime_root,
+            provider=foreign["provider"],
+            channel_id=foreign["channel_id"],
+            expected_identity=turn_identity,
+            ok_marker=ok_marker,
+            late_marker=late_marker,
+            timeout_s=float(hold_cfg.get("witness_timeout_s", 180)),
+            poll_interval_s=float(hold_cfg.get("witness_poll_interval_s", 1)),
+        )
+
+        # The /api/health/detail excerpt the restart guard will name on refusal.
+        result["foreign_mailbox_evidence"] = _wait_for_foreign_mailbox_busy(
+            base_url=args.base_url,
+            channel_id=foreign["channel_id"],
+            provider=foreign["provider"],
+            timeout_s=float(hold_cfg.get("busy_timeout_s", 45)),
+            poll_interval_s=float(hold_cfg.get("busy_poll_interval_s", 2)),
+        )
+
+        # Attempt the codex-tui destructive restart: drive ONLY the refusal guard.
+        # restart_dcserver_for_e2e is intentionally NOT called — the guard is the
+        # "refuses before restart" gate, and skipping the real kickstart is the
+        # safety boundary that keeps this destructive scenario inert.
+        refusal: str | None = None
+        try:
+            cell_driver._guard_no_foreign_active_turns(  # noqa: SLF001
+                args.base_url,
+                attempt["channel_id"],
+                attempt["cell"],
+            )
+        except assertions.AssertionError as error:
+            refusal = str(error)
+
+        if refusal is None:
+            raise assertions.AssertionError(
+                f"restart guard did NOT refuse while a foreign {foreign['provider']} "
+                f"mailbox (channel={foreign['channel_id']}) was active — #2935 "
+                f"regression; foreign evidence={result.get('foreign_mailbox_evidence')}"
+            )
+        if foreign_label not in refusal:
+            raise assertions.AssertionError(
+                f"restart guard refused but did not name foreign mailbox "
+                f"{foreign_label!r}; refusal={refusal!r}"
+            )
+        result["restart_refusal"] = refusal
+
+        result["foreign_hold_cancel"] = cell_driver.cancel_turn(
+            base_url=args.base_url,
+            channel_id=foreign["channel_id"],
+            force=True,
+        )
+        hold_released = True
+
+        result["idle_checks"] = {
+            "foreign_hold": cell_driver.assert_cell_idle(
+                base_url=args.base_url,
+                channel_id=foreign["channel_id"],
+                cell=foreign["cell"],
+                runtime_root=runtime_root,
+            ),
+            "restart_attempt": cell_driver.assert_cell_idle(
+                base_url=args.base_url,
+                channel_id=attempt["channel_id"],
+                cell=attempt["cell"],
+                runtime_root=runtime_root,
+            ),
+        }
+        result["status"] = "pass"
+        result["coverage_class_actual"] = "live"
+        result["coverage_class_contract"] = cell_driver._coverage_class_contract(  # noqa: SLF001
+            declared=declared_coverage_class,
+            actual="live",
+            dry_run=False,
+        )
+        result["ok"] = True
+    except assertions.AssertionError as error:
+        result["status"] = "fail"
+        result["reason"] = f"assertion: {error}"
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "assertion",
+            str(error),
+        )
+    except Exception as error:  # noqa: BLE001
+        result["status"] = "fail"
+        result["reason"] = f"{type(error).__name__}: {error}"
+        result["failure_attribution"] = cell_driver._failure_attribution(  # noqa: SLF001
+            "exception",
+            str(result["reason"]),
+        )
+    finally:
+        if not hold_released:
+            # Best-effort release so a failed run never strands the foreign turn.
+            try:
+                result.setdefault("teardown", {})["foreign_hold_cancel"] = (
+                    cell_driver.cancel_turn(
+                        base_url=args.base_url,
+                        channel_id=foreign["channel_id"],
+                        force=True,
+                    )
+                )
+            except Exception as cleanup_error:  # noqa: BLE001
+                result.setdefault("teardown_errors", []).append(
+                    "foreign_hold_cancel: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}"
+                )
+
+    result["completed_at"] = dt.datetime.now().isoformat(timespec="seconds")
+    return result
+
+
 def _matrix_agent_mode_totals(results: list[dict[str, Any]]) -> dict[str, int]:
     totals = {mode: 0 for mode in cell_driver.AGENT_MODES}
     for result in results:
@@ -1059,10 +1583,16 @@ def main() -> int:
     cells = parse_cells(args.cells)
     channel_ids = load_channel_ids(Path(args.config).expanduser())
     cross_scenarios = load_cross_channel_scenarios(Path(args.scenarios))
+    restart_guard_scenarios = load_restart_guard_scenarios(Path(args.scenarios))
     wanted = parse_filter(args.filter)
     if wanted:
         cross_scenarios = [
             scenario for scenario in cross_scenarios if str(scenario.get("id")) in wanted
+        ]
+        restart_guard_scenarios = [
+            scenario
+            for scenario in restart_guard_scenarios
+            if str(scenario.get("id")) in wanted
         ]
     output_dir = resolve_output_dir(args.output)
     pass_count = 2 if args.twice else 1
@@ -1102,12 +1632,34 @@ def main() -> int:
                 f"status={result['status']} ok={result['ok']} "
                 f"reason={result.get('reason') or ''}"
             )
+        for scenario in restart_guard_scenarios:
+            print(
+                f"[matrix] restart-guard pass={pass_index} scenario={scenario.get('id')}"
+            )
+            result = run_foreign_active_restart_guard_scenario(
+                scenario,
+                args=args,
+                run_id=output_dir.name,
+                channel_ids=channel_ids,
+                selected_cells=cells,
+                pass_index=pass_index,
+            )
+            results.append(result)
+            print(
+                "[matrix] restart-guard result "
+                f"pass={pass_index} scenario={scenario.get('id')} "
+                f"status={result['status']} ok={result['ok']} "
+                f"reason={result.get('reason') or ''}"
+            )
 
     summary = {
         "output": str(output_dir),
         "cells": cells,
         "passes": pass_count,
         "cross_channel_scenarios": [str(scenario.get("id")) for scenario in cross_scenarios],
+        "restart_guard_scenarios": [
+            str(scenario.get("id")) for scenario in restart_guard_scenarios
+        ],
         "agent_mode_totals": _matrix_agent_mode_totals(results),
         "coverage_class_totals": _matrix_coverage_class_totals(results),
         "coverage_class_violations": _matrix_coverage_class_violations(results),

--- a/scripts/e2e/run_tui_relay.py
+++ b/scripts/e2e/run_tui_relay.py
@@ -77,6 +77,13 @@ CONTROLLED_HARNESS_STEP_KEYS: tuple[str, ...] = (
     "kill_pane",
     "send_keys_no_enter",
 )
+# Orchestration kinds owned by run_multi_provider_matrix.py that contact a real
+# provider/cell across channels (so they plan agent_mode=real_live even though
+# the single-cell driver never sees their steps). E-11 cross-channel concurrency
+# and E-17 foreign-active restart-guard both hold/dispatch real provider turns.
+LIVE_ORCHESTRATION_KINDS: frozenset[str] = frozenset(
+    {"cross_channel", "foreign_active_restart_guard"}
+)
 
 IDLE_MAILBOX_STATUSES = {"", "idle", "none"}
 IDLE_RELAY_STALL_STATES = {"", "healthy"}
@@ -400,7 +407,7 @@ def infer_planned_agent_mode(
     for step in scenario.get("steps") or []:
         if isinstance(step, dict) and _step_contacts_real_provider(step):
             return "real_live"
-    if scenario.get("orchestration") == "cross_channel":
+    if scenario.get("orchestration") in LIVE_ORCHESTRATION_KINDS:
         return "real_live"
     if scenario_has_controlled_harness_evidence(scenario):
         return "controlled"
@@ -1952,6 +1959,37 @@ def _mailbox_busy_reasons(mailbox: dict[str, Any]) -> list[str]:
     return reasons
 
 
+def _mailbox_idle_evidence(mailbox: dict[str, Any]) -> dict[str, Any]:
+    """Capture the /api/health/detail idle fields a regression like #2935 watches.
+
+    Returned verbatim into ``post_scenario_idle`` so a scenario report carries the
+    explicit proof that the tested mailbox released — agent_turn_status idle,
+    queue_depth 0, no cancel token, no inflight state, no active user message, and
+    no stale queued placeholder / pending discord callback — instead of only the
+    derived ``status: idle`` verdict.
+    """
+
+    relay = _relay_health(mailbox)
+    return {
+        "agent_turn_status": mailbox.get("agent_turn_status"),
+        "queue_depth": mailbox.get("queue_depth"),
+        "has_cancel_token": mailbox.get("has_cancel_token"),
+        "inflight_state_present": mailbox.get("inflight_state_present"),
+        "active_user_message_id": mailbox.get("active_user_message_id"),
+        "active_dispatch_present": mailbox.get("active_dispatch_present"),
+        "relay_stall_state": mailbox.get("relay_stall_state"),
+        "relay_health": {
+            "active_turn": relay.get("active_turn"),
+            "queue_depth": relay.get("queue_depth"),
+            "mailbox_has_cancel_token": relay.get("mailbox_has_cancel_token"),
+            "pending_discord_callback_msg_id": relay.get(
+                "pending_discord_callback_msg_id"
+            ),
+            "bridge_inflight_present": relay.get("bridge_inflight_present"),
+        },
+    }
+
+
 def _runtime_payload_has_entries(payload: Any) -> bool:
     if payload in (None, False, "", [], {}):
         return False
@@ -2052,6 +2090,8 @@ def assert_cell_idle(
                 "provider": provider,
                 "mailboxes_seen": last_mailbox_count,
                 "status": "idle",
+                "queue_files_clear": True,
+                "mailbox_idle_evidence": _mailbox_idle_evidence(target_mailboxes[0]),
             }
         time.sleep(poll_interval_s)
 

--- a/scripts/e2e/tui_relay/test_cell_resolution.py
+++ b/scripts/e2e/tui_relay/test_cell_resolution.py
@@ -107,8 +107,12 @@ class ScenarioFilter(unittest.TestCase):
         self.assertIn("E-10", ids)
         self.assertIn("E-12", ids)
         e16 = next(s for s in scenarios if s.get("id") == "E-16")
-        self.assertIn("skip_reason", e16)
+        # #3797: E-16 is now an executable live scenario, not a #2935 stub.
+        self.assertNotIn("skip_reason", e16)
         self.assertIn("acceptance_criteria", e16)
+        self.assertEqual(driver.scenario_agent_mode(e16), "real_live")
+        self.assertEqual(driver.scenario_coverage_class(e16), "live")
+        self.assertTrue(e16.get("steps"))
         self.assertNotIn("E-7", ids)
 
     def test_claude_e_scenarios(self):
@@ -141,7 +145,11 @@ class ScenarioFilter(unittest.TestCase):
         ids = {str(s.get("id")) for s in scenarios}
         self.assertIn("E-7", ids)
         self.assertIn("E-4", ids)
-        self.assertIn("E-17", ids)
+        # #3797: E-17 is now an orchestrator-owned restart-guard scenario
+        # (cells: []), so the single-cell codex-tui driver no longer loads it
+        # — same convention as the E-11 cross-channel scenario.
+        self.assertNotIn("E-17", ids)
+        self.assertNotIn("E-11", ids)
         self.assertIn("E-18", ids)
         self.assertIn("E-19", ids)
         self.assertIn("E-20", ids)
@@ -149,9 +157,6 @@ class ScenarioFilter(unittest.TestCase):
         self.assertIn("E-25", ids)
         self.assertNotIn("E-22", ids)
         self.assertNotIn("E-23", ids)
-        e17 = next(s for s in scenarios if s.get("id") == "E-17")
-        self.assertIn("skip_reason", e17)
-        self.assertIn("acceptance_criteria", e17)
         e18 = next(s for s in scenarios if s.get("id") == "E-18")
         self.assertNotIn("skip_reason", e18)
         self.assertIn("acceptance_criteria", e18)

--- a/scripts/e2e/tui_relay/test_driver_health.py
+++ b/scripts/e2e/tui_relay/test_driver_health.py
@@ -637,6 +637,35 @@ class PostScenarioIdle(unittest.TestCase):
         self.assertEqual(result["status"], "idle")
         self.assertEqual(result["mailboxes_seen"], 1)
 
+    def test_assert_cell_idle_captures_mailbox_idle_evidence(self):
+        # #3797 (E-16): the idle invariant now carries the explicit
+        # /api/health/detail field evidence that the tested mailbox released.
+        payloads = {
+            "/api/health/detail": [
+                (200, _health_detail(_idle_mailbox("42", provider="claude")))
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("run_tui_relay.urllib.request.urlopen", _fake_urlopen_for(payloads)):
+                result = driver.assert_cell_idle(
+                    base_url="http://agentdesk.test",
+                    channel_id="42",
+                    cell="claude-tui",
+                    runtime_root=Path(tmpdir),
+                    timeout_s=1,
+                    poll_interval_s=0,
+                )
+        self.assertEqual(result["status"], "idle")
+        self.assertTrue(result["queue_files_clear"])
+        evidence = result["mailbox_idle_evidence"]
+        self.assertEqual(evidence["agent_turn_status"], "idle")
+        self.assertEqual(evidence["queue_depth"], 0)
+        self.assertFalse(evidence["has_cancel_token"])
+        self.assertFalse(evidence["inflight_state_present"])
+        self.assertIsNone(evidence["active_user_message_id"])
+        self.assertIsNone(evidence["relay_health"]["pending_discord_callback_msg_id"])
+
     def test_claude_tui_idle_draft_guard_detects_stuck_prompt(self):
         pane = "\n".join(
             [
@@ -2795,6 +2824,137 @@ class ScenarioTeardown(unittest.TestCase):
         self.assertTrue(
             any(message.startswith("### E2E TEARDOWN") for message in client.control_messages),
             client.control_messages,
+        )
+
+
+class Issue3797E16QuiescenceRelease(unittest.TestCase):
+    """#3797: E-16 is an executable live scenario, not a #2935 stub."""
+
+    def setUp(self):
+        self.scenarios_dir = ROOT / "tests" / "e2e" / "tui_relay" / "scenarios"
+        self.e16 = next(
+            scenario
+            for scenario in driver.load_scenarios(self.scenarios_dir, cell="claude-tui")
+            if scenario.get("id") == "E-16"
+        )
+
+    def test_e16_metadata_is_executable_live_real_provider(self):
+        self.assertNotIn("skip_reason", self.e16)
+        self.assertEqual(driver.scenario_agent_mode(self.e16), "real_live")
+        self.assertEqual(driver.scenario_coverage_class(self.e16), "live")
+        # The second prompt must be sent before the second marker wait, with no
+        # intervening wait_idle_s — that is the post-delivery release window.
+        step_keys = [next(iter(step)) for step in self.e16["steps"]]
+        self.assertEqual(
+            step_keys,
+            [
+                "send_prompt",
+                "wait_for_discord_text",
+                "send_prompt",
+                "wait_for_discord_text",
+                "wait_idle_s",
+                "assert_health",
+            ],
+        )
+
+    def test_e16_immediate_followup_relays_both_markers_and_returns_idle(self):
+        class FakeClient:
+            base_url = "http://agentdesk.test"
+
+            def __init__(self):
+                self.next_id = 5000
+                self.prompts: list[str] = []
+
+            def _id(self) -> str:
+                self.next_id += 1
+                return str(self.next_id)
+
+            def send_control(self, channel_id, content):  # noqa: ARG002
+                return {"id": self._id()}
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):  # noqa: ARG002
+                self.prompts.append(content)
+                return {"id": self._id()}
+
+            def fetch_messages(self, channel_id, *, after_id=None, limit=100):  # noqa: ARG002
+                return []
+
+        client = FakeClient()
+        idle_calls: list[dict] = []
+
+        def fake_wait(**kwargs):
+            needle = str(kwargs.get("needle"))
+            message = {
+                "id": client._id(),
+                "content": needle,
+                "author": {"id": "adk-relay-bot", "bot": True},
+                "type": 0,
+                "timestamp": "2026-05-31T00:00:00Z",
+            }
+            return message, [message]
+
+        def fake_idle(**kwargs):
+            idle_calls.append(kwargs)
+            return {
+                "status": "idle",
+                "channel_id": kwargs.get("channel_id"),
+                "mailboxes_seen": 1,
+                "queue_files_clear": True,
+                "mailbox_idle_evidence": {
+                    "agent_turn_status": "idle",
+                    "queue_depth": 0,
+                    "has_cancel_token": False,
+                    "inflight_state_present": False,
+                    "active_user_message_id": None,
+                    "relay_health": {"pending_discord_callback_msg_id": None},
+                },
+            }
+
+        args = Namespace(
+            cell="claude-tui",
+            channel_id="42",
+            thread_channel_id=None,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+        )
+
+        with (
+            patch("run_tui_relay.time.sleep", return_value=None),
+            patch(
+                "run_tui_relay.wait_for_discord_text_with_tui_idle_draft_guard",
+                side_effect=fake_wait,
+            ),
+            patch("run_tui_relay.assert_health", return_value={"status": "healthy"}),
+            patch("run_tui_relay.assert_cell_idle", side_effect=fake_idle),
+            patch("run_tui_relay.send_teardown_marker", return_value=None),
+        ):
+            record = driver.run_one_cell(
+                scenario=self.e16,
+                cell="claude-tui",
+                channel_id="42",
+                client=client,  # type: ignore[arg-type]
+                run_id="run-1",
+                dry_run=False,
+                args=args,
+            )
+
+        # Two real prompts dispatched, both markers relayed, all scenario
+        # assertions plus the post-scenario idle invariant passed.
+        self.assertEqual(len(client.prompts), 2)
+        self.assertIn("[E2E:E16:ONE]", client.prompts[0])
+        self.assertIn("[E2E:E16:TWO]", client.prompts[1])
+        self.assertTrue(record["real_provider_contacted"])
+        self.assertEqual(record["agent_mode_actual"], "real_live")
+        self.assertEqual(record["coverage_class_actual"], "live")
+        self.assertEqual(len(idle_calls), 1)
+        idle_specs = [
+            entry
+            for entry in record["assertions"]
+            if entry.get("spec", {}).get("post_scenario_cell_idle")
+        ]
+        self.assertEqual(len(idle_specs), 1)
+        self.assertTrue(idle_specs[0]["passed"])
+        self.assertEqual(
+            idle_specs[0]["details"]["mailbox_idle_evidence"]["queue_depth"], 0
         )
 
 

--- a/scripts/e2e/tui_relay/test_matrix_runner.py
+++ b/scripts/e2e/tui_relay/test_matrix_runner.py
@@ -8,7 +8,7 @@ import threading
 import unittest
 from argparse import Namespace
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "scripts" / "e2e"))
@@ -659,6 +659,292 @@ class CrossChannelMatrix(unittest.TestCase):
             if not assertion["passed"]
         ]
         self.assertTrue(failed_records)
+
+
+def _restart_guard_health_detail() -> dict:
+    return {
+        "status": "unhealthy",
+        "ok": False,
+        "fully_recovered": False,
+        "global_active": 1,
+        "global_finalizing": 0,
+        "mailboxes": [
+            _busy_mailbox("111", provider="claude"),
+            _idle_mailbox("222", provider="codex"),
+        ],
+    }
+
+
+class RestartGuardOrchestration(unittest.TestCase):
+    """#3797: E-17 holds a foreign turn active and proves the restart guard refuses."""
+
+    def setUp(self):
+        self.scenarios_dir = ROOT / "tests" / "e2e" / "tui_relay" / "scenarios"
+        self.e17 = next(
+            scenario
+            for scenario in matrix.load_restart_guard_scenarios(self.scenarios_dir)
+            if scenario.get("id") == "E-17"
+        )
+        self.channel_ids = {
+            "claude-pipe": "101",
+            "claude-tui": "111",
+            "claude-e": "102",
+            "codex-pipe": "201",
+            "codex-tui": "222",
+        }
+
+    def _args(self, **overrides):
+        base = dict(
+            base_url="http://agentdesk.test",
+            dry_run=False,
+            queue_runtime_root="/tmp/agentdesk-e2e-test-runtime",
+            reset_before_each=False,
+            turn_start_timeout_s=5,
+            allow_destructive=True,
+            required_agent_mode=None,
+            required_coverage_class=None,
+        )
+        base.update(overrides)
+        return Namespace(**base)
+
+    @staticmethod
+    def _fake_client_class():
+        sends: list[tuple[str, str, str]] = []
+
+        class FakeClient:
+            instances: list["FakeClient"] = []
+
+            def __init__(self, *, base_url, timeout_s, handoff_to_agent, handoff_from_agent):
+                self.base_url = base_url
+                self.handoff_to_agent = handoff_to_agent
+                FakeClient.instances.append(self)
+
+            def send_prompt(self, channel_id, content, *, channel_kind="cc"):
+                sends.append((str(channel_id), channel_kind, content))
+                return {"id": "5001"}
+
+        FakeClient.sends = sends
+        return FakeClient
+
+    def _run(
+        self,
+        *,
+        guard,
+        args=None,
+        selected_cells=None,
+        health_detail=None,
+        allow_destructive_env=True,
+    ):
+        fake_client = self._fake_client_class()
+        restart = MagicMock(name="restart_dcserver_for_e2e")
+        cancel = MagicMock(return_value={"ok": True, "queued_remaining": 0})
+        env = {"AGENTDESK_E2E_ALLOW_DESTRUCTIVE": "1"} if allow_destructive_env else {}
+        with (
+            patch.dict("os.environ", env, clear=False),
+            patch(
+                "run_multi_provider_matrix.cell_driver.discord.DiscordClient",
+                fake_client,
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver.reset_channel_state",
+                return_value={"actions": []},
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver.turn_identity_from_send_response",
+                return_value={"channel_id": "111"},
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver.wait_for_provider_hold_state",
+                return_value={
+                    "classification": "provider_hold_observed",
+                    "ok_marker_seen": True,
+                },
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver._read_health_detail",
+                return_value=health_detail or _restart_guard_health_detail(),
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver._guard_no_foreign_active_turns",
+                side_effect=guard,
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver.cancel_turn",
+                cancel,
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver.assert_cell_idle",
+                return_value={"status": "idle", "queue_files_clear": True},
+            ),
+            patch(
+                "run_multi_provider_matrix.cell_driver.restart_dcserver_for_e2e",
+                restart,
+            ),
+            patch("run_multi_provider_matrix.time.sleep", return_value=None),
+        ):
+            result = matrix.run_foreign_active_restart_guard_scenario(
+                self.e17,
+                args=args or self._args(),
+                run_id="run-1",
+                channel_ids=self.channel_ids,
+                selected_cells=selected_cells or ["claude-tui", "codex-tui"],
+                pass_index=1,
+            )
+        return result, fake_client, cancel, restart
+
+    @staticmethod
+    def _refuse_naming_foreign(*_args, **_kwargs):
+        raise assertions.AssertionError(
+            "refusing to restart dcserver: live mailbox state outside cell codex-tui "
+            "(channel=222). Active: ['claude:111 [agent_turn_status=active, "
+            "has_cancel_token=true, inflight_state_present=true]']."
+        )
+
+    def test_loads_e17_as_restart_guard_scenario(self):
+        ids = {
+            str(scenario.get("id"))
+            for scenario in matrix.load_restart_guard_scenarios(self.scenarios_dir)
+        }
+        self.assertIn("E-17", ids)
+        self.assertEqual(matrix.cell_driver.scenario_agent_mode(self.e17), "real_live")
+        self.assertEqual(matrix.cell_driver.scenario_coverage_class(self.e17), "live")
+        self.assertTrue(self.e17.get("destructive"))
+
+    def test_resolve_roles_maps_foreign_hold_and_restart_attempt(self):
+        roles = matrix.resolve_restart_guard_roles(
+            self.e17,
+            channel_ids=self.channel_ids,
+            selected_cells=["claude-tui", "codex-tui"],
+        )
+        self.assertEqual(roles["foreign_hold"]["cell"], "claude-tui")
+        self.assertEqual(roles["foreign_hold"]["channel_id"], "111")
+        self.assertEqual(roles["foreign_hold"]["provider"], "claude")
+        self.assertEqual(roles["restart_attempt"]["cell"], "codex-tui")
+        self.assertEqual(roles["restart_attempt"]["channel_id"], "222")
+        self.assertEqual(roles["restart_attempt"]["provider"], "codex")
+
+    def test_required_cells_rejects_identical_cells(self):
+        scenario = {
+            "id": "E-X",
+            "restart_guard": {
+                "foreign_hold": {"cell": "codex-tui"},
+                "restart_attempt": {"cell": "codex-tui"},
+            },
+        }
+        with self.assertRaises(ValueError):
+            matrix._restart_guard_required_cells(scenario)  # noqa: SLF001
+
+    def test_passes_when_guard_refuses_naming_foreign_mailbox(self):
+        result, fake_client, cancel, restart = self._run(
+            guard=self._refuse_naming_foreign
+        )
+
+        self.assertEqual(result["status"], "pass", result.get("reason"))
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["real_provider_contacted"])
+        self.assertEqual(result["agent_mode_actual"], "real_live")
+        self.assertEqual(result["coverage_class_actual"], "live")
+        # The foreign hold prompt was dispatched to the claude-tui channel.
+        self.assertEqual(len(fake_client.sends), 1)
+        self.assertEqual(fake_client.sends[0][0], "111")
+        self.assertIn("[E2E:E17:HOLD-OK]", fake_client.sends[0][2])
+        # The /api/health/detail excerpt naming the foreign mailbox is captured.
+        self.assertEqual(result["foreign_mailbox_evidence"]["channel_id"], "111")
+        self.assertEqual(result["foreign_mailbox_evidence"]["provider"], "claude")
+        self.assertTrue(result["foreign_mailbox_evidence"]["busy_reasons"])
+        self.assertIn("claude:111", result["restart_refusal"])
+        # The hold was released and both mailboxes asserted idle.
+        cancel.assert_called_once()
+        self.assertEqual(cancel.call_args.kwargs["channel_id"], "111")
+        self.assertIn("foreign_hold", result["idle_checks"])
+        self.assertIn("restart_attempt", result["idle_checks"])
+        # SAFETY: the real restart is never invoked.
+        restart.assert_not_called()
+
+    def test_fails_when_guard_allows_restart_during_foreign_hold(self):
+        # #2935 regression: the guard does not refuse despite an active foreign
+        # mailbox — the scenario must fail and still never restart.
+        result, _fake_client, cancel, restart = self._run(guard=lambda *a, **k: None)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("did NOT refuse", result["reason"])
+        self.assertEqual(result["failure_attribution"]["source"], "assertion")
+        restart.assert_not_called()
+        # The foreign hold is still released on the failure path.
+        cancel.assert_called_once()
+
+    def test_fails_when_refusal_does_not_name_foreign_mailbox(self):
+        def refuse_without_label(*_args, **_kwargs):
+            raise assertions.AssertionError(
+                "refusing to restart dcserver: something is busy"
+            )
+
+        result, _fake_client, cancel, restart = self._run(guard=refuse_without_label)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("did not name foreign mailbox", result["reason"])
+        restart.assert_not_called()
+        cancel.assert_called_once()
+
+    def test_destructive_gate_skips_without_allow_destructive(self):
+        result, fake_client, cancel, restart = self._run(
+            guard=self._refuse_naming_foreign,
+            args=self._args(allow_destructive=False),
+            allow_destructive_env=False,
+        )
+
+        self.assertEqual(result["status"], "skipped")
+        self.assertTrue(result["ok"])
+        self.assertIn("destructive", result["reason"])
+        self.assertEqual(fake_client.sends, [])
+        restart.assert_not_called()
+        cancel.assert_not_called()
+
+    def test_destructive_gate_skip_fails_required_live_coverage(self):
+        result, _fake_client, _cancel, _restart = self._run(
+            guard=self._refuse_naming_foreign,
+            args=self._args(allow_destructive=False, required_coverage_class="live"),
+            allow_destructive_env=False,
+        )
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["failure_attribution"]["source"], "coverage_class_gate")
+
+    def test_skips_cleanly_when_required_cell_not_selected(self):
+        args = self._args(dry_run=True)
+        result = matrix.run_foreign_active_restart_guard_scenario(
+            self.e17,
+            args=args,
+            run_id="run-1",
+            channel_ids=self.channel_ids,
+            selected_cells=["claude-tui"],
+            pass_index=1,
+        )
+        self.assertEqual(result["status"], "skipped")
+        self.assertTrue(result["ok"])
+        self.assertIn("codex-tui", result["reason"])
+
+    def test_dry_run_reports_pass_without_contacting_provider(self):
+        fake_client = self._fake_client_class()
+        with (
+            patch.dict("os.environ", {"AGENTDESK_E2E_ALLOW_DESTRUCTIVE": "1"}, clear=False),
+            patch(
+                "run_multi_provider_matrix.cell_driver.discord.DiscordClient", fake_client
+            ),
+        ):
+            result = matrix.run_foreign_active_restart_guard_scenario(
+                self.e17,
+                args=self._args(dry_run=True),
+                run_id="run-1",
+                channel_ids=self.channel_ids,
+                selected_cells=["claude-tui", "codex-tui"],
+                pass_index=1,
+            )
+        self.assertEqual(result["status"], "pass")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["coverage_class_actual"], "live")
+        self.assertFalse(result["real_provider_contacted"])
+        self.assertEqual(fake_client.sends, [])
 
 
 if __name__ == "__main__":

--- a/tests/e2e/tui_relay/scenarios/E-16-claude-tui-quiescence-timeout-release.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-16-claude-tui-quiescence-timeout-release.yaml
@@ -1,18 +1,56 @@
 id: E-16
-title: Claude TUI quiescence timeout still releases mailbox
-agent_mode: controlled
-coverage_class: unsupported-known-gap
+title: Claude TUI completion-quiescence release accepts an immediate follow-up
+agent_mode: real_live
+coverage_class: live
 cells: [claude-tui]
 isolation: required
-skip_reason: >
-  Stub for #2935. Full live simulation needs a runtime hook that forces the
-  TUI completion-quiescence gate to time out after response delivery. The
-  harness pieces are in place: every executed scenario now asserts the tested
-  mailbox returns idle with queue/inflight/cancel/pending-callback state clear.
 acceptance_criteria:
-  - Force or simulate tui_completion_quiescence timeout after a delivered Claude TUI response.
-  - Send a second prompt immediately after the first response marker arrives.
-  - Assert the second prompt starts and replies without an indefinite queued placeholder.
-  - Assert /api/health/detail mailboxes shows idle, queue_depth=0, inflight_state_present=false, has_cancel_token=false.
-steps: []
-assertions: []
+  - Deliver a first Claude TUI response, then send a second prompt immediately
+    after the first response marker arrives (no inter-step idle wait), exercising
+    the completion-quiescence release window after response delivery.
+  - Assert the second prompt starts and replies without an indefinite queued
+    placeholder (the second marker relays within the budget).
+  - Assert /api/health/detail shows the tested mailbox idle — agent_turn_status
+    idle, queue_depth=0, has_cancel_token=false, inflight_state_present=false, no
+    active user message, and no stale queued placeholder/pending-callback state.
+notes: |
+  #2935 regression coverage. After a delivered Claude TUI response the
+  completion-quiescence gate (TUI_COMPLETION_QUIESCENCE_TIMEOUT, a 3s const in
+  src/services/discord/tmux.rs) must release the mailbox so the next prompt is
+  not stranded as an indefinite queued placeholder. The 3s gate fires naturally
+  at the turn boundary; deterministically *forcing* the timeout would require a
+  production-source hook, so this scenario instead exercises the live relay path
+  (agent_mode=real_live) by sending the second prompt immediately at the first
+  response marker — the exact post-delivery window #2935 stranded. The
+  always-on post-scenario idle invariant (assert_cell_idle ->
+  post_scenario_idle.mailbox_idle_evidence) captures the /api/health/detail proof
+  that the tested mailbox returned to idle with queue/inflight/cancel/pending
+  callback state clear and no on-disk queued placeholder.
+steps:
+  - send_prompt: "응답에 정확히 한 줄로 [E2E:E16:ONE] 만 출력해줘."
+  - wait_for_discord_text: "[E2E:E16:ONE]"
+    timeout_s: 240
+  # Second prompt immediately after the first marker (no wait_idle_s): this is
+  # the completion-quiescence release window #2935 stranded. If the mailbox does
+  # not release, this prompt never starts and the next wait times out.
+  - send_prompt: "응답에 정확히 한 줄로 [E2E:E16:TWO] 만 출력해줘."
+  - wait_for_discord_text: "[E2E:E16:TWO]"
+    timeout_s: 240
+  - wait_idle_s: 5
+  - assert_health:
+      timeout_s: 45
+      poll_interval_s: 2
+      forbid_degraded_reasons:
+        - global_active_counter_out_of_bounds
+      global_active_max: 0
+      global_finalizing_max: 0
+assertions:
+  - text_present: "[E2E:E16:ONE]"
+  - text_present: "[E2E:E16:TWO]"
+  - ordered_text_present:
+      - "[E2E:E16:ONE]"
+      - "[E2E:E16:TWO]"
+  - no_duplicate_marker: "[E2E:E16:ONE]"
+  - no_duplicate_marker: "[E2E:E16:TWO]"
+  - no_duplicate_content: true
+  - no_resume_prompt_chrome: true

--- a/tests/e2e/tui_relay/scenarios/E-17-foreign-active-restart-guard.yaml
+++ b/tests/e2e/tui_relay/scenarios/E-17-foreign-active-restart-guard.yaml
@@ -1,19 +1,43 @@
 id: E-17
-title: Destructive restart refuses foreign active mailbox
-agent_mode: controlled
-coverage_class: unsupported-known-gap
-cells: [codex-tui]
+title: Destructive restart refuses while a foreign mailbox is active
+agent_mode: real_live
+coverage_class: live
+cells: []  # orchestrator-owned restart-guard scenario (run_multi_provider_matrix.py)
+orchestration: foreign_active_restart_guard
 isolation: required
 destructive: true
-skip_reason: >
-  Stub for #2935. The destructive guard is implemented and unit-tested against
-  synthetic /api/health/detail mailbox evidence. A full live scenario needs the
-  orchestrator to hold a separate claude-tui turn active while this codex-tui
-  cell attempts restart.
 acceptance_criteria:
-  - Start or hold a claude-tui turn on a different channel.
-  - Verify /api/health/detail mailboxes reports foreign active/cancel/inflight/queue or relay stall state.
-  - Attempt a codex-tui destructive restart scenario.
-  - Assert the harness refuses before restart and names the foreign mailbox evidence.
-steps: []
-assertions: []
+  - Hold a foreign claude-tui turn active on a different channel/provider via the
+    deterministic provider-hold witness primitive.
+  - Verify /api/health/detail reports the foreign mailbox active/cancel/inflight/
+    queue or relay-stall state.
+  - Attempt a codex-tui destructive restart and prove the harness refuses before
+    restart, naming the foreign mailbox evidence from /api/health/detail.
+  - Release the foreign hold on teardown and verify both mailboxes return idle.
+notes: |
+  #2935 coverage. SAFETY BOUNDARY: this orchestration NEVER restarts dcserver. It
+  drives only the harness restart-refusal guard
+  (run_tui_relay._guard_no_foreign_active_turns) — the "refuses before restart"
+  half of restart_dcserver_for_e2e — and asserts it raises while a foreign
+  claude-tui turn is held active. Because the actual restart/kickstart is never
+  invoked, the destructive scenario cannot kill panes or harm unrelated active
+  production work even if the guard regressed. The foreign hold is created with
+  the deterministic provider-hold witness (send_provider_hold_prompt /
+  wait_for_provider_hold_state — no sleeps), the matrix then waits until
+  /api/health/detail surfaces the foreign mailbox as busy, runs the codex-tui
+  restart guard expecting a refusal that names the foreign mailbox, then releases
+  the hold (cancel_turn) and asserts both channels idle. It uses claude-tui (not
+  claude-e) for the foreign hold because the restart guard inspects a
+  relay-backed foreground mailbox.
+restart_guard:
+  foreign_hold:
+    cell: claude-tui
+    ok_marker: "[E2E:E17:HOLD-OK]"
+    late_marker: "[E2E:E17:HOLD-LATE]"
+    hold_seconds: 90
+    witness_timeout_s: 180
+    witness_poll_interval_s: 1
+    busy_timeout_s: 45
+    busy_poll_interval_s: 2
+  restart_attempt:
+    cell: codex-tui


### PR DESCRIPTION
Closes #3797. Test-only: turns the two #2935 relay regression stubs (E-16, E-17) into executable live scenarios with deterministic unit coverage. No production source touched.

## What E-16 / E-17 cover (the #2935 gap)

#2935 was a stale active mailbox / inflight cleanup regression after a delivered response. The two stub scenarios that were `loaded-but-skipped` until now:

- **E-16 — Claude TUI completion-quiescence release.** After a delivered Claude TUI response the completion-quiescence gate (`TUI_COMPLETION_QUIESCENCE_TIMEOUT`, the 3s const in `src/services/discord/tmux.rs`) must release the mailbox so the next prompt is not stranded as an indefinite queued placeholder.
- **E-17 — foreign-active destructive restart guard.** A destructive restart must refuse while a foreign mailbox (different channel/provider) is active, naming the foreign `/api/health/detail` evidence.

## New scenarios

### E-16 (`claude-tui`, `agent_mode: real_live`, `coverage_class: live`)
Sends a first prompt, waits for `[E2E:E16:ONE]`, then sends a second prompt **immediately at the first marker (no `wait_idle_s`)** — the exact post-delivery window #2935 stranded — and waits for `[E2E:E16:TWO]`. Asserts: both markers present + ordered, each marker non-duplicated, no duplicate content, no resume-prompt chrome, `assert_health` counters drained.

Determinism note: deterministically *forcing* the 3s quiescence timeout would need a production hook (forbidden by scope), so E-16 exercises the natural release window on the live relay path (consistent with E-18/E-20 `real_live` failure-injection). If the mailbox fails to release, the second prompt never starts and the wait times out → the regression fails the scenario.

The always-on post-scenario idle invariant (`assert_cell_idle`) is enriched to capture **`mailbox_idle_evidence`** (`agent_turn_status=idle`, `queue_depth=0`, no cancel token, no inflight state, no active user message, no stale queued placeholder / pending callback) — the explicit `/api/health/detail` proof the tested mailbox returned to idle.

### E-17 (`cells: []`, `orchestration: foreign_active_restart_guard`, `agent_mode: real_live`, `coverage_class: live`, destructive)
Orchestrator-owned (like E-11), run by a new `run_multi_provider_matrix.py` executor:
1. Holds a foreign `claude-tui` turn active via the deterministic provider-hold witness (`send_provider_hold_prompt` / `wait_for_provider_hold_state` — no sleeps).
2. Waits until `/api/health/detail` surfaces that mailbox busy (captured as the report excerpt).
3. Attempts a `codex-tui` destructive restart and asserts the harness **refuses before restart**, naming the foreign mailbox (`claude:<channel>`).
4. Releases the hold (`cancel_turn`) and asserts both channels idle.

**Safety boundary:** the executor drives **only** the restart-refusal guard (`_guard_no_foreign_active_turns`) and **never** invokes the real restart/kickstart, so even a regressed guard cannot harm unrelated active production work. Destructive-gated (`--allow-destructive` + `AGENTDESK_E2E_ALLOW_DESTRUCTIVE=1`); a destructive skip fails `--required-coverage-class live`.

## Tests (13 new, deterministic)
- `test_driver_health.py`: `assert_cell_idle` mailbox-idle-evidence capture; E-16 metadata; **E-16 end-to-end execution** through `run_one_cell` (two prompts dispatched, both markers relayed, idle invariant passes).
- `test_matrix_runner.py` `RestartGuardOrchestration`: loader + role resolution + executor **pass** (guard refuses naming foreign), **regression** (guard allows → fail, never restarts), **naming-omission fail**, destructive-gate skip, required-live-coverage fail, missing-cell skip, dry-run. All assert `restart_dcserver_for_e2e` is never called.
- `test_cell_resolution.py`: E-16 no longer skipped (real_live/live with steps); E-17 no longer in the single-cell `codex-tui` list.

Determinism: the full e2e suite (170 tests) passes; the new tests were run 5× + the full suite 3× with no flake.

## Gates (self-passed, `CARGO_BUILD_JOBS=5`)
- `cargo fmt --check` → 0; `cargo check --tests` → 0 (zero Rust touched)
- `check_hotfile_ratchet.py` → 0; `audit_maintainability.py --check` → 0
- `check_agent_maintenance_docs.py` → "freshness check passed"
- clippy: N/A (no Rust files touched)
- Note: `generate_inventory_docs.py --check` reports `route-inventory.md`/`worker-inventory.md` stale — confirmed **pre-existing on pristine origin/main** (`src/`-derived, warning-only per `scripts/ci-script-checks.sh`); not touched to keep this PR test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)