### PR TITLE
fix(test): #4210 env-race sweep + #4182 stale providerless_strict_repair fixture + drop-order fix

### DIFF
--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -4903,6 +4903,9 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test]
     async fn stall_watchdog_cleanup_releases_residual_orphan_pending_token() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
         let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
         let provider = ProviderKind::Codex;
@@ -4980,15 +4983,23 @@ mod hard_stop_completion_event_tests {
     use crate::services::turn_orchestrator::{Intervention, InterventionMode};
 
     struct EnvVarReset {
+        _lock: std::sync::MutexGuard<'static, ()>,
         key: &'static str,
         previous: Option<std::ffi::OsString>,
     }
 
     impl EnvVarReset {
         fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let lock = crate::config::shared_test_env_lock()
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
             let previous = std::env::var_os(key);
             unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
+            Self {
+                _lock: lock,
+                key,
+                previous,
+            }
         }
     }
 

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -5221,6 +5221,9 @@ mod hard_stop_completion_event_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn providerless_strict_repair_ignores_empty_mailbox_created_by_snapshot_scan() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
         let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
         let provider = ProviderKind::Claude;
@@ -5264,21 +5267,21 @@ mod hard_stop_completion_event_tests {
             .await
             .expect("providerless pre-repair snapshot should find second runtime's mailbox");
         assert!(observed.has_pending_queue);
-        let first_snapshot = first
-            .mailbox_peek(channel)
-            .expect("providerless snapshot scan should materialize first runtime mailbox")
-            .snapshot()
-            .await;
-        assert!(first_snapshot.cancel_token.is_none());
-        assert!(first_snapshot.intervention_queue.is_empty());
+        // cfcdcd6135572601af287e2165afae34b3ddd464 (#4068) made health
+        // snapshots peek-only: observation must not materialize or globalize
+        // an empty first-runtime mailbox.
+        assert!(
+            first.mailbox_peek(channel).is_none(),
+            "providerless snapshot scan must leave the first runtime without local mailbox evidence"
+        );
         let global_after_observation =
             crate::services::turn_orchestrator::ChannelMailboxRegistry::global_handle(channel)
                 .expect("snapshot scan should leave a process-global handle");
         let global_snapshot = global_after_observation.snapshot().await;
-        assert!(global_snapshot.cancel_token.is_none());
+        assert!(global_snapshot.cancel_token.is_some());
         assert!(
-            global_snapshot.intervention_queue.is_empty(),
-            "pre-repair observation should clobber the global handle to first runtime's empty mailbox"
+            !global_snapshot.intervention_queue.is_empty(),
+            "pre-repair observation should keep the global handle on the owning second runtime"
         );
 
         let mut first_rx =
@@ -5295,7 +5298,7 @@ mod hard_stop_completion_event_tests {
 
         assert!(
             result.had_active_turn,
-            "strict repair must skip first runtime's empty mailbox and finalize second runtime"
+            "strict repair must select and finalize the owning second runtime"
         );
         assert!(result.has_pending_queue);
         assert!(
@@ -5314,13 +5317,11 @@ mod hard_stop_completion_event_tests {
             "empty first runtime must not be selected or publish completion"
         );
 
-        let first_after = first
-            .mailbox_peek(channel)
-            .expect("empty first runtime mailbox should remain only as observation artifact")
-            .snapshot()
-            .await;
-        assert!(first_after.cancel_token.is_none());
-        assert!(first_after.intervention_queue.is_empty());
+        let first_after = first.mailbox_peek(channel);
+        assert!(
+            first_after.is_none(),
+            "empty first runtime mailbox should not be created by observation or repair"
+        );
         let second_after = second
             .mailbox_peek(channel)
             .expect("owning second runtime mailbox should remain registered")

--- a/src/services/discord/tmux_watcher/tests.rs
+++ b/src/services/discord/tmux_watcher/tests.rs
@@ -1682,17 +1682,21 @@ impl Drop for RootEnvGuard {
     }
 }
 
+/// #4210: tuple fields drop in declaration order, so the guard (which removes
+/// the env var) and the tempdir MUST come before the lock — otherwise the lock
+/// releases first and the deferred `remove_var` can delete a var another test
+/// (already holding the freed lock) just set.
 fn pin_runtime_root_for_test() -> (
-    std::sync::MutexGuard<'static, ()>,
-    tempfile::TempDir,
     RootEnvGuard,
+    tempfile::TempDir,
+    std::sync::MutexGuard<'static, ()>,
 ) {
     let lock = crate::config::shared_test_env_lock()
         .lock()
         .unwrap_or_else(|poison| poison.into_inner());
     let root = tempfile::tempdir().expect("runtime root");
     unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root.path()) };
-    (lock, root, RootEnvGuard)
+    (RootEnvGuard, root, lock)
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **#4210**: 로컬 테스트 스탬피드(env-race) 스윕 — 런타임 스토어 루트를 읽는 테스트들이 #3293 규율(shared_test_env_lock 선점 + AGENTDESK_ROOT_DIR TempDir 핀)을 지키도록 일괄 정비, `pin_runtime_root_for_test()` 헬퍼 도입
- **#4182**: providerless_strict_repair의 stale fixture 수정 (수정 전 2 failed 재현 확인됨)
- 내 후속 수정: `pin_runtime_root_for_test` 튜플 drop 순서 버그 — guard가 lock보다 먼저 drop되도록 `(RootEnvGuard, TempDir, MutexGuard)` 순서 교정 (b7643f897, #4210 코멘트 참조)

## Verification
- 테스트 전용 변경 (프로덕션 코드 무변경) — **CI Fast check + non-PG tests가 권위 검증** (로컬 검증은 머신 I/O 폭주로 CI 위임; 수정 전 로컬 재현에서 2 failed → 수정 커밋 포함 후 CI green 기대)
- 경량 티어 (test-only): 구현 codex(스윕)+오케스트레이터(drop-order), 디프 검토 완료

Closes #4210, Closes #4182

🤖 Generated with [Claude Code](https://claude.com/claude-code)