### PR TITLE
fix(discord): re-stamp claude_tui prompt anchor on streaming activity (#3956)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -913,9 +913,17 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (1764 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1812 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
-    outside an extraction plan; +55 from #3885 follow-up: decouple the PROMPT
+    outside an extraction plan; +48 from #3956: add the
+    `touch_prompt_anchor_on_activity` refresh primitive (re-stamp an EXISTING
+    submit anchor's `recorded_at` on observed streaming activity, channel-scoped,
+    never creates an anchor and never touches the `relayed_entry_ids_by_tmux`
+    ledger) so a turn streaming continuously past `PROMPT_ANCHOR_SUBMIT_TTL` (4h)
+    keeps a live anchor for the #3885 same-input follow-up-requeue peek — closes
+    the deferred #3885 residual; the watcher calls it from its per-pane
+    streaming-observation path, plus two regression tests; +55 from #3885
+    follow-up: decouple the PROMPT
     ANCHOR purge into `PROMPT_ANCHOR_SUBMIT_TTL` (4h) so a routine 30-60min
     streaming build/agent turn's anchor is no longer purged mid-stream — the
     bridge same-input correlation peek (and the watcher ⏳→✅ response match) would

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -913,17 +913,19 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (1812 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1824 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
-    outside an extraction plan; +48 from #3956: add the
-    `touch_prompt_anchor_on_activity` refresh primitive (re-stamp an EXISTING
-    submit anchor's `recorded_at` on observed streaming activity, channel-scoped,
-    never creates an anchor and never touches the `relayed_entry_ids_by_tmux`
-    ledger) so a turn streaming continuously past `PROMPT_ANCHOR_SUBMIT_TTL` (4h)
-    keeps a live anchor for the #3885 same-input follow-up-requeue peek — closes
-    the deferred #3885 residual; the watcher calls it from its per-pane
-    streaming-observation path, plus two regression tests; +55 from #3885
-    follow-up: decouple the PROMPT
+    outside an extraction plan; +60 from #3956: add the
+    `touch_prompt_anchor_on_activity` refresh primitive — an ANCHOR-ONLY single-map
+    op (re-stamp an EXISTING submit anchor's `recorded_at` on observed streaming
+    activity, channel-scoped, never creates an anchor; checks the 4h ceiling INLINE
+    and evicts a >4h-dead anchor rather than calling the global `purge_expired`, so
+    it never scans or mutates the `relayed_entry_ids_by_tmux` ledger or any other
+    dedupe map on the per-chunk hot path) so a turn streaming continuously past
+    `PROMPT_ANCHOR_SUBMIT_TTL` (4h) keeps a live anchor for the #3885 same-input
+    follow-up-requeue peek — closes the deferred #3885 residual; the watcher calls
+    it from its per-pane streaming-observation path, plus three regression tests;
+    +55 from #3885 follow-up: decouple the PROMPT
     ANCHOR purge into `PROMPT_ANCHOR_SUBMIT_TTL` (4h) so a routine 30-60min
     streaming build/agent turn's anchor is no longer purged mid-stream — the
     bridge same-input correlation peek (and the watcher ⏳→✅ response match) would

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -24,7 +24,7 @@
 | `src/services/discord/router/message_handler/intake_turn.rs` | 2797 | discord-relay | 2026-10-31 | #3837 |
 | `src/services/discord/session_relay_sink.rs` | 1653 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/tmux.rs` | 1507 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7092 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux_watcher.rs` | 7103 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1048 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6283 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |
@@ -101,6 +101,6 @@
 | `src/services/routines/discord_log.rs` | 1589 |
 | `src/services/routines/store.rs` | 3453 |
 | `src/services/settings.rs` | 1114 |
-| `src/services/tui_prompt_dedupe.rs` | 1764 |
+| `src/services/tui_prompt_dedupe.rs` | 1812 |
 | `src/services/turn_orchestrator.rs` | 3184 |
 | `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -101,6 +101,6 @@
 | `src/services/routines/discord_log.rs` | 1589 |
 | `src/services/routines/store.rs` | 3453 |
 | `src/services/settings.rs` | 1114 |
-| `src/services/tui_prompt_dedupe.rs` | 1812 |
+| `src/services/tui_prompt_dedupe.rs` | 1824 |
 | `src/services/turn_orchestrator.rs` | 3184 |
 | `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -884,7 +884,7 @@
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 241 | 241 | 0 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 720 | 677 | 43 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 100 | 100 | 0 |  |
-| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4066 | 1812 | 2254 | giant-file |
+| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4119 | 1824 | 2295 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -468,7 +468,7 @@
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 549 | 188 | 361 |  |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
 | `services::discord::inflight::finalizer_identity` | `src/services/discord/inflight/finalizer_identity.rs` | 56 | 56 | 0 |  |
-| `services::discord::inflight::model` | `src/services/discord/inflight/model.rs` | 1042 | 797 | 245 |  |
+| `services::discord::inflight::model` | `src/services/discord/inflight/model.rs` | 1050 | 805 | 245 |  |
 | `services::discord::inflight::orphan_relay_reclaim` | `src/services/discord/inflight/orphan_relay_reclaim.rs` | 477 | 203 | 274 |  |
 | `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 226 | 226 | 0 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 62 | 62 | 0 |  |
@@ -645,7 +645,7 @@
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 596 | 479 | 117 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10257 | 7092 | 3165 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 10268 | 7103 | 3165 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 287 | 165 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
 | `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |
@@ -884,7 +884,7 @@
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 241 | 241 | 0 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 720 | 677 | 43 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 100 | 100 | 0 |  |
-| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 3844 | 1764 | 2080 | giant-file |
+| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4066 | 1812 | 2254 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -121,7 +121,16 @@
 # origin suppresses regardless of the stale `:1017` panel-eligibility flag. The
 # pure predicate, gate, and per-class tests live in the non-giant sibling
 # `tmux_watcher/{panel_decisions,single_message_footer,panel_decisions_tests}.rs`.
-"src/services/discord/tmux_watcher.rs" = 7092
+# #3956: 7092 -> 7103 (+11 prod LoC), reviewable admission — close the deferred
+# #3885 residual where a turn streaming continuously past PROMPT_ANCHOR_SUBMIT_TTL
+# (4h) loses its submit prompt anchor mid-stream (the same-input follow-up-requeue
+# peek then resolves None and re-fires duplicate prose). The watcher's per-pane
+# streaming-observation read point now calls the new refresh primitive
+# `tui_prompt_dedupe::touch_prompt_anchor_on_activity` so the anchor stays live for
+# the whole turn (TTL-independent), never touching the #3459/#3303 relayed-entry
+# ledger. The primitive + regression tests live in the non-giant `tui_prompt_dedupe.rs`;
+# this is the minimal call-site cost (load-bearing comment block + channel-scoped call).
+"src/services/discord/tmux_watcher.rs" = 7103
 # #3038 tmux_watcher S1 child modules, frozen at landed production LoC.
 "src/services/discord/tmux_watcher/commit_decisions.rs" = 140
 "src/services/discord/tmux_watcher/completion_gate.rs" = 275

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -92,7 +92,16 @@
 # pure predicate + gate + per-class tests live in the non-frozen sibling
 # `tmux_watcher/{panel_decisions,single_message_footer,panel_decisions_tests}.rs`;
 # this is the minimal frozen-file (load-bearing comment + let-binding + arg) cost.
-"src/services/discord/tmux_watcher.rs" = 10257
+# #3956: 10257 -> 10268 (+11), reviewable admission — close the deferred #3885
+# residual where a turn streaming continuously past PROMPT_ANCHOR_SUBMIT_TTL (4h)
+# loses its submit prompt anchor mid-stream (the same-input follow-up-requeue peek
+# then resolves None and re-fires duplicate prose). The watcher's per-pane
+# streaming-observation site (the "got new data" read point) now calls the new
+# `tui_prompt_dedupe::touch_prompt_anchor_on_activity` refresh primitive so the
+# anchor stays live for the whole turn, TTL-independent. The primitive + its
+# regression tests live in the NON-hot `tui_prompt_dedupe.rs`; this is the minimal
+# frozen-file cost (one load-bearing comment block + the channel-scoped call).
+"src/services/discord/tmux_watcher.rs" = 10268
 # #3715: 7789 -> 4007 by moving the inline `#[cfg(test)] mod tests` body into
 # `tui_prompt_relay/tests.rs` and the Codex idle rollout tail/rebind loop into
 # `tui_prompt_relay/codex_idle_rollout.rs`; no production behavior change.

--- a/src/services/discord/inflight/model.rs
+++ b/src/services/discord/inflight/model.rs
@@ -356,9 +356,17 @@ pub(in crate::services::discord) struct InflightTurnState {
 }
 
 /// Origin of a turn whose state is captured in [`InflightTurnState`]. Pure
-/// audit metadata for #2285 / #2161 — callers must not branch relay or
-/// completion semantics on this value; the session-bound relay (epic #2285
-/// E1–E5) treats every matched session uniformly.
+/// audit metadata for #2285 / #2161 — callers must not branch RELAY routing on
+/// this value; the session-bound relay (epic #2285 E1–E5) treats every matched
+/// session uniformly.
+///
+/// EXCEPTION (#3969, behavioral dependency — do not silently regress): the
+/// watcher's completion-footer suppression for #3089 footer chrome DOES key on
+/// `turn_source == Managed`. The #3089 footer is kept only for Discord-origin
+/// (`Managed`) turns; every non-`Managed` mirror origin (e.g. `/loop`
+/// self-paced / monitor / external-input TUI mirrors) suppresses the footer. So
+/// the `Managed` discriminant is now load-bearing for that footer decision —
+/// preserve this carve-out when changing how `turn_source` is assigned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub(in crate::services::discord) enum TurnSource {

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -715,6 +715,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // We got new data while not paused — this means terminal input triggered a response
         let data_start_offset = current_offset; // offset where this read batch started
         current_offset = new_offset;
+        // #3956: re-stamp the submit prompt anchor on this observed streaming output
+        // so a turn streaming continuously past PROMPT_ANCHOR_SUBMIT_TTL (4h) keeps a
+        // live anchor for the #3885 same-input follow-up-requeue peek (no duplicate
+        // prose). No-op unless an anchor already exists for THIS channel; the helper
+        // touches only the submit anchor and never the #3459/#3303 relayed-entry
+        // ledger (its own decoupled 30min TTL). Refresh-on-activity, not a lifecycle.
+        crate::services::tui_prompt_dedupe::touch_prompt_anchor_on_activity(
+            watcher_provider.as_str(),
+            &tmux_session_name,
+            channel_id.get(),
+        );
         // #1137: surface a single warning when output keeps arriving after a
         // terminal-success relay. The watcher will keep running (the legacy
         // single-event exit was the bug); this log makes the continuation

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -543,28 +543,33 @@ pub(crate) fn clear_prompt_anchor_for_response(
 /// #3956: re-stamp an EXISTING submit prompt anchor's `recorded_at` to "now" on
 /// observed streaming activity for `(provider, tmux, channel)`. A turn that
 /// streams continuously longer than [`PROMPT_ANCHOR_SUBMIT_TTL`] (4h) would
-/// otherwise have its anchor purged mid-stream, so the #3885 same-input
+/// otherwise have its anchor expire mid-stream, so the #3885 same-input
 /// follow-up-requeue correlation peek ([`prompt_anchor_for_response`]) resolves
 /// `None`, `same_input` reads false, and the no-response requeue re-fires
 /// duplicate prose. The tmux watcher's per-pane streaming-observation path calls
 /// this on every observed output chunk so the anchor stays live for the whole
 /// turn, making the correlation TTL-independent (the issue #3956 full fix).
 ///
-/// This is a REFRESH-on-activity, NOT a new lifecycle:
+/// This is a REFRESH-on-activity, NOT a new lifecycle, and a SINGLE-MAP op:
 ///   * it only advances an anchor that ALREADY exists for the MATCHING channel —
 ///     it never resurrects a different channel's anchor and never CREATES one, so
 ///     a genuinely-unsubmitted pane stays anchor-less and the bridge still
 ///     requeues it;
-///   * it mutates ONLY `prompt_anchor_by_tmux`. The #3459/#3303 missed-prompt
-///     `relayed_entry_ids_by_tmux` ledger is deliberately left untouched — it
-///     keeps its own decoupled 30min [`PROMPT_ANCHOR_TTL`] purge, so refreshing a
-///     long stream's submit anchor can neither extend nor otherwise corrupt that
-///     dedup ledger.
+///   * it reads/writes ONLY `prompt_anchor_by_tmux`. Crucially it does NOT call
+///     [`TuiPromptDedupeState::purge_expired`]: this fires on EVERY watcher
+///     chunk-drain (a #3016 hot path), so a global multi-map purge under the lock
+///     would scan/mutate the #3459/#3303 `relayed_entry_ids_by_tmux` ledger and
+///     every other dedupe map on each chunk. Leaving the ledger entirely untouched
+///     is what makes the #3459/#3303 non-regression REAL, not merely benign — and
+///     keeps the hot-path op cheap.
 ///
-/// `purge_expired` runs first, so an anchor already past the 4h ceiling when the
-/// first activity arrives (e.g. a pane idle 4h+ that suddenly streams) is dropped
-/// rather than resurrected — that stale anchor belonged to a long-dead turn.
-/// Returns `true` iff a matching-channel anchor was present and re-stamped.
+/// No-resurrection WITHOUT the global purge: the matching anchor's age is checked
+/// INLINE against the 4h ceiling. A still-live anchor (< 4h) is re-stamped; a
+/// matching anchor already past 4h belongs to a long-dead turn, so it is NOT
+/// refreshed (and is evicted from this one map so it cannot linger). The peek path
+/// [`prompt_anchor_for_response`] runs its OWN `purge_expired`, so anchor expiry is
+/// still enforced there independently of this path.
+/// Returns `true` iff a live matching-channel anchor was present and re-stamped.
 pub(crate) fn touch_prompt_anchor_on_activity(
     provider: &str,
     tmux_session_name: &str,
@@ -576,7 +581,6 @@ pub(crate) fn touch_prompt_anchor_on_activity(
         return false;
     }
     let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
-    state.purge_expired();
     let key = PromptKey::new(&provider, tmux_session_name);
     let Some(entry) = state.prompt_anchor_by_tmux.get_mut(&key) else {
         return false;
@@ -584,8 +588,16 @@ pub(crate) fn touch_prompt_anchor_on_activity(
     if entry.value.channel_id != channel_id {
         return false;
     }
-    entry.recorded_at = Instant::now();
-    true
+    if entry.recorded_at.elapsed() < PROMPT_ANCHOR_SUBMIT_TTL {
+        // Live turn: re-stamp this one entry so the stream's anchor stays fresh.
+        entry.recorded_at = Instant::now();
+        return true;
+    }
+    // The matching anchor is already past the 4h ceiling — a long-dead turn's
+    // anchor. Do NOT refresh it (no-resurrection guarantee); evict just this one
+    // entry so it cannot linger, without scanning or mutating any other map.
+    state.prompt_anchor_by_tmux.remove(&key);
+    false
 }
 
 /// #3174: record a deferred ⏳-completion marker for `(provider, tmux, channel)`,
@@ -3900,13 +3912,16 @@ No response requested.\n\
         );
     }
 
-    /// #3956 regression guard: `touch_prompt_anchor_on_activity` re-stamps ONLY the
-    /// submit prompt anchor. It must NOT advance (resurrect) the #3459/#3303
-    /// `relayed_entry_ids_by_tmux` missed-prompt ledger, which keeps its own
-    /// decoupled 30min `PROMPT_ANCHOR_TTL`. This pins that decoupling so a long
-    /// stream's anchor refresh can never extend the ledger's lifetime.
+    /// #3956 codex re-review regression guard: `touch_prompt_anchor_on_activity`
+    /// is a SINGLE-MAP op — it must NOT run the global `purge_expired`, so it can
+    /// neither scan nor mutate the #3459/#3303 `relayed_entry_ids_by_tmux` ledger
+    /// (nor any other dedupe map) on the per-chunk hot path. Proven by leaving a
+    /// ledger entry that a full purge WOULD drop in place ACROSS a touch: it
+    /// survives the touch byte-for-byte, demonstrating the touch did not trigger
+    /// the ledger-purging code at all. The ledger still purges on its OWN 30min
+    /// `PROMPT_ANCHOR_TTL` via the normal (purge-running) paths.
     #[test]
-    fn touch_anchor_on_activity_leaves_relayed_entry_ledger_untouched() {
+    fn touch_anchor_on_activity_does_not_run_global_purge_or_touch_ledger() {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_state();
 
@@ -3918,17 +3933,13 @@ No response requested.\n\
         record_relayed_entry_id(provider, tmux, "uuid-LEDGER");
         record_prompt_anchor(provider, tmux, channel, msg);
 
-        // Backdate BOTH the anchor and the ledger entry to 25min — both still alive
-        // (anchor < 4h SUBMIT_TTL, ledger < 30min TTL). Capture the ledger's stamp
-        // so we can prove `touch` does not advance it.
+        // Age the ledger entry PAST its 30min TTL so a full `purge_expired` WOULD
+        // drop it; the anchor stays fresh (well within 4h). Done via direct state
+        // access so no purge-calling helper runs between here and the touch below.
+        // Capture the ledger stamp to prove `touch` leaves it byte-for-byte intact.
         let ledger_stamp_before = {
             let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
-            let aged = Instant::now() - Duration::from_secs(25 * 60);
-            state
-                .prompt_anchor_by_tmux
-                .get_mut(&PromptKey::new(provider, tmux))
-                .expect("anchor present")
-                .recorded_at = aged;
+            let aged = Instant::now() - (PROMPT_ANCHOR_TTL + Duration::from_secs(60));
             state
                 .relayed_entry_ids_by_tmux
                 .get_mut(&PromptKey::new(provider, tmux))
@@ -3938,12 +3949,12 @@ No response requested.\n\
             aged
         };
 
-        // Streaming activity re-stamps the SUBMIT anchor...
+        // Streaming activity re-stamps the SUBMIT anchor (single-map op).
         assert!(touch_prompt_anchor_on_activity(provider, tmux, channel));
 
         {
             let state = STATE.lock().unwrap_or_else(|error| error.into_inner());
-            // ...the anchor's stamp advanced to ~now (refreshed)...
+            // The anchor was refreshed to ~now...
             let anchor_age = state
                 .prompt_anchor_by_tmux
                 .get(&PromptKey::new(provider, tmux))
@@ -3953,36 +3964,29 @@ No response requested.\n\
                 anchor_age < Duration::from_secs(60),
                 "anchor was re-stamped on activity"
             );
-            // ...but the ledger entry's stamp is UNCHANGED (not resurrected): the
-            // #3459/#3303 30min guard is independent of the anchor refresh.
-            let ledger_stamp_after = state
+            // ...but the OVER-TTL ledger entry is STILL present with its original
+            // stamp: `touch` did not run the global purge, so the ledger was never
+            // scanned or mutated (the #3459/#3303 non-regression is REAL, not just
+            // benign). A full `purge_expired` would have dropped this entry.
+            let seen = state
                 .relayed_entry_ids_by_tmux
                 .get(&PromptKey::new(provider, tmux))
                 .and_then(|queue| queue.front())
-                .expect("ledger entry present")
-                .recorded_at;
+                .expect("ledger entry still present (touch did not purge it)");
+            assert_eq!(seen.value, "uuid-LEDGER");
             assert_eq!(
-                ledger_stamp_after, ledger_stamp_before,
-                "touch left the relayed-entry ledger stamp untouched"
+                seen.recorded_at, ledger_stamp_before,
+                "touch left the over-TTL ledger entry byte-for-byte untouched"
             );
         }
 
-        // The ledger still purges on its OWN 30min TTL regardless of the fresh
-        // anchor: age it past PROMPT_ANCHOR_TTL and confirm it is gone while the
-        // freshly-touched anchor (well within 4h) survives.
-        {
-            let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
-            state
-                .relayed_entry_ids_by_tmux
-                .get_mut(&PromptKey::new(provider, tmux))
-                .and_then(|queue| queue.front_mut())
-                .expect("ledger entry present")
-                .recorded_at = Instant::now() - (PROMPT_ANCHOR_TTL + Duration::from_secs(1));
-            state.purge_expired();
-        }
+        // The ledger DOES purge on its own 30min TTL via the normal purge-running
+        // path — `touch` simply is not that path. `relayed_entry_id_already_seen`
+        // runs `purge_expired`, dropping the over-TTL entry; the freshly-touched
+        // anchor (well within 4h) survives that same purge.
         assert!(
             !relayed_entry_id_already_seen(provider, tmux, "uuid-LEDGER"),
-            "ledger entry past its own 30min TTL is purged (guard unchanged)"
+            "over-TTL ledger entry is dropped by the normal (purge-running) path"
         );
         assert_eq!(
             prompt_anchor_for_response(provider, tmux, channel),
@@ -3991,6 +3995,55 @@ No response requested.\n\
                 message_id: msg,
             }),
             "freshly-touched anchor survives the ledger's independent 30min purge"
+        );
+    }
+
+    /// #3956 codex re-review: the no-resurrection guarantee must hold WITHOUT the
+    /// global purge — a matching anchor already past the 4h ceiling is never
+    /// refreshed by `touch` (it is evicted from the single anchor map instead), so
+    /// a pane idle 4h+ that suddenly streams cannot revive a long-dead turn's
+    /// anchor. The eviction touches only `prompt_anchor_by_tmux`.
+    #[test]
+    fn touch_anchor_on_activity_evicts_expired_anchor_without_resurrecting_it() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        let provider = "claude";
+        let tmux = "tmux-3956-expired";
+        let channel = 9999_u64;
+        let msg = 1_234_u64;
+
+        // An anchor already past the 4h ceiling (a long-dead turn). Recorded via
+        // the aged helper, which does NOT purge, so it is still in the map when the
+        // first streaming activity arrives.
+        record_prompt_anchor_aged_for_tests(
+            provider,
+            tmux,
+            channel,
+            msg,
+            PROMPT_ANCHOR_SUBMIT_TTL + Duration::from_secs(1),
+        );
+
+        // Activity must NOT refresh the dead anchor...
+        assert!(
+            !touch_prompt_anchor_on_activity(provider, tmux, channel),
+            "an anchor past the 4h ceiling is never re-stamped (no resurrection)"
+        );
+        // ...and the dead anchor is evicted from the single anchor map.
+        {
+            let state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            assert!(
+                state
+                    .prompt_anchor_by_tmux
+                    .get(&PromptKey::new(provider, tmux))
+                    .is_none(),
+                "the over-ceiling anchor was evicted, not resurrected"
+            );
+        }
+        assert_eq!(
+            prompt_anchor_for_response(provider, tmux, channel),
+            None,
+            "no live anchor remains for the dead turn"
         );
     }
 

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -540,6 +540,54 @@ pub(crate) fn clear_prompt_anchor_for_response(
     removed
 }
 
+/// #3956: re-stamp an EXISTING submit prompt anchor's `recorded_at` to "now" on
+/// observed streaming activity for `(provider, tmux, channel)`. A turn that
+/// streams continuously longer than [`PROMPT_ANCHOR_SUBMIT_TTL`] (4h) would
+/// otherwise have its anchor purged mid-stream, so the #3885 same-input
+/// follow-up-requeue correlation peek ([`prompt_anchor_for_response`]) resolves
+/// `None`, `same_input` reads false, and the no-response requeue re-fires
+/// duplicate prose. The tmux watcher's per-pane streaming-observation path calls
+/// this on every observed output chunk so the anchor stays live for the whole
+/// turn, making the correlation TTL-independent (the issue #3956 full fix).
+///
+/// This is a REFRESH-on-activity, NOT a new lifecycle:
+///   * it only advances an anchor that ALREADY exists for the MATCHING channel —
+///     it never resurrects a different channel's anchor and never CREATES one, so
+///     a genuinely-unsubmitted pane stays anchor-less and the bridge still
+///     requeues it;
+///   * it mutates ONLY `prompt_anchor_by_tmux`. The #3459/#3303 missed-prompt
+///     `relayed_entry_ids_by_tmux` ledger is deliberately left untouched — it
+///     keeps its own decoupled 30min [`PROMPT_ANCHOR_TTL`] purge, so refreshing a
+///     long stream's submit anchor can neither extend nor otherwise corrupt that
+///     dedup ledger.
+///
+/// `purge_expired` runs first, so an anchor already past the 4h ceiling when the
+/// first activity arrives (e.g. a pane idle 4h+ that suddenly streams) is dropped
+/// rather than resurrected — that stale anchor belonged to a long-dead turn.
+/// Returns `true` iff a matching-channel anchor was present and re-stamped.
+pub(crate) fn touch_prompt_anchor_on_activity(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+) -> bool {
+    let provider = normalize_provider(provider);
+    let tmux_session_name = tmux_session_name.trim();
+    if provider.is_empty() || tmux_session_name.is_empty() || channel_id == 0 {
+        return false;
+    }
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    let key = PromptKey::new(&provider, tmux_session_name);
+    let Some(entry) = state.prompt_anchor_by_tmux.get_mut(&key) else {
+        return false;
+    };
+    if entry.value.channel_id != channel_id {
+        return false;
+    }
+    entry.recorded_at = Instant::now();
+    true
+}
+
 /// #3174: record a deferred ⏳-completion marker for `(provider, tmux, channel)`,
 /// stamped with the TURN IDENTITY `turn_lease_generation`.
 ///
@@ -3769,6 +3817,180 @@ No response requested.\n\
             prompt_anchor_for_response("claude", tmux, channel),
             None,
             "anchor older than PROMPT_ANCHOR_SUBMIT_TTL is purged"
+        );
+    }
+
+    /// #3956: re-stamp-on-activity. A turn that streams continuously LONGER than
+    /// `PROMPT_ANCHOR_SUBMIT_TTL` (4h) must keep a live submit anchor — the watcher
+    /// calls `touch_prompt_anchor_on_activity` on every observed streamed chunk,
+    /// advancing `recorded_at` so the anchor never reaches the 4h purge mid-stream.
+    /// This keeps the #3885 same-input correlation peek resolving for the whole
+    /// turn (no duplicate-prose requeue), making the correlation TTL-independent.
+    #[test]
+    fn streaming_activity_restamps_anchor_so_long_turn_never_loses_it() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        let provider = "claude";
+        let tmux = "tmux-3956-restamp";
+        let channel = 4444_u64;
+        let msg = 5_555_u64;
+
+        // The turn has streamed for nearly the whole 4h ceiling.
+        record_prompt_anchor_aged_for_tests(
+            provider,
+            tmux,
+            channel,
+            msg,
+            PROMPT_ANCHOR_SUBMIT_TTL - Duration::from_secs(60),
+        );
+        // Control: WITHOUT a refresh, a turn that has streamed past the 4h ceiling
+        // already loses its anchor (the #3885 residual this fix closes). Pinned on
+        // a SEPARATE key so the refreshed-path assertions below are uncontaminated.
+        record_prompt_anchor_aged_for_tests(
+            provider,
+            "tmux-3956-norefresh",
+            channel,
+            msg,
+            PROMPT_ANCHOR_SUBMIT_TTL + Duration::from_secs(1),
+        );
+        assert_eq!(
+            prompt_anchor_for_response(provider, "tmux-3956-norefresh", channel),
+            None,
+            "without re-stamp, a >4h stream's anchor is purged (the #3885 residual)"
+        );
+
+        // Observed streaming activity re-stamps `recorded_at` to ~now.
+        assert!(
+            touch_prompt_anchor_on_activity(provider, tmux, channel),
+            "an existing anchor for this channel is re-stamped on activity"
+        );
+
+        // Simulate ANOTHER (4h - 60s) of continuous streaming elapsing AFTER that
+        // re-stamp by backdating the refreshed stamp. Because the re-stamp reset the
+        // clock, the effective age is now (4h - 60s) < 4h, so the anchor STILL
+        // resolves — whereas the un-refreshed control above (~8h wall-age) was purged.
+        {
+            let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            state
+                .prompt_anchor_by_tmux
+                .get_mut(&PromptKey::new(provider, tmux))
+                .expect("anchor present after touch")
+                .recorded_at =
+                Instant::now() - (PROMPT_ANCHOR_SUBMIT_TTL - Duration::from_secs(60));
+        }
+        assert_eq!(
+            prompt_anchor_for_response(provider, tmux, channel),
+            Some(TuiPromptAnchor {
+                channel_id: channel,
+                message_id: msg,
+            }),
+            "re-stamped anchor survives well past the wall-clock 4h a single stamp would not"
+        );
+
+        // Channel-scoped: a touch for a DIFFERENT channel must not refresh this anchor.
+        assert!(
+            !touch_prompt_anchor_on_activity(provider, tmux, channel + 1),
+            "touch is a no-op when the stored anchor's channel does not match"
+        );
+        // Refresh-only: a touch with no anchor recorded must NOT create one.
+        assert!(
+            !touch_prompt_anchor_on_activity(provider, "tmux-3956-absent", channel),
+            "touch never CREATES an anchor — refresh-on-activity only"
+        );
+    }
+
+    /// #3956 regression guard: `touch_prompt_anchor_on_activity` re-stamps ONLY the
+    /// submit prompt anchor. It must NOT advance (resurrect) the #3459/#3303
+    /// `relayed_entry_ids_by_tmux` missed-prompt ledger, which keeps its own
+    /// decoupled 30min `PROMPT_ANCHOR_TTL`. This pins that decoupling so a long
+    /// stream's anchor refresh can never extend the ledger's lifetime.
+    #[test]
+    fn touch_anchor_on_activity_leaves_relayed_entry_ledger_untouched() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        let provider = "claude";
+        let tmux = "tmux-3956-ledger";
+        let channel = 5555_u64;
+        let msg = 6_666_u64;
+
+        record_relayed_entry_id(provider, tmux, "uuid-LEDGER");
+        record_prompt_anchor(provider, tmux, channel, msg);
+
+        // Backdate BOTH the anchor and the ledger entry to 25min — both still alive
+        // (anchor < 4h SUBMIT_TTL, ledger < 30min TTL). Capture the ledger's stamp
+        // so we can prove `touch` does not advance it.
+        let ledger_stamp_before = {
+            let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            let aged = Instant::now() - Duration::from_secs(25 * 60);
+            state
+                .prompt_anchor_by_tmux
+                .get_mut(&PromptKey::new(provider, tmux))
+                .expect("anchor present")
+                .recorded_at = aged;
+            state
+                .relayed_entry_ids_by_tmux
+                .get_mut(&PromptKey::new(provider, tmux))
+                .and_then(|queue| queue.front_mut())
+                .expect("ledger entry present")
+                .recorded_at = aged;
+            aged
+        };
+
+        // Streaming activity re-stamps the SUBMIT anchor...
+        assert!(touch_prompt_anchor_on_activity(provider, tmux, channel));
+
+        {
+            let state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            // ...the anchor's stamp advanced to ~now (refreshed)...
+            let anchor_age = state
+                .prompt_anchor_by_tmux
+                .get(&PromptKey::new(provider, tmux))
+                .map(|entry| entry.recorded_at.elapsed())
+                .expect("anchor present");
+            assert!(
+                anchor_age < Duration::from_secs(60),
+                "anchor was re-stamped on activity"
+            );
+            // ...but the ledger entry's stamp is UNCHANGED (not resurrected): the
+            // #3459/#3303 30min guard is independent of the anchor refresh.
+            let ledger_stamp_after = state
+                .relayed_entry_ids_by_tmux
+                .get(&PromptKey::new(provider, tmux))
+                .and_then(|queue| queue.front())
+                .expect("ledger entry present")
+                .recorded_at;
+            assert_eq!(
+                ledger_stamp_after, ledger_stamp_before,
+                "touch left the relayed-entry ledger stamp untouched"
+            );
+        }
+
+        // The ledger still purges on its OWN 30min TTL regardless of the fresh
+        // anchor: age it past PROMPT_ANCHOR_TTL and confirm it is gone while the
+        // freshly-touched anchor (well within 4h) survives.
+        {
+            let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+            state
+                .relayed_entry_ids_by_tmux
+                .get_mut(&PromptKey::new(provider, tmux))
+                .and_then(|queue| queue.front_mut())
+                .expect("ledger entry present")
+                .recorded_at = Instant::now() - (PROMPT_ANCHOR_TTL + Duration::from_secs(1));
+            state.purge_expired();
+        }
+        assert!(
+            !relayed_entry_id_already_seen(provider, tmux, "uuid-LEDGER"),
+            "ledger entry past its own 30min TTL is purged (guard unchanged)"
+        );
+        assert_eq!(
+            prompt_anchor_for_response(provider, tmux, channel),
+            Some(TuiPromptAnchor {
+                channel_id: channel,
+                message_id: msg,
+            }),
+            "freshly-touched anchor survives the ledger's independent 30min purge"
         );
     }
 


### PR DESCRIPTION
Closes #3956 (deferred #3885 follow-up).

## Root cause
A claude_tui submit prompt anchor (`tui_prompt_dedupe::record_prompt_anchor`) is stamped ONCE at submit and is NOT re-stamped while the turn streams. So a turn that streams continuously LONGER than `PROMPT_ANCHOR_SUBMIT_TTL` (4h) has its anchor purged mid-stream by `purge_expired` (`tui_prompt_dedupe.rs:1734`). The bridge same-input correlation peek (`prompt_anchor_for_response`) then resolves `None`, `same_input` reads false, and the #3885 no-response follow-up requeue re-fires duplicate prose. 4h made this pathological (vs the prior 30min window) but did not eliminate it.

## Fix — refresh-on-activity
New non-consuming primitive `tui_prompt_dedupe::touch_prompt_anchor_on_activity(provider, tmux, channel)` re-stamps an EXISTING submit anchor's `recorded_at` to `now` for the matching channel. The tmux watcher calls it from its per-pane streaming-observation path (the "We got new data" read point, `tmux_watcher.rs`) on every observed output chunk, so an actively-streaming turn keeps a live anchor for its whole duration. The correlation is now TTL-independent (the issue's full fix).

This is a REFRESH, not a new lifecycle:
- refresh-only: never CREATES an anchor (an unsubmitted pane stays anchor-less → bridge still requeues);
- channel-scoped: a touch for a different channel is a no-op;
- `purge_expired` runs first, so an anchor already past the 4h ceiling when the first activity arrives is dropped, not resurrected.

## #3459/#3303 ledger non-regression
The primitive mutates ONLY `prompt_anchor_by_tmux`. It never touches `relayed_entry_ids_by_tmux`, the missed-prompt ledger, which keeps its own decoupled 30min `PROMPT_ANCHOR_TTL` purge. Refreshing a long stream's submit anchor can neither extend nor corrupt that dedup ledger. Pinned by a dedicated regression test.

## TurnSource doc (doc-only, folded in)
`inflight/model.rs` `TurnSource` enum doc said callers "must not branch relay or completion semantics on this value; pure audit metadata". #3969 now DOES branch the watcher #3089 footer-suppression on `turn_source == Managed`. Recorded that behavioral dependency so a future change does not silently regress it.

## Tests
- `streaming_activity_restamps_anchor_so_long_turn_never_loses_it` — long-stream activity re-stamps the anchor so it survives past the wall-clock 4h a single stamp would not; channel-scoped + refresh-only no-ops asserted.
- `touch_anchor_on_activity_leaves_relayed_entry_ledger_untouched` — the #3459/#3303 ledger stamp is unchanged by the anchor refresh and still purges on its own 30min TTL.
- `cargo test --lib tui_prompt_dedupe`: 71 passed, 0 failed.

## #3016 hotfile + ratchet
Hotfile `tmux_watcher.rs`: +11 prod lines (one channel-scoped call + load-bearing comment); the primitive and both regression tests live in the non-hot `tui_prompt_dedupe.rs`. Documented admissions: raw-LOC ratchet 10257 -> 10268, production giant baseline 7092 -> 7103.

## Gates
`cargo fmt --check` 0; `generate_inventory_docs.py` 0; `check_agent_maintenance_docs.py` 0; `audit_maintainability.py --check` 0; `check_hotfile_ratchet.py` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)