### PR TITLE
fix(build): windows cargo check 복구 — placeholder_sweeper cfg(unix) 게이트

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1565,7 +1565,8 @@
   - `src/services/discord/{commands/text_commands.rs,
     discord_config_audit.rs, router/intake_gate.rs}` (all 1000+ production
     lines).
-  - `src/services/discord/placeholder_sweeper.rs` (1019 lines; +5 from #3886
+  - `src/services/discord/placeholder_sweeper.rs` (1020 lines; +1 from the
+    windows-build `#[cfg(unix)]` gate on the #3886 reconcile call; +5 from #3886
     calling the deterministic TimedOut-completion-gate status-panel reconcile
     (`super::tmux::reconcile_timed_out_tui_status_panel`) before the age-based
     orphan-panel reclaim; +10 from #3859

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -18,7 +18,7 @@
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
 | `src/services/discord/health/recovery.rs` | 2498 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1252 | discord-relay | 2026-08-31 | #3405 |
-| `src/services/discord/placeholder_sweeper.rs` | 1019 | discord-relay | 2026-08-31 | #3405 |
+| `src/services/discord/placeholder_sweeper.rs` | 1020 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/recovery_engine.rs` | 2935 | discord-relay | 2026-10-31 | #3834 |
 | `src/services/discord/relay_recovery.rs` | 1276 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/router/intake_gate.rs` | 1611 | discord-relay | 2026-10-31 | #3838 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -527,7 +527,7 @@
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 348 | 348 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 185 | 185 | 0 |  |
-| `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1314 | 1019 | 295 | giant-file |
+| `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 431 | 431 | 0 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 387 | 264 | 123 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -615,7 +615,11 @@
 # TurnCompleted is finalized the moment the turn's JSONL confirms terminal. The
 # reconcile body lives in the new (non-hot) status_panel_timedout_reconcile.rs;
 # this is the minimal sweep-loop call + comment. Bugfix-only.
-"src/services/discord/placeholder_sweeper.rs" = 1019
+# windows-build fix: 1019 -> 1020 (+1) — statement-level #[cfg(unix)] gate on the
+# #3886 reconcile call (the tmux module is cfg-out on windows; E0433 since
+# 733fb9f2d broke main's windows cargo check). Attribute line only, no logic.
+# rustfmt rejects the single-line form, so the +1 is irreducible.
+"src/services/discord/placeholder_sweeper.rs" = 1020
 # #3479: turn_bridge/tmux_runtime.rs decomposed into tmux_runtime/ directory
 # modules (root tmux_runtime.rs 964 prod LoC + sub-1000-LoC
 # tmux_runtime/{interrupt_policy,process_table,pid_exit}.rs) — dropped below the

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -399,6 +399,7 @@ async fn run_placeholder_sweep_pass(
             // after a TimedOut gate. MUST run before the age-based orphan reclaim
             // below — a committed finalize registers the #3607 terminal anchor the
             // reclaim then skips (DEFECT 3). Self-guards via a fresh same-turn re-read.
+            #[cfg(unix)]
             super::tmux::reconcile_timed_out_tui_status_panel(http, shared, provider, &state).await;
             sweep_orphan_status_panel(
                 http,


### PR DESCRIPTION
## 문제
main이 733fb9f2d(#4019 R2)부터 windows cargo check 실패 (E0433: `placeholder_sweeper.rs:402`가 cfg-out된 `tmux` 모듈 참조). 이후 7커밋 연속 CI Main failure — 모든 PR의 required cross-OS 체크를 오염시키는 파이프라인 블로커.

## 수정
문장 레벨 `#[cfg(unix)]` 게이트 1줄 (recovery_engine.rs:561의 기존 컨벤션과 동일). side-effect 전용 호출이라 fallback 불요, 인자들은 이어지는 `sweep_orphan_status_panel`이 계속 사용. unix 동작 불변.

## 검증
- host `cargo check` green, `rustc --print cfg --target x86_64-pc-windows-msvc`로 cfg elision 확인
- 이 PR의 windows CI가 R2 이후 첫 green 여부 = 실검증

P0 파이프라인 팔리아티브 (에픽 #4046 가드레일 내 허용). 구현: Codex / 리뷰: Claude PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)