### PR TITLE
chore(inflight): #4259 PR-1 — blind save 봉인 래칫 + stale 인벤토리 제거

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -750,6 +750,15 @@ jobs:
       - name: Hotfile LOC ratchet (always, #3565)
         run: python3 scripts/check_hotfile_ratchet.py
 
+      # Blind `save_inflight_state(` write ratchet (#4259) runs UNCONDITIONALLY
+      # for the same reason as the hotfile ratchet above: it must NOT inherit
+      # the `ci_relax_safe` skip on "Run script checks". Sealing the blind
+      # whole-blob write is pointless if a relax branch can add a new blind
+      # caller and merge before main CI catches it. This standalone step keeps
+      # the monotonic blind-write ceiling in force for every branch, no skip gate.
+      - name: Inflight blind-save ratchet (always, #4259)
+        run: python3 scripts/check_inflight_blind_save_ratchet.py
+
       - name: Upload maintainability audit artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -490,7 +490,7 @@
 | `services::discord::inflight::ownership_ops` | `src/services/discord/inflight/ownership_ops.rs` | 329 | 329 | 0 |  |
 | `services::discord::inflight::rebind_reap` | `src/services/discord/inflight/rebind_reap.rs` | 810 | 810 | 0 |  |
 | `services::discord::inflight::removal` | `src/services/discord/inflight/removal.rs` | 465 | 465 | 0 |  |
-| `services::discord::inflight::save_store` | `src/services/discord/inflight/save_store.rs` | 913 | 266 | 647 |  |
+| `services::discord::inflight::save_store` | `src/services/discord/inflight/save_store.rs` | 878 | 231 | 647 |  |
 | `services::discord::inflight::save_store::identity_gate` | `src/services/discord/inflight/save_store/identity_gate.rs` | 842 | 842 | 0 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 350 | 350 | 0 |  |
 | `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 365 | 365 | 0 |  |

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Ratchet guard for blind `save_inflight_state(...)` writes (#4259).
+
+`save_inflight_state` is the store-side "blind whole-blob write" half of the
+inflight sidecar contract (src/services/discord/inflight/save_store.rs): it
+serializes the WHOLE `InflightTurnState` row and clobbers whatever is on disk,
+with no compare-and-set on turn identity. A concurrent turn that legitimately
+re-owns the channel between a caller's snapshot and its write is silently
+overwritten. The drop-in guarded variant
+`save_inflight_state_if_identity_unchanged(state, caller)`
+(save_store/identity_gate.rs) refuses that race (returns `GuardedSaveOutcome`),
+and every remaining blind caller holds a snapshot local it can pin an identity
+against.
+
+This guard is a monotonic ceiling on the number of *production* blind
+`save_inflight_state(` call sites. It may only ever go DOWN: converting a site
+to the guarded variant (or a `_if_absent` / `_create_new` create-shaped variant)
+drops the count, and the ceiling is lowered to match. It can never grow back, so
+the blind-write debt converges to zero (#4259 PR-2..N do the per-track
+conversions) without anyone having to remember to chase it.
+
+Only `src/services/discord/**/*.rs` is scanned. Test surfaces are excluded:
+files named `tests.rs` / `*_tests.rs`, and `#[cfg(test)]` / `#[cfg(all(test, ...))]`
+modules/items (balanced-brace tracked). Suffixed variants
+(`save_inflight_state_if_identity_unchanged`, `_in_root`, `_if_matches_identity`,
+...) are NOT blind writes and are not counted — the regex requires `(` to follow
+`save_inflight_state` directly. The `fn save_inflight_state(` definition itself is
+skipped.
+
+To intentionally remove a blind write, convert the site then lower BASELINE to
+the new count. Raising BASELINE is a deliberate, reviewable diff edit that should
+carry justification — it is not the normal path.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Monotonic ceiling: the number of production blind `save_inflight_state(`
+# call sites permitted under src/services/discord. Lower this as sites convert
+# to the identity-guarded variant; never raise it casually.
+#
+# #4259 PR-1 baseline = 29. Track decomposition (convert + lower per PR-2..N):
+#   turn_bridge/runtime_handoff_loop.rs .. 9
+#   turn_bridge/stream_tick.rs .......... 5
+#   turn_bridge/stream_loop.rs .......... 2
+#   turn_bridge/post_loop_finalize.rs ... 4
+#   turn_bridge/mod.rs (hotfile, solo) .. 1
+#   external (router/session/tui) ....... 8
+#     (headless_turn, intake_turn, provider_isolation, watchdog,
+#      session_runtime/worktree, tui_prompt_relay/synthetic_start x2,
+#      tui_prompt_relay/codex_idle_rollout)
+BASELINE = 29
+
+SCAN_ROOT = Path("src") / "services" / "discord"
+
+# `save_inflight_state` followed directly by `(` — a blind write. The left
+# `\b` rejects longer identifiers ending in the name; requiring `(` right after
+# rejects every suffixed variant (`_if_identity_unchanged`, `_in_root`, ...).
+CALL_RE = re.compile(r"\bsave_inflight_state\(")
+DEFN_RE = re.compile(r"\bfn\s+save_inflight_state\(")
+# `#[cfg(test)]`, `#[cfg(all(test, ...))]`, `#[cfg(any(test, ...))]`.
+CFG_TEST_RE = re.compile(r"#\[\s*cfg\s*\(\s*(?:all|any)?\s*\(?\s*test\b")
+
+# String / char literals whose `{ } ; //` must not corrupt brace tracking or
+# comment stripping. Best-effort single-line (matches rustfmt-normalized source).
+STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+CHAR_RE = re.compile(r"'(?:[^'\\]|\\.)'")
+
+
+def strip_code(line: str) -> str:
+    """Return the code-only portion of a line: string / char literals blanked,
+    trailing `//` comment removed. Full-line `//` / `///` / `//!` comments
+    collapse to leading whitespace. Keeps `{`/`}`/`;` counts honest."""
+    line = STRING_RE.sub('""', line)
+    line = CHAR_RE.sub("''", line)
+    idx = line.find("//")
+    if idx != -1:
+        line = line[:idx]
+    return line
+
+
+def count_blind_saves(repo_root: Path) -> tuple[int, list[str]]:
+    """Count production blind `save_inflight_state(` call sites under
+    src/services/discord. Excludes test files, `#[cfg(test)]` modules/items
+    (balanced-brace tracked), comments/strings, and the fn definition."""
+    total = 0
+    locations: list[str] = []
+    scan_root = repo_root / SCAN_ROOT
+    for path in sorted(scan_root.rglob("*.rs")):
+        rel = path.relative_to(repo_root)
+        if "target" in rel.parts:
+            continue
+        name = path.name
+        if name == "tests.rs" or name.endswith("_tests.rs"):
+            continue
+
+        brace_depth = 0
+        mode = "normal"  # normal | armed (saw cfg(test) attr) | skip (in test block)
+        skip_start_depth = 0
+        for lineno, raw in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            code = strip_code(raw)
+            countable = mode == "normal"
+
+            if mode == "normal" and CFG_TEST_RE.search(code):
+                mode = "armed"
+
+            # Walk braces / statement terminators to update the test-region state
+            # machine. An armed cfg(test) attribute resolves on the item that
+            # follows: a `{` opens a balanced-brace skip region; a `;` at the
+            # attribute's depth means a statement item (use/const/type) — disarm.
+            for ch in code:
+                if ch == "{":
+                    if mode == "armed":
+                        mode = "skip"
+                        skip_start_depth = brace_depth
+                    brace_depth += 1
+                elif ch == "}":
+                    brace_depth -= 1
+                    if mode == "skip" and brace_depth <= skip_start_depth:
+                        mode = "normal"
+                elif ch == ";":
+                    if mode == "armed":
+                        mode = "normal"
+
+            if not countable:
+                continue
+            if DEFN_RE.search(code):
+                continue
+            for _ in CALL_RE.finditer(code):
+                total += 1
+                locations.append(f"{rel}:{lineno}")
+
+    return total, locations
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    current, locations = count_blind_saves(repo_root)
+
+    if current > BASELINE:
+        print(
+            f"FAIL: {current} blind `save_inflight_state(` call sites exceed the "
+            f"ratchet baseline of {BASELINE}.",
+            file=sys.stderr,
+        )
+        print(
+            "      The blind-write count may only decrease. Convert a site to "
+            "`save_inflight_state_if_identity_unchanged` (or a `_if_absent` / "
+            "`_create_new` create variant) instead of adding a blind write.",
+            file=sys.stderr,
+        )
+        for loc in locations:
+            print(f"        {loc}", file=sys.stderr)
+        return 1
+
+    if current < BASELINE:
+        print(
+            f"NOTE: {current} blind save sites is below the baseline of {BASELINE}. "
+            f"Lower BASELINE to {current} in "
+            "scripts/check_inflight_blind_save_ratchet.py to lock in the win."
+        )
+        return 0
+
+    print(f"OK: {current} blind `save_inflight_state(` call sites (baseline {BASELINE}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -27,6 +27,16 @@ modules/items (balanced-brace tracked). Suffixed variants
 `save_inflight_state` directly. The `fn save_inflight_state(` definition itself is
 skipped.
 
+String/comment handling: a cross-line lexer (`StripState` / `strip_line`,
+ported verbatim from `scripts/check_log_key_drift.py`, #4218 — kept as a copy
+so both guards stay dependency-free single-file scripts) blanks string literals
+(normal strings with escapes, `b"…"`, and `r"…"` / `r#"…"#` raw strings — all
+of which may span lines), char literals, `//` line comments, and nested
+`/* … */` block comments BEFORE the cfg(test) brace tracking and call matching
+run. Without the cross-line state, an unbalanced `{` inside a multi-line raw
+string in a cfg(test) module would poison the brace depth, keep skip mode alive
+past the module, and hide every later production call (codex r1).
+
 To intentionally remove a blind write, convert the site then lower BASELINE to
 the new count. Raising BASELINE is a deliberate, reviewable diff edit that should
 carry justification — it is not the normal path.
@@ -64,28 +74,112 @@ DEFN_RE = re.compile(r"\bfn\s+save_inflight_state\(")
 # `#[cfg(test)]`, `#[cfg(all(test, ...))]`, `#[cfg(any(test, ...))]`.
 CFG_TEST_RE = re.compile(r"#\[\s*cfg\s*\(\s*(?:all|any)?\s*\(?\s*test\b")
 
-# String / char literals whose `{ } ; //` must not corrupt brace tracking or
-# comment stripping. Best-effort single-line (matches rustfmt-normalized source).
-STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
-CHAR_RE = re.compile(r"'(?:[^'\\]|\\.)'")
+# --- Cross-line string/comment stripper, ported verbatim from
+# scripts/check_log_key_drift.py (#4218). Copied rather than imported so both
+# guards remain dependency-free single-file scripts; if a bug is found here,
+# fix it in both. Blanked output keeps `{` / `}` / `;` counts honest for the
+# cfg(test) brace tracking below (codex r1: a single-line stripper let an
+# unbalanced `{` in a multi-line raw string poison the brace depth). ---
+
+# Char literal (so `'"'` / `'{'` cannot desync the scanners). Lifetimes (`'a`)
+# do not match and fall through harmlessly.
+_CHAR_LITERAL = re.compile(r"'(\\.|[^'\\])'")
+
+# Raw / byte string openers: r"…", r#"…"#, br"…"; b"…" is handled separately.
+_RAW_STRING_OPEN = re.compile(r'(?:r|br)(#*)"')
 
 
-def strip_code(line: str) -> str:
-    """Return the code-only portion of a line: string / char literals blanked,
-    trailing `//` comment removed. Full-line `//` / `///` / `//!` comments
-    collapse to leading whitespace. Keeps `{`/`}`/`;` counts honest."""
-    line = STRING_RE.sub('""', line)
-    line = CHAR_RE.sub("''", line)
-    idx = line.find("//")
-    if idx != -1:
-        line = line[:idx]
-    return line
+class StripState:
+    """Cross-line lexer state: strings and block comments span lines."""
+
+    __slots__ = ("in_string", "raw_hashes", "block_depth")
+
+    def __init__(self) -> None:
+        self.in_string = False  # inside a normal "…" / b"…" string
+        self.raw_hashes: int | None = None  # inside r"…" / r#"…"# (hash count)
+        self.block_depth = 0  # nested /* … */ depth
+
+
+def strip_line(line: str, state: StripState) -> str:
+    """Blank out string-literal/comment content, preserving column positions.
+
+    Quote and comment delimiters themselves are blanked too — only real code
+    survives. `state` carries over between lines so multi-line strings
+    (including `\\`-newline continuations) and block comments stay stripped.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if state.block_depth > 0:
+            if line.startswith("/*", i):
+                state.block_depth += 1
+                out.append("  ")
+                i += 2
+            elif line.startswith("*/", i):
+                state.block_depth -= 1
+                out.append("  ")
+                i += 2
+            else:
+                out.append(" ")
+                i += 1
+            continue
+        if state.raw_hashes is not None:
+            closer = '"' + "#" * state.raw_hashes
+            if line.startswith(closer, i):
+                state.raw_hashes = None
+                out.append(" " * len(closer))
+                i += len(closer)
+            else:
+                out.append(" ")
+                i += 1
+            continue
+        if state.in_string:
+            if line[i] == "\\" and i + 1 < n:
+                out.append("  ")
+                i += 2
+            else:
+                if line[i] == '"':
+                    state.in_string = False
+                out.append(" ")
+                i += 1
+            continue
+        # --- normal code ---
+        if line.startswith("//", i):
+            break  # line comment: drop the rest of the line
+        if line.startswith("/*", i):
+            state.block_depth = 1
+            out.append("  ")
+            i += 2
+            continue
+        raw = _RAW_STRING_OPEN.match(line, i)
+        if raw:
+            state.raw_hashes = len(raw.group(1))
+            out.append(" " * (raw.end() - i))
+            i = raw.end()
+            continue
+        if line[i] == '"' or line.startswith('b"', i):
+            skip = 2 if line[i] == "b" else 1
+            state.in_string = True
+            out.append(" " * skip)
+            i += skip
+            continue
+        if line[i] == "'":
+            m = _CHAR_LITERAL.match(line, i)
+            if m:
+                out.append(" " * (m.end() - i))
+                i = m.end()
+                continue
+        out.append(line[i])
+        i += 1
+    return "".join(out)
 
 
 def count_blind_saves(repo_root: Path) -> tuple[int, list[str]]:
     """Count production blind `save_inflight_state(` call sites under
     src/services/discord. Excludes test files, `#[cfg(test)]` modules/items
-    (balanced-brace tracked), comments/strings, and the fn definition."""
+    (balanced-brace tracked), comments/strings (cross-line stripped), and the
+    fn definition."""
     total = 0
     locations: list[str] = []
     scan_root = repo_root / SCAN_ROOT
@@ -97,13 +191,14 @@ def count_blind_saves(repo_root: Path) -> tuple[int, list[str]]:
         if name == "tests.rs" or name.endswith("_tests.rs"):
             continue
 
+        strip_state = StripState()
         brace_depth = 0
         mode = "normal"  # normal | armed (saw cfg(test) attr) | skip (in test block)
         skip_start_depth = 0
         for lineno, raw in enumerate(
             path.read_text(encoding="utf-8").splitlines(), start=1
         ):
-            code = strip_code(raw)
+            code = strip_line(raw, strip_state)
             countable = mode == "normal"
 
             if mode == "normal" and CFG_TEST_RE.search(code):

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -66,11 +66,14 @@ BASELINE = 29
 
 SCAN_ROOT = Path("src") / "services" / "discord"
 
-# `save_inflight_state` followed directly by `(` — a blind write. The left
-# `\b` rejects longer identifiers ending in the name; requiring `(` right after
-# rejects every suffixed variant (`_if_identity_unchanged`, `_in_root`, ...).
-CALL_RE = re.compile(r"\bsave_inflight_state\(")
-DEFN_RE = re.compile(r"\bfn\s+save_inflight_state\(")
+# `save_inflight_state` followed by `(` — a blind write. The left `\b` rejects
+# longer identifiers ending in the name; `\s*` tolerates whitespace left behind
+# by the stripper blanking an interleaved comment (`save_inflight_state /* x */ (`,
+# a form rustfmt preserves — codex r2). Suffixed variants
+# (`_if_identity_unchanged`, `_in_root`, ...) are still rejected because `_`
+# is not whitespace.
+CALL_RE = re.compile(r"\bsave_inflight_state\s*\(")
+DEFN_RE = re.compile(r"\bfn\s+save_inflight_state\s*\(")
 # `#[cfg(test)]`, `#[cfg(all(test, ...))]`, `#[cfg(any(test, ...))]`.
 CFG_TEST_RE = re.compile(r"#\[\s*cfg\s*\(\s*(?:all|any)?\s*\(?\s*test\b")
 

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -68,6 +68,10 @@ echo "=== Discord log field-key drift guard (#4218) ==="
 "$PYTHON" scripts/check_log_key_drift.py
 "$PYTHON" -m unittest tests.test_log_key_drift
 
+echo "=== Inflight blind-save ratchet guard (#4259) ==="
+"$PYTHON" scripts/check_inflight_blind_save_ratchet.py
+"$PYTHON" -m unittest tests.test_inflight_blind_save_ratchet
+
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -37,53 +37,18 @@ pub(super) use self::identity_gate::{
     save_inflight_state_if_matches_identity_in_root,
 };
 
-// Direct production callers of `save_inflight_state` remain intentionally broad
-// while #4111 narrows three RMW sites. Starting inventory for a future
-// write-API restriction, generated with `rg -n "save_inflight_state\("
-// src/services/discord` and excluding test-only surfaces: files/modules named
-// `tests.rs` / `*_tests.rs` and any `#[cfg(test)]` or `#[cfg(all(test, unix))]`
-// test modules are not production call sites. Current production inventory: 40
-// callers.
-// - src/services/discord/router/message_handler/headless_turn.rs:1071
-// - src/services/discord/router/message_handler/intake_turn.rs:2515
-// - src/services/discord/router/message_handler/provider_isolation.rs:460
-// - src/services/discord/router/message_handler/watchdog.rs:822
-// - src/services/discord/session_runtime/worktree.rs:599
-// - src/services/discord/tui_prompt_relay/codex_idle_rollout.rs:140
-// - src/services/discord/tui_prompt_relay/synthetic_start.rs:297
-// - src/services/discord/tui_prompt_relay/synthetic_start.rs:344
-// - src/services/discord/turn_bridge/mod.rs:1094
-// - src/services/discord/turn_bridge/mod.rs:1139
-// - src/services/discord/turn_bridge/mod.rs:1161
-// - src/services/discord/turn_bridge/mod.rs:1650
-// - src/services/discord/turn_bridge/mod.rs:1694
-// - src/services/discord/turn_bridge/mod.rs:2531
-// - src/services/discord/turn_bridge/mod.rs:2987
-// - src/services/discord/turn_bridge/mod.rs:3040
-// - src/services/discord/turn_bridge/mod.rs:3064
-// - src/services/discord/turn_bridge/mod.rs:3239
-// - src/services/discord/turn_bridge/mod.rs:3270
-// - src/services/discord/turn_bridge/mod.rs:3300
-// - src/services/discord/turn_bridge/mod.rs:3704
-// - src/services/discord/turn_bridge/mod.rs:3725
-// - src/services/discord/turn_bridge/mod.rs:3735
-// - src/services/discord/turn_bridge/mod.rs:3774
-// - src/services/discord/turn_bridge/mod.rs:3829
-// - src/services/discord/turn_bridge/mod.rs:3851
-// - src/services/discord/turn_bridge/mod.rs:3868
-// - src/services/discord/turn_bridge/mod.rs:3897
-// - src/services/discord/turn_bridge/mod.rs:3929
-// - src/services/discord/turn_bridge/mod.rs:4500
-// - src/services/discord/turn_bridge/mod.rs:4524
-// - src/services/discord/turn_bridge/mod.rs:4537
-// - src/services/discord/turn_bridge/mod.rs:4549
-// - src/services/discord/turn_bridge/mod.rs:5536
-// - src/services/discord/turn_bridge/mod.rs:6330
-// - src/services/discord/turn_bridge/mod.rs:6374
-// - src/services/discord/turn_bridge/retry_state.rs:328
-// - src/services/discord/turn_bridge/two_message_panel.rs:205
-// - src/services/discord/turn_bridge/watcher_handoff.rs:427
-// - src/services/discord/turn_bridge/watcher_handoff.rs:451
+/// Blind whole-blob write of `InflightTurnState`: serializes the ENTIRE row and
+/// clobbers whatever is on disk, with no compare-and-set on turn identity.
+///
+/// SEALED (#4259) — do not add new callers. A concurrent turn that legitimately
+/// re-owns the channel between a caller's snapshot and this write is silently
+/// overwritten. For any new site use the drop-in guarded variant
+/// `save_inflight_state_if_identity_unchanged` (save_store/identity_gate.rs),
+/// which refuses that race and returns a `GuardedSaveOutcome`. The remaining
+/// blind callers are tracked as a monotonically-decreasing ceiling by
+/// `scripts/check_inflight_blind_save_ratchet.py` — that ratchet is the living
+/// inventory that replaced the stale hand-maintained line-number list, and its
+/// BASELINE is lowered per track as #4259 PR-2..N convert the sites.
 pub(in crate::services::discord) fn save_inflight_state(
     state: &InflightTurnState,
 ) -> Result<(), String> {

--- a/tests/test_inflight_blind_save_ratchet.py
+++ b/tests/test_inflight_blind_save_ratchet.py
@@ -182,6 +182,22 @@ class CountingTests(unittest.TestCase):
         self.assertEqual(total, 1, locs)
         self.assertTrue(locs[0].endswith(":5"), locs)
 
+    def test_interleaved_comment_before_paren_still_counted(self):
+        # codex r2: `save_inflight_state /* blind */ (&s)` — the stripper blanks
+        # the comment to spaces, so the call regex must tolerate whitespace
+        # before `(`. Suffixed variants must still be rejected.
+        body = (
+            "fn production() {\n"
+            "    let _ = save_inflight_state /* blind */ (&state);\n"
+            "    save_inflight_state_if_identity_unchanged /* g */ (&s, \"c\");\n"
+            "}\n"
+        )
+        total, locs = self._count(
+            lambda r: _write(r, "src/services/discord/interleaved.rs", body)
+        )
+        self.assertEqual(total, 1, locs)
+        self.assertTrue(locs[0].endswith(":2"), locs)
+
     def test_guard_variant_only_file_counts_zero(self):
         # (d) a file with only the guarded/suffixed variants -> 0.
         body = (

--- a/tests/test_inflight_blind_save_ratchet.py
+++ b/tests/test_inflight_blind_save_ratchet.py
@@ -3,8 +3,11 @@
 Covers the counting contract: (a) production call count, (b) test-file
 exclusion, (c) `#[cfg(test)]` module exclusion (incl. a test block sitting
 BEFORE a later production call, mirroring turn_bridge/mod.rs), (d) guarded /
-suffixed variants not counted, (e) comment/string exclusion — plus the
-FAIL/NOTE/OK exit branches and the live-repo baseline agreement.
+suffixed variants not counted, (e) comment/string exclusion — incl. the
+codex r1 cross-line cases: an unbalanced `{` in a multi-line raw string inside
+a cfg(test) module must not hide later production calls, and fake calls inside
+multi-line raw strings / block comments must not count — plus the FAIL/NOTE/OK
+exit branches and the live-repo baseline agreement.
 """
 
 from __future__ import annotations
@@ -122,6 +125,62 @@ class CountingTests(unittest.TestCase):
         total, locs = self._count(build)
         self.assertEqual(total, 1, locs)
         self.assertIn("inside.rs", locs[0])
+
+    def test_unbalanced_brace_in_cfg_test_raw_string_does_not_hide_later_calls(self):
+        # codex r1 repro: an unbalanced `{` inside a MULTI-LINE raw string in a
+        # cfg(test) module must not poison the brace depth — with a single-line
+        # stripper, skip mode outlived the module and hid the production call.
+        body = (
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            '    const TEMPLATE: &str = r#"\n'
+            '        { "channel_id": 1,\n'
+            '    "#;\n'
+            "    fn t() { save_inflight_state(&x).unwrap(); }\n"
+            "}\n"
+            "\n"
+            "fn production() {\n"
+            "    let _ = save_inflight_state(&y);\n"
+            "}\n"
+        )
+        total, locs = self._count(
+            lambda r: _write(r, "src/services/discord/repro.rs", body)
+        )
+        self.assertEqual(total, 1, locs)
+        self.assertTrue(locs[0].endswith(":10"), locs)
+
+    def test_fake_call_inside_multiline_raw_string_not_counted(self):
+        # A `save_inflight_state(` spelled inside a production-side multi-line
+        # raw string is prose, not a call site.
+        body = (
+            "fn production() {\n"
+            '    let doc: &str = r#"\n'
+            "        example: save_inflight_state(&x) must NOT count\n"
+            '    "#;\n'
+            "    let _ = save_inflight_state(&y);\n"
+            "}\n"
+        )
+        total, locs = self._count(
+            lambda r: _write(r, "src/services/discord/raw.rs", body)
+        )
+        self.assertEqual(total, 1, locs)
+        self.assertTrue(locs[0].endswith(":5"), locs)
+
+    def test_fake_call_inside_block_comment_not_counted(self):
+        # Multi-line /* … */ comments are stripped cross-line too.
+        body = (
+            "/*\n"
+            " * save_inflight_state(&x) in a block comment must NOT count\n"
+            " */\n"
+            "fn production() {\n"
+            "    let _ = save_inflight_state(&y);\n"
+            "}\n"
+        )
+        total, locs = self._count(
+            lambda r: _write(r, "src/services/discord/blockc.rs", body)
+        )
+        self.assertEqual(total, 1, locs)
+        self.assertTrue(locs[0].endswith(":5"), locs)
 
     def test_guard_variant_only_file_counts_zero(self):
         # (d) a file with only the guarded/suffixed variants -> 0.

--- a/tests/test_inflight_blind_save_ratchet.py
+++ b/tests/test_inflight_blind_save_ratchet.py
@@ -1,0 +1,184 @@
+"""Self-tests for scripts/check_inflight_blind_save_ratchet.py (#4259 PR-1).
+
+Covers the counting contract: (a) production call count, (b) test-file
+exclusion, (c) `#[cfg(test)]` module exclusion (incl. a test block sitting
+BEFORE a later production call, mirroring turn_bridge/mod.rs), (d) guarded /
+suffixed variants not counted, (e) comment/string exclusion — plus the
+FAIL/NOTE/OK exit branches and the live-repo baseline agreement.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_inflight_blind_save_ratchet.py"
+
+_spec = importlib.util.spec_from_file_location("check_inflight_blind_save_ratchet", SCRIPT)
+ratchet = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ratchet)
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# A single production file exercising every counting rule. Expected production
+# hits are the four lines tagged `// COUNT`.
+SAMPLE_RS = """\
+// line comment mentioning save_inflight_state(&ignored) must NOT count
+/// doc comment mentioning save_inflight_state(&ignored) must NOT count
+
+// the definition itself is not a blind call site
+fn save_inflight_state(state: &S) -> Result<(), String> {
+    save_inflight_state_in_root(&root, state)
+}
+
+fn production() {
+    let _ = save_inflight_state(&a);                      // COUNT
+    save_inflight_state(&b).expect("save inflight");      // COUNT
+    let s = "save_inflight_state(&in_a_string)";          // string, NOT counted
+    save_inflight_state_if_identity_unchanged(&g, "who"); // guard variant, NOT counted
+    save_inflight_state_if_matches_identity(&g);          // suffix variant, NOT counted
+    save_inflight_state(&c); // trailing save_inflight_state(&x) comment  COUNT (once)
+}
+
+#[cfg(test)]
+mod early_tests {
+    fn t() {
+        save_inflight_state(&t1).unwrap();  // cfg(test), NOT counted
+        save_inflight_state(&t2).unwrap();  // cfg(test), NOT counted
+    }
+}
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    fn u() {
+        save_inflight_state(&u1).unwrap();  // cfg(all(test, ...)), NOT counted
+    }
+}
+
+fn after_tests() {
+    // a production call AFTER earlier cfg(test) blocks must still count
+    let _ = save_inflight_state(&z);                      // COUNT
+}
+"""
+
+
+class CountingTests(unittest.TestCase):
+    def _count(self, builder) -> tuple[int, list[str]]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            builder(root)
+            return ratchet.count_blind_saves(root)
+
+    def test_production_calls_counted_and_variants_comments_strings_defn_excluded(self):
+        # (a) production count, (d) variants, (e) comments/strings, definition.
+        total, locs = self._count(
+            lambda r: _write(r, "src/services/discord/sample.rs", SAMPLE_RS)
+        )
+        self.assertEqual(total, 4, locs)
+        self.assertEqual(len(locs), 4)
+        self.assertTrue(all("sample.rs" in loc for loc in locs))
+
+    def test_cfg_test_block_before_production_call_is_excluded_but_call_survives(self):
+        # (c) balanced-brace tracking: the early cfg(test) blocks are skipped,
+        # yet `after_tests` (past them) is still counted.
+        _total, locs = self._count(
+            lambda r: _write(r, "src/services/discord/sample.rs", SAMPLE_RS)
+        )
+        lines = sorted(int(loc.rsplit(":", 1)[1]) for loc in locs)
+        # last COUNT (after_tests) is the highest line and must be present.
+        self.assertIn(max(lines), lines)
+        self.assertEqual(len(lines), 4)
+
+    def test_test_files_excluded_by_name(self):
+        # (b) tests.rs / *_tests.rs are never production.
+        call = "fn t() { let _ = save_inflight_state(&x); }\n"
+
+        def build(r: Path) -> None:
+            _write(r, "src/services/discord/tests.rs", call)
+            _write(r, "src/services/discord/widget_tests.rs", call)
+
+        total, locs = self._count(build)
+        self.assertEqual(total, 0, locs)
+
+    def test_files_outside_scan_root_are_ignored(self):
+        # Scoped to src/services/discord only.
+        def build(r: Path) -> None:
+            _write(r, "src/other_area/outside.rs", "fn f() { save_inflight_state(&x); }\n")
+            _write(r, "src/services/discord/inside.rs", "fn f() { save_inflight_state(&x); }\n")
+
+        total, locs = self._count(build)
+        self.assertEqual(total, 1, locs)
+        self.assertIn("inside.rs", locs[0])
+
+    def test_guard_variant_only_file_counts_zero(self):
+        # (d) a file with only the guarded/suffixed variants -> 0.
+        body = (
+            "fn f() {\n"
+            "    save_inflight_state_if_identity_unchanged(&s, \"c\");\n"
+            "    save_inflight_state_in_root(&root, &s);\n"
+            "    save_inflight_state_if_matches_identity(&s);\n"
+            "}\n"
+        )
+        total, _ = self._count(
+            lambda r: _write(r, "src/services/discord/guarded.rs", body)
+        )
+        self.assertEqual(total, 0)
+
+
+class ExitBranchTests(unittest.TestCase):
+    """FAIL/NOTE/OK branches, isolated from the real tree via mocking."""
+
+    def _run_main(self, current: int, baseline: int) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(ratchet, "BASELINE", baseline), mock.patch.object(
+            ratchet, "count_blind_saves", return_value=(current, ["a.rs:1"] * current)
+        ), redirect_stdout(out), redirect_stderr(err):
+            code = ratchet.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_over_baseline_fails(self):
+        code, _out, err = self._run_main(current=30, baseline=29)
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL", err)
+
+    def test_below_baseline_notes_and_passes(self):
+        code, out, _err = self._run_main(current=28, baseline=29)
+        self.assertEqual(code, 0)
+        self.assertIn("NOTE", out)
+        self.assertIn("Lower BASELINE to 28", out)
+
+    def test_at_baseline_ok(self):
+        code, out, _err = self._run_main(current=29, baseline=29)
+        self.assertEqual(code, 0)
+        self.assertIn("OK", out)
+
+
+class LiveRepoBaselineTests(unittest.TestCase):
+    def test_live_repo_matches_baseline(self):
+        # (a) The real src/services/discord tree matches the frozen BASELINE.
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"OK: {ratchet.BASELINE}", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #4259 PR-1 (봉인 인프라 — 호출자 전환은 PR-2+)

- `scripts/check_inflight_blind_save_ratchet.py`: production `save_inflight_state(` 호출 BASELINE=29(감소 단조), 가드 변형/tests.rs/#[cfg(test)](브레이스 추적 — mod.rs의 test-블록-후-프로덕션-호출 함정 처리)/주석·문자열 제외. 트랙 분해 주석(runtime_handoff_loop 9/stream_tick 5/stream_loop 2/post_loop_finalize 4/mod.rs 1/외부 8).
- **이중 CI 배선**: ci-script-checks.sh(+unittest 셀프테스트 9종) + ci-pr.yml 무조건 독립 스텝(hotfile 래칫 #3565 모델 — ci_relax_safe 우회 봉쇄).
- save_store.rs:40-86 stale 인벤토리(죽은 라인 40곳) 삭제 → 봉인 doc comment로 대체. Rust 동작 변화 0.

게이트: 래칫 OK(29/29) / unittest 9/9 / fmt·check ✅ / freshness ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)