### PR TITLE
fix(observability): #4075 stop EnvFilter dropping observability targets while keeping policy bridge logs dark

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -147,7 +147,7 @@
 | `engine::hooks` | `src/engine/hooks.rs` | 84 | 84 | 0 |  |
 | `engine::intent` | `src/engine/intent.rs` | 525 | 504 | 21 |  |
 | `engine::loader` | `src/engine/loader.rs` | 2013 | 1332 | 681 | giant-file |
-| `engine::ops` | `src/engine/ops.rs` | 95 | 95 | 0 |  |
+| `engine::ops` | `src/engine/ops.rs` | 97 | 97 | 0 |  |
 | `engine::ops::agent_ops` | `src/engine/ops/agent_ops.rs` | 246 | 246 | 0 |  |
 | `engine::ops::auto_queue_ops` | `src/engine/ops/auto_queue_ops.rs` | 662 | 662 | 0 |  |
 | `engine::ops::cards_ops` | `src/engine/ops/cards_ops.rs` | 448 | 448 | 0 |  |
@@ -160,7 +160,7 @@
 | `engine::ops::http_ops` | `src/engine/ops/http_ops.rs` | 243 | 149 | 94 |  |
 | `engine::ops::kanban_ops` | `src/engine/ops/kanban_ops.rs` | 1540 | 942 | 598 |  |
 | `engine::ops::kv_ops` | `src/engine/ops/kv_ops.rs` | 202 | 202 | 0 |  |
-| `engine::ops::log_ops` | `src/engine/ops/log_ops.rs` | 39 | 39 | 0 |  |
+| `engine::ops::log_ops` | `src/engine/ops/log_ops.rs` | 76 | 60 | 16 |  |
 | `engine::ops::message_ops` | `src/engine/ops/message_ops.rs` | 103 | 103 | 0 |  |
 | `engine::ops::pipeline_ops` | `src/engine/ops/pipeline_ops.rs` | 225 | 225 | 0 |  |
 | `engine::ops::quality_ops` | `src/engine/ops/quality_ops.rs` | 95 | 95 | 0 |  |
@@ -192,7 +192,7 @@
 | `kanban::transition_core` | `src/kanban/transition_core.rs` | 674 | 674 | 0 |  |
 | `launch` | `src/launch.rs` | 67 | 67 | 0 |  |
 | `lib` | `src/lib.rs` | 162 | 162 | 0 |  |
-| `logging` | `src/logging.rs` | 427 | 373 | 54 |  |
+| `logging` | `src/logging.rs` | 546 | 374 | 172 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 35 | 35 | 0 |  |
 | `pipeline` | `src/pipeline.rs` | 1517 | 1383 | 134 | giant-file |
 | `receipt` | `src/receipt.rs` | 1842 | 1842 | 0 | giant-file |

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -172,7 +172,7 @@ test("timeouts card timeout module marks requested dispatches failed before retr
   const shadowLine = state.logs.info.find((line) => line.startsWith("[timeout_shadow] "));
   assert.ok(shadowLine);
   const shadow = JSON.parse(shadowLine.slice("[timeout_shadow] ".length));
-  assert.equal(shadow.target, "timeout_shadow");
+  assert.equal(shadow.target, "agentdesk::timeout_shadow");
   assert.equal(shadow.card_id, "card-requested-1");
   assert.equal(shadow.section, "_section_A");
   assert.equal(shadow.js_decision, "retry");
@@ -312,7 +312,7 @@ test("timeouts dispatch maintenance shadows failed-dispatch retries without chan
   const shadowLine = state.logs.info.find((line) => line.startsWith("[timeout_shadow] "));
   assert.ok(shadowLine);
   const shadow = JSON.parse(shadowLine.slice("[timeout_shadow] ".length));
-  assert.equal(shadow.target, "timeout_shadow");
+  assert.equal(shadow.target, "agentdesk::timeout_shadow");
   assert.equal(shadow.card_id, "card-retry-1");
   assert.equal(shadow.section, "_section_J");
   assert.equal(shadow.js_decision, "retry");

--- a/policies/lib/timeouts-helpers.js
+++ b/policies/lib/timeouts-helpers.js
@@ -15,6 +15,8 @@ function timeoutReducerDecisionLabel(preview) {
   return preview.resolution || "unknown";
 }
 
+var TIMEOUT_SHADOW_LOG_TARGET = "agentdesk::timeout_shadow";
+
 function emitTimeoutShadowLog(record) {
   try {
     agentdesk.log.info("[timeout_shadow] " + JSON.stringify(record));
@@ -26,7 +28,7 @@ function shadowTimeoutDecision(payload) {
   var section = payload && payload.section ? payload.section : null;
   var jsDecision = payload && payload.js_decision ? payload.js_decision : "unknown";
   var record = {
-    target: "timeout_shadow",
+    target: TIMEOUT_SHADOW_LOG_TARGET,
     card_id: cardId,
     section: section,
     js_decision: jsDecision,

--- a/src/api_caller_observability.rs
+++ b/src/api_caller_observability.rs
@@ -1,6 +1,6 @@
 use axum::http::HeaderMap;
 
-pub const LOG_TARGET: &str = "api_caller_observability";
+pub const LOG_TARGET: &str = "agentdesk::api_caller_observability";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthStrength {

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -28,6 +28,8 @@ mod timeouts_ops;
 pub(crate) mod turn_ops;
 
 pub(crate) use db_ops::execute_policy_sql;
+#[cfg(test)]
+pub(crate) use log_ops::TIMEOUT_SHADOW_LOG_TARGET;
 pub(crate) use review_ops::{ADVANCE_REVIEW_ROUND_HINT_KEY, ensure_js_error_json};
 
 use crate::supervisor::BridgeHandle;

--- a/src/engine/ops/log_ops.rs
+++ b/src/engine/ops/log_ops.rs
@@ -2,6 +2,10 @@ use rquickjs::{Ctx, Function, Object, Result as JsResult};
 
 // ── Log ops ──────────────────────────────────────────────────────
 
+// #4075 review: intentionally outside agentdesk so policy JS logs stay out of production logs until a sensitivity sweep.
+pub(crate) const POLICY_LOG_TARGET: &str = "policy";
+pub(crate) const TIMEOUT_SHADOW_LOG_TARGET: &str = "agentdesk::timeout_shadow";
+const TIMEOUT_SHADOW_LOG_PREFIX: &str = "[timeout_shadow] ";
 pub(super) fn register_log_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let log_obj = Object::new(ctx.clone())?;
@@ -9,31 +13,64 @@ pub(super) fn register_log_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
     log_obj.set(
         "info",
         Function::new(ctx.clone(), |msg: String| {
-            tracing::info!(target: "policy", message = %msg, "policy log");
+            emit_policy_info_log(msg);
         })?,
     )?;
 
     log_obj.set(
         "warn",
         Function::new(ctx.clone(), |msg: String| {
-            tracing::warn!(target: "policy", "{}", msg);
+            tracing::warn!(target: POLICY_LOG_TARGET, "{}", msg);
         })?,
     )?;
 
     log_obj.set(
         "error",
         Function::new(ctx.clone(), |msg: String| {
-            tracing::error!(target: "policy", "{}", msg);
+            tracing::error!(target: POLICY_LOG_TARGET, "{}", msg);
         })?,
     )?;
 
     log_obj.set(
         "debug",
         Function::new(ctx.clone(), |msg: String| {
-            tracing::debug!(target: "policy", "{}", msg);
+            tracing::debug!(target: POLICY_LOG_TARGET, "{}", msg);
         })?,
     )?;
 
     ad.set("log", log_obj)?;
     Ok(())
+}
+
+fn emit_policy_info_log(msg: String) {
+    if policy_info_target(&msg) == TIMEOUT_SHADOW_LOG_TARGET {
+        tracing::info!(target: TIMEOUT_SHADOW_LOG_TARGET, message = %msg, "policy log");
+    } else {
+        tracing::info!(target: POLICY_LOG_TARGET, message = %msg, "policy log");
+    }
+}
+
+fn policy_info_target(msg: &str) -> &'static str {
+    if msg.starts_with(TIMEOUT_SHADOW_LOG_PREFIX) {
+        TIMEOUT_SHADOW_LOG_TARGET
+    } else {
+        POLICY_LOG_TARGET
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_info_uses_bare_target_except_timeout_shadow_prefix() {
+        assert_eq!(
+            policy_info_target("[timeout_shadow] {\"target\":\"agentdesk::timeout_shadow\"}"),
+            TIMEOUT_SHADOW_LOG_TARGET
+        );
+        assert_eq!(
+            policy_info_target("[timeout] ordinary policy log"),
+            "policy"
+        );
+    }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,11 +10,130 @@ use tracing_subscriber::fmt::writer::MakeWriter;
 const DEFAULT_DCSERVER_LOG_MAX_BYTES: u64 = 100 * 1024 * 1024;
 const DEFAULT_DCSERVER_LOG_MAX_FILES: usize = 10;
 
-fn tracing_env_filter() -> Result<EnvFilter> {
+pub(crate) fn tracing_env_filter() -> Result<EnvFilter> {
     let directive = "agentdesk=info"
         .parse()
         .map_err(|error| anyhow::anyhow!("Failed to parse tracing directive: {error}"))?;
     Ok(EnvFilter::from_default_env().add_directive(directive))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use tracing_subscriber::fmt::writer::MakeWriter;
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn tracing_env_filter_with_rust_log_unset() -> EnvFilter {
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var_os("RUST_LOG");
+        remove_rust_log_for_test();
+        let filter = tracing_env_filter().expect("default tracing filter");
+        restore_rust_log_for_test(saved);
+        filter
+    }
+
+    fn remove_rust_log_for_test() {
+        // SAFETY: logging tests serialize this process-wide mutation with ENV_LOCK
+        // and restore the previous value before releasing the lock.
+        unsafe {
+            std::env::remove_var("RUST_LOG");
+        }
+    }
+
+    fn restore_rust_log_for_test(saved: Option<OsString>) {
+        // SAFETY: logging tests serialize this process-wide mutation with ENV_LOCK
+        // and restore the previous value before releasing the lock.
+        unsafe {
+            match saved {
+                Some(value) => std::env::set_var("RUST_LOG", value),
+                None => std::env::remove_var("RUST_LOG"),
+            }
+        }
+    }
+
+    fn capture_logs_with_default_filter<F>(emit: F) -> String
+    where
+        F: FnOnce(),
+    {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(tracing_env_filter_with_rust_log_unset())
+            .with_ansi(false)
+            .without_time()
+            .with_target(true)
+            .with_writer(CapturingWriter {
+                buffer: buffer.clone(),
+            })
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, emit);
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
+
+    #[test]
+    fn default_agentdesk_filter_keeps_observability_targets_and_drops_policy_target() {
+        let logs = capture_logs_with_default_filter(|| {
+            tracing::info!(
+                target: crate::api_caller_observability::LOG_TARGET,
+                "api caller production filter marker"
+            );
+            tracing::info!(
+                target: crate::engine::ops::TIMEOUT_SHADOW_LOG_TARGET,
+                "timeout shadow production filter marker"
+            );
+            tracing::info!(
+                target: "policy",
+                "policy production filter marker"
+            );
+        });
+
+        assert!(
+            logs.contains("api caller production filter marker"),
+            "logs={logs}"
+        );
+        assert!(
+            logs.contains(crate::api_caller_observability::LOG_TARGET),
+            "logs={logs}"
+        );
+        assert!(
+            logs.contains("timeout shadow production filter marker"),
+            "logs={logs}"
+        );
+        assert!(
+            logs.contains(crate::engine::ops::TIMEOUT_SHADOW_LOG_TARGET),
+            "logs={logs}"
+        );
+        assert!(
+            !logs.contains("policy production filter marker"),
+            "logs={logs}"
+        );
+        assert!(!logs.contains("policy"), "logs={logs}");
+    }
 }
 
 fn init_tracing_once() -> Result<()> {


### PR DESCRIPTION
## Summary
- `EnvFilter::from_default_env().add_directive("agentdesk=info")` + unset RUST_LOG dropped every non-agentdesk target — #4038 slice-1 and #3950 slice-1 shipped and produced **zero log lines** in production. This routes exactly the two observability targets through the filter without exposing the JS policy bridge.
- `src/engine/ops/log_ops.rs`: bridge default target stays bare `policy` (dropped); only the `[timeout_shadow] ` prefix routes to `agentdesk::timeout_shadow`
- `src/api_caller_observability.rs`: logs under `agentdesk::api_caller_observability`
- `src/logging.rs`: `tracing_env_filter()` seam + non-vacuous pin (RUST_LOG save/restore) asserting kept/dropped targets

## Review
- Round-1 codex REJECT: full-bridge exposure leaked review content (review-automation.js:553) + 30s heartbeat spam (active-monitor.js:161) → scope narrowed, both sites stay dark
- Round-2 codex PASS (session 019f2ae2-cf2f): checklist 5/5 after reverting an out-of-scope audit-script CLI arg (leftover from an earlier prompt-typo incident)

## Verification
- `python3 scripts/audit_maintainability.py --check` exit 0
- `cargo check --all-targets` clean
- logging pin: 5 passed / policies JS: 35 passed

Closes #4075

🤖 Generated with [Claude Code](https://claude.com/claude-code)