### PR TITLE
fix(relay): fresh-idle watcher clear pins observed-turn nonce — id-0 full-identity alias hardening (#4273)

### DIFF
--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2813,27 +2813,26 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         // on-disk clear must not wipe a FOLLOW-UP turn's inflight.
                         // The earlier read→check→unconditional-clear spanned TWO
                         // locks, so a follow-up saved on another worker thread in
-                        // the gap was wiped. `clear_inflight_state_if_matches_identity`
-                        // (inflight.rs) closes the window atomically: read +
-                        // validate + unlink under ONE sidecar lock, deleting only
-                        // while the on-disk identity (`user_msg_id` + `started_at`
-                        // + `tmux_session_name`) still equals the PINNED turn's
-                        // (`pinned_pre_cleanup_inflight`, the same snapshot that
-                        // derived `user_msg_id` above) — a follow-up's identity
-                        // differs (`UserMsgMismatch`), guaranteed no-op. The
-                        // finalize-skip for a NEWER pinned turn stays a SEPARATE
-                        // decision in `watcher_fresh_idle_finalize_decision`;
-                        // finalize below runs on the PINNED id (idempotent)
-                        // regardless of the clear outcome.
+                        // the gap was wiped. The nonce-aware guarded clear closes
+                        // the window atomically: read + validate + unlink under ONE
+                        // sidecar lock, deleting only while the on-disk FULL
+                        // identity (`user_msg_id` + `started_at` + `tmux_session_name`
+                        // + `turn_start_offset`) and, when both rows carry one, the
+                        // `turn_nonce` still equal the PINNED pre-cleanup snapshot.
+                        // A nonce-distinct follow-up is a no-op; finalize still runs on the PINNED id.
                         let pinned_clear_identity = pinned_pre_cleanup_inflight.as_ref().map(
                             crate::services::discord::inflight::InflightTurnIdentity::from_state,
                         );
+                        let pinned_clear_turn_nonce = pinned_pre_cleanup_inflight
+                            .as_ref()
+                            .and_then(|state| state.turn_nonce.as_deref());
                         if let Some(pinned_clear_identity) = pinned_clear_identity.as_ref() {
                             let clear_outcome =
-                                crate::services::discord::inflight::clear_inflight_state_if_matches_identity(
+                                crate::services::discord::inflight::clear_inflight_state_if_matches_identity_turn_nonce(
                                     &watcher_provider,
                                     channel_id.get(),
                                     pinned_clear_identity,
+                                    pinned_clear_turn_nonce,
                                 );
                             match clear_outcome {
                                 crate::services::discord::inflight::GuardedClearOutcome::Cleared => {

--- a/src/services/discord/tmux_watcher/tests.rs
+++ b/src/services/discord/tmux_watcher/tests.rs
@@ -2361,6 +2361,95 @@ fn committed_clear_with_captured_turn_nonce_clears_matching_same_turn_row() {
     );
 }
 
+#[test]
+fn fresh_idle_clear_uses_pinned_nonce_to_preserve_id0_full_identity_alias_followup() {
+    let _lock = crate::config::shared_test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _root_guard = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+        "AGENTDESK_ROOT_DIR",
+        tmp.path(),
+    );
+
+    let provider = ProviderKind::Claude;
+    let session = "AgentDesk-claude-adk-cc-4273-fresh-idle";
+    let channel_id = 4_273_000u64;
+
+    let mut pinned_current = fresh_idle_inflight(provider.clone(), channel_id, session, 0, 50);
+    pinned_current.started_at = "2026-07-08 01:33:00".to_string();
+    pinned_current.turn_nonce = Some("turn-4273-pinned".to_string());
+    crate::services::discord::inflight::save_inflight_state(&pinned_current)
+        .expect("save pinned pre-cleanup id-0 inflight");
+
+    let pinned_pre_cleanup_inflight =
+        crate::services::discord::inflight::load_inflight_state(&provider, channel_id)
+            .expect("load pinned pre-cleanup snapshot");
+    let pinned_clear_identity = InflightTurnIdentity::from_state(&pinned_pre_cleanup_inflight);
+    let pinned_clear_turn_nonce = pinned_pre_cleanup_inflight.turn_nonce.as_deref();
+
+    let mut alias_followup = fresh_idle_inflight(provider.clone(), channel_id, session, 0, 50);
+    alias_followup.started_at = pinned_pre_cleanup_inflight.started_at.clone();
+    alias_followup.turn_nonce = Some("turn-4273-followup".to_string());
+    assert!(
+        pinned_clear_identity.matches_state(&alias_followup),
+        "test fixture must alias the pinned full identity"
+    );
+    assert_ne!(
+        pinned_clear_turn_nonce,
+        alias_followup.turn_nonce.as_deref(),
+        "only the observed-turn nonce distinguishes the follow-up"
+    );
+    crate::services::discord::inflight::save_inflight_state(&alias_followup)
+        .expect("save id-0 full-identity-alias follow-up");
+
+    let outcome =
+        crate::services::discord::inflight::clear_inflight_state_if_matches_identity_turn_nonce(
+            &provider,
+            channel_id,
+            &pinned_clear_identity,
+            pinned_clear_turn_nonce,
+        );
+    assert_eq!(
+        outcome,
+        crate::services::discord::inflight::GuardedClearOutcome::UserMsgMismatch,
+        "fresh-idle clear must not delete an id-0 full-identity alias with a different nonce"
+    );
+    let survived = crate::services::discord::inflight::load_inflight_state(&provider, channel_id)
+        .expect("different-nonce follow-up must survive");
+    assert_eq!(survived.user_msg_id, 0);
+    assert_eq!(survived.started_at, pinned_pre_cleanup_inflight.started_at);
+    assert_eq!(survived.turn_start_offset, Some(50));
+    assert_eq!(survived.turn_nonce.as_deref(), Some("turn-4273-followup"));
+
+    let mut same_nonce_row = fresh_idle_inflight(provider.clone(), channel_id, session, 0, 50);
+    same_nonce_row.started_at = pinned_current.started_at.clone();
+    same_nonce_row.turn_nonce = Some("turn-4273-pinned".to_string());
+    assert!(
+        pinned_clear_identity.matches_state(&same_nonce_row),
+        "same-nonce fixture must still match the pinned full identity"
+    );
+    crate::services::discord::inflight::save_inflight_state(&same_nonce_row)
+        .expect("save id-0 full-identity row with matching nonce");
+
+    let outcome =
+        crate::services::discord::inflight::clear_inflight_state_if_matches_identity_turn_nonce(
+            &provider,
+            channel_id,
+            &pinned_clear_identity,
+            pinned_clear_turn_nonce,
+        );
+    assert_eq!(
+        outcome,
+        crate::services::discord::inflight::GuardedClearOutcome::Cleared,
+        "fresh-idle clear should still delete the same id-0 row when the nonce matches"
+    );
+    assert!(
+        crate::services::discord::inflight::load_inflight_state(&provider, channel_id).is_none(),
+        "same-nonce matching row should be cleared"
+    );
+}
+
 // #3016 S3 — end-to-end through the REAL completion signal AND the REAL
 // finalizer actor: a genuine empty/suppressed delegated completion whose
 // on-disk transcript HAS a structural terminator (Claude `result`) finalizes


### PR DESCRIPTION
## Summary (#4273, #4184 follow-up)
fresh-idle watcher clear(tmux_watcher.rs:~2831)가 nonce-less `clear_inflight_state_if_matches_identity`를 쓰고 있어, id-0 + 동초 started_at + 동일 turn_start_offset로 **풀 아이덴티티를 alias하는 후속 턴 row**가 이론상 wipe될 수 있었음. #4184가 도입한 관측-턴 nonce를 **동일한 pinned_pre_cleanup_inflight 스냅샷에서** 파생해 nonce-aware clear(`..._turn_nonce`)로 교체 (call-site 스왑 + 주석 갱신, clear_store 무변경, net -1줄 → ratchet 불필요 7583≤7584).

- 시맨틱스: (Some,Some) nonce 불일치 → skip(보존), 어느 쪽 None → 기존과 동일(identity-only). **실패 모드가 보수적**(과보존 시 기존 reconcile 경로가 회수).
- nonce 소스 검증: 후행 refresh가 아니라 identity와 같은 조기 핀 스냅샷 (오케스트레이터 디프 확인).

## Test
- `fresh_idle_clear_uses_pinned_nonce_to_preserve_id0_full_identity_alias_followup` — nonce-distinct alias 생존 + same-nonce 클리어 양방향 (#3293 env-pin)

## Gates
- base 176910917(최신 main), 클린 클론 ci-script-checks.sh EXIT 0, 컴파일/테스트 CI 권위

## Tier
- 경량(단일 call-site 스왑, #4184 r2 CLEAN 받은 API 재사용, 보수적 실패 모드) — 구현 codex, 검토 Claude(오케스트레이터)

🤖 Generated with [Claude Code](https://claude.com/claude-code)