### PR TITLE
fix(discord): #4275 — watcher/jsonl 경로 세그먼트 경계 \n\n 삽입 (#3608 쌍둥이 수정)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -405,6 +405,21 @@
 
 ### Audited touches
 
+- #4275 watcher/jsonl segment-boundary separator: `tmux_output_stream.rs`
+  (WATCHER) `process_watcher_lines_for_turn` now guards the bare
+  `full_response.push_str(text)` for `assistant` text blocks — when the running
+  response is non-empty and `semantic_boundaries::semantic_chunk_separator_needed`
+  reports a genuine sentence boundary (not a decimal, file extension, markdown
+  continuation, or open inline-code span), it inserts `"\n\n"` before appending.
+  This is the watcher-path twin of the #3608 streaming-path separator: Claude
+  interleaves prose with `tool_use`, so pre-/post-tool text arrive as two discrete
+  events that previously glued into one run-on line. The `content_block_delta`
+  intra-block streaming push (qwen `--include-partial-messages`) is deliberately
+  left a bare `push_str` so a separator never fractures a single sentence.
+  Classification: worker-local — the change only reshapes the per-node watcher's
+  in-memory `full_response` assembly before relay; it adds no new inflight-row
+  field, delivery record, PG lease, leader gate, or cross-node routing state, and
+  no DB/schema change.
 - #3805 P2 PR-D two-message rollover re-anchor: `turn_bridge/mod.rs` (SINK) and
   `tmux_watcher.rs` (WATCHER) each re-anchor the separate two-message status panel
   BELOW the new tail answer after a mid-turn answer rollover, gated on the

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -410,7 +410,10 @@
   `full_response.push_str(text)` for `assistant` text blocks — when the running
   response is non-empty and `semantic_boundaries::semantic_chunk_separator_needed`
   reports a genuine sentence boundary (not a decimal, file extension, markdown
-  continuation, or open inline-code span), it inserts `"\n\n"` before appending.
+  continuation, open inline-code span, or — r2, folded into the shared predicate
+  via `text_ends_inside_open_code_fence` so the watcher matches the streaming
+  path's `streamed_text_inside_open_code_fence` guard — inside an open ``` code
+  fence), it inserts `"\n\n"` before appending.
   This is the watcher-path twin of the #3608 streaming-path separator: Claude
   interleaves prose with `tool_use`, so pre-/post-tool text arrive as two discrete
   events that previously glued into one run-on line. The `content_block_delta`

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -674,7 +674,7 @@
 | `services::discord::tmux_error_detect` | `src/services/discord/tmux_error_detect.rs` | 70 | 60 | 10 |  |
 | `services::discord::tmux_kill_policy` | `src/services/discord/tmux_kill_policy.rs` | 637 | 547 | 90 |  |
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 190 | 190 | 0 |  |
-| `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1118 | 733 | 385 |  |
+| `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1259 | 755 | 504 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 347 | 200 | 147 |  |
 | `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1377 | 348 | 1029 |  |
 | `services::discord::tmux_placeholder_suppression::evidence` | `src/services/discord/tmux_placeholder_suppression/evidence.rs` | 259 | 259 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -640,7 +640,7 @@
 | `services::discord::runtime_bootstrap::startup_doctor` | `src/services/discord/runtime_bootstrap/startup_doctor.rs` | 156 | 156 | 0 |  |
 | `services::discord::runtime_bootstrap::voice` | `src/services/discord/runtime_bootstrap/voice.rs` | 140 | 140 | 0 |  |
 | `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 497 | 469 | 28 |  |
-| `services::discord::semantic_boundaries` | `src/services/discord/semantic_boundaries.rs` | 261 | 261 | 0 |  |
+| `services::discord::semantic_boundaries` | `src/services/discord/semantic_boundaries.rs` | 286 | 286 | 0 |  |
 | `services::discord::session_banner` | `src/services/discord/session_banner.rs` | 68 | 68 | 0 |  |
 | `services::discord::session_identity` | `src/services/discord/session_identity.rs` | 214 | 141 | 73 |  |
 | `services::discord::session_relay_sink` | `src/services/discord/session_relay_sink.rs` | 4757 | 1690 | 3067 | giant-file |
@@ -674,7 +674,7 @@
 | `services::discord::tmux_error_detect` | `src/services/discord/tmux_error_detect.rs` | 70 | 60 | 10 |  |
 | `services::discord::tmux_kill_policy` | `src/services/discord/tmux_kill_policy.rs` | 637 | 547 | 90 |  |
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 190 | 190 | 0 |  |
-| `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1259 | 755 | 504 |  |
+| `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1295 | 757 | 538 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 347 | 200 | 147 |  |
 | `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1377 | 348 | 1029 |  |
 | `services::discord::tmux_placeholder_suppression::evidence` | `src/services/discord/tmux_placeholder_suppression/evidence.rs` | 259 | 259 | 0 |  |

--- a/src/services/discord/semantic_boundaries.rs
+++ b/src/services/discord/semantic_boundaries.rs
@@ -209,6 +209,21 @@ pub(in crate::services::discord) fn message_split_boundary(
     }
 }
 
+/// #4275: true when `text` currently ends *inside* an open ``` code fence.
+/// Uses this module's canonical fence toggle (`line_starts_code_fence`, i.e.
+/// `trim_start().starts_with("```")`) — the same toggle
+/// `chunk_compose::streamed_text_inside_open_code_fence` mirrors on the #3608
+/// streaming path.
+pub(in crate::services::discord) fn text_ends_inside_open_code_fence(text: &str) -> bool {
+    let mut in_code_block = false;
+    for line in text.lines() {
+        if line_starts_code_fence(line) {
+            in_code_block = !in_code_block;
+        }
+    }
+    in_code_block
+}
+
 pub(in crate::services::discord) fn semantic_chunk_separator_needed(
     prefix: &str,
     incoming: &str,
@@ -221,6 +236,16 @@ pub(in crate::services::discord) fn semantic_chunk_separator_needed(
         return false;
     }
     if markdown_continuation_head(incoming) {
+        return false;
+    }
+    // #4275 r2 (codex review Finding 1): a paragraph separator is NEVER
+    // needed while the accumulated prefix still ends inside an open ``` code
+    // fence — injecting "\n\n" there corrupts fenced content (e.g. a fenced
+    // line ending "complete." followed by the next segment). The #3608
+    // streaming caller (chunk_compose) already guards externally with
+    // `streamed_text_inside_open_code_fence`, so this fold is a no-op there;
+    // it closes the gap for the #4275 watcher/jsonl caller and any future one.
+    if text_ends_inside_open_code_fence(prefix) {
         return false;
     }
 

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -277,6 +277,28 @@ pub(in crate::services::discord) fn process_watcher_lines_for_turn(
                                         if let Some(text) =
                                             block.get("text").and_then(|t| t.as_str())
                                         {
+                                            // #4275: the watcher/jsonl path emits each
+                                            // assistant text block as a discrete event
+                                            // (split by interleaved tool_use blocks), so a
+                                            // bare push_str glued the tail of one segment
+                                            // onto the head of the next with no boundary —
+                                            // "…정리합니다." + "macOS엔…" became one run-on
+                                            // line. Mirror the #3608 streaming-path
+                                            // separator: insert "\n\n" only when the two
+                                            // segments form a genuine sentence boundary
+                                            // (not a decimal, file extension, markdown
+                                            // continuation, or mid-code span). content_block_delta
+                                            // (line ~360, qwen intra-block streaming) must
+                                            // stay a bare push_str — a separator there would
+                                            // fracture a single sentence.
+                                            if !full_response.is_empty()
+                                                && crate::services::discord::semantic_boundaries::semantic_chunk_separator_needed(
+                                                    &full_response,
+                                                    text,
+                                                )
+                                            {
+                                                full_response.push_str("\n\n");
+                                            }
                                             full_response.push_str(text);
                                             outcome.assistant_text_seen = true;
                                             push_transcript_event(
@@ -1114,5 +1136,124 @@ mod tests {
         assert!(!outcome.found_result);
         assert!(outcome.soft_terminal_candidate);
         assert_eq!(full_response, "ssh direct answer");
+    }
+
+    // ---- #4275: watcher/jsonl segment-boundary separator ----
+
+    fn assistant_text_line(text: &str) -> String {
+        serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": text}]},
+            "sessionId": "sess-4275",
+        })
+        .to_string()
+            + "\n"
+    }
+
+    fn assistant_tool_use_line(name: &str) -> String {
+        serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{
+                "type": "tool_use",
+                "name": name,
+                "input": {"command": "timeout 5 sleep 10"},
+            }]},
+            "sessionId": "sess-4275",
+        })
+        .to_string()
+            + "\n"
+    }
+
+    /// Drive two discrete assistant text blocks through the real watcher entry
+    /// point and return the accumulated `full_response`.
+    fn watcher_full_response_for_two_segments(first: &str, second: &str) -> String {
+        let mut buffer = String::new();
+        buffer.push_str(&assistant_text_line(first));
+        buffer.push_str(&assistant_text_line(second));
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+        process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+        full_response
+    }
+
+    /// #4275 live repro (2026-07-08): Claude interleaves assistant text with a
+    /// `tool_use`, so the watcher/jsonl path sees the pre-tool and post-tool
+    /// prose as two discrete `assistant` text events. Before the fix a bare
+    /// `push_str` glued them into one run-on line ("…정리합니다.macOS엔…"); the
+    /// guard must insert a blank-line boundary at the sentence break.
+    #[test]
+    fn process_watcher_lines_inserts_boundary_between_tool_split_assistant_segments() {
+        let mut buffer = String::new();
+        buffer.push_str(&assistant_text_line("필요한 명령어를 정리합니다."));
+        buffer.push_str(&assistant_tool_use_line("Bash"));
+        buffer.push_str(&assistant_text_line("macOS엔 timeout이 없네요."));
+
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+
+        process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+
+        assert!(
+            full_response.contains("정리합니다.\n\nmacOS"),
+            "split assistant segments must gain a blank-line boundary, got: {full_response:?}"
+        );
+    }
+
+    /// Negative: a decimal fraction spanning the split ("1." + "2") must NOT
+    /// gain a boundary — the guard evaluates but declines.
+    #[test]
+    fn process_watcher_lines_keeps_decimal_across_split_segments() {
+        let full = watcher_full_response_for_two_segments("버전은 1.", "2로 올렸습니다.");
+        assert!(
+            !full.contains("\n\n"),
+            "decimal fraction must not gain a boundary, got: {full:?}"
+        );
+        assert!(
+            full.contains("1.2"),
+            "decimal must stay glued, got: {full:?}"
+        );
+    }
+
+    /// Negative: a file extension spanning the split ("config." + "yaml") must
+    /// NOT gain a boundary.
+    #[test]
+    fn process_watcher_lines_keeps_file_extension_across_split_segments() {
+        let full = watcher_full_response_for_two_segments("설정은 config.", "yaml에 있습니다.");
+        assert!(
+            !full.contains("\n\n"),
+            "file extension must not gain a boundary, got: {full:?}"
+        );
+        assert!(
+            full.contains("config.yaml"),
+            "extension must stay glued, got: {full:?}"
+        );
+    }
+
+    /// Negative: a markdown list continuation ("- item." + "- next") must NOT
+    /// gain a boundary that would fracture the list structure.
+    #[test]
+    fn process_watcher_lines_keeps_markdown_continuation_across_split_segments() {
+        let full = watcher_full_response_for_two_segments("- 첫 항목.", "- 다음 항목");
+        assert!(
+            !full.contains("\n\n"),
+            "markdown list continuation must not gain a boundary, got: {full:?}"
+        );
+    }
+
+    /// Negative: text with no sentence-terminal punctuation ("…계속" + "진행…")
+    /// is a mid-sentence continuation and must NOT gain a boundary.
+    #[test]
+    fn process_watcher_lines_keeps_unterminated_run_on_across_split_segments() {
+        let full = watcher_full_response_for_two_segments("이 작업은 계속", "진행됩니다.");
+        assert!(
+            !full.contains("\n\n"),
+            "unterminated continuation must not gain a boundary, got: {full:?}"
+        );
+        assert!(
+            full.contains("계속진행됩니다"),
+            "continuation must stay glued, got: {full:?}"
+        );
     }
 }

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -287,7 +287,9 @@ pub(in crate::services::discord) fn process_watcher_lines_for_turn(
                                             // separator: insert "\n\n" only when the two
                                             // segments form a genuine sentence boundary
                                             // (not a decimal, file extension, markdown
-                                            // continuation, or mid-code span). content_block_delta
+                                            // continuation, mid-inline-code span, or — r2,
+                                            // folded into the predicate itself — inside an
+                                            // open ``` code fence). content_block_delta
                                             // (line ~360, qwen intra-block streaming) must
                                             // stay a bare push_str — a separator there would
                                             // fracture a single sentence.
@@ -1239,6 +1241,40 @@ mod tests {
         assert!(
             !full.contains("\n\n"),
             "markdown list continuation must not gain a boundary, got: {full:?}"
+        );
+    }
+
+    /// Negative (#4275 r2, codex review Finding 1): when the accumulated
+    /// response ends INSIDE an open ``` code fence, a fenced line ending with
+    /// sentence punctuation ("complete.") followed by a non-whitespace-start
+    /// segment must NOT gain a boundary — "\n\n" inside fenced content would
+    /// corrupt it. Mirrors the #3608 streaming-path
+    /// `streamed_text_inside_open_code_fence` guard.
+    #[test]
+    fn process_watcher_lines_keeps_open_code_fence_interior_across_split_segments() {
+        let full =
+            watcher_full_response_for_two_segments("```bash\necho complete.", "echo two\n```");
+        assert!(
+            !full.contains("complete.\n\n"),
+            "open-fence interior must not gain a boundary, got: {full:?}"
+        );
+        assert!(
+            full.contains("complete.echo two"),
+            "fenced content must stay glued, got: {full:?}"
+        );
+    }
+
+    /// Positive pair for the open-fence negative: once the fence is CLOSED,
+    /// a genuine sentence boundary after the fence gains the separator again.
+    #[test]
+    fn process_watcher_lines_inserts_boundary_after_closed_code_fence_segment() {
+        let full = watcher_full_response_for_two_segments(
+            "```bash\necho hi\n```\n실행을 완료했습니다.",
+            "다음 단계로 넘어갑니다.",
+        );
+        assert!(
+            full.contains("완료했습니다.\n\n다음"),
+            "closed fence must not suppress a genuine boundary, got: {full:?}"
         );
     }
 


### PR DESCRIPTION
## #4275 — 문장 경계 소실 (오늘 라이브 20% 재현)

### 근본원인
`process_watcher_lines_for_turn`의 assistant text 블록 처리가 구분자 없이 bare `push_str` — 턴이 text→tool_use→text로 구성되면 tool 경계에서 \n\n 미삽입. #3608이 스트리밍 SDK 경로(chunk_compose/stream_loop)만 고치고 watcher/jsonl 쌍둥이 경로를 누락한 회귀.

### 수정
- 가드 삽입: `semantic_chunk_separator_needed` (스트리밍 경로와 동일 프리미티브 재사용 — 소수/파일확장자/markdown-continuation 오탐 가드 승계)
- content_block_delta(qwen intra-block delta) 경로는 무수정
- 단일 파일 격리, #3016 핫파일·#4229/#4230 트랙 무충돌

### 테스트 (20/20)
- 신규 양성: text→tool_use→text 시퀀스에서 "정리합니다.\n\nmacOS" (오늘 라이브 재현 픽스처)
- 신규 음성 4종: decimal / file-extension / markdown-continuation / unterminated run-on → 구분자 미삽입
- 실제 진입점 process_watcher_lines 통과 (프리미티브 단위 아님)

### 게이트
fmt --check ✅ / check --lib ✅ / tmux_output_stream 테스트 20/20 ✅ / agent-maintenance freshness ✅

라이브 증거: #4275 코멘트 (오늘 09:11~10:29 KST 창에서 8건 관찰)

🤖 Generated with [Claude Code](https://claude.com/claude-code)