### PR TITLE
fix(intake-routing): #4349 claim on the forwarding bot's provider, not agents.provider

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -111,7 +111,7 @@
 | `db::dispatches::outbox::notify` | `src/db/dispatches/outbox/notify.rs` | 75 | 75 | 0 |  |
 | `db::dispatches::outbox::retry` | `src/db/dispatches/outbox/retry.rs` | 60 | 60 | 0 |  |
 | `db::idempotency` | `src/db/idempotency.rs` | 659 | 302 | 357 |  |
-| `db::intake_outbox` | `src/db/intake_outbox.rs` | 1779 | 630 | 1149 |  |
+| `db::intake_outbox` | `src/db/intake_outbox.rs` | 2095 | 663 | 1432 |  |
 | `db::kanban` | `src/db/kanban.rs` | 1 | 1 | 0 |  |
 | `db::kanban_cards` | `src/db/kanban_cards/mod.rs` | 273 | 273 | 0 |  |
 | `db::kanban_cards::crud` | `src/db/kanban_cards/crud.rs` | 414 | 414 | 0 |  |
@@ -382,9 +382,9 @@
 | `services::claude_tui::tui_relay` | `src/services/claude_tui/tui_relay.rs` | 1129 | 587 | 542 |  |
 | `services::cluster` | `src/services/cluster/mod.rs` | 32 | 32 | 0 |  |
 | `services::cluster::capability_routing` | `src/services/cluster/capability_routing.rs` | 261 | 261 | 0 |  |
-| `services::cluster::intake_router_hook` | `src/services/cluster/intake_router_hook.rs` | 1312 | 632 | 680 |  |
+| `services::cluster::intake_router_hook` | `src/services/cluster/intake_router_hook.rs` | 1326 | 645 | 681 |  |
 | `services::cluster::intake_routing` | `src/services/cluster/intake_routing.rs` | 351 | 149 | 202 |  |
-| `services::cluster::intake_worker` | `src/services/cluster/intake_worker.rs` | 417 | 336 | 81 |  |
+| `services::cluster::intake_worker` | `src/services/cluster/intake_worker.rs` | 418 | 336 | 82 |  |
 | `services::cluster::intake_worker_capabilities` | `src/services/cluster/intake_worker_capabilities.rs` | 83 | 83 | 0 |  |
 | `services::cluster::node_registry` | `src/services/cluster/node_registry.rs` | 1021 | 751 | 270 |  |
 | `services::cluster::registry_adapter_sink` | `src/services/cluster/registry_adapter_sink.rs` | 344 | 117 | 227 |  |
@@ -603,7 +603,7 @@
 | `services::discord::router::intake_gate::busy_duplicate_notice` | `src/services/discord/router/intake_gate/busy_duplicate_notice.rs` | 55 | 27 | 28 |  |
 | `services::discord::router::intake_gate::component_events` | `src/services/discord/router/intake_gate/component_events.rs` | 41 | 41 | 0 |  |
 | `services::discord::router::intake_gate::gate` | `src/services/discord/router/intake_gate/gate.rs` | 79 | 79 | 0 |  |
-| `services::discord::router::intake_gate::node_override_routing` | `src/services/discord/router/intake_gate/node_override_routing.rs` | 62 | 62 | 0 |  |
+| `services::discord::router::intake_gate::node_override_routing` | `src/services/discord/router/intake_gate/node_override_routing.rs` | 63 | 63 | 0 |  |
 | `services::discord::router::intake_gate::queue_effects` | `src/services/discord/router/intake_gate/queue_effects.rs` | 953 | 745 | 208 |  |
 | `services::discord::router::intake_gate::reaction_remove` | `src/services/discord/router/intake_gate/reaction_remove.rs` | 226 | 226 | 0 |  |
 | `services::discord::router::intake_gate::stale_turn` | `src/services/discord/router/intake_gate/stale_turn.rs` | 630 | 283 | 347 |  |

--- a/migrations/postgres/0079_intake_outbox_provider.sql
+++ b/migrations/postgres/0079_intake_outbox_provider.sql
@@ -1,0 +1,41 @@
+-- #4349: record which bot provider forwarded an intake row.
+--
+-- Worker claim previously resolved the provider by joining `agents` and
+-- reading `agents.provider`, a single column per agent. Agents that own
+-- both a `discord_channel_cc` (claude) and a `discord_channel_cdx`
+-- (codex) therefore claimed rows with whichever provider happened to be
+-- stored on the agent — running the turn on the wrong bot's token,
+-- SharedData, and mailboxes. Storing the forwarding bot's provider on
+-- the row makes claim eligibility exact.
+
+ALTER TABLE intake_outbox
+  ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT '';
+
+-- Backfill closed rows from the agent they belonged to. Only rows in a
+-- terminal status are backfilled this way: for them the (possibly wrong)
+-- agent provider is simply what already ran, so it is the honest record.
+-- Open rows are left at '' deliberately — see the guard below.
+UPDATE intake_outbox io
+SET provider = a.provider
+FROM agents a
+WHERE a.id = io.agent_id
+  AND io.provider = ''
+  AND io.status IN ('done', 'failed_pre_accept', 'failed_post_accept');
+
+-- Any row still open at deploy time predates the provider column, so its
+-- true forwarding provider is unknowable. Fail them closed rather than
+-- let a worker claim one with an empty provider (which matches nothing)
+-- and strand it in `pending` forever.
+UPDATE intake_outbox
+SET status = 'failed_pre_accept',
+    last_error = 'migration 0079: open row predates provider column (#4349)'
+WHERE provider = ''
+  AND status IN ('pending', 'claimed', 'accepted', 'spawned');
+
+-- Worker poll is (target_instance_id, provider) scoped now. Replace the
+-- pre-#4349 index so the claim scan stays index-only.
+DROP INDEX IF EXISTS idx_intake_outbox_worker_pending;
+
+CREATE INDEX IF NOT EXISTS idx_intake_outbox_worker_pending
+    ON intake_outbox (target_instance_id, provider, status, created_at)
+    WHERE status = 'pending';

--- a/migrations/postgres/0079_intake_outbox_provider.sql
+++ b/migrations/postgres/0079_intake_outbox_provider.sql
@@ -49,9 +49,15 @@ WHERE provider = ''
 --    the turn can already have emitted to Discord. Auto-retry is forbidden
 --    past `accepted` (intake_worker.rs: "a failure is post-accept and is NOT
 --    auto-retried"; the operator alert IS the recovery signal), so these must
---    never be labelled pre-accept. Mark them post-accept and leave recovery to
---    `force_fail_and_retry_as_new`, whose TRANSITION_12_ALLOWED accepts exactly
---    this state.
+--    never be labelled pre-accept.
+--
+--    These rows keep `provider = ''`. That is deliberate and it is NOT
+--    silently retryable: `force_fail_and_retry_as_new` copies `provider` into
+--    the fresh `pending` row it inserts, and claim is scoped on
+--    `intake_outbox.provider`, so a retry would strand invisible pending work.
+--    It therefore rejects an empty provider with `ForceFailError::UnknownProvider`
+--    (#4349 review r2). An operator who wants to retry one of these must first
+--    decide which bot forwarded it and set `provider` by hand.
 --
 --    Reaching here requires a malformed `claim_owner`, since `mark_accepted`
 --    only advances a row whose `claim_owner` matches. Kept as a defensive arm.

--- a/migrations/postgres/0079_intake_outbox_provider.sql
+++ b/migrations/postgres/0079_intake_outbox_provider.sql
@@ -11,10 +11,21 @@
 ALTER TABLE intake_outbox
   ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT '';
 
--- Backfill closed rows from the agent they belonged to. Only rows in a
--- terminal status are backfilled this way: for them the (possibly wrong)
--- agent provider is simply what already ran, so it is the honest record.
--- Open rows are left at '' deliberately — see the guard below.
+-- 1. Exact recovery. `claim_owner` is written as "{instance_id}:{provider}"
+--    (runtime_bootstrap/intake.rs), and `instance_id` is restricted to
+--    [A-Za-z0-9._-], so the suffix is unambiguous. Every row a worker ever
+--    claimed carries it. `sweep_stale_pre_accept_claims` nulls `claim_owner`
+--    when it resets `claimed -> pending`, so a surviving value always names
+--    the bot that actually held the row.
+UPDATE intake_outbox
+SET provider = split_part(claim_owner, ':', 2)
+WHERE provider = ''
+  AND claim_owner IS NOT NULL
+  AND split_part(claim_owner, ':', 2) IN ('claude', 'codex', 'gemini', 'qwen', 'opencode');
+
+-- 2. Rows that died before any worker claimed them but are already terminal.
+--    Nothing will ever re-read their provider, so the owning agent's provider
+--    is the closest honest record.
 UPDATE intake_outbox io
 SET provider = a.provider
 FROM agents a
@@ -22,15 +33,34 @@ WHERE a.id = io.agent_id
   AND io.provider = ''
   AND io.status IN ('done', 'failed_pre_accept', 'failed_post_accept');
 
--- Any row still open at deploy time predates the provider column, so its
--- true forwarding provider is unknowable. Fail them closed rather than
--- let a worker claim one with an empty provider (which matches nothing)
--- and strand it in `pending` forever.
+-- 3. Open PRE-accept rows with no recoverable provider. An empty provider
+--    matches no worker, so leaving them `pending` strands them forever.
+--    `pending` and `claimed` are both pre-accept: the sweep already resets
+--    `claimed -> pending`, and `mark_failed_pre_accept` is their normal
+--    failure path, so a retryable terminal state is correct here.
 UPDATE intake_outbox
 SET status = 'failed_pre_accept',
-    last_error = 'migration 0079: open row predates provider column (#4349)'
+    last_error = 'migration 0079: provider unrecoverable for pre-accept row (#4349)'
 WHERE provider = ''
-  AND status IN ('pending', 'claimed', 'accepted', 'spawned');
+  AND status IN ('pending', 'claimed');
+
+-- 4. Open POST-accept rows with no recoverable provider. `accepted` and
+--    `spawned` mean the worker already validated cwd and may have spawned —
+--    the turn can already have emitted to Discord. Auto-retry is forbidden
+--    past `accepted` (intake_worker.rs: "a failure is post-accept and is NOT
+--    auto-retried"; the operator alert IS the recovery signal), so these must
+--    never be labelled pre-accept. Mark them post-accept and leave recovery to
+--    `force_fail_and_retry_as_new`, whose TRANSITION_12_ALLOWED accepts exactly
+--    this state.
+--
+--    Reaching here requires a malformed `claim_owner`, since `mark_accepted`
+--    only advances a row whose `claim_owner` matches. Kept as a defensive arm.
+UPDATE intake_outbox
+SET status = 'failed_post_accept',
+    completed_at = COALESCE(completed_at, NOW()),
+    last_error = 'migration 0079: provider unrecoverable for post-accept row; operator recovery required (#4349)'
+WHERE provider = ''
+  AND status IN ('accepted', 'spawned');
 
 -- Worker poll is (target_instance_id, provider) scoped now. Replace the
 -- pre-#4349 index so the claim scan stays index-only.

--- a/migrations/postgres/0080_intake_outbox_provider.sql
+++ b/migrations/postgres/0080_intake_outbox_provider.sql
@@ -40,7 +40,7 @@ WHERE a.id = io.agent_id
 --    failure path, so a retryable terminal state is correct here.
 UPDATE intake_outbox
 SET status = 'failed_pre_accept',
-    last_error = 'migration 0079: provider unrecoverable for pre-accept row (#4349)'
+    last_error = 'migration 0080: provider unrecoverable for pre-accept row (#4349)'
 WHERE provider = ''
   AND status IN ('pending', 'claimed');
 
@@ -64,7 +64,7 @@ WHERE provider = ''
 UPDATE intake_outbox
 SET status = 'failed_post_accept',
     completed_at = COALESCE(completed_at, NOW()),
-    last_error = 'migration 0079: provider unrecoverable for post-accept row; operator recovery required (#4349)'
+    last_error = 'migration 0080: provider unrecoverable for post-accept row; operator recovery required (#4349)'
 WHERE provider = ''
   AND status IN ('accepted', 'spawned');
 

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -410,6 +410,11 @@
       "path": "migrations/postgres/0079_relay_dead_letter.sql",
       "sha256": "b36edaa1a22ee07137a8911d9a9a39b34a70488228501b23bf08f65e3ce75304",
       "version": 79
+    },
+    {
+      "path": "migrations/postgres/0080_intake_outbox_provider.sql",
+      "sha256": "051f5ddd45e12577f7fe0e7c77ee049687b3a7722ca6bef8666662faa46c7f2f",
+      "version": 80
     }
   ],
   "version": 1

--- a/src/db/intake_outbox.rs
+++ b/src/db/intake_outbox.rs
@@ -453,6 +453,13 @@ pub(crate) enum ForceFailError {
          double-emit a Discord turn)"
     )]
     DisallowedStatus { id: i64, status: String },
+    #[error(
+        "intake_outbox row id={id} has no recorded provider; a retry would insert pending work \
+         that no worker can claim (claim is scoped on intake_outbox.provider since #4349). This \
+         row predates the provider column and its forwarding bot is unknowable — set \
+         intake_outbox.provider explicitly before retrying, or leave it terminal"
+    )]
+    UnknownProvider { id: i64 },
     #[error("postgres error: {0}")]
     Db(#[from] sqlx::Error),
 }
@@ -504,6 +511,19 @@ pub(crate) async fn force_fail_and_retry_as_new(
             id: stuck_id,
             status: row.status.clone(),
         });
+    }
+
+    // #4349 review r2: the retry below copies `row.provider` into a fresh
+    // `pending` row, and claim is scoped on `intake_outbox.provider`. An empty
+    // provider matches no worker, so retrying such a row would silently strand
+    // it in `pending` forever — exactly the failure migration 0079 fails closed
+    // to avoid. Refuse loudly and BEFORE any state change, so the operator sees
+    // it instead of inheriting invisible pending work.
+    //
+    // Only rows that predate the provider column and whose `claim_owner` was
+    // unusable can reach here; 0079 recovers every other row.
+    if row.provider.trim().is_empty() {
+        return Err(ForceFailError::UnknownProvider { id: stuck_id });
     }
 
     // Force-terminate if not already terminal:
@@ -777,8 +797,44 @@ mod migration_tests {
             orphan_status, "failed_post_accept",
             "post-accept row must not be misclassified as retryable pre-accept"
         );
-        // And it lands in exactly the state force_fail_and_retry_as_new accepts.
+        // It lands in a state force_fail_and_retry_as_new would otherwise accept…
         assert!(super::TRANSITION_12_ALLOWED.contains(&orphan_status.as_str()));
+
+        // …but retrying it would insert `pending` work with provider='' that no
+        // worker can claim. #4349 review r2: refuse loudly, change nothing.
+        let err = super::force_fail_and_retry_as_new(&pool, orphan_post, "operator: retry")
+            .await
+            .expect_err("orphan row with no provider must be refused");
+        match err {
+            super::ForceFailError::UnknownProvider { id } => assert_eq!(id, orphan_post),
+            other => panic!("expected UnknownProvider, got {other:?}"),
+        }
+
+        // The refusal is total: no child row, original row untouched.
+        let family: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::BIGINT FROM intake_outbox WHERE channel_id = 'ch-g'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count family");
+        assert_eq!(family, 1, "refusal must not insert a retry attempt");
+        assert_eq!(
+            row_state(&pool, orphan_post).await,
+            ("".to_string(), "failed_post_accept".to_string())
+        );
+
+        // No pending row anywhere can carry an unclaimable empty provider.
+        let unclaimable: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::BIGINT FROM intake_outbox
+             WHERE provider = '' AND status IN ('pending','claimed','accepted','spawned')",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count unclaimable open rows");
+        assert_eq!(
+            unclaimable, 0,
+            "migration must leave no open row that a worker can never claim"
+        );
 
         pool.close().await;
         pg_db.drop().await;

--- a/src/db/intake_outbox.rs
+++ b/src/db/intake_outbox.rs
@@ -646,6 +646,144 @@ mod migration_tests {
     use serde_json::json;
     use sqlx::Row;
 
+    /// Migration 0079 verbatim. Every statement is idempotent — the DDL is
+    /// `IF [NOT] EXISTS` and each backfill/fail-closed UPDATE is gated on
+    /// `provider = ''` — so replaying it over synthetic pre-#4349 rows exercises
+    /// exactly what a real deploy runs.
+    const MIGRATION_0079: &str =
+        include_str!("../../migrations/postgres/0079_intake_outbox_provider.sql");
+
+    /// Executed as one script over the simple query protocol, exactly how
+    /// `sqlx::migrate` runs it in production. Splitting on `;` would break on
+    /// semicolons inside comments and string literals.
+    async fn replay_migration_0079(pool: &sqlx::PgPool) {
+        sqlx::raw_sql(MIGRATION_0079)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("replay 0079 failed: {e}"));
+    }
+
+    /// A pre-#4349 row: `provider = ''`, which is what the column default leaves
+    /// behind for rows written before the migration ran.
+    async fn seed_legacy_row(
+        pool: &sqlx::PgPool,
+        channel: &str,
+        status: &str,
+        claim_owner: Option<&str>,
+    ) -> i64 {
+        sqlx::query_scalar(
+            "INSERT INTO intake_outbox (
+                target_instance_id, forwarded_by_instance_id,
+                channel_id, user_msg_id, request_owner_id, user_text, turn_kind,
+                agent_id, provider, status, claim_owner
+             ) VALUES (
+                'worker-1', 'leader-1',
+                $1, $1, '100', 'hi', 'foreground',
+                'agent-paired', '', $2, $3
+             ) RETURNING id",
+        )
+        .bind(channel)
+        .bind(status)
+        .bind(claim_owner)
+        .fetch_one(pool)
+        .await
+        .expect("seed legacy row")
+    }
+
+    async fn row_state(pool: &sqlx::PgPool, id: i64) -> (String, String) {
+        sqlx::query_as("SELECT provider, status FROM intake_outbox WHERE id = $1")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .expect("read row state")
+    }
+
+    /// #4349 review round 1 (REJECT): an earlier draft failed *every* open row to
+    /// `failed_pre_accept`. `accepted`/`spawned` are POST-accept — the turn may
+    /// already have emitted to Discord, and auto-retry is forbidden past
+    /// `accepted` (intake_worker.rs: "a failure is post-accept and is NOT
+    /// auto-retried"). Labelling them pre-accept misclassifies an orphaned turn
+    /// as retryable.
+    ///
+    /// The migration must instead recover `provider` from `claim_owner`
+    /// ("{instance_id}:{provider}") for every row a worker ever held, and
+    /// fail-close only what is genuinely unrecoverable — pre-accept rows to
+    /// `failed_pre_accept`, post-accept rows to `failed_post_accept`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn migration_0079_recovers_provider_from_claim_owner_and_fails_closed_by_accept_phase() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        sqlx::query(
+            "INSERT INTO agents (id, name, provider, discord_channel_id, discord_channel_cc)
+             VALUES ('agent-paired', 'Paired', 'codex', 'ch-cdx-mig', 'ch-cc-mig')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed paired agent");
+
+        // Worker-held rows. `claim_owner` names the real forwarding bot, and for
+        // the claude ones it disagrees with `agents.provider` ('codex') — which
+        // is precisely the #4349 bug.
+        let claimed = seed_legacy_row(&pool, "ch-a", "claimed", Some("worker-1:claude")).await;
+        let accepted = seed_legacy_row(&pool, "ch-b", "accepted", Some("worker-1:claude")).await;
+        let spawned = seed_legacy_row(&pool, "ch-c", "spawned", Some("worker-1:codex")).await;
+        let done = seed_legacy_row(&pool, "ch-d", "done", Some("worker-1:claude")).await;
+
+        // `pending` never carries a claim_owner (the sweep nulls it on reset).
+        let pending = seed_legacy_row(&pool, "ch-e", "pending", None).await;
+        // Terminal but never claimed — falls back to the agent's provider.
+        let dead_terminal = seed_legacy_row(&pool, "ch-f", "failed_pre_accept", None).await;
+        // Defensive arm: post-accept with an unusable claim_owner.
+        let orphan_post = seed_legacy_row(&pool, "ch-g", "spawned", Some("malformed")).await;
+
+        replay_migration_0079(&pool).await;
+
+        // Recovered exactly; status untouched.
+        assert_eq!(
+            row_state(&pool, claimed).await,
+            ("claude".to_string(), "claimed".to_string())
+        );
+        assert_eq!(
+            row_state(&pool, accepted).await,
+            ("claude".to_string(), "accepted".to_string())
+        );
+        assert_eq!(
+            row_state(&pool, spawned).await,
+            ("codex".to_string(), "spawned".to_string())
+        );
+        assert_eq!(
+            row_state(&pool, done).await,
+            ("claude".to_string(), "done".to_string())
+        );
+
+        // Unrecoverable + pre-accept → retryable terminal.
+        assert_eq!(
+            row_state(&pool, pending).await,
+            ("".to_string(), "failed_pre_accept".to_string()),
+            "pending is pre-accept; failing it closed must stay retryable"
+        );
+
+        // Terminal, never claimed → the agent's provider is the honest record.
+        assert_eq!(
+            row_state(&pool, dead_terminal).await,
+            ("codex".to_string(), "failed_pre_accept".to_string())
+        );
+
+        // Unrecoverable + post-accept → operator-only, NEVER pre-accept.
+        let (orphan_provider, orphan_status) = row_state(&pool, orphan_post).await;
+        assert_eq!(orphan_provider, "");
+        assert_eq!(
+            orphan_status, "failed_post_accept",
+            "post-accept row must not be misclassified as retryable pre-accept"
+        );
+        // And it lands in exactly the state force_fail_and_retry_as_new accepts.
+        assert!(super::TRANSITION_12_ALLOWED.contains(&orphan_status.as_str()));
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
     /// The migration must add the new `agents.preferred_intake_node_labels`
     /// column with a default of `'[]'::JSONB`. Existing agent reads must
     /// continue to work — verified by inserting a row without referencing

--- a/src/db/intake_outbox.rs
+++ b/src/db/intake_outbox.rs
@@ -516,12 +516,12 @@ pub(crate) async fn force_fail_and_retry_as_new(
     // #4349 review r2: the retry below copies `row.provider` into a fresh
     // `pending` row, and claim is scoped on `intake_outbox.provider`. An empty
     // provider matches no worker, so retrying such a row would silently strand
-    // it in `pending` forever — exactly the failure migration 0079 fails closed
+    // it in `pending` forever — exactly the failure migration 0080 fails closed
     // to avoid. Refuse loudly and BEFORE any state change, so the operator sees
     // it instead of inheriting invisible pending work.
     //
     // Only rows that predate the provider column and whose `claim_owner` was
-    // unusable can reach here; 0079 recovers every other row.
+    // unusable can reach here; 0080 recovers every other row.
     if row.provider.trim().is_empty() {
         return Err(ForceFailError::UnknownProvider { id: stuck_id });
     }
@@ -666,21 +666,21 @@ mod migration_tests {
     use serde_json::json;
     use sqlx::Row;
 
-    /// Migration 0079 verbatim. Every statement is idempotent — the DDL is
+    /// Migration 0080 verbatim. Every statement is idempotent — the DDL is
     /// `IF [NOT] EXISTS` and each backfill/fail-closed UPDATE is gated on
     /// `provider = ''` — so replaying it over synthetic pre-#4349 rows exercises
     /// exactly what a real deploy runs.
-    const MIGRATION_0079: &str =
-        include_str!("../../migrations/postgres/0079_intake_outbox_provider.sql");
+    const MIGRATION_0080: &str =
+        include_str!("../../migrations/postgres/0080_intake_outbox_provider.sql");
 
     /// Executed as one script over the simple query protocol, exactly how
     /// `sqlx::migrate` runs it in production. Splitting on `;` would break on
     /// semicolons inside comments and string literals.
-    async fn replay_migration_0079(pool: &sqlx::PgPool) {
-        sqlx::raw_sql(MIGRATION_0079)
+    async fn replay_migration_0080(pool: &sqlx::PgPool) {
+        sqlx::raw_sql(MIGRATION_0080)
             .execute(pool)
             .await
-            .unwrap_or_else(|e| panic!("replay 0079 failed: {e}"));
+            .unwrap_or_else(|e| panic!("replay 0080 failed: {e}")); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
     }
 
     /// A pre-#4349 row: `provider = ''`, which is what the column default leaves
@@ -707,7 +707,7 @@ mod migration_tests {
         .bind(claim_owner)
         .fetch_one(pool)
         .await
-        .expect("seed legacy row")
+        .expect("seed legacy row") // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
     }
 
     async fn row_state(pool: &sqlx::PgPool, id: i64) -> (String, String) {
@@ -715,7 +715,7 @@ mod migration_tests {
             .bind(id)
             .fetch_one(pool)
             .await
-            .expect("read row state")
+            .expect("read row state") // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
     }
 
     /// #4349 review round 1 (REJECT): an earlier draft failed *every* open row to
@@ -730,7 +730,7 @@ mod migration_tests {
     /// fail-close only what is genuinely unrecoverable — pre-accept rows to
     /// `failed_pre_accept`, post-accept rows to `failed_post_accept`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn migration_0079_recovers_provider_from_claim_owner_and_fails_closed_by_accept_phase() {
+    async fn migration_0080_recovers_provider_from_claim_owner_and_fails_closed_by_accept_phase() {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
 
@@ -740,7 +740,7 @@ mod migration_tests {
         )
         .execute(&pool)
         .await
-        .expect("seed paired agent");
+        .expect("seed paired agent"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         // Worker-held rows. `claim_owner` names the real forwarding bot, and for
         // the claude ones it disagrees with `agents.provider` ('codex') — which
@@ -757,7 +757,7 @@ mod migration_tests {
         // Defensive arm: post-accept with an unusable claim_owner.
         let orphan_post = seed_legacy_row(&pool, "ch-g", "spawned", Some("malformed")).await;
 
-        replay_migration_0079(&pool).await;
+        replay_migration_0080(&pool).await;
 
         // Recovered exactly; status untouched.
         assert_eq!(
@@ -807,7 +807,7 @@ mod migration_tests {
             .expect_err("orphan row with no provider must be refused");
         match err {
             super::ForceFailError::UnknownProvider { id } => assert_eq!(id, orphan_post),
-            other => panic!("expected UnknownProvider, got {other:?}"),
+            other => panic!("expected UnknownProvider, got {other:?}"), // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         }
 
         // The refusal is total: no child row, original row untouched.
@@ -816,7 +816,7 @@ mod migration_tests {
         )
         .fetch_one(&pool)
         .await
-        .expect("count family");
+        .expect("count family"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         assert_eq!(family, 1, "refusal must not insert a retry attempt");
         assert_eq!(
             row_state(&pool, orphan_post).await,
@@ -830,7 +830,7 @@ mod migration_tests {
         )
         .fetch_one(&pool)
         .await
-        .expect("count unclaimable open rows");
+        .expect("count unclaimable open rows"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         assert_eq!(
             unclaimable, 0,
             "migration must leave no open row that a worker can never claim"
@@ -1967,7 +1967,7 @@ mod helper_tests {
         )
         .execute(&pool)
         .await
-        .expect("seed paired agent");
+        .expect("seed paired agent"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         // The claude bot forwards a message from the agent's cc channel.
         let mut cc_row = payload("ch-cc", "msg-cc");
@@ -1975,13 +1975,13 @@ mod helper_tests {
         cc_row.provider = "claude".to_string();
         insert_pending(&pool, &cc_row, 1, None)
             .await
-            .expect("insert cc row");
+            .expect("insert cc row"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         // The codex worker shares `target_instance_id`. It must NOT claim
         // this row even though `agents.provider = 'codex'` matches it.
         let stolen = claim_pending_for_target(&pool, "worker-1", "codex", "owner-codex")
             .await
-            .expect("codex claim ok");
+            .expect("codex claim ok"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         assert!(
             stolen.is_none(),
             "codex worker must not claim a row forwarded by the claude bot"
@@ -1990,8 +1990,8 @@ mod helper_tests {
         // The claude worker claims it, despite `agents.provider = 'codex'`.
         let claimed = claim_pending_for_target(&pool, "worker-1", "claude", "owner-claude")
             .await
-            .expect("claude claim ok")
-            .expect("claude worker must claim its own row");
+            .expect("claude claim ok") // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
+            .expect("claude worker must claim its own row"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         assert_eq!(claimed.channel_id, "ch-cc");
         assert_eq!(claimed.provider, "claude");
         assert_eq!(claimed.agent_id, "agent-paired");
@@ -2014,34 +2014,34 @@ mod helper_tests {
         )
         .execute(&pool)
         .await
-        .expect("seed paired agent");
+        .expect("seed paired agent"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         let mut cc_row = payload("ch-cc2", "msg-retry");
         cc_row.agent_id = "agent-paired".to_string();
         cc_row.provider = "claude".to_string();
-        insert_pending(&pool, &cc_row, 1, None).await.expect("seed");
+        insert_pending(&pool, &cc_row, 1, None).await.expect("seed"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         let claimed = claim_pending_for_target(&pool, "worker-1", "claude", "owner-1")
             .await
-            .expect("claim")
-            .expect("row");
+            .expect("claim") // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
+            .expect("row"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         mark_accepted(&pool, claimed.id, "owner-1")
             .await
-            .expect("accept");
+            .expect("accept"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         mark_spawned(&pool, claimed.id, "owner-1")
             .await
-            .expect("spawn");
+            .expect("spawn"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         let new_id = force_fail_and_retry_as_new(&pool, claimed.id, "operator: hung")
             .await
-            .expect("force-fail");
+            .expect("force-fail"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
 
         let retry_provider: String =
             sqlx::query_scalar("SELECT provider FROM intake_outbox WHERE id = $1")
                 .bind(new_id)
                 .fetch_one(&pool)
                 .await
-                .expect("read retry provider");
+                .expect("read retry provider"); // agentdesk-audit: allow-unwrap — test helper/assert in #[cfg(test)] module
         assert_eq!(
             retry_provider, "claude",
             "retry must stay on the forwarding bot, not fall back to agents.provider"

--- a/src/db/intake_outbox.rs
+++ b/src/db/intake_outbox.rs
@@ -38,6 +38,9 @@ pub(crate) struct IntakeOutboxRow {
     pub defer_watcher_resume: bool,
     pub wait_for_completion: bool,
     pub agent_id: String,
+    /// Provider of the bot that forwarded this row (#4349). Carried through
+    /// `force_fail_and_retry_as_new` so a retry stays on the same bot.
+    pub provider: String,
     pub status: String,
     // reason: intake-outbox row column consumed by select claim/retry routes,
     // not every compile target. See #3034.
@@ -73,6 +76,10 @@ pub(crate) struct InsertPendingPayload {
     pub defer_watcher_resume: bool,
     pub wait_for_completion: bool,
     pub agent_id: String,
+    /// Provider of the bot that forwarded this row (#4349). Claim
+    /// eligibility is scoped on this, not on `agents.provider`, because a
+    /// cc/cdx paired agent has one `agents.provider` but two bots.
+    pub provider: String,
 }
 
 /// INSERT a fresh `pending` row into `intake_outbox` for the given
@@ -100,15 +107,15 @@ pub(crate) async fn insert_pending(
             channel_id, user_msg_id, request_owner_id, request_owner_name,
             user_text, reply_context, has_reply_boundary, dm_hint, turn_kind,
             merge_consecutive, reply_to_user_message, defer_watcher_resume,
-            wait_for_completion, agent_id,
+            wait_for_completion, agent_id, provider,
             status, attempt_no, parent_outbox_id
         ) VALUES (
             $1, $2, $3,
             $4, $5, $6, $7,
             $8, $9, $10, $11, $12,
             $13, $14, $15,
-            $16, $17,
-            'pending', $18, $19
+            $16, $17, $18,
+            'pending', $19, $20
         )
         RETURNING id
         "#,
@@ -130,6 +137,7 @@ pub(crate) async fn insert_pending(
     .bind(payload.defer_watcher_resume)
     .bind(payload.wait_for_completion)
     .bind(&payload.agent_id)
+    .bind(&payload.provider)
     .bind(attempt_no)
     .bind(parent_outbox_id)
     .fetch_one(pool)
@@ -197,10 +205,10 @@ pub(crate) async fn family_max_attempt(
 }
 
 /// Worker-side claim. Atomically promotes a single `pending` row owned
-/// by `target_instance_id` whose `agent_id` belongs to a `provider`-
-/// matching agent into `claimed`, and stamps `claim_owner` +
-/// `claimed_at`. Uses `FOR UPDATE SKIP LOCKED` so concurrent worker
-/// pollers do not stall each other.
+/// by `target_instance_id` and forwarded by a `provider`-matching bot
+/// into `claimed`, and stamps `claim_owner` + `claimed_at`. Uses
+/// `FOR UPDATE SKIP LOCKED` so concurrent worker pollers do not stall
+/// each other.
 ///
 /// **Provider filter (codex Phase 5 P0 #1):** a single AgentDesk
 /// process can host multiple bot tokens (claude, codex, etc.), each
@@ -208,9 +216,14 @@ pub(crate) async fn family_max_attempt(
 /// `SharedData`. Without this filter, every bot's worker would share
 /// the same `target_instance_id` and could claim a row destined for
 /// another provider's runtime — running it with the wrong token,
-/// settings, mailboxes, and placeholder controller. The JOIN on
-/// `agents.provider` makes claim eligibility provider-scoped so each
-/// worker only handles rows that belong to its own bot.
+/// settings, mailboxes, and placeholder controller.
+///
+/// **#4349:** this filter used to JOIN `agents` and compare
+/// `agents.provider`, which is a single column per agent. An agent that
+/// owns both a `discord_channel_cc` (claude) and a `discord_channel_cdx`
+/// (codex) has one `agents.provider` but two bots, so the wrong runtime
+/// claimed the row. `intake_outbox.provider` records the bot that
+/// actually forwarded it, making claim eligibility exact.
 ///
 /// Returns `Ok(Some(row))` on a successful claim; `Ok(None)` when the
 /// queue has no eligible row for this `(target_instance_id, provider)`
@@ -225,10 +238,9 @@ pub(crate) async fn claim_pending_for_target(
 
     let candidate: Option<i64> = sqlx::query_scalar(
         "SELECT io.id FROM intake_outbox io
-         INNER JOIN agents a ON a.id = io.agent_id
          WHERE io.target_instance_id = $1
            AND io.status = 'pending'
-           AND a.provider = $2
+           AND io.provider = $2
          ORDER BY io.created_at ASC
          LIMIT 1
          FOR UPDATE OF io SKIP LOCKED",
@@ -531,15 +543,15 @@ pub(crate) async fn force_fail_and_retry_as_new(
             channel_id, user_msg_id, request_owner_id, request_owner_name,
             user_text, reply_context, has_reply_boundary, dm_hint, turn_kind,
             merge_consecutive, reply_to_user_message, defer_watcher_resume,
-            wait_for_completion, agent_id,
+            wait_for_completion, agent_id, provider,
             status, attempt_no, parent_outbox_id
         ) VALUES (
             $1, $2, $3,
             $4, $5, $6, $7,
             $8, $9, $10, $11, $12,
             $13, $14, $15,
-            $16, $17,
-            'pending', $18, $19
+            $16, $17, $18,
+            'pending', $19, $20
         )
         RETURNING id
         "#,
@@ -561,6 +573,7 @@ pub(crate) async fn force_fail_and_retry_as_new(
     .bind(row.defer_watcher_resume)
     .bind(row.wait_for_completion)
     .bind(&row.agent_id)
+    .bind(&row.provider)
     .bind(next_attempt)
     .bind(stuck_id)
     .fetch_one(&mut *tx)
@@ -947,6 +960,7 @@ mod helper_tests {
         InsertPendingPayload {
             target_instance_id: "worker-1".to_string(),
             forwarded_by_instance_id: "leader-1".to_string(),
+            provider: "claude".to_string(),
             required_labels: json!(["unreal"]),
             channel_id: channel.to_string(),
             user_msg_id: msg.to_string(),
@@ -1674,13 +1688,16 @@ mod helper_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn claim_pending_for_target_filters_by_provider_join() {
+    async fn claim_pending_for_target_filters_by_row_provider() {
         // Codex Phase 5 P0 #1: a single AgentDesk process can host
         // claude AND codex bots; both call `run_intake_worker_loop`
-        // with the same `target_instance_id`. The provider JOIN
-        // ensures a claude bot's worker only claims rows whose
-        // `agents.provider = 'claude'` and never picks up a codex
-        // row (which would run with the wrong Http/SharedData/token).
+        // with the same `target_instance_id`. The provider filter
+        // ensures a claude bot's worker only claims rows forwarded by
+        // the claude bot and never picks up a codex row (which would
+        // run with the wrong Http/SharedData/token).
+        //
+        // #4349: the filter reads `intake_outbox.provider`, not
+        // `agents.provider`.
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
 
@@ -1697,12 +1714,14 @@ mod helper_tests {
         // Insert a row for each provider — both targeted at worker-1.
         let mut claude_payload = payload("ch-claude", "msg-claude");
         claude_payload.agent_id = "agent-claude".to_string();
+        claude_payload.provider = "claude".to_string();
         insert_pending(&pool, &claude_payload, 1, None)
             .await
             .expect("insert claude row");
 
         let mut codex_payload = payload("ch-codex", "msg-codex");
         codex_payload.agent_id = "agent-codex".to_string();
+        codex_payload.provider = "codex".to_string();
         insert_pending(&pool, &codex_payload, 1, None)
             .await
             .expect("insert codex row");
@@ -1730,6 +1749,109 @@ mod helper_tests {
             .expect("codex claim ok")
             .expect("must claim something");
         assert_eq!(codex_claimed.agent_id, "agent-codex");
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn claim_scopes_on_row_provider_not_agent_provider_for_paired_agent() {
+        // #4349 regression. A cc/cdx paired agent has ONE `agents.provider`
+        // but TWO bots. `project-agentdesk` is stored with provider='codex'
+        // while its `discord_channel_cc` is served by the claude bot.
+        //
+        // Claiming on `agents.provider` handed the claude bot's row to the
+        // codex worker, which then ran the turn with the codex token — a
+        // Codex reply in a Claude channel. Claim must key on the provider
+        // that actually forwarded the row.
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        sqlx::query(
+            "INSERT INTO agents (id, name, provider, discord_channel_id, discord_channel_cc)
+             VALUES ('agent-paired', 'Paired', 'codex', 'ch-cdx', 'ch-cc')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed paired agent");
+
+        // The claude bot forwards a message from the agent's cc channel.
+        let mut cc_row = payload("ch-cc", "msg-cc");
+        cc_row.agent_id = "agent-paired".to_string();
+        cc_row.provider = "claude".to_string();
+        insert_pending(&pool, &cc_row, 1, None)
+            .await
+            .expect("insert cc row");
+
+        // The codex worker shares `target_instance_id`. It must NOT claim
+        // this row even though `agents.provider = 'codex'` matches it.
+        let stolen = claim_pending_for_target(&pool, "worker-1", "codex", "owner-codex")
+            .await
+            .expect("codex claim ok");
+        assert!(
+            stolen.is_none(),
+            "codex worker must not claim a row forwarded by the claude bot"
+        );
+
+        // The claude worker claims it, despite `agents.provider = 'codex'`.
+        let claimed = claim_pending_for_target(&pool, "worker-1", "claude", "owner-claude")
+            .await
+            .expect("claude claim ok")
+            .expect("claude worker must claim its own row");
+        assert_eq!(claimed.channel_id, "ch-cc");
+        assert_eq!(claimed.provider, "claude");
+        assert_eq!(claimed.agent_id, "agent-paired");
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn force_fail_and_retry_as_new_preserves_row_provider() {
+        // #4349: a retry must stay on the bot that forwarded the original.
+        // Rebuilding the row from `agents.provider` would silently move the
+        // retry to the other bot on a paired agent.
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        sqlx::query(
+            "INSERT INTO agents (id, name, provider, discord_channel_id, discord_channel_cc)
+             VALUES ('agent-paired', 'Paired', 'codex', 'ch-cdx2', 'ch-cc2')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed paired agent");
+
+        let mut cc_row = payload("ch-cc2", "msg-retry");
+        cc_row.agent_id = "agent-paired".to_string();
+        cc_row.provider = "claude".to_string();
+        insert_pending(&pool, &cc_row, 1, None).await.expect("seed");
+
+        let claimed = claim_pending_for_target(&pool, "worker-1", "claude", "owner-1")
+            .await
+            .expect("claim")
+            .expect("row");
+        mark_accepted(&pool, claimed.id, "owner-1")
+            .await
+            .expect("accept");
+        mark_spawned(&pool, claimed.id, "owner-1")
+            .await
+            .expect("spawn");
+
+        let new_id = force_fail_and_retry_as_new(&pool, claimed.id, "operator: hung")
+            .await
+            .expect("force-fail");
+
+        let retry_provider: String =
+            sqlx::query_scalar("SELECT provider FROM intake_outbox WHERE id = $1")
+                .bind(new_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read retry provider");
+        assert_eq!(
+            retry_provider, "claude",
+            "retry must stay on the forwarding bot, not fall back to agents.provider"
+        );
 
         pool.close().await;
         pg_db.drop().await;

--- a/src/services/cluster/intake_router_hook.rs
+++ b/src/services/cluster/intake_router_hook.rs
@@ -276,6 +276,11 @@ pub(crate) enum RanLocalReason {
 pub(crate) struct IntakeRouterContext<'a> {
     pub mode: IntakeRoutingMode,
     pub leader_instance_id: &'a str,
+    /// Provider of the bot handling this intake (#4349). Worker claim is
+    /// scoped on this, so it must be the forwarding bot's provider — never
+    /// `agents.provider`, which is a single column shared by an agent's
+    /// cc and cdx channels.
+    pub provider: &'a str,
     pub channel_id: &'a str,
     pub user_msg_id: &'a str,
     pub request_owner_id: &'a str,
@@ -343,7 +348,12 @@ pub(crate) async fn try_route_intake(
 
     // Resolve agent + preference. NoAgentForChannel is NOT an error —
     // many channels (DMs, ad-hoc cross-bot) have no agent row.
-    let (agent_id, agent_provider, preferred_labels) =
+    //
+    // #4349: the agent's own `provider` column is deliberately ignored for
+    // routing. It is a single value shared by the agent's cc and cdx
+    // channels, so on a paired agent it disagrees with the bot that is
+    // actually handling this message. `ctx.provider` is that bot.
+    let (agent_id, _agent_provider, preferred_labels) =
         match agent_id_and_preferred_labels(pool, ctx.channel_id).await {
             Ok(Some((agent_id, provider, labels))) => (agent_id, provider, labels),
             Ok(None) => {
@@ -378,7 +388,7 @@ pub(crate) async fn try_route_intake(
                 .filter(|node| {
                     crate::services::cluster::node_registry::node_supports_intake_provider(
                         node,
-                        &agent_provider,
+                        ctx.provider,
                     )
                 })
                 .collect();
@@ -466,7 +476,9 @@ async fn try_route_node_override(
     ctx: &IntakeRouterContext<'_>,
     target: &str,
 ) -> IntakeRouterDecision {
-    let (agent_id, agent_provider, _) =
+    // #4349: `agents.provider` is ignored here for the same reason as in
+    // `try_route_intake` — the handling bot is `ctx.provider`.
+    let (agent_id, _agent_provider, _) =
         match agent_id_and_preferred_labels(pool, ctx.channel_id).await {
             Ok(Some((agent_id, provider, labels))) => (agent_id, provider, labels),
             Ok(None) => {
@@ -512,7 +524,7 @@ async fn try_route_node_override(
                 .is_some_and(|status| status.eq_ignore_ascii_case("online"))
             && crate::services::cluster::node_registry::node_supports_intake_provider(
                 node,
-                &agent_provider,
+                ctx.provider,
             )
     });
     if !target_online {
@@ -558,6 +570,7 @@ fn build_payload_for_insert(
     InsertPendingPayload {
         target_instance_id: target.to_string(),
         forwarded_by_instance_id: ctx.leader_instance_id.to_string(),
+        provider: ctx.provider.to_string(),
         required_labels: serde_json::Value::Array(
             preferred_labels
                 .iter()
@@ -681,6 +694,7 @@ mod pg_tests {
         IntakeRouterContext {
             mode,
             leader_instance_id: "leader-1",
+            provider: "claude",
             channel_id: channel,
             user_msg_id: "9999",
             request_owner_id: "100",

--- a/src/services/cluster/intake_worker.rs
+++ b/src/services/cluster/intake_worker.rs
@@ -328,6 +328,7 @@ mod tests {
             id: 42,
             target_instance_id: "worker-1".to_string(),
             forwarded_by_instance_id: "leader-1".to_string(),
+            provider: "claude".to_string(),
             required_labels: serde_json::json!(["unreal"]),
             channel_id: "1234567890".to_string(),
             user_msg_id: "9876543210".to_string(),

--- a/src/services/discord/router/intake_gate/node_override_routing.rs
+++ b/src/services/discord/router/intake_gate/node_override_routing.rs
@@ -43,6 +43,7 @@ pub(super) async fn try_route_intake_for_message(
     let hook_ctx = crate::services::cluster::intake_router_hook::IntakeRouterContext {
         mode,
         leader_instance_id: &leader_instance_id,
+        provider: data.provider.as_str(),
         channel_id: &channel_id_str,
         user_msg_id: &user_msg_id_str,
         request_owner_id: &request_owner_id_str,


### PR DESCRIPTION
Closes #4349

## 문제

cc/cdx 채널을 모두 가진 에이전트는 `agents.provider` 컬럼이 하나인데 봇은 둘이다. `intake_outbox` claim이 `agents`를 조인해 `agents.provider`로 판정하므로, forward한 봇과 다른 provider의 worker가 row를 집어간다.

`project-agentdesk`는 `agents.provider='codex'`이고 `discord_channel_cc`는 claude 봇이 서빙한다. claude 봇이 forward한 row를 codex worker가 claim해 codex 토큰·SharedData·mailbox로 실행한다 — **Claude 채널에 Codex가 답한다.** `ch-td`(provider='claude')는 방향만 반대인 같은 버그다.

단일 provider 에이전트(`generic-claude-macmini`)에서는 우연히 일치해 정상 동작했고, 그래서 이 경로가 건강해 보였다.

## 수정

`intake_outbox.provider`에 **forward한 봇의 provider**를 기록하고 claim을 그것으로 스코프한다.

- `IntakeRouterContext.provider` 추가, ctx build 사이트가 `Data.provider` 전달
- 후보 필터(`node_supports_intake_provider`)와 `/node` override target 검사도 `agents.provider` 대신 사용
- `claim_pending_for_target`: `a.provider = $2` → `io.provider = $2`
- `force_fail_and_retry_as_new`가 row의 provider를 승계 (retry가 다른 봇으로 넘어가지 않도록)
- worker poll 인덱스를 `(target_instance_id, provider, status, created_at)`로 재생성

### migration 0079

- `claim_owner`(`"{instance_id}:{provider}"`)에서 provider를 정확히 복원한다. `sweep_stale_pre_accept_claims`가 `claimed→pending` 리셋 시 `claim_owner`를 NULL로 지우므로, 살아있는 값은 항상 그 row를 실제로 잡았던 봇을 가리킨다. status는 건드리지 않는다.
- claim된 적 없는 terminal row는 `agents.provider`로 backfill (아무도 다시 안 읽는다)
- 복원 불가한 row만 fail-closed. **accept phase로 나눈다**: pending/claimed → `failed_pre_accept`(재시도 가능), accepted/spawned → `failed_post_accept`(operator 전용). post-accept는 turn이 이미 emit됐을 수 있어 auto-retry가 금지돼 있다.
- 그 orphan row들은 `provider=''`로 남는데, `force_fail_and_retry_as_new`가 이를 새 pending row에 복사하면 아무도 claim 못 하는 작업이 된다. 그래서 **상태 변경 전에** `ForceFailError::UnknownProvider`로 거부한다.

## 검증

- 회귀 테스트 3개 추가. 각각 **수정 전 코드로 되돌리면 실패하는 것**을 확인했다:
  - paired agent의 claude-forwarded row가 codex worker에게 안 보임
  - retry가 forwarding provider를 유지
  - 0079을 `sqlx::raw_sql`로 verbatim 재실행(프로덕션 `sqlx::migrate`와 동일한 simple protocol)해 복원/fail-closed/force-fail 거부를 전부 검증. 테이블 전역 불변식(open row 중 `provider=''` 0개)도 포함.
- `cargo test --lib intake_outbox` 30 passed / `cluster::` 131 passed / fmt clean / `cargo check --all-targets` 0 errors

## 리뷰

cdx 교차 리뷰 3라운드. r1·r2 REJECT를 반영했고 r3 VERDICT CLEAN.

- r1: accepted/spawned를 pre-accept로 오분류 → accept phase 분리 + claim_owner 복원
- r2: force-fail retry가 `provider=''` pending을 만듦 → UnknownProvider로 거부

🤖 Generated with [Claude Code](https://claude.com/claude-code)