### PR TITLE
fix(voice): play fallback ack on TTS model failure + stop progress stealing the final-result playback handle (#3908)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -715,11 +715,11 @@
 | `services::discord::turn_finalizer::watcher_backstop` | `src/services/discord/turn_finalizer/watcher_backstop.rs` | 172 | 120 | 52 |  |
 | `services::discord::voice_acknowledgement` | `src/services/discord/voice_acknowledgement.rs` | 61 | 61 | 0 |  |
 | `services::discord::voice_background_driver` | `src/services/discord/voice_background_driver.rs` | 235 | 200 | 35 |  |
-| `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 4953 | 2893 | 2060 | giant-file |
+| `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 5106 | 2893 | 2213 | giant-file |
 | `services::discord::voice_barge_in::final_result_playback` | `src/services/discord/voice_barge_in/final_result_playback.rs` | 243 | 243 | 0 |  |
-| `services::discord::voice_barge_in::foreground_decision` | `src/services/discord/voice_barge_in/foreground_decision.rs` | 214 | 214 | 0 |  |
-| `services::discord::voice_barge_in::live_cut_playback` | `src/services/discord/voice_barge_in/live_cut_playback.rs` | 120 | 120 | 0 |  |
-| `services::discord::voice_barge_in::progress_playback` | `src/services/discord/voice_barge_in/progress_playback.rs` | 423 | 423 | 0 |  |
+| `services::discord::voice_barge_in::foreground_decision` | `src/services/discord/voice_barge_in/foreground_decision.rs` | 242 | 242 | 0 |  |
+| `services::discord::voice_barge_in::live_cut_playback` | `src/services/discord/voice_barge_in/live_cut_playback.rs` | 154 | 154 | 0 |  |
+| `services::discord::voice_barge_in::progress_playback` | `src/services/discord/voice_barge_in/progress_playback.rs` | 422 | 422 | 0 |  |
 | `services::discord::voice_barge_in::receive_hook` | `src/services/discord/voice_barge_in/receive_hook.rs` | 114 | 114 | 0 |  |
 | `services::discord::voice_barge_in::routing` | `src/services/discord/voice_barge_in/routing.rs` | 500 | 500 | 0 |  |
 | `services::discord::voice_barge_in::stt` | `src/services/discord/voice_barge_in/stt.rs` | 326 | 326 | 0 |  |

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -401,7 +401,8 @@ async fn generate_foreground_ack_text(
     foreground: &EffectiveVoiceForegroundConfig,
     cancel_token: Arc<crate::services::provider::CancelToken>,
 ) -> Option<VoiceForegroundDecision> {
-    let _fallback_for_tests_and_docs = foreground_ack_text(transcript, language);
+    // #3908: spoken on model failure/timeout instead of discarding to silence.
+    let fallback = || VoiceForegroundDecision::Speak(foreground_ack_text(transcript, language));
     let prompt =
         crate::voice::prompt::voice_foreground_prompt(transcript, language, foreground.max_chars);
     let provider = foreground.provider.clone();
@@ -447,18 +448,18 @@ async fn generate_foreground_ack_text(
                 error = %error,
                 foreground_provider = %foreground.provider,
                 foreground_model = %foreground.model,
-                "voice foreground model call failed; skipping spoken fallback"
+                "voice foreground model call failed; speaking fallback ack (#3908)"
             );
-            return None;
+            return Some(fallback());
         }
         Ok(Err(error)) => {
             tracing::warn!(
                 error = %error,
                 foreground_provider = %foreground.provider,
                 foreground_model = %foreground.model,
-                "voice foreground model task failed; skipping spoken fallback"
+                "voice foreground model task failed; speaking fallback ack (#3908)"
             );
-            return None;
+            return Some(fallback());
         }
         Err(_) => {
             // #2250: on timeout, flip the shared CancelToken so the
@@ -474,9 +475,9 @@ async fn generate_foreground_ack_text(
                 timeout_ms = foreground.timeout_ms,
                 foreground_provider = %foreground.provider,
                 foreground_model = %foreground.model,
-                "voice foreground model timed out; skipping spoken fallback (#2250: token cancelled)"
+                "voice foreground model timed out; speaking fallback ack (#3908; #2250 token cancelled to kill child)"
             );
-            return None;
+            return Some(fallback());
         }
     };
 
@@ -1771,8 +1772,7 @@ impl VoiceBargeInRuntime {
             );
         };
 
-        // First gate: cancel that arrived during ack generation.
-        if cancel_token.cancelled.load(Ordering::Relaxed) {
+        if foreground_decision::ack_cancel_suppresses_fallback(&cancel_token) {
             record_cancel_suppressed("post_generation");
             log_cancel_suppressed("post_generation");
             return true;
@@ -1804,7 +1804,7 @@ impl VoiceBargeInRuntime {
                 );
             }
             VoiceForegroundDecision::Speak(spoken) => {
-                if cancel_token.cancelled.load(Ordering::Relaxed) {
+                if foreground_decision::ack_cancel_suppresses_fallback(&cancel_token) {
                     record_cancel_suppressed("pre_speak_synth");
                     log_cancel_suppressed("pre_speak_synth");
                     return true;
@@ -1813,7 +1813,7 @@ impl VoiceBargeInRuntime {
                     .synthesize_acknowledgement(&spoken, source_channel_id)
                     .await
                 {
-                    if cancel_token.cancelled.load(Ordering::Relaxed) {
+                    if foreground_decision::ack_cancel_suppresses_fallback(&cancel_token) {
                         record_cancel_suppressed("post_speak_synth");
                         log_cancel_suppressed("post_speak_synth");
                         return true;
@@ -4076,6 +4076,101 @@ mod tests {
         );
     }
 
+    // #3908 (bug A): a foreground model/synth failure must SPEAK the fallback
+    // ack instead of being discarded to silence. Drive the real
+    // `generate_foreground_ack_text` against an unsupported provider so the
+    // model-call-error branch fires deterministically (no live CLI).
+    #[tokio::test]
+    async fn foreground_model_failure_speaks_fallback_instead_of_silence() {
+        let foreground = EffectiveVoiceForegroundConfig {
+            provider: "adk_unsupported_provider_for_tests".to_string(),
+            model: "none".to_string(),
+            max_chars: 200,
+            timeout_ms: 1_000,
+        };
+        let cancel = Arc::new(crate::services::provider::CancelToken::new());
+        let decision =
+            generate_foreground_ack_text("로그 확인해줘", "ko", &foreground, cancel.clone()).await;
+        assert_eq!(
+            decision,
+            Some(VoiceForegroundDecision::Speak(foreground_ack_text(
+                "로그 확인해줘",
+                "ko"
+            ))),
+            "model/synth failure must speak the fallback ack, not fall through to silence"
+        );
+        assert!(
+            !cancel.cancelled.load(Ordering::Relaxed),
+            "a model failure (not a barge-in) must not flag the shared cancel token"
+        );
+    }
+
+    // #3908 (bug A): the self-inflicted foreground-ack timeout flips the shared
+    // cancel token only to kill the detached model child, so it must NOT
+    // suppress the spoken fallback; a genuine user barge-in must keep silence.
+    #[test]
+    fn foreground_ack_timeout_keeps_fallback_but_barge_in_suppresses() {
+        use crate::services::provider::CancelToken;
+
+        let idle = CancelToken::new();
+        assert!(
+            !foreground_decision::ack_cancel_suppresses_fallback(&idle),
+            "an un-cancelled token never suppresses"
+        );
+
+        let timed_out = CancelToken::new();
+        timed_out.set_cancel_source("voice_foreground_ack_timeout");
+        timed_out.cancelled.store(true, Ordering::Relaxed);
+        assert!(
+            !foreground_decision::ack_cancel_suppresses_fallback(&timed_out),
+            "a foreground-ack timeout (model failure) must still speak the fallback ack"
+        );
+
+        let barged_in = CancelToken::new();
+        barged_in.set_cancel_source("voice_barge_in_explicit_stop");
+        barged_in.cancelled.store(true, Ordering::Relaxed);
+        assert!(
+            foreground_decision::ack_cancel_suppresses_fallback(&barged_in),
+            "a genuine user barge-in must keep the channel silent"
+        );
+    }
+
+    // #3908 (review): a user barge-in must DOMINATE a self-timeout on the SAME
+    // shared token in EITHER race order. The cancel KIND is first-wins and the
+    // free-form LABEL is last-wins, so each ordering leaves the barge-in trace
+    // in a different field; both must suppress the fallback (no fallback spoken
+    // over a user who interrupted).
+    #[test]
+    fn foreground_ack_user_barge_in_dominates_self_timeout_on_shared_token() {
+        use crate::services::provider::CancelToken;
+
+        // Timeout recorded first (kind=WatchdogTimeout), barge-in lands after
+        // (overwrites the label only). Must suppress.
+        let timeout_then_barge_in = CancelToken::new();
+        timeout_then_barge_in.set_cancel_source("voice_foreground_ack_timeout");
+        timeout_then_barge_in
+            .cancelled
+            .store(true, Ordering::Relaxed);
+        timeout_then_barge_in.set_cancel_source("voice_barge_in_explicit_stop");
+        assert!(
+            foreground_decision::ack_cancel_suppresses_fallback(&timeout_then_barge_in),
+            "a barge-in after a self-timeout must suppress the fallback (kind stays WatchdogTimeout)"
+        );
+
+        // Barge-in recorded first (kind=UserBargeIn, sticky), self-timeout
+        // overwrites the label afterwards. Must still suppress.
+        let barge_in_then_timeout = CancelToken::new();
+        barge_in_then_timeout.set_cancel_source("voice_barge_in_live_cut");
+        barge_in_then_timeout
+            .cancelled
+            .store(true, Ordering::Relaxed);
+        barge_in_then_timeout.set_cancel_source("voice_foreground_ack_timeout");
+        assert!(
+            foreground_decision::ack_cancel_suppresses_fallback(&barge_in_then_timeout),
+            "a self-timeout that lands after a barge-in must not revive the fallback"
+        );
+    }
+
     #[test]
     fn foreground_decision_parses_silence_handoff_and_spoken_text() {
         assert_eq!(
@@ -4788,6 +4883,64 @@ mod tests {
         runtime.clear_playback_if_owner(channel_id, 1);
 
         assert_eq!(runtime.playbacks.get(&42).unwrap().owner, Some(2));
+    }
+
+    // #3908 (bug B): a queued progress/chime flush must NOT steal the barge-in
+    // handle while a final-result playback owns the channel, otherwise a user
+    // barge-in would stop only the progress track and leave the nested final
+    // answer playing.
+    #[test]
+    fn progress_playback_does_not_steal_active_final_result_handle() {
+        let runtime = enabled_runtime();
+        let channel_id = ChannelId::new(77);
+
+        // Final-result playback owns the channel: session + barge-in handle.
+        let (final_id, _cancel) = runtime.start_spoken_result_playback(channel_id);
+        runtime.reset_after_playback_start_with_owner(
+            channel_id,
+            Arc::new(MockPlayer::default()),
+            CancellationToken::new(),
+            Some(final_id),
+        );
+
+        let registered = runtime.register_progress_barge_in_handle(
+            channel_id,
+            Arc::new(MockPlayer::default()),
+            9_999,
+        );
+
+        assert!(
+            !registered,
+            "progress must not register while a final-result playback owns the handle"
+        );
+        assert_eq!(
+            runtime.playbacks.get(&channel_id.get()).unwrap().owner,
+            Some(final_id),
+            "final-result playback must keep owning the barge-in handle so barge-in stops it"
+        );
+    }
+
+    // #3908 (bug B): when no final-result playback is active, progress keeps its
+    // own barge-in handle so it can still be stopped by a user barge-in.
+    #[test]
+    fn progress_playback_registers_handle_when_no_final_result_active() {
+        let runtime = enabled_runtime();
+        let channel_id = ChannelId::new(78);
+
+        let registered = runtime.register_progress_barge_in_handle(
+            channel_id,
+            Arc::new(MockPlayer::default()),
+            555,
+        );
+
+        assert!(
+            registered,
+            "progress owns the barge-in handle when no final-result playback is active"
+        );
+        assert_eq!(
+            runtime.playbacks.get(&channel_id.get()).unwrap().owner,
+            Some(555)
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/voice_barge_in/foreground_decision.rs
+++ b/src/services/discord/voice_barge_in/foreground_decision.rs
@@ -16,6 +16,34 @@ pub(super) fn foreground_ack_text(transcript: &str, language: &str) -> String {
     }
 }
 
+/// #3908: decide whether a foreground-ack cancellation must SUPPRESS the spoken
+/// fallback. A genuine interruption (user barge-in / explicit stop / session
+/// teardown) suppresses and keeps the channel silent; a self-inflicted
+/// foreground-ack timeout does NOT — the timeout flips the shared cancel token
+/// only so #2250 can terminate the detached model child, yet the user is still
+/// owed an audible fallback acknowledgement.
+///
+/// A user barge-in must always DOMINATE the timeout regardless of ordering. On
+/// the shared token the cancel KIND is first-wins while the free-form LABEL is
+/// last-wins (`provider::CancelToken::set_cancel_source`), so a barge-in racing
+/// the self-timeout leaves its trace in exactly one of the two fields: the kind
+/// if it cancelled first, the label if it cancelled last. Keep the fallback
+/// only when BOTH signals are still the `voice_foreground_ack_timeout` self-
+/// cancel (no barge-in ever touched this token); otherwise suppress.
+pub(super) fn ack_cancel_suppresses_fallback(
+    cancel_token: &crate::services::provider::CancelToken,
+) -> bool {
+    use crate::services::provider::CancelSource;
+    if !cancel_token.cancelled.load(Ordering::Relaxed) {
+        return false;
+    }
+    let kind_is_timeout = cancel_token.cancel_source_kind() == Some(CancelSource::WatchdogTimeout);
+    let label_is_timeout = cancel_token
+        .cancel_source()
+        .is_some_and(|label| CancelSource::classify(&label) == CancelSource::WatchdogTimeout);
+    !(kind_is_timeout && label_is_timeout)
+}
+
 pub(super) fn parse_voice_foreground_decision(
     text: &str,
     transcript: &str,

--- a/src/services/discord/voice_barge_in/live_cut_playback.rs
+++ b/src/services/discord/voice_barge_in/live_cut_playback.rs
@@ -55,6 +55,40 @@ impl VoiceBargeInRuntime {
             .remove_if(&channel_id.get(), |_, session| session.owner == Some(owner));
     }
 
+    /// #3908: register a progress/chime playback as the live barge-in handle,
+    /// but ONLY when no final-result playback owns the channel. A queued
+    /// progress flush that lands AFTER the final answer started must not steal
+    /// the final-result barge-in handle — otherwise a user barge-in would stop
+    /// only this progress track and leave the (nested) final answer playing.
+    /// The progress audio still mixes via songbird `play_input`; we only skip
+    /// the handle bookkeeping. Returns `true` when the handle was registered
+    /// (caller arms the expiry timer), `false` when skipped.
+    pub(super) fn register_progress_barge_in_handle<P>(
+        &self,
+        channel_id: ChannelId,
+        player: Arc<P>,
+        playback_id: u64,
+    ) -> bool
+    where
+        P: BargeInPlayerStop + 'static,
+    {
+        if self.spoken_result_playbacks.contains_key(&channel_id.get()) {
+            tracing::debug!(
+                channel_id = channel_id.get(),
+                playback_id,
+                "voice progress playback left unregistered: final-result playback owns the barge-in handle (#3908)"
+            );
+            return false;
+        }
+        self.reset_after_playback_start_with_owner(
+            channel_id,
+            player,
+            CancellationToken::new(),
+            Some(playback_id),
+        );
+        true
+    }
+
     pub(in crate::services::discord) fn observe_live_pcm_i16(
         &self,
         channel_id: ChannelId,

--- a/src/services/discord/voice_barge_in/progress_playback.rs
+++ b/src/services/discord/voice_barge_in/progress_playback.rs
@@ -399,18 +399,17 @@ impl VoiceBargeInRuntime {
         // 30s 만료 타이머는 `clear_playback_if_owner` 로 동일 owner 일 때만 정리.
         // 후속 progress/spoken_result playback 이 entry 를 덮어쓰면 mismatch 로
         // no-op → 후속 playback 의 barge-in 이 깨지지 않는다.
+        // #3908: skip the handle registration entirely while a final-result
+        // playback owns the channel so a queued progress/chime flush cannot
+        // steal the final answer's barge-in handle.
         let playback_id = self.id_sequences.next_progress_playback_id();
-        self.reset_after_playback_start_with_owner(
-            channel_id,
-            Arc::new(track),
-            CancellationToken::new(),
-            Some(playback_id),
-        );
-        let runtime = self.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(30)).await;
-            runtime.clear_playback_if_owner(channel_id, playback_id);
-        });
+        if self.register_progress_barge_in_handle(channel_id, Arc::new(track), playback_id) {
+            let runtime = self.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                runtime.clear_playback_if_owner(channel_id, playback_id);
+            });
+        }
         tracing::info!(
             channel_id = channel_id.get(),
             guild_id = guild_id.get(),


### PR DESCRIPTION
Fixes #3908 (split from #3906). Two related voice TTS inconsistencies.

## Bug A — model failure → silence (no audible feedback)
`generate_foreground_ack_text` already computed a fallback ack
(`foreground_ack_text(...)`) but **discarded** it (`_fallback_for_tests_and_docs`)
and returned `None` on every model-call error / task error / timeout. The caller
then defaulted to `VoiceForegroundDecision::Silence` → the user heard nothing when
the foreground model failed.

**Fix:** each failure branch now **speaks** the fallback ack instead of discarding
it (preserving the existing fallback content). The timeout path still flips the
shared `CancelToken` so #2250 can terminate the detached model child, but a new
`ack_cancel_suppresses_fallback` gate distinguishes:
- a self-inflicted ack timeout (`WatchdogTimeout` kind) → **still speak** the fallback,
- a genuine user barge-in (`UserBargeIn`/teardown) → **stay silent** (normal mute).

Applied to the `post_generation` / `pre_speak_synth` / `post_speak_synth` gates only;
the background-handoff gates are untouched (the fallback is always a `Speak`).

Root cause sites: `voice_barge_in.rs` `generate_foreground_ack_text` (discard at the
old `:404`, the three `return None` failure arms) + the suppression gates.

## Bug B — progress steals the final-result playback handle
`play_progress_audio` unconditionally overwrote `playbacks[channel]` (the live
barge-in handle) with the progress/chime track via
`reset_after_playback_start_with_owner`. A queued progress/chime flush landing
**after** the final answer started thus hijacked the handle, so a user barge-in
stopped only the progress chime and left the **nested final answer playing**.

**Fix:** new `register_progress_barge_in_handle` skips the handle registration while
a final-result playback owns the channel (`spoken_result_playbacks` active). The
progress audio still mixes via songbird `play_input`; only the barge-in bookkeeping
is gated, so the final answer keeps owning its handle and barge-in reliably stops it.

**Normal (success) audible output is unchanged** — the final-answer path and
progress-during-turn behavior are identical; only the handle-steal window changes.

## Scope / conflict avoidance
Touched only the TTS synth-fallback + playback-handle ownership: `voice_barge_in.rs`,
`voice_barge_in/foreground_decision.rs`, `voice_barge_in/live_cut_playback.rs`,
`voice_barge_in/progress_playback.rs` (+ regenerated `module-inventory.md`).
`final_result_playback.rs` (#3911's `InflightForegroundCancelGuard`) and the #3910
feed-task/stt reap logic were **not** reworked. No forbidden/concurrent-track files
touched (announce route, intake gate/turn, inflight, status_panel, recovery, #3016
hotfiles).

## Tests (`cargo test --lib voice_barge_in`, 62 passed)
- `foreground_model_failure_speaks_fallback_instead_of_silence` — synth/model failure → fallback ack is PLAYED (Speak), not silence.
- `foreground_ack_timeout_keeps_fallback_but_barge_in_suppresses` — ack timeout keeps the fallback; genuine barge-in stays silent.
- `progress_playback_does_not_steal_active_final_result_handle` — progress does not register while final-result owns the handle.
- `progress_playback_registers_handle_when_no_final_result_active` — progress still owns the handle when no final-result is active.

## Gates
fmt --check ✓ · check --lib ✓ · test --lib voice ✓ (62/62) · audit_maintainability --check exit 0 (voice_barge_in prod LoC held at 2893 baseline) · check_hotfile_ratchet exit 0 · inventory + agent-maintenance freshness ✓ · clippy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)