### PR TITLE
feat(prompt): #4306 — Proactive Memory Guidance에 memento tool_feedback 상시 계약 복원

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -549,7 +549,7 @@
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 387 | 264 | 123 |  |
 | `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 334 | 334 | 0 |  |
-| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 71 | 71 | 0 |  |
+| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 72 | 72 | 0 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 1918 | 715 | 1203 |  |

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -745,3 +745,92 @@ fn review_lite_prompt_keeps_review_contract_while_trimming_full_sections() {
     }
     assert!(review_words * 2 < full_words);
 }
+
+#[test]
+fn full_memento_prompt_carries_tool_feedback_contract() {
+    // #4306: the Proactive Memory Guidance memento branch must carry the
+    // always-on `tool_feedback` contract that was dropped during the da7ccb39
+    // provider-prompt slim-down. It is gated to the Full profile with the
+    // memento backend and the MCP available.
+    let settings = ResolvedMemorySettings {
+        backend: MemoryBackendKind::Memento,
+        ..ResolvedMemorySettings::default()
+    };
+    let prompt = build_system_prompt(
+        "ctx",
+        &[],
+        "/tmp/agentdesk",
+        ChannelId::new(1),
+        "tok",
+        None,
+        false,
+        DispatchProfile::Full,
+        None,
+        None,
+        None,
+        None,
+        Some(&settings),
+        true,
+    );
+
+    assert!(
+        prompt.contains("[Proactive Memory Guidance]"),
+        "Full+memento prompt must include the proactive memory guidance block, got: {prompt}"
+    );
+    assert!(
+        prompt.contains(
+            "feedback contract: in the same turn you use `recall`/`context` results, \
+             call `mcp__memento__tool_feedback` once"
+        ),
+        "Full+memento prompt must carry the tool_feedback contract, got: {prompt}"
+    );
+    // Required params surfaced verbatim per the current memento schema.
+    assert!(prompt.contains("`search_event_id`=`_meta.searchEventId`"));
+    assert!(prompt.contains("`relevant`"));
+    assert!(prompt.contains("`sufficient`"));
+    // Deferred-tool loading instruction.
+    assert!(prompt.contains("ToolSearch `select:mcp__memento__tool_feedback`"));
+}
+
+#[test]
+fn review_lite_and_lite_prompts_omit_tool_feedback_contract() {
+    // #4306: the tool_feedback contract lives inside the Full-only Proactive
+    // Memory Guidance block. ReviewLite/Lite must show zero output change — the
+    // whole block (and thus the contract) stays absent even with the memento
+    // backend selected and the MCP available.
+    let settings = ResolvedMemorySettings {
+        backend: MemoryBackendKind::Memento,
+        ..ResolvedMemorySettings::default()
+    };
+
+    for profile in [DispatchProfile::ReviewLite, DispatchProfile::Lite] {
+        let dispatch_type = match profile {
+            DispatchProfile::ReviewLite => Some("review"),
+            _ => None,
+        };
+        let prompt = build_system_prompt(
+            "ctx",
+            &[],
+            "/tmp/agentdesk",
+            ChannelId::new(1),
+            "tok",
+            None,
+            false,
+            profile,
+            dispatch_type,
+            None,
+            None,
+            None,
+            Some(&settings),
+            true,
+        );
+        assert!(
+            !prompt.contains("[Proactive Memory Guidance]"),
+            "{profile:?} prompt must not include the proactive memory guidance block, got: {prompt}"
+        );
+        assert!(
+            !prompt.contains("mcp__memento__tool_feedback"),
+            "{profile:?} prompt must not carry the tool_feedback contract, got: {prompt}"
+        );
+    }
+}

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -784,10 +784,14 @@ fn full_memento_prompt_carries_tool_feedback_contract() {
         ),
         "Full+memento prompt must carry the tool_feedback contract, got: {prompt}"
     );
-    // Required params surfaced verbatim per the current memento schema.
-    assert!(prompt.contains("`search_event_id`=`_meta.searchEventId`"));
-    assert!(prompt.contains("`relevant`"));
-    assert!(prompt.contains("`sufficient`"));
+    // Required params surfaced verbatim per the current memento schema:
+    // required = tool_name/relevant/sufficient; search_event_id is optional
+    // (recommended when the response carries _meta.searchEventId).
+    assert!(prompt.contains("required: `tool_name`, `relevant`, `sufficient`"));
+    assert!(prompt.contains(
+        "when the response carries `_meta.searchEventId`, \
+         also pass it as `search_event_id` — recommended"
+    ));
     // Deferred-tool loading instruction.
     assert!(prompt.contains("ToolSearch `select:mcp__memento__tool_feedback`"));
 }

--- a/src/services/discord/prompt_builder/memory_guidance.rs
+++ b/src/services/discord/prompt_builder/memory_guidance.rs
@@ -58,7 +58,8 @@ pub(super) fn proactive_memory_guidance(
                 "`remember` MCP tool",
                 format!(
                     "\n- scope hints: project=`workspace={workspace_scope}, agentId=default`; agent-private=`workspace={agent_workspace}, agentId={agent_id}`.\n\
-                     - full memory policy: `docs/memory-scope.md`; read it before broad memory cleanup or scope changes."
+                     - full memory policy: `docs/memory-scope.md`; read it before broad memory cleanup or scope changes.\n\
+                     - feedback contract: in the same turn you use `recall`/`context` results, call `mcp__memento__tool_feedback` once (required: `search_event_id`=`_meta.searchEventId`, `relevant`, `sufficient`). If the tool is deferred, load it first via ToolSearch `select:mcp__memento__tool_feedback`."
                 ),
             )
         }

--- a/src/services/discord/prompt_builder/memory_guidance.rs
+++ b/src/services/discord/prompt_builder/memory_guidance.rs
@@ -59,7 +59,7 @@ pub(super) fn proactive_memory_guidance(
                 format!(
                     "\n- scope hints: project=`workspace={workspace_scope}, agentId=default`; agent-private=`workspace={agent_workspace}, agentId={agent_id}`.\n\
                      - full memory policy: `docs/memory-scope.md`; read it before broad memory cleanup or scope changes.\n\
-                     - feedback contract: in the same turn you use `recall`/`context` results, call `mcp__memento__tool_feedback` once (required: `search_event_id`=`_meta.searchEventId`, `relevant`, `sufficient`). If the tool is deferred, load it first via ToolSearch `select:mcp__memento__tool_feedback`."
+                     - feedback contract: in the same turn you use `recall`/`context` results, call `mcp__memento__tool_feedback` once (required: `tool_name`, `relevant`, `sufficient`; when the response carries `_meta.searchEventId`, also pass it as `search_event_id` — recommended). If the tool is deferred, load it first via ToolSearch `select:mcp__memento__tool_feedback`."
                 ),
             )
         }


### PR DESCRIPTION
## #4306 — tool_feedback 상시 계약 복원 (P1)

da7ccb39(04-30 'Slim provider prompt injection')가 드롭한 계약을 현행 memento 스키마(search_event_id=_meta.searchEventId)에 맞춰 복원. Full 프로필 memento 분기 extra_note에 1줄:

> feedback contract: in the same turn you use recall/context results, call mcp__memento__tool_feedback once (required: search_event_id, relevant, sufficient). If deferred, load via ToolSearch first.

- Full 한정 게이트(29-31) 무변경 — ReviewLite/Lite 출력 변화 0 (신규 테스트로 증명)
- File 백엔드 분기 무변경 (memory-read/write 스킬 문구와 모순 없음)
- 테스트 2종 추가: full_memento_prompt_carries_tool_feedback_contract / review_lite_and_lite_prompts_omit_tool_feedback_contract — 32/32

게이트: fmt ✅ check ✅ freshness ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)