### PR TITLE
feat(pipeline): #3950 slice 1 — shadow-only timeout reducer observability

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -166,7 +166,7 @@
 | `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 804 | 804 | 0 |  |
 | `engine::ops::review_ops` | `src/engine/ops/review_ops.rs` | 417 | 417 | 0 |  |
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 275 | 275 | 0 |  |
-| `engine::ops::timeouts_ops` | `src/engine/ops/timeouts_ops.rs` | 529 | 508 | 21 |  |
+| `engine::ops::timeouts_ops` | `src/engine/ops/timeouts_ops.rs` | 772 | 671 | 101 |  |
 | `engine::ops::turn_ops` | `src/engine/ops/turn_ops.rs` | 348 | 255 | 93 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 189 | 189 | 0 |  |
 | `engine::transition` | `src/engine/transition.rs` | 1485 | 835 | 650 |  |

--- a/policies/__tests__/support/harness.js
+++ b/policies/__tests__/support/harness.js
@@ -144,6 +144,7 @@ function createAgentdeskMock(options) {
     timeoutTerminationRecords: [],
     timeoutInactiveCounterCleanups: 0,
     timeoutHistoryCleanupCalls: [],
+    timeoutPreviewCalls: [],
     retrospectiveCalls: [],
     runtimeSignals: [],
     httpPosts: [],
@@ -377,6 +378,21 @@ function createAgentdeskMock(options) {
           return clone(timeouts.cleanupDeadlockHistoryBefore(cutoffMs, state));
         }
         return { ok: true, deleted: 0 };
+      },
+      previewTimeoutDecision(payload) {
+        state.timeoutPreviewCalls.push(clone(payload || {}));
+        if (typeof timeouts.previewTimeoutDecision === "function") {
+          return clone(timeouts.previewTimeoutDecision(payload || {}, state));
+        }
+        return {
+          would_retry: false,
+          would_exhaust: false,
+          resolution: "incomparable",
+          attempt: payload && Object.prototype.hasOwnProperty.call(payload, "attempt") ? payload.attempt : null,
+          delay: null,
+          incomparable: true,
+          reason: "mock preview"
+        };
       }
     },
     http: {

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -100,9 +100,37 @@ test("timeouts reconciliation module scans pending fallback dispatch keys", () =
   assert.match(state.queries[0].sql, /reconcile_dispatch:%/);
 });
 
+test("timeouts harness previewTimeoutDecision handles null payload without throwing", () => {
+  const { agentdesk, state } = loadPolicy("policies/timeouts.js");
+  let result = null;
+
+  assert.doesNotThrow(() => {
+    result = agentdesk.timeouts.previewTimeoutDecision(null);
+  });
+
+  assert.equal(state.timeoutPreviewCalls.length, 1);
+  assert.deepEqual(state.timeoutPreviewCalls[0], {});
+  assert.equal(result && typeof result, "object");
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(result, "resolution") ||
+      Object.prototype.hasOwnProperty.call(result, "error")
+  );
+});
+
 test("timeouts card timeout module marks requested dispatches failed before retry", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     config: { requested_timeout_min: 30 },
+    timeouts: {
+      previewTimeoutDecision(payload) {
+        return {
+          would_retry: true,
+          would_exhaust: false,
+          resolution: "retry",
+          attempt: payload.attempt,
+          delay: 300
+        };
+      }
+    },
     dbQuery: createSqlRouter([
       {
         match: "FROM kanban_cards kc LEFT JOIN task_dispatches td ON td.id = kc.latest_dispatch_id",
@@ -124,6 +152,32 @@ test("timeouts card timeout module marks requested dispatches failed before retr
   assert.deepEqual(state.dispatchMarkFailedCalls, [
     { dispatchId: "dispatch-requested-1", reason: "Timed out waiting for agent" }
   ]);
+  assert.equal(state.timeoutPreviewCalls.length, 1);
+  assert.deepEqual(
+    {
+      card_id: state.timeoutPreviewCalls[0].card_id,
+      status: state.timeoutPreviewCalls[0].status,
+      state: state.timeoutPreviewCalls[0].state,
+      latest_dispatch_id: state.timeoutPreviewCalls[0].latest_dispatch_id,
+      attempt: state.timeoutPreviewCalls[0].attempt
+    },
+    {
+      card_id: "card-requested-1",
+      status: "requested",
+      state: "requested",
+      latest_dispatch_id: "dispatch-requested-1",
+      attempt: 2
+    }
+  );
+  const shadowLine = state.logs.info.find((line) => line.startsWith("[timeout_shadow] "));
+  assert.ok(shadowLine);
+  const shadow = JSON.parse(shadowLine.slice("[timeout_shadow] ".length));
+  assert.equal(shadow.target, "timeout_shadow");
+  assert.equal(shadow.card_id, "card-requested-1");
+  assert.equal(shadow.section, "_section_A");
+  assert.equal(shadow.js_decision, "retry");
+  assert.equal(shadow.reducer_decision, "retry");
+  assert.equal(shadow.agree, true);
   assert.match(state.executions[0].sql, /UPDATE kanban_cards SET requested_at/);
   assert.deepEqual(toPlain(state.executions[0].params), ["card-requested-1"]);
 });
@@ -188,6 +242,83 @@ test("timeouts requested sweep skips scope-assessment side-path even when overdu
     state.executions.filter((e) => /UPDATE kanban_cards SET requested_at/.test(e.sql)).length,
     0
   );
+});
+
+test("timeouts dispatch maintenance shadows failed-dispatch retries without changing retry mutations", () => {
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    timeouts: {
+      previewTimeoutDecision(payload) {
+        return {
+          would_retry: false,
+          would_exhaust: false,
+          resolution: "incomparable",
+          attempt: payload.attempt,
+          delay: null,
+          incomparable: true,
+          reason: "state missing"
+        };
+      }
+    },
+    dbQuery: createSqlRouter([
+      {
+        match: "FROM task_dispatches td JOIN kanban_cards kc ON kc.id = td.kanban_card_id",
+        result: [
+          {
+            id: "dispatch-failed-1",
+            kanban_card_id: "card-retry-1",
+            to_agent_id: "agent-1",
+            dispatch_type: "implementation",
+            title: "Retry implementation",
+            retry_count: 3,
+            github_issue_url: null,
+            github_issue_number: null
+          }
+        ]
+      }
+    ])
+  });
+
+  policy._section_J();
+
+  assert.equal(state.timeoutPreviewCalls.length, 1);
+  assert.deepEqual(
+    {
+      card_id: state.timeoutPreviewCalls[0].card_id,
+      status: state.timeoutPreviewCalls[0].status,
+      state: state.timeoutPreviewCalls[0].state,
+      latest_dispatch_id: state.timeoutPreviewCalls[0].latest_dispatch_id,
+      attempt: state.timeoutPreviewCalls[0].attempt
+    },
+    {
+      card_id: "card-retry-1",
+      status: null,
+      state: null,
+      latest_dispatch_id: "dispatch-failed-1",
+      attempt: 3
+    }
+  );
+  assert.deepEqual(state.dispatchCreates, [
+    {
+      cardId: "card-retry-1",
+      agentId: "agent-1",
+      dispatchType: "implementation",
+      title: "Retry implementation",
+      context: null
+    }
+  ]);
+  assert.deepEqual(state.dispatchRetryCountCalls, [
+    { dispatchId: "dispatch-1", count: 4 }
+  ]);
+  const shadowLine = state.logs.info.find((line) => line.startsWith("[timeout_shadow] "));
+  assert.ok(shadowLine);
+  const shadow = JSON.parse(shadowLine.slice("[timeout_shadow] ".length));
+  assert.equal(shadow.target, "timeout_shadow");
+  assert.equal(shadow.card_id, "card-retry-1");
+  assert.equal(shadow.section, "_section_J");
+  assert.equal(shadow.js_decision, "retry");
+  assert.equal(shadow.reducer_decision, "incomparable");
+  assert.equal(shadow.agree, false);
+  assert.equal(shadow.incomparable, true);
 });
 
 test("timeouts reconcile fallback does not advance a completed scope-assessment (#3605)", () => {

--- a/policies/lib/timeouts-helpers.js
+++ b/policies/lib/timeouts-helpers.js
@@ -7,6 +7,66 @@ function sendDeadlockAlert(message) {
 // Shared constant used by sections [A] and [J]
 var MAX_DISPATCH_RETRIES = 10;
 
+function timeoutReducerDecisionLabel(preview) {
+  if (!preview) return "missing";
+  if (preview.incomparable) return "incomparable";
+  if (preview.would_retry) return "retry";
+  if (preview.would_exhaust) return "exhaust";
+  return preview.resolution || "unknown";
+}
+
+function emitTimeoutShadowLog(record) {
+  try {
+    agentdesk.log.info("[timeout_shadow] " + JSON.stringify(record));
+  } catch(_e) {}
+}
+
+function shadowTimeoutDecision(payload) {
+  var cardId = payload && payload.card_id ? payload.card_id : null;
+  var section = payload && payload.section ? payload.section : null;
+  var jsDecision = payload && payload.js_decision ? payload.js_decision : "unknown";
+  var record = {
+    target: "timeout_shadow",
+    card_id: cardId,
+    section: section,
+    js_decision: jsDecision,
+    reducer_decision: "error",
+    agree: false
+  };
+  try {
+    var previewPayload = {
+      card_id: cardId,
+      status: payload && Object.prototype.hasOwnProperty.call(payload, "status") ? payload.status : null,
+      state: payload && Object.prototype.hasOwnProperty.call(payload, "state") ? payload.state : null,
+      review_status: payload && Object.prototype.hasOwnProperty.call(payload, "review_status") ? payload.review_status : null,
+      latest_dispatch_id: payload && Object.prototype.hasOwnProperty.call(payload, "latest_dispatch_id") ? payload.latest_dispatch_id : null,
+      // Provisional for #3950 slice 1: dispatch retry_count is the shadow
+      // attempt until slice 2 defines durable card/state budget identity.
+      attempt: payload && Object.prototype.hasOwnProperty.call(payload, "attempt") ? payload.attempt : null,
+      pipeline: payload && Object.prototype.hasOwnProperty.call(payload, "pipeline") ? payload.pipeline : null
+    };
+    var preview = agentdesk.timeouts.previewTimeoutDecision(previewPayload);
+    var reducerDecision = timeoutReducerDecisionLabel(preview);
+    record.reducer_decision = reducerDecision;
+    record.agree = reducerDecision === jsDecision && !preview.incomparable;
+    record.reducer_resolution = preview.resolution || null;
+    record.reducer_attempt = Object.prototype.hasOwnProperty.call(preview, "attempt") ? preview.attempt : null;
+    record.reducer_delay = Object.prototype.hasOwnProperty.call(preview, "delay") ? preview.delay : null;
+    record.reducer_would_retry = !!preview.would_retry;
+    record.reducer_would_exhaust = !!preview.would_exhaust;
+    if (preview.incomparable) {
+      record.incomparable = true;
+      record.reason = preview.reason || null;
+    }
+    emitTimeoutShadowLog(record);
+  } catch(e) {
+    record.reducer_decision = "error";
+    record.incomparable = true;
+    record.error = String(e && e.message ? e.message : e);
+    emitTimeoutShadowLog(record);
+  }
+}
+
 // Helper: read timeout config as SQL interval string
 function getTimeoutInterval(key, fallbackMinutes) {
   var val = parseInt(agentdesk.config.get(key), 10);
@@ -327,6 +387,7 @@ function _flushPMDecisions() {
 module.exports = {
   sendDeadlockAlert: sendDeadlockAlert,
   MAX_DISPATCH_RETRIES: MAX_DISPATCH_RETRIES,
+  shadowTimeoutDecision: shadowTimeoutDecision,
   getTimeoutInterval: getTimeoutInterval,
   latestCardActivityExpr: latestCardActivityExpr,
   parseLocalTimestampMs: parseLocalTimestampMs,

--- a/policies/timeouts/card-timeouts.js
+++ b/policies/timeouts/card-timeouts.js
@@ -3,6 +3,7 @@ var isSidePathDispatch = require("../lib/dispatch-side-path").isSidePathDispatch
 module.exports = function attachCardTimeouts(timeouts, helpers) {
   var sendDeadlockAlert = helpers.sendDeadlockAlert;
   var MAX_DISPATCH_RETRIES = helpers.MAX_DISPATCH_RETRIES;
+  var shadowTimeoutDecision = helpers.shadowTimeoutDecision;
   var getTimeoutInterval = helpers.getTimeoutInterval;
   var latestCardActivityExpr = helpers.latestCardActivityExpr;
   var parseLocalTimestampMs = helpers.parseLocalTimestampMs;
@@ -68,6 +69,18 @@ module.exports = function attachCardTimeouts(timeouts, helpers) {
             continue;
           }
         }
+
+        shadowTimeoutDecision({
+          section: "_section_A",
+          card_id: rc.id,
+          js_decision: rc.retry_count < MAX_DISPATCH_RETRIES ? "retry" : "exhaust",
+          status: aInitial,
+          state: aInitial,
+          review_status: null,
+          latest_dispatch_id: rc.latest_dispatch_id,
+          attempt: rc.retry_count,
+          pipeline: aCfg
+        });
 
         if (rc.retry_count < MAX_DISPATCH_RETRIES) {
           // 재시도 여유 있음 → card 상태 유지 (requested_at 갱신하여 [A] 재트리거 방지)

--- a/policies/timeouts/dispatch-maintenance.js
+++ b/policies/timeouts/dispatch-maintenance.js
@@ -1,6 +1,7 @@
 module.exports = function attachDispatchMaintenance(timeouts, helpers) {
   var sendDeadlockAlert = helpers.sendDeadlockAlert;
   var MAX_DISPATCH_RETRIES = helpers.MAX_DISPATCH_RETRIES;
+  var shadowTimeoutDecision = helpers.shadowTimeoutDecision;
   var getTimeoutInterval = helpers.getTimeoutInterval;
   var latestCardActivityExpr = helpers.latestCardActivityExpr;
   var parseLocalTimestampMs = helpers.parseLocalTimestampMs;
@@ -129,6 +130,17 @@ module.exports = function attachDispatchMaintenance(timeouts, helpers) {
       for (var jr = 0; jr < failedForRetry.length; jr++) {
         var fd = failedForRetry[jr];
         var newRetryCount = fd.retry_count + 1;
+        shadowTimeoutDecision({
+          section: "_section_J",
+          card_id: fd.kanban_card_id,
+          js_decision: "retry",
+          status: null,
+          state: null,
+          review_status: null,
+          latest_dispatch_id: fd.id,
+          attempt: fd.retry_count,
+          pipeline: jCfg
+        });
         try {
           var newDispatchId = agentdesk.dispatch.create(
             fd.kanban_card_id,

--- a/src/engine/ops/timeouts_ops.rs
+++ b/src/engine/ops/timeouts_ops.rs
@@ -1,7 +1,12 @@
+use crate::engine::transition::{
+    CardState, GateSnapshot, TransitionContext, TransitionEvent, TransitionIntent,
+    TransitionOutcome, decide_transition,
+};
+use crate::pipeline::PipelineConfig;
 use chrono::{DateTime, Utc};
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
 use sqlx::{PgPool, Row as SqlxRow};
 
 // ── Timeout policy typed facade (#3733) ─────────────────────────────
@@ -91,6 +96,13 @@ pub(super) fn register_timeouts_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
         })?,
     )?;
 
+    obj.set(
+        "__previewTimeoutDecisionRaw",
+        Function::new(ctx.clone(), move |payload_json: String| -> String {
+            preview_timeout_decision_raw(&payload_json)
+        })?,
+    )?;
+
     ad.set("timeouts", obj)?;
 
     ctx.eval::<(), _>(
@@ -131,6 +143,9 @@ pub(super) fn register_timeouts_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
             };
             agentdesk.timeouts.cleanupDeadlockHistoryBefore = function(cutoffMs) {
                 return unwrap(JSON.parse(agentdesk.timeouts.__cleanupDeadlockHistoryBeforeRaw(cutoffMs || 0)));
+            };
+            agentdesk.timeouts.previewTimeoutDecision = function(payload) {
+                return unwrap(JSON.parse(agentdesk.timeouts.__previewTimeoutDecisionRaw(JSON.stringify(payload || {}))));
             };
         })();
         "#,
@@ -177,6 +192,154 @@ fn format_ts(value: Option<DateTime<Utc>>) -> serde_json::Value {
         Some(value) => json!(value.format("%Y-%m-%d %H:%M:%S").to_string()),
         None => serde_json::Value::Null,
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct TimeoutDecisionPreviewPayload {
+    card_id: Option<String>,
+    status: Option<String>,
+    state: Option<String>,
+    review_status: Option<String>,
+    latest_dispatch_id: Option<String>,
+    attempt: Option<u32>,
+    pipeline: Option<PipelineConfig>,
+}
+
+fn preview_timeout_decision_raw(payload_json: &str) -> String {
+    match preview_timeout_decision(payload_json) {
+        Ok(value) => value.to_string(),
+        Err(error) => json!({ "error": error }).to_string(),
+    }
+}
+
+fn preview_timeout_decision(payload_json: &str) -> Result<Value, String> {
+    let payload: TimeoutDecisionPreviewPayload = serde_json::from_str(payload_json)
+        .map_err(|error| format!("parse timeout decision preview payload: {error}"))?;
+    let attempt = payload.attempt.unwrap_or(0);
+    let card_id = match required_preview_field(payload.card_id, "card_id", attempt) {
+        Ok(value) => value,
+        Err(value) => return Ok(value),
+    };
+    let status = match required_preview_field(payload.status, "status", attempt) {
+        Ok(value) => value,
+        Err(value) => return Ok(value),
+    };
+    let state = match required_preview_field(payload.state, "state", attempt) {
+        Ok(value) => value,
+        Err(value) => return Ok(value),
+    };
+    let Some(pipeline) = payload.pipeline else {
+        return Ok(incomparable_timeout_preview("pipeline missing", attempt));
+    };
+
+    let ctx = TransitionContext {
+        card: CardState {
+            id: card_id,
+            status,
+            review_status: payload.review_status,
+            latest_dispatch_id: payload.latest_dispatch_id,
+        },
+        pipeline,
+        gates: GateSnapshot::default(),
+    };
+    let decision = decide_transition(&ctx, &TransitionEvent::TimeoutExpired { state, attempt });
+    Ok(timeout_preview_json(&decision, attempt))
+}
+
+fn required_preview_field(
+    value: Option<String>,
+    field: &str,
+    attempt: u32,
+) -> Result<String, Value> {
+    match value.map(|value| value.trim().to_string()) {
+        Some(value) if !value.is_empty() => Ok(value),
+        _ => Err(incomparable_timeout_preview(
+            &format!("{field} missing"),
+            attempt,
+        )),
+    }
+}
+
+fn incomparable_timeout_preview(reason: &str, attempt: u32) -> Value {
+    json!({
+        "would_retry": false,
+        "would_exhaust": false,
+        "resolution": "incomparable",
+        "attempt": attempt,
+        "delay": null,
+        "incomparable": true,
+        "reason": reason,
+    })
+}
+
+fn timeout_preview_json(
+    decision: &crate::engine::transition::TransitionDecision,
+    attempt: u32,
+) -> Value {
+    let mut scheduled_attempt = None;
+    let mut delay = None;
+    let mut target_status = None;
+    let mut saw_audit = false;
+
+    for intent in &decision.intents {
+        match intent {
+            TransitionIntent::ScheduleStageRetry {
+                attempt,
+                delay_seconds,
+                ..
+            } => {
+                scheduled_attempt = Some(*attempt);
+                delay = Some(*delay_seconds);
+            }
+            TransitionIntent::UpdateStatus { to, .. } => {
+                target_status = Some(to.clone());
+            }
+            TransitionIntent::AuditLog { .. } => {
+                saw_audit = true;
+            }
+            _ => {}
+        }
+    }
+
+    let would_retry = scheduled_attempt.is_some();
+    let would_exhaust = !would_retry
+        && matches!(decision.outcome, TransitionOutcome::Allowed)
+        && !decision.intents.is_empty();
+    let resolution = if would_retry {
+        "retry".to_string()
+    } else if target_status.is_some() {
+        "transition".to_string()
+    } else if would_exhaust && saw_audit {
+        "audit".to_string()
+    } else if would_exhaust {
+        "exhaust".to_string()
+    } else {
+        match &decision.outcome {
+            TransitionOutcome::Allowed => "allowed".to_string(),
+            TransitionOutcome::NoOp => "noop".to_string(),
+            TransitionOutcome::Blocked(_) => "blocked".to_string(),
+        }
+    };
+    let blocked_reason = match &decision.outcome {
+        TransitionOutcome::Blocked(reason) => Some(reason.clone()),
+        _ => None,
+    };
+
+    json!({
+        "would_retry": would_retry,
+        "would_exhaust": would_exhaust,
+        "resolution": resolution,
+        "attempt": attempt,
+        "next_attempt": scheduled_attempt,
+        "delay": delay,
+        "target_status": target_status,
+        "outcome": match &decision.outcome {
+            TransitionOutcome::Allowed => "allowed",
+            TransitionOutcome::NoOp => "noop",
+            TransitionOutcome::Blocked(_) => "blocked",
+        },
+        "blocked_reason": blocked_reason,
+    })
 }
 
 fn clear_deadlock_counters_for_fresh_sessions_raw(
@@ -525,5 +688,85 @@ mod tests {
             valid_session_key(" provider:tmux ").unwrap(),
             "provider:tmux"
         );
+    }
+
+    #[test]
+    fn preview_timeout_decision_returns_dry_run_retry_shape() {
+        let payload = json!({
+            "card_id": "card-1",
+            "status": "in_progress",
+            "state": "in_progress",
+            "review_status": null,
+            "latest_dispatch_id": "dispatch-1",
+            "attempt": 0,
+            "pipeline": {
+                "name": "test",
+                "version": 1,
+                "states": [
+                    { "id": "in_progress", "label": "In Progress" },
+                    { "id": "escalated", "label": "Escalated" },
+                    { "id": "done", "label": "Done", "terminal": true }
+                ],
+                "transitions": [
+                    { "from": "in_progress", "to": "escalated", "type": "free" }
+                ],
+                "timeouts": {
+                    "in_progress": {
+                        "duration": "1m",
+                        "clock": "started_at",
+                        "max_retries": 2,
+                        "backoff": "exponential",
+                        "on_failure": "retry-with-backoff",
+                        "on_exhaust": "escalated",
+                        "on_exhaust_policy": "escalate"
+                    }
+                }
+            }
+        });
+
+        let raw = preview_timeout_decision_raw(&payload.to_string());
+        let parsed: Value = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(parsed["would_retry"], true);
+        assert_eq!(parsed["would_exhaust"], false);
+        assert_eq!(parsed["resolution"], "retry");
+        assert_eq!(parsed["attempt"], 0);
+        assert_eq!(parsed["next_attempt"], 1);
+        assert_eq!(parsed["delay"], 60);
+    }
+
+    #[test]
+    fn preview_timeout_decision_marks_missing_status_state_incomparable() {
+        let payload = json!({
+            "card_id": "card-retry-1",
+            "status": null,
+            "state": null,
+            "review_status": null,
+            "latest_dispatch_id": "dispatch-failed-1",
+            "attempt": 3,
+            "pipeline": {
+                "name": "test",
+                "version": 1,
+                "states": [
+                    { "id": "requested", "label": "Requested" },
+                    { "id": "in_progress", "label": "In Progress" },
+                    { "id": "done", "label": "Done", "terminal": true }
+                ],
+                "transitions": [
+                    { "from": "requested", "to": "in_progress", "type": "free" },
+                    { "from": "in_progress", "to": "done", "type": "free" }
+                ]
+            }
+        });
+
+        let parsed = preview_timeout_decision(&payload.to_string()).unwrap();
+
+        assert_eq!(parsed["would_retry"], false);
+        assert_eq!(parsed["would_exhaust"], false);
+        assert_eq!(parsed["resolution"], "incomparable");
+        assert_eq!(parsed["attempt"], 3);
+        assert_eq!(parsed["delay"], Value::Null);
+        assert_eq!(parsed["incomparable"], true);
+        assert_eq!(parsed["reason"], "status missing");
     }
 }


### PR DESCRIPTION
Slice 1 of #3950 (slicing plan + recommended defaults in the 2026-07-03 issue comment).

## What
- `agentdesk.timeouts.previewTimeoutDecision`: dry-run facade over the pure `decide_transition` timeout path — classify-only, returns would_retry/would_exhaust/resolution/attempt/delay JSON, executes zero intents (pre-existing DB writes in `timeouts_ops.rs` untouched/unreachable from preview)
- `_section_A` / `_section_J` call it at their decision points and emit one `timeout_shadow` log line (js_decision vs reducer_decision, agree flag); shadow is try/catch-isolated — a facade failure cannot affect the sweep
- All existing sweep mutations byte-identical (verified against HEAD in review: markFailed/requested-refresh/escalation/dispatch.create/setRetryCount order+args unchanged)
- `_section_J` logs `incomparable:true` (query lacks `kc.status`; widening queries deferred to slice 2)

## Review
Dual review passed: Codex adversarial (mutation identity vs HEAD, dry-run purity, failure isolation) + Claude. Review minors (incomparable-shape unit + null-payload test) fixed and re-verified.

## Verification
cargo timeouts 8 / transition green; `npm run test:policies` 181 green; fmt/check/audit/inventory gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)