### PR TITLE
fix(test): pin AGENTDESK_ROOT_DIR in monotonic_3358 carry-forward test (scheduling-dependent flake, CI blocker)

### DIFF
--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -3569,6 +3569,10 @@ mod stall_recovery_tests {
         // FIX: birth carried up to the committed frontier → re-claim is forward/
         // equal, ZERO invariant violations, offsets end at the frontier.
         let temp = TempDir::new().unwrap();
+        // The refresh path records inflight-invariant observability via the
+        // PROCESS-WIDE runtime root (#3293 guard) — pin it to the tempdir so a
+        // standalone/parallel run never resolves the live release root.
+        let _env_reset = set_agentdesk_root_for_test(temp.path());
         let relay_last_offset: u64 = 2_821_677;
         let committed_frontier: u64 = 2_838_484;
         // Drive the ACTUAL production carry-forward helper (not an inline copy) so


### PR DESCRIPTION
## 문제
`synthetic_carry_forward_keeps_reclaim_monotonic_3358`가 스케줄링 의존 flake — 테스트가 `AGENTDESK_ROOT_DIR`을 pin하지 않는데, 검증 대상인 `refresh_inflight_last_offset_if_matches_identity_in_root`의 invariant observability(`record_inflight_invariant` → `inflight_runtime_root()`)가 프로세스 전역 runtime root를 해석함(#3293 가드 발동). 병렬로 도는 다른 테스트가 env를 세팅해준 경우에만 통과 → 오늘부터 Trusted macOS check을 간헐 red로 만들어 **전 PR CI 블로커**.

재현: `cargo test --lib synthetic_carry_forward_keeps_reclaim_monotonic_3358` 단독 실행 → 100% 실패 (수정 전).

## 수정
같은 파일 형제 테스트들의 기존 패턴(`set_agentdesk_root_for_test` EnvReset 가드)을 이 테스트에도 적용 — tempdir로 pin.

## 검증
- 단독 실행: pass (수정 전 100% fail → 후 pass)
- monotonic_3358 패밀리: pass
- 테스트 전용 변경 (prod 코드 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
