### PR TITLE
fix(discord): permit legitimate same-turn retry reset under authority-ON (#3933)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1415,7 +1415,7 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (2309 lines; +8 from #3960
+    lines) and `src/services/discord/inflight.rs` (2328 lines; +8 from #3960
     `mod orphan_relay_reclaim` + its re-export — the producer-liveness TOCTOU
     reclaim predicate and the locked owner-downgrade RMW live in their own
     submodule, not this giant file; this is the mod-decl + re-export cost; +1
@@ -1452,7 +1452,14 @@
     splitting `persist_under_lock` into a bump-parameterized `persist_under_lock_inner`
     plus a `persist_under_lock_preserving_updated_at` wrapper, so the orphan
     owner-downgrade can persist without resetting the quiescence clock — all
-    existing `persist_under_lock` callers unchanged).
+    existing `persist_under_lock` callers unchanged; +19 from #3933 deriving the
+    `is_legitimate_full_reset` signal inside `validate_inflight_state_for_save`
+    (empty `full_response` + `response_sent_offset == 0` for the SAME turn — the
+    Gemini/Qwen `RetryBoundary` rewind signature) and passing it to the enforce
+    guard so the authority-ON release path permits the legitimate re-stream
+    instead of enforce-skipping it, plus the paired monotonic debug-tripwire
+    relaxation for the already-skipped case; the enforce decision itself stays a
+    pure helper in `outbound/delivery_record.rs`).
   - `src/services/discord/placeholder_sweeper.rs` (1019 lines; +5 from #3886
     calling the deterministic TimedOut-completion-gate status-panel reconcile
     (`super::tmux::reconcile_timed_out_tui_status_panel`) before the age-based

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -17,7 +17,7 @@
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
 | `src/services/discord/health/recovery.rs` | 2223 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1252 | discord-relay | 2026-08-31 | #3405 |
-| `src/services/discord/inflight.rs` | 2309 | discord-relay | 2026-10-31 | #3835 |
+| `src/services/discord/inflight.rs` | 2328 | discord-relay | 2026-10-31 | #3835 |
 | `src/services/discord/placeholder_sweeper.rs` | 1019 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/recovery_engine.rs` | 2935 | discord-relay | 2026-10-31 | #3834 |
 | `src/services/discord/router/intake_gate.rs` | 1591 | discord-relay | 2026-10-31 | #3838 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -464,7 +464,7 @@
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
 | `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
-| `services::discord::inflight` | `src/services/discord/inflight.rs` | 7415 | 2309 | 5106 | giant-file |
+| `services::discord::inflight` | `src/services/discord/inflight.rs` | 7556 | 2328 | 5228 | giant-file |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 549 | 188 | 361 |  |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
 | `services::discord::inflight::finalizer_identity` | `src/services/discord/inflight/finalizer_identity.rs` | 56 | 56 | 0 |  |
@@ -492,7 +492,7 @@
 | `services::discord::outbound::decision` | `src/services/discord/outbound/decision.rs` | 248 | 248 | 0 |  |
 | `services::discord::outbound::delivery` | `src/services/discord/outbound/delivery.rs` | 1271 | 693 | 578 |  |
 | `services::discord::outbound::delivery_frontier_probe` | `src/services/discord/outbound/delivery_frontier_probe.rs` | 75 | 75 | 0 |  |
-| `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2032 | 944 | 1088 |  |
+| `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2130 | 971 | 1159 |  |
 | `services::discord::outbound::manual_delivery` | `src/services/discord/outbound/manual_delivery.rs` | 1177 | 580 | 597 |  |
 | `services::discord::outbound::message` | `src/services/discord/outbound/message.rs` | 426 | 426 | 0 |  |
 | `services::discord::outbound::policy` | `src/services/discord/outbound/policy.rs` | 124 | 124 | 0 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -610,7 +610,8 @@
 # not stale → the view builder keeps it → the deferred claim keeps aborting ~300 s.
 # The split keeps ONE implementation (no duplicated validate/atomic-write) behind
 # the flag. Root-consistent with #3960; smallest possible blast radius.
-"src/services/discord/inflight.rs" = 2309 # #3835: 3077 -> 2275, locked-in win — verbatim decompose moved the status-panel/current-message ownership writes to inflight/ownership_ops.rs and the staleness predicates + orphan-lock/rebind-origin reap helpers to inflight/rebind_reap.rs (zero behavior change, facade re-exports keep inflight::* paths byte-identical); #3982 -> 2309 (+34) persist bump-flag split (see comment above)
+# 2026-07-01 #3933: +19 prod LoC — is_legitimate_full_reset enforce-guard precision (live data-loss fix); 로직은 validate_inflight_state_for_save에 상주해야 함
+"src/services/discord/inflight.rs" = 2328 # #3835: 3077 -> 2275, locked-in win — verbatim decompose moved the status-panel/current-message ownership writes to inflight/ownership_ops.rs and the staleness predicates + orphan-lock/rebind-origin reap helpers to inflight/rebind_reap.rs (zero behavior change, facade re-exports keep inflight::* paths byte-identical); #3982 -> 2309 (+34) persist bump-flag split (see comment above); #3933 -> 2328 (+19) is_legitimate_full_reset enforce-guard precision (see comment above)
 # #3779 extracted relay-recovery auto-heal attempt accounting to a sibling
 # module, dropping relay_recovery.rs below the prod-giant threshold; the ratchet
 # entry is retired instead of raising the baseline.

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -346,12 +346,25 @@ fn validate_inflight_state_for_save(
     // actually persists below, so the violation stays ERROR (a genuine breach).
     // Computed BEFORE the records so the severity is correct; the enforce branch
     // itself (skip + return false) is unchanged.
+    // #3933: a legitimate Gemini/Qwen `RetryBoundary` reset rewinds the SAME
+    // turn's frontier to the start — `full_response` cleared and
+    // `response_sent_offset` back to 0 — to re-stream the answer
+    // (turn_bridge/retry_state.rs::clear_response_delivery_state). That backward
+    // move is NOT a stale-snapshot regression, so the enforce guard must permit
+    // it (the release runs AGENTDESK_DELIVERY_RECORD_AUTHORITY=1; blocking it
+    // drops the re-streamed body). A genuine backward regression carries a
+    // non-empty body, so it never matches this rewind signature and stays
+    // blocked. The signal is derived here from the incoming state — no call-site
+    // change — so the guard stays self-contained.
+    let is_legitimate_full_reset =
+        same_turn_identity && state.full_response.is_empty() && state.response_sent_offset == 0;
     use crate::services::discord::outbound::delivery_record as dr;
     let authority = dr::delivery_record_authority_enabled();
     let enforce_skips_backward_write = dr::authority_blocks_backward_inflight_write(
         authority,
         monotonic_offset,
         last_offset_monotonic,
+        is_legitimate_full_reset,
     );
     let offset_monotonic_severity =
         offset_monotonic_invariant_severity(enforce_skips_backward_write);
@@ -370,8 +383,14 @@ fn validate_inflight_state_for_save(
         }),
         offset_monotonic_severity,
     );
+    // #3933: when the enforce guard is about to SKIP this backward write it never
+    // persists, so the debug tripwire has nothing to catch — asserting there would
+    // panic on a write we already discard. Relax the tripwire for that skipped
+    // case only; a backward move that actually PERSISTS (enforce OFF, or a
+    // permitted legitimate reset in release) still trips it, preserving the
+    // tripwire's purpose and every existing observe-only test verbatim.
     debug_assert!(
-        monotonic_offset,
+        monotonic_offset || enforce_skips_backward_write,
         "inflight response_sent_offset must not move backwards for the same turn identity"
     );
 
@@ -390,7 +409,7 @@ fn validate_inflight_state_for_save(
         offset_monotonic_severity,
     );
     debug_assert!(
-        last_offset_monotonic,
+        last_offset_monotonic || enforce_skips_backward_write,
         "inflight last_offset must not move backwards for the same turn identity"
     );
 
@@ -3265,6 +3284,123 @@ mod stall_recovery_tests {
         );
     }
 
+    /// #3933 (release-path coverage): under authority-ON — the live release config
+    /// (`AGENTDESK_DELIVERY_RECORD_AUTHORITY=1`) — the LEGITIMATE Gemini/Qwen
+    /// `RetryBoundary` reset (`full_response` cleared + `response_sent_offset`→0 for
+    /// the SAME turn identity to re-stream) must NOT be enforce-skipped, so the
+    /// re-streamed answer survives. Before the `is_legitimate_full_reset` carve-out
+    /// the coarse guard returned `false` here and dropped the body live. The suite
+    /// default is authority-OFF, so this path is only exercised by forcing the flag
+    /// ON via the per-thread test seam.
+    #[test]
+    fn authority_on_permits_legit_retry_reset_3933() {
+        use crate::services::discord::outbound::delivery_record as dr;
+        // Share the panic-hook serialization the other tripwire tests use.
+        let _serialized = monotonic_3358_test_mutex()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let temp = TempDir::new().unwrap();
+        let channel_id = 39_330_101;
+        // Existing on-disk row: a streamed answer with an advanced frontier.
+        let mut reset = seed_watcher_stream_state(
+            temp.path(),
+            channel_id,
+            "AgentDesk-claude-3933a",
+            "streamed answer body",
+            120,
+        );
+        // The RetryBoundary reset rewinds the SAME turn to re-stream from empty.
+        reset.full_response = String::new();
+        reset.response_sent_offset = 0;
+        let provider = ProviderKind::Claude;
+        let path = inflight_state_path(temp.path(), &provider, channel_id);
+
+        // Force authority-ON for THIS thread only (the release config).
+        let _authority = dr::authority_test_seam::force(true);
+        let verdict = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            validate_inflight_state_for_save(
+                temp.path(),
+                &path,
+                &reset,
+                "src/services/discord/inflight.rs:test",
+            )
+        }));
+        // The reset is a same-turn backward move. The debug tripwire relaxes ONLY
+        // for an enforce-SKIP, and this write is PERMITTED (not skipped), so in
+        // debug it fires — the panic itself witnesses "permitted, not
+        // enforce-skipped" (a wrongly-blocked reset would relax the tripwire and
+        // return `false` WITHOUT panicking, failing this assert). In release the
+        // tripwire is compiled out, `validate` returns `true`, and the reset
+        // persists end-to-end.
+        match verdict {
+            Ok(permitted) => {
+                assert!(
+                    permitted,
+                    "authority-ON must PERMIT the legitimate retry reset, not enforce-skip it"
+                );
+                save_inflight_state_in_root(temp.path(), &reset).unwrap();
+                let persisted = loaded_row(temp.path(), channel_id);
+                assert!(
+                    persisted.full_response.is_empty(),
+                    "the permitted retry reset must persist (cleared body survives the re-stream)"
+                );
+                assert_eq!(persisted.response_sent_offset, 0);
+            }
+            Err(_) => assert!(
+                cfg!(debug_assertions),
+                "a panic is only expected from the debug tripwire on the permitted backward move"
+            ),
+        }
+    }
+
+    /// #3933 (release-path coverage): a GENUINE stale-snapshot backward regression
+    /// — a NON-EMPTY body moving the frontier back for the SAME turn — must STILL
+    /// be enforce-skipped under authority-ON. The reset carve-out must not weaken
+    /// the real guard, so the committed answer already on disk survives untouched.
+    /// The skipped case is exactly what the #3933 tripwire relaxation exempts, so
+    /// this runs cleanly (no panic) even in debug builds.
+    #[test]
+    fn authority_on_still_skips_nonempty_stale_backward_write_3933() {
+        use crate::services::discord::outbound::delivery_record as dr;
+        let temp = TempDir::new().unwrap();
+        let channel_id = 39_330_102;
+        let committed_body = "the full committed answer";
+        let streamed = seed_watcher_stream_state(
+            temp.path(),
+            channel_id,
+            "AgentDesk-claude-3933b",
+            committed_body,
+            200,
+        );
+        // A stale snapshot for the SAME turn: non-empty but SHORTER body, backward
+        // rso and last_offset. NOT the reset signature (the body is non-empty).
+        let mut stale = streamed.clone();
+        stale.full_response = "stale".to_string();
+        stale.response_sent_offset = 3;
+        stale.last_offset = 50;
+        let provider = ProviderKind::Claude;
+        let path = inflight_state_path(temp.path(), &provider, channel_id);
+
+        let _authority = dr::authority_test_seam::force(true);
+        assert!(
+            !validate_inflight_state_for_save(
+                temp.path(),
+                &path,
+                &stale,
+                "src/services/discord/inflight.rs:test",
+            ),
+            "authority-ON must still enforce-skip a non-empty stale backward write"
+        );
+        // Driving the honor path, the committed body on disk must survive untouched.
+        save_inflight_state_in_root(temp.path(), &stale).unwrap();
+        let persisted = loaded_row(temp.path(), channel_id);
+        assert_eq!(
+            persisted.full_response, committed_body,
+            "the enforce-skipped stale write must not clobber the committed answer"
+        );
+        assert_eq!(persisted.response_sent_offset, committed_body.len());
+    }
+
     // ---- #3077: typed status-panel ownership write tests ----
 
     /// Seeds a single inflight row in `root` and returns it. `user_msg_id` /
@@ -4967,34 +5103,39 @@ mod stall_recovery_tests {
     }
 
     #[test]
-    fn authority_guard_would_suppress_same_turn_frontier_reset_3860() {
-        // #3860 SAFETY rationale (why the compiled monotonic-guard default stays
-        // OFF and is NOT flipped to enforce-ON in this PR): when ON,
-        // `authority_blocks_backward_inflight_write` blocks ANY same-turn backward
-        // `response_sent_offset` write — including the LEGITIMATE Gemini/Qwen
-        // RetryBoundary reset (turn_bridge/retry_state.rs clears `full_response`
-        // and rewinds rso→0 for the SAME identity to re-stream the turn). Blocking
-        // it drops the re-streamed body (a real, observed danger — the live
-        // AGENTDESK_DELIVERY_RECORD_AUTHORITY=1 config enforce-skips that reset).
-        // The root-cause fix (the per-row RMW restart-mode marker) avoids the
-        // frontier regression WITHOUT this collateral suppression, so the risky
-        // default flip is deferred, not taken here.
+    fn authority_guard_distinguishes_legit_reset_from_stale_regression_3933() {
+        // #3933 (supersedes the #3860-era "would suppress" doc-guard): under
+        // authority-ON the enforce guard MUST tell apart the LEGITIMATE Gemini/Qwen
+        // RetryBoundary reset (turn_bridge/retry_state.rs clears `full_response` and
+        // rewinds rso→0 for the SAME identity to re-stream) from a genuine
+        // stale-snapshot backward regression (a non-empty body moving the frontier
+        // back). The release runs AGENTDESK_DELIVERY_RECORD_AUTHORITY=1, so the old
+        // coarse guard dropped the re-streamed body live; the `is_legitimate_full_reset`
+        // signal carves the reset out while keeping the real regression blocked.
         use crate::services::discord::outbound::delivery_record as dr;
-        // authority ON + same-turn backward rso (monotonic == false) → blocked
-        // (this is the legitimate retry reset that would be wrongly suppressed).
-        assert!(dr::authority_blocks_backward_inflight_write(
-            true, false, true
-        ));
-        assert!(dr::authority_blocks_backward_inflight_write(
-            true, true, false
-        ));
-        // authority OFF (compiled default) → never blocks → reset persists.
+        // authority ON + same-turn backward move + legit reset signature → PERMIT
+        // (the retry reset persists and the re-streamed body survives).
         assert!(!dr::authority_blocks_backward_inflight_write(
-            false, false, true
+            true, false, true, true
+        ));
+        assert!(!dr::authority_blocks_backward_inflight_write(
+            true, true, false, true
+        ));
+        // authority ON + same-turn backward move + NON-reset (non-empty body) → BLOCK
+        // (a genuine stale-snapshot regression stays suppressed).
+        assert!(dr::authority_blocks_backward_inflight_write(
+            true, false, true, false
+        ));
+        assert!(dr::authority_blocks_backward_inflight_write(
+            true, true, false, false
+        ));
+        // authority OFF (compiled default) → never blocks, reset flag irrelevant.
+        assert!(!dr::authority_blocks_backward_inflight_write(
+            false, false, true, false
         ));
         // authority ON but fully monotonic → not blocked (forward writes pass).
         assert!(!dr::authority_blocks_backward_inflight_write(
-            true, true, true
+            true, true, true, false
         ));
     }
 

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -480,6 +480,15 @@ pub(in crate::services::discord) fn delivery_record_shadow_enabled() -> bool {
 /// gates consult the durable `delivered_frontier` (fused with in-memory) so the
 /// "already-relayed → skip" decision survives a restart / cross-actor boundary.
 pub(in crate::services::discord) fn delivery_record_authority_enabled() -> bool {
+    // #3933: a per-thread test override (see `authority_test_seam`) lets a unit
+    // test drive the authority-ON enforce path (the release config) through the
+    // real save path WITHOUT poisoning the env-global `OnceLock` cache for
+    // sibling tests that assume the compiled-default OFF. Production strips this
+    // branch entirely (`cfg(test)`), so the flag stays byte-identical at runtime.
+    #[cfg(test)]
+    if let Some(forced) = authority_test_seam::current_override() {
+        return forced;
+    }
     static CACHED: OnceLock<bool> = OnceLock::new();
     *CACHED.get_or_init(|| {
         let on = std::env::var("AGENTDESK_DELIVERY_RECORD_AUTHORITY")
@@ -491,6 +500,48 @@ pub(in crate::services::discord) fn delivery_record_authority_enabled() -> bool 
         }
         on
     })
+}
+
+/// #3933 test seam: a per-thread override of `delivery_record_authority_enabled()`
+/// so a unit test can drive the authority-ON enforce path (the release config)
+/// deterministically. Housed in a `#[cfg(test)] mod` (not inline `#[cfg(test)]`
+/// items) so the seam counts as test — not production — review surface.
+#[cfg(test)]
+pub(in crate::services::discord) mod authority_test_seam {
+    use std::cell::Cell;
+
+    thread_local! {
+        /// When `Some`, forces the flag on THIS thread only; `None` (default)
+        /// falls through to the env-cached `OnceLock`.
+        static OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+    }
+
+    pub(in crate::services::discord) fn current_override() -> Option<bool> {
+        OVERRIDE.with(Cell::get)
+    }
+
+    /// RAII: force `delivery_record_authority_enabled()` to `value` on the
+    /// current thread until the returned guard drops (then restore the prior
+    /// override). The env-cached `OnceLock` cannot be re-set once initialized,
+    /// and mutating the process-global env would race sibling tests, so a
+    /// thread-local + RAII keeps the authority-ON honor path order-independent
+    /// and leak-free.
+    #[must_use]
+    pub(in crate::services::discord) fn force(value: bool) -> Guard {
+        Guard {
+            previous: OVERRIDE.with(|cell| cell.replace(Some(value))),
+        }
+    }
+
+    pub(in crate::services::discord) struct Guard {
+        previous: Option<bool>,
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            OVERRIDE.with(|cell| cell.set(self.previous));
+        }
+    }
 }
 
 pub(super) fn delivery_record_rollout_health_json() -> serde_json::Value {
@@ -543,19 +594,32 @@ fn delivery_record_rollout_health_json_for_flags(
     })
 }
 
-/// #3089 B3 / #3416 (pure, testable): the same-turn monotonic guard's enforce
-/// decision. Returns `true` (block the backward inflight write) ONLY when the
-/// durable delivered-frontier authority is ON **and** a same-turn offset moved
-/// backward (`response_sent_offset` or `last_offset`). Authority OFF (default) →
-/// always `false` → the guard stays observe-only and the write proceeds
-/// byte-identically (deploy no-op). Gated by the SAME flag as the read-authority
-/// flip so the single offset authority + its enforcement cut over atomically.
+/// #3089 B3 / #3416 / #3933 (pure, testable): the same-turn monotonic guard's
+/// enforce decision. Returns `true` (block the backward inflight write) ONLY when
+/// the durable delivered-frontier authority is ON, a same-turn offset moved
+/// backward (`response_sent_offset` or `last_offset`), **and** the backward move
+/// is NOT a legitimate full reset. Authority OFF (default) → always `false` → the
+/// guard stays observe-only and the write proceeds byte-identically (deploy
+/// no-op). Gated by the SAME flag as the read-authority flip so the single offset
+/// authority + its enforcement cut over atomically.
+///
+/// #3933: `is_legitimate_full_reset` carves the legitimate Gemini/Qwen
+/// `RetryBoundary` rewind (turn_bridge/retry_state.rs clears `full_response` and
+/// rewinds `response_sent_offset`→0 for the SAME turn identity to re-stream) out
+/// of the coarse backward-write skip. The release runs
+/// `AGENTDESK_DELIVERY_RECORD_AUTHORITY=1`, so before this carve-out the enforce
+/// branch dropped the re-streamed body (live data loss). A genuine stale-snapshot
+/// backward regression carries a NON-EMPTY body, so it never matches the reset
+/// signature and stays blocked.
 pub(in crate::services::discord) fn authority_blocks_backward_inflight_write(
     authority_enabled: bool,
     response_sent_offset_monotonic: bool,
     last_offset_monotonic: bool,
+    is_legitimate_full_reset: bool,
 ) -> bool {
-    authority_enabled && (!response_sent_offset_monotonic || !last_offset_monotonic)
+    authority_enabled
+        && (!response_sent_offset_monotonic || !last_offset_monotonic)
+        && !is_legitimate_full_reset
 }
 
 /// Pure fusion (testable): the effective committed offset under the flip. The
@@ -1194,17 +1258,51 @@ mod tests {
     fn authority_blocks_backward_inflight_write_truth_table() {
         // #3416 (#3089 B3): ENFORCE only when authority is ON AND a same-turn
         // offset moved backward. OFF → never blocks (observe-only, no-op deploy).
-        // authority OFF → false regardless of the monotonic flags.
+        // authority OFF → false regardless of the monotonic flags. The 4th arg
+        // (#3933 is_legitimate_full_reset) is `false` for every genuine-regression
+        // row here — it only ever RELAXES, never tightens.
         assert!(!authority_blocks_backward_inflight_write(
-            false, false, false
+            false, false, false, false
         ));
-        assert!(!authority_blocks_backward_inflight_write(false, true, true));
+        assert!(!authority_blocks_backward_inflight_write(
+            false, true, true, false
+        ));
         // authority ON, both monotonic OK → permit the write.
-        assert!(!authority_blocks_backward_inflight_write(true, true, true));
+        assert!(!authority_blocks_backward_inflight_write(
+            true, true, true, false
+        ));
         // authority ON, a backward move on EITHER offset → block (pins the OR).
-        assert!(authority_blocks_backward_inflight_write(true, false, true));
-        assert!(authority_blocks_backward_inflight_write(true, true, false));
-        assert!(authority_blocks_backward_inflight_write(true, false, false));
+        assert!(authority_blocks_backward_inflight_write(
+            true, false, true, false
+        ));
+        assert!(authority_blocks_backward_inflight_write(
+            true, true, false, false
+        ));
+        assert!(authority_blocks_backward_inflight_write(
+            true, false, false, false
+        ));
+
+        // #3933: a legitimate full reset (empty body + rso→0, same turn) must be
+        // PERMITTED even under authority-ON with a backward move — otherwise the
+        // Gemini/Qwen retry re-stream is dropped. The carve-out only fires for a
+        // backward move; a fully-monotonic forward write is unaffected either way.
+        assert!(!authority_blocks_backward_inflight_write(
+            true, false, true, true
+        ));
+        assert!(!authority_blocks_backward_inflight_write(
+            true, true, false, true
+        ));
+        assert!(!authority_blocks_backward_inflight_write(
+            true, false, false, true
+        ));
+        // The reset flag never turns a permitted write into a block.
+        assert!(!authority_blocks_backward_inflight_write(
+            true, true, true, true
+        ));
+        // Authority OFF stays a no-op regardless of the reset flag.
+        assert!(!authority_blocks_backward_inflight_write(
+            false, false, false, true
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## ROOT CAUSE (live data loss, release is authority-ON)

The release runs `AGENTDESK_DELIVERY_RECORD_AUTHORITY=1`. Under that flag the same-turn backward-write **enforce** guard (`validate_inflight_state_for_save` → `authority_blocks_backward_inflight_write`) hard-SKIPPED **any** same-turn backward inflight write. That includes the **legitimate Gemini/Qwen `RetryBoundary` reset**: `turn_bridge/retry_state.rs::clear_response_delivery_state` clears `full_response` and rewinds `response_sent_offset`→0 for the **same** turn identity to re-stream the answer. Blocking it drops the re-streamed body — a live, user-visible relay loss on the release deployment. (CI never caught it because the suite defaults to authority-OFF, so the release path was untested — the exact blind spot design-3933 calls out.)

This is prerequisite #1 of #3933 (precise the enforce guard). The mechanical compiled-default flip and the read-authority validation (#2) are intentionally **out of scope** here; §3-3 co-carried field-preserving merge is deferred (per-row RMW from #3860 already mitigates immediate lost-update).

## FIX (self-contained in inflight.rs + delivery_record.rs pure helper)

- `delivery_record.rs`: `authority_blocks_backward_inflight_write` gains `is_legitimate_full_reset: bool`; returns `authority && (!rso_monotonic || !last_offset_monotonic) && !is_legitimate_full_reset`. Pure/testable.
- `inflight.rs`: `validate_inflight_state_for_save` derives the reset signature `same_turn_identity && full_response.is_empty() && response_sent_offset == 0` from the incoming state and passes it to the helper. **No call-site (turn_bridge/mod.rs) touch** — the signal is internal. Severity/log logic unchanged. The monotonic debug-tripwire is relaxed only for the enforce-skipped case (a write already discarded) — a no-op at authority-OFF (real CI), so every existing observe-only test stays green verbatim.

## Invariants (INV)

- **INV1** legit full-reset (empty body + rso 0, same identity) → **permitted** at authority-ON (not enforce-skipped) → re-streamed body survives.
- **INV2** non-empty stale-snapshot backward regression → **still enforce-skipped** at authority-ON → committed answer survives untouched.
- **INV3** authority-OFF (compiled default / CI) → guard is a byte-identical no-op; debug-tripwire relaxation is inert.
- **INV4** no public-API widening (helper + test seam stay `pub(in crate::services::discord)`); core hotfiles (turn_bridge/mod.rs, tmux_watcher.rs, session_relay_sink.rs, turn_finalizer) untouched.
- **INV5** on-disk schema unchanged → MULTINODE-COMPATIBLE / no-migration.

## Tests

- `delivery_record.rs`: `authority_blocks_backward_inflight_write_truth_table` extended for the 4th arg (legit reset RELAXES, never tightens).
- `inflight.rs`:
  - `authority_guard_distinguishes_legit_reset_from_stale_regression_3933` (supersedes the #3860 "would suppress" doc-guard).
  - `authority_on_permits_legit_retry_reset_3933` — **authority forced ON via a per-thread cfg(test) seam**; the legit reset is permitted and persists.
  - `authority_on_still_skips_nonempty_stale_backward_write_3933` — non-empty backward write is enforce-skipped; committed body survives.
- Existing guards green: `watcher_stream_progress_preserves_gemini_retry_reset`, `restart_marker_preserves_legitimate_frontier_reset_3860`, `restart_marker_skips_deleted_row_3860`, `synthetic_lagging_birth_reproduces_backward_regression_3358`.

The authority-ON release path is covered even though CI defaults to authority-OFF, via a thread-local override seam (the env `OnceLock` can't be re-set once initialized; mutating global env would race sibling tests).

## Gate results

- `cargo fmt --check`: clean
- `cargo check --lib`: clean (pre-existing warnings only, untouched files)
- `cargo test --lib -- delivery_record inflight` (clean CI env, authority OFF): **361 passed, 0 failed**
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: pass (delivery_record.rs kept < 1000 prod lines by housing the seam in a `#[cfg(test)] mod`; inflight.rs freeze entry synced to 2328)
- `audit_maintainability.py --check`: pass (no new giant)
- `check_hotfile_ratchet.py`: pass (3 hotfiles unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)