### PR TITLE
fix(discord): #4041 command-message wakeup 턴 slash-control kind 보존 — assistant relay/lifecycle 유지

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -689,7 +689,7 @@
 | `services::discord::tui_prompt_relay::codex_idle_rollout` | `src/services/discord/tui_prompt_relay/codex_idle_rollout.rs` | 613 | 613 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_offset_resolution` | `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` | 100 | 100 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_transcript_scan` | `src/services/discord/tui_prompt_relay/idle_transcript_scan.rs` | 495 | 347 | 148 |  |
-| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 462 | 462 | 0 |  |
+| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 467 | 467 | 0 |  |
 | `services::discord::tui_prompt_relay::launch_script` | `src/services/discord/tui_prompt_relay/launch_script.rs` | 129 | 107 | 22 |  |
 | `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 994 | 793 | 201 |  |
 | `services::discord::tui_prompt_relay::relay_ownership` | `src/services/discord/tui_prompt_relay/relay_ownership.rs` | 506 | 506 | 0 |  |

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -294,15 +294,11 @@ pub(super) fn slash_command_control_kind(prompt: &str) -> String {
     if starts_with_complete_local_command_stdout(&normalized) {
         return "local-command-stdout".to_string();
     }
-    if let Some(after) = normalized
-        .find("<command-name>")
-        .map(|idx| &normalized[idx + "<command-name>".len()..])
-    {
-        let name = after.split('<').next().unwrap_or("").trim();
-        let name = name.split_whitespace().next().unwrap_or("");
-        if !name.is_empty() {
-            return name.to_string();
-        }
+    if let Some(name) = first_xml_tag_token(&normalized, "command-name") {
+        return name;
+    }
+    if let Some(name) = first_xml_tag_token(&normalized, "command-message") {
+        return name;
     }
     if normalized.starts_with("/loop ") || normalized.starts_with("/loop\t") {
         return "/loop".to_string();
@@ -319,6 +315,15 @@ pub(super) fn slash_command_control_kind(prompt: &str) -> String {
         }
     }
     "slash".to_string()
+}
+
+fn first_xml_tag_token(text: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let after = text.split_once(&open)?.1;
+    let (body, _) = after.split_once(&close)?;
+    let token = body.split_whitespace().next()?.trim();
+    (!token.is_empty()).then(|| token.to_string())
 }
 
 /// Slash-control note; `/loop` and generic local stdout may include a short body.

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1254,6 +1254,45 @@ fn local_only_slash_prompt_preserves_loop_wakeup_lifecycle() {
     }
 }
 
+#[test]
+fn command_message_skill_wakeup_preserves_assistant_relay_lifecycle() {
+    let wakeup = "<command-message>agentdesk-issue-pipeline</command-message>\n\
+                  <command-args>issue 4041 --continue autonomous pipeline</command-args>";
+
+    assert_eq!(
+        classify_injected_prompt(wakeup),
+        InjectedPromptClass::SlashCommandControl,
+        "machine command-message wakeups should hide the raw echo without becoming human text",
+    );
+    assert_eq!(
+        slash_command_control_kind(wakeup),
+        "agentdesk-issue-pipeline",
+        "command-message-only wakeups need a stable non-fallback kind for lifecycle dedupe",
+    );
+
+    let decision = relay_observed_prompt_injected_prompt_decision(wakeup);
+    assert_eq!(
+        decision.injected_class,
+        InjectedPromptClass::SlashCommandControl,
+    );
+    assert_eq!(
+        decision.slash_command_kind.as_deref(),
+        Some("agentdesk-issue-pipeline"),
+    );
+    assert!(
+        !decision.local_only_slash,
+        "a skill wakeup starts a model turn and must not take the local-only echo path",
+    );
+    assert!(
+        !decision.injected_class.suppresses_user_turn_lifecycle(),
+        "wakeup turns still need anchor/reaction/synthetic ownership",
+    );
+    assert!(
+        decision.injected_class.still_delivers_assistant_output(),
+        "wakeup assistant prose must stay relayable even when the injected echo is sanitized",
+    );
+}
+
 // #3305: non-command text, the system-continuation banner, task notifications,
 // a token-boundary near-miss, and an UNLISTED command must all be rejected so
 // the local-only skip never fires for a real turn (fail-safe = lifecycle kept).
@@ -1743,6 +1782,18 @@ fn slash_command_control_kind_distinguishes_distinct_unknown_commands() {
         slash_command_control_kind(foo),
         slash_command_control_kind(bar),
         "distinct unknown commands must NOT collapse to one kind"
+    );
+
+    let skill = "<command-message>agentdesk-issue-pipeline</command-message>\n\
+                 <command-args>issue 4041</command-args>";
+    assert_eq!(
+        slash_command_control_kind(skill),
+        "agentdesk-issue-pipeline"
+    );
+    assert_ne!(
+        slash_command_control_kind(skill),
+        slash_command_control_kind("<local-command-caveat>x</local-command-caveat>"),
+        "a local-only caveat fallback must not consume a command-message wakeup dedupe key",
     );
 }
 


### PR DESCRIPTION
## 문제 (#4041)
배포 dd7ce8147 이후 웨이크업(ScheduleWakeup → `<command-message>` 주입) 턴의 어시스턴트 출력이 스트리밍으로 게시됐다가 **finalize 때 삭제**되고 ⏳ 리액션이 플립되지 않음 (라이브 3회+ 확정, 사용자 직접 관측 포함).

## 근본 원인
`injected_prompt_policy.rs:297-321`이 `<command-name>`만 slash-control kind로 읽고 `<command-message>` 주입은 fallback `"slash"`로 떨어뜨림 → `tui_prompt_relay.rs:348-363`의 SlashCommandControl dedupe가 **lease/anchor 확보 전에 조기 return** → 그 턴의 출력이 anchor 없는 ephemeral로만 흐르다가 turn 정리와 함께 증발.

## 수정
- `<command-message>` 첫 토큰도 slash-control kind로 추출 — dedupe key를 실제 스킬명(예: `agentdesk-issue-pipeline`)으로 보존해 정상 lease/anchor 라이프사이클을 태움.
- 불변식: **주입 에코 억제(#3178/#3153)는 유지**, 어시스턴트 출력 릴레이·리액션 플립은 일반 턴과 동일.
- 회귀 테스트: command-message wakeup이 echo만 숨기고 assistant relay/lifecycle은 유지됨을 검증.

## 게이트
fmt ✓ / check --lib ✓ / tui_prompt_relay·injected_prompt_policy·tui_prompt_dedupe 테스트 ✓ / agent-maintenance freshness passed ✓ / audit --check 0 ✓ / await-holding-lock ratchet ✓

구현: codex(gpt-5.5 xhigh). 리뷰: 듀얼(codex xhigh + Fable) 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)