### PR TITLE
fix(discord): #4068 health snapshot becomes non-creating (peek vs create)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -597,7 +597,6 @@ src/
 │   │   │   ├── read.rs
 │   │   │   ├── validation.rs
 │   │   │   └── write.rs
-│   │   ├── single_message_panel/
 │   │   ├── tmux_watcher/
 │   │   │   ├── commit_decisions.rs
 │   │   │   ├── completion_gate.rs

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -90,7 +90,7 @@
 | `src/services/discord/commands/text_commands.rs` | 1476 |
 | `src/services/discord/formatting.rs` | 2856 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
-| `src/services/discord/mod.rs` | 4158 |
+| `src/services/discord/mod.rs` | 4161 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1543 |
 | `src/services/discord_config_audit.rs` | 1288 |
 | `src/services/dispatched_sessions.rs` | 1546 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -401,7 +401,7 @@
 | `services::codex_tui::rollout_tail` | `src/services/codex_tui/rollout_tail.rs` | 4201 | 1276 | 2925 | giant-file |
 | `services::codex_tui::rollout_tail::parser` | `src/services/codex_tui/rollout_tail/parser.rs` | 405 | 405 | 0 |  |
 | `services::codex_tui::session` | `src/services/codex_tui/session.rs` | 800 | 316 | 484 |  |
-| `services::discord` | `src/services/discord/mod.rs` | 5311 | 4158 | 1153 | giant-file |
+| `services::discord` | `src/services/discord/mod.rs` | 5314 | 4161 | 1153 | giant-file |
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 980 | 854 | 126 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
@@ -463,7 +463,7 @@
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 266 | 100 | 166 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
-| `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 998 | 887 | 111 |  |
+| `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1065 | 887 | 178 |  |
 | `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 1574 | 662 | 912 |  |
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1125 | 497 | 628 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -278,7 +278,7 @@
 # carry-forward parameter (`None` here; queued kickoff carries the voice payload via
 # the accepted-replay store reinsert above) plus its one-line rationale comment.
 # Bugfix-only (#3905 direct-dispatch carry-forward).
-"src/services/discord/mod.rs" = 4159 # 2026-07-02 #3805 P2 PR-A: 4158 -> 4159 (+1 prod LoC), reviewable admission — the `make_shared_data_for_tests` fixture literal gains one `two_message_panel_enabled: false` line for the new additive scaffolding flag (no-op, no reader); no logic added to this giant. Prior: #3983 item4 4156 -> 4158 (session_banner module registration).
+"src/services/discord/mod.rs" = 4161 # 2026-07-04 #4068: 4159 -> 4161 (+2 prod LoC), reviewable admission — mailbox_snapshot call-site adaptation (peek + default fallback) for the non-creating snapshot fix; no logic beyond the fix. Prior: 2026-07-02 #3805 P2 PR-A: 4158 -> 4159 (+1 prod LoC), reviewable admission — the `make_shared_data_for_tests` fixture literal gains one `two_message_panel_enabled: false` line for the new additive scaffolding flag (no-op, no reader); no logic added to this giant. Prior: #3983 item4 4156 -> 4158 (session_banner module registration).
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).

--- a/scripts/check_await_holding_lock_ratchet.py
+++ b/scripts/check_await_holding_lock_ratchet.py
@@ -30,7 +30,7 @@ from pathlib import Path
 # serializes tests mutating the process-wide PRESENT index / durable-store root;
 # releasing it before the awaits would let concurrent tests stomp the statics.
 # Both are test-only and cannot deadlock a live task. Justified, reviewable raise.
-BASELINE = 35
+BASELINE = 36  # +1 (#4068): mailbox snapshot peek-only test holds lock_test_env() guard across await to serialize AGENTDESK_ROOT_DIR
 
 ALLOW_RE = re.compile(r"#\[allow\([^)]*\bclippy::await_holding_lock\b")
 

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -888,14 +888,29 @@ pub(super) fn observe_global_active_invariant(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use poise::serenity_prelude::{ChannelId, MessageId, UserId};
 
-    use super::{HealthRegistry, rebind_origin_inflight_is_idle, relay_active_turn_from_inflight};
+    use super::{
+        HealthRegistry, build_health_snapshot, rebind_origin_inflight_is_idle,
+        relay_active_turn_from_inflight,
+    };
     use crate::services::discord::inflight::InflightTurnState;
     use crate::services::discord::relay_health::RelayActiveTurn;
     use crate::services::provider::{CancelToken, ProviderKind};
     use chrono::TimeZone;
+
+    const AGENTDESK_ROOT_DIR_ENV: &str = "AGENTDESK_ROOT_DIR";
+    static NEXT_ABSENT_MAILBOX_CHANNEL: AtomicU64 = AtomicU64::new(9_406_800_000_000);
+
+    struct EnvGuard;
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) };
+        }
+    }
 
     /// #3631: a rebind-origin row with NO cancel token is idle (so the channel
     /// is not falsely reported as an active foreground stream and queued
@@ -993,6 +1008,58 @@ mod tests {
         assert!(
             snapshot.is_none(),
             "provider/channel resolve timeout must not scan a possibly wrong same-provider runtime"
+        );
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn mailbox_snapshot_absent_channel_is_peek_only_for_health() {
+        let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        let registry = HealthRegistry::new();
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        registry
+            .register(ProviderKind::Codex.as_str().to_string(), shared.clone())
+            .await;
+
+        let channel = ChannelId::new(NEXT_ABSENT_MAILBOX_CHANNEL.fetch_add(1, Ordering::Relaxed));
+        assert!(
+            crate::services::discord::ChannelMailboxRegistry::global_handle(channel).is_none(),
+            "test channel should start without a process-global mailbox"
+        );
+
+        let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel).await;
+        assert!(snapshot.cancel_token.is_none());
+        assert!(snapshot.active_user_message_id.is_none());
+        assert!(snapshot.intervention_queue.is_empty());
+        assert!(
+            crate::services::discord::ChannelMailboxRegistry::global_handle(channel).is_none(),
+            "snapshotting an absent mailbox must not create or globalize one"
+        );
+
+        let watcher = registry
+            .snapshot_watcher_state_for_provider(&ProviderKind::Codex, channel.get())
+            .await;
+        assert!(
+            watcher.is_none(),
+            "health watcher-state for an absent mailbox/session should report absence"
+        );
+        assert!(
+            crate::services::discord::ChannelMailboxRegistry::global_handle(channel).is_none(),
+            "health observation must not materialize a mailbox"
+        );
+
+        let health = build_health_snapshot(&registry).await;
+        assert!(
+            health.mailboxes.is_empty(),
+            "health snapshot should tolerate providers with no mailbox entries"
+        );
+        assert!(
+            crate::services::discord::ChannelMailboxRegistry::global_handle(channel).is_none(),
+            "health snapshot construction must remain peek-only for absent channels"
         );
     }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2428,7 +2428,10 @@ fn queue_persistence_context(
 }
 
 async fn mailbox_snapshot(shared: &SharedData, channel_id: ChannelId) -> ChannelMailboxSnapshot {
-    shared.mailbox(channel_id).snapshot().await
+    match shared.mailbox_peek(channel_id) {
+        Some(handle) => handle.snapshot().await,
+        None => ChannelMailboxSnapshot::default(),
+    }
 }
 
 async fn mailbox_cancel_token(


### PR DESCRIPTION
Closes #4068. observation/health 경로의 mailbox_snapshot이 mailbox를 생성/글로벌 클로버하던 것을 non-creating(peek)으로 전환. Codex 구현(커밋 d0cd4bbb). health/snapshot.rs +69, mod.rs +5/-2. non-hot Rust (#4049 핫파일 무충돌). 듀얼리뷰(opus, 보통 위험) + CI 검증 예정. 🤖 codex-implemented, orchestrated by Claude Code