### PR TITLE
fix(cluster): #4356 read the gateway self-id from config, not the bootstrap race

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -590,6 +590,7 @@ src/
 │   │   ├── runtime_bootstrap/
 │   │   │   ├── framework_setup.rs
 │   │   │   ├── gateway_lease.rs
+│   │   │   ├── gateway_lease_tests.rs
 │   │   │   ├── gateway_runtime.rs
 │   │   │   ├── intake.rs
 │   │   │   ├── orphan_recovery.rs

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -629,7 +629,7 @@
 | `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 522 | 522 | 0 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 893 | 301 | 592 |  |
 | `services::discord::runtime_bootstrap::framework_setup` | `src/services/discord/runtime_bootstrap/framework_setup.rs` | 350 | 326 | 24 |  |
-| `services::discord::runtime_bootstrap::gateway_lease` | `src/services/discord/runtime_bootstrap/gateway_lease.rs` | 696 | 549 | 147 |  |
+| `services::discord::runtime_bootstrap::gateway_lease` | `src/services/discord/runtime_bootstrap/gateway_lease.rs` | 587 | 587 | 0 |  |
 | `services::discord::runtime_bootstrap::gateway_runtime` | `src/services/discord/runtime_bootstrap/gateway_runtime.rs` | 148 | 148 | 0 |  |
 | `services::discord::runtime_bootstrap::intake` | `src/services/discord/runtime_bootstrap/intake.rs` | 83 | 83 | 0 |  |
 | `services::discord::runtime_bootstrap::orphan_recovery` | `src/services/discord/runtime_bootstrap/orphan_recovery.rs` | 336 | 336 | 0 |  |

--- a/src/services/discord/runtime_bootstrap/gateway_lease.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_lease.rs
@@ -41,12 +41,46 @@ fn resolve_gateway_preference(
     })
 }
 
-fn gateway_preference() -> Option<GatewayPreference> {
+/// Which instance are we, as far as the gateway preference is concerned?
+///
+/// #4356: **not** `resolve_self_instance_id_without_config()`. That falls back to
+/// `hostname-pid` whenever the `SELF_INSTANCE_ID` cell is still empty, and gateway
+/// acquisition runs *before* `cluster::bootstrap` fills it:
+///
+/// ```text
+/// 19:15:25.925  GATEWAY-LEASE: Claude launch skipped — singleton lease held elsewhere
+/// 19:15:26.543  [cluster] runtime bootstrapped instance_id="mac-book-release"
+/// ```
+///
+/// The preferred node therefore never recognized itself, never registered as a
+/// waiter, and the holder never saw a reason to yield.
+///
+/// `cluster.instance_id` is the same value bootstrap publishes, and we already hold
+/// the config here, so reading it directly removes the race rather than timing
+/// around it. Only an unset (`auto`) id needs to wait for bootstrap to derive one.
+async fn resolve_self_instance_id_for_preference(cluster: &crate::config::ClusterConfig) -> String {
+    if let Some(configured) = cluster
+        .instance_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return configured.to_string();
+    }
+    crate::services::cluster::node_registry::wait_for_self_instance_id(Duration::from_secs(10))
+        .await
+}
+
+async fn gateway_preference() -> Option<GatewayPreference> {
     let config = crate::config::load_graceful();
-    resolve_gateway_preference(
-        &config.cluster,
-        crate::services::cluster::node_registry::resolve_self_instance_id_without_config(),
-    )
+    // Cheap exits first: no clustering, or no preference configured. Neither needs
+    // a self-id, and the `auto`-id path would otherwise block on bootstrap for
+    // every node that never opted into a preference.
+    if !config.cluster.enabled || config.cluster.gateway_preferred_instance_id.is_none() {
+        return None;
+    }
+    let self_instance_id = resolve_self_instance_id_for_preference(&config.cluster).await;
+    resolve_gateway_preference(&config.cluster, self_instance_id)
 }
 
 /// May we hand the gateway over to the preferred node?
@@ -276,7 +310,7 @@ pub(super) async fn run_bot_acquire_gateway_lease(
     match shared.pg_pool.as_ref() {
         Some(pool) => {
             // #4351: honor the configured gateway owner before racing for the lock.
-            let preference = gateway_preference();
+            let preference = gateway_preference().await;
             let acquired = match preference.as_ref() {
                 Some(pref) if pref.self_is_preferred() => {
                     acquire_as_preferred_gateway(pool, token_hash, provider, shared).await
@@ -429,11 +463,12 @@ pub(super) fn run_bot_spawn_gateway_lease_keepalive(
     let shared_for_lease = shared.clone();
     let provider_for_lease = provider.clone();
     let mut current_lease = Some(lease);
-    // Resolved once: `resolve_self_instance_id_without_config` is stable for the
-    // life of the process, and a hot config reload that changed the preferred
-    // node mid-flight would race the yield against the acquire.
-    let preference = gateway_preference();
     tokio::spawn(async move {
+        // Resolved once, inside the task because it may await bootstrap (#4356):
+        // the self-id is stable for the life of the process, and a hot config
+        // reload that changed the preferred node mid-flight would race the yield
+        // against the acquire.
+        let preference = gateway_preference().await;
         let mut interval = tokio::time::interval(DISCORD_GATEWAY_LEASE_KEEPALIVE_INTERVAL);
         interval.tick().await;
         loop {
@@ -548,149 +583,5 @@ pub(super) fn run_bot_spawn_gateway_lease_keepalive(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    fn cluster(enabled: bool, preferred: Option<&str>) -> crate::config::ClusterConfig {
-        crate::config::ClusterConfig {
-            enabled,
-            gateway_preferred_instance_id: preferred.map(str::to_string),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn no_preference_configured_keeps_first_come_behavior() {
-        assert!(resolve_gateway_preference(&cluster(true, None), "a".into()).is_none());
-        // Blank / whitespace is treated as unset, not as an instance named "".
-        assert!(resolve_gateway_preference(&cluster(true, Some("   ")), "a".into()).is_none());
-    }
-
-    #[test]
-    fn preference_is_ignored_when_clustering_is_off() {
-        // A single-node deploy must never wait for a peer that cannot exist.
-        assert!(
-            resolve_gateway_preference(&cluster(false, Some("mac-book-release")), "a".into())
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn preferred_node_recognizes_itself() {
-        let pref = resolve_gateway_preference(
-            &cluster(true, Some("  mac-book-release  ")),
-            "mac-book-release".into(),
-        )
-        .expect("preference");
-        assert_eq!(pref.preferred_instance_id, "mac-book-release");
-        assert!(pref.self_is_preferred());
-    }
-
-    #[test]
-    fn non_preferred_node_knows_it_must_yield() {
-        let pref = resolve_gateway_preference(
-            &cluster(true, Some("mac-book-release")),
-            "mac-mini-release".into(),
-        )
-        .expect("preference");
-        assert!(!pref.self_is_preferred());
-        assert_eq!(
-            pref.yield_grace,
-            Duration::from_secs(crate::config::ClusterConfig::default().gateway_yield_grace_secs)
-        );
-    }
-
-    fn waiting_node(instance_id: &str, status: &str, waiting: &[&str]) -> serde_json::Value {
-        json!({
-            "instance_id": instance_id,
-            "status": status,
-            "capabilities": { "discord_gateway": { "waiting_providers": waiting } },
-        })
-    }
-
-    #[test]
-    fn yields_only_to_a_preferred_node_that_wants_this_gateway() {
-        let nodes = vec![
-            waiting_node("mac-mini-release", "online", &[]),
-            waiting_node("mac-book-release", "ONLINE", &["claude", "codex"]),
-        ];
-        assert!(should_yield_to_preferred(
-            &nodes,
-            "mac-book-release",
-            "claude"
-        ));
-        assert!(should_yield_to_preferred(
-            &nodes,
-            "mac-book-release",
-            "CODEX"
-        ));
-        // Same node, a provider it is not waiting for.
-        assert!(!should_yield_to_preferred(
-            &nodes,
-            "mac-book-release",
-            "gemini"
-        ));
-        assert!(!should_yield_to_preferred(
-            &nodes,
-            "ghost-release",
-            "claude"
-        ));
-    }
-
-    /// #4351 review (cdx, REJECT round 1). The preferred node's dcserver can be
-    /// up and heartbeating while its bot never starts — no token for this
-    /// provider, a startup failure, or an acquire that gave up. Yielding on
-    /// `status == "online"` alone handed the gateway to nobody: the holder
-    /// released, self-fenced, restarted, re-acquired, and yielded again — an
-    /// outage loop. Only a live `waiting_providers` advertisement may trigger a
-    /// yield.
-    #[test]
-    fn never_yields_to_a_preferred_node_that_is_merely_online() {
-        let no_capability = vec![json!({"instance_id": "mac-book-release", "status": "online"})];
-        assert!(!should_yield_to_preferred(
-            &no_capability,
-            "mac-book-release",
-            "claude"
-        ));
-
-        let up_but_not_contending = vec![waiting_node("mac-book-release", "online", &[])];
-        assert!(!should_yield_to_preferred(
-            &up_but_not_contending,
-            "mac-book-release",
-            "claude"
-        ));
-
-        // Bot for the *other* provider is waiting; ours is not.
-        let other_provider_only = vec![waiting_node("mac-book-release", "online", &["codex"])];
-        assert!(!should_yield_to_preferred(
-            &other_provider_only,
-            "mac-book-release",
-            "claude"
-        ));
-    }
-
-    #[test]
-    fn never_yields_to_an_offline_or_malformed_preferred_node() {
-        // A stale peer must not hold the gateway hostage.
-        let offline = vec![waiting_node("mac-book-release", "offline", &["claude"])];
-        assert!(!should_yield_to_preferred(
-            &offline,
-            "mac-book-release",
-            "claude"
-        ));
-
-        let malformed = vec![
-            json!({"instance_id": "mac-book-release"}),
-            json!({"status": "online"}),
-            json!("not-an-object"),
-            json!({"instance_id": "mac-book-release", "status": "online",
-                   "capabilities": {"discord_gateway": {"waiting_providers": "claude"}}}),
-        ];
-        assert!(!should_yield_to_preferred(
-            &malformed,
-            "mac-book-release",
-            "claude"
-        ));
-    }
-}
+#[path = "gateway_lease_tests.rs"]
+mod tests;

--- a/src/services/discord/runtime_bootstrap/gateway_lease_tests.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_lease_tests.rs
@@ -1,0 +1,182 @@
+//! Tests for `gateway_lease`.
+//!
+//! Split out of `gateway_lease.rs` (#4356): the file crossed the 700-LoC
+//! namespace cap once these gained coverage of self-id resolution.
+
+use super::*;
+use serde_json::json;
+
+fn cluster(enabled: bool, preferred: Option<&str>) -> crate::config::ClusterConfig {
+    crate::config::ClusterConfig {
+        enabled,
+        gateway_preferred_instance_id: preferred.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn no_preference_configured_keeps_first_come_behavior() {
+    assert!(resolve_gateway_preference(&cluster(true, None), "a".into()).is_none());
+    // Blank / whitespace is treated as unset, not as an instance named "".
+    assert!(resolve_gateway_preference(&cluster(true, Some("   ")), "a".into()).is_none());
+}
+
+#[test]
+fn preference_is_ignored_when_clustering_is_off() {
+    // A single-node deploy must never wait for a peer that cannot exist.
+    assert!(
+        resolve_gateway_preference(&cluster(false, Some("mac-book-release")), "a".into()).is_none()
+    );
+}
+
+#[test]
+fn preferred_node_recognizes_itself() {
+    let pref = resolve_gateway_preference(
+        &cluster(true, Some("  mac-book-release  ")),
+        "mac-book-release".into(),
+    )
+    .expect("preference");
+    assert_eq!(pref.preferred_instance_id, "mac-book-release");
+    assert!(pref.self_is_preferred());
+}
+
+/// #4356. The tests above all *hand* the self-id to the pure function, so they
+/// could not see that the caller derived it from
+/// `resolve_self_instance_id_without_config()` — which returns `hostname-pid`
+/// until `cluster::bootstrap` populates `SELF_INSTANCE_ID`, and the gateway
+/// acquires its lease before that happens. The preferred node never recognized
+/// itself in production.
+///
+/// `SELF_INSTANCE_ID` is deliberately left unset here: that is exactly the state
+/// at gateway-acquire time, and the configured id must still win.
+#[tokio::test]
+async fn self_id_is_read_from_config_not_from_the_bootstrap_race() {
+    let mut cluster = cluster(true, Some("mac-book-release"));
+    cluster.instance_id = Some("mac-book-release".to_string());
+
+    let self_id = resolve_self_instance_id_for_preference(&cluster).await;
+
+    assert_eq!(self_id, "mac-book-release");
+    let pref = resolve_gateway_preference(&cluster, self_id).expect("preference");
+    assert!(
+        pref.self_is_preferred(),
+        "the configured preferred node must recognize itself before cluster bootstrap runs"
+    );
+}
+
+#[tokio::test]
+async fn configured_self_id_is_trimmed() {
+    let mut cluster = cluster(true, Some("mac-book-release"));
+    cluster.instance_id = Some("  mac-book-release  ".to_string());
+    assert_eq!(
+        resolve_self_instance_id_for_preference(&cluster).await,
+        "mac-book-release"
+    );
+}
+
+#[test]
+fn non_preferred_node_knows_it_must_yield() {
+    let pref = resolve_gateway_preference(
+        &cluster(true, Some("mac-book-release")),
+        "mac-mini-release".into(),
+    )
+    .expect("preference");
+    assert!(!pref.self_is_preferred());
+    assert_eq!(
+        pref.yield_grace,
+        Duration::from_secs(crate::config::ClusterConfig::default().gateway_yield_grace_secs)
+    );
+}
+
+fn waiting_node(instance_id: &str, status: &str, waiting: &[&str]) -> serde_json::Value {
+    json!({
+        "instance_id": instance_id,
+        "status": status,
+        "capabilities": { "discord_gateway": { "waiting_providers": waiting } },
+    })
+}
+
+#[test]
+fn yields_only_to_a_preferred_node_that_wants_this_gateway() {
+    let nodes = vec![
+        waiting_node("mac-mini-release", "online", &[]),
+        waiting_node("mac-book-release", "ONLINE", &["claude", "codex"]),
+    ];
+    assert!(should_yield_to_preferred(
+        &nodes,
+        "mac-book-release",
+        "claude"
+    ));
+    assert!(should_yield_to_preferred(
+        &nodes,
+        "mac-book-release",
+        "CODEX"
+    ));
+    // Same node, a provider it is not waiting for.
+    assert!(!should_yield_to_preferred(
+        &nodes,
+        "mac-book-release",
+        "gemini"
+    ));
+    assert!(!should_yield_to_preferred(
+        &nodes,
+        "ghost-release",
+        "claude"
+    ));
+}
+
+/// #4351 review (cdx, REJECT round 1). The preferred node's dcserver can be
+/// up and heartbeating while its bot never starts — no token for this
+/// provider, a startup failure, or an acquire that gave up. Yielding on
+/// `status == "online"` alone handed the gateway to nobody: the holder
+/// released, self-fenced, restarted, re-acquired, and yielded again — an
+/// outage loop. Only a live `waiting_providers` advertisement may trigger a
+/// yield.
+#[test]
+fn never_yields_to_a_preferred_node_that_is_merely_online() {
+    let no_capability = vec![json!({"instance_id": "mac-book-release", "status": "online"})];
+    assert!(!should_yield_to_preferred(
+        &no_capability,
+        "mac-book-release",
+        "claude"
+    ));
+
+    let up_but_not_contending = vec![waiting_node("mac-book-release", "online", &[])];
+    assert!(!should_yield_to_preferred(
+        &up_but_not_contending,
+        "mac-book-release",
+        "claude"
+    ));
+
+    // Bot for the *other* provider is waiting; ours is not.
+    let other_provider_only = vec![waiting_node("mac-book-release", "online", &["codex"])];
+    assert!(!should_yield_to_preferred(
+        &other_provider_only,
+        "mac-book-release",
+        "claude"
+    ));
+}
+
+#[test]
+fn never_yields_to_an_offline_or_malformed_preferred_node() {
+    // A stale peer must not hold the gateway hostage.
+    let offline = vec![waiting_node("mac-book-release", "offline", &["claude"])];
+    assert!(!should_yield_to_preferred(
+        &offline,
+        "mac-book-release",
+        "claude"
+    ));
+
+    let malformed = vec![
+        json!({"instance_id": "mac-book-release"}),
+        json!({"status": "online"}),
+        json!("not-an-object"),
+        json!({"instance_id": "mac-book-release", "status": "online",
+               "capabilities": {"discord_gateway": {"waiting_providers": "claude"}}}),
+    ];
+    assert!(!should_yield_to_preferred(
+        &malformed,
+        "mac-book-release",
+        "claude"
+    ));
+}


### PR DESCRIPTION
Closes #4356

## #4351은 배포되었으나 아무 일도 하지 않았다

양쪽 노드에 `gateway_preferred_instance_id: mac-book-release`를 넣고 mac-book을 재시작했다. 결과:

```
19:15:25.925  GATEWAY-LEASE: Claude launch skipped — singleton lease held elsewhere
19:15:26.543  [cluster] runtime bootstrapped instance_id="mac-book-release"
```

preferred 노드가 lease를 시도한 시점이 cluster bootstrap이 `SELF_INSTANCE_ID`를 발행하기 **0.6초 전**이다. 따라서 `resolve_self_instance_id_without_config()`는 `hostname-pid` 폴백을 반환했고, `self_is_preferred()`는 false였고, mac-book은 non-preferred 분기를 탔다.

그 결과 `register_gateway_waiter`가 한 번도 불리지 않았고 → `discord_gateway.waiting_providers`가 `[]`로 남았고 → 보유자는 양보할 근거를 못 봤다. **인수가 애초에 불가능했다.** 24회 폴링 동안 `waiting_providers`는 계속 비어 있었다.

이 race는 이미 문서화되어 있었다. 한 함수 건너에 있다:

> `wait_for_self_instance_id` — Used by callers (Phase 5.1 intake_worker spawn) that race with cluster bootstrap and would otherwise pick up the hostname+PID fallback.

## 수정

`gateway_preference()`는 이미 `load_graceful()`로 config 전체를 읽는다. `cluster.instance_id`가 bootstrap이 `SELF_INSTANCE_ID`에 넣는 바로 그 값이다. 직접 읽으면 race를 **타이밍으로 피하는 게 아니라 없앤다**. `auto`(미설정)일 때만 bootstrap을 기다린다.

두 호출부 모두 async 컨텍스트다. keepalive는 spawn된 태스크 안에서 한 번만 resolve한다 (원래 주석의 "Resolved once" 의도 유지).

preference가 설정되지 않은 노드는 self-id를 아예 구하지 않고 조기 반환한다 — `auto` id 경로가 불필요하게 bootstrap을 기다리지 않도록.

## 기존 테스트가 잡을 수 없었던 이유

테스트 7개는 전부 `resolve_gateway_preference`(순수 함수)에 self-id를 **인자로 건네준다**. 호출자가 그 id를 어떻게 구하는지는 테스트 표면 밖이었다. cdx 리뷰 2라운드도 이 층을 보지 않았다.

새 테스트 2개는 `SELF_INSTANCE_ID`를 의도적으로 비워둔 채 검증한다 — gateway 획득 시점의 실제 상태다. `resolve_self_instance_id_for_preference`를 원래 구현으로 되돌리면 **둘 다 실패**하는 것을 확인했다.

## 참고

`gateway_lease.rs`가 700 LoC namespace cap을 넘어서 테스트를 `gateway_lease_tests.rs`로 분리했다 (`#[path]`, 저장소 기존 관행).

`gateway_lease` 9 passed / `cluster::` 132 passed / script checks exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)