### PR TITLE
fix(discord): re-anchor watcher completion footer to last continuation chunk (#3805 P1)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -197,7 +197,12 @@
     late-frame fresh row B is rejected; -576 from #3841 extracting placeholder
     suppression helpers to `tmux_placeholder_suppression.rs`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7106 production lines; +10 from #3558
+  - `src/services/discord/tmux_watcher.rs` (7120 production lines; +14 from #3805
+    P1 (footer re-anchor) capturing the tail continuation chunk (id + text) in the
+    terminal in-place edit arm and re-anchoring the completion footer onto it so a
+    2000+ char answer no longer strands the footer in a middle chunk — the anchor
+    struct, out-param plumbing, selection helper and its tests live in the
+    non-giant `formatting.rs`; +10 from #3558
     (codex review follow-up) routing the two remaining session-bound-relay-success
     sites — which still did an unlocked `load_inflight_state` -> mutate ->
     `save_inflight_state` (re-writing a stale `last_offset`/`response_sent_offset`)
@@ -1315,7 +1320,13 @@
     `turn_finalizer/watcher_backstop.rs` (watcher far-backstop tunables +
     terminal-or-defer verdict pair). Bugfix only outside a
     finalizer-decomposition plan).
-  - `src/services/discord/formatting.rs` (2801 lines; #3807 wires semantic
+  - `src/services/discord/formatting.rs` (2860 lines; #3805 P1 adds the watcher
+    completion-footer re-anchor machinery here — the `ReplaceLastChunkAnchor`
+    struct, the `&mut Option<..>` last-chunk out-param on
+    `replace_long_message_raw_with_outcome`, and the pure
+    `watcher_completion_footer_anchor` selection helper + its regression tests —
+    worker-local presentation logic only, no relay ownership/lease change. #3807
+    wires semantic
     sentence-boundary callsites while keeping the shared boundary classifier
     and compact continuation-context helper in `semantic_boundaries.rs`;
     worker-local presentation logic only, no relay ownership/lease change.

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -22,9 +22,9 @@
 | `src/services/discord/recovery_engine.rs` | 2935 | discord-relay | 2026-10-31 | #3834 |
 | `src/services/discord/router/intake_gate.rs` | 1591 | discord-relay | 2026-10-31 | #3838 |
 | `src/services/discord/router/message_handler/intake_turn.rs` | 2797 | discord-relay | 2026-10-31 | #3837 |
-| `src/services/discord/session_relay_sink.rs` | 1670 | discord-relay | 2026-08-31 | #3405 |
+| `src/services/discord/session_relay_sink.rs` | 1673 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/tmux.rs` | 1507 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7106 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux_watcher.rs` | 7120 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1125 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/turn_bridge/mod.rs` | 6201 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_finalizer.rs` | 1038 | discord-finalizer | 2026-08-31 | #3016 |
@@ -83,7 +83,7 @@
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1366 |
 | `src/services/discord/commands/text_commands.rs` | 1476 |
-| `src/services/discord/formatting.rs` | 2801 |
+| `src/services/discord/formatting.rs` | 2860 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
 | `src/services/discord/mod.rs` | 4156 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1543 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -438,8 +438,8 @@
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1025 | 967 | 58 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 527 | 527 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
-| `services::discord::formatting` | `src/services/discord/formatting.rs` | 3755 | 2801 | 954 | giant-file |
-| `services::discord::gateway` | `src/services/discord/gateway.rs` | 1231 | 993 | 238 |  |
+| `services::discord::formatting` | `src/services/discord/formatting.rs` | 3852 | 2860 | 992 | giant-file |
+| `services::discord::gateway` | `src/services/discord/gateway.rs` | 1234 | 996 | 238 |  |
 | `services::discord::gateway_voice_queue` | `src/services/discord/gateway_voice_queue.rs` | 92 | 17 | 75 |  |
 | `services::discord::health` | `src/services/discord/health.rs` | 810 | 657 | 153 |  |
 | `services::discord::health::headless_turn` | `src/services/discord/health/headless_turn.rs` | 369 | 369 | 0 |  |
@@ -609,7 +609,7 @@
 | `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 385 | 357 | 28 |  |
 | `services::discord::semantic_boundaries` | `src/services/discord/semantic_boundaries.rs` | 261 | 261 | 0 |  |
 | `services::discord::session_identity` | `src/services/discord/session_identity.rs` | 214 | 141 | 73 |  |
-| `services::discord::session_relay_sink` | `src/services/discord/session_relay_sink.rs` | 4170 | 1670 | 2500 | giant-file |
+| `services::discord::session_relay_sink` | `src/services/discord/session_relay_sink.rs` | 4173 | 1673 | 2500 | giant-file |
 | `services::discord::session_relay_sink::idle_jsonl` | `src/services/discord/session_relay_sink/idle_jsonl.rs` | 169 | 169 | 0 |  |
 | `services::discord::session_relay_sink::orphan_reclaim` | `src/services/discord/session_relay_sink/orphan_reclaim.rs` | 218 | 116 | 102 |  |
 | `services::discord::session_runtime` | `src/services/discord/session_runtime.rs` | 1027 | 501 | 526 |  |
@@ -628,7 +628,7 @@
 | `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2803 | 865 | 1938 |  |
 | `services::discord::single_message_panel::completion_footer_registry` | `src/services/discord/single_message_panel/completion_footer_registry.rs` | 624 | 624 | 0 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
-| `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1642 | 912 | 730 |  |
+| `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1644 | 914 | 730 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |
 | `services::discord::status_panel_orphan_store` | `src/services/discord/status_panel_orphan_store.rs` | 499 | 383 | 116 |  |
 | `services::discord::status_panel_timedout_reconcile` | `src/services/discord/status_panel_timedout_reconcile.rs` | 405 | 405 | 0 |  |
@@ -648,7 +648,7 @@
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 596 | 479 | 117 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 7106 | 7106 | 0 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 7120 | 7120 | 0 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 287 | 165 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 287 | 287 | 0 |  |
 | `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 403 | 321 | 82 |  |
@@ -671,7 +671,7 @@
 | `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 999 | 999 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 449 | 213 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
-| `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 208 | 208 | 0 |  |
+| `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 211 | 211 | 0 |  |
 | `services::discord::tui_prompt_relay::claude_idle_bridge` | `src/services/discord/tui_prompt_relay/claude_idle_bridge.rs` | 582 | 582 | 0 |  |
 | `services::discord::tui_prompt_relay::claude_idle_runtime` | `src/services/discord/tui_prompt_relay/claude_idle_runtime.rs` | 606 | 606 | 0 |  |
 | `services::discord::tui_prompt_relay::claude_idle_tail` | `src/services/discord/tui_prompt_relay/claude_idle_tail.rs` | 473 | 473 | 0 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -130,7 +130,14 @@
 # the whole turn (TTL-independent), never touching the #3459/#3303 relayed-entry
 # ledger. The primitive + regression tests live in the non-giant `tui_prompt_dedupe.rs`;
 # this is the minimal call-site cost (load-bearing comment block + channel-scoped call).
-"src/services/discord/tmux_watcher.rs" = 7106
+# 2026-07-01 #3805 P1: footer re-anchor bug fix +14 (7106 -> 7120 prod LoC),
+# reviewable admission — the terminal in-place edit arm (arm c) now captures the
+# tail continuation chunk (id + text) and re-anchors the completion footer onto
+# it so a 2000+ char answer no longer strands the footer in a middle chunk. The
+# anchor struct, out-param plumbing, the pure selection helper, and its
+# regression tests all live in the non-giant `formatting.rs`; the giant-file cost
+# is just the arm-c anchor capture + footer-target computation.
+"src/services/discord/tmux_watcher.rs" = 7120
 # #3832: 7103 -> 7106 (+3 prod LoC), reviewable admission — moved the inline
 # `#[cfg(test)] mod tests` body verbatim into the non-giant `tmux_watcher/tests.rs`
 # (in TEST_FILE_NAMES, so excluded from the production splitter). RAW lines drop
@@ -476,7 +483,14 @@
 # check + handler delegation in the `InteractionCreate` arm of `handle_event`;
 # the handler logic itself lives in the non-giant `sidecar_interaction.rs`.
 "src/services/discord/router/intake_gate.rs" = 2986
-"src/services/discord/formatting.rs" = 2802
+# 2026-07-01 #3805 P1: footer re-anchor bug fix +58 (2802 -> 2860 prod LoC),
+# reviewable admission — hosts the #3805 machinery for the watcher footer fix:
+# the `ReplaceLastChunkAnchor` struct, the `&mut Option<..>` last-chunk out-param
+# threaded through `replace_long_message_raw_with_outcome` (set only on the
+# fully-successful multi-chunk edit path), and the pure `watcher_completion_footer_anchor`
+# selection helper. Placed in this giant (rather than the 700-capped
+# `tmux_watcher/**` namespace) so the tmux_watcher.rs hot file grows minimally.
+"src/services/discord/formatting.rs" = 2860
 # #3038 run_bot S0/S1: lowered 2802 -> 1918 by adding characterization tests and
 # moving restored_state, queued_placeholders, startup_doctor, orphan_recovery,
 # and session_gc into sub-700 `runtime_bootstrap/` modules.

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -106,7 +106,15 @@
 # for `tui_prompt_relay/tests.rs`); pure move, zero production behavior change,
 # no visibility widening — the relocated module keeps `use super::*` access to
 # the root coordinator's items.
-"src/services/discord/tmux_watcher.rs" = 7106
+# 2026-07-01 #3805 P1: footer re-anchor bug fix +14 (7106 -> 7120), reviewable
+# admission — the terminal in-place edit arm (arm c) captures the tail
+# continuation chunk (id + text) via a new `&mut Option<ReplaceLastChunkAnchor>`
+# out-param on `replace_long_message_raw_with_outcome` and re-anchors the
+# completion footer onto it, so a 2000+ char answer no longer strands the footer
+# in a middle chunk. The out-param + anchor struct + the pure selection helper
+# and its regression tests live in the NON-hot `formatting.rs`; this frozen-file
+# cost is just the arm-c anchor capture + the footer-target computation.
+"src/services/discord/tmux_watcher.rs" = 7120
 # #3715: 7789 -> 4007 by moving the inline `#[cfg(test)] mod tests` body into
 # `tui_prompt_relay/tests.rs` and the Codex idle rollout tail/rebind loop into
 # `tui_prompt_relay/codex_idle_rollout.rs`; no production behavior change.

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -2242,7 +2242,12 @@ pub(super) async fn replace_long_message_raw(
     shared: &Arc<SharedData>,
 ) -> Result<(), Error> {
     replace_long_message_outcome_to_result(
-        replace_long_message_raw_with_outcome(http, channel_id, message_id, text, shared).await?,
+        // #3805 P1: this wrapper discards the last-chunk anchor (footer re-anchor
+        // is watcher-only); pass a throwaway sink.
+        replace_long_message_raw_with_outcome(
+            http, channel_id, message_id, text, shared, &mut None,
+        )
+        .await?,
     )
 }
 
@@ -2270,6 +2275,43 @@ pub(super) enum ReplaceLongMessageOutcome {
     },
 }
 
+/// #3805 P1: the LAST continuation chunk produced by a fully-successful
+/// multi-chunk `replace_long_message_raw_with_outcome` (`EditedOriginal` where
+/// the body split into 2+ chunks). Carries BOTH the tail chunk's message id
+/// (the highest snowflake — #3717 latest-wins) AND its exact text so a caller
+/// that appends a completion footer can re-anchor onto the tail chunk instead of
+/// stranding the footer on the edited chunk 0. The text MUST be the tail chunk's
+/// OWN text: the footer edit rewrites the target message with `strip(text) +
+/// footer`, so registering the full body would clobber the tail chunk with the
+/// entire answer. Reported via a `&mut Option` out-param (the enum stays a unit
+/// variant — ~20 `matches!` commit/delivered sites depend on that) and left
+/// `None` for single-chunk answers, where chunk 0 already IS the tail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ReplaceLastChunkAnchor {
+    pub(super) msg_id: u64,
+    pub(super) text: String,
+}
+
+/// #3805 P1: pick the completion-footer terminal target (message id + text) for
+/// the watcher's in-place edit arm (`replace_long_message_raw_with_outcome`
+/// `EditedOriginal`). When the answer split into multiple chunks the tail
+/// continuation is the durable anchor (highest snowflake — #3717 latest-wins),
+/// and its edit text MUST be the tail chunk's OWN text: the completion edit
+/// rewrites the target with `strip(text) + footer`, so passing the full body
+/// would overwrite the tail chunk with the entire answer (§4 regression). For a
+/// single-chunk answer there is no continuation anchor, so the edited chunk-0 id
+/// plus the full relay text are the target (identical there — no regression).
+pub(super) fn watcher_completion_footer_anchor<'a>(
+    last_chunk_anchor: Option<&'a ReplaceLastChunkAnchor>,
+    edited_chunk0_msg_id: MessageId,
+    full_relay_text: &'a str,
+) -> (MessageId, &'a str) {
+    match last_chunk_anchor {
+        Some(anchor) => (MessageId::new(anchor.msg_id), anchor.text.as_str()),
+        None => (edited_chunk0_msg_id, full_relay_text),
+    }
+}
+
 /// Replace an existing Discord message and report whether the original
 /// placeholder was actually edited. If the edit fails but the fallback send
 /// succeeds, wrapper callers treat delivery as committed, while callers that
@@ -2281,6 +2323,11 @@ pub(super) async fn replace_long_message_raw_with_outcome(
     message_id: MessageId,
     text: &str,
     shared: &Arc<SharedData>,
+    // #3805 P1: on the fully-successful multi-chunk edit path this is set to the
+    // tail continuation chunk (id + text) so a footer-appending caller can
+    // re-anchor onto it; left untouched (caller-initialised `None`) on every
+    // other path (single-chunk, edit-failure fallback, partial failure).
+    last_chunk_anchor: &mut Option<ReplaceLastChunkAnchor>,
 ) -> Result<ReplaceLongMessageOutcome, Error> {
     let payload_byte_len = text.len();
     let chunks = split_message(text);
@@ -2592,6 +2639,18 @@ pub(super) async fn replace_long_message_raw_with_outcome(
             error,
         });
     }
+    // #3805 P1: fully-successful edit+continuations. When continuations were
+    // sent, hand back the TAIL chunk (id + its own text) so the watcher footer
+    // can re-anchor onto it (highest snowflake, #3717 latest-wins). Empty
+    // continuations ⇒ single-chunk answer ⇒ leave `None` (chunk 0 is the tail).
+    *last_chunk_anchor =
+        sent_continuation_message_ids
+            .last()
+            .copied()
+            .map(|msg_id| ReplaceLastChunkAnchor {
+                msg_id,
+                text: chunks.last().cloned().unwrap_or_default(),
+            });
     Ok(ReplaceLongMessageOutcome::EditedOriginal)
 }
 
@@ -2805,6 +2864,44 @@ mod replace_long_message_tests {
                 None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
             }
         }
+    }
+
+    // #3805 P1: a multi-chunk answer must re-anchor the completion footer onto the
+    // TAIL continuation chunk (highest snowflake, #3717 latest-wins) carrying the
+    // tail chunk's OWN text — NOT chunk 0, and NOT the full body (which would
+    // clobber the tail chunk once the footer edit rewrites it, §4 regression).
+    #[test]
+    fn completion_footer_anchor_reanchors_to_last_chunk_with_tail_text() {
+        let chunk0 = MessageId::new(1000);
+        let full_body = "chunk-0 body ... continuation tail body";
+        let tail = super::ReplaceLastChunkAnchor {
+            msg_id: 2000,
+            text: "continuation tail body".to_string(),
+        };
+
+        let (target_id, target_text) =
+            super::watcher_completion_footer_anchor(Some(&tail), chunk0, full_body);
+
+        // Re-anchored to the tail chunk id (2000 > 1000: never re-anchors DOWN).
+        assert_eq!(target_id, MessageId::new(2000));
+        assert!(target_id > chunk0, "must re-anchor to the higher snowflake");
+        // Registered text is the tail chunk's OWN text, never the full body.
+        assert_eq!(target_text, "continuation tail body");
+        assert_ne!(target_text, full_body);
+    }
+
+    // #3805 P1: single-chunk answers have no continuation anchor → keep chunk 0 +
+    // the full relay text (identical there); the fix is a strict no-op for them.
+    #[test]
+    fn completion_footer_anchor_single_chunk_keeps_chunk0_and_full_text() {
+        let chunk0 = MessageId::new(1000);
+        let full_body = "short single-chunk answer";
+
+        let (target_id, target_text) =
+            super::watcher_completion_footer_anchor(None, chunk0, full_body);
+
+        assert_eq!(target_id, chunk0);
+        assert_eq!(target_text, full_body);
     }
 
     #[test]

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -626,6 +626,9 @@ impl TurnGateway for DiscordGateway {
                 message_id,
                 content,
                 &self.shared,
+                // #3805 P1: gateway trait returns the outcome only; the last-chunk
+                // footer anchor is consumed exclusively by the tmux watcher.
+                &mut None,
             )
             .await
             .map_err(|e| e.to_string())

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -983,6 +983,9 @@ impl SessionBoundDiscordRelaySink {
                 msg_id,
                 &relay_text,
                 &shared,
+                // #3805 P1: the session-bound relay sink does not append a
+                // completion footer, so the last-chunk anchor is unused here.
+                &mut None,
             )
             .await
             {

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -811,7 +811,9 @@ async fn deliver_response(
                 .await;
             }
             let outcome = formatting::replace_long_message_raw_with_outcome(
-                http, channel_id, msg_id, &formatted, shared,
+                // #3805 P1: standby relay does not append a completion footer, so
+                // the last-chunk anchor is unused here.
+                http, channel_id, msg_id, &formatted, shared, &mut None,
             )
             .await;
             // #3089 A0: the "delivered?" return is sourced from the shared

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -5010,12 +5010,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             )
                             .await;
                         } else {
+                            // #3805 P1: capture the tail continuation chunk (id +
+                            // its own text) so the completion footer re-anchors onto
+                            // it instead of stranding on the edited chunk 0.
+                            let mut last_chunk_anchor = None;
                             match replace_long_message_raw_with_outcome(
                                 &http,
                                 channel_id,
                                 msg_id,
                                 &relay_text,
                                 &shared,
+                                &mut last_chunk_anchor,
                             )
                             .await
                             {
@@ -5026,11 +5031,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                         watcher_inflight_represents_external_input(
                                             inflight_before_relay.as_ref(),
                                         );
+                                    // #3805 P1: re-anchor the completion footer to the
+                                    // LAST continuation chunk with the tail chunk's OWN
+                                    // text (single-chunk ⇒ chunk 0 + full body).
+                                    let (footer_target_msg_id, footer_target_text) =
+                                        crate::services::discord::formatting::watcher_completion_footer_anchor(
+                                            last_chunk_anchor.as_ref(),
+                                            msg_id,
+                                            &relay_text,
+                                        );
                                     remember_watcher_completion_footer_terminal_target(
                                         single_message_panel_footer_mode,
                                         &mut completion_footer_terminal_target,
-                                        msg_id,
-                                        &relay_text,
+                                        footer_target_msg_id,
+                                        footer_target_text,
                                     );
                                     placeholder_msg_id = None;
                                     placeholder_from_restored_inflight = false;

--- a/src/services/discord/tui_prompt_relay/bridge_gateway.rs
+++ b/src/services/discord/tui_prompt_relay/bridge_gateway.rs
@@ -93,6 +93,9 @@ impl TurnGateway for TuiDirectBridgeGateway {
                 message_id,
                 content,
                 &self.shared,
+                // #3805 P1: bridge gateway returns the outcome only; the last-chunk
+                // footer anchor is consumed exclusively by the tmux watcher.
+                &mut None,
             )
             .await
             .map_err(|error| error.to_string())


### PR DESCRIPTION
## Phase 1 of #3805 — footer re-anchor (correctness fix only)

Scoped to the operator LIVE repro: **the completion footer is stranded in a middle chunk of a multi-chunk (>2000 char) answer**. This does NOT include the P2+ two-message layout / `AGENTDESK_BOTTOM_STATUS_PANEL` work. **Issue stays open** (no `Closes`).

### Bug (footer stranding)
For a 2+ chunk terminal answer, the watcher's in-place edit arm (arm c, `tmux_watcher.rs`) registered the completion-footer target as **chunk 0** (the top edited message) with the **full relay text**. The completion edit then landed the footer at the end of chunk 0 — i.e. wedged in the *middle* of the answer, above the continuation chunk(s). Single-chunk answers were unaffected (chunk 0 is the only chunk).

### Fix (last-chunk anchor)
`replace_long_message_raw_with_outcome` now reports the **tail continuation chunk** (message id + its own text) via a new `&mut Option<ReplaceLastChunkAnchor>` out-param, populated **only on the fully-successful multi-chunk edit path** (`None` for single-chunk, edit-failure fallback, and every partial-failure return). The watcher edit arm re-anchors the footer onto the tail chunk via the pure `watcher_completion_footer_anchor` helper.

### Variant approach (out-param, not a tuple *variant*)
The `ReplaceLongMessageOutcome::EditedOriginal` **unit variant is preserved** — ~20 `matches!` commit/delivered sites across the relay depend on it. The anchor is threaded on a **separate channel** (a `&mut Option<..>` out-param), so the return type is unchanged and the 5 non-consumer callers (formatting wrapper, gateway, bridge_gateway, standby_relay, session_relay_sink) just pass `&mut None` — byte-identical downstream. Only the watcher arm-c consumes the anchor. Chosen over a tuple return for the smaller blast radius in the EXTREME hot file (`tmux_watcher.rs` match arms stay byte-identical; no return-type ripple).

### §4 verification (registered text = LAST chunk text)
The completion path edits `target_msg_id` with `finalize_streaming_footer_with_completion(target_text)` = `strip(target_text) + footer`. If `target_text` were the full body, re-anchoring to the tail chunk would **clobber the tail chunk with the entire answer**. The anchor therefore carries the tail chunk's **own** text (`chunks.last()`), and `watcher_completion_footer_anchor` registers `(tail_id, tail_text)`. Verified by unit test `completion_footer_anchor_reanchors_to_last_chunk_with_tail_text` (`assert_ne!(target_text, full_body)`).

### Invariants preserved
- **EditedOriginal** unit variant unchanged (all `matches!` sites intact).
- **#3717 latest-wins**: only re-anchors **up** to a higher snowflake (tail chunk id > chunk 0); never down.
- **#3142** stale-newer-turn gate (turn identity, msg-id independent) — untouched.
- **#3477** streaming stability — terminal-only change; streaming rollover freeze/strip untouched.
- **#3016** ledger — footer edit runs post commit+advance (M4); ledger untouched.
- **arm(a)** #3610/#3871 recovery anchor (`watcher_long_chunk_anchor_msg_id`) deliberately left arm(a)-only.
- **arm(b)** controller cutover (default per rollout) — untouched.
- Single-chunk answers: strict no-op (chunk 0 + full text).

### Ceiling raise rationale
`tmux_watcher.rs` was at the ratchet ceiling (7106, zero headroom). The arm-c change is minimal (anchor capture + footer-target computation, +14 raw); the struct, out-param plumbing, selection helper, and its regression tests live in the **non-hot `formatting.rs`** to keep hot-file growth minimal. Reviewable admissions: `hotfile_ratchet.toml` 7106→7120, giant baseline `tmux_watcher.rs` 7106→7120 and `formatting.rs` 2802→2860, inventory + change-surfaces docs synced.

### Regression tests (in non-hot `formatting.rs`)
- `completion_footer_anchor_reanchors_to_last_chunk_with_tail_text` — multi-chunk → tail id (higher snowflake) + tail text, never full body.
- `completion_footer_anchor_single_chunk_keeps_chunk0_and_full_text` — single-chunk no-op.

### Gates (all exit 0)
`cargo fmt --check` · `cargo check --lib` · `cargo test --lib -- tmux_watcher formatting` (260 passed under CI-equivalent env) · `check_hotfile_ratchet.py` · `audit_maintainability.py --check` · `generate_inventory_docs.py --check` · `check_agent_maintenance_docs.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)