### PR TITLE
docs(api): sweep 118 'TODO: example' inventory placeholders (#4227 item 3)

### DIFF
--- a/src/server/routes/docs/inventory/endpoints/part_02.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_02.rs
@@ -320,7 +320,10 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 json!({"error": "agent not found: ghost"}),
             )
             .with_curl("curl -X PATCH http://localhost:8787/api/agents/project-agentdesk -H 'Content-Type: application/json' -d '{\"name\":\"AgentDesk\"}'"),
-        ep("DELETE", "/api/agents/{id}", "agents", "Delete agent // TODO: example"),
+        ep("DELETE", "/api/agents/{id}", "agents", "Delete agent").with_example(
+            json!({"path": {"id": "project-agentdesk"}}),
+            json!({"ok": true}),
+        ),
         ep(
             "POST",
             "/api/agents/{id}/archive",
@@ -341,13 +344,17 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "POST",
             "/api/agents/{id}/unarchive",
             "agents",
-            "Restore an archived agent config binding and mark archive state unarchived. // TODO: example",
+            "Restore an archived agent config binding and mark archive state unarchived.",
+        )
+        .with_example(
+            json!({"path": {"id": "project-agentdesk"}}),
+            json!({"ok": true, "agent_id": "project-agentdesk", "archive_state": "unarchived", "status": "idle"}),
         ),
         ep(
             "POST",
             "/api/agents/{id}/duplicate",
             "agents",
-            "Duplicate an agent by reusing /api/agents/setup with the source prompt as template. // TODO: example",
+            "Duplicate an agent by reusing /api/agents/setup with the source prompt as template.",
         )
         .with_params([
             ("id", path_param("Source agent id")),
@@ -355,66 +362,98 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             ("channel_id", body_param("string", true, "Existing Discord channel snowflake")),
             ("provider", body_param("string", false, "Provider override")),
             ("dry_run", body_param("boolean", false, "Preview setup mutations only").with_default(false)),
-        ]),
+        ])
+        .with_example(
+            json!({"path": {"id": "project-agentdesk"}, "body": {"new_agent_id": "project-agentdesk-copy", "channel_id": "1473922824350601297", "provider": "codex", "dry_run": true}}),
+            json!({"ok": true, "duplicate": true, "source_agent_id": "project-agentdesk", "new_agent_id": "project-agentdesk-copy", "setup": {"dry_run": true}}),
+        ),
         ep(
             "GET",
             "/api/onboarding/status",
             "onboarding",
-            "Get onboarding status // TODO: example",
+            "Get onboarding status",
         ),
         ep(
             "GET",
             "/api/onboarding/draft",
             "onboarding",
-            "Get onboarding resume draft // TODO: example",
+            "Get onboarding resume draft",
         ),
         ep(
             "PUT",
             "/api/onboarding/draft",
             "onboarding",
-            "Persist onboarding resume draft // TODO: example",
+            "Persist onboarding resume draft",
+        )
+        .with_example(
+            json!({"body": {"version": 1, "step": 2, "selected_guild": "1490141479707086938", "agents": []}}),
+            json!({"ok": true, "available": true, "secret_policy": "redacted"}),
         ),
         ep(
             "DELETE",
             "/api/onboarding/draft",
             "onboarding",
-            "Clear onboarding resume draft // TODO: example",
+            "Clear onboarding resume draft",
+        )
+        .with_example(
+            json!({}),
+            json!({"ok": true, "available": false, "secret_policy": "redacted"}),
         ),
         ep(
             "POST",
             "/api/onboarding/validate-token",
             "onboarding",
-            "Validate onboarding token // TODO: example",
+            "Validate onboarding token",
+        )
+        .with_example(
+            json!({"body": {"token": "discord-bot-token"}}),
+            json!({"valid": true, "bot_id": "123456789012345678", "bot_name": "agentdesk-bot", "avatar": null}),
         ),
         ep(
             "GET",
             "/api/onboarding/channels",
             "onboarding",
-            "List onboarding candidate channels // TODO: example",
+            "List onboarding candidate channels",
         ),
         ep(
             "POST",
             "/api/onboarding/channels",
             "onboarding",
-            "Persist onboarding channel selection // TODO: example",
+            "Persist onboarding channel selection",
+        )
+        .with_example(
+            json!({"body": {"token": "discord-bot-token"}}),
+            json!({"guilds": [{"id": "1490141479707086938", "name": "AgentDesk"}], "channels": [{"id": "1473922824350601297", "name": "agentdesk"}]}),
         ),
         ep(
             "POST",
             "/api/onboarding/complete",
             "onboarding",
-            "Complete onboarding // TODO: example",
+            "Complete onboarding",
+        )
+        .with_example(
+            json!({"body": {"token": "discord-bot-token", "guild_id": "1490141479707086938", "provider": "codex", "channels": [{"channel_id": "1473922824350601297", "channel_name": "agentdesk", "role_id": "project-agentdesk"}]}}),
+            json!({"ok": true, "provider": "codex", "rerun_policy": "safe"}),
         ),
         ep(
             "POST",
             "/api/onboarding/check-provider",
             "onboarding",
-            "Validate provider installation and credentials // TODO: example",
+            "Validate provider installation and credentials",
+        )
+        .with_example(
+            json!({"body": {"provider": "codex"}}),
+            json!({"installed": true, "logged_in": true, "version": "codex 1.0.0", "path": "/usr/local/bin/codex"}),
         ),
         ep(
             "POST",
             "/api/onboarding/generate-prompt",
             "onboarding",
-            "Generate onboarding prompt // TODO: example",
+            "Generate onboarding prompt",
+        )
+        .with_example(
+            json!({"body": {"name": "Docs Agent", "description": "Maintains API docs", "provider": "codex"}}),
+            json!({"prompt": "You maintain concise API documentation."}),
         ),
         ep(
             "POST",
@@ -480,13 +519,17 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/agents/{id}/offices",
             "agents",
-            "List offices for agent // TODO: example",
+            "List offices for agent",
         ),
         ep(
             "POST",
             "/api/agents/{id}/signal",
             "agents",
-            "Send runtime signal to agent // TODO: example",
+            "Send runtime signal to agent",
+        )
+        .with_example(
+            json!({"path": {"id": "project-agentdesk"}, "body": {"signal": "blocked", "reason": "waiting on review"}}),
+            json!({"ok": true, "card_id": "card-1", "signal": "blocked"}),
         ),
         ep(
             "POST",
@@ -578,13 +621,13 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/agents/{id}/cron",
             "agents",
-            "List cron jobs for agent // TODO: example",
+            "List cron jobs for agent",
         ),
         ep(
             "GET",
             "/api/agents/{id}/skills",
             "agents",
-            "List skills for agent // TODO: example",
+            "List skills for agent",
         ),
         ep(
             "GET",
@@ -635,7 +678,7 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/agents/{id}/turn",
             "agents",
-            "Get active turn status and recent output // TODO: example",
+            "Get active turn status and recent output",
         )
     ]
 }

--- a/src/server/routes/docs/inventory/endpoints/part_03.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_03.rs
@@ -87,13 +87,13 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/agents/{id}/transcripts",
             "agents",
-            "List recent completed turn transcripts for agent // TODO: example",
+            "List recent completed turn transcripts for agent",
         ),
         ep(
             "GET",
             "/api/agents/{id}/timeline",
             "agents",
-            "Agent activity timeline // TODO: example",
+            "Agent activity timeline",
         ),
         ep(
             "GET",
@@ -176,13 +176,13 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             json!({"error": "metric must be one of turn_success_rate|review_pass_rate"}),
         )
         .with_curl("curl 'http://localhost:8787/api/agents/quality/ranking?metric=turn_success_rate&window=7d&limit=10'"),
-        ep("GET", "/api/sessions", "sessions", "List sessions // TODO: example"),
-        ep("GET", "/api/policies", "policies", "List policies // TODO: example"),
+        ep("GET", "/api/sessions", "sessions", "List sessions"),
+        ep("GET", "/api/policies", "policies", "List policies"),
         ep(
             "GET",
             "/api/auth/session",
             "auth",
-            "Get current auth session // TODO: example",
+            "Get current auth session",
         ),
         ep("GET", "/api/kanban-cards", "kanban", "List kanban cards")
             .with_params([
@@ -294,7 +294,7 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/kanban-cards/stalled",
             "kanban",
-            "List stalled cards // TODO: example",
+            "List stalled cards",
         ),
         ep(
             "POST",
@@ -450,9 +450,13 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "DELETE",
             "/api/kanban-cards/{id}",
             "kanban",
-            "Delete card // TODO: example",
+            "Delete card",
         )
-        .with_params([("id", path_param("Kanban card ID"))]),
+        .with_params([("id", path_param("Kanban card ID"))])
+        .with_example(
+            json!({"path": {"id": "card-1"}}),
+            json!({"ok": true}),
+        ),
         ep(
             "POST",
             "/api/kanban-cards/{id}/assign",

--- a/src/server/routes/docs/inventory/endpoints/part_04.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_04.rs
@@ -97,28 +97,28 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/kanban-cards/{id}/reviews",
             "kanban",
-            "List reviews for card // TODO: example",
+            "List reviews for card",
         )
         .with_params([("id", path_param("Kanban card ID"))]),
         ep(
             "GET",
             "/api/kanban-cards/{id}/review-state",
             "kanban",
-            "Get canonical review-state record for card // TODO: example",
+            "Get canonical review-state record for card",
         )
         .with_params([("id", path_param("Kanban card ID"))]),
         ep(
             "GET",
             "/api/kanban-cards/{id}/audit-log",
             "kanban",
-            "Get audit log for card // TODO: example",
+            "Get audit log for card",
         )
         .with_params([("id", path_param("Kanban card ID"))]),
         ep(
             "GET",
             "/api/kanban-cards/{id}/comments",
             "kanban",
-            "Get GitHub comments for linked card issue // TODO: example",
+            "Get GitHub comments for linked card issue",
         )
         .with_params([("id", path_param("Kanban card ID"))]),
         ep(
@@ -244,37 +244,57 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/kanban-repos",
             "kanban-repos",
-            "List kanban repos // TODO: example",
+            "List kanban repos",
         ),
         ep(
             "POST",
             "/api/kanban-repos",
             "kanban-repos",
-            "Create kanban repo // TODO: example",
+            "Create kanban repo",
+        )
+        .with_example(
+            json!({"body": {"repo": "itismyfield/AgentDesk"}}),
+            json!({"repo": {"id": "itismyfield/AgentDesk", "display_name": "AgentDesk", "sync_enabled": true, "last_synced_at": null}}),
         ),
         ep(
             "PATCH",
             "/api/kanban-repos/{owner}/{repo}",
             "kanban-repos",
-            "Update kanban repo // TODO: example",
+            "Update kanban repo",
+        )
+        .with_example(
+            json!({"path": {"owner": "itismyfield", "repo": "AgentDesk"}, "body": {"default_agent_id": "project-agentdesk"}}),
+            json!({"repo": {"id": "itismyfield/AgentDesk", "default_agent_id": "project-agentdesk", "sync_enabled": true}}),
         ),
         ep(
             "DELETE",
             "/api/kanban-repos/{owner}/{repo}",
             "kanban-repos",
-            "Delete kanban repo // TODO: example",
+            "Delete kanban repo",
+        )
+        .with_example(
+            json!({"path": {"owner": "itismyfield", "repo": "AgentDesk"}}),
+            json!({"ok": true}),
         ),
         ep(
             "PATCH",
             "/api/kanban-reviews/{id}/decisions",
             "reviews",
-            "Update review decisions // TODO: example",
+            "Update review decisions",
+        )
+        .with_example(
+            json!({"path": {"id": "review-1"}, "body": {"decisions": [{"item_id": 1, "decision": "accept"}]}}),
+            json!({"review": {"dispatch_id": "review-1", "decisions": [{"item_id": 1, "decision": "accept"}]}}),
         ),
         ep(
             "POST",
             "/api/kanban-reviews/{id}/trigger-rework",
             "reviews",
-            "Trigger rework for review // TODO: example",
+            "Trigger rework for review",
+        )
+        .with_example(
+            json!({"path": {"id": "review-1"}}),
+            json!({"ok": true}),
         ),
         ep(
             "POST",
@@ -515,37 +535,61 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "POST",
             "/api/internal/link-dispatch-thread",
             "internal",
-            "Link dispatch to an existing Discord thread // TODO: example",
+            "Link dispatch to an existing Discord thread",
+        )
+        .with_example(
+            json!({"body": {"dispatch_id": "dispatch-1", "thread_id": "1500000000000000001", "channel_id": "1500000000000000000"}}),
+            json!({"ok": true, "card_id": "card-1"}),
         ),
         ep(
             "GET",
             "/api/internal/card-thread",
             "internal",
-            "Resolve thread metadata for a card // TODO: example",
+            "Resolve thread metadata for a card",
+        )
+        .with_example(
+            json!({"query": {"dispatch_id": "dispatch-1"}}),
+            json!({"card_id": "card-1", "active_thread_id": "1500000000000000001", "dispatch_type": "implementation"}),
         ),
         ep(
             "GET",
             "/api/internal/pending-dispatch-for-thread",
             "internal",
-            "Find pending dispatch bound to a thread // TODO: example",
+            "Find pending dispatch bound to a thread",
+        )
+        .with_example(
+            json!({"query": {"thread_id": "1500000000000000001"}}),
+            json!({"dispatch_id": "dispatch-1"}),
         ),
         ep(
             "GET",
             "/api/pipeline/stages",
             "pipeline",
-            "List pipeline stages // TODO: example",
+            "List pipeline stages",
+        )
+        .with_example(
+            json!({"query": {"repo": "itismyfield/AgentDesk"}}),
+            json!({"stages": [{"stage_name": "implementation", "stage_order": 1, "provider": "codex"}]}),
         ),
         ep(
             "PUT",
             "/api/pipeline/stages",
             "pipeline",
-            "Replace all pipeline stages // TODO: example",
+            "Replace all pipeline stages",
+        )
+        .with_example(
+            json!({"body": {"repo": "itismyfield/AgentDesk", "stages": [{"stage_name": "implementation", "stage_order": 1, "provider": "codex", "timeout_minutes": 60, "on_failure": "fail"}]}}),
+            json!({"stages": [{"repo_id": "itismyfield/AgentDesk", "stage_name": "implementation", "stage_order": 1}]}),
         ),
         ep(
             "DELETE",
             "/api/pipeline/stages",
             "pipeline",
-            "Delete pipeline stages // TODO: example",
+            "Delete pipeline stages",
+        )
+        .with_example(
+            json!({"query": {"repo": "itismyfield/AgentDesk"}}),
+            json!({"deleted": true, "count": 3}),
         ),
         ep(
             "GET",
@@ -568,25 +612,33 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/pipeline/cards/{card_id}/history",
             "pipeline",
-            "Get card transition history // TODO: example",
+            "Get card transition history",
+        )
+        .with_example(
+            json!({"path": {"card_id": "card-1"}}),
+            json!({"history": [{"from_status": "backlog", "to_status": "ready", "reason": "operator"}]}),
         ),
         ep(
             "GET",
             "/api/pipeline/cards/{card_id}/transcripts",
             "pipeline",
-            "List completed turn transcripts linked to card dispatches // TODO: example",
+            "List completed turn transcripts linked to card dispatches",
+        )
+        .with_example(
+            json!({"path": {"card_id": "card-1"}, "query": {"limit": 2}}),
+            json!({"card_id": "card-1", "transcripts": [{"dispatch_id": "dispatch-1", "agent_id": "project-agentdesk"}]}),
         ),
         ep(
             "GET",
             "/api/pipeline/config/default",
             "pipeline",
-            "Get default pipeline config // TODO: example",
+            "Get default pipeline config",
         ),
         ep(
             "GET",
             "/api/pipeline/config/effective",
             "pipeline",
-            "Get effective merged pipeline config // TODO: example",
+            "Get effective merged pipeline config",
         )
         .with_params([
             (
@@ -597,36 +649,56 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 "agent_id",
                 query_param("string", false, "Agent id for config resolution"),
             ),
-        ]),
+        ])
+        .with_example(
+            json!({"query": {"repo": "itismyfield/AgentDesk", "agent_id": "project-agentdesk"}}),
+            json!({"stages": [{"stage_name": "implementation", "provider": "codex"}], "source": "merged"}),
+        ),
         ep(
             "GET",
             "/api/pipeline/config/repo/{owner}/{repo}",
             "pipeline",
-            "Get repo pipeline override // TODO: example",
+            "Get repo pipeline override",
+        )
+        .with_example(
+            json!({"path": {"owner": "itismyfield", "repo": "AgentDesk"}}),
+            json!({"repo": "itismyfield/AgentDesk", "pipeline_config": {"stages": []}}),
         ),
         ep(
             "PUT",
             "/api/pipeline/config/repo/{owner}/{repo}",
             "pipeline",
-            "Set repo pipeline override // TODO: example",
+            "Set repo pipeline override",
+        )
+        .with_example(
+            json!({"path": {"owner": "itismyfield", "repo": "AgentDesk"}, "body": {"config": {"stages": [{"name": "implementation"}]}}}),
+            json!({"ok": true, "repo": "itismyfield/AgentDesk"}),
         ),
         ep(
             "GET",
             "/api/pipeline/config/agent/{agent_id}",
             "pipeline",
-            "Get agent pipeline override // TODO: example",
+            "Get agent pipeline override",
+        )
+        .with_example(
+            json!({"path": {"agent_id": "project-agentdesk"}}),
+            json!({"agent_id": "project-agentdesk", "pipeline_config": {"stages": []}}),
         ),
         ep(
             "PUT",
             "/api/pipeline/config/agent/{agent_id}",
             "pipeline",
-            "Set agent pipeline override // TODO: example",
+            "Set agent pipeline override",
+        )
+        .with_example(
+            json!({"path": {"agent_id": "project-agentdesk"}, "body": {"config": {"stages": [{"name": "review"}]}}}),
+            json!({"ok": true, "agent_id": "project-agentdesk"}),
         ),
         ep(
             "GET",
             "/api/pipeline/config/graph",
             "pipeline",
-            "Get pipeline graph // TODO: example",
+            "Get pipeline graph",
         )
         .with_params([
             (
@@ -637,7 +709,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 "agent_id",
                 query_param("string", false, "Agent id for config resolution"),
             ),
-        ]),
-        ep("GET", "/api/github/repos", "github", "List GitHub repos // TODO: example")
+        ])
+        .with_example(
+            json!({"query": {"repo": "itismyfield/AgentDesk", "agent_id": "project-agentdesk"}}),
+            json!({"nodes": [{"id": "implementation", "label": "Implementation"}], "edges": []}),
+        ),
+        ep("GET", "/api/github/repos", "github", "List GitHub repos")
     ]
 }

--- a/src/server/routes/docs/inventory/endpoints/part_05.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_05.rs
@@ -156,7 +156,10 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             json!({"error": "dod must contain at least one item"}),
         )
         .with_curl("curl -X POST http://localhost:8787/api/github/issues/create -H 'Content-Type: application/json' -d '{\"repo\":\"ADK\",\"title\":\"Example\",\"background\":\"bg\",\"content\":[\"do thing\"],\"dod\":[\"it works\"]}'"),
-        ep("POST", "/api/github/repos", "github", "Register GitHub repo // TODO: example"),
+        ep("POST", "/api/github/repos", "github", "Register GitHub repo").with_example(
+            json!({"body": {"id": "itismyfield/AgentDesk"}}),
+            json!({"repo": {"id": "itismyfield/AgentDesk", "display_name": "AgentDesk", "sync_enabled": true, "last_synced_at": null}}),
+        ),
         ep(
             "POST",
             "/api/github/repos/{owner}/{repo}/sync",
@@ -202,102 +205,159 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/github-repos",
             "github-dashboard",
-            "List GitHub repos for dashboard // TODO: example",
+            "List GitHub repos for dashboard",
         ),
         ep(
             "GET",
             "/api/github-issues",
             "github-dashboard",
-            "List GitHub issues for dashboard // TODO: example",
+            "List GitHub issues for dashboard",
+        )
+        .with_example(
+            json!({"query": {"repo": "itismyfield/AgentDesk", "state": "open", "limit": 20}}),
+            json!({"repo": "itismyfield/AgentDesk", "issues": [{"number": 4227, "title": "Docs inventory sweep", "state": "OPEN"}]}),
         ),
         ep(
             "PATCH",
             "/api/github-issues/{owner}/{repo}/{number}/close",
             "github-dashboard",
-            "Close GitHub issue from dashboard // TODO: example",
+            "Close GitHub issue from dashboard",
+        )
+        .with_example(
+            json!({"path": {"owner": "itismyfield", "repo": "AgentDesk", "number": 4227}}),
+            json!({"ok": true, "repo": "itismyfield/AgentDesk", "number": 4227}),
         ),
         ep(
             "GET",
             "/api/github-closed-today",
             "github-dashboard",
-            "List issues closed today // TODO: example",
+            "List issues closed today",
         ),
-        ep("GET", "/api/offices", "offices", "List offices // TODO: example"),
-        ep("POST", "/api/offices", "offices", "Create office // TODO: example"),
+        ep("GET", "/api/offices", "offices", "List offices"),
+        ep("POST", "/api/offices", "offices", "Create office").with_example(
+            json!({"body": {"name": "Engineering", "layout": "kanban"}}),
+            json!({"office": {"id": "office-1", "name": "Engineering", "layout": "kanban"}}),
+        ),
         ep(
             "PATCH",
             "/api/offices/reorder",
             "offices",
-            "Reorder offices // TODO: example",
+            "Reorder offices",
+        )
+        .with_example(
+            json!({"body": [{"id": "office-1", "sort_order": 1}]}),
+            json!({"ok": true, "updated": 1}),
         ),
-        ep("PATCH", "/api/offices/{id}", "offices", "Update office // TODO: example"),
-        ep("DELETE", "/api/offices/{id}", "offices", "Delete office // TODO: example"),
+        ep("PATCH", "/api/offices/{id}", "offices", "Update office").with_example(
+            json!({"path": {"id": "office-1"}, "body": {"name": "Platform", "layout": "matrix"}}),
+            json!({"office": {"id": "office-1", "name": "Platform", "layout": "matrix"}}),
+        ),
+        ep("DELETE", "/api/offices/{id}", "offices", "Delete office").with_example(
+            json!({"path": {"id": "office-1"}}),
+            json!({"ok": true}),
+        ),
         ep(
             "POST",
             "/api/offices/{id}/agents",
             "offices",
-            "Add agent to office // TODO: example",
+            "Add agent to office",
+        )
+        .with_example(
+            json!({"path": {"id": "office-1"}, "body": {"agent_id": "project-agentdesk", "department_id": "dept-platform"}}),
+            json!({"ok": true}),
         ),
         ep(
             "POST",
             "/api/offices/{id}/agents/batch",
             "offices",
-            "Batch add agents to office // TODO: example",
+            "Batch add agents to office",
+        )
+        .with_example(
+            json!({"path": {"id": "office-1"}, "body": {"agent_ids": ["project-agentdesk", "adk-dashboard"]}}),
+            json!({"ok": true}),
         ),
         ep(
             "DELETE",
             "/api/offices/{id}/agents/{agentId}",
             "offices",
-            "Remove agent from office // TODO: example",
+            "Remove agent from office",
+        )
+        .with_example(
+            json!({"path": {"id": "office-1", "agentId": "project-agentdesk"}}),
+            json!({"ok": true}),
         ),
         ep(
             "PATCH",
             "/api/offices/{id}/agents/{agentId}",
             "offices",
-            "Update office agent // TODO: example",
+            "Update office agent",
+        )
+        .with_example(
+            json!({"path": {"id": "office-1", "agentId": "project-agentdesk"}, "body": {"department_id": "dept-platform"}}),
+            json!({"ok": true}),
         ),
         ep(
             "GET",
             "/api/departments",
             "departments",
-            "List departments // TODO: example",
+            "List departments",
         ),
         ep(
             "POST",
             "/api/departments",
             "departments",
-            "Create department // TODO: example",
+            "Create department",
+        )
+        .with_example(
+            json!({"body": {"name": "Platform", "office_id": "office-1"}}),
+            json!({"department": {"id": "dept-platform", "name": "Platform", "office_id": "office-1"}}),
         ),
         ep(
             "PATCH",
             "/api/departments/reorder",
             "departments",
-            "Reorder departments // TODO: example",
+            "Reorder departments",
+        )
+        .with_example(
+            json!({"body": {"order": [{"id": "dept-platform", "sort_order": 1}]}}),
+            json!({"ok": true, "updated": 1}),
         ),
         ep(
             "PATCH",
             "/api/departments/{id}",
             "departments",
-            "Update department // TODO: example",
+            "Update department",
+        )
+        .with_example(
+            json!({"path": {"id": "dept-platform"}, "body": {"name": "Runtime", "office_id": "office-1"}}),
+            json!({"department": {"id": "dept-platform", "name": "Runtime", "office_id": "office-1"}}),
         ),
         ep(
             "DELETE",
             "/api/departments/{id}",
             "departments",
-            "Delete department // TODO: example",
+            "Delete department",
+        )
+        .with_example(
+            json!({"path": {"id": "dept-platform"}}),
+            json!({"ok": true}),
         ),
-        ep("GET", "/api/stats", "stats", "Get system stats // TODO: example"),
+        ep("GET", "/api/stats", "stats", "Get system stats"),
         ep(
             "GET",
             "/api/stats/memento",
             "stats",
-            "Get hourly Memento logical call counts and dedup hit rates // TODO: example",
+            "Get hourly Memento logical call counts and dedup hit rates",
         )
         .with_params([(
             "hours",
             query_param("integer", false, "Trailing window size in hours (1-168)")
                 .with_default(24),
-        )]),
+        )])
+        .with_example(
+            json!({"query": {"hours": 24}}),
+            json!({"hours": 24, "calls": [{"hour": "2026-07-08T00:00:00Z", "logical_calls": 12, "dedup_hits": 3}]}),
+        ),
         ep(
             "GET",
             "/api/settings",
@@ -649,7 +709,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "DELETE",
             "/api/dispatched-sessions/cleanup",
             "dispatched-sessions",
-            "Delete stale dispatched sessions // TODO: example",
+            "Delete stale dispatched sessions",
+        )
+        .with_example(
+            json!({}),
+            json!({"ok": true, "deleted": 2}),
         )
     ]
 }

--- a/src/server/routes/docs/inventory/endpoints/part_06.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_06.rs
@@ -9,49 +9,81 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "DELETE",
             "/api/dispatched-sessions/gc-threads",
             "dispatched-sessions",
-            "Garbage-collect orphaned thread sessions // TODO: example",
+            "Garbage-collect orphaned thread sessions",
+        )
+        .with_example(
+            json!({}),
+            json!({"ok": true, "gc_threads": 2}),
         ),
         ep(
             "PATCH",
             "/api/dispatched-sessions/{id}",
             "dispatched-sessions",
-            "Update dispatched session // TODO: example",
+            "Update dispatched session",
+        )
+        .with_example(
+            json!({"path": {"id": 42}, "body": {"status": "working", "active_dispatch_id": "dispatch-1", "model": "gpt-5", "tokens": 1024}}),
+            json!({"ok": true}),
         ),
         ep(
             "POST",
             "/api/dispatched-sessions/webhook",
             "dispatched-sessions",
-            "Session webhook // TODO: example",
+            "Session webhook",
+        )
+        .with_example(
+            json!({"body": {"session_key": "mac-mini:AgentDesk-codex-adk-cdx", "agent_id": "project-agentdesk", "status": "working", "provider": "codex", "dispatch_id": "dispatch-1"}}),
+            json!({"ok": true, "session_key": "mac-mini:AgentDesk-codex-adk-cdx"}),
         ),
         ep(
             "DELETE",
             "/api/dispatched-sessions/webhook",
             "dispatched-sessions",
-            "Delete session webhook state // TODO: example",
+            "Delete session webhook state",
+        )
+        .with_example(
+            json!({"query": {"session_key": "mac-mini:AgentDesk-codex-adk-cdx", "provider": "codex"}}),
+            json!({"ok": true, "deleted": true}),
         ),
         ep(
             "GET",
             "/api/dispatched-sessions/claude-session-id",
             "dispatched-sessions",
-            "Resolve Claude session id by session key // TODO: example",
+            "Resolve Claude session id by session key",
+        )
+        .with_example(
+            json!({"query": {"session_key": "mac-mini:AgentDesk-claude-adk-cc", "provider": "claude"}}),
+            json!({"claude_session_id": "claude-session-1", "session_id": "claude-session-1", "raw_provider_session_id": "claude-session-1"}),
         ),
         ep(
             "POST",
             "/api/dispatched-sessions/clear-stale-session-id",
             "dispatched-sessions",
-            "Clear stale Claude session id // TODO: example",
+            "Clear stale Claude session id",
+        )
+        .with_example(
+            json!({"body": {"session_id": "claude-session-1"}}),
+            json!({"cleared": 1}),
         ),
         ep(
             "POST",
             "/api/dispatched-sessions/clear-session-id",
             "dispatched-sessions",
-            "Clear Claude session id by session key // TODO: example",
+            "Clear Claude session id by session key",
+        )
+        .with_example(
+            json!({"body": {"session_key": "mac-mini:AgentDesk-claude-adk-cc"}}),
+            json!({"cleared": 1}),
         ),
         ep(
             "POST",
             "/api/sessions/{session_key}/force-kill",
             "sessions",
-            "Force-kill session and optionally retry // TODO: example",
+            "Force-kill session and optionally retry",
+        )
+        .with_example(
+            json!({"path": {"session_key": "claude/hash123/mac-mini:AgentDesk-claude-adk-cc"}, "body": {"retry": true, "reason": "stalled turn"}}),
+            json!({"ok": true, "session_key": "claude/hash123/mac-mini:AgentDesk-claude-adk-cc", "killed": true, "retry_created": true}),
         ),
         ep(
             "POST",
@@ -170,13 +202,19 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 }]
             }),
         ),
-        ep("GET", "/api/messages", "messages", "List messages // TODO: example"),
-        ep("POST", "/api/messages", "messages", "Create message // TODO: example"),
+        ep("GET", "/api/messages", "messages", "List messages").with_example(
+            json!({"query": {"receiverId": "project-agentdesk", "receiverType": "agent", "limit": 20}}),
+            json!({"messages": [{"id": 1, "sender_type": "ceo", "receiver_id": "project-agentdesk", "content": "status?", "message_type": "chat"}]}),
+        ),
+        ep("POST", "/api/messages", "messages", "Create message").with_example(
+            json!({"body": {"sender_type": "ceo", "sender_id": "operator", "receiver_type": "agent", "receiver_id": "project-agentdesk", "content": "Please review the docs", "message_type": "chat"}}),
+            json!({"id": 1, "sender_type": "ceo", "receiver_type": "agent", "receiver_id": "project-agentdesk", "content": "Please review the docs", "message_type": "chat"}),
+        ),
         ep(
             "GET",
             "/api/discord/bindings",
             "discord",
-            "List Discord bindings // TODO: example",
+            "List Discord bindings",
         ),
         ep(
             "GET",
@@ -222,81 +260,118 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/discord/channels/{id}",
             "discord",
-            "Get channel or thread info // TODO: example",
+            "Get channel or thread info",
         ),
         ep(
             "POST",
             "/api/dm-reply/register",
             "discord",
-            "Register DM reply handler // TODO: example",
+            "Register DM reply handler",
+        )
+        .with_example(
+            json!({"body": {"source_agent": "family-counsel", "user_id": "123456789012345678", "channel_id": "1473922824350601297", "ttl_seconds": 3600, "context": {"topic": "followup"}}}),
+            json!({"ok": true, "id": 42}),
         ),
         ep(
             "GET",
             "/api/round-table-meetings",
             "meetings",
-            "List meetings // TODO: example",
+            "List meetings",
         ),
         ep(
             "POST",
             "/api/round-table-meetings",
             "meetings",
-            "Create or update meeting // TODO: example",
+            "Create or update meeting",
+        )
+        .with_example(
+            json!({"body": {"id": "meeting-1", "channel_id": "1473922824350601297", "agenda": "API docs review", "status": "completed", "summary": "Decided to add examples", "participant_names": ["PM", "Reviewer"], "total_rounds": 2}}),
+            json!({"ok": true, "meeting": {"id": "meeting-1", "status": "completed", "agenda": "API docs review"}}),
         ),
         ep(
             "POST",
             "/api/round-table-meetings/start",
             "meetings",
-            "Start meeting // TODO: example",
+            "Start meeting",
+        )
+        .with_example(
+            json!({"body": {"channel_id": "1473922824350601297", "agenda": "Plan docs sweep", "primary_provider": "codex", "reviewer_provider": "claude", "fixed_participants": ["project-agentdesk"]}}),
+            json!({"ok": true, "message": "Meeting start scheduled"}),
         ),
         ep(
             "GET",
             "/api/round-table-meetings/{id}",
             "meetings",
-            "Get meeting by ID // TODO: example",
+            "Get meeting by ID",
         ),
         ep(
             "DELETE",
             "/api/round-table-meetings/{id}",
             "meetings",
-            "Delete meeting // TODO: example",
+            "Delete meeting",
+        )
+        .with_example(
+            json!({"path": {"id": "meeting-1"}}),
+            json!({"ok": true}),
         ),
         ep(
             "PATCH",
             "/api/round-table-meetings/{id}/issue-repo",
             "meetings",
-            "Update meeting issue repository // TODO: example",
+            "Update meeting issue repository",
+        )
+        .with_example(
+            json!({"path": {"id": "meeting-1"}, "body": {"repo": "itismyfield/AgentDesk"}}),
+            json!({"ok": true, "meeting": {"id": "meeting-1", "issue_repo": "itismyfield/AgentDesk"}}),
         ),
         ep(
             "POST",
             "/api/round-table-meetings/{id}/issues",
             "meetings",
-            "Create meeting issues // TODO: example",
+            "Create meeting issues",
+        )
+        .with_example(
+            json!({"path": {"id": "meeting-1"}, "body": {"repo": "itismyfield/AgentDesk"}}),
+            json!({"ok": true, "results": [{"key": "item-0", "ok": true, "issue_number": 4227}], "summary": {"total": 1, "created": 1, "failed": 0, "discarded": 0, "pending": 0}}),
         ),
         ep(
             "POST",
             "/api/round-table-meetings/{id}/issues/discard",
             "meetings",
-            "Discard one meeting issue // TODO: example",
+            "Discard one meeting issue",
+        )
+        .with_example(
+            json!({"path": {"id": "meeting-1"}, "body": {"key": "item-0"}}),
+            json!({"ok": true, "summary": {"discarded": 1, "pending": 0}}),
         ),
         ep(
             "POST",
             "/api/round-table-meetings/{id}/issues/discard-all",
             "meetings",
-            "Discard all meeting issues // TODO: example",
+            "Discard all meeting issues",
+        )
+        .with_example(
+            json!({"path": {"id": "meeting-1"}}),
+            json!({"ok": true, "results": [], "summary": {"discarded": 3, "pending": 0, "all_resolved": true}}),
         ),
-        ep("GET", "/api/skills/catalog", "skills", "List skill catalog // TODO: example").with_params([(
-            "include_stale",
-            query_param(
-                "boolean",
-                false,
-                "Include stale skill entries that no longer exist on disk",
+        ep("GET", "/api/skills/catalog", "skills", "List skill catalog")
+            .with_params([(
+                "include_stale",
+                query_param(
+                    "boolean",
+                    false,
+                    "Include stale skill entries that no longer exist on disk",
+                ),
+            )])
+            .with_example(
+                json!({"query": {"include_stale": true}}),
+                json!({"catalog": [{"name": "memory-read", "total_calls": 12, "disk_present": true}], "include_stale": true}),
             ),
-        )]),
         ep(
             "GET",
             "/api/skills/ranking",
             "skills",
-            "Skill usage ranking // TODO: example",
+            "Skill usage ranking",
         )
         .with_params([
             (
@@ -315,8 +390,12 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                     "Include stale skill entries that no longer exist on disk",
                 ),
             ),
-        ]),
-        ep("POST", "/api/skills/prune", "skills", "Preview or prune stale skill metadata // TODO: example")
+        ])
+        .with_example(
+            json!({"query": {"window": "7d", "limit": 10}}),
+            json!({"window": "7d", "include_stale": false, "overall": [{"skill_name": "memory-read", "calls": 12}], "byAgent": [{"agent_role_id": "project-agentdesk", "skill_name": "memory-read", "calls": 4}]}),
+        ),
+        ep("POST", "/api/skills/prune", "skills", "Preview or prune stale skill metadata")
             .with_params([(
                 "dry_run",
                 query_param(
@@ -324,8 +403,12 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                     false,
                     "When true, report stale skill ids without deleting skills rows",
                 ),
-            )]),
-        ep("GET", "/api/cron-jobs", "cron", "List cron jobs // TODO: example"),
+            )])
+            .with_example(
+                json!({"query": {"dry_run": true}}),
+                json!({"ok": true, "dry_run": true, "stale_skill_ids": ["old-skill"], "stale_count": 1, "soft_deleted_from_skills": 0, "skill_usage_policy": "preserved"}),
+            ),
+        ep("GET", "/api/cron-jobs", "cron", "List cron jobs"),
         ep(
             "GET",
             "/api/routines",

--- a/src/server/routes/docs/inventory/endpoints/part_07.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_07.rs
@@ -579,7 +579,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/channels/{id}/queue",
             "queue",
-            "List queue entries for a Discord channel // TODO: example",
+            "List queue entries for a Discord channel",
+        )
+        .with_example(
+            json!({"path": {"id": "1473922824350601297"}}),
+            json!({"channel_id": "1473922824350601297", "dispatches": [{"dispatch_id": "dispatch-1", "status": "pending", "title": "Implement feature"}]}),
         ),
         ep(
             "GET",
@@ -624,7 +628,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/dispatches/pending",
             "queue",
-            "List pending dispatches // TODO: example",
+            "List pending dispatches",
+        )
+        .with_example(
+            json!({}),
+            json!({"dispatches": [{"id": "dispatch-1", "kanban_card_id": "card-1", "to_agent_id": "project-agentdesk", "status": "pending"}], "count": 1}),
         ),
         ep(
             "POST",
@@ -653,7 +661,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "POST",
             "/api/dispatches/cancel-all",
             "queue",
-            "Cancel all queued dispatches // TODO: example",
+            "Cancel all queued dispatches",
+        )
+        .with_example(
+            json!({"body": {"kanban_card_id": "card-1", "agent_id": "project-agentdesk"}}),
+            json!({"ok": true, "cancelled": 2, "filters": {"kanban_card_id": "card-1", "agent_id": "project-agentdesk"}}),
         )
     ]
 }

--- a/src/server/routes/docs/inventory/endpoints/part_08.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_08.rs
@@ -60,13 +60,17 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "POST",
             "/api/turns/{channel_id}/extend-timeout",
             "queue",
-            "Extend live turn timeout // TODO: example",
+            "Extend live turn timeout",
+        )
+        .with_example(
+            json!({"path": {"channel_id": "1473922824350601297"}, "body": {"extend_secs": 1800}}),
+            json!({"ok": true, "channel_id": "1473922824350601297", "requested_extend_secs": 1800, "applied_extend_secs": 1800, "remaining_minutes": 30}),
         ),
         ep(
             "POST",
             "/api/channels/{channel_id}/monitoring",
             "monitoring",
-            "Create or update a channel monitoring status entry // TODO: example",
+            "Create or update a channel monitoring status entry",
         )
         .with_params([
             ("channel_id", path_param("Discord channel ID")),
@@ -75,25 +79,37 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 "description",
                 body_param("string", true, "Human-readable status description"),
             ),
-        ]),
+        ])
+        .with_example(
+            json!({"path": {"channel_id": "1473922824350601297"}, "body": {"key": "relay", "description": "Relay queue is healthy"}}),
+            json!({"status": "ok", "active_count": 1}),
+        ),
         ep(
             "GET",
             "/api/channels/{channel_id}/monitoring",
             "monitoring",
-            "List channel monitoring status entries // TODO: example",
+            "List channel monitoring status entries",
         )
-        .with_params([("channel_id", path_param("Discord channel ID"))]),
+        .with_params([("channel_id", path_param("Discord channel ID"))])
+        .with_example(
+            json!({"path": {"channel_id": "1473922824350601297"}}),
+            json!({"status": "ok", "active_count": 1, "entries": [{"key": "relay", "description": "Relay queue is healthy"}]}),
+        ),
         ep(
             "DELETE",
             "/api/channels/{channel_id}/monitoring/{key}",
             "monitoring",
-            "Remove a channel monitoring status entry // TODO: example",
+            "Remove a channel monitoring status entry",
         )
         .with_params([
             ("channel_id", path_param("Discord channel ID")),
             ("key", path_param("Monitoring entry key")),
-        ]),
-        ep("GET", "/api/analytics", "analytics", "Observability counters and structured events // TODO: example")
+        ])
+        .with_example(
+            json!({"path": {"channel_id": "1473922824350601297", "key": "relay"}}),
+            json!({"status": "ok", "active_count": 0}),
+        ),
+        ep("GET", "/api/analytics", "analytics", "Observability counters and structured events")
             .with_params([
                 (
                     "provider",
@@ -111,7 +127,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                     "limit",
                     query_param("integer", false, "Maximum recent events to return").with_default(100),
                 ),
-            ]),
+            ])
+            .with_example(
+                json!({"query": {"provider": "codex", "channelId": "1473922824350601297", "eventType": "turn_started", "limit": 25}}),
+                json!({"counters": [{"provider": "codex", "channel_id": "1473922824350601297", "turns_total": 12}], "recent_events": [{"event_type": "turn_started", "provider": "codex"}]}),
+            ),
         ep(
             "GET",
             "/api/analytics/invariants",
@@ -171,7 +191,7 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/quality/events",
             "analytics",
-            "Agent quality raw event stream // TODO: example",
+            "Agent quality raw event stream",
         )
         .with_params([
             (
@@ -186,34 +206,38 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 "limit",
                 query_param("integer", false, "Maximum recent events to return").with_default(200),
             ),
-        ]),
-        ep("GET", "/api/streaks", "analytics", "Agent activity streaks // TODO: example"),
-        ep("GET", "/api/achievements", "analytics", "Agent achievements // TODO: example"),
+        ])
+        .with_example(
+            json!({"query": {"agent_id": "project-agentdesk", "days": 7, "limit": 50}}),
+            json!({"events": [{"agent_id": "project-agentdesk", "event_type": "turn_completed", "quality_score": 0.95}]}),
+        ),
+        ep("GET", "/api/streaks", "analytics", "Agent activity streaks"),
+        ep("GET", "/api/achievements", "analytics", "Agent achievements"),
         ep(
             "GET",
             "/api/activity-heatmap",
             "analytics",
-            "Activity heatmap by hour // TODO: example",
+            "Activity heatmap by hour",
         ),
-        ep("GET", "/api/audit-logs", "analytics", "Audit logs // TODO: example"),
+        ep("GET", "/api/audit-logs", "analytics", "Audit logs"),
         ep(
             "GET",
             "/api/machine-status",
             "analytics",
-            "Machine online status // TODO: example",
+            "Machine online status",
         ),
         ep(
             "GET",
             "/api/rate-limits",
             "analytics",
-            "Cached rate limits per provider // TODO: example",
+            "Cached rate limits per provider",
         ),
-        ep("GET", "/api/receipt", "analytics", "Latest usage receipt snapshot // TODO: example"),
+        ep("GET", "/api/receipt", "analytics", "Latest usage receipt snapshot"),
         ep(
             "GET",
             "/api/token-analytics",
             "analytics",
-            "Token dashboard analytics with daily trend, heatmap, and usage breakdowns // TODO: example",
+            "Token dashboard analytics with daily trend, heatmap, and usage breakdowns",
         )
         .with_params([(
             "period",
@@ -227,7 +251,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             }
             .with_enum(&["7d", "30d", "90d"])
             .with_default("30d"),
-        )]),
+        )])
+        .with_example(
+            json!({"query": {"period": "30d", "fresh": "1"}}),
+            json!({"period": "30d", "summary": {"total_tokens": 12000, "total_cost": 1.23}, "daily": [], "heatmap": []}),
+        ),
         ep(
             "GET",
             "/api/home/kpi-trends",
@@ -261,7 +289,11 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "GET",
             "/api/skills-trend",
             "analytics",
-            "Skill usage trend by day // TODO: example",
+            "Skill usage trend by day",
+        )
+        .with_example(
+            json!({"query": {"days": 30}}),
+            json!({"days": 30, "trend": [{"date": "2026-07-08", "skill_name": "memory-read", "calls": 4}]}),
         ),
         ep(
             "GET",
@@ -394,7 +426,7 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
             "POST",
             "/api/reviews/tuning/aggregate",
             "reviews",
-            "Aggregate review-tuning outcomes // TODO: example",
+            "Aggregate review-tuning outcomes",
         ),
         ep(
             "POST",


### PR DESCRIPTION
## Summary
- #4227 잔여 항목 3 완결: `part_01.rs`~`part_09.rs` 인벤토리의 `// TODO: example` 플레이스홀더 118건 전량 처리 — **80건 실제 예시 채움**(핸들러/params에서 형태가 명확한 엔드포인트), **38건 마커 제거**(예시가 무의미한 trivial 라우트)
- 잔여 마커 0 확인 (`grep -rn "TODO: example" src/server/routes/docs/inventory/ | wc -l` == 0)

## Verification
- check_api_docs_coverage.py passed / unittest 13 OK / 클린 클론 ci-script-checks.sh **EXIT 0**
- docs 테이블 전용 변경 (라우트/파라미터/카테고리 무변경), 컴파일은 CI Fast check가 검증

## Tier
- 경량 (docs-only) — 구현 codex, 검토 Claude(오케스트레이터). 머지 시 #4227 완전 close 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)