### PR TITLE
ci(macos): cap self-hosted runner CPU to spare co-located Postgres (#3658, Option B)

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -158,6 +158,19 @@ jobs:
     # at 45 min — comfortably above observed cold-sccache build+test durations
     # while still freeing the host for the live control plane on a stall.
     timeout-minutes: 45
+    # CPU headroom for the co-located operational Postgres (see #3658). This
+    # self-hosted runner shares the Mac mini (M4 Pro, 12-14 cores) with the
+    # production Postgres + a dcserver worker node, so an unbounded parallel
+    # cargo build saturated every core and starved Postgres → cluster-wide pool
+    # acquire timeouts. Cap cargo's parallel build units at 8 to leave >=4 cores
+    # for Postgres + the control plane. This only bounds peak CPU; it cannot
+    # break the build, only slow it slightly on a cold cache. The heavy cargo
+    # steps below are additionally wrapped in `nice -n 10` so Postgres (default
+    # nice 0, or raised per the #3658 host step) always preempts CI under
+    # contention. Zero-cost mitigation (Option B); does not change any required
+    # check or correctness gate.
+    env:
+      CARGO_BUILD_JOBS: "8"
     steps:
       - name: Trusted event / runner sanity check
         shell: bash
@@ -231,22 +244,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-trusted-macos-
 
+      # `nice -n 10` (lower scheduling priority) on the CPU-heavy cargo steps so
+      # the co-located production Postgres preempts CI under contention (#3658,
+      # Option B). `nice` only de-prioritizes; it cannot fail the build.
       - name: cargo check
-        run: cargo check --all-targets
+        run: nice -n 10 cargo check --all-targets
 
       - name: cargo test (non-PG, targeted subset)
         shell: bash
         run: |
           set -euo pipefail
-          cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
-          cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
-          cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
-          cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
-          cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
+          nice -n 10 cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
       - name: Fresh user portable smoke
         shell: bash
-        run: bash scripts/ci-macos-fresh-user-smoke.sh
+        run: nice -n 10 bash scripts/ci-macos-fresh-user-smoke.sh
 
       - name: sccache stats
         if: always()


### PR DESCRIPTION
Closes #3658 (part) — implements **Option B (zero-cost mitigation)** from the proposal comment.

## Problem
The operational Postgres lives on the **Mac mini** (M4 Pro), which *also* hosts a dcserver worker node **and** the self-hosted macOS CI runner (`agentdesk-mac-mini`, the "Trusted macOS check (self-hosted)" job). Heavy CI builds saturate every core → Postgres response latency → cluster-wide pool `acquire` timeouts (both nodes depend on the same DB over the SSH reverse tunnel).

## Part (a) — CI runner CPU cap (this PR)
Two complementary, build-safe levers on the **self-hosted macOS job only** (`.github/workflows/ci-macos-trusted.yml`):

| Lever | Value | Where | Rationale |
|---|---|---|---|
| `CARGO_BUILD_JOBS` | `8` | job-level `env` (line ~171) | Caps cargo's parallel build units. On a 12–14 core M4 Pro this leaves **≥4 cores** for Postgres + the control plane. Conservative end (guarantees headroom even on the 12-core 8P+4E base SKU). |
| `nice -n 10` | wraps `cargo check`, the non-PG `cargo test` subset, and the fresh-user smoke (lines ~251, ~257–261, ~265) | Lowers CI scheduling priority so Postgres (default nice 0, or raised per part (b)) **preempts** CI under contention. |

Both levers only **bound / de-prioritize** CPU — neither can fail or break the build, only slow it slightly on a cold sccache. The existing 45-min `timeout-minutes`, workflow-level `concurrency` group, and sccache config are untouched.

**Not changed:** the GitHub-hosted macOS job, the ubuntu/hosted correctness workflows, which checks are required, and any Rust/docs/freeze-doc artifact. `git diff --stat`: a single file, +23/−7. `scripts/check-ci-runner-hardening.sh` still passes; YAML still parses.

> Note on concurrency=1: the single registered self-hosted runner already serializes execution at the host level (one job at a time), so a cross-ref `cancel-in-progress` group was intentionally **not** added — it would cancel other branches' legitimate CI for no extra host benefit.

## Part (b) — Raise Postgres scheduling priority (MANUAL host step — run on mac-mini)
The operational Postgres is **Homebrew `postgresql@17`, host-managed** — it is *not* started by any repo plist/script (the only repo-managed launchd job is the dcserver `com.agentdesk.release`). So per the task guidance I did **not** SSH or guess. Apply this **on the mac-mini host**:

**Immediate (raise priority of the running cluster):**
```bash
# Raise the postmaster + all live backends above default priority (needs root for a negative nice)
sudo renice -n -5 -p 2394
# verify
ps -Ao pid,ni,comm | grep -i postgres
```

**Persistent (survives restart):** add a `Nice` key to the Homebrew launchd job. A **negative** nice requires the job to run in the **system/root** domain, so install the service as root:
```bash
sudo brew services stop  postgresql@17
sudo /usr/libexec/PlistBuddy -c "Add :Nice integer -5" \
  /opt/homebrew/opt/postgresql@17/homebrew.mxcl.postgresql@17.plist 2>/dev/null \
  || sudo /usr/libexec/PlistBuddy -c "Set :Nice -5" \
       /opt/homebrew/opt/postgresql@17/homebrew.mxcl.postgresql@17.plist
sudo brew services start postgresql@17
# verify the running postmaster picked up the nice
ps -Ao pid,ni,comm | grep -i postgres
```
(If the plist path differs, resolve it with `brew services info postgresql@17`.) With CI now niced to +10 and Postgres at −5, Postgres preempts CI **and** any other default-priority compute on the host under contention.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-macos-trusted.yml'))"` → OK
- `bash scripts/check-ci-runner-hardening.sh` → exit 0
- Diff touches only `.github/workflows/ci-macos-trusted.yml` (no Rust, no module-inventory / freeze-doc impact, no required-check change).

Head SHA: `0ea67f0feefb49efe139c34e87826a94ec50677d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
