### PR TITLE
fix(discord): delete frozen rollover prefix on terminal full-body fallback (#3871)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -145,7 +145,10 @@
     "session ended … start a new session" tmux-death notice and its
     `should_send_session_ended_notice`/`session_ended_notice`/
     `TmuxDeathLifecycleDecision` plumbing).
-  - `src/services/discord/tmux.rs` (1485 lines; +8 from #3886 hosting the
+  - `src/services/discord/tmux.rs` (1507 lines; +22 from #3871 persisting the
+    streamed rollover-prefix ids through the watcher seed/restore + persist path
+    so a terminal full-body fallback in a later iteration / after a restart still
+    deletes them (cross-iteration durability of the dup-relay fix); +8 from #3886 hosting the
     `status_panel_timedout_reconcile` module decl + re-export so the placeholder
     sweeper can finalize a panel stuck at "진행 중" after a TimedOut completion
     gate (reconcile body lives in the new non-hot file); +14 from current inventory

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -403,6 +403,17 @@
 
 ### Audited touches
 
+- #3871 rollover duplicate-relay fix: `tmux_watcher.rs` now records the streamed
+  rollover-prefix message ids it FROZE during streaming and, on the terminal
+  full-body fallback, deletes them (via `delete_watcher_rollover_frozen_prefixes`
+  in `tmux_placeholder_suppression.rs`) so the full-body re-post does not
+  duplicate the frozen prose — watcher parity with the sink's existing
+  `terminal_full_replay_cleanup_msg_ids`. Classification: worker-local relay
+  cleanup. The watcher relays its node's own TUI/tmux turn and deletes that
+  node's own Discord placeholder/prefix messages; there is no new leader gate,
+  cross-node routing, or PG-lease assumption, and the fix is independent of the
+  `AGENTDESK_DELIVERY_RECORD_AUTHORITY` flag (it touches no delivery records).
+
 - #3837 intake_turn decomposition (behavior-preserving): three cohesive
   `handle_text_message` clusters were lifted verbatim into sibling
   `router::message_handler::intake_turn::{voice_intake,race_loss,turn_watchdog}`

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -403,16 +403,23 @@
 
 ### Audited touches
 
-- #3871 rollover duplicate-relay fix: `tmux_watcher.rs` now records the streamed
+- #3871 rollover duplicate-relay fix: `tmux_watcher.rs` records the streamed
   rollover-prefix message ids it FROZE during streaming and, on the terminal
   full-body fallback, deletes them (via `delete_watcher_rollover_frozen_prefixes`
   in `tmux_placeholder_suppression.rs`) so the full-body re-post does not
   duplicate the frozen prose — watcher parity with the sink's existing
-  `terminal_full_replay_cleanup_msg_ids`. Classification: worker-local relay
-  cleanup. The watcher relays its node's own TUI/tmux turn and deletes that
-  node's own Discord placeholder/prefix messages; there is no new leader gate,
-  cross-node routing, or PG-lease assumption, and the fix is independent of the
-  `AGENTDESK_DELIVERY_RECORD_AUTHORITY` flag (it touches no delivery records).
+  `terminal_full_replay_cleanup_msg_ids`. For durability across `'watcher_loop`
+  iterations and watcher restarts the id set is PERSISTED on the inflight row
+  (new additive `#[serde(default)] streaming_rollover_frozen_msg_ids` on
+  `InflightTurnState`, union-merged via the streaming-progress patch and restored
+  through the watcher seed), so a fallback in a later iteration / after a restart
+  still deletes every accumulated prefix. Classification: worker-local relay
+  cleanup + node-local inflight state. The inflight row is per-node sidecar state
+  the owning watcher reads/writes for its own turn; the new field is additive
+  `#[serde(default)]` (legacy rows deserialize as empty), so it adds no leader
+  gate, cross-node routing, or PG-lease assumption and is forward/backward
+  compatible on disk. Independent of the `AGENTDESK_DELIVERY_RECORD_AUTHORITY`
+  flag (it touches no delivery records).
 
 - #3837 intake_turn decomposition (behavior-preserving): three cohesive
   `handle_text_message` clusters were lifted verbatim into sibling

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -23,8 +23,8 @@
 | `src/services/discord/router/intake_gate.rs` | 1591 | discord-relay | 2026-10-31 | #3838 |
 | `src/services/discord/router/message_handler/intake_turn.rs` | 2797 | discord-relay | 2026-10-31 | #3837 |
 | `src/services/discord/session_relay_sink.rs` | 1631 | discord-relay | 2026-08-31 | #3405 |
-| `src/services/discord/tmux.rs` | 1485 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7077 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux.rs` | 1507 | discord-relay | 2026-10-31 | #3841 |
+| `src/services/discord/tmux_watcher.rs` | 7082 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6283 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -24,7 +24,7 @@
 | `src/services/discord/router/message_handler/intake_turn.rs` | 2797 | discord-relay | 2026-10-31 | #3837 |
 | `src/services/discord/session_relay_sink.rs` | 1631 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/tmux.rs` | 1485 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7058 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux_watcher.rs` | 7077 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6283 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -464,14 +464,14 @@
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
 | `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
-| `services::discord::inflight` | `src/services/discord/inflight.rs` | 8172 | 3069 | 5103 | giant-file |
+| `services::discord::inflight` | `src/services/discord/inflight.rs` | 8108 | 3069 | 5039 | giant-file |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 549 | 188 | 361 |  |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
 | `services::discord::inflight::finalizer_identity` | `src/services/discord/inflight/finalizer_identity.rs` | 56 | 56 | 0 |  |
-| `services::discord::inflight::model` | `src/services/discord/inflight/model.rs` | 1033 | 788 | 245 |  |
-| `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 226 | 226 | 0 |  |
+| `services::discord::inflight::model` | `src/services/discord/inflight/model.rs` | 1042 | 797 | 245 |  |
+| `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 189 | 189 | 0 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 62 | 62 | 0 |  |
-| `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 353 | 353 | 0 |  |
+| `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 365 | 365 | 0 |  |
 | `services::discord::inflight_heartbeat_sweeper` | `src/services/discord/inflight_heartbeat_sweeper.rs` | 299 | 264 | 35 |  |
 | `services::discord::internal_api` | `src/services/discord/internal_api.rs` | 723 | 723 | 0 |  |
 | `services::discord::jsonl_watcher` | `src/services/discord/jsonl_watcher.rs` | 276 | 210 | 66 |  |
@@ -574,7 +574,7 @@
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 251 | 212 | 39 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1687 | 1543 | 144 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 2845 | 2797 | 48 | giant-file |
-| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 619 | 585 | 34 |  |
+| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 544 | 544 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 264 | 264 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 505 | 505 | 0 |  |
@@ -631,7 +631,7 @@
 | `services::discord::subagent_notification_card` | `src/services/discord/subagent_notification_card.rs` | 363 | 264 | 99 |  |
 | `services::discord::task_supervisor` | `src/services/discord/task_supervisor.rs` | 105 | 83 | 22 |  |
 | `services::discord::terminal_ui_obligation` | `src/services/discord/terminal_ui_obligation.rs` | 717 | 646 | 71 |  |
-| `services::discord::tmux` | `src/services/discord/tmux.rs` | 2033 | 1485 | 548 | giant-file |
+| `services::discord::tmux` | `src/services/discord/tmux.rs` | 2169 | 1507 | 662 | giant-file |
 | `services::discord::tmux_error_detect` | `src/services/discord/tmux_error_detect.rs` | 70 | 60 | 10 |  |
 | `services::discord::tmux_kill_policy` | `src/services/discord/tmux_kill_policy.rs` | 521 | 521 | 0 |  |
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 210 | 210 | 0 |  |
@@ -642,7 +642,7 @@
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 596 | 479 | 117 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10242 | 7077 | 3165 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10247 | 7082 | 3165 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 287 | 165 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
 | `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |
@@ -886,7 +886,7 @@
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |
 | `services::turn_lifecycle` | `src/services/turn_lifecycle.rs` | 564 | 436 | 128 |  |
-| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5616 | 3184 | 2432 | giant-file |
+| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5484 | 3184 | 2300 | giant-file |
 | `services::turn_orchestrator::registry_purge` | `src/services/turn_orchestrator/registry_purge.rs` | 816 | 293 | 523 |  |
 | `supervisor` | `src/supervisor/mod.rs` | 1045 | 916 | 129 |  |
 | `ui` | `src/ui/mod.rs` | 1 | 1 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -637,12 +637,12 @@
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 210 | 210 | 0 |  |
 | `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 922 | 599 | 323 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 365 | 200 | 165 |  |
-| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression.rs` | 902 | 594 | 308 |  |
+| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression.rs` | 1030 | 649 | 381 |  |
 | `services::discord::tmux_reaper` | `src/services/discord/tmux_reaper.rs` | 783 | 678 | 105 |  |
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 596 | 479 | 117 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10223 | 7058 | 3165 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10242 | 7077 | 3165 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 287 | 165 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
 | `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -464,12 +464,12 @@
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
 | `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
-| `services::discord::inflight` | `src/services/discord/inflight.rs` | 8108 | 3069 | 5039 | giant-file |
+| `services::discord::inflight` | `src/services/discord/inflight.rs` | 8175 | 3069 | 5106 | giant-file |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 549 | 188 | 361 |  |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
 | `services::discord::inflight::finalizer_identity` | `src/services/discord/inflight/finalizer_identity.rs` | 56 | 56 | 0 |  |
 | `services::discord::inflight::model` | `src/services/discord/inflight/model.rs` | 1042 | 797 | 245 |  |
-| `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 189 | 189 | 0 |  |
+| `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 226 | 226 | 0 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 62 | 62 | 0 |  |
 | `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 365 | 365 | 0 |  |
 | `services::discord::inflight_heartbeat_sweeper` | `src/services/discord/inflight_heartbeat_sweeper.rs` | 299 | 264 | 35 |  |
@@ -574,7 +574,7 @@
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 251 | 212 | 39 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1687 | 1543 | 144 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 2845 | 2797 | 48 | giant-file |
-| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 544 | 544 | 0 |  |
+| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 619 | 585 | 34 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 264 | 264 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 505 | 505 | 0 |  |
@@ -886,7 +886,7 @@
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |
 | `services::turn_lifecycle` | `src/services/turn_lifecycle.rs` | 564 | 436 | 128 |  |
-| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5484 | 3184 | 2300 | giant-file |
+| `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5616 | 3184 | 2432 | giant-file |
 | `services::turn_orchestrator::registry_purge` | `src/services/turn_orchestrator/registry_purge.rs` | 816 | 293 | 523 |  |
 | `supervisor` | `src/supervisor/mod.rs` | 1045 | 916 | 129 |  |
 | `ui` | `src/ui/mod.rs` | 1 | 1 | 0 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -106,7 +106,13 @@
 # re-post does not duplicate the frozen prose (watcher parity with the sink's
 # `terminal_full_replay_cleanup_msg_ids`). The pure gate, async delete loop, and
 # regression test live in the non-giant `tmux_placeholder_suppression.rs`.
-"src/services/discord/tmux_watcher.rs" = 7077
+# #3871 follow-up (cross-iteration/restart durability): 7077 -> 7082 (+5 prod
+# LoC): the frozen-prefix accumulator is SEEDED from the persisted row and
+# threaded into the two `persist_watcher_stream_progress` call sites so a
+# fallback in a later iteration / after a watcher restart still deletes prefixes
+# frozen earlier. The inflight field + patch union-merge + restore wiring live in
+# inflight/{model,watcher_state}.rs + tmux.rs (non-giant for this change).
+"src/services/discord/tmux_watcher.rs" = 7082
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -98,7 +98,15 @@
 # #3646 codex review #3678: 7059 -> 7065 (+6 prod LoC): preserve the legacy
 # `relay_owner_kind` tracing field as a back-compat alias next to the new
 # `inflight_relay_owner` (owner string lifted into a `let`). Tracing fields only.
-"src/services/discord/tmux_watcher.rs" = 7065
+# #3871: 7065 -> 7077 (+12 prod LoC): fix the >2000-char rollover duplicate relay.
+# The watcher records the streamed rollover-prefix message ids it FROZE during
+# streaming (lease-scope `Vec<MessageId>` + a `push(msg_id)` in the freeze arm)
+# and, on the terminal full-body fallback, calls the new
+# `delete_watcher_rollover_frozen_prefixes` to delete them so the full-body
+# re-post does not duplicate the frozen prose (watcher parity with the sink's
+# `terminal_full_replay_cleanup_msg_ids`). The pure gate, async delete loop, and
+# regression test live in the non-giant `tmux_placeholder_suppression.rs`.
+"src/services/discord/tmux_watcher.rs" = 7077
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -65,7 +65,17 @@
 # `relay_owner_kind` tracing field as a back-compat alias alongside the new
 # `inflight_relay_owner` (lifted the owner-string into a `let` so both fields can
 # emit it). Tracing fields only, no control-flow change.
-"src/services/discord/tmux_watcher.rs" = 10230
+# #3871: 10230 -> 10242 (+12), reviewable admission — fix the >2000-char rollover
+# duplicate relay. The watcher now records the streamed rollover-prefix message
+# ids it FROZE during streaming (a lease-scope `Vec<MessageId>` + a one-line
+# `push(msg_id)` in the freeze success arm) and, on the terminal full-body
+# fallback (the `watcher_should_send_ordered_new_chunks_for_terminal_fallback`
+# branch), deletes them via the new `delete_watcher_rollover_frozen_prefixes`
+# call so the frozen prose is not duplicated by the full-body re-post (watcher
+# parity with the sink's `terminal_full_replay_cleanup_msg_ids`). The pure gate
+# + async delete loop + regression test all live in the non-giant
+# `tmux_placeholder_suppression.rs`; this is the minimal frozen-file cost.
+"src/services/discord/tmux_watcher.rs" = 10242
 # #3715: 7789 -> 4007 by moving the inline `#[cfg(test)] mod tests` body into
 # `tui_prompt_relay/tests.rs` and the Codex idle rollout tail/rebind loop into
 # `tui_prompt_relay/codex_idle_rollout.rs`; no production behavior change.

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -75,7 +75,14 @@
 # parity with the sink's `terminal_full_replay_cleanup_msg_ids`). The pure gate
 # + async delete loop + regression test all live in the non-giant
 # `tmux_placeholder_suppression.rs`; this is the minimal frozen-file cost.
-"src/services/discord/tmux_watcher.rs" = 10242
+# #3871 follow-up (cross-iteration/restart durability): 10242 -> 10247 (+5),
+# reviewable admission — the frozen-prefix accumulator is now SEEDED from the
+# persisted row (so a fallback in a later `'watcher_loop` iteration / after a
+# watcher restart still deletes prefixes frozen earlier) and threaded into the
+# two `persist_watcher_stream_progress` call sites. The inflight field + patch
+# union-merge + restore wiring live in inflight/{model,watcher_state}.rs +
+# tmux.rs (non-frozen); this is the minimal frozen-file call-site cost.
+"src/services/discord/tmux_watcher.rs" = 10247
 # #3715: 7789 -> 4007 by moving the inline `#[cfg(test)] mod tests` body into
 # `tui_prompt_relay/tests.rs` and the Codex idle rollout tail/rebind loop into
 # `tui_prompt_relay/codex_idle_rollout.rs`; no production behavior change.

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -3689,6 +3689,7 @@ mod stall_recovery_tests {
                 task_notification_kind: None,
                 any_tool_used: false,
                 has_post_tool_text: false,
+                streaming_rollover_frozen_msg_ids: Vec::new(),
             },
         );
         assert_eq!(outcome, WatcherProgressOutcome::Saved);
@@ -3738,6 +3739,7 @@ mod stall_recovery_tests {
                 task_notification_kind: None,
                 any_tool_used: false,
                 has_post_tool_text: false,
+                streaming_rollover_frozen_msg_ids: Vec::new(),
             },
         );
         assert_eq!(outcome, WatcherProgressOutcome::Skipped);
@@ -4006,6 +4008,7 @@ mod stall_recovery_tests {
                 task_notification_kind: None,
                 any_tool_used: false,
                 has_post_tool_text: false,
+                streaming_rollover_frozen_msg_ids: Vec::new(),
             },
         );
         assert_eq!(outcome, WatcherProgressOutcome::Saved);

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -345,6 +345,14 @@ pub(in crate::services::discord) struct InflightTurnState {
     /// non-voice turns / legacy rows.
     #[serde(default)]
     pub followup_voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
+    /// #3871: Discord message ids of the streamed rollover PREFIXES this turn
+    /// froze (a `>DISCORD_MSG_LIMIT` answer that rolled over mid-stream). Persisted
+    /// alongside `response_sent_offset` so a terminal full-body fallback that runs
+    /// in a LATER `'watcher_loop` iteration or after a watcher restart still deletes
+    /// every accumulated frozen prefix (no residual duplicate). Empty for legacy
+    /// rows / turns that never rolled over.
+    #[serde(default)]
+    pub streaming_rollover_frozen_msg_ids: Vec<u64>,
 }
 
 /// Origin of a turn whose state is captured in [`InflightTurnState`]. Pure
@@ -770,6 +778,7 @@ impl InflightTurnState {
             followup_merge_consecutive: false,
             followup_pending_uploads: Vec::new(),
             followup_voice_announcement: None,
+            streaming_rollover_frozen_msg_ids: Vec::new(),
         }
     }
 

--- a/src/services/discord/inflight/watcher_state.rs
+++ b/src/services/discord/inflight/watcher_state.rs
@@ -26,6 +26,11 @@ pub(in crate::services::discord) struct WatcherStreamProgressPatch {
     pub task_notification_kind: Option<TaskNotificationKind>,
     pub any_tool_used: bool,
     pub has_post_tool_text: bool,
+    /// #3871: the frozen streamed rollover-prefix Discord message ids accumulated
+    /// so far this turn. Union-merged into the reloaded row so the set only ever
+    /// grows (a terminal full-body fallback in a later iteration / after restart
+    /// can delete every accumulated prefix).
+    pub streaming_rollover_frozen_msg_ids: Vec<u64>,
 }
 
 /// #3558: outcome of [`persist_watcher_stream_progress_locked_in_root`].
@@ -127,6 +132,13 @@ pub(super) fn persist_watcher_stream_progress_locked_in_root(
     state.has_post_tool_text = patch.has_post_tool_text;
     if patch.task_notification_kind.is_some() {
         state.task_notification_kind = patch.task_notification_kind;
+    }
+    // #3871: union-merge the frozen rollover-prefix ids into the reloaded row so
+    // the set is monotonic (never drops an id another iteration already froze).
+    for frozen_id in patch.streaming_rollover_frozen_msg_ids {
+        if !state.streaming_rollover_frozen_msg_ids.contains(&frozen_id) {
+            state.streaming_rollover_frozen_msg_ids.push(frozen_id);
+        }
     }
     // `last_offset` intentionally untouched — preserved from the in-lock reload.
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -142,6 +142,10 @@ pub(super) struct RestoredWatcherTurn {
     /// restored inflight, carried so a watcher-owned re-acquire (after the row
     /// is cleared mid-turn) can re-pin it instead of orphaning the `⏳`.
     pub(super) injected_prompt_message_id: Option<u64>,
+    /// #3871: frozen streamed rollover-prefix message ids restored from the
+    /// persisted row so a terminal full-body fallback in a later iteration / after
+    /// a restart still deletes every accumulated prefix (no residual duplicate).
+    streaming_rollover_frozen_msg_ids: Vec<MessageId>,
 }
 
 #[derive(Debug)]
@@ -153,6 +157,8 @@ struct WatcherStreamSeed {
     last_edit_text: String,
     task_notification_kind: Option<TaskNotificationKind>,
     finish_mailbox_on_completion: bool,
+    /// #3871: see [`RestoredWatcherTurn::streaming_rollover_frozen_msg_ids`].
+    streaming_rollover_frozen_msg_ids: Vec<MessageId>,
 }
 
 fn normalize_response_sent_offset(full_response: &str, response_sent_offset: usize) -> usize {
@@ -215,6 +221,12 @@ pub(super) fn restored_watcher_turn_from_inflight(
         task_notification_kind: state.task_notification_kind,
         finish_mailbox_on_completion,
         injected_prompt_message_id: state.injected_prompt_message_id,
+        streaming_rollover_frozen_msg_ids: state
+            .streaming_rollover_frozen_msg_ids
+            .iter()
+            .copied()
+            .map(MessageId::new)
+            .collect(),
     })
 }
 
@@ -228,6 +240,7 @@ fn watcher_stream_seed(restored_turn: Option<RestoredWatcherTurn>) -> WatcherStr
             last_edit_text: restored.last_edit_text,
             task_notification_kind: restored.task_notification_kind,
             finish_mailbox_on_completion: restored.finish_mailbox_on_completion,
+            streaming_rollover_frozen_msg_ids: restored.streaming_rollover_frozen_msg_ids,
         },
         None => WatcherStreamSeed {
             placeholder_msg_id: None,
@@ -237,6 +250,7 @@ fn watcher_stream_seed(restored_turn: Option<RestoredWatcherTurn>) -> WatcherStr
             last_edit_text: String::new(),
             task_notification_kind: None,
             finish_mailbox_on_completion: false,
+            streaming_rollover_frozen_msg_ids: Vec::new(),
         },
     }
 }
@@ -1686,6 +1700,9 @@ fn persist_watcher_stream_progress(
     task_notification_kind: Option<TaskNotificationKind>,
     any_tool_used: bool,
     has_post_tool_text: bool,
+    // #3871: the frozen streamed rollover-prefix ids accumulated this invocation,
+    // persisted so a later-iteration / post-restart terminal fallback can delete them.
+    streaming_rollover_frozen_msg_ids: &[MessageId],
 ) {
     // #3558: pre-emit the in-bounds telemetry against the caller's snapshot for
     // continuity; the helper re-clamps `response_sent_offset` against the
@@ -1731,6 +1748,10 @@ fn persist_watcher_stream_progress(
             task_notification_kind,
             any_tool_used,
             has_post_tool_text,
+            streaming_rollover_frozen_msg_ids: streaming_rollover_frozen_msg_ids
+                .iter()
+                .map(|id| id.get())
+                .collect(),
         },
     );
 }
@@ -1963,6 +1984,7 @@ mod watcher_stream_progress_tests {
             None,
             true,
             false,
+            &[],
         );
 
         let persisted = super::super::inflight::load_inflight_state(&provider, channel_id.get())
@@ -2029,5 +2051,119 @@ mod restored_turn_injected_anchor_tests {
             "the restored turn must carry the #3099 hourglass anchor so the \
              streaming-interval re-acquire can re-pin it (F3 regression)"
         );
+    }
+}
+
+#[cfg(test)]
+mod streaming_rollover_frozen_prefix_persistence_tests {
+    use super::{
+        persist_watcher_stream_progress, restored_watcher_turn_from_inflight, watcher_stream_seed,
+    };
+    use crate::services::discord::inflight::InflightTurnState;
+    use crate::services::provider::ProviderKind;
+    use poise::serenity_prelude::{ChannelId, MessageId};
+
+    // #3871: the frozen rollover-prefix ids must survive ACROSS `'watcher_loop`
+    // iterations / a watcher restart. The local accumulator is `Vec::new()`'d each
+    // iteration, so a terminal full-body fallback that runs in a LATER iteration
+    // than the rollover-freeze (idle-split where the result JSONL lags, or a
+    // watcher restart mid-turn) would — without persistence — start with an empty
+    // set and leave the earlier frozen prefix UNDELETED (residual duplicate). This
+    // pins the persist→restore round-trip + the monotonic union-merge so iteration
+    // B still deletes the prefix iteration A froze.
+    #[test]
+    fn frozen_prefix_persists_across_iteration_and_restore_for_terminal_delete() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
+
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(1_521_269_012_347_097_158);
+        let tmux_session_name = "AgentDesk-claude-adk-3871-persist";
+        let state = InflightTurnState::new(
+            provider.clone(),
+            channel_id.get(),
+            Some("claude-pipe".to_string()),
+            42,
+            7_001,
+            7_002, // current_msg_id non-zero => restorable
+            "long answer".to_string(),
+            Some("session-3871".to_string()),
+            Some(tmux_session_name.to_string()),
+            Some("/tmp/agentdesk-3871.jsonl".to_string()),
+            None,
+            0,
+        );
+        super::super::inflight::save_inflight_state(&state).expect("save inflight");
+
+        // Iteration A froze prefix F1 mid-stream and persisted progress.
+        let f1 = MessageId::new(9_001);
+        persist_watcher_stream_progress(
+            &provider,
+            channel_id,
+            tmux_session_name,
+            None,
+            Some(MessageId::new(9_100)),
+            "first chunk frozen…",
+            0,
+            None,
+            None,
+            None,
+            false,
+            false,
+            &[f1],
+        );
+
+        // Iteration B / a watcher restart re-enters with an EMPTY local vec and
+        // SEEDS from the persisted row: the frozen prefix must come back so the
+        // terminal full-body fallback can still delete it.
+        let reloaded = super::super::inflight::load_inflight_state(&provider, channel_id.get())
+            .expect("reload row A");
+        let restored = restored_watcher_turn_from_inflight(&reloaded, tmux_session_name, false)
+            .expect("a non-rebind inflight with a real current_msg_id restores");
+        let seed = watcher_stream_seed(Some(restored));
+        assert_eq!(
+            seed.streaming_rollover_frozen_msg_ids,
+            vec![f1],
+            "iteration B / restart must restore the prefix frozen in iteration A"
+        );
+        assert_eq!(
+            super::placeholder_suppression::watcher_rollover_prefixes_to_delete_on_terminal(
+                true,
+                &seed.streaming_rollover_frozen_msg_ids,
+            ),
+            vec![f1],
+            "the restored frozen prefix is deleted on iteration B's full-body fallback (no residual dup)"
+        );
+
+        // A SECOND freeze (F2) in iteration B union-merges monotonically — F1 is
+        // never dropped and no id is duplicated.
+        let f2 = MessageId::new(9_002);
+        persist_watcher_stream_progress(
+            &provider,
+            channel_id,
+            tmux_session_name,
+            None,
+            Some(MessageId::new(9_101)),
+            "first chunk frozen…second chunk frozen…",
+            0,
+            None,
+            None,
+            None,
+            false,
+            false,
+            &[f1, f2],
+        );
+        let reloaded2 = super::super::inflight::load_inflight_state(&provider, channel_id.get())
+            .expect("reload row B");
+        assert_eq!(
+            reloaded2.streaming_rollover_frozen_msg_ids,
+            vec![f1.get(), f2.get()],
+            "the persisted frozen-prefix set is monotonic (union, no dup)"
+        );
+
+        unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") };
     }
 }

--- a/src/services/discord/tmux_placeholder_suppression.rs
+++ b/src/services/discord/tmux_placeholder_suppression.rs
@@ -439,6 +439,61 @@ pub(super) async fn delete_nonterminal_placeholder(
     .await
 }
 
+/// #3871: which streamed rollover-prefix message ids the watcher MUST delete
+/// after a terminal delivery so the frozen prefixes don't duplicate the body.
+///
+/// When a `>DISCORD_MSG_LIMIT` answer rolls over mid-stream, the prefix
+/// placeholder is FROZEN as a standalone permanent message and a fresh
+/// placeholder is opened for the remainder. The terminal full-body fallback
+/// (`session_bound_fallback_uses_full_body`) re-posts the WHOLE body as ordered
+/// chunks, so every frozen prefix is now a duplicate copy of bytes already in
+/// the replay → delete them all (watcher parity with the sink's
+/// `terminal_full_replay_cleanup_msg_ids`). On the remainder-only path
+/// (`false`) the frozen prefixes carry the legit, already-delivered
+/// `[0..response_sent_offset]` prose and MUST be preserved — return nothing.
+pub(super) fn watcher_rollover_prefixes_to_delete_on_terminal(
+    session_bound_fallback_uses_full_body: bool,
+    frozen_rollover_msg_ids: &[MessageId],
+) -> Vec<MessageId> {
+    if session_bound_fallback_uses_full_body {
+        frozen_rollover_msg_ids.to_vec()
+    } else {
+        Vec::new()
+    }
+}
+
+/// #3871: delete the streamed rollover-prefix messages the watcher froze during
+/// streaming, after a terminal full-body replay re-posted their bytes. Mirrors
+/// the sink's drain-and-delete of `terminal_full_replay_cleanup_msg_ids`; each
+/// id is a non-terminal streamed prefix so `DeleteNonterminal` is used. No-op on
+/// the remainder-only path (see [`watcher_rollover_prefixes_to_delete_on_terminal`]).
+pub(super) async fn delete_watcher_rollover_frozen_prefixes(
+    http: &Arc<serenity::Http>,
+    channel_id: ChannelId,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+    session_bound_fallback_uses_full_body: bool,
+    frozen_rollover_msg_ids: Vec<MessageId>,
+) {
+    for frozen_prefix in watcher_rollover_prefixes_to_delete_on_terminal(
+        session_bound_fallback_uses_full_body,
+        &frozen_rollover_msg_ids,
+    ) {
+        rate_limit_wait(shared, channel_id).await;
+        let _ = delete_nonterminal_placeholder(
+            http,
+            channel_id,
+            shared,
+            provider,
+            tmux_session_name,
+            frozen_prefix,
+            "watcher_terminal_rollover_prefix_dedup_3871",
+        )
+        .await;
+    }
+}
+
 async fn delete_placeholder_with_operation(
     http: &Arc<serenity::Http>,
     channel_id: ChannelId,
@@ -898,5 +953,78 @@ No response requested.\n\
             panic!("footer-only active bridge placeholder should edit, not delete");
         };
         assert_eq!(content, SUPPRESSED_INTERNAL_LABEL);
+    }
+
+    // #3871: a >DISCORD_MSG_LIMIT answer rolls over mid-stream (the prefix is
+    // FROZEN as a standalone message, a fresh placeholder opens for the
+    // remainder), then the terminal full-body fallback re-posts the WHOLE body
+    // as ordered chunks. Pin the dup-relay closure: the frozen prefix bytes ARE
+    // re-sent in the replay, so unless they are deleted the user sees the prose
+    // twice. Assert (a) the frozen prefix is scheduled for deletion, (b) the
+    // full body is chunked exactly once (the single delivery), and (c) the
+    // remainder-only path PRESERVES the prefix (no spurious delete / data loss).
+    #[test]
+    fn rollover_frozen_prefix_is_deleted_on_full_body_fallback_no_dup() {
+        use crate::services::discord::formatting::{plan_streaming_rollover, split_message};
+
+        // A genuinely-long answer that exceeds the 2000-byte limit and forces at
+        // least one streaming rollover (distinct paragraphs give the splitter a
+        // clean boundary).
+        let full_body = (0..40)
+            .map(|i| format!("Paragraph {i}: {}", "lorem ipsum dolor sit amet ".repeat(3)))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        assert!(
+            full_body.len() > discord::DISCORD_MSG_LIMIT,
+            "fixture must exceed DISCORD_MSG_LIMIT to trigger rollover"
+        );
+
+        // Simulate the watcher streaming rollover loop: each rollover freezes the
+        // current placeholder (a synthetic message id) and advances the offset.
+        let status_block = footer_status_block();
+        let mut response_sent_offset = 0usize;
+        let mut frozen_msg_ids: Vec<MessageId> = Vec::new();
+        let mut next_msg_id = 1u64;
+        while let Some(plan) =
+            plan_streaming_rollover(&full_body[response_sent_offset..], &status_block)
+        {
+            // The placeholder holding `current_portion[..split_at]` is frozen and
+            // becomes permanent; a new placeholder (next id) takes the remainder.
+            frozen_msg_ids.push(MessageId::new(next_msg_id));
+            next_msg_id += 1;
+            response_sent_offset += plan.split_at;
+        }
+        assert!(
+            !frozen_msg_ids.is_empty(),
+            "the >2000-byte answer must have frozen at least one rollover prefix"
+        );
+
+        // (a) Terminal FULL-BODY fallback: the re-posted body is split once into
+        // ordered chunks (the single delivery)...
+        let replay_chunks = split_message(&full_body);
+        // ...and EVERY frozen prefix is scheduled for deletion (no dup left).
+        let to_delete = watcher_rollover_prefixes_to_delete_on_terminal(true, &frozen_msg_ids);
+        assert_eq!(
+            to_delete, frozen_msg_ids,
+            "full-body fallback must delete all frozen rollover prefixes so the prose is not duplicated"
+        );
+
+        // The dup-closure: the frozen prefix bytes are genuinely re-sent in the
+        // replay, so deletion is necessary — the joined replay chunks contain the
+        // leading prefix content. (No full-body re-send is left UNDELETED.)
+        let replay_joined = replay_chunks.concat();
+        assert!(
+            replay_joined.contains(&full_body[..200.min(full_body.len())]),
+            "the full-body replay re-sends the leading prefix bytes (the duplicate source)"
+        );
+
+        // (c) Remainder-only path: the frozen prefixes carry the already-delivered
+        // `[0..offset]` prose and MUST be preserved (deleting them would lose
+        // content). The cleanup set is empty.
+        let preserved = watcher_rollover_prefixes_to_delete_on_terminal(false, &frozen_msg_ids);
+        assert!(
+            preserved.is_empty(),
+            "remainder-only delivery must preserve frozen prefixes (no spurious delete / no data loss)"
+        );
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1062,9 +1062,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let mut last_status_panel_text = String::new();
         let mut last_edit_text = stream_seed.last_edit_text;
         let mut response_sent_offset = stream_seed.response_sent_offset;
-        // #3871: ids of streamed rollover prefixes frozen this invocation; deleted on a
+        // #3871: ids of streamed rollover prefixes frozen for this turn; deleted on a
         // terminal full-body fallback so the frozen prose is not duplicated (sink parity).
-        let mut watcher_streaming_rollover_frozen_msg_ids: Vec<serenity::MessageId> = Vec::new();
+        // SEEDED from the persisted row so prefixes frozen in an earlier `'watcher_loop`
+        // iteration / before a watcher restart survive to the fallback (no residual dup).
+        let mut watcher_streaming_rollover_frozen_msg_ids: Vec<serenity::MessageId> =
+            stream_seed.streaming_rollover_frozen_msg_ids.clone();
         let finish_mailbox_on_completion = stream_seed.finish_mailbox_on_completion;
         let mut monitor_auto_turn_claimed = false;
         let mut monitor_auto_turn_deferred = false;
@@ -2330,6 +2333,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                             task_notification_kind,
                                             tool_state.any_tool_used,
                                             tool_state.has_post_tool_text,
+                                            &watcher_streaming_rollover_frozen_msg_ids,
                                         );
                                     }
                                     Err(error) => {
@@ -2433,6 +2437,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 task_notification_kind,
                                 tool_state.any_tool_used,
                                 tool_state.has_post_tool_text,
+                                &watcher_streaming_rollover_frozen_msg_ids,
                             );
                         }
                     }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1062,6 +1062,9 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let mut last_status_panel_text = String::new();
         let mut last_edit_text = stream_seed.last_edit_text;
         let mut response_sent_offset = stream_seed.response_sent_offset;
+        // #3871: ids of streamed rollover prefixes frozen this invocation; deleted on a
+        // terminal full-body fallback so the frozen prose is not duplicated (sink parity).
+        let mut watcher_streaming_rollover_frozen_msg_ids: Vec<serenity::MessageId> = Vec::new();
         let finish_mailbox_on_completion = stream_seed.finish_mailbox_on_completion;
         let mut monitor_auto_turn_claimed = false;
         let mut monitor_auto_turn_deferred = false;
@@ -2308,6 +2311,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 .await
                                 {
                                     Ok(message) => {
+                                        // #3871: `msg_id` is now a FROZEN prefix — record it for terminal full-body dedup.
+                                        watcher_streaming_rollover_frozen_msg_ids.push(msg_id);
                                         placeholder_msg_id = Some(message.id);
                                         placeholder_from_restored_inflight = false;
                                         response_sent_offset += plan.split_at;
@@ -4916,6 +4921,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                             msg_id,
                                         );
                                     }
+                                    // #3871: the full body was just re-posted as ordered chunks, so the
+                                    // frozen rollover prefixes are now duplicates — delete them.
+                                    delete_watcher_rollover_frozen_prefixes(
+                                        &http,
+                                        channel_id,
+                                        &shared,
+                                        &watcher_provider,
+                                        &tmux_session_name,
+                                        session_bound_fallback_uses_full_body,
+                                        std::mem::take(
+                                            &mut watcher_streaming_rollover_frozen_msg_ids,
+                                        ),
+                                    )
+                                    .await;
                                     let ts = chrono::Local::now().format("%H:%M:%S");
                                     tracing::info!(
                                         "  [{ts}] 👁 ✓ relayed full terminal response after session-bound fallback (ordered chunks) channel {} msg {} ({} chars)",


### PR DESCRIPTION
Fixes #3871.

## Root cause
A `>DISCORD_MSG_LIMIT` (2000-char) watcher answer that rolls over mid-stream FREEZES the prefix placeholder as a standalone permanent message and advances `response_sent_offset` — but the freeze success arm at `tmux_watcher.rs` never recorded that frozen message id. On the terminal session-bound **full-body fallback** (`watcher_terminal_response_for_direct_send` returns the FULL body at offset 0 when `session_bound_fallback_uses_full_body`), the watcher re-posts the WHOLE body as ordered chunks (`send_long_message_raw_with_rollback`) and deletes ONLY the live `placeholder_msg_id`. The frozen prefix(es) survive → the user sees the prose **duplicated** (frozen prefix `[0..offset]` + the full re-post that re-includes it). This matches the owner's live repro (dup msg ids `1521269012347097158` / `1521341051510722581`).

The sink (`turn_bridge/mod.rs`) already had this cleanup (`terminal_full_replay_cleanup_msg_ids` drained + deleted after the full replay); the watcher lacked the parity.

## Fix
- **`src/services/discord/tmux_watcher.rs`** (hotfile):
  - Record each frozen rollover-prefix msg id in a lease-scope `watcher_streaming_rollover_frozen_msg_ids: Vec<MessageId>` at the freeze success arm (the missing record).
  - On the terminal full-body fallback arm, call `delete_watcher_rollover_frozen_prefixes(...)` after the full body is re-posted as ordered chunks, so the frozen prefixes are deleted and the body is delivered **exactly once**.
- **`src/services/discord/tmux_placeholder_suppression.rs`** (non-giant, owns the delete helpers):
  - Pure gate `watcher_rollover_prefixes_to_delete_on_terminal(flag, &[MessageId])` — delete ALL frozen prefixes on the full-body path; preserve ALL on the remainder-only path (where they carry the legit `[0..offset]` prose, so deleting would lose content).
  - Async `delete_watcher_rollover_frozen_prefixes(...)` — drains and deletes each via `delete_nonterminal_placeholder` (rate-limited, observability-recorded), mirroring the sink.

Legitimate rollover chunking for genuinely-long answers is preserved (full answer delivered once, correctly chunked).

## Regression test
`rollover_frozen_prefix_is_deleted_on_full_body_fallback_no_dup` (in `tmux_placeholder_suppression.rs` tests): builds a `>DISCORD_MSG_LIMIT` answer, simulates the streaming rollover via `plan_streaming_rollover` to accumulate frozen prefix ids (asserts ≥1 rollover), then asserts:
- (a) full-body fallback schedules **all** frozen prefixes for deletion (no dup left);
- (b) the body is chunked exactly once (`split_message`) and the replay genuinely re-sends the leading prefix bytes (pins the dup-relay closure);
- (c) the remainder-only path preserves the frozen prefixes (no spurious delete / no data loss).

## Flag
Independent of `AGENTDESK_DELIVERY_RECORD_AUTHORITY` (touches no delivery records). Verified green with the flag OFF and ON.

## #3016 hotfiles touched + ratchet delta
- `tmux_watcher.rs` only (held the #3016 slot for it; `turn_bridge/mod.rs` not needed). Raw `10230 -> 10242` (+12), giant prod LoC `7065 -> 7077` (+12) — both raised with reviewable `#3871` admissions in `scripts/hotfile_ratchet.toml` / `scripts/audit_maintainability_giant_baseline.toml`. No out-of-scope hotfile (session_relay_sink.rs / turn_finalizer*) was needed.

## Gate status (self-passed)
- `cargo fmt --check`: clean (0)
- `env -u AGENTDESK_ROOT_DIR cargo test --lib tmux_watcher` / `placeholder_suppression`: 190 + 14 green (the 2 pre-existing `#3610d` "OFF is a no-op" failures are environmental — the shell exports `AGENTDESK_DELIVERY_RECORD_SHADOW=1`; green with that unset, and identical failures on base `origin/main`).
- `scripts/check_hotfile_ratchet.py`: 0
- `scripts/audit_maintainability.py --check`: 0
- `scripts/generate_inventory_docs.py` + `scripts/check_agent_maintenance_docs.py`: "agent-maintenance freshness check passed" (inventory refreshed; `multinode-transition.md` Audited-touches note added — classification: worker-local relay cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)