### PR TITLE
chore(maintenance): name per-job startup-stagger literals (#4231)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1826,12 +1826,14 @@
     stale-inflight preservation review hardening; periodic reconcile loop
     covering stale inflights, orphan uploads, dispatched-session drift, and
     queue-review drift — split before adding non-bugfix behavior).
-  - `src/server/maintenance.rs` (1014 lines; #3909 added the leader-only voice
+  - `src/server/maintenance.rs` (1119 lines; #3909 added the leader-only voice
     TTS cache/temp sweep (`ProgressTtsCacheSweepJob`, 15th MaintenanceJob) +
     runtime-config threading, tipping the per-job-impl static registry over the
     1000-line giant threshold — also registered in `giant_file_registry.toml`.
-    The sweep LOGIC lives in `services::maintenance::jobs::voice_cache_sweep`;
-    bugfix-only, decompose the storage/voice job-impl clusters into siblings).
+    The sweep LOGIC lives in `services::maintenance::jobs::voice_cache_sweep`.
+    #4231 promoted the per-job startup-stagger literals to named `*_STARTUP_STAGGER`
+    constants with rationale comments (behavior-preserving; +105 doc/const lines).
+    Bugfix/readability-only, decompose the storage/voice job-impl clusters into siblings).
 - active_callsite_coverage: n/a.
 - invariants: config precedence, runtime path generation, kanban state, receipt
   persistence, and GitHub sync must keep their existing owner-specific

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -12,7 +12,7 @@
 | Path | Prod | Owner | Deadline | Decompose Issue |
 | --- | ---: | --- | --- | --- |
 | `src/db/automation_candidates.rs` | 1003 | automation-pipeline | 2026-08-31 | #3405 |
-| `src/server/maintenance.rs` | 1014 | server-runtime | 2026-10-31 | #3909 |
+| `src/server/maintenance.rs` | 1119 | server-runtime | 2026-10-31 | #3909 |
 | `src/server/worker_registry.rs` | 1278 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
 | `src/services/discord/catch_up.rs` | 1659 | discord-relay | 2026-10-31 | #3405 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -214,7 +214,7 @@
 | `server::dto::kanban` | `src/server/dto/kanban.rs` | 109 | 109 | 0 |  |
 | `server::dto::settings` | `src/server/dto/settings.rs` | 16 | 16 | 0 |  |
 | `server::issue_specs` | `src/server/issue_specs.rs` | 396 | 284 | 112 |  |
-| `server::maintenance` | `src/server/maintenance.rs` | 1149 | 1014 | 135 | giant-file |
+| `server::maintenance` | `src/server/maintenance.rs` | 1254 | 1119 | 135 | giant-file |
 | `server::multinode_regression` | `src/server/multinode_regression.rs` | 419 | 0 | 419 |  |
 | `server::outbox_delivery_alert` | `src/server/outbox_delivery_alert.rs` | 148 | 148 | 0 |  |
 | `server::resource_locks` | `src/server/resource_locks.rs` | 416 | 239 | 177 |  |

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -13,6 +13,81 @@ type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, String>> + Send 
 const DEFAULT_SCHEDULER_TICK: Duration = Duration::from_secs(1);
 const EXTRA_STAGGER_PER_JOB: Duration = Duration::from_secs(15);
 
+// ── Per-job startup stagger offsets ─────────────────────────────────────────
+//
+// Every job carries a *base* startup stagger (the second argument to
+// `MaintenanceSchedule::every`). On a cold start `startup_stagger_for_index`
+// adds `EXTRA_STAGGER_PER_JOB * <registry index>` on top of this base, so the
+// two mechanisms compose: the index-based auto-stagger fans the jobs out, and
+// the per-job bases below fine-tune the ordering *within* that fan-out (e.g.
+// keeping the quality rollup ahead of the alerters that read its aggregates on
+// the same tick). They are intentionally NOT folded into the auto-stagger —
+// doing so would change the real boot timings. The values here are byte-for-byte
+// identical to the historical inline literals; naming them just makes the
+// existing schedule self-describing (cf. `REREVIEW_TRANSIENT_DIRTY_RETRY_DELAY`
+// in `dispatch_context.rs`).
+
+/// `noop_heartbeat` (registry index 0): a small boot offset so the liveness
+/// heartbeat is among the earliest maintenance signals without racing the pool.
+const NOOP_HEARTBEAT_STARTUP_STAGGER: Duration = Duration::from_secs(10);
+
+/// `agent_quality_rollup`: zero base so the hourly rollup runs *before* the
+/// regression + relay alerters below that read its aggregates on the same tick.
+const AGENT_QUALITY_ROLLUP_STARTUP_STAGGER: Duration = Duration::from_secs(0);
+
+/// `quality_regression_alerter`: sequenced after `agent_quality_rollup` (base 0)
+/// on the same hourly tick so alerts evaluate against the freshest aggregates.
+const QUALITY_REGRESSION_ALERTER_STARTUP_STAGGER: Duration = Duration::from_secs(15);
+
+/// `relay_signal_alerter`: sequenced after the quality alerter on the same
+/// hourly tick so the two alert pipelines do not race for a connection at boot.
+const RELAY_SIGNAL_ALERTER_STARTUP_STAGGER: Duration = Duration::from_secs(30);
+
+/// `storage.cancel_tombstone_prune`: small boot offset so the tombstone prune
+/// does not pile on top of the other storage jobs at startup.
+const CANCEL_TOMBSTONE_PRUNE_STARTUP_STAGGER: Duration = Duration::from_secs(20);
+
+/// `voice.turn_link_gc`: staggered ~25s after boot so it does not pile on top
+/// of the other storage jobs (see the job's rationale comment).
+const VOICE_TURN_LINK_GC_STARTUP_STAGGER: Duration = Duration::from_secs(25);
+
+/// `storage.prompt_manifest_retention`: small startup stagger so the daily
+/// retention sweep does not pile on top of the other storage jobs at boot.
+const PROMPT_MANIFEST_RETENTION_STARTUP_STAGGER: Duration = Duration::from_secs(45);
+
+/// `storage.voice_transcript_announcement_meta_gc`: boot offset that keeps this
+/// voice-meta GC clear of the sibling voice GC jobs on the same tick.
+const VOICE_TRANSCRIPT_ANNOUNCEMENT_META_GC_STARTUP_STAGGER: Duration = Duration::from_secs(60);
+
+/// `storage.voice_background_handoff_meta_gc`: a touch longer than the
+/// announce-meta GC (60s) so the two voice storage GCs do not race for the same
+/// connection on the same tick.
+const VOICE_BACKGROUND_HANDOFF_META_GC_STARTUP_STAGGER: Duration = Duration::from_secs(75);
+
+/// `voice.progress_tts_cache_sweep`: 35s keeps it clear of the other voice GC
+/// jobs (25/60/75s); the first run is the startup bound (#3909).
+const PROGRESS_TTS_CACHE_SWEEP_STARTUP_STAGGER: Duration = Duration::from_secs(35);
+
+/// `storage.target_sweep`: 30s keeps the monthly `target/` sweep off the
+/// boot-time pile-up (the job also self-triggers on the disk threshold).
+const STORAGE_TARGET_SWEEP_STARTUP_STAGGER: Duration = Duration::from_secs(30);
+
+/// `storage.worktree_orphan_sweep`: boot offset so the hourly orphan sweep does
+/// not pile on top of the other storage jobs at startup.
+const STORAGE_WORKTREE_ORPHAN_SWEEP_STARTUP_STAGGER: Duration = Duration::from_secs(50);
+
+/// `storage.hang_dump_cleanup`: boot offset so the weekly hang-dump cleanup does
+/// not pile on top of the other storage jobs at startup.
+const STORAGE_HANG_DUMP_CLEANUP_STARTUP_STAGGER: Duration = Duration::from_secs(70);
+
+/// `storage.db_retention`: later boot offset so the weekly PG retention sweep
+/// trails the lighter storage GCs at startup.
+const STORAGE_DB_RETENTION_STARTUP_STAGGER: Duration = Duration::from_secs(90);
+
+/// `memory.memento_consolidation`: last base offset (registry tail) so the
+/// weekly memento consolidation trails every other job at startup.
+const MEMORY_MEMENTO_CONSOLIDATION_STARTUP_STAGGER: Duration = Duration::from_secs(110);
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct MaintenanceSchedule {
     every: Duration,
@@ -106,7 +181,7 @@ impl MaintenanceJob for NoopHeartbeatJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(15 * 60), Duration::from_secs(10))
+        MaintenanceSchedule::every(Duration::from_secs(15 * 60), NOOP_HEARTBEAT_STARTUP_STAGGER)
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -126,7 +201,10 @@ impl MaintenanceJob for AgentQualityRollupJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(60 * 60), Duration::from_secs(0))
+        MaintenanceSchedule::every(
+            Duration::from_secs(60 * 60),
+            AGENT_QUALITY_ROLLUP_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -157,7 +235,10 @@ impl MaintenanceJob for QualityRegressionAlerterJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(60 * 60), Duration::from_secs(15))
+        MaintenanceSchedule::every(
+            Duration::from_secs(60 * 60),
+            QUALITY_REGRESSION_ALERTER_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -192,7 +273,10 @@ impl MaintenanceJob for RelaySignalAlerterJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(60 * 60), Duration::from_secs(30))
+        MaintenanceSchedule::every(
+            Duration::from_secs(60 * 60),
+            RELAY_SIGNAL_ALERTER_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -221,7 +305,10 @@ impl MaintenanceJob for CancelTombstonePruneJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(30 * 60), Duration::from_secs(20))
+        MaintenanceSchedule::every(
+            Duration::from_secs(30 * 60),
+            CANCEL_TOMBSTONE_PRUNE_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -261,7 +348,10 @@ impl MaintenanceJob for VoiceTurnLinkGcJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(60 * 60), Duration::from_secs(25))
+        MaintenanceSchedule::every(
+            Duration::from_secs(60 * 60),
+            VOICE_TURN_LINK_GC_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -304,7 +394,10 @@ impl MaintenanceJob for PromptManifestRetentionJob {
     fn schedule(&self) -> MaintenanceSchedule {
         // Daily cadence with a small startup stagger so it doesn't pile on
         // top of the other storage jobs at boot.
-        MaintenanceSchedule::every(Duration::from_secs(24 * 60 * 60), Duration::from_secs(45))
+        MaintenanceSchedule::every(
+            Duration::from_secs(24 * 60 * 60),
+            PROMPT_MANIFEST_RETENTION_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -346,7 +439,10 @@ impl MaintenanceJob for VoiceTranscriptAnnouncementMetaGcJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(15 * 60), Duration::from_secs(60))
+        MaintenanceSchedule::every(
+            Duration::from_secs(15 * 60),
+            VOICE_TRANSCRIPT_ANNOUNCEMENT_META_GC_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -390,7 +486,10 @@ impl MaintenanceJob for VoiceBackgroundHandoffMetaGcJob {
         // 15-minute cadence matches the announce-meta GC pattern; the
         // stagger is a touch longer so the two storage GCs do not race
         // for the same connection on the same tick.
-        MaintenanceSchedule::every(Duration::from_secs(15 * 60), Duration::from_secs(75))
+        MaintenanceSchedule::every(
+            Duration::from_secs(15 * 60),
+            VOICE_BACKGROUND_HANDOFF_META_GC_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -432,7 +531,10 @@ impl MaintenanceJob for ProgressTtsCacheSweepJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(30 * 60), Duration::from_secs(35))
+        MaintenanceSchedule::every(
+            Duration::from_secs(30 * 60),
+            PROGRESS_TTS_CACHE_SWEEP_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -461,7 +563,7 @@ impl MaintenanceJob for StorageTargetSweepJob {
         // threshold. 30s stagger keeps it off the boot-time pile-up.
         MaintenanceSchedule::every(
             Duration::from_secs(30 * 24 * 60 * 60),
-            Duration::from_secs(30),
+            STORAGE_TARGET_SWEEP_STARTUP_STAGGER,
         )
     }
 
@@ -491,7 +593,10 @@ impl MaintenanceJob for StorageWorktreeOrphanSweepJob {
     }
 
     fn schedule(&self) -> MaintenanceSchedule {
-        MaintenanceSchedule::every(Duration::from_secs(60 * 60), Duration::from_secs(50))
+        MaintenanceSchedule::every(
+            Duration::from_secs(60 * 60),
+            STORAGE_WORKTREE_ORPHAN_SWEEP_STARTUP_STAGGER,
+        )
     }
 
     fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
@@ -519,7 +624,7 @@ impl MaintenanceJob for StorageHangDumpCleanupJob {
     fn schedule(&self) -> MaintenanceSchedule {
         MaintenanceSchedule::every(
             Duration::from_secs(7 * 24 * 60 * 60),
-            Duration::from_secs(70),
+            STORAGE_HANG_DUMP_CLEANUP_STARTUP_STAGGER,
         )
     }
 
@@ -548,7 +653,7 @@ impl MaintenanceJob for StorageDbRetentionJob {
     fn schedule(&self) -> MaintenanceSchedule {
         MaintenanceSchedule::every(
             crate::services::maintenance::jobs::STORAGE_MAINTENANCE_INTERVAL,
-            Duration::from_secs(90),
+            STORAGE_DB_RETENTION_STARTUP_STAGGER,
         )
     }
 
@@ -581,7 +686,7 @@ impl MaintenanceJob for MemoryMementoConsolidationJob {
     fn schedule(&self) -> MaintenanceSchedule {
         MaintenanceSchedule::every(
             crate::services::maintenance::jobs::memento_consolidation::DEFAULT_INTERVAL,
-            Duration::from_secs(110),
+            MEMORY_MEMENTO_CONSOLIDATION_STARTUP_STAGGER,
         )
     }
 


### PR DESCRIPTION
## 요약
`src/server/maintenance.rs`의 무명 stagger 리터럴 15개(각 job `every`의 2번째 인자)를 `<JOB>_STARTUP_STAGGER` named const로 승격 + 근거 주석(dispatch_context.rs:1988 스타일). 그룹 헤더에 'per-job base + EXTRA_STAGGER_PER_JOB * index' 합성 관계와 왜 index 자동 stagger로 병합하지 않는지(부팅 타이밍 변경 방지) 명시.

## 불변식 (behavior-preserving)
- 모든 duration은 이전 인라인 리터럴과 byte-for-byte 동일. `every` interval 리터럴·`ttl` 계산 미변경.
- 값이 같은 const도 공유하지 않고 독립 유지(예: 30s 2건 = RELAY_SIGNAL_ALERTER / STORAGE_TARGET_SWEEP, 각기 다른 스케줄 의도).

## 검증
- fmt/check 클린, test 53 passed (startup_stagger_ms 단언 포함), agent-maintenance freshness passed.
- change-surfaces freeze 1119로 동기(1014→1119).

Closes #4231

🤖 Generated with [Claude Code](https://claude.com/claude-code)