### PR TITLE
fix(discord): #4097 suppress internal background task-notification panel bridge (relay noise)

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -26,7 +26,7 @@
 | `src/services/discord/router/message_handler/intake_turn.rs` | 2825 | discord-relay | 2026-10-31 | #3837 |
 | `src/services/discord/session_relay_sink.rs` | 1676 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/tmux.rs` | 1482 | discord-relay | 2026-10-31 | #3841 |
-| `src/services/discord/tmux_watcher.rs` | 7174 | discord-relay | 2026-10-31 | #3832 |
+| `src/services/discord/tmux_watcher.rs` | 7187 | discord-relay | 2026-10-31 | #3832 |
 | `src/services/discord/tui_direct_pending_start.rs` | 1491 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 1040 | discord-relay | 2026-10-31 | #4019 |
 | `src/services/discord/tui_task_card.rs` | 1065 | discord-relay | 2026-10-31 | #3405 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -519,7 +519,7 @@
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3466 | 1148 | 2318 | giant-file |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 664 | 424 | 240 |  |
 | `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 977 | 573 | 404 |  |
-| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 646 | 646 | 0 |  |
+| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 649 | 649 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 548 | 548 | 0 |  |
@@ -528,7 +528,7 @@
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
-| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 700 | 700 | 0 |  |
+| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 716 | 716 | 0 |  |
 | `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 703 | 703 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 445 | 270 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
@@ -666,12 +666,12 @@
 | `services::discord::tmux_reattach_offsets` | `src/services/discord/tmux_reattach_offsets.rs` | 82 | 82 | 0 |  |
 | `services::discord::tmux_restart_handoff` | `src/services/discord/tmux_restart_handoff.rs` | 602 | 479 | 123 |  |
 | `services::discord::tmux_session_files` | `src/services/discord/tmux_session_files.rs` | 586 | 554 | 32 |  |
-| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 7174 | 7174 | 0 | giant-file |
+| `services::discord::tmux_watcher` | `src/services/discord/tmux_watcher.rs` | 7187 | 7187 | 0 | giant-file |
 | `services::discord::tmux_watcher::commit_decisions` | `src/services/discord/tmux_watcher/commit_decisions.rs` | 296 | 174 | 122 |  |
 | `services::discord::tmux_watcher::completion_gate` | `src/services/discord/tmux_watcher/completion_gate.rs` | 250 | 250 | 0 |  |
 | `services::discord::tmux_watcher::completion_producer` | `src/services/discord/tmux_watcher/completion_producer.rs` | 54 | 54 | 0 |  |
 | `services::discord::tmux_watcher::controller_heartbeat` | `src/services/discord/tmux_watcher/controller_heartbeat.rs` | 34 | 34 | 0 |  |
-| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 566 | 484 | 82 |  |
+| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 568 | 486 | 82 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
 | `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 598 | 598 | 0 |  |
 | `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 106 | 106 | 0 |  |

--- a/scripts/audit_maintainability_config.toml
+++ b/scripts/audit_maintainability_config.toml
@@ -17,6 +17,7 @@
 # new turn_anchor.rs). More specific than the `**` glob below, so it must precede it
 # for fnmatch first-match precedence.
 "src/services/discord/placeholder_live_events/status_panel.rs" = 703
+"src/services/discord/placeholder_live_events/status_events.rs" = 720 # 2026-07-04 #4097 admission: +21 for kind=background XML task-notification suppression (relay noise fix); cohesive documented helper, namespace effectively full (precedent: status_panel.rs).
 "src/services/discord/placeholder_live_events/**" = 700
 "src/services/discord/prompt_builder/**" = 700
 "src/services/discord/runtime_bootstrap/**" = 700

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -272,6 +272,9 @@ impl PlaceholderLiveEvents {
         raw: &str,
         footer_mode_enabled: bool,
     ) -> bool {
+        if status_events::should_suppress_background_task_notification_xml(raw) {
+            return true;
+        }
         if !footer_mode_enabled {
             return false;
         }

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -272,7 +272,7 @@ impl PlaceholderLiveEvents {
         raw: &str,
         footer_mode_enabled: bool,
     ) -> bool {
-        if status_events::should_suppress_background_task_notification_xml(raw) {
+        if status_events::is_background_task_notification_xml_status_transition(raw) {
             return true;
         }
         if !footer_mode_enabled {

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -243,8 +243,12 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
     if status.is_empty() {
         return Vec::new();
     }
+    let kind = parsed.kind();
+    if background_task_notification_xml_status_transition(kind, Some(status)) {
+        return Vec::new();
+    }
     let events = status_events_from_task_notification_with_tool_use_id(
-        parsed.kind(),
+        kind,
         status,
         parsed.summary.as_deref().unwrap_or(""),
         parsed.tool_use_id.as_deref(),
@@ -254,6 +258,21 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
     // the WRONG one (permanently, post-#3391). A missing id → no terminal effect
     // (heartbeat/activity kept). The `system` path keeps its id-less fallback.
     events.into_iter().filter(idful_subagent_or_other).collect()
+}
+
+/// #4097: `kind=background` XML task notifications are internal helper
+/// lifecycle chatter (pollers / re-attach jobs / background orchestration), not
+/// user-facing panel state. Keep the JSON/system path intact; suppress only the
+/// #3393 user-record XML bridge and its duplicate card surface.
+pub(in crate::services::discord) fn should_suppress_background_task_notification_xml(
+    raw: &str,
+) -> bool {
+    let parsed = super::super::tui_task_card::parse_task_notification(raw);
+    background_task_notification_xml_status_transition(parsed.kind(), parsed.status.as_deref())
+}
+
+fn background_task_notification_xml_status_transition(kind: &str, status: Option<&str>) -> bool {
+    kind == "background" && status.is_some_and(|value| !value.trim().is_empty())
 }
 
 /// #3393 finding 1 XML-bridge drop predicate: `false` for an id-less `SubagentEnd`.

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -244,9 +244,6 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
         return Vec::new();
     }
     let kind = parsed.kind();
-    if background_task_notification_xml_status_transition(kind, Some(status)) {
-        return Vec::new();
-    }
     let events = status_events_from_task_notification_with_tool_use_id(
         kind,
         status,
@@ -260,11 +257,11 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
     events.into_iter().filter(idful_subagent_or_other).collect()
 }
 
-/// #4097: `kind=background` XML task notifications are internal helper
-/// lifecycle chatter (pollers / re-attach jobs / background orchestration), not
-/// user-facing panel state. Keep the JSON/system path intact; suppress only the
-/// #3393 user-record XML bridge and its duplicate card surface.
-pub(in crate::services::discord) fn should_suppress_background_task_notification_xml(
+/// #4097: `kind=background` XML task-notification cards are noisy lifecycle
+/// chatter. The bridge still emits slot-keyed `BackgroundTaskEnd` events so a
+/// real background Bash slot can flip ✓/✗; only the duplicate card surface is
+/// suppressed.
+pub(in crate::services::discord) fn is_background_task_notification_xml_status_transition(
     raw: &str,
 ) -> bool {
     let parsed = super::super::tui_task_card::parse_task_notification(raw);

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -5197,19 +5197,18 @@ fn status_events_toolsearch_pretty_json_args_summary_not_bare_brace() {
 // ---------------------------------------------------------------------------
 // #3393: user-record `<task-notification>` XML → live panel terminal StatusEvents.
 //
-// Background-task / subagent completions reach the transcript ONLY as this XML
-// (never the stream-json `system` record the panel's `system_status_events`
-// parses). These tests drive the FULL ingestion: real-shape XML text (incl. the
+// Subagent completions reach the transcript ONLY as this XML (never the
+// stream-json `system` record the panel's `system_status_events` parses).
+// These tests drive the FULL ingestion: real-shape XML text (incl. the
 // hyphenated `<tool-use-id>` from the live transcript) → bridge parse → push →
-// `render_completion_footer` shows ✓. State-machine-only proof is explicitly
-// forbidden by the issue, so every assertion goes through the panel render.
+// `render_completion_footer` shows ✓. #4097 excludes internal
+// `kind=background` XML lifecycle chatter from that bridge.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn task_notification_xml_background_bash_flips_footer_slot_to_done() {
+fn task_notification_xml_background_killed_is_suppressed_but_subagent_still_bridges() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_393_001);
-    // A running background Bash slot keyed by the launch tool-use id.
     events.push_status_events(
         channel_id,
         status_events_from_tool_use_with_id_for_footer_mode(
@@ -5224,43 +5223,83 @@ fn task_notification_xml_background_bash_flips_footer_slot_to_done() {
             true,
         ),
     );
-    let running = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
-    let running_block = running
-        .block
-        .expect("running background Bash should render");
-    assert!(running.has_unfinished_entries);
-    assert!(running_block.contains("Bash Wait until PR 3392 CI settles ⠸"));
-    assert!(!running_block.contains('✓'));
-
-    // Real-shape XML user-record text (background Bash variant, hyphenated
-    // `<tool-use-id>` child tag, status `completed`) — copied from a live
-    // transcript notification.
-    let raw = "<task-notification>\n\
+    let raw_background = "<task-notification>\n\
         <task-id>b5gr0v9xj</task-id>\n\
         <tool-use-id>toolu_01Ls2svfdnzcn9uGwA7aHjHW</tool-use-id>\n\
         <output-file>/private/tmp/claude-501/sess/tasks/b5gr0v9xj.output</output-file>\n\
-        <status>completed</status>\n\
-        <summary>Background command \"Wait until PR 3392 CI settles\" completed (exit code 0)</summary>\n\
+        <status>killed</status>\n\
+        <summary>Background command \"Wait until PR 3392 CI settles\" killed</summary>\n\
         </task-notification>";
-    let bridged = status_events_from_task_notification_xml_for_footer_mode(raw, true);
-    assert!(
-        bridged
-            .iter()
-            .any(|e| matches!(e, StatusEvent::BackgroundTaskEnd { .. })),
-        "background XML must bridge to BackgroundTaskEnd: {bridged:?}"
-    );
-    events.push_status_events(channel_id, bridged);
 
-    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
-    let done_block = done
-        .block
-        .expect("finished background Bash should stay visible");
-    assert!(!done.has_unfinished_entries);
+    let bridged = status_events_from_task_notification_xml_for_footer_mode(raw_background, true);
     assert!(
-        done_block.contains("Bash Wait until PR 3392 CI settles ✓"),
-        "matching XML notification must flip ✓: {done_block}"
+        bridged.is_empty(),
+        "kind=background XML must not bridge StatusEvents: {bridged:?}"
     );
-    assert!(!done_block.contains('⠼'));
+    assert!(
+        events.task_notification_completion_visible_in_footer_for_mode(
+            channel_id,
+            raw_background,
+            true,
+        ),
+        "background lifecycle XML should be consumed quietly instead of posting a notify card"
+    );
+    assert!(
+        events.task_notification_completion_visible_in_footer_for_mode(
+            channel_id,
+            raw_background,
+            false,
+        ),
+        "background lifecycle XML should stay quiet even when footer mode is off"
+    );
+    events.bridge_task_notification_xml(channel_id, raw_background);
+
+    let still_running = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
+    let running_block = still_running
+        .block
+        .expect("running background Bash should remain visible");
+    assert!(still_running.has_unfinished_entries);
+    assert!(
+        running_block.contains("Bash Wait until PR 3392 CI settles ⠼"),
+        "background XML must not flip or evict the slot: {running_block}"
+    );
+    assert!(!running_block.contains('✓') && !running_block.contains('✗'));
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "scout",
+                "description": "Scout issues #3275 #3276"
+            })
+            .to_string(),
+            Some("toolu_user_facing_subagent"),
+        ),
+    );
+    let raw_subagent = "<task-notification>\n\
+        <task-id>a09e45d12a68015a5</task-id>\n\
+        <tool-use-id>toolu_user_facing_subagent</tool-use-id>\n\
+        <status>completed</status>\n\
+        <summary>Agent \"Scout issues #3275 #3276\" completed</summary>\n\
+        <result>Done.</result>\n\
+        </task-notification>";
+    let subagent_events =
+        status_events_from_task_notification_xml_for_footer_mode(raw_subagent, true);
+    assert!(
+        subagent_events
+            .iter()
+            .any(|e| matches!(e, StatusEvent::SubagentEnd { .. })),
+        "user-facing subagent XML must still bridge: {subagent_events:?}"
+    );
+    events.push_status_events(channel_id, subagent_events);
+
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let done_block = done.block.expect("subagent completion should render");
+    assert!(
+        done_block.contains("Scout issues #3275 #3276") && done_block.contains('✓'),
+        "user-facing XML notification must still flip ✓: {done_block}"
+    );
 }
 
 #[test]
@@ -5361,17 +5400,15 @@ fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
         "unknown-id notification must not flip the known slot: {block}"
     );
 
-    // (b) Non-terminal status: produces NO terminal End event.
+    // (b) Background XML is suppressed even for non-terminal status.
     let nonterminal = "<task-notification><task-id>x2</task-id>\
         <tool-use-id>toolu_known</tool-use-id><status>running</status>\
         <summary>Background command \"Deploy runtime\" running</summary></task-notification>";
     let nonterminal_events =
         status_events_from_task_notification_xml_for_footer_mode(nonterminal, true);
     assert!(
-        !nonterminal_events
-            .iter()
-            .any(|e| matches!(e, StatusEvent::BackgroundTaskEnd { .. })),
-        "non-terminal status must not bridge a BackgroundTaskEnd: {nonterminal_events:?}"
+        nonterminal_events.is_empty(),
+        "kind=background XML must not bridge live-panel events: {nonterminal_events:?}"
     );
     events.push_status_events(channel_id, nonterminal_events);
     let still_running = events
@@ -5383,8 +5420,8 @@ fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
         "non-terminal must not flip ✓: {still_running}"
     );
 
-    // (c) Terminal match flips ✓; a DUPLICATE terminal notification must not flip
-    // the slot back to running.
+    // (c) Even a matching terminal background XML notification is display-layer
+    // noise; duplicates remain no-ops.
     let done_xml = "<task-notification><task-id>x3</task-id>\
         <tool-use-id>toolu_known</tool-use-id><status>completed</status>\
         <summary>Background command \"Deploy runtime\" completed (exit code 0)</summary></task-notification>";
@@ -5396,13 +5433,12 @@ fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
         channel_id,
         status_events_from_task_notification_xml_for_footer_mode(done_xml, true),
     );
-    let done = events
-        .render_completion_footer(channel_id, &ProviderKind::Claude, "⠼")
-        .block
-        .expect("done slot renders");
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
+    let done_block = done.block.expect("running slot still renders");
+    assert!(done.has_unfinished_entries);
     assert!(
-        done.contains("Bash Deploy runtime ✓") && !done.contains('⠼'),
-        "duplicate terminal notification must stay ✓, not flip back: {done}"
+        done_block.contains("Bash Deploy runtime ⠼") && !done_block.contains('✓'),
+        "background XML terminal notification must not flip ✓: {done_block}"
     );
 }
 
@@ -5421,7 +5457,7 @@ fn task_notification_xml_bridge_inert_when_footer_mode_off() {
 }
 
 #[test]
-fn task_completion_card_suppression_requires_footer_mode_and_matching_background_slot() {
+fn task_completion_card_suppression_quiets_background_xml_lifecycle() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_654_001);
     events.push_status_events(
@@ -5445,28 +5481,36 @@ fn task_completion_card_suppression_requires_footer_mode_and_matching_background
     assert!(
         events
             .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
-        "footer-on matching background completion should suppress the notify card"
+        "background completion XML should suppress the notify card"
     );
     assert!(
-        !events
+        events
             .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, false,),
-        "footer-off/legacy mode must keep the notify card"
+        "background completion XML should stay quiet even when footer mode is off"
     );
 
     let unknown = "<task-notification><task-id>bg2</task-id>\
         <tool-use-id>toolu_bg_unknown</tool-use-id><status>completed</status>\
         <summary>Background command \"Other\" completed (exit code 0)</summary></task-notification>";
     assert!(
-        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, unknown, true),
-        "unknown tool-use-id has no footer completion surface, so the card must remain"
+        events.task_notification_completion_visible_in_footer_for_mode(channel_id, unknown, true),
+        "background lifecycle XML should be quiet even without a matching slot"
     );
 
     let failed = "<task-notification><task-id>bg3</task-id>\
         <tool-use-id>toolu_bg_match</tool-use-id><status>failed</status>\
         <summary>Background command \"Watch CI\" failed (exit code 1)</summary></task-notification>";
     assert!(
-        !events.task_notification_completion_visible_in_footer_for_mode(channel_id, failed, true),
-        "failure/error notifications keep their card for details instead of being footer-suppressed"
+        events.task_notification_completion_visible_in_footer_for_mode(channel_id, failed, true),
+        "background failure XML should be consumed quietly"
+    );
+
+    let killed = "<task-notification><task-id>bg4</task-id>\
+        <tool-use-id>toolu_bg_match</tool-use-id><status>killed</status>\
+        <summary>Background command \"Watch CI\" killed</summary></task-notification>";
+    assert!(
+        events.task_notification_completion_visible_in_footer_for_mode(channel_id, killed, true),
+        "background killed XML should be consumed quietly"
     );
 }
 

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -5201,12 +5201,12 @@ fn status_events_toolsearch_pretty_json_args_summary_not_bare_brace() {
 // stream-json `system` record the panel's `system_status_events` parses).
 // These tests drive the FULL ingestion: real-shape XML text (incl. the
 // hyphenated `<tool-use-id>` from the live transcript) → bridge parse → push →
-// `render_completion_footer` shows ✓. #4097 excludes internal
-// `kind=background` XML lifecycle chatter from that bridge.
+// `render_completion_footer` shows ✓/✗. #4097 keeps that bridge for matching
+// background Bash slots, but suppresses the duplicate notify-card surface.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn task_notification_xml_background_killed_is_suppressed_but_subagent_still_bridges() {
+fn task_notification_xml_background_flips_matching_slot_but_suppresses_card() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_393_001);
     events.push_status_events(
@@ -5233,8 +5233,10 @@ fn task_notification_xml_background_killed_is_suppressed_but_subagent_still_brid
 
     let bridged = status_events_from_task_notification_xml_for_footer_mode(raw_background, true);
     assert!(
-        bridged.is_empty(),
-        "kind=background XML must not bridge StatusEvents: {bridged:?}"
+        bridged
+            .iter()
+            .any(|event| matches!(event, StatusEvent::BackgroundTaskEnd { success: false, .. })),
+        "matching kind=background XML must still bridge terminal slot events: {bridged:?}"
     );
     assert!(
         events.task_notification_completion_visible_in_footer_for_mode(
@@ -5254,16 +5256,16 @@ fn task_notification_xml_background_killed_is_suppressed_but_subagent_still_brid
     );
     events.bridge_task_notification_xml(channel_id, raw_background);
 
-    let still_running = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
-    let running_block = still_running
+    let failed = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
+    let failed_block = failed
         .block
-        .expect("running background Bash should remain visible");
-    assert!(still_running.has_unfinished_entries);
+        .expect("finished background Bash should remain visible");
+    assert!(!failed.has_unfinished_entries);
     assert!(
-        running_block.contains("Bash Wait until PR 3392 CI settles ⠼"),
-        "background XML must not flip or evict the slot: {running_block}"
+        failed_block.contains("Bash Wait until PR 3392 CI settles ✗"),
+        "background XML must flip the matching slot to failure: {failed_block}"
     );
-    assert!(!running_block.contains('✓') && !running_block.contains('✗'));
+    assert!(!failed_block.contains('⠼'));
 
     events.push_status_events(
         channel_id,
@@ -5400,15 +5402,17 @@ fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
         "unknown-id notification must not flip the known slot: {block}"
     );
 
-    // (b) Background XML is suppressed even for non-terminal status.
+    // (b) Non-terminal status: produces NO terminal End event.
     let nonterminal = "<task-notification><task-id>x2</task-id>\
         <tool-use-id>toolu_known</tool-use-id><status>running</status>\
         <summary>Background command \"Deploy runtime\" running</summary></task-notification>";
     let nonterminal_events =
         status_events_from_task_notification_xml_for_footer_mode(nonterminal, true);
     assert!(
-        nonterminal_events.is_empty(),
-        "kind=background XML must not bridge live-panel events: {nonterminal_events:?}"
+        !nonterminal_events
+            .iter()
+            .any(|e| matches!(e, StatusEvent::BackgroundTaskEnd { .. })),
+        "non-terminal status must not bridge a BackgroundTaskEnd: {nonterminal_events:?}"
     );
     events.push_status_events(channel_id, nonterminal_events);
     let still_running = events
@@ -5420,8 +5424,8 @@ fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
         "non-terminal must not flip ✓: {still_running}"
     );
 
-    // (c) Even a matching terminal background XML notification is display-layer
-    // noise; duplicates remain no-ops.
+    // (c) Terminal match flips ✓; a DUPLICATE terminal notification must not flip
+    // the slot back to running.
     let done_xml = "<task-notification><task-id>x3</task-id>\
         <tool-use-id>toolu_known</tool-use-id><status>completed</status>\
         <summary>Background command \"Deploy runtime\" completed (exit code 0)</summary></task-notification>";
@@ -5433,12 +5437,13 @@ fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
         channel_id,
         status_events_from_task_notification_xml_for_footer_mode(done_xml, true),
     );
-    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
-    let done_block = done.block.expect("running slot still renders");
-    assert!(done.has_unfinished_entries);
+    let done = events
+        .render_completion_footer(channel_id, &ProviderKind::Claude, "⠼")
+        .block
+        .expect("done slot renders");
     assert!(
-        done_block.contains("Bash Deploy runtime ⠼") && !done_block.contains('✓'),
-        "background XML terminal notification must not flip ✓: {done_block}"
+        done.contains("Bash Deploy runtime ✓") && !done.contains('⠼'),
+        "duplicate terminal notification must stay ✓, not flip back: {done}"
     );
 }
 


### PR DESCRIPTION
Closes #4097. #3393 placeholder_live_events가 내부 오케스트레이션 헬퍼 태스크(codex 폴러/서브에이전트 lifecycle, kind=background, status=killed)를 채널 라이브 패널로 중계하던 노이즈 억제. Codex 구현(커밋 9fad980a). display-layer 저위험 → opus 단독리뷰 예정. 머지+배포 시 사용자 '태스크킬' 알림 멈춤. 🤖 codex-implemented, orchestrated by Claude Code