### PR TITLE
fix(discord): reap idle-but-live-pane watcher rebind-origin past deadline (#3879)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -464,12 +464,12 @@
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
 | `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
-| `services::discord::inflight` | `src/services/discord/inflight.rs` | 8105 | 3069 | 5036 | giant-file |
+| `services::discord::inflight` | `src/services/discord/inflight.rs` | 8172 | 3069 | 5103 | giant-file |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 549 | 188 | 361 |  |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
 | `services::discord::inflight::finalizer_identity` | `src/services/discord/inflight/finalizer_identity.rs` | 56 | 56 | 0 |  |
 | `services::discord::inflight::model` | `src/services/discord/inflight/model.rs` | 1033 | 788 | 245 |  |
-| `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 189 | 189 | 0 |  |
+| `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 226 | 226 | 0 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 62 | 62 | 0 |  |
 | `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 353 | 353 | 0 |  |
 | `services::discord::inflight_heartbeat_sweeper` | `src/services/discord/inflight_heartbeat_sweeper.rs` | 299 | 264 | 35 |  |

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -34,13 +34,13 @@ pub(crate) use store::lock_inflight_state_path;
 // sibling module so this hot state parent stays below the frozen production-LoC
 // baseline without changing call-site names.
 mod rebind_reap;
-#[cfg(test)]
-use self::rebind_reap::should_reap_dead_watcher_rebind_origin;
 use self::rebind_reap::{
     RuntimeWatcherLiveness, WatcherLiveness, dead_watcher_rebind_structurally_reapable,
     inflight_json_path_for_lock, is_inflight_json_lock_path, metadata_mtime_unix_secs,
     rebind_origin_age_secs, watcher_runtime_activity_recent,
 };
+#[cfg(test)]
+use self::rebind_reap::{proven_dead_from_signals, should_reap_dead_watcher_rebind_origin};
 
 mod watcher_state;
 pub(in crate::services::discord) use self::watcher_state::{
@@ -6925,11 +6925,12 @@ mod rebind_origin_reap_tests {
         DEAD_WATCHER_PROVEN_DEAD_SECS, InflightTurnState, REBIND_ORIGIN_DEADLINE_SECS_DEFAULT,
         RebindReapOutcome, RelayOwnerKind, TurnSource, WatcherLiveness,
         invalidate_stale_generation_in_root, load_inflight_states_from_root,
-        reap_abandoned_rebind_origin_locked_in_root,
+        proven_dead_from_signals, reap_abandoned_rebind_origin_locked_in_root,
         reap_dead_watcher_rebind_origin_locked_in_root, save_inflight_state_in_root,
         should_reap_abandoned_rebind_origin, should_reap_dead_watcher_rebind_origin,
     };
     use crate::services::discord::InflightRestartMode;
+    use crate::services::platform::tmux::PaneLiveness;
     use crate::services::provider::ProviderKind;
     use tempfile::TempDir;
 
@@ -7387,6 +7388,72 @@ mod rebind_origin_reap_tests {
             CURRENT_GEN,
             &DEAD
         ));
+    }
+
+    #[test]
+    fn idle_live_pane_rebind_reaped_at_deadline_3879() {
+        // (a) #3879 REGRESSION GUARD — proven-dead/idle-stuck reaped at deadline.
+        //
+        // The live evidence: a watcher with a LIVE tmux pane (an idle TUI sitting
+        // at `❯`) but NO recent runtime activity never adopted its empty
+        // rebind-origin and was never reaped, leaving the placeholder LIVE for 64
+        // min (32× the 120s deadline) and ABORTing every new TUI-direct turn.
+        // The fixed `is_proven_dead` core now classifies `(Live, !activity)` as
+        // proven dead, so the (correct) structural+deadline predicate finally
+        // fires — but ONLY past the deadline (the re-adopt window stays open until
+        // then).
+        let proven_dead =
+            proven_dead_from_signals(PaneLiveness::Live, /* activity_recent */ false);
+        assert!(
+            proven_dead,
+            "#3879: an idle live-pane watcher (no recent activity) must be proven dead"
+        );
+        let oracle = StubLiveness { proven_dead };
+        let state = watcher_owned_rebind(7201, 4096, CURRENT_GEN);
+        assert!(
+            should_reap_dead_watcher_rebind_origin(&state, PAST_DEADLINE, CURRENT_GEN, &oracle),
+            "#3879: idle live-pane rebind-origin is reaped once past the deadline"
+        );
+        assert!(
+            !should_reap_dead_watcher_rebind_origin(&state, WITHIN_DEADLINE, CURRENT_GEN, &oracle),
+            "within the deadline the re-adopt window is still open — never reaped early"
+        );
+    }
+
+    #[test]
+    fn active_or_unknown_watcher_rebind_not_reaped_readopt_preserved_3879() {
+        // (b) #3879 REGRESSION GUARD — re-adopt path preserved (#897/#3635).
+        //
+        // A watcher producing RECENT runtime activity (jsonl/.generation/rollout
+        // writes) is genuinely working / re-adoptable and is NEVER proven dead,
+        // so its rebind-origin survives even past the deadline — distinguishing
+        // "temporarily quiet but re-adoptable" from "idle-stuck/dead".
+        assert!(
+            !proven_dead_from_signals(PaneLiveness::Live, /* activity_recent */ true),
+            "live pane WITH recent activity = working/re-adoptable ⇒ preserved"
+        );
+        // A just-restarting watcher touches `.generation` before its pane
+        // re-appears: DeadOrAbsent + recent activity must still preserve.
+        assert!(
+            !proven_dead_from_signals(PaneLiveness::DeadOrAbsent, /* activity_recent */ true),
+            "restarting watcher (recent activity, pane not yet up) ⇒ preserved"
+        );
+        // An UNKNOWN probe (transient tmux hiccup) preserves regardless of activity.
+        assert!(!proven_dead_from_signals(PaneLiveness::ProbeError, false));
+        assert!(!proven_dead_from_signals(PaneLiveness::ProbeError, true));
+
+        // End-to-end: the active-watcher verdict preserves the row past deadline.
+        let oracle = StubLiveness {
+            proven_dead: proven_dead_from_signals(
+                PaneLiveness::Live,
+                /* activity_recent */ true,
+            ),
+        };
+        let state = watcher_owned_rebind(7202, 4096, CURRENT_GEN);
+        assert!(
+            !should_reap_dead_watcher_rebind_origin(&state, PAST_DEADLINE, CURRENT_GEN, &oracle),
+            "active/re-adoptable watcher is NOT reaped — #897/#3635 re-adopt preserved"
+        );
     }
 
     #[test]

--- a/src/services/discord/inflight/rebind_reap.rs
+++ b/src/services/discord/inflight/rebind_reap.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::services::platform::tmux::PaneLiveness;
 
 /// #3635: runtime-liveness oracle for the dead-watcher rebind-origin reap path.
 ///
@@ -15,11 +16,20 @@ use super::*;
 /// never evaluated against a naive oracle that would mis-judge their synthetic
 /// session as dead).
 pub(super) trait WatcherLiveness {
-    /// True only when the watcher owning `state` is *provably* dead: its tmux
-    /// session has no live pane AND no runtime activity (jsonl/.generation
-    /// mtime) has advanced within [`DEAD_WATCHER_PROVEN_DEAD_SECS`]. Any
-    /// positive signal (or an unknown session name) yields `false` — the
-    /// conservative, live-protecting default.
+    /// True only when the watcher owning `state` is *provably* dead **or idle-
+    /// stuck**: no runtime activity (jsonl / `.generation` / rollout mtime) has
+    /// advanced within [`DEAD_WATCHER_PROVEN_DEAD_SECS`].
+    ///
+    /// #3879: a live tmux pane is NO LONGER an unconditional `false`. An idle
+    /// TUI watcher keeps its pane up indefinitely while never adopting its empty
+    /// rebind-origin placeholder; treating "pane up" as "alive forever" left the
+    /// placeholder LIVE past its deadline (observed 64 min, 32× the deadline),
+    /// wedging every new turn. The binding death/idle signal is therefore
+    /// runtime-activity quiescence, applied whether the pane reads `Live` or
+    /// `DeadOrAbsent`. A watcher producing *recent* activity (genuinely working /
+    /// re-adoptable, #897/#3635) still yields `false`, as does an unknown probe
+    /// (`ProbeError`) or a missing session name — the conservative, re-adopt-
+    /// protecting defaults.
     fn is_proven_dead(&self, state: &InflightTurnState) -> bool;
 }
 
@@ -31,7 +41,6 @@ pub(super) struct RuntimeWatcherLiveness;
 
 impl WatcherLiveness for RuntimeWatcherLiveness {
     fn is_proven_dead(&self, state: &InflightTurnState) -> bool {
-        use crate::services::platform::tmux::PaneLiveness;
         // No session name to probe => cannot prove death => never reap.
         let Some(session) = state.tmux_session_name.as_deref() else {
             return false;
@@ -42,19 +51,43 @@ impl WatcherLiveness for RuntimeWatcherLiveness {
         }
         // #3635 (codex review): use the THREE-state pane probe. A transient tmux
         // probe failure (`ProbeError`) is "unknown", NOT "dead" — it must never
-        // license reaping a live-but-idle watcher. Only a *definitive* dead/absent
-        // answer is even a candidate for reap; any live signal or unknown answer
-        // preserves the row (the #3154/#3540 live-protection invariant at its
-        // weakest point).
-        match crate::services::tmux_diagnostics::tmux_session_pane_liveness(session) {
-            PaneLiveness::Live => return false,       // hard "alive" signal
-            PaneLiveness::ProbeError => return false, // unknown ⇒ preserve
-            PaneLiveness::DeadOrAbsent => {}          // candidate — confirm via activity
+        // license reaping a row whose owner might still be alive, so we preserve
+        // before even touching the activity stat.
+        let pane = crate::services::tmux_diagnostics::tmux_session_pane_liveness(session);
+        if pane == PaneLiveness::ProbeError {
+            return false; // unknown ⇒ preserve
         }
-        // No live pane, definitively. Fresh runtime activity (jsonl / .generation
-        // mtime) within the window is still "alive" — a just-restarting watcher.
-        // Only a dead/absent session AND no recent activity is provably dead.
-        !watcher_runtime_activity_recent(session)
+        // #3879: a `Live` pane no longer short-circuits to "alive". An idle TUI
+        // keeps its pane up while never adopting the empty rebind-origin, so the
+        // pane state alone cannot tell "working" from "idle-stuck". The binding
+        // signal is runtime-activity quiescence: fresh jsonl / `.generation` /
+        // rollout writes (a just-restarting or actively-producing watcher, the
+        // #897/#3635 re-adoptable case) preserve the row; no write within the
+        // window is proven dead/idle and reapable, whatever the pane reads.
+        proven_dead_from_signals(pane, watcher_runtime_activity_recent(session))
+    }
+}
+
+/// #3879: pure proven-dead/idle-stuck decision from the two probed signals,
+/// extracted so unit tests can pin every `(pane, activity)` combination without
+/// spawning tmux or touching jsonl/`.generation` files.
+///
+/// Returns `true` (reapable) only on runtime-activity quiescence. A live tmux
+/// pane ALONE no longer preserves the row (#3879: an idle TUI pane that never
+/// adopts its empty rebind-origin past the deadline wedged the relay for 64
+/// min). Only a genuine *working* signal — recent jsonl / `.generation` /
+/// rollout write (`activity_recent == true`, the #897/#3635 re-adoptable case) —
+/// or an UNKNOWN probe (`ProbeError`) preserves it. `DeadOrAbsent` with recent
+/// activity is still preserved: a just-restarting watcher touches `.generation`
+/// before its pane re-appears.
+pub(super) fn proven_dead_from_signals(pane: PaneLiveness, activity_recent: bool) -> bool {
+    match pane {
+        // Unknown ⇒ preserve (the production caller short-circuits this before the
+        // activity stat; handled here too so the core is total and testable).
+        PaneLiveness::ProbeError => false,
+        // Live OR DeadOrAbsent: runtime-activity quiescence is the death/idle
+        // signal. Recent activity ⇒ working / re-adoptable ⇒ preserve.
+        PaneLiveness::Live | PaneLiveness::DeadOrAbsent => !activity_recent,
     }
 }
 
@@ -85,12 +118,16 @@ pub(super) fn watcher_runtime_activity_recent(session: &str) -> bool {
 /// The structural conjunction is byte-identical to
 /// [`should_reap_abandoned_rebind_origin`] EXCEPT the owner conjunct flips from
 /// `== None` to `== Watcher`, and the reap is additionally gated on
-/// `liveness.is_proven_dead(state)`. A live watcher (positive tmux pane or
-/// recent runtime activity) is `is_proven_dead == false`, so this predicate is
-/// `false` and the row is preserved — the #3154/#3540 / keystone live-
-/// protection invariant holds verbatim. Every non-owner live signal (adoption,
-/// streamed bytes, anchor, terminal commit, offset progress, planned restart)
-/// still independently blocks the reap via the shared structural conjunction.
+/// `liveness.is_proven_dead(state)`. A watcher producing recent runtime activity
+/// (jsonl / `.generation` / rollout writes — the #897/#3635 re-adoptable case)
+/// is `is_proven_dead == false`, so this predicate is `false` and the row is
+/// preserved; an unknown tmux probe (`ProbeError`) preserves it too. #3879: a
+/// merely-`Live` tmux pane no longer preserves on its own — an idle watcher with
+/// no recent activity past the deadline IS reaped (see [`is_proven_dead`]).
+/// Every non-owner live signal (adoption, streamed bytes, anchor, terminal
+/// commit, offset progress, planned restart) still independently blocks the reap
+/// via the shared structural conjunction, and the deadline/generation disjunct
+/// keeps the re-adopt window open until the deadline elapses.
 #[cfg(test)]
 pub(super) fn should_reap_dead_watcher_rebind_origin(
     state: &InflightTurnState,


### PR DESCRIPTION
## Problem (#3879)
A Watcher-owned **rebind-origin** placeholder (`relay_owner_kind=Watcher`, `user_msg_id=0`, `rebind_origin_deadline_secs=120`) is only reaped when its owning watcher is **proven dead**. The proven-dead oracle treated a `Live` tmux pane as "alive forever", so a **live but idle** TUI session (pane up, never adopting the empty placeholder, no runtime activity) kept the placeholder **LIVE far past its deadline**.

Live evidence (cookingheart-dev-cc, channel 1475086789696946196): a rebind-origin born at 16:23:35 was still LIVE + blocking at 17:27 — **~64 min, 32× the 120s deadline**. While it lingered, the #3296 turn-start backstop saw it as a live FOREIGN inflight (`foreign_user_msg_id=Some(0)`) and **ABORTed every new TUI-direct turn**, so the channel relay was effectively **down until session restart**.

## Root cause
`RuntimeWatcherLiveness::is_proven_dead` (`src/services/discord/inflight/rebind_reap.rs:50`) short-circuited `PaneLiveness::Live => return false`. An idle TUI keeps its pane up indefinitely, so `is_proven_dead` never returned `true` and the (otherwise correct) structural + past-deadline reap predicate never fired.

## Fix (deadline-enforce direction, non-hotfile)
The binding death/idle signal is **runtime-activity quiescence**, not pane liveness. A `Live` pane no longer preserves on its own: a watcher with no jsonl/`.generation`/rollout write within `DEAD_WATCHER_PROVEN_DEAD_SECS` (600s, kept conservative) is proven dead/idle and reapable whatever the pane reads. A watcher producing **recent activity** (a just-restarting `.generation` write, or an actively-working watcher — the #897/#3635 re-adoptable case) still preserves, as does an unknown probe (`ProbeError`). The decision is extracted into a pure, testable `proven_dead_from_signals(pane, activity_recent)` core; combined with the existing structural past-deadline gate it reaps the empty placeholder once past its deadline.

## Regression guard (`rebind_origin_reap_tests`)
- **(a) reap**: `idle_live_pane_rebind_reaped_at_deadline_3879` — `(Live, !activity)` is proven dead; the rebind-origin is reaped **past** the deadline and **not before** (re-adopt window stays open until the deadline).
- **(b) re-adopt preserved**: `active_or_unknown_watcher_rebind_not_reaped_readopt_preserved_3879` — `(Live|DeadOrAbsent, activity)` and `ProbeError` are **NOT** reaped even past the deadline → #897/#3635 re-adopt path preserved.

## Disjointness
- No #3016 hotfile touched: `turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, `turn_finalizer*` untouched.
- Did **not** take the alternative `tui_direct_pending_start.rs` (#3296 backstop) direction — change confined to `inflight/rebind_reap.rs` (+ regenerated `module-inventory.md` and the two tests in `inflight.rs`).

## Gates
- `cargo fmt --check`: clean
- `env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::inflight`: 171 passed / 0 failed (incl. the 2 new tests); `placeholder_sweeper`: 19 passed
- `generate_inventory_docs --check`: pass; `check_agent_maintenance_docs`: freshness check passed
- `audit_maintainability --check`: exit 0; `check_hotfile_ratchet`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)