### PR TITLE
chore(voice): P3 cleanup bundle — observability/leak/validation (#3914)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1314,7 +1314,9 @@
     `audit_maintainability_config.toml`; the root is no longer a prod giant and
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
-  - `src/services/discord/voice_barge_in.rs` (2893 lines after #3038
+  - `src/services/discord/voice_barge_in.rs` (2899 lines after #3914 added the
+    `FOREGROUND_MODEL_TIMEOUT_SLACK` const that de-duplicated the triplicated
+    250ms timeout slack; #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
     S2 moved the progress playback method cluster to
@@ -1353,9 +1355,11 @@
     orchestration surface; tracked decompose target — see
     `giant-file-registry.md` (owner `voice-runtime`, deadline 2026-08-31,
     #3036)).
-  - `src/voice/receiver.rs` (1052 lines; voice receive pipeline, utterance
-    segmentation, artifact cleanup, and retention policy surface; split before
-    adding non-bugfix behavior).
+  - `src/voice/receiver.rs` (1108 lines after #3914 added the songbird
+    `ClientDisconnect` handler that drops a leaver's SSRC→user mapping to stop
+    monotonic `ssrc_users` growth under channel churn; voice receive pipeline,
+    utterance segmentation, artifact cleanup, and retention policy surface;
+    split before adding non-bugfix behavior).
   - `src/voice/announce_meta.rs` (1001 lines; voice announcement durability /
     handoff metadata surface; crossed the giant threshold when #3034 restored
     per-item dead_code reasoning on the runtime-gated durable helpers; tracked

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -994,3 +994,22 @@
     `voice.tts.progress_cache_dir` / `voice.audio.temp_dir` are swept, not the
     defaults. Pool-less, no new lease, durable queue, leader-election surface, or
     singleton assumption.
+- #3914 voice P3 cleanup bundle (observability / leak / validation) — **all
+  Worker-local**: every state surface touched is process-global on the node that
+  holds the live voice session, with no cross-node coordination introduced.
+  - `src/voice/receiver.rs`: the songbird `ClientDisconnect` handler prunes the
+    leaver's SSRC→user entries from the in-process `ssrc_users` map. The map is
+    pinned to the node running that voice connection (songbird driver is
+    node-local), so disconnect cleanup is purely worker-local.
+  - `src/voice/metrics.rs`: the new STT outcome counters and `voice_stt_outcome`
+    structured events are process-local telemetry (same class as the existing
+    `voice_latency_turn` registry), flowing through the node-local observability
+    event sink. No leader/standby ownership.
+  - `src/voice/cancel_tombstone.rs`: the re-fire guard remains an explicitly
+    process-local `OnceLock<RwLock<HashMap>>` (documented in its module header) —
+    the poison-recovery + read-path prune changes do not alter that boundary; a
+    dcserver restart between the two cancel attempts is still covered by the
+    background turn's own cancel-on-restart recovery.
+  - `src/voice/tts/edge.rs` keeps the edge-tts subprocess timeout a worker-local
+    constant; making it configurable + adding TTS synth/cache hit-miss metrics is
+    explicitly deferred (informational sub-item) and would also be worker-local.

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -28,7 +28,7 @@
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6283 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |
-| `src/services/discord/voice_barge_in.rs` | 2893 | voice-runtime | 2026-08-31 | #3405 |
+| `src/services/discord/voice_barge_in.rs` | 2899 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2079 | discord-relay | 2026-10-31 | #3840 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
@@ -103,4 +103,4 @@
 | `src/services/settings.rs` | 1114 |
 | `src/services/tui_prompt_dedupe.rs` | 1764 |
 | `src/services/turn_orchestrator.rs` | 3184 |
-| `src/voice/receiver.rs` | 1052 |
+| `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -435,7 +435,7 @@
 | `services::discord::commands::steer` | `src/services/discord/commands/steer.rs` | 146 | 146 | 0 |  |
 | `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1476 | 1476 | 0 | giant-file |
 | `services::discord::commands::tui_passthrough` | `src/services/discord/commands/tui_passthrough.rs` | 412 | 357 | 55 |  |
-| `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1018 | 960 | 58 |  |
+| `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1025 | 967 | 58 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 527 | 527 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
 | `services::discord::formatting` | `src/services/discord/formatting.rs` | 3755 | 2801 | 954 | giant-file |
@@ -720,13 +720,13 @@
 | `services::discord::turn_finalizer::watcher_backstop` | `src/services/discord/turn_finalizer/watcher_backstop.rs` | 172 | 120 | 52 |  |
 | `services::discord::voice_acknowledgement` | `src/services/discord/voice_acknowledgement.rs` | 61 | 61 | 0 |  |
 | `services::discord::voice_background_driver` | `src/services/discord/voice_background_driver.rs` | 235 | 200 | 35 |  |
-| `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 5106 | 2893 | 2213 | giant-file |
+| `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 5140 | 2899 | 2241 | giant-file |
 | `services::discord::voice_barge_in::final_result_playback` | `src/services/discord/voice_barge_in/final_result_playback.rs` | 243 | 243 | 0 |  |
 | `services::discord::voice_barge_in::foreground_decision` | `src/services/discord/voice_barge_in/foreground_decision.rs` | 242 | 242 | 0 |  |
-| `services::discord::voice_barge_in::live_cut_playback` | `src/services/discord/voice_barge_in/live_cut_playback.rs` | 154 | 154 | 0 |  |
+| `services::discord::voice_barge_in::live_cut_playback` | `src/services/discord/voice_barge_in/live_cut_playback.rs` | 160 | 160 | 0 |  |
 | `services::discord::voice_barge_in::progress_playback` | `src/services/discord/voice_barge_in/progress_playback.rs` | 422 | 422 | 0 |  |
-| `services::discord::voice_barge_in::receive_hook` | `src/services/discord/voice_barge_in/receive_hook.rs` | 114 | 114 | 0 |  |
-| `services::discord::voice_barge_in::routing` | `src/services/discord/voice_barge_in/routing.rs` | 500 | 500 | 0 |  |
+| `services::discord::voice_barge_in::receive_hook` | `src/services/discord/voice_barge_in/receive_hook.rs` | 113 | 113 | 0 |  |
+| `services::discord::voice_barge_in::routing` | `src/services/discord/voice_barge_in/routing.rs` | 532 | 504 | 28 |  |
 | `services::discord::voice_barge_in::stt` | `src/services/discord/voice_barge_in/stt.rs` | 326 | 326 | 0 |  |
 | `services::discord::voice_barge_in::tts_pipeline` | `src/services/discord/voice_barge_in/tts_pipeline.rs` | 86 | 86 | 0 |  |
 | `services::discord::voice_config_cache` | `src/services/discord/voice_config_cache.rs` | 79 | 79 | 0 |  |
@@ -903,19 +903,19 @@
 | `voice` | `src/voice/mod.rs` | 21 | 21 | 0 |  |
 | `voice::announce_meta` | `src/voice/announce_meta.rs` | 1979 | 1001 | 978 | giant-file |
 | `voice::barge_in` | `src/voice/barge_in.rs` | 937 | 592 | 345 |  |
-| `voice::cancel_tombstone` | `src/voice/cancel_tombstone.rs` | 201 | 131 | 70 |  |
-| `voice::commands` | `src/voice/commands.rs` | 839 | 541 | 298 |  |
-| `voice::config` | `src/voice/config.rs` | 601 | 379 | 222 |  |
+| `voice::cancel_tombstone` | `src/voice/cancel_tombstone.rs` | 274 | 147 | 127 |  |
+| `voice::commands` | `src/voice/commands.rs` | 860 | 548 | 312 |  |
+| `voice::config` | `src/voice/config.rs` | 627 | 392 | 235 |  |
 | `voice::flight` | `src/voice/flight.rs` | 252 | 138 | 114 |  |
-| `voice::metrics` | `src/voice/metrics.rs` | 377 | 275 | 102 |  |
+| `voice::metrics` | `src/voice/metrics.rs` | 438 | 336 | 102 |  |
 | `voice::progress` | `src/voice/progress.rs` | 448 | 353 | 95 |  |
 | `voice::prompt` | `src/voice/prompt.rs` | 823 | 540 | 283 |  |
-| `voice::receiver` | `src/voice/receiver.rs` | 1479 | 1052 | 427 | giant-file |
+| `voice::receiver` | `src/voice/receiver.rs` | 1592 | 1108 | 484 | giant-file |
 | `voice::runtime_boundary` | `src/voice/runtime_boundary.rs` | 281 | 212 | 69 |  |
 | `voice::runtime_process` | `src/voice/runtime_process.rs` | 217 | 158 | 59 |  |
-| `voice::sanitizer` | `src/voice/sanitizer.rs` | 328 | 247 | 81 |  |
-| `voice::stt` | `src/voice/stt.rs` | 1276 | 971 | 305 |  |
-| `voice::stt_streaming` | `src/voice/stt_streaming.rs` | 293 | 185 | 108 |  |
+| `voice::sanitizer` | `src/voice/sanitizer.rs` | 419 | 298 | 121 |  |
+| `voice::stt` | `src/voice/stt.rs` | 1387 | 991 | 396 |  |
+| `voice::stt_streaming` | `src/voice/stt_streaming.rs` | 335 | 185 | 150 |  |
 | `voice::tts` | `src/voice/tts/mod.rs` | 939 | 557 | 382 |  |
 | `voice::tts::chunks` | `src/voice/tts/chunks.rs` | 387 | 270 | 117 |  |
 | `voice::tts::edge` | `src/voice/tts/edge.rs` | 439 | 235 | 204 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -296,7 +296,11 @@
 # voice-channel teardown (Stream-mode inner-session leak, codex review; the stt
 # read guard is hoisted to a local so it is not held across the discard awaits).
 # Minimum surface for the leak fix; no decomposition opportunity in this slice.
-"src/services/discord/voice_barge_in.rs" = 2893
+# #3914: +6 (2893 -> 2899) for the `FOREGROUND_MODEL_TIMEOUT_SLACK` const that
+# de-duplicated the 250ms timeout slack previously hardcoded at three foreground
+# model timeout sites (ack / channel-text / background-summary). Net reduction in
+# magic numbers; the const + doc comment is the minimum surface.
+"src/services/discord/voice_barge_in.rs" = 2899
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/commands/voice.rs
+++ b/src/services/discord/commands/voice.rs
@@ -820,6 +820,13 @@ async fn join_voice_channel(
         Event::Core(CoreEvent::SpeakingStateUpdate),
         receiver_handler.clone(),
     );
+    // #3914: subscribe to ClientDisconnect so the receiver can drop a leaver's
+    // SSRC→user mapping; otherwise `ssrc_users` grows monotonically under
+    // long-running channel churn (every (re)join allocates a fresh SSRC).
+    handler.add_global_event(
+        Event::Core(CoreEvent::ClientDisconnect),
+        receiver_handler.clone(),
+    );
     handler.add_global_event(Event::Core(CoreEvent::VoiceTick), receiver_handler);
     Ok(())
 }

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -92,6 +92,12 @@ pub(in crate::services::discord) fn is_synthetic_voice_message_id(
 const STT_TRANSCRIPT_POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const STT_TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESSING_CHIME_FILE_NAME: &str = "agentdesk-voice-processing-chime.wav";
+/// #3914: slack added to the configured foreground model timeout for the OUTER
+/// `tokio::time::timeout` guard so the model child's own watchdog fires (and
+/// flips the #2250 cancel token to kill the detached child) just before the
+/// outer guard trips. Previously this 250ms value was a magic number duplicated
+/// across the ack / channel-text / background-summary timeout sites.
+const FOREGROUND_MODEL_TIMEOUT_SLACK: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::services::discord) enum VoiceBargeInTranscriptOutcome {
@@ -411,7 +417,7 @@ async fn generate_foreground_ack_text(
     let timeout = Duration::from_millis(foreground.timeout_ms);
     let cancel_for_blocking = cancel_token.clone();
     let result = tokio::time::timeout(
-        timeout + Duration::from_millis(250),
+        timeout + FOREGROUND_MODEL_TIMEOUT_SLACK,
         tokio::task::spawn_blocking(move || {
             let provider_kind = ProviderKind::from_str_or_unsupported(&provider);
             match provider_kind {
@@ -533,7 +539,7 @@ async fn generate_voice_channel_text_reply(
     let timeout = Duration::from_millis(foreground.timeout_ms);
     let cancel_for_blocking = cancel_token.clone();
     let result = tokio::time::timeout(
-        timeout + Duration::from_millis(250),
+        timeout + FOREGROUND_MODEL_TIMEOUT_SLACK,
         tokio::task::spawn_blocking(move || {
             let provider_kind = ProviderKind::from_str_or_unsupported(&provider);
             match provider_kind {
@@ -625,7 +631,7 @@ async fn generate_voice_background_result_summary(
     let timeout = Duration::from_millis(foreground.timeout_ms);
     let cancel_for_blocking = cancel_token.clone();
     let result = tokio::time::timeout(
-        timeout + Duration::from_millis(250),
+        timeout + FOREGROUND_MODEL_TIMEOUT_SLACK,
         tokio::task::spawn_blocking(move || {
             let provider_kind = ProviderKind::from_str_or_unsupported(&provider);
             match provider_kind {
@@ -4715,12 +4721,40 @@ mod tests {
 
         let loud = [16_384, -16_384, 16_384, -16_384];
         assert!(runtime.observe_live_pcm_i16(channel_id, &loud).is_none());
-        let cut = runtime.observe_live_pcm_i16(channel_id, &loud).unwrap();
+        let (cut, owner) = runtime.observe_live_pcm_i16(channel_id, &loud).unwrap();
 
         assert_eq!(cut.candidate_frames, 2);
+        // `reset_after_playback_start` registers no owner.
+        assert_eq!(owner, None);
         assert_eq!(player.stops.load(Ordering::SeqCst), 1);
         assert!(cancellation.is_cancelled());
         assert!(runtime.observe_live_pcm_i16(channel_id, &loud).is_none());
+    }
+
+    /// #3914 (item 4): the cut must report the owner of the playback session it
+    /// stopped. The owner is snapshotted before the entry is removed, so the
+    /// F22 `playback_owner` diagnostic is no longer always `None`.
+    #[test]
+    fn live_pcm_observation_reports_owner_of_cut_playback() {
+        let runtime = enabled_runtime();
+        let channel_id = ChannelId::new(7_314);
+        let player = Arc::new(MockPlayer::default());
+        runtime.reset_after_playback_start_with_owner(
+            channel_id,
+            player.clone(),
+            CancellationToken::new(),
+            Some(99),
+        );
+
+        let loud = [16_384, -16_384, 16_384, -16_384];
+        assert!(runtime.observe_live_pcm_i16(channel_id, &loud).is_none());
+        let (_cut, owner) = runtime.observe_live_pcm_i16(channel_id, &loud).unwrap();
+
+        assert_eq!(
+            owner,
+            Some(99),
+            "the cut must carry the owner of the stopped playback session"
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/voice_barge_in/live_cut_playback.rs
+++ b/src/services/discord/voice_barge_in/live_cut_playback.rs
@@ -89,11 +89,16 @@ impl VoiceBargeInRuntime {
         true
     }
 
+    /// Returns the detected cut alongside the `owner` of the playback session
+    /// that was actually cut. F22 (#2046) diagnostics log `playback_owner`, but
+    /// the caller used to read it from `self.playbacks` AFTER this method had
+    /// already removed the entry on a cut, so it was always `None` (#3914). The
+    /// owner is therefore snapshotted here, from the very session being stopped.
     pub(in crate::services::discord) fn observe_live_pcm_i16(
         &self,
         channel_id: ChannelId,
         samples: &[i16],
-    ) -> Option<LiveBargeInCut> {
+    ) -> Option<(LiveBargeInCut, Option<u64>)> {
         if !self.barge_in_enabled || samples.is_empty() {
             return None;
         }
@@ -102,6 +107,7 @@ impl VoiceBargeInRuntime {
             .playbacks
             .get(&channel_id.get())
             .map(|entry| entry.value().clone())?;
+        let playback_owner = playback.owner;
         let sensitivity = self.current_sensitivity();
         let monitor = self.monitor_for_channel(channel_id, sensitivity);
         let mut monitor = lock_monitor(&monitor);
@@ -111,7 +117,7 @@ impl VoiceBargeInRuntime {
         match monitor.observe_pcm(&pcm, playback.player.as_ref(), &playback.cancellation) {
             Ok(Some(cut)) => {
                 self.playbacks.remove(&channel_id.get());
-                Some(cut)
+                Some((cut, playback_owner))
             }
             Ok(None) => None,
             Err(error) => {

--- a/src/services/discord/voice_barge_in/receive_hook.rs
+++ b/src/services/discord/voice_barge_in/receive_hook.rs
@@ -32,18 +32,17 @@ impl VoiceReceiveHook for DiscordVoiceBargeInHook {
         let channel_id = ChannelId::new(control_channel_id);
         self.runtime
             .observe_streaming_stt_pcm_i16(channel_id, user_id, samples);
-        let Some(cut) = self.runtime.observe_live_pcm_i16(channel_id, samples) else {
+        // F22 (#2046): playback_owner 라벨 — 어떤 progress / spoken_result
+        // playback 이 cut 되었는지 사후 분석. #3914: the owner is returned by
+        // `observe_live_pcm_i16` (snapshotted from the cut session) because the
+        // cut already removed the `playbacks` entry, so a post-cut read here was
+        // always `None`.
+        let Some((cut, playback_owner)) = self.runtime.observe_live_pcm_i16(channel_id, samples)
+        else {
             return;
         };
 
         let shared = self.shared.clone();
-        // F22 (#2046): playback_owner 라벨 추가 — 어떤 progress / spoken_result
-        // playback 이 cut 되었는지 사후 분석 가능.
-        let playback_owner = self
-            .runtime
-            .playbacks
-            .get(&channel_id.get())
-            .and_then(|entry| entry.value().owner);
         // Issue #2335 (b): the live PCM cut path is a parallel termination
         // path that, prior to this fix, did NOT call
         // `cancel_inflight_foreground_calls`. As a result PCM cut would

--- a/src/services/discord/voice_barge_in/routing.rs
+++ b/src/services/discord/voice_barge_in/routing.rs
@@ -492,9 +492,41 @@ fn normalized_foreground_max_chars(value: usize) -> usize {
 }
 
 fn normalized_foreground_timeout_ms(value: u64) -> u64 {
-    if value == 0 {
+    let value = if value == 0 {
         crate::voice::config::DEFAULT_FOREGROUND_TIMEOUT_MS
     } else {
         value
+    };
+    // #3914: clamp up tiny misconfigured values so a typo cannot make every
+    // foreground call time out and degrade to Silence.
+    value.max(crate::voice::config::MIN_FOREGROUND_TIMEOUT_MS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voice::config::{DEFAULT_FOREGROUND_TIMEOUT_MS, MIN_FOREGROUND_TIMEOUT_MS};
+
+    #[test]
+    fn foreground_timeout_zero_falls_back_to_default() {
+        assert_eq!(
+            normalized_foreground_timeout_ms(0),
+            DEFAULT_FOREGROUND_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn foreground_timeout_below_minimum_is_clamped_up() {
+        // #3914: a 50ms misconfiguration must not make every foreground call
+        // time out (which would degrade each utterance to Silence).
+        assert_eq!(
+            normalized_foreground_timeout_ms(50),
+            MIN_FOREGROUND_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn foreground_timeout_above_minimum_is_preserved() {
+        assert_eq!(normalized_foreground_timeout_ms(10_000), 10_000);
     }
 }

--- a/src/voice/cancel_tombstone.rs
+++ b/src/voice/cancel_tombstone.rs
@@ -70,49 +70,65 @@ pub(crate) struct VoiceCancelTombstoneStore {
 }
 
 impl VoiceCancelTombstoneStore {
+    /// Acquire the write guard, recovering in place if the lock was poisoned.
+    ///
+    /// #3914: the prior code matched `if let Ok(..) = self.entries.write()` and
+    /// silently dropped the operation on a poisoned lock. That defeats the whole
+    /// re-fire guard with no signal — a single panic while a guard was held would
+    /// permanently stop both recording and pruning tombstones. A poisoned
+    /// `RwLock` only means a writer panicked; the `HashMap` itself is still
+    /// consistent, so we log once and recover the inner map.
+    fn write_entries(&self) -> std::sync::RwLockWriteGuard<'_, HashMap<u64, StoredTombstone>> {
+        self.entries.write().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                "voice cancel-tombstone lock was poisoned; recovering in place so re-fire \
+                 protection keeps working (#3914)"
+            );
+            poisoned.into_inner()
+        })
+    }
+
     /// Record (or refresh) a tombstone for `handoff_message_id`. Idempotent;
     /// a later record with a different reason overwrites the prior reason
     /// (last-cancel-wins for the label, but presence-of-tombstone is what
     /// downstream consumers branch on).
     pub(crate) fn record(&self, handoff_message_id: MessageId, reason: impl Into<String>) {
-        if let Ok(mut entries) = self.entries.write() {
-            let now = Instant::now();
-            prune_expired_locked(&mut entries, now);
-            entries.insert(
-                handoff_message_id.get(),
-                StoredTombstone {
-                    reason: reason.into(),
-                    expires_at: now + TOMBSTONE_TTL,
-                },
-            );
-        }
+        let mut entries = self.write_entries();
+        let now = Instant::now();
+        prune_expired_locked(&mut entries, now);
+        entries.insert(
+            handoff_message_id.get(),
+            StoredTombstone {
+                reason: reason.into(),
+                expires_at: now + TOMBSTONE_TTL,
+            },
+        );
     }
 
     /// Return the recorded cancel reason if a non-expired tombstone exists.
     ///
     /// The tombstone is NOT consumed by lookup — multiple late callers may
-    /// each need to observe it. The TTL bounds memory growth.
+    /// each need to observe it. #3914: lookups now also prune expired entries,
+    /// so eviction no longer depends solely on a steady stream of `record`
+    /// writes (a channel that stops writing tombstones is still bounded by reads).
     pub(crate) fn lookup(&self, handoff_message_id: MessageId) -> Option<String> {
-        let entries = self.entries.read().ok()?;
-        let stored = entries.get(&handoff_message_id.get())?;
-        if Instant::now() >= stored.expires_at {
-            None
-        } else {
-            Some(stored.reason.clone())
-        }
+        let mut entries = self.write_entries();
+        let now = Instant::now();
+        prune_expired_locked(&mut entries, now);
+        entries
+            .get(&handoff_message_id.get())
+            .map(|stored| stored.reason.clone())
     }
 
     /// Explicit removal (test helper / future graceful-shutdown path).
     #[cfg(test)]
     pub(crate) fn forget(&self, handoff_message_id: MessageId) {
-        if let Ok(mut entries) = self.entries.write() {
-            entries.remove(&handoff_message_id.get());
-        }
+        self.write_entries().remove(&handoff_message_id.get());
     }
 
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
-        self.entries.read().map(|guard| guard.len()).unwrap_or(0)
+        self.write_entries().len()
     }
 }
 
@@ -190,6 +206,63 @@ mod tests {
         store.record(msg(9), "x");
         store.forget(msg(9));
         assert!(store.lookup(msg(9)).is_none());
+    }
+
+    /// #3914: a lookup must prune already-expired tombstones, so eviction no
+    /// longer depends solely on a steady stream of `record` writes.
+    #[test]
+    fn lookup_prunes_expired_entries() {
+        let store = VoiceCancelTombstoneStore::default();
+        {
+            // Bypass `record()` (which always stores a future expiry) to seed one
+            // already-expired entry and one fresh entry.
+            let mut entries = store.write_entries();
+            entries.insert(
+                1,
+                StoredTombstone {
+                    reason: "stale".to_string(),
+                    expires_at: Instant::now() - Duration::from_secs(1),
+                },
+            );
+            entries.insert(
+                2,
+                StoredTombstone {
+                    reason: "fresh".to_string(),
+                    expires_at: Instant::now() + TOMBSTONE_TTL,
+                },
+            );
+        }
+        assert_eq!(store.len(), 2);
+
+        // Querying id 2 still prunes the expired id 1.
+        assert_eq!(store.lookup(msg(2)).as_deref(), Some("fresh"));
+        assert_eq!(store.len(), 1, "expired tombstone must be pruned on lookup");
+        assert!(store.lookup(msg(1)).is_none());
+    }
+
+    /// #3914: a poisoned lock must NOT silently disable the re-fire guard — the
+    /// store recovers in place and keeps recording/looking up.
+    #[test]
+    fn recovers_from_a_poisoned_lock() {
+        let store = std::sync::Arc::new(VoiceCancelTombstoneStore::default());
+        store.record(msg(1), "before");
+
+        // Poison the RwLock by panicking while holding the write guard.
+        let poison_store = store.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poison_store.write_entries();
+            panic!("intentional poison for test");
+        })
+        .join();
+
+        // Recovery: subsequent operations still work (not silent no-ops).
+        store.record(msg(2), "after");
+        assert_eq!(store.lookup(msg(2)).as_deref(), Some("after"));
+        assert_eq!(
+            store.lookup(msg(1)).as_deref(),
+            Some("before"),
+            "pre-poison tombstones must survive lock recovery"
+        );
     }
 
     #[test]

--- a/src/voice/commands.rs
+++ b/src/voice/commands.rs
@@ -156,6 +156,13 @@ pub(crate) fn wake_word_decision(
     required: bool,
 ) -> WakeWordDecision {
     let transcript = transcript.trim();
+    // #3914: if the gate is "required" but there is no usable wake word to match
+    // against, gating is impossible — every utterance would fall through to
+    // `Missing` and be silently dropped. Fail open in that case.
+    let required = required
+        && wake_words
+            .iter()
+            .any(|wake_word| !wake_word.trim().is_empty());
     if !required {
         return WakeWordDecision::NotRequired(transcript.to_string());
     }
@@ -635,6 +642,20 @@ mod tests {
         assert_eq!(
             wake_word_decision("상태 알려줘", &wake_words, true),
             WakeWordDecision::Missing
+        );
+    }
+
+    /// #3914: with `required = true` but no usable wake word to match against,
+    /// the gate must fail open instead of silently dropping every utterance.
+    #[test]
+    fn wake_word_decision_fails_open_without_usable_wake_words() {
+        assert_eq!(
+            wake_word_decision("아무 말이나 해봐", &[], true),
+            WakeWordDecision::NotRequired("아무 말이나 해봐".to_string())
+        );
+        assert_eq!(
+            wake_word_decision("상태 알려줘", &["   ".to_string(), String::new()], true),
+            WakeWordDecision::NotRequired("상태 알려줘".to_string())
         );
     }
 

--- a/src/voice/config.rs
+++ b/src/voice/config.rs
@@ -27,6 +27,11 @@ pub(crate) const DEFAULT_FOREGROUND_PROVIDER: &str = "claude";
 pub(crate) const DEFAULT_FOREGROUND_MODEL: &str = "sonnet";
 pub(crate) const DEFAULT_FOREGROUND_MAX_CHARS: usize = 220;
 pub(crate) const DEFAULT_FOREGROUND_TIMEOUT_MS: u64 = 3_000;
+/// #3914: lower bound for the foreground model timeout. A small misconfigured
+/// value (e.g. `timeout_ms: 50`) would otherwise make every foreground call time
+/// out and degrade to Silence on each utterance. Values below this are clamped
+/// up so a typo cannot silently mute the assistant.
+pub(crate) const MIN_FOREGROUND_TIMEOUT_MS: u64 = 500;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
@@ -86,14 +91,22 @@ impl VoiceConfig {
     }
 
     pub(crate) fn wake_word_required(&self) -> bool {
+        // #3914: you cannot gate on a wake word that is not configured. A live
+        // yaml with `wake_words: []` plus `REQUIRE_WAKE_WORD=1` would otherwise
+        // make EVERY utterance fail the (impossible-to-satisfy) gate and be
+        // silently dropped. Fail open: require a wake word only when at least one
+        // usable wake word exists, regardless of the env override.
+        let has_usable_wake_word = self
+            .wake_words
+            .iter()
+            .any(|wake_word| !wake_word.trim().is_empty());
+        if !has_usable_wake_word {
+            return false;
+        }
         std::env::var("REQUIRE_WAKE_WORD")
             .ok()
             .and_then(|value| parse_bool_env(&value))
-            .unwrap_or_else(|| {
-                self.wake_words
-                    .iter()
-                    .any(|wake_word| !wake_word.trim().is_empty())
-            })
+            .unwrap_or(has_usable_wake_word)
     }
 
     pub(crate) fn lobby_channel_id_u64(&self) -> Option<u64> {
@@ -416,6 +429,19 @@ mod tests {
             DEFAULT_BARGE_IN_TTL_SECS
         );
         assert!(config.barge_in.acknowledgement_enabled);
+    }
+
+    #[test]
+    fn wake_word_not_required_when_no_usable_wake_words() {
+        // #3914: blank / empty wake words can never be matched, so the gate must
+        // fail open. This early return wins before the REQUIRE_WAKE_WORD env is
+        // even consulted, so it holds regardless of the ambient env.
+        let mut config = VoiceConfig::default();
+        config.wake_words = Vec::new();
+        assert!(!config.wake_word_required());
+
+        config.wake_words = vec!["   ".to_string(), String::new()];
+        assert!(!config.wake_word_required());
     }
 
     #[test]

--- a/src/voice/metrics.rs
+++ b/src/voice/metrics.rs
@@ -203,6 +203,67 @@ pub fn discard(channel_id: u64) {
     }
 }
 
+/// #3914: terminal outcome of a file-mode STT transcription. STT previously
+/// swallowed low-volume skips and empty-after-retry results as
+/// `Ok(String::new())` with at most a debug log, so a systemic regression
+/// (whisper returning empty, the volume gate over-skipping, or `volumedetect`
+/// failing) was invisible. These outcomes are counted process-wide and the
+/// anomalous ones are emitted as a structured `voice_stt_outcome` event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SttOutcome {
+    /// whisper produced a usable (non-empty, cleaned) transcript.
+    Transcribed,
+    /// the utterance was gated out by the low-volume silence check before whisper.
+    LowVolumeSkipped,
+    /// whisper ran (including one retry) but the cleaned transcript was empty.
+    EmptyAfterRetry,
+    /// the `volumedetect` pre-pass failed; STT continued without the gate.
+    VolumeDetectFailed,
+}
+
+impl SttOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Transcribed => "transcribed",
+            Self::LowVolumeSkipped => "low_volume_skipped",
+            Self::EmptyAfterRetry => "empty_after_retry",
+            Self::VolumeDetectFailed => "volumedetect_failed",
+        }
+    }
+}
+
+fn stt_outcome_registry() -> &'static Mutex<HashMap<&'static str, u64>> {
+    static REG: OnceLock<Mutex<HashMap<&'static str, u64>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record one STT outcome: bumps the process-wide counter and (for the
+/// anomalous outcomes) emits a structured `voice_stt_outcome` event. The common
+/// success path only bumps the counter so the shared event buffer is not
+/// crowded out of its `voice_latency_turn` samples.
+pub fn record_stt_outcome(outcome: SttOutcome) {
+    if let Ok(mut map) = stt_outcome_registry().lock() {
+        *map.entry(outcome.as_str()).or_insert(0) += 1;
+    }
+    if !matches!(outcome, SttOutcome::Transcribed) {
+        events::record_simple(
+            "voice_stt_outcome",
+            None,
+            Some("voice"),
+            json!({ "outcome": outcome.as_str() }),
+        );
+    }
+}
+
+#[cfg(test)]
+pub fn stt_outcome_count(outcome: SttOutcome) -> u64 {
+    stt_outcome_registry()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(outcome.as_str()).copied())
+        .unwrap_or(0)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LatencySummary {
     pub sample_count: usize,

--- a/src/voice/receiver.rs
+++ b/src/voice/receiver.rs
@@ -175,6 +175,27 @@ impl VoiceReceiver {
             .await;
     }
 
+    /// #3914: drop the SSRC→user mappings for a client that left the voice
+    /// session. Songbird emits `ClientDisconnect` on leave but the receiver
+    /// previously never handled it, so `ssrc_users` grew monotonically under
+    /// long-running channel churn (every (re)join allocates a fresh SSRC).
+    pub(crate) async fn forget_disconnected_user(&self, user_id: u64) {
+        self.inner.forget_disconnected_user(None, user_id).await;
+    }
+
+    /// F2-scoped variant of [`forget_disconnected_user`]: only removes mappings
+    /// bound to `control_channel_id` so a leave in one guild/channel never drops
+    /// another channel's live SSRC mapping.
+    pub(crate) async fn forget_disconnected_user_for_control_channel(
+        &self,
+        control_channel_id: u64,
+        user_id: u64,
+    ) {
+        self.inner
+            .forget_disconnected_user(Some(control_channel_id), user_id)
+            .await;
+    }
+
     pub(crate) async fn queue_pcm(
         &self,
         ssrc: u32,
@@ -250,6 +271,9 @@ impl EventHandler for VoiceReceiver {
                     }
                 }
             }
+            EventContext::ClientDisconnect(disconnect) => {
+                self.forget_disconnected_user(disconnect.user_id.0).await;
+            }
             _ => {}
         }
 
@@ -293,6 +317,14 @@ impl EventHandler for VoiceReceiverEventHandler {
                         }
                     }
                 }
+            }
+            EventContext::ClientDisconnect(disconnect) => {
+                self.receiver
+                    .forget_disconnected_user_for_control_channel(
+                        self.control_channel_id,
+                        disconnect.user_id.0,
+                    )
+                    .await;
             }
             _ => {}
         }
@@ -357,6 +389,30 @@ impl ReceiverState {
             },
             user_id,
         );
+    }
+
+    /// #3914: remove every SSRC mapping for `user_id` (optionally scoped to a
+    /// single `control_channel_id`). Called on songbird `ClientDisconnect` so a
+    /// leaver's SSRC entries do not accumulate indefinitely.
+    async fn forget_disconnected_user(&self, control_channel_id: Option<u64>, user_id: u64) {
+        if user_id == 0 {
+            return;
+        }
+        let mut ssrc_users = self.ssrc_users.write().await;
+        let before = ssrc_users.len();
+        ssrc_users.retain(|key, mapped_user| {
+            !(*mapped_user == user_id
+                && (control_channel_id.is_none() || key.control_channel_id == control_channel_id))
+        });
+        let removed = before - ssrc_users.len();
+        if removed > 0 {
+            tracing::debug!(
+                user_id,
+                control_channel_id = ?control_channel_id,
+                removed,
+                "voice receiver dropped SSRC mappings for disconnected client (#3914)"
+            );
+        }
     }
 
     async fn queue_pcm(
@@ -1340,6 +1396,63 @@ mod tests {
         assert_eq!(flushed[0].control_channel_id, None);
         assert_eq!(flushed[0].samples_written, 960);
         assert_eq!(receiver.take_pending().await.len(), 1);
+    }
+
+    /// #3914: a songbird `ClientDisconnect` must drop the leaver's SSRC mapping
+    /// so it cannot accumulate, and must leave other speakers untouched.
+    #[tokio::test]
+    async fn client_disconnect_drops_only_the_leavers_ssrc_mapping() {
+        let temp = tempfile::tempdir().unwrap();
+        let receiver = VoiceReceiver::new(test_config(temp.path().to_path_buf()));
+        receiver.register_speaking(42, 7).await;
+        receiver.register_speaking(43, 8).await;
+
+        // User 8 leaves — user 7's mapping must survive.
+        receiver.forget_disconnected_user(8).await;
+        assert!(receiver.queue_pcm(42, &[1; 480]).await.is_ok());
+        assert!(matches!(
+            receiver.queue_pcm(43, &[1; 480]).await.unwrap_err(),
+            VoiceReceiverError::UnknownSsrc(43)
+        ));
+
+        // Now user 7 leaves — its mapping is gone too (no monotonic growth).
+        receiver.forget_disconnected_user(7).await;
+        assert!(matches!(
+            receiver.queue_pcm(42, &[1; 480]).await.unwrap_err(),
+            VoiceReceiverError::UnknownSsrc(42)
+        ));
+    }
+
+    /// #3914 / F2: a disconnect in one control channel must not drop the same
+    /// user's SSRC mapping in another control channel.
+    #[tokio::test]
+    async fn client_disconnect_is_scoped_to_control_channel() {
+        let temp = tempfile::tempdir().unwrap();
+        let receiver = VoiceReceiver::new(test_config(temp.path().to_path_buf()));
+        receiver
+            .register_speaking_for_control_channel(101, 42, 7)
+            .await;
+        receiver
+            .register_speaking_for_control_channel(202, 43, 7)
+            .await;
+
+        receiver
+            .forget_disconnected_user_for_control_channel(101, 7)
+            .await;
+
+        assert!(matches!(
+            receiver
+                .queue_pcm_for_control_channel(101, 42, &[1; 480])
+                .await
+                .unwrap_err(),
+            VoiceReceiverError::UnknownSsrc(42)
+        ));
+        assert!(
+            receiver
+                .queue_pcm_for_control_channel(202, 43, &[1; 480])
+                .await
+                .is_ok()
+        );
     }
 
     async fn wait_for_pending_io(receiver: &VoiceReceiver, key: VoiceAudioKey) -> bool {

--- a/src/voice/sanitizer.rs
+++ b/src/voice/sanitizer.rs
@@ -118,7 +118,7 @@ fn is_bare_command_line(lower: &str) -> bool {
         return false;
     };
 
-    match binary {
+    let is_known_command = match binary {
         "cargo" => matches!(
             subcommand,
             "bench"
@@ -161,7 +161,58 @@ fn is_bare_command_line(lower: &str) -> bool {
                 | "switch"
         ),
         _ => false,
+    };
+    if !is_known_command {
+        return false;
     }
+
+    // #3914 (review fix): command detection above runs regardless of Hangul. The
+    // Hangul check below only disambiguates the boundary case "starts with a real
+    // command token but is actually Korean prose". A sentence that merely
+    // MENTIONS a command — e.g. "git status 명령을 실행했어요" — has standalone
+    // Hangul *words* among its operands and must be spoken, not dropped. A
+    // genuine command with a Hangul *path* operand (e.g. "git add 한글.md") has no
+    // such prose word and is still stripped. The earlier blanket
+    // `contains_hangul -> not a command` short-circuit over-corrected by letting
+    // every Hangul-argument command survive.
+    !parts.any(is_prose_hangul_token)
+}
+
+/// #3914: a whitespace-separated token that reads like a Korean prose word
+/// rather than a command operand. Flags (`-x`), paths (`src/한글`), and Hangul
+/// filenames with an extension (`한글.md`) are operands, not prose; a standalone
+/// Hangul word — even with trailing sentence punctuation like `완료.` — is prose.
+fn is_prose_hangul_token(token: &str) -> bool {
+    if !contains_hangul(token) {
+        return false;
+    }
+    if token.starts_with('-') || token.contains(['/', '\\']) {
+        return false;
+    }
+    !has_file_extension(token)
+}
+
+/// True when `token` ends in a `.<ascii-ext>` file extension (e.g. `한글.md`),
+/// as opposed to a bare trailing sentence period (`완료.`) which is not one.
+fn has_file_extension(token: &str) -> bool {
+    match token.rsplit_once('.') {
+        Some((stem, ext)) => {
+            !stem.is_empty() && !ext.is_empty() && ext.chars().all(|ch| ch.is_ascii_alphanumeric())
+        }
+        None => false,
+    }
+}
+
+/// #3914: true when `text` contains any Hangul syllable or jamo — used to
+/// distinguish Korean prose from a bare shell command line.
+fn contains_hangul(text: &str) -> bool {
+    text.chars().any(|ch| {
+        matches!(ch,
+            '\u{AC00}'..='\u{D7A3}'   // Hangul syllables
+            | '\u{1100}'..='\u{11FF}' // Hangul jamo
+            | '\u{3130}'..='\u{318F}' // Hangul compatibility jamo
+        )
+    })
 }
 
 fn strip_markdown_noise(line: &str) -> String {
@@ -290,6 +341,46 @@ mod tests {
             spoken,
             "cargo 는 러스트 빌드 도구입니다. git 이 익숙하면 작업이 빨라져요."
         );
+    }
+
+    /// #3914: a Korean sentence that embeds a real command token (where the
+    /// first two words happen to be `git status` / `cargo test`) must be spoken,
+    /// not dropped as a bare command line. Pure bare command lines are still cut.
+    #[test]
+    fn keeps_korean_prose_that_embeds_a_command_token() {
+        let spoken = spoken_result_only(
+            "git status 명령을 실행했어요.\ncargo test 를 돌려서 확인했습니다.\ngit status",
+            "ko",
+        );
+
+        assert_eq!(
+            spoken,
+            "git status 명령을 실행했어요. cargo test 를 돌려서 확인했습니다."
+        );
+    }
+
+    /// #3914 (review fix): the Hangul guard must NOT blanket-disable command
+    /// detection. A genuine bare command whose operand is a Hangul *path*
+    /// (filename with an extension) is still stripped; only the surrounding prose
+    /// survives. Regression pin for the over-correction.
+    #[test]
+    fn bare_command_with_hangul_path_arg_is_still_stripped() {
+        let spoken = spoken_result_only(
+            "작업을 마쳤어요.\ngit add 한글.md\ncargo build 산출물.log\n끝났습니다.",
+            "ko",
+        );
+
+        assert_eq!(spoken, "작업을 마쳤어요. 끝났습니다.");
+    }
+
+    /// #3914: pure Korean prose (no leading command token) is preserved — the
+    /// original item-10 intent. Mentioning a filename mid-sentence does not make
+    /// it a command line.
+    #[test]
+    fn pure_korean_prose_without_command_token_is_preserved() {
+        let spoken = spoken_result_only("오늘 결과가 좋네요. 한글.md 파일도 확인했어요.", "ko");
+
+        assert_eq!(spoken, "오늘 결과가 좋네요. 한글.md 파일도 확인했어요.");
     }
 
     #[test]

--- a/src/voice/stt.rs
+++ b/src/voice/stt.rs
@@ -13,6 +13,7 @@ use tracing::{debug, warn};
 
 use super::VoiceConfig;
 use super::config::VoiceSttMode;
+use super::metrics::{SttOutcome, record_stt_outcome};
 use super::stt_streaming::{
     StreamingDecodeWindow, StreamingDecodeWindowMeta, StreamingOverlapConfig,
     WHISPER_STREAM_SAMPLE_RATE_HZ, WhisperStreamOverlapSegmenter,
@@ -65,12 +66,17 @@ impl SttConfig {
             temp_dir: expand_tilde(&config.audio.temp_dir),
             timeout: STT_TIMEOUT,
             speech_start_db: config.thresholds.speech_start_db,
+            // #3914: normalize the live config so a `length_ms < keep_ms` /
+            // `keep_ms > step_ms` misconfiguration cannot reach the segmenter
+            // inverted. `step_ms = 0` still survives here but is rejected with a
+            // clear error by `WhisperStreamOverlapSegmenter::new` (`validate`).
             stream_overlap: StreamingOverlapConfig {
                 sample_rate_hz: WHISPER_STREAM_SAMPLE_RATE_HZ,
                 step_ms: config.stt.stream.step_ms,
                 length_ms: config.stt.stream.length_ms,
                 keep_ms: config.stt.stream.keep_ms,
-            },
+            }
+            .normalized(),
         }
     }
 }
@@ -168,6 +174,7 @@ impl SttRuntime {
                 path = %wav_path.display(),
                 "voice STT skipped low-volume utterance"
             );
+            record_stt_outcome(SttOutcome::LowVolumeSkipped);
             return Ok(String::new());
         }
 
@@ -214,9 +221,17 @@ impl SttRuntime {
             output_path: None,
             transcript_path: None,
         };
-        let output = (self.runner)(invocation)
-            .await
-            .with_context(|| format!("run ffmpeg volumedetect for {}", wav_path.display()))?;
+        // #3914: a `volumedetect` process failure must NOT abort the whole
+        // transcription (whisper never runs → the utterance is lost). Parse-
+        // misses were already graceful; treat a process failure the same way.
+        let output = match (self.runner)(invocation).await {
+            Ok(output) => output,
+            Err(error) => {
+                warn!(path = %wav_path.display(), %error, "ffmpeg volumedetect failed; continuing with STT (#3914)");
+                record_stt_outcome(SttOutcome::VolumeDetectFailed);
+                return Ok(false);
+            }
+        };
         let stderr = String::from_utf8_lossy(&output.stderr);
         let Some(levels) = parse_volume_levels(&stderr) else {
             warn!(
@@ -278,10 +293,15 @@ impl SttRuntime {
             let raw = read_whisper_text(transcript_path, &output).await?;
             let cleaned = clean_transcript(&raw);
             if !cleaned.is_empty() {
+                record_stt_outcome(SttOutcome::Transcribed);
                 return Ok(cleaned);
             }
         }
 
+        // #3914: an empty cleaned transcript after the retry used to return
+        // `Ok("")` with no log at all, hiding sustained whisper-empty regressions.
+        warn!("voice STT produced an empty transcript after retry (#3914)");
+        record_stt_outcome(SttOutcome::EmptyAfterRetry);
         Ok(String::new())
     }
 
@@ -1192,6 +1212,97 @@ mod tests {
         assert!(whisper.args.iter().any(|arg| arg == "-otxt"));
         assert!(whisper.args.iter().any(|arg| arg == "-sns"));
         assert!(whisper.args.iter().any(|arg| arg == "-nf"));
+    }
+
+    /// #3914 (item 3): a `volumedetect` process failure must not abort the
+    /// whole transcription — whisper still runs and the utterance is preserved.
+    /// The failure is counted via the `VolumeDetectFailed` outcome.
+    #[tokio::test]
+    async fn volumedetect_process_failure_does_not_abort_transcription() {
+        let temp = tempfile::tempdir().unwrap();
+        let before = crate::voice::metrics::stt_outcome_count(
+            crate::voice::metrics::SttOutcome::VolumeDetectFailed,
+        );
+        let runner: SttCommandRunner = Arc::new(move |invocation| {
+            Box::pin(async move {
+                match invocation.kind {
+                    SttCommandKind::VolumeDetect => {
+                        anyhow::bail!("mock ffmpeg volumedetect crash")
+                    }
+                    SttCommandKind::Convert => {
+                        fs::write(invocation.output_path.as_ref().unwrap(), b"wav").await?;
+                        Ok(SttCommandOutput::default())
+                    }
+                    SttCommandKind::Whisper => {
+                        fs::write(
+                            invocation.transcript_path.as_ref().unwrap(),
+                            "이 내용도 반영해줘",
+                        )
+                        .await?;
+                        Ok(SttCommandOutput::default())
+                    }
+                }
+            })
+        });
+        let runtime = SttRuntime::with_runner(test_config(temp.path().to_path_buf()), runner);
+
+        let transcript = runtime
+            .transcribe(temp.path().join("speech.wav"))
+            .await
+            .unwrap();
+
+        assert_eq!(transcript, "이 내용도 반영해줘");
+        assert!(
+            crate::voice::metrics::stt_outcome_count(
+                crate::voice::metrics::SttOutcome::VolumeDetectFailed
+            ) > before,
+            "a volumedetect failure must be observable via the outcome counter"
+        );
+    }
+
+    /// #3914 (item 2): an empty cleaned transcript after the retry must be
+    /// observable rather than silently returned as `Ok(\"\")`.
+    #[tokio::test]
+    async fn empty_transcript_after_retry_is_counted() {
+        let temp = tempfile::tempdir().unwrap();
+        let before = crate::voice::metrics::stt_outcome_count(
+            crate::voice::metrics::SttOutcome::EmptyAfterRetry,
+        );
+        let runner: SttCommandRunner = Arc::new(move |invocation| {
+            Box::pin(async move {
+                match invocation.kind {
+                    SttCommandKind::VolumeDetect => Ok(SttCommandOutput {
+                        stderr: b"mean_volume: -22.0 dB\nmax_volume: -4.0 dB".to_vec(),
+                        stdout: Vec::new(),
+                    }),
+                    SttCommandKind::Convert => {
+                        fs::write(invocation.output_path.as_ref().unwrap(), b"wav").await?;
+                        Ok(SttCommandOutput::default())
+                    }
+                    SttCommandKind::Whisper => {
+                        // A hallucination phrase that `clean_transcript` strips to
+                        // empty on every attempt.
+                        fs::write(invocation.transcript_path.as_ref().unwrap(), "구독 좋아요")
+                            .await?;
+                        Ok(SttCommandOutput::default())
+                    }
+                }
+            })
+        });
+        let runtime = SttRuntime::with_runner(test_config(temp.path().to_path_buf()), runner);
+
+        let transcript = runtime
+            .transcribe(temp.path().join("speech.wav"))
+            .await
+            .unwrap();
+
+        assert_eq!(transcript, "");
+        assert!(
+            crate::voice::metrics::stt_outcome_count(
+                crate::voice::metrics::SttOutcome::EmptyAfterRetry
+            ) > before,
+            "an empty-after-retry result must be observable via the outcome counter"
+        );
     }
 
     #[tokio::test]

--- a/src/voice/stt_streaming.rs
+++ b/src/voice/stt_streaming.rs
@@ -211,6 +211,48 @@ mod tests {
         assert_eq!(config.context_reset_interval(), 1);
     }
 
+    /// #3914: range validation must reject the unrecoverable cases (zero step /
+    /// zero sample rate) and normalize the recoverable inversion
+    /// (`length_ms < keep_ms`) so the segmenter can never run with `keep > step`
+    /// or `length < step`.
+    #[test]
+    fn streaming_overlap_config_validation_guards_out_of_range_windows() {
+        assert!(
+            StreamingOverlapConfig {
+                sample_rate_hz: 16_000,
+                step_ms: 0,
+                length_ms: 100,
+                keep_ms: 10,
+            }
+            .validate()
+            .is_err(),
+            "step_ms = 0 must be rejected (would otherwise spin the feed loop)"
+        );
+        assert!(
+            StreamingOverlapConfig {
+                sample_rate_hz: 0,
+                step_ms: 10,
+                length_ms: 100,
+                keep_ms: 10,
+            }
+            .validate()
+            .is_err(),
+            "sample_rate_hz = 0 must be rejected"
+        );
+
+        // length_ms < keep_ms is normalized, never inverted: keep <= step <= length.
+        let normalized = StreamingOverlapConfig {
+            sample_rate_hz: 16_000,
+            step_ms: 50,
+            length_ms: 10,
+            keep_ms: 999,
+        }
+        .validate()
+        .unwrap();
+        assert!(normalized.keep_ms <= normalized.step_ms);
+        assert!(normalized.step_ms <= normalized.length_ms);
+    }
+
     #[test]
     fn streaming_overlap_segmenter_emits_step_windows_with_keep_resets() {
         let mut segmenter = WhisperStreamOverlapSegmenter::new(StreamingOverlapConfig {


### PR DESCRIPTION
Closes #3914 (partial — see deferrals below). Low-risk, isolated voice-subsystem cleanups built on top of #3908 (no #3908 logic regressed/re-touched). **Only voice files + required agent-maintenance/generated docs touched** — no concurrent-track or #3016 hotfile.

## Per-item status (11 items from the issue)

| # | Item | Status | Site | What |
|---|------|--------|------|------|
| 1 | disconnect → ssrc_users leak | **DONE** | `voice/receiver.rs`, `discord/commands/voice.rs` | Subscribe to songbird `ClientDisconnect`; drop the leaver's SSRC→user mappings (scoped per control-channel) so `ssrc_users` stops growing under channel churn |
| 2 | STT empty/skip/fail unobserved | **DONE** | `voice/stt.rs`, `voice/metrics.rs` | New `SttOutcome` counters + `voice_stt_outcome` events for skip/empty/fail/transcribed; empty-after-retry now also logs (was silent) |
| 3 | volumedetect failure aborts transcription | **DONE** | `voice/stt.rs` | A `volumedetect` process failure now warns + counts + continues to STT (same graceful path as a parse-miss) instead of aborting the utterance |
| 4 | live-cut log always `playback_owner=None` | **DONE** | `voice_barge_in/live_cut_playback.rs`, `.../receive_hook.rs` | `observe_live_pcm_i16` returns the cut session's owner (snapshotted before the entry is removed); caller no longer reads it post-cut (always None) |
| 5 | `voice_turn_link` active/cancelled leak | **DEFERRED** | `voice/turn_link.rs` | GC change to PG deletion semantics + wiring lives in `src/server/maintenance.rs` (outside the voice blast radius); the code explicitly preserves active/cancelled rows for 24h+ background turns / late reconciliation, so a safe orphan-TTL needs its own design. Tracked for a follow-up |
| 6 | cancel-tombstone no prune + poisoned lock swallowed | **DONE** | `voice/cancel_tombstone.rs` | Lock poison now recovers-in-place + warns (was a silent no-op that disabled re-fire protection); lookups also prune expired entries (eviction no longer write-only) |
| 7 | foreground `timeout_ms` no floor + 250ms slack ×3 | **DONE** | `voice_barge_in/routing.rs`, `voice_barge_in.rs`, `voice/config.rs` | Clamp tiny `timeout_ms` up to `MIN_FOREGROUND_TIMEOUT_MS` (500) so a typo can't degrade every utterance to Silence; extracted the triplicated 250ms slack into `FOREGROUND_MODEL_TIMEOUT_SLACK` |
| 8 | `REQUIRE_WAKE_WORD=1` + empty `wake_words` mutes all | **DONE** | `voice/config.rs`, `voice/commands.rs` | Fail-open: `wake_word_required()` and `wake_word_decision()` return not-required when no usable wake word exists, even under the env override |
| 9 | `stt.stream.*` range validation | **DONE** | `voice/stt.rs`, `voice/stt_streaming.rs` | Live config now `.normalized()` (keep≤step≤length can't reach the segmenter inverted); regression test locks `validate()` rejecting `step_ms=0`/`sample_rate_hz=0`. (Core `StreamingOverlapConfig::validate` already existed at segmenter construction; this surfaces + locks it) |
| 10 | sanitizer drops Korean prose with command tokens | **DONE** | `voice/sanitizer.rs` | `is_bare_command_line` now returns false when the line contains Hangul, so "git status 명령을 실행했어요" is spoken, not dropped; pure bare command lines are still cut |
| 11 | (informational) edge-tts timeout hardcoded; TTS metrics absent; state process-local | **PARTIAL** | `docs/agent-maintenance/multinode-transition.md` | Multinode worker-local classification documented (Audited-touches note covering receiver SSRC map / STT counters / cancel-tombstone / edge-tts). **DEFERRED**: making the edge-tts timeout configurable + promoting TTS synth-fail/cache hit-miss to metrics (informational, surface-expanding; cache status already tracked via `ProgressTtsCacheStatus`) |

## Tests added
- `receiver.rs`: `client_disconnect_drops_only_the_leavers_ssrc_mapping`, `client_disconnect_is_scoped_to_control_channel`
- `stt.rs`: `volumedetect_process_failure_does_not_abort_transcription`, `empty_transcript_after_retry_is_counted`
- `voice_barge_in.rs`: `live_pcm_observation_reports_owner_of_cut_playback` (+ updated `live_pcm_observation_stops_registered_player_and_cancels_token`)
- `cancel_tombstone.rs`: `lookup_prunes_expired_entries`, `recovers_from_a_poisoned_lock`
- `routing.rs`: `foreground_timeout_{zero_falls_back_to_default,below_minimum_is_clamped_up,above_minimum_is_preserved}`
- `config.rs`: `wake_word_not_required_when_no_usable_wake_words`
- `commands.rs`: `wake_word_decision_fails_open_without_usable_wake_words`
- `sanitizer.rs`: `keeps_korean_prose_that_embeds_a_command_token`
- `stt_streaming.rs`: `streaming_overlap_config_validation_guards_out_of_range_windows`

## CI gates (self-passed)
- `cargo fmt --check`: clean
- `cargo check --lib`: clean (only pre-existing warnings in non-voice files)
- `cargo test --lib voice`: **329 passed, 0 failed** (one pre-existing env-only failure — `#3293` runtime-store guard tripping on `AGENTDESK_ROOT_DIR` pointed at the live release dir — passes with a tempdir root; unrelated to this diff)
- agent-maintenance freshness: **passed** (synced `voice_barge_in.rs` 2893→2899 and `receiver.rs` 1052→1108 freeze counts; regenerated inventory; stt.rs kept under the 1000-line giant threshold by importing the metrics fns)
- `audit_maintainability.py --check`: exit 0
- `check_hotfile_ratchet.py`: exit 0 (no #3016 hotfile touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)