### PR TITLE
obs(logging): #4218 — 로그 키 channel_id/session_key 통일 + drift 게이트 (#2871 잔여)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,7 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-07-08 (against #4229 S3 streaming-status-tick extraction — freeze counts re-synced to the regenerated module inventory).
+> Last refreshed: 2026-07-08 (against #4218 log field-key unification — tmux watcher path touched by tracing key rename only, `channel =` -> `channel_id =`; line counts and freeze entries unchanged).
 >
 > PR #3456 dcserver-robustness: freeze counts re-synced after the reconcile
 > row-allocation churn reduction (`src/reconcile.rs` now 1816 prod lines) and the

--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -528,3 +528,5 @@ changing runtime behavior.
 > Last refreshed: 2026-07-05 (#4130 — delivery_record.rs gains a cfg(test)-only shadow_test_seam override; no production callsite/coverage change.)
 
 > Last refreshed: 2026-07-06 (#4115 r5 — classify_transport_failure's permanent-failure WARN routes the error text through strip_watcher_send_failure_class_marker so structured class markers stay out of operator logs; log hygiene only, no delivery verb / API / callsite coverage change.)
+
+> Last refreshed: 2026-07-08 (#4218 — tracing log field key rename only across outbound (`channel =` -> `channel_id =` / shorthand); no delivery verb / API / callsite coverage change.)

--- a/scripts/check_log_key_drift.py
+++ b/scripts/check_log_key_drift.py
@@ -19,10 +19,12 @@ Detection (on string/comment-stripped code):
   positions a tracing-macro field key can occupy, which covers both the rustfmt
   multi-line form and single-line calls like
   `tracing::info!(channel = id, "msg");` — AND the value is either a sigil
-  capture (`%expr` / `?expr`, tracing-only syntax) or terminated by a `,` at
-  bracket-depth 0 before any depth-0 `;` on the line (the tracing field
-  separator). `let` bindings (`let channel = …`) fail the preceder rule;
-  reassignment statements (`session_id = None;`) fail the terminator rule.
+  capture (`%expr` / `?expr`, tracing-only syntax) or terminated at
+  bracket-depth 0, before any depth-0 `;`, by a `,` (field separator) or an
+  unmatched `)` / `]` / `}` (enclosing call closing after a trailing-comma-less
+  LAST field, e.g. `tracing::info!(channel = id);`). `let` bindings
+  (`let channel = …`) fail the preceder rule; reassignment statements
+  (`session_id = None;`) fail the terminator rule.
 
 String/comment handling: a lightweight cross-line scanner blanks out string
 literals (normal strings with escapes, `b"…"`, and `r"…"` / `r#"…"#` raw
@@ -178,13 +180,16 @@ def _field_violation(code: str, match: re.Match[str]) -> str | None:
     This excludes `let <key> = …`, `x.<key> = …`, `=> <key> = …`, etc.
 
     Terminator rule: sigil values (`%`/`?`) are tracing-only syntax and count
-    immediately; otherwise the value must be closed by a `,` at bracket-depth 0
-    before any depth-0 `;` (fields separate with `,`; statements end with `;`).
-    Hitting an unmatched closer (`)`, `]`, `}`) first means the enclosing call
-    ended without a field separator — a trailing macro arg or plain expression,
-    not something this guard can distinguish from a statement, so it is skipped
-    (rustfmt puts a `,` after every real field, including the last one before
-    the message literal).
+    immediately; otherwise the value must be closed — at bracket-depth 0,
+    before any depth-0 `;` — by either a `,` (field separator) or an unmatched
+    closer `)` / `]` / `}` (the enclosing macro/`fields(…)` list ending right
+    after the LAST field, which single-line calls like
+    `tracing::info!(channel = id);` write without a trailing comma; codex r2).
+    Treating the closer as a terminator is safe because the preceder rule has
+    already pinned the key to a call-argument position, and plain Rust has no
+    named arguments — `(key = value)` outside a macro would be an
+    assignment-expression-in-parens, which real code does not write.
+    Statements end with `;` and stay excluded.
     """
     before = code[: match.start()].rstrip()
     if before and before[-1] not in "(,":
@@ -193,16 +198,29 @@ def _field_violation(code: str, match: re.Match[str]) -> str | None:
     rest = match.group("rest")
     stripped = rest.lstrip()
     if stripped.startswith("%") or stripped.startswith("?"):
-        end = stripped.find(",")
-        return (stripped[:end] if end != -1 else stripped).strip()
+        value = _terminated_value(rest)
+        # Sigil syntax is tracing-only: still a violation even if no same-line
+        # terminator is found (e.g. a multi-line sigil value).
+        return value if value is not None else stripped
+    return _terminated_value(rest)
 
+
+def _terminated_value(rest: str) -> str | None:
+    """Return the value slice if `rest` closes like a tracing field on this line.
+
+    Scans with bracket-depth tracking: a depth-0 `,` (field separator) or a
+    depth-0 unmatched closer (`)`, `]`, `}` — the enclosing call ending after
+    the last field) terminates the value; a depth-0 `;` means a statement.
+    Matched pairs inside the value (`Some(x)`, `pair[1]`, `id.get()`) pass
+    through: their closers drop the depth back without hitting -1.
+    """
     depth = 0
     for pos, ch in enumerate(rest):
         if ch in "([{":
             depth += 1
         elif ch in ")]}":
             if depth == 0:
-                return None  # enclosing call closed without a field separator
+                return rest[:pos].strip()  # enclosing call closed: last field
             depth -= 1
         elif depth == 0 and ch == ";":
             return None  # plain (re)assignment statement

--- a/scripts/check_log_key_drift.py
+++ b/scripts/check_log_key_drift.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Log field-key drift guard for `src/services/discord/` (#4218).
+
+Tracing log FIELD keys had drifted across the Discord relay: channel identifiers
+were logged under `channel = …`, `chan = …`, and `discord_channel_id = …`, and a
+handful of session identifiers under `session_id = …`, instead of the canonical
+`channel_id = …` / `session_key = …` used by the majority of the relay path.
+#4218 unified them. This guard blocks the drift from creeping back: it scans the
+Discord service tree for the forbidden log-field keys and fails (non-zero exit,
+`file:line` output) if any reappear.
+
+The scope is deliberately narrow — ONLY tracing-macro FIELD keys are policed,
+never struct fields, DB columns, SQL text, format-string interpolations
+(`"… channel={} …"`), `let` bindings, or plain reassignments. Detection matches
+the two shapes a tracing field key actually takes:
+
+  * canonical rustfmt multi-line form — ``<key> = <value>,`` on its own line, and
+  * the sigil form — ``<key> = %expr`` / ``<key> = ?expr`` (Display / Debug),
+
+both of which are unambiguous tracing syntax. Statements (`;`-terminated),
+`let`/`x.field` bindings, and string-literal interpolations do not match either.
+
+`session_id` carries a small, documented allowlist: a few log sites record a
+genuinely different identifier than the relay's `adk_session_key` — the Discord
+voice-gateway session (songbird `DriverConnect`/`DriverReconnect`) and the raw
+provider-CLI hook session (`HookEvent.session_id`). Renaming those to
+`session_key` would mislabel the value, so they are exempt by
+`(path-suffix, value-expression)` signature rather than by line number (which
+drifts). New `session_id` log fields anywhere else in the Discord tree fail.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCAN_ROOT = Path("src/services/discord")
+
+# Canonical replacements, surfaced in the failure message.
+CHANNEL_KEYS = ("channel", "chan", "discord_channel_id")
+SESSION_KEY = "session_id"
+
+# Multi-line tracing field form: `<key> = <value>,` on its own line.
+#   - `^\s*<key>` anchors the key at line start → excludes `let <key> =`,
+#     `x.<key> =`, and `"… <key>=…"` string interpolations.
+#   - `[^=]` after `=` excludes the `==` comparison operator.
+#   - trailing `,` is the tracing field separator → excludes `;`-terminated
+#     statements (e.g. `session_id = None;`) and struct-init `:` fields.
+_KEY_ALT = "|".join(re.escape(k) for k in (*CHANNEL_KEYS, SESSION_KEY))
+MULTILINE_FIELD = re.compile(rf"^\s*(?P<key>{_KEY_ALT})\s*=\s*(?P<val>[^=].*),\s*$")
+
+# Sigil form: `<key> = %expr` / `<key> = ?expr` — Display/Debug capture. `\b`
+# keeps `channel` from matching inside `channel_id`. `= %` / `= ?` is tracing-only
+# syntax (a bare `%`/`?` cannot open a normal Rust r-value expression).
+SIGIL_FIELD = re.compile(rf"\b(?P<key>{_KEY_ALT})\s*=\s*(?P<val>[%?]\S.*?)\s*,?\s*$")
+
+# `session_id` sites that log a genuinely different identifier than the relay
+# `adk_session_key`. Exempt by (path suffix, value expression after `=`).
+SESSION_ID_ALLOWLIST: set[tuple[str, str]] = {
+    # Discord voice-gateway session id (songbird DriverConnect / DriverReconnect
+    # event payload) — the voice WebSocket session, not an agent session.
+    ("services/discord/voice_lifecycle.rs", "data.session_id"),
+    # Raw provider-CLI hook session id (HookEvent.session_id) observed off the
+    # UserPromptSubmit hook — the provider's own session, not adk_session_key.
+    ("services/discord/tui_prompt_relay.rs", "%event.session_id"),
+}
+
+
+def _canonical_hint(key: str) -> str:
+    if key in CHANNEL_KEYS:
+        return "channel_id"
+    return "session_key"
+
+
+def scan(repo_root: Path) -> list[tuple[str, int, str, str]]:
+    """Return (relpath, lineno, key, source-line) for every forbidden log field."""
+    violations: list[tuple[str, int, str, str]] = []
+    root = repo_root / SCAN_ROOT
+    for path in sorted(root.rglob("*.rs")):
+        rel = path.relative_to(repo_root)
+        if "target" in rel.parts:
+            continue
+        rel_str = rel.as_posix()
+        for lineno, raw in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if raw.lstrip().startswith("//"):
+                continue
+            # Drop trailing line comments so prose can mention old keys freely.
+            code = raw.split("//", 1)[0]
+
+            match = MULTILINE_FIELD.match(code) or SIGIL_FIELD.search(code)
+            if not match:
+                continue
+            key = match.group("key")
+            value = match.group("val").strip().rstrip(",").strip()
+
+            if key == SESSION_KEY:
+                if any(
+                    rel_str.endswith(suffix) and value == allowed_val
+                    for suffix, allowed_val in SESSION_ID_ALLOWLIST
+                ):
+                    continue
+            violations.append((rel_str, lineno, key, raw.strip()))
+    return violations
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    violations = scan(repo_root)
+
+    if violations:
+        print(
+            f"FAIL: {len(violations)} forbidden log field key(s) in "
+            f"{SCAN_ROOT}/ (#4218 drift).",
+            file=sys.stderr,
+        )
+        print(
+            "      Tracing log field keys must be canonical: "
+            "channel/chan/discord_channel_id -> channel_id, session_id -> "
+            "session_key (relay session). Struct fields, DB columns, SQL text, "
+            "format strings, and `let` bindings are NOT policed — only tracing "
+            "field keys are.",
+            file=sys.stderr,
+        )
+        for rel, lineno, key, src in violations:
+            print(
+                f"        {rel}:{lineno}: `{key} =` -> `{_canonical_hint(key)} =`"
+                f"    {src}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"OK: no forbidden log field keys in {SCAN_ROOT}/ (#4218).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_log_key_drift.py
+++ b/scripts/check_log_key_drift.py
@@ -11,14 +11,32 @@ Discord service tree for the forbidden log-field keys and fails (non-zero exit,
 
 The scope is deliberately narrow — ONLY tracing-macro FIELD keys are policed,
 never struct fields, DB columns, SQL text, format-string interpolations
-(`"… channel={} …"`), `let` bindings, or plain reassignments. Detection matches
-the two shapes a tracing field key actually takes:
+(`"… channel={} …"`), `let` bindings, or plain reassignments.
 
-  * canonical rustfmt multi-line form — ``<key> = <value>,`` on its own line, and
-  * the sigil form — ``<key> = %expr`` / ``<key> = ?expr`` (Display / Debug),
+Detection (on string/comment-stripped code):
+  A forbidden key counts as a tracing field when `<key> = <value>` appears with
+  the key preceded (ignoring whitespace) by start-of-line, `(`, or `,` — the
+  positions a tracing-macro field key can occupy, which covers both the rustfmt
+  multi-line form and single-line calls like
+  `tracing::info!(channel = id, "msg");` — AND the value is either a sigil
+  capture (`%expr` / `?expr`, tracing-only syntax) or terminated by a `,` at
+  bracket-depth 0 before any depth-0 `;` on the line (the tracing field
+  separator). `let` bindings (`let channel = …`) fail the preceder rule;
+  reassignment statements (`session_id = None;`) fail the terminator rule.
 
-both of which are unambiguous tracing syntax. Statements (`;`-terminated),
-`let`/`x.field` bindings, and string-literal interpolations do not match either.
+String/comment handling: a lightweight cross-line scanner blanks out string
+literals (normal strings with escapes, `b"…"`, and `r"…"` / `r#"…"#` raw
+strings — all of which may span lines), char literals (so `'"'` cannot desync
+quote tracking), `//` line comments, and nested `/* … */` block comments
+before matching. This kills false positives from prose such as
+`"… channel = foo, …"` inside log messages, SQL text, or doc examples.
+
+Known limits (accepted; this is a grep-grade guard, not a Rust parser): a
+field whose VALUE expression spans lines with the terminating `,` on a later
+line is not detected, and macro-generated code is out of scope. rustfmt
+(enforced by fmt-check in CI) keeps real field lines in the shapes covered
+above. Covered and excluded shapes are pinned by `tests/test_log_key_drift.py`
+(run in CI next to this guard).
 
 `session_id` carries a small, documented allowlist: a few log sites record a
 genuinely different identifier than the relay's `adk_session_key` — the Discord
@@ -41,19 +59,18 @@ SCAN_ROOT = Path("src/services/discord")
 CHANNEL_KEYS = ("channel", "chan", "discord_channel_id")
 SESSION_KEY = "session_id"
 
-# Multi-line tracing field form: `<key> = <value>,` on its own line.
-#   - `^\s*<key>` anchors the key at line start → excludes `let <key> =`,
-#     `x.<key> =`, and `"… <key>=…"` string interpolations.
-#   - `[^=]` after `=` excludes the `==` comparison operator.
-#   - trailing `,` is the tracing field separator → excludes `;`-terminated
-#     statements (e.g. `session_id = None;`) and struct-init `:` fields.
 _KEY_ALT = "|".join(re.escape(k) for k in (*CHANNEL_KEYS, SESSION_KEY))
-MULTILINE_FIELD = re.compile(rf"^\s*(?P<key>{_KEY_ALT})\s*=\s*(?P<val>[^=].*),\s*$")
+# `<key> = <not-=>` anywhere in stripped code (`[^=]` rejects `==`). The
+# position/termination rules live in `_field_violation` — this regex alone is
+# deliberately loose.
+KEY_ASSIGN = re.compile(rf"\b(?P<key>{_KEY_ALT})\s*=\s*(?P<rest>[^=].*)$")
 
-# Sigil form: `<key> = %expr` / `<key> = ?expr` — Display/Debug capture. `\b`
-# keeps `channel` from matching inside `channel_id`. `= %` / `= ?` is tracing-only
-# syntax (a bare `%`/`?` cannot open a normal Rust r-value expression).
-SIGIL_FIELD = re.compile(rf"\b(?P<key>{_KEY_ALT})\s*=\s*(?P<val>[%?]\S.*?)\s*,?\s*$")
+# Char literal (so `'"'` / `'\"'` cannot desync the quote scanner). Lifetimes
+# (`'a`) do not match and fall through harmlessly.
+_CHAR_LITERAL = re.compile(r"'(\\.|[^'\\])'")
+
+# Raw / byte string openers: r"…", r#"…"#, br"…", b"…" is handled separately.
+_RAW_STRING_OPEN = re.compile(r'(?:r|br)(#*)"')
 
 # `session_id` sites that log a genuinely different identifier than the relay
 # `adk_session_key`. Exempt by (path suffix, value expression after `=`).
@@ -65,6 +82,133 @@ SESSION_ID_ALLOWLIST: set[tuple[str, str]] = {
     # UserPromptSubmit hook — the provider's own session, not adk_session_key.
     ("services/discord/tui_prompt_relay.rs", "%event.session_id"),
 }
+
+
+class StripState:
+    """Cross-line lexer state: strings and block comments span lines."""
+
+    __slots__ = ("in_string", "raw_hashes", "block_depth")
+
+    def __init__(self) -> None:
+        self.in_string = False  # inside a normal "…" / b"…" string
+        self.raw_hashes: int | None = None  # inside r"…" / r#"…"# (hash count)
+        self.block_depth = 0  # nested /* … */ depth
+
+
+def strip_line(line: str, state: StripState) -> str:
+    """Blank out string-literal/comment content, preserving column positions.
+
+    Quote and comment delimiters themselves are blanked too — only real code
+    survives. `state` carries over between lines so multi-line strings
+    (including `\\`-newline continuations) and block comments stay stripped.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if state.block_depth > 0:
+            if line.startswith("/*", i):
+                state.block_depth += 1
+                out.append("  ")
+                i += 2
+            elif line.startswith("*/", i):
+                state.block_depth -= 1
+                out.append("  ")
+                i += 2
+            else:
+                out.append(" ")
+                i += 1
+            continue
+        if state.raw_hashes is not None:
+            closer = '"' + "#" * state.raw_hashes
+            if line.startswith(closer, i):
+                state.raw_hashes = None
+                out.append(" " * len(closer))
+                i += len(closer)
+            else:
+                out.append(" ")
+                i += 1
+            continue
+        if state.in_string:
+            if line[i] == "\\" and i + 1 < n:
+                out.append("  ")
+                i += 2
+            else:
+                if line[i] == '"':
+                    state.in_string = False
+                out.append(" ")
+                i += 1
+            continue
+        # --- normal code ---
+        if line.startswith("//", i):
+            break  # line comment: drop the rest of the line
+        if line.startswith("/*", i):
+            state.block_depth = 1
+            out.append("  ")
+            i += 2
+            continue
+        raw = _RAW_STRING_OPEN.match(line, i)
+        if raw:
+            state.raw_hashes = len(raw.group(1))
+            out.append(" " * (raw.end() - i))
+            i = raw.end()
+            continue
+        if line[i] == '"' or line.startswith('b"', i):
+            skip = 2 if line[i] == "b" else 1
+            state.in_string = True
+            out.append(" " * skip)
+            i += skip
+            continue
+        if line[i] == "'":
+            m = _CHAR_LITERAL.match(line, i)
+            if m:
+                out.append(" " * (m.end() - i))
+                i = m.end()
+                continue
+        out.append(line[i])
+        i += 1
+    return "".join(out)
+
+
+def _field_violation(code: str, match: re.Match[str]) -> str | None:
+    """Return the field's value expression if this match is a tracing field.
+
+    Preceder rule: the key must sit at line start or right after `(` / `,`
+    (ignoring whitespace) — the only places a tracing field key can appear.
+    This excludes `let <key> = …`, `x.<key> = …`, `=> <key> = …`, etc.
+
+    Terminator rule: sigil values (`%`/`?`) are tracing-only syntax and count
+    immediately; otherwise the value must be closed by a `,` at bracket-depth 0
+    before any depth-0 `;` (fields separate with `,`; statements end with `;`).
+    Hitting an unmatched closer (`)`, `]`, `}`) first means the enclosing call
+    ended without a field separator — a trailing macro arg or plain expression,
+    not something this guard can distinguish from a statement, so it is skipped
+    (rustfmt puts a `,` after every real field, including the last one before
+    the message literal).
+    """
+    before = code[: match.start()].rstrip()
+    if before and before[-1] not in "(,":
+        return None
+
+    rest = match.group("rest")
+    stripped = rest.lstrip()
+    if stripped.startswith("%") or stripped.startswith("?"):
+        end = stripped.find(",")
+        return (stripped[:end] if end != -1 else stripped).strip()
+
+    depth = 0
+    for pos, ch in enumerate(rest):
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            if depth == 0:
+                return None  # enclosing call closed without a field separator
+            depth -= 1
+        elif depth == 0 and ch == ";":
+            return None  # plain (re)assignment statement
+        elif depth == 0 and ch == ",":
+            return rest[:pos].strip()
+    return None  # no same-line terminator — statement or multi-line value
 
 
 def _canonical_hint(key: str) -> str:
@@ -82,27 +226,27 @@ def scan(repo_root: Path) -> list[tuple[str, int, str, str]]:
         if "target" in rel.parts:
             continue
         rel_str = rel.as_posix()
+        state = StripState()
         for lineno, raw in enumerate(
             path.read_text(encoding="utf-8").splitlines(), start=1
         ):
-            if raw.lstrip().startswith("//"):
-                continue
-            # Drop trailing line comments so prose can mention old keys freely.
-            code = raw.split("//", 1)[0]
-
-            match = MULTILINE_FIELD.match(code) or SIGIL_FIELD.search(code)
-            if not match:
-                continue
-            key = match.group("key")
-            value = match.group("val").strip().rstrip(",").strip()
-
-            if key == SESSION_KEY:
-                if any(
+            code = strip_line(raw, state)
+            search_from = 0
+            while True:
+                match = KEY_ASSIGN.search(code, search_from)
+                if not match:
+                    break
+                search_from = match.start() + 1
+                value = _field_violation(code, match)
+                if value is None:
+                    continue
+                key = match.group("key")
+                if key == SESSION_KEY and any(
                     rel_str.endswith(suffix) and value == allowed_val
                     for suffix, allowed_val in SESSION_ID_ALLOWLIST
                 ):
                     continue
-            violations.append((rel_str, lineno, key, raw.strip()))
+                violations.append((rel_str, lineno, key, raw.strip()))
     return violations
 
 

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -64,6 +64,9 @@ echo "=== await_holding_lock ratchet guard ==="
 echo "=== Hotfile LOC ratchet guard (#3565) ==="
 "$PYTHON" scripts/check_hotfile_ratchet.py
 
+echo "=== Discord log field-key drift guard (#4218) ==="
+"$PYTHON" scripts/check_log_key_drift.py
+
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -66,6 +66,7 @@ echo "=== Hotfile LOC ratchet guard (#3565) ==="
 
 echo "=== Discord log field-key drift guard (#4218) ==="
 "$PYTHON" scripts/check_log_key_drift.py
+"$PYTHON" -m unittest tests.test_log_key_drift
 
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh

--- a/src/services/discord/inflight/anchor_repost.rs
+++ b/src/services/discord/inflight/anchor_repost.rs
@@ -92,7 +92,7 @@ where
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 context,
                 error = %error,
                 "inflight anchor-repost row write failed; leaving on-disk row untouched"

--- a/src/services/discord/inflight/budget.rs
+++ b/src/services/discord/inflight/budget.rs
@@ -98,7 +98,7 @@ pub(in crate::services::discord) fn bump_recovery_relay_attempts_if_matches_iden
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "inflight relay-attempt bump failed; leaving on-disk row untouched"
             );

--- a/src/services/discord/inflight/clear_store/abandon.rs
+++ b/src/services/discord/inflight/clear_store/abandon.rs
@@ -61,7 +61,7 @@ fn enqueue_abandon_request_for_row(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 msg_id = state.current_msg_id,
                 error = %error,
                 "abandon-request enqueue failed; PRESERVING inflight row so the placeholder is not stranded (sweeper retries next pass)"
@@ -175,7 +175,7 @@ pub(in crate::services::discord::inflight) fn request_inflight_abandon_if_matche
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected_user_msg_id,
                 error = %error,
                 "inflight abandon-request remove_file failed; treating as IoError so sweeper retries"
@@ -243,7 +243,7 @@ pub(in crate::services::discord::inflight) fn request_inflight_abandon_if_matche
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "inflight zero-owned abandon-request remove_file failed; treating as IoError so sweeper retries"
             );

--- a/src/services/discord/inflight/clear_store/mod.rs
+++ b/src/services/discord/inflight/clear_store/mod.rs
@@ -296,7 +296,7 @@ pub(in crate::services::discord) fn clear_inflight_state_if_matches_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected_user_msg_id,
                 error = %error,
                 "inflight guarded-clear remove_file failed; treating as IoError so sweeper retries"
@@ -373,7 +373,7 @@ pub(in crate::services::discord) fn clear_inflight_state_if_matches_zero_owned_i
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "inflight zero-owned guarded-clear remove_file failed; treating as IoError so sweeper retries"
             );
@@ -448,7 +448,7 @@ pub(super) fn clear_inflight_state_if_matches_identity_turn_nonce_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "inflight identity-guarded clear remove_file failed; treating as IoError so sweeper retries"
@@ -504,7 +504,7 @@ pub(super) fn clear_inflight_state_if_matches_identity_generation_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 expected_finalizer_turn_id,
                 error = %error,
@@ -553,7 +553,7 @@ pub(super) fn clear_rebind_origin_inflight_state_if_matches_identity_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "rebind-origin inflight guarded-clear remove_file failed; treating as IoError so sweeper retries"
@@ -606,7 +606,7 @@ pub(super) fn clear_lifecycle_inflight_state_if_matches_identity_after_death_evi
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "lifecycle inflight guarded-clear after death evidence remove_file failed; treating as IoError so sweeper retries"
@@ -679,7 +679,7 @@ pub(super) fn clear_inflight_state_if_matches_identity_after_delivery_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "inflight delivery mirror failed before identity-guarded clear"
@@ -701,7 +701,7 @@ pub(super) fn clear_inflight_state_if_matches_identity_after_delivery_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "inflight identity-guarded delivery clear remove_file failed; treating as IoError so sweeper retries"
@@ -764,7 +764,7 @@ pub(super) fn clear_inflight_state_if_matches_tmux_response_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 tmux_session_name,
                 error = %error,
                 "inflight tmux-response guarded clear remove_file failed; treating as IoError so sweeper retries"

--- a/src/services/discord/inflight/rebind_reap.rs
+++ b/src/services/discord/inflight/rebind_reap.rs
@@ -564,7 +564,7 @@ pub(super) fn reap_abandoned_rebind_origin_locked_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = snapshot.channel_id,
+                channel_id = snapshot.channel_id,
                 error = %error,
                 "#3581 rebind reap remove_file failed under lock; treating as Missing"
             );
@@ -652,7 +652,7 @@ pub(super) fn reap_dead_watcher_rebind_origin_locked_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = snapshot.channel_id,
+                channel_id = snapshot.channel_id,
                 error = %error,
                 "#3635 dead-watcher rebind reap remove_file failed under lock; treating as Missing"
             );

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -30,7 +30,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     let Ok(data) = fs::read_to_string(&path) else {
         tracing::debug!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?InflightTurnIdentity::from_state(state),
             "inflight identity-refresh save skipped because durable row is missing"
@@ -40,7 +40,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     let Ok(on_disk) = serde_json::from_str::<InflightTurnState>(&data) else {
         tracing::debug!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?InflightTurnIdentity::from_state(state),
             "inflight identity-refresh save skipped because durable row is malformed"
@@ -52,7 +52,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     if state.user_msg_id == 0 && state.turn_start_offset.is_none() {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
@@ -65,7 +65,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     if on_disk.output_path != state.output_path {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
@@ -81,7 +81,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
@@ -102,7 +102,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     ) {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
@@ -120,7 +120,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 caller = caller,
                 snapshot_identity = ?expected,
                 error = %error,
@@ -176,7 +176,7 @@ pub(in crate::services::discord::inflight) fn patch_restart_full_response_if_ide
     if state.user_msg_id == 0 && state.turn_start_offset.is_none() {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
@@ -193,7 +193,7 @@ pub(in crate::services::discord::inflight) fn patch_restart_full_response_if_ide
     {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
@@ -215,7 +215,7 @@ pub(in crate::services::discord::inflight) fn patch_restart_full_response_if_ide
     {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             response_sent_offset = response_sent_offset,
             full_response_len = state.full_response.len(),
@@ -229,7 +229,7 @@ pub(in crate::services::discord::inflight) fn patch_restart_full_response_if_ide
     {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             caller = caller,
             response_sent_offset = response_sent_offset,
             raw_full_response_len = on_disk.full_response.len(),
@@ -250,7 +250,7 @@ pub(in crate::services::discord::inflight) fn patch_restart_full_response_if_ide
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 caller = caller,
                 error = %error,
                 "restart-preserved full_response patch failed; leaving durable row untouched"
@@ -399,7 +399,7 @@ pub(in crate::services::discord) fn bind_recovery_anchor_if_matches_identity(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "inflight recovery anchor bind could not read on-disk row; blocking durable anchor write"
             );
@@ -428,7 +428,7 @@ pub(in crate::services::discord) fn bind_recovery_anchor_if_matches_identity(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "inflight recovery anchor bind failed; leaving on-disk row untouched"
             );
@@ -500,7 +500,7 @@ pub(in crate::services::discord::inflight) fn persist_leak_recovery_response_off
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "leak recovery offset patch failed; leaving on-disk row untouched"
@@ -562,7 +562,7 @@ pub(in crate::services::discord::inflight) fn persist_recovery_output_path_if_ma
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "recovery output-path patch failed; leaving on-disk row untouched"
@@ -742,7 +742,7 @@ fn save_existing_inflight_rebind_adoption_impl_in_root(
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "existing inflight rebind adoption save failed; leaving on-disk row untouched"
@@ -800,7 +800,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_matches_ide
     if on_disk.output_path != state.output_path {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             snapshot_identity = ?expected,
             durable_identity = ?InflightTurnIdentity::from_state(&on_disk),
             snapshot_output_path = ?state.output_path.as_deref(),
@@ -831,7 +831,7 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_matches_ide
         Err(error) => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 expected_user_msg_id = expected.user_msg_id,
                 error = %error,
                 "inflight identity-guarded save failed; leaving on-disk row untouched"

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -1012,7 +1012,7 @@ fn record_delivered_content_fingerprint_for_generation(
         Err(error) => {
             tracing::warn!(
                 provider = provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "delivery content fingerprint path unavailable"
             );
@@ -1028,7 +1028,7 @@ fn record_delivered_content_fingerprint_for_generation(
     ) {
         tracing::warn!(
             provider = provider.as_str(),
-            channel = channel_id,
+            channel_id,
             error = %error,
             "delivery content fingerprint write failed"
         );
@@ -1140,7 +1140,7 @@ fn record_delivered_frontier_shadow(
         Err(error) => {
             tracing::error!(
                 provider = provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 error = %error,
                 "#3089 B1: shadow delivery-record path unavailable (observe-only)"
             );
@@ -1159,7 +1159,7 @@ fn record_delivered_frontier_shadow(
         Ok(false) => {}
         Ok(true) => tracing::error!(
             provider = provider.as_str(),
-            channel = channel_id,
+            channel_id,
             durable_end = range.1,
             in_memory_confirmed_end,
             generation_mtime_ns,
@@ -1167,7 +1167,7 @@ fn record_delivered_frontier_shadow(
         ),
         Err(error) => tracing::error!(
             provider = provider.as_str(),
-            channel = channel_id,
+            channel_id,
             error = %error,
             "#3089 B1: shadow delivery-record write failed (observe-only)"
         ),

--- a/src/services/discord/outbound/turn_output_controller.rs
+++ b/src/services/discord/outbound/turn_output_controller.rs
@@ -1011,7 +1011,7 @@ where
     if let PlaceholderSlot::Active { message_id, .. } = slot {
         if let Err(error) = gateway.delete_message(ctx.channel_id, *message_id).await {
             tracing::warn!(
-                channel = ctx.channel_id.get(),
+                channel_id = ctx.channel_id.get(),
                 message_id = message_id.get(),
                 error = %error,
                 "long chunk delivery succeeded but anchor delete failed; proceeding as delivered"
@@ -1103,7 +1103,7 @@ fn classify_transport_failure<L: DeliveryLease + ?Sized>(
     {
         let display_error = strip_watcher_send_failure_class_marker(error);
         tracing::warn!(
-            channel = ctx.channel_id.get(),
+            channel_id = ctx.channel_id.get(),
             owner = ?ctx.owner,
             failure_class = class.as_str(),
             error = %display_error,

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -595,11 +595,11 @@ async fn run_placeholder_sweep_pass(
                 // SAFETY-NET so triage can hunt the missing hook.
                 tracing::warn!(
                     "[sweeper SAFETY-NET] abandoning inflight age={age_secs}s — \
-                     explicit cleanup signal missed for {provider}/{channel} (msg {msg_id}); \
+                     explicit cleanup signal missed for {provider}/{channel_id} (msg {msg_id}); \
                      investigate (pane_dead/generation/heartbeat hooks)",
                     age_secs = age_secs,
                     provider = provider.as_str(),
-                    channel = state.channel_id,
+                    channel_id = state.channel_id,
                     msg_id = state.current_msg_id,
                 );
                 let text = build_abandoned_placeholder(&state);

--- a/src/services/discord/reaction_lifecycle.rs
+++ b/src/services/discord/reaction_lifecycle.rs
@@ -181,7 +181,7 @@ async fn try_reaction_raw_once_on_channel_detailed(
 ) -> Result<(), ReactionLifecycleError> {
     if !is_real_discord_message_id(message_id) {
         tracing::debug!(
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             message = message_id.get(),
             emoji = %emoji,
             action = action.label(),
@@ -211,7 +211,7 @@ async fn try_reaction_raw_on_channel_detailed(
                 .filter(|parent| *parent != channel_id)
             {
                 tracing::debug!(
-                    channel = channel_id.get(),
+                    channel_id = channel_id.get(),
                     parent_channel = parent_channel_id.get(),
                     message = message_id.get(),
                     emoji = %emoji,
@@ -258,7 +258,7 @@ async fn try_reaction_raw_with_shared_detailed(
         Ok(()) => Ok(()),
         Err(first_error) => {
             tracing::debug!(
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 target_channel = target_channel_id.get(),
                 message = message_id.get(),
                 emoji = %emoji,

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -382,7 +382,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::warn!(
                         provider = %provider.as_str(),
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         "[{ts}] ⚠ recovery (completed_during_downtime) deferred by non-proceeding visible outcome"
                     );
                     continue;
@@ -1021,7 +1021,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(
                     provider = %provider.as_str(),
-                    channel = channel_id.get(),
+                    channel_id = channel_id.get(),
                     "[{ts}] ⚠ recovery (captured_full_response) deferred by non-proceeding visible outcome"
                 );
                 continue;
@@ -1278,7 +1278,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(
                     provider = %provider.as_str(),
-                    channel = channel_id.get(),
+                    channel_id = channel_id.get(),
                     "[{ts}] ⚠ recovery (output_completed) deferred by non-proceeding visible outcome"
                 );
                 continue;
@@ -1743,7 +1743,7 @@ pub(in crate::services::discord) async fn restore_inflight_turns(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 user_msg_id = state.user_msg_id,
                 "  [{ts}] ✓ recovery: clearing delivered inflight before watcher re-register; terminal response already reached Discord"
             );

--- a/src/services/discord/recovery_engine/runtime.rs
+++ b/src/services/discord/recovery_engine/runtime.rs
@@ -68,7 +68,7 @@ pub(in crate::services::discord) async fn reregister_active_turn_from_inflight(
     if recovery_terminal_delivery_already_committed(state) {
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             finalizer_turn_id,
             "inflight reregister skipped: terminal delivery already committed; clearing stale active turn state"
         );

--- a/src/services/discord/recovery_engine/terminal_text_idempotency.rs
+++ b/src/services/discord/recovery_engine/terminal_text_idempotency.rs
@@ -222,7 +222,7 @@ impl RecoveryDeliveryContext {
         } else {
             tracing::warn!(
                 provider = %self.provider.as_str(),
-                channel = self.channel_id.get(),
+                channel_id = self.channel_id.get(),
                 anchor_msg_id = anchor.get(),
                 outcome = ?bind,
                 "recovery no-anchor delivery: inflight anchor bind did not persist; skipping durable anchor write"
@@ -237,7 +237,7 @@ impl RecoveryDeliveryContext {
         if range.1 <= range.0 {
             tracing::warn!(
                 provider = %self.provider.as_str(),
-                channel = self.channel_id.get(),
+                channel_id = self.channel_id.get(),
                 range = ?range,
                 "recovery no-anchor delivery: refusing to record empty durable range"
             );
@@ -246,7 +246,7 @@ impl RecoveryDeliveryContext {
         let Some(tmux_session_name) = self.tmux_session_name.as_deref() else {
             tracing::warn!(
                 provider = %self.provider.as_str(),
-                channel = self.channel_id.get(),
+                channel_id = self.channel_id.get(),
                 "recovery no-anchor delivery: no tmux session name; durable anchor unavailable"
             );
             return;
@@ -255,7 +255,7 @@ impl RecoveryDeliveryContext {
         if generation_mtime_ns == 0 {
             tracing::warn!(
                 provider = %self.provider.as_str(),
-                channel = self.channel_id.get(),
+                channel_id = self.channel_id.get(),
                 tmux_session_name,
                 "recovery no-anchor delivery: no current generation marker; durable anchor unavailable"
             );
@@ -275,7 +275,7 @@ impl RecoveryDeliveryContext {
         ) {
             tracing::warn!(
                 provider = %self.provider.as_str(),
-                channel = self.channel_id.get(),
+                channel_id = self.channel_id.get(),
                 record_channel = self.record_channel_id.get(),
                 error = %error,
                 "recovery no-anchor delivery: durable anchor write failed"

--- a/src/services/discord/recovery_paths/restart.rs
+++ b/src/services/discord/recovery_paths/restart.rs
@@ -63,7 +63,7 @@ pub(in crate::services::discord) async fn finish_recovered_turn_mailbox_if_regis
     if !registered {
         tracing::debug!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             stop_source,
             "recovery force-clear: no mailbox registry entry — skipping finish to avoid creating one"
         );
@@ -114,7 +114,7 @@ pub(in crate::services::discord) async fn dispose_recovery_relay_outcome(
             if !inflight::clear_inflight_state(provider, state.channel_id) {
                 tracing::warn!(
                     provider = %provider.as_str(),
-                    channel = state.channel_id,
+                    channel_id = state.channel_id,
                     branch,
                     "recovery: clear_inflight_state returned false (row still on disk) after a \
                      delivered relay — next boot may re-enter this branch (an anchor-repost \
@@ -244,7 +244,7 @@ fn matching_recovery_anchors(
         ) else {
             tracing::debug!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 record_channel = record_channel_id,
                 "  · recovery anchor-repost: no current anchor at candidate record channel"
             );
@@ -256,7 +256,7 @@ fn matching_recovery_anchors(
         if !anchor_panel_channel_matches_turn(anchor.panel_channel_id, state.channel_id) {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 record_channel = record_channel_id,
                 anchor_channel_id = anchor.panel_channel_id,
                 "  ✗ recovery anchor-repost: anchor channel does not match this turn — trying next candidate (stale-owner guard)"
@@ -268,7 +268,7 @@ fn matching_recovery_anchors(
         if !anchor_range_matches_turn(anchor.range, state.turn_start_offset, state.last_offset) {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 record_channel = record_channel_id,
                 anchor_range = ?anchor.range,
                 turn_start_offset = ?state.turn_start_offset,
@@ -438,7 +438,7 @@ pub(in crate::services::discord) async fn try_recover_anchor_repost(
     ) {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             anchor_reposted = state.anchor_reposted,
             anchor_repost_attempts = state.anchor_repost_attempts,
             budget = inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
@@ -472,7 +472,7 @@ pub(in crate::services::discord) async fn try_recover_anchor_repost(
         if !anchor_probe_should_repost(probe) {
             tracing::info!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 record_channel = record_channel_id,
                 anchor_msg_id = anchor.panel_msg_id,
                 anchor_channel_id = anchor.panel_channel_id,
@@ -494,7 +494,7 @@ pub(in crate::services::discord) async fn try_recover_anchor_repost(
     // records the replacement anchor after a successful POST.
     tracing::warn!(
         provider = %provider.as_str(),
-        channel = state.channel_id,
+        channel_id = state.channel_id,
         record_channel = record_channel_id,
         anchor_msg_id = anchor.panel_msg_id,
         anchor_channel_id = anchor.panel_channel_id,
@@ -538,7 +538,7 @@ pub(in crate::services::discord) async fn try_recover_anchor_repost(
     if let Some(refusal) = anchor_repost_pre_send_refusal(bump_outcome) {
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = state.channel_id,
+            channel_id = state.channel_id,
             outcome = ?bump_outcome,
             "  ⚠ recovery anchor-repost: pre-send attempt counter NOT persisted — \
              REFUSING the send-new and PRESERVING the inflight row (the hard bound \
@@ -584,7 +584,7 @@ pub(in crate::services::discord) async fn try_recover_anchor_repost(
         if !matches!(marked, inflight::GuardedSaveOutcome::Saved) {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 outcome = ?marked,
                 "  ⚠ recovery anchor-repost: durable 'anchor_reposted' marker NOT persisted after \
                  a delivered send — a crash before the row clears could re-post (bounded by the \
@@ -710,7 +710,7 @@ async fn apply_undeliverable_relay_disposition(
                 Err(error) => {
                     tracing::warn!(
                         provider = %provider.as_str(),
-                        channel = state.channel_id,
+                        channel_id = state.channel_id,
                         reason_code,
                         error = %error,
                         "recovery force-clear report write FAILED — clearing anyway; \
@@ -738,7 +738,7 @@ async fn apply_undeliverable_relay_disposition(
             let report_path_display = report_path.as_ref().map(|path| path.display().to_string());
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 user_msg_id = state.user_msg_id,
                 branch,
                 reason_code,
@@ -769,7 +769,7 @@ async fn apply_undeliverable_relay_disposition(
             );
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = state.channel_id,
+                channel_id = state.channel_id,
                 branch,
                 attempts = state.recovery_relay_attempts.saturating_add(1),
                 budget = inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -559,7 +559,7 @@ impl SessionBoundDiscordRelaySink {
         let Some(inflight) = inflight else {
             tracing::debug!(
                 provider = provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 tmux_session = %session_name,
                 frame_user_msg_id = delivery.frame_turn_user_msg_id,
                 "session-bound sink: terminal frame carried a commit fence but inflight is gone; identity gate blocks advance"
@@ -578,7 +578,7 @@ impl SessionBoundDiscordRelaySink {
         if !identity_matches {
             tracing::debug!(
                 provider = provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 tmux_session = %session_name,
                 frame_user_msg_id = delivery.frame_turn_user_msg_id,
                 inflight_user_msg_id = inflight.user_msg_id,
@@ -714,7 +714,7 @@ impl SessionBoundDiscordRelaySink {
                 self.delivered_total.fetch_add(1, Ordering::AcqRel);
                 tracing::info!(
                     provider = provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     message = msg_id.get(),
                     tmux_session = %delivery.session_name,
                     turn_id = trace.turn_id().unwrap_or(""),
@@ -787,7 +787,7 @@ impl SessionBoundDiscordRelaySink {
             SessionBoundTerminalDeliveryRouteDecision::Skipped => {
                 tracing::debug!(
                     provider = provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %delivery.session_name,
                     turn_id = trace.turn_id().unwrap_or(""),
                     dispatch_id = trace.dispatch_id().unwrap_or(""),
@@ -929,7 +929,7 @@ impl SessionBoundDiscordRelaySink {
                 self.delivered_total.fetch_add(1, Ordering::AcqRel);
                 tracing::info!(
                     provider = provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     message = msg_id.get(),
                     tmux_session = %delivery.session_name,
                     turn_id = trace.turn_id().unwrap_or(""),
@@ -983,7 +983,7 @@ impl SessionBoundDiscordRelaySink {
                     self.delivered_total.fetch_add(1, Ordering::AcqRel);
                     tracing::info!(
                         provider = provider.as_str(),
-                        channel = channel_id,
+                        channel_id,
                         message = msg_id.get(),
                         tmux_session = %delivery.session_name,
                         turn_id = trace.turn_id().unwrap_or(""),
@@ -1031,7 +1031,7 @@ impl SessionBoundDiscordRelaySink {
                     self.delivered_total.fetch_add(1, Ordering::AcqRel);
                     tracing::warn!(
                         provider = provider.as_str(),
-                        channel = channel_id,
+                        channel_id,
                         message = msg_id.get(),
                         tmux_session = %delivery.session_name,
                         turn_id = trace.turn_id().unwrap_or(""),
@@ -1115,7 +1115,7 @@ impl SessionBoundDiscordRelaySink {
             // #3041 P1-4 (§4-④): lease released by the RAII guard on exit.
             tracing::info!(
                 provider = provider.as_str(),
-                channel = channel_id,
+                channel_id,
                 tmux_session = %delivery.session_name,
                 turn_id = trace.turn_id().unwrap_or(""),
                 dispatch_id = trace.dispatch_id().unwrap_or(""),
@@ -1328,7 +1328,7 @@ async fn run_idle_jsonl_relay_loop(
                 last_inflight_seen_at.remove(&session_name);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     user_msg_id = inflight.user_msg_id,
                     updated_at = %inflight.updated_at,
@@ -1364,7 +1364,7 @@ async fn run_idle_jsonl_relay_loop(
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     bytes = payload.len(),
                     "idle JSONL relay skipped new-session grace payload"
@@ -1375,7 +1375,7 @@ async fn run_idle_jsonl_relay_loop(
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Clear);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     bytes = payload.len(),
                     "idle JSONL relay skipped active-turn payload with user/tool-result event"
@@ -1386,7 +1386,7 @@ async fn run_idle_jsonl_relay_loop(
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     bytes = payload.len(),
                     "idle JSONL relay skipped ScheduleWakeup setup payload"
@@ -1409,7 +1409,7 @@ async fn run_idle_jsonl_relay_loop(
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     bytes = payload.len(),
                     "idle JSONL relay skipped non-init active-session payload"
@@ -1426,7 +1426,7 @@ async fn run_idle_jsonl_relay_loop(
             if idle_jsonl_should_retry_without_dedup_shared(shared_for_dedup.as_ref()) {
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     range_start = start,
                     range_end = end,
@@ -1462,7 +1462,7 @@ async fn run_idle_jsonl_relay_loop(
                         consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                         tracing::debug!(
                             provider = matched.provider.as_str(),
-                            channel = channel_id,
+                            channel_id,
                             tmux_session = %session_name,
                             committed_relay_offset = committed,
                             end,
@@ -1487,7 +1487,7 @@ async fn run_idle_jsonl_relay_loop(
                             consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                             tracing::debug!(
                                 provider = matched.provider.as_str(),
-                                channel = channel_id,
+                                channel_id,
                                 tmux_session = %session_name,
                                 committed_relay_offset = committed,
                                 start,
@@ -1509,7 +1509,7 @@ async fn run_idle_jsonl_relay_loop(
                 consume_idle_offset!(end, IdleJsonlSessionInitRearm::Keep);
                 tracing::debug!(
                     provider = matched.provider.as_str(),
-                    channel = channel_id,
+                    channel_id,
                     tmux_session = %session_name,
                     bytes = payload.len(),
                     "idle JSONL relay forwarded background session output"

--- a/src/services/discord/session_relay_sink/idle_jsonl.rs
+++ b/src/services/discord/session_relay_sink/idle_jsonl.rs
@@ -266,7 +266,7 @@ fn log_mismatched_inflight_skip(
     }
     tracing::debug!(
         provider = provider.as_str(),
-        channel = channel_id,
+        channel_id,
         tmux_session = %tmux_session_name,
         inflight_tmux_session = %inflight.tmux_session_name.as_deref().unwrap_or("(none)"),
         user_msg_id = inflight.user_msg_id,

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -540,7 +540,7 @@ fn complete_standby_inflight_state(
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             output_path = output_path,
             placeholder_msg_id = placeholder_msg_id.map(|msg| msg.get()),
             "[{ts}] ⚠ standby_relay skipped inflight cleanup because the on-disk row no longer matches this relay"
@@ -587,7 +587,7 @@ fn complete_standby_inflight_state(
         GuardedClearOutcome::Cleared | GuardedClearOutcome::Missing => {
             tracing::debug!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 outcome = outcome_label,
                 "standby_relay completed delegated inflight cleanup"
             );
@@ -596,7 +596,7 @@ fn complete_standby_inflight_state(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 user_msg_id = user_msg_id,
                 "[{ts}] ⚠ standby_relay did not clear inflight because the guarded identity no longer matches"
             );
@@ -604,7 +604,7 @@ fn complete_standby_inflight_state(
         GuardedClearOutcome::PlannedRestartSkipped | GuardedClearOutcome::RebindOriginSkipped => {
             tracing::debug!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 outcome = outcome_label,
                 "standby_relay preserved inflight row after delegated completion"
             );
@@ -612,7 +612,7 @@ fn complete_standby_inflight_state(
         GuardedClearOutcome::IoError => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 "standby_relay failed to clear inflight after delegated completion; sweeper will see mirrored response state"
             );
         }

--- a/src/services/discord/terminal_ui_obligation.rs
+++ b/src/services/discord/terminal_ui_obligation.rs
@@ -194,7 +194,7 @@ async fn reconcile_terminal_ui_obligation(
             if clear_obligation_by_key(&obligation.provider, obligation.channel_id) {
                 tracing::warn!(
                     provider = %obligation.provider,
-                    channel = obligation.channel_id,
+                    channel_id = obligation.channel_id,
                     status_message_id = obligation.status_message_id,
                     reason,
                     "cleared stale terminal UI obligation without editing status card"
@@ -211,7 +211,7 @@ async fn reconcile_terminal_ui_obligation(
                 if clear_obligation_by_key(&obligation.provider, obligation.channel_id) {
                     tracing::warn!(
                         provider = %obligation.provider,
-                        channel = obligation.channel_id,
+                        channel_id = obligation.channel_id,
                         status_message_id = obligation.status_message_id,
                         reason,
                         "cleared terminal UI obligation after reconcile context stayed unavailable"
@@ -247,7 +247,7 @@ async fn reconcile_terminal_ui_obligation(
         Err(error) => {
             tracing::warn!(
                 provider = %obligation.provider,
-                channel = obligation.channel_id,
+                channel_id = obligation.channel_id,
                 status_message_id = obligation.status_message_id,
                 action = ?action,
                 error = %error,

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1853,7 +1853,7 @@ fn persist_watcher_stream_progress(
     if full_response.len() < response_sent_offset {
         tracing::debug!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             response_sent_offset,
             full_response_len = full_response.len(),

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1089,7 +1089,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         ) {
             tracing::info!(
                 provider = %watcher_provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 restored_response_seed_len = restored_response_seed.len(),
                 fresh_response_len = full_response.len(),
@@ -1193,7 +1193,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             if let Some(stale_msg_id) = placeholder_msg_id {
                 tracing::info!(
                     provider = %watcher_provider.as_str(),
-                    channel = channel_id.get(),
+                    channel_id = channel_id.get(),
                     tmux_session = %tmux_session_name,
                     stale_placeholder_msg_id = stale_msg_id.get(),
                     status_panel_msg_id = status_panel_msg_id.map(|id| id.get()).unwrap_or(0),
@@ -1553,7 +1553,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 if !delivered {
                     tracing::warn!(
                         provider = watcher_provider.as_str(),
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         tmux_session = %tmux_session_name,
                         ?ack_outcome,
                         "session-bound StreamRelay terminal delivery was not acknowledged"
@@ -1690,7 +1690,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 provider = watcher_provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 start = watcher_resend_range_start,
                 end = watcher_resend_range_end,
@@ -1706,7 +1706,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 provider = watcher_provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 start = watcher_resend_range_start,
                 end = watcher_resend_range_end,
@@ -1780,7 +1780,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         tracing::info!(
             target: "agentdesk::relay_flight_recorder",
             provider = watcher_provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             data_start_offset,
             current_offset,
@@ -2091,7 +2091,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %watcher_provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 data_start_offset = watcher_lease_start,
                 lease_end = watcher_lease_end,
@@ -2101,7 +2101,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         } else if direct_terminal_response_refused_duplicate {
             tracing::warn!(
                 provider = %watcher_provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 data_start_offset = watcher_lease_start,
                 lease_end = watcher_lease_end,
@@ -3227,7 +3227,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %watcher_provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 "[{ts}] ⚠ watcher: dispatch finalization deferred — TUI quiescence gate timed out (#2161)"
             );

--- a/src/services/discord/tmux_watcher/commit_decisions.rs
+++ b/src/services/discord/tmux_watcher/commit_decisions.rs
@@ -88,7 +88,7 @@ pub(super) fn mark_watcher_terminal_delivery_committed(
         crate::services::discord::inflight::WatcherTerminalCommitOutcome::IoError => {
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 "watcher failed to mirror committed terminal delivery into inflight state"
             );

--- a/src/services/discord/tmux_watcher/completion_gate.rs
+++ b/src/services/discord/tmux_watcher/completion_gate.rs
@@ -168,7 +168,7 @@ pub(in crate::services::discord) async fn run_tui_completion_gate(
     if inflight_skips_tui_completion_observation(inflight.as_ref()) {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             inflight_user_msg_id = inflight.as_ref().map(|state| state.user_msg_id).unwrap_or(0),
             inflight_current_msg_id = inflight.as_ref().map(|state| state.current_msg_id).unwrap_or(0),
@@ -209,7 +209,7 @@ pub(in crate::services::discord) async fn run_tui_completion_gate(
     ) {
         tracing::info!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             "TUI completion gate skipped because tmux pane is no longer live"
         );
@@ -239,7 +239,7 @@ pub(in crate::services::discord) async fn run_tui_completion_gate(
     };
     tracing::info!(
         provider = %provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         completion_signal = ?completion_signal,
         fallback_ready,

--- a/src/services/discord/tmux_watcher/loop_poll_prologue.rs
+++ b/src/services/discord/tmux_watcher/loop_poll_prologue.rs
@@ -535,7 +535,7 @@ pub(super) async fn poll_watcher_output_or_continue(
         ) && !post_terminal_payload_allows_external_relay;
     if post_terminal_payload_allows_external_relay {
         tracing::info!(
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             range_start = data_start_offset,
             range_end = current_offset,

--- a/src/services/discord/tmux_watcher/no_result_exits.rs
+++ b/src/services/discord/tmux_watcher/no_result_exits.rs
@@ -212,7 +212,7 @@ pub(super) async fn handle_no_result_exits(
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(
                     provider = watcher_provider.as_str(),
-                    channel = channel_id.get(),
+                    channel_id = channel_id.get(),
                     tmux_session = %tmux_session_name,
                     turn_start_offset = plan.turn_start_offset,
                     current_offset,

--- a/src/services/discord/tmux_watcher/post_stream_exit.rs
+++ b/src/services/discord/tmux_watcher/post_stream_exit.rs
@@ -241,7 +241,7 @@ pub(super) async fn run_post_stream_exit(ctx: PostStreamExitContext) {
     } else if cleanup_plan.report_idle_status {
         tracing::debug!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             "watcher deferred idle status because bridge-owned inflight still needs terminal Discord finalization"
         );

--- a/src/services/discord/tmux_watcher/prompt_observe.rs
+++ b/src/services/discord/tmux_watcher/prompt_observe.rs
@@ -98,7 +98,7 @@ pub(super) fn observe_legacy_wrapper_direct_prompt_from_pane(
         );
     tracing::info!(
         provider = %provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         data_start_offset,
         current_offset,

--- a/src/services/discord/tmux_watcher/session_bound_ack.rs
+++ b/src/services/discord/tmux_watcher/session_bound_ack.rs
@@ -467,7 +467,7 @@ pub(super) fn warn_watcher_completion_chrome_timeout(
 ) {
     tracing::warn!(
         provider = %watcher_provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         data_start_offset,
         current_offset,
@@ -486,7 +486,7 @@ pub(super) fn watcher_relay_emission_timeout_failure_plan(
 ) -> crate::services::discord::replace_outcome_policy::WatcherTerminalRelayPlan {
     tracing::warn!(
         provider = %watcher_provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         data_start_offset,
         current_offset,

--- a/src/services/discord/tmux_watcher/terminal_readiness.rs
+++ b/src/services/discord/tmux_watcher/terminal_readiness.rs
@@ -316,7 +316,7 @@ pub(super) fn warn_terminal_partial_no_rewind(
     let error = stripped_send_error(&error);
     tracing::warn!(
         provider = %watcher_provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         failure_class = failure_class.as_str(),
         error = %error,
@@ -335,7 +335,7 @@ pub(super) fn warn_terminal_edit_full_no_rewind(
     let error = stripped_send_error(&error);
     tracing::warn!(
         provider = %watcher_provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         failure_class = failure_class.as_str(),
         error = %error,
@@ -354,7 +354,7 @@ pub(super) fn warn_terminal_placeholderless_full_no_rewind(
     let error = stripped_send_error(&error);
     tracing::warn!(
         provider = %watcher_provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         failure_class = failure_class.as_str(),
         error = %error,
@@ -371,7 +371,7 @@ pub(super) fn warn_terminal_rewind_give_up(
 ) {
     tracing::warn!(
         provider = %watcher_provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         tmux_session = %tmux_session_name,
         turn_data_start_offset,
         attempts = terminal_rewind_attempts,

--- a/src/services/discord/tmux_watcher/turn_identity.rs
+++ b/src/services/discord/tmux_watcher/turn_identity.rs
@@ -47,7 +47,7 @@ pub(super) fn log_explicit_inflight_cleanup_outcome(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 user_msg_id = expected_user_msg_id,
                 reason = reason,
                 "[{ts}] 🧹 inflight cleared via explicit completion signal (#2427)"
@@ -56,7 +56,7 @@ pub(super) fn log_explicit_inflight_cleanup_outcome(
         crate::services::discord::inflight::GuardedClearOutcome::Missing => {
             tracing::trace!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 reason = reason,
                 "inflight already absent — explicit signal redundant (#2427)"
             );
@@ -65,7 +65,7 @@ pub(super) fn log_explicit_inflight_cleanup_outcome(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 expected_user_msg_id = expected_user_msg_id,
                 reason = reason,
                 "[{ts}] ⚠ inflight user_msg_id mismatch — stale explicit signal ignored (#2427 Pitfall #1)"
@@ -74,7 +74,7 @@ pub(super) fn log_explicit_inflight_cleanup_outcome(
         crate::services::discord::inflight::GuardedClearOutcome::PlannedRestartSkipped => {
             tracing::debug!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 reason = reason,
                 "skipping explicit inflight cleanup — planned-restart marker present (#2427)"
             );
@@ -82,7 +82,7 @@ pub(super) fn log_explicit_inflight_cleanup_outcome(
         crate::services::discord::inflight::GuardedClearOutcome::RebindOriginSkipped => {
             tracing::debug!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 reason = reason,
                 "skipping explicit inflight cleanup — rebind_origin row (#2427 Pitfall #5)"
             );
@@ -93,7 +93,7 @@ pub(super) fn log_explicit_inflight_cleanup_outcome(
             // catching the failed cleanup. Caller does not clear watcher.
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 reason = reason,
                 "explicit inflight cleanup failed with IO error — sweeper safety-net will retry"
             );
@@ -127,7 +127,7 @@ pub(in crate::services::discord) fn emit_explicit_inflight_cleanup_signal_pane_d
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::debug!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             on_disk = ?state.tmux_session_name,
             expected = expected_tmux_session_name,
             "[{ts}] skipping pane-dead explicit cleanup — inflight points at a different tmux session (#2427 A self-auth guard)"
@@ -137,7 +137,7 @@ pub(in crate::services::discord) fn emit_explicit_inflight_cleanup_signal_pane_d
     let Some(identity) = expected_identity else {
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             expected_tmux_session_name,
             "pane-dead inflight cleanup skipped because watcher attach identity is unavailable (#2450)"
         );
@@ -302,7 +302,7 @@ pub(super) fn watcher_direct_terminal_response_decision(
     if duplicate && !fresh_assistant_text_in_observed_range {
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             response_len = response.len(),
             fresh_assistant_text_in_observed_range,

--- a/src/services/discord/tmux_watcher/turn_stream_collector.rs
+++ b/src/services/discord/tmux_watcher/turn_stream_collector.rs
@@ -256,7 +256,7 @@ pub(super) async fn collect_turn_stream_until_terminal(
         && seed_disposition.restored_seed_undelivered_body_len > 0
     {
         tracing::info!(
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             body_len = seed_disposition.restored_seed_undelivered_body_len,
             tmux_session = %tmux_session_name,
             "watcher: preserving restored stream seed with undelivered body for idle SSH-direct prompt"

--- a/src/services/discord/turn_bridge/completion_postlude.rs
+++ b/src/services/discord/turn_bridge/completion_postlude.rs
@@ -248,7 +248,7 @@ pub(super) async fn run_completion_postlude(
     } else if status_panel_terminal_committed && !status_panel_completion_committed {
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             "turn bridge withheld final idle status because status-panel completion edit did not commit"
         );
     }
@@ -824,7 +824,7 @@ pub(super) async fn run_completion_postlude(
                 GuardedClearOutcome::IoError => {
                     tracing::warn!(
                         provider = %provider.as_str(),
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         this_turn_user_msg_id,
                         "turn bridge epilogue inflight guarded-clear hit IoError; sweeper will retry"
                     );
@@ -859,7 +859,7 @@ pub(super) async fn run_completion_postlude(
                 GuardedClearOutcome::IoError => {
                     tracing::warn!(
                         provider = %provider.as_str(),
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         "turn bridge epilogue zero-owned inflight guarded-clear hit IoError; sweeper will retry"
                     );
                 }

--- a/src/services/discord/turn_bridge/early_tui_completion.rs
+++ b/src/services/discord/turn_bridge/early_tui_completion.rs
@@ -47,7 +47,7 @@ pub(super) async fn run_early_tui_completion_gate(
         if inflight_state.relay_ownership_only {
             tracing::info!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 tmux_session = %tmux_session_name,
                 inflight_user_msg_id = inflight_state.user_msg_id,
                 inflight_current_msg_id = inflight_state.current_msg_id,

--- a/src/services/discord/turn_bridge/followup_requeue.rs
+++ b/src/services/discord/turn_bridge/followup_requeue.rs
@@ -19,7 +19,7 @@ pub(super) async fn requeue_claude_tui_followup_pre_submit_timeout(
     let requeue_refusal_reason = requeue_outcome.refusal_reason.map(|reason| reason.as_str());
     tracing::info!(
         provider = %provider.as_str(),
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         user_msg_id = inflight_state.user_msg_id,
         requeue_enqueued = requeue_outcome.enqueued,
         requeue_merged = requeue_outcome.merged,

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1168,7 +1168,7 @@ pub(super) fn spawn_turn_bridge(
                     }
                     Err(error) => {
                         tracing::warn!(
-                            channel = channel_id.get(),
+                            channel_id = channel_id.get(),
                             "[turn_bridge] recovery turn has no anchored placeholder and creating one failed: {error}; continuing — streaming will retry placeholder creation"
                         );
                         // No placeholder yet. Use a synthetic-headless sentinel

--- a/src/services/discord/turn_bridge/post_loop_finalize.rs
+++ b/src/services/discord/turn_bridge/post_loop_finalize.rs
@@ -525,7 +525,7 @@ pub(super) async fn run_post_loop_finalize(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 watcher_owner_channel = watcher_owner_channel_id.get(),
                 tui_gate_timed_out = bridge_early_gate_timed_out,
                 "  [{ts}] ⚠ bridge watcher handoff missing finalizer; bridge is releasing mailbox to avoid stranded queued turns"
@@ -623,7 +623,7 @@ pub(super) async fn run_post_loop_finalize(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 "  [{ts}] ⚠ #2293/#2780: bridge releasing mailbox despite TUI quiescence timeout; follow-up pre-submit gate will requeue if pane is still busy"
             );
         }

--- a/src/services/discord/turn_bridge/retry_state.rs
+++ b/src/services/discord/turn_bridge/retry_state.rs
@@ -126,7 +126,7 @@ fn persist_delivery_rewind(
         }
         Err(error) => {
             tracing::warn!(
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 reason = reason.as_str(),
                 error = %error,
                 "turn_bridge failed to persist legitimate delivery rewind; preserving local rewind state"
@@ -192,7 +192,7 @@ pub(super) fn rewind_delivery_on_reclaim(
     *response_sent_offset = bridge_confirmed_response_sent_offset;
     sync_response_delivery_state(full_response, response_sent_offset, inflight_state);
     tracing::warn!(
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         response_sent_offset,
         "turn_bridge rewound response_sent_offset after reclaiming missing watcher"
     );

--- a/src/services/discord/turn_bridge/stream_loop.rs
+++ b/src/services/discord/turn_bridge/stream_loop.rs
@@ -1129,7 +1129,7 @@ pub(super) async fn run_stream_loop(
                                 tracing::info!(
                                     target: "agentdesk::codex_rollout_handoff",
                                     provider = %provider.as_str(),
-                                    channel = channel_id.get(),
+                                    channel_id = channel_id.get(),
                                     previous_response_sent_offset = response_sent_offset,
                                     full_response_len = full_response.len(),
                                     done_result_len = result.len(),

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -506,7 +506,7 @@ pub(super) async fn apply_bridge_long_chunks_legacy(
     if matches!(lease_acquire, BridgeLeaseAcquire::Skip) {
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate long terminal send (channel {})",
             channel_id
         );

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -292,7 +292,7 @@ pub(super) fn empty_sink_preserves_retry(
         return false;
     }
     tracing::warn!(
-        channel = channel_id.get(),
+        channel_id = channel_id.get(),
         full_response_len = full_response.len(),
         response_sent_offset,
         "turn_bridge reached empty terminal delivery without queued resume retry; preserving inflight for retry"

--- a/src/services/discord/turn_bridge/terminal_outcome_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_outcome_delivery.rs
@@ -426,7 +426,7 @@ pub(super) async fn run_terminal_outcome_delivery(
         if matches!(stop_lease_acquire, BridgeLeaseAcquire::Skip) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate cancel/stop terminal replace (channel {})",
                 channel_id
             );
@@ -531,7 +531,7 @@ pub(super) async fn run_terminal_outcome_delivery(
         if matches!(plt_lease_acquire, BridgeLeaseAcquire::Skip) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate prompt-too-long terminal replace (channel {})",
                 channel_id
             );
@@ -955,7 +955,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                     bridge_skip_holder_owns_inflight = true;
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::warn!(
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge silent_turn skipped offset advance, left turn retry-able (channel {})",
                         channel_id
                     );
@@ -1179,7 +1179,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                         if matches!(lease_acquire, BridgeLeaseAcquire::Skip) {
                             let ts = chrono::Local::now().format("%H:%M:%S");
                             tracing::warn!(
-                                channel = channel_id.get(),
+                                channel_id = channel_id.get(),
                                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate terminal replace (channel {})",
                                 channel_id
                             );
@@ -1332,7 +1332,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                 crate::services::discord::inflight::GuardedSaveOutcome::IoError => {
                     tracing::warn!(
                         provider = %provider.as_str(),
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         "turn bridge failed to mirror committed terminal delivery before cleanup"
                     );
                 }
@@ -1355,7 +1355,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                         tracing::info!(
                             target: "agentdesk::codex_rollout_handoff",
                             provider = %provider.as_str(),
-                            channel = channel_id.get(),
+                            channel_id = channel_id.get(),
                             message_id = frozen_msg_id.get(),
                             "turn_bridge removed streamed rollover prefix after full terminal replay"
                         );
@@ -1365,7 +1365,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                         tracing::warn!(
                             target: "agentdesk::codex_rollout_handoff",
                             provider = %provider.as_str(),
-                            channel = channel_id.get(),
+                            channel_id = channel_id.get(),
                             message_id = frozen_msg_id.get(),
                             error = %error,
                             "turn_bridge failed to remove streamed rollover prefix after full terminal replay"
@@ -1533,7 +1533,7 @@ pub(super) async fn run_terminal_outcome_delivery(
                 if terminal_delivery_committed && tui_transport_error_skip_gate {
                     tracing::info!(
                         provider = %provider.as_str(),
-                        channel = channel_id.get(),
+                        channel_id = channel_id.get(),
                         runtime_kind = ?inflight_state.runtime_kind,
                         "TUI transport error was already delivered; skipping quiescence gate so inflight cleanup can complete"
                     );

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -352,7 +352,7 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 watcher_owner_channel = watcher_owner_channel_id.get(),
                 current_msg_id,
                 response_pending_bytes = response_unsent.len(),
@@ -401,7 +401,7 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
                 provider = %provider.as_str(),
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 watcher_owner_channel = watcher_owner_channel_id.get(),
                 turn_start_offset,
                 tmux_last_offset = tmux_last_offset.unwrap_or(0),
@@ -444,7 +444,7 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
             provider = %provider.as_str(),
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             watcher_owner_channel = watcher_owner_channel_id.get(),
             "  [{ts}] 👁 #3268: TUI still busy on quiescence timeout — bridge handing long-lived turn back to live watcher instead of finalizing (relay continues)"
         );

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -1073,7 +1073,7 @@ async fn handle_terminal(
         Err(payload) => {
             tracing::error!(
                 panic = %panic_payload_summary(payload.as_ref()),
-                channel = ledger_key.channel_id.get(),
+                channel_id = ledger_key.channel_id.get(),
                 user_msg_id = ledger_key.user_msg_id,
                 "TurnFinalizer do_finalize panicked on the terminal path; contained, the \
                  ledger entry is reset Finalizing->Finalized below so it is never stuck (#3866)"

--- a/src/services/discord/turn_finalizer/reconcile.rs
+++ b/src/services/discord/turn_finalizer/reconcile.rs
@@ -55,7 +55,7 @@ async fn run_backstop_finalize(
     {
         tracing::error!(
             panic = %panic_payload_summary(payload.as_ref()),
-            channel = ledger_key.channel_id.get(),
+            channel_id = ledger_key.channel_id.get(),
             user_msg_id = ledger_key.user_msg_id,
             "TurnFinalizer do_finalize panicked on the reconcile/backstop path; contained, the \
              ledger entry is reset Finalizing->Finalized below so it is never stuck and the \
@@ -163,7 +163,7 @@ pub(super) async fn reconcile(
             entry.watcher_backstop_deadline = Some(now + GATE_BACKSTOP);
             entry.watcher_backstop_deadline_pulled = true;
             tracing::warn!(
-                channel = channel_id.get(),
+                channel_id = channel_id.get(),
                 provider = %provider.as_str(),
                 streak = entry.watcher_backstop_terminal_streak,
                 "#3277: watcher-owned turn is provably terminal but no terminal was ever \

--- a/src/services/discord/turn_finalizer/watcher_backstop.rs
+++ b/src/services/discord/turn_finalizer/watcher_backstop.rs
@@ -114,7 +114,7 @@ pub(super) fn watcher_backstop_turn_is_terminal(
     let delivery_confirmed_or_natural_deadline_escape = delivery_confirmed || at_deadline;
     if matches!(signal, CompletionSignal::Done) && !delivery_confirmed {
         tracing::warn!(
-            channel = channel_id.get(),
+            channel_id = channel_id.get(),
             provider = %provider.as_str(),
             tmux_session = %tmux_session_name,
             confirmed_end_offset,

--- a/src/services/discord/turn_view_reconciler.rs
+++ b/src/services/discord/turn_view_reconciler.rs
@@ -448,7 +448,7 @@ impl TurnViewReconciler {
     ) -> bool {
         let Some(desired) = TurnViewState::from_queue_marker_emoji(emoji) else {
             tracing::warn!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 emoji = %emoji,
@@ -512,7 +512,7 @@ impl TurnViewReconciler {
     ) -> TurnViewDelivery {
         if !super::reaction_lifecycle::is_real_discord_message_id(target.message_id) {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 emoji = %emoji,
@@ -554,7 +554,7 @@ impl TurnViewReconciler {
     ) -> TurnViewDelivery {
         if !super::reaction_lifecycle::is_real_discord_message_id(target.message_id) {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 source,
@@ -574,7 +574,7 @@ impl TurnViewReconciler {
 
         let Some(current) = current else {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 source,
@@ -588,7 +588,7 @@ impl TurnViewReconciler {
             || current.start_attempt != Some(start_attempt)
         {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 source,
@@ -822,7 +822,7 @@ impl TurnViewReconciler {
         let start_attempt = self.start_attempt_for(desired);
         if !super::reaction_lifecycle::is_real_discord_message_id(target.message_id) {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 desired = ?desired,
@@ -839,7 +839,7 @@ impl TurnViewReconciler {
             && self.recently_finalized_blocks_queued(target, owner.generation)
         {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 source,
@@ -862,7 +862,7 @@ impl TurnViewReconciler {
                     || current.start_attempt != Some(clear_start_attempt))
             {
                 tracing::debug!(
-                    channel = target.channel_id.get(),
+                    channel_id = target.channel_id.get(),
                     message = target.message_id.get(),
                     target_kind = ?target.kind,
                     source,
@@ -883,7 +883,7 @@ impl TurnViewReconciler {
                 && current.applied.started_or_terminal()
             {
                 tracing::debug!(
-                    channel = target.channel_id.get(),
+                    channel_id = target.channel_id.get(),
                     message = target.message_id.get(),
                     target_kind = ?target.kind,
                     source,
@@ -925,7 +925,7 @@ impl TurnViewReconciler {
                     }
                 } else {
                     tracing::debug!(
-                        channel = target.channel_id.get(),
+                        channel_id = target.channel_id.get(),
                         message = target.message_id.get(),
                         target_kind = ?target.kind,
                         desired = ?desired,
@@ -1045,7 +1045,7 @@ impl TurnViewReconciler {
     ) -> TurnViewDelivery {
         let Some(expected_state) = TurnViewState::from_queue_marker_emoji(emoji) else {
             tracing::warn!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 emoji = %emoji,
@@ -1056,7 +1056,7 @@ impl TurnViewReconciler {
         };
         if !super::reaction_lifecycle::is_real_discord_message_id(target.message_id) {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 source,
@@ -1076,7 +1076,7 @@ impl TurnViewReconciler {
 
         let Some(current) = current else {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 emoji = %emoji,
@@ -1097,7 +1097,7 @@ impl TurnViewReconciler {
 
         if current.applied != expected_state {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 emoji = %emoji,
@@ -1115,7 +1115,7 @@ impl TurnViewReconciler {
 
         if current.owner != owner {
             tracing::debug!(
-                channel = target.channel_id.get(),
+                channel_id = target.channel_id.get(),
                 message = target.message_id.get(),
                 target_kind = ?target.kind,
                 source,
@@ -1395,7 +1395,7 @@ impl TurnViewReconciler {
                 version = record.version,
                 provider = %record.provider,
                 kind = %record.kind,
-                channel = record.channel_id,
+                channel_id = record.channel_id,
                 message = record.message_id,
                 source,
                 "turn view persisted reaction state did not match target; deleting"
@@ -1598,7 +1598,7 @@ impl TurnViewReconciler {
             };
             if let Err(error) = result {
                 tracing::warn!(
-                    channel = target.channel_id.get(),
+                    channel_id = target.channel_id.get(),
                     message = target.message_id.get(),
                     target_kind = ?target.kind,
                     identity = identity.label,

--- a/tests/test_log_key_drift.py
+++ b/tests/test_log_key_drift.py
@@ -1,0 +1,303 @@
+"""Unit tests for scripts/check_log_key_drift.py (#4218).
+
+Pins the detection contract of the log field-key drift guard:
+  * both violation shapes — rustfmt multi-line field lines AND inline
+    single-line macro calls (codex r1: inline forms were previously missed);
+  * string-literal / comment stripping (codex r1: prose like
+    `"channel = foo,"` inside strings previously false-positived);
+  * the statement/binding exclusions and the session_id allowlist.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_log_key_drift.py"
+
+_SPEC = importlib.util.spec_from_file_location("check_log_key_drift", SCRIPT_PATH)
+CHECKER = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = CHECKER
+_SPEC.loader.exec_module(CHECKER)
+
+
+def _scan_fixture(body: str, rel: str = "src/services/discord/probe.rs"):
+    """Write one fixture file into a temp repo root and scan it."""
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+        return CHECKER.scan(root)
+
+
+def _keys(violations) -> list[str]:
+    return [key for (_rel, _line, key, _src) in violations]
+
+
+class MultiLineFieldDetectionTest(unittest.TestCase):
+    """The original rustfmt multi-line shapes stay covered."""
+
+    def test_all_forbidden_keys_flagged_in_multiline_form(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(
+                    channel = channel_id.get(),
+                    chan = x,
+                    discord_channel_id = y,
+                    session_id = other.session_id,
+                    provider = %p,
+                    "probe"
+                );
+            }
+            """
+        )
+        self.assertEqual(
+            _keys(violations),
+            ["channel", "chan", "discord_channel_id", "session_id"],
+        )
+
+    def test_shorthand_and_canonical_keys_pass(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(
+                    channel_id = channel_id.get(),
+                    channel_id,
+                    session_key = trace.session_key().unwrap_or(""),
+                    "probe"
+                );
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+
+class InlineMacroDetectionTest(unittest.TestCase):
+    """codex r1 gap 1: single-line macro calls must be caught too."""
+
+    def test_inline_single_line_macro_non_sigil_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(channel = channel_id, "msg");
+            }
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+    def test_inline_sigil_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::debug!(channel = %cid, "inline sigil");
+            }
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+    def test_mid_line_field_after_comma_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(
+                    provider = x, channel = y,
+                    "msg"
+                );
+            }
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+    def test_instrument_attribute_field_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            #[tracing::instrument(fields(channel = %id), skip_all)]
+            fn probe() {}
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+
+class StringAndCommentExclusionTest(unittest.TestCase):
+    """codex r1 gap 2: matches inside string literals/comments must not flag."""
+
+    def test_plain_string_literal_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                let msg = "channel = foo, bar";
+                let sql = "WHERE discord_channel_id = $1";
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_raw_string_literal_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                let q = r#"channel = x, session_id = y,"#;
+                let r = r"chan = z,";
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_multiline_string_continuation_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::warn!(
+                    "prefix channel = old, \\
+                     session_id = stale, tail",
+                    count = 1,
+                );
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_comments_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                // channel = x,
+                /* chan = y,
+                   session_id = z, */
+                let a = 1; // trailing: discord_channel_id = w,
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_quote_char_literal_does_not_desync_stripping(self) -> None:
+        # If '"' desynced quote tracking, the string on the next line would
+        # be treated as code and false-positive.
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                let c = '"';
+                let s = "channel = nope,";
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_code_after_string_on_same_line_still_scanned(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!("channel = prose,", channel = real_id, "m");
+            }
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+
+class StatementAndBindingExclusionTest(unittest.TestCase):
+    def test_let_bindings_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                let channel = ChannelId::new(1);
+                let chan = serenity::ChannelId::new(channel_id);
+                let discord_channel_id = ChannelId::new(channel_id);
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_reassignment_statements_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                session_id = None;
+                session_id = Some(pair[1].clone());
+                session_id = Some(restored_session_id);
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_field_access_assignment_not_flagged(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                state.channel = 5;
+                self.session_id = value;
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+
+class SessionIdAllowlistTest(unittest.TestCase):
+    def test_allowlisted_voice_gateway_site_passes(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(
+                    session_id = data.session_id,
+                    "voice driver connected"
+                );
+            }
+            """,
+            rel="src/services/discord/voice_lifecycle.rs",
+        )
+        self.assertEqual(violations, [])
+
+    def test_same_value_in_other_file_still_fails(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(
+                    session_id = data.session_id,
+                    "not the voice file"
+                );
+            }
+            """,
+            rel="src/services/discord/other.rs",
+        )
+        self.assertEqual(_keys(violations), ["session_id"])
+
+    def test_allowlisted_file_with_other_value_still_fails(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(
+                    session_id = something_else,
+                    "voice file but different value"
+                );
+            }
+            """,
+            rel="src/services/discord/voice_lifecycle.rs",
+        )
+        self.assertEqual(_keys(violations), ["session_id"])
+
+
+class CleanTreeTest(unittest.TestCase):
+    def test_clean_fixture_returns_no_violations(self) -> None:
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(channel_id = 1, session_key = %key, "ok");
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_live_tree_has_no_violations(self) -> None:
+        """The real Discord tree must stay clean under the current rules."""
+        self.assertEqual(CHECKER.scan(REPO_ROOT), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_log_key_drift.py
+++ b/tests/test_log_key_drift.py
@@ -125,6 +125,50 @@ class InlineMacroDetectionTest(unittest.TestCase):
         )
         self.assertEqual(_keys(violations), ["channel"])
 
+    def test_trailing_comma_less_last_field_flagged(self) -> None:
+        """codex r2: depth-0 `)` terminates the LAST field of a call."""
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(channel = channel_id);
+            }
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+    def test_instrument_fields_without_trailing_comma_flagged(self) -> None:
+        """codex r2: `fields(channel = id)` closes with `)` — still a field."""
+        violations = _scan_fixture(
+            """
+            #[tracing::instrument(fields(channel = id))]
+            fn probe() {}
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+    def test_last_field_with_method_call_value_flagged(self) -> None:
+        # Matched pairs inside the value must not eat the closing terminator.
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(channel = channel_id.get());
+            }
+            """
+        )
+        self.assertEqual(_keys(violations), ["channel"])
+
+    def test_sigil_last_field_without_comma_extracts_clean_value(self) -> None:
+        # Allowlist matching depends on the value excluding the `)` closer.
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                tracing::info!(session_id = %event.session_id);
+            }
+            """,
+            rel="src/services/discord/tui_prompt_relay.rs",
+        )
+        self.assertEqual(violations, [])
+
 
 class StringAndCommentExclusionTest(unittest.TestCase):
     """codex r1 gap 2: matches inside string literals/comments must not flag."""
@@ -233,6 +277,30 @@ class StatementAndBindingExclusionTest(unittest.TestCase):
             fn probe() {
                 state.channel = 5;
                 self.session_id = value;
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_tail_expression_with_matched_parens_not_flagged(self) -> None:
+        # codex r2 guard: a matched `(…)` pair inside the value drops depth
+        # back to 0 without terminating — `)` only terminates when UNmatched.
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                session_id = compute(x)
+            }
+            """
+        )
+        self.assertEqual(violations, [])
+
+    def test_closure_body_assignment_not_flagged(self) -> None:
+        # codex r2 guard: `|| key = value)` — the preceder is `|`, not `(`/`,`.
+        violations = _scan_fixture(
+            """
+            fn probe() {
+                spawn(move || session_id = None);
+                run(|| channel = next());
             }
             """
         )


### PR DESCRIPTION
## #4218

**채널 키 통일 (174 로그 필드 / 45 파일)**: `channel =` 133건 rename + `channel = channel_id` 41건 shorthand 축약. `chan =`/`discord_channel_id =` 로그 필드는 실매치 0(바인딩/SQL 컬럼만). placeholder_sweeper의 named format 인자 1건은 `{channel}`→`{channel_id}` 동반 갱신(cargo check로 검출).

**세션 키**: 릴레이 경로는 이미 session_key 다수파. 남은 `session_id =` 3건은 **개념이 다른 식별자**(voice-gateway 세션 2, provider CLI hook 세션 1)라 오표기 방지 위해 allowlist 문서화.

**드리프트 게이트**: `scripts/check_log_key_drift.py` — discord/ 이하 금지 키 검출(비-0 exit + file:line), tracing 필드 형태만 매치(let/SQL/포맷 문자열 제외). `ci-script-checks.sh`에 배선(기존 ratchet 가드 관례).

핫파일 대량 편집이나 전부 키 rename — 라인 수 불변, freeze 무영향. 로그 파싱 외부 소비자/로그 assert 테스트 검색 결과 없음. 로컬 테스트 1030 pass, 실패 9건은 baseline 바이너리 재현으로 선재/환경성 판정.

게이트: fmt ✅ check ✅ drift 0 ✅ freshness ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)