### PR TITLE
ci: add routines to the required non-PG test subset (#4072 follow-up)

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -138,6 +138,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
       - name: Fresh user portable smoke
@@ -260,6 +261,7 @@ jobs:
           nice -n 10 cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
       - name: Fresh user portable smoke

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -411,6 +411,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
       - name: sccache stats


### PR DESCRIPTION
## Summary
#4072 (PR #4077) made routines loader tests hermetic with tracked fixtures. This re-adds the `routines` module to the required non-PG test subset — it was previously kept out because fresh clones (no untracked `routines/`) failed the loader tests.

- `.github/workflows/ci-pr.yml`: 1 insertion next to `stall_recovery`
- `.github/workflows/ci-macos-trusted.yml`: 2 insertions (both subset sites)

## Verification
- Fresh worktree (hermetic condition, no untracked routines/): `cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres` → **163 passed, 0 failed**
- This PR's own CI run exercises the added subset lines directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)