### PR TITLE
test(watcher): #4321 — suppression_arms 상시 실패 테스트 교정 (S2 분해 자식 모듈 탐색 추가)

### DIFF
--- a/src/services/discord/tmux_watcher/completion_gate_tests.rs
+++ b/src/services/discord/tmux_watcher/completion_gate_tests.rs
@@ -1595,16 +1595,31 @@ fn unprocessed_tail_after_first_terminal(batch: &str) -> String {
 }
 
 fn assert_suppression_arm_uses_confirmed_end_helper(reason: &str) {
-    let module_src = include_str!("../tmux_watcher.rs");
-    let reason_idx = module_src
-        .find(reason)
+    // #4321: #4229 S2 (#4297) extracted the post-terminal-no-inflight arm into
+    // tmux_watcher/loop_poll_prologue.rs, so the suppression arms now live
+    // across the parent module and its decomposed children. Search every module
+    // that can host an `advance_watcher_confirmed_end` suppression arm so this
+    // wiring guarantee survives further extraction (each source must be an
+    // `include_str!` literal because the paths are resolved at compile time; a
+    // reason that goes missing from all of them still trips the panic below).
+    const MODULE_SOURCES: &[&str] = &[
+        include_str!("../tmux_watcher.rs"),
+        include_str!("loop_poll_prologue.rs"),
+    ];
+    let (module_src, reason_idx) = MODULE_SOURCES
+        .iter()
+        .find_map(|src| src.find(reason).map(|idx| (*src, idx)))
         .unwrap_or_else(|| panic!("missing suppression reason {reason}"));
     let call_start = module_src[..reason_idx]
         .rfind("advance_watcher_confirmed_end(")
         .unwrap_or_else(|| panic!("missing advance call for {reason}"));
     let call_src = &module_src[call_start..reason_idx];
+    // The arm may pass the batch data by reference or by value (`&all_data` when
+    // the module owns a `String`, `all_data` when it already borrows a slice);
+    // both are the same consumed-terminal-end wiring.
     assert!(
-        call_src.contains("suppressed_terminal_confirmed_end(current_offset, &all_data)"),
+        call_src.contains("suppressed_terminal_confirmed_end(current_offset, &all_data)")
+            || call_src.contains("suppressed_terminal_confirmed_end(current_offset, all_data)"),
         "suppression arm {reason} must advance only to the consumed terminal end"
     );
 }


### PR DESCRIPTION
## #4321

**근본**: 소스단언 테스트가 `include_str!(tmux_watcher.rs)` 부모만 grep — S2(#4297)가 `post_terminal_no_inflight` arm을 loop_poll_prologue.rs:574로 이동한 뒤 상시 실패. **실배선은 정상**(consumed_end helper 경유 확인) — 배선 결함 아님.

**수정**: 테스트 파일만 — MODULE_SOURCES(부모+자식) 탐색 + `&all_data`/`all_data` 양형 인정. 원 계약(raw batch end가 아닌 suppressed_terminal_confirmed_end로만 워터마크 전진) 그대로 유지 — 약화 아님. 자식에서 reason 소실 시 여전히 panic으로 드리프트 검출.

코드·CI에 이 테스트 예외 배선 없음(전수 확인). 게이트: 대상 테스트 1 pass, completion_gate 62, tmux_watcher 268, fmt/check ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)