### PR TITLE
fix(relay): idle-JSONL skips send+consume when dedup SharedData unavailable (#4164)

### DIFF
--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -605,7 +605,7 @@
 # #3610 PR-1: 1731 -> 1738 — pass terminal anchor (current_msg_id) explicitly to
 # shadow_mirror_delivered_frontier at the sink delivery call site (Phase B prereq;
 # irreducible 6-arg rustfmt-wrapped call). panel_msg_id has 0 prod readers -> dedup unchanged.
-"src/services/discord/session_relay_sink.rs" = 1679 # 2026-07-03 #3998 S1-f2: 1738 -> 1679 (-59 prod LoC), ratchet down after retiring the A2b rollout getter/cache and flag-OFF pin tests.
+"src/services/discord/session_relay_sink.rs" = 1690 # 2026-07-08 #4164: 1679 -> 1690 (+11 prod LoC), reviewable admission — idle JSONL now gates the producer send on dedup SharedData availability, logging provider/channel/range and retrying without cursor consumption when the offset authority is unavailable after boot. # 2026-07-03 #3998 S1-f2: 1738 -> 1679 (-59 prod LoC), ratchet down after retiring the A2b rollout getter/cache and flag-OFF pin tests.
 # #3635: placeholder_sweeper.rs crossed the 1000-prod-LoC giant threshold (993 ->
 # 1004) when the dead-watcher rebind-origin reap branch was added to the
 # rebind-origin arm of the sweep loop (the watcher-owned #897 orphan the #3581

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -40,7 +40,8 @@ use self::idle_jsonl::{
     idle_jsonl_clear_session_init_on_generation_signature_change, idle_jsonl_consume_offset,
     idle_jsonl_payload_contains_init_event, idle_jsonl_payload_contains_schedule_wakeup_setup,
     idle_jsonl_payload_contains_user_event, idle_jsonl_prepare_dedup_shared,
-    idle_jsonl_relay_source_for_matched, idle_jsonl_session_has_init, idle_relay_range_action,
+    idle_jsonl_relay_source_for_matched, idle_jsonl_session_has_init,
+    idle_jsonl_should_retry_without_dedup_shared, idle_relay_range_action,
     prune_idle_jsonl_session_state, read_jsonl_range,
 };
 
@@ -1422,6 +1423,17 @@ async fn run_idle_jsonl_relay_loop(
                 );
                 continue;
             };
+            if idle_jsonl_should_retry_without_dedup_shared(shared_for_dedup.as_ref()) {
+                tracing::debug!(
+                    provider = matched.provider.as_str(),
+                    channel = channel_id,
+                    tmux_session = %session_name,
+                    range_start = start,
+                    range_end = end,
+                    "idle JSONL relay skipped range because dedup shared data is unavailable; will retry without consuming"
+                );
+                continue;
+            }
             // #3017 single output-offset authority: this idle path and the watcher both read
             // the SAME JSONL (E-13: an inflight-less wake relayed twice). The watcher is PRIMARY
             // and advances `confirmed_end_offset`; this backstop only CONSULTS it read-only

--- a/src/services/discord/session_relay_sink/idle_jsonl.rs
+++ b/src/services/discord/session_relay_sink/idle_jsonl.rs
@@ -44,6 +44,12 @@ pub(super) enum IdleJsonlInflightGateDecision {
     ConsumeToEnd,
 }
 
+pub(super) fn idle_jsonl_should_retry_without_dedup_shared<T>(
+    shared_for_dedup: Option<&T>,
+) -> bool {
+    shared_for_dedup.is_none()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum IdleJsonlSessionInitRearm {
     Keep,
@@ -406,5 +412,154 @@ mod tests {
         assert!(logged_at.contains_key("session-prune-seen"));
         assert!(!logged_at.contains_key("session-prune-gone"));
         logged_at.remove("session-prune-seen");
+    }
+
+    #[test]
+    fn idle_jsonl_missing_dedup_shared_retries_without_send_or_consume() {
+        let session_name = "AgentDesk-claude-4164-none-shared";
+        let payload = concat!(
+            "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"s4164\"}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"wake answer\"}]}}\n"
+        )
+        .as_bytes();
+        let mut session_init_seen = HashSet::new();
+        let mut offset = 128u64;
+        let start = offset;
+        let end = start + payload.len() as u64;
+        let shared_for_dedup: Option<&()> = None;
+        let mut send_attempts = 0;
+
+        let session_has_init =
+            idle_jsonl_session_has_init(&mut session_init_seen, session_name, payload);
+        assert!(session_has_init);
+        assert_eq!(
+            idle_relay_range_action(payload, start, end, 0, false, false, session_has_init),
+            IdleRelayRangeAction::SendFull,
+            "without the missing-shared gate this eligible range would fall through to send"
+        );
+
+        let retry_without_consuming =
+            idle_jsonl_should_retry_without_dedup_shared(shared_for_dedup);
+        assert!(retry_without_consuming);
+        if !retry_without_consuming
+            && idle_relay_range_action(payload, start, end, 0, false, false, session_has_init)
+                == IdleRelayRangeAction::SendFull
+        {
+            send_attempts += 1;
+            idle_jsonl_consume_offset(
+                &mut session_init_seen,
+                session_name,
+                &mut offset,
+                end,
+                IdleJsonlSessionInitRearm::Keep,
+            );
+        }
+
+        assert_eq!(send_attempts, 0, "None-shared window must not enqueue");
+        assert_eq!(offset, start, "None-shared window must leave cursor intact");
+        assert!(
+            session_init_seen.contains(session_name),
+            "retry keeps the init marker for the next idle tick"
+        );
+    }
+
+    #[test]
+    fn idle_jsonl_shared_dedup_sends_range_once_then_skips_committed_retry() {
+        use std::sync::atomic::Ordering;
+
+        let _authority =
+            crate::services::discord::outbound::delivery_record::authority_test_seam::force(false);
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel = ChannelId::new(4_164);
+        let session_name = "AgentDesk-claude-4164-shared";
+        let payload = concat!(
+            "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"s4164\"}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"wake answer\"}]}}\n"
+        )
+        .as_bytes();
+        let start = 0u64;
+        let end = payload.len() as u64;
+        let mut offset = start;
+        let mut duplicate_actor_offset = start;
+        let mut session_init_seen = HashSet::new();
+        let mut send_attempts = 0;
+
+        assert!(!idle_jsonl_should_retry_without_dedup_shared(Some(
+            shared.as_ref()
+        )));
+        let session_has_init =
+            idle_jsonl_session_has_init(&mut session_init_seen, session_name, payload);
+        let committed =
+            crate::services::discord::outbound::delivery_record::effective_committed_offset(
+                shared.as_ref(),
+                &provider,
+                channel,
+                session_name,
+                Some(end),
+            );
+        assert_eq!(committed, 0);
+        match idle_relay_range_action(
+            payload,
+            start,
+            end,
+            committed,
+            false,
+            false,
+            session_has_init,
+        ) {
+            IdleRelayRangeAction::SendFull => {
+                send_attempts += 1;
+                idle_jsonl_consume_offset(
+                    &mut session_init_seen,
+                    session_name,
+                    &mut offset,
+                    end,
+                    IdleJsonlSessionInitRearm::Keep,
+                );
+            }
+            other => panic!("first shared pass must send, got {other:?}"),
+        }
+
+        shared
+            .tmux_relay_coord(channel)
+            .confirmed_end_offset
+            .store(end, Ordering::Release);
+        let committed =
+            crate::services::discord::outbound::delivery_record::effective_committed_offset(
+                shared.as_ref(),
+                &provider,
+                channel,
+                session_name,
+                Some(end),
+            );
+        assert_eq!(committed, end);
+        match idle_relay_range_action(
+            payload,
+            start,
+            end,
+            committed,
+            false,
+            false,
+            session_init_seen.contains(session_name),
+        ) {
+            IdleRelayRangeAction::SkipAlreadyRelayed => {
+                idle_jsonl_consume_offset(
+                    &mut session_init_seen,
+                    session_name,
+                    &mut duplicate_actor_offset,
+                    end,
+                    IdleJsonlSessionInitRearm::Keep,
+                );
+            }
+            other => panic!("committed replay must dedup-skip, got {other:?}"),
+        }
+
+        assert_eq!(
+            send_attempts, 1,
+            "shared dedup sends the range exactly once"
+        );
+        assert_eq!(offset, end);
+        assert_eq!(duplicate_actor_offset, end);
     }
 }


### PR DESCRIPTION
## Problem (#4164, P3 relay correctness)
`session_relay_sink.rs:1416-1491`의 idle-JSONL 경로가 `idle_jsonl_prepare_dedup_shared`==None(부트 직후 SharedData 미등록 창)이면 offset-권위 dedup 블록을 통째로 건너뛰고 전 범위를 무조건 전송 — orphan_reclaim의 send-point 권위 위반. 같은 창에서 sink Err(Transient)면 프레임 무재시도 드랍인데 커서는 이미 `consume_idle_offset!(end)`로 소비 → **영구 릴레이 유실**(부트 직후) 또는 **중복 게시**(워처 기커밋 범위 재전송, #4277 계열).

## Fix
- shared_for_dedup==None이면 **전송·커서 소비 모두 스킵**하고 다음 ~500ms idle 틱 재시도 (프로듀서-부재 no-consume continue와 대칭). 구조화 debug 로그(provider/channel/range) 추가.
- 최소 디프 — dedup 블록 구조 무변경.

## Tests
- `idle_jsonl_missing_dedup_shared_retries_without_send_or_consume`
- `idle_jsonl_shared_dedup_sends_range_once_then_skips_committed_retry`
- #3293 env-pin 준수

## Gates
- 최신 main(e17a9be5) 리베이스, 클린 클론 ci-script-checks.sh EXIT 0, giant baseline sink 1679→1690 admission
- 컴파일/테스트는 CI 권위 검증

## Tier
- #3016 핫파일(session_relay_sink) — opus 적대 리뷰 예정, 리뷰 CLEAN+CI green 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)