### PR TITLE
fix(discord): legit-reset severity WARN + read-authority ON dedup verification (#3933 follow-up)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1418,7 +1418,7 @@
     2026-08-31, #3036)).
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
-    lines) and `src/services/discord/inflight.rs` (2328 lines; +8 from #3960
+    lines) and `src/services/discord/inflight.rs` (2339 lines; +8 from #3960
     `mod orphan_relay_reclaim` + its re-export — the producer-liveness TOCTOU
     reclaim predicate and the locked owner-downgrade RMW live in their own
     submodule, not this giant file; this is the mod-decl + re-export cost; +1
@@ -1462,7 +1462,13 @@
     guard so the authority-ON release path permits the legitimate re-stream
     instead of enforce-skipping it, plus the paired monotonic debug-tripwire
     relaxation for the already-skipped case; the enforce decision itself stays a
-    pure helper in `outbound/delivery_record.rs`).
+    pure helper in `outbound/delivery_record.rs`; +11 from the #3933 follow-up
+    classifying a permitted full reset's offset-monotonic violation as WARN
+    instead of ERROR (the `monotonic_violation_safely_handled =
+    enforce_skips_backward_write || is_legitimate_full_reset` input at the
+    save-path chokepoint — log-severity ONLY; enforce guard, debug tripwire, and
+    on-disk schema unchanged, killing the per-retry authority-ON operator ERROR
+    noise on every Gemini/Qwen `RetryBoundary`)).
   - `src/services/discord/placeholder_sweeper.rs` (1019 lines; +5 from #3886
     calling the deterministic TimedOut-completion-gate status-panel reconcile
     (`super::tmux::reconcile_timed_out_tui_status_panel`) before the age-based

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -17,7 +17,7 @@
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
 | `src/services/discord/health/recovery.rs` | 2223 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1252 | discord-relay | 2026-08-31 | #3405 |
-| `src/services/discord/inflight.rs` | 2328 | discord-relay | 2026-10-31 | #3835 |
+| `src/services/discord/inflight.rs` | 2339 | discord-relay | 2026-10-31 | #3835 |
 | `src/services/discord/placeholder_sweeper.rs` | 1019 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/recovery_engine.rs` | 2935 | discord-relay | 2026-10-31 | #3834 |
 | `src/services/discord/router/intake_gate.rs` | 1591 | discord-relay | 2026-10-31 | #3838 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -464,7 +464,7 @@
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
 | `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
-| `services::discord::inflight` | `src/services/discord/inflight.rs` | 7556 | 2328 | 5228 | giant-file |
+| `services::discord::inflight` | `src/services/discord/inflight.rs` | 7721 | 2339 | 5382 | giant-file |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 549 | 188 | 361 |  |
 | `services::discord::inflight::budget` | `src/services/discord/inflight/budget.rs` | 339 | 108 | 231 |  |
 | `services::discord::inflight::finalizer_identity` | `src/services/discord/inflight/finalizer_identity.rs` | 56 | 56 | 0 |  |
@@ -492,7 +492,7 @@
 | `services::discord::outbound::decision` | `src/services/discord/outbound/decision.rs` | 248 | 248 | 0 |  |
 | `services::discord::outbound::delivery` | `src/services/discord/outbound/delivery.rs` | 1271 | 693 | 578 |  |
 | `services::discord::outbound::delivery_frontier_probe` | `src/services/discord/outbound/delivery_frontier_probe.rs` | 75 | 75 | 0 |  |
-| `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2130 | 971 | 1159 |  |
+| `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2364 | 971 | 1393 |  |
 | `services::discord::outbound::manual_delivery` | `src/services/discord/outbound/manual_delivery.rs` | 1177 | 580 | 597 |  |
 | `services::discord::outbound::message` | `src/services/discord/outbound/message.rs` | 426 | 426 | 0 |  |
 | `services::discord::outbound::policy` | `src/services/discord/outbound/policy.rs` | 124 | 124 | 0 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -614,7 +614,14 @@
 # The split keeps ONE implementation (no duplicated validate/atomic-write) behind
 # the flag. Root-consistent with #3960; smallest possible blast radius.
 # 2026-07-01 #3933: +19 prod LoC — is_legitimate_full_reset enforce-guard precision (live data-loss fix); 로직은 validate_inflight_state_for_save에 상주해야 함
-"src/services/discord/inflight.rs" = 2328 # #3835: 3077 -> 2275, locked-in win — verbatim decompose moved the status-panel/current-message ownership writes to inflight/ownership_ops.rs and the staleness predicates + orphan-lock/rebind-origin reap helpers to inflight/rebind_reap.rs (zero behavior change, facade re-exports keep inflight::* paths byte-identical); #3982 -> 2309 (+34) persist bump-flag split (see comment above); #3933 -> 2328 (+19) is_legitimate_full_reset enforce-guard precision (see comment above)
+# 2026-07-01 #3933 follow-up: +11 prod LoC — severity WARN downgrade for a legitimate
+# full reset. The `monotonic_violation_safely_handled = enforce_skips_backward_write ||
+# is_legitimate_full_reset` binding + its rationale comment make a permitted re-stream
+# rewind record its offset-monotonic violation at WARN (not ERROR), removing the
+# per-retry operator ERROR noise the release (authority-ON) emits on every Gemini/Qwen
+# RetryBoundary. Log-severity ONLY — enforce guard, debug tripwire, and on-disk schema
+# unchanged; the classification input necessarily lives at the save-path chokepoint.
+"src/services/discord/inflight.rs" = 2339 # #3835: 3077 -> 2275, locked-in win — verbatim decompose moved the status-panel/current-message ownership writes to inflight/ownership_ops.rs and the staleness predicates + orphan-lock/rebind-origin reap helpers to inflight/rebind_reap.rs (zero behavior change, facade re-exports keep inflight::* paths byte-identical); #3982 -> 2309 (+34) persist bump-flag split (see comment above); #3933 -> 2328 (+19) is_legitimate_full_reset enforce-guard precision (see comment above); #3933 follow-up -> 2339 (+11) severity WARN downgrade (see comment above)
 # #3779 extracted relay-recovery auto-heal attempt accounting to a sibling
 # module, dropping relay_recovery.rs below the prod-giant threshold; the ratchet
 # entry is retired instead of raising the baseline.

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -342,10 +342,11 @@ fn validate_inflight_state_for_save(
     // and preserve the offset (zero data loss), the offset-monotonic violation
     // has already been safely handled — record it at WARN instead of ERROR so
     // the paired `#3416 enforce` WARN is the only operator-facing log, killing
-    // the duplicate ERROR-log noise. When enforce is OFF the backward write
-    // actually persists below, so the violation stays ERROR (a genuine breach).
-    // Computed BEFORE the records so the severity is correct; the enforce branch
-    // itself (skip + return false) is unchanged.
+    // the duplicate ERROR-log noise. When enforce is OFF a GENUINE (non-reset)
+    // backward write actually persists below, so that violation stays ERROR (a
+    // real breach); the legitimate re-stream reset (#3933) is handled separately
+    // just before the records below. Computed BEFORE the records so the severity
+    // is correct; the enforce branch itself (skip + return false) is unchanged.
     // #3933: a legitimate Gemini/Qwen `RetryBoundary` reset rewinds the SAME
     // turn's frontier to the start — `full_response` cleared and
     // `response_sent_offset` back to 0 — to re-stream the answer
@@ -366,8 +367,18 @@ fn validate_inflight_state_for_save(
         last_offset_monotonic,
         is_legitimate_full_reset,
     );
+    // #3933: a legitimate full reset PERSISTS its backward write (it is a permitted
+    // re-stream rewind, so the enforce guard does NOT skip it —
+    // `enforce_skips_backward_write` is false). That rewind is intended, not a
+    // data-loss regression, so it must not surface an operator-facing ERROR: treat
+    // it as "safely handled" (WARN) exactly like the enforce-skip case. This is a
+    // severity-label change ONLY — the enforce guard, the debug tripwire (which
+    // still keys off `enforce_skips_backward_write`), and the on-disk schema are
+    // all unchanged.
+    let monotonic_violation_safely_handled =
+        enforce_skips_backward_write || is_legitimate_full_reset;
     let offset_monotonic_severity =
-        offset_monotonic_invariant_severity(enforce_skips_backward_write);
+        offset_monotonic_invariant_severity(monotonic_violation_safely_handled);
 
     record_inflight_invariant_with_severity(
         monotonic_offset,
@@ -3399,6 +3410,160 @@ mod stall_recovery_tests {
             "the enforce-skipped stale write must not clobber the committed answer"
         );
         assert_eq!(persisted.response_sent_offset, committed_body.len());
+    }
+
+    /// #3933 (severity WARN downgrade): a legitimate full reset (same turn
+    /// identity, cleared body, `response_sent_offset` back to 0) PERSISTS its
+    /// backward write — the enforce guard PERMITS the re-stream rewind, so
+    /// `enforce_skips_backward_write` is false — yet that rewind is intended, not a
+    /// data-loss regression. The offset-monotonic violation must therefore be
+    /// recorded at WARN (not ERROR), killing the per-retry operator ERROR noise the
+    /// release (authority-ON) emits on every Gemini/Qwen `RetryBoundary`. The
+    /// control at the end proves a GENUINE non-reset backward write still records at
+    /// ERROR, so the capture actually differentiates WARN vs ERROR (non-vacuous).
+    #[test]
+    fn legit_reset_records_monotonic_violation_at_warn_3933() {
+        use crate::services::discord::outbound::delivery_record as dr;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        // A legit reset is a same-turn backward move, so the debug tripwire fires
+        // (it relaxes ONLY for an enforce-SKIP; a PERMITTED reset is not skipped) —
+        // share the panic-hook serialization the sibling tripwire tests use.
+        let _serialized = monotonic_3358_test_mutex()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+
+        #[derive(Clone)]
+        struct CapturingWriter {
+            buffer: Arc<Mutex<Vec<u8>>>,
+        }
+        impl std::io::Write for CapturingWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.buffer.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for CapturingWriter {
+            type Writer = CapturingWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        // Capture WARN+ERROR (max-level WARN admits the more-severe ERROR too), so a
+        // downgrade-to-WARN and any stray ERROR both land in the buffer — making
+        // "WARN, not ERROR" directly observable. The debug tripwire's panic goes to
+        // the process panic hook (stderr), NOT this subscriber, so it never pollutes
+        // the buffer; the invariant records are emitted BEFORE the panic anyway.
+        fn capture<F: FnOnce()>(f: F) -> String {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::WARN)
+                .with_ansi(false)
+                .without_time()
+                .with_writer(CapturingWriter {
+                    buffer: buffer.clone(),
+                })
+                .finish();
+            let guard = tracing::subscriber::set_default(subscriber);
+            f();
+            drop(guard);
+            String::from_utf8_lossy(&buffer.lock().unwrap()).into_owned()
+        }
+
+        // The WARN branch appends this suffix to the invariant message; the ERROR
+        // branch does not — so its presence is an unambiguous WARN witness.
+        const WARN_SUFFIX: &str = "(handled by downstream guard — downgraded to WARN)";
+
+        // ---- legit reset → WARN, under BOTH authority states -----------------
+        // The flag is forced EXPLICITLY (not env) so the assertion is independent
+        // of the release shell's AGENTDESK_DELIVERY_RECORD_AUTHORITY. A legit reset
+        // is safely-handled regardless of the flag, so both must downgrade to WARN.
+        for authority_on in [false, true] {
+            let temp = TempDir::new().unwrap();
+            let channel_id = 39_330_200 + authority_on as u64;
+            // On-disk row: an advanced streamed frontier (non-empty body, rso > 0).
+            let mut reset = seed_watcher_stream_state(
+                temp.path(),
+                channel_id,
+                "AgentDesk-claude-3933warn",
+                "streamed answer body",
+                120,
+            );
+            // Same-turn RetryBoundary reset: cleared body + rso 0 (last_offset left
+            // forward so ONLY response_sent_offset_monotonic violates → one record).
+            reset.full_response = String::new();
+            reset.response_sent_offset = 0;
+            let path = inflight_state_path(temp.path(), &ProviderKind::Claude, channel_id);
+
+            let logs = capture(|| {
+                let _authority = dr::authority_test_seam::force(authority_on);
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    validate_inflight_state_for_save(
+                        temp.path(),
+                        &path,
+                        &reset,
+                        "src/services/discord/inflight.rs:test",
+                    );
+                }));
+            });
+
+            assert!(
+                logs.contains("response_sent_offset_monotonic"),
+                "legit reset must record the response_sent_offset_monotonic violation (authority_on={authority_on}): {logs}"
+            );
+            assert!(
+                logs.contains(WARN_SUFFIX),
+                "legit reset offset-monotonic violation must be downgraded to WARN (authority_on={authority_on}): {logs}"
+            );
+            assert!(
+                !logs.contains("ERROR"),
+                "legit reset must not emit an ERROR-level invariant log (authority_on={authority_on}): {logs}"
+            );
+        }
+
+        // ---- control: a GENUINE non-reset backward write stays ERROR ----------
+        // authority OFF (forced) → the backward write persists, so it is a real
+        // breach, not a safely-handled rewind. This proves the capture genuinely
+        // differentiates WARN vs ERROR, so the WARN assertions above are not vacuous.
+        let temp = TempDir::new().unwrap();
+        let channel_id = 39_330_299;
+        let mut regression = seed_watcher_stream_state(
+            temp.path(),
+            channel_id,
+            "AgentDesk-claude-3933err",
+            "the full committed answer",
+            200,
+        );
+        // NON-empty (shorter) body moving the frontier back for the SAME turn — NOT
+        // the reset signature, so `is_legitimate_full_reset` is false → ERROR.
+        regression.full_response = "stale".to_string();
+        regression.response_sent_offset = 3;
+        let path = inflight_state_path(temp.path(), &ProviderKind::Claude, channel_id);
+
+        let logs = capture(|| {
+            let _authority = dr::authority_test_seam::force(false);
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                validate_inflight_state_for_save(
+                    temp.path(),
+                    &path,
+                    &regression,
+                    "src/services/discord/inflight.rs:test",
+                );
+            }));
+        });
+        assert!(
+            logs.contains("response_sent_offset_monotonic") && !logs.contains(WARN_SUFFIX),
+            "a genuine non-reset backward write must stay ERROR (no WARN downgrade): {logs}"
+        );
+        assert!(
+            logs.contains("ERROR"),
+            "a genuine non-reset backward write must record at ERROR: {logs}"
+        );
     }
 
     // ---- #3077: typed status-panel ownership write tests ----

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -2127,4 +2127,238 @@ mod tests {
         assert!(!should_shadow_mirror(false, true)); // not-advanced/partial → no record (M4/I2)
         assert!(!should_shadow_mirror(true, false)); // flag OFF → no record (deploy no-op)
     }
+
+    // ---- #3933 item 1: read-authority (authority-ON) end-to-end wiring --------
+    // The pure helpers above (fuse / #1270 generation gate / range_already_committed)
+    // are covered, but no test drove the ENV-RESOLVED public gates
+    // (`effective_committed_offset` / `committed_floor_for_resend_dedup`) with the
+    // flag FORCED ON — the release config (AGENTDESK_DELIVERY_RECORD_AUTHORITY=1)
+    // the compiled default (OFF) never exercises. These tests force it ON via the
+    // #3993 per-thread seam and verify the whole wiring end-to-end (not by
+    // hand-computing the fusion): the dedup floor is `max(durable, in_memory)` so it
+    // never over-suppresses, the #1270 gate distrusts a stale generation, and the
+    // #3871 / #3885 duplicate-relay scenarios are correctly suppressed. This closes
+    // #3933 prerequisite #2 (independent read-authority verification).
+
+    /// RAII: point `AGENTDESK_ROOT_DIR` at an isolated tempdir for a test
+    /// (restoring the prior value on drop) while holding the process-global env
+    /// lock. BOTH the delivery-record path and the tmux `.generation` marker path
+    /// resolve through this root, so the whole read-authority wiring runs against a
+    /// throw-away tree with zero cross-test interference.
+    struct IsolatedRoot {
+        _dir: tempfile::TempDir,
+        previous: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl IsolatedRoot {
+        fn new() -> Self {
+            let lock = crate::config::shared_test_env_lock()
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let dir = tempfile::tempdir().expect("isolated runtime root");
+            let previous = std::env::var_os("AGENTDESK_ROOT_DIR");
+            unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", dir.path()) };
+            Self {
+                _dir: dir,
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for IsolatedRoot {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    /// Seed a CURRENT-generation durable frontier for `(provider, channel)` under
+    /// the isolated root plus its matching `.generation` marker, and return the
+    /// generation mtime the record was stamped with. The record's
+    /// `generation_mtime_ns` is set to the marker's REAL on-disk mtime so the #1270
+    /// generation gate TRUSTS it — mirroring the production write/read parity.
+    fn seed_current_generation_frontier(
+        provider: &ProviderKind,
+        channel: ChannelId,
+        tmux_session_name: &str,
+        durable_end: u64,
+    ) -> i64 {
+        let gen_path =
+            crate::services::tmux_common::session_temp_path(tmux_session_name, "generation");
+        if let Some(parent) = Path::new(&gen_path).parent() {
+            fs::create_dir_all(parent).expect("create sessions dir");
+        }
+        fs::write(&gen_path, b"1").expect("write generation marker");
+        let gen_ns = current_generation_mtime_ns(tmux_session_name);
+        assert_ne!(
+            gen_ns, 0,
+            "seeded .generation marker must have a readable mtime"
+        );
+        let record_path =
+            delivery_record_path(provider, channel.get()).expect("env-resolved record path");
+        write_delivered_frontier_at(
+            &record_path,
+            DeliveredCommit {
+                range: (0, durable_end),
+                generation_mtime_ns: gen_ns,
+                attempts: 1,
+                panel_msg_id: Some(1),
+                panel_channel_id: None,
+            },
+        )
+        .expect("seed durable frontier");
+        gen_ns
+    }
+
+    fn shared_with_committed(
+        channel: ChannelId,
+        in_memory: u64,
+    ) -> std::sync::Arc<crate::services::discord::SharedData> {
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        shared
+            .tmux_relay_coord(channel)
+            .confirmed_end_offset
+            .store(in_memory, Ordering::Release);
+        shared
+    }
+
+    /// authority-ON fuses the CURRENT-generation durable frontier into the dedup
+    /// floor (`max(durable, in_memory)`) through the ENV-RESOLVED public reader,
+    /// while authority-OFF returns the in-memory value verbatim (deploy no-op).
+    /// This proves the flag actually gates the wiring — not just the pure `fuse`
+    /// arithmetic already covered above.
+    #[test]
+    fn effective_committed_offset_authority_on_fuses_durable_3933() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Claude;
+        let channel = ChannelId::new(39_330_401);
+        let tmux = "AgentDesk-claude-3933fuse";
+        let durable_end = 443_154_u64;
+        let in_memory = 100_u64;
+        seed_current_generation_frontier(&provider, channel, tmux, durable_end);
+        let shared = shared_with_committed(channel, in_memory);
+
+        {
+            // authority ON → durable frontier RAISES the floor above in-memory.
+            let _authority = authority_test_seam::force(true);
+            assert_eq!(
+                effective_committed_offset(shared.as_ref(), &provider, channel, tmux),
+                durable_end.max(in_memory),
+            );
+            // `committed_floor_for_resend_dedup` = effective.max(flag-independent
+            // durable) → the same fused value (floor never drops below in-memory).
+            assert_eq!(
+                committed_floor_for_resend_dedup(shared.as_ref(), &provider, channel, tmux),
+                durable_end.max(in_memory),
+            );
+        }
+        {
+            // authority OFF (forced) → in-memory verbatim; the durable frontier is
+            // hidden by the flag. Pins the flag-gated branch.
+            let _authority = authority_test_seam::force(false);
+            assert_eq!(
+                effective_committed_offset(shared.as_ref(), &provider, channel, tmux),
+                in_memory,
+            );
+        }
+    }
+
+    /// #3871 (rollover dup relay): after a JSONL rollover a re-observing pass would
+    /// re-relay the frozen PREFIX range (ends BELOW the durable committed floor →
+    /// already delivered → suppressed), while a genuinely-NEW tail produced after
+    /// the rollover ends ABOVE the floor → NOT suppressed → relayed. The floor is
+    /// `max(durable, in_memory)`, so raising it to the known-delivered watermark
+    /// never over-suppresses fresh output. Rides the in-memory=0 restart hazard.
+    #[test]
+    fn committed_floor_authority_on_does_not_oversuppress_rollover_resend_3871() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Claude;
+        let channel = ChannelId::new(39_330_402);
+        let tmux = "AgentDesk-claude-3871";
+        let durable_end = 443_154_u64;
+        seed_current_generation_frontier(&provider, channel, tmux, durable_end);
+        // In-memory reset to 0 (the restart / synthetic-resume hazard #3871 rides).
+        let shared = shared_with_committed(channel, 0);
+
+        let _authority = authority_test_seam::force(true);
+        let floor = committed_floor_for_resend_dedup(shared.as_ref(), &provider, channel, tmux);
+        assert_eq!(
+            floor, durable_end,
+            "durable frontier must lift the reset in-memory floor"
+        );
+        // Frozen prefix already delivered → suppressed (no dup relay).
+        assert!(range_already_committed(422_855, floor));
+        // New tail past the durable high watermark → relayed (no over-suppression).
+        assert!(!range_already_committed(443_500, floor));
+    }
+
+    /// #3885 (no-response watchdog re-relay): the streaming-aware watchdog can
+    /// trigger a re-observing pass over an ALREADY-delivered range. Under
+    /// authority-ON the durable frontier makes the committed floor recognize that
+    /// range as delivered (`range_already_committed == true`) → the watchdog
+    /// re-relay is suppressed (no duplicate) even though the in-memory offset was
+    /// reset. The boundary (range_end == floor) is inclusive.
+    #[test]
+    fn committed_floor_authority_on_suppresses_watchdog_rerelay_3885() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(39_330_403);
+        let tmux = "AgentDesk-codex-3885";
+        let durable_end = 512_000_u64;
+        seed_current_generation_frontier(&provider, channel, tmux, durable_end);
+        let shared = shared_with_committed(channel, 0); // watchdog fires post in-memory reset
+
+        let _authority = authority_test_seam::force(true);
+        let floor = committed_floor_for_resend_dedup(shared.as_ref(), &provider, channel, tmux);
+        assert_eq!(floor, durable_end);
+        // Watchdog re-relay of the delivered body → suppressed (dup guard).
+        assert!(range_already_committed(500_000, floor));
+        assert!(range_already_committed(durable_end, floor)); // inclusive boundary
+    }
+
+    /// Even with authority ON, a STALE prior-generation durable frontier is
+    /// distrusted (#1270 gate) → it does NOT raise the floor → a genuinely-new
+    /// answer after a pane reset / same-named respawn is never over-suppressed.
+    /// Proves the generation gate is honored through the ENV-RESOLVED wiring, not
+    /// only in the pure helper.
+    #[test]
+    fn effective_committed_offset_authority_on_distrusts_stale_generation_3933() {
+        let _root = IsolatedRoot::new();
+        let provider = ProviderKind::Claude;
+        let channel = ChannelId::new(39_330_404);
+        let tmux = "AgentDesk-claude-3933stale";
+        // Seed marker + a current-gen frontier, then OVERWRITE the record with a
+        // PRIOR-generation stamp (mtime 1 ≠ the marker's real nanosecond mtime).
+        seed_current_generation_frontier(&provider, channel, tmux, 443_154);
+        let record_path = delivery_record_path(&provider, channel.get()).unwrap();
+        write_delivered_frontier_at(
+            &record_path,
+            DeliveredCommit {
+                range: (0, 443_154),
+                generation_mtime_ns: 1, // PRIOR generation → distrusted
+                attempts: 1,
+                panel_msg_id: None,
+                panel_channel_id: None,
+            },
+        )
+        .unwrap();
+        let shared = shared_with_committed(channel, 0);
+
+        let _authority = authority_test_seam::force(true);
+        // Stale frontier distrusted → floor stays at the in-memory value (0).
+        assert_eq!(
+            effective_committed_offset(shared.as_ref(), &provider, channel, tmux),
+            0,
+        );
+        assert_eq!(
+            committed_floor_for_resend_dedup(shared.as_ref(), &provider, channel, tmux),
+            0,
+        );
+        // A fresh answer above 0 is NOT over-suppressed.
+        assert!(!range_already_committed(422_855, 0));
+    }
 }


### PR DESCRIPTION
Two low-risk, non-hotfile hardening items from the #3933 delivery-authority follow-up design. **Does NOT close #3933** — item 3 (the compiled-default flip) remains open for Phase B.

## Item 2 — severity WARN downgrade (`inflight.rs`, log-severity only, +11 prod LoC)

A legitimate Gemini/Qwen `RetryBoundary` full reset (same turn identity, cleared body, `response_sent_offset` back to 0) **persists** its backward write — the enforce guard *permits* the re-stream rewind, so `enforce_skips_backward_write` is false — yet that rewind is intended, not a data-loss regression. Under the live release config (`AGENTDESK_DELIVERY_RECORD_AUTHORITY=1`) the offset-monotonic invariant was recorded at **ERROR on every retry**, spamming the operator log.

- `offset_monotonic_severity` now classifies on `monotonic_violation_safely_handled = enforce_skips_backward_write || is_legitimate_full_reset` (the exact form the design specified), so a permitted reset records at **WARN** instead of ERROR.
- **Log-severity ONLY.** The classifier signature, the enforce guard, the debug tripwire (still keyed off `enforce_skips_backward_write`), and the on-disk schema are all unchanged. The existing `offset_monotonic_severity_downgrades_only_when_enforce_skips` test stays verbatim green.
- Scope note: a legit reset also persists under authority-OFF (a legitimate re-stream), so this downgrades that severity to WARN under OFF too — intended and correct (a legit rewind is never a regression); not a byte-identical no-op under OFF (only the log level changes).
- New test `legit_reset_records_monotonic_violation_at_warn_3933`: a tracing-capture witness under **both** authority states, plus a genuine-regression ERROR **control** proving the capture actually differentiates WARN vs ERROR (non-vacuous).

## Item 1 — read-authority ON verification (`delivery_record.rs`, TEST-ONLY, 0 prod LoC)

The pure fusion / generation-gate / predicate helpers were already covered, but nothing drove the **env-resolved public gates** with the flag forced ON — the release path the compiled default (OFF) never exercises. These tests use the #3993 per-thread `authority_test_seam::force(true)` to verify the wiring end-to-end:

- `effective_committed_offset_authority_on_fuses_durable_3933` — ON fuses `max(durable, in_memory)`; OFF returns in-memory verbatim (deploy no-op), proving the flag gates the wiring.
- `committed_floor_authority_on_does_not_oversuppress_rollover_resend_3871` — #3871 rollover: frozen prefix suppressed, new tail (range_end > floor) relayed (floor=max ⇒ no over-suppression).
- `committed_floor_authority_on_suppresses_watchdog_rerelay_3885` — #3885 watchdog re-relay of an already-delivered range suppressed (dup guard).
- `effective_committed_offset_authority_on_distrusts_stale_generation_3933` — #1270 gate distrusts a stale prior-generation frontier even under authority-ON ⇒ fresh output never over-suppressed.

Closes #3933 **prerequisite #2** (independent read-authority verification). **No dedup bug revealed** — all scenarios behaved exactly as the design predicted.

## Item 3 — authority flip: DEFERRED (Phase B)

The compiled-default OFF→ON flip is intentionally **not** included. The release already runs authority ON via `launchd.env`, so the flip's only effect is CI-default + defense-in-depth, and it has a wide CI blast radius (many tests implicitly assume the OFF default). It is gated behind item 1 (now done) plus a CI-wide OFF-assumption audit — tracked separately.

## Gates (all green)

- `cargo fmt --check` — exit 0
- `cargo check --lib` — clean (pre-existing unrelated warnings only)
- `cargo test --lib -- inflight delivery_record` — 366 passed, 0 failed (incl. 5 new; authority-ON tests force the seam, CI default is OFF)
- Freeze sync: giant baseline `2328 → 2339` (+11 admission), `change-surfaces.md` synced, regenerated `giant-file-registry.md` / `module-inventory.md`
- `audit_maintainability.py --check` — exit 0; `check_hotfile_ratchet.py` — exit 0
- No #3016 core hotfile touched (`inflight.rs` / `delivery_record.rs` are not ratchet hotfiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
