### PR TITLE
fix(status-panel): #4177 — 완료된 async 서브에이전트 유령 '실행 중' 누적 수정 (fail-closed 페어링 fallback + finished 우선 축출)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -308,7 +308,7 @@
 | `server::worker_registry` | `src/server/worker_registry.rs` | 1515 | 1278 | 237 | giant-file |
 | `server::ws` | `src/server/ws.rs` | 140 | 140 | 0 |  |
 | `services` | `src/services/mod.rs` | 131 | 131 | 0 |  |
-| `services::agent_protocol` | `src/services/agent_protocol.rs` | 593 | 593 | 0 |  |
+| `services::agent_protocol` | `src/services/agent_protocol.rs` | 596 | 596 | 0 |  |
 | `services::agent_quality` | `src/services/agent_quality/mod.rs` | 24 | 24 | 0 |  |
 | `services::agent_quality::regression_alerts` | `src/services/agent_quality/regression_alerts.rs` | 523 | 463 | 60 |  |
 | `services::agents` | `src/services/agents/mod.rs` | 3 | 3 | 0 |  |
@@ -450,7 +450,7 @@
 | `services::discord::destructive_cancel_gate` | `src/services/discord/destructive_cancel_gate.rs` | 688 | 337 | 351 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 507 | 507 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
-| `services::discord::footer_view_reconciler` | `src/services/discord/footer_view_reconciler/mod.rs` | 660 | 473 | 187 |  |
+| `services::discord::footer_view_reconciler` | `src/services/discord/footer_view_reconciler/mod.rs` | 661 | 473 | 188 |  |
 | `services::discord::footer_view_reconciler::registry` | `src/services/discord/footer_view_reconciler/registry.rs` | 624 | 624 | 0 |  |
 | `services::discord::formatting` | `src/services/discord/formatting.rs` | 4100 | 2862 | 1238 | giant-file |
 | `services::discord::formatting::long_send_rollback` | `src/services/discord/formatting/long_send_rollback.rs` | 314 | 314 | 0 |  |
@@ -537,9 +537,9 @@
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
-| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 716 | 716 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 738 | 738 | 0 |  |
-| `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 445 | 270 | 175 |  |
+| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 779 | 779 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 794 | 794 | 0 |  |
+| `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 481 | 306 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 348 | 348 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
@@ -660,7 +660,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2826 | 861 | 1965 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2830 | 861 | 1969 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1637 | 904 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -537,7 +537,7 @@
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
-| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 779 | 779 | 0 |  |
+| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 782 | 782 | 0 |  |
 | `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 794 | 794 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 481 | 306 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |

--- a/scripts/audit_maintainability_config.toml
+++ b/scripts/audit_maintainability_config.toml
@@ -23,7 +23,7 @@
 # new turn_anchor.rs). More specific than the `**` glob below, so it must precede it
 # for fnmatch first-match precedence.
 "src/services/discord/placeholder_live_events/status_panel.rs" = 794 # 2026-07-08 #4177: 738 -> 794 (+56), reviewable admission — store subagent agentId metadata, safely fallback-pair genuine async completions, and trim finished slots first.
-"src/services/discord/placeholder_live_events/status_events.rs" = 779 # 2026-07-08 #4177: 720 -> 779 (+59), reviewable admission — carry task-notification/toolUseResult agentId and description metadata into SubagentEnd fallback matching.
+"src/services/discord/placeholder_live_events/status_events.rs" = 782 # 2026-07-08 #4177 r2: 779 -> 782 (+3), reviewable admission — restore parent_tool_use_id doc placement and add task_notification_agent_id doc; prior #4177: 720 -> 779 (+59), carry task-notification/toolUseResult agentId and description metadata into SubagentEnd fallback matching.
 "src/services/discord/placeholder_live_events/**" = 700
 "src/services/discord/prompt_builder/**" = 700
 "src/services/discord/runtime_bootstrap/**" = 700

--- a/scripts/audit_maintainability_config.toml
+++ b/scripts/audit_maintainability_config.toml
@@ -22,8 +22,8 @@
 # anchor-prepend param (the heavier setter/line-builder/store helpers live in the
 # new turn_anchor.rs). More specific than the `**` glob below, so it must precede it
 # for fnmatch first-match precedence.
-"src/services/discord/placeholder_live_events/status_panel.rs" = 738 # 2026-07-06 #4183 CI-red reconcile: 703 -> 738 (+35 prod LoC drift from recent landings; masked behind the hotfile-ratchet set -e exit until #4183 fixed it); admission to unblock main red, a proper split is tracked separately.
-"src/services/discord/placeholder_live_events/status_events.rs" = 720 # 2026-07-04 #4097 admission: +21 for kind=background XML task-notification suppression (relay noise fix); cohesive documented helper, namespace effectively full (precedent: status_panel.rs).
+"src/services/discord/placeholder_live_events/status_panel.rs" = 794 # 2026-07-08 #4177: 738 -> 794 (+56), reviewable admission — store subagent agentId metadata, safely fallback-pair genuine async completions, and trim finished slots first.
+"src/services/discord/placeholder_live_events/status_events.rs" = 779 # 2026-07-08 #4177: 720 -> 779 (+59), reviewable admission — carry task-notification/toolUseResult agentId and description metadata into SubagentEnd fallback matching.
 "src/services/discord/placeholder_live_events/**" = 700
 "src/services/discord/prompt_builder/**" = 700
 "src/services/discord/runtime_bootstrap/**" = 700

--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -292,6 +292,7 @@ pub enum StatusEvent {
     SubagentStart {
         subagent_type: Option<String>,
         desc: Option<String>,
+        agent_id: Option<String>,
         /// Originating Task tool-use id, used to pair the eventual
         /// `SubagentEnd` to the exact slot rather than the first unfinished
         /// one (which mis-attributes across parallel subagents). `None` when
@@ -323,6 +324,8 @@ pub enum StatusEvent {
     },
     SubagentEnd {
         success: bool,
+        agent_id: Option<String>,
+        desc: Option<String>,
         /// Tool-use id of the Task whose result closed this subagent. Matched
         /// against [`StatusEvent::SubagentStart::tool_use_id`]; `None` falls
         /// back to closing the first unfinished slot.

--- a/src/services/discord/footer_view_reconciler/mod.rs
+++ b/src/services/discord/footer_view_reconciler/mod.rs
@@ -482,6 +482,7 @@ mod tests {
             StatusEvent::SubagentStart {
                 subagent_type: Some("bgworker".to_string()),
                 desc: Some("Review".to_string()),
+                agent_id: None,
                 tool_use_id: Some(format!("toolu_agent_{}", channel_id.get())),
                 background: true,
             },

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -688,9 +688,9 @@ fn system_status_events(value: &Value) -> Vec<StatusEvent> {
     )
 }
 
-/// Returns the launching Task's tool-use id from a nested subagent record's
-/// top-level `parent_tool_use_id` (Claude Code marks every subagent-internal
-/// record with it). `None` for top-level records → normal panel path.
+/// Returns the cleaned agent/task id from a subagent task notification,
+/// accepting `agentId`/`agent_id`/`agent-id` and
+/// `task_id`/`task-id`/`taskId`. `None` for non-subagent notifications.
 fn task_notification_agent_id(value: &Value, kind: &str) -> Option<String> {
     (kind == "subagent").then(|| {
         [
@@ -702,6 +702,9 @@ fn task_notification_agent_id(value: &Value, kind: &str) -> Option<String> {
     })?
 }
 
+/// Returns the launching Task's tool-use id from a nested subagent record's
+/// top-level `parent_tool_use_id` (Claude Code marks every subagent-internal
+/// record with it). `None` for top-level records → normal panel path.
 fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
     ["parent_tool_use_id", "parentToolUseId"]
         .into_iter()

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -98,6 +98,7 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id_for_foot
                 .map(str::to_string)
                 .or_else(|| Some(name.to_string())),
             desc: subagent_description(&value).or(args_summary.clone()),
+            agent_id: subagent_agent_id(&value),
             tool_use_id: tool_use_id.map(str::to_string),
             background,
         });
@@ -143,6 +144,8 @@ pub(in crate::services::discord) fn status_events_from_tool_result_with_id(
     if tool_name.is_some_and(tool_result_completes_subagent) {
         events.push(StatusEvent::SubagentEnd {
             success: !is_error,
+            agent_id: None,
+            desc: None,
             tool_use_id: tool_use_id.map(str::to_string),
             summary: None,
             // A SUCCESSFUL `run_in_background` launch is ack-only: dispatch
@@ -169,11 +172,22 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
     summary: &str,
     tool_use_id: Option<&str>,
 ) -> Vec<StatusEvent> {
+    status_events_from_task_notification_with_metadata(kind, status, summary, tool_use_id, None)
+}
+
+fn status_events_from_task_notification_with_metadata(
+    kind: &str,
+    status: &str,
+    summary: &str,
+    tool_use_id: Option<&str>,
+    agent_id: Option<&str>,
+) -> Vec<StatusEvent> {
     let mut events = Vec::new();
     match kind {
         "monitor_auto_turn" => events.push(StatusEvent::MonitorWait),
         "subagent" => {
             let summary = first_content_line(summary);
+            let desc = subagent_desc_from_notification_summary(&summary);
             if !summary.is_empty() {
                 events.push(match tool_use_id {
                     Some(tool_use_id) => StatusEvent::SubagentActivity {
@@ -186,6 +200,8 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
             if notification_is_terminal(status) {
                 events.push(StatusEvent::SubagentEnd {
                     success: !notification_is_error(status),
+                    agent_id: clean_status_key(agent_id),
+                    desc,
                     tool_use_id: tool_use_id.map(str::to_string),
                     summary: None,
                     // A terminal task_notification is the subagent's REAL
@@ -244,11 +260,15 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
         return Vec::new();
     }
     let kind = parsed.kind();
-    let events = status_events_from_task_notification_with_tool_use_id(
+    let agent_id = (kind == "subagent")
+        .then(|| parsed.task_id.as_deref())
+        .flatten();
+    let events = status_events_from_task_notification_with_metadata(
         kind,
         status,
         parsed.summary.as_deref().unwrap_or(""),
         parsed.tool_use_id.as_deref(),
+        agent_id,
     );
     // #3393 finding 1 (XML-scoped): drop an id-less terminal `SubagentEnd` — it
     // would fall back in the panel to "the last unfinished slot" and flip/evict
@@ -387,6 +407,29 @@ fn subagent_description(value: &Value) -> Option<String> {
     .find_map(|key| value.get(key).and_then(Value::as_str))
     .map(normalize_summary)
     .filter(|summary| !summary.is_empty())
+}
+
+fn subagent_agent_id(value: &Value) -> Option<String> {
+    ["agentId", "agent_id", "agent-id"]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(Value::as_str))
+        .and_then(|value| clean_status_key(Some(value)))
+}
+
+fn subagent_desc_from_notification_summary(summary: &str) -> Option<String> {
+    ["Agent \"", "Background agent \""]
+        .into_iter()
+        .find_map(|prefix| {
+            let rest = summary.trim_start().strip_prefix(prefix)?;
+            let (desc, _) = rest.split_once('"')?;
+            Some(normalize_summary(desc)).filter(|value| !value.is_empty())
+        })
+}
+
+fn clean_status_key(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn todo_items_from_input(value: &Value) -> Option<Vec<StatusTodoItem>> {
@@ -532,7 +575,7 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
     let record_summary = if any_block_aggregate {
         None
     } else {
-        subagent_summary_from_record(value)
+        subagent_completion_from_record(value)
     };
     let record_summary_owner_idx = record_summary.as_ref().and_then(|_| {
         blocks.iter().position(|block| {
@@ -566,8 +609,8 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
             // This block's OWN aggregate (batched case), keyed by THIS block's
             // tool_use_id; else the legacy record-level aggregate on the first
             // id-bearing block.
-            let block_summary = subagent_summary_from_record(block);
-            let summary = block_summary.or_else(|| {
+            let block_completion = subagent_completion_from_record(block);
+            let completion = block_completion.or_else(|| {
                 if Some(idx) == record_summary_owner_idx {
                     record_summary.clone()
                 } else {
@@ -575,7 +618,7 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                 }
             });
 
-            if let Some(summary) = summary {
+            if let Some((summary, agent_id, desc)) = completion {
                 // Pair by this block's own tool_use_id; the panel refuses the
                 // summary unless the id matches a real tracked slot.
                 let tool_use_id = block
@@ -586,6 +629,8 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                     StatusEvent::ToolEnd { success: !is_error },
                     StatusEvent::SubagentEnd {
                         success: !is_error,
+                        agent_id,
+                        desc,
                         tool_use_id,
                         summary: Some(summary),
                         // A summary-bearing end carries real accounting — a
@@ -605,11 +650,16 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
 /// block (batched) or the whole `user` record (legacy single). `None` for
 /// ordinary results. #3086 P1: live hot path — in-stream aggregate only (no disk
 /// IO); the prior synchronous rollout `read_to_string` was removed.
-fn subagent_summary_from_record(
+fn subagent_completion_from_record(
     value: &Value,
-) -> Option<crate::services::agent_protocol::SubagentSummary> {
-    let (summary, _agent_id) = super::subagent_rollout::summary_from_tool_use_result(value)?;
-    Some(summary)
+) -> Option<(
+    crate::services::agent_protocol::SubagentSummary,
+    Option<String>,
+    Option<String>,
+)> {
+    let (summary, agent_id) = super::subagent_rollout::summary_from_tool_use_result(value)?;
+    let desc = super::subagent_rollout::description_from_tool_use_result(value);
+    Some((summary, agent_id, desc))
 }
 
 fn system_status_events(value: &Value) -> Vec<StatusEvent> {
@@ -628,17 +678,30 @@ fn system_status_events(value: &Value) -> Vec<StatusEvent> {
     let status = value.get("status").and_then(Value::as_str).unwrap_or("");
     let summary = value.get("summary").and_then(Value::as_str).unwrap_or("");
     let tool_use_id = tool_use_id_from_notification(value);
-    status_events_from_task_notification_with_tool_use_id(
+    let agent_id = task_notification_agent_id(value, kind);
+    status_events_from_task_notification_with_metadata(
         kind,
         status,
         summary,
         tool_use_id.as_deref(),
+        agent_id.as_deref(),
     )
 }
 
 /// Returns the launching Task's tool-use id from a nested subagent record's
 /// top-level `parent_tool_use_id` (Claude Code marks every subagent-internal
 /// record with it). `None` for top-level records → normal panel path.
+fn task_notification_agent_id(value: &Value, kind: &str) -> Option<String> {
+    (kind == "subagent").then(|| {
+        [
+            "agentId", "agent_id", "agent-id", "task_id", "task-id", "taskId",
+        ]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(Value::as_str))
+        .and_then(|value| clean_status_key(Some(value)))
+    })?
+}
+
 fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
     ["parent_tool_use_id", "parentToolUseId"]
         .into_iter()

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -32,6 +32,7 @@ pub(super) struct SubagentSlot {
     /// #3084: Task tool-use id that opened this slot, so `SubagentEnd` closes the
     /// exact slot among parallels instead of the first unfinished one.
     pub(super) tool_use_id: Option<String>,
+    agent_id: Option<String>,
     /// #3086: TUI-parity accounting from the finishing `SubagentEnd`; drives the
     /// `Done (N tools · M tokens · Xs)` summary on the render line.
     summary: Option<SubagentSummary>,
@@ -209,6 +210,7 @@ impl StatusPanelState {
             StatusEvent::SubagentStart {
                 subagent_type,
                 desc,
+                agent_id,
                 tool_use_id,
                 background,
             } => {
@@ -218,6 +220,7 @@ impl StatusPanelState {
                 // description with the `subagent`/`Task` placeholders.
                 let provided_desc = desc.filter(|value| !value.trim().is_empty());
                 let provided_type = subagent_type.filter(|value| !value.trim().is_empty());
+                let provided_agent_id = agent_id.filter(|value| !value.trim().is_empty());
                 // A background `SubagentStart` re-affirms (and #3920: PROMOTES) the
                 // still-running slot for this tool-use id. Matching ANY unfinished
                 // slot — not only an already-background one — lets an async/
@@ -239,6 +242,9 @@ impl StatusPanelState {
                     if let Some(desc) = provided_desc {
                         slot.desc = desc;
                     }
+                    if let Some(agent_id) = provided_agent_id {
+                        slot.agent_id = Some(agent_id);
+                    }
                     let running_desc = slot.desc.clone();
                     self.status = DerivedStatus::SubagentRunning { desc: running_desc };
                     return;
@@ -253,6 +259,7 @@ impl StatusPanelState {
                     finished: None,
                     tool_use_id,
                     summary: None,
+                    agent_id: provided_agent_id,
                     background,
                     ordinal,
                     started_at: std::time::Instant::now(),
@@ -279,6 +286,8 @@ impl StatusPanelState {
             } => self.set_subagent_activity(tool_use_id, summary),
             StatusEvent::SubagentEnd {
                 success,
+                agent_id,
+                desc,
                 tool_use_id,
                 summary,
                 ack_only,
@@ -292,17 +301,25 @@ impl StatusPanelState {
                         slot.finished.is_none() && slot.tool_use_id.as_deref() == Some(id)
                     })
                 });
-                // #3086 P1 / #3359: a summary/id-bearing ack-only end is safe only
-                // on an exact id match; id-less legacy acks close only id-less slots.
-                let has_summary = summary.as_ref().is_some_and(|s| !s.is_empty());
+                // #3086 P1 / #3359: ack-only id-bearing ends are safe only
+                // on an exact id match; genuine id-bearing completions may use
+                // a unique agent-id/description fallback (#4177).
+                let fallback = (!ack_only && id.is_some())
+                    .then(|| {
+                        match_subagent_end_fallback(
+                            &self.subagents,
+                            agent_id.as_deref(),
+                            desc.as_deref(),
+                        )
+                    })
+                    .flatten();
                 let target = match matched {
                     Some(index) => Some(index),
-                    None if id.is_some() => None,
+                    None if id.is_some() => fallback,
                     None if ack_only => self
                         .subagents
                         .iter()
                         .rposition(|slot| slot.finished.is_none() && slot.tool_use_id.is_none()),
-                    None if has_summary && id.is_some() => None,
                     None => self
                         .subagents
                         .iter()
@@ -726,13 +743,52 @@ pub(super) fn force_abort_stuck_subagent_slots(
     swept
 }
 
+fn match_subagent_end_fallback(
+    slots: &[SubagentSlot],
+    agent_id: Option<&str>,
+    desc: Option<&str>,
+) -> Option<usize> {
+    if let Some(agent_id) = clean_match_key(agent_id) {
+        match unique_unfinished_subagent(slots, |slot| slot.agent_id.as_deref() == Some(agent_id)) {
+            Ok(Some(index)) => return Some(index),
+            Err(()) => return None,
+            Ok(None) => {}
+        }
+    }
+    let desc = clean_match_key(desc)?;
+    unique_unfinished_subagent(slots, |slot| slot.desc == desc).ok()?
+}
+
+fn unique_unfinished_subagent(
+    slots: &[SubagentSlot],
+    mut matches: impl FnMut(&SubagentSlot) -> bool,
+) -> Result<Option<usize>, ()> {
+    let mut found = None;
+    for (index, slot) in slots.iter().enumerate().rev() {
+        if slot.finished.is_none() && matches(slot) {
+            if found.is_some() {
+                return Err(());
+            }
+            found = Some(index);
+        }
+    }
+    Ok(found)
+}
+
+fn clean_match_key(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|value| !value.is_empty())
+}
+
 fn sanitize_label(raw: &str) -> String {
     sanitized_tool_name(raw).unwrap_or_else(|| "Task".to_string())
 }
 
 fn trim_subagents(slots: &mut Vec<SubagentSlot>) {
-    if slots.len() > STATUS_PANEL_SUBAGENT_LIMIT {
-        let excess = slots.len() - STATUS_PANEL_SUBAGENT_LIMIT;
-        slots.drain(0..excess);
+    while slots.len() > STATUS_PANEL_SUBAGENT_LIMIT {
+        let remove_index = slots
+            .iter()
+            .position(|slot| slot.finished.is_some())
+            .unwrap_or(0);
+        slots.remove(remove_index);
     }
 }

--- a/src/services/discord/placeholder_live_events/subagent_rollout.rs
+++ b/src/services/discord/placeholder_live_events/subagent_rollout.rs
@@ -47,11 +47,7 @@ pub(super) fn summary_from_tool_use_result(
         return None;
     }
 
-    let agent_id = result
-        .get("agentId")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .filter(|id| !id.trim().is_empty());
+    let agent_id = agent_id_from_tool_use_result(value);
 
     let has_accounting_field = result.contains_key("totalToolUseCount")
         || result.contains_key("totalTokens")
@@ -79,6 +75,29 @@ pub(super) fn summary_from_tool_use_result(
         return None;
     }
     Some((summary, agent_id))
+}
+
+/// Extracts the async/completion agent id from `toolUseResult`.
+pub(super) fn agent_id_from_tool_use_result(value: &Value) -> Option<String> {
+    value
+        .get("toolUseResult")?
+        .as_object()?
+        .get("agentId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}
+
+pub(super) fn description_from_tool_use_result(value: &Value) -> Option<String> {
+    value
+        .get("toolUseResult")?
+        .as_object()?
+        .get("description")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|desc| !desc.is_empty())
+        .map(str::to_string)
 }
 
 /// #3920: `true` when a parent-transcript `tool_result`/`user` record (or a
@@ -121,9 +140,9 @@ pub(super) fn async_launch_promote_events(
     if is_error {
         return None;
     }
-    let is_async_launch = tool_use_result_is_async_launch(block)
-        || (tool_use_result_is_async_launch(value)
-            && Some(idx) == first_idful_tool_result_idx(blocks));
+    let record_owns_launch =
+        tool_use_result_is_async_launch(value) && Some(idx) == first_idful_tool_result_idx(blocks);
+    let is_async_launch = tool_use_result_is_async_launch(block) || record_owns_launch;
     if !is_async_launch {
         return None;
     }
@@ -133,11 +152,28 @@ pub(super) fn async_launch_promote_events(
         .map(str::trim)
         .filter(|id| !id.is_empty())
         .map(str::to_string);
+    let agent_id = agent_id_from_tool_use_result(block).or_else(|| {
+        record_owns_launch
+            .then(|| agent_id_from_tool_use_result(value))
+            .flatten()
+    });
+    let desc = tool_use_id
+        .as_ref()
+        .is_none()
+        .then(|| {
+            description_from_tool_use_result(block).or_else(|| {
+                record_owns_launch
+                    .then(|| description_from_tool_use_result(value))
+                    .flatten()
+            })
+        })
+        .flatten();
     Some(vec![
         StatusEvent::ToolEnd { success: true },
         StatusEvent::SubagentStart {
             subagent_type: None,
-            desc: None,
+            desc,
+            agent_id,
             tool_use_id,
             background: true,
         },

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4597,6 +4597,118 @@ fn status_panel_unmatched_completion_fallback_pairs_by_agent_id_or_description()
 }
 
 #[test]
+fn status_panel_async_completion_agent_id_e2e_pairs_launch_ack_and_task_notification_xml() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_177_013);
+    let launch_tool_use_id = "toolu_agent_4177_launch";
+    let mismatched_tool_use_id = "toolu_agent_4177_mismatched";
+    let agent_id = "a09e45d12a68015a5";
+    let launch_desc = "Async #4177 primary slot";
+    let xml_desc = "Different #4177 terminal caption";
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Agent",
+            &json!({
+                "subagent_type": "general-purpose",
+                "description": launch_desc
+            })
+            .to_string(),
+            Some(launch_tool_use_id),
+        ),
+    );
+
+    let launch_ack = json!({
+        "type": "user",
+        "message": {
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": launch_tool_use_id,
+                "is_error": false
+            }]
+        },
+        "toolUseResult": {
+            "isAsync": true,
+            "status": "async_launched",
+            "agentId": agent_id,
+            "description": launch_desc,
+            "prompt": "...",
+            "outputFile": "/private/tmp/claude-4177/sess/tasks/a09e45d12a68015a5.output",
+            "canReadOutputFile": true
+        }
+    });
+    let launch_blocks = launch_ack["message"]["content"]
+        .as_array()
+        .expect("launch ack content blocks");
+    let promotion_events =
+        super::subagent_rollout::async_launch_promote_events(&launch_ack, launch_blocks, 0, false)
+            .expect("async launch ack should promote the slot");
+    assert!(
+        promotion_events.iter().any(|event| matches!(
+            event,
+            StatusEvent::SubagentStart {
+                agent_id: Some(extracted_agent_id),
+                tool_use_id: Some(extracted_tool_use_id),
+                background: true,
+                ..
+            } if extracted_agent_id.as_str() == agent_id
+                && extracted_tool_use_id.as_str() == launch_tool_use_id
+        )),
+        "launch ack promotion must carry toolUseResult.agentId: {promotion_events:?}"
+    );
+    events.push_status_events(channel_id, promotion_events);
+
+    let raw = format!(
+        "<task-notification>\n\
+        <task-id>{agent_id}</task-id>\n\
+        <tool-use-id>{mismatched_tool_use_id}</tool-use-id>\n\
+        <output-file>/private/tmp/claude-4177/sess/tasks/{agent_id}.output</output-file>\n\
+        <status>completed</status>\n\
+        <summary>Agent \"{xml_desc}\" completed</summary>\n\
+        <result>Done.</result>\n\
+        </task-notification>"
+    );
+    let completion_events = status_events_from_task_notification_xml_for_footer_mode(&raw, true);
+    assert!(
+        completion_events.iter().any(|event| matches!(
+            event,
+            StatusEvent::SubagentEnd {
+                success: true,
+                agent_id: Some(extracted_agent_id),
+                desc: Some(extracted_desc),
+                tool_use_id: Some(extracted_tool_use_id),
+                ack_only: false,
+                ..
+            } if extracted_agent_id.as_str() == agent_id
+                && extracted_tool_use_id.as_str() == mismatched_tool_use_id
+                && extracted_desc.as_str() == xml_desc
+        )),
+        "task-notification XML must extract task-id as SubagentEnd agent_id: {completion_events:?}"
+    );
+    events.push_status_events(channel_id, completion_events);
+
+    let status_entry = events
+        .status_by_channel
+        .get(&channel_id)
+        .expect("status panel state");
+    let guard = status_entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let slot = guard
+        .subagents
+        .iter()
+        .find(|slot| slot.tool_use_id.as_deref() == Some(launch_tool_use_id))
+        .unwrap_or_else(|| panic!("launched subagent slot missing: {:?}", guard.subagents));
+    assert_eq!(slot.desc.as_str(), launch_desc);
+    assert_eq!(
+        slot.finished,
+        Some(true),
+        "mismatched tool-use-id and mismatched desc must finalize only via the aligned agent_id fallback"
+    );
+}
+
+#[test]
 fn status_panel_unmatched_completion_ambiguous_auxiliary_match_is_noop() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(4_177_011);

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -2481,6 +2481,7 @@ fn completion_footer_terminal_subagent_evicts_after_delivery_inflight_unaffected
         StatusEvent::SubagentStart {
             subagent_type: Some("reviewer".to_string()),
             desc: Some("Audit the diff".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_done_sub".to_string()),
             background: false,
         },
@@ -2490,6 +2491,7 @@ fn completion_footer_terminal_subagent_evicts_after_delivery_inflight_unaffected
         StatusEvent::SubagentStart {
             subagent_type: Some("reviewer".to_string()),
             desc: Some("Still inspecting".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_running_sub".to_string()),
             background: false,
         },
@@ -2498,6 +2500,8 @@ fn completion_footer_terminal_subagent_evicts_after_delivery_inflight_unaffected
         channel_id,
         StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_done_sub".to_string()),
             summary: None,
             ack_only: false,
@@ -2594,6 +2598,7 @@ fn completion_footer_long_subagent_line_ends_with_check_mark() {
         StatusEvent::SubagentStart {
             subagent_type: Some("reviewer".to_string()),
             desc: Some(long_desc),
+            agent_id: None,
             tool_use_id: Some("toolu_3391_long_sub".to_string()),
             background: false,
         },
@@ -2602,6 +2607,8 @@ fn completion_footer_long_subagent_line_ends_with_check_mark() {
         channel_id,
         StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_3391_long_sub".to_string()),
             summary: None,
             ack_only: false,
@@ -2674,6 +2681,7 @@ fn completion_footer_evicted_subagent_does_not_survive_migration_carry_over() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("Finished bg agent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_bg_done".to_string()),
             background: true,
         },
@@ -2683,6 +2691,7 @@ fn completion_footer_evicted_subagent_does_not_survive_migration_carry_over() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("Running bg agent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_bg_run".to_string()),
             background: true,
         },
@@ -2691,6 +2700,8 @@ fn completion_footer_evicted_subagent_does_not_survive_migration_carry_over() {
         channel_id,
         StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_bg_done".to_string()),
             summary: None,
             ack_only: false,
@@ -4149,6 +4160,8 @@ fn status_panel_background_ack_only_unmatched_id_waits_for_matching_completion()
         channel_id,
         vec![StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_other".to_string()),
             summary: None,
             ack_only: true,
@@ -4170,6 +4183,8 @@ fn status_panel_background_ack_only_unmatched_id_waits_for_matching_completion()
         channel_id,
         vec![StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_bg_real".to_string()),
             summary: Some(crate::services::agent_protocol::SubagentSummary {
                 tool_count: Some(3),
@@ -4229,6 +4244,8 @@ fn status_panel_ack_only_unmatched_id_does_not_fallback_to_any_slot() {
         channel_id,
         vec![StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_wrong".to_string()),
             summary: None,
             ack_only: true,
@@ -4266,6 +4283,8 @@ fn status_panel_foreground_subagent_summary_completion_still_marks_done() {
         channel_id,
         vec![StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_fg_summary".to_string()),
             summary: Some(crate::services::agent_protocol::SubagentSummary {
                 tool_count: Some(2),
@@ -4485,6 +4504,8 @@ fn status_panel_unmatched_summary_end_is_dropped_not_misrouted() {
         channel_id,
         vec![StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_ghost".to_string()),
             summary: Some(crate::services::agent_protocol::SubagentSummary {
                 tool_count: Some(99),
@@ -4507,6 +4528,175 @@ fn status_panel_unmatched_summary_end_is_dropped_not_misrouted() {
     assert!(
         !worker_line.contains('✓') && !worker_line.contains('✗'),
         "unmatched summary-bearing end must not close the slot, got: {worker_line}"
+    );
+}
+
+#[test]
+fn status_panel_unmatched_completion_fallback_pairs_by_agent_id_or_description() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_177_010);
+
+    events.push_status_event(
+        channel_id,
+        StatusEvent::SubagentStart {
+            subagent_type: Some("agent".to_string()),
+            desc: Some("Agent-id carried slot".to_string()),
+            agent_id: Some("agent-alpha-4177".to_string()),
+            tool_use_id: None,
+            background: true,
+        },
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::SubagentEnd {
+            success: true,
+            agent_id: Some("agent-alpha-4177".to_string()),
+            desc: None,
+            tool_use_id: Some("toolu_mismatched_alpha".to_string()),
+            summary: None,
+            ack_only: false,
+        },
+    );
+
+    events.push_status_event(
+        channel_id,
+        StatusEvent::SubagentStart {
+            subagent_type: Some("agent".to_string()),
+            desc: Some("Description carried slot".to_string()),
+            agent_id: None,
+            tool_use_id: None,
+            background: true,
+        },
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::SubagentEnd {
+            success: true,
+            agent_id: None,
+            desc: Some("Description carried slot".to_string()),
+            tool_use_id: Some("toolu_mismatched_desc".to_string()),
+            summary: None,
+            ack_only: false,
+        },
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    for expected in [
+        "agent Agent-id carried slot",
+        "agent Description carried slot",
+    ] {
+        let line = rendered
+            .lines()
+            .find(|line| line.contains(expected))
+            .unwrap_or_else(|| panic!("subagent slot missing in: {rendered}"));
+        assert!(
+            line.contains('✓'),
+            "unique fallback completion must finalize {expected}, got: {line}"
+        );
+    }
+}
+
+#[test]
+fn status_panel_unmatched_completion_ambiguous_auxiliary_match_is_noop() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_177_011);
+
+    for desc in ["First duplicate", "Second duplicate"] {
+        events.push_status_event(
+            channel_id,
+            StatusEvent::SubagentStart {
+                subagent_type: Some("agent".to_string()),
+                desc: Some(desc.to_string()),
+                agent_id: Some("agent-ambiguous-4177".to_string()),
+                tool_use_id: None,
+                background: true,
+            },
+        );
+    }
+    events.push_status_event(
+        channel_id,
+        StatusEvent::SubagentEnd {
+            success: true,
+            agent_id: Some("agent-ambiguous-4177".to_string()),
+            desc: Some("First duplicate".to_string()),
+            tool_use_id: Some("toolu_mismatched_ambiguous".to_string()),
+            summary: None,
+            ack_only: false,
+        },
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    for expected in ["agent First duplicate", "agent Second duplicate"] {
+        let line = rendered
+            .lines()
+            .find(|line| line.contains(expected))
+            .unwrap_or_else(|| panic!("subagent slot missing in: {rendered}"));
+        assert!(
+            !line.contains('✓') && !line.contains('✗'),
+            "ambiguous fallback must leave {expected} unfinished, got: {line}"
+        );
+    }
+}
+
+#[test]
+fn status_panel_trim_subagents_evicts_finished_before_unfinished() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_177_012);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "agent", "description": "unfinished 0"}).to_string(),
+            Some("toolu_unfinished_0"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "agent", "description": "finished middle"}).to_string(),
+            Some("toolu_finished_middle"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("toolu_finished_middle")),
+    );
+    for idx in 1..STATUS_PANEL_SUBAGENT_LIMIT {
+        events.push_status_events(
+            channel_id,
+            status_events_from_tool_use_with_id(
+                "Task",
+                &json!({"subagent_type": "agent", "description": format!("unfinished {idx}")})
+                    .to_string(),
+                Some(&format!("toolu_unfinished_{idx}")),
+            ),
+        );
+    }
+
+    let status_entry = events
+        .status_by_channel
+        .get(&channel_id)
+        .expect("status panel state");
+    let guard = status_entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    assert_eq!(guard.subagents.len(), STATUS_PANEL_SUBAGENT_LIMIT);
+    assert!(
+        guard
+            .subagents
+            .iter()
+            .any(|slot| slot.desc == "unfinished 0"),
+        "oldest unfinished slot must survive finished-first trim"
+    );
+    assert!(
+        guard
+            .subagents
+            .iter()
+            .all(|slot| slot.desc != "finished middle"),
+        "finished slot should be evicted before unfinished slots"
     );
 }
 
@@ -5107,6 +5297,8 @@ fn status_tool_result_closes_subagent_only_for_task_tools() {
             StatusEvent::ToolEnd { success: false },
             StatusEvent::SubagentEnd {
                 success: false,
+                agent_id: None,
+                desc: None,
                 tool_use_id: None,
                 summary: None,
                 ack_only: false
@@ -5121,6 +5313,8 @@ fn status_tool_result_closes_subagent_only_for_task_tools() {
             StatusEvent::ToolEnd { success: true },
             StatusEvent::SubagentEnd {
                 success: true,
+                agent_id: None,
+                desc: None,
                 tool_use_id: None,
                 summary: None,
                 ack_only: true
@@ -5914,6 +6108,7 @@ fn clear_channel_purges_unfinished_background_zombie_slots_3436() {
         StatusEvent::SubagentStart {
             subagent_type: Some("reviewer".to_string()),
             desc: Some("never finishes".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_sub_zombie".to_string()),
             background: true,
         },
@@ -6181,6 +6376,7 @@ fn live_panel_compaction_keeps_subagents_section_and_running_entry() {
             StatusEvent::SubagentStart {
                 subagent_type: Some("reviewer".to_string()),
                 desc: Some(format!("Audit chunk {i:02}")),
+                agent_id: None,
                 tool_use_id: Some(id.clone()),
                 background: false,
             },
@@ -6189,6 +6385,8 @@ fn live_panel_compaction_keeps_subagents_section_and_running_entry() {
             channel_id,
             StatusEvent::SubagentEnd {
                 success: true,
+                agent_id: None,
+                desc: None,
                 tool_use_id: Some(id),
                 summary: None,
                 ack_only: false,
@@ -6200,6 +6398,7 @@ fn live_panel_compaction_keeps_subagents_section_and_running_entry() {
         StatusEvent::SubagentStart {
             subagent_type: Some("reviewer".to_string()),
             desc: Some("Live inspection".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_3404_sub_live".to_string()),
             background: false,
         },
@@ -6560,6 +6759,7 @@ fn stuck_background_subagent_slot_dropped_on_turn_boundary_reconciliation() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("stuck subagent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_stuck_subagent_boundary".to_string()),
             background: true,
         },
@@ -6569,6 +6769,7 @@ fn stuck_background_subagent_slot_dropped_on_turn_boundary_reconciliation() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("fresh subagent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_fresh_subagent_boundary".to_string()),
             background: true,
         },
@@ -6635,6 +6836,7 @@ fn stuck_background_subagent_slot_force_aborted_and_evicted() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("stuck subagent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_stuck_subagent".to_string()),
             background: true,
         },
@@ -6696,6 +6898,7 @@ fn fresh_background_subagent_slot_preserved_by_ttl_sweep() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("fresh subagent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_fresh_subagent".to_string()),
             background: true,
         },
@@ -6741,6 +6944,7 @@ fn finished_background_subagent_slot_untouched_by_ttl_sweep() {
         StatusEvent::SubagentStart {
             subagent_type: Some("bgworker".to_string()),
             desc: Some("finished subagent".to_string()),
+            agent_id: None,
             tool_use_id: Some("toolu_finished_subagent".to_string()),
             background: true,
         },
@@ -6749,6 +6953,8 @@ fn finished_background_subagent_slot_untouched_by_ttl_sweep() {
         channel_id,
         StatusEvent::SubagentEnd {
             success: true,
+            agent_id: None,
+            desc: None,
             tool_use_id: Some("toolu_finished_subagent".to_string()),
             summary: None,
             ack_only: false,

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -885,6 +885,7 @@ mod tests {
             StatusEvent::SubagentStart {
                 subagent_type: Some("reviewer".to_string()),
                 desc: Some("Long background job".to_string()),
+                agent_id: None,
                 tool_use_id: Some(format!("tool-{}", channel_id.get())),
                 background: true,
             },
@@ -1557,6 +1558,7 @@ mod tests {
             StatusEvent::SubagentStart {
                 subagent_type: Some("bgworker".to_string()),
                 desc: Some("Carried agent".to_string()),
+                agent_id: None,
                 tool_use_id: Some("toolu_latest_agent".to_string()),
                 background: true,
             },
@@ -1612,6 +1614,8 @@ mod tests {
             channel_id,
             StatusEvent::SubagentEnd {
                 success: true,
+                agent_id: None,
+                desc: None,
                 tool_use_id: Some("toolu_latest_agent".to_string()),
                 summary: None,
                 ack_only: false,


### PR DESCRIPTION
## #4177: async 완료 슬롯 페어링 실패 → 유령 누적 수정

근본 원인: async 서브에이전트 완료 `<task-notification>`의 tool-use-id가 런치 슬롯과 미매칭 시 `None if id.is_some() => None` 분기로 조용히 drop → `slot.finished` 영영 None → ✓ 미렌더 → #3404 compaction/#3391 eviction 모두 무력 → 유령 '실행 중' 누적.

### 구현 (이슈 검토안 1+2)
1. **페어링 fallback (fail-closed)**: 슬롯에 agentId 메타 보존, `SubagentEnd`에 agentId/desc 전달. id 매칭 실패 시 **유일** agentId 또는 **유일** description 매치일 때만 finalize — 후보 2+는 no-op(오매칭 finalize 금지). `status_panel.rs:287,746`, `status_events.rs:178`, `subagent_rollout.rs:77`
2. **trim_subagents finished 우선 축출**: 상한 초과 시 finished=Some 슬롯 먼저, oldest-first tie-break. `status_panel.rs:786`
3. 이슈 검토안 3(compaction/eviction 터미널 판정 상태 직참조)은 **의도적 스킵** — #3404 '✓ 미표시 상태 mutation 금지' 불변식 리스크 대비 이득 없음(1번이 근본 원인 차단).

### 테스트 3종 (placeholder_live_events/tests.rs)
- 유일 agentId/desc fallback finalize / 모호 2후보 no-op / trim finished-우선

### 게이트
ratchet admission: status_panel.rs 738→794(+56), status_events.rs 720→779(+59) — dated comment. ci-script-checks exit 0, base 93d84d805 리베이스(무충돌, regen 무변화 확인).

구현: codex(gpt-5.5) task-mrayp8vq / 리뷰: opus 적대 리뷰(behavior fix)

Closes #4177