### PR TITLE
fix(discord): <local-command-stdout> 후반부 머신 에코 일반화 — 가짜 ⏳/synthetic inflight 차단 (#4033)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -678,7 +678,7 @@
 | `services::discord::tui_direct_abort_marker::deferred_claim` | `src/services/discord/tui_direct_abort_marker/deferred_claim.rs` | 669 | 265 | 404 |  |
 | `services::discord::tui_direct_abort_marker::store` | `src/services/discord/tui_direct_abort_marker/store.rs` | 348 | 348 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 2795 | 1125 | 1670 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 967 | 967 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 999 | 999 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 449 | 213 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 211 | 211 | 0 |  |
@@ -688,7 +688,7 @@
 | `services::discord::tui_prompt_relay::codex_idle_rollout` | `src/services/discord/tui_prompt_relay/codex_idle_rollout.rs` | 613 | 613 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_offset_resolution` | `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` | 100 | 100 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_transcript_scan` | `src/services/discord/tui_prompt_relay/idle_transcript_scan.rs` | 495 | 347 | 148 |  |
-| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 394 | 394 | 0 |  |
+| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 432 | 432 | 0 |  |
 | `services::discord::tui_prompt_relay::launch_script` | `src/services/discord/tui_prompt_relay/launch_script.rs` | 129 | 107 | 22 |  |
 | `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 994 | 793 | 201 |  |
 | `services::discord::tui_prompt_relay::relay_ownership` | `src/services/discord/tui_prompt_relay/relay_ownership.rs` | 506 | 506 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -688,7 +688,7 @@
 | `services::discord::tui_prompt_relay::codex_idle_rollout` | `src/services/discord/tui_prompt_relay/codex_idle_rollout.rs` | 613 | 613 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_offset_resolution` | `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` | 100 | 100 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_transcript_scan` | `src/services/discord/tui_prompt_relay/idle_transcript_scan.rs` | 495 | 347 | 148 |  |
-| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 432 | 432 | 0 |  |
+| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 444 | 444 | 0 |  |
 | `services::discord::tui_prompt_relay::launch_script` | `src/services/discord/tui_prompt_relay/launch_script.rs` | 129 | 107 | 22 |  |
 | `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 994 | 793 | 201 |  |
 | `services::discord::tui_prompt_relay::relay_ownership` | `src/services/discord/tui_prompt_relay/relay_ownership.rs` | 506 | 506 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -678,7 +678,7 @@
 | `services::discord::tui_direct_abort_marker::deferred_claim` | `src/services/discord/tui_direct_abort_marker/deferred_claim.rs` | 669 | 265 | 404 |  |
 | `services::discord::tui_direct_abort_marker::store` | `src/services/discord/tui_direct_abort_marker/store.rs` | 348 | 348 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 2795 | 1125 | 1670 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 965 | 965 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 967 | 967 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 449 | 213 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 211 | 211 | 0 |  |
@@ -688,7 +688,7 @@
 | `services::discord::tui_prompt_relay::codex_idle_rollout` | `src/services/discord/tui_prompt_relay/codex_idle_rollout.rs` | 613 | 613 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_offset_resolution` | `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` | 100 | 100 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_transcript_scan` | `src/services/discord/tui_prompt_relay/idle_transcript_scan.rs` | 495 | 347 | 148 |  |
-| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 375 | 375 | 0 |  |
+| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 394 | 394 | 0 |  |
 | `services::discord::tui_prompt_relay::launch_script` | `src/services/discord/tui_prompt_relay/launch_script.rs` | 129 | 107 | 22 |  |
 | `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 994 | 793 | 201 |  |
 | `services::discord::tui_prompt_relay::relay_ownership` | `src/services/discord/tui_prompt_relay/relay_ownership.rs` | 506 | 506 | 0 |  |

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -30,6 +30,7 @@ use self::injected_prompt_policy::{
     format_system_continuation_note, is_slash_command_control_prompt,
     is_start_anchored_task_notification, should_suppress_local_only_kind_note_after_continuation,
     slash_command_control_kind, slash_command_control_prompt_is_caveat_only,
+    slash_command_control_prompt_is_local_command_stdout,
 };
 
 mod idle_transcript_scan;
@@ -909,6 +910,7 @@ fn is_local_only_slash_command_prompt(prompt: &str) -> bool {
     let kind = slash_command_control_kind(prompt);
     super::commands::is_local_only_slash_command_kind(&kind)
         || slash_command_control_prompt_is_caveat_only(prompt)
+        || slash_command_control_prompt_is_local_command_stdout(prompt)
 }
 
 /// Dedupe the two slash-control halves before lease/anchor/synthetic ownership.

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -340,18 +340,17 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     // turn's lease and its guard would clear that generation, stranding the first
     // bridge tail. Drop the duplicate here, before any lease/anchor/inflight exists;
     // a genuine second /loop / /compact falls outside the 2s window → fresh turn.
-    let injected_class = classify_injected_prompt(&prompt.prompt);
-    // #3305: hoist the slash-command kind so the first-sighting gate AND the
-    // local-only lifecycle-skip below share one computation. `local_only_slash`
-    // is true ONLY for a LOCAL-completing pass-through (/effort /compact /cost
-    // /context) — it posts a guidance note but mints no turn (an allow-list, so
-    // /loop and any unknown command keep full lifecycle, fail-safe).
-    let mut local_only_slash = false;
+    let relay_prompt_decision = relay_observed_prompt_injected_prompt_decision(&prompt.prompt);
+    let injected_class = relay_prompt_decision.injected_class;
+    // #3305/#4033: one pure decision drives dedupe and the local-only lifecycle
+    // skip, so stdout halves use the same allow-list as helper-level checks.
+    let local_only_slash = relay_prompt_decision.local_only_slash;
     if matches!(injected_class, InjectedPromptClass::SlashCommandControl) {
-        let kind = slash_command_control_kind(&prompt.prompt);
-        local_only_slash = super::commands::is_local_only_slash_command_kind(&kind)
-            || slash_command_control_prompt_is_caveat_only(&prompt.prompt);
-        if !slash_command_control_turn_is_first_sighting(&prompt.tmux_session_name, &kind) {
+        let kind = relay_prompt_decision
+            .slash_command_kind
+            .as_deref()
+            .expect("slash command control decisions carry a kind");
+        if !slash_command_control_turn_is_first_sighting(&prompt.tmux_session_name, kind) {
             // #3153 second half within the 2s window: drop before any lease/anchor/
             // inflight exists; the first half already relays via its own bridge tail.
             tracing::info!(
@@ -473,13 +472,15 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         // add≡remove invariant holds trivially: no add, no asymmetry); no
         // `claim_tui_direct_synthetic_turn` → no synthetic inflight → the next
         // injection is not FOREIGN-ABORTed and the #3302 sweeper sees no fake row.
-        let kind = slash_command_control_kind(&prompt.prompt);
+        let kind = relay_prompt_decision
+            .slash_command_kind
+            .as_deref()
+            .expect("local-only slash decisions carry a kind");
         // #3388: in-session /compact rewrites can replay the local command stub
         // seconds after the continuation banner; hide that duplicate note. The
         // real machine-injected /compact (#3262) happens minutes before compaction
         // completes, so it stays outside this narrow replay window.
-        if local_only_kind_note_suppressed_by_recent_continuation(&prompt.tmux_session_name, &kind)
-        {
+        if local_only_kind_note_suppressed_by_recent_continuation(&prompt.tmux_session_name, kind) {
             tracing::info!(
                 provider = %prompt.provider,
                 channel_id = channel_id.get(),
@@ -490,7 +491,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             return;
         }
         let note =
-            format_slash_command_control_note(&prompt.tmux_session_name, &kind, &prompt.prompt);
+            format_slash_command_control_note(&prompt.tmux_session_name, kind, &prompt.prompt);
         match channel_id.say(&*notify_http, note).await {
             Ok(message) => tracing::info!(
                 provider = %prompt.provider,
@@ -585,8 +586,11 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         // live card or no-ops; the first sighting posts as the #3099 anchor).
         // HumanTuiDirect keeps the raw render; SystemContinuation handled above (#3100).
         let content = if matches!(injected_class, InjectedPromptClass::SlashCommandControl) {
-            let kind = slash_command_control_kind(&prompt.prompt);
-            format_slash_command_control_note(&prompt.tmux_session_name, &kind, &prompt.prompt)
+            let kind = relay_prompt_decision
+                .slash_command_kind
+                .as_deref()
+                .expect("slash command control decisions carry a kind");
+            format_slash_command_control_note(&prompt.tmux_session_name, kind, &prompt.prompt)
         } else if matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
             // #3393: background-task / subagent completions arrive ONLY as this
             // `user`-record `<task-notification>` XML — never the stream-json
@@ -742,8 +746,12 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         // short-circuit here. Only SystemContinuation skips this active-turn block.
         debug_assert!(
             injected_class.is_human_active_turn()
-                || matches!(injected_class, InjectedPromptClass::TaskNotificationEvent),
-            "system-continuation injections must not reach active-turn handling",
+                || matches!(
+                    injected_class,
+                    InjectedPromptClass::TaskNotificationEvent
+                        | InjectedPromptClass::SlashCommandControl
+                ),
+            "passive system injections must not reach active-turn handling",
         );
         // #3154 P1-3 / #4002: run the shared synthetic-start wiring. It reads the
         // prior-turn view and either DEFERS to the detached per-channel worker when
@@ -899,6 +907,30 @@ fn resolve_owner_channel_authoritatively(
             None
         }
         (None, None) => None,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RelayObservedPromptInjectionDecision {
+    injected_class: InjectedPromptClass,
+    slash_command_kind: Option<String>,
+    local_only_slash: bool,
+}
+
+/// Pure classification used before relay lease/ownership side effects.
+fn relay_observed_prompt_injected_prompt_decision(
+    prompt: &str,
+) -> RelayObservedPromptInjectionDecision {
+    let injected_class = classify_injected_prompt(prompt);
+    let slash_command_kind = matches!(injected_class, InjectedPromptClass::SlashCommandControl)
+        .then(|| slash_command_control_kind(prompt));
+    let local_only_slash = matches!(injected_class, InjectedPromptClass::SlashCommandControl)
+        && is_local_only_slash_command_prompt(prompt);
+
+    RelayObservedPromptInjectionDecision {
+        injected_class,
+        slash_command_kind,
+        local_only_slash,
     }
 }
 

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -89,7 +89,7 @@ pub(super) fn is_slash_command_control_prompt(prompt: &str) -> bool {
     }
     if normalized.starts_with("<command-message>")
         || normalized.starts_with("<command-name>")
-        || normalized.starts_with(COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX)
+        || starts_with_compacted_local_command_stdout(&normalized)
         || starts_with_complete_local_command_stdout(&normalized)
         || normalized.starts_with("/loop ")
     {
@@ -105,9 +105,21 @@ pub(super) fn is_slash_command_control_prompt(prompt: &str) -> bool {
 }
 
 fn starts_with_complete_local_command_stdout(normalized: &str) -> bool {
+    // Open-only generic stdout falls back to HumanTuiDirect; the line scanner rolls back and retries.
     normalized
         .strip_prefix(LOCAL_COMMAND_STDOUT_OPEN)
-        .is_some_and(|rest| rest.contains(LOCAL_COMMAND_STDOUT_CLOSE))
+        .is_some_and(|rest| rest.trim_end().ends_with(LOCAL_COMMAND_STDOUT_CLOSE))
+}
+
+fn starts_with_compacted_local_command_stdout(normalized: &str) -> bool {
+    if !normalized.starts_with(COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX) {
+        return false;
+    }
+    let trimmed = normalized.trim_end();
+    if trimmed.contains(LOCAL_COMMAND_STDOUT_CLOSE) {
+        return trimmed.ends_with(LOCAL_COMMAND_STDOUT_CLOSE);
+    }
+    !trimmed.contains('\r') && !trimmed.contains('\n')
 }
 
 pub(super) fn slash_command_control_prompt_is_local_command_stdout(prompt: &str) -> bool {
@@ -261,6 +273,12 @@ pub(super) fn format_subagent_notification_card(tmux_session_name: &str, prompt:
 /// Canonical command kind for slash-control dedupe and kind-only notes.
 pub(super) fn slash_command_control_kind(prompt: &str) -> String {
     let (normalized, _peeled_caveat) = normalize_slash_command_control_prompt(prompt);
+    if starts_with_compacted_local_command_stdout(&normalized) {
+        return "/compact".to_string();
+    }
+    if starts_with_complete_local_command_stdout(&normalized) {
+        return "local-command-stdout".to_string();
+    }
     if let Some(after) = normalized
         .find("<command-name>")
         .map(|idx| &normalized[idx + "<command-name>".len()..])
@@ -279,12 +297,6 @@ pub(super) fn slash_command_control_kind(prompt: &str) -> String {
             return "/compact".to_string();
         }
     }
-    if normalized.starts_with(COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX) {
-        return "/compact".to_string();
-    }
-    if starts_with_complete_local_command_stdout(&normalized) {
-        return "local-command-stdout".to_string();
-    }
     if normalized.starts_with('/') {
         let name = normalized.split_whitespace().next().unwrap_or("");
         if name.len() > 1 {
@@ -294,7 +306,7 @@ pub(super) fn slash_command_control_kind(prompt: &str) -> String {
     "slash".to_string()
 }
 
-/// Kind-only slash-control note; `/loop` may include its directive body.
+/// Slash-control note; `/loop` and generic local stdout may include a short body.
 pub(super) fn format_slash_command_control_note(
     tmux_session_name: &str,
     kind: &str,
@@ -312,6 +324,15 @@ pub(super) fn format_slash_command_control_note(
     );
     if kind == "/loop" {
         if let Some(body) = extract_loop_body(raw_prompt) {
+            let preview = truncate_chars(body.trim(), SSH_DIRECT_PROMPT_PREVIEW_LIMIT)
+                .replace("```", "` ` `");
+            if !preview.is_empty() {
+                return format!("{header}:\n```text\n{preview}\n```");
+            }
+        }
+    }
+    if kind == "local-command-stdout" {
+        if let Some(body) = extract_local_command_stdout_body(raw_prompt) {
             let preview = truncate_chars(body.trim(), SSH_DIRECT_PROMPT_PREVIEW_LIMIT)
                 .replace("```", "` ` `");
             if !preview.is_empty() {
@@ -351,6 +372,23 @@ pub(super) fn extract_loop_body(prompt: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn extract_local_command_stdout_body(prompt: &str) -> Option<String> {
+    let (normalized, _peeled_caveat) = normalize_slash_command_control_prompt(prompt);
+    let rest = normalized.strip_prefix(LOCAL_COMMAND_STDOUT_OPEN)?;
+    let rest = rest.trim_end();
+    if !rest.ends_with(LOCAL_COMMAND_STDOUT_CLOSE) {
+        return None;
+    }
+    let body = &rest[..rest.len() - LOCAL_COMMAND_STDOUT_CLOSE.len()];
+    let body = body
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!body.is_empty()).then_some(body)
 }
 
 pub(super) fn should_suppress_local_only_kind_note_after_continuation(

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -244,11 +244,23 @@ pub(super) fn strip_leading_injection_wrapper(text: &str) -> &str {
     let trimmed = after_wrapper_line.trim_start_matches(['\r', '\n']);
     if let Some(rest) = trimmed.strip_prefix("```") {
         if let Some(idx) = rest.find('\n') {
-            return &rest[idx + 1..];
+            return strip_trailing_injection_code_fence(&rest[idx + 1..]);
         }
         return after_wrapper_line;
     }
     after_wrapper_line
+}
+
+fn strip_trailing_injection_code_fence(text: &str) -> &str {
+    let trimmed = text.trim_end();
+    let Some(before_fence) = trimmed.strip_suffix("```") else {
+        return text;
+    };
+    if before_fence.is_empty() || before_fence.ends_with('\r') || before_fence.ends_with('\n') {
+        before_fence
+    } else {
+        text
+    }
 }
 
 pub(super) fn format_ssh_direct_prompt_notification(

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -19,6 +19,10 @@ use super::super::tui_task_card::{
     strip_terminal_controls, truncate_chars_ascii as truncate_chars,
 };
 
+const LOCAL_COMMAND_STDOUT_OPEN: &str = "<local-command-stdout>";
+const LOCAL_COMMAND_STDOUT_CLOSE: &str = "</local-command-stdout>";
+const COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX: &str = "<local-command-stdout>Compacted";
+
 /// Classification of TUI-injected prompt text. Each class drives different
 /// lifecycle handling: human/task turns get active-turn ownership, continuation
 /// banners stay passive, and slash-control echoes use command-kind rendering.
@@ -85,7 +89,8 @@ pub(super) fn is_slash_command_control_prompt(prompt: &str) -> bool {
     }
     if normalized.starts_with("<command-message>")
         || normalized.starts_with("<command-name>")
-        || normalized.starts_with("<local-command-stdout>Compacted")
+        || normalized.starts_with(COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX)
+        || starts_with_complete_local_command_stdout(&normalized)
         || normalized.starts_with("/loop ")
     {
         return true;
@@ -97,6 +102,17 @@ pub(super) fn is_slash_command_control_prompt(prompt: &str) -> bool {
         return rest.is_empty() || rest.starts_with(char::is_whitespace);
     }
     false
+}
+
+fn starts_with_complete_local_command_stdout(normalized: &str) -> bool {
+    normalized
+        .strip_prefix(LOCAL_COMMAND_STDOUT_OPEN)
+        .is_some_and(|rest| rest.contains(LOCAL_COMMAND_STDOUT_CLOSE))
+}
+
+pub(super) fn slash_command_control_prompt_is_local_command_stdout(prompt: &str) -> bool {
+    let (normalized, _peeled_caveat) = normalize_slash_command_control_prompt(prompt);
+    starts_with_complete_local_command_stdout(&normalized)
 }
 
 pub(super) fn normalize_slash_command_control_prompt(prompt: &str) -> (String, bool) {
@@ -263,8 +279,11 @@ pub(super) fn slash_command_control_kind(prompt: &str) -> String {
             return "/compact".to_string();
         }
     }
-    if normalized.starts_with("<local-command-stdout>Compacted") {
+    if normalized.starts_with(COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX) {
         return "/compact".to_string();
+    }
+    if starts_with_complete_local_command_stdout(&normalized) {
+        return "local-command-stdout".to_string();
     }
     if normalized.starts_with('/') {
         let name = normalized.split_whitespace().next().unwrap_or("");

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1500,6 +1500,75 @@ fn local_command_stdout_compacted_path_stays_kind_only() {
 }
 
 #[test]
+fn wrapped_local_command_stdout_is_local_only_slash_control() {
+    let wrapped_stdout = "터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n\
+        <local-command-stdout>Set model to Fable 5</local-command-stdout>\n```";
+
+    assert_eq!(
+        classify_injected_prompt(wrapped_stdout),
+        InjectedPromptClass::SlashCommandControl,
+        "a fence-wrapped stdout echo must classify as machine slash control",
+    );
+    assert_eq!(
+        slash_command_control_kind(wrapped_stdout),
+        "local-command-stdout",
+    );
+    assert!(is_local_only_slash_command_prompt(wrapped_stdout));
+
+    let decision = relay_observed_prompt_injected_prompt_decision(wrapped_stdout);
+    assert_eq!(
+        decision.injected_class,
+        InjectedPromptClass::SlashCommandControl,
+    );
+    assert_eq!(
+        decision.slash_command_kind.as_deref(),
+        Some("local-command-stdout"),
+    );
+    assert!(
+        decision.local_only_slash,
+        "local-only stdout returns before anchor/reaction/synthetic ownership",
+    );
+    assert!(!decision.injected_class.is_human_active_turn());
+}
+
+#[test]
+fn wrapped_compacted_stdout_keeps_prefix_only_kind() {
+    let wrapped_compacted = "터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n\
+        <local-command-stdout>Compacted 12 messages\n```";
+
+    assert_eq!(
+        classify_injected_prompt(wrapped_compacted),
+        InjectedPromptClass::SlashCommandControl,
+        "open-fenced Compacted stdout must keep the legacy prefix-only match",
+    );
+    assert_eq!(slash_command_control_kind(wrapped_compacted), "/compact");
+    assert!(is_local_only_slash_command_prompt(wrapped_compacted));
+
+    let decision = relay_observed_prompt_injected_prompt_decision(wrapped_compacted);
+    assert_eq!(decision.slash_command_kind.as_deref(), Some("/compact"));
+    assert!(decision.local_only_slash);
+}
+
+#[test]
+fn wrapped_local_command_stdout_with_appended_user_text_stays_human() {
+    let wrapped_with_user_text = "터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n\
+        <local-command-stdout>Set model to Fable 5</local-command-stdout>\n```\n\
+        이 출력 설명해줘";
+
+    assert_eq!(
+        classify_injected_prompt(wrapped_with_user_text),
+        InjectedPromptClass::HumanTuiDirect,
+        "human text appended after the stdout echo must not be over-suppressed",
+    );
+    assert!(!is_local_only_slash_command_prompt(wrapped_with_user_text));
+
+    let decision = relay_observed_prompt_injected_prompt_decision(wrapped_with_user_text);
+    assert_eq!(decision.injected_class, InjectedPromptClass::HumanTuiDirect,);
+    assert_eq!(decision.slash_command_kind, None);
+    assert!(!decision.local_only_slash);
+}
+
+#[test]
 fn local_command_stdout_negative_cases_stay_human_direct() {
     let trailing_text = "<local-command-stdout>x</local-command-stdout>\n이 출력 설명해줘";
     let open_tag_only = "<local-command-stdout>Set model to Fable 5";

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1305,11 +1305,19 @@ fn local_only_slash_prompt_skips_model_two_half_transcript() {
         "<command-message>x</command-message>\n<command-name>/model</command-name>";
     let stdout_half = "<local-command-stdout>Set model to Fable 5</local-command-stdout>";
 
-    for half in [command_name_half, stdout_half] {
+    for (half, expected_kind) in [
+        (command_name_half, "/model"),
+        (stdout_half, "local-command-stdout"),
+    ] {
         assert_eq!(
             classify_injected_prompt(half),
             InjectedPromptClass::SlashCommandControl,
             "both /model transcript halves must be machine slash-control echoes",
+        );
+        assert_eq!(
+            slash_command_control_kind(half),
+            expected_kind,
+            "each /model transcript half keeps the production dedupe kind it really carries",
         );
         assert!(
             is_local_only_slash_command_prompt(half),
@@ -1320,6 +1328,40 @@ fn local_only_slash_prompt_skips_model_two_half_transcript() {
             "neither /model transcript half is human TUI-direct input",
         );
     }
+}
+
+#[test]
+fn relay_prompt_decision_skips_model_two_half_transcript() {
+    let command_name_half =
+        "<command-message>x</command-message>\n<command-name>/model</command-name>";
+    let stdout_half = "<local-command-stdout>Set model to Fable 5</local-command-stdout>";
+
+    let command_decision = relay_observed_prompt_injected_prompt_decision(command_name_half);
+    assert_eq!(
+        command_decision.injected_class,
+        InjectedPromptClass::SlashCommandControl,
+    );
+    assert_eq!(
+        command_decision.slash_command_kind.as_deref(),
+        Some("/model")
+    );
+    assert!(command_decision.local_only_slash);
+
+    let stdout_decision = relay_observed_prompt_injected_prompt_decision(stdout_half);
+    assert_eq!(
+        stdout_decision.injected_class,
+        InjectedPromptClass::SlashCommandControl,
+    );
+    assert_eq!(
+        stdout_decision.slash_command_kind.as_deref(),
+        Some("local-command-stdout"),
+    );
+    assert!(stdout_decision.local_only_slash);
+
+    assert_ne!(
+        command_decision.slash_command_kind, stdout_decision.slash_command_kind,
+        "the two /model transcript halves intentionally carry different dedupe keys; lifecycle skip must not rely on dedupe",
+    );
 }
 
 // #3178: the machine slash-command control trigger now resolves to a stable
@@ -1356,13 +1398,11 @@ fn slash_command_control_kind_is_stable_across_double_post_halves() {
     assert_eq!(slash_command_control_kind(wrapped_loop), "/loop");
 }
 
-// The note always names the command KIND + tmux session and marks the
-// injection non-active. `/loop` ALSO carries its directive body (operator
-// wants the recurring loop content visible). Every OTHER machine command
-// (`/compact`, the `Compacted …` stdout) stays kind-only and never leaks its
-// payload.
+// The note always names the command KIND + tmux session and marks the injection
+// non-active. `/loop` carries its directive body, generic stdout carries a short
+// output preview, and `/compact`/`Compacted …` stdout stays kind-only.
 #[test]
-fn slash_command_control_note_loop_shows_body_others_kind_only() {
+fn slash_command_control_note_loop_and_generic_stdout_show_body() {
     let loop_note =
         format_slash_command_control_note("sess-a", "/loop", "/loop 290s relay check directive");
     assert!(
@@ -1424,6 +1464,18 @@ fn slash_command_control_note_loop_shows_body_others_kind_only() {
         !compact_note.contains("Compacted"),
         "note must NOT leak the compact stdout body",
     );
+
+    let stdout_note = format_slash_command_control_note(
+        "sess-a",
+        "local-command-stdout",
+        "<local-command-stdout>Set model to Fable 5</local-command-stdout>",
+    );
+    assert!(stdout_note.contains("머신 슬래시 명령"));
+    assert!(
+        stdout_note.contains("Set model to Fable 5"),
+        "generic stdout notes must include a short body preview",
+    );
+    assert!(stdout_note.contains("```text"));
 }
 
 // #4033 regression guard: broad `<local-command-stdout>...</local-command-stdout>`
@@ -1445,6 +1497,87 @@ fn local_command_stdout_compacted_path_stays_kind_only() {
         !compact_note.contains("Compacted"),
         "legacy /compact stdout note must stay kind-only",
     );
+}
+
+#[test]
+fn local_command_stdout_negative_cases_stay_human_direct() {
+    let trailing_text = "<local-command-stdout>x</local-command-stdout>\n이 출력 설명해줘";
+    let open_tag_only = "<local-command-stdout>Set model to Fable 5";
+    let mid_body_tag = "please explain this transcript:\n\
+                        <local-command-stdout>x</local-command-stdout>";
+
+    for (prompt, label) in [
+        (
+            trailing_text,
+            "trailing user text after the closing tag is a human prompt",
+        ),
+        (
+            open_tag_only,
+            "open-only non-Compacted stdout is incomplete scanner input",
+        ),
+        (mid_body_tag, "mid-body stdout tags are quoted human text"),
+    ] {
+        assert_eq!(
+            classify_injected_prompt(prompt),
+            InjectedPromptClass::HumanTuiDirect,
+            "{label}",
+        );
+        assert!(
+            !is_local_only_slash_command_prompt(prompt),
+            "{label}: local-only slash detection must stay start-anchored",
+        );
+        let decision = relay_observed_prompt_injected_prompt_decision(prompt);
+        assert_eq!(
+            decision.injected_class,
+            InjectedPromptClass::HumanTuiDirect,
+            "{label}: relay decision must agree with the helper classifier",
+        );
+        assert_eq!(decision.slash_command_kind, None, "{label}");
+        assert!(!decision.local_only_slash, "{label}");
+    }
+
+    let rendered = format_ssh_direct_prompt_notification("claude", "sess-mid-body", mid_body_tag);
+    assert!(
+        rendered.contains("<local-command-stdout>x</local-command-stdout>"),
+        "a mid-body stdout tag should remain part of the human prompt preview",
+    );
+}
+
+#[test]
+fn local_command_stdout_body_command_name_does_not_hijack_kind() {
+    let stdout_with_embedded_command_name = "<local-command-stdout>Set model to Fable 5\n\
+                                            <command-name>/loop</command-name>\n\
+                                            </local-command-stdout>";
+
+    assert_eq!(
+        classify_injected_prompt(stdout_with_embedded_command_name),
+        InjectedPromptClass::SlashCommandControl,
+    );
+    assert_eq!(
+        slash_command_control_kind(stdout_with_embedded_command_name),
+        "local-command-stdout",
+        "a command-name string embedded inside stdout body must not hijack the kind",
+    );
+    assert!(is_local_only_slash_command_prompt(
+        stdout_with_embedded_command_name
+    ));
+
+    let decision =
+        relay_observed_prompt_injected_prompt_decision(stdout_with_embedded_command_name);
+    assert_eq!(
+        decision.slash_command_kind.as_deref(),
+        Some("local-command-stdout"),
+    );
+    assert!(decision.local_only_slash);
+
+    let note = format_slash_command_control_note(
+        "sess-a",
+        "local-command-stdout",
+        stdout_with_embedded_command_name,
+    );
+    assert!(note.contains("머신 슬래시 명령"));
+    assert!(!note.contains("자동 점검(/loop)"));
+    assert!(note.contains("Set model to Fable 5"));
 }
 
 // #3178 CORE (codex fix): the same trigger (a /loop double-post: raw echo +

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1078,6 +1078,14 @@ fn classify_injected_prompt_slash_command_control() {
         classify_injected_prompt("<local-command-stdout>Compacted (12.3k tokens)"),
         InjectedPromptClass::SlashCommandControl,
     );
+    // /model command stdout line: local command output is a machine echo, not
+    // a human TUI-direct prompt that should mint a synthetic turn.
+    assert_eq!(
+        classify_injected_prompt(
+            "<local-command-stdout>Set model to Fable 5</local-command-stdout>"
+        ),
+        InjectedPromptClass::SlashCommandControl,
+    );
     let command_name_first = compact_command_name_first_stub();
     assert_eq!(command_name_first.chars().count(), 134);
     assert_eq!(
@@ -1287,6 +1295,33 @@ fn local_only_slash_prompt_rejects_non_command_text() {
     assert!(is_local_only_slash_command_prompt(model_wrapper));
 }
 
+// #4033: `/model` writes two adjacent transcript user entries. The
+// `<command-name>` half was already local-only (#3500); the stdout half must be
+// local-only too, or the relay mints a fake synthetic inflight and queues the
+// next real user message behind it.
+#[test]
+fn local_only_slash_prompt_skips_model_two_half_transcript() {
+    let command_name_half =
+        "<command-message>x</command-message>\n<command-name>/model</command-name>";
+    let stdout_half = "<local-command-stdout>Set model to Fable 5</local-command-stdout>";
+
+    for half in [command_name_half, stdout_half] {
+        assert_eq!(
+            classify_injected_prompt(half),
+            InjectedPromptClass::SlashCommandControl,
+            "both /model transcript halves must be machine slash-control echoes",
+        );
+        assert!(
+            is_local_only_slash_command_prompt(half),
+            "both /model transcript halves must skip the turn lifecycle",
+        );
+        assert!(
+            !classify_injected_prompt(half).is_human_active_turn(),
+            "neither /model transcript half is human TUI-direct input",
+        );
+    }
+}
+
 // #3178: the machine slash-command control trigger now resolves to a stable
 // command KIND that BOTH the raw `/loop` echo and the expanded `<command-*>`
 // wrapper for the SAME command map to (so the #3153 double-post collapses to
@@ -1307,6 +1342,12 @@ fn slash_command_control_kind_is_stable_across_double_post_halves() {
     assert_eq!(slash_command_control_kind("/compact"), "/compact");
     assert_eq!(
         slash_command_control_kind("<local-command-stdout>Compacted (12.3k tokens)"),
+        "/compact",
+    );
+    assert_eq!(
+        slash_command_control_kind(
+            "<local-command-stdout>Compacted 12 messages</local-command-stdout>"
+        ),
         "/compact",
     );
 
@@ -1382,6 +1423,27 @@ fn slash_command_control_note_loop_shows_body_others_kind_only() {
     assert!(
         !compact_note.contains("Compacted"),
         "note must NOT leak the compact stdout body",
+    );
+}
+
+// #4033 regression guard: broad `<local-command-stdout>...</local-command-stdout>`
+// detection must not disturb the legacy /compact stdout path. Compacted stdout
+// still resolves to `/compact`, remains local-only, and keeps the body hidden.
+#[test]
+fn local_command_stdout_compacted_path_stays_kind_only() {
+    let compact_stdout = "<local-command-stdout>Compacted 12 messages</local-command-stdout>";
+    assert_eq!(
+        classify_injected_prompt(compact_stdout),
+        InjectedPromptClass::SlashCommandControl,
+    );
+    assert_eq!(slash_command_control_kind(compact_stdout), "/compact");
+    assert!(is_local_only_slash_command_prompt(compact_stdout));
+
+    let compact_note = format_slash_command_control_note("sess-a", "/compact", compact_stdout);
+    assert!(compact_note.contains("/compact"));
+    assert!(
+        !compact_note.contains("Compacted"),
+        "legacy /compact stdout note must stay kind-only",
     );
 }
 


### PR DESCRIPTION
## 요약 (#4033, P1)
/model 등 로컬 슬래시 명령의 `<local-command-stdout>` 후반부가 HumanTuiDirect로 오분류되어 가짜 턴(⏳+synthetic inflight)이 실제 턴 슬롯을 점유하던 결함 수정 (#3500 미완성 수정 완결). 구현: codex (task-mr3bm3jt-lqvdya).

## 변경
- `injected_prompt_policy.rs`: start-anchored `<local-command-stdout>…</local-command-stdout>` 전체를 머신 에코로 인식 → 턴 라이프사이클 완전 스킵
- **Compacted(/compact) 특례는 generic 판정보다 선행 유지** — 회귀 테스트로 고정
- 회귀 테스트: /model 2-half fixture(command-name half + stdout half 모두 스킵), classify 15 + local_only 4 + control 6 + stdout 1 통과

## 알려진 제한
사람이 해당 XML 태그를 프롬프트 맨 앞에 직접 쓰면 local-only로 오분류 — 기존 start-anchored command XML 정책과 동일 성격.

## 게이트
cargo fmt --check / cargo check --lib / 관련 테스트 통과 / agent-maintenance freshness passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)