### PR TITLE
feat(discord): #3983 3-line status footer content redesign (Track A)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -508,21 +508,21 @@
 | `services::discord::outbound::turn_output_controller_rollout_health` | `src/services/discord/outbound/turn_output_controller_rollout_health.rs` | 195 | 129 | 66 |  |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 664 | 424 | 240 |  |
 | `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 977 | 573 | 404 |  |
-| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 700 | 700 | 0 |  |
+| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 673 | 673 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 536 | 536 | 0 |  |
 | `services::discord::placeholder_live_events::context_panel` | `src/services/discord/placeholder_live_events/context_panel.rs` | 72 | 72 | 0 |  |
-| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 362 | 182 | 180 |  |
+| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 201 | 90 | 111 |  |
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
 | `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 700 | 700 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 688 | 688 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 654 | 654 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 445 | 270 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 348 | 348 | 0 |  |
-| `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 207 | 112 | 95 |  |
+| `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 185 | 185 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1314 | 1019 | 295 | giant-file |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 431 | 431 | 0 |  |
@@ -625,7 +625,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 737 | 666 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2759 | 821 | 1938 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2803 | 865 | 1938 |  |
 | `services::discord::single_message_panel::completion_footer_registry` | `src/services/discord/single_message_panel/completion_footer_registry.rs` | 624 | 624 | 0 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1642 | 912 | 730 |  |

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -1,153 +1,61 @@
-//! #3812: live/stale confidence indicator + status-header rendering for the
-//! Discord status panel.
+//! #3983: status-panel activity + time-line rendering for the Discord footer.
 //!
 //! Offloaded from the at-cap `status_panel.rs` (mirrors the #3811 `turn_anchor.rs`
-//! split): `status_panel.rs` keeps only the header-build call site, while the
-//! derived-status label, the confidence classifier, the confidence-line renderer,
-//! and the store-facing line builder all live here with their tests.
+//! split): `status_panel.rs` keeps only the panel-assembly call site, while the
+//! derived-status activity label and the store-facing time-line builder live here
+//! with their tests.
 //!
-//! The confidence label is derived from ONLY deterministic ADK status signals —
-//! never from timestamp age alone — so a healthy but quiet long-running turn stays
-//! `live`, and `stale` is reached only with corroborating relay/watch evidence
-//! (`TerminalDeliveryUnconfirmed`: the answer was relayed but session termination
-//! could not be confirmed).
+//! The footer header is a fixed two-line block:
+//! - line 1 is the derived-status ACTIVITY label alone (`🟢 진행 중` /
+//!   `🔧 도구 실행 중 (…)` / `✅ 완료` / `🟡 응답 지연 · 조사 권장`). The spinner
+//!   merge (`single_message_panel::merged_footer_header_line`) swaps the leading
+//!   status emoji for the animated spinner, so the marker set there must stay in
+//!   sync with the emojis this label can start with.
+//! - line 2 is the relative TIME line (`마지막 업데이트 : <t:last:R> / 턴 시작 :
+//!   <t:start:R>`). It replaces the pre-#3983 confidence line + `진행 중 —
+//!   provider` header; the freshness class is now absorbed into the line-1 emoji
+//!   (item B), and the provider moved off the footer entirely.
 //!
-//! The relative age is rendered with Discord's native `<t:UNIX:R>` relative-time
-//! token (the same convention the header already uses for the turn start), anchored
-//! to the store's STABLE per-channel last-activity unix stamp. That keeps the panel
-//! text byte-identical across heartbeat ticks with no new content (so the message
-//! is not needlessly re-edited — the #3477 stability invariant), while Discord
-//! renders the localized live age (`마지막 업데이트 18초 전`, `final · 2분 전`) on
-//! the client and keeps it ticking with zero server churn.
+//! Both relative ages render with Discord's native `<t:UNIX:R>` token anchored to
+//! STABLE store stamps (never "now"), so the footer text stays byte-identical
+//! across heartbeat ticks — the message is not needlessly re-edited (the #3477
+//! stability invariant) while Discord renders the live localized age client-side.
 
 use poise::serenity_prelude::ChannelId;
 
-use crate::services::provider::ProviderKind;
-
 use super::common::{escape_status_panel_markdown, tool_prefix, truncate_chars};
-use super::status_panel::{CompletedKind, DerivedStatus, StatusPanelState};
+use super::status_panel::{CompletedKind, DerivedStatus};
 
 impl super::PlaceholderLiveEvents {
-    /// #3812: builds the panel's live/stale confidence line from deterministic
-    /// store signals — the snapshot's derived status (the class) and the channel's
-    /// STABLE last-activity unix stamp (the relative age). The store hook lives
-    /// here (not in the at-cap `mod.rs` / `status_panel.rs`), mirroring the #3811
-    /// `turn_anchor.rs` split. Always `Some` so every panel surfaces its confidence.
-    pub(super) fn panel_confidence_line(
-        &self,
-        channel_id: ChannelId,
-        snapshot: &StatusPanelState,
-        started_at_unix: i64,
-    ) -> Option<String> {
+    /// #3983: builds the panel's time line from the channel's STABLE last-activity
+    /// unix stamp (set once when the content arrived, never recomputed at render
+    /// time), falling back to the turn's `started_at_unix` when no live content has
+    /// arrived yet. The store hook lives here (not in the at-cap `mod.rs` /
+    /// `status_panel.rs`), mirroring the #3811 `turn_anchor.rs` split.
+    pub(super) fn panel_time_line(&self, channel_id: ChannelId, started_at_unix: i64) -> String {
         let last_activity_unix = self
             .last_recent_event_unix
             .get(&channel_id)
             .map(|stamp| *stamp.value());
-        Some(confidence_line(
-            &snapshot.status,
-            last_activity_unix,
-            started_at_unix,
-        ))
+        render_time_line(last_activity_unix, started_at_unix)
     }
 }
 
-/// #3812: user-facing confidence class for the status panel.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum PanelConfidence {
-    /// Actively running (or intentionally quiet, e.g. monitor/scheduled wait).
-    Live,
-    /// The turn completed cleanly — the panel is just the final status.
-    Final,
-    /// Corroborating relay/watch evidence says the turn stalled — investigate.
-    Stale,
-    /// Ambiguous or pending evidence — surfaced as `상태 불명확`, never a false stale.
-    Unknown,
+/// #3983: renders the footer's relative time line. `last_activity_unix` is the
+/// store's STABLE per-channel last-live-content arrival stamp; it falls back to the
+/// turn start when no live content has arrived yet. Uses Discord's `<t:UNIX:R>`
+/// token so the text is identical across heartbeat ticks (never re-edited) while
+/// the client shows the live localized age.
+pub(super) fn render_time_line(last_activity_unix: Option<i64>, started_at_unix: i64) -> String {
+    let last = last_activity_unix.unwrap_or(started_at_unix);
+    format!("마지막 업데이트 : <t:{last}:R> / 턴 시작 : <t:{started_at_unix}:R>")
 }
 
-/// #3812: maps the panel's derived status to a confidence class using ONLY
-/// deterministic ADK status signals (never timestamp age alone):
-/// - a clean `Completed { .. }` turn → `Final`;
-/// - `TerminalDeliveryUnconfirmed` (answer relayed, session-end could NOT be
-///   confirmed) is corroborating relay/watch evidence of a stall → `Stale`;
-/// - `TerminalDeliveryPending` (delivery done, termination still confirming) is
-///   ambiguous / evidence-pending → `Unknown`;
-/// - every actively-running or intentionally-quiet status (tool / subagent /
-///   workflow / monitor-wait / scheduled-wakeup) → `Live`.
-///
-/// A quiet long-running turn therefore stays `Live` — it is never reclassified
-/// `Stale` from age, matching the conservative intake-gate policy (#3812 evidence:
-/// `router/intake_gate.rs:407/442/502`).
-pub(super) fn panel_confidence(status: &DerivedStatus) -> PanelConfidence {
-    match status {
-        DerivedStatus::Completed { .. } => PanelConfidence::Final,
-        DerivedStatus::TerminalDeliveryUnconfirmed => PanelConfidence::Stale,
-        DerivedStatus::TerminalDeliveryPending => PanelConfidence::Unknown,
-        DerivedStatus::Running
-        | DerivedStatus::MonitorWait
-        | DerivedStatus::ScheduleWakeup(_)
-        | DerivedStatus::ToolRunning { .. }
-        | DerivedStatus::SubagentRunning { .. }
-        | DerivedStatus::WorkflowRunning { .. } => PanelConfidence::Live,
-    }
-}
-
-/// #3812: renders the compact confidence line from a class + a stable unix anchor
-/// for the relative age. The age uses Discord's `<t:UNIX:R>` token so the text is
-/// heartbeat-stable while the client shows the live localized age. `Unknown`
-/// deliberately omits an age (the point is that the evidence is missing).
-pub(super) fn render_confidence_line(confidence: PanelConfidence, age_anchor_unix: i64) -> String {
-    let age = format!("<t:{age_anchor_unix}:R>");
-    match confidence {
-        PanelConfidence::Live => format!("신뢰도: live · 마지막 업데이트 {age}"),
-        PanelConfidence::Final => format!("신뢰도: final · {age}"),
-        PanelConfidence::Stale => format!("신뢰도: stale · {age} · 조사 권장"),
-        PanelConfidence::Unknown => "신뢰도: 상태 불명확".to_string(),
-    }
-}
-
-/// #3812: store-facing builder for the confidence line appended under the header.
-///
-/// `last_activity_unix` is the store's STABLE per-channel last-live-content arrival
-/// stamp (set once when the content arrived, never recomputed at render time, so
-/// the line is identical across heartbeat ticks). It falls back to the turn's
-/// `started_at_unix` when no live content has arrived yet (a just-started turn).
-pub(super) fn confidence_line(
-    status: &DerivedStatus,
-    last_activity_unix: Option<i64>,
-    started_at_unix: i64,
-) -> String {
-    let confidence = panel_confidence(status);
-    let age_anchor_unix = last_activity_unix.unwrap_or(started_at_unix);
-    render_confidence_line(confidence, age_anchor_unix)
-}
-
-/// #3812: builds the status-panel header line (derived-status label + provider +
-/// relative start time) and, when present, appends the compact confidence line as
-/// a second header row so the freshness signal leads the panel's first metadata
-/// block. Kept here (not in the at-cap `status_panel.rs`) alongside
-/// `render_derived_status`.
-pub(super) fn render_status_header(
-    status: &DerivedStatus,
-    provider: &ProviderKind,
-    started_at_unix: i64,
-    confidence_line: Option<&str>,
-) -> String {
-    let mut header = format!(
-        "{} — {} (<t:{started_at_unix}:R>)",
-        render_derived_status(status),
-        provider.as_str()
-    );
-    if let Some(line) = confidence_line
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-    {
-        header.push('\n');
-        header.push_str(line);
-    }
-    header
-}
-
-fn render_derived_status(status: &DerivedStatus) -> String {
+/// #3983: the panel's first (activity) line — the derived-status label alone (no
+/// provider, no timestamp; those moved to the time line). The stale/final
+/// confidence classes are absorbed into the emoji here (item B): a stalled
+/// answer-relayed turn reads `🟡 응답 지연 · 조사 권장`, a clean completion `✅ 완료`.
+pub(super) fn render_activity_line(status: &DerivedStatus) -> String {
     match status {
         DerivedStatus::Running => "🟢 진행 중".to_string(),
         DerivedStatus::MonitorWait => "💤 monitor 대기".to_string(),
@@ -156,15 +64,15 @@ fn render_derived_status(status: &DerivedStatus) -> String {
         }
         DerivedStatus::ScheduleWakeup(None) => "⏰ scheduled wakeup".to_string(),
         DerivedStatus::TerminalDeliveryPending => "↻ 응답 전달됨 · 세션 종료 확인 중".to_string(),
-        DerivedStatus::TerminalDeliveryUnconfirmed => {
-            "⚠ 응답 전달됨 · 세션 종료 미확인".to_string()
-        }
+        // #3983 item B: the corroborated stall (answer relayed, session-end
+        // unconfirmed) reads as the `stale` class right in the activity emoji.
+        DerivedStatus::TerminalDeliveryUnconfirmed => "🟡 응답 지연 · 조사 권장".to_string(),
         DerivedStatus::Completed {
             kind: CompletedKind::Background,
-        } => "✅ **백그라운드 완료**".to_string(),
+        } => "✅ 백그라운드 완료".to_string(),
         DerivedStatus::Completed {
             kind: CompletedKind::Foreground,
-        } => "✅ **응답 완료**".to_string(),
+        } => "✅ 완료".to_string(),
         DerivedStatus::ToolRunning { name, summary: _ } => {
             let rendered = tool_prefix(name);
             format!("🔧 도구 실행 중 ({})", truncate_chars(&rendered, 140))
@@ -187,12 +95,54 @@ mod tests {
     const STARTED_AT: i64 = 1_700_000_000;
     const LAST_ACTIVITY: i64 = 1_700_000_300; // 5 min after start
 
-    // ---- panel_confidence: the five acceptance cases ----------------------
+    // ---- render_activity_line: the derived-status labels ------------------
 
     #[test]
-    fn live_running_status_classifies_live() {
-        // A plainly-running turn, and an intentionally-quiet monitor/scheduled
-        // wait, are all `live` — never stale from quietness.
+    fn running_turn_renders_green_activity_label() {
+        assert_eq!(render_activity_line(&DerivedStatus::Running), "🟢 진행 중");
+    }
+
+    #[test]
+    fn tool_running_renders_wrench_activity_label() {
+        assert_eq!(
+            render_activity_line(&DerivedStatus::ToolRunning {
+                name: "Bash".to_string(),
+                summary: None,
+            }),
+            "🔧 도구 실행 중 ([Bash])"
+        );
+    }
+
+    #[test]
+    fn completed_turn_renders_final_check_label() {
+        // #3983 item B: `final` is absorbed into the ✅ activity emoji.
+        assert_eq!(
+            render_activity_line(&DerivedStatus::Completed {
+                kind: CompletedKind::Foreground
+            }),
+            "✅ 완료"
+        );
+        assert_eq!(
+            render_activity_line(&DerivedStatus::Completed {
+                kind: CompletedKind::Background
+            }),
+            "✅ 백그라운드 완료"
+        );
+    }
+
+    #[test]
+    fn unconfirmed_delivery_renders_stale_activity_label() {
+        // #3983 item B: the corroborated stall reads as `🟡 응답 지연 · 조사 권장`.
+        assert_eq!(
+            render_activity_line(&DerivedStatus::TerminalDeliveryUnconfirmed),
+            "🟡 응답 지연 · 조사 권장"
+        );
+    }
+
+    #[test]
+    fn activity_labels_lead_with_a_spinner_swap_marker() {
+        // Every actively-rendered label must lead with a status emoji so the
+        // spinner-merge swaps it for the animation cleanly (spinner-prefix parity).
         for status in [
             DerivedStatus::Running,
             DerivedStatus::MonitorWait,
@@ -204,159 +154,48 @@ mod tests {
             DerivedStatus::SubagentRunning {
                 desc: "explore".to_string(),
             },
+            DerivedStatus::WorkflowRunning {
+                label: "review".to_string(),
+            },
+            DerivedStatus::Completed {
+                kind: CompletedKind::Foreground,
+            },
+            DerivedStatus::TerminalDeliveryUnconfirmed,
         ] {
-            assert_eq!(
-                panel_confidence(&status),
-                PanelConfidence::Live,
-                "{status:?}"
+            let line = render_activity_line(&status);
+            let first = line.chars().next().expect("non-empty label");
+            assert!(
+                ['🟢', '💤', '⏰', '🔧', '🧵', '🧬', '✅', '🟡'].contains(&first),
+                "label {line:?} must lead with a spinner-swap marker"
             );
         }
     }
 
-    #[test]
-    fn completed_turn_classifies_final() {
-        assert_eq!(
-            panel_confidence(&DerivedStatus::Completed {
-                kind: CompletedKind::Foreground
-            }),
-            PanelConfidence::Final
-        );
-        assert_eq!(
-            panel_confidence(&DerivedStatus::Completed {
-                kind: CompletedKind::Background
-            }),
-            PanelConfidence::Final
-        );
-    }
+    // ---- render_time_line: anchor selection + heartbeat stability ---------
 
     #[test]
-    fn relay_stalled_unconfirmed_delivery_classifies_stale() {
-        // Answer relayed but session-end could not be confirmed = corroborating
-        // relay/watch evidence of a stall (the intake-gate `RelayStalled` class).
+    fn time_line_anchors_update_to_last_activity_and_start() {
         assert_eq!(
-            panel_confidence(&DerivedStatus::TerminalDeliveryUnconfirmed),
-            PanelConfidence::Stale
+            render_time_line(Some(LAST_ACTIVITY), STARTED_AT),
+            "마지막 업데이트 : <t:1700000300:R> / 턴 시작 : <t:1700000000:R>"
         );
-    }
-
-    #[test]
-    fn queue_orphan_quiet_running_turn_is_not_stale_from_age() {
-        // A long-quiet running turn (the shape a queue-blocked/orphan suspicion
-        // would otherwise mis-flag) must stay `live` — `stale` requires corroborating
-        // evidence, never age alone. The confidence line still surfaces the age.
-        assert_eq!(
-            panel_confidence(&DerivedStatus::Running),
-            PanelConfidence::Live
-        );
-        let line = confidence_line(&DerivedStatus::Running, Some(LAST_ACTIVITY), STARTED_AT);
-        assert_eq!(line, "신뢰도: live · 마지막 업데이트 <t:1700000300:R>");
-        assert!(!line.contains("stale"));
-    }
-
-    #[test]
-    fn ambiguous_pending_delivery_classifies_unknown() {
-        assert_eq!(
-            panel_confidence(&DerivedStatus::TerminalDeliveryPending),
-            PanelConfidence::Unknown
-        );
-    }
-
-    // ---- render_confidence_line: the proposed states ----------------------
-
-    #[test]
-    fn render_confidence_line_matches_proposed_states() {
-        assert_eq!(
-            render_confidence_line(PanelConfidence::Live, LAST_ACTIVITY),
-            "신뢰도: live · 마지막 업데이트 <t:1700000300:R>"
-        );
-        assert_eq!(
-            render_confidence_line(PanelConfidence::Final, LAST_ACTIVITY),
-            "신뢰도: final · <t:1700000300:R>"
-        );
-        assert_eq!(
-            render_confidence_line(PanelConfidence::Stale, LAST_ACTIVITY),
-            "신뢰도: stale · <t:1700000300:R> · 조사 권장"
-        );
-        assert_eq!(
-            render_confidence_line(PanelConfidence::Unknown, LAST_ACTIVITY),
-            "신뢰도: 상태 불명확"
-        );
-    }
-
-    // ---- confidence_line: anchor selection + heartbeat stability ----------
-
-    #[test]
-    fn fresh_running_turn_anchors_age_to_last_activity() {
-        let line = confidence_line(&DerivedStatus::Running, Some(LAST_ACTIVITY), STARTED_AT);
-        assert_eq!(line, "신뢰도: live · 마지막 업데이트 <t:1700000300:R>");
-    }
-
-    #[test]
-    fn completed_turn_renders_final_state() {
-        let line = confidence_line(
-            &DerivedStatus::Completed {
-                kind: CompletedKind::Foreground,
-            },
-            Some(LAST_ACTIVITY),
-            STARTED_AT,
-        );
-        assert_eq!(line, "신뢰도: final · <t:1700000300:R>");
-    }
-
-    #[test]
-    fn unconfirmed_delivery_renders_stale_marker() {
-        let line = confidence_line(
-            &DerivedStatus::TerminalDeliveryUnconfirmed,
-            Some(LAST_ACTIVITY),
-            STARTED_AT,
-        );
-        assert_eq!(line, "신뢰도: stale · <t:1700000300:R> · 조사 권장");
     }
 
     #[test]
     fn missing_activity_stamp_falls_back_to_turn_start() {
-        // No live content yet → the age anchors to the turn start (still stable).
-        let line = confidence_line(&DerivedStatus::Running, None, STARTED_AT);
-        assert_eq!(line, "신뢰도: live · 마지막 업데이트 <t:1700000000:R>");
-    }
-
-    #[test]
-    fn confidence_line_is_independent_of_render_time() {
-        // The line depends only on the snapshot status + the stable activity anchor,
-        // never on "now" — so two renders between heartbeats are byte-identical and
-        // never re-edit the Discord message.
-        let a = confidence_line(&DerivedStatus::Running, None, STARTED_AT);
-        let b = confidence_line(&DerivedStatus::Running, None, STARTED_AT);
-        assert_eq!(a, b);
-    }
-
-    // ---- render_status_header: placement ---------------------------------
-
-    #[test]
-    fn header_appends_confidence_line_as_second_row() {
-        let header = render_status_header(
-            &DerivedStatus::Running,
-            &ProviderKind::Claude,
-            STARTED_AT,
-            Some("신뢰도: live · 마지막 업데이트 <t:1700000300:R>"),
-        );
-        let mut lines = header.lines();
-        assert_eq!(lines.next(), Some("🟢 진행 중 — claude (<t:1700000000:R>)"));
+        // No live content yet → the update age anchors to the turn start.
         assert_eq!(
-            lines.next(),
-            Some("신뢰도: live · 마지막 업데이트 <t:1700000300:R>")
+            render_time_line(None, STARTED_AT),
+            "마지막 업데이트 : <t:1700000000:R> / 턴 시작 : <t:1700000000:R>"
         );
-        assert_eq!(lines.next(), None);
     }
 
     #[test]
-    fn header_without_confidence_line_is_single_row() {
-        let header = render_status_header(
-            &DerivedStatus::Running,
-            &ProviderKind::Claude,
-            STARTED_AT,
-            None,
-        );
-        assert_eq!(header, "🟢 진행 중 — claude (<t:1700000000:R>)");
+    fn time_line_is_independent_of_render_time() {
+        // Depends only on the stable stamps, never on "now" — two renders between
+        // heartbeats are byte-identical and never re-edit the Discord message.
+        let a = render_time_line(Some(LAST_ACTIVITY), STARTED_AT);
+        let b = render_time_line(Some(LAST_ACTIVITY), STARTED_AT);
+        assert_eq!(a, b);
     }
 }

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -45,7 +45,7 @@ use common::{
     STATUS_PANEL_WORKFLOW_LIMIT, STATUS_PANEL_WORKFLOW_PHASE_LIMIT,
 };
 #[cfg(test)]
-use status_panel::{render_recent_section_header, truncate_status_panel_sections};
+use status_panel::truncate_status_panel_sections;
 
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
@@ -563,19 +563,9 @@ impl PlaceholderLiveEvents {
             },
             TerminalUiObligationPanelStatus::Deadline => DerivedStatus::TerminalDeliveryUnconfirmed,
         };
-        let completed = matches!(status, TerminalUiObligationPanelStatus::Completed);
-        let request_anchor_line = self.request_anchor_line(channel_id, &snapshot);
-        let confidence_line = self.panel_confidence_line(channel_id, &snapshot, started_at_unix);
-        render_status_panel(
-            snapshot,
-            self.render_block(channel_id),
-            provider,
-            started_at_unix,
-            chrono::Utc::now().timestamp(),
-            !completed,
-            request_anchor_line,
-            confidence_line,
-        )
+        let turn_trigger_line = self.request_anchor_line(channel_id, &snapshot);
+        let time_line = self.panel_time_line(channel_id, started_at_unix);
+        render_status_panel(snapshot, provider, time_line, turn_trigger_line)
     }
 
     // True when the live-panel compaction counts for this channel differ from
@@ -600,7 +590,9 @@ impl PlaceholderLiveEvents {
         channel_id: ChannelId,
         provider: &ProviderKind,
         started_at_unix: i64,
-        heartbeat_at_unix: i64,
+        // #3983: retained for call-site parity (the footer time line anchors to the
+        // stable stored last-activity stamp, not this render-time heartbeat).
+        _heartbeat_at_unix: i64,
     ) -> String {
         let snapshot = self
             .status_by_channel
@@ -627,28 +619,9 @@ impl PlaceholderLiveEvents {
                 "#3404: compacted delivered terminal slots from the live status panel"
             );
         }
-        // #3477 item 3: a live batch counts as "fresh" when it arrived strictly
-        // after the turn's completion instant. `None` completed_at means the turn
-        // never completed (still running), so any present live content is fresh.
-        let live_content_fresh = match snapshot.completed_at {
-            Some(completed_at) => self
-                .last_recent_event_at
-                .get(&channel_id)
-                .is_some_and(|stamp| *stamp.value() > completed_at),
-            None => true,
-        };
-        let request_anchor_line = self.request_anchor_line(channel_id, &snapshot);
-        let confidence_line = self.panel_confidence_line(channel_id, &snapshot, started_at_unix);
-        render_status_panel(
-            snapshot,
-            self.render_block(channel_id),
-            provider,
-            started_at_unix,
-            heartbeat_at_unix,
-            live_content_fresh,
-            request_anchor_line,
-            confidence_line,
-        )
+        let turn_trigger_line = self.request_anchor_line(channel_id, &snapshot);
+        let time_line = self.panel_time_line(channel_id, started_at_unix);
+        render_status_panel(snapshot, provider, time_line, turn_trigger_line)
     }
 
     pub(in crate::services::discord) fn render_completion_footer(

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -458,15 +458,12 @@ impl StatusPanelState {
 
 pub(super) fn render_status_panel(
     snapshot: StatusPanelState,
-    live_block: Option<String>,
     provider: &ProviderKind,
-    started_at_unix: i64,
-    _heartbeat_at_unix: i64,
-    // #3477 item 3: live batch arrived AFTER `completed_at` → a Completed turn
-    // keeps 🖥️ Recent (late batch not blanked; stale idle block still dropped).
-    live_content_fresh: bool,
-    request_anchor_line: Option<String>, // #3811: precomputed `요청:` line, or `None`
-    confidence_line: Option<String>,     // #3812: precomputed live/stale confidence line
+    // #3983 item 2: precomputed `마지막 업데이트 : … / 턴 시작 : …` time line (line 2).
+    time_line: String,
+    // #3983 item 3: precomputed `턴 트리거:` deeplink, appended as the LAST footer
+    // line (or `None` for headless/synthetic/id-0 turns with no real user message).
+    turn_trigger_line: Option<String>,
 ) -> String {
     let header_status = if matches!(provider, ProviderKind::Codex)
         && matches!(snapshot.status, DerivedStatus::SubagentRunning { .. })
@@ -475,15 +472,15 @@ pub(super) fn render_status_panel(
     } else {
         snapshot.status.clone()
     };
-    // #3812: header + freshness confidence line built in the colocated `freshness`
-    // module (status_panel.rs is at the namespace cap — keep it to the call site).
-    let mut sections = vec![super::freshness::render_status_header(
-        &header_status,
-        provider,
-        started_at_unix,
-        confidence_line.as_deref(),
-    )];
-    super::turn_anchor::prepend_request_anchor(&mut sections, request_anchor_line); // #3811
+    // #3983: line 1 = derived-status ACTIVITY label, line 2 = relative TIME line
+    // (both built in the colocated `freshness` module — status_panel.rs is at the
+    // namespace cap). The pre-#3983 confidence line + `진행 중 — provider` header is
+    // retired (item 2); the request anchor no longer prepends here (item 3, see the
+    // trailing `턴 트리거:` push below).
+    let mut sections = vec![
+        super::freshness::render_activity_line(&header_status),
+        time_line,
+    ];
 
     if let Some(session) = snapshot.session.as_ref() {
         sections.push(render_session_panel_line(session, provider));
@@ -518,23 +515,8 @@ pub(super) fn render_status_panel(
         sections.push(format!("Plan\n{}", lines.join("\n")));
     }
 
-    // #3477 item 4: 🖥️ Recent renders BEFORE Tasks/Subagents/Workflow (top
-    // signal + shielded from the trailing-section footer-budget drop — item 3).
-    let cluster_config = &crate::config::load_graceful().cluster;
-    let recent_header = render_recent_section_header(
-        snapshot.task.as_ref(),
-        cluster_config.enabled,
-        cluster_config.instance_id.as_deref(),
-    );
-    // #3394 self-contained fenced section (overflow drops it whole). #3477 item 3:
-    // a Completed turn suppresses it only when stale; a fresh late batch shows.
-    let completed = matches!(header_status, DerivedStatus::Completed { .. });
-    if (!completed || live_content_fresh)
-        && let Some(block) = live_block.filter(|block| !block.trim().is_empty())
-    {
-        sections.push(format!("{recent_header}\n{block}"));
-    }
-
+    // #3983 item 5a: the compact 🖥️ Recent + host block is removed from the footer
+    // (the terminal echo is retired from the status panel entirely).
     if !snapshot.tasks.is_empty() {
         let lines = snapshot
             .tasks
@@ -572,6 +554,13 @@ pub(super) fn render_status_panel(
         }
     }
 
+    // #3983 item 3: the `턴 트리거:` original-request deeplink is the LAST footer
+    // line (it previously prepended above the header). Absent for headless /
+    // synthetic / id-0 turns that carry no real Discord user message.
+    if let Some(trigger) = turn_trigger_line.filter(|line| !line.trim().is_empty()) {
+        sections.push(trigger);
+    }
+
     truncate_status_panel_sections(sections)
 }
 
@@ -595,29 +584,6 @@ pub(super) fn truncate_status_panel_sections(mut sections: Vec<String>) -> Strin
         return repair_fence_parity(&joined);
     }
     repair_fence_parity(&truncate_chars(&joined, STATUS_PANEL_MAX_CHARS))
-}
-
-pub(super) fn render_recent_section_header(
-    task: Option<&TaskPanelSnapshot>,
-    cluster_enabled: bool,
-    local_instance_id: Option<&str>,
-) -> String {
-    if !cluster_enabled {
-        return "🖥️ Recent".to_string();
-    }
-    let dispatch_owner = task
-        .and_then(|task| task.owner_instance_id.as_deref())
-        .map(str::trim)
-        .filter(|owner| !owner.is_empty());
-    let owner = dispatch_owner.or_else(|| {
-        local_instance_id
-            .map(str::trim)
-            .filter(|owner| !owner.is_empty())
-    });
-    match owner {
-        Some(owner) => format!("🖥️ Recent ({})", escape_status_panel_markdown(owner)),
-        None => "🖥️ Recent".to_string(),
-    }
 }
 
 pub(super) fn render_subagent_slot(slot: &SubagentSlot) -> String {

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -280,8 +280,10 @@ fn status_panel_recent_compacts_raw_command_details() {
     );
 
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(rendered.contains("🖥️ Recent"));
-    assert!(rendered.contains("• [Bash] 실행"));
+    // #3983 item 5a: the footer no longer echoes the compact 🖥️ Recent block; the
+    // activity label shows the tool class, never the raw command detail.
+    assert!(rendered.contains("🔧 도구 실행 중"));
+    assert!(!rendered.contains("🖥️ Recent"));
     assert!(!rendered.contains("```text"));
     assert!(
         !rendered.contains(raw_command),
@@ -361,83 +363,43 @@ fn status_panel_turn_completed_renders_foreground_completion() {
         }
     );
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(rendered.starts_with("✅ **응답 완료** — claude"));
+    assert!(rendered.starts_with("✅ 완료"));
     assert!(!rendered.contains("🟢 진행 중"));
 }
 
 #[test]
-fn status_panel_turn_completed_drops_recent_live_block() {
-    let events = PlaceholderLiveEvents::default();
-    let channel_id = ChannelId::new(174);
-    events.push_status_events(
-        channel_id,
-        status_events_from_tool_use(
-            "Bash",
-            &json!({"command": "printf E2E_TOOL_OK"}).to_string(),
-        ),
-    );
-    events.push_event(
-        channel_id,
-        RecentPlaceholderEvent::tool_use(
-            "Bash",
-            &json!({"command": "printf E2E_TOOL_OK"}).to_string(),
-        )
-        .unwrap(),
-    );
-
-    let active = events.render_status_panel_with_heartbeat(
-        channel_id,
-        &ProviderKind::Claude,
-        1_700_000_000,
-        1_700_000_005,
-    );
-    assert!(active.contains("🖥️ Recent"));
-    assert!(active.contains("[Bash]"));
-    assert!(!active.contains("계속 처리 중"));
-
-    events.push_status_event(channel_id, StatusEvent::TurnCompleted { background: false });
-
-    let completed = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(completed.starts_with("✅ **응답 완료** — claude"));
-    assert!(!completed.contains("🖥️ Recent"));
-    assert!(!completed.contains("[Bash]"));
-    assert!(!completed.contains("계속 처리 중"));
-}
-
-#[test]
-fn status_panel_surfaces_live_final_stale_and_unknown_confidence() {
-    // #3812: every status panel carries a compact live/stale confidence line in
-    // its header block, derived from deterministic ADK status signals (never age
-    // alone). Pins the four user-facing states end-to-end through the store.
+fn status_panel_absorbs_stale_and_final_into_the_activity_emoji() {
+    // #3983 items 2 + B: the separate 신뢰도 line is retired; the freshness class is
+    // absorbed into the line-1 activity emoji, and line 2 carries the time line.
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(38120);
 
-    // Running turn with a fresh live event → `live`.
+    // Running turn → 🟢 activity + `마지막 업데이트`/`턴 시작` time line, no 신뢰도.
     events.push_status_events(
         channel_id,
         status_events_from_tool_use("Bash", &json!({"command": "cargo test"}).to_string()),
     );
-    events.push_event(
-        channel_id,
-        RecentPlaceholderEvent::tool_use("Bash", &json!({"command": "cargo test"}).to_string())
-            .unwrap(),
-    );
     let live = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
     assert!(
-        live.contains("신뢰도: live · 마지막 업데이트"),
-        "running panel must show a live confidence line: {live:?}"
+        live.contains("🔧 도구 실행 중"),
+        "running activity: {live:?}"
+    );
+    assert!(
+        live.contains("마지막 업데이트 : <t:") && live.contains("턴 시작 : <t:"),
+        "time line must render: {live:?}"
+    );
+    assert!(
+        !live.contains("신뢰도"),
+        "confidence line is retired: {live:?}"
     );
 
-    // Completion → distinct `final` confidence state (not `live`).
+    // Completion → `✅ 완료` (final absorbed into the emoji).
     events.push_status_event(channel_id, StatusEvent::TurnCompleted { background: false });
     let done = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(
-        done.contains("신뢰도: final"),
-        "completed panel must show a final confidence line: {done:?}"
-    );
-    assert!(!done.contains("신뢰도: live"));
+    assert!(done.starts_with("✅ 완료"), "final activity: {done:?}");
+    assert!(!done.contains("신뢰도"));
 
-    // Answer relayed but session-end unconfirmed → corroborated `stale · 조사 권장`.
+    // Answer relayed but session-end unconfirmed → `🟡 응답 지연 · 조사 권장`.
     let stale = events.render_terminal_ui_obligation_panel(
         channel_id,
         &ProviderKind::Claude,
@@ -445,11 +407,11 @@ fn status_panel_surfaces_live_final_stale_and_unknown_confidence() {
         TerminalUiObligationPanelStatus::Deadline,
     );
     assert!(
-        stale.contains("신뢰도: stale") && stale.contains("조사 권장"),
-        "unconfirmed-delivery panel must show a stale confidence line: {stale:?}"
+        stale.starts_with("🟡 응답 지연 · 조사 권장"),
+        "stale is absorbed into the 🟡 activity emoji: {stale:?}"
     );
 
-    // Delivery done, termination still confirming → ambiguous `상태 불명확`.
+    // Delivery done, termination still confirming → the pending `↻` activity.
     let pending = events.render_terminal_ui_obligation_panel(
         channel_id,
         &ProviderKind::Claude,
@@ -457,8 +419,8 @@ fn status_panel_surfaces_live_final_stale_and_unknown_confidence() {
         TerminalUiObligationPanelStatus::Pending,
     );
     assert!(
-        pending.contains("신뢰도: 상태 불명확"),
-        "pending-delivery panel must show an unknown confidence line: {pending:?}"
+        pending.starts_with("↻ 응답 전달됨 · 세션 종료 확인 중"),
+        "pending activity: {pending:?}"
     );
 }
 
@@ -490,8 +452,9 @@ fn status_panel_codex_active_omits_processing_tail_after_recent_block() {
     );
 
     assert!(rendered.contains("🔧 도구 실행 중"));
-    assert!(rendered.contains("🖥️ Recent"));
     assert!(rendered.contains("[Bash]"));
+    // #3983 item 5a: the 🖥️ Recent echo is retired from the footer.
+    assert!(!rendered.contains("🖥️ Recent"));
     assert!(!rendered.contains("계속 처리 중"));
 }
 
@@ -541,7 +504,7 @@ fn status_panel_turn_completed_after_monitor_wait_renders_background_completion(
         }
     );
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(rendered.starts_with("✅ **백그라운드 완료** — claude"));
+    assert!(rendered.starts_with("✅ 백그라운드 완료"));
     assert!(!rendered.contains("💤 monitor 대기"));
 }
 
@@ -566,7 +529,7 @@ fn status_panel_turn_completed_after_aborted_tool_renders_terminal_completion() 
         }
     );
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert!(rendered.starts_with("✅ **응답 완료** — claude"));
+    assert!(rendered.starts_with("✅ 완료"));
     assert!(!rendered.contains("🟢 진행 중"));
 }
 
@@ -1453,66 +1416,6 @@ fn status_panel_omits_context_line_when_token_data_is_absent() {
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
 
     assert!(!rendered.contains("Context   "));
-}
-
-#[test]
-fn recent_header_prefers_dispatch_owner_over_local_node() {
-    let snapshot = TaskPanelSnapshot {
-        dispatch_id: "dsp_55".to_string(),
-        card_id: None,
-        dispatch_type: None,
-        owner_instance_id: Some("mac-book-release".to_string()),
-        card_title: None,
-        dispatch_title: None,
-        github_issue_number: None,
-    };
-    assert_eq!(
-        render_recent_section_header(Some(&snapshot), true, Some("mac-mini-release")),
-        "🖥️ Recent (mac-book-release)"
-    );
-}
-
-#[test]
-fn recent_header_falls_back_to_local_node_when_no_dispatch_owner() {
-    assert_eq!(
-        render_recent_section_header(None, true, Some("mac-mini-release")),
-        "🖥️ Recent (mac-mini-release)"
-    );
-    let snapshot_without_owner = TaskPanelSnapshot {
-        dispatch_id: "dsp_99".to_string(),
-        card_id: None,
-        dispatch_type: None,
-        owner_instance_id: None,
-        card_title: None,
-        dispatch_title: None,
-        github_issue_number: None,
-    };
-    assert_eq!(
-        render_recent_section_header(
-            Some(&snapshot_without_owner),
-            true,
-            Some("mac-mini-release")
-        ),
-        "🖥️ Recent (mac-mini-release)"
-    );
-}
-
-#[test]
-fn recent_header_omits_node_when_cluster_disabled_or_unknown() {
-    let snapshot = TaskPanelSnapshot {
-        dispatch_id: "dsp_55".to_string(),
-        card_id: None,
-        dispatch_type: None,
-        owner_instance_id: Some("mac-book-release".to_string()),
-        card_title: None,
-        dispatch_title: None,
-        github_issue_number: None,
-    };
-    assert_eq!(
-        render_recent_section_header(Some(&snapshot), false, Some("mac-mini-release")),
-        "🖥️ Recent"
-    );
-    assert_eq!(render_recent_section_header(None, true, None), "🖥️ Recent");
 }
 
 #[test]
@@ -6128,112 +6031,6 @@ fn compaction_log_gate_fires_on_change_only() {
 // #3477 / #3473 — live panel terminal block reorder/blank/multiline + TTL.
 // ===========================================================================
 
-// #3477 item 4: the 🖥️ Recent/terminal block renders BEFORE the Tasks and
-// Subagents sections (it is the most useful at-a-glance signal and, ahead of the
-// bulky sections, is also protected from trailing-section budget drops).
-#[test]
-fn status_panel_recent_block_renders_before_tasks_and_subagents() {
-    let events = PlaceholderLiveEvents::default();
-    let channel_id = ChannelId::new(3_477_001);
-    // A running background task (Tasks section) and a running subagent.
-    events.push_status_event(
-        channel_id,
-        StatusEvent::BackgroundTaskStart {
-            name: "Bash".to_string(),
-            summary: "long build".to_string(),
-            tool_use_id: "bg-1".to_string(),
-        },
-    );
-    events.push_status_event(
-        channel_id,
-        StatusEvent::SubagentStart {
-            subagent_type: Some("Explore".to_string()),
-            desc: Some("scan repo".to_string()),
-            tool_use_id: Some("sa-1".to_string()),
-            background: false,
-        },
-    );
-    // A live Recent event.
-    events.push_event(
-        channel_id,
-        RecentPlaceholderEvent::tool_use("Read", &json!({"file_path": "/tmp/x.rs"}).to_string())
-            .unwrap(),
-    );
-
-    let rendered = events.render_status_panel_with_heartbeat(
-        channel_id,
-        &ProviderKind::Claude,
-        1_700_000_000,
-        1_700_000_005,
-    );
-    let recent_at = rendered.find("🖥️ Recent").expect("recent present");
-    let tasks_at = rendered.find("Tasks").expect("tasks present");
-    let subagents_at = rendered.find("Subagents").expect("subagents present");
-    assert!(
-        recent_at < tasks_at,
-        "Recent must precede Tasks: {rendered}"
-    );
-    assert!(
-        recent_at < subagents_at,
-        "Recent must precede Subagents: {rendered}"
-    );
-}
-
-// #3477 item 3: a live output batch that lands AFTER TurnCompleted keeps the
-// 🖥️ Recent block visible (the late batch is not blanked), while a genuinely idle
-// completed turn (no fresh content) still drops its stale block.
-#[test]
-fn status_panel_late_batch_after_completion_keeps_recent_block() {
-    let events = PlaceholderLiveEvents::default();
-    let channel_id = ChannelId::new(3_477_002);
-
-    // Stale pre-completion content, then completion: must be suppressed.
-    events.push_event(
-        channel_id,
-        RecentPlaceholderEvent::tool_use("Bash", &json!({"command": "echo stale"}).to_string())
-            .unwrap(),
-    );
-    events.push_status_event(channel_id, StatusEvent::TurnCompleted { background: false });
-    let idle_completed = events.render_status_panel_with_heartbeat(
-        channel_id,
-        &ProviderKind::Claude,
-        1_700_000_000,
-        1_700_000_010,
-    );
-    assert!(
-        !idle_completed.contains("🖥️ Recent"),
-        "stale block on a genuinely idle completed turn must be dropped: {idle_completed}"
-    );
-
-    // A late output batch arrives AFTER completion: must keep showing Recent.
-    events.push_event(
-        channel_id,
-        RecentPlaceholderEvent::tool_use(
-            "Bash",
-            &json!({"command": "echo LATE_BATCH"}).to_string(),
-        )
-        .unwrap(),
-    );
-    let late = events.render_status_panel_with_heartbeat(
-        channel_id,
-        &ProviderKind::Claude,
-        1_700_000_000,
-        1_700_000_011,
-    );
-    assert!(
-        late.contains("🖥️ Recent"),
-        "a fresh late batch racing TurnCompleted must not be blanked: {late}"
-    );
-    assert!(
-        late.contains("• [Bash] 실행"),
-        "late compact activity must render without raw command text: {late}"
-    );
-    assert!(
-        !late.contains("LATE_BATCH"),
-        "raw late command leaked: {late}"
-    );
-}
-
 // #3477 item 1: multi-line tool output stays readable in the Recent/terminal
 // block (multiple lines preserved) instead of collapsing to one run-on line.
 #[test]
@@ -6505,13 +6302,13 @@ fn completion_footer_free_renderer_prepends_request_anchor_and_target() {
         snapshot,
         &ProviderKind::Claude,
         "⠸",
-        Some("요청: https://discord.com/channels/1/2/3".to_string()),
+        Some("턴 트리거: https://discord.com/channels/1/2/3".to_string()),
     );
     let block = render
         .block
         .expect("anchor + target should render on the result surface");
     assert!(
-        block.starts_with("요청: https://discord.com/channels/1/2/3"),
+        block.starts_with("턴 트리거: https://discord.com/channels/1/2/3"),
         "request anchor must lead the footer: {block:?}"
     );
     assert!(
@@ -6541,31 +6338,34 @@ fn completion_footer_free_renderer_omits_anchor_and_target_when_absent() {
 }
 
 #[test]
-fn status_panel_free_renderer_keeps_request_anchor_first_on_overflow() {
-    // Long-message split: the 요청 anchor is the FIRST section, so it survives the
-    // trailing-section overflow trim on the first visible status surface.
-    let huge_recent = "X".repeat(STATUS_PANEL_MAX_CHARS + 400);
+fn status_panel_free_renderer_leads_with_activity_and_time_lines() {
+    // #3983: the panel opens with the activity label (line 1) then the time line
+    // (line 2); the 턴 트리거 deeplink trails as the last section.
     let out = super::status_panel::render_status_panel(
         StatusPanelState::default(),
-        Some(huge_recent.clone()),
         &ProviderKind::Claude,
-        1_700_000_000,
-        1_700_000_000,
-        true,
-        Some("요청: https://discord.com/channels/1/2/3".to_string()),
-        None,
+        "마지막 업데이트 : <t:1700000000:R> / 턴 시작 : <t:1700000000:R>".to_string(),
+        Some("턴 트리거: https://discord.com/channels/1/2/3".to_string()),
+    );
+    let mut sections = out.split("\n\n");
+    assert_eq!(
+        sections.next(),
+        Some("🟢 진행 중"),
+        "line 1 = activity: {out:?}"
+    );
+    assert_eq!(
+        sections.next(),
+        Some("마지막 업데이트 : <t:1700000000:R> / 턴 시작 : <t:1700000000:R>"),
+        "line 2 = time line: {out:?}"
     );
     assert!(
-        out.starts_with("요청: https://discord.com/channels/1/2/3"),
-        "anchor must lead the panel: {out:?}"
+        out.trim_end()
+            .ends_with("턴 트리거: https://discord.com/channels/1/2/3"),
+        "턴 트리거 must be the last footer line: {out:?}"
     );
     assert!(
         out.chars().count() <= STATUS_PANEL_MAX_CHARS,
         "panel must respect the size cap"
-    );
-    assert!(
-        !out.contains(&huge_recent),
-        "the oversized trailing section must be trimmed, not the anchor"
     );
 }
 

--- a/src/services/discord/placeholder_live_events/turn_anchor.rs
+++ b/src/services/discord/placeholder_live_events/turn_anchor.rs
@@ -1,7 +1,7 @@
 //! #3811: deterministic turn-anchor rendering + store plumbing for the
 //! status/result surfaces.
 //!
-//! The `요청:` original-request line is built from ADK relay metadata
+//! The `턴 트리거:` original-request line is built from ADK relay metadata
 //! (`guild_id` + `channel_id` + the real Discord `user_msg_id`), never from
 //! agent prose. It deliberately renders ONLY for genuine interactive Discord
 //! turns: headless / synthetic / voice / id-0 turns carry no real user message,
@@ -17,9 +17,9 @@ use poise::serenity_prelude::ChannelId;
 use super::status_panel::StatusPanelState;
 use crate::services::discord::is_synthetic_headless_message_id_raw;
 
-/// Builds the `요청:` original-request deeplink, or `None` when no real Discord
-/// user message backs the turn (headless / synthetic / voice / id-0) or the
-/// process has no configured guild id.
+/// Builds the `턴 트리거:` original-request deeplink, or `None` when no real
+/// Discord user message backs the turn (headless / synthetic / voice / id-0) or
+/// the process has no configured guild id.
 ///
 /// Gating: id `0` is the id-less sentinel; the synthetic-headless floor
 /// (`SYNTHETIC_HEADLESS_MESSAGE_ID_FLOOR`, 8e18) sits BELOW both the voice
@@ -37,8 +37,11 @@ pub(super) fn render_request_anchor_line(
         return None;
     }
     let guild_id = guild_id.map(str::trim).filter(|guild| !guild.is_empty())?;
+    // #3983 item 3: the label reads `턴 트리거:` (the turn's triggering request),
+    // rendered as the LAST footer line by `render_status_panel` (the completion
+    // footer still prepends it via `prepend_request_anchor`).
     Some(format!(
-        "요청: https://discord.com/channels/{guild_id}/{}/{user_msg_id}",
+        "턴 트리거: https://discord.com/channels/{guild_id}/{}/{user_msg_id}",
         channel_id.get()
     ))
 }
@@ -129,7 +132,7 @@ mod tests {
         assert_eq!(
             line.as_deref(),
             Some(
-                "요청: https://discord.com/channels/1469870512812462284/1475086789696946196/1520312799245504542"
+                "턴 트리거: https://discord.com/channels/1469870512812462284/1475086789696946196/1520312799245504542"
             )
         );
     }

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -225,7 +225,12 @@ fn strip_panel_header_status_marker(header_line: &str) -> Option<&str> {
 }
 
 fn is_panel_header_status_marker(marker: char) -> bool {
-    matches!(marker, '🟢' | '💤' | '⏰' | '✅' | '🔧' | '🧵' | '🧬')
+    // #3983: `🟡` is the new stale activity marker (`🟡 응답 지연 · 조사 권장`), swapped
+    // for the spinner like every other leading status emoji.
+    matches!(
+        marker,
+        '🟢' | '💤' | '⏰' | '✅' | '🔧' | '🧵' | '🧬' | '🟡'
+    )
 }
 
 fn clamp_footer_panel_text(panel_text: &str) -> String {
@@ -659,6 +664,9 @@ fn text_has_single_message_footer_surface(text: &str) -> bool {
                 || line == "Tasks"
                 || line == "Subagents"
                 || line.starts_with("└ ")
+                // #3983: the footer's line-2 time line identifies the new panel surface.
+                || line.starts_with("마지막 업데이트 ")
+                // Legacy pre-#3983 merged header shape.
                 || (line.contains(" — ") && line.contains("(<t:"))
         })
 }
@@ -796,16 +804,52 @@ fn is_merged_footer_status_line(line: &str) -> bool {
     let Some(status) = strip_footer_braille_spinner_prefix(line) else {
         return false;
     };
-    status.contains(" — ")
-        && status.contains("(<t:")
-        && (status.starts_with("진행 중")
-            || status.starts_with("monitor 대기")
-            || status.starts_with("scheduled wakeup")
-            || status.starts_with("**백그라운드 완료**")
-            || status.starts_with("**응답 완료**")
-            || status.starts_with("도구 실행 중")
-            || status.starts_with("subagent 실행 중")
-            || status.starts_with("workflow 실행 중"))
+    // #3983: the header first line is now the BARE activity label — the provider +
+    // relative-start suffix moved to the separate time line. Match those exact
+    // labels so a user body line that merely opens with the same words (e.g.
+    // `진행 중 — my note`) is not mistaken for the panel status line now that the
+    // disambiguating `(<t:` suffix is gone.
+    is_panel_activity_status_label(status)
+        // Legacy pre-#3983 merged header (`<label> — <provider> (<t:..:R>)`), kept so
+        // in-flight messages during a rollout keep stripping/comparing correctly.
+        || (status.contains(" — ")
+            && status.contains("(<t:")
+            && legacy_merged_status_prefix(status))
+}
+
+/// #3983: exact-shape match for the bare footer activity labels
+/// (`freshness::render_activity_line`, marker emoji already swapped for the
+/// spinner). Fixed labels match exactly; parameterized labels match their
+/// `<phrase> (…)` shape — never a bare prefix — so ordinary prose does not
+/// false-positive without the old `(<t:` disambiguator.
+fn is_panel_activity_status_label(status: &str) -> bool {
+    matches!(
+        status,
+        "진행 중" | "monitor 대기" | "완료" | "백그라운드 완료" | "scheduled wakeup"
+    ) || status.starts_with("응답 지연")
+        || parenthesized_status_label(status, "scheduled wakeup")
+        || parenthesized_status_label(status, "도구 실행 중")
+        || parenthesized_status_label(status, "subagent 실행 중")
+        || parenthesized_status_label(status, "workflow 실행 중")
+}
+
+/// True when `status` is exactly `<phrase> (…)` — the shape of the parameterized
+/// activity labels — so a bare `<phrase> …` prose line does not match.
+fn parenthesized_status_label(status: &str, phrase: &str) -> bool {
+    status
+        .strip_prefix(phrase)
+        .is_some_and(|rest| rest.starts_with(" (") && rest.ends_with(')'))
+}
+
+fn legacy_merged_status_prefix(status: &str) -> bool {
+    status.starts_with("진행 중")
+        || status.starts_with("monitor 대기")
+        || status.starts_with("scheduled wakeup")
+        || status.starts_with("**백그라운드 완료**")
+        || status.starts_with("**응답 완료**")
+        || status.starts_with("도구 실행 중")
+        || status.starts_with("subagent 실행 중")
+        || status.starts_with("workflow 실행 중")
 }
 
 fn strip_footer_braille_spinner_prefix(line: &str) -> Option<&str> {

--- a/src/services/discord/turn_bridge/status_panel_tests.rs
+++ b/src/services/discord/turn_bridge/status_panel_tests.rs
@@ -643,7 +643,7 @@ async fn status_panel_fallback_completion_is_blocked_until_body_visible() {
         .expect("sent messages lock")
         .clone();
     assert_eq!(sent_messages.len(), 1);
-    assert!(sent_messages[0].contains("응답 완료"));
+    assert!(sent_messages[0].contains("완료"));
 }
 
 #[tokio::test]
@@ -684,7 +684,7 @@ async fn status_panel_completion_fallback_posts_when_message_id_is_synthetic() {
         .expect("sent messages lock")
         .clone();
     assert_eq!(sent_messages.len(), 1);
-    assert!(sent_messages[0].contains("응답 완료"));
+    assert!(sent_messages[0].contains("완료"));
     assert_eq!(last_status_panel_text, sent_messages[0]);
 
     let committed = complete_status_panel_v2(
@@ -760,7 +760,7 @@ async fn status_panel_completion_sends_wip_warning_before_completion_surface() {
     assert!(sent_messages[0].contains("WIP uncommitted files detected"));
     assert!(sent_messages[0].contains(&format!("Workspace: `{}`", worktree.path().display())));
     assert!(sent_messages[0].contains("Counts: 0 staged, 0 unstaged, 1 untracked."));
-    assert!(sent_messages[1].contains("응답 완료"));
+    assert!(sent_messages[1].contains("완료"));
 
     let committed_retry = complete_status_panel_v2(
         shared.as_ref(),
@@ -861,7 +861,7 @@ async fn status_panel_completion_fallback_posts_after_unknown_message_edit() {
         .expect("sent messages lock")
         .clone();
     assert_eq!(sent_messages.len(), 1);
-    assert!(sent_messages[0].contains("응답 완료"));
+    assert!(sent_messages[0].contains("완료"));
     assert_eq!(last_status_panel_text, sent_messages[0]);
 }
 


### PR DESCRIPTION
## ROOT CAUSE / 요약 (#3983 Track A)

The Discord live status footer (shared `render_status_panel`, rendered by both
the sink and tmux-watcher single-message footers) carried noisy, redundant
metadata: a two-line `진행 중 — provider (<t:…>)` + `신뢰도:` header, a compact
`🖥️ Recent (host)` terminal echo, and a `요청:` anchor prepended above
everything. This PR redesigns the footer CONTENT into a fixed 3-line header
(design §6 **Track A** only). It touches the placeholder_live_events content
functions plus the co-located footer-detection matchers — **not** the finalize
core (`turn_bridge/mod.rs`) or `tmux_watcher.rs`.

### New footer layout
- **line 1** — derived-status ACTIVITY label alone: `🟢 진행 중` /
  `🔧 도구 실행 중 (…)` / `✅ 완료` / `🟡 응답 지연 · 조사 권장`. The spinner merge
  swaps the leading emoji for the animation.
- **line 2** — relative TIME line: `마지막 업데이트 : <t:last:R> / 턴 시작 : <t:start:R>`.
- **line 3** — `턴 트리거:` deeplink, now the LAST footer line.

### Item mapping (§3 #3983 content table)
| item | change |
|---|---|
| 1 | request-anchor index-0 prepend removed; `render_activity_line` DerivedStatus label is line 1 |
| 2 | `render_status_header` → single time line; confidence line + `진행 중 — provider` header retired |
| 3 | `turn_anchor` label `요청:`→`턴 트리거:`, appended as the footer's last line |
| 5a | compact `🖥️ Recent` + host block deleted from the footer |
| B | stale/final freshness absorbed into the line-1 emoji (`🟡 응답 지연 · 조사 권장` / `✅ 완료`) |

**Out of scope** (Tracks B/C/D): item4 (top one-time host message), item5b
(raw-stream toggle), #3805 message-structure (Stage 2–5).

## 불변식 (INV)
- **INV #3477 stability** — the time line uses stable `<t:…:R>` relative tokens
  anchored to stored stamps (never "now"), so identical snapshots render
  byte-identical across heartbeat ticks (no needless re-edits). Covered by
  `time_line_is_independent_of_render_time`, `status_panel_heartbeat_without_new_events_is_stable`.
- **INV spinner-prefix parity** — `single_message_panel::is_panel_header_status_marker`
  gains `🟡`; every activity label leads with a swap marker
  (`activity_labels_lead_with_a_spinner_swap_marker`).
- **INV sink+watcher parity** — both footers call the shared `render_status_panel`,
  so the content change lands on both automatically; no `turn_bridge/mod.rs` or
  `tmux_watcher.rs` edits.
- **INV headless/synthetic id** — the `턴 트리거:` line renders only for a valid
  real Discord `user_msg_id` (turn_anchor gate unchanged).
- **INV completion/stale mapping** — `render_activity_line` maps
  Running→🟢 / Tool→🔧 / Completed→✅ / stalled→🟡.
- **Footer-detection kept in sync** — `is_merged_footer_status_line` /
  `text_has_single_message_footer_surface` match the new bare label + time line
  while keeping the legacy merged-header shape (in-flight messages + #3717
  spinner-tick compare still work). The `(<t:` disambiguator is replaced by
  exact-label matching so ordinary prose is not stripped.

## Tests
- freshness: activity labels (running/tool/completed/bg-completed/stale), spinner-swap
  markers, time-line anchors + heartbeat stability.
- placeholder_live_events: `status_panel_free_renderer_leads_with_activity_and_time_lines`,
  `status_panel_absorbs_stale_and_final_into_the_activity_emoji`, updated completion +
  codex + raw-command tests; obsolete Recent-block tests removed.
- turn_anchor: `턴 트리거:` label.
- single_message_panel legacy detection tests still pass (legacy merged-header branch kept).

## CI gates (all green locally)
- `cargo fmt --check` ✓
- `cargo check --lib` ✓ (0 errors; 5 pre-existing unrelated warnings)
- `cargo test --lib -- placeholder_live_events status_panel freshness turn_anchor` → 313 passed, 0 failed
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` freshness ✓
- `audit_maintainability.py --check` ✓ · `check_hotfile_ratchet.py` ✓

The 15 full-suite failures are pre-existing/environmental (verified to fail on
`origin/main` without this change; unrelated modules: delivery_record, followup-requeue
env flags, send_gate, memory_api, routines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)