### PR TITLE
fix(memory): #4330 — PostToolUse 훅 search_event_id 지시를 searchEventId 실재 시로 조건화

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -367,13 +367,13 @@
 | `services::claude_tui` | `src/services/claude_tui/mod.rs` | 14 | 14 | 0 |  |
 | `services::claude_tui::hook_bundle` | `src/services/claude_tui/hook_bundle.rs` | 1223 | 733 | 490 |  |
 | `services::claude_tui::hook_registry` | `src/services/claude_tui/hook_registry.rs` | 1333 | 718 | 615 |  |
-| `services::claude_tui::hook_relay` | `src/services/claude_tui/hook_relay.rs` | 852 | 481 | 371 |  |
+| `services::claude_tui::hook_relay` | `src/services/claude_tui/hook_relay.rs` | 899 | 482 | 417 |  |
 | `services::claude_tui::hook_server` | `src/services/claude_tui/hook_server.rs` | 1161 | 532 | 629 |  |
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
 | `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3358 | 1932 | 1426 | giant-file |
-| `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 576 | 446 | 130 |  |
+| `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 626 | 460 | 166 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 431 | 180 | 251 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
 | `services::claude_tui::transcript_tail` | `src/services/claude_tui/transcript_tail.rs` | 600 | 299 | 301 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -367,13 +367,13 @@
 | `services::claude_tui` | `src/services/claude_tui/mod.rs` | 14 | 14 | 0 |  |
 | `services::claude_tui::hook_bundle` | `src/services/claude_tui/hook_bundle.rs` | 1223 | 733 | 490 |  |
 | `services::claude_tui::hook_registry` | `src/services/claude_tui/hook_registry.rs` | 1333 | 718 | 615 |  |
-| `services::claude_tui::hook_relay` | `src/services/claude_tui/hook_relay.rs` | 899 | 482 | 417 |  |
+| `services::claude_tui::hook_relay` | `src/services/claude_tui/hook_relay.rs` | 944 | 483 | 461 |  |
 | `services::claude_tui::hook_server` | `src/services/claude_tui/hook_server.rs` | 1161 | 532 | 629 |  |
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
 | `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3358 | 1932 | 1426 | giant-file |
-| `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 626 | 460 | 166 |  |
+| `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 845 | 553 | 292 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 431 | 180 | 251 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
 | `services::claude_tui::transcript_tail` | `src/services/claude_tui/transcript_tail.rs` | 600 | 299 | 301 |  |

--- a/src/services/claude_tui/hook_relay.rs
+++ b/src/services/claude_tui/hook_relay.rs
@@ -248,8 +248,9 @@ fn memento_search_tool_name(payload: &Value) -> Option<String> {
 /// recall result may be nested inside a stringified MCP text block, so a
 /// structural lookup is unreliable. Scan the serialized `tool_response` (then
 /// the whole payload) for the first integer following the `searchEventId`
-/// marker. Returns `None` when absent — the nudge still fires, just without an
-/// explicit id (the model has the id in its own recall result).
+/// marker. Returns `None` when absent — the nudge still fires, but (per #4330)
+/// without any `search_event_id` ask, since that line is conditional on the
+/// response actually carrying `_meta.searchEventId`.
 fn extract_search_event_id(payload: &Value) -> Option<String> {
     memento_feedback::extract_search_event_id(payload)
 }
@@ -599,18 +600,64 @@ mod tests {
     }
 
     #[test]
-    fn claude_posttooluse_memento_context_injects_even_without_extractable_id() {
-        // tool is a memento search but the payload carries no searchEventId:
-        // still nudge, deferring the id to the model's own recall result.
+    fn claude_posttooluse_memento_context_without_id_omits_search_event_id() {
+        // #4330: tool is a memento search but the payload carries no
+        // searchEventId -> still nudge, but the reminder must NOT fabricate a
+        // search_event_id / `_meta.searchEventId` ask. Only the required
+        // tool_name/relevant/sufficient contract fields remain.
         let payload = serde_json::json!({ "tool_name": "mcp__memento__context" });
         let out = hook_stdout("claude", "PostToolUse", &payload);
         let value: Value = serde_json::from_str(&out).unwrap();
         let ctx = value["hookSpecificOutput"]["additionalContext"]
             .as_str()
             .unwrap();
-        assert!(ctx.contains("_meta.searchEventId"));
         assert!(ctx.contains("mcp__memento__tool_feedback"));
-        assert!(!ctx.contains("search_event_id="));
+        assert!(ctx.contains("tool_name"));
+        assert!(ctx.contains("relevant"));
+        assert!(ctx.contains("sufficient"));
+        assert!(!ctx.contains("search_event_id"));
+        assert!(!ctx.contains("searchEventId"));
+    }
+
+    #[test]
+    fn claude_posttooluse_memento_context_injects_feedback_nudge_with_id() {
+        // #4330: context also returns `_meta.searchEventId`; when present it is
+        // inlined into the reminder just like recall.
+        let payload = serde_json::json!({
+            "tool_name": "mcp__memento__context",
+            "tool_response": [{
+                "type": "text",
+                "text": "{\"fragments\":[],\"_meta\":{\"searchEventId\":\"5150\"}}"
+            }]
+        });
+        let out = hook_stdout("claude", "PostToolUse", &payload);
+        let value: Value = serde_json::from_str(&out).unwrap();
+        let ctx = value["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap();
+        assert!(ctx.contains("search_event_id=5150"));
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(ctx.contains("tool_name"));
+        assert_eq!(value["suppressOutput"], true);
+    }
+
+    #[test]
+    fn claude_posttooluse_memento_recall_without_id_omits_search_event_id() {
+        // #4330: recall normally carries the id, but the hook payload may not
+        // surface it. Without an extractable id the reminder drops the
+        // search_event_id ask and keeps only the required contract fields.
+        let payload = serde_json::json!({ "tool_name": "mcp__memento__recall" });
+        let out = hook_stdout("claude", "PostToolUse", &payload);
+        let value: Value = serde_json::from_str(&out).unwrap();
+        let ctx = value["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap();
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(ctx.contains("tool_name"));
+        assert!(ctx.contains("relevant"));
+        assert!(ctx.contains("sufficient"));
+        assert!(!ctx.contains("search_event_id"));
+        assert!(!ctx.contains("searchEventId"));
     }
 
     #[test]

--- a/src/services/claude_tui/hook_relay.rs
+++ b/src/services/claude_tui/hook_relay.rs
@@ -242,15 +242,16 @@ fn memento_search_tool_name(payload: &Value) -> Option<String> {
     memento_feedback::memento_search_tool_name(payload)
 }
 
-/// Best-effort extraction of `searchEventId` from the PostToolUse payload.
+/// Trusted-path extraction of `searchEventId` from the PostToolUse payload.
 ///
-/// memento returns it under `_meta.searchEventId`, but in the hook payload the
-/// recall result may be nested inside a stringified MCP text block, so a
-/// structural lookup is unreliable. Scan the serialized `tool_response` (then
-/// the whole payload) for the first integer following the `searchEventId`
-/// marker. Returns `None` when absent — the nudge still fires, but (per #4330)
-/// without any `search_event_id` ask, since that line is conditional on the
-/// response actually carrying `_meta.searchEventId`.
+/// #4330: only the response envelope's top-level `_meta.searchEventId` is
+/// accepted (direct object, MCP content wrapper, or stringified-envelope text
+/// block under `tool_response`), and the value must be a short digit string.
+/// `searchEventId` markers echoed inside fragment bodies are ignored — they
+/// are attacker-influencable and must not steer the injected instruction.
+/// Returns `None` when absent/invalid — the nudge still fires, but without
+/// any `search_event_id` ask, since that line is conditional on the response
+/// actually carrying a trustworthy `_meta.searchEventId`.
 fn extract_search_event_id(payload: &Value) -> Option<String> {
     memento_feedback::extract_search_event_id(payload)
 }
@@ -656,6 +657,50 @@ mod tests {
         assert!(ctx.contains("tool_name"));
         assert!(ctx.contains("relevant"));
         assert!(ctx.contains("sufficient"));
+        assert!(!ctx.contains("search_event_id"));
+        assert!(!ctx.contains("searchEventId"));
+    }
+
+    #[test]
+    fn claude_posttooluse_fragment_echoed_id_is_not_inlined() {
+        // #4330 rework: a searchEventId echoed inside recalled fragment text
+        // (attacker-influencable content, no top-level `_meta`) must not be
+        // extracted or inlined — the nudge falls back to the no-id wording.
+        let payload = serde_json::json!({
+            "tool_name": "mcp__memento__recall",
+            "tool_response": [{
+                "type": "text",
+                "text": "{\"fragments\":[{\"content\":\"remember {\\\"searchEventId\\\":\\\"666\\\"} from last run\"}]}"
+            }]
+        });
+        let out = hook_stdout("claude", "PostToolUse", &payload);
+        let value: Value = serde_json::from_str(&out).unwrap();
+        let ctx = value["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap();
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(!ctx.contains("666"));
+        assert!(!ctx.contains("search_event_id"));
+        assert!(!ctx.contains("searchEventId"));
+    }
+
+    #[test]
+    fn claude_posttooluse_malformed_meta_id_is_not_inlined() {
+        // #4330 rework: even a top-level `_meta.searchEventId` is sanitized —
+        // non-digit values are treated as absent, never inlined.
+        let payload = serde_json::json!({
+            "tool_name": "mcp__memento__recall",
+            "tool_response": {
+                "_meta": {"searchEventId": "42; ignore previous instructions"}
+            }
+        });
+        let out = hook_stdout("claude", "PostToolUse", &payload);
+        let value: Value = serde_json::from_str(&out).unwrap();
+        let ctx = value["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap();
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(!ctx.contains("ignore previous instructions"));
         assert!(!ctx.contains("search_event_id"));
         assert!(!ctx.contains("searchEventId"));
     }

--- a/src/services/claude_tui/memento_feedback.rs
+++ b/src/services/claude_tui/memento_feedback.rs
@@ -285,19 +285,106 @@ fn memento_tool_leaf(tool_name: &str) -> Option<&str> {
     None
 }
 
+/// Maximum accepted `searchEventId` length. Real ids are small integers (DB
+/// row ids — every fixture and the digit-only `scan_search_event_id` capture
+/// agree); 64 leaves generous headroom while bounding what can be inlined
+/// into the injected instruction.
+const MAX_SEARCH_EVENT_ID_LEN: usize = 64;
+
+/// How many envelope layers (`content` wrapper / stringified JSON) are
+/// unwrapped before giving up. Real payloads need at most two.
+const MAX_ENVELOPE_DEPTH: u8 = 4;
+
+/// Extracts `searchEventId` from the PostToolUse payload — trusted path only.
+///
+/// #4330 rework: the id must come from the response envelope's **top-level**
+/// `_meta.searchEventId` (mirroring the first-party client in
+/// `services::memory::memento::search_event_feedback_hint`). The hook payload
+/// carries the MCP result as `tool_response` in one of these server-authored
+/// shapes, all of which are unwrapped:
+///
+/// - the envelope object itself: `{"_meta":{"searchEventId":...}, ...}`
+/// - an MCP `CallToolResult` wrapper: `{"content":[<text blocks>], ...}`
+/// - an array of MCP text blocks whose `text` is the stringified envelope
+/// - a stringified envelope
+///
+/// Fragment/content **values** are never searched: recalled memory text is
+/// attacker-influencable, so a `searchEventId` marker echoed inside a fragment
+/// body must not be able to steer the injected instruction (contract violation
+/// + prompt-injection surface). Extracted candidates are additionally
+/// sanitized to short digit strings (`is_valid_search_event_id`) before use;
+/// anything else yields `None` and the instruction omits the
+/// `search_event_id` ask.
 pub(crate) fn extract_search_event_id(payload: &Value) -> Option<String> {
-    for hay in [payload.get("tool_response"), Some(payload)]
-        .into_iter()
-        .flatten()
-    {
-        if let Some(id) = search_event_id_from_value(hay) {
-            return Some(id);
-        }
-        if let Some(id) = scan_search_event_id(&hay.to_string()) {
+    for key in ["tool_response", "toolResponse"] {
+        if let Some(id) = payload
+            .get(key)
+            .and_then(|response| envelope_search_event_id(response, 0))
+        {
             return Some(id);
         }
     }
     None
+}
+
+fn envelope_search_event_id(response: &Value, depth: u8) -> Option<String> {
+    if depth > MAX_ENVELOPE_DEPTH {
+        return None;
+    }
+    match response {
+        Value::Object(map) => {
+            if let Some(id) = meta_search_event_id(map) {
+                return Some(id);
+            }
+            // MCP CallToolResult wrapper: the envelope JSON lives inside the
+            // `content` text blocks. This is the only key descended into —
+            // notably NOT `fragments` or other result data.
+            map.get("content")
+                .and_then(|content| envelope_search_event_id(content, depth + 1))
+        }
+        Value::Array(blocks) => blocks.iter().find_map(|block| {
+            block
+                .get("text")
+                .and_then(Value::as_str)
+                .and_then(|text| serde_json::from_str::<Value>(text).ok())
+                .and_then(|parsed| envelope_search_event_id(&parsed, depth + 1))
+        }),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|parsed| envelope_search_event_id(&parsed, depth + 1)),
+        _ => None,
+    }
+}
+
+/// Reads `searchEventId` from an envelope object's **top-level** `_meta`
+/// only, applying `is_valid_search_event_id` to the candidate value.
+fn meta_search_event_id(map: &serde_json::Map<String, Value>) -> Option<String> {
+    let meta = map.get("_meta").and_then(Value::as_object)?;
+    for key in [
+        "searchEventId",
+        "search_event_id",
+        "_searchEventId",
+        "searchEventID",
+    ] {
+        if let Some(id) = meta
+            .get(key)
+            .and_then(string_or_integer)
+            .map(|candidate| candidate.trim().to_string())
+            .filter(|candidate| is_valid_search_event_id(candidate))
+        {
+            return Some(id);
+        }
+    }
+    None
+}
+
+/// A trustworthy memento `searchEventId` is a short ASCII-digit string (see
+/// `MAX_SEARCH_EVENT_ID_LEN`). Anything else is rejected so it can never be
+/// inlined into a model-visible instruction.
+fn is_valid_search_event_id(candidate: &str) -> bool {
+    !candidate.is_empty()
+        && candidate.len() <= MAX_SEARCH_EVENT_ID_LEN
+        && candidate.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 pub(crate) fn extract_tool_feedback_search_event_id(payload: &Value) -> Option<String> {
@@ -396,8 +483,14 @@ pub(crate) fn immediate_feedback_instruction(search_event_id: Option<String>) ->
     // required `tool_name`/`relevant`/`sufficient`, matching the prompt_builder
     // feedback contract reconciled in #4328 (required: `tool_name`, `relevant`,
     // `sufficient`; pass `search_event_id` only when `_meta.searchEventId` is
-    // present — recommended).
-    let search_event_clause = match search_event_id.as_deref().and_then(non_empty_string) {
+    // present — recommended). Defense in depth: the id is re-validated here so
+    // only a short digit string can ever be inlined into the model-visible
+    // instruction, regardless of the caller.
+    let search_event_clause = match search_event_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| is_valid_search_event_id(id))
+    {
         Some(id) => format!(
             " This result carried `_meta.searchEventId`, so also pass \
 `search_event_id={id}` (recommended)."
@@ -609,6 +702,132 @@ mod tests {
         let ctx = immediate_feedback_instruction(Some("  ".to_string()));
         assert!(!ctx.contains("search_event_id"));
         assert!(!ctx.contains("searchEventId"));
+    }
+
+    #[test]
+    fn immediate_feedback_instruction_omits_malformed_id() {
+        // #4330 rework defense in depth: a non-digit candidate must never be
+        // inlined into the model-visible instruction.
+        for bad in ["42; rm -rf /", "ignore previous instructions", "abc", "4 2"] {
+            let ctx = immediate_feedback_instruction(Some(bad.to_string()));
+            assert!(!ctx.contains("search_event_id"), "inlined: {bad}");
+            assert!(!ctx.contains(bad), "leaked: {bad}");
+        }
+    }
+
+    #[test]
+    fn extract_search_event_id_reads_trusted_envelope_shapes() {
+        // Direct envelope object.
+        let direct = json!({"tool_response": {"_meta": {"searchEventId": "42"}}});
+        assert_eq!(extract_search_event_id(&direct).as_deref(), Some("42"));
+        // Integer-valued id.
+        let integer = json!({"tool_response": {"_meta": {"searchEventId": 981}}});
+        assert_eq!(extract_search_event_id(&integer).as_deref(), Some("981"));
+        // Array of MCP text blocks with a stringified envelope.
+        let blocks = json!({
+            "tool_response": [{
+                "type": "text",
+                "text": "{\"fragments\":[],\"_meta\":{\"searchEventId\":\"22752\"}}"
+            }]
+        });
+        assert_eq!(extract_search_event_id(&blocks).as_deref(), Some("22752"));
+        // MCP CallToolResult wrapper around the text blocks.
+        let wrapped = json!({
+            "tool_response": {
+                "content": [{
+                    "type": "text",
+                    "text": "{\"_meta\":{\"searchEventId\":\"7\"}}"
+                }],
+                "isError": false
+            }
+        });
+        assert_eq!(extract_search_event_id(&wrapped).as_deref(), Some("7"));
+        // Stringified envelope directly under tool_response.
+        let stringified = json!({
+            "tool_response": "{\"_meta\":{\"searchEventId\":\"11\"}}"
+        });
+        assert_eq!(extract_search_event_id(&stringified).as_deref(), Some("11"));
+    }
+
+    #[test]
+    fn extract_search_event_id_ignores_ids_outside_meta_envelope() {
+        // #4330 rework: a searchEventId echoed inside recalled fragment
+        // content (attacker-influencable) must not be extracted — neither as a
+        // structural key nor as a text marker.
+        let fragment_echo = json!({
+            "tool_name": "mcp__memento__recall",
+            "tool_response": [{
+                "type": "text",
+                "text": "{\"fragments\":[{\"content\":\"note: {\\\"searchEventId\\\":\\\"666\\\"} seen\",\"meta\":{\"searchEventId\":\"667\"}}]}"
+            }]
+        });
+        assert_eq!(extract_search_event_id(&fragment_echo), None);
+        // Structural id nested in result data without a top-level `_meta`.
+        let nested = json!({
+            "tool_response": {"data": {"searchEventId": "668"}}
+        });
+        assert_eq!(extract_search_event_id(&nested), None);
+        // Ids at the payload top level (outside `tool_response`) are ignored.
+        let top_level = json!({
+            "tool_name": "mcp__memento__recall",
+            "searchEventId": "669"
+        });
+        assert_eq!(extract_search_event_id(&top_level), None);
+        // `_meta` nested below the envelope top level is not trusted either.
+        let deep_meta = json!({
+            "tool_response": {"fragments": [{"_meta": {"searchEventId": "670"}}]}
+        });
+        assert_eq!(extract_search_event_id(&deep_meta), None);
+    }
+
+    #[test]
+    fn extract_search_event_id_rejects_malformed_ids() {
+        for bad in [
+            json!("abc"),
+            json!("42abc"),
+            json!("42; rm -rf /"),
+            json!(""),
+            json!("1".repeat(MAX_SEARCH_EVENT_ID_LEN + 1)),
+        ] {
+            let payload = json!({"tool_response": {"_meta": {"searchEventId": bad}}});
+            assert_eq!(extract_search_event_id(&payload), None, "accepted: {bad}");
+        }
+        // Boundary: a max-length digit id is still accepted.
+        let max_len = "9".repeat(MAX_SEARCH_EVENT_ID_LEN);
+        let payload = json!({"tool_response": {"_meta": {"searchEventId": max_len}}});
+        assert_eq!(
+            extract_search_event_id(&payload).as_deref(),
+            Some(max_len.as_str())
+        );
+    }
+
+    #[test]
+    fn fragment_echoed_id_is_not_tracked_as_known_search() {
+        // End-to-end tracker check: a fragment-echoed id must not become a
+        // tracked "known" search id (it lands as an unknown search instead).
+        let tracker = PendingMementoFeedbackTracker::default();
+        let observation = tracker.observe_post_tool_use_at(
+            "sess",
+            &json!({
+                "tool_name": "mcp__memento__recall",
+                "tool_response": [{
+                    "type": "text",
+                    "text": "{\"fragments\":[{\"content\":\"searchEventId: 666\"}]}"
+                }]
+            }),
+            Utc::now(),
+        );
+        assert_eq!(
+            observation,
+            MementoPostToolUseObservation::SearchTracked {
+                search_event_id: None
+            }
+        );
+        let flush = tracker
+            .take_stop_flush_at("sess", &json!({}), Utc::now())
+            .unwrap();
+        assert!(flush.search_event_ids.is_empty());
+        assert!(flush.includes_unknown_searches);
     }
 
     #[test]

--- a/src/services/claude_tui/memento_feedback.rs
+++ b/src/services/claude_tui/memento_feedback.rs
@@ -387,17 +387,31 @@ fn scan_search_event_id_marker(serialized: &str, marker: &str) -> Option<String>
 }
 
 pub(crate) fn immediate_feedback_instruction(search_event_id: Option<String>) -> String {
-    let target = match search_event_id {
-        Some(id) => format!("search_event_id={id}"),
-        None => "the search_event_id shown under `_meta.searchEventId` in that result".to_string(),
+    // #4330: the `search_event_id` ask is conditional on the tool response
+    // actually carrying `_meta.searchEventId`. `recall`/`context` normally
+    // return it, but the hook payload may not surface it (nested/stringified MCP
+    // text), and the fixed defect injected a "submit the searchEventId shown
+    // under `_meta.searchEventId`" line even when the result had none. When we
+    // do have the id we inline it; otherwise the reminder only asks for the
+    // required `tool_name`/`relevant`/`sufficient`, matching the prompt_builder
+    // feedback contract reconciled in #4328 (required: `tool_name`, `relevant`,
+    // `sufficient`; pass `search_event_id` only when `_meta.searchEventId` is
+    // present — recommended).
+    let search_event_clause = match search_event_id.as_deref().and_then(non_empty_string) {
+        Some(id) => format!(
+            " This result carried `_meta.searchEventId`, so also pass \
+`search_event_id={id}` (recommended)."
+        ),
+        None => String::new(),
     };
     format!(
         "Action required: you just received a memento search result. Submit one \
-`mcp__memento__tool_feedback` call immediately for THIS result with \
-{target}, `relevant` = whether any returned fragment was on-topic, and `sufficient` = whether the \
-results were enough to proceed. If `mcp__memento__tool_feedback` is not in your active tools \
-(memento tools are deferred), first load it with ToolSearch query \
-`select:mcp__memento__tool_feedback`, then make the call. Do this now, then continue."
+`mcp__memento__tool_feedback` call immediately for THIS result with the required `tool_name` (the \
+memento search tool you just called), `relevant` = whether any returned fragment was on-topic, and \
+`sufficient` = whether the results were enough to proceed.{search_event_clause} If \
+`mcp__memento__tool_feedback` is not in your active tools (memento tools are deferred), first load \
+it with ToolSearch query `select:mcp__memento__tool_feedback`, then make the call. Do this now, \
+then continue."
     )
 }
 
@@ -559,6 +573,42 @@ mod tests {
                 .take_stop_flush_at("sess", &json!({}), Utc::now())
                 .is_none()
         );
+    }
+
+    #[test]
+    fn immediate_feedback_instruction_inlines_id_when_present() {
+        // #4330: with an extractable searchEventId, the reminder keeps the full
+        // contract (tool_name/relevant/sufficient) and recommends the id inline.
+        let ctx = immediate_feedback_instruction(Some("22752".to_string()));
+        assert!(ctx.contains("search_event_id=22752"));
+        assert!(ctx.contains("_meta.searchEventId"));
+        assert!(ctx.contains("tool_name"));
+        assert!(ctx.contains("relevant"));
+        assert!(ctx.contains("sufficient"));
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(ctx.contains("immediately"));
+    }
+
+    #[test]
+    fn immediate_feedback_instruction_omits_id_when_absent() {
+        // #4330: no searchEventId in the result -> the reminder must not fabricate
+        // a search_event_id ask; only tool_name/relevant/sufficient are required.
+        let ctx = immediate_feedback_instruction(None);
+        assert!(!ctx.contains("search_event_id"));
+        assert!(!ctx.contains("searchEventId"));
+        assert!(ctx.contains("tool_name"));
+        assert!(ctx.contains("relevant"));
+        assert!(ctx.contains("sufficient"));
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(ctx.contains("immediately"));
+    }
+
+    #[test]
+    fn immediate_feedback_instruction_treats_empty_id_as_absent() {
+        // An empty/whitespace id string must fall back to the no-id wording.
+        let ctx = immediate_feedback_instruction(Some("  ".to_string()));
+        assert!(!ctx.contains("search_event_id"));
+        assert!(!ctx.contains("searchEventId"));
     }
 
     #[test]


### PR DESCRIPTION
## #4330

훅 리마인더(`immediate_feedback_instruction`, memento_feedback.rs:389)를 조건부로:
- `_meta.searchEventId` 실재: 실제 ID 값을 지시문에 인라인 (`search_event_id={id}` recommended)
- 부재/빈문자열: search_event_id 언급 자체 제거 — required(tool_name/relevant/sufficient)만 요구
- 보너스 교정: 기존 문구에 required `tool_name`이 누락돼 있던 것 추가

#4328 prompt_builder 정적 계약과 동일 규약. 잘못된 동작을 고정하던 기존 테스트 1건 교정 + 신규 5건 (recall/context × ID 유/무 4분면 커버).

게이트: fmt ✅ check ✅ 테스트 32/32 ✅ freshness ✅ allow 신규 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)