### PR TITLE
fix(queue): #4270 — pre-claim TUI readiness 게이트 + busy 재큐 edge-trigger 전환

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -94,7 +94,7 @@
 | `src/services/discord/commands/text_commands.rs` | 1476 |
 | `src/services/discord/formatting.rs` | 2862 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
-| `src/services/discord/mod.rs` | 4139 |
+| `src/services/discord/mod.rs` | 4150 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1337 |
 | `src/services/discord_config_audit.rs` | 1288 |
 | `src/services/dispatched_sessions.rs` | 1815 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -404,7 +404,7 @@
 | `services::codex_tui::rollout_tail::parser` | `src/services/codex_tui/rollout_tail/parser.rs` | 405 | 405 | 0 |  |
 | `services::codex_tui::session` | `src/services/codex_tui/session.rs` | 800 | 316 | 484 |  |
 | `services::cswap` | `src/services/cswap.rs` | 887 | 552 | 335 |  |
-| `services::discord` | `src/services/discord/mod.rs` | 5522 | 4139 | 1383 | giant-file |
+| `services::discord` | `src/services/discord/mod.rs` | 5533 | 4150 | 1383 | giant-file |
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 981 | 855 | 126 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
@@ -454,7 +454,7 @@
 | `services::discord::footer_view_reconciler::registry` | `src/services/discord/footer_view_reconciler/registry.rs` | 624 | 624 | 0 |  |
 | `services::discord::formatting` | `src/services/discord/formatting.rs` | 4100 | 2862 | 1238 | giant-file |
 | `services::discord::formatting::long_send_rollback` | `src/services/discord/formatting/long_send_rollback.rs` | 314 | 314 | 0 |  |
-| `services::discord::gateway` | `src/services/discord/gateway.rs` | 1189 | 969 | 220 |  |
+| `services::discord::gateway` | `src/services/discord/gateway.rs` | 1446 | 984 | 462 |  |
 | `services::discord::gateway_voice_queue` | `src/services/discord/gateway_voice_queue.rs` | 95 | 17 | 78 |  |
 | `services::discord::health` | `src/services/discord/health.rs` | 836 | 683 | 153 |  |
 | `services::discord::health::headless_turn` | `src/services/discord/health/headless_turn.rs` | 369 | 369 | 0 |  |
@@ -552,7 +552,7 @@
 | `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 71 | 71 | 0 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
-| `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 1918 | 715 | 1203 |  |
+| `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2307 | 751 | 1556 |  |
 | `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 622 | 194 | 428 |  |
 | `services::discord::queue_reactions` | `src/services/discord/queue_reactions.rs` | 35 | 25 | 10 |  |
 | `services::discord::queued_placeholders_store` | `src/services/discord/queued_placeholders_store.rs` | 251 | 251 | 0 |  |
@@ -593,7 +593,7 @@
 | `services::discord::restart_mode` | `src/services/discord/restart_mode.rs` | 32 | 32 | 0 |  |
 | `services::discord::restart_report` | `src/services/discord/restart_report.rs` | 438 | 438 | 0 |  |
 | `services::discord::role_map` | `src/services/discord/role_map.rs` | 642 | 642 | 0 |  |
-| `services::discord::router` | `src/services/discord/router/mod.rs` | 23 | 23 | 0 |  |
+| `services::discord::router` | `src/services/discord/router/mod.rs` | 26 | 26 | 0 |  |
 | `services::discord::router::authorization` | `src/services/discord/router/authorization.rs` | 48 | 48 | 0 |  |
 | `services::discord::router::dispatch_trigger` | `src/services/discord/router/dispatch_trigger.rs` | 203 | 143 | 60 |  |
 | `services::discord::router::intake_gate` | `src/services/discord/router/intake_gate.rs` | 1645 | 1607 | 38 | giant-file |
@@ -605,7 +605,7 @@
 | `services::discord::router::intake_gate::reaction_remove` | `src/services/discord/router/intake_gate/reaction_remove.rs` | 226 | 226 | 0 |  |
 | `services::discord::router::intake_gate::stale_turn` | `src/services/discord/router/intake_gate/stale_turn.rs` | 630 | 283 | 347 |  |
 | `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 832 | 474 | 358 |  |
-| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 74 | 74 | 0 |  |
+| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 82 | 82 | 0 |  |
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 149 | 149 | 0 |  |
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 250 | 211 | 39 |  |
@@ -616,14 +616,14 @@
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::latency_spans` | `src/services/discord/router/message_handler/latency_spans.rs` | 230 | 158 | 72 |  |
 | `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 505 | 505 | 0 |  |
-| `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 804 | 778 | 26 |  |
+| `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 963 | 937 | 26 |  |
 | `services::discord::router::message_handler::turn_lifecycle` | `src/services/discord/router/message_handler/turn_lifecycle.rs` | 183 | 183 | 0 |  |
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
 | `services::discord::router::message_handler::voice_announcement_scope` | `src/services/discord/router/message_handler/voice_announcement_scope.rs` | 125 | 73 | 52 |  |
 | `services::discord::router::message_handler::watchdog` | `src/services/discord/router/message_handler/watchdog.rs` | 1228 | 959 | 269 |  |
 | `services::discord::router::response_format` | `src/services/discord/router/response_format.rs` | 360 | 336 | 24 |  |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 130 | 130 | 0 |  |
-| `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 442 | 442 | 0 |  |
+| `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 449 | 449 | 0 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 893 | 301 | 592 |  |
 | `services::discord::runtime_bootstrap::framework_setup` | `src/services/discord/runtime_bootstrap/framework_setup.rs` | 350 | 326 | 24 |  |
 | `services::discord::runtime_bootstrap::gateway_lease` | `src/services/discord/runtime_bootstrap/gateway_lease.rs` | 259 | 259 | 0 |  |

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -714,6 +714,21 @@ impl TurnGateway for DiscordGateway {
         has_more_queued_turns: bool,
     ) -> GatewayFuture<'a, Result<(), String>> {
         Box::pin(async move {
+            // #4270 A — pre-drain hosted-TUI readiness gate: a busy TUI defers
+            // the promotion (front-requeue + slow backstop, zero view teardown)
+            // BEFORE the marker drain / merged-card deletion below. `Ok` keeps
+            // the epilogue from re-arming the fast ~2s kickoff (the #4270 spin).
+            if router::defer_promoted_dispatch_if_hosted_tui_busy(
+                &self.shared,
+                &self.provider,
+                channel_id,
+                intervention,
+            )
+            .await
+            {
+                return Ok(());
+            }
+
             let Some(live_turn) = self.live_turn.as_ref() else {
                 return Err("missing live Discord context".to_string());
             };
@@ -1111,6 +1126,248 @@ mod tests {
         assert_eq!(
             gateway.deleted.lock().expect("deleted lock").as_slice(),
             &[MessageId::new(8001)]
+        );
+    }
+
+    /// #4270 — env-lock + temp runtime root held in a struct so no MutexGuard
+    /// binding lives across `.await` (keeps the `await_holding_lock` allow
+    /// ratchet flat; same pattern as `queue_marker.rs::ScopedRuntimeRoot`).
+    struct ScopedRuntimeRoot {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _temp: tempfile::TempDir,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for ScopedRuntimeRoot {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev.take() {
+                    Some(value) => std::env::set_var("AGENTDESK_ROOT_DIR", value),
+                    None => std::env::remove_var("AGENTDESK_ROOT_DIR"),
+                }
+            }
+        }
+    }
+
+    fn scoped_runtime_root() -> ScopedRuntimeRoot {
+        let lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let prev = std::env::var_os("AGENTDESK_ROOT_DIR");
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        unsafe {
+            std::env::set_var(
+                "AGENTDESK_ROOT_DIR",
+                temp.path().to_str().expect("temp path must be valid utf-8"),
+            );
+        }
+        ScopedRuntimeRoot {
+            _lock: lock,
+            _temp: temp,
+            prev,
+        }
+    }
+
+    fn promoted_intervention(id: u64, text: &str) -> Intervention {
+        Intervention {
+            author_id: UserId::new(id),
+            author_is_bot: false,
+            message_id: MessageId::new(id),
+            queued_generation: crate::services::discord::runtime_store::load_generation(),
+            source_message_ids: vec![MessageId::new(id)],
+            source_message_queued_generations: Vec::new(),
+            source_text_segments: Vec::new(),
+            text: text.to_string(),
+            mode: crate::services::turn_orchestrator::InterventionMode::Soft,
+            created_at: std::time::Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
+            pending_uploads: Vec::new(),
+            voice_announcement: None,
+        }
+    }
+
+    fn turn_view_persisted_path(
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> std::path::PathBuf {
+        crate::services::discord::runtime_store::discord_turn_view_reconciler_root()
+            .expect("turn view reconciler root")
+            .join("intake_user_message")
+            .join(format!("{}-{}.json", channel_id.get(), message_id.get()))
+    }
+
+    /// #4270 pin (entrypoint, busy) — the promote gate at the head of
+    /// `DiscordGateway::dispatch_queued_turn` defers a hosted-TUI-busy queued
+    /// turn BEFORE any teardown, SILENTLY, across repeated retry cycles: each
+    /// cycle the intervention goes back to the queue front with the dispatch
+    /// reservation consumed, the mailbox is never claimed, the slow (60s)
+    /// fail-open backstop stays coalesced to ONE, and — the user-visible
+    /// invariant — the head's `📬 Queued` turn-view state survives byte-for-byte
+    /// with ZERO reconciler reaction ops (no `⏳` flip, no `📬` drain, no merged
+    /// queued-card deletion) and no notice/card accumulation: the defer branch
+    /// contains no Discord send/edit/post call site at all (user report: the
+    /// old spin posted a fresh `📬 재시도 큐 등록` card every cycle).
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_promote_gate_busy_defers_silently_across_retry_cycles_4270() {
+        let _root = scoped_runtime_root();
+        let _busy = crate::services::discord::router::set_hosted_tui_promote_busy_for_tests(true);
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(100_000_004_270_600);
+        let user_msg = MessageId::new(100_000_004_270_601);
+
+        // Seed the promoted follow-up's user-visible queued view: 📬 marker via
+        // the reconciler (persisted Queued state + one recorded reaction op).
+        crate::services::discord::turn_view_reconciler::note_intake_queue_marker_added_current(
+            &shared,
+            &http,
+            channel_id,
+            user_msg,
+            crate::services::discord::queue_reactions::QUEUE_STANDALONE_PENDING_REACTION,
+            "test_seed_queued_view",
+        )
+        .await;
+        let view_path = turn_view_persisted_path(channel_id, user_msg);
+        assert!(view_path.exists(), "seeded 📬 queued view must persist");
+        let view_before = std::fs::read(&view_path).expect("read seeded turn view state");
+        let ops_before = shared.turn_view_reconciler.ops().len();
+
+        let persistence =
+            crate::services::discord::queue_persistence_context(&shared, &provider, channel_id);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![promoted_intervention(user_msg.get(), "busy promote head")],
+                persistence.clone(),
+            )
+            .await;
+
+        let gateway = DiscordGateway::new(http.clone(), shared.clone(), provider.clone(), None);
+        // Three watcher-idle/backstop retry cycles while the TUI stays busy:
+        // promote (soft-take) → dispatch → gate defers. Every cycle must be
+        // invisible to the user (reaction ops, view bytes, message posts: 0).
+        for cycle in 0..3 {
+            let taken = shared
+                .mailbox(channel_id)
+                .take_next_soft(persistence.clone())
+                .await;
+            let intervention = taken
+                .intervention
+                .unwrap_or_else(|| panic!("cycle {cycle}: the head must still be promotable"));
+            let result = gateway
+                .dispatch_queued_turn(channel_id, &intervention, "tester", false)
+                .await;
+            assert!(
+                result.is_ok(),
+                "cycle {cycle}: busy defer must report Ok so the epilogue does not requeue-front + fast-kick again"
+            );
+
+            let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+            assert_eq!(
+                snapshot.intervention_queue.len(),
+                1,
+                "cycle {cycle}: the deferred head is re-preserved in the queue (no duplicates)"
+            );
+            assert_eq!(
+                snapshot.intervention_queue[0].message_id, user_msg,
+                "cycle {cycle}: the SAME intervention (merged identity intact) sits back at the front"
+            );
+            assert_eq!(
+                snapshot.pending_user_dispatch, None,
+                "cycle {cycle}: the front-requeue consumes the stale dispatch reservation"
+            );
+            assert!(
+                snapshot.cancel_token.is_none(),
+                "cycle {cycle}: the mailbox is never claimed by the deferred promotion"
+            );
+            assert_eq!(
+                shared.turn_view_reconciler.ops().len(),
+                ops_before,
+                "cycle {cycle}: the busy defer performs ZERO reaction ops — no ⏳ flip, no 📬 drain"
+            );
+            let view_after = std::fs::read(&view_path).expect("read turn view state after defer");
+            assert_eq!(
+                view_before, view_after,
+                "cycle {cycle}: the head's persisted 📬 Queued turn-view state survives byte-for-byte"
+            );
+            assert_eq!(
+                shared
+                    .restart
+                    .deferred_hook_backlog
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "cycle {cycle}: the slow (60s) fail-open backstop stays coalesced to one — no fast kick"
+            );
+        }
+    }
+
+    /// #4270 pin (entrypoint, ready) — with the hosted TUI ready the promote
+    /// gate returns `false` and `dispatch_queued_turn` proceeds INTO the
+    /// dispatch body (proven by reaching the live-context requirement past the
+    /// gate). The gate itself touches neither the queue nor the reservation nor
+    /// the turn view on the ready path.
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_promote_gate_ready_passes_through_to_dispatch_4270() {
+        let _root = scoped_runtime_root();
+        let _ready = crate::services::discord::router::set_hosted_tui_promote_busy_for_tests(false);
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(100_000_004_270_700);
+        let user_msg = MessageId::new(100_000_004_270_701);
+
+        let persistence =
+            crate::services::discord::queue_persistence_context(&shared, &provider, channel_id);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![promoted_intervention(user_msg.get(), "ready promote head")],
+                persistence.clone(),
+            )
+            .await;
+        let taken = shared.mailbox(channel_id).take_next_soft(persistence).await;
+        let intervention = taken.intervention.expect("soft-take promotes the head");
+        let ops_before = shared.turn_view_reconciler.ops().len();
+
+        let gateway = DiscordGateway::new(http.clone(), shared.clone(), provider.clone(), None);
+        let result = gateway
+            .dispatch_queued_turn(channel_id, &intervention, "tester", false)
+            .await;
+        let error = result.expect_err(
+            "gate pass-through must continue into the dispatch body, which requires live context",
+        );
+        assert!(
+            error.contains("missing live Discord context"),
+            "the ready path reaches the dispatch body past the gate (got: {error})"
+        );
+
+        let snapshot = crate::services::discord::mailbox_snapshot(&shared, channel_id).await;
+        assert!(
+            snapshot.intervention_queue.is_empty(),
+            "the ready pass-through leaves the soft-taken head with the caller (no gate requeue)"
+        );
+        assert_eq!(
+            snapshot.pending_user_dispatch,
+            Some(user_msg),
+            "the dispatch reservation stays with the in-flight promotion on the ready path"
+        );
+        assert_eq!(
+            shared.turn_view_reconciler.ops().len(),
+            ops_before,
+            "the gate itself performs no reaction ops on the ready path"
+        );
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "no backstop is armed by a ready pass-through"
         );
     }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -442,8 +442,8 @@ mod last_message_checkpoint_tests {
 }
 
 pub(in crate::services::discord) use queue_io::{
-    schedule_deferred_idle_queue_kickoff, schedule_deferred_idle_queue_kickoff_immediate,
-    spawn_turn_completion_idle_queue_listener,
+    arm_slow_idle_queue_backstop_if_queue_nonempty, schedule_deferred_idle_queue_kickoff,
+    schedule_deferred_idle_queue_kickoff_immediate, spawn_turn_completion_idle_queue_listener,
 };
 pub(super) fn single_message_panel_enabled() -> bool {
     single_message_panel::enabled()
@@ -4046,6 +4046,17 @@ async fn kickoff_idle_queue_channel(
             provider = provider.as_str(),
             "KICKOFF: skipped queued turn after fresh mailbox/TUI guard"
         );
+        return IdleQueueKickoffChannelOutcome::default();
+    }
+
+    // #4270 A — pre-dequeue hosted-TUI readiness gate. A verifiably busy hosted
+    // TUI defers the promotion BEFORE `take_next_soft` and BEFORE the queued-view
+    // teardown below (turn-view started/⏳ flip + 📬 marker drain + merged-card
+    // deletion), so a still-busy channel keeps its steady `📬 Queued` view with
+    // zero churn. No-start here is fail-open: callers arm the slow (60s)
+    // backstop on a no-start with backlog, and the watcher-idle re-drain
+    // delivers the fast edge once the TUI reaches Idle.
+    if router::hosted_tui_promote_readiness_blocked(shared, provider, channel_id).await {
         return IdleQueueKickoffChannelOutcome::default();
     }
 

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -408,6 +408,33 @@ pub(super) async fn arm_event_backstop_after_no_start_if_queue_nonempty(
     )
 }
 
+/// #4270 — busy-defer edge-trigger net: arm ONLY the slow (60s) fail-open
+/// backstop for a channel, WITHOUT the fast 2s deferred kick. Used by (1) the
+/// hosted-TUI busy-defer release path
+/// (`release_mailbox_after_hosted_tui_busy_pre_submit`) and (2) the live
+/// dispatch promote gate (`DiscordGateway::dispatch_queued_turn`), so a
+/// still-busy follow-up does not fast-spin the kickoff: the watcher-idle
+/// re-drain delivers the fast edge when the TUI reaches Idle, and this backstop
+/// is the lost-wakeup net. Thin wrapper over
+/// [`arm_event_backstop_after_no_start_if_queue_nonempty`] with a synthetic
+/// no-start outcome so the same "arm only when queue is non-empty" guard and
+/// single-backstop coalescing apply.
+pub(super) async fn arm_slow_idle_queue_backstop_if_queue_nonempty(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    reason: &'static str,
+) -> bool {
+    arm_event_backstop_after_no_start_if_queue_nonempty(
+        shared,
+        provider,
+        channel_id,
+        IdleQueueKickoffChannelOutcome { started: false },
+        reason,
+    )
+    .await
+}
+
 fn emit_idle_queue_backstop_warn(
     provider: &ProviderKind,
     channel_id: Option<ChannelId>,
@@ -466,12 +493,21 @@ async fn run_single_slow_idle_queue_backstop(
         backlog_units,
         "channel_backstop",
     );
-    let outcome =
+    let _outcome =
         kick_idle_queue_channel_if_context_available(shared, provider, channel_id, reason).await;
-    if outcome.started {
-        return None;
-    }
 
+    // #4270 — decide the re-arm from the ACTUAL post-kick mailbox state, not
+    // from the kick's `started` flag. A kickoff can report `started == true`
+    // without a real turn owning the slot: the pre-claim readiness gate (#4270 A)
+    // re-preserves a still-busy hosted-TUI follow-up and returns `Ok`, so the
+    // kickoff reports `started` while the message is merely back in the queue.
+    // The previous `if outcome.started { return None; }` short-circuit then
+    // dropped this backstop (and the gate's own re-arm had coalesced onto this
+    // very still-registered task), stranding the follow-up with no fail-open net
+    // until the watcher-idle edge — a #4247-class lost-wakeup. Re-checking the
+    // real state below is strictly more precise: a genuinely started turn now
+    // owns the slot (`blocked_by_real_turn`) and still suppresses the successor,
+    // while a defer/no-start that leaves un-drained backlog re-arms as intended.
     let snapshot = super::mailbox_snapshot(shared.as_ref(), channel_id).await;
     let backlog_units =
         idle_queue_backstop_backlog_units(shared.as_ref(), provider, channel_id, &snapshot);
@@ -1914,5 +1950,358 @@ mod presleep_tests {
         });
 
         super::super::tui_direct_pending_start::reset_present_for_tests();
+    }
+
+    /// #4270 — env-lock + temp runtime root held inside a struct so the guard
+    /// is not a local binding across `.await` (keeps the repo-wide
+    /// `await_holding_lock` allow ratchet flat; same pattern as
+    /// `queue_marker.rs::ScopedRuntimeRoot`).
+    struct ScopedRuntimeRoot {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _temp: tempfile::TempDir,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for ScopedRuntimeRoot {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev.take() {
+                    Some(value) => std::env::set_var("AGENTDESK_ROOT_DIR", value),
+                    None => std::env::remove_var("AGENTDESK_ROOT_DIR"),
+                }
+            }
+        }
+    }
+
+    fn scoped_runtime_root() -> ScopedRuntimeRoot {
+        let lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let prev = std::env::var_os("AGENTDESK_ROOT_DIR");
+        let temp = tempfile::tempdir().expect("temp runtime root");
+        unsafe {
+            std::env::set_var(
+                "AGENTDESK_ROOT_DIR",
+                temp.path().to_str().expect("temp path must be valid utf-8"),
+            );
+        }
+        ScopedRuntimeRoot {
+            _lock: lock,
+            _temp: temp,
+            prev,
+        }
+    }
+
+    /// #4270 pin — sustained-busy convergence over the PRODUCTION defer
+    /// sequence (`take_next_soft` promote → `mailbox_requeue_intervention_front`
+    /// + slow-backstop arm, exactly what the `dispatch_queued_turn` promote gate
+    /// runs): repeated cycles converge to a SINGLE queue entry and a SINGLE
+    /// coalesced slow backstop (no accumulation / oscillation), and never fire a
+    /// fast kick.
+    #[tokio::test(flavor = "current_thread")]
+    async fn promote_defer_requeue_converges_no_oscillation_across_cycles_4270() {
+        let _root = scoped_runtime_root();
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_270_200);
+        let user_msg = MessageId::new(4_270_201);
+
+        let kick_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel == channel_id {
+                        hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    None
+                })
+            },
+        ));
+
+        with_post_enqueue_idle_queue_kick_suppressed(mailbox_enqueue_intervention(
+            &shared,
+            &provider,
+            channel_id,
+            user_intervention(user_msg.get(), "sustained busy follow-up"),
+        ))
+        .await;
+
+        for cycle in 0..3 {
+            let taken = shared
+                .mailbox(channel_id)
+                .take_next_soft(queue_persistence_context(&shared, &provider, channel_id))
+                .await;
+            let intervention = taken
+                .intervention
+                .unwrap_or_else(|| panic!("cycle {cycle}: the follow-up must still be promotable"));
+            mailbox_requeue_intervention_front(&shared, &provider, channel_id, intervention).await;
+            arm_slow_idle_queue_backstop_if_queue_nonempty(
+                &shared,
+                &provider,
+                channel_id,
+                "hosted_tui_busy_pre_drain_defer",
+            )
+            .await;
+            yield_backstop_tasks().await;
+
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
+            assert_eq!(
+                snapshot.intervention_queue.len(),
+                1,
+                "cycle {cycle}: exactly one queue entry (never accumulates duplicates)"
+            );
+            assert_eq!(
+                snapshot.pending_user_dispatch, None,
+                "cycle {cycle}: the front-requeue consumes the stale dispatch reservation"
+            );
+            assert!(
+                snapshot.cancel_token.is_none(),
+                "cycle {cycle}: the mailbox is never claimed by the still-busy follow-up"
+            );
+            assert_eq!(
+                shared
+                    .restart
+                    .deferred_hook_backlog
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "cycle {cycle}: the slow backstop coalesces to a single armed net"
+            );
+        }
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "no fast kick across any busy cycle"
+        );
+    }
+
+    /// #4270 pin #2 — the busy-defer edge-trigger helper arms ONLY the slow
+    /// (60s) fail-open backstop for a non-empty queue and fires NO fast kickoff;
+    /// the fast wakeup is delegated to the watcher-idle re-drain. This is the
+    /// arm that both `release_mailbox_after_hosted_tui_busy_pre_submit`
+    /// (post-claim busy defer, turn_start.rs) and the `dispatch_queued_turn`
+    /// promote gate call instead of the fixed-delay kickoff.
+    #[tokio::test(flavor = "current_thread")]
+    async fn busy_defer_arms_slow_backstop_not_fast_kickoff_4270() {
+        let _root = scoped_runtime_root();
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_270_300);
+        let user_msg = MessageId::new(4_270_301);
+
+        let kick_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel == channel_id {
+                        hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    None
+                })
+            },
+        ));
+
+        // Suppress the setup enqueue's OWN post-enqueue kick so this test
+        // exercises `arm_slow_idle_queue_backstop_if_queue_nonempty` in
+        // isolation (otherwise that kick would arm the backstop first and this
+        // direct call would merely coalesce).
+        with_post_enqueue_idle_queue_kick_suppressed(mailbox_enqueue_intervention(
+            &shared,
+            &provider,
+            channel_id,
+            user_intervention(user_msg.get(), "busy-defer backlog"),
+        ))
+        .await;
+
+        let armed = arm_slow_idle_queue_backstop_if_queue_nonempty(
+            &shared,
+            &provider,
+            channel_id,
+            "hosted_tui_busy_pre_submit_pending",
+        )
+        .await;
+        assert!(armed, "a non-empty queue arms the slow backstop");
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the slow-backstop arm must not fire an immediate fast kickoff"
+        );
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "exactly one slow (60s) backstop is armed"
+        );
+
+        // A second call for the same channel coalesces onto the single armed
+        // backstop (no accumulation) rather than arming a duplicate.
+        let armed_again = arm_slow_idle_queue_backstop_if_queue_nonempty(
+            &shared,
+            &provider,
+            channel_id,
+            "hosted_tui_busy_pre_submit_pending",
+        )
+        .await;
+        assert!(
+            !armed_again,
+            "a second arm coalesces onto the single channel-scoped backstop"
+        );
+        assert_eq!(
+            shared
+                .restart
+                .deferred_hook_backlog
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the slow backstop stays coalesced to a single armed net"
+        );
+    }
+
+    /// #4270 pin #4 — TUI Idle transition: once the promote gate has re-preserved
+    /// the follow-up at the queue front (production defer sequence), the
+    /// watcher-idle drain (soft-take → claim) dispatches it EXACTLY once and
+    /// empties the queue.
+    #[tokio::test(flavor = "current_thread")]
+    async fn idle_drain_after_promote_defer_dispatches_exactly_once_4270() {
+        let _root = scoped_runtime_root();
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_270_400);
+        let user_msg = MessageId::new(4_270_401);
+        let owner = UserId::new(4_270_402);
+
+        with_post_enqueue_idle_queue_kick_suppressed(mailbox_enqueue_intervention(
+            &shared,
+            &provider,
+            channel_id,
+            user_intervention(user_msg.get(), "deferred until TUI idle"),
+        ))
+        .await;
+        let taken = shared
+            .mailbox(channel_id)
+            .take_next_soft(queue_persistence_context(&shared, &provider, channel_id))
+            .await;
+        let intervention = taken.intervention.expect("promote once");
+        mailbox_requeue_intervention_front(&shared, &provider, channel_id, intervention).await;
+
+        // Watcher-idle drain: the TUI reached Idle, so the drain soft-takes and
+        // claims. It must start exactly once and leave the queue empty.
+        let drained = shared
+            .mailbox(channel_id)
+            .take_next_soft(queue_persistence_context(&shared, &provider, channel_id))
+            .await
+            .intervention
+            .expect("idle drain re-promotes the preserved follow-up");
+        let started = mailbox_try_start_turn(
+            &shared,
+            channel_id,
+            Arc::new(CancelToken::new()),
+            owner,
+            drained.message_id,
+        )
+        .await;
+        assert!(started, "on TUI Idle the follow-up claims exactly once");
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert_eq!(snapshot.active_user_message_id, Some(user_msg));
+        assert!(
+            snapshot.intervention_queue.is_empty(),
+            "the idle dispatch consumes the single queued follow-up"
+        );
+    }
+
+    /// #4270 fail-open — the slow (60s) backstop RE-ARMS itself when its own kick
+    /// reports `started` yet leaves un-drained backlog with no real turn owning
+    /// the slot. That is exactly the promote gate's steady state (the kickoff
+    /// defers pre-dequeue and reports no-start, or the dispatch gate re-preserves
+    /// and returns `Ok`), and the gate's own inline re-arm coalesces onto THIS
+    /// still-registered task. The net must therefore persist across busy cycles
+    /// instead of dying after a single fire — otherwise the follow-up strands
+    /// with no fail-open net until the watcher-idle edge (a #4247-class
+    /// lost-wakeup).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn slow_backstop_rearms_when_kick_defers_without_claiming_4270() {
+        let _root = scoped_runtime_root();
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(4_270_500);
+
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(4_270_501, "still-busy follow-up")],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        // Emulate the promote-gate deferral: the kick reports `started` but
+        // never claims and leaves the follow-up queued (no active turn).
+        let kick_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_calls = kick_calls.clone();
+        let _hook = set_idle_queue_kick_hook_for_tests(Arc::new(
+            move |_shared, _provider, channel, _reason| {
+                let hook_calls = hook_calls.clone();
+                Box::pin(async move {
+                    if channel != channel_id {
+                        return None;
+                    }
+                    hook_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Some(IdleQueueKickoffChannelOutcome { started: true })
+                })
+            },
+        ));
+
+        assert!(
+            arm_slow_idle_queue_backstop_if_queue_nonempty(
+                &shared,
+                &provider,
+                channel_id,
+                "hosted_tui_busy_pre_submit_pending",
+            )
+            .await
+        );
+
+        // Let the spawned backstop task reach its 60s sleep before advancing.
+        yield_backstop_tasks().await;
+
+        // First fire (60s): the kick defers again ⇒ the successor net must re-arm.
+        tokio::time::advance(idle_queue_backstop_delay_for_tests()).await;
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the backstop fired once"
+        );
+        assert!(
+            shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id),
+            "a started-but-deferred kick that leaves backlog must re-arm the fail-open backstop (no strand)"
+        );
+
+        // Second fire: still deferring ⇒ the net persists across successive cycles.
+        tokio::time::advance(idle_queue_backstop_delay_for_tests()).await;
+        yield_backstop_tasks().await;
+        assert_eq!(
+            kick_calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the re-armed backstop fires again on the next cycle"
+        );
+        assert!(
+            shared
+                .restart
+                .deferred_hook_channels
+                .contains_key(&channel_id),
+            "the fail-open net persists across successive busy cycles"
+        );
     }
 }

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -69,6 +69,14 @@ pub(in crate::services::discord) use self::headless_turn::{
 };
 pub(in crate::services::discord) use self::intake_turn::{IntakeDeps, handle_text_message};
 pub(crate) use self::intake_turn::{IntakeRequest, execute_intake_turn_core};
+// #4270 — pre-teardown hosted-TUI readiness probe + live-dispatch defer for the
+// queued-turn promote entrypoints (idle kickoff in discord/mod.rs, live
+// dispatch in gateway.rs).
+#[cfg(test)]
+pub(in crate::services::discord) use self::tui_followup::set_hosted_tui_promote_busy_for_tests;
+pub(in crate::services::discord) use self::tui_followup::{
+    defer_promoted_dispatch_if_hosted_tui_busy, hosted_tui_promote_readiness_blocked,
+};
 
 #[cfg(test)]
 mod session_strategy_lifecycle_tests;

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -701,6 +701,165 @@ pub(super) fn tui_busy_followup_diagnostic(
     )
 }
 
+/// #4270 test seam for [`hosted_tui_promote_readiness_blocked`]: lets pin tests
+/// force the busy/ready verdict without a live tmux pane + hook server. `None`
+/// (production) falls through to the real diagnostic.
+#[cfg(test)]
+pub(in crate::services::discord) static HOSTED_TUI_PROMOTE_BUSY_HOOK_FOR_TESTS: std::sync::Mutex<
+    Option<bool>,
+> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+pub(in crate::services::discord) struct HostedTuiPromoteBusyHookResetForTests;
+
+#[cfg(test)]
+impl Drop for HostedTuiPromoteBusyHookResetForTests {
+    fn drop(&mut self) {
+        *HOSTED_TUI_PROMOTE_BUSY_HOOK_FOR_TESTS
+            .lock()
+            .expect("hosted tui promote busy hook lock") = None;
+    }
+}
+
+#[cfg(test)]
+pub(in crate::services::discord) fn set_hosted_tui_promote_busy_for_tests(
+    busy: bool,
+) -> HostedTuiPromoteBusyHookResetForTests {
+    *HOSTED_TUI_PROMOTE_BUSY_HOOK_FOR_TESTS
+        .lock()
+        .expect("hosted tui promote busy hook lock") = Some(busy);
+    HostedTuiPromoteBusyHookResetForTests
+}
+
+/// #4270 A — pre-teardown hosted-TUI readiness probe for the two queued-turn
+/// promote entrypoints (`kickoff_idle_queue_channel` pre-dequeue and
+/// `DiscordGateway::dispatch_queued_turn` pre-drain). Returns `true` when the
+/// channel's hosted TUI is verifiably busy per the SAME diagnostic the
+/// post-claim busy branch uses (`tui_busy_followup_diagnostic`), so the caller
+/// can defer the promotion BEFORE any user-visible teardown (turn-view
+/// started/⏳ flip, 📬/➕ marker drain, merged queued-card deletion, mailbox
+/// claim). Everything else — no session, no tmux pane, remote profile,
+/// non-hosted driver, ready, unknown — returns `false`: fail-open to the normal
+/// dispatch path, whose existing post-claim busy branch owns the defer UX
+/// (queued-card render + 📬 re-attach). This probe must NEVER be load-bearing
+/// for message preservation; it only avoids churn.
+///
+/// Root cause it closes (#4270): the promote path used to dequeue + flip the
+/// head's turn-view to started/⏳ + drain 📬 + claim the mailbox, and only THEN
+/// discover the hosted TUI was busy — re-queue + re-attach + release + fast
+/// re-kick, every ~2s, forever. Probing the same verdict before teardown
+/// short-circuits the whole cycle with zero visible state change.
+///
+/// Session context (tmux name / current_path / session_id / remote-profile
+/// presence) is resolved here once from the channel session snapshot; the
+/// promote entrypoints have no resolved intake context yet, so nothing is
+/// duplicated.
+pub(in crate::services::discord) async fn hosted_tui_promote_readiness_blocked(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+) -> bool {
+    #[cfg(test)]
+    if let Some(busy) = *HOSTED_TUI_PROMOTE_BUSY_HOOK_FOR_TESTS
+        .lock()
+        .expect("hosted tui promote busy hook lock")
+    {
+        return busy;
+    }
+
+    let (tmux_session_name, remote_profile_named, current_path, session_id) = {
+        let data = shared.core.lock().await;
+        let Some(session) = data.sessions.get(&channel_id) else {
+            return false;
+        };
+        let tmux_session_name = if provider.uses_managed_tmux_backend() {
+            session
+                .channel_name
+                .as_ref()
+                .map(|name| provider.build_tmux_session_name(name))
+        } else {
+            None
+        };
+        (
+            tmux_session_name,
+            session.remote_profile_name.is_some(),
+            session.current_path.clone(),
+            session.session_id.clone(),
+        )
+    };
+    let Some(tmux_session_name) = tmux_session_name else {
+        return false;
+    };
+    // `remote_profile_named` (name recorded on the session) is a conservative
+    // stand-in for the intake path's settings-resolved profile: a named-but-
+    // missing profile makes the probe return `false` (fail-open to normal
+    // dispatch) instead of misclassifying a remote session as a local TUI.
+    let blocked = tui_busy_followup_diagnostic(
+        shared,
+        provider,
+        channel_id,
+        Some(tmux_session_name.as_str()),
+        remote_profile_named,
+        current_path.as_deref(),
+        session_id.as_deref(),
+    )
+    .is_some();
+    if blocked {
+        tracing::info!(
+            channel_id = channel_id.get(),
+            provider = provider.as_str(),
+            tmux_session_name = %tmux_session_name,
+            "#4270 promote gate: hosted TUI busy before queued-turn teardown; deferring promotion"
+        );
+    }
+    blocked
+}
+
+/// #4270 A — live-dispatch promote defer: the composite the
+/// `DiscordGateway::dispatch_queued_turn` gate runs when
+/// [`hosted_tui_promote_readiness_blocked`] says the hosted TUI is busy. The
+/// caller (finalize epilogue) already soft-took `intervention` off the queue;
+/// put it straight back at the FRONT (order + merged identity preserved; the
+/// front-requeue consumes the dispatch reservation/marker) BEFORE any teardown
+/// (📬/➕ marker drain, merged queued-card deletion, turn-view ⏳ flip), so the
+/// user keeps the steady `📬 Queued` view with zero churn. Only the slow (60s)
+/// fail-open backstop is armed — the watcher-idle re-drain delivers the fast
+/// edge on TUI Idle. Returns `true` when deferred (caller must return `Ok`:
+/// the epilogue's success branch is a no-op after the reservation was
+/// consumed, while its `Err` branch would re-arm the fast ~2s kickoff — the
+/// exact spin #4270 removes).
+pub(in crate::services::discord) async fn defer_promoted_dispatch_if_hosted_tui_busy(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+    intervention: &crate::services::turn_orchestrator::Intervention,
+) -> bool {
+    if !hosted_tui_promote_readiness_blocked(shared, provider, channel_id).await {
+        return false;
+    }
+    super::super::super::mailbox_requeue_intervention_front(
+        shared,
+        provider,
+        channel_id,
+        intervention.clone(),
+    )
+    .await;
+    super::super::super::arm_slow_idle_queue_backstop_if_queue_nonempty(
+        shared,
+        provider,
+        channel_id,
+        "hosted_tui_busy_pre_drain_defer",
+    )
+    .await;
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::info!(
+        "  [{ts}] 📬 #4270 promote gate: hosted TUI busy — queued turn re-preserved at queue front without teardown (channel {}, msg {})",
+        channel_id,
+        intervention.message_id
+    );
+    true
+}
+
 pub(super) async fn enqueue_busy_tui_followup_for_retry(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,

--- a/src/services/discord/router/mod.rs
+++ b/src/services/discord/router/mod.rs
@@ -9,8 +9,11 @@ mod turn_start;
 
 pub(crate) use authorization::TurnKind;
 pub(super) use intake_gate::{handle_event, should_process_turn_message};
+#[cfg(test)]
+pub(super) use message_handler::set_hosted_tui_promote_busy_for_tests;
 pub(super) use message_handler::{
-    IntakeDeps, handle_text_message, start_headless_turn, start_reserved_headless_turn,
+    IntakeDeps, defer_promoted_dispatch_if_hosted_tui_busy, handle_text_message,
+    hosted_tui_promote_readiness_blocked, start_headless_turn, start_reserved_headless_turn,
 };
 pub(crate) use message_handler::{IntakeRequest, execute_intake_turn_core};
 pub(super) use turn_start::reserve_headless_turn;

--- a/src/services/discord/router/turn_start.rs
+++ b/src/services/discord/router/turn_start.rs
@@ -429,13 +429,20 @@ pub(in crate::services::discord) async fn release_mailbox_after_hosted_tui_busy_
 ) -> bool {
     let finish = super::super::mailbox_finish_turn(shared, provider, channel_id).await;
     if finish.mailbox_online && finish.has_pending {
-        super::super::schedule_deferred_idle_queue_kickoff(
-            shared.clone(),
-            provider.clone(),
+        // #4270 B — edge-trigger conversion: do NOT re-arm the fast ~2s deferred
+        // kickoff for a hosted-TUI busy-defer release (that fixed-delay re-kick,
+        // combined with the mailbox-only kickoff gate, was the ~2s promote
+        // spin). Arm ONLY the slow (60s) fail-open backstop; the fast wakeup is
+        // delegated to the watcher-idle re-drain when the TUI reaches Idle, and
+        // the pre-claim readiness gate (#4270 A) absorbs any interim kick
+        // without re-claiming the mailbox.
+        super::super::arm_slow_idle_queue_backstop_if_queue_nonempty(
+            shared,
+            provider,
             channel_id,
             "hosted_tui_busy_pre_submit_pending",
-        );
-        true
+        )
+        .await
     } else {
         false
     }


### PR DESCRIPTION
## #4270 — busy 턴 follow-up promote 무한 재큐잉 (P1)

### 근본원인
mailbox busy와 hosted-TUI busy(JSONL)의 이원화: promote가 readiness 확인 전에 커밋(dequeue→turn-view ⏳ 플립→📬 drain→claim) → TUI busy 발견 → 재큐+📬재부착+⏳제거 → 무조건 2s 킥오프 재예약 → 게이트는 mailbox만 확인 → **~3.5s 주기 무한 스핀** (라이브 87초 25회 진동).

### 수정 (듀얼리뷰 반영 — codex F1 방향 (a), opus F5/F1/F6 통합)
- **A (flap 근절, teardown-앞 게이트)**: `hosted_tui_promote_readiness_blocked` — 두 promote 진입점에서 **모든 teardown 이전에** hosted-TUI busy를 선확인.
  - **kickoff** (`mod.rs::kickoff_idle_queue_channel`): `take_next_soft` **이전** — busy면 dequeue/마커 drain/⏳ 플립/카드 삭제/claim 아무것도 안 함 (view 변화 0).
  - **live dispatch** (`gateway.rs::dispatch_queued_turn` → `defer_promoted_dispatch_if_hosted_tui_busy`): 마커 drain **이전** — busy면 원본 Intervention을 **front-requeue** (병합 identity/순서 보존, dispatch 예약 소비) 후 `Ok` 반환 (epilogue의 fast 킥오프 Err 경로 회피).
  - 불변식: **재보존 후 사용자가 보는 상태 = 📬 Queued** (opus F5) — busy면 뷰를 건드리지 않으므로 롤백 자체가 불필요. probe는 fail-open (세션/tmux 부재·remote profile·unknown → false): 누수 시 기존 post-claim busy 경로가 재렌더(📬 복원) UX를 소유, 메시지 보존은 durable 큐/마커가 담당.
- **B (spin 근절, edge-trigger)**: busy-defer 재큐 시 고정 2s 킥오프 대신 slow backstop(60s)만 arm (`turn_start.rs` release + dispatch 게이트) — fast 재drain은 기존 watcher-idle 훅에 위임 (tmux_watcher 무수정).
- **lost-wakeup 갭 수정**: backstop 재장전이 `started` 플래그 대신 실제 post-kick 상태(잔여 backlog + !blocked_by_real_turn) 기준 — busy 사이클 넘어 fail-open 그물 유지 (#4247류 strand 차단).

### Silent requeue (사용자 피드백 반영)
busy 재시도 사이클의 defer 경로(kickoff pre-dequeue / dispatch pre-drain / 60s backstop re-fire)는 **Discord 메시지·카드를 일절 게시하지 않는다** — front-requeue + backstop arm + tracing 로그뿐 (send/edit/post call site 부재, 정적 확인). 구 스핀에서 사이클마다 누적되던 `📬 재시도 큐 등록` 카드는 post-claim busy 분기가 매 사이클 재진입했기 때문 — 이제 그 분기는 busy 재시도 중 도달 불가(게이트가 pre-claim에서 차단). 첫 busy 큐잉 시 최초 📬 카드 1장은 기존 동작 유지(범위 밖, 별도 이슈).

### 테스트 (opus F6 반영 — 진입점 레벨 2종 포함)
- **진입점 핀 (gateway.rs)**: (i) busy → `dispatch_queued_turn`이 **3회 재시도 사이클에 걸쳐** teardown 전에 silent defer — 큐 front 재보존(중복 0) + 예약 소비 + reconciler 리액션 op **증가 0** + 영속 turn-view `📬 Queued` **byte-for-byte 보존** + slow backstop 단일 coalesce; (ii) ready → 게이트 false 통과 → dispatch 본문 진행 (뷰/큐/예약 무접촉).
- **queue_io 핀**: 지속 busy 3사이클 수렴(단일 큐 엔트리/단일 backstop/fast kick 0), slow-only arm+coalesce, TUI Idle 후 정확 1회 dispatch, backstop 재장전 fail-open.
- 기존 회귀 (`hosted_tui_followup_busy_retry_…_4107`, `abandon_pending_dispatch…` 등) 포함 전체 통과.

### 게이트
fmt ✅ / check ✅ / freshness ✅ / `await_holding_lock` ratchet **53/53** (allow 신규 0 — guard-in-struct 패턴, opus F1) ✅ / giant threshold (gateway.rs 984 < 1000) ✅ / 핫파일(watcher/bridge/sink/finalizer) 무접촉 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
