### PR TITLE
fix(discord): rescue queued user message preempted by /loop injection (#3903)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -574,7 +574,7 @@
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 251 | 212 | 39 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1687 | 1543 | 144 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 2845 | 2797 | 48 | giant-file |
-| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 544 | 544 | 0 |  |
+| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 619 | 585 | 34 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 264 | 264 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 505 | 505 | 0 |  |
@@ -886,7 +886,7 @@
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |
 | `services::turn_lifecycle` | `src/services/turn_lifecycle.rs` | 564 | 436 | 128 |  |
-| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5484 | 3184 | 2300 | giant-file |
+| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5616 | 3184 | 2432 | giant-file |
 | `services::turn_orchestrator::registry_purge` | `src/services/turn_orchestrator/registry_purge.rs` | 816 | 293 | 523 |  |
 | `supervisor` | `src/supervisor/mod.rs` | 1045 | 916 | 129 |  |
 | `ui` | `src/ui/mod.rs` | 1 | 1 | 0 |  |

--- a/src/services/discord/router/message_handler/intake_turn/race_loss.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss.rs
@@ -91,11 +91,27 @@ pub(super) async fn handle_race_loss_enqueue(
     // turn finished between `mailbox_try_start_turn` and the enqueue
     // above. In that case `mailbox_finish_turn` saw an empty queue and
     // skipped the dequeue chain — schedule a deferred drain so the
-    // intervention we just enqueued does not strand. Cheap no-op when
-    // the active turn is still running. Round-9: this still runs first
-    // so the deferred kickoff fires even if the placeholder POST below
-    // ends up failing.
-    if enqueued && !crate::services::discord::mailbox_has_active_turn(shared, channel_id).await {
+    // intervention we just enqueued does not strand. Round-9: this still
+    // runs first so the deferred kickoff fires even if the placeholder
+    // POST below ends up failing.
+    //
+    // #3903: gate on the BLOCKING (real) active turn, not on *any* active
+    // turn. The previous `mailbox_has_active_turn` skipped this drain
+    // whenever a background SYSTEM-INJECTION turn (e.g. a `/loop`
+    // auto-check) held the slot — but such a turn's finalize does NOT
+    // re-kick the user queue, so a genuine user message re-enqueued here
+    // (it lost the start-turn race to the injection) stranded in the queue
+    // until an external fetch surfaced it (user-message loss → data
+    // integrity). A background turn is non-blocking (#3167), so scheduling
+    // the (idempotent, gated, bounded-retry) drain now lets the drain
+    // supersede the background injection and dispatch the queued user
+    // message as soon as the pane is idle — exactly-once, never doubled
+    // (the dequeue is actor-serialized through `take_next_soft`). When a
+    // REAL turn holds the slot we still skip the drain: that turn's own
+    // finalize owns the dequeue chain (unchanged pre-#3903 behavior).
+    let has_blocking_active_turn =
+        crate::services::discord::mailbox_has_blocking_active_turn(shared, channel_id).await;
+    if should_schedule_post_enqueue_idle_drain(enqueued, has_blocking_active_turn) {
         crate::services::discord::schedule_deferred_idle_queue_kickoff(
             shared.clone(),
             bot_owner_provider.clone(),
@@ -541,4 +557,63 @@ pub(super) async fn handle_race_loss_enqueue(
         channel_id
     );
     return Ok(());
+}
+
+/// #3903 — pure verdict for whether a race-loss enqueue must schedule a
+/// post-enqueue deferred idle-queue drain.
+///
+/// Schedule the drain when the intervention was actually `enqueued` AND no
+/// REAL (blocking) turn currently holds the channel's active-turn slot:
+///
+/// * slot idle → the active turn finished in the race window and skipped the
+///   dequeue chain (the original codex-P1 reason); the drain prevents a strand.
+/// * slot held by a BACKGROUND turn (a `/loop`/system-injection auto-check, or
+///   a self-paced TUI loop) → that turn's finalize does NOT re-kick the user
+///   queue, and a background turn is non-blocking (#3167). Without the drain
+///   the re-enqueued genuine user message stranded until an external fetch
+///   surfaced it (#3903 user-message loss). The drain is idempotent, gated by
+///   the same kickable/TUI-busy checks, and bounded-retry, so it safely
+///   supersedes the background turn and dispatches the queued user message
+///   exactly once once the pane is idle.
+///
+/// When a REAL (`UserOrAgent`) turn holds the slot we DELIBERATELY skip the
+/// drain: that turn owns the dequeue chain through its own finalize, matching
+/// the pre-#3903 behavior — scheduling here would only spin redundantly.
+fn should_schedule_post_enqueue_idle_drain(enqueued: bool, has_blocking_active_turn: bool) -> bool {
+    enqueued && !has_blocking_active_turn
+}
+
+#[cfg(test)]
+mod schedule_post_enqueue_idle_drain_tests {
+    use super::should_schedule_post_enqueue_idle_drain;
+
+    #[test]
+    fn schedules_when_enqueued_and_slot_idle() {
+        // Slot idle (no blocking turn) and the message was enqueued — the
+        // original race-window strand guard must still schedule the drain.
+        assert!(should_schedule_post_enqueue_idle_drain(true, false));
+    }
+
+    #[test]
+    fn schedules_when_enqueued_behind_background_injection() {
+        // #3903 core case: a `/loop`/system-injection turn holds the slot, so
+        // it is NOT a blocking turn. The re-enqueued genuine user message must
+        // still trigger a drain so it is not stranded behind the injection.
+        assert!(should_schedule_post_enqueue_idle_drain(true, false));
+    }
+
+    #[test]
+    fn skips_when_real_turn_holds_slot() {
+        // A real (blocking) turn owns the dequeue chain via its own finalize —
+        // scheduling here would only spin redundantly (pre-#3903 behavior).
+        assert!(!should_schedule_post_enqueue_idle_drain(true, true));
+    }
+
+    #[test]
+    fn skips_when_enqueue_was_refused() {
+        // Dedup/duplicate refusal: nothing landed in the queue, so there is
+        // nothing to drain regardless of the slot state.
+        assert!(!should_schedule_post_enqueue_idle_drain(false, false));
+        assert!(!should_schedule_post_enqueue_idle_drain(false, true));
+    }
 }

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -4578,6 +4578,138 @@ mod active_turn_kind_tests {
         );
         assert!(!handle.has_active_turn().await);
     }
+
+    // #3903 — a genuine user message queued behind a `/loop`/system-injection
+    // turn must NOT be lost. The live incident: a queued user reply lost the
+    // start-turn race to a `/loop` auto-check (a Background turn), so it was
+    // re-enqueued behind the injection. The race-loss drain-scheduling guard
+    // (`race_loss.rs`) keyed on `has_active_turn` (ANY turn) and therefore
+    // skipped scheduling the deferred drain while the Background injection held
+    // the slot — and the injection's own finalize never re-kicks the user
+    // queue, so the message stranded until an external fetch surfaced it.
+    //
+    // This test pins the two invariants the fix relies on:
+    //   1. the scheduling DISCRIMINATOR — a Background injection makes
+    //      `has_active_turn()` true (the old guard skips → bug) but
+    //      `has_blocking_active_turn()` false (the new guard schedules → fix);
+    //   2. the END-TO-END outcome — once the injection turn completes, the
+    //      queued user message is dequeued exactly once (not lost, not doubled).
+    //
+    // #3034: hold the test-env lock across a SYNCHRONOUS `block_on` (not across
+    // an `.await` inside an async fn) so the global `AGENTDESK_ROOT_DIR` stays
+    // stable for the durable-queue persistence WITHOUT an
+    // `#[allow(clippy::await_holding_lock)]` site (matches the `run_async`
+    // pattern in `actor_hydrate_regression_tests`).
+    #[test]
+    fn queued_user_message_survives_loop_injection_preemption() {
+        let _lock = lock_test_env();
+        let _env_guard = EnvGuard;
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let registry = ChannelMailboxRegistry::default();
+                let handle = registry.handle(ChannelId::new(3_903_001));
+
+                // A `/loop` auto-check is injected and claims the slot as a
+                // Background turn (mirrors `synthetic_start.rs`
+                // `try_start_turn_kinded(Background)`).
+                let loop_token = Arc::new(CancelToken::new());
+                assert!(
+                    handle
+                        .try_start_turn_kinded(
+                            loop_token.clone(),
+                            UserId::new(1),
+                            MessageId::new(7_001),
+                            ActiveTurnKind::Background,
+                        )
+                        .await,
+                    "the /loop injection claims the idle slot as a Background turn"
+                );
+
+                // The genuine user reply lost the start-turn race and is queued
+                // behind the injection.
+                let user_msg = test_intervention(7_100);
+                assert!(
+                    handle
+                        .enqueue(user_msg.clone(), test_persistence())
+                        .await
+                        .enqueued,
+                    "the genuine user message is queued behind the injection"
+                );
+
+                // Invariant 1 — the scheduling discriminator. The OLD race-loss
+                // guard (`!has_active_turn`) would be FALSE here and skip the
+                // drain (the #3903 bug); the NEW guard
+                // (`!has_blocking_active_turn`) is TRUE and schedules it.
+                assert!(
+                    handle.has_active_turn().await,
+                    "the Background injection holds the slot for has_active_turn — old guard skipped the drain"
+                );
+                assert!(
+                    !handle.has_blocking_active_turn().await,
+                    "#3903: a Background injection is non-blocking, so the new guard schedules the rescue drain"
+                );
+
+                // The deferred drain supersedes the non-blocking injection
+                // (`#3167` `cancel_active_background_turn_if_current`) and the
+                // injection's finalizer releases the slot.
+                assert!(
+                    handle.cancel_active_background_turn_if_current().await,
+                    "the drain cancels ONLY the Background injection to free the slot for the user"
+                );
+                let finish = handle.finish_turn(test_persistence()).await;
+                assert!(
+                    finish.has_pending,
+                    "the queued user message is still pending after the injection finalizes"
+                );
+                assert!(!handle.has_active_turn().await, "the slot is now free");
+
+                // Invariant 2 — exactly-once delivery. The drain dequeues the
+                // queued user message and the dispatched user turn claims the
+                // slot.
+                let taken = handle.take_next_soft(test_persistence()).await;
+                let dequeued = taken.intervention.expect(
+                    "the queued user message must be dequeued after the injection completes",
+                );
+                assert_eq!(
+                    dequeued.message_id,
+                    MessageId::new(7_100),
+                    "the genuine user message is the one delivered — not lost"
+                );
+                assert_eq!(
+                    taken.queue_len_after, 0,
+                    "no duplicate copy is left in the queue"
+                );
+                assert!(
+                    handle
+                        .try_start_turn(
+                            Arc::new(CancelToken::new()),
+                            UserId::new(2),
+                            MessageId::new(7_100),
+                        )
+                        .await,
+                    "the dispatched user turn claims the slot and clears the dequeue reservation"
+                );
+
+                // Not doubled — after the user turn finishes there is nothing
+                // left to re-deliver.
+                let finish = handle.finish_turn(test_persistence()).await;
+                assert!(
+                    !finish.has_pending,
+                    "the user message was delivered exactly once — the queue is drained"
+                );
+                let drained = handle.take_next_soft(test_persistence()).await;
+                assert!(
+                    drained.intervention.is_none(),
+                    "a second dequeue yields nothing — no double-processing"
+                );
+            });
+    }
 }
 
 // #2728 — verify the refusal_reason field correctly tags each of the


### PR DESCRIPTION
## Bug (#3903, live 2026-06-29)

A queued genuine user reply (`📬 메시지 대기 중`) lost the start-turn race to a `/loop` auto-check (a Background system-injection turn) and was re-enqueued behind it — then **never re-kicked** after the injection turn completed. The user instruction sat unprocessed for ~2.5 min until an unrelated relay-audit happened to fetch the message directly. With the audit loop off, the message would be lost entirely (user-message loss → data integrity).

## Root cause

`intake_turn/race_loss.rs:98` (`handle_race_loss_enqueue`) scheduled the post-enqueue deferred idle-queue drain only when `!mailbox_has_active_turn` — i.e. it **skipped the drain whenever ANY turn (including a background `/loop` injection) held the slot**, assuming that turn's finalize would re-kick the user queue. A background turn's finalize does **not** re-kick the user queue, so the re-enqueued user message stranded in the mailbox queue with no scheduled drain.

## Fix

`intake_turn/race_loss.rs` — gate the deferred drain on `mailbox_has_blocking_active_turn` instead of `mailbox_has_active_turn`. A background (system-injection) turn is **non-blocking** (#3167), so the drain is now scheduled when the slot is idle **or** held by a background injection. The deferred drain is idempotent, kickable/TUI-busy-gated, and bounded-retry, so it supersedes the background injection (`cancel_active_background_turn_if_current`, #3167) and dispatches the queued user message **exactly once** as soon as the pane is idle — actor-serialized through `take_next_soft`, never doubled. A **real** (`UserOrAgent`) turn still skips the drain (its own finalize owns the dequeue chain), so pre-#3903 behavior is unchanged.

`/loop` injections keep firing — cancelling only releases the mailbox slot; the watcher relays the injection's output independently.

The decision is extracted into a pure `should_schedule_post_enqueue_idle_drain(enqueued, has_blocking_active_turn)` predicate for direct unit coverage.

## #3016 hotfile safety

**No #3016 hotfile touched.** Changes are confined to `intake_turn/race_loss.rs` (non-hotfile) and a regression test in `turn_orchestrator.rs` (non-hotfile). `turn_finalizer/cleanup.rs` and the other core hotfiles are untouched — the fix did not require the shared injected-prompt slot pin.

## Regression tests

- `race_loss::schedule_post_enqueue_idle_drain_tests` — pure truth table: schedule when enqueued+idle and when enqueued+behind-background-injection; skip when a real turn holds the slot or the enqueue was dedup-refused.
- `turn_orchestrator::active_turn_kind_tests::queued_user_message_survives_loop_injection_preemption` — models the incident end-to-end: a `/loop` Background turn holds the slot, a user message is queued behind it; asserts the scheduling discriminator (`has_active_turn` true / `has_blocking_active_turn` false), then proves the queued user message is dequeued **exactly once** after the injection completes (not lost, not doubled).

## Gates

- `cargo fmt --check`: clean
- `env -u AGENTDESK_ROOT_DIR cargo test --lib turn_orchestrator::active_turn_kind_tests` → 11 passed; `…race_loss` → 4 passed
- `generate_inventory_docs` + `check_agent_maintenance_docs` → freshness check passed (regenerated `module-inventory.md` committed)
- `audit_maintainability --check` → exit 0
- `check_hotfile_ratchet` → exit 0; `check_await_holding_lock_ratchet` → OK (34/34, no new allow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)