### PR TITLE
fix(discord): bound + log catch-up Deferred re-arm cycles (#4156)

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -15,7 +15,7 @@
 | `src/server/maintenance.rs` | 1014 | server-runtime | 2026-10-31 | #3909 |
 | `src/server/worker_registry.rs` | 1278 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
-| `src/services/discord/catch_up.rs` | 1484 | discord-relay | 2026-10-31 | #3405 |
+| `src/services/discord/catch_up.rs` | 1504 | discord-relay | 2026-10-31 | #3405 |
 | `src/services/discord/health/recovery.rs` | 2724 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1374 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/outbound/delivery_record.rs` | 1276 | discord-relay | 2026-10-31 | #3405 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -15,7 +15,7 @@
 | `src/server/maintenance.rs` | 1014 | server-runtime | 2026-10-31 | #3909 |
 | `src/server/worker_registry.rs` | 1278 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
-| `src/services/discord/catch_up.rs` | 1402 | discord-relay | 2026-10-31 | #3405 |
+| `src/services/discord/catch_up.rs` | 1484 | discord-relay | 2026-10-31 | #3405 |
 | `src/services/discord/health/recovery.rs` | 2724 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1374 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/outbound/delivery_record.rs` | 1276 | discord-relay | 2026-10-31 | #3405 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -410,7 +410,7 @@
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
-| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2450 | 1402 | 1048 | giant-file |
+| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2582 | 1484 | 1098 | giant-file |
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 48 | 48 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 120 | 120 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -410,7 +410,7 @@
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
-| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2582 | 1484 | 1098 | giant-file |
+| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2649 | 1504 | 1145 | giant-file |
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 48 | 48 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 120 | 120 | 0 |  |

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -833,6 +833,15 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
         return;
     }
 
+    // #4156: phase-1 CONSUMES (removes) each channel's pending retry entry
+    // before scanning, so by the time phase-2 runs later in the same cycle the
+    // Deferred budget no longer lives in the pending map. Stash the consumed
+    // state per channel here so phase-2's re-arm can recover the accumulated
+    // budget instead of resetting it to 1 (which would leave phase-2-origin
+    // defers in an unbounded, unlogged re-arm cycle).
+    let mut consumed_retry_states_this_cycle: HashMap<ChannelId, CatchUpRetryState> =
+        HashMap::new();
+
     // Pace successive per-channel REST scans so a many-channel sweep doesn't
     // fire as one tight burst (see `catch_up_scan_pace`). The first eligible
     // channel runs immediately; subsequent scans wait the configured gap.
@@ -863,6 +872,12 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
             CatchUpRetryScanDecision::Proceed(retry_state) => retry_state,
             CatchUpRetryScanDecision::SkipConsumed => continue,
         };
+        // #4156: remember the budget this scan consumed so phase-2 can carry it
+        // forward even when phase-1 does not itself re-arm (which would leave the
+        // pending map empty by phase-2 time).
+        if let Some(state) = retry_state {
+            consumed_retry_states_this_cycle.insert(channel_id, state);
+        }
         paced_scan = true;
         let retry_checkpoint = retry_state.map(|state| state.checkpoint);
         let live_checkpoint = shared.last_message_ids.get(&channel_id).map(|entry| *entry);
@@ -1420,9 +1435,10 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
                             shared,
                             channel_id,
                             retry_after,
-                            // phase-2 does not consume the pending entry, so the
-                            // Deferred budget is read from the map inside the helper.
-                            None,
+                            // #4156: recover the budget phase-1 consumed this cycle
+                            // (the pending map entry is gone by now); the helper
+                            // merges it with any surviving map entry (most-exhausted).
+                            consumed_retry_states_this_cycle.get(&channel_id).copied(),
                         );
                         stats.deferred += 1;
                         break;
@@ -1435,8 +1451,12 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
                         phase2_checkpoint,
                         last_bot_response_id,
                     );
-                    phase2_retry_after =
-                        rearm_catch_up_retry_after_defer(shared, channel_id, retry_after, None);
+                    phase2_retry_after = rearm_catch_up_retry_after_defer(
+                        shared,
+                        channel_id,
+                        retry_after,
+                        consumed_retry_states_this_cycle.get(&channel_id).copied(),
+                    );
                     stats.deferred += 1;
                     break;
                 }
@@ -2499,6 +2519,53 @@ mod catch_up_recovery_tests {
             .expect("re-arm below cap should stay pending");
         assert_eq!(pending.deferred_rearms, CATCH_UP_RETRY_DEFERRED_REARM_LIMIT);
         assert_eq!(pending.armed_at, armed_at);
+    }
+
+    // #4156 (opus review): phase-1 CONSUMES the pending entry before phase-2
+    // runs, so phase-2 must recover the Deferred budget from the state phase-1
+    // consumed this cycle (`threaded_prior`) even when the pending map is empty
+    // — otherwise a phase-2-origin defer would reset the budget to 1 forever and
+    // the cap would never bind. This asserts the budget still climbs to the cap
+    // through the threaded path with NO surviving map entry.
+    #[test]
+    fn deferred_rearm_accumulates_via_threaded_prior_when_map_entry_absent() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(4_156_222);
+        let checkpoint = 1504812094456070130;
+        let armed_at = Instant::now();
+
+        // Simulate phase-2 re-arming with the budget phase-1 consumed this cycle
+        // while the pending map is empty (phase-1 removed it and did not re-arm).
+        let mut budget = 2u8;
+        loop {
+            let consumed = CatchUpRetryState {
+                checkpoint,
+                fetch_failures: 0,
+                deferred_rearms: budget,
+                armed_at,
+            };
+            // The pending map is empty each iteration (phase-1 consumed it).
+            shared.catch_up_retry_pending.remove(&channel_id);
+            let result =
+                rearm_catch_up_retry_after_defer(&shared, channel_id, checkpoint, Some(consumed));
+            if budget >= CATCH_UP_RETRY_DEFERRED_REARM_LIMIT {
+                assert!(
+                    result.is_none(),
+                    "at/over the cap the threaded path must give up, not reset to 1"
+                );
+                assert!(!shared.catch_up_retry_pending.contains_key(&channel_id));
+                break;
+            }
+            assert_eq!(result, Some(checkpoint));
+            let pending = *shared
+                .catch_up_retry_pending
+                .get(&channel_id)
+                .expect("below cap should re-arm");
+            // Budget climbs by exactly one — never resets to 1.
+            assert_eq!(pending.deferred_rearms, budget + 1);
+            budget += 1;
+        }
+        assert_eq!(budget, CATCH_UP_RETRY_DEFERRED_REARM_LIMIT);
     }
 
     #[test]

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -20,11 +20,21 @@ use super::*;
 
 const CATCH_UP_RETRY_QUEUE_THRESHOLD: usize = MAX_INTERVENTIONS_PER_CHANNEL / 2;
 const CATCH_UP_RETRY_FETCH_FAILURE_LIMIT: u8 = 4;
+// #4156: a channel whose fetch keeps SUCCEEDING but whose messages keep being
+// Deferred (persistently busy / repeated ActorUnreachable) re-arms the catch-up
+// retry every scan. Without a bound that cycle is unbounded and unlogged. Cap
+// the consecutive Deferred re-arms (independently of the fetch-failure budget)
+// and emit a giving-up WARN at the cap, mirroring the fetch-failure path.
+const CATCH_UP_RETRY_DEFERRED_REARM_LIMIT: u8 = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::services) struct CatchUpRetryState {
     checkpoint: u64,
     fetch_failures: u8,
+    // #4156: consecutive Deferred re-arms (fetch succeeded, enqueue deferred).
+    // Tracked separately from `fetch_failures` because a Deferred re-arm is not
+    // a fetch error; both budgets share the merge's most-exhausted semantics.
+    deferred_rearms: u8,
     armed_at: Instant,
 }
 
@@ -33,6 +43,7 @@ impl CatchUpRetryState {
         Self {
             checkpoint,
             fetch_failures: 0,
+            deferred_rearms: 0,
             armed_at: Instant::now(),
         }
     }
@@ -42,6 +53,22 @@ impl CatchUpRetryState {
         (fetch_failures <= CATCH_UP_RETRY_FETCH_FAILURE_LIMIT).then_some(Self {
             checkpoint: self.checkpoint,
             fetch_failures,
+            deferred_rearms: self.deferred_rearms,
+            armed_at: self.armed_at,
+        })
+    }
+
+    // #4156: advance the Deferred re-arm budget. Returns `None` once the cap is
+    // exhausted so the caller stops re-arming (the backlog then ages out or a
+    // fresh catch-up trigger restarts the cycle), matching `after_fetch_failure`.
+    fn after_deferred_rearm(self, checkpoint: u64) -> Option<Self> {
+        let deferred_rearms = self.deferred_rearms.saturating_add(1);
+        (deferred_rearms <= CATCH_UP_RETRY_DEFERRED_REARM_LIMIT).then_some(Self {
+            checkpoint,
+            fetch_failures: self.fetch_failures,
+            deferred_rearms,
+            // Preserve the original arm time so the arm-time age window
+            // (`catch_up_message_age_reference_time`) is NOT reset each cycle.
             armed_at: self.armed_at,
         })
     }
@@ -177,6 +204,8 @@ fn merge_catch_up_retry_state(
         // A merged older checkpoint inherits the most exhausted budget so the
         // same old backlog cannot gain unbounded retries through fresh arms.
         fetch_failures: existing.fetch_failures.max(retry_state.fetch_failures),
+        // #4156: same most-exhausted rule for the Deferred re-arm budget.
+        deferred_rearms: existing.deferred_rearms.max(retry_state.deferred_rearms),
         armed_at: existing.armed_at.min(retry_state.armed_at),
     }
 }
@@ -245,6 +274,49 @@ fn rearm_catch_up_retry_after_fetch_failure(
         CATCH_UP_RETRY_FETCH_FAILURE_LIMIT
     );
     Some(rearmed)
+}
+
+// #4156: re-arm the catch-up retry after a fetch-succeeded-but-enqueue-Deferred
+// scan, carrying forward the prior scan's Deferred budget + original arm time
+// (`prior`, the state consumed for THIS scan). Returns the armed checkpoint, or
+// `None` once the Deferred re-arm cap is exhausted — at which point it emits a
+// giving-up WARN and does NOT re-arm, so a persistently-busy channel can no
+// longer spin an unbounded, unlogged re-arm cycle.
+fn rearm_catch_up_retry_after_defer(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    retry_after: u64,
+    threaded_prior: Option<CatchUpRetryState>,
+) -> Option<u64> {
+    // The prior Deferred budget can live in the state consumed for THIS scan
+    // (phase-1 removes the pending entry up front, so it hands the state in via
+    // `threaded_prior`) OR still in the pending map (phase-2 does not consume,
+    // so it passes `None` and the budget is read from the map). Take the
+    // most-exhausted of the two so neither phase resets the other's budget.
+    let map_prior = shared
+        .catch_up_retry_pending
+        .get(&channel_id)
+        .map(|entry| *entry.value());
+    let prior = match (threaded_prior, map_prior) {
+        (Some(threaded), Some(mapped)) => Some(merge_catch_up_retry_state(Some(threaded), mapped)),
+        (Some(state), None) | (None, Some(state)) => Some(state),
+        (None, None) => None,
+    };
+    let base = prior.unwrap_or_else(|| CatchUpRetryState::new(retry_after));
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    let attempted_rearms = base.deferred_rearms.saturating_add(1);
+    let Some(next_retry_state) = base.after_deferred_rearm(retry_after) else {
+        tracing::warn!(
+            "  [{ts}] ⚠ catch-up: channel {} deferred {} time(s); giving up after {} re-arm(s) at checkpoint {}",
+            channel_id,
+            attempted_rearms,
+            CATCH_UP_RETRY_DEFERRED_REARM_LIMIT,
+            retry_after
+        );
+        return None;
+    };
+    let rearmed = arm_catch_up_retry_state(shared, channel_id, next_retry_state);
+    Some(rearmed.checkpoint)
 }
 
 fn merge_catch_up_retry_checkpoint(existing: Option<u64>, retry_after: u64) -> u64 {
@@ -1046,7 +1118,12 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
                         let retry_after = max_recovered_id
                             .or(scan_checkpoint)
                             .unwrap_or_else(|| mid.saturating_sub(1));
-                        arm_catch_up_retry_pending(shared, channel_id, retry_after);
+                        rearm_catch_up_retry_after_defer(
+                            shared,
+                            channel_id,
+                            retry_after,
+                            retry_state,
+                        );
                         break;
                     }
                 }
@@ -1055,7 +1132,7 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
                     let retry_after = max_recovered_id
                         .or(scan_checkpoint)
                         .unwrap_or_else(|| mid.saturating_sub(1));
-                    arm_catch_up_retry_pending(shared, channel_id, retry_after);
+                    rearm_catch_up_retry_after_defer(shared, channel_id, retry_after, retry_state);
                     break;
                 }
             }
@@ -1339,9 +1416,14 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
                             phase2_checkpoint,
                             last_bot_response_id,
                         );
-                        let retry_after =
-                            arm_catch_up_retry_pending(shared, channel_id, retry_after);
-                        phase2_retry_after = Some(retry_after);
+                        phase2_retry_after = rearm_catch_up_retry_after_defer(
+                            shared,
+                            channel_id,
+                            retry_after,
+                            // phase-2 does not consume the pending entry, so the
+                            // Deferred budget is read from the map inside the helper.
+                            None,
+                        );
                         stats.deferred += 1;
                         break;
                     }
@@ -1353,8 +1435,8 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
                         phase2_checkpoint,
                         last_bot_response_id,
                     );
-                    let retry_after = arm_catch_up_retry_pending(shared, channel_id, retry_after);
-                    phase2_retry_after = Some(retry_after);
+                    phase2_retry_after =
+                        rearm_catch_up_retry_after_defer(shared, channel_id, retry_after, None);
                     stats.deferred += 1;
                     break;
                 }
@@ -1403,22 +1485,22 @@ async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
 #[cfg(test)]
 mod catch_up_recovery_tests {
     use super::{
-        CATCH_UP_RECENT_MAX_PAGES, CATCH_UP_RETRY_FETCH_FAILURE_LIMIT,
-        CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate, CatchUpClassification,
-        CatchUpDiscordApi, CatchUpFetchMode, CatchUpMessageView, CatchUpRetryScanDecision,
-        CatchUpRetryState, ChannelId, MessageId, Phase2EnqueueCommit, ProviderKind,
-        RuntimeChannelBindingStatus, advance_phase2_checkpoint, arm_catch_up_retry_pending,
-        catch_up_enqueue_accepted, catch_up_fetch_mode_for_scan, catch_up_intervention_created_at,
-        catch_up_last_item_dedup_is_checkpoint_safe, catch_up_message_age_reference_time,
-        catch_up_missed_messages_inner_with_api,
+        CATCH_UP_RECENT_MAX_PAGES, CATCH_UP_RETRY_DEFERRED_REARM_LIMIT,
+        CATCH_UP_RETRY_FETCH_FAILURE_LIMIT, CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate,
+        CatchUpClassification, CatchUpDiscordApi, CatchUpFetchMode, CatchUpMessageView,
+        CatchUpRetryScanDecision, CatchUpRetryState, ChannelId, MessageId, Phase2EnqueueCommit,
+        ProviderKind, RuntimeChannelBindingStatus, advance_phase2_checkpoint,
+        arm_catch_up_retry_pending, catch_up_enqueue_accepted, catch_up_fetch_mode_for_scan,
+        catch_up_intervention_created_at, catch_up_last_item_dedup_is_checkpoint_safe,
+        catch_up_message_age_reference_time, catch_up_missed_messages_inner_with_api,
         catch_up_missed_messages_inner_with_api_and_pending_retry_channels,
         catch_up_remaining_queue_capacity, classify_catch_up_message,
         classify_phase2_enqueue_commit, collect_catch_up_retry_pending_channels,
         consume_catch_up_retry_state_for_scan, insert_configured_catch_up_candidate,
         merge_catch_up_retry_checkpoint, parse_catch_up_scan_pace, phase2_retry_after_checkpoint,
-        prune_stale_checkpoint_files, rearm_catch_up_retry_after_fetch_failure,
-        should_fetch_older_recent_page, should_pace_before_scan,
-        take_catch_up_retry_checkpoint_after_queue_drain,
+        prune_stale_checkpoint_files, rearm_catch_up_retry_after_defer,
+        rearm_catch_up_retry_after_fetch_failure, should_fetch_older_recent_page,
+        should_pace_before_scan, take_catch_up_retry_checkpoint_after_queue_drain,
     };
     use crate::services::turn_orchestrator::EnqueueRefusalReason;
     use poise::serenity_prelude as serenity;
@@ -1937,6 +2019,7 @@ mod catch_up_recovery_tests {
             CatchUpRetryState {
                 checkpoint: 1504812094456070200,
                 fetch_failures: 2,
+                deferred_rearms: 0,
                 armed_at: older_armed_at,
             },
         );
@@ -1946,6 +2029,7 @@ mod catch_up_recovery_tests {
             CatchUpRetryState {
                 checkpoint: 1504812094456070300,
                 fetch_failures: 1,
+                deferred_rearms: 0,
                 armed_at: newer_armed_at,
             },
         )]);
@@ -1982,6 +2066,7 @@ mod catch_up_recovery_tests {
             CatchUpRetryState {
                 checkpoint,
                 fetch_failures: 1,
+                deferred_rearms: 0,
                 armed_at: Instant::now(),
             },
         );
@@ -2231,6 +2316,7 @@ mod catch_up_recovery_tests {
         let retry_state = CatchUpRetryState {
             checkpoint: 1504812094456070130,
             fetch_failures: 1,
+            deferred_rearms: 0,
             armed_at,
         };
 
@@ -2267,6 +2353,7 @@ mod catch_up_recovery_tests {
         let retry_state = CatchUpRetryState {
             checkpoint,
             fetch_failures: 1,
+            deferred_rearms: 0,
             armed_at,
         };
         let retry_checkpoints = HashMap::from([(channel_id, retry_state)]);
@@ -2302,6 +2389,7 @@ mod catch_up_recovery_tests {
         let retry_state = CatchUpRetryState {
             checkpoint,
             fetch_failures: 1,
+            deferred_rearms: 0,
             armed_at,
         };
         let retry_checkpoints = HashMap::from([(channel_id, retry_state)]);
@@ -2358,6 +2446,7 @@ mod catch_up_recovery_tests {
         let exhausted_retry = CatchUpRetryState {
             checkpoint,
             fetch_failures: CATCH_UP_RETRY_FETCH_FAILURE_LIMIT,
+            deferred_rearms: 0,
             armed_at: Instant::now(),
         };
 
@@ -2367,6 +2456,49 @@ mod catch_up_recovery_tests {
             "retry fetch failures must not re-arm forever"
         );
         assert!(!shared.catch_up_retry_pending.contains_key(&channel_id));
+    }
+
+    // #4156: a channel whose fetch keeps succeeding but whose messages keep
+    // being Deferred must not re-arm the catch-up retry forever.
+    #[test]
+    fn deferred_rearm_gives_up_after_bounded_attempts_and_preserves_arm_time() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(1479671298497183835);
+        let checkpoint = 1504812094456070130;
+        let armed_at = Instant::now();
+
+        // Already at the Deferred cap ⇒ no further re-arm, nothing left pending.
+        let exhausted = CatchUpRetryState {
+            checkpoint,
+            fetch_failures: 0,
+            deferred_rearms: CATCH_UP_RETRY_DEFERRED_REARM_LIMIT,
+            armed_at,
+        };
+        assert!(
+            rearm_catch_up_retry_after_defer(&shared, channel_id, checkpoint, Some(exhausted))
+                .is_none(),
+            "deferred re-arms must not spin forever"
+        );
+        assert!(!shared.catch_up_retry_pending.contains_key(&channel_id));
+
+        // One below the cap ⇒ re-arms, carrying the incremented Deferred budget
+        // and the ORIGINAL arm time forward (the age window must not reset).
+        let almost = CatchUpRetryState {
+            checkpoint,
+            fetch_failures: 0,
+            deferred_rearms: CATCH_UP_RETRY_DEFERRED_REARM_LIMIT - 1,
+            armed_at,
+        };
+        assert_eq!(
+            rearm_catch_up_retry_after_defer(&shared, channel_id, checkpoint, Some(almost)),
+            Some(checkpoint),
+        );
+        let pending = *shared
+            .catch_up_retry_pending
+            .get(&channel_id)
+            .expect("re-arm below cap should stay pending");
+        assert_eq!(pending.deferred_rearms, CATCH_UP_RETRY_DEFERRED_REARM_LIMIT);
+        assert_eq!(pending.armed_at, armed_at);
     }
 
     #[test]

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -289,9 +289,9 @@ fn rearm_catch_up_retry_after_defer(
     threaded_prior: Option<CatchUpRetryState>,
 ) -> Option<u64> {
     // The prior Deferred budget can live in the state consumed for THIS scan
-    // (phase-1 removes the pending entry up front, so it hands the state in via
-    // `threaded_prior`) OR still in the pending map (phase-2 does not consume,
-    // so it passes `None` and the budget is read from the map). Take the
+    // (both phases thread it in via `threaded_prior`: phase-1 from the entry it
+    // just removed, phase-2 from `consumed_retry_states_this_cycle`) AND/OR still
+    // in the pending map (e.g. phase-1 re-armed before phase-2 ran). Take the
     // most-exhausted of the two so neither phase resets the other's budget.
     let map_prior = shared
         .catch_up_retry_pending


### PR DESCRIPTION
## Problem (#4156)

The catch-up retry cap (`after_fetch_failure`, limit 4) applies **only to fetch FAILURES**. A channel whose fetch keeps **succeeding** but whose messages keep being **Deferred** (persistently busy / repeated `ActorUnreachable`) re-armed the retry on every scan:
- `arm_catch_up_retry_pending` → `CatchUpRetryState::new` reset `fetch_failures: 0` + a fresh `armed_at`
- `consume_catch_up_retry_state_for_scan` removed the pending entry before the scan, so the merge (min `armed_at` / max budget) never applied

→ the ≤4 cap never engaged and the arm-time age window reset forever: an **unbounded, unlogged** re-arm cycle. Message-preserving (safe) but noisy and without a give-up bound. (Split from PR #4155 opus review Finding 2; inherited from phase-2 behavior.)

## Fix

- Add a separate `deferred_rearms` budget to `CatchUpRetryState` (cap `CATCH_UP_RETRY_DEFERRED_REARM_LIMIT = 8`), tracked independently of `fetch_failures` (a Deferred re-arm is not a fetch error). Both budgets share the merge's most-exhausted (`max`) semantics; `armed_at` keeps the min so the age window is never reset by a fresh arm.
- New `rearm_catch_up_retry_after_defer` replaces the bare `arm_catch_up_retry_pending` at the four **enqueue-not-accepted** sites (phase-1 Deferred + LastItemDedup-unsafe, phase-2 Deferred + LastItemDedup-unsafe). It reconstructs the prior budget from **either** the state consumed for this scan (phase-1 threads it in) **or** the surviving pending-map entry (phase-2 does not consume), taking the most-exhausted of the two. At the cap it emits a `giving up` WARN — mirroring the fetch-failure path — and does **not** re-arm.
- The legitimate **queue-cap backpressure** re-arm (`stats.enqueued >= remaining_capacity`) is intentionally left unchanged — that is real progress, not a stuck cycle.

## Verification
- `cargo check --lib --tests` clean.
- `cargo test --lib discord::catch_up` → **32 passed, 0 failed**, incl. new `deferred_rearm_gives_up_after_bounded_attempts_and_preserves_arm_time` (asserts: at cap → no re-arm + nothing pending; one below cap → re-arms carrying incremented budget + original `armed_at`).
- No maintenance admission needed (hotfile ratchet / maintainability audit / agent-maintenance line-count gates pass; catch_up.rs under its giant-file ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)