### PR TITLE
fix(discord): reclaim stale stranded UserSubmitted in busy gate via double-AND corroboration (#3981)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -582,7 +582,7 @@
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 264 | 264 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 505 | 505 | 0 |  |
-| `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 681 | 681 | 0 |  |
+| `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 852 | 782 | 70 |  |
 | `services::discord::router::message_handler::turn_lifecycle` | `src/services/discord/router/message_handler/turn_lifecycle.rs` | 183 | 183 | 0 |  |
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
 | `services::discord::router::message_handler::voice_announcement_scope` | `src/services/discord/router/message_handler/voice_announcement_scope.rs` | 125 | 73 | 52 |  |
@@ -888,7 +888,7 @@
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 100 | 100 | 0 |  |
 | `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4119 | 1824 | 2295 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
-| `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2211 | 909 | 1302 |  |
+| `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2236 | 909 | 1327 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |
 | `services::turn_lifecycle` | `src/services/turn_lifecycle.rs` | 564 | 436 | 128 |  |
 | `services::turn_orchestrator` | `src/services/turn_orchestrator.rs` | 5616 | 3184 | 2432 | giant-file |

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -520,6 +520,71 @@ pub(super) fn observe_codex_tui_rollout_state_for_cwd_with_sessions(
     crate::services::tui_turn_state::TuiTurnState::Unknown
 }
 
+/// #3981: a busy JSONL `UserSubmitted` turn-state is only reclaimed as a stale
+/// stranded turn (one stopped before claude could write a terminator or the
+/// `[Request interrupted by user]` marker) once its runtime-activity mtime has
+/// been frozen for at least this long *and* the live pane shows the at-rest
+/// prompt marker (the double-AND in [`user_submitted_is_stale_stranded`]).
+///
+/// Aligned with the proven `DEAD_WATCHER_PROVEN_DEAD_SECS = 600` reclaim floor
+/// (`inflight::rebind_reap`, #3879): both classify "the pane may still be alive,
+/// but runtime activity has gone quiescent past a long inter-activity ceiling".
+/// 600s sits safely above the worst-case live inter-activity gap (long tool
+/// calls / extended thinking), so a genuinely live turn never trips it (INV-3).
+#[cfg(unix)]
+const STALE_USER_SUBMITTED_RECLAIM_SECS: i64 = 600;
+
+/// #3981: decide whether a busy JSONL `UserSubmitted` turn-state is actually a
+/// stale stranded turn (stopped before a terminator / interrupt marker was
+/// written) rather than a live submission still awaiting its first assistant
+/// flush. Pure decision so the gate is unit-testable; the gate fills the two
+/// arguments from fs/tmux.
+///
+/// - INV-1 (Streaming inviolable): only `UserSubmitted` is ever reclaimed.
+///   `Streaming` (an `assistant` envelope already exists) is unconditionally
+///   live and returns `false`.
+/// - INV-2 (double AND): reclaim requires BOTH (a) runtime-activity quiescence
+///   (`activity_age_secs >= STALE_USER_SUBMITTED_RECLAIM_SECS`) AND (b) the live
+///   pane at-rest prompt marker (`prompt_marker_detected`). A live turn fails
+///   (a) — activity keeps advancing — *and* fails (b) — the busy spinner
+///   suppresses the marker — so two independent signals must agree before
+///   release. Never an OR.
+#[cfg(unix)]
+fn user_submitted_is_stale_stranded(
+    state: crate::services::tui_turn_state::TuiTurnState,
+    activity_age_secs: i64,
+    prompt_marker_detected: bool,
+) -> bool {
+    matches!(
+        state,
+        crate::services::tui_turn_state::TuiTurnState::UserSubmitted
+    ) && activity_age_secs >= STALE_USER_SUBMITTED_RECLAIM_SECS
+        && prompt_marker_detected
+}
+
+/// #3981: age in seconds since the most recent runtime-activity mtime
+/// (relay jsonl / `.generation` / rollout) for this tmux session.
+///
+/// Returns `0` (treated as "just active", i.e. live) when no activity is
+/// observable, so the AND gate in [`user_submitted_is_stale_stranded`] never
+/// reclaims a turn without positive quiescence evidence (over-release-safe
+/// default). Read fresh at the call site and consumed immediately — never
+/// cached across an await (INV-4).
+#[cfg(unix)]
+fn runtime_activity_age_secs(tmux_session_name: &str) -> i64 {
+    let activity_nanos =
+        crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(tmux_session_name);
+    if activity_nanos <= 0 {
+        return 0;
+    }
+    let now_nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|elapsed| i64::try_from(elapsed.as_nanos()).ok())
+        .unwrap_or(0);
+    now_nanos.saturating_sub(activity_nanos) / 1_000_000_000
+}
+
 #[cfg(unix)]
 pub(super) fn tui_busy_followup_diagnostic(
     shared: &Arc<SharedData>,
@@ -590,6 +655,41 @@ pub(super) fn tui_busy_followup_diagnostic(
         return None;
     }
     if transcript_turn_state.is_busy() {
+        // #3981: a turn stopped immediately (⏳-removal / `!stop` / `/stop` /
+        // watchdog) before claude wrote a terminator or the
+        // `[Request interrupted by user]` marker leaves a trailing bare
+        // `type=user` envelope. The pure classifier (`tui_turn_state.rs`) only
+        // sees disk shape and structurally reports `UserSubmitted` (busy)
+        // forever, so the next message wedges into `*_tui_busy_pre_submit` with
+        // no terminator ever arriving to dequeue it. `Streaming` (an `assistant`
+        // envelope already exists) is unconditionally live and is NEVER
+        // reclaimed here (INV-1).
+        //
+        // For a Claude `UserSubmitted` only, corroborate "stranded/stopped" with
+        // TWO independent runtime signals before trusting the busy verdict
+        // (INV-2, AND): (a) runtime-activity quiescence — no relay
+        // jsonl/`.generation` mtime advance for >=
+        // STALE_USER_SUBMITTED_RECLAIM_SECS — and (b) the live pane shows the
+        // at-rest prompt marker, which is suppressed during a genuine agentic
+        // turn (`intake_turn.rs` #3208 A), so marker=true ⟹ not mid-turn. Only
+        // when BOTH hold do we fall through to `None` (pass) instead of emitting
+        // the busy diagnostic. Codex is left on the existing JSONL-authoritative
+        // path (its composer marker semantics are out of scope for #3981).
+        if matches!(provider, ProviderKind::Claude)
+            && transcript_turn_state == crate::services::tui_turn_state::TuiTurnState::UserSubmitted
+        {
+            let activity_age_secs = runtime_activity_age_secs(tmux_session_name);
+            let prompt_marker_detected =
+                crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name)
+                    .prompt_marker_detected;
+            if user_submitted_is_stale_stranded(
+                transcript_turn_state,
+                activity_age_secs,
+                prompt_marker_detected,
+            ) {
+                return None;
+            }
+        }
         let snapshot = HostedTuiPromptReadinessSnapshot::jsonl_authoritative(true);
         return classify_claude_tui_followup_submission(
             &snapshot,
@@ -678,4 +778,75 @@ pub(super) fn recapture_inflight_offset_after_successful_busy_wait(
         .and_then(|path| std::fs::metadata(path).ok())
         .map(|metadata| metadata.len())
         .unwrap_or(previous_offset)
+}
+
+#[cfg(all(test, unix))]
+mod stale_user_submitted_tests {
+    use super::STALE_USER_SUBMITTED_RECLAIM_SECS;
+    use super::user_submitted_is_stale_stranded;
+    use crate::services::tui_turn_state::TuiTurnState;
+
+    // INV-1: Streaming (assistant envelope already written) is unconditionally
+    // live — it is NEVER reclaimed, even with old activity and an at-rest marker.
+    #[test]
+    fn streaming_is_never_reclaimed_even_when_old_and_marker_present() {
+        assert!(!user_submitted_is_stale_stranded(
+            TuiTurnState::Streaming,
+            STALE_USER_SUBMITTED_RECLAIM_SECS + 1,
+            true,
+        ));
+    }
+
+    // The reclaim case: UserSubmitted + quiescent activity (>= T) + at-rest pane
+    // marker ⇒ stranded/stopped, release (return true).
+    #[test]
+    fn user_submitted_old_with_marker_is_stale() {
+        assert!(user_submitted_is_stale_stranded(
+            TuiTurnState::UserSubmitted,
+            STALE_USER_SUBMITTED_RECLAIM_SECS,
+            true,
+        ));
+    }
+
+    // INV-2 leg (a): recent activity (< T) means the turn is still advancing —
+    // a live submission awaiting its first assistant flush. Never reclaim.
+    #[test]
+    fn user_submitted_recent_with_marker_is_live() {
+        assert!(!user_submitted_is_stale_stranded(
+            TuiTurnState::UserSubmitted,
+            STALE_USER_SUBMITTED_RECLAIM_SECS - 1,
+            true,
+        ));
+    }
+
+    // INV-2 leg (b): no at-rest prompt marker (busy spinner) means the pane is
+    // mid-turn even if activity looks frozen. Never reclaim on the mtime signal
+    // alone — the gate is an AND, not an OR.
+    #[test]
+    fn user_submitted_old_without_marker_is_live() {
+        assert!(!user_submitted_is_stale_stranded(
+            TuiTurnState::UserSubmitted,
+            STALE_USER_SUBMITTED_RECLAIM_SECS + 10_000,
+            false,
+        ));
+    }
+
+    // Non-busy / non-UserSubmitted states are out of scope for the reclaim path.
+    #[test]
+    fn idle_and_unknown_are_not_reclaimed() {
+        for state in [TuiTurnState::Idle, TuiTurnState::Unknown] {
+            assert!(!user_submitted_is_stale_stranded(
+                state,
+                STALE_USER_SUBMITTED_RECLAIM_SECS + 1,
+                true,
+            ));
+        }
+    }
+
+    // The reclaim floor is aligned with the proven dead-watcher reclaim floor
+    // (#3879) and stays well above worst-case live inter-activity gaps (INV-3).
+    #[test]
+    fn reclaim_floor_aligns_with_dead_watcher_precedent() {
+        assert_eq!(STALE_USER_SUBMITTED_RECLAIM_SECS, 600);
+    }
 }

--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -941,6 +941,31 @@ mod tests {
         );
     }
 
+    // #3981 (classifier invariant): a turn stopped immediately — before claude
+    // could write a terminator (`result`) or the `[Request interrupted by user]`
+    // marker — leaves an `assistant` envelope followed by a trailing *bare*
+    // `type=user` envelope. Structurally this is indistinguishable from a fresh
+    // submission, so the PURE classifier MUST still report `UserSubmitted`.
+    // Distinguishing dead (stopped) from live (about to flush) needs runtime
+    // evidence (activity mtime + live pane marker) that this pure function does
+    // not have — that staleness decision is the busy gate's responsibility
+    // (`tui_followup::user_submitted_is_stale_stranded`), NOT the classifier's.
+    // This test pins the separation of responsibilities: the #3981 fix must not
+    // be pushed down into the classifier.
+    #[test]
+    fn claude_trailing_bare_user_after_assistant_remains_user_submitted() {
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"do something"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"and another thing"}]}}"#,
+        ]);
+
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::UserSubmitted
+        );
+    }
+
     // #3221: a turn aborted via a session-preserving interrupt (ESC / wrapper
     // control_request{interrupt}, #3207) leaves a trailing
     // `[Request interrupted by user]` user envelope. That marks the turn ENDED,


### PR DESCRIPTION
## ROOT CAUSE (#3981)

A turn stopped immediately (⏳-removal / `!stop` / `/stop` / watchdog) **before** claude could write a terminator (`result`) or the `[Request interrupted by user]` marker leaves a trailing bare `type=user` envelope. The pure classifier (`tui_turn_state.rs:708`) can only see disk shape and structurally reports `UserSubmitted` (busy) **forever**. The JSONL-authoritative busy gate (`tui_followup.rs:592`) then confirms in-flight with **zero extra evidence**, so the next message wedges into `*_tui_busy_pre_submit` with no terminator ever arriving to dequeue it → permanent queue stall.

## FIX — gate-side double-evidence corroboration (Claude path only)

The classifier is a **pure function** (no time/pane context) and is left unchanged. Live-vs-dead discrimination is done at the **gate**, which has runtime evidence. In `tui_busy_followup_diagnostic`'s busy branch, for a Claude `UserSubmitted` **only**, we corroborate "stranded/stopped" via the pure helper `user_submitted_is_stale_stranded(state, activity_age_secs, prompt_marker_detected)` before trusting the busy verdict. Only when **both** runtime signals agree does the gate return `None` (pass) instead of emitting the busy diagnostic. Codex stays on the existing JSONL-authoritative path (its composer-marker semantics are out of scope for #3981).

## Invariants (over-release safety)

- **INV-1 (Streaming inviolable)**: only `UserSubmitted` is ever reclaimed. `Streaming` (an `assistant` envelope already exists) is unconditionally live and is never released via the staleness path.
- **INV-2 (double AND)**: reclaim requires **(a)** runtime-activity mtime (`dispatched_sessions::latest_runtime_activity_unix_nanos`) frozen `>= STALE_USER_SUBMITTED_RECLAIM_SECS` **AND (b)** the live pane at-rest prompt marker (`claude_tui::input::prompt_readiness_snapshot().prompt_marker_detected`, suppressed during a genuine agentic turn). Never an OR — two independent signals must agree.
- **INV-3 (threshold)**: `STALE_USER_SUBMITTED_RECLAIM_SECS = 600`, a dedicated documented const aligned with the proven `DEAD_WATCHER_PROVEN_DEAD_SECS = 600` reclaim floor (#3879); sits safely above the worst-case live inter-activity gap.
- **INV-4 (injection race)**: the activity stamp is read fresh and consumed immediately — never cached across an await. The injection path's `wait_for_prompt_ready` re-validation is unchanged (we return `None` = pass, so the normal injection flow re-validates).
- **Classifier invariant**: `tui_turn_state.rs:708` is unchanged; staleness is the gate's responsibility, not the pure classifier's.

## Tests

- Pure-helper table (`tui_followup.rs`): Streaming+old+marker → false (INV-1); UserSubmitted+old(≥T)+marker → true; UserSubmitted+recent(<T)+marker → false (INV-2a); UserSubmitted+old+no-marker → false (INV-2b); Idle/Unknown → false; floor == 600 (INV-3).
- Classifier regression (`tui_turn_state.rs`): a trailing bare `type=user` after an `assistant` envelope still classifies `UserSubmitted` — pins the separation of responsibilities (the #3981 fix is not pushed into the classifier). The existing `claude_user_without_terminal_envelope_is_user_submitted` is retained.

## Scope

First PR = gate-side core only (non-hotfile `tui_followup.rs` + classifier regression in non-hot `tui_turn_state.rs`). `intake_turn.rs` is unchanged (it consumes `transcript_turn_state.is_busy()`; the gate returning `None` passes through). Follow-up serial tracks (out of scope here): source-side draft-clear (`claude_tui/input.rs`) and recovery self-heal (`relay_recovery.rs`).

## Gate results

- `cargo fmt --check`: clean
- `cargo check --lib`: clean (only pre-existing unrelated warnings)
- `cargo test --lib tui_followup` / `tui_turn_state`: pass (incl. new tests)
- `check_agent_maintenance_docs.py`, `audit_maintainability.py --check`, `check_hotfile_ratchet.py`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)