### PR TITLE
fix(policies): restore automation-candidate routine scripts untracked by mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,19 @@ __pycache__/
 /docs/ops/
 
 # Operator-private routine scripts. Keep local/runtime routines out of public repo history.
-routines/
+routines/*
 !tests/fixtures/routines/
 !tests/fixtures/routines/**
 !src/server/routes/routines/
 !src/server/routes/routines/*.rs
+
+# Exception: the automation-candidate pipeline routines are shipped engine code
+# (feat(pipeline-v2) #2064), loaded by name via RoutineScriptLoader's default
+# `./routines` dir and exercised by `npm run test:policies`. They were swept up
+# by mistake in the operator-routine untrack pass (#4076) — keep them tracked.
+!routines/monitoring/
+routines/monitoring/*
+!routines/monitoring/automation-executor.js
+!routines/monitoring/automation-candidate-executor.js
+!routines/monitoring/automation-candidate-detector.js
+!routines/monitoring/automation-candidate-recommender.js

--- a/routines/monitoring/automation-candidate-detector.js
+++ b/routines/monitoring/automation-candidate-detector.js
@@ -1,0 +1,309 @@
+// Automation Candidate Detector
+// Reads candidate_review:* observations (written by recommender escalation handler)
+// and applies a quality gate. Passing candidates are forwarded to the agent for
+// approval kv_meta write. Already approved/dispatched candidates are skipped.
+
+const EVIDENCE_AGE_MAX_MS = 48 * 3600 * 1000;   // 48h — matches candidate_review TTL
+const MIN_SCORE_THRESHOLD = 80;
+const CHECKPOINT_VERSION = 1;
+const SEEN_CANDIDATE_TTL_MS = 72 * 3600 * 1000;   // matches candidate_approved TTL
+const EMITTED_RETRY_MS = 60 * 60 * 1000;          // retry if no durable approval marker appears
+const MAX_EMIT_RETRIES = 5;                        // give up and mark stalled after this many no-shows
+
+// --- Checkpoint helpers ---
+
+function emptyCheckpoint() {
+  return {
+    version: CHECKPOINT_VERSION,
+    seen_candidates: {},   // signature -> { first_seen_at, last_emitted_at, status }
+    stats: {
+      ticks: 0,
+      materialized: 0,
+      skipped_already_approved: 0,
+      skipped_quality_gate: 0,
+      stalled_candidates: 0,
+    },
+  };
+}
+
+function loadCheckpoint(raw) {
+  if (!raw || typeof raw !== "object" || raw.version !== CHECKPOINT_VERSION) {
+    return emptyCheckpoint();
+  }
+  const cp = Object.assign(emptyCheckpoint(), raw);
+  cp.seen_candidates = raw.seen_candidates || {};
+  cp.stats = Object.assign(emptyCheckpoint().stats, raw.stats || {});
+  return cp;
+}
+
+function nowIso(now) {
+  return typeof now === "string" ? now : now.toISOString ? now.toISOString() : String(now);
+}
+
+function isRecentIso(value, nowStr, maxAgeMs) {
+  const timestamp = new Date(value || "").getTime();
+  if (!Number.isFinite(timestamp)) return false;
+  return new Date(nowStr).getTime() - timestamp < maxAgeMs;
+}
+
+function observationKey(obs) {
+  if (typeof obs.key === "string") return obs.key;
+  if (typeof obs.evidence_ref === "string") {
+    if (obs.evidence_ref.startsWith("kv_meta:routine_observation:")) {
+      return obs.evidence_ref.slice("kv_meta:".length);
+    }
+    if (obs.evidence_ref.startsWith("routine_observation:")) {
+      return obs.evidence_ref;
+    }
+  }
+  return "";
+}
+
+function observationSignature(obs, prefix) {
+  const key = observationKey(obs);
+  return key.startsWith(prefix) ? key.slice(prefix.length) : null;
+}
+
+function observationPayload(obs) {
+  return obs.value && typeof obs.value === "object" ? obs.value : obs;
+}
+
+// --- Prune expired seen_candidates ---
+
+function pruneSeen(cp, nowStr) {
+  const cutoff = new Date(nowStr).getTime() - SEEN_CANDIDATE_TTL_MS;
+  for (const [sig, entry] of Object.entries(cp.seen_candidates)) {
+    if (new Date(entry.first_seen_at).getTime() < cutoff) {
+      delete cp.seen_candidates[sig];
+    }
+  }
+}
+
+// --- Quality gate ---
+
+function passesQualityGate(candidate, nowStr) {
+  const score = typeof candidate.score === "number" ? candidate.score : 0;
+  if (score < MIN_SCORE_THRESHOLD) return { pass: false, reason: `score=${score} < ${MIN_SCORE_THRESHOLD}` };
+
+  if (candidate.evidence_age_ms != null) {
+    if (candidate.evidence_age_ms > EVIDENCE_AGE_MAX_MS) {
+      return { pass: false, reason: `evidence_age=${candidate.evidence_age_ms}ms > ${EVIDENCE_AGE_MAX_MS}ms` };
+    }
+  } else if (candidate.last_seen_at) {
+    const seenAtMs = new Date(candidate.last_seen_at).getTime();
+    if (!Number.isFinite(seenAtMs)) {
+      return { pass: false, reason: `invalid_last_seen_at=${candidate.last_seen_at}` };
+    }
+    const ageMs = new Date(nowStr).getTime() - seenAtMs;
+    if (ageMs > EVIDENCE_AGE_MAX_MS) {
+      return { pass: false, reason: `evidence_age=${ageMs}ms > ${EVIDENCE_AGE_MAX_MS}ms` };
+    }
+  }
+
+  return { pass: true, reason: null };
+}
+
+// --- Build materialization prompt ---
+// After quality gate passes, instruct the LLM to:
+// 1. Create the Kanban card via POST /api/automation-candidates
+// 2. Write candidate_approved:* kv_meta with the resulting card_id
+
+function buildMaterializationPrompt(signature, candidate) {
+  const mr = candidate.materialize_request || {};
+  const mrBody = mr.body || {};
+  const program = mrBody.program || {};
+
+  const materializeBody = {
+    title: mrBody.title || `[automation-candidate] ${signature}`,
+    source: mrBody.source || "routine_recommender",
+    dedupe_key: mrBody.dedupe_key || signature,
+    start_ready: true,
+    program: {
+      repo_dir: program.repo_dir || "<determine from your workspace context>",
+      allowed_write_paths: program.allowed_write_paths || ["src"],
+      metric_name: program.metric_name || "automation_friction_count",
+      metric_target: program.metric_target ?? 0,
+      metric_direction: program.metric_direction || "lower_is_better",
+      final_gate: program.final_gate || "manual_review",
+      iteration_budget: program.iteration_budget || 3,
+    },
+  };
+
+  const lines = [
+    "# 자동화 후보 카드 생성 요청",
+    "",
+    `**후보 ID**: \`${signature}\``,
+    `**카테고리**: ${candidate.category || "routine-candidate"}`,
+    `**점수**: ${candidate.score} / 100`,
+    `**증거 수**: ${candidate.evidence_count || 0}`,
+    `**제안된 자동화**: ${candidate.suggested_automation || "(없음)"}`,
+    `**결과 요약**: ${candidate.outcome_summary || "(없음)"}`,
+    "",
+    "---",
+    "## 실행 지침",
+    "",
+    "이 후보는 품질 게이트를 통과했습니다. 아래 두 단계를 순서대로 실행하세요.",
+    "",
+    "### 1단계: Kanban 카드 생성",
+    "",
+    "아래 API를 호출하여 자동화 후보 카드를 생성합니다:",
+    "",
+    "```",
+    "POST /api/automation-candidates",
+    "Content-Type: application/json",
+    "",
+    JSON.stringify(materializeBody, null, 2),
+    "```",
+    "",
+    "**중요**: `program.repo_dir`가 `<determine from your workspace context>` 상태라면,",
+    "현재 워크스페이스의 agentdesk 리포지터리 절대 경로로 대체하세요.",
+    "예: `/Users/example/workspaces/agentdesk`",
+    "",
+    "API 응답에서 `card_id`를 저장해두세요.",
+    "",
+    "### 2단계: 승인 마커 기록",
+    "",
+    "카드 생성에 성공한 경우, 아래 kv_meta를 기록합니다 (TTL: 72h):",
+    "```",
+    `routine_observation:candidate_approved:${signature}`,
+    "```",
+    `값(JSON): {\"signature\":\"${signature}\",\"score\":${candidate.score},\"card_id\":\"<생성된 card_id>\",\"approved_at\":\"<현재시각ISO>\",\"category\":\"${candidate.category || "routine-candidate"}\"}`,
+    "",
+    "카드 생성에 실패하거나 후보가 자동화 가치가 없다고 판단되면 kv_meta를 기록하지 마세요.",
+    "",
+    "**주의**: 카드를 생성하지 않고 kv_meta만 기록하면 자동화 루프가 동작하지 않습니다.",
+  ];
+  return lines.join("\n");
+}
+
+// --- Main tick ---
+
+agentdesk.routines.register({
+  name: "Automation Candidate Detector",
+
+  tick(ctx) {
+    const nowStr = nowIso(ctx.now);
+    const cp = loadCheckpoint(ctx.checkpoint);
+    const observations = ctx.observations || [];
+
+    pruneSeen(cp, nowStr);
+
+    // Find candidate_review observations
+    const reviewPrefix = "routine_observation:candidate_review:";
+    const approvedPrefix = "routine_observation:candidate_approved:";
+    const dispatchedPrefix = "routine_observation:candidate_dispatched:";
+    const reviewObs = observations.filter((obs) => observationSignature(obs, reviewPrefix));
+
+    // Find already-approved and dispatched signatures from observations
+    const approvedSigs = new Set(
+      observations
+        .map((obs) => observationSignature(obs, approvedPrefix))
+        .filter(Boolean)
+    );
+    const dispatchedSigs = new Set(
+      observations
+        .map((obs) => observationSignature(obs, dispatchedPrefix))
+        .filter(Boolean)
+    );
+
+    cp.stats.ticks++;
+
+    if (reviewObs.length === 0) {
+      return {
+        action: "complete",
+        result: {
+          status: "ok",
+          summary: "검토할 후보 없음",
+          review_count: 0,
+        },
+        checkpoint: cp,
+      };
+    }
+
+    // Process each candidate_review observation
+    const emitPrompts = [];
+    const queuedSignatures = new Set();
+    for (const obs of reviewObs) {
+      const signature = observationSignature(obs, reviewPrefix);
+      const candidate = observationPayload(obs);
+
+      // Skip already approved/dispatched
+      if (approvedSigs.has(signature) || dispatchedSigs.has(signature)) {
+        cp.stats.skipped_already_approved++;
+        cp.seen_candidates[signature] = cp.seen_candidates[signature] || {
+          first_seen_at: nowStr,
+          status: "skipped_already_handled",
+        };
+        continue;
+      }
+
+      // Skip only recent emits. If no durable approved/dispatched marker appears,
+      // retry before the candidate_review marker can age out.
+      const seen = cp.seen_candidates[signature];
+      if (queuedSignatures.has(signature)) {
+        cp.stats.skipped_already_approved++;
+        continue;
+      }
+      // Give up if LLM has repeatedly failed to write the approved marker.
+      if (seen && (seen.emit_count || 0) >= MAX_EMIT_RETRIES) {
+        if (seen.status !== "stalled") {
+          cp.seen_candidates[signature] = Object.assign({}, seen, { status: "stalled" });
+        }
+        cp.stats.stalled_candidates++;
+        continue;
+      }
+      if (
+        seen &&
+        seen.status === "emitted" &&
+        isRecentIso(seen.last_emitted_at || seen.first_seen_at, nowStr, EMITTED_RETRY_MS)
+      ) {
+        cp.stats.skipped_already_approved++;
+        continue;
+      }
+
+      // Quality gate
+      const gate = passesQualityGate(candidate, nowStr);
+      if (!gate.pass) {
+        cp.stats.skipped_quality_gate++;
+        cp.seen_candidates[signature] = { first_seen_at: nowStr, status: "rejected", reason: gate.reason };
+        continue;
+      }
+
+      emitPrompts.push({ signature, candidate });
+      queuedSignatures.add(signature);
+    }
+
+    if (emitPrompts.length === 0) {
+      return {
+        action: "complete",
+        result: {
+          status: "ok",
+          summary: `검토 ${reviewObs.length}건 처리됨 (카드 생성 요청 없음)`,
+          review_count: reviewObs.length,
+          skipped_approved: cp.stats.skipped_already_approved,
+          skipped_quality_gate: cp.stats.skipped_quality_gate,
+        },
+        checkpoint: cp,
+      };
+    }
+
+    // Emit one materialization prompt (first candidate, others handled on next ticks)
+    const { signature, candidate } = emitPrompts[0];
+    const prompt = buildMaterializationPrompt(signature, candidate);
+    const previousSeen = cp.seen_candidates[signature];
+    const emitCount = (previousSeen?.emit_count || 0) + 1;
+    cp.seen_candidates[signature] = {
+      first_seen_at: previousSeen?.first_seen_at || nowStr,
+      last_emitted_at: nowStr,
+      emit_count: emitCount,
+      status: "emitted",
+    };
+    cp.stats.materialized++;
+
+    return {
+      action: "agent",
+      prompt,
+      checkpoint: cp,
+    };
+  },
+});

--- a/routines/monitoring/automation-candidate-executor.js
+++ b/routines/monitoring/automation-candidate-executor.js
@@ -1,0 +1,305 @@
+// Automation Candidate Executor
+//
+// Consumes kanban_ready observations (pipeline_stage_id='automation-candidate', status='ready')
+// and drives an autoresearch-style iteration loop per card:
+//
+//   ready → requested → in_progress → [metric-regression re-queue OR review → done]
+//
+// Re-queue on metric regression: current card → "review", new child card → "ready"
+// (intermediate cards go to "review", NOT "done", to avoid premature kanban_dispatched suppression)
+//
+// Loop ends when MAX_ITERATIONS is reached or final gate triggers.
+// LLM submits iteration results via POST /api/automation-candidates/{card_id}/iteration-result.
+// Rust computes keep/discard verdict deterministically.
+
+const MAX_ITERATIONS = 10;
+const DISPATCH_RETRY_MS = 30 * 60 * 1000;
+const MAX_DISPATCH_RETRIES = 3;
+const DISPATCHED_WINDOW_DAYS = 7;
+const CHECKPOINT_VERSION = 2;
+const AUTOMATION_CANDIDATE_CONTRACT = Object.freeze({
+  pipelineStageId: "automation-candidate",
+  programKey: "program",
+  requiredProgramFields: Object.freeze([
+    "repo_dir",
+    "allowed_write_paths",
+    "metric_name",
+    "metric_target",
+  ]),
+});
+
+// --- Checkpoint helpers ---
+
+function emptyCheckpoint() {
+  return {
+    version: CHECKPOINT_VERSION,
+    // card_id -> { dispatched_at, iteration, status }
+    dispatched: {},
+    // card_id -> { attempt_count, last_attempted_at, first_attempted_at }
+    pending: {},
+    stats: { ticks: 0, dispatched: 0, skipped: 0, max_iterations_reached: 0 },
+  };
+}
+
+function loadCheckpoint(raw) {
+  if (!raw || raw.version !== CHECKPOINT_VERSION) return emptyCheckpoint();
+  const cp = Object.assign(emptyCheckpoint(), raw);
+  cp.dispatched = raw.dispatched || {};
+  cp.pending    = raw.pending || {};
+  cp.stats      = Object.assign(emptyCheckpoint().stats, raw.stats || {});
+  return cp;
+}
+
+function nowIso(now) {
+  return typeof now === "string" ? now : now.toISOString ? now.toISOString() : String(now);
+}
+
+function isRecent(iso, nowStr, maxMs) {
+  const t = new Date(iso || "").getTime();
+  return Number.isFinite(t) && new Date(nowStr).getTime() - t < maxMs;
+}
+
+function pruneDispatched(cp, nowStr) {
+  const cutoff = new Date(nowStr).getTime() - DISPATCHED_WINDOW_DAYS * 86400 * 1000;
+  for (const [id, entry] of Object.entries(cp.dispatched)) {
+    if (new Date(entry.dispatched_at || 0).getTime() < cutoff) delete cp.dispatched[id];
+  }
+  for (const [id, entry] of Object.entries(cp.pending)) {
+    if (new Date(entry.first_attempted_at || 0).getTime() < cutoff) delete cp.pending[id];
+  }
+}
+
+function hasCompleteProgramContract(program) {
+  const [repoDirField, allowedPathsField, metricNameField, metricTargetField] =
+    AUTOMATION_CANDIDATE_CONTRACT.requiredProgramFields;
+  return typeof program[repoDirField] === "string"
+    && program[repoDirField].trim().length > 0
+    && Array.isArray(program[allowedPathsField])
+    && program[allowedPathsField].length > 0
+    && program[allowedPathsField].every((path) => typeof path === "string" && path.trim().length > 0)
+    && typeof program[metricNameField] === "string"
+    && program[metricNameField].trim().length > 0
+    && program[metricTargetField] != null;
+}
+
+function isAutomationCandidateCard(obs) {
+  const program = (obs.metadata || {})[AUTOMATION_CANDIDATE_CONTRACT.programKey] || {};
+  return obs.pipeline_stage_id === AUTOMATION_CANDIDATE_CONTRACT.pipelineStageId
+    && hasCompleteProgramContract(program);
+}
+
+function candidateIterationBudget(program) {
+  const value = Number(program.iteration_budget || MAX_ITERATIONS);
+  if (!Number.isFinite(value)) return MAX_ITERATIONS;
+  return Math.max(1, Math.min(MAX_ITERATIONS, Math.floor(value)));
+}
+
+function previousIterationsFor(inventory, cardId) {
+  if (!inventory) return [];
+  if (Array.isArray(inventory)) {
+    return inventory.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const itemCardId = item.card_id || item.kanban_card_id;
+      if (itemCardId !== cardId) return [];
+      if (Array.isArray(item.iterations)) return item.iterations;
+      return [item];
+    });
+  }
+  if (Array.isArray(inventory[cardId])) return inventory[cardId];
+  if (inventory[cardId] && Array.isArray(inventory[cardId].iterations)) {
+    return inventory[cardId].iterations;
+  }
+  if (inventory.card_id === cardId && Array.isArray(inventory.iterations)) {
+    return inventory.iterations;
+  }
+  return [];
+}
+
+// --- Build executor prompt (autoresearch-style: program contract + previous findings) ---
+
+function buildIterationPrompt(cardId, card, iteration, previousIterations) {
+  const program = (card.metadata && card.metadata.program) || {};
+  const allowedPaths = (program.allowed_write_paths || []).join(", ") || "(not specified)";
+  const metricName   = program.metric_name || "improvement_score";
+  const metricDirection = program.metric_direction || program.direction || "lower_is_better";
+  const metricTarget = program.metric_target != null ? String(program.metric_target) : "(not specified)";
+  const iterBudget   = candidateIterationBudget(program);
+  const description  = program.description || card.title || "(no description)";
+
+  const prevSummary = previousIterations.length === 0
+    ? "(이전 반복 없음 — 첫 번째 시도입니다)"
+    : previousIterations.map((r, i) =>
+        `  반복 ${r.iteration}: ${r.status} | ${metricName}: ${r.metric_before} → ${r.metric_after} | ${r.description || ""}`
+      ).join("\n");
+
+  return [
+    "## 자동화 후보 반복 실행 요청 (Automation Candidate Executor)",
+    "",
+    `**카드 ID**: \`${cardId}\``,
+    `**제목**: ${card.title || "(no title)"}`,
+    `**반복 번호**: ${iteration} / ${iterBudget}`,
+    "",
+    "### Program Contract",
+    `- **목표**: ${description}`,
+    `- **수정 허용 경로**: \`${allowedPaths}\``,
+    `- **지표명**: ${metricName}`,
+    `- **지표 방향**: ${metricDirection}`,
+    `- **목표값**: ${metricTarget}`,
+    "",
+    "### 이전 반복 결과",
+    prevSummary,
+    "",
+    "### 실행 지침",
+    "",
+    "1. **먼저 아래 API로 격리된 git worktree를 준비**하고, 응답의 `path`에서만 작업:",
+    "",
+    "```",
+    `POST /api/automation-candidates/${cardId}/prepare-worktree`,
+    "Content-Type: application/json",
+    "",
+    JSON.stringify({ iteration }, null, 2),
+    "```",
+    "",
+    "2. **allowed_write_paths 내에서만** 코드 수정",
+    "3. 지표 측정 (변경 전/후)",
+    "4. **반드시 아래 API 호출로 결과 제출** (다른 방법으로 상태 변경 금지):",
+    "",
+    "```",
+    `POST /api/automation-candidates/${cardId}/iteration-result`,
+    "Content-Type: application/json",
+    "",
+    JSON.stringify({
+      iteration,
+      branch: `automation/${cardId}/iter-${iteration}`,
+      commit_hash: "<커밋 해시>",
+      metric_before: "<변경 전 수치>",
+      metric_after:  "<변경 후 수치>",
+      is_simplification: false,
+      status: "keep",
+      description: "<변경 요약>",
+      allowed_write_paths_used: program.allowed_write_paths || [],
+      run_seconds: "<소요 초>",
+      crash_trace: null,
+    }, null, 2),
+    "```",
+    "",
+    "**주의**: `lower_is_better`에서는 `metric_after < metric_before`, `higher_is_better`에서는 `metric_after > metric_before`인 경우에만 Rust가 `keep` 판정합니다.",
+    "**주의**: allowed_write_paths 외 경로 수정 시 API가 403을 반환합니다.",
+    "**주의**: 이 API 호출 없이 카드 상태를 직접 변경하지 마세요.",
+  ].join("\n");
+}
+
+// --- Main tick ---
+
+agentdesk.routines.register({
+  name: "Automation Candidate Executor",
+
+  tick(ctx) {
+    const nowStr = nowIso(ctx.now);
+    const cp = loadCheckpoint(ctx.checkpoint);
+    const observations = ctx.observations || [];
+
+    pruneDispatched(cp, nowStr);
+
+    // Collect kanban_ready candidates (source 8 in store.rs)
+    const readyCards = observations
+      .filter((o) => o.source === "kanban_ready")
+      .filter((o) => {
+        const valid = isAutomationCandidateCard(o);
+        if (!valid) cp.stats.skipped++;
+        return valid;
+      })
+      .map((o) => ({ cardId: o.card_id || o.evidence_ref?.replace("kanban_cards:", ""), obs: o }))
+      .filter((c) => c.cardId);
+
+    // Collect kanban_dispatched to suppress already-completed cards (source 9)
+    const dispatchedCardIds = new Set(
+      observations
+        .filter((o) => o.source === "kanban_dispatched")
+        .map((o) => o.card_id || o.evidence_ref?.replace("kanban_cards:", ""))
+        .filter(Boolean)
+    );
+
+    cp.stats.ticks++;
+
+    if (readyCards.length === 0) {
+      return {
+        action: "complete",
+        result: { status: "ok", summary: "실행 대기 중인 자동화 후보 없음" },
+        checkpoint: cp,
+      };
+    }
+
+    // Filter candidates
+    const toProcess = [];
+    for (const { cardId, obs } of readyCards) {
+      if (cp.dispatched[cardId] || dispatchedCardIds.has(cardId)) {
+        cp.stats.skipped++;
+        continue;
+      }
+      const meta = obs.metadata || {};
+      const program = meta.program || {};
+      const maxIterations = candidateIterationBudget(program);
+      const iteration = (program.current_iteration || 0) + 1;
+      const pending = cp.pending[cardId];
+      const pendingIteration = Number.isFinite(Number(pending?.iteration))
+        ? Number(pending.iteration)
+        : iteration;
+      if (pending && pendingIteration !== iteration) {
+        delete cp.pending[cardId];
+      }
+      const activePending = pending && pendingIteration === iteration ? pending : null;
+
+      if (activePending && (activePending.attempt_count || 0) >= MAX_DISPATCH_RETRIES) continue;
+      if (activePending && isRecent(activePending.last_attempted_at, nowStr, DISPATCH_RETRY_MS)) {
+        cp.stats.skipped++;
+        continue;
+      }
+
+      if (iteration > maxIterations) {
+        cp.stats.max_iterations_reached++;
+        cp.dispatched[cardId] = { dispatched_at: nowStr, status: "max_iterations_reached", iteration };
+        continue;
+      }
+
+      toProcess.push({ cardId, obs, iteration, program });
+    }
+
+    if (toProcess.length === 0) {
+      return {
+        action: "complete",
+        result: {
+          status: "ok",
+          summary: `ready 후보 ${readyCards.length}건 모두 처리됨 또는 대기 중`,
+          skipped: cp.stats.skipped,
+        },
+        checkpoint: cp,
+      };
+    }
+
+    // Process first candidate
+    const { cardId, obs, iteration } = toProcess[0];
+    const card = {
+      title: obs.summary || "",
+      metadata: obs.metadata || {},
+    };
+
+    // Read previous iteration results from ctx.automationInventory if available
+    const previousIterations = previousIterationsFor(ctx.automationInventory, cardId);
+
+    const prevPending = cp.pending[cardId];
+    cp.pending[cardId] = {
+      first_attempted_at: prevPending?.first_attempted_at || nowStr,
+      last_attempted_at: nowStr,
+      attempt_count: (prevPending?.attempt_count || 0) + 1,
+      iteration,
+    };
+    cp.stats.dispatched++;
+
+    return {
+      action: "agent",
+      prompt: buildIterationPrompt(cardId, card, iteration, previousIterations),
+      checkpoint: cp,
+    };
+  },
+});

--- a/routines/monitoring/automation-candidate-recommender.js
+++ b/routines/monitoring/automation-candidate-recommender.js
@@ -1,0 +1,1336 @@
+// Automation Candidate Recommender
+// 매 tick마다 bounded observations를 checkpoint에 누적하고,
+// 강한 근거(score >= 80)에서만 agent proposal을 생성한다.
+// P0: read-only, no auto-implementation, proposal-only.
+
+const SCORE_THRESHOLD = 80;
+const DAILY_CAP = 3;
+const COOLDOWN_HOURS = 6;
+const MAX_EXAMPLES_PER_CANDIDATE = 3;
+const PROMPT_CAP_BYTES = 12288;
+const CHECKPOINT_CAP_BYTES = 65536;
+const CHECKPOINT_VERSION = 1;
+const CANDIDATE_TTL_DAYS = 30;
+const REPO_DIR_PLACEHOLDER = "<determine from your workspace context>";
+
+// seen_evidence dedup: prevents the same evidence from incrementing score/evidence_count
+// across multiple ticks.  TTL covers the 24h observation query window with margin.
+const SEEN_EVIDENCE_TTL_MS = 25 * 3600 * 1000;   // 25 h
+const SEEN_EVIDENCE_MAX_ENTRIES = 500;             // LRU cap
+
+// Saturation detection & re-optimization (P0-E)
+// EMA formula mirrors autoresearch train.py ema_beta=0.9 (karpathy/autoresearch).
+// Fast-fail tier: analogous to autoresearch "if isnan(loss): exit(1)".
+// Re-optimization (partial reset + diversity mode) is original design.
+const EMA_BETA = 0.9;
+const EMA_SATURATION_THRESHOLD = 0.3;   // ema_scored below this → saturation_ticks++
+const SATURATION_TICKS = 5;             // consecutive EMA-saturated ticks → reopt
+const FAST_FAIL_TICKS = 2;              // all-dedup consecutive ticks → immediate reopt
+const REOPT_WINDOW_MS = 12 * 3600 * 1000;  // partial reset: remove seen_evidence older than 12h
+const DIVERSITY_BOOST_TICKS = 10;       // ticks of diversity mode after each reopt
+const DIVERSITY_LOOKBACK_TICKS = 5;    // history window for underrepresented category detection
+
+const KNOWN_CATEGORIES = new Set([
+  "routine-candidate",
+  "release-freshness",
+  "outbox-delivery",
+  "memento-hygiene",
+  "api-friction",
+  "kanban-flow",
+  "dispatch-retry",
+  "session-pattern",
+  "log-signal",
+  "automation-candidate",
+]);
+
+const CATEGORY_GATES = Object.freeze({
+  "routine-candidate": { minScore: SCORE_THRESHOLD, minEvidence: 5 },
+  "release-freshness": { minScore: SCORE_THRESHOLD, minEvidence: 5 },
+  "outbox-delivery": { minScore: 60, minEvidence: 3 },
+  "memento-hygiene": { minScore: 60, minEvidence: 3 },
+  "api-friction": { minScore: 60, minEvidence: 3 },
+  "kanban-flow": { minScore: 60, minEvidence: 3 },
+  "dispatch-retry": { minScore: 60, minEvidence: 3 },
+  "session-pattern": { minScore: 60, minEvidence: 3 },
+  "log-signal": { minScore: 60, minEvidence: 3 },
+  "automation-candidate": { minScore: SCORE_THRESHOLD, minEvidence: 5 },
+});
+
+const CATEGORY_SCORE_MULTIPLIERS = Object.freeze({
+  "outbox-delivery": 1.25,
+  "api-friction": 1.2,
+  "memento-hygiene": 1.1,
+  "kanban-flow": 1.15,
+  "dispatch-retry": 1.2,
+  "session-pattern": 1.15,
+  "log-signal": 1.15,
+});
+
+// --- Scoring weights ---
+const WEIGHT_BASE = 10;
+const WEIGHT_RECENCY_BONUS = 10;   // occurred in last 30 min
+const WEIGHT_FIRST_SEEN = 5;       // new candidate bonus
+
+// --- Checkpoint helpers ---
+
+function emptyCheckpoint() {
+  return {
+    version: CHECKPOINT_VERSION,
+    cursors: {},
+    candidates: {},
+    suppressions: {},
+    seen_evidence: {},   // evidence_key -> { seen_at, occurrences } (legacy ISO string accepted)
+    recommendations: [],
+    last_tick_at: null,
+    // P0-E saturation tracking
+    ema_scored: 0,
+    saturation_ticks: 0,
+    fast_fail_ticks: 0,
+    reopt_count: 0,
+    diversity_mode_ticks_remaining: 0,
+    last_reopt_at: null,
+    stats: {
+      ticks: 0,
+      observations_seen: 0,
+      agent_escalations: 0,
+      recommendations_today: 0,
+      recommendation_day: null,
+      category_scored: {},
+      category_scored_history: [],   // [{cat: count, ...}, ...] last DIVERSITY_LOOKBACK_TICKS entries
+    },
+  };
+}
+
+function loadCheckpoint(raw) {
+  if (!raw || typeof raw !== "object" || raw.version !== CHECKPOINT_VERSION) {
+    return emptyCheckpoint();
+  }
+  const cp = Object.assign(emptyCheckpoint(), raw);
+  cp.candidates = raw.candidates || {};
+  cp.suppressions = raw.suppressions || {};
+  cp.seen_evidence = raw.seen_evidence || {};
+  cp.stats = Object.assign(emptyCheckpoint().stats, raw.stats || {});
+  cp.stats.category_scored = (raw.stats && raw.stats.category_scored) ? raw.stats.category_scored : {};
+  cp.stats.category_scored_history = (raw.stats && Array.isArray(raw.stats.category_scored_history))
+    ? raw.stats.category_scored_history : [];
+  // P0-E backward-compat defaults
+  if (typeof cp.ema_scored !== "number") cp.ema_scored = 0;
+  if (typeof cp.saturation_ticks !== "number") cp.saturation_ticks = 0;
+  if (typeof cp.fast_fail_ticks !== "number") cp.fast_fail_ticks = 0;
+  if (typeof cp.reopt_count !== "number") cp.reopt_count = 0;
+  if (typeof cp.diversity_mode_ticks_remaining !== "number") cp.diversity_mode_ticks_remaining = 0;
+  if (cp.last_reopt_at === undefined) cp.last_reopt_at = null;
+  return cp;
+}
+
+function nowIso(now) {
+  return typeof now === "string" ? now : now.toISOString ? now.toISOString() : String(now);
+}
+
+function dateOf(iso) {
+  return iso ? iso.slice(0, 10) : null;
+}
+
+function addHours(isoStr, hours) {
+  const ms = new Date(isoStr).getTime() + hours * 3600 * 1000;
+  return new Date(ms).toISOString();
+}
+
+function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16);
+}
+
+// --- seen_evidence dedup helpers ---
+
+function seenEvidenceTimestamp(entry) {
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry === "object") {
+    return entry.seen_at || entry.first_seen_at || null;
+  }
+  return null;
+}
+
+function seenEvidenceOccurrences(entry) {
+  if (!entry || typeof entry !== "object") return 0;
+  const value = Number(entry.occurrences || 0);
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return Math.floor(value);
+}
+
+function isSeenEvidenceFresh(entry, nowStr) {
+  const ts = seenEvidenceTimestamp(entry);
+  if (!ts) return false;
+  return new Date(nowStr).getTime() - new Date(ts).getTime() < SEEN_EVIDENCE_TTL_MS;
+}
+
+function evidenceKey(obs) {
+  if (obs.evidence_ref) return obs.evidence_ref;
+  return `${obs.source || ""}|${obs.category || ""}|${obs.signature || ""}|${simpleHash(String(obs.summary || ""))}`;
+}
+
+function seenOccurrences(cp, key, nowStr) {
+  const entry = cp.seen_evidence[key];
+  if (!isSeenEvidenceFresh(entry, nowStr)) return 0;
+  return seenEvidenceOccurrences(entry);
+}
+
+function isEvidenceFullySeen(cp, key, nowStr, occurrences) {
+  const entry = cp.seen_evidence[key];
+  if (!isSeenEvidenceFresh(entry, nowStr)) return false;
+  if (typeof entry === "string") return true;
+  return seenEvidenceOccurrences(entry) >= occurrences;
+}
+
+function markEvidenceSeen(cp, key, nowStr, occurrences) {
+  const value = Number(occurrences || 0);
+  cp.seen_evidence[key] = {
+    seen_at: nowStr,
+    occurrences: Number.isFinite(value) && value > 0 ? Math.floor(value) : 0,
+  };
+}
+
+function pruneSeenEvidence(cp, nowStr) {
+  const cutoffMs = new Date(nowStr).getTime() - SEEN_EVIDENCE_TTL_MS;
+  // Expire TTL-exceeded entries
+  for (const key of Object.keys(cp.seen_evidence)) {
+    const seenAt = seenEvidenceTimestamp(cp.seen_evidence[key]);
+    if (!seenAt || new Date(seenAt).getTime() < cutoffMs) {
+      delete cp.seen_evidence[key];
+    }
+  }
+  // LRU eviction: drop oldest entries if still over cap
+  const keys = Object.keys(cp.seen_evidence);
+  if (keys.length > SEEN_EVIDENCE_MAX_ENTRIES) {
+    keys.sort((a, b) =>
+      new Date(seenEvidenceTimestamp(cp.seen_evidence[a])).getTime() -
+      new Date(seenEvidenceTimestamp(cp.seen_evidence[b])).getTime()
+    );
+    for (const key of keys.slice(0, keys.length - SEEN_EVIDENCE_MAX_ENTRIES)) {
+      delete cp.seen_evidence[key];
+    }
+  }
+}
+
+// --- P0-E: Saturation detection & re-optimization helpers ---
+
+function updateEmaScored(cp, scoredThisTick) {
+  cp.ema_scored = EMA_BETA * cp.ema_scored + (1 - EMA_BETA) * scoredThisTick;
+}
+
+function updateFastFailTicks(cp, scoringReport, obsCount) {
+  // Fast-fail: all observations were deduped (no new scoring signal at all)
+  const allDeduped =
+    scoringReport.scored === 0 &&
+    scoringReport.deduped > 0 &&
+    scoringReport.deduped === obsCount;
+  if (allDeduped) {
+    cp.fast_fail_ticks++;
+  } else {
+    cp.fast_fail_ticks = 0;
+  }
+}
+
+function updateSaturationTicks(cp) {
+  if (cp.ema_scored < EMA_SATURATION_THRESHOLD) {
+    cp.saturation_ticks++;
+  } else {
+    cp.saturation_ticks = 0;
+  }
+}
+
+function shouldTriggerReopt(cp) {
+  if (cp.fast_fail_ticks >= FAST_FAIL_TICKS) return { trigger: true, reason: "fast_fail" };
+  if (cp.saturation_ticks >= SATURATION_TICKS) return { trigger: true, reason: "ema_saturation" };
+  return { trigger: false, reason: null };
+}
+
+function partialResetSeenEvidence(cp, nowStr) {
+  const cutoff = new Date(new Date(nowStr).getTime() - REOPT_WINDOW_MS).getTime();
+  for (const [key, entry] of Object.entries(cp.seen_evidence)) {
+    const seenAt = seenEvidenceTimestamp(entry);
+    if (!seenAt || new Date(seenAt).getTime() < cutoff) {
+      delete cp.seen_evidence[key];
+    }
+  }
+}
+
+function triggerReopt(cp, nowStr) {
+  partialResetSeenEvidence(cp, nowStr);
+  cp.diversity_mode_ticks_remaining = DIVERSITY_BOOST_TICKS;
+  cp.reopt_count++;
+  cp.saturation_ticks = 0;
+  cp.fast_fail_ticks = 0;
+  cp.last_reopt_at = nowStr;
+}
+
+// Returns Set of underrepresented categories using last DIVERSITY_LOOKBACK_TICKS tick history.
+// A category is underrepresented when its summed scored count is below the per-category average.
+function underrepresentedCatsFromHistory(cp) {
+  const totals = {};
+  for (const cat of KNOWN_CATEGORIES) totals[cat] = 0;
+  for (const snapshot of cp.stats.category_scored_history || []) {
+    for (const [cat, n] of Object.entries(snapshot)) {
+      totals[cat] = (totals[cat] || 0) + n;
+    }
+  }
+  const vals = Object.values(totals);
+  const avg = vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : 0;
+  return new Set(Object.entries(totals).filter(([, n]) => n < avg).map(([c]) => c));
+}
+
+function normalizeCategory(value) {
+  if (typeof value === "string" && KNOWN_CATEGORIES.has(value)) {
+    return value;
+  }
+  return "routine-candidate";
+}
+
+function categoryGate(category) {
+  return CATEGORY_GATES[normalizeCategory(category)] || CATEGORY_GATES["routine-candidate"];
+}
+
+function categoryScoreMultiplier(category) {
+  const value = CATEGORY_SCORE_MULTIPLIERS[normalizeCategory(category)] || 1;
+  return Math.min(1.5, Math.max(1, value));
+}
+
+function candidateGate(candidate) {
+  return categoryGate(candidate && candidate.category);
+}
+
+function candidateMeetsGate(candidate) {
+  const gate = candidateGate(candidate);
+  return (candidate.score || 0) >= gate.minScore
+    && (candidate.evidence_count || 0) >= gate.minEvidence;
+}
+
+function observationOccurrences(obs) {
+  const value = Number(obs.occurrences || obs.count || 1);
+  if (!Number.isFinite(value) || value < 1) {
+    return 1;
+  }
+  return Math.min(50, Math.floor(value));
+}
+
+function observationKey(obs) {
+  if (typeof obs.key === "string") return obs.key;
+  if (typeof obs.evidence_ref === "string") {
+    if (obs.evidence_ref.startsWith("kv_meta:routine_observation:")) {
+      return obs.evidence_ref.slice("kv_meta:".length);
+    }
+    if (obs.evidence_ref.startsWith("routine_observation:")) {
+      return obs.evidence_ref;
+    }
+  }
+  return "";
+}
+
+function compactText(value, maxChars) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxChars);
+}
+
+function topEvidenceForCandidate(candidate, limit) {
+  return (candidate.examples || [])
+    .slice(-limit)
+    .reverse()
+    .map((example) => ({
+      summary: compactText(example.summary, 140),
+      timestamp: example.timestamp || null,
+      evidence_ref: example.evidence_ref || null,
+      weight: example.weight || 1,
+      occurrences: example.occurrences || 1,
+    }));
+}
+
+function topEvidenceSummaryForCandidate(candidate) {
+  const evidence = topEvidenceForCandidate(candidate, 2);
+  if (evidence.length === 0) return "핵심 근거 없음";
+  return evidence
+    .map(
+      (item, index) =>
+        `${index + 1}) ${item.summary || "요약 없음"} (occurrences=${item.occurrences}, weight=${item.weight})`
+    )
+    .join(" / ");
+}
+
+function topContributionSummary(map, limit) {
+  const entries = Object.entries(map || {})
+    .sort(([, a], [, b]) => Number(b || 0) - Number(a || 0))
+    .slice(0, limit)
+    .map(([key, count]) => `${key}=${count}`);
+  return entries.length ? entries.join(", ") : "none";
+}
+
+function candidateSourceSummary(candidate) {
+  return [
+    `sources(${topContributionSummary(candidate.sources, 3)})`,
+    `categories(${topContributionSummary(candidate.source_categories, 3)})`,
+  ].join(" ");
+}
+
+function topCandidateEvidence(cp, limit) {
+  return Object.entries(cp.candidates || {})
+    .filter(([, candidate]) => candidate.state === "observing" || candidate.state === "recommended")
+    .sort(([, a], [, b]) => (b.score || 0) - (a.score || 0))
+    .slice(0, limit)
+    .map(([patternId, candidate]) => ({
+      pattern_id: patternId,
+      score: candidate.score || 0,
+      score_delta_last_tick: candidate.score_delta_last_tick || 0,
+      evidence_count: candidate.evidence_count || 0,
+      gate: candidateGate(candidate),
+      latest_evidence: topEvidenceSummaryForCandidate(candidate),
+    }));
+}
+
+function topCandidateEvidenceSummary(cp) {
+  const top = topCandidateEvidence(cp, 3);
+  if (top.length === 0) return "관찰 중인 후보 없음";
+  return top
+    .map(
+      (item, index) =>
+        `${index + 1}) ${item.pattern_id}: score=${item.score}, delta=${item.score_delta_last_tick}, evidence=${item.evidence_count}, 근거=${item.latest_evidence}`
+    )
+    .join(" / ");
+}
+
+function suppressionSummary(suppressedObservations, droppedCandidates) {
+  const parts = [];
+  for (const item of (suppressedObservations || []).slice(0, 3)) {
+    parts.push(`${item.pattern_id}: ${item.reason}`);
+  }
+  for (const item of (droppedCandidates || []).slice(0, 3)) {
+    parts.push(`${item.pattern_id}: ${item.reason}`);
+  }
+  return parts.length ? parts.join(" / ") : "중복/억제 후보 없음";
+}
+
+function noEscalationReason(cp, nowStr) {
+  if (cp.stats.recommendations_today >= DAILY_CAP) {
+    return `보류 이유: 일일 추천 한도 ${DAILY_CAP}개에 도달했습니다.`;
+  }
+  const top = topCandidateEvidence(cp, 1)[0];
+  if (!top) {
+    return "보류 이유: 관찰된 후보가 없습니다.";
+  }
+  const candidate = cp.candidates[top.pattern_id] || {};
+  const gate = candidateGate(candidate);
+  if ((candidate.evidence_count || 0) < gate.minEvidence) {
+    return `보류 이유: 최상위 후보 ${top.pattern_id}의 근거가 ${candidate.evidence_count || 0}회로 category=${normalizeCategory(candidate.category)} 최소 ${gate.minEvidence}회 미만입니다.`;
+  }
+  if ((candidate.score || 0) < gate.minScore) {
+    return `보류 이유: 최상위 후보 ${top.pattern_id}의 점수 ${candidate.score || 0}가 category=${normalizeCategory(candidate.category)} 기준 ${gate.minScore} 미만입니다.`;
+  }
+  if (candidate.cooldown_until && candidate.cooldown_until > nowStr) {
+    return `보류 이유: 최상위 후보 ${top.pattern_id}가 ${candidate.cooldown_until}까지 쿨다운 중입니다.`;
+  }
+  return `보류 이유: 최상위 후보 ${top.pattern_id}는 중복 추천 해시 또는 게이트 조건으로 보류됐습니다.`;
+}
+
+function utf8CharBytes(ch) {
+  const codePoint = ch.codePointAt(0);
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function utf8ByteLength(value) {
+  let bytes = 0;
+  for (const ch of String(value || "")) {
+    bytes += utf8CharBytes(ch);
+  }
+  return bytes;
+}
+
+function truncateUtf8(value, maxBytes) {
+  if (maxBytes <= 0) return "";
+  let bytes = 0;
+  let out = "";
+  for (const ch of String(value || "")) {
+    const nextBytes = utf8CharBytes(ch);
+    if (bytes + nextBytes > maxBytes) break;
+    out += ch;
+    bytes += nextBytes;
+  }
+  return out;
+}
+
+// --- Daily cap reset ---
+
+function resetDailyCapIfNeeded(cp, nowStr) {
+  const today = dateOf(nowStr);
+  if (cp.stats.recommendation_day !== today) {
+    cp.stats.recommendations_today = 0;
+    cp.stats.recommendation_day = today;
+  }
+}
+
+// --- Suppression / inventory filter ---
+
+function hasDurableAcceptance(entry) {
+  return Boolean(entry && (entry.automation_ref || entry.source_ref));
+}
+
+function buildSuppressedSet(cp, inventory, observations) {
+  const exact = new Map();
+  const prefixes = [];
+
+  function addPattern(patternId, reason) {
+    if (!patternId) return;
+    if (patternId.endsWith(":*")) {
+      prefixes.push({ prefix: patternId.slice(0, -1), reason });
+    } else {
+      exact.set(patternId, reason);
+    }
+  }
+
+  // From checkpoint suppressions
+  for (const [patternId, entry] of Object.entries(cp.suppressions || {})) {
+    const state = entry.state;
+    if (
+      (state === "accepted" && hasDurableAcceptance(entry)) ||
+      state === "implemented" ||
+      state === "suppressed" ||
+      state === "rejected"
+    ) {
+      addPattern(patternId, `체크포인트 억제 상태=${state}`);
+    }
+  }
+
+  // From automation inventory (exact pattern_id match only)
+  for (const item of inventory || []) {
+    if (
+      item.pattern_id &&
+      ((item.status === "accepted" && hasDurableAcceptance(item)) ||
+        item.status === "implemented" ||
+        item.status === "suppressed" ||
+        item.status === "rejected")
+    ) {
+      addPattern(
+        item.pattern_id,
+        `자동화 인벤토리 상태=${item.status}${item.source_ref ? ` ref=${item.source_ref}` : ""}`
+      );
+    }
+  }
+
+  // Candidate-level accepted/implemented/suppressed/rejected states
+  for (const [patternId, candidate] of Object.entries(cp.candidates || {})) {
+    const s = candidate.state;
+    if (
+      (s === "accepted" && hasDurableAcceptance(candidate)) ||
+      s === "implemented" ||
+      s === "suppressed" ||
+      s === "rejected"
+    ) {
+      addPattern(patternId, `후보 상태=${s}`);
+    }
+  }
+
+  // Contract: executor/dispatched markers must suffix the same signature used by obs.signature.
+  // candidate_dispatched:* kv_meta observations → suppress re-recommendation (REQ-P1-004)
+  for (const obs of observations || []) {
+    const key = observationKey(obs);
+    if (key.startsWith("routine_observation:candidate_dispatched:")) {
+      const signature = key.replace("routine_observation:candidate_dispatched:", "");
+      if (signature) addPattern(signature, "dispatched kv_meta 존재 (재추천 차단)");
+    }
+  }
+
+  return {
+    has(patternId) {
+      return exact.has(patternId) || prefixes.some((item) => patternId.startsWith(item.prefix));
+    },
+    reason(patternId) {
+      if (exact.has(patternId)) return exact.get(patternId);
+      const matched = prefixes.find((item) => patternId.startsWith(item.prefix));
+      return matched ? matched.reason : null;
+    },
+  };
+}
+
+function dropSuppressedCandidates(cp, suppressedSet) {
+  const dropped = [];
+  for (const [patternId, candidate] of Object.entries(cp.candidates || {})) {
+    if (suppressedSet.has(patternId)) {
+      const s = candidate.state;
+      if (
+        (s === "accepted" && hasDurableAcceptance(candidate)) ||
+        s === "implemented" ||
+        s === "suppressed" ||
+        s === "rejected"
+      ) {
+        continue;
+      }
+      dropped.push({
+        pattern_id: patternId,
+        state: s,
+        reason: suppressedSet.reason(patternId) || "인벤토리/체크포인트 기준으로 억제",
+      });
+      delete cp.candidates[patternId];
+    }
+  }
+
+  if (Array.isArray(cp.recommendations)) {
+    cp.recommendations = cp.recommendations.filter((item) => !suppressedSet.has(item.pattern_id));
+  }
+
+  return dropped.slice(0, 5);
+}
+
+// --- Expired suppression cleanup ---
+
+function pruneExpiredSuppressions(cp, nowStr) {
+  for (const [patternId, entry] of Object.entries(cp.suppressions || {})) {
+    if (entry.expires_at && entry.expires_at < nowStr) {
+      delete cp.suppressions[patternId];
+      if (cp.candidates[patternId]) {
+        cp.candidates[patternId].state = "observing";
+      }
+    }
+  }
+}
+
+function expireStaleCandidates(cp, nowStr) {
+  const cutoff = new Date(new Date(nowStr).getTime() - CANDIDATE_TTL_DAYS * 24 * 3600 * 1000).toISOString();
+  for (const candidate of Object.values(cp.candidates || {})) {
+    if (
+      candidate.last_seen_at &&
+      candidate.last_seen_at < cutoff &&
+      (candidate.state === "observing" || candidate.state === "recommended")
+    ) {
+      candidate.state = "expired";
+    }
+  }
+}
+
+// --- Score observations into candidates ---
+
+function scoreObservations(cp, observations, suppressedSet, nowStr, diversityMode) {
+  const thirtyMinAgo = new Date(new Date(nowStr).getTime() - 30 * 60 * 1000).toISOString();
+  const report = {
+    scored: 0,
+    deduped: 0,
+    suppressed: [],
+    category_scored_this_tick: {},
+  };
+
+  // Diversity mode: underrepresented categories from last DIVERSITY_LOOKBACK_TICKS tick history
+  const underrepresentedCats = diversityMode ? underrepresentedCatsFromHistory(cp) : null;
+
+  for (const candidate of Object.values(cp.candidates || {})) {
+    candidate.score_delta_last_tick = 0;
+    candidate.scored_observations_last_tick = 0;
+    candidate.last_score_reason = null;
+  }
+
+  for (const obs of observations) {
+    cp.stats.observations_seen++;
+
+    const patternId = obs.signature;
+    if (!patternId) continue;
+    if (suppressedSet.has(patternId)) {
+      report.suppressed.push({
+        pattern_id: patternId,
+        reason: suppressedSet.reason(patternId) || "인벤토리/체크포인트 기준으로 억제",
+      });
+      continue;
+    }
+
+    // Cross-tick dedup: skip evidence already scored in a previous tick, but
+    // score only the newly increased occurrence count for rolling grouped sources.
+    const eKey = evidenceKey(obs);
+    const totalOccurrences = observationOccurrences(obs);
+    if (isEvidenceFullySeen(cp, eKey, nowStr, totalOccurrences)) {
+      markEvidenceSeen(cp, eKey, nowStr, totalOccurrences);
+      report.deduped++;
+      continue;
+    }
+    const priorOccurrences = seenOccurrences(cp, eKey, nowStr);
+    const occurrences = Math.max(1, totalOccurrences - priorOccurrences);
+    markEvidenceSeen(cp, eKey, nowStr, totalOccurrences);
+
+    const category = normalizeCategory(obs.category);
+    let candidate = cp.candidates[patternId];
+    if (!candidate) {
+      candidate = {
+        category,
+        state: "observing",
+        score: WEIGHT_FIRST_SEEN,
+        evidence_count: 0,
+        first_seen_at: obs.timestamp || nowStr,
+        last_seen_at: null,
+        examples: [],
+        sources: {},
+        source_categories: {},
+        last_recommended_at: null,
+        last_recommendation_hash: null,
+        cooldown_until: null,
+        automation_ref: null,
+        has_error_evidence: false,
+      };
+      cp.candidates[patternId] = candidate;
+    } else {
+      candidate.category = normalizeCategory(candidate.category || category);
+    }
+
+    // Skip if already resolved
+    if (candidate.state === "accepted" && !hasDurableAcceptance(candidate)) {
+      candidate.state = "recommended";
+    }
+    if (
+      (candidate.state === "accepted" && hasDurableAcceptance(candidate)) ||
+      candidate.state === "implemented" ||
+      candidate.state === "suppressed" ||
+      candidate.state === "rejected"
+    ) {
+      continue;
+    }
+
+    candidate.evidence_count += occurrences;
+    candidate.last_seen_at = obs.timestamp || nowStr;
+    candidate.sources = candidate.sources || {};
+    candidate.source_categories = candidate.source_categories || {};
+    const source = String(obs.source || "unknown");
+    candidate.sources[source] = (candidate.sources[source] || 0) + occurrences;
+    candidate.source_categories[category] = (candidate.source_categories[category] || 0) + occurrences;
+
+    // Score delta
+    const weight = typeof obs.weight === "number" ? obs.weight : 1;
+    const scoredOccurrences = Math.min(occurrences, 5);
+    let delta = WEIGHT_BASE * weight * scoredOccurrences;
+    if (weight === 2) {
+      candidate.has_error_evidence = true;
+    }
+
+    // Recency bonus
+    const recencyBonus = obs.timestamp && obs.timestamp >= thirtyMinAgo ? WEIGHT_RECENCY_BONUS : 0;
+    if (obs.timestamp && obs.timestamp >= thirtyMinAgo) {
+      delta += recencyBonus;
+    }
+
+    // Diversity mode: 1.5× boost for underrepresented categories
+    const diversityBoost = (underrepresentedCats && underrepresentedCats.has(category)) ? 1.5 : 1;
+    const categoryMultiplier = categoryScoreMultiplier(category);
+    delta = delta * diversityBoost * categoryMultiplier;
+
+    candidate.score = Math.min(100, candidate.score + delta);
+    candidate.score_delta_last_tick = (candidate.score_delta_last_tick || 0) + delta;
+    candidate.scored_observations_last_tick =
+      (candidate.scored_observations_last_tick || 0) + 1;
+    candidate.last_score_reason =
+      `weight=${weight}, occurrences=${occurrences}, recency_bonus=${recencyBonus}, category_multiplier=${categoryMultiplier}${diversityBoost > 1 ? ", diversity_boost=1.5" : ""}`;
+    candidate.last_scored_at = nowStr;
+    report.scored++;
+
+    // Track per-category scoring stats (cumulative + per-tick for diversity history)
+    cp.stats.category_scored[category] = (cp.stats.category_scored[category] || 0) + 1;
+    report.category_scored_this_tick[category] = (report.category_scored_this_tick[category] || 0) + 1;
+
+    // Keep up to 3 examples
+    if (candidate.examples.length < MAX_EXAMPLES_PER_CANDIDATE) {
+      candidate.examples.push({
+        summary: obs.summary,
+        timestamp: obs.timestamp,
+        evidence_ref: obs.evidence_ref,
+        source: obs.source,
+        category,
+        weight,
+        occurrences,
+      });
+    }
+  }
+
+  return report;
+}
+
+// --- Find best escalation candidate ---
+
+function findEscalationCandidate(cp, nowStr) {
+  if (cp.stats.recommendations_today >= DAILY_CAP) {
+    return null;
+  }
+
+  let best = null;
+  let bestScore = -1;
+
+  for (const [patternId, candidate] of Object.entries(cp.candidates || {})) {
+    if (candidate.state !== "observing" && candidate.state !== "recommended") {
+      continue;
+    }
+    if (!candidateMeetsGate(candidate)) {
+      continue;
+    }
+    if (candidate.score <= bestScore) {
+      continue;
+    }
+    if (candidate.cooldown_until && candidate.cooldown_until > nowStr) {
+      continue;
+    }
+
+    // Dedupe: same hash within cooldown
+    const hash = simpleHash(patternId + ":" + candidate.evidence_count);
+    if (candidate.last_recommendation_hash === hash) {
+      continue;
+    }
+
+    bestScore = candidate.score;
+    best = { patternId, candidate, hash };
+  }
+
+  return best;
+}
+
+// --- Mark candidate as recommended ---
+
+function markRecommended(cp, escalation, nowStr) {
+  const { patternId, candidate, hash } = escalation;
+  const assessment = candidateAssessment(patternId, candidate);
+  const decisionSummary = candidateDecisionSummary(patternId, candidate, assessment);
+  const topEvidenceSummary = topEvidenceSummaryForCandidate(candidate);
+  candidate.state = "recommended";
+  candidate.last_recommended_at = nowStr;
+  candidate.last_recommendation_hash = hash;
+  candidate.cooldown_until = addHours(nowStr, COOLDOWN_HOURS);
+  candidate.suggested_automation = assessment.suggestedAutomation;
+  candidate.recommended_execution = assessment.recommendedExecution;
+  candidate.outcome_summary = assessment.outcomeSummary;
+  candidate.before_after = assessment.beforeAfter;
+  candidate.expected_files = assessment.expectedFiles;
+  candidate.expected_side_effects = assessment.expectedSideEffects;
+  candidate.verification_method = assessment.verificationMethod;
+  candidate.gated_handoff = assessment.gatedHandoff;
+  candidate.materialize_request = assessment.materializeRequest;
+  candidate.decision_summary = decisionSummary;
+  candidate.top_evidence = topEvidenceForCandidate(candidate, 3);
+  candidate.top_evidence_summary = topEvidenceSummary;
+  cp.stats.recommendations_today++;
+  cp.stats.agent_escalations++;
+  cp.recommendations.push({
+    pattern_id: patternId,
+    recommended_at: nowStr,
+    hash,
+    score: candidate.score,
+    score_delta_last_tick: candidate.score_delta_last_tick || 0,
+    evidence_count: candidate.evidence_count,
+    sources: candidate.sources || {},
+    source_categories: candidate.source_categories || {},
+    outcome_summary: assessment.outcomeSummary,
+    decision_summary: decisionSummary,
+    top_evidence_summary: topEvidenceSummary,
+    materialize_request: assessment.materializeRequest,
+  });
+  // Keep recommendations list bounded
+  if (cp.recommendations.length > 50) {
+    cp.recommendations = cp.recommendations.slice(-50);
+  }
+}
+
+// --- Agent prompt builder ---
+
+function buildOutcomeSummary(patternId, candidate, isErrorPattern, category) {
+  const latestExample = (candidate.examples || []).slice(-1)[0] || {};
+  const latestSummary = String(latestExample.summary || patternId)
+    .replace(/\s+/g, " ")
+    .slice(0, 120);
+  const count = candidate.evidence_count || observationOccurrences(latestExample) || 0;
+  const categoryLabel = {
+    "routine-candidate": "루틴 반복",
+    "release-freshness": "릴리스 신선도",
+    "outbox-delivery": "메시지 발송",
+    "memento-hygiene": "메모리 위생",
+    "api-friction": "API 마찰",
+    "kanban-flow": "칸반 흐름",
+    "dispatch-retry": "디스패치 재시도",
+    "session-pattern": "세션 오류",
+    "log-signal": "운영 로그",
+    "automation-candidate": "자동화 후보",
+  }[category] || "루틴 후보";
+  const prefix = isErrorPattern || category === "outbox-delivery" || category === "api-friction"
+    ? "실패 요약"
+    : "성공 요약";
+  const action = prefix === "실패 요약"
+    ? "자동 복구나 알림 후보입니다"
+    : "수동 확인 없이 루틴화할 후보입니다";
+  return `${prefix}: ${categoryLabel} 패턴이 ${count}회 반복되어 ${action}. 최근 근거: ${latestSummary}`;
+}
+
+function candidateAssessment(patternId, candidate) {
+  const isErrorPattern = Boolean(candidate.has_error_evidence) ||
+    (candidate.examples || []).some((example) => example.weight === 2);
+  const category = normalizeCategory(candidate.category);
+  const categoryProfiles = {
+    "routine-candidate": {
+      suggestedAutomation: isErrorPattern
+        ? "반복 실패 루틴에 대한 자동 재시도 또는 알림"
+        : "반복 패턴을 자동 처리하는 예약 루틴",
+      before: "반복 루틴 근거는 수동 로그 확인 후에만 보입니다.",
+      after: "제한된 루틴/규칙이 반복 패턴을 처리하거나 쿨다운을 두고 에스컬레이션합니다.",
+      files: ["routines/monitoring/*.js", "src/services/routines/*"],
+      sideEffects: "루틴 또는 규칙 경로가 추가될 수 있으므로 쿨다운, 중복 제거, Discord 노이즈를 검증해야 합니다.",
+      verification: "대상 루틴 로더 테스트를 실행하고 체크포인트 후보 필드를 확인합니다.",
+    },
+    "release-freshness": {
+      suggestedAutomation: "오래된 배포, 버전, 생성 인벤토리 신호를 감지하는 릴리스 신선도 모니터",
+      before: "버전이나 생성 문서가 오래된 뒤에야 사람이 릴리스 드리프트를 발견합니다.",
+      after: "신선도 점검이 오래된 릴리스 상태가 누적되기 전에 업데이트 경로를 제안합니다.",
+      files: ["scripts/*release*", "src/cli/*", "docs/generated/worker-inventory.md"],
+      sideEffects: "읽기 전용 신선도 점검이 추가될 수 있으며 자동 게시, 태깅, 배포는 피해야 합니다.",
+      verification: "스크립트 검사와 릴리스 부작용이 없음을 증명하는 신선도 픽스처를 실행합니다.",
+    },
+    "outbox-delivery": {
+      suggestedAutomation: "반복 전송 또는 큐 적재 실패를 감지하는 메시지 아웃박스 전달 모니터",
+      before: "전달 실패 반복 패턴을 찾으려면 DB/로그를 사람이 직접 확인해야 합니다.",
+      after: "반복 아웃박스 실패가 명확한 전달 수정 경로를 가진 제한된 제안으로 묶입니다.",
+      files: ["src/services/message_outbox.rs", "src/services/routines/discord_log.rs", "src/services/discord/*"],
+      sideEffects: "알림 재시도 또는 폴백 동작이 바뀔 수 있으므로 중복 제거와 전달 대상을 검증해야 합니다.",
+      verification: "아웃박스/루틴 대상 테스트를 실행하고 전달 실패 픽스처를 확인합니다.",
+    },
+    "memento-hygiene": {
+      suggestedAutomation: "반복되는 메모리 품질 또는 라우팅 문제를 요약하는 Memento 위생 다이제스트 모니터",
+      before: "메모리 위생 문제는 원문 노트에 흩어져 있어 안전하게 조치하기 어렵습니다.",
+      after: "토픽/횟수/최신 예시 다이제스트만 제한된 제안으로 변환합니다.",
+      files: ["src/services/memory/*", "src/services/routines/store.rs", "routines/monitoring/*.js"],
+      sideEffects: "이 루틴은 원문 메모리 본문을 읽거나 쓰면 안 되며 다이제스트 절단을 검증해야 합니다.",
+      verification: "추천기 다이제스트 픽스처를 실행하고 프롬프트에 원문 메모리 본문이 없는지 확인합니다.",
+    },
+    "api-friction": {
+      suggestedAutomation: "반복되는 문서 또는 엔드포인트 워크플로 붕괴를 감지하는 API 마찰 모니터",
+      before: "API 마찰이 에이전트 응답에서 반복되지만 통합 개선 제안으로 이어지지 않습니다.",
+      after: "반복 마찰 마커가 지문별로 묶이고 문서 및 검증 가이드가 함께 제안됩니다.",
+      files: ["src/services/api_friction.rs", "src/server/routes/*", "docs/*"],
+      sideEffects: "문서 또는 API 라우팅이 바뀔 수 있으며 DB 직접 우회가 도입되지 않았는지 검증해야 합니다.",
+      verification: "API 마찰 파싱 테스트와 대상 루틴 추천기 픽스처를 실행합니다.",
+    },
+    "kanban-flow": {
+      suggestedAutomation: "정체되거나 차단된 칸반 흐름을 감지하고 다음 조치 후보를 생성하는 칸반 흐름 모니터",
+      before: "오래 멈춘 카드와 차단 사유를 사람이 수동으로 훑어야 합니다.",
+      after: "정체/차단 패턴이 에이전트별·상태별로 묶여 자동화 후보 카드로 올라옵니다.",
+      files: ["src/server/routes/kanban.rs", "src/db/kanban_cards/*", "routines/monitoring/*.js"],
+      sideEffects: "카드 상태 전이는 직접 수행하지 않고, 후보 카드와 검증 지시만 생성해야 합니다.",
+      verification: "칸반 observation fixture와 executor ready-card 회귀 테스트를 실행합니다.",
+    },
+    "dispatch-retry": {
+      suggestedAutomation: "반복 재시도되는 디스패치 흐름을 감지하는 dispatch retry monitor",
+      before: "반복 재시도/실패 디스패치는 로그나 DB를 직접 확인해야 합니다.",
+      after: "from/to agent와 status별 반복 재시도 패턴이 후보로 묶입니다.",
+      files: ["src/server/routes/dispatches/*", "src/db/auto_queue/*", "policies/timeouts/*"],
+      sideEffects: "재시도 정책은 중복 디스패치와 알림 폭증을 만들 수 있으므로 dry-run 검증이 필요합니다.",
+      verification: "dispatch/outbox 관련 테스트와 retry fixture를 실행합니다.",
+    },
+    "session-pattern": {
+      suggestedAutomation: "반복 에러가 발생하는 agent/session 패턴을 감지하고 개선 후보를 만드는 세션 패턴 모니터",
+      before: "같은 agent 오류가 대화 로그에 흩어져 후속 개선으로 이어지기 어렵습니다.",
+      after: "agent별 반복 오류가 bounded observation으로 점수화되어 개선 후보가 됩니다.",
+      files: ["src/db/session_transcripts.rs", "src/services/discord/*", "routines/monitoring/*.js"],
+      sideEffects: "세션 본문 원문을 후보에 과도하게 싣지 않고 집계와 최신 예시만 사용해야 합니다.",
+      verification: "session_transcripts observation과 recommender ROI gate 테스트를 실행합니다.",
+    },
+    "log-signal": {
+      suggestedAutomation: "audit_logs와 kanban_audit_logs 반복 패턴을 감지하는 운영 로그 모니터",
+      before: "운영 로그의 반복 action/source 패턴은 analytics 화면에서만 보이고 자동화 후보로 이어지지 않습니다.",
+      after: "반복 로그 패턴이 category별 후보로 묶이고 ROI gate에 포함됩니다.",
+      files: ["src/services/analytics/*", "src/services/routines/store.rs", "src/kanban/audit.rs"],
+      sideEffects: "로그는 읽기 전용 근거로만 사용하고 audit log write path는 변경하지 않아야 합니다.",
+      verification: "store.rs observation 테스트와 recommender ROI gate 테스트를 실행합니다.",
+    },
+    "automation-candidate": {
+      suggestedAutomation: "이미 준비된 automation-candidate 카드의 반복 실행 상태를 관리하는 후보 루프 모니터",
+      before: "준비된 자동화 후보 카드가 executor까지 이어졌는지 사람이 확인해야 합니다.",
+      after: "ready/done 후보 카드가 observation으로 들어와 executor/suppression 경로를 안정화합니다.",
+      files: ["src/services/automation_candidate_materializer.rs", "src/services/routines/store.rs", "routines/monitoring/automation-candidate-executor.js"],
+      sideEffects: "후보 실행은 allowed_write_paths와 iteration result API 계약 안에서만 진행해야 합니다.",
+      verification: "automation-candidate executor tests와 materializer tests를 실행합니다.",
+    },
+  };
+  const profile = categoryProfiles[category] || categoryProfiles["routine-candidate"];
+  const recommendedExecution = category === "routine-candidate" && candidate.score < 90
+    ? "rule"
+    : "agent";
+  const title = patternId.replace(/\s+/g, " ").slice(0, 96);
+  const allowedWritePaths = candidateProgramAllowedPaths(profile.files);
+  return {
+    suggestedAutomation: profile.suggestedAutomation,
+    recommendedExecution,
+    outcomeSummary: buildOutcomeSummary(patternId, candidate, isErrorPattern, category),
+    beforeAfter: {
+      before: profile.before,
+      after: profile.after,
+    },
+    expectedFiles: profile.files,
+    expectedSideEffects: profile.sideEffects,
+    verificationMethod: profile.verification,
+    gatedHandoff: {
+      status: "requires_human_approval",
+      kanban_card_draft: {
+        title: `[automation-candidate] ${title}`,
+        category,
+        acceptance: [
+          "브랜치/카드 변경 전에 제안 승인이 완료되어야 합니다",
+          "루틴은 제한적이고 멱등적으로 유지되어야 합니다",
+          "검증 명령 또는 픽스처가 PR/카드에 기록되어야 합니다",
+        ],
+      },
+      pr_draft: {
+        title: `자동화 후보 구현: ${title}`,
+        body_hint: "Before/After, 예상 파일, 부작용, 검증 근거를 포함합니다.",
+      },
+      side_effects: "사람이 게이트된 핸드오프를 명시적으로 승인하기 전까지는 없음",
+    },
+    materializeRequest: {
+      endpoint: "POST /api/automation-candidates",
+      body: {
+        title: `[automation-candidate] ${title}`,
+        source: "routine_recommender",
+        dedupe_key: patternId,
+        start_ready: false,
+        program: {
+          repo_dir: REPO_DIR_PLACEHOLDER,
+          allowed_write_paths: allowedWritePaths,
+          metric_name: candidateMetricName(category),
+          metric_target: 0,
+          metric_direction: "lower_is_better",
+          final_gate: "manual_review",
+          iteration_budget: 3,
+        },
+      },
+      needs_human_fields: ["program.repo_dir"],
+    },
+  };
+}
+
+function candidateProgramAllowedPaths(files) {
+  const out = [];
+  for (const file of files || []) {
+    let path = String(file || "").trim();
+    if (!path || path.startsWith("/") || path.includes("..")) continue;
+    const star = path.indexOf("*");
+    if (star >= 0) path = path.slice(0, star);
+    path = path.replace(/\/+$/, "");
+    if (!path) continue;
+    if (!out.includes(path)) out.push(path);
+  }
+  return out.length ? out : ["src"];
+}
+
+function candidateMetricName(category) {
+  return {
+    "routine-candidate": "manual_routine_touch_count",
+    "release-freshness": "release_drift_count",
+    "outbox-delivery": "outbox_delivery_failure_count",
+    "memento-hygiene": "memento_hygiene_issue_count",
+    "api-friction": "api_friction_count",
+    "kanban-flow": "kanban_stuck_or_blocked_count",
+    "dispatch-retry": "dispatch_retry_count",
+    "session-pattern": "session_error_pattern_count",
+    "log-signal": "audit_log_pattern_count",
+    "automation-candidate": "automation_candidate_backlog_count",
+  }[category] || "automation_friction_count";
+}
+
+function candidateDecisionSummary(patternId, candidate, assessment) {
+  const score = candidate.score || 0;
+  const delta = candidate.score_delta_last_tick || 0;
+  const evidenceCount = candidate.evidence_count || 0;
+  const gate = candidateGate(candidate);
+  const evidenceSummary = topEvidenceSummaryForCandidate(candidate);
+  return `선택 이유: ${patternId} 후보가 category=${normalizeCategory(candidate.category)}, score=${score}, delta=${delta}, evidence=${evidenceCount}, gate=${gate.minScore}/${gate.minEvidence}로 ROI 기준을 충족했습니다. ${candidateSourceSummary(candidate)}. ${assessment.outcomeSummary} 핵심 근거: ${evidenceSummary}`;
+}
+
+function convergenceSummary(candidate) {
+  if (!candidate.last_recommended_at && !candidate.last_recommendation_hash) {
+    return "이 후보는 이전 추천 이력이 없습니다. 현재 tick의 새 근거를 중심으로 평가합니다.";
+  }
+  const parts = [];
+  if (candidate.last_recommended_at) {
+    parts.push(`이전 추천 시각=${candidate.last_recommended_at}`);
+  }
+  if (candidate.last_recommendation_hash) {
+    parts.push(`이전 추천 해시=${candidate.last_recommendation_hash}`);
+  }
+  if (candidate.cooldown_until) {
+    parts.push(`쿨다운 종료=${candidate.cooldown_until}`);
+  }
+  return `이 후보는 이전 추천/체크포인트 이력이 있습니다. ${parts.join(", ")}`;
+}
+
+function buildPrompt(escalation) {
+  const { patternId, candidate } = escalation;
+  const evidenceLines = (candidate.examples || [])
+    .map((ex, i) => `${i + 1}. [${ex.timestamp || "?"}] ${ex.summary || ""} (occurrences=${ex.occurrences || 1})`)
+    .join("\n");
+
+  const {
+    suggestedAutomation,
+    recommendedExecution,
+    beforeAfter,
+    expectedFiles,
+    expectedSideEffects,
+    verificationMethod,
+    outcomeSummary,
+    gatedHandoff,
+    materializeRequest,
+  } = candidateAssessment(patternId, candidate);
+  const decisionSummary = candidateDecisionSummary(patternId, candidate, {
+    outcomeSummary,
+  });
+  const handoffAcceptance = (gatedHandoff.kanban_card_draft.acceptance || [])
+    .map((item) => `- ${item}`)
+    .join("\n");
+
+  const raw = `# 자동화 후보 추천
+
+패턴: ${patternId}
+카테고리: ${normalizeCategory(candidate.category)}
+점수: ${candidate.score}/100
+근거: ${candidate.evidence_count}회 발생 (최초: ${candidate.first_seen_at || "?"}, 최신: ${candidate.last_seen_at || "?"})
+
+## 근거 예시
+${evidenceLines || "(기록 없음)"}
+
+## 성공/실패 한 줄 요약
+${outcomeSummary}
+
+## 선택 판단 근거
+${decisionSummary}
+
+## 루트 기반 JS 자동화 패턴 탐지 가이드
+- 이 제안은 runtime이 제공한 bounded observation, checkpoint, automation inventory만 근거로 판단합니다.
+- 같은 증상이 아니라 같은 루트 원인 또는 같은 수동 작업이 반복되는지 pattern/category/count/first-last/example을 연결해 설명합니다.
+- 단순 빈도만 보지 말고 최근성, 실패 weight, 운영 ROI, 부작용, 이미 구현/억제된 자동화와의 중복 가능성을 함께 평가합니다.
+- 규칙으로 충분한 deterministic retry/check/threshold인지, 문맥 판단과 코드 변경 설계가 필요한 agent 주도 자동화인지 구분합니다.
+- 근거가 부족하거나 오탐 가능성이 높으면 자동화 보류로 결론을 내립니다.
+
+## 이전 작업/체크포인트 수렴 대응
+${convergenceSummary(candidate)}
+- 이전 추천, checkpoint, inventory를 보고 같은 결론에 수렴하더라도 "추가 개선 없음"으로만 끝내지 않습니다.
+- 반복 제안이 되지 않게 새 근거, 새 실패 양상, 새 검증 경로, 기존 자동화의 누락 지점 중 하나를 반드시 확인합니다.
+- 목표 달성을 위해 대체 탐색 경로를 최소 1개 제안합니다: observation 스키마 보강, 로그 수집 위치 변경, suppression/inventory 오탐 점검, rule 기반 작은 자동화, agent 주도 핸드오프 분리, 검증 metric 추가.
+- 여전히 보류라면 다음 tick에서 어떤 근거를 더 수집해야 하는지 한 줄로 남깁니다.
+
+## 이미 자동화됨 판단 기준
+- automation inventory, checkpoint suppression, candidate state 중 하나가 같은 pattern_id 또는 wildcard prefix와 매칭되어야 합니다.
+- status가 implemented/suppressed/rejected이면 이미 처리된 것으로 봅니다.
+- status가 accepted인 경우에는 automation_ref 또는 source_ref 같은 지속 증거(durable proof)가 있을 때만 이미 자동화된 것으로 봅니다.
+- 지속 증거가 없는 accepted 또는 단순 이전 추천 이력은 자동화 완료가 아니라 "이전 제안"으로만 봅니다.
+- 이름이 비슷한 정도로 중복 처리하지 말고 pattern/category/evidence_ref가 같은 루트 원인이나 같은 반복 수동 작업을 가리키는지 확인합니다.
+
+## 자료 범위 및 검색 정책
+- 기본 판단 근거는 PostgreSQL-backed routine observation/checkpoint/inventory, 로그 기반 observation, memento-mcp digest observation입니다.
+- 유저 프롬프트와 메모리는 runtime이 구조화 observation 또는 승인된 digest로 제공한 범위만 사용합니다.
+- 외부 웹자료 검색은 기본 동작이 아닙니다. 최신 외부 문서/버전 확인이 꼭 필요하면 opt-in evidence provider 필요성을 제안만 합니다.
+- 이 프롬프트 안에서 임의 웹 검색, 지속 크롤링, memento 쓰기, DB 직접 우회는 수행하지 않습니다.
+
+## Before / After
+- Before: ${beforeAfter.before}
+- After: ${beforeAfter.after}
+
+## 예상 구현 파일
+${expectedFiles.map((file) => `- ${file}`).join("\n")}
+
+## 판단
+- 제안 자동화: ${suggestedAutomation}
+- 권장 실행 방식: ${recommendedExecution} (규칙 기반 vs 에이전트 주도)
+- 예상 부작용: ${expectedSideEffects}
+
+## 검증 방법
+${verificationMethod}
+
+## 게이트된 핸드오프 초안
+- 상태: ${gatedHandoff.status}
+- Kanban 제목: ${gatedHandoff.kanban_card_draft.title}
+- PR 제목: ${gatedHandoff.pr_draft.title}
+- 핸드오프 부작용: ${gatedHandoff.side_effects}
+${handoffAcceptance}
+
+## 자동화 후보 카드 생성 초안
+아래 JSON은 탐지기(detector)가 자동으로 카드를 생성할 때 사용합니다.
+\`program.repo_dir\`에 현재 워크스페이스의 실제 절대 경로를 채워 kv_meta를 기록해주세요.
+${JSON.stringify(materializeRequest, null, 2)}
+
+## 지시사항
+에이전트가 도출한 내용은 반드시 한국어로 작성합니다. 이 자동화를 구현할 가치가 있는지 평가하고 다음을 제공합니다:
+1. 자동화 여부(예 / 아니오 / 보류), 신뢰도, 그리고 이유
+2. 루트 원인 또는 반복 수동 작업 가설과 그 근거
+3. 구현한다면 제안 구현 방식, rule-vs-agent 선택 이유, 영향 파일/루틴
+4. 성공/실패에 대한 한 줄 요약
+5. 예상 부작용, 오탐/중복 억제 방법, 자동화 동작 검증 방법
+6. 이전 추천과 같은 결론이면 다른 탐색/진행 방식 또는 추가로 수집할 근거
+
+## kv_meta 기록 지침
+
+평가 완료 후 **자동화 가치가 있다(예 / 부분 예)** 고 판단한 경우에만 아래를 실행합니다.
+
+**key** (TTL: 48h):
+\`routine_observation:candidate_review:${patternId}\`
+
+**value** (JSON):
+\`\`\`json
+{
+  "score": ${candidate.score},
+  "evidence_count": ${candidate.evidence_count || 0},
+  "last_seen_at": "${candidate.last_seen_at || ""}",
+  "category": "${normalizeCategory(candidate.category)}",
+  "suggested_automation": "<평가에서 도출한 제안 자동화 내용>",
+  "outcome_summary": "<평가에서 도출한 한 줄 결과 요약>",
+  "materialize_request": <위 '자동화 후보 카드 생성 초안' JSON에서 program.repo_dir을 실제 절대 경로로 채운 버전>
+}
+\`\`\`
+
+\`program.repo_dir\`는 현재 워크스페이스에서 확인한 agentdesk 리포지터리 절대 경로로 채웁니다.
+자동화 가치가 없거나 보류라면 kv_meta를 기록하지 않습니다.
+구현, 파일 수정, 서비스 재시작, memento 쓰기, PR/카드/이슈 생성은 금지합니다.`;
+
+  if (utf8ByteLength(raw) <= PROMPT_CAP_BYTES) {
+    return raw;
+  }
+
+  // Trim examples first while preserving policy and decision sections.
+  const evidenceHeader = "## 근거 예시\n";
+  const [header, restWithEvidence] = raw.split(evidenceHeader);
+  const evidenceBlock = evidenceLines || "(기록 없음)";
+  const rest = restWithEvidence.slice(evidenceBlock.length);
+  const budget =
+    PROMPT_CAP_BYTES -
+    utf8ByteLength(header) -
+    utf8ByteLength(evidenceHeader) -
+    utf8ByteLength(rest) -
+    20;
+  const trimmedEvidence =
+    budget > 32
+      ? truncateUtf8(evidenceBlock, budget)
+      : "(근거 예시는 크기 제한으로 생략됨)";
+  return header + evidenceHeader + trimmedEvidence + rest;
+}
+
+// --- Checkpoint size guard ---
+
+function guardCheckpointSize(cp) {
+  const json = JSON.stringify(cp);
+  if (json.length <= CHECKPOINT_CAP_BYTES) return cp;
+
+  // Prune least-recently-observed candidates first.
+  const entries = Object.entries(cp.candidates).sort(
+    ([, a], [, b]) => String(a.last_seen_at || "").localeCompare(String(b.last_seen_at || ""))
+  );
+  let pruned = 0;
+  for (const [patternId] of entries) {
+    if (JSON.stringify(cp).length <= CHECKPOINT_CAP_BYTES) break;
+    if (
+      cp.candidates[patternId].state === "observing"
+    ) {
+      delete cp.candidates[patternId];
+      pruned++;
+    }
+  }
+
+  // Trim examples on remaining candidates
+  for (const candidate of Object.values(cp.candidates)) {
+    if (candidate.examples && candidate.examples.length > 1) {
+      candidate.examples = candidate.examples.slice(-1);
+    }
+  }
+
+  return cp;
+}
+
+// --- Main tick ---
+
+agentdesk.routines.register({
+  name: "Automation Candidate Recommender",
+
+  tick(ctx) {
+    const nowStr = nowIso(ctx.now);
+    const cp = loadCheckpoint(ctx.checkpoint);
+    const observations = ctx.observations || [];
+    const inventory = ctx.automationInventory || [];
+
+    resetDailyCapIfNeeded(cp, nowStr);
+    pruneExpiredSuppressions(cp, nowStr);
+    pruneSeenEvidence(cp, nowStr);
+    expireStaleCandidates(cp, nowStr);
+
+    const suppressedSet = buildSuppressedSet(cp, inventory, observations);
+    const droppedCandidates = dropSuppressedCandidates(cp, suppressedSet);
+    const diversityMode = cp.diversity_mode_ticks_remaining > 0;
+    const scoringReport = scoreObservations(cp, observations, suppressedSet, nowStr, diversityMode);
+
+    // Update category scored history for diversity mode (keep last DIVERSITY_LOOKBACK_TICKS entries)
+    cp.stats.category_scored_history.push(scoringReport.category_scored_this_tick);
+    if (cp.stats.category_scored_history.length > DIVERSITY_LOOKBACK_TICKS) {
+      cp.stats.category_scored_history.shift();
+    }
+
+    // P0-E: saturation detection & re-optimization
+    updateEmaScored(cp, scoringReport.scored);
+    updateFastFailTicks(cp, scoringReport, observations.length);
+    updateSaturationTicks(cp);
+    const reoptCheck = shouldTriggerReopt(cp);
+    if (reoptCheck.trigger) {
+      triggerReopt(cp, nowStr);
+    } else if (cp.diversity_mode_ticks_remaining > 0) {
+      cp.diversity_mode_ticks_remaining--;
+    }
+
+    cp.stats.ticks++;
+    cp.last_tick_at = nowStr;
+
+    const escalation = findEscalationCandidate(cp, nowStr);
+
+    if (!escalation) {
+      const activeCandidates = Object.values(cp.candidates).filter(
+        (c) => c.state === "observing" || c.state === "recommended"
+      ).length;
+      const summary = `관찰=${observations.length}, 후보=${activeCandidates}, 오늘 추천=${cp.stats.recommendations_today}`;
+      const outcomeSummary = `성공 요약: 새 자동화 추천 후보 없음 (${summary})`;
+      const decisionSummary = noEscalationReason(cp, nowStr);
+      const topEvidenceSummary = topCandidateEvidenceSummary(cp);
+      const suppressedSummary = suppressionSummary(scoringReport.suppressed, droppedCandidates);
+      const scoringSummary = [
+        `scored=${scoringReport.scored}`,
+        `deduped=${scoringReport.deduped}`,
+        `suppressed=${scoringReport.suppressed.length + droppedCandidates.length}`,
+        `ema_scored=${cp.ema_scored.toFixed(3)}`,
+        `saturation_ticks=${cp.saturation_ticks}`,
+        `fast_fail_ticks=${cp.fast_fail_ticks}`,
+        `reopt_count=${cp.reopt_count}`,
+        diversityMode ? `diversity_mode_remaining=${cp.diversity_mode_ticks_remaining}` : null,
+        reoptCheck.trigger ? `reopt_triggered=${reoptCheck.reason}` : null,
+      ].filter(Boolean).join(", ");
+      return {
+        action: "complete",
+        result: {
+          status: "ok",
+          summary,
+          outcome_summary: outcomeSummary,
+          decision_summary: decisionSummary,
+          top_evidence_summary: topEvidenceSummary,
+          suppression_summary: suppressedSummary,
+          scoring_summary: scoringSummary,
+          observation_count: observations.length,
+          active_candidate_count: activeCandidates,
+          recommendations_today: cp.stats.recommendations_today,
+          reopt_count: cp.reopt_count,
+        },
+        checkpoint: guardCheckpointSize(cp),
+        lastResult: outcomeSummary,
+      };
+    }
+
+    const prompt = buildPrompt(escalation);
+    markRecommended(cp, escalation, nowStr);
+
+    return {
+      action: "agent",
+      prompt,
+      checkpoint: guardCheckpointSize(cp),
+    };
+  },
+});

--- a/routines/monitoring/automation-executor.js
+++ b/routines/monitoring/automation-executor.js
@@ -1,0 +1,242 @@
+// Automation Executor
+// Reads candidate_approved:* observations and dispatches GitHub Issue + Kanban card
+// creation prompts to the agent. Dedup via candidate_dispatched:* observations and
+// checkpoint dispatched_signatures. A signature is marked dispatched only after
+// durable candidate_dispatched kv_meta is observed.
+
+const DISPATCHED_TTL_DAYS = 7;
+const DISPATCH_RETRY_MS = 60 * 60 * 1000;  // re-emit at most once per hour per candidate
+const MAX_DISPATCH_RETRIES = 5;             // give up and mark stalled after this many no-shows
+const CHECKPOINT_VERSION = 1;
+
+// --- Checkpoint helpers ---
+
+function emptyCheckpoint() {
+  return {
+    version: CHECKPOINT_VERSION,
+    dispatched_signatures: {},   // signature -> dispatched_at ISO string (TTL 7d)
+    pending_dispatches: {},      // signature -> { attempt_count, last_attempted_at, first_attempted_at }
+    stats: {
+      ticks: 0,
+      dispatched: 0,
+      skipped_already_dispatched: 0,
+      stalled_candidates: 0,
+    },
+  };
+}
+
+function loadCheckpoint(raw) {
+  if (!raw || typeof raw !== "object" || raw.version !== CHECKPOINT_VERSION) {
+    return emptyCheckpoint();
+  }
+  const cp = Object.assign(emptyCheckpoint(), raw);
+  cp.dispatched_signatures = raw.dispatched_signatures || {};
+  cp.pending_dispatches = raw.pending_dispatches || {};
+  cp.stats = Object.assign(emptyCheckpoint().stats, raw.stats || {});
+  return cp;
+}
+
+function nowIso(now) {
+  return typeof now === "string" ? now : now.toISOString ? now.toISOString() : String(now);
+}
+
+function validIso(value) {
+  const timestamp = new Date(value || "").getTime();
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function observationKey(obs) {
+  if (typeof obs.key === "string") return obs.key;
+  if (typeof obs.evidence_ref === "string") {
+    if (obs.evidence_ref.startsWith("kv_meta:routine_observation:")) {
+      return obs.evidence_ref.slice("kv_meta:".length);
+    }
+    if (obs.evidence_ref.startsWith("routine_observation:")) {
+      return obs.evidence_ref;
+    }
+  }
+  return "";
+}
+
+function observationSignature(obs, prefix) {
+  const key = observationKey(obs);
+  return key.startsWith(prefix) ? key.slice(prefix.length) : null;
+}
+
+function observationPayload(obs) {
+  return obs.value && typeof obs.value === "object" ? obs.value : obs;
+}
+
+function isRecentIso(value, nowStr, maxAgeMs) {
+  const timestamp = new Date(value || "").getTime();
+  if (!Number.isFinite(timestamp)) return false;
+  return new Date(nowStr).getTime() - timestamp < maxAgeMs;
+}
+
+function observationDispatchedAt(obs, fallback) {
+  const payload = observationPayload(obs);
+  return (
+    validIso(payload.dispatched_at) ||
+    validIso(payload.timestamp) ||
+    validIso(obs.timestamp) ||
+    fallback
+  );
+}
+
+// --- Prune expired dispatched_signatures ---
+
+function pruneDispatched(cp, nowStr) {
+  const cutoffMs = DISPATCHED_TTL_DAYS * 24 * 3600 * 1000;
+  const cutoff = new Date(nowStr).getTime() - cutoffMs;
+  for (const [sig, dispatchedAt] of Object.entries(cp.dispatched_signatures)) {
+    if (new Date(dispatchedAt).getTime() < cutoff) {
+      delete cp.dispatched_signatures[sig];
+    }
+  }
+  // Prune stale pending entries (same TTL as dispatched)
+  for (const [sig, entry] of Object.entries(cp.pending_dispatches)) {
+    if (new Date(entry.first_attempted_at || 0).getTime() < cutoff) {
+      delete cp.pending_dispatches[sig];
+    }
+  }
+}
+
+// --- Build dispatch prompt ---
+
+function buildDispatchPrompt(signature, candidate) {
+  const lines = [
+    "승인된 자동화 후보에 대한 GitHub Issue 및 Kanban 카드 생성을 요청합니다.",
+    "",
+    `**후보 ID (signature)**: \`${signature}\``,
+    `**카테고리**: ${candidate.category || "routine-candidate"}`,
+    `**점수**: ${candidate.score || 0}`,
+    `**승인 시각**: ${candidate.approved_at || "(알 수 없음)"}`,
+    `**제안된 자동화**: ${candidate.suggested_automation || "(없음)"}`,
+    `**결과 요약**: ${candidate.outcome_summary || "(없음)"}`,
+    "",
+    "---",
+    "## 작업 지침",
+    "",
+    "1. **GitHub Issue 생성**: `kunkunGames/agentdesk` 저장소에 이슈를 생성해주세요.",
+    "   - 제목: `[자동화 후보] " + (candidate.category || "routine-candidate") + ": " + signature + "`",
+    "   - 레이블: `automation-candidate`",
+    "   - 본문: 위 후보 정보 포함",
+    "",
+    "2. **Kanban 카드 생성**: kanban-writer 스킬을 사용해 카드를 생성해주세요.",
+    "",
+    "3. **완료 후 kv_meta 기록**:",
+    "```",
+    `routine_observation:candidate_dispatched:${signature}`,
+    "```",
+    "값(JSON): `{\"signature\":\"" + signature + "\",\"dispatched_at\":\"<현재시각ISO>\",\"category\":\"" + (candidate.category || "routine-candidate") + "\"}`",
+    "TTL: 7d (604800초)",
+    "",
+    "이 kv_meta 기록은 executor 중복 방지 및 recommender 재추천 억제에 사용됩니다.",
+  ];
+  return lines.join("\n");
+}
+
+// --- Main tick ---
+
+agentdesk.routines.register({
+  name: "Automation Executor",
+
+  tick(ctx) {
+    const nowStr = nowIso(ctx.now);
+    const cp = loadCheckpoint(ctx.checkpoint);
+    const observations = ctx.observations || [];
+
+    pruneDispatched(cp, nowStr);
+
+    // Find candidate_approved observations
+    const approvedPrefix = "routine_observation:candidate_approved:";
+    const dispatchedPrefix = "routine_observation:candidate_dispatched:";
+    const approvedObs = observations.filter((obs) => observationSignature(obs, approvedPrefix));
+
+    // Find already-dispatched signatures (from kv_meta observations + checkpoint)
+    const dispatchedFromObs = new Map();
+    for (const obs of observations) {
+      const signature = observationSignature(obs, dispatchedPrefix);
+      if (signature) {
+        dispatchedFromObs.set(signature, observationDispatchedAt(obs, nowStr));
+      }
+    }
+    for (const [signature, dispatchedAt] of dispatchedFromObs.entries()) {
+      const current = cp.dispatched_signatures[signature];
+      if (!current || new Date(dispatchedAt).getTime() < new Date(current).getTime()) {
+        cp.dispatched_signatures[signature] = dispatchedAt;
+      }
+    }
+
+    cp.stats.ticks++;
+
+    if (approvedObs.length === 0) {
+      return {
+        action: "complete",
+        result: {
+          status: "ok",
+          summary: "승인된 후보 없음",
+          approved_count: 0,
+        },
+        checkpoint: cp,
+      };
+    }
+
+    // Filter to candidates not yet dispatched
+    const toDispatch = [];
+    for (const obs of approvedObs) {
+      const signature = observationSignature(obs, approvedPrefix);
+      const candidate = observationPayload(obs);
+
+      if (dispatchedFromObs.has(signature) || cp.dispatched_signatures[signature]) {
+        cp.stats.skipped_already_dispatched++;
+        continue;
+      }
+
+      // Give up if LLM has repeatedly failed to write the dispatched marker.
+      const pending = cp.pending_dispatches[signature];
+      if (pending && (pending.attempt_count || 0) >= MAX_DISPATCH_RETRIES) {
+        cp.stats.stalled_candidates = (cp.stats.stalled_candidates || 0) + 1;
+        continue;
+      }
+      // Throttle: don't re-emit within cooldown window.
+      if (pending && isRecentIso(pending.last_attempted_at, nowStr, DISPATCH_RETRY_MS)) {
+        cp.stats.skipped_already_dispatched++;
+        continue;
+      }
+
+      toDispatch.push({ signature, candidate });
+    }
+
+    if (toDispatch.length === 0) {
+      return {
+        action: "complete",
+        result: {
+          status: "ok",
+          summary: `승인 후보 ${approvedObs.length}건 모두 이미 처리됨`,
+          approved_count: approvedObs.length,
+          skipped: cp.stats.skipped_already_dispatched,
+        },
+        checkpoint: cp,
+      };
+    }
+
+    // Dispatch first pending candidate; remaining handled on next ticks
+    const { signature, candidate } = toDispatch[0];
+    const prevPending = cp.pending_dispatches[signature];
+    cp.pending_dispatches[signature] = {
+      first_attempted_at: prevPending?.first_attempted_at || nowStr,
+      last_attempted_at: nowStr,
+      attempt_count: (prevPending?.attempt_count || 0) + 1,
+    };
+    cp.stats.dispatched++;
+
+    const prompt = buildDispatchPrompt(signature, candidate);
+
+    return {
+      action: "agent",
+      prompt,
+      checkpoint: cp,
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- CI Main's `Full tests (ubuntu-latest)` job's "Policy JS unit tests" step (`npm run test:policies`) has been RED since commit 29ba2fcf1 (`chore(routines): untrack operator routine scripts`), which swept the entire `routines/` tree into `.gitignore`.
- That commit's intent was to stop tracking **operator-private personal** automation scripts (`family-profile-probe-*.js`, `banchan-day-reminder-*.js`, `cookingheart-daily-briefing.js`, `memento-*.js`, etc.) — see the updated `docs/source-of-truth.md` row it added.
- Four files caught in that blanket ignore are not personal scripts — they're the shipped engine implementation of the pipeline-v2 **automation-candidate** feature (#2064): `routines/monitoring/automation-executor.js`, `automation-candidate-executor.js`, `automation-candidate-detector.js`, `automation-candidate-recommender.js`. `RoutineScriptLoader`'s default routines dir is `./routines` (`src/config.rs::default_routines_dir`), and `src/services/routines/loader.rs` hardcodes `monitoring/automation-candidate-executor.js` as `CANONICAL_AUTOMATION_CANDIDATE_EXECUTOR_REF`. Six policy test files load and exercise these files' real behavior via `policies/__tests__/support/routine-harness.js`, so removing them broke CI with `ENOENT` on `node --test policies/__tests__/*.test.js`.
- Restored the four files byte-identical to their pre-removal blobs and added a narrow `.gitignore` carve-out (`routines/*` + per-level negation down to the four filenames) so they stay tracked while the rest of `routines/` (genuinely personal scripts) remains untracked, preserving 29ba2fcf1's original intent.

Closes #4076

## Test plan

- [x] `npm run test:policies` locally → 181/181 pass, 0 fail (previously errored with `ENOENT ... automation-candidate-executor.js` etc.)
- [x] Verified all 4 restored files are byte-identical to `git show 29ba2fcf1^:routines/monitoring/<file>`
- [x] Verified `git add -n routines/` only stages the 4 intended files (no accidental exposure of other/personal routine scripts)
- [ ] CI Main will confirm on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)