### PR TITLE
ux(cli): #4223 — 연결 실패 시 doctor/API_URL 힌트 + json 모드 stderr 에러 출력

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -48,7 +48,7 @@
 
 | Path | Prod |
 | --- | ---: |
-| `src/cli/client.rs` | 2404 |
+| `src/cli/client.rs` | 2410 |
 | `src/cli/dcserver.rs` | 1633 |
 | `src/cli/direct.rs` | 1812 |
 | `src/cli/doctor/orchestrator.rs` | 4381 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -48,7 +48,7 @@
 
 | Path | Prod |
 | --- | ---: |
-| `src/cli/client.rs` | 2378 |
+| `src/cli/client.rs` | 2404 |
 | `src/cli/dcserver.rs` | 1633 |
 | `src/cli/direct.rs` | 1812 |
 | `src/cli/doctor/orchestrator.rs` | 4381 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 21 | 21 | 0 |  |
 | `cli::args` | `src/cli/args.rs` | 1037 | 969 | 68 |  |
-| `cli::client` | `src/cli/client.rs` | 2563 | 2378 | 185 | giant-file |
+| `cli::client` | `src/cli/client.rs` | 2627 | 2404 | 223 | giant-file |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1633 | 1633 | 0 | giant-file |
 | `cli::direct` | `src/cli/direct.rs` | 1812 | 1812 | 0 | giant-file |
 | `cli::discord` | `src/cli/discord.rs` | 123 | 123 | 0 |  |
@@ -71,10 +71,10 @@
 | `cli::migrate::apply` | `src/cli/migrate/apply.rs` | 3237 | 3237 | 0 | giant-file |
 | `cli::migrate::plan` | `src/cli/migrate/plan.rs` | 1513 | 1513 | 0 | giant-file |
 | `cli::migrate::source` | `src/cli/migrate/source.rs` | 1612 | 1612 | 0 | giant-file |
-| `cli::monitoring` | `src/cli/monitoring.rs` | 123 | 123 | 0 |  |
+| `cli::monitoring` | `src/cli/monitoring.rs` | 124 | 124 | 0 |  |
 | `cli::provider_cli` | `src/cli/provider_cli/mod.rs` | 1039 | 1039 | 0 | giant-file |
 | `cli::query` | `src/cli/query.rs` | 462 | 379 | 83 |  |
-| `cli::run` | `src/cli/run.rs` | 663 | 663 | 0 |  |
+| `cli::run` | `src/cli/run.rs` | 700 | 678 | 22 |  |
 | `cli::utils` | `src/cli/utils.rs` | 581 | 473 | 108 |  |
 | `compat` | `src/compat/mod.rs` | 39 | 39 | 0 |  |
 | `compat::legacy_db_paths` | `src/compat/legacy_db_paths.rs` | 12 | 12 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 21 | 21 | 0 |  |
 | `cli::args` | `src/cli/args.rs` | 1037 | 969 | 68 |  |
-| `cli::client` | `src/cli/client.rs` | 2627 | 2404 | 223 | giant-file |
+| `cli::client` | `src/cli/client.rs` | 2653 | 2410 | 243 | giant-file |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1633 | 1633 | 0 | giant-file |
 | `cli::direct` | `src/cli/direct.rs` | 1812 | 1812 | 0 | giant-file |
 | `cli::discord` | `src/cli/discord.rs` | 123 | 123 | 0 |  |
@@ -71,7 +71,7 @@
 | `cli::migrate::apply` | `src/cli/migrate/apply.rs` | 3237 | 3237 | 0 | giant-file |
 | `cli::migrate::plan` | `src/cli/migrate/plan.rs` | 1513 | 1513 | 0 | giant-file |
 | `cli::migrate::source` | `src/cli/migrate/source.rs` | 1612 | 1612 | 0 | giant-file |
-| `cli::monitoring` | `src/cli/monitoring.rs` | 124 | 124 | 0 |  |
+| `cli::monitoring` | `src/cli/monitoring.rs` | 127 | 127 | 0 |  |
 | `cli::provider_cli` | `src/cli/provider_cli/mod.rs` | 1039 | 1039 | 0 | giant-file |
 | `cli::query` | `src/cli/query.rs` | 462 | 379 | 83 |  |
 | `cli::run` | `src/cli/run.rs` | 700 | 678 | 22 |  |

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -99,6 +99,7 @@ fn request_json(method: &str, path: &str, body: Option<&str>) -> Result<Value, S
             return Err(connection_error_hint(
                 &format!("Request failed: {err}"),
                 &api_base(),
+                "AGENTDESK_API_URL",
             ));
         }
     };
@@ -122,10 +123,15 @@ fn status_error_message(code: u16, body: &str) -> String {
 /// HTTP status response means the server *did* answer, so it stays hint-free.
 /// The tone is advisory ("may not be running"), never a flat assertion that
 /// the server is down.
-pub(crate) fn connection_error_hint(raw: &str, effective_url: &str) -> String {
+///
+/// `env_hint` names the environment variable(s) the *caller's* `api_base()`
+/// actually honors — client.rs resolves `AGENTDESK_API_URL` only, while
+/// monitoring.rs prefers `ADK_API_URL` over `AGENTDESK_API_URL` — so the hint
+/// never steers the operator toward a variable that path would ignore.
+pub(crate) fn connection_error_hint(raw: &str, effective_url: &str, env_hint: &str) -> String {
     format!(
         "{raw}\n  힌트: dcserver가 실행 중이 아닐 수 있습니다 — `agentdesk doctor`로 진단하고, \
-         접속 URL(현재: {effective_url})이 맞는지 AGENTDESK_API_URL 환경변수를 확인하세요."
+         접속 URL(현재: {effective_url})이 맞는지 {env_hint} 환경변수를 확인하세요."
     )
 }
 
@@ -135,9 +141,11 @@ mod connection_hint_tests {
 
     #[test]
     fn transport_error_gets_connection_hint() {
+        // client.rs path — api_base() honors AGENTDESK_API_URL only.
         let msg = connection_error_hint(
             "Request failed: Network Error: Connection refused (os error 61)",
             "http://127.0.0.1:8791",
+            "AGENTDESK_API_URL",
         );
         // Raw error is preserved verbatim …
         assert!(msg.contains("Connection refused"));
@@ -146,6 +154,24 @@ mod connection_hint_tests {
         assert!(msg.contains("AGENTDESK_API_URL"));
         assert!(msg.contains("http://127.0.0.1:8791"));
         // Advisory, not a flat "server is down" assertion.
+        assert!(msg.contains("아닐 수 있습니다"));
+        // The client path must not mention ADK_API_URL — its api_base()
+        // never reads it.
+        assert!(!msg.contains("ADK_API_URL(우선)"));
+    }
+
+    #[test]
+    fn monitoring_env_hint_mentions_both_vars_in_priority_order() {
+        // monitoring.rs path — its api_base() prefers ADK_API_URL over
+        // AGENTDESK_API_URL, and the hint must say so.
+        let msg = connection_error_hint(
+            "monitoring API request failed: Connection refused",
+            "http://127.0.0.1:8791",
+            "ADK_API_URL(우선) 또는 AGENTDESK_API_URL",
+        );
+        assert!(msg.contains("agentdesk doctor"));
+        assert!(msg.contains("ADK_API_URL(우선) 또는 AGENTDESK_API_URL"));
+        assert!(msg.contains("http://127.0.0.1:8791"));
         assert!(msg.contains("아닐 수 있습니다"));
     }
 

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -93,15 +93,79 @@ fn request_json(method: &str, path: &str, body: Option<&str>) -> Result<Value, S
         Ok(resp) => resp,
         Err(ureq::Error::Status(code, resp)) => {
             let body = resp.into_string().unwrap_or_default();
-            let detail = parse_error_message(&body)
-                .map(|msg| format!("Request failed ({code}): {msg}"))
-                .unwrap_or_else(|| format!("Request failed ({code})"));
-            return Err(detail);
+            return Err(status_error_message(code, &body));
         }
-        Err(ureq::Error::Transport(err)) => return Err(format!("Request failed: {err}")),
+        Err(ureq::Error::Transport(err)) => {
+            return Err(connection_error_hint(
+                &format!("Request failed: {err}"),
+                &api_base(),
+            ));
+        }
     };
 
     resp.into_json().map_err(|e| format!("Parse error: {e}"))
+}
+
+/// Assemble the error message for an HTTP *status* failure — the server
+/// answered with a non-2xx code. Deliberately hint-free: the server is
+/// reachable, so a "dcserver not running" hint would only mislead.
+fn status_error_message(code: u16, body: &str) -> String {
+    parse_error_message(body)
+        .map(|msg| format!("Request failed ({code}): {msg}"))
+        .unwrap_or_else(|| format!("Request failed ({code})"))
+}
+
+/// Append an advisory connection hint to a raw transport-error message.
+///
+/// Pure + `pub(crate)` so `monitoring.rs` reuses the exact same wording and
+/// both can be unit-tested. Only the ureq `Transport` branch calls this — an
+/// HTTP status response means the server *did* answer, so it stays hint-free.
+/// The tone is advisory ("may not be running"), never a flat assertion that
+/// the server is down.
+pub(crate) fn connection_error_hint(raw: &str, effective_url: &str) -> String {
+    format!(
+        "{raw}\n  힌트: dcserver가 실행 중이 아닐 수 있습니다 — `agentdesk doctor`로 진단하고, \
+         접속 URL(현재: {effective_url})이 맞는지 AGENTDESK_API_URL 환경변수를 확인하세요."
+    )
+}
+
+#[cfg(test)]
+mod connection_hint_tests {
+    use super::*;
+
+    #[test]
+    fn transport_error_gets_connection_hint() {
+        let msg = connection_error_hint(
+            "Request failed: Network Error: Connection refused (os error 61)",
+            "http://127.0.0.1:8791",
+        );
+        // Raw error is preserved verbatim …
+        assert!(msg.contains("Connection refused"));
+        // … then the advisory hint is appended.
+        assert!(msg.contains("agentdesk doctor"));
+        assert!(msg.contains("AGENTDESK_API_URL"));
+        assert!(msg.contains("http://127.0.0.1:8791"));
+        // Advisory, not a flat "server is down" assertion.
+        assert!(msg.contains("아닐 수 있습니다"));
+    }
+
+    #[test]
+    fn status_error_keeps_server_detail_without_hint() {
+        let msg = status_error_message(404, r#"{"error":"card not found"}"#);
+        assert!(msg.contains("404"));
+        assert!(msg.contains("card not found"));
+        // Server answered — no connection hint.
+        assert!(!msg.contains("agentdesk doctor"));
+        assert!(!msg.contains("AGENTDESK_API_URL"));
+    }
+
+    #[test]
+    fn status_error_without_body_is_hint_free() {
+        let msg = status_error_message(500, "");
+        assert!(msg.contains("500"));
+        assert!(!msg.contains("agentdesk doctor"));
+        assert!(!msg.contains("AGENTDESK_API_URL"));
+    }
 }
 
 pub(crate) fn get_json(path: &str) -> Result<Value, String> {

--- a/src/cli/monitoring.rs
+++ b/src/cli/monitoring.rs
@@ -78,6 +78,9 @@ fn request_json(method: &str, path: &str, body: Option<Value>) -> Result<Value, 
         Err(ureq::Error::Transport(error)) => Err(super::client::connection_error_hint(
             &format!("monitoring API request failed: {error}"),
             &api_base(),
+            // This module's api_base() prefers ADK_API_URL over
+            // AGENTDESK_API_URL — the hint must match that order.
+            "ADK_API_URL(우선) 또는 AGENTDESK_API_URL",
         )),
     }
 }

--- a/src/cli/monitoring.rs
+++ b/src/cli/monitoring.rs
@@ -75,9 +75,10 @@ fn request_json(method: &str, path: &str, body: Option<Value>) -> Result<Value, 
             };
             Err(format_monitoring_error(code, &body))
         }
-        Err(ureq::Error::Transport(error)) => {
-            Err(format!("monitoring API request failed: {error}"))
-        }
+        Err(ureq::Error::Transport(error)) => Err(super::client::connection_error_hint(
+            &format!("monitoring API request failed: {error}"),
+            &api_base(),
+        )),
     }
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -32,8 +32,22 @@ fn exit_for_cli(result: std::result::Result<(), String>) -> Result<()> {
 fn exit_for_json_cli(result: std::result::Result<(), String>) -> Result<()> {
     match result {
         Ok(()) => Ok(()),
-        Err(_) => std::process::exit(1),
+        Err(error) => {
+            // stdout stays pure so piped JSON consumers see clean output; the
+            // failure is reported as one line of error JSON on stderr instead.
+            eprintln!("{}", json_cli_error_line(&error));
+            std::process::exit(1);
+        }
     }
+}
+
+/// Build the single-line `{"error":"…"}` string emitted to stderr when a
+/// JSON-mode CLI command fails. Pure (the caller then does `process::exit`,
+/// which is not directly testable) and serde-serialized so quotes/newlines in
+/// the message — e.g. the multi-line connection hint — are escaped into one
+/// physical line.
+fn json_cli_error_line(message: &str) -> String {
+    serde_json::json!({ "error": message }).to_string()
 }
 
 pub(crate) fn execute(command: Commands) -> Result<()> {
@@ -659,5 +673,28 @@ fn build_restart_report_context(
                 current_msg_id,
             }))
         }
+    }
+}
+
+#[cfg(test)]
+mod exit_json_tests {
+    use super::*;
+
+    #[test]
+    fn json_cli_error_line_is_single_line_json() {
+        assert_eq!(json_cli_error_line("boom"), r#"{"error":"boom"}"#);
+    }
+
+    #[test]
+    fn json_cli_error_line_escapes_newlines_and_quotes() {
+        let raw = "Request failed: refused\n  힌트: \"x\"";
+        let line = json_cli_error_line(raw);
+        // Embedded newline is escaped — the payload stays one physical line.
+        assert_eq!(line.lines().count(), 1);
+        assert!(line.contains("\\n"));
+        assert!(line.contains("\\\""));
+        // Round-trips back to the original message.
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["error"], raw);
     }
 }


### PR DESCRIPTION
## #4223

1. **연결 실패 힌트**: `request_json` 전송오류 분기 한 곳에 `connection_error_hint(raw, effective_url)` — 전 커맨드 공통 효과. 안내형 문구(doctor 진단 + AGENTDESK_API_URL 확인, 현재 유효 URL 인라인). HTTP status 오류엔 힌트 없음. monitoring.rs 동일 헬퍼 재사용.
2. **JSON 모드 무언 종료 수정**: `exit_for_json_cli` 실패 시 stderr에 `{"error":"..."}` 한 줄 후 exit(1). stdout 순수성 유지, 텍스트 모드 불변.

테스트 5종 신규 (힌트 부착/미부착, JSON 이스케이프). 게이트: fmt ✅ check ✅ cli 테스트 67/67 ✅ freshness ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)