### PR TITLE
chore(inflight): #4280 후속 — PR #4290 r2 수정분 복원 (dead cfg(test) import 제거)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -490,8 +490,8 @@
 | `services::discord::inflight::ownership_ops` | `src/services/discord/inflight/ownership_ops.rs` | 329 | 329 | 0 |  |
 | `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 810 | 810 | 0 |  |
 | `services::discord::inflight::removal` | `src/services/discord/inflight/removal.rs` | 465 | 465 | 0 |  |
-| `services::discord::inflight::save_store` | `src/services/discord/inflight/save_store.rs` | 916 | 269 | 647 |  |
-| `services::discord::inflight::save_store::identity_gate` | `src/services/discord/inflight/save_store/identity_gate.rs` | 841 | 841 | 0 |  |
+| `services::discord::inflight::save_store` | `src/services/discord/inflight/save_store.rs` | 913 | 266 | 647 |  |
+| `services::discord::inflight::save_store::identity_gate` | `src/services/discord/inflight/save_store/identity_gate.rs` | 842 | 842 | 0 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 350 | 350 | 0 |  |
 | `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 365 | 365 | 0 |  |
 | `services::discord::inflight_heartbeat_sweeper` | `src/services/discord/inflight_heartbeat_sweeper.rs` | 299 | 264 | 35 |  |

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -29,10 +29,7 @@ pub(in crate::services::discord) use self::identity_gate::{
 };
 
 #[cfg(test)]
-use self::identity_gate::{
-    patch_restart_full_response_if_identity_unchanged_in_root,
-    save_inflight_state_if_identity_unchanged_in_root,
-};
+use self::identity_gate::save_inflight_state_if_identity_unchanged_in_root;
 #[cfg(test)]
 pub(super) use self::identity_gate::{
     save_existing_inflight_rebind_adoption_if_matches_identity_in_root,

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -315,6 +315,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_delivery_rewind_if_m
     atomic_write(&path, &json)?;
     Ok(true)
 }
+
 /// Outcome of [`save_inflight_state_if_matches_identity`] — the #3041 P1-2 R3
 /// identity-guarded re-save used on a delivery-lease `Skip` epilogue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
PR #4290의 opus 리뷰 r2 수정 2건이 **GitHub 미반영 헤드(r1)로 머지**되어 유실됨 — 이 PR이 복원:
1. [MED] `save_store.rs` — dead `#[cfg(test)] use`에서 미사용 `patch_restart_full_response_if_identity_unchanged_in_root` 제거 (unused_imports 경고 해소)
2. [LOW] `identity_gate.rs` — 이동 아이템 사이 빈 줄 복원 (cosmetic)

원인: r2 amend를 클론→workspace 로컬 remote까지만 push하고 worktree→GitHub push를 누락 (운영 교훈으로 기록). 게이트 exit 0.

Part of #4280 (CLOSED — 코드 정리만)