### PR TITLE
docs(api): document 4 hook/internal routes + remove api-docs coverage gate allowlist blind spot (#4226)

### DIFF
--- a/scripts/check_api_docs_coverage.py
+++ b/scripts/check_api_docs_coverage.py
@@ -21,24 +21,7 @@ GLOB_CHARS_RE = re.compile(r"[*?\[\]]")
 # Exact mounted routes that intentionally stay out of /api/docs. Keep this
 # dictionary narrow: no globbing, no path-prefix entries, and every reason must
 # explain why callers should not discover the route from the public docs shape.
-UNDOCUMENTED_API_ROUTES: dict[tuple[str, str], str] = {
-    (
-        "POST",
-        "/api/hook/reset-status",
-    ): "Loopback-only hook control-plane mutation for status reconciliation; not an operator-facing API.",
-    (
-        "POST",
-        "/api/hook/skill-usage",
-    ): "Loopback-only hook ingestion endpoint for skill usage telemetry; callers use docs-visible analytics routes instead.",
-    (
-        "DELETE",
-        "/api/hook/session/{sessionKey}",
-    ): "Loopback-only hook session disconnect endpoint with hook-client path casing; not part of the public API docs contract.",
-    (
-        "POST",
-        "/api/internal/escalation/emit",
-    ): "Loopback-only internal escalation emitter under /internal; not discoverable as a public operator route.",
-}
+UNDOCUMENTED_API_ROUTES: dict[tuple[str, str], str] = {}
 
 
 @dataclass(frozen=True, order=True)

--- a/src/server/routes/docs/inventory/endpoints/part_08.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_08.rs
@@ -541,6 +541,57 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "Policy hook timeout and execution counters.",
         ),
         ep(
+            "POST",
+            "/api/hook/reset-status",
+            "ops",
+            "Reset agents currently marked working back to idle and report rows updated.",
+        ),
+        ep(
+            "POST",
+            "/api/hook/skill-usage",
+            "skills",
+            "Record one skill usage event with optional agent, role, and session context.",
+        )
+        .with_params([
+            ("skill_id", body_param("string", true, "Skill identifier to record")),
+            ("agent_id", body_param("string", false, "Optional agent id")),
+            (
+                "role_id",
+                body_param(
+                    "string",
+                    false,
+                    "Optional role id used to resolve an agent when agent_id is absent",
+                ),
+            ),
+            (
+                "session_key",
+                body_param("string", false, "Optional session key associated with the usage event"),
+            ),
+        ]),
+        ep(
+            "DELETE",
+            "/api/hook/session/{sessionKey}",
+            "sessions",
+            "Mark the matching session disconnected by session key.",
+        )
+        .with_params([(
+            "sessionKey",
+            path_param("Session key to mark disconnected"),
+        )]),
+        ep(
+            "POST",
+            "/api/internal/escalation/emit",
+            "internal",
+            "Emit a manual-decision escalation for a card through the configured user-thread or PM Discord route.",
+        )
+        .with_params([
+            ("card_id", body_param("string", true, "Kanban card id to escalate")),
+            (
+                "reasons",
+                body_param("array<string>", true, "Non-empty escalation reasons"),
+            ),
+        ]),
+        ep(
             "GET",
             "/api/github/pr-summary",
             "github",


### PR DESCRIPTION
## Summary
- #4226 항목 1·2 해결 (항목 3 'TODO: example' 119건은 후속):
  - `/api/docs` 인벤토리에 누락 4건 문서화: `POST /api/hook/reset-status`, `POST /api/hook/skill-usage`(+params), `DELETE /api/hook/session/{sessionKey}`(+param), `POST /api/internal/escalation/emit`(+params) — `part_08.rs`
  - #3719 게이트 blind spot 제거: `check_api_docs_coverage.py`의 `UNDOCUMENTED_API_ROUTES` allowlist가 /api/hook/* 드리프트를 통째로 억제하고 있었음 → allowlist 비움 (이후 신규 라우트는 문서화 없이 통과 불가)

## Verification (클론 격리 실행)
- `python3 scripts/check_api_docs_coverage.py` → passed
- `python3 -m unittest tests.test_api_docs_coverage` → 13 tests OK
- 컴파일은 CI Fast check가 검증 (ep() 테이블 항목 추가만)

## Tier
- 경량 (docs/scripts) — 구현 codex, 검토 Claude(오케스트레이터 디프 검토)

🤖 Generated with [Claude Code](https://claude.com/claude-code)