### PR TITLE
ci(main): #4245 — 테스트 빌드 debuginfo 제거로 main 양 레인 SIGTERM/OOM 완화

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -113,6 +113,12 @@ jobs:
         run: just check
         env:
           RUST_BACKTRACE: 1
+          # #4245: both main test lanes die with SIGTERM (exit 143) during the
+          # `--all-targets` test build/link phase — hosted-runner memory kill.
+          # Strip debuginfo from test builds to cut link memory/time; symbol-less
+          # backtraces are an accepted CI trade-off.
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
 
       - name: sccache stats
         if: always()
@@ -164,6 +170,11 @@ jobs:
       - name: just test-postgres
         timeout-minutes: 15
         run: just test-postgres
+        env:
+          # #4245: see Full tests lane — the 15-minute step budget is consumed
+          # by the test build; debuginfo=0 shrinks it back under the timeout.
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
 
       - name: Stop PostgreSQL service
         if: always()


### PR DESCRIPTION
## #4245: main full CI 상시 red — 실측 원인 완화 1차

진단(이슈 코멘트 참조): 최근 40개 main 런 연속 red의 실제 모드는 테스트 실패가 아니라 **양 레인 SIGTERM**:
- Full tests `just check` → `recipe 'test-non-pg' terminated by signal 15` (exit 143), timeout 미설정 스텝 — hosted runner 메모리 kill 패턴(링크 단계 침묵 후)
- PostgreSQL tests `just test-postgres` → 동일 signal 15, timeout-minutes:15 스텝 — 테스트 빌드가 예산 소진

완화: 두 잡에 `CARGO_PROFILE_TEST_DEBUG=0` + `CARGO_PROFILE_DEV_DEBUG=0` — `--all-targets` 테스트 빌드/링크 메모리·시간 대폭 절감. 심볼 없는 백트레이스는 CI 트레이드오프로 수용(RUST_BACKTRACE=1 유지).

- CI-only 변경(런타임 무영향), 즉시 revert 가능
- 검증: CI Main은 main push 전용 → 머지 후 다음 main push 런에서 관찰. 불충분 시 후속(cargo-nextest / 레인 분할 / larger runner)
- 게이트: ci-script-checks exit 0, yaml parse OK

Part of #4245