### PR TITLE
fix(discord): suppress #3089 footer chrome on /loop self-paced TUI mirror via root invariant (#3969)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -587,6 +587,7 @@ src/
 │   │   │   ├── liveness.rs
 │   │   │   ├── orphan_status_panel_cleanup.rs
 │   │   │   ├── panel_decisions.rs
+│   │   │   ├── panel_decisions_tests.rs
 │   │   │   ├── placeholder_reclaim.rs
 │   │   │   ├── prompt_observe.rs
 │   │   │   ├── provider_session_persistence.rs

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -24,7 +24,7 @@
 | `src/services/discord/router/message_handler/intake_turn.rs` | 2797 | discord-relay | 2026-10-31 | #3837 |
 | `src/services/discord/session_relay_sink.rs` | 1631 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/tmux.rs` | 1507 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7082 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux_watcher.rs` | 7092 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6283 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -643,17 +643,17 @@
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 596 | 479 | 117 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10247 | 7082 | 3165 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10257 | 7092 | 3165 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 287 | 165 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
 | `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 225 | 225 | 0 |  |
-| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 643 | 547 | 96 |  |
+| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 598 | 598 | 0 |  |
 | `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 106 | 106 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 147 | 101 | 46 |  |
 | `services::discord::tmux_watcher::session_bound_ack` | `src/services/discord/tmux_watcher/session_bound_ack.rs` | 427 | 427 | 0 |  |
-| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 684 | 570 | 114 |  |
+| `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 690 | 576 | 114 |  |
 | `services::discord::tmux_watcher::supervisor_relay` | `src/services/discord/tmux_watcher/supervisor_relay.rs` | 393 | 393 | 0 |  |
 | `services::discord::tmux_watcher::terminal_readiness` | `src/services/discord/tmux_watcher/terminal_readiness.rs` | 214 | 214 | 0 |  |
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 700 | 654 | 46 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -112,7 +112,16 @@
 # fallback in a later iteration / after a watcher restart still deletes prefixes
 # frozen earlier. The inflight field + patch union-merge + restore wiring live in
 # inflight/{model,watcher_state}.rs + tmux.rs (non-giant for this change).
-"src/services/discord/tmux_watcher.rs" = 7082
+# #3969: 7082 -> 7092 (+10 prod LoC), reviewable admission — close the residual
+# #3089 footer-chrome leak on the /loop ScheduleWakeup self-paced orchestrator-TUI
+# turn class (#3961/#3964/#3967 missed it). The completion chokepoint reads the
+# CHOKEPOINT-FRESH `inflight_before_relay` and threads one root-invariant bool
+# (`turn_is_non_managed_tui_mirror` = `turn_source != Managed`) into
+# `complete_watcher_terminal_footer_or_status_panel`, so EVERY non-Discord mirror
+# origin suppresses regardless of the stale `:1017` panel-eligibility flag. The
+# pure predicate, gate, and per-class tests live in the non-giant sibling
+# `tmux_watcher/{panel_decisions,single_message_footer,panel_decisions_tests}.rs`.
+"src/services/discord/tmux_watcher.rs" = 7092
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -82,7 +82,17 @@
 # two `persist_watcher_stream_progress` call sites. The inflight field + patch
 # union-merge + restore wiring live in inflight/{model,watcher_state}.rs +
 # tmux.rs (non-frozen); this is the minimal frozen-file call-site cost.
-"src/services/discord/tmux_watcher.rs" = 10247
+# #3969: 10247 -> 10257 (+10), reviewable admission — close the residual #3089
+# footer-chrome leak on the /loop ScheduleWakeup self-paced orchestrator-TUI turn
+# class (#3961/#3964/#3967 missed it). The completion chokepoint now reads the
+# CHOKEPOINT-FRESH `inflight_before_relay` and threads a single root-invariant bool
+# (`turn_is_non_managed_tui_mirror` = `turn_source != Managed`) into
+# `complete_watcher_terminal_footer_or_status_panel`, so EVERY non-Discord mirror
+# origin suppresses regardless of the stale `:1017` panel-eligibility flag. The
+# pure predicate + gate + per-class tests live in the non-frozen sibling
+# `tmux_watcher/{panel_decisions,single_message_footer,panel_decisions_tests}.rs`;
+# this is the minimal frozen-file (load-bearing comment + let-binding + arg) cost.
+"src/services/discord/tmux_watcher.rs" = 10257
 # #3715: 7789 -> 4007 by moving the inline `#[cfg(test)] mod tests` body into
 # `tui_prompt_relay/tests.rs` and the Codex idle rollout tail/rebind loop into
 # `tui_prompt_relay/codex_idle_rollout.rs`; no production behavior change.

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -5725,6 +5725,15 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     task_notification_kind,
                     Some(TaskNotificationKind::Background | TaskNotificationKind::MonitorAutoTurn)
                 );
+                // #3969 root invariant: read the CHOKEPOINT-FRESH inflight (this
+                // `inflight_before_relay` is re-loaded after the synthetic row exists,
+                // unlike the stale `:1017` flag) and suppress the #3089 footer for any
+                // non-Managed (TUI-mirror) turn — closing the /loop self-paced leak.
+                let turn_is_non_managed_tui_mirror =
+                    watcher_inflight_is_non_managed_tui_mirror_for_session(
+                        inflight_before_relay.as_ref(),
+                        &tmux_session_name,
+                    );
                 complete_watcher_terminal_footer_or_status_panel(
                     &http,
                     &shared,
@@ -5741,6 +5750,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     completion_background,
                     status_panel_completion_user_msg_id,
                     turn_is_external_input_for_session,
+                    turn_is_non_managed_tui_mirror,
                 )
                 .await;
             } // #3142: end `if !inflight_before_relay_is_stale_newer_turn` (EDIT/finalize gate)

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -418,6 +418,40 @@ pub(super) fn watcher_inflight_is_panel_eligible_for_session(
         })
 }
 
+/// #3969: the ROOT INVARIANT behind the #3089 footer-chrome suppression. A
+/// watcher-relayed orchestrator-TUI session emits exactly two turn classes:
+///
+///   * a genuine Discord-USER-message turn (`TurnSource::Managed`) — the user
+///     typed in Discord, so the reconstructed footer (`Context … tokens`,
+///     `Tasks`, `Subagents`) is their ONLY status surface → KEEP it; and
+///   * every OTHER origin (`ExternalInput` terminal-typed / `/loop` self-paced,
+///     `ExternalAdopted`, `MonitorTriggered`) — a MIRROR of what the user is
+///     already watching live in the terminal, so the footer is duplicate chrome
+///     → SUPPRESS it.
+///
+/// `turn_is_external_input_for_session` (the cached `:1017` panel-eligibility
+/// flag) ENUMERATES the mirror sub-cases but is read from the top-of-iteration
+/// `:1009` snapshot, so a turn whose inflight row is created LATER in the same
+/// iteration (the `/loop` ScheduleWakeup self-paced class, #3969 — created by
+/// the claude idle bridge, NOT a `<task-notification>`, so `completion_background`
+/// is also `false`) is stale-`false` and leaks. This predicate instead reads the
+/// CHOKEPOINT-FRESH `inflight_before_relay` (`tmux_watcher.rs:3857`, re-loaded
+/// AFTER the row exists) and keys on the COMPLETE complement of `Managed`
+/// (`turn_source != Managed`), so every non-Discord origin is caught and no
+/// mirror class can be missed by enumeration. The `tmux_session_name` guard
+/// ignores a stale inflight bound to a different pane. A genuine Discord turn is
+/// `Managed` → this returns `false` → the #3089 footer is KEPT (non-regression).
+pub(super) fn watcher_inflight_is_non_managed_tui_mirror_for_session(
+    inflight: Option<&InflightTurnState>,
+    tmux_session_name: &str,
+) -> bool {
+    inflight
+        .filter(|state| state.tmux_session_name.as_deref() == Some(tmux_session_name))
+        .is_some_and(|state| {
+            state.turn_source != crate::services::discord::inflight::TurnSource::Managed
+        })
+}
+
 /// #3003 single-chokepoint orphan reclaim: has the in-flight TUI-direct turn
 /// been abandoned, so a watcher-created v2 panel can never reach terminal
 /// completion?
@@ -533,111 +567,32 @@ pub(super) fn watcher_completion_footer_should_tick(
 ///    value (merged at `:1170`/`:1464`) that is correct regardless of row timing.
 ///    This catches the common fresh synthetic turn the cached flag misses.
 ///
-/// Both are `false` for a genuine Discord-origin turn (`TurnSource::Managed` is not
-/// panel-eligible; a real user message carries no `<task-notification>` marker), so
-/// its #3089 footer — the user's only status surface — is never stripped.
+/// All three are `false` for a genuine Discord-origin turn (`TurnSource::Managed`
+/// is not panel-eligible, carries no `<task-notification>` marker, and is the one
+/// origin `turn_is_non_managed_tui_mirror` excludes), so its #3089 footer — the
+/// user's only status surface — is never stripped.
+///
+/// 3. `turn_is_non_managed_tui_mirror` (#3969) — the ROOT INVARIANT disjunct:
+///    `watcher_inflight_is_non_managed_tui_mirror_for_session` over the
+///    CHOKEPOINT-FRESH `inflight_before_relay`. The cached `turn_is_external_input_for_session`
+///    enumerates the mirror sub-cases from a STALE top-of-iteration snapshot and
+///    misses the `/loop` self-paced (`ExternalInput`) class whose row is created
+///    later (#3969); `completion_background` only catches `<task-notification>`
+///    turns. This disjunct keys on the complete complement of `Managed`, so EVERY
+///    non-Discord origin suppresses regardless of row timing. Additive: it only
+///    ever fires for `turn_source != Managed`, so it can never strip a Discord turn.
 pub(super) fn watcher_external_input_completion_footer_suppressed(
     single_message_panel_footer_mode: bool,
     turn_is_external_input_for_session: bool,
     completion_background: bool,
+    turn_is_non_managed_tui_mirror: bool,
 ) -> bool {
     single_message_panel_footer_mode
-        && (turn_is_external_input_for_session || completion_background)
+        && (turn_is_external_input_for_session
+            || completion_background
+            || turn_is_non_managed_tui_mirror)
 }
 
 #[cfg(test)]
-mod completion_footer_suppression_tests {
-    use super::*;
-    use crate::services::discord::ProviderKind;
-
-    #[test]
-    fn completion_footer_tick_requires_registered_unfinished_target() {
-        let interval = std::time::Duration::from_secs(5);
-        assert!(watcher_completion_footer_should_tick(
-            true, interval, interval
-        ));
-        assert!(!watcher_completion_footer_should_tick(
-            false, interval, interval
-        ));
-        assert!(!watcher_completion_footer_should_tick(
-            true,
-            std::time::Duration::from_secs(4),
-            interval
-        ));
-    }
-
-    #[test]
-    fn gate_suppresses_for_either_mirror_signal_and_keeps_discord_origin_3964() {
-        // cached flag true (row pre-existed) → suppress.
-        assert!(watcher_external_input_completion_footer_suppressed(
-            true, true, false
-        ));
-        // cached flag FALSE but completion_background true — the #3964 fresh
-        // synthetic /loop·MonitorAutoTurn / background regression the bridge-style
-        // cached flag cannot catch at the terminal chokepoint → still suppress.
-        assert!(watcher_external_input_completion_footer_suppressed(
-            true, false, true
-        ));
-        assert!(watcher_external_input_completion_footer_suppressed(
-            true, true, true
-        ));
-        // genuine Discord-origin turn: both signals false → KEEP the #3089 footer.
-        assert!(!watcher_external_input_completion_footer_suppressed(
-            true, false, false
-        ));
-        // non-footer-mode is never the single-message footer path.
-        assert!(!watcher_external_input_completion_footer_suppressed(
-            false, true, true
-        ));
-        assert!(!watcher_external_input_completion_footer_suppressed(
-            false, false, true
-        ));
-    }
-
-    #[test]
-    fn synthetic_tui_mirror_emits_prose_without_tui_chrome_3964() {
-        // The exact #3964 corruption: assistant prose + the rendered
-        // Context/Tasks/Subagents footer. A suppressed mirror composes with a `None`
-        // block → prose ALONE; a Discord-origin turn (block present) keeps the footer.
-        let prose = "#3879 작업 완료 — 다음 이슈 대기.";
-        let chrome = "Context   📦 166.4k / 1.0M tokens (16%) · auto-compact 60%\n\nTasks\n└ TaskUpdate 4\n\nSubagents\n└ general-purpose Fix #3879";
-
-        let discord_origin =
-            crate::services::discord::single_message_panel::compose_completion_footer_text(
-                prose,
-                Some(chrome),
-            );
-        assert!(discord_origin.starts_with(prose));
-        assert!(discord_origin.contains("Context   📦"));
-        assert!(discord_origin.contains("Subagents"));
-
-        let mirror = crate::services::discord::single_message_panel::compose_completion_footer_text(
-            prose, None,
-        );
-        assert_eq!(mirror, prose);
-        assert!(!mirror.contains("Context"));
-        assert!(!mirror.contains("auto-compact"));
-        assert!(!mirror.contains("Subagents"));
-    }
-
-    #[test]
-    fn synthetic_tui_mirror_finalize_strips_live_status_footer_to_prose_3964() {
-        // The non-short-replace path: a live status footer still on the message at
-        // completion finalizes (block = None) down to prose, no chrome re-appended.
-        let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
-        let body = format!(
-            "Final answer\n\n{}",
-            crate::services::discord::single_message_panel::compose_footer_status_block("⠸", panel)
-        );
-        let finalized =
-            crate::services::discord::single_message_panel::finalize_streaming_footer_with_completion(
-                &body,
-                &ProviderKind::Claude,
-                None,
-            )
-            .expect("a live status footer must finalize to a stripped edit");
-        assert_eq!(finalized, "Final answer");
-        assert!(!finalized.contains("Subagents"));
-        assert!(!finalized.contains("진행 중"));
-    }
-}
+#[path = "panel_decisions_tests.rs"]
+mod completion_footer_suppression_tests;

--- a/src/services/discord/tmux_watcher/panel_decisions_tests.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions_tests.rs
@@ -1,0 +1,228 @@
+//! Tests for the watcher status-panel / completion-footer DECISIONS.
+//!
+//! PURE MOVE of `panel_decisions.rs`'s `#[cfg(test)] mod
+//! completion_footer_suppression_tests` (zero logic change), kept in a sibling
+//! `*_tests.rs` so the production module stays within the
+//! `src/services/discord/tmux_watcher/**` namespace LoC cap (test files are
+//! excluded from the cap by the audit's `production_rust_files()` filter).
+//! #3969 additions: the `/loop` self-paced (`ExternalInput`) vs Discord-origin
+//! (`Managed`) per-class regression coverage for the root-invariant signal.
+
+use super::*;
+use crate::services::discord::ProviderKind;
+use crate::services::discord::inflight::{InflightTurnState, TurnSource};
+
+const ADK_CC_SESSION: &str = "AgentDesk-claude-adk-cc";
+
+/// Build an inflight row for the orchestrator TUI channel with a given
+/// `turn_source`, mirroring the shape the watcher loads as `inflight_before_relay`
+/// at the terminal chokepoint (`tmux_watcher.rs:3857`).
+fn inflight_with_turn_source(
+    turn_source: TurnSource,
+    tmux_session_name: Option<&str>,
+) -> InflightTurnState {
+    let mut state = InflightTurnState::new(
+        ProviderKind::Claude,
+        123,
+        Some("adk-cc".to_string()),
+        42,
+        1001,
+        2002,
+        "prompt".to_string(),
+        Some("session".to_string()),
+        tmux_session_name.map(str::to_string),
+        Some("/tmp/out.jsonl".to_string()),
+        None,
+        0,
+    );
+    state.turn_source = turn_source;
+    state
+}
+
+#[test]
+fn completion_footer_tick_requires_registered_unfinished_target() {
+    let interval = std::time::Duration::from_secs(5);
+    assert!(watcher_completion_footer_should_tick(
+        true, interval, interval
+    ));
+    assert!(!watcher_completion_footer_should_tick(
+        false, interval, interval
+    ));
+    assert!(!watcher_completion_footer_should_tick(
+        true,
+        std::time::Duration::from_secs(4),
+        interval
+    ));
+}
+
+#[test]
+fn gate_suppresses_for_either_mirror_signal_and_keeps_discord_origin_3964() {
+    // cached flag true (row pre-existed) → suppress.
+    assert!(watcher_external_input_completion_footer_suppressed(
+        true, true, false, false
+    ));
+    // cached flag FALSE but completion_background true — the #3964 fresh
+    // synthetic MonitorAutoTurn / background regression the bridge-style
+    // cached flag cannot catch at the terminal chokepoint → still suppress.
+    assert!(watcher_external_input_completion_footer_suppressed(
+        true, false, true, false
+    ));
+    assert!(watcher_external_input_completion_footer_suppressed(
+        true, true, true, false
+    ));
+    // #3969: cached flag AND completion_background BOTH false (the /loop
+    // ScheduleWakeup self-paced class — stale :1017 flag + no task-notification),
+    // but the chokepoint-fresh non-Managed mirror signal is true → suppress.
+    // This is the previously-missed leak the root invariant closes.
+    assert!(watcher_external_input_completion_footer_suppressed(
+        true, false, false, true
+    ));
+    // genuine Discord-origin turn: ALL three mirror signals false → KEEP the
+    // #3089 footer (the Managed turn's only status surface).
+    assert!(!watcher_external_input_completion_footer_suppressed(
+        true, false, false, false
+    ));
+    // non-footer-mode is never the single-message footer path.
+    assert!(!watcher_external_input_completion_footer_suppressed(
+        false, true, true, false
+    ));
+    assert!(!watcher_external_input_completion_footer_suppressed(
+        false, false, true, false
+    ));
+    assert!(!watcher_external_input_completion_footer_suppressed(
+        false, false, false, true
+    ));
+}
+
+/// #3969 PER-CLASS REGRESSION: the `/loop` ScheduleWakeup self-paced turn class
+/// (the case #3961/#3964/#3967 all missed). Its inflight carries
+/// `TurnSource::ExternalInput` (created by the claude idle bridge), is NOT a
+/// `<task-notification>`, and its `:1017` panel-eligibility flag is stale-`false`
+/// — so BOTH pre-#3969 gate disjuncts are `false` and the #3089 footer leaked.
+/// The chokepoint-fresh non-Managed signal catches it, and the full gate (with
+/// the two stale disjuncts forced `false`, exactly as the live leak presented)
+/// now suppresses.
+#[test]
+fn loop_self_paced_external_input_turn_suppresses_footer_3969() {
+    let inflight = inflight_with_turn_source(TurnSource::ExternalInput, Some(ADK_CC_SESSION));
+
+    let mirror =
+        watcher_inflight_is_non_managed_tui_mirror_for_session(Some(&inflight), ADK_CC_SESSION);
+    assert!(
+        mirror,
+        "a /loop self-paced ExternalInput turn is a non-Managed TUI mirror"
+    );
+
+    // Reproduce the exact live leak signal values: stale cached flag false,
+    // not a background task-notification — only the root-invariant disjunct fires.
+    assert!(
+        watcher_external_input_completion_footer_suppressed(true, false, false, mirror),
+        "the /loop self-paced turn must SUPPRESS the reconstructed #3089 footer"
+    );
+
+    // The other two non-Managed mirror origins are caught identically.
+    assert!(watcher_inflight_is_non_managed_tui_mirror_for_session(
+        Some(&inflight_with_turn_source(
+            TurnSource::MonitorTriggered,
+            Some(ADK_CC_SESSION)
+        )),
+        ADK_CC_SESSION,
+    ));
+    assert!(watcher_inflight_is_non_managed_tui_mirror_for_session(
+        Some(&inflight_with_turn_source(
+            TurnSource::ExternalAdopted,
+            Some(ADK_CC_SESSION)
+        )),
+        ADK_CC_SESSION,
+    ));
+}
+
+/// #3969 NON-REGRESSION: a genuine Discord-USER-message turn on the SAME TUI
+/// channel carries `TurnSource::Managed`, so the non-Managed signal is `false`
+/// and — with the other two disjuncts also `false` for a real user message — the
+/// gate KEEPS the #3089 footer (the Discord user's only status surface). Proves
+/// the root-invariant signal can never misclassify a Discord-origin turn as a
+/// mirror.
+#[test]
+fn discord_origin_managed_turn_keeps_footer_3969() {
+    let inflight = inflight_with_turn_source(TurnSource::Managed, Some(ADK_CC_SESSION));
+
+    let mirror =
+        watcher_inflight_is_non_managed_tui_mirror_for_session(Some(&inflight), ADK_CC_SESSION);
+    assert!(
+        !mirror,
+        "a Discord-origin Managed turn is NOT a mirror — never suppress its footer"
+    );
+    assert!(
+        !watcher_external_input_completion_footer_suppressed(true, false, false, mirror),
+        "the Discord-user-message turn must KEEP its #3089 footer (#3089 non-regression)"
+    );
+}
+
+/// #3969 guard: the `tmux_session_name` filter ignores a stale inflight bound to
+/// a DIFFERENT pane (or a missing row) — a non-matching session never flips the
+/// mirror signal true, so it cannot suppress a footer it does not own.
+#[test]
+fn non_managed_mirror_signal_requires_session_match_3969() {
+    let other_session =
+        inflight_with_turn_source(TurnSource::ExternalInput, Some("AgentDesk-claude-other"));
+    assert!(!watcher_inflight_is_non_managed_tui_mirror_for_session(
+        Some(&other_session),
+        ADK_CC_SESSION,
+    ));
+    let no_session = inflight_with_turn_source(TurnSource::ExternalInput, None);
+    assert!(!watcher_inflight_is_non_managed_tui_mirror_for_session(
+        Some(&no_session),
+        ADK_CC_SESSION,
+    ));
+    assert!(!watcher_inflight_is_non_managed_tui_mirror_for_session(
+        None,
+        ADK_CC_SESSION,
+    ));
+}
+
+#[test]
+fn synthetic_tui_mirror_emits_prose_without_tui_chrome_3964() {
+    // The exact #3964 corruption: assistant prose + the rendered
+    // Context/Tasks/Subagents footer. A suppressed mirror composes with a `None`
+    // block → prose ALONE; a Discord-origin turn (block present) keeps the footer.
+    let prose = "#3879 작업 완료 — 다음 이슈 대기.";
+    let chrome = "Context   📦 166.4k / 1.0M tokens (16%) · auto-compact 60%\n\nTasks\n└ TaskUpdate 4\n\nSubagents\n└ general-purpose Fix #3879";
+
+    let discord_origin =
+        crate::services::discord::single_message_panel::compose_completion_footer_text(
+            prose,
+            Some(chrome),
+        );
+    assert!(discord_origin.starts_with(prose));
+    assert!(discord_origin.contains("Context   📦"));
+    assert!(discord_origin.contains("Subagents"));
+
+    let mirror =
+        crate::services::discord::single_message_panel::compose_completion_footer_text(prose, None);
+    assert_eq!(mirror, prose);
+    assert!(!mirror.contains("Context"));
+    assert!(!mirror.contains("auto-compact"));
+    assert!(!mirror.contains("Subagents"));
+}
+
+#[test]
+fn synthetic_tui_mirror_finalize_strips_live_status_footer_to_prose_3964() {
+    // The non-short-replace path: a live status footer still on the message at
+    // completion finalizes (block = None) down to prose, no chrome re-appended.
+    let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+    let body = format!(
+        "Final answer\n\n{}",
+        crate::services::discord::single_message_panel::compose_footer_status_block("⠸", panel)
+    );
+    let finalized =
+        crate::services::discord::single_message_panel::finalize_streaming_footer_with_completion(
+            &body,
+            &ProviderKind::Claude,
+            None,
+        )
+        .expect("a live status footer must finalize to a stripped edit");
+    assert_eq!(finalized, "Final answer");
+    assert!(!finalized.contains("Subagents"));
+    assert!(!finalized.contains("진행 중"));
+}

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -478,6 +478,11 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
     completion_background: bool,
     status_panel_completion_user_msg_id: Option<u64>,
     turn_is_external_input_for_session: bool,
+    // #3969 root invariant: chokepoint-fresh "this turn is a non-Managed TUI
+    // mirror" (`turn_source != Managed`). Suppresses the #3089 footer for the
+    // /loop self-paced (ExternalInput) class the stale `turn_is_external_input_for_session`
+    // flag misses; never set for a Discord-origin Managed turn.
+    turn_is_non_managed_tui_mirror: bool,
 ) {
     let committed = if single_message_panel_footer_mode {
         let fallback_target =
@@ -495,6 +500,7 @@ pub(super) async fn complete_watcher_terminal_footer_or_status_panel(
             single_message_panel_footer_mode,
             turn_is_external_input_for_session,
             completion_background,
+            turn_is_non_managed_tui_mirror,
         ) {
             // #3964: watcher-relayed TUI mirror — clean prose, no chrome.
             complete_watcher_single_message_terminal_no_footer(


### PR DESCRIPTION
Closes #3969.

## Problem
#3961 (bridge), #3964/#3967 (watcher Background/MonitorAutoTurn) each fixed an **enumerated** synthetic-turn sub-case, but the **/loop ScheduleWakeup self-paced** orchestrator-TUI turn still leaks the #3089 completion footer (Context-tokens line + `Tasks`/`Subagents` trees).

Live evidence (deployed 44267f73f, with #3967): the `15:07:21` /loop self-paced turn ends with `…폴백 00:30.\n\nContext 📦 411.5k / 1.0M tokens (41%) · auto-compact 60%\n\nTasks\n└ TaskUpdate 4 …` (CHROME), while the `15:12:52` Background turn on the same binary is clean.

## Per-turn-class classification at the footer chokepoint
| Class | inflight `TurnSource` | `turn_is_external_input_for_session` | `completion_background` | `task_notification_kind` | #3967 gate | Correct? |
|---|---|---|---|---|---|---|
| (a) Discord USER message | `Managed` | false | false | None | KEEP | ✅ keep |
| (b) terminal-typed input | `ExternalInput` | true (or stale-false) | false | None | suppress/**leak** | suppress |
| (c) **/loop ScheduleWakeup self-paced** | `ExternalInput` | **stale-false** | **false** | **None** | **LEAK** ❌ | suppress |
| (d) Background task-notification | non-`Managed` | maybe stale-false | **true** | Background | suppress | ✅ |
| (e) MonitorAutoTurn | `MonitorTriggered` | true (or stale-false) | **true** | MonitorAutoTurn | suppress | ✅ |

## Root cause
For (c): the inflight row is created by the claude idle bridge **later in the same `'watcher_loop` iteration** than the `:1009` snapshot that feeds `turn_is_external_input_for_session` (`:1017`), so that flag is **stale-false** at the chokepoint; and a /loop turn carries **no `<task-notification>`** marker → `completion_background=false`. Both #3967 disjuncts false → footer re-appended.

## Fix — the root invariant (not another enumerated case)
A watcher-relayed orchestrator-TUI session emits exactly two classes: a genuine Discord-USER-message turn (`TurnSource::Managed` — the footer is the user's only status surface → **KEEP**) and **every other origin** (`ExternalInput` / `ExternalAdopted` / `MonitorTriggered` — a live mirror of the terminal → **SUPPRESS**). Key on the **complete complement of `Managed`**, read from the **chokepoint-fresh** `inflight_before_relay` (`tmux_watcher.rs:3857`, re-loaded after the synthetic row exists) so no mirror class can be missed by row timing.

- `tmux_watcher/panel_decisions.rs`: new pure predicate `watcher_inflight_is_non_managed_tui_mirror_for_session` (`turn_source != Managed`, `tmux_session`-guarded); `watcher_external_input_completion_footer_suppressed` gains the additive root-invariant disjunct.
- `tmux_watcher/single_message_footer.rs` + `tmux_watcher.rs`: thread the chokepoint-computed bool.

### #3089 non-regression proof
The new disjunct **only ever fires for `turn_source != Managed`**. A Discord-user-message turn is `Managed` (the synthetic `ExternalInput` claim provably skips when the mailbox already owns the Discord turn — `tui_prompt_relay/synthetic_start.rs:168`), so it can never be misclassified as a mirror; with the other two disjuncts also false for a real user message, its #3089 footer is kept.

## Scope / hot-files
- Edited the non-hot submodule (`panel_decisions.rs`, `single_message_footer.rs`, new sibling `panel_decisions_tests.rs`) as #3967 did. `tmux_watcher.rs` (#3016 hot file) threads one load-bearing comment + let-binding + arg (**+10 raw / +10 prod LoC**), admitted in both `hotfile_ratchet.toml` and `audit_maintainability_giant_baseline.toml`.
- Did **not** touch `session_relay_sink.rs`, `turn_finalizer*`, or `turn_bridge/mod.rs`.

## Tests (per-class, in sibling `panel_decisions_tests.rs`, excluded from the namespace cap)
- `loop_self_paced_external_input_turn_suppresses_footer_3969` — the previously-missed class (stale flag + no task-notification) → footer **suppressed**.
- `discord_origin_managed_turn_keeps_footer_3969` — Discord-origin `Managed` → footer **kept**.
- `non_managed_mirror_signal_requires_session_match_3969` — session/None guard.

## Gate exit codes
- `cargo fmt --check` → 0
- `cargo test --lib tmux_watcher::panel_decisions` → 0 (7 passed)
- `cargo test --lib tmux_watcher::single_message_footer` → 0 (8 passed)
- `generate_inventory_docs.py` → 0 (regenerated docs included)
- `check_agent_maintenance_docs.py` → 0 (freshness passed)
- `audit_maintainability.py --check` → 0
- `check_hotfile_ratchet.py` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)