### PR TITLE
fix(build): #4353 restore the windows build — cfg(unix) items referenced unguarded

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -94,7 +94,7 @@
 | `src/services/discord/commands/text_commands.rs` | 1476 |
 | `src/services/discord/formatting.rs` | 2862 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
-| `src/services/discord/mod.rs` | 4166 |
+| `src/services/discord/mod.rs` | 4165 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1337 |
 | `src/services/discord_config_audit.rs` | 1288 |
 | `src/services/dispatched_sessions.rs` | 1815 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -406,7 +406,7 @@
 | `services::codex_tui::rollout_tail::parser` | `src/services/codex_tui/rollout_tail/parser.rs` | 405 | 405 | 0 |  |
 | `services::codex_tui::session` | `src/services/codex_tui/session.rs` | 800 | 316 | 484 |  |
 | `services::cswap` | `src/services/cswap.rs` | 887 | 552 | 335 |  |
-| `services::discord` | `src/services/discord/mod.rs` | 5550 | 4166 | 1384 | giant-file |
+| `services::discord` | `src/services/discord/mod.rs` | 5549 | 4165 | 1384 | giant-file |
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 981 | 855 | 126 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
@@ -449,7 +449,7 @@
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1056 | 998 | 58 |  |
 | `services::discord::delivery_lease_key` | `src/services/discord/delivery_lease_key.rs` | 156 | 156 | 0 |  |
 | `services::discord::destructive_cancel_capture` | `src/services/discord/destructive_cancel_capture.rs` | 63 | 34 | 29 |  |
-| `services::discord::destructive_cancel_gate` | `src/services/discord/destructive_cancel_gate.rs` | 688 | 337 | 351 |  |
+| `services::discord::destructive_cancel_gate` | `src/services/discord/destructive_cancel_gate.rs` | 705 | 350 | 355 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 507 | 507 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
 | `services::discord::footer_view_reconciler` | `src/services/discord/footer_view_reconciler/mod.rs` | 661 | 473 | 188 |  |
@@ -563,7 +563,7 @@
 | `services::discord::reaction_lifecycle` | `src/services/discord/reaction_lifecycle.rs` | 363 | 321 | 42 |  |
 | `services::discord::recovery_engine` | `src/services/discord/recovery_engine.rs` | 489 | 433 | 56 |  |
 | `services::discord::recovery_engine::analytics_transcript` | `src/services/discord/recovery_engine/analytics_transcript.rs` | 110 | 110 | 0 |  |
-| `services::discord::recovery_engine::completion_delivery` | `src/services/discord/recovery_engine/completion_delivery.rs` | 802 | 300 | 502 |  |
+| `services::discord::recovery_engine::completion_delivery` | `src/services/discord/recovery_engine/completion_delivery.rs` | 814 | 312 | 502 |  |
 | `services::discord::recovery_engine::jsonl_extract` | `src/services/discord/recovery_engine/jsonl_extract.rs` | 137 | 137 | 0 |  |
 | `services::discord::recovery_engine::manual_rebind` | `src/services/discord/recovery_engine/manual_rebind/mod.rs` | 919 | 785 | 134 |  |
 | `services::discord::recovery_engine::manual_rebind::adoption` | `src/services/discord/recovery_engine/manual_rebind/adoption.rs` | 286 | 77 | 209 |  |
@@ -590,7 +590,7 @@
 | `services::discord::relay_recovery` | `src/services/discord/relay_recovery.rs` | 3376 | 1520 | 1856 | giant-file |
 | `services::discord::relay_recovery_auto_heal_attempts` | `src/services/discord/relay_recovery_auto_heal_attempts.rs` | 92 | 92 | 0 |  |
 | `services::discord::relay_recovery_completion_footer` | `src/services/discord/relay_recovery_completion_footer.rs` | 9 | 9 | 0 |  |
-| `services::discord::replace_outcome_policy` | `src/services/discord/replace_outcome_policy.rs` | 683 | 363 | 320 |  |
+| `services::discord::replace_outcome_policy` | `src/services/discord/replace_outcome_policy.rs` | 691 | 371 | 320 |  |
 | `services::discord::response_sanitizer` | `src/services/discord/response_sanitizer.rs` | 177 | 177 | 0 |  |
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 102 | 102 | 0 |  |
 | `services::discord::restart_mode` | `src/services/discord/restart_mode.rs` | 32 | 32 | 0 |  |
@@ -619,7 +619,7 @@
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::latency_spans` | `src/services/discord/router/message_handler/latency_spans.rs` | 230 | 158 | 72 |  |
 | `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 505 | 505 | 0 |  |
-| `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 978 | 952 | 26 |  |
+| `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 994 | 968 | 26 |  |
 | `services::discord::router::message_handler::turn_lifecycle` | `src/services/discord/router/message_handler/turn_lifecycle.rs` | 183 | 183 | 0 |  |
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
 | `services::discord::router::message_handler::voice_announcement_scope` | `src/services/discord/router/message_handler/voice_announcement_scope.rs` | 125 | 73 | 52 |  |
@@ -767,7 +767,7 @@
 | `services::discord::turn_bridge::retry_state` | `src/services/discord/turn_bridge/retry_state.rs` | 753 | 384 | 369 |  |
 | `services::discord::turn_bridge::runtime_handoff_loop` | `src/services/discord/turn_bridge/runtime_handoff_loop.rs` | 992 | 992 | 0 |  |
 | `services::discord::turn_bridge::runtime_handoff_loop::guarded_save` | `src/services/discord/turn_bridge/runtime_handoff_loop/guarded_save.rs` | 211 | 76 | 135 |  |
-| `services::discord::turn_bridge::single_message_footer` | `src/services/discord/turn_bridge/single_message_footer.rs` | 825 | 511 | 314 |  |
+| `services::discord::turn_bridge::single_message_footer` | `src/services/discord/turn_bridge/single_message_footer.rs` | 835 | 521 | 314 |  |
 | `services::discord::turn_bridge::skill_usage` | `src/services/discord/turn_bridge/skill_usage.rs` | 80 | 80 | 0 |  |
 | `services::discord::turn_bridge::stale_resume` | `src/services/discord/turn_bridge/stale_resume.rs` | 301 | 144 | 157 |  |
 | `services::discord::turn_bridge::status_panel` | `src/services/discord/turn_bridge/status_panel.rs` | 684 | 684 | 0 |  |
@@ -776,7 +776,7 @@
 | `services::discord::turn_bridge::streaming_edit_text` | `src/services/discord/turn_bridge/streaming_edit_text.rs` | 619 | 219 | 400 |  |
 | `services::discord::turn_bridge::task_notification_lifecycle` | `src/services/discord/turn_bridge/task_notification_lifecycle.rs` | 221 | 104 | 117 |  |
 | `services::discord::turn_bridge::terminal_controller_cutover` | `src/services/discord/turn_bridge/terminal_controller_cutover.rs` | 1838 | 960 | 878 |  |
-| `services::discord::turn_bridge::terminal_delivery` | `src/services/discord/turn_bridge/terminal_delivery.rs` | 1977 | 737 | 1240 |  |
+| `services::discord::turn_bridge::terminal_delivery` | `src/services/discord/turn_bridge/terminal_delivery.rs` | 1979 | 737 | 1242 |  |
 | `services::discord::turn_bridge::terminal_outcome_delivery` | `src/services/discord/turn_bridge/terminal_outcome_delivery.rs` | 1669 | 1669 | 0 | giant-file |
 | `services::discord::turn_bridge::tmux_runtime` | `src/services/discord/turn_bridge/tmux_runtime.rs` | 1267 | 983 | 284 |  |
 | `services::discord::turn_bridge::tmux_runtime::interrupt_policy` | `src/services/discord/turn_bridge/tmux_runtime/interrupt_policy.rs` | 374 | 225 | 149 |  |
@@ -967,7 +967,7 @@
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 100 | 100 | 0 |  |
 | `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4192 | 1849 | 2343 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
-| `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2031 | 646 | 1385 |  |
+| `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2033 | 648 | 1385 |  |
 | `services::tui_turn_state::completion_scan` | `src/services/tui_turn_state/completion_scan.rs` | 360 | 360 | 0 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 479 | 150 | 329 |  |
 | `services::turn_lifecycle` | `src/services/turn_lifecycle.rs` | 564 | 436 | 128 |  |

--- a/src/services/discord/destructive_cancel_gate.rs
+++ b/src/services/discord/destructive_cancel_gate.rs
@@ -101,6 +101,10 @@ impl DestructiveCancelProbeSnapshot {
     }
 }
 
+/// #4353: the frontier lives in tmux session files, and `super::tmux` is
+/// `cfg(unix)`. Without a session there is no frontier, which is exactly the
+/// answer on a platform that cannot host one.
+#[cfg(unix)]
 fn relay_frontier_for_current_generation(
     shared: &SharedData,
     watcher_owner_channel: ChannelId,
@@ -113,6 +117,15 @@ fn relay_frontier_for_current_generation(
             tmux_session_name,
         )
     })
+}
+
+#[cfg(not(unix))]
+fn relay_frontier_for_current_generation(
+    _shared: &SharedData,
+    _watcher_owner_channel: ChannelId,
+    _tmux_session_name: Option<&str>,
+) -> Option<u64> {
+    None
 }
 
 pub(in crate::services::discord) fn terminal_envelope_present(
@@ -530,6 +543,8 @@ mod tests {
         });
     }
 
+    // #4353: reads tmux generation files via `super::super::tmux` (cfg(unix)).
+    #[cfg(unix)]
     #[test]
     fn generation_mismatched_relay_frontier_does_not_fake_reprobe_progress() {
         let _lock = crate::config::shared_test_env_lock()
@@ -584,6 +599,8 @@ mod tests {
         });
     }
 
+    // #4353: reads tmux generation files via `super::super::tmux` (cfg(unix)).
+    #[cfg(unix)]
     #[test]
     fn current_generation_relay_frontier_after_empty_snapshot_denies_destructive_cancel() {
         let _lock = crate::config::shared_test_env_lock()

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -52,7 +52,6 @@ mod reaction_cleanup;
 mod reaction_lifecycle;
 mod relay_health;
 pub(crate) mod relay_recovery;
-#[cfg(unix)] // #3089 A0: shared ReplaceLongMessageOutcome disposition policy.
 mod replace_outcome_policy;
 pub(crate) mod response_sanitizer;
 // #3983 item4: one-shot top session banner emit + dual-path (sink/watcher) de-dup.

--- a/src/services/discord/recovery_engine/completion_delivery.rs
+++ b/src/services/discord/recovery_engine/completion_delivery.rs
@@ -194,8 +194,20 @@ pub(super) async fn complete_recovery_visible_turn(
         background,
         source,
         |tmux_session_name| async move {
-            super::tmux::sniff_background_agent_pending_for_completion(tmux_session_name.as_deref())
+            // #4353: `super::tmux` is cfg(unix). No tmux pane means nothing can be
+            // pending in one.
+            #[cfg(unix)]
+            {
+                super::tmux::sniff_background_agent_pending_for_completion(
+                    tmux_session_name.as_deref(),
+                )
                 .await
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = tmux_session_name;
+                false
+            }
         },
     )
     .await

--- a/src/services/discord/replace_outcome_policy.rs
+++ b/src/services/discord/replace_outcome_policy.rs
@@ -1,3 +1,11 @@
+//! #3089 A0: shared `ReplaceLongMessageOutcome` disposition policy.
+//!
+//! #4353: this module is pure disposition logic — no tmux, no unix syscalls, no
+//! imports at all. It used to be declared `#[cfg(unix)]` in `discord/mod.rs`,
+//! which only reflected that its first callers were unix-only. `formatting`,
+//! `gateway`, `long_send_rollback`, `bridge_gateway`, `terminal_delivery` and
+//! `turn_output_controller` all reference it unguarded, so the gate broke every
+//! non-unix build (34 errors, nightly red for 5 days).
 //! #3089 A0 — behavior-preserving disposition policy for the
 //! `ReplaceLongMessageOutcome` returned by `replace_long_message_raw_with_outcome`.
 //!

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -794,6 +794,10 @@ pub(in crate::services::discord) async fn hosted_tui_promote_readiness_blocked(
     // stand-in for the intake path's settings-resolved profile: a named-but-
     // missing profile makes the probe return `false` (fail-open to normal
     // dispatch) instead of misclassifying a remote session as a local TUI.
+    // #4353: `tui_busy_followup_diagnostic` probes a live tmux pane, so it is
+    // cfg(unix). A platform without tmux can never host a busy TUI, and the gate
+    // fails open exactly as it does for a missing pane.
+    #[cfg(unix)]
     let blocked = tui_busy_followup_diagnostic(
         shared,
         provider,
@@ -804,6 +808,18 @@ pub(in crate::services::discord) async fn hosted_tui_promote_readiness_blocked(
         session_id.as_deref(),
     )
     .is_some();
+    #[cfg(not(unix))]
+    let blocked = {
+        let _ = (
+            shared,
+            provider,
+            &tmux_session_name,
+            remote_profile_named,
+            &current_path,
+            &session_id,
+        );
+        false
+    };
     if blocked {
         tracing::info!(
             channel_id = channel_id.get(),

--- a/src/services/discord/turn_bridge/single_message_footer.rs
+++ b/src/services/discord/turn_bridge/single_message_footer.rs
@@ -375,10 +375,20 @@ pub(super) async fn complete_bridge_terminal_footer_or_status_panel<G: TurnGatew
         this_turn_status_panel_generation,
         tmux_session_name.map(str::to_string),
         |tmux_session_name| async move {
-            super::super::tmux::sniff_background_agent_pending_for_completion(
-                tmux_session_name.as_deref(),
-            )
-            .await
+            // #4353: `super::super::tmux` is cfg(unix). No tmux pane means nothing
+            // can be pending in one.
+            #[cfg(unix)]
+            {
+                super::super::tmux::sniff_background_agent_pending_for_completion(
+                    tmux_session_name.as_deref(),
+                )
+                .await
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = tmux_session_name;
+                false
+            }
         },
     )
     .await

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -1238,6 +1238,8 @@ mod tests {
         ));
     }
 
+    // #4353: drives `discord::tmux` (cfg(unix)) directly.
+    #[cfg(unix)]
     #[test]
     fn stopped_turn_terminal_replace_raw_fingerprint_refuses_phantom_rerelay_4081() {
         let _lock = crate::config::shared_test_env_lock()

--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -78,7 +78,9 @@ impl TuiReadyState {
 /// (`inflight::rebind_reap`, #3879): both classify "the pane may still be
 /// alive, but runtime activity has gone quiescent past a long inter-activity
 /// ceiling".
-#[cfg(unix)]
+// #4353: a plain `i64`. `destructive_cancel_gate`, `manual_rebind_output_path`
+// and `dispatched_sessions` all read it unguarded, so `cfg(unix)` broke non-unix
+// builds without gating anything platform-specific.
 pub(crate) const STALE_USER_SUBMITTED_RECLAIM_SECS: i64 = 600;
 
 /// #3981/#4024: decide whether a busy JSONL `UserSubmitted` turn-state is a


### PR DESCRIPTION
Closes #4353

## 문제

windows에서 `cargo check --lib`가 **34개 에러**로 실패한다. `ci-nightly.yml`은 최소 2026-07-03부터 **5일 연속 red**다.

아무도 못 본 이유: PR CI의 cross-OS 레인(`check_fast_cross_os`)은 `cross_os_rust == 'true'`일 때만 돈다 (`ci-pr.yml:343`). relay-only PR(`src/services/discord/**`)은 이 필터에서 빠진다. 최근 PR이 대부분 relay 계열이라 결함이 계속 누적됐다.

그런데 `check_fast_cross_os_required_context`(`ci-pr.yml:680-704`)가 이 결과를 branch protection으로 미러링한다. 즉 `src/db/`나 `src/services/cluster/`를 건드리는 PR은 **머지 불가**다. #4349(PR #4352)가 여기 막혔다.

## 원인

`#[cfg(unix)]`로 정의된 아이템 3개를 가드 없는 코드가 참조한다.

**둘은 애초에 플랫폼 의존이 아니어서 게이트를 제거한다:**

| 심볼 | 실체 | 무가드 사용처 |
|---|---|---|
| `discord::replace_outcome_policy` | import 하나 없는 순수 disposition 로직. tmux는 주석에만 등장 | formatting, gateway, long_send_rollback, bridge_gateway, terminal_delivery, turn_output_controller |
| `tui_turn_state::STALE_USER_SUBMITTED_RECLAIM_SECS` | `i64` 상수 | destructive_cancel_gate, manual_rebind_output_path, dispatched_sessions |

둘 다 `cfg(unix)`는 "첫 호출자가 unix 전용이었다"는 사실만 반영했을 뿐이다.

**`discord::tmux`는 진짜 unix 전용이므로 호출부를 가드한다:**

- `destructive_cancel_gate::relay_frontier_for_current_generation` → `None` (tmux 세션이 없으면 frontier도 없다 — 세션 없는 턴에 이미 주는 답과 동일)
- `completion_delivery` / `single_message_footer`의 background-agent sniff → `false` (존재할 수 없는 pane에 pending일 수 없다)
- `tui_followup::hosted_tui_promote_readiness_blocked` → `false` (pane이 없을 때 이미 하는 fail-open과 동일)
- tmux 세션 파일을 직접 다루는 테스트 3개 → `#[cfg(unix)]`

## 검증

`ring`의 build script 때문에 macOS에서 windows 타겟 `cargo check`가 불가하다. 대신 **windows cfg 우주를 macOS에서 시뮬레이션**했다 (`cfg(unix)` → 항상 false, `cfg(not(unix))` → 항상 true).

- baseline(main): 총 45개, 그중 **target 관련 34개** — CI가 보고하는 34개와 정확히 일치
- 이 PR: 총 11개, **target 관련 0개**

남은 11개는 시뮬레이션 아티팩트다 (macOS에는 `std::os::windows`가 없다). 실제 windows 타겟에서는 나타나지 않으며, 이 PR의 CI windows 레인이 그것을 확인해줄 것이다.

macOS 빌드와 영향 모듈 테스트는 불변이다.

## 후속

nightly가 5일 red인 걸 아무도 보지 않았다. 알림 경로 점검이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)