### PR TITLE
fix(recap): #4079 idle-recap UX batch — user-perspective suggestions, real prompt preview, compact button, one card per channel

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -927,18 +927,24 @@
     `normalize_transcript_fallback_offset` stays private; below the giant-file
     threshold).
   - `src/services/discord/idle_recap.rs` (idle-recap card compose/post/clear
-    surface; #3479 dropped it below the giant-file threshold by extracting the
-    scrollback/summarizer and token-context-display clusters into the two
-    submodules below, so it is no longer a registered giant — its registry entry
-    and ratchet baseline were removed. Remaining surface: the
-    snapshot/compose/post/clear/CAS lifecycle, the `channel_has_active_turn`
-    mailbox/inflight probe, and the `post_recheck_action` seam that skips/undoes
-    a recap post when a turn raced the compose window).
+    surface; #3479 extracted the scrollback/summarizer and
+    token-context-display clusters into the two submodules below, but #4079's
+    recap UX/lifecycle fixes pushed the file back over the giant-file threshold
+    and its registered ratchet now tracks 1378 prod lines. Remaining surface:
+    the snapshot/compose/post/clear/CAS lifecycle, per-channel recap
+    superseding via `sessions.idle_recap_message_id`, routine-session
+    suppression, the recap button plan including "맥락 압축", the
+    `channel_has_active_turn` mailbox/inflight probe, and the
+    `post_recheck_action` seam that skips/undoes a recap post when a turn raced
+    the compose window. `src/services/discord/idle_recap_interaction.rs` owns
+    the corresponding button dispatch, suggested-reply enqueue, and `/compact`
+    enqueue response copy).
   - `src/services/discord/idle_recap/scrollback.rs` (#3479 scrollback: the tmux
     `capture-pane` tail capture, the `claude-e` transcript-tail fallback
     (`capture_transcript_scrollback` + the unit-testable `extract_transcript_tail_text`
     / `parse_transcript_line_text` workers), and the Haiku `summarize_with_haiku`
-    call — extracted verbatim from `idle_recap.rs`. Deps reached via `use super::*;`;
+    call plus #4079's user-perspective suggested-reply prompt contract. Deps
+    reached via `use super::*;`;
     `capture_tmux_scrollback` / `capture_transcript_scrollback` / `summarize_with_haiku`
     are re-exported by the parent so the `server::routes::idle_recap` caller keeps
     byte-identical `idle_recap::<fn>` call sites, while the parsing workers stay

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -16,7 +16,7 @@
 | `src/server/worker_registry.rs` | 1267 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
 | `src/services/discord/health/recovery.rs` | 2580 | discord-relay | 2026-10-31 | #3839 |
-| `src/services/discord/idle_recap.rs` | 1252 | discord-relay | 2026-08-31 | #3405 |
+| `src/services/discord/idle_recap.rs` | 1373 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/outbound/turn_output_controller.rs` | 1148 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/placeholder_sweeper.rs` | 1014 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/recovery_engine.rs` | 3010 | discord-relay | 2026-10-31 | #3834 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -264,7 +264,7 @@
 | `server::routes::health_api` | `src/server/routes/health_api.rs` | 2355 | 1664 | 691 | giant-file |
 | `server::routes::home_metrics` | `src/server/routes/home_metrics.rs` | 352 | 352 | 0 |  |
 | `server::routes::hooks` | `src/server/routes/hooks.rs` | 129 | 129 | 0 |  |
-| `server::routes::idle_recap` | `src/server/routes/idle_recap.rs` | 357 | 357 | 0 |  |
+| `server::routes::idle_recap` | `src/server/routes/idle_recap.rs` | 405 | 405 | 0 |  |
 | `server::routes::kanban` | `src/server/routes/kanban.rs` | 2788 | 2725 | 63 | giant-file |
 | `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 266 | 266 | 0 |  |
 | `server::routes::maintenance` | `src/server/routes/maintenance.rs` | 17 | 17 | 0 |  |
@@ -466,11 +466,11 @@
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1125 | 497 | 628 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |
-| `services::discord::idle_recap` | `src/services/discord/idle_recap.rs` | 2407 | 1252 | 1155 | giant-file |
+| `services::discord::idle_recap` | `src/services/discord/idle_recap.rs` | 2585 | 1373 | 1212 | giant-file |
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
-| `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 279 | 279 | 0 |  |
-| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 458 | 424 | 34 |  |
+| `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 301 | 287 | 14 |  |
+| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 545 | 494 | 51 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 6436 | 931 | 5505 |  |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 550 | 189 | 361 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -255,7 +255,7 @@
 | `GET` | `/api/sessions` | `agents_crud::list_sessions` | `src/server/routes/agents_crud.rs:1831` | `src/server/routes/domains/agents.rs:51` |
 | `GET` | `/api/sessions/{id}/tmux-output` | `dispatched_sessions::tmux_output` | `src/server/routes/dispatched_sessions.rs:93` | `src/server/routes/domains/ops.rs:203` |
 | `POST` | `/api/sessions/{session_key}/force-kill` | `dispatched_sessions::force_kill_session` | `src/server/routes/dispatched_sessions.rs:109` | `src/server/routes/domains/ops.rs:189` |
-| `POST` | `/api/sessions/{session_key}/idle-recap` | `idle_recap::post_idle_recap` | `src/server/routes/idle_recap.rs:68` | `src/server/routes/domains/ops.rs:197` |
+| `POST` | `/api/sessions/{session_key}/idle-recap` | `idle_recap::post_idle_recap` | `src/server/routes/idle_recap.rs:69` | `src/server/routes/domains/ops.rs:197` |
 | `POST` | `/api/sessions/{session_key}/kill-tmux` | `dispatched_sessions::kill_tmux_session` | `src/server/routes/dispatched_sessions.rs:125` | `src/server/routes/domains/ops.rs:193` |
 | `GET` | `/api/settings` | `settings::get_settings` | `src/server/routes/settings.rs:28` | `src/server/routes/domains/admin.rs:48` |
 | `PUT` | `/api/settings` | `settings::put_settings` | `src/server/routes/settings.rs:38` | `src/server/routes/domains/admin.rs:48` |

--- a/src/server/routes/idle_recap.rs
+++ b/src/server/routes/idle_recap.rs
@@ -13,12 +13,13 @@
 //!      20 s timeout; fall back to a header-only card if it fails).
 //!   5. Re-check whether a turn became active during the (slow) compose
 //!      window (#3146 Part 1, codex clear/post race); if so, SKIP posting.
-//!   6. Otherwise delete the previous recap card for this channel (best
-//!      effort) and post the new one via the provider bot.
+//!   6. Otherwise post the new recap card via the provider bot.
 //!   7. Re-check active-turn ONCE MORE after the POST returns (#3146 Part 1,
 //!      codex R3 P1 — check-then-post TOCTOU). If a turn raced into the
 //!      (step-5 check → step-6 POST) window, UNDO the post: delete the
-//!      just-posted card and do NOT persist its pointer. Otherwise persist.
+//!      just-posted card and do NOT persist its pointer. Otherwise persist with
+//!      a newest-wins conditional swap, then clear any older recap pointer for
+//!      the channel so only the newest card survives overlapping recap jobs.
 //!
 //! Lifecycle hooks live in two places, both now using capture-at-claim +
 //! compare-and-clear (codex R3 P2):
@@ -81,6 +82,9 @@ pub async fn post_idle_recap(
 
     if !snapshot.has_resumable_provider_session() {
         return skip("no resumable provider session");
+    }
+    if snapshot.is_routine_session {
+        return skip("routine session");
     }
 
     let Some(channel_id) = idle_recap::resolve_post_channel(&snapshot) else {
@@ -241,12 +245,6 @@ async fn run_idle_recap_post_job(
         return Ok(());
     }
 
-    if let (Some(prev_msg), Some(prev_chan)) =
-        (snapshot.previous_message_id, snapshot.previous_channel_id)
-    {
-        idle_recap::delete_previous_card(http.as_ref(), prev_chan as u64, prev_msg as u64).await;
-    }
-
     match idle_recap::post_recap_card(http.as_ref(), channel_id, &content, actions).await {
         Ok(message_id) => {
             // #3146 Part 1 (codex R3 P1 — check-then-post TOCTOU): the pre-post
@@ -293,13 +291,13 @@ async fn run_idle_recap_post_job(
             // bumped the generation, so the conditional UPDATE matches 0 rows.
             // The claim's increment and this persist serialize on the same
             // Postgres row, so this CAS is the ATOMIC close of Window 1: if a
-            // claim committed first we delete the just-posted card and skip
-            // persisting (treated like `DeleteAndSkipPersist`; an expected race
-            // outcome, NOT an error — the idle-cycle stamp already deduped this
-            // cycle so it does not re-fire). If the persist committed first, the
-            // claim's relocated post-claim clear sees the just-committed pointer
-            // and removes the card.
-            let rows_affected = match idle_recap::persist_recap_message_id(
+            // claim committed first, or a newer recap card already owns this
+            // session row, we delete the just-posted card and skip persisting
+            // (an expected race outcome, NOT an error — the idle-cycle stamp
+            // already deduped this cycle so it does not re-fire). If the
+            // persist committed first, the claim's relocated post-claim clear
+            // sees the just-committed pointer and removes the card.
+            let persist_result = match idle_recap::persist_recap_message_id(
                 &pool,
                 &session_key,
                 channel_id,
@@ -308,7 +306,7 @@ async fn run_idle_recap_post_job(
             )
             .await
             {
-                Ok(rows) => rows,
+                Ok(result) => result,
                 Err(e) => {
                     // Best-effort: clear the now-orphan card and report. The
                     // stamp at the top still dedupes this cycle.
@@ -316,17 +314,67 @@ async fn run_idle_recap_post_job(
                     return Err(format!("persist: {e}"));
                 }
             };
-            if idle_recap::persist_cas_outcome(rows_affected)
-                == idle_recap::PersistCasOutcome::CasLostDeleteAndSkip
+            let previous_card = match persist_result {
+                idle_recap::PersistRecapMessageIdResult::Persisted { previous_card } => {
+                    previous_card
+                }
+                idle_recap::PersistRecapMessageIdResult::LostDeleteAndSkip => {
+                    idle_recap::delete_previous_card(http.as_ref(), channel_id, message_id).await;
+                    tracing::info!(
+                        session_key = %session_key,
+                        channel_id = channel_id,
+                        message_id = message_id,
+                        "idle_recap: persist lost to a turn claim or newer recap; deleted just-posted card"
+                    );
+                    return Ok(());
+                }
+            };
+            if let Some(previous_card) = previous_card {
+                idle_recap::delete_previous_card(
+                    http.as_ref(),
+                    previous_card.channel_id,
+                    previous_card.message_id,
+                )
+                .await;
+            }
+            match idle_recap::recap_channel_has_newer_card(&pool, channel_id, message_id).await {
+                Ok(true) => {
+                    let _ = idle_recap::clear_recap_pointer(&pool, &session_key, message_id).await;
+                    idle_recap::delete_previous_card(http.as_ref(), channel_id, message_id).await;
+                    tracing::info!(
+                        session_key = %session_key,
+                        channel_id = channel_id,
+                        message_id = message_id,
+                        "idle_recap: deleted just-posted card because a newer recap already owns the channel"
+                    );
+                    return Ok(());
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        session_key = %session_key,
+                        channel_id = channel_id,
+                        message_id = message_id,
+                        error = %error,
+                        "idle_recap: newer-card check failed; keeping just-posted recap"
+                    );
+                }
+            }
+            if let Err(error) = idle_recap::delete_older_recorded_recaps_for_channel(
+                http.as_ref(),
+                &pool,
+                channel_id,
+                message_id,
+            )
+            .await
             {
-                idle_recap::delete_previous_card(http.as_ref(), channel_id, message_id).await;
-                tracing::info!(
+                tracing::warn!(
                     session_key = %session_key,
                     channel_id = channel_id,
                     message_id = message_id,
-                    "idle_recap: turn claimed during persist window (generation CAS lost); deleted just-posted card"
+                    error = %error,
+                    "idle_recap: older channel recap cleanup failed"
                 );
-                return Ok(());
             }
             tracing::info!(
                 session_key = %session_key,

--- a/src/services/discord/idle_recap.rs
+++ b/src/services/discord/idle_recap.rs
@@ -76,6 +76,7 @@ const RECAP_SUMMARY_MODEL: &str = "claude-haiku-4-5-20251001";
 pub(crate) const IDLE_RECAP_CLEAR_BUTTON_PREFIX: &str = "idle_recap:clear:";
 pub(crate) const IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX: &str = "idle_recap:relay_diag:";
 pub(crate) const IDLE_RECAP_SUGGEST_BUTTON_PREFIX: &str = "idle_recap:suggest:";
+pub(crate) const IDLE_RECAP_COMPACT_BUTTON_PREFIX: &str = "idle_recap:compact:";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RecapLiveContextUsage {
@@ -102,8 +103,6 @@ pub(crate) struct RecapSnapshot {
     pub(crate) latest_turn_input_tokens: Option<i64>,
     pub(crate) latest_turn_cache_create_tokens: Option<i64>,
     pub(crate) latest_turn_cache_read_tokens: Option<i64>,
-    pub(crate) previous_message_id: Option<i64>,
-    pub(crate) previous_channel_id: Option<i64>,
     pub(crate) discord_channel_id: Option<String>,
     pub(crate) discord_channel_cc: Option<String>,
     pub(crate) discord_channel_cdx: Option<String>,
@@ -112,6 +111,7 @@ pub(crate) struct RecapSnapshot {
     /// Used as the fallback source for transcript-based scrollback when no
     /// live tmux pane exists (e.g. the `claude-e` per-turn spawn runtime).
     pub(crate) cwd: Option<String>,
+    pub(crate) is_routine_session: bool,
     /// #3148: per-channel turn-generation counter captured at snapshot load.
     /// The persist CAS (`persist_recap_message_id`) folds this into the UPDATE
     /// `WHERE` so a turn claimed during the (multi-second) compose/persist
@@ -150,8 +150,17 @@ pub(crate) async fn load_recap_snapshot(
                 s.claude_session_id,
                 s.raw_provider_session_id,
                 s.cwd,
-                s.idle_recap_message_id,
-                s.idle_recap_channel_id,
+                EXISTS (
+                    SELECT 1
+                    FROM routine_runs rr
+                    WHERE rr.owned_tmux_session = s.session_key
+                       OR EXISTS (
+                            SELECT 1
+                            FROM turns rt
+                            WHERE rt.session_key = s.session_key
+                              AND rt.turn_id = rr.turn_id
+                       )
+                ) AS is_routine_session,
                 s.idle_recap_turn_generation,
                 a.discord_channel_id,
                 a.discord_channel_cc,
@@ -211,8 +220,7 @@ struct RecapSnapshotRow {
     claude_session_id: Option<String>,
     raw_provider_session_id: Option<String>,
     cwd: Option<String>,
-    idle_recap_message_id: Option<i64>,
-    idle_recap_channel_id: Option<i64>,
+    is_routine_session: bool,
     idle_recap_turn_generation: i64,
     discord_channel_id: Option<String>,
     discord_channel_cc: Option<String>,
@@ -246,14 +254,13 @@ impl RecapSnapshotRow {
             latest_turn_input_tokens: self.latest_turn_input_tokens,
             latest_turn_cache_create_tokens: self.latest_turn_cache_create_tokens,
             latest_turn_cache_read_tokens: self.latest_turn_cache_read_tokens,
-            previous_message_id: self.idle_recap_message_id,
-            previous_channel_id: self.idle_recap_channel_id,
             idle_recap_turn_generation: self.idle_recap_turn_generation,
             discord_channel_id: self.discord_channel_id,
             discord_channel_cc: self.discord_channel_cc,
             discord_channel_cdx: self.discord_channel_cdx,
             discord_channel_alt: self.discord_channel_alt,
             cwd: self.cwd,
+            is_routine_session: self.is_routine_session,
         }
     }
 }
@@ -551,8 +558,7 @@ fn compose_recap_header(snapshot: &RecapSnapshot, relay_status: RelayIntegritySt
         RecapContextDisplay::Unknown => "context unknown".to_string(),
     };
     format!(
-        "📦 응답 완료 · {state_label}\n세션: {provider_label} · {context_label} · idle {idle_since} · {}",
-        relay_status.label()
+        "📦 응답 완료 · {state_label}\n세션: {provider_label} · {context_label} · idle {idle_since}"
     )
 }
 
@@ -614,6 +620,7 @@ pub(crate) async fn post_recap_card(
 pub(crate) struct RecapCardActions {
     pub(crate) relay_investigate: bool,
     pub(crate) suggested_reply: bool,
+    pub(crate) context_compact: bool,
 }
 
 impl RecapCardActions {
@@ -627,6 +634,7 @@ impl RecapCardActions {
                 .and_then(|output| output.suggested_reply.as_deref())
                 .and_then(sanitize_recap_line)
                 .is_some(),
+            context_compact: true,
         }
     }
 }
@@ -634,12 +642,16 @@ impl RecapCardActions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RecapButtonKind {
     ClearSession,
+    ContextCompact,
     RelayInvestigate,
     SendSuggestedReply,
 }
 
 fn recap_button_plan(actions: RecapCardActions) -> Vec<RecapButtonKind> {
     let mut plan = vec![RecapButtonKind::ClearSession];
+    if actions.context_compact {
+        plan.push(RecapButtonKind::ContextCompact);
+    }
     if actions.relay_investigate {
         plan.push(RecapButtonKind::RelayInvestigate);
     }
@@ -665,6 +677,11 @@ fn recap_button(kind: RecapButtonKind, message_id_suffix: &str) -> CreateButton 
         RecapButtonKind::ClearSession => (
             IDLE_RECAP_CLEAR_BUTTON_PREFIX,
             "새 세션 시작",
+            ButtonStyle::Secondary,
+        ),
+        RecapButtonKind::ContextCompact => (
+            IDLE_RECAP_COMPACT_BUTTON_PREFIX,
+            "맥락 압축",
             ButtonStyle::Secondary,
         ),
         RecapButtonKind::RelayInvestigate => (
@@ -751,6 +768,105 @@ pub(crate) async fn delete_previous_card(http: &serenity::Http, channel_id: u64,
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecordedRecapCard {
+    pub(crate) session_key: String,
+    pub(crate) channel_id: u64,
+    pub(crate) message_id: u64,
+}
+
+pub(crate) async fn lookup_recorded_recaps_for_channel(
+    pool: &PgPool,
+    channel_id: u64,
+) -> Result<Vec<RecordedRecapCard>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, i64, i64)>(
+        "SELECT session_key, idle_recap_channel_id, idle_recap_message_id
+         FROM sessions
+         WHERE idle_recap_channel_id = $1
+           AND idle_recap_message_id IS NOT NULL
+         ORDER BY idle_recap_message_id DESC",
+    )
+    .bind(channel_id as i64)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|(session_key, channel_id, message_id)| {
+            Some(RecordedRecapCard {
+                session_key,
+                channel_id: u64::try_from(channel_id).ok()?,
+                message_id: u64::try_from(message_id).ok()?,
+            })
+        })
+        .collect())
+}
+
+pub(crate) async fn delete_older_recorded_recaps_for_channel(
+    http: &serenity::Http,
+    pool: &PgPool,
+    channel_id: u64,
+    current_message_id: u64,
+) -> Result<(), sqlx::Error> {
+    let cards = lookup_recorded_recaps_for_channel(pool, channel_id)
+        .await?
+        .into_iter()
+        .filter(|card| recap_card_should_be_superseded(card.message_id, current_message_id))
+        .collect();
+    delete_recorded_recap_cards(http, pool, cards).await;
+    Ok(())
+}
+
+async fn delete_recorded_recap_cards(
+    http: &serenity::Http,
+    pool: &PgPool,
+    cards: Vec<RecordedRecapCard>,
+) {
+    for card in cards {
+        delete_previous_card(http, card.channel_id, card.message_id).await;
+        if let Err(error) = clear_recap_pointer(pool, &card.session_key, card.message_id).await {
+            tracing::warn!(
+                error = %error,
+                session_key = %card.session_key,
+                channel_id = card.channel_id,
+                message_id = card.message_id,
+                "idle_recap: failed to clear superseded recap pointer"
+            );
+        }
+    }
+}
+
+pub(crate) async fn recap_channel_has_newer_card(
+    pool: &PgPool,
+    channel_id: u64,
+    message_id: u64,
+) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM sessions
+            WHERE idle_recap_channel_id = $1
+              AND idle_recap_message_id IS NOT NULL
+              AND idle_recap_message_id > $2
+         )",
+    )
+    .bind(channel_id as i64)
+    .bind(message_id as i64)
+    .fetch_one(pool)
+    .await
+}
+
+fn recap_card_should_be_superseded(candidate_message_id: u64, current_message_id: u64) -> bool {
+    candidate_message_id < current_message_id
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PersistRecapMessageIdResult {
+    Persisted {
+        previous_card: Option<RecordedRecapCard>,
+    },
+    LostDeleteAndSkip,
+}
+
 /// Persist the freshly-posted message id (and the channel it lives in) so
 /// the next cycle can delete it and `message_handler` can clear it the
 /// moment the user sends their next turn.
@@ -763,30 +879,63 @@ pub(crate) async fn delete_previous_card(http: &serenity::Http, channel_id: u64,
 /// UPDATEs serialize on the Postgres row, so if a claim committed first this
 /// CAS matches 0 rows and the caller deletes the just-posted card instead of
 /// stamping it over the now-active turn (closing Window 1 atomically). Returns
-/// the number of rows affected: `1` = card persisted, `0` = CAS lost (a turn
-/// raced in).
+/// `LostDeleteAndSkip` when the generation CAS lost or this session already
+/// points at a newer recap card.
 pub(crate) async fn persist_recap_message_id(
     pool: &PgPool,
     session_key: &str,
     channel_id: u64,
     message_id: u64,
     captured_generation: i64,
-) -> Result<u64, sqlx::Error> {
-    sqlx::query(
-        "UPDATE sessions
-         SET idle_recap_message_id = $1,
-             idle_recap_channel_id = $2,
-             idle_recap_posted_at  = NOW()
-         WHERE session_key = $3
-           AND idle_recap_turn_generation = $4",
+) -> Result<PersistRecapMessageIdResult, sqlx::Error> {
+    let previous = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+        "WITH current AS (
+             SELECT session_key,
+                    idle_recap_message_id AS previous_message_id,
+                    idle_recap_channel_id AS previous_channel_id
+             FROM sessions
+             WHERE session_key = $3
+               AND idle_recap_turn_generation = $4
+               AND (
+                    idle_recap_message_id IS NULL
+                    OR idle_recap_message_id < $1
+               )
+             FOR UPDATE
+         ),
+         updated AS (
+             UPDATE sessions AS s
+             SET idle_recap_message_id = $1,
+                 idle_recap_channel_id = $2,
+                 idle_recap_posted_at  = NOW()
+             FROM current
+             WHERE s.session_key = current.session_key
+             RETURNING current.previous_message_id, current.previous_channel_id
+         )
+         SELECT previous_message_id, previous_channel_id
+         FROM updated",
     )
     .bind(message_id as i64)
     .bind(channel_id as i64)
     .bind(session_key)
     .bind(captured_generation)
-    .execute(pool)
-    .await
-    .map(|result| result.rows_affected())
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((previous_message_id, previous_channel_id)) = previous else {
+        return Ok(PersistRecapMessageIdResult::LostDeleteAndSkip);
+    };
+
+    let previous_card =
+        previous_message_id
+            .zip(previous_channel_id)
+            .and_then(|(message_id, channel_id)| {
+                Some(RecordedRecapCard {
+                    session_key: session_key.to_string(),
+                    channel_id: u64::try_from(channel_id).ok()?,
+                    message_id: u64::try_from(message_id).ok()?,
+                })
+            });
+    Ok(PersistRecapMessageIdResult::Persisted { previous_card })
 }
 
 /// #3148 / #3158: which row(s) a turn-claim bump targets.
@@ -1222,34 +1371,6 @@ pub(crate) fn post_recheck_action(active_turn_after_post: bool) -> PostRecheckAc
     }
 }
 
-/// #3148: what the post job does with the result of the conditional persist
-/// (`persist_recap_message_id`, which folds the turn-generation CAS into its
-/// `WHERE`). This is the atomic close of Window 1: a turn that claims in the
-/// post-recheck→persist gap bumps the generation, the persist matches 0 rows,
-/// and we treat the card the same as the `DeleteAndSkipPersist` path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PersistCasOutcome {
-    /// `rows_affected == 1`: the generation was unchanged, the pointer is now
-    /// persisted, log success.
-    Persisted,
-    /// `rows_affected == 0`: a turn claimed during the persist window and
-    /// bumped the generation, so the CAS lost. Delete the just-posted card and
-    /// skip persisting (an expected race outcome, NOT an error — the idle-cycle
-    /// stamp already deduped this cycle so it does not re-fire).
-    CasLostDeleteAndSkip,
-}
-
-/// Pure decision seam mapping the persist CAS `rows_affected` to the post job's
-/// action, so the "0 rows ⇒ delete + skip" branch is unit-testable without a
-/// live Postgres.
-pub(crate) fn persist_cas_outcome(rows_affected: u64) -> PersistCasOutcome {
-    if rows_affected == 0 {
-        PersistCasOutcome::CasLostDeleteAndSkip
-    } else {
-        PersistCasOutcome::Persisted
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1490,14 +1611,13 @@ mod tests {
             latest_turn_input_tokens: None,
             latest_turn_cache_create_tokens: None,
             latest_turn_cache_read_tokens: None,
-            previous_message_id: None,
-            previous_channel_id: None,
             idle_recap_turn_generation: 0,
             discord_channel_id: None,
             discord_channel_cc: None,
             discord_channel_cdx: Some("1506295335096549406".to_string()),
             discord_channel_alt: None,
             cwd: None,
+            is_routine_session: false,
         }
     }
 
@@ -1629,7 +1749,10 @@ mod tests {
         };
         let ok = relay_probe_with(RelayIntegrityStatus::Ok);
         let content = compose_recap_text(&snapshot, Some(&composer), &ok);
-        assert!(content.contains("relay OK"));
+        assert!(!content.contains("relay OK"));
+        let header = compose_recap_header(&snapshot, RelayIntegrityStatus::Ok);
+        assert_eq!(header.lines().count(), 2);
+        assert!(!header.contains("relay OK"));
         // Labelled blocks on their own lines for legibility (the summary and the
         // suggested reply are separated by blank lines, not crammed together).
         assert!(content.contains("> 📝 **요약**\n> 작업 요약"));
@@ -1665,14 +1788,14 @@ mod tests {
             &relay_probe_with(RelayIntegrityStatus::Suspect),
         );
         assert!(suspect.contains("릴레이 누락 의심"));
-        assert!(suspect.contains("relay suspect"));
+        assert!(!suspect.contains("relay suspect"));
 
         let unknown = compose_recap_text(
             &snapshot,
             Some(&composer),
             &relay_probe_with(RelayIntegrityStatus::Unknown),
         );
-        assert!(unknown.contains("relay unknown"));
+        assert!(!unknown.contains("relay unknown"));
     }
 
     #[test]
@@ -1689,6 +1812,7 @@ mod tests {
             recap_button_plan(normal),
             vec![
                 RecapButtonKind::ClearSession,
+                RecapButtonKind::ContextCompact,
                 RecapButtonKind::SendSuggestedReply
             ]
         );
@@ -1701,6 +1825,7 @@ mod tests {
             recap_button_plan(suspect),
             vec![
                 RecapButtonKind::ClearSession,
+                RecapButtonKind::ContextCompact,
                 RecapButtonKind::RelayInvestigate,
                 RecapButtonKind::SendSuggestedReply
             ]
@@ -1714,6 +1839,7 @@ mod tests {
             recap_button_plan(unknown),
             vec![
                 RecapButtonKind::ClearSession,
+                RecapButtonKind::ContextCompact,
                 RecapButtonKind::SendSuggestedReply
             ]
         );
@@ -1726,11 +1852,19 @@ mod tests {
             recap_button_plan(no_suggestion),
             vec![
                 RecapButtonKind::ClearSession,
+                RecapButtonKind::ContextCompact,
                 RecapButtonKind::RelayInvestigate
             ]
         );
-        assert!(recap_button_plan(suspect).len() <= 3);
-        assert!(recap_button_plan(normal).len() <= 2);
+        assert!(recap_button_plan(suspect).len() <= 4);
+        assert!(recap_button_plan(normal).len() <= 3);
+    }
+
+    #[test]
+    fn recap_supersedes_only_older_channel_cards() {
+        assert!(recap_card_should_be_superseded(99, 100));
+        assert!(!recap_card_should_be_superseded(100, 100));
+        assert!(!recap_card_should_be_superseded(101, 100));
     }
 
     #[test]
@@ -2069,62 +2203,58 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // #3148 (per-channel turn-generation CAS): the persist folds a
-    // compare-and-swap on the generation captured at snapshot load. A turn
-    // claimed in the post-recheck→persist gap (residual Window 1) bumps the
-    // generation, so the conditional UPDATE matches 0 rows and the just-posted
-    // card is deleted instead of stamped over the now-active turn.
+    // #3148 / #4079 persist swap: the persist folds a compare-and-swap on the
+    // generation captured at snapshot load AND a newest-wins message pointer
+    // guard. A losing persist deletes only its just-posted card.
     // ---------------------------------------------------------------
 
-    /// Pure decision seam: `rows_affected == 0` (CAS lost — a turn claimed in
-    /// the persist window and bumped the generation) → delete the just-posted
-    /// card and skip persist; `rows_affected == 1` → persisted.
-    #[test]
-    fn persist_cas_outcome_skips_when_generation_bumped_persists_otherwise() {
-        assert_eq!(
-            persist_cas_outcome(0),
-            PersistCasOutcome::CasLostDeleteAndSkip,
-            "0 rows ⇒ a turn claimed during the persist window bumped the generation ⇒ delete+skip"
-        );
-        assert_eq!(
-            persist_cas_outcome(1),
-            PersistCasOutcome::Persisted,
-            "1 row ⇒ generation unchanged ⇒ card persisted"
-        );
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum PersistModelOutcome {
+        Persisted,
+        LostDeleteAndSkip,
+    }
+
+    fn model_persist_recap_pointer(
+        pointer: &mut Option<u64>,
+        captured_generation: i64,
+        current_generation: i64,
+        own_message_id: u64,
+    ) -> PersistModelOutcome {
+        if captured_generation == current_generation
+            && pointer.is_none_or(|current_message_id| current_message_id < own_message_id)
+        {
+            *pointer = Some(own_message_id);
+            PersistModelOutcome::Persisted
+        } else {
+            PersistModelOutcome::LostDeleteAndSkip
+        }
     }
 
     /// Interleaving (Window 1): the recap job captures generation `G` at
     /// snapshot load; a turn claims between capture and persist, bumping the
-    /// row's generation to `G+1`. The persist's `... AND
-    /// idle_recap_turn_generation = G` then matches 0 rows. This models that
-    /// conditional UPDATE purely: the persist succeeds only when the captured
-    /// generation still equals the row's CURRENT generation. The post job must
-    /// then DELETE the just-posted card and NOT persist it.
+    /// row's generation to `G+1`. The persist's generation guard then matches 0
+    /// rows. The post job must DELETE the just-posted card and NOT persist it.
     #[tokio::test]
-    async fn persist_cas_noop_when_turn_claimed_between_capture_and_persist() {
-        // The recap job captured this at snapshot load (~20s before persist).
+    async fn persist_swap_noop_when_turn_claimed_between_capture_and_persist() {
         let captured_generation: i64 = 7;
-        // A turn claimed in the compose/persist window and bumped the row.
         let row_generation_now: i64 = 8;
-
-        // Model the conditional persist UPDATE's row count: 1 iff the captured
-        // generation still matches the row's current generation, else 0.
-        let rows_affected: u64 = if captured_generation == row_generation_now {
-            1
-        } else {
-            0
-        };
+        let mut pointer = None;
 
         let deleted: Rc<RefCell<Vec<(u64, u64)>>> = Rc::new(RefCell::new(Vec::new()));
         let persisted: Rc<RefCell<Vec<(u64, u64)>>> = Rc::new(RefCell::new(Vec::new()));
         let channel_id = 4242u64;
         let posted_message_id = 9090u64;
 
-        match persist_cas_outcome(rows_affected) {
-            PersistCasOutcome::CasLostDeleteAndSkip => {
+        match model_persist_recap_pointer(
+            &mut pointer,
+            captured_generation,
+            row_generation_now,
+            posted_message_id,
+        ) {
+            PersistModelOutcome::LostDeleteAndSkip => {
                 deleted.borrow_mut().push((channel_id, posted_message_id));
             }
-            PersistCasOutcome::Persisted => {
+            PersistModelOutcome::Persisted => {
                 persisted.borrow_mut().push((channel_id, posted_message_id));
             }
         }
@@ -2132,50 +2262,98 @@ mod tests {
         assert_eq!(
             deleted.borrow().as_slice(),
             &[(channel_id, posted_message_id)],
-            "a turn claimed in the persist window bumped the generation ⇒ card deleted, not persisted"
+            "a turn claimed in the persist window bumped the generation => card deleted, not persisted"
         );
         assert!(
             persisted.borrow().is_empty(),
-            "the card must NOT be persisted over the now-active turn (Window 1 closed by the CAS)"
+            "the card must NOT be persisted over the now-active turn"
         );
+        assert_eq!(pointer, None);
     }
 
-    /// Positive control: no claim raced in, so the captured generation still
-    /// equals the row's current generation → persist succeeds (1 row), the card
-    /// is persisted, nothing deleted. Guards against a false-skip on a genuinely
-    /// idle channel.
+    /// Positive control: no claim raced in and no newer recap exists, so the
+    /// captured generation still equals the row's current generation and the
+    /// pointer is empty. Persist succeeds and nothing is deleted.
     #[tokio::test]
-    async fn persist_cas_persists_when_generation_unchanged() {
+    async fn persist_swap_persists_when_generation_unchanged_and_no_newer_card() {
         let captured_generation: i64 = 3;
         let row_generation_now: i64 = 3;
-        let rows_affected: u64 = if captured_generation == row_generation_now {
-            1
-        } else {
-            0
-        };
+        let mut pointer = None;
 
         let deleted: Rc<RefCell<Vec<(u64, u64)>>> = Rc::new(RefCell::new(Vec::new()));
         let persisted: Rc<RefCell<Vec<(u64, u64)>>> = Rc::new(RefCell::new(Vec::new()));
         let channel_id = 555u64;
         let posted_message_id = 6161u64;
 
-        match persist_cas_outcome(rows_affected) {
-            PersistCasOutcome::CasLostDeleteAndSkip => {
+        match model_persist_recap_pointer(
+            &mut pointer,
+            captured_generation,
+            row_generation_now,
+            posted_message_id,
+        ) {
+            PersistModelOutcome::LostDeleteAndSkip => {
                 deleted.borrow_mut().push((channel_id, posted_message_id));
             }
-            PersistCasOutcome::Persisted => {
+            PersistModelOutcome::Persisted => {
                 persisted.borrow_mut().push((channel_id, posted_message_id));
             }
         }
 
         assert!(
             deleted.borrow().is_empty(),
-            "no false-skip on a genuinely idle channel: nothing deleted when generation unchanged"
+            "no false-skip on a genuinely idle channel"
         );
         assert_eq!(
             persisted.borrow().as_slice(),
             &[(channel_id, posted_message_id)],
-            "the card is persisted when no turn claimed during the persist window"
+            "the card is persisted when no turn claimed and no newer recap exists"
+        );
+        assert_eq!(pointer, Some(posted_message_id));
+    }
+
+    #[test]
+    fn concurrent_same_session_recap_persist_keeps_newer_card_when_older_persists_later() {
+        let channel_id = 777u64;
+        let generation = 4i64;
+        let older_message_id = 100u64;
+        let newer_message_id = 101u64;
+        let mut pointer = None;
+        let visible_cards: Rc<RefCell<Vec<(u64, u64)>>> = Rc::new(RefCell::new(vec![
+            (channel_id, older_message_id),
+            (channel_id, newer_message_id),
+        ]));
+        let deleted: Rc<RefCell<Vec<(u64, u64)>>> = Rc::new(RefCell::new(Vec::new()));
+
+        assert_eq!(
+            model_persist_recap_pointer(&mut pointer, generation, generation, newer_message_id),
+            PersistModelOutcome::Persisted,
+            "job B persists the newer snowflake first"
+        );
+        assert_eq!(pointer, Some(newer_message_id));
+
+        if model_persist_recap_pointer(&mut pointer, generation, generation, older_message_id)
+            == PersistModelOutcome::LostDeleteAndSkip
+        {
+            visible_cards
+                .borrow_mut()
+                .retain(|card| *card != (channel_id, older_message_id));
+            deleted.borrow_mut().push((channel_id, older_message_id));
+        }
+
+        assert_eq!(
+            pointer,
+            Some(newer_message_id),
+            "the older late persist must not overwrite the newer pointer"
+        );
+        assert_eq!(
+            visible_cards.borrow().as_slice(),
+            &[(channel_id, newer_message_id)],
+            "exactly one visible recap card remains"
+        );
+        assert_eq!(
+            deleted.borrow().as_slice(),
+            &[(channel_id, older_message_id)],
+            "the late older job deletes its own just-posted card"
         );
     }
 

--- a/src/services/discord/idle_recap/scrollback.rs
+++ b/src/services/discord/idle_recap/scrollback.rs
@@ -164,17 +164,7 @@ pub(crate) async fn compose_with_haiku(scrollback: &str) -> Option<RecapComposer
     if scrollback.is_empty() {
         return None;
     }
-    let prompt = format!(
-        "다음은 AI 코딩 에이전트와 사용자의 마지막 대화 ~100줄입니다. \
-         사용자가 지금 다시 돌아왔을 때 \"어떤 작업을 하던 중이었는지\"를 \
-         즉시 기억할 수 있도록 1-2문장으로 한국어 요약을 만드세요. \
-         이어서 보낼 만한 사용자 답변이 명확할 때만 suggested_reply를 한 개 제안하세요. \
-         도구 호출 / 스크롤 / 진행 표시 같은 노이즈는 무시하고 \
-         실제 작업 내용(파일·결정·다음 단계)에 집중하세요. \
-         반드시 JSON 객체 하나만 출력하세요. 형식: \
-         {{\"summary\":\"...\",\"suggested_reply\":\"...\"}}. \
-         suggested_reply가 없으면 null로 두세요.\n\n---\n\n{scrollback}",
-    );
+    let prompt = recap_composer_prompt(scrollback);
 
     let cancel = std::sync::Arc::new(CancelToken::new());
     let cancel_for_blocking = cancel.clone();
@@ -202,6 +192,23 @@ pub(crate) async fn compose_with_haiku(scrollback: &str) -> Option<RecapComposer
     };
 
     parse_recap_composer_output(&result)
+}
+
+fn recap_composer_prompt(scrollback: &str) -> String {
+    format!(
+        "다음은 AI 코딩 에이전트와 사용자의 마지막 대화 ~100줄입니다. \
+         사용자가 지금 다시 돌아왔을 때 \"어떤 작업을 하던 중이었는지\"를 \
+         즉시 기억할 수 있도록 1-2문장으로 한국어 요약을 만드세요. \
+         이어서 보낼 만한 사용자 답변이 명확할 때만 suggested_reply를 한 개 제안하세요. \
+         suggested_reply는 에이전트가 말할 문장이 아니라 사용자가 다음에 직접 입력할 \
+         요청/지시/질문이어야 합니다. \"진행하겠습니다\", \"확인했습니다\" 같은 \
+         에이전트 관점의 응답은 쓰지 말고, \"테스트 계속 진행해줘\"처럼 사용자 관점으로 쓰세요. \
+         도구 호출 / 스크롤 / 진행 표시 같은 노이즈는 무시하고 \
+         실제 작업 내용(파일·결정·다음 단계)에 집중하세요. \
+         반드시 JSON 객체 하나만 출력하세요. 형식: \
+         {{\"summary\":\"...\",\"suggested_reply\":\"...\"}}. \
+         suggested_reply가 없으면 null로 두세요.\n\n---\n\n{scrollback}",
+    )
 }
 
 /// Backward-compatible summary-only wrapper for any local callers that still
@@ -275,5 +282,20 @@ fn first_suggested_reply_value(value: &serde_json::Value) -> Option<&str> {
         serde_json::Value::Array(items) => items.iter().find_map(|item| item.as_str()),
         serde_json::Value::Null => None,
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recap_composer_prompt_requires_user_perspective_suggestion() {
+        let prompt = recap_composer_prompt("[user] 다음 단계 알려줘");
+
+        assert!(prompt.contains("사용자가 다음에 직접 입력할"));
+        assert!(prompt.contains("에이전트 관점의 응답은 쓰지 말고"));
+        assert!(prompt.contains("테스트 계속 진행해줘"));
+        assert!(prompt.contains("[user] 다음 단계 알려줘"));
     }
 }

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -10,8 +10,9 @@ use sqlx::PgPool;
 
 use super::{Data, Error, check_auth};
 use crate::services::discord::idle_recap::{
-    IDLE_RECAP_CLEAR_BUTTON_PREFIX, IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX,
-    IDLE_RECAP_SUGGEST_BUTTON_PREFIX, clear_recap_pointer, delete_previous_card,
+    IDLE_RECAP_CLEAR_BUTTON_PREFIX, IDLE_RECAP_COMPACT_BUTTON_PREFIX,
+    IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX, IDLE_RECAP_SUGGEST_BUTTON_PREFIX, clear_recap_pointer,
+    delete_previous_card,
 };
 use crate::services::provider::ProviderKind;
 
@@ -29,6 +30,7 @@ pub(super) fn is_idle_recap_clear_custom_id(custom_id: &str) -> bool {
 
 pub(super) fn is_idle_recap_custom_id(custom_id: &str) -> bool {
     is_idle_recap_clear_custom_id(custom_id)
+        || custom_id.starts_with(IDLE_RECAP_COMPACT_BUTTON_PREFIX)
         || custom_id.starts_with(IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX)
         || custom_id.starts_with(IDLE_RECAP_SUGGEST_BUTTON_PREFIX)
 }
@@ -44,6 +46,9 @@ pub(super) async fn handle_idle_recap_interaction(
     }
     if custom_id.starts_with(IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX) {
         return handle_idle_recap_relay_diag_interaction(ctx, component, data).await;
+    }
+    if custom_id.starts_with(IDLE_RECAP_COMPACT_BUTTON_PREFIX) {
+        return handle_idle_recap_compact_interaction(ctx, component, data).await;
     }
     if custom_id.starts_with(IDLE_RECAP_SUGGEST_BUTTON_PREFIX) {
         return handle_idle_recap_suggest_interaction(ctx, component, data).await;
@@ -249,6 +254,65 @@ async fn handle_idle_recap_relay_diag_interaction(
     Ok(())
 }
 
+async fn handle_idle_recap_compact_interaction(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    data: &Data,
+) -> Result<(), Error> {
+    if !authorize_component(ctx, component, data).await {
+        return Ok(());
+    }
+
+    let Some(message_id) =
+        parse_message_id(&component.data.custom_id, IDLE_RECAP_COMPACT_BUTTON_PREFIX)
+    else {
+        let _ = component
+            .create_response(ctx, serenity::CreateInteractionResponse::Acknowledge)
+            .await;
+        return Ok(());
+    };
+    let Some(pool) = data.shared.pg_pool.as_ref().cloned() else {
+        send_ephemeral(ctx, component, "맥락 압축 요청 실패: DB 연결 없음.").await;
+        return Ok(());
+    };
+    let Some(target) = lookup_current_recap_target(
+        &pool,
+        message_id,
+        component.channel_id.get(),
+        data.provider.as_str(),
+    )
+    .await?
+    else {
+        send_ephemeral(
+            ctx,
+            component,
+            "맥락 압축 대상이 더 이상 유효하지 않습니다.",
+        )
+        .await;
+        return Ok(());
+    };
+
+    let prompt = "/compact";
+    let enqueued = crate::services::discord::enqueue_internal_followup(
+        &data.shared,
+        &data.provider,
+        component.channel_id,
+        serenity::MessageId::new(message_id),
+        prompt,
+        "idle recap context compact",
+    )
+    .await;
+    if !enqueued {
+        send_ephemeral(ctx, component, "맥락 압축 요청을 큐에 넣지 못했습니다.").await;
+        return Ok(());
+    }
+
+    send_ephemeral(ctx, component, &prompt_sent_ephemeral(prompt)).await;
+    let _ = clear_recap_pointer(&pool, &target.session_key, message_id).await;
+    delete_previous_card(&ctx.http, component.channel_id.get(), message_id).await;
+    Ok(())
+}
+
 async fn handle_idle_recap_suggest_interaction(
     ctx: &serenity::Context,
     component: &serenity::ComponentInteraction,
@@ -274,6 +338,7 @@ async fn handle_idle_recap_suggest_interaction(
         send_ephemeral(ctx, component, "추천 답변을 찾을 수 없습니다.").await;
         return Ok(());
     };
+    let prompt_text = suggested_reply.clone();
     let Some(pool) = data.shared.pg_pool.as_ref().cloned() else {
         send_ephemeral(ctx, component, "추천 답변 전송 실패: DB 연결 없음.").await;
         return Ok(());
@@ -309,7 +374,7 @@ async fn handle_idle_recap_suggest_interaction(
         return Ok(());
     }
 
-    send_ephemeral(ctx, component, "추천 답변을 큐에 넣었습니다.").await;
+    send_ephemeral(ctx, component, &prompt_sent_ephemeral(&prompt_text)).await;
     let _ = clear_recap_pointer(&pool, &target.session_key, message_id).await;
     delete_previous_card(&ctx.http, component.channel_id.get(), message_id).await;
     Ok(())
@@ -366,6 +431,11 @@ fn truncate_interaction_body(body: &str) -> String {
         out.push('…');
     }
     out
+}
+
+fn prompt_sent_ephemeral(prompt: &str) -> String {
+    let prompt = truncate_interaction_body(prompt);
+    format!("다음 프롬프트를 보냈습니다:\n> {prompt}")
 }
 
 fn parse_message_id(custom_id: &str, prefix: &str) -> Option<u64> {
@@ -430,6 +500,7 @@ mod tests {
     fn idle_recap_component_router_accepts_all_recap_actions() {
         assert!(is_idle_recap_custom_id("idle_recap:clear:1"));
         assert!(is_idle_recap_custom_id("idle_recap:relay_diag:1"));
+        assert!(is_idle_recap_custom_id("idle_recap:compact:1"));
         assert!(is_idle_recap_custom_id("idle_recap:suggest:1"));
         assert!(!is_idle_recap_custom_id("steer:cancel:1"));
     }
@@ -444,6 +515,10 @@ mod tests {
             Some(42)
         );
         assert_eq!(
+            parse_message_id("idle_recap:compact:42", IDLE_RECAP_COMPACT_BUTTON_PREFIX),
+            Some(42)
+        );
+        assert_eq!(
             parse_message_id(
                 "idle_recap:relay_diag:0",
                 IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX
@@ -453,6 +528,18 @@ mod tests {
         assert_eq!(
             parse_message_id("idle_recap:suggest:42", IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX),
             None
+        );
+    }
+
+    #[test]
+    fn recap_prompt_sent_ephemeral_includes_actual_prompt_text() {
+        assert_eq!(
+            prompt_sent_ephemeral("테스트 계속 진행해줘"),
+            "다음 프롬프트를 보냈습니다:\n> 테스트 계속 진행해줘"
+        );
+        assert_eq!(
+            prompt_sent_ephemeral("/compact"),
+            "다음 프롬프트를 보냈습니다:\n> /compact"
         );
     }
 }


### PR DESCRIPTION
## Summary
User-reported idle-recap UX batch:
1. Suggested replies phrased from the user's perspective
2. Ephemeral button responses show the exact prompt that will be sent
3. New **맥락 압축** button — literal `/compact` through the existing follow-up enqueue seam (defers via mailbox mid-turn)
4. Routines sessions suppressed; **at most one recap card per channel** via newest-wins single-statement conditional swap (`SELECT ... FOR UPDATE` + `UPDATE ... FROM current`, snowflake monotonicity); race loser deletes its own card
5. Header relay-status duplication removed

## Review
- Fresh codex REJECT: concurrent same-session recap jobs could leave two visible cards (pointer overwrite race)
- Fix: row-locked conditional swap + loser self-delete
- Scoped confirm **PASS** (session 019f2bcb-3b86): all interleavings → exactly one survivor; generation-bump race leaks no orphan card

## Verification
- Local battery: idle_recap 49 / idle_recap_interaction 3 — 0 failed
- audit --check, inventory --check, freshness, hotfile — all pass; no relay/queue/reconciler surfaces touched (parallel-work isolation verified by reviewer)

Closes #4079

🤖 Generated with [Claude Code](https://claude.com/claude-code)