### PR TITLE
fix(discord): #4078 race-loss requeue no longer refires the post-enqueue kick

### DIFF
--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -28,6 +28,10 @@ const IDLE_QUEUE_BACKSTOP_WARN_TARGET: &str = "agentdesk::discord::idle_queue_ba
 static IDLE_QUEUE_BACKSTOP_FIRES_FOR_TESTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+tokio::task_local! {
+    static SUPPRESS_POST_ENQUEUE_IDLE_QUEUE_KICK: bool;
+}
+
 #[cfg(test)]
 type IdleQueueKickHookForTests = std::sync::Arc<
     dyn Fn(
@@ -79,6 +83,75 @@ async fn idle_queue_kick_hook_outcome_for_tests(
         .expect("idle queue kick hook lock")
         .clone();
     hook?(shared, provider, channel_id, reason).await
+}
+
+pub(super) async fn with_post_enqueue_idle_queue_kick_suppressed<F>(future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    SUPPRESS_POST_ENQUEUE_IDLE_QUEUE_KICK
+        .scope(true, future)
+        .await
+}
+
+fn post_enqueue_idle_queue_kick_suppressed() -> bool {
+    SUPPRESS_POST_ENQUEUE_IDLE_QUEUE_KICK
+        .try_with(|suppressed| *suppressed)
+        .unwrap_or(false)
+}
+
+fn race_loss_requeue_snapshot_has_active_holder(snapshot: &ChannelMailboxSnapshot) -> bool {
+    snapshot.cancel_token.is_some()
+        || snapshot.active_request_owner.is_some()
+        || snapshot.active_user_message_id.is_some()
+}
+
+fn race_loss_requeue_snapshot_has_idle_kickable_backlog(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &ChannelMailboxSnapshot,
+) -> bool {
+    !race_loss_requeue_snapshot_has_active_holder(snapshot)
+        && idle_queue_snapshot_has_kickable_backlog(shared, provider, channel_id, snapshot)
+}
+
+pub(super) fn schedule_race_loss_requeue_post_enqueue_idle_recheck(
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+    channel_id: ChannelId,
+) {
+    super::task_supervisor::spawn_observed("race_loss_requeue_idle_recheck", async move {
+        let snapshot = super::mailbox_snapshot(&shared, channel_id).await;
+        if !race_loss_requeue_snapshot_has_idle_kickable_backlog(
+            &shared, &provider, channel_id, &snapshot,
+        ) {
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel_id = channel_id.get(),
+                active_holder = race_loss_requeue_snapshot_has_active_holder(&snapshot),
+                queue_len = snapshot.intervention_queue.len(),
+                "Deferred drain: race-loss requeue post-enqueue recheck found no idle kickable backlog"
+            );
+            return;
+        }
+
+        let outcome = kick_idle_queue_channel_if_context_available(
+            &shared,
+            &provider,
+            channel_id,
+            "race_loss_requeue_idle_recheck",
+        )
+        .await;
+        arm_event_backstop_after_no_start_if_queue_nonempty(
+            &shared,
+            &provider,
+            channel_id,
+            outcome,
+            "race_loss_requeue_idle_recheck",
+        )
+        .await;
+    });
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -198,6 +271,15 @@ pub(super) fn schedule_post_enqueue_idle_queue_kick(
     provider: ProviderKind,
     channel_id: ChannelId,
 ) {
+    if post_enqueue_idle_queue_kick_suppressed() {
+        tracing::debug!(
+            provider = provider.as_str(),
+            channel_id = channel_id.get(),
+            "Deferred drain: suppressed post-enqueue idle snapshot kick for race-loss requeue"
+        );
+        return;
+    }
+
     // #4048 S3 enqueue-then-check closes the lost-wakeup window that remains
     // after subscribe-then-snapshot on the completion listener: a turn can
     // publish/release before this enqueue is durable, so the event listener's
@@ -1235,6 +1317,270 @@ mod presleep_tests {
                 .deferred_hook_channels
                 .contains_key(&channel_id),
             "generic enqueue helper must kick immediately enough to arm the channel backstop without advancing time"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn race_loss_requeue_does_not_rekick_until_holding_turn_completes_4078() {
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_078_200);
+        let holder_msg = MessageId::new(4_078_201);
+        let queued_msg = MessageId::new(4_078_202);
+
+        spawn_turn_completion_idle_queue_listener(shared.clone(), provider.clone());
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            mailbox_try_start_turn_kinded(
+                &shared,
+                channel_id,
+                Arc::new(CancelToken::new()),
+                UserId::new(4_078_201),
+                holder_msg,
+                ActiveTurnKind::Background,
+            )
+            .await,
+            "seed the mailbox-holding background turn"
+        );
+
+        let kick_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |shared, provider, channel, reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    let call = hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let taken = shared
+                        .mailbox(channel)
+                        .take_next_soft(queue_persistence_context(&shared, &provider, channel))
+                        .await;
+                    let intervention = taken
+                        .intervention
+                        .expect("kick should dequeue the queued message");
+                    assert_eq!(intervention.message_id, queued_msg);
+
+                    if call == 0 {
+                        assert_eq!(reason, "post_enqueue_idle_snapshot");
+                        let started = mailbox_try_start_turn(
+                            &shared,
+                            channel,
+                            Arc::new(CancelToken::new()),
+                            intervention.author_id,
+                            intervention.message_id,
+                        )
+                        .await;
+                        assert!(
+                            !started,
+                            "the mailbox holder has not completed, so the dequeued turn loses the race"
+                        );
+                        let requeued_msg = intervention.message_id;
+                        let requeue = with_post_enqueue_idle_queue_kick_suppressed(
+                            mailbox_enqueue_intervention(&shared, &provider, channel, intervention),
+                        )
+                        .await;
+                        assert!(requeue.enqueued, "race-loss path requeues the message");
+                        mailbox_abandon_pending_dispatch(&shared, &provider, channel, requeued_msg)
+                            .await;
+                        schedule_race_loss_requeue_post_enqueue_idle_recheck(
+                            shared.clone(),
+                            provider.clone(),
+                            channel,
+                        );
+                        return Some(IdleQueueKickoffChannelOutcome { started });
+                    }
+
+                    assert_eq!(reason, "turn_completion_event");
+                    let started = mailbox_try_start_turn(
+                        &shared,
+                        channel,
+                        Arc::new(CancelToken::new()),
+                        intervention.author_id,
+                        intervention.message_id,
+                    )
+                    .await;
+                    assert!(
+                        started,
+                        "the completion-event kick must start the requeued message after the holder finishes"
+                    );
+                    Some(IdleQueueKickoffChannelOutcome { started })
+                })
+            },
+        ));
+
+        let enqueue = mailbox_enqueue_intervention(
+            &shared,
+            &provider,
+            channel_id,
+            user_intervention(queued_msg.get(), "queued behind background holder"),
+        )
+        .await;
+        assert!(enqueue.enqueued);
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "fresh enqueue gets the initial post-enqueue kick"
+        );
+
+        tokio::time::advance(
+            DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY + std::time::Duration::from_secs(1),
+        )
+        .await;
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "race-loss requeue must not schedule another immediate/deferred kick while the holder is live"
+        );
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert!(snapshot.cancel_token.is_some());
+        assert_eq!(snapshot.active_user_message_id, Some(holder_msg));
+        assert_eq!(snapshot.intervention_queue.len(), 1);
+        assert_eq!(snapshot.intervention_queue[0].message_id, queued_msg);
+
+        let finish = mailbox_finish_turn(&shared, &provider, channel_id).await;
+        assert!(
+            finish.has_pending,
+            "the holder completion observes the requeued message and publishes the wake edge"
+        );
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "only the holder completion event produces the second kick"
+        );
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert!(snapshot.cancel_token.is_some());
+        assert_eq!(snapshot.active_user_message_id, Some(queued_msg));
+        assert!(
+            snapshot.intervention_queue.is_empty(),
+            "completion-event kick consumes the requeued message"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn race_loss_requeue_idle_recheck_kicks_after_missed_completion_4078() {
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_078_300);
+        let holder_msg = MessageId::new(4_078_301);
+        let queued_msg = MessageId::new(4_078_302);
+
+        spawn_turn_completion_idle_queue_listener(shared.clone(), provider.clone());
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            mailbox_try_start_turn(
+                &shared,
+                channel_id,
+                Arc::new(CancelToken::new()),
+                UserId::new(4_078_301),
+                holder_msg,
+            )
+            .await,
+            "seed the mailbox holder before the missed-completion window"
+        );
+
+        let finish = mailbox_finish_turn(&shared, &provider, channel_id).await;
+        assert!(
+            !finish.has_pending,
+            "holder completion must see the queue empty before the race-loss requeue lands"
+        );
+        yield_backstop_tasks().await;
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "empty completion-event drain must arm no backstop before the requeue"
+        );
+
+        let kick_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |shared, provider, channel, reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    assert_eq!(reason, "race_loss_requeue_idle_recheck");
+                    let taken = shared
+                        .mailbox(channel)
+                        .take_next_soft(queue_persistence_context(&shared, &provider, channel))
+                        .await;
+                    let intervention = taken
+                        .intervention
+                        .expect("idle recheck kick should dequeue the missed race-loss requeue");
+                    assert_eq!(intervention.message_id, queued_msg);
+                    let started = mailbox_try_start_turn(
+                        &shared,
+                        channel,
+                        Arc::new(CancelToken::new()),
+                        intervention.author_id,
+                        intervention.message_id,
+                    )
+                    .await;
+                    assert!(
+                        started,
+                        "the channel is already idle, so the recheck kick must start the queued message"
+                    );
+                    Some(IdleQueueKickoffChannelOutcome { started })
+                })
+            },
+        ));
+
+        let requeue = with_post_enqueue_idle_queue_kick_suppressed(mailbox_enqueue_intervention(
+            &shared,
+            &provider,
+            channel_id,
+            user_intervention(queued_msg.get(), "missed completion race-loss requeue"),
+        ))
+        .await;
+        assert!(requeue.enqueued, "race-loss requeue lands durably");
+        mailbox_abandon_pending_dispatch(&shared, &provider, channel_id, queued_msg).await;
+        schedule_race_loss_requeue_post_enqueue_idle_recheck(
+            shared.clone(),
+            provider.clone(),
+            channel_id,
+        );
+        yield_backstop_tasks().await;
+
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the post-enqueue idle recheck schedules exactly one missed-completion kick"
+        );
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert!(snapshot.cancel_token.is_some());
+        assert_eq!(snapshot.active_user_message_id, Some(queued_msg));
+        assert!(
+            snapshot.intervention_queue.is_empty(),
+            "the recheck kick consumes and starts the requeued message"
+        );
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "a successful recheck kick must not leave a slow backstop armed"
         );
     }
 

--- a/src/services/discord/router/message_handler/intake_turn/race_loss.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss.rs
@@ -1,5 +1,48 @@
 use super::*;
 
+async fn enqueue_race_loss_requeued_intervention(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    user_msg_id: MessageId,
+    intervention: Intervention,
+) -> crate::services::discord::MailboxEnqueueOutcome {
+    let outcome = crate::services::discord::queue_io::with_post_enqueue_idle_queue_kick_suppressed(
+        crate::services::discord::mailbox_enqueue_intervention(
+            shared,
+            provider,
+            channel_id,
+            intervention,
+        ),
+    )
+    .await;
+    if outcome.persistence_error.is_some() {
+        crate::services::discord::mailbox_clear_pending_dispatch_reservation(
+            shared,
+            provider,
+            channel_id,
+            user_msg_id,
+        )
+        .await;
+    } else {
+        crate::services::discord::mailbox_abandon_pending_dispatch(
+            shared,
+            provider,
+            channel_id,
+            user_msg_id,
+        )
+        .await;
+    }
+    if outcome.enqueued && outcome.persistence_error.is_none() {
+        crate::services::discord::queue_io::schedule_race_loss_requeue_post_enqueue_idle_recheck(
+            shared.clone(),
+            provider.clone(),
+            channel_id,
+        );
+    }
+    outcome
+}
+
 /// #3837 decomposition: the start-turn race-loss enqueue path lifted verbatim
 /// from `handle_text_message`. Behavior-preserving — this is the exact body of
 /// the `if !started { ... }` block (mailbox enqueue, queued-placeholder render,
@@ -56,10 +99,11 @@ pub(super) async fn handle_race_loss_enqueue(
     // mapping insert: if the dispatch path has already promoted our
     // intervention into an active turn (with its own fresh card), we
     // delete our orphan POST and skip the mapping insert.
-    let enqueue_outcome = crate::services::discord::mailbox_enqueue_intervention(
+    let enqueue_outcome = enqueue_race_loss_requeued_intervention(
         shared,
         &bot_owner_provider,
         channel_id,
+        user_msg_id,
         build_race_requeued_intervention(
             // #2266: attribute the queued `Intervention` to the original
             // Discord author (the announce bot for voice transcripts) so
@@ -86,59 +130,15 @@ pub(super) async fn handle_race_loss_enqueue(
     )
     .await;
     let enqueued = enqueue_outcome.enqueued;
-    if enqueue_outcome.persistence_error.is_some() {
-        crate::services::discord::mailbox_clear_pending_dispatch_reservation(
-            shared,
-            &bot_owner_provider,
-            channel_id,
-            user_msg_id,
-        )
-        .await;
-    } else {
-        crate::services::discord::mailbox_abandon_pending_dispatch(
-            shared,
-            &bot_owner_provider,
-            channel_id,
-            user_msg_id,
-        )
-        .await;
-    }
 
-    // codex review P1: cover the residual race window where the active
-    // turn finished between `mailbox_try_start_turn` and the enqueue
-    // above. In that case `mailbox_finish_turn` saw an empty queue and
-    // skipped the dequeue chain — schedule a deferred drain so the
-    // intervention we just enqueued does not strand. Round-9: this still
-    // runs first so the deferred kickoff fires even if the placeholder
-    // POST below ends up failing.
-    //
-    // #3903: gate on the BLOCKING (real) active turn, not on *any* active
-    // turn. The previous `mailbox_has_active_turn` skipped this drain
-    // whenever a background SYSTEM-INJECTION turn (e.g. a `/loop`
-    // auto-check) held the slot — but such a turn's finalize does NOT
-    // re-kick the user queue, so a genuine user message re-enqueued here
-    // (it lost the start-turn race to the injection) stranded in the queue
-    // until an external fetch surfaced it (user-message loss → data
-    // integrity). A background turn is non-blocking (#3167), so scheduling
-    // the (idempotent, gated, bounded-retry) drain now lets the drain
-    // supersede the background injection and dispatch the queued user
-    // message as soon as the pane is idle — exactly-once, never doubled
-    // (the dequeue is actor-serialized through `take_next_soft`). When a
-    // REAL turn holds the slot we still skip the drain: that turn's own
-    // finalize owns the dequeue chain (unchanged pre-#3903 behavior).
-    let has_blocking_active_turn =
-        crate::services::discord::mailbox_has_blocking_active_turn(shared, channel_id).await;
-    if super::super::super::intake_gate::should_schedule_post_enqueue_idle_drain(
-        enqueued,
-        has_blocking_active_turn,
-    ) {
-        crate::services::discord::schedule_deferred_idle_queue_kickoff(
-            shared.clone(),
-            bot_owner_provider.clone(),
-            channel_id,
-            "race-loss enqueue idle drain",
-        );
-    }
+    // #4078: this is not a fresh enqueue; it is the same message being returned
+    // after losing a mailbox-start race to a still-live opponent. Scheduling a
+    // blind post-enqueue kick self-feeds KICKOFF -> race-loss -> requeue loops
+    // while that opponent keeps the token. The helper above suppresses the blind
+    // generic kick, clears this lost dispatch reservation, then restores the
+    // enqueue-then-check invariant with a strict post-enqueue snapshot: still-live
+    // holder => stay silent and let its completion event wake us; already-idle
+    // channel => one missed-completion kick.
 
     // If the enqueue was rejected (dedup / duplicate) there is nothing
     // for the dispatch path to pick up. Skip the placeholder POST + the
@@ -580,36 +580,90 @@ pub(super) async fn handle_race_loss_enqueue(
 }
 
 #[cfg(test)]
-mod schedule_post_enqueue_idle_drain_tests {
-    use super::super::super::super::intake_gate::should_schedule_post_enqueue_idle_drain;
+mod race_loss_requeue_tests {
+    use super::*;
 
-    #[test]
-    fn schedules_when_enqueued_and_slot_idle() {
-        // Slot idle (no blocking turn) and the message was enqueued — the
-        // original race-window strand guard must still schedule the drain.
-        assert!(should_schedule_post_enqueue_idle_drain(true, false));
+    struct EnvReset(Option<std::ffi::OsString>);
+
+    impl Drop for EnvReset {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
     }
 
-    #[test]
-    fn schedules_when_enqueued_behind_background_injection() {
-        // #3903 core case: a `/loop`/system-injection turn holds the slot, so
-        // it is NOT a blocking turn. The re-enqueued genuine user message must
-        // still trigger a drain so it is not stranded behind the injection.
-        assert!(should_schedule_post_enqueue_idle_drain(true, false));
+    fn user_intervention(id: u64, text: &str) -> Intervention {
+        Intervention {
+            author_id: UserId::new(id),
+            author_is_bot: false,
+            message_id: MessageId::new(id),
+            source_message_ids: vec![MessageId::new(id)],
+            text: text.to_string(),
+            mode: InterventionMode::Soft,
+            created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
+            pending_uploads: Vec::new(),
+            voice_announcement: None,
+        }
     }
 
-    #[test]
-    fn skips_when_real_turn_holds_slot() {
-        // A real (blocking) turn owns the dequeue chain via its own finalize —
-        // scheduling here would only spin redundantly (pre-#3903 behavior).
-        assert!(!should_schedule_post_enqueue_idle_drain(true, true));
-    }
+    #[tokio::test(flavor = "current_thread")]
+    async fn race_loss_requeue_suppresses_post_enqueue_idle_kick_while_holder_active() {
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
 
-    #[test]
-    fn skips_when_enqueue_was_refused() {
-        // Dedup/duplicate refusal: nothing landed in the queue, so there is
-        // nothing to drain regardless of the slot state.
-        assert!(!should_schedule_post_enqueue_idle_drain(false, false));
-        assert!(!should_schedule_post_enqueue_idle_drain(false, true));
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_078_100);
+        let holder_msg = MessageId::new(4_078_102);
+
+        assert!(
+            crate::services::discord::mailbox_try_start_turn(
+                &shared,
+                channel_id,
+                Arc::new(CancelToken::new()),
+                UserId::new(4_078_102),
+                holder_msg,
+            )
+            .await,
+            "seed the active holder that owns the completion wake edge"
+        );
+
+        let outcome = enqueue_race_loss_requeued_intervention(
+            &shared,
+            &provider,
+            channel_id,
+            MessageId::new(4_078_101),
+            user_intervention(4_078_101, "race loss requeue"),
+        )
+        .await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(outcome.enqueued);
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "race-loss requeue must not arm a post-enqueue kick/backstop"
+        );
+        assert!(
+            !shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id),
+            "race-loss requeue must not arm a post-enqueue kick/backstop"
+        );
+        let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert!(snapshot.cancel_token.is_some());
+        assert_eq!(snapshot.active_user_message_id, Some(holder_msg));
+        assert_eq!(snapshot.intervention_queue.len(), 1);
     }
 }


### PR DESCRIPTION
## Incident
2026-07-04 adk-cc soak (with the #4082 phantom inflight holding the mailbox): enqueued message entered a self-feeding KICKOFF → race-loss → requeue → post-enqueue kick loop, ~4s period, >9 minutes, flapping 📬↔⏳ reactions. Live evidence on issue #4078.

## Fix
1. **Loop break**: race-loss requeue enqueues under a task-local suppression scope — no post-enqueue kick. Completion event (S3 broadcast) + 60s backstop remain the wake edges.
2. **Starvation window** (round-1 review blocker): holder completing before the requeue lands would leave no wake edge. After durable enqueue + pending-dispatch cleanup, a strict idle recheck fires exactly one kick iff there is NO holder evidence (cancel_token/owner/message-id) and backlog is kickable.

## Review (dual, fresh adversarial per round)
- Round-1: REJECT — CONFIRMED starvation in the finish-before-enqueue window
- Round-2: **PASS** — all 5 attack points CONFIRMED closed: actor-ordered visibility (recheck cannot read stale pre-enqueue state), recheck predicate strictly tighter than try_start (no loop regression), recheck not self-suppressed + crash covered by durable restore/startup kickoff, double-kick converges via dispatch reservation, pin simulates the real interleaving (session 019f2b12-e692)

## Verification
- Local battery: queue_io 19 / race_loss 3 / intake_gate 26 / turn_bridge 258 / completion_gate 58 / auto_queue 121 — 0 failed
- `audit_maintainability.py --check` exit 0, `cargo check --all-targets` clean, fmt clean, `mod.rs` untouched

Closes #4078

🤖 Generated with [Claude Code](https://claude.com/claude-code)