### PR TITLE
fix(api): accept fractional usageAgeSeconds from cswap — /api/claude-accounts 502 (#4126)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -402,7 +402,7 @@
 | `services::codex_tui::rollout_tail` | `src/services/codex_tui/rollout_tail.rs` | 4201 | 1276 | 2925 | giant-file |
 | `services::codex_tui::rollout_tail::parser` | `src/services/codex_tui/rollout_tail/parser.rs` | 405 | 405 | 0 |  |
 | `services::codex_tui::session` | `src/services/codex_tui/session.rs` | 800 | 316 | 484 |  |
-| `services::cswap` | `src/services/cswap.rs` | 847 | 549 | 298 |  |
+| `services::cswap` | `src/services/cswap.rs` | 887 | 552 | 335 |  |
 | `services::discord` | `src/services/discord/mod.rs` | 5412 | 4158 | 1254 | giant-file |
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 980 | 854 | 126 |  |

--- a/src/services/cswap.rs
+++ b/src/services/cswap.rs
@@ -97,7 +97,8 @@ pub struct ClaudeAccount {
     pub usage_status: Option<String>,
     pub usage: Option<ClaudeAccountUsage>,
     pub usage_fetched_at: Option<String>,
-    pub usage_age_seconds: Option<u64>,
+    // cswap 0.17+ emits fractional seconds (e.g. 5.4) — must stay f64 (#4126).
+    pub usage_age_seconds: Option<f64>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, Value>,
 }
@@ -505,10 +506,11 @@ fn response_for_serve(
 }
 
 fn recompute_usage_age_seconds(response: &mut ClaudeAccountsResponse, served_at: DateTime<Utc>) {
-    let base_elapsed = served_at
+    let base_elapsed = (served_at
         .signed_duration_since(response.fetched_at)
-        .num_seconds()
-        .max(0) as u64;
+        .num_milliseconds()
+        .max(0) as f64)
+        / 1000.0;
     for account in &mut response.accounts {
         if let Some(fetched_at) = account
             .usage_fetched_at
@@ -516,13 +518,14 @@ fn recompute_usage_age_seconds(response: &mut ClaudeAccountsResponse, served_at:
             .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
         {
             account.usage_age_seconds = Some(
-                served_at
+                (served_at
                     .signed_duration_since(fetched_at.with_timezone(&Utc))
-                    .num_seconds()
-                    .max(0) as u64,
+                    .num_milliseconds()
+                    .max(0) as f64)
+                    / 1000.0,
             );
         } else if let Some(age) = account.usage_age_seconds {
-            account.usage_age_seconds = Some(age.saturating_add(base_elapsed));
+            account.usage_age_seconds = Some(age.max(0.0) + base_elapsed);
         }
     }
 }
@@ -777,7 +780,7 @@ mod tests {
                 usage_status: Some("ok".to_string()),
                 usage: None,
                 usage_fetched_at: Some("2026-06-22T20:29:00Z".to_string()),
-                usage_age_seconds: Some(12),
+                usage_age_seconds: Some(12.0),
                 extra: BTreeMap::new(),
             }],
         };
@@ -785,7 +788,44 @@ mod tests {
         let served = response_for_serve(&response, served_at);
 
         assert_eq!(served.served_at, served_at);
-        assert_eq!(served.accounts[0].usage_age_seconds, Some(135));
+        assert_eq!(served.accounts[0].usage_age_seconds, Some(135.0));
+    }
+
+    #[test]
+    fn list_payload_accepts_fractional_usage_age_seconds_4126() {
+        // Shape observed from cswap 0.17.1 `--list --json` on a host with
+        // registered accounts: usageAgeSeconds is fractional (5.4), which the
+        // original u64 field rejected and turned every list call into a 502.
+        let raw = r#"{
+            "schemaVersion": 1,
+            "activeAccountNumber": 3,
+            "accounts": [
+                {
+                    "number": 1,
+                    "email": "you@example.com",
+                    "organizationName": "Example Org",
+                    "isOrganization": true,
+                    "active": false,
+                    "usageStatus": "ok",
+                    "usage": {
+                        "fiveHour": {"pct": 96.0, "resetsAt": "2026-07-05T04:40:00+00:00", "countdown": "47m"},
+                        "sevenDay": {"pct": 39.0, "resetsAt": "2026-07-06T07:00:00+00:00"}
+                    },
+                    "usageFetchedAt": "2026-07-05T03:52:27Z",
+                    "usageAgeSeconds": 5.4
+                },
+                {
+                    "number": 2,
+                    "active": true,
+                    "usageAgeSeconds": 0.0
+                }
+            ]
+        }"#;
+
+        let payload = parse_list_json(raw).expect("fractional usageAgeSeconds must parse");
+        let accounts = payload.accounts.expect("accounts present");
+        assert_eq!(accounts[0].usage_age_seconds, Some(5.4));
+        assert_eq!(accounts[1].usage_age_seconds, Some(0.0));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Closes #4126.

## 문제

post-deploy 점검에서 발견: cswap 0.17.1이 `usageAgeSeconds`를 소수(예: `5.4`)로 내보내는데 #4122 파서가 `Option<u64>`로 선언되어 serde 역직렬화가 결정적으로 실패 → 계정이 등록된 호스트에서 `GET /api/claude-accounts`가 항상 502.

개발 당시 cswap 계정이 없어(`accounts: []`) 필드가 역직렬화된 적이 없어 게이트를 통과했음.

## 수정

- `usage_age_seconds`: `Option<u64>` → `Option<f64>` (이유 주석 포함)
- `recompute_usage_age_seconds`: u64 산술 → 밀리초 기반 f64 (정밀도 유지, 음수 클램프 유지)
- 회귀 테스트: 실측 cswap JSON 형태(소수 `usageAgeSeconds`) 역직렬화 성공 검증
- 대시보드 TS는 `number | null`이라 무변경, 다른 Rust 참조 없음 확인

## 검증

- `cargo check -j2` PASS
- `cargo test -j2 --lib cswap` 8 passed / 0 failed (신규 회귀 테스트 포함)
- `audit_maintainability --check` findings 없음, inventory docs regen, freshness gate PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)