### PR TITLE
docs(outbound): #3998 S1-e — A2b/A3/A6a 잔존 배제 인벤토리 + pin 테스트

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -44,6 +44,8 @@ Last refreshed: 2026-06-16 (against `main` @ `8ec7336e32eb6ef89e1143fab2543f2fc6
 >
 > Last refreshed: 2026-07-03 (#3998 S1-d — A4 watcher anchored full-body long chunks and A5 turn_bridge anchored long chunks now route through the turn-output controller behind their existing owner flags. `OutputPlan::SendNewChunks` gained `delete_anchor`; controller transport sends rollback-aware chunks first, then best-effort deletes the active anchor, and returns chunk metadata for owner cleanup/durable-anchor records. The retained turn-output exclusions are now exactly five: empty body, `NoRange` deliver-without-advance (#4048), headless enqueue (no direct Discord POST), watcher no-placeholder new-message fresh-send (`placeholder_msg_id == None`; anchor-less fresh-send is not yet a controller verb, same class as A6a's `None`-placeholder fresh-send and re-evaluated with the #3998 flip/legacy-retirement phase), and TUI completion gate (#4047). Compiled defaults and release env remain unchanged).
 >
+> Last refreshed: 2026-07-03 (#3998 S1-e — the remaining A2b/A3/A6a retained exclusions are enumerated in §8.1.1 with code conditions, rationale, blockers, and pin tests. Together with #4053's A4/A5 inventory and #4054's A6a D1 idempotency fix, the Phase-B excluded-arm GO condition is satisfied as "all arms represented or explicitly retained with linked blockers". No code/default/flip changed).
+>
 > Companion docs: [`docs/discord-outbound-remaining-producers.md`](../discord-outbound-remaining-producers.md) (#1175 closure), [`docs/source-of-truth.md`](../source-of-truth.md).
 
 This is the single source of truth for "where is each Discord outbound callsite
@@ -97,7 +99,9 @@ non-TUI body, `placeholder_msg_id == None` fails the watcher `has_placeholder`
 gate and takes the raw fresh-send branch because anchor-less fresh-send is not
 yet a controller verb. The retained exclusions are empty body, `NoRange`,
 headless enqueue, watcher no-placeholder new-message fresh-send, and the TUI
-completion gate, so the legacy branches are not yet vestigial. Release
+completion gate; §8.1.1 records the remaining A2b/A3/A6a owner-specific arms
+beside the #4053 A4/A5 inventory, so the legacy branches are intentional rather
+than untracked. Release
 health reports the effective per-node rollout under `turn_output_controller_rollout`
 (#3794, read-only): per-owner `enabled`, `enabled_count`, and an
 `effective_authority` of `controller` / `mixed` / `legacy` so operators can detect
@@ -469,6 +473,22 @@ code: even with a flag ON, the retained exclusions still route the legacy
     re-evaluated with the #3998 flip/legacy-retirement phase.
   - TUI completion gate: lifecycle pause/commit semantics retire with #4047.
 
+#### 8.1.1 Retained-exclusion inventory (#3998 S1-e)
+
+#4053 already documents the A4/A5 retained arms. The remaining controller-owner
+arms are explicitly retained here so the Phase-B inventory is closed without
+changing runtime behavior.
+
+| owner / arm | code condition | decision / rationale | blocker / re-eval | pin test |
+|---|---|---|---|---|
+| A2b sink `NoRange` / `cutover_range == None` short-replace | `src/services/discord/session_relay_sink.rs:884-895` requires `cutover_range.is_some()` before controller routing; the legacy replace arm starts at `session_relay_sink.rs:990`. | **RETAIN.** This is the no-advance class: without a real ordered `[start,end)` range, the controller has no offset authority to commit. | #4048 advance-authority work / #3998 flip re-eval. | `flag_on_exclusion_gate_keeps_no_range_and_empty_body_on_legacy_path` |
+| A2b sink empty body | `src/services/discord/session_relay_sink.rs:891-895` requires `!relay_text.is_empty()` before controller routing. | **RETAIN.** Legacy zero-chunk replace is committed/advanced; the controller returns `Skipped`, so migrating would flip Skipped-vs-advance semantics. | #4047 / #4048 semantics re-eval. | `controller_skips_empty_body_so_cutover_gate_keeps_it_legacy`; `flag_on_exclusion_gate_keeps_no_range_and_empty_body_on_legacy_path` |
+| A3 standby empty body | `src/services/discord/standby_relay.rs:77-79` gates short-replace on `controller_enabled && !formatted.is_empty()`; legacy replace starts at `standby_relay.rs:814`. | **RETAIN.** Same empty-body parity class as A2b/A4/A5: controller `Skipped` would not match legacy committed replace. | #4047 / #4048 semantics re-eval. | `standby_short_replace_should_cutover_pins_both_conditions` |
+| A3 standby transport-only `NoLease` | `src/services/discord/standby_relay.rs:672-725` uses `toc::NoLease`, `lease_key: None`, `advance: None`, and `heartbeat: None`. | **RETAIN.** Standby has no lease, no offset authority, and no heartbeat to unify; this is intentionally transport-only instead of inventing a lease. | #3998 flip/legacy-retirement re-eval. | `edited_original_returns_true_and_does_not_delete_original`; `fallback_after_edit_failure_returns_true_and_preserves_original` |
+| A3 standby `placeholder_msg_id == None` new-message send | `src/services/discord/standby_relay.rs:893-895` calls legacy `formatting::send_long_message_raw`. | **RETAIN.** Anchor-less fresh-send is not a controller verb yet, same class as watcher no-placeholder (#4053) and A6a `None`-placeholder fresh-send. | #3998 flip/legacy-retirement re-eval after an anchor-less fresh-send verb exists. | `none_placeholder_new_message_stays_legacy_even_when_controller_flag_on` |
+| A6a recovery empty body | `src/services/discord/recovery_paths/controller_cutover.rs:112-117` requires `enabled && has_placeholder && !body.is_empty()`. | **RETAIN.** Same empty-body parity class: legacy anchored replace delivers, while the controller would `Skipped` → non-delivered. | #4047 / #4048 semantics re-eval. | `should_cutover_pins_each_condition` |
+| A6a recovery `placeholder == None` fresh-send | `src/services/discord/recovery_paths/controller_cutover.rs:112-117` requires `has_placeholder`; caller legacy branch is `src/services/discord/recovery_engine.rs:463-470` via `relay_no_anchor_terminal_text`. | **RETAIN.** Anchor-less fresh-send is not a controller verb yet. #4054 already made this path idempotent through `RecoveryDeliveryContext`, so the residual risk is transport-uniformity, not correctness. The #3297 gone-channel probe remains represented in the anchored controller adapter and must stay. | #3998 flip/legacy-retirement re-eval after an anchor-less fresh-send verb exists. | `should_cutover_pins_each_condition`; `controller_fallback_records_replacement_anchor`; `non_delivered_gone_probe_escalates_permanent` |
+
 ### 8.2 Per-flag flip evaluation
 
 | flag (owner) | flip runtime benefit | flip risk / blocker | decision |
@@ -508,11 +528,11 @@ precise.
 The flip becomes a real single-authority win only when coupled with legacy
 retirement. Before flipping:
 
-1. **Retained-exclusion resolution** — either migrate or intentionally retire the
-   remaining legacy-only arms: `NoRange` waits on #4048 advance authority,
-   TUI-gate waits on #4047, headless has no direct POST, watcher
-   no-placeholder / A6a `None`-placeholder fresh-send waits on an anchor-less
-   fresh-send controller verb, and empty body must keep A2b/A3 parity.
+1. **Retained-exclusion resolution** — satisfied for Phase-B by #4053, #4054,
+   and this §8.1.1 inventory: every excluded arm is either represented by the
+   controller or explicitly retained with a linked blocker / flip re-eval
+   (`NoRange` → #4048, TUI-gate → #4047, empty body → #4047/#4048, headless/no
+   direct POST, anchor-less fresh-send → #3998 flip/legacy-retirement re-eval).
 2. **CI-wide OFF-assumption audit** — invert/re-author the six default-OFF
    assertions and audit any other dev/CI default-OFF assumptions.
 3. **Release soak evidence** — record duplicate-relay / missed-terminal-body

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -620,7 +620,7 @@
 | `services::discord::semantic_boundaries` | `src/services/discord/semantic_boundaries.rs` | 261 | 261 | 0 |  |
 | `services::discord::session_banner` | `src/services/discord/session_banner.rs` | 68 | 68 | 0 |  |
 | `services::discord::session_identity` | `src/services/discord/session_identity.rs` | 214 | 141 | 73 |  |
-| `services::discord::session_relay_sink` | `src/services/discord/session_relay_sink.rs` | 4258 | 1700 | 2558 | giant-file |
+| `services::discord::session_relay_sink` | `src/services/discord/session_relay_sink.rs` | 4297 | 1700 | 2597 | giant-file |
 | `services::discord::session_relay_sink::idle_jsonl` | `src/services/discord/session_relay_sink/idle_jsonl.rs` | 169 | 169 | 0 |  |
 | `services::discord::session_relay_sink::orphan_reclaim` | `src/services/discord/session_relay_sink/orphan_reclaim.rs` | 218 | 116 | 102 |  |
 | `services::discord::session_runtime` | `src/services/discord/session_runtime.rs` | 1027 | 501 | 526 |  |
@@ -639,7 +639,7 @@
 | `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2803 | 865 | 1938 |  |
 | `services::discord::single_message_panel::completion_footer_registry` | `src/services/discord/single_message_panel/completion_footer_registry.rs` | 624 | 624 | 0 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
-| `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1648 | 917 | 731 |  |
+| `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1683 | 917 | 766 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |
 | `services::discord::status_panel_orphan_store` | `src/services/discord/status_panel_orphan_store.rs` | 700 | 700 | 0 |  |
 | `services::discord::status_panel_timedout_reconcile` | `src/services/discord/status_panel_timedout_reconcile.rs` | 405 | 405 | 0 |  |

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -3032,6 +3032,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn flag_on_exclusion_gate_keeps_no_range_and_empty_body_on_legacy_path() {
+        let module_src = include_str!("session_relay_sink.rs");
+
+        let assignment = format!("let {} = ", "cutover_short_replace");
+        let gate_start = module_src
+            .find(&assignment)
+            .expect("session sink cutover gate assignment");
+        let gate_src = &module_src[gate_start
+            ..gate_start
+                + module_src[gate_start..]
+                    .find(';')
+                    .expect("session sink cutover gate terminator")];
+
+        assert!(
+            gate_src.contains("sink_short_replace_controller_enabled()"),
+            "A2b flag ON must be only one term in the gate, not enough to cut over retained arms"
+        );
+        assert!(
+            gate_src.contains(&format!("&& {}.is_some()", "cutover_range")),
+            "A2b cutover_range=None / NoRange must stay on the legacy no-advance path"
+        );
+        assert!(
+            gate_src.contains(&format!("&& !{}.is_empty()", "relay_text")),
+            "A2b empty-body must stay legacy because controller Skipped would not advance"
+        );
+        assert!(
+            gate_src.contains("SessionBoundTerminalDeliveryRoute::PlaceholderEdit(_)"),
+            "A2b controller path is limited to anchored placeholder edits"
+        );
+        assert!(
+            module_src.contains(&format!(
+                "{}.filter(|_| {})",
+                "cutover_range", "cutover_short_replace"
+            )),
+            "A2b controller branch must require both the ordered range and cutover gate"
+        );
+    }
+
     #[allow(dead_code)] // #3034: test helper superseded by `inflight_with_identity_offset`.
     fn inflight_with_identity(
         channel_id: u64,

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -1644,5 +1644,40 @@ mod tests {
                 "the ONLY cut-over case: flag ON + non-empty body"
             );
         }
+
+        #[test]
+        fn none_placeholder_new_message_stays_legacy_even_when_controller_flag_on() {
+            let module_src = include_str!("standby_relay.rs");
+            let match_marker = format!("match {} {{", "placeholder_msg_id");
+            let match_src = module_src
+                .split(&match_marker)
+                .nth(1)
+                .expect("standby placeholder route match");
+            let none_marker = format!("{} => {{", "None");
+            let none_src = match_src
+                .split(&none_marker)
+                .nth(1)
+                .expect("standby no-placeholder branch");
+            let legacy_send_window = &none_src[..none_src
+                .find("match result")
+                .expect("standby no-placeholder result match")];
+
+            assert!(
+                standby_short_replace_should_cutover(true, "answer"),
+                "sanity: flag ON + non-empty cuts over only inside the Some(placeholder) branch"
+            );
+            assert!(
+                legacy_send_window.contains(&format!("formatting::{}(", "send_long_message_raw")),
+                "A3 placeholder=None must keep the legacy fresh-send transport"
+            );
+            assert!(
+                !legacy_send_window.contains("deliver_short_replace_via_controller"),
+                "A3 placeholder=None must not route through the short-replace controller"
+            );
+            assert!(
+                !legacy_send_window.contains("deliver_turn_output"),
+                "A3 placeholder=None remains an anchor-less fresh-send legacy branch"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 배경 (#3998 Phase-B GO 조건 마감)

A2b sink / A3 standby / A6a recovery의 excluded arms를 'represented or explicitly retained with a linked blocker'로 처리하는 마지막 조각.

## 변경 (프로덕션 로직 변경 0)
- `discord-outbound-migration.md` §8.1.1: per-arm 잔존 배제 표 — A2b NoRange(→#4048)/empty-body(→#4047·#4048), A3 empty-body/NoLease(transport-only)/no-placeholder new-message(anchor-less fresh-send 클래스), A6a empty-body/None-placeholder fresh-send(#4054로 멱등화 완료, 잔여=transport 균일성)/#3297 probe(REPRESENTED·유지)
- Phase-B GO 조건 'excluded-arm 마이그레이션' → #4053(A4/A5 이관+5종 배제) + #4054(A6a 멱등화) + 본 문서로 **충족** 처리
- pin 테스트: flag-ON에서 각 잔존 arm이 레거시로 라우팅됨을 고정 (predicate 확장 시 실패하도록)

## 검증
게이트 전부 green. 리뷰: fresh codex 단독 PASS (docs+테스트 경량 구간 정책) — 문서 조건을 실제 predicate와 대조 검증, 프로덕션 변경 0 확인. Claude 결정표 대조 일치.

Part of #3998 (EPIC #4046 S1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)