### PR TITLE
fix(discord): suppress #3089 footer chrome on watcher-relayed synthetic/system-injected TUI mirrors (#3964)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -652,7 +652,7 @@
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 147 | 101 | 46 |  |
 | `services::discord::tmux_watcher::session_bound_ack` | `src/services/discord/tmux_watcher/session_bound_ack.rs` | 427 | 427 | 0 |  |
-| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 645 | 514 | 131 |  |
+| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 830 | 614 | 216 |  |
 | `services::discord::tmux_watcher::supervisor_relay` | `src/services/discord/tmux_watcher/supervisor_relay.rs` | 393 | 393 | 0 |  |
 | `services::discord::tmux_watcher::terminal_readiness` | `src/services/discord/tmux_watcher/terminal_readiness.rs` | 214 | 214 | 0 |  |
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 700 | 654 | 46 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -647,12 +647,12 @@
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
 | `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 225 | 225 | 0 |  |
-| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 502 | 502 | 0 |  |
+| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 643 | 547 | 96 |  |
 | `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 106 | 106 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 147 | 101 | 46 |  |
 | `services::discord::tmux_watcher::session_bound_ack` | `src/services/discord/tmux_watcher/session_bound_ack.rs` | 427 | 427 | 0 |  |
-| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 830 | 614 | 216 |  |
+| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 684 | 570 | 114 |  |
 | `services::discord::tmux_watcher::supervisor_relay` | `src/services/discord/tmux_watcher/supervisor_relay.rs` | 393 | 393 | 0 |  |
 | `services::discord::tmux_watcher::terminal_readiness` | `src/services/discord/tmux_watcher/terminal_readiness.rs` | 214 | 214 | 0 |  |
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 700 | 654 | 46 |  |

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -500,3 +500,144 @@ pub(super) fn watcher_should_reclaim_orphan_turn_placeholder(
 pub(super) fn watcher_inflight_absence_is_abandonment(pane_actively_streaming: bool) -> bool {
     !pane_actively_streaming
 }
+
+/// Pure decision for the watcher completion-footer idle refresh: tick only when a
+/// footer target is registered AND the refresh interval has elapsed.
+pub(super) fn watcher_completion_footer_should_tick(
+    has_registered_target: bool,
+    elapsed: std::time::Duration,
+    interval: std::time::Duration,
+) -> bool {
+    has_registered_target && elapsed >= interval
+}
+
+/// #3964: should the #3089 single-message-panel completion footer (`Context …
+/// tokens`, `Tasks`, `Subagents`) be SUPPRESSED for this WATCHER-relayed terminal
+/// mirror? The tmux-watcher analogue of the bridge gate
+/// `tui_direct_completion_footer_suppressed` (#3959/#3961): #3961 stripped the
+/// chrome only on the bridge relay path, but a TUI session's SYNTHETIC turns
+/// (background task-notifications, `/loop`·MonitorAutoTurn) are relayed by the live
+/// WATCHER, which re-appended it (#3964). Two complementary signals mark a mirror:
+///
+/// 1. `turn_is_external_input_for_session` — the cached panel-eligibility flag
+///    (`watcher_inflight_is_panel_eligible_for_session`). Computed ONCE at the top
+///    of each `'watcher_loop` iteration (`tmux_watcher.rs:1017`) from the `:1009`
+///    inflight snapshot, so it is reliable only for a turn whose row already
+///    existed. A FRESH synthetic turn's row is created LATER in the same iteration
+///    (`ensure_monitor_auto_turn_inflight`, `:1226`/`:1495`), so the cached flag is
+///    still `false` when the turn's `Done` reaches the terminal chokepoint (the
+///    `:2013` late set-true lives in the separate-panel branch, mutually exclusive
+///    with footer mode).
+/// 2. `completion_background` — computed at the chokepoint (`tmux_watcher.rs:5700`)
+///    as `task_notification_kind ∈ {Background, MonitorAutoTurn}`, a STREAM-derived
+///    value (merged at `:1170`/`:1464`) that is correct regardless of row timing.
+///    This catches the common fresh synthetic turn the cached flag misses.
+///
+/// Both are `false` for a genuine Discord-origin turn (`TurnSource::Managed` is not
+/// panel-eligible; a real user message carries no `<task-notification>` marker), so
+/// its #3089 footer — the user's only status surface — is never stripped.
+pub(super) fn watcher_external_input_completion_footer_suppressed(
+    single_message_panel_footer_mode: bool,
+    turn_is_external_input_for_session: bool,
+    completion_background: bool,
+) -> bool {
+    single_message_panel_footer_mode
+        && (turn_is_external_input_for_session || completion_background)
+}
+
+#[cfg(test)]
+mod completion_footer_suppression_tests {
+    use super::*;
+    use crate::services::discord::ProviderKind;
+
+    #[test]
+    fn completion_footer_tick_requires_registered_unfinished_target() {
+        let interval = std::time::Duration::from_secs(5);
+        assert!(watcher_completion_footer_should_tick(
+            true, interval, interval
+        ));
+        assert!(!watcher_completion_footer_should_tick(
+            false, interval, interval
+        ));
+        assert!(!watcher_completion_footer_should_tick(
+            true,
+            std::time::Duration::from_secs(4),
+            interval
+        ));
+    }
+
+    #[test]
+    fn gate_suppresses_for_either_mirror_signal_and_keeps_discord_origin_3964() {
+        // cached flag true (row pre-existed) → suppress.
+        assert!(watcher_external_input_completion_footer_suppressed(
+            true, true, false
+        ));
+        // cached flag FALSE but completion_background true — the #3964 fresh
+        // synthetic /loop·MonitorAutoTurn / background regression the bridge-style
+        // cached flag cannot catch at the terminal chokepoint → still suppress.
+        assert!(watcher_external_input_completion_footer_suppressed(
+            true, false, true
+        ));
+        assert!(watcher_external_input_completion_footer_suppressed(
+            true, true, true
+        ));
+        // genuine Discord-origin turn: both signals false → KEEP the #3089 footer.
+        assert!(!watcher_external_input_completion_footer_suppressed(
+            true, false, false
+        ));
+        // non-footer-mode is never the single-message footer path.
+        assert!(!watcher_external_input_completion_footer_suppressed(
+            false, true, true
+        ));
+        assert!(!watcher_external_input_completion_footer_suppressed(
+            false, false, true
+        ));
+    }
+
+    #[test]
+    fn synthetic_tui_mirror_emits_prose_without_tui_chrome_3964() {
+        // The exact #3964 corruption: assistant prose + the rendered
+        // Context/Tasks/Subagents footer. A suppressed mirror composes with a `None`
+        // block → prose ALONE; a Discord-origin turn (block present) keeps the footer.
+        let prose = "#3879 작업 완료 — 다음 이슈 대기.";
+        let chrome = "Context   📦 166.4k / 1.0M tokens (16%) · auto-compact 60%\n\nTasks\n└ TaskUpdate 4\n\nSubagents\n└ general-purpose Fix #3879";
+
+        let discord_origin =
+            crate::services::discord::single_message_panel::compose_completion_footer_text(
+                prose,
+                Some(chrome),
+            );
+        assert!(discord_origin.starts_with(prose));
+        assert!(discord_origin.contains("Context   📦"));
+        assert!(discord_origin.contains("Subagents"));
+
+        let mirror = crate::services::discord::single_message_panel::compose_completion_footer_text(
+            prose, None,
+        );
+        assert_eq!(mirror, prose);
+        assert!(!mirror.contains("Context"));
+        assert!(!mirror.contains("auto-compact"));
+        assert!(!mirror.contains("Subagents"));
+    }
+
+    #[test]
+    fn synthetic_tui_mirror_finalize_strips_live_status_footer_to_prose_3964() {
+        // The non-short-replace path: a live status footer still on the message at
+        // completion finalizes (block = None) down to prose, no chrome re-appended.
+        let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let body = format!(
+            "Final answer\n\n{}",
+            crate::services::discord::single_message_panel::compose_footer_status_block("⠸", panel)
+        );
+        let finalized =
+            crate::services::discord::single_message_panel::finalize_streaming_footer_with_completion(
+                &body,
+                &ProviderKind::Claude,
+                None,
+            )
+            .expect("a live status footer must finalize to a stripped edit");
+        assert_eq!(finalized, "Final answer");
+        assert!(!finalized.contains("Subagents"));
+        assert!(!finalized.contains("진행 중"));
+    }
+}

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -155,14 +155,6 @@ pub(super) fn finalize_watcher_streaming_footer(
     }
 }
 
-pub(super) fn watcher_completion_footer_should_tick(
-    has_registered_target: bool,
-    elapsed: std::time::Duration,
-    interval: std::time::Duration,
-) -> bool {
-    has_registered_target && elapsed >= interval
-}
-
 pub(super) struct WatcherCompletionFooterIdleState {
     tick_at: tokio::time::Instant,
     spin_idx: usize,
@@ -226,44 +218,12 @@ pub(super) async fn refresh_watcher_completion_footer_if_due(
     refresh_watcher_registered_completion_footer(http, shared, channel_id, indicator).await;
 }
 
-/// #3964: should the #3089 single-message-panel completion footer
-/// (`Context … tokens`, `Tasks`, `Subagents`) be SUPPRESSED for this
-/// WATCHER-relayed terminal mirror?
-///
-/// This is the tmux-watcher analogue of the turn-bridge gate
-/// `tui_direct_completion_footer_suppressed` (#3959/#3961). #3961 stripped the
-/// chrome only on the turn-bridge relay path (`is_external_input_tui_direct`),
-/// but a TUI session's SYNTHETIC / system-injected turns (background
-/// task-notifications, `/loop`·ScheduleWakeup) are relayed by the live tmux
-/// WATCHER, not the idle bridge — so they reached
-/// `complete_watcher_single_message_completion_footer`, which re-appended the
-/// reconstructed footer (#3964). For a watcher-relayed mirror the user is
-/// already watching the very same Context/Tasks/Subagents chrome in their
-/// Claude Code TUI pane, so the relayed body must carry the assistant prose
-/// ALONE.
-///
-/// Pure + mutation-pinned: the `turn_is_external_input_for_session &&` scoping
-/// keeps Discord-origin (`TurnSource::Managed`) #3089 footers untouched — that
-/// flag is `true` ONLY for external-input/adopted/monitor-triggered turns owned
-/// by the watcher relay (`watcher_inflight_is_panel_eligible_for_session`), so a
-/// genuine Discord-origin turn (whose Discord message is the user's only status
-/// surface) can never be misclassified as a mirror.
-pub(super) fn watcher_external_input_completion_footer_suppressed(
-    single_message_panel_footer_mode: bool,
-    turn_is_external_input_for_session: bool,
-) -> bool {
-    single_message_panel_footer_mode && turn_is_external_input_for_session
-}
-
-/// #3964: deliver the watcher-relayed TUI mirror as clean assistant prose with
-/// NO completion footer appended (and no footer-refresh target left registered).
-///
-/// Mirrors the turn-bridge `complete_bridge_single_message_terminal_no_footer`:
-/// run the shared finalize with a `None` completion block so any residual live
-/// status footer is stripped but nothing is re-appended; an already-clean body
-/// short-circuits to no edit. The registry target is forgotten first so the
-/// background `refresh_watcher_completion_footer_if_due` loop never re-adds the
-/// chrome onto this mirror.
+/// #3964: deliver the watcher-relayed TUI mirror as clean assistant prose with NO
+/// completion footer (mirror of the bridge's
+/// `complete_bridge_single_message_terminal_no_footer`). Forgets the registry
+/// target first so `refresh_watcher_completion_footer_if_due` can't re-add chrome,
+/// then finalizes with a `None` block (strips any residual live footer; an
+/// already-clean body short-circuits to no edit).
 async fn complete_watcher_single_message_terminal_no_footer(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
@@ -286,25 +246,21 @@ async fn complete_watcher_single_message_terminal_no_footer(
             None,
         )
     else {
-        // Already clean (short-replace rewrote the message to this prose) — the
-        // mirror carries the assistant turn with no chrome, nothing to edit.
-        return true;
+        return true; // already clean prose (short-replace) — nothing to edit.
     };
     rate_limit_wait(shared, channel_id).await;
-    match crate::services::discord::http::edit_channel_message(http, channel_id, msg_id, &finalized)
-        .await
+    if let Err(error) =
+        crate::services::discord::http::edit_channel_message(http, channel_id, msg_id, &finalized)
+            .await
     {
-        Ok(_) => true,
-        Err(error) => {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!(
-                "  [{ts}] ⚠ watcher: #3964 TUI-mirror footer strip failed for channel {} msg {}: {error}",
-                channel_id.get(),
-                msg_id.get()
-            );
-            false
-        }
+        tracing::warn!(
+            "  ⚠ watcher: #3964 TUI-mirror footer strip failed for channel {} msg {}: {error}",
+            channel_id.get(),
+            msg_id.get()
+        );
+        return false;
     }
+    true
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -530,21 +486,24 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
                 text: last_edit_text.to_string(),
             });
         let target = terminal_target.or(fallback_target);
+        let target_msg_id = target.as_ref().map(|target| target.msg_id);
+        let target_text = target
+            .as_ref()
+            .map(|target| target.text.as_str())
+            .unwrap_or("");
         if watcher_external_input_completion_footer_suppressed(
             single_message_panel_footer_mode,
             turn_is_external_input_for_session,
+            completion_background,
         ) {
-            // #3964: watcher-relayed TUI mirror — deliver clean prose, no chrome.
+            // #3964: watcher-relayed TUI mirror — clean prose, no chrome.
             complete_watcher_single_message_terminal_no_footer(
                 http,
                 shared,
                 channel_id,
-                target.as_ref().map(|target| target.msg_id),
+                target_msg_id,
                 provider,
-                target
-                    .as_ref()
-                    .map(|target| target.text.as_str())
-                    .unwrap_or(""),
+                target_text,
             )
             .await
         } else {
@@ -561,14 +520,11 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
                 http,
                 shared,
                 channel_id,
-                target.as_ref().map(|target| target.msg_id),
+                target_msg_id,
                 owner,
                 provider,
                 started_at_unix,
-                target
-                    .as_ref()
-                    .map(|target| target.text.as_str())
-                    .unwrap_or(""),
+                target_text,
                 indicator,
                 completion_background,
             )
@@ -724,107 +680,5 @@ mod tests {
 
         assert!(rendered.len() <= DISCORD_MSG_LIMIT);
         assert!(rendered.contains("\n\n"));
-    }
-
-    #[test]
-    fn completion_footer_tick_requires_registered_unfinished_target() {
-        let interval = std::time::Duration::from_secs(5);
-
-        assert!(watcher_completion_footer_should_tick(
-            true, interval, interval
-        ));
-        assert!(!watcher_completion_footer_should_tick(
-            false, interval, interval
-        ));
-        assert!(!watcher_completion_footer_should_tick(
-            true,
-            std::time::Duration::from_secs(4),
-            interval
-        ));
-    }
-
-    // ---- #3964: watcher-relayed synthetic/system-injected TUI mirror suppresses
-    // the #3089 chrome footer ----
-    //
-    // #3961 stripped the `Context … tokens · auto-compact` / `Tasks` / `Subagents`
-    // chrome only on the turn-bridge relay path. A TUI session's SYNTHETIC turns
-    // (background task-notifications, `/loop`·ScheduleWakeup) are relayed by the
-    // live tmux WATCHER instead, so they reached this module's completion footer
-    // and leaked the chrome again (#3964). The watcher gate must suppress the same
-    // chrome for any watcher-owned mirror turn while leaving a genuine
-    // Discord-origin turn's footer (the user's only status surface) intact.
-
-    #[test]
-    fn watcher_external_input_completion_footer_suppression_gate_3964() {
-        // Scoped: suppressed ONLY for a watcher-owned external-input / synthetic
-        // mirror turn in footer mode. A Discord-origin (`TurnSource::Managed`)
-        // footer-mode turn — for which `turn_is_external_input_for_session` is
-        // false — keeps the #3089 footer; non-footer-mode is unaffected.
-        assert!(watcher_external_input_completion_footer_suppressed(
-            true, true
-        ));
-        assert!(!watcher_external_input_completion_footer_suppressed(
-            true, false
-        ));
-        assert!(!watcher_external_input_completion_footer_suppressed(
-            false, true
-        ));
-        assert!(!watcher_external_input_completion_footer_suppressed(
-            false, false
-        ));
-    }
-
-    #[test]
-    fn synthetic_tui_mirror_emits_prose_without_tui_chrome_3964() {
-        // The exact #3964 corruption observed on synthetic / system-injected turns:
-        // assistant prose followed by the rendered Context/Tasks/Subagents
-        // completion footer. The watcher mirror suppresses the completion block
-        // (None), so the relayed body is the assistant turn ALONE — no chrome; while
-        // a Discord-origin turn (block present) still carries the footer.
-        let prose = "#3879 작업 완료 — 다음 이슈 대기.";
-        let chrome_block = "Context   📦 166.4k / 1.0M tokens (16%) · auto-compact 60%\n\nTasks\n└ TaskUpdate 4 · 머지 완료\n\nSubagents\n└ general-purpose Fix #3879 — Agent \"Implement #3886\"";
-
-        let discord_origin =
-            crate::services::discord::single_message_panel::compose_completion_footer_text(
-                prose,
-                Some(chrome_block),
-            );
-        assert!(discord_origin.starts_with(prose));
-        assert!(discord_origin.contains("Context   📦"));
-        assert!(discord_origin.contains("Subagents"));
-        assert!(discord_origin.contains("auto-compact"));
-
-        let synthetic_tui_mirror =
-            crate::services::discord::single_message_panel::compose_completion_footer_text(
-                prose, None,
-            );
-        assert_eq!(synthetic_tui_mirror, prose);
-        assert!(!synthetic_tui_mirror.contains("Context"));
-        assert!(!synthetic_tui_mirror.contains("tokens"));
-        assert!(!synthetic_tui_mirror.contains("auto-compact"));
-        assert!(!synthetic_tui_mirror.contains("Tasks"));
-        assert!(!synthetic_tui_mirror.contains("Subagents"));
-    }
-
-    #[test]
-    fn synthetic_tui_mirror_finalize_strips_live_status_footer_to_prose_3964() {
-        // If the streaming placeholder still carries the LIVE status footer at
-        // completion (the non-short-replace watcher path), the mirror finalize
-        // (block = None) strips it down to the assistant prose with no chrome
-        // re-appended.
-        let body_with_footer = format!(
-            "Final answer\n\n{}",
-            compose_single_message_footer_status_block("⠸", PANEL)
-        );
-        let finalized =
-            crate::services::discord::single_message_panel::finalize_streaming_footer_with_completion(
-                &body_with_footer,
-                &ProviderKind::Claude,
-                None,
-            )
-            .expect("a live status footer must finalize to a stripped edit");
-        assert_eq!(finalized, "Final answer");
-        assert!(!finalized.contains("Subagents"));
-        assert!(!finalized.contains("진행 중"));
     }
 }

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -226,6 +226,87 @@ pub(super) async fn refresh_watcher_completion_footer_if_due(
     refresh_watcher_registered_completion_footer(http, shared, channel_id, indicator).await;
 }
 
+/// #3964: should the #3089 single-message-panel completion footer
+/// (`Context … tokens`, `Tasks`, `Subagents`) be SUPPRESSED for this
+/// WATCHER-relayed terminal mirror?
+///
+/// This is the tmux-watcher analogue of the turn-bridge gate
+/// `tui_direct_completion_footer_suppressed` (#3959/#3961). #3961 stripped the
+/// chrome only on the turn-bridge relay path (`is_external_input_tui_direct`),
+/// but a TUI session's SYNTHETIC / system-injected turns (background
+/// task-notifications, `/loop`·ScheduleWakeup) are relayed by the live tmux
+/// WATCHER, not the idle bridge — so they reached
+/// `complete_watcher_single_message_completion_footer`, which re-appended the
+/// reconstructed footer (#3964). For a watcher-relayed mirror the user is
+/// already watching the very same Context/Tasks/Subagents chrome in their
+/// Claude Code TUI pane, so the relayed body must carry the assistant prose
+/// ALONE.
+///
+/// Pure + mutation-pinned: the `turn_is_external_input_for_session &&` scoping
+/// keeps Discord-origin (`TurnSource::Managed`) #3089 footers untouched — that
+/// flag is `true` ONLY for external-input/adopted/monitor-triggered turns owned
+/// by the watcher relay (`watcher_inflight_is_panel_eligible_for_session`), so a
+/// genuine Discord-origin turn (whose Discord message is the user's only status
+/// surface) can never be misclassified as a mirror.
+pub(super) fn watcher_external_input_completion_footer_suppressed(
+    single_message_panel_footer_mode: bool,
+    turn_is_external_input_for_session: bool,
+) -> bool {
+    single_message_panel_footer_mode && turn_is_external_input_for_session
+}
+
+/// #3964: deliver the watcher-relayed TUI mirror as clean assistant prose with
+/// NO completion footer appended (and no footer-refresh target left registered).
+///
+/// Mirrors the turn-bridge `complete_bridge_single_message_terminal_no_footer`:
+/// run the shared finalize with a `None` completion block so any residual live
+/// status footer is stripped but nothing is re-appended; an already-clean body
+/// short-circuits to no edit. The registry target is forgotten first so the
+/// background `refresh_watcher_completion_footer_if_due` loop never re-adds the
+/// chrome onto this mirror.
+async fn complete_watcher_single_message_terminal_no_footer(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    terminal_msg_id: Option<serenity::MessageId>,
+    provider: &ProviderKind,
+    terminal_text: &str,
+) -> bool {
+    let Some(msg_id) = terminal_msg_id else {
+        return true;
+    };
+    crate::services::discord::single_message_panel::completion_footer_forget_registered_target_if_message(
+        channel_id,
+        msg_id,
+    );
+    let Some(finalized) =
+        crate::services::discord::single_message_panel::finalize_streaming_footer_with_completion(
+            terminal_text,
+            provider,
+            None,
+        )
+    else {
+        // Already clean (short-replace rewrote the message to this prose) — the
+        // mirror carries the assistant turn with no chrome, nothing to edit.
+        return true;
+    };
+    rate_limit_wait(shared, channel_id).await;
+    match crate::services::discord::http::edit_channel_message(http, channel_id, msg_id, &finalized)
+        .await
+    {
+        Ok(_) => true,
+        Err(error) => {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] ⚠ watcher: #3964 TUI-mirror footer strip failed for channel {} msg {}: {error}",
+                channel_id.get(),
+                msg_id.get()
+            );
+            false
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn complete_watcher_single_message_completion_footer(
     http: &Arc<serenity::Http>,
@@ -449,31 +530,50 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
                 text: last_edit_text.to_string(),
             });
         let target = terminal_target.or(fallback_target);
-        let owner = crate::services::discord::single_message_panel::CompletionFooterOwner::new(
-            status_panel_completion_user_msg_id.unwrap_or(0),
-            started_at_unix,
-        );
-        let indicator =
-            crate::services::discord::single_message_panel::single_message_panel_spinner_frame(
-                *spin_idx,
+        if watcher_external_input_completion_footer_suppressed(
+            single_message_panel_footer_mode,
+            turn_is_external_input_for_session,
+        ) {
+            // #3964: watcher-relayed TUI mirror — deliver clean prose, no chrome.
+            complete_watcher_single_message_terminal_no_footer(
+                http,
+                shared,
+                channel_id,
+                target.as_ref().map(|target| target.msg_id),
+                provider,
+                target
+                    .as_ref()
+                    .map(|target| target.text.as_str())
+                    .unwrap_or(""),
+            )
+            .await
+        } else {
+            let owner = crate::services::discord::single_message_panel::CompletionFooterOwner::new(
+                status_panel_completion_user_msg_id.unwrap_or(0),
+                started_at_unix,
             );
-        *spin_idx = (*spin_idx).wrapping_add(1);
-        complete_watcher_single_message_completion_footer(
-            http,
-            shared,
-            channel_id,
-            target.as_ref().map(|target| target.msg_id),
-            owner,
-            provider,
-            started_at_unix,
-            target
-                .as_ref()
-                .map(|target| target.text.as_str())
-                .unwrap_or(""),
-            indicator,
-            completion_background,
-        )
-        .await
+            let indicator =
+                crate::services::discord::single_message_panel::single_message_panel_spinner_frame(
+                    *spin_idx,
+                );
+            *spin_idx = (*spin_idx).wrapping_add(1);
+            complete_watcher_single_message_completion_footer(
+                http,
+                shared,
+                channel_id,
+                target.as_ref().map(|target| target.msg_id),
+                owner,
+                provider,
+                started_at_unix,
+                target
+                    .as_ref()
+                    .map(|target| target.text.as_str())
+                    .unwrap_or(""),
+                indicator,
+                completion_background,
+            )
+            .await
+        }
     } else {
         complete_watcher_status_panel_v2(
             http,
@@ -641,5 +741,90 @@ mod tests {
             std::time::Duration::from_secs(4),
             interval
         ));
+    }
+
+    // ---- #3964: watcher-relayed synthetic/system-injected TUI mirror suppresses
+    // the #3089 chrome footer ----
+    //
+    // #3961 stripped the `Context … tokens · auto-compact` / `Tasks` / `Subagents`
+    // chrome only on the turn-bridge relay path. A TUI session's SYNTHETIC turns
+    // (background task-notifications, `/loop`·ScheduleWakeup) are relayed by the
+    // live tmux WATCHER instead, so they reached this module's completion footer
+    // and leaked the chrome again (#3964). The watcher gate must suppress the same
+    // chrome for any watcher-owned mirror turn while leaving a genuine
+    // Discord-origin turn's footer (the user's only status surface) intact.
+
+    #[test]
+    fn watcher_external_input_completion_footer_suppression_gate_3964() {
+        // Scoped: suppressed ONLY for a watcher-owned external-input / synthetic
+        // mirror turn in footer mode. A Discord-origin (`TurnSource::Managed`)
+        // footer-mode turn — for which `turn_is_external_input_for_session` is
+        // false — keeps the #3089 footer; non-footer-mode is unaffected.
+        assert!(watcher_external_input_completion_footer_suppressed(
+            true, true
+        ));
+        assert!(!watcher_external_input_completion_footer_suppressed(
+            true, false
+        ));
+        assert!(!watcher_external_input_completion_footer_suppressed(
+            false, true
+        ));
+        assert!(!watcher_external_input_completion_footer_suppressed(
+            false, false
+        ));
+    }
+
+    #[test]
+    fn synthetic_tui_mirror_emits_prose_without_tui_chrome_3964() {
+        // The exact #3964 corruption observed on synthetic / system-injected turns:
+        // assistant prose followed by the rendered Context/Tasks/Subagents
+        // completion footer. The watcher mirror suppresses the completion block
+        // (None), so the relayed body is the assistant turn ALONE — no chrome; while
+        // a Discord-origin turn (block present) still carries the footer.
+        let prose = "#3879 작업 완료 — 다음 이슈 대기.";
+        let chrome_block = "Context   📦 166.4k / 1.0M tokens (16%) · auto-compact 60%\n\nTasks\n└ TaskUpdate 4 · 머지 완료\n\nSubagents\n└ general-purpose Fix #3879 — Agent \"Implement #3886\"";
+
+        let discord_origin =
+            crate::services::discord::single_message_panel::compose_completion_footer_text(
+                prose,
+                Some(chrome_block),
+            );
+        assert!(discord_origin.starts_with(prose));
+        assert!(discord_origin.contains("Context   📦"));
+        assert!(discord_origin.contains("Subagents"));
+        assert!(discord_origin.contains("auto-compact"));
+
+        let synthetic_tui_mirror =
+            crate::services::discord::single_message_panel::compose_completion_footer_text(
+                prose, None,
+            );
+        assert_eq!(synthetic_tui_mirror, prose);
+        assert!(!synthetic_tui_mirror.contains("Context"));
+        assert!(!synthetic_tui_mirror.contains("tokens"));
+        assert!(!synthetic_tui_mirror.contains("auto-compact"));
+        assert!(!synthetic_tui_mirror.contains("Tasks"));
+        assert!(!synthetic_tui_mirror.contains("Subagents"));
+    }
+
+    #[test]
+    fn synthetic_tui_mirror_finalize_strips_live_status_footer_to_prose_3964() {
+        // If the streaming placeholder still carries the LIVE status footer at
+        // completion (the non-short-replace watcher path), the mirror finalize
+        // (block = None) strips it down to the assistant prose with no chrome
+        // re-appended.
+        let body_with_footer = format!(
+            "Final answer\n\n{}",
+            compose_single_message_footer_status_block("⠸", PANEL)
+        );
+        let finalized =
+            crate::services::discord::single_message_panel::finalize_streaming_footer_with_completion(
+                &body_with_footer,
+                &ProviderKind::Claude,
+                None,
+            )
+            .expect("a live status footer must finalize to a stripped edit");
+        assert_eq!(finalized, "Final answer");
+        assert!(!finalized.contains("Subagents"));
+        assert!(!finalized.contains("진행 중"));
     }
 }


### PR DESCRIPTION
## What & why
Closes #3964. The #3089 completion-footer chrome (`Context … tokens · auto-compact`, `Tasks`, `Subagents` trees) STILL leaked into relayed prose on **synthetic / system-injected** TUI-direct turns (background task-notifications, `/loop`·ScheduleWakeup), even after #3961.

## Root cause (corrects the issue's hypothesis)
There are **two** terminal completion-footer appenders:
- `turn_bridge/single_message_footer.rs` → `complete_bridge_single_message_completion_footer` — **#3961 fixed this** (gated on `is_external_input_tui_direct`).
- `tmux_watcher/single_message_footer.rs` → `complete_watcher_single_message_completion_footer` — **#3961 never touched it.**

A TUI session's synthetic turns are relayed by the live **tmux WATCHER** (relay-owner == `Watcher`), so they hit the watcher's appender, which had no #3959 suppression and re-appended the chrome.

The issue guessed the leak was the bridge path with `is_external_input_tui_direct=false` (intake_turn.rs:2785). That line is inside `handle_text_message` (genuine Discord messages only) — synthetic turns can't reach it. A synthetic turn delivered via the bridge gets `is_external_input_tui_direct=true` and is **already** suppressed by #3961. The only unhandled terminal-footer path was the watcher's.

## Fix (containment a-style: contained in the footer module, no hotfile flag threading)
`tmux_watcher/single_message_footer.rs` — add the watcher analogue of #3961's gate:
- New pure gate `watcher_external_input_completion_footer_suppressed(footer_mode, turn_is_external_input_for_session)`.
- New `complete_watcher_single_message_terminal_no_footer` (strips any residual live status footer, appends NO completion block, forgets the registry target so the background refresh loop can't re-add chrome).
- `complete_watcher_terminal_footer_or_status_panel` routes footer-mode + external-input turns through it.

`turn_is_external_input_for_session` is **already** a parameter of that function, so **no new flag is routed through `turn_bridge/mod.rs` or any hotfile**.

## Why it avoids the #3016 hotfiles
- Does **not** edit `turn_bridge/mod.rs` (held by the #3871 lane), `tmux_watcher.rs`, `session_relay_sink.rs`, or `turn_finalizer*`.
- The edited `tmux_watcher/single_message_footer.rs` is a **non-hotfile submodule** (not in `scripts/hotfile_ratchet.toml`), distinct from the 517 KB `tmux_watcher.rs`.
- A channel-keyed TUI-hosting lookup (the issue's other suggested containment) was investigated and **rejected**: `PROVIDER_TUI_HOSTING_BY_CHANNEL` encodes channel *config*, not turn *origin*, and would false-positive on Discord-origin turns on a (default-Claude) TUI-hosting channel — the exact #3089 regression #3961 avoided.

## No #3089 regression
`turn_is_external_input_for_session` is true **only** for watcher-owned external-input / adopted / monitor-triggered turns (`watcher_inflight_is_panel_eligible_for_session` + relay-owner == `Watcher`). A genuine Discord-origin (`TurnSource::Managed`) turn is **always** false, so its #3089 footer — the user's only status surface — is untouched.

## Tests (added)
- `watcher_external_input_completion_footer_suppression_gate_3964` — gate scoping (suppress only footer-mode + external-input; Discord-origin keeps footer).
- `synthetic_tui_mirror_emits_prose_without_tui_chrome_3964` — synthetic mirror → prose alone (no Context/Tasks/Subagents); Discord-origin → footer kept.
- `synthetic_tui_mirror_finalize_strips_live_status_footer_to_prose_3964` — residual live footer stripped to prose.

## Gates
`cargo fmt --check` clean; `cargo test --lib …single_message_footer` → 22 passed (3 new + all #3959 bridge tests, no regression); `generate_inventory_docs` (inventory committed) + `check_agent_maintenance_docs` → freshness check passed; `audit_maintainability --check` exit 0; `check_hotfile_ratchet` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)