### PR TITLE
fix(memory): #4307 PR-A — 데드 auto-submit 제거 + memento_feedback_turn_stats writer 복원

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1238,7 +1238,10 @@
     clusters into `tmux_runtime/` child modules (`interrupt_policy.rs`,
     `process_table.rs`, `pid_exit.rs` — see their entries below); no longer a
     giant-file. Bugfix only outside a further extraction plan).
-  - `src/services/discord/turn_bridge/mod.rs` (1232 lines; production LoC; -1260
+  - `src/services/discord/turn_bridge/mod.rs` (1231 lines; production LoC; -1
+    from #4307 PR-A removing the dead auto-submit re-export
+    (`submit_pending_feedbacks` / `should_submit_automatic_feedback_fallback`);
+    prior -1260
     from #4230 S6 moving the main stream loop shell + remaining event arms to
     `turn_bridge/stream_loop.rs`; behavior-preserving decompose. Prior -1339
     from #4230 S5 moving the terminal outcome delivery block to

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -32,7 +32,7 @@
 | `src/services/discord/tui_direct_pending_start.rs` | 1495 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 1051 | discord-relay | 2026-10-31 | #4019 |
 | `src/services/discord/tui_task_card.rs` | 1065 | discord-relay | 2026-10-31 | #3405 |
-| `src/services/discord/turn_bridge/mod.rs` | 1232 | discord-relay | 2026-08-31 | #3038 |
+| `src/services/discord/turn_bridge/mod.rs` | 1231 | discord-relay | 2026-08-31 | #3038 |
 | `src/services/discord/turn_bridge/stream_loop.rs` | 1638 | discord-relay | 2026-08-31 | #4230 |
 | `src/services/discord/turn_bridge/terminal_outcome_delivery.rs` | 1669 | discord-relay | 2026-08-31 | #4230 |
 | `src/services/discord/turn_finalizer.rs` | 1048 | discord-finalizer | 2026-08-31 | #3016 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -130,7 +130,7 @@
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 304 | 278 | 26 |  |
 | `db::session_observability` | `src/db/session_observability.rs` | 216 | 216 | 0 |  |
 | `db::session_status` | `src/db/session_status.rs` | 78 | 78 | 0 |  |
-| `db::session_transcripts` | `src/db/session_transcripts.rs` | 303 | 303 | 0 |  |
+| `db::session_transcripts` | `src/db/session_transcripts.rs` | 418 | 418 | 0 |  |
 | `db::table_metadata` | `src/db/table_metadata.rs` | 181 | 181 | 0 |  |
 | `db::turns` | `src/db/turns.rs` | 216 | 173 | 43 |  |
 | `dispatch` | `src/dispatch/mod.rs` | 55 | 55 | 0 |  |
@@ -296,7 +296,7 @@
 | `server::routes::settings` | `src/server/routes/settings.rs` | 93 | 93 | 0 |  |
 | `server::routes::skill_usage_analytics` | `src/server/routes/skill_usage_analytics.rs` | 425 | 425 | 0 |  |
 | `server::routes::skills_api` | `src/server/routes/skills_api.rs` | 684 | 684 | 0 |  |
-| `server::routes::stats` | `src/server/routes/stats.rs` | 588 | 588 | 0 |  |
+| `server::routes::stats` | `src/server/routes/stats.rs` | 722 | 589 | 133 |  |
 | `server::routes::termination_events` | `src/server/routes/termination_events.rs` | 152 | 152 | 0 |  |
 | `server::routes::tests::preflight_harness::types` | `src/server/routes/tests/preflight_harness/types.rs` | 217 | 217 | 0 |  |
 | `server::routes::tests::preflight_harness::validation` | `src/server/routes/tests/preflight_harness/validation.rs` | 260 | 260 | 0 |  |
@@ -739,14 +739,14 @@
 | `services::discord::tui_prompt_relay::synthetic_start::stale_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs` | 225 | 225 | 0 |  |
 | `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 137 | 137 | 0 |  |
 | `services::discord::tui_task_card` | `src/services/discord/tui_task_card.rs` | 1861 | 1065 | 796 | giant-file |
-| `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 1692 | 1232 | 460 | giant-file |
+| `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 1691 | 1231 | 460 | giant-file |
 | `services::discord::turn_bridge::bridge_latency_spans` | `src/services/discord/turn_bridge/bridge_latency_spans.rs` | 236 | 142 | 94 |  |
 | `services::discord::turn_bridge::cancel_finalize_policy` | `src/services/discord/turn_bridge/cancel_finalize_policy.rs` | 581 | 131 | 450 |  |
 | `services::discord::turn_bridge::chunk_compose` | `src/services/discord/turn_bridge/chunk_compose.rs` | 68 | 68 | 0 |  |
 | `services::discord::turn_bridge::completion_guard` | `src/services/discord/turn_bridge/completion_guard.rs` | 936 | 878 | 58 |  |
 | `services::discord::turn_bridge::completion_guard::completion_context` | `src/services/discord/turn_bridge/completion_guard/completion_context.rs` | 449 | 449 | 0 |  |
 | `services::discord::turn_bridge::completion_guard::completion_postgres` | `src/services/discord/turn_bridge/completion_guard/completion_postgres.rs` | 644 | 548 | 96 |  |
-| `services::discord::turn_bridge::completion_postlude` | `src/services/discord/turn_bridge/completion_postlude.rs` | 917 | 917 | 0 |  |
+| `services::discord::turn_bridge::completion_postlude` | `src/services/discord/turn_bridge/completion_postlude.rs` | 915 | 915 | 0 |  |
 | `services::discord::turn_bridge::context_window` | `src/services/discord/turn_bridge/context_window.rs` | 170 | 100 | 70 |  |
 | `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 71 | 71 | 0 |  |
 | `services::discord::turn_bridge::finalize_epilogue` | `src/services/discord/turn_bridge/finalize_epilogue.rs` | 306 | 156 | 150 |  |
@@ -757,7 +757,7 @@
 | `services::discord::turn_bridge::output_lifecycle` | `src/services/discord/turn_bridge/output_lifecycle.rs` | 75 | 28 | 47 |  |
 | `services::discord::turn_bridge::panel_lifecycle` | `src/services/discord/turn_bridge/panel_lifecycle.rs` | 232 | 232 | 0 |  |
 | `services::discord::turn_bridge::post_loop_finalize` | `src/services/discord/turn_bridge/post_loop_finalize.rs` | 720 | 720 | 0 |  |
-| `services::discord::turn_bridge::recall_feedback` | `src/services/discord/turn_bridge/recall_feedback.rs` | 493 | 475 | 18 |  |
+| `services::discord::turn_bridge::recall_feedback` | `src/services/discord/turn_bridge/recall_feedback.rs` | 482 | 372 | 110 |  |
 | `services::discord::turn_bridge::recovery_text` | `src/services/discord/turn_bridge/recovery_text.rs` | 654 | 511 | 143 |  |
 | `services::discord::turn_bridge::response_delivery` | `src/services/discord/turn_bridge/response_delivery.rs` | 139 | 75 | 64 |  |
 | `services::discord::turn_bridge::retry_state` | `src/services/discord/turn_bridge/retry_state.rs` | 753 | 384 | 369 |  |

--- a/src/db/session_transcripts.rs
+++ b/src/db/session_transcripts.rs
@@ -142,6 +142,121 @@ async fn persist_turn_pg(pool: &PgPool, entry: &PreparedSessionTranscript) -> Re
     Ok(())
 }
 
+/// #4307: per-turn memento recall/feedback stats surfaced by the `/api/stats`
+/// reader (`load_memento_feedback_counts`). Restores the writer a1492c05 dropped
+/// when it removed the SQLite twin without porting the PG path — the
+/// `memento_feedback_turn_stats` table has shipped in the PG schema all along
+/// (migrations/postgres/0001_initial_schema.sql) but nothing wrote to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MementoFeedbackTurnStat {
+    pub turn_id: String,
+    pub stat_date: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub recall_count: i64,
+    pub manual_tool_feedback_count: i64,
+    pub manual_covered_recall_count: i64,
+    pub auto_tool_feedback_count: i64,
+    pub covered_recall_count: i64,
+}
+
+/// Upsert a turn's memento feedback stats keyed by `turn_id`. Returns `Err`
+/// when no PG pool is available (the caller gates on `pg_pool.is_some()`).
+pub async fn record_memento_feedback_turn_stats(
+    pg_pool: Option<&PgPool>,
+    stat: &MementoFeedbackTurnStat,
+) -> Result<()> {
+    let Some(pool) = pg_pool else {
+        return Err(anyhow!(
+            "postgres pool is required to record memento feedback stats"
+        ));
+    };
+    validate_memento_feedback_turn_stat(stat)?;
+
+    sqlx::query(
+        "INSERT INTO memento_feedback_turn_stats (
+            turn_id,
+            stat_date,
+            agent_id,
+            provider,
+            recall_count,
+            manual_tool_feedback_count,
+            manual_covered_recall_count,
+            auto_tool_feedback_count,
+            covered_recall_count
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT (turn_id) DO UPDATE SET
+            stat_date = EXCLUDED.stat_date,
+            agent_id = EXCLUDED.agent_id,
+            provider = EXCLUDED.provider,
+            recall_count = EXCLUDED.recall_count,
+            manual_tool_feedback_count = EXCLUDED.manual_tool_feedback_count,
+            manual_covered_recall_count = EXCLUDED.manual_covered_recall_count,
+            auto_tool_feedback_count = EXCLUDED.auto_tool_feedback_count,
+            covered_recall_count = EXCLUDED.covered_recall_count",
+    )
+    .bind(&stat.turn_id)
+    .bind(&stat.stat_date)
+    .bind(&stat.agent_id)
+    .bind(&stat.provider)
+    .bind(stat.recall_count)
+    .bind(stat.manual_tool_feedback_count)
+    .bind(stat.manual_covered_recall_count)
+    .bind(stat.auto_tool_feedback_count)
+    .bind(stat.covered_recall_count)
+    .execute(pool)
+    .await
+    .map_err(|e| anyhow!("record memento feedback turn stats failed: {e}"))?;
+
+    Ok(())
+}
+
+fn validate_memento_feedback_turn_stat(stat: &MementoFeedbackTurnStat) -> Result<()> {
+    if stat.turn_id.trim().is_empty() {
+        return Err(anyhow!("memento feedback stats require non-empty turn_id"));
+    }
+    if stat.stat_date.trim().is_empty() {
+        return Err(anyhow!(
+            "memento feedback stats require non-empty stat_date"
+        ));
+    }
+    if stat.agent_id.trim().is_empty() {
+        return Err(anyhow!("memento feedback stats require non-empty agent_id"));
+    }
+    if stat.provider.trim().is_empty() {
+        return Err(anyhow!("memento feedback stats require non-empty provider"));
+    }
+
+    for (label, value) in [
+        ("recall_count", stat.recall_count),
+        (
+            "manual_tool_feedback_count",
+            stat.manual_tool_feedback_count,
+        ),
+        (
+            "manual_covered_recall_count",
+            stat.manual_covered_recall_count,
+        ),
+        ("auto_tool_feedback_count", stat.auto_tool_feedback_count),
+        ("covered_recall_count", stat.covered_recall_count),
+    ] {
+        if value < 0 {
+            return Err(anyhow!(
+                "memento feedback stats {label} must be non-negative"
+            ));
+        }
+    }
+    if stat.manual_covered_recall_count > stat.recall_count {
+        return Err(anyhow!(
+            "manual_covered_recall_count cannot exceed recall_count"
+        ));
+    }
+    if stat.covered_recall_count > stat.recall_count {
+        return Err(anyhow!("covered_recall_count cannot exceed recall_count"));
+    }
+    Ok(())
+}
+
 fn prepare_persist_entry_base(
     entry: &PersistSessionTranscript<'_>,
 ) -> Result<Option<PreparedSessionTranscript>> {

--- a/src/server/routes/stats.rs
+++ b/src/server/routes/stats.rs
@@ -586,3 +586,137 @@ async fn load_memento_feedback_counts(state: &AppState) -> Option<(i64, i64)> {
 fn load_memento_feedback_counts_legacy(_state: &AppState) -> Option<(i64, i64)> {
     None
 }
+
+#[cfg(test)]
+mod memento_feedback_stats_pg_tests {
+    use super::{AppState, load_memento_feedback_counts};
+    use crate::db::session_transcripts::{
+        MementoFeedbackTurnStat, record_memento_feedback_turn_stats,
+    };
+
+    const PG_TEST_LABEL: &str = "stats memento feedback counts pg test";
+
+    struct StatsPostgresDb {
+        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
+        admin_url: String,
+        database_name: String,
+        database_url: String,
+    }
+
+    impl StatsPostgresDb {
+        async fn try_create() -> Option<Self> {
+            let lock = crate::db::postgres::lock_test_lifecycle();
+            let admin_url = crate::dispatch::test_support::postgres_admin_database_url();
+            let database_name = format!("agentdesk_pg_stats_{}", uuid::Uuid::new_v4().simple());
+            let database_url = format!(
+                "{}/{}",
+                crate::dispatch::test_support::postgres_base_database_url(),
+                database_name
+            );
+            if let Err(error) =
+                crate::db::postgres::create_test_database(&admin_url, &database_name, PG_TEST_LABEL)
+                    .await
+            {
+                eprintln!("skipping {PG_TEST_LABEL}: {error}");
+                drop(lock);
+                return None;
+            }
+
+            Some(Self {
+                _lock: lock,
+                admin_url,
+                database_name,
+                database_url,
+            })
+        }
+
+        async fn connect_and_migrate(&self) -> sqlx::PgPool {
+            crate::db::postgres::connect_test_pool_and_migrate(&self.database_url, PG_TEST_LABEL)
+                .await
+                .expect("connect + migrate stats postgres test db")
+        }
+
+        async fn drop(self) {
+            crate::db::postgres::drop_test_database(
+                &self.admin_url,
+                &self.database_name,
+                PG_TEST_LABEL,
+            )
+            .await
+            .expect("drop stats postgres test db");
+        }
+    }
+
+    fn test_state_with_pg(pg_pool: sqlx::PgPool) -> AppState {
+        let mut config = crate::config::Config::default();
+        config.policies.dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
+        config.policies.hot_reload = false;
+        let engine =
+            crate::engine::PolicyEngine::new_with_pg(&config, Some(pg_pool.clone())).unwrap();
+        let tx = crate::eventbus::new_broadcast();
+        let buf = crate::eventbus::spawn_batch_flusher(tx.clone());
+        AppState {
+            pg_pool: Some(pg_pool),
+            engine,
+            config: std::sync::Arc::new(crate::config::Config::default()),
+            broadcast_tx: tx,
+            batch_buffer: buf,
+            health_registry: None,
+            cluster_instance_id: None,
+        }
+    }
+
+    fn stat(turn_id: &str, manual: i64, manual_covered: i64, auto: i64) -> MementoFeedbackTurnStat {
+        MementoFeedbackTurnStat {
+            turn_id: turn_id.to_string(),
+            stat_date: "2026-07-08".to_string(),
+            agent_id: "project-agentdesk".to_string(),
+            provider: "codex".to_string(),
+            recall_count: 6,
+            manual_tool_feedback_count: manual,
+            manual_covered_recall_count: manual_covered,
+            auto_tool_feedback_count: auto,
+            covered_recall_count: manual_covered,
+        }
+    }
+
+    // #4307 PR-A: prove the restored writer round-trips through the /api/stats
+    // reader (`load_memento_feedback_counts`): the reader returns the real
+    // persisted SUM(auto_tool_feedback_count) / SUM(manual_tool_feedback_count),
+    // and the writer's ON CONFLICT(turn_id) upsert replaces a turn in place.
+    #[tokio::test]
+    async fn load_memento_feedback_counts_returns_persisted_writer_values_pg() {
+        let Some(pg_db) = StatsPostgresDb::try_create().await else {
+            return;
+        };
+        let pool = pg_db.connect_and_migrate().await;
+        let state = test_state_with_pg(pool.clone());
+
+        // Empty table: the reader returns real zero sums (COALESCE), not None.
+        assert_eq!(load_memento_feedback_counts(&state).await, Some((0, 0)));
+
+        // Production-shaped row (auto is always 0 post-#4307) ...
+        record_memento_feedback_turn_stats(Some(&pool), &stat("turn-1", 1, 1, 0))
+            .await
+            .expect("write turn-1");
+        // ... plus a row with a non-zero auto count so the reader's `automatic`
+        // sum column is exercised end-to-end, not just defaulted to 0.
+        record_memento_feedback_turn_stats(Some(&pool), &stat("turn-2", 2, 2, 3))
+            .await
+            .expect("write turn-2");
+
+        // automatic = 0 + 3, voluntary = 1 + 2.
+        assert_eq!(load_memento_feedback_counts(&state).await, Some((3, 3)));
+
+        // ON CONFLICT(turn_id) DO UPDATE replaces turn-2 in place (no dup row).
+        record_memento_feedback_turn_stats(Some(&pool), &stat("turn-2", 5, 4, 1))
+            .await
+            .expect("upsert turn-2");
+
+        // automatic = 0 + 1, voluntary = 1 + 5.
+        assert_eq!(load_memento_feedback_counts(&state).await, Some((1, 6)));
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+}

--- a/src/services/discord/turn_bridge/completion_postlude.rs
+++ b/src/services/discord/turn_bridge/completion_postlude.rs
@@ -371,12 +371,10 @@ pub(super) async fn run_completion_postlude(
     } else {
         None
     };
-    let mut voluntary_feedback_reminder_injected = false;
     if let Some(analysis) = recall_feedback_analysis.as_ref()
         && let Some(reminder) = build_voluntary_feedback_reminder(analysis)
     {
         push_transcript_event(&mut transcript_events, reminder_transcript_event(reminder));
-        voluntary_feedback_reminder_injected = true;
         recall_feedback_analysis = Some(analyze_recall_feedback_turn(&transcript_events));
     }
     let model_token_usage = TurnTokenUsage {
@@ -469,6 +467,40 @@ pub(super) async fn run_completion_postlude(
         }
     }
 
+    // #4307 PR-A: persist per-turn memento recall/feedback stats so the
+    // /api/stats reader (load_memento_feedback_counts) surfaces real
+    // compliance/coverage counts. Restores the writer a1492c05 dropped when it
+    // removed the SQLite twin without porting the PG path. auto_tool_feedback_count
+    // is always 0 now that the dead auto-submit fallback is gone.
+    if shared_owned.pg_pool.is_some()
+        && let Some(analysis) = recall_feedback_analysis.as_ref()
+        && analysis.recall_count > 0
+    {
+        let stat = crate::db::session_transcripts::MementoFeedbackTurnStat {
+            turn_id: turn_id.clone(),
+            stat_date: chrono::Local::now().format("%Y-%m-%d").to_string(),
+            agent_id: memory_role_id.clone(),
+            provider: provider.as_str().to_string(),
+            recall_count: i64::try_from(analysis.recall_count).unwrap_or(i64::MAX),
+            manual_tool_feedback_count: i64::try_from(analysis.manual_feedback_count)
+                .unwrap_or(i64::MAX),
+            manual_covered_recall_count: i64::try_from(analysis.manual_covered_recall_count)
+                .unwrap_or(i64::MAX),
+            auto_tool_feedback_count: 0,
+            covered_recall_count: i64::try_from(analysis.manual_covered_recall_count)
+                .unwrap_or(i64::MAX),
+        };
+        if let Err(error) = crate::db::session_transcripts::record_memento_feedback_turn_stats(
+            shared_owned.pg_pool.as_ref(),
+            &stat,
+        )
+        .await
+        {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!("  [{ts}] ⚠ failed to persist memento feedback stats: {error}");
+        }
+    }
+
     if shared_owned.pg_pool.is_some() && !api_friction_reports.is_empty() {
         match crate::services::api_friction::record_api_friction_reports(
             shared_owned.pg_pool.as_ref(),
@@ -520,40 +552,6 @@ pub(super) async fn run_completion_postlude(
             model_token_usage,
             turn_duration_ms(turn_start),
         );
-    }
-
-    if let Some(analysis) = recall_feedback_analysis.as_ref()
-        && should_submit_automatic_feedback_fallback(analysis, voluntary_feedback_reminder_injected)
-    {
-        let submit_result = match tokio::time::timeout(
-            std::time::Duration::from_secs(20),
-            submit_pending_feedbacks(
-                &capture_memory_settings,
-                session_id_to_persist.as_deref(),
-                analysis.pending_feedbacks.clone(),
-            ),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
-                    "  [{ts}] [memory] submit_pending_feedbacks timed out after 20s for channel {}",
-                    channel_id.get(),
-                );
-                Default::default()
-            }
-        };
-        let _submitted_count = submit_result.submitted_count;
-        accumulated_memory_input_tokens =
-            accumulated_memory_input_tokens.saturating_add(submit_result.token_usage.input_tokens);
-        accumulated_memory_output_tokens = accumulated_memory_output_tokens
-            .saturating_add(submit_result.token_usage.output_tokens);
-        for error in submit_result.errors {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::warn!("  [{ts}] ⚠ failed to auto-submit recall tool_feedback: {error}");
-        }
     }
 
     let mut background_memory_tasks = Vec::new();

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -192,7 +192,6 @@ pub(in crate::services::discord) use memory_lifecycle::{
 };
 use recall_feedback::{
     analyze_recall_feedback_turn, build_voluntary_feedback_reminder, reminder_transcript_event,
-    should_submit_automatic_feedback_fallback, submit_pending_feedbacks,
     transcript_contains_explicit_memento_tool_call,
 };
 use retry_state::{

--- a/src/services/discord/turn_bridge/recall_feedback.rs
+++ b/src/services/discord/turn_bridge/recall_feedback.rs
@@ -1,37 +1,12 @@
 use std::collections::VecDeque;
-use std::time::Duration;
 
 use serde_json::Value;
 
 use crate::db::session_transcripts::{SessionTranscriptEvent, SessionTranscriptEventKind};
-use crate::services::discord::settings::ResolvedMemorySettings;
-use crate::services::memory::{MementoBackend, MementoToolFeedbackRequest, TokenUsage};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PendingRecallFeedback {
-    pub session_id: Option<String>,
     pub search_event_id: Option<String>,
-    pub fragment_ids: Vec<String>,
-    pub relevant: bool,
-    pub sufficient: bool,
-}
-
-impl PendingRecallFeedback {
-    fn into_request(self, session_id_fallback: Option<&str>) -> MementoToolFeedbackRequest {
-        MementoToolFeedbackRequest {
-            tool_name: "recall".to_string(),
-            relevant: self.relevant,
-            sufficient: self.sufficient,
-            session_id: self
-                .session_id
-                .or_else(|| normalized_opt(session_id_fallback)),
-            search_event_id: self.search_event_id,
-            fragment_ids: self.fragment_ids,
-            suggestion: None,
-            context: None,
-            trigger_type: Some("sampled".to_string()),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -72,20 +47,6 @@ pub(super) fn build_voluntary_feedback_reminder(
     ))
 }
 
-pub(super) fn should_submit_automatic_feedback_fallback(
-    analysis: &RecallFeedbackTurnAnalysis,
-    voluntary_reminder_injected: bool,
-) -> bool {
-    !voluntary_reminder_injected && !analysis.pending_feedbacks.is_empty()
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(super) struct RecallFeedbackAutoSubmitResult {
-    pub submitted_count: usize,
-    pub token_usage: TokenUsage,
-    pub errors: Vec<String>,
-}
-
 #[derive(Debug, Clone)]
 struct PendingToolCall {
     name: String,
@@ -109,7 +70,6 @@ struct CompletedMementoToolCall {
 #[derive(Debug, Clone)]
 struct RecallObservation {
     completed_at: usize,
-    session_id: Option<String>,
     search_event_id: Option<String>,
     fragment_ids: Vec<String>,
 }
@@ -155,12 +115,8 @@ pub(super) fn analyze_recall_feedback_turn(
         .iter()
         .enumerate()
         .filter(|(index, _)| !matched_recalls[*index])
-        .map(|(index, recall)| PendingRecallFeedback {
-            session_id: recall.session_id.clone(),
+        .map(|(_, recall)| PendingRecallFeedback {
             search_event_id: recall.search_event_id.clone(),
-            fragment_ids: recall.fragment_ids.clone(),
-            relevant: recall_is_relevant(events, recall),
-            sufficient: index + 1 == recalls.len(),
         })
         .collect::<Vec<_>>();
 
@@ -173,40 +129,6 @@ pub(super) fn analyze_recall_feedback_turn(
             .count(),
         pending_feedbacks,
     }
-}
-
-pub(super) async fn submit_pending_feedbacks(
-    settings: &ResolvedMemorySettings,
-    session_id: Option<&str>,
-    pending_feedbacks: Vec<PendingRecallFeedback>,
-) -> RecallFeedbackAutoSubmitResult {
-    if pending_feedbacks.is_empty() {
-        return RecallFeedbackAutoSubmitResult::default();
-    }
-
-    let backend = MementoBackend::new(settings.clone());
-    let mut result = RecallFeedbackAutoSubmitResult::default();
-
-    for pending_feedback in pending_feedbacks {
-        match tokio::time::timeout(
-            Duration::from_millis(settings.capture_timeout_ms),
-            backend.tool_feedback(pending_feedback.into_request(session_id)),
-        )
-        .await
-        {
-            Ok(Ok(token_usage)) => {
-                result.submitted_count += 1;
-                result.token_usage.saturating_add_assign(token_usage);
-            }
-            Ok(Err(error)) => result.errors.push(error),
-            Err(_) => result.errors.push(format!(
-                "memento tool_feedback timed out after {}ms",
-                settings.capture_timeout_ms
-            )),
-        }
-    }
-
-    result
 }
 
 pub(super) fn transcript_contains_explicit_memento_tool_call(
@@ -270,11 +192,9 @@ fn completed_memento_tool_calls(
 }
 
 fn parse_recall_observation(call: &CompletedMementoToolCall) -> RecallObservation {
-    let input = serde_json::from_str::<Value>(&call.input).unwrap_or(Value::Null);
     let payload = serde_json::from_str::<Value>(&call.output).unwrap_or(Value::Null);
     RecallObservation {
         completed_at: call.completed_at,
-        session_id: string_field(&input, &["session_id", "sessionId"]),
         search_event_id: string_field(
             &payload,
             &["_searchEventId", "searchEventId", "search_event_id"],
@@ -366,22 +286,6 @@ fn find_latest_prior_unmatched_recall(
         .map(|(index, _)| index)
 }
 
-fn recall_is_relevant(events: &[SessionTranscriptEvent], recall: &RecallObservation) -> bool {
-    if recall.fragment_ids.is_empty() {
-        return false;
-    }
-
-    events.iter().skip(recall.completed_at + 1).any(|event| {
-        matches!(
-            event.kind,
-            SessionTranscriptEventKind::Assistant | SessionTranscriptEventKind::Result
-        ) && recall
-            .fragment_ids
-            .iter()
-            .any(|fragment_id| event.content.contains(fragment_id))
-    })
-}
-
 fn canonical_memento_tool_kind(name: &str) -> Option<MementoToolKind> {
     let normalized = name.trim().to_ascii_lowercase();
     match normalized.as_str() {
@@ -455,13 +359,6 @@ fn string_array_field(payload: &Value, keys: &[&str]) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn normalized_opt(value: Option<&str>) -> Option<String> {
-    value
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
-}
-
 pub(super) fn reminder_transcript_event(content: String) -> SessionTranscriptEvent {
     SessionTranscriptEvent {
         kind: SessionTranscriptEventKind::System,
@@ -474,20 +371,112 @@ pub(super) fn reminder_transcript_event(content: String) -> SessionTranscriptEve
 }
 
 #[cfg(test)]
-mod trigger_type_tests {
+mod recall_feedback_reminder_tests {
     use super::*;
 
-    #[test]
-    fn automatic_fallback_request_uses_sampled_trigger_type() {
-        let request = PendingRecallFeedback {
-            session_id: None,
-            search_event_id: Some("search-1".to_string()),
-            fragment_ids: vec!["frag-1".to_string()],
-            relevant: true,
-            sufficient: true,
+    fn tool_event(
+        kind: SessionTranscriptEventKind,
+        tool_name: &str,
+        content: &str,
+    ) -> SessionTranscriptEvent {
+        SessionTranscriptEvent {
+            kind,
+            tool_name: Some(tool_name.to_string()),
+            summary: None,
+            content: content.to_string(),
+            status: None,
+            is_error: false,
         }
-        .into_request(Some("session-1"));
+    }
 
-        assert_eq!(request.trigger_type.as_deref(), Some("sampled"));
+    fn recall_pair(search_event_id: &str) -> Vec<SessionTranscriptEvent> {
+        vec![
+            tool_event(SessionTranscriptEventKind::ToolUse, "recall", "{}"),
+            tool_event(
+                SessionTranscriptEventKind::ToolResult,
+                "recall",
+                &format!("{{\"_searchEventId\":\"{search_event_id}\"}}"),
+            ),
+        ]
+    }
+
+    fn tool_feedback_pair(search_event_id: &str) -> Vec<SessionTranscriptEvent> {
+        vec![
+            tool_event(
+                SessionTranscriptEventKind::ToolUse,
+                "tool_feedback",
+                &format!("{{\"tool_name\":\"recall\",\"search_event_id\":\"{search_event_id}\"}}"),
+            ),
+            tool_event(
+                SessionTranscriptEventKind::ToolResult,
+                "tool_feedback",
+                "{}",
+            ),
+        ]
+    }
+
+    // Truth table core: whenever there is at least one recall AND at least one
+    // uncovered recall (pending_feedbacks non-empty), a voluntary reminder is
+    // required — and therefore always injected. This is exactly why the removed
+    // auto-submit fallback (`!reminder_injected && !pending.is_empty()`) was
+    // unreachable: its second conjunct implies the first is false. #4307 PR-A.
+    #[test]
+    fn pending_feedback_presence_drives_reminder_truth_table() {
+        let with_pending = RecallFeedbackTurnAnalysis {
+            recall_count: 2,
+            manual_feedback_count: 1,
+            manual_covered_recall_count: 1,
+            pending_feedbacks: vec![PendingRecallFeedback {
+                search_event_id: Some("evt-1".to_string()),
+            }],
+        };
+        assert!(with_pending.needs_voluntary_feedback_reminder());
+        assert!(build_voluntary_feedback_reminder(&with_pending).is_some());
+
+        let all_covered = RecallFeedbackTurnAnalysis {
+            recall_count: 2,
+            manual_feedback_count: 2,
+            manual_covered_recall_count: 2,
+            pending_feedbacks: Vec::new(),
+        };
+        assert!(!all_covered.needs_voluntary_feedback_reminder());
+        assert!(build_voluntary_feedback_reminder(&all_covered).is_none());
+
+        let no_recall = RecallFeedbackTurnAnalysis::default();
+        assert!(!no_recall.needs_voluntary_feedback_reminder());
+        assert!(build_voluntary_feedback_reminder(&no_recall).is_none());
+    }
+
+    #[test]
+    fn uncovered_recall_yields_pending_and_requires_reminder() {
+        let events = recall_pair("evt-1");
+        let analysis = analyze_recall_feedback_turn(&events);
+
+        assert_eq!(analysis.recall_count, 1);
+        assert_eq!(analysis.manual_feedback_count, 0);
+        assert_eq!(analysis.manual_covered_recall_count, 0);
+        assert_eq!(analysis.pending_feedbacks.len(), 1);
+        assert_eq!(
+            analysis.pending_feedbacks[0].search_event_id.as_deref(),
+            Some("evt-1")
+        );
+        assert!(analysis.needs_voluntary_feedback_reminder());
+
+        let reminder = build_voluntary_feedback_reminder(&analysis).expect("reminder");
+        assert!(reminder.contains("evt-1"));
+    }
+
+    #[test]
+    fn covered_recall_leaves_no_pending_and_no_reminder() {
+        let mut events = recall_pair("evt-1");
+        events.extend(tool_feedback_pair("evt-1"));
+        let analysis = analyze_recall_feedback_turn(&events);
+
+        assert_eq!(analysis.recall_count, 1);
+        assert_eq!(analysis.manual_feedback_count, 1);
+        assert_eq!(analysis.manual_covered_recall_count, 1);
+        assert!(analysis.pending_feedbacks.is_empty());
+        assert!(!analysis.needs_voluntary_feedback_reminder());
+        assert!(build_voluntary_feedback_reminder(&analysis).is_none());
     }
 }


### PR DESCRIPTION
## #4307 PR-A (결함 2+3 — #4326 무충돌 파트)

### 데드패스 제거 (진리표 증명 기반)
pending 비어있지 않음 ⟹ reminder 주입 ⟹ fallback 영구 false → submit_pending_feedbacks 도달 불가. 해당 블록 + 제출 전용 잔재(into_request, recall_is_relevant false-편향 휴리스틱 등) 제거, net -103 prod줄. RecallFeedbackTurnAnalysis/reminder 생성은 PR-B용 보존. 진리표 테스트로 고정.

### 지표 writer 복원 (a1492c05 SQLite 제거 때 PG 포팅 누락)
record_memento_feedback_turn_stats — session_transcripts.rs (persist_turn_pg 패턴 미러, ON CONFLICT(turn_id) DO UPDATE). PG 왕복 테스트: empty→(0,0), writer→reader (3,3), upsert (1,6) — 격리 agentdesk_pg_* DB 실측.

### 범위 노트
- 결함 1(다음턴 주입)은 PR-B로 분리 (#4326 랜딩 후 → 이제 언블록, 착수)
- turn_bridge/mod.rs는 불가피한 unused-import 1줄 trim만 (+freeze 1231 동기)

게이트: fmt ✅ check ✅ 테스트 8/8(PG 포함) ✅ freshness ✅ ratchet allow 신규 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)