### PR TITLE
chore(discord): flatten catch_up.rs wrapper chain into CatchUpDeps struct (#4233)

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -15,7 +15,7 @@
 | `src/server/maintenance.rs` | 1014 | server-runtime | 2026-10-31 | #3909 |
 | `src/server/worker_registry.rs` | 1278 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1276 | discord-relay | 2026-10-31 | #3843 |
-| `src/services/discord/catch_up.rs` | 1659 | discord-relay | 2026-10-31 | #3405 |
+| `src/services/discord/catch_up.rs` | 1691 | discord-relay | 2026-10-31 | #3405 |
 | `src/services/discord/health/recovery.rs` | 2750 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1374 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/outbound/delivery_record.rs` | 1276 | discord-relay | 2026-10-31 | #3405 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -412,7 +412,7 @@
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
-| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2938 | 1659 | 1279 | giant-file |
+| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2961 | 1691 | 1270 | giant-file |
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 48 | 48 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 121 | 121 | 0 |  |

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use poise::serenity_prelude as serenity;
@@ -773,7 +773,6 @@ pub(in crate::services::discord) async fn catch_up_missed_messages(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
 ) {
-    let retry_checkpoints = HashMap::new();
     let pending_retry_channels = collect_catch_up_retry_pending_channels(shared);
     let pending_count = pending_retry_channels.len();
     if pending_count > 0 {
@@ -783,60 +782,93 @@ pub(in crate::services::discord) async fn catch_up_missed_messages(
         );
     }
     let api = SerenityCatchUpDiscordApi { http };
-    catch_up_missed_messages_inner_with_api_and_pending_retry_channels(
-        &api,
-        shared,
-        provider,
-        &retry_checkpoints,
-        &pending_retry_channels,
+    run_catch_up_sweep(
+        CatchUpDeps::new(&api, shared, provider)
+            .with_pending_retry_channels(&pending_retry_channels),
     )
     .await;
 }
 
-pub(in crate::services::discord) async fn catch_up_missed_messages_inner(
+/// #4165 queue-drain retry entry: the same sweep as [`catch_up_missed_messages`]
+/// but seeded with caller-owned retry checkpoints (and no pending-channel
+/// collection) so a single channel can be re-scanned after its queue drains.
+pub(in crate::services::discord) async fn catch_up_missed_messages_for_retry(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     retry_checkpoints: &HashMap<ChannelId, CatchUpRetryState>,
 ) {
-    let pending_retry_channels = HashSet::new();
     let api = SerenityCatchUpDiscordApi { http };
-    catch_up_missed_messages_inner_with_api_and_pending_retry_channels(
-        &api,
-        shared,
-        provider,
-        retry_checkpoints,
-        &pending_retry_channels,
+    run_catch_up_sweep(
+        CatchUpDeps::new(&api, shared, provider).with_retry_checkpoints(retry_checkpoints),
     )
     .await;
 }
 
-async fn catch_up_missed_messages_inner_with_api<A: CatchUpDiscordApi + ?Sized>(
-    api: &A,
-    shared: &Arc<SharedData>,
-    provider: &ProviderKind,
-    retry_checkpoints: &HashMap<ChannelId, CatchUpRetryState>,
-) {
-    let pending_retry_channels = HashSet::new();
-    catch_up_missed_messages_inner_with_api_and_pending_retry_channels(
+/// #4233: injected dependencies for one catch-up sweep. Collapses the former
+/// 4-level wrapper chain (`catch_up_missed_messages` → `_inner` →
+/// `_inner_with_api` → `_inner_with_api_and_pending_retry_channels`), where each
+/// added injection point spawned a longer function name. Production builds this
+/// via [`CatchUpDeps::new`] (empty retry/pending defaults); the retry-drain
+/// entry and tests override the api / retry-checkpoint / pending-channel seams
+/// with the `with_*` builders.
+struct CatchUpDeps<'a, A: CatchUpDiscordApi + ?Sized> {
+    api: &'a A,
+    shared: &'a Arc<SharedData>,
+    provider: &'a ProviderKind,
+    retry_checkpoints: &'a HashMap<ChannelId, CatchUpRetryState>,
+    pending_retry_channels: &'a HashSet<ChannelId>,
+}
+
+/// Empty defaults so [`CatchUpDeps::new`] can hand out `'static` references for
+/// the common "no injected retry checkpoints / no pending channels" path.
+static CATCH_UP_EMPTY_RETRY_CHECKPOINTS: LazyLock<HashMap<ChannelId, CatchUpRetryState>> =
+    LazyLock::new(HashMap::new);
+static CATCH_UP_EMPTY_PENDING_RETRY_CHANNELS: LazyLock<HashSet<ChannelId>> =
+    LazyLock::new(HashSet::new);
+
+impl<'a, A: CatchUpDiscordApi + ?Sized> CatchUpDeps<'a, A> {
+    /// Default seam: no injected retry checkpoints and no pending retry
+    /// channels. Override with the `with_*` builders below.
+    fn new(api: &'a A, shared: &'a Arc<SharedData>, provider: &'a ProviderKind) -> Self {
+        Self {
+            api,
+            shared,
+            provider,
+            retry_checkpoints: &CATCH_UP_EMPTY_RETRY_CHECKPOINTS,
+            pending_retry_channels: &CATCH_UP_EMPTY_PENDING_RETRY_CHANNELS,
+        }
+    }
+
+    /// Inject the caller-owned per-channel retry checkpoints for this sweep
+    /// (queue-drain retry entry + retry-mode tests).
+    fn with_retry_checkpoints(
+        mut self,
+        retry_checkpoints: &'a HashMap<ChannelId, CatchUpRetryState>,
+    ) -> Self {
+        self.retry_checkpoints = retry_checkpoints;
+        self
+    }
+
+    /// Inject the channels observed carrying a pending retry checkpoint
+    /// (startup sweep + pending-map race tests).
+    fn with_pending_retry_channels(
+        mut self,
+        pending_retry_channels: &'a HashSet<ChannelId>,
+    ) -> Self {
+        self.pending_retry_channels = pending_retry_channels;
+        self
+    }
+}
+
+async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_, A>) {
+    let CatchUpDeps {
         api,
         shared,
         provider,
         retry_checkpoints,
-        &pending_retry_channels,
-    )
-    .await;
-}
-
-async fn catch_up_missed_messages_inner_with_api_and_pending_retry_channels<
-    A: CatchUpDiscordApi + ?Sized,
->(
-    api: &A,
-    shared: &Arc<SharedData>,
-    provider: &ProviderKind,
-    retry_checkpoints: &HashMap<ChannelId, CatchUpRetryState>,
-    pending_retry_channels: &HashSet<ChannelId>,
-) {
+        pending_retry_channels,
+    } = deps;
     let Some(root) = runtime_store::last_message_root() else {
         return;
     };
@@ -1662,20 +1694,19 @@ mod catch_up_recovery_tests {
     use super::{
         CATCH_UP_RECENT_MAX_PAGES, CATCH_UP_RETRY_DEFERRED_REARM_LIMIT,
         CATCH_UP_RETRY_FETCH_FAILURE_LIMIT, CATCH_UP_SCAN_PACE_DEFAULT_MS, CatchUpChannelCandidate,
-        CatchUpClassification, CatchUpDiscordApi, CatchUpFetchMode, CatchUpMessageView,
-        CatchUpRetryScanDecision, CatchUpRetryState, CatchUpTooOldDrop, ChannelId, MessageId,
-        Phase2EnqueueCommit, ProviderKind, RuntimeChannelBindingStatus, advance_phase2_checkpoint,
-        arm_catch_up_retry_pending, catch_up_enqueue_accepted, catch_up_fetch_mode_for_scan,
-        catch_up_intervention_created_at, catch_up_last_item_dedup_is_checkpoint_safe,
-        catch_up_message_age_reference_time, catch_up_missed_messages_inner_with_api,
-        catch_up_missed_messages_inner_with_api_and_pending_retry_channels,
+        CatchUpClassification, CatchUpDeps, CatchUpDiscordApi, CatchUpFetchMode,
+        CatchUpMessageView, CatchUpRetryScanDecision, CatchUpRetryState, CatchUpTooOldDrop,
+        ChannelId, MessageId, Phase2EnqueueCommit, ProviderKind, RuntimeChannelBindingStatus,
+        advance_phase2_checkpoint, arm_catch_up_retry_pending, catch_up_enqueue_accepted,
+        catch_up_fetch_mode_for_scan, catch_up_intervention_created_at,
+        catch_up_last_item_dedup_is_checkpoint_safe, catch_up_message_age_reference_time,
         catch_up_remaining_queue_capacity, catch_up_too_old_notice, catch_up_too_old_snippet,
         classify_catch_up_message, classify_phase2_enqueue_commit,
         collect_catch_up_retry_pending_channels, consume_catch_up_retry_state_for_scan,
         insert_configured_catch_up_candidate, merge_catch_up_retry_checkpoint,
         parse_catch_up_scan_pace, phase2_retry_after_checkpoint, prune_stale_checkpoint_files,
         rearm_catch_up_retry_after_defer, rearm_catch_up_retry_after_fetch_failure,
-        should_fetch_older_recent_page, should_pace_before_scan,
+        run_catch_up_sweep, should_fetch_older_recent_page, should_pace_before_scan,
         take_catch_up_retry_checkpoint_after_queue_drain,
     };
     use crate::services::turn_orchestrator::{
@@ -2317,13 +2348,9 @@ mod catch_up_recovery_tests {
             fetch_attempts: Some(Arc::clone(&fetch_attempts)),
             cleanup_hook: None,
         };
-        let retry_checkpoints = HashMap::new();
-        catch_up_missed_messages_inner_with_api_and_pending_retry_channels(
-            &api,
-            &shared,
-            &provider,
-            &retry_checkpoints,
-            &pending_retry_channels,
+        run_catch_up_sweep(
+            CatchUpDeps::new(&api, &shared, &provider)
+                .with_pending_retry_channels(&pending_retry_channels),
         )
         .await;
 
@@ -2379,9 +2406,7 @@ mod catch_up_recovery_tests {
                 }
             })),
         };
-        let retry_checkpoints = HashMap::new();
-
-        catch_up_missed_messages_inner_with_api(&api, &shared, &provider, &retry_checkpoints).await;
+        run_catch_up_sweep(CatchUpDeps::new(&api, &shared, &provider)).await;
         set_dir_readonly(&pending_queue_dir, false);
         assert_eq!(cleanup_calls.load(Ordering::SeqCst), 1);
 
@@ -2497,9 +2522,7 @@ mod catch_up_recovery_tests {
             fetch_attempts: None,
             cleanup_hook: None,
         };
-        let retry_checkpoints = HashMap::new();
-
-        catch_up_missed_messages_inner_with_api(&api, &shared, &provider, &retry_checkpoints).await;
+        run_catch_up_sweep(CatchUpDeps::new(&api, &shared, &provider)).await;
 
         assert!(shared.last_message_ids.get(&channel_id).is_none());
         let pending = shared
@@ -2552,9 +2575,7 @@ mod catch_up_recovery_tests {
             fetch_attempts: None,
             cleanup_hook: None,
         };
-        let retry_checkpoints = HashMap::new();
-
-        catch_up_missed_messages_inner_with_api(&api, &shared, &provider, &retry_checkpoints).await;
+        run_catch_up_sweep(CatchUpDeps::new(&api, &shared, &provider)).await;
 
         let saved_checkpoint = *shared
             .last_message_ids
@@ -2594,9 +2615,7 @@ mod catch_up_recovery_tests {
             fetch_attempts: None,
             cleanup_hook: None,
         };
-        let retry_checkpoints = HashMap::new();
-
-        catch_up_missed_messages_inner_with_api(&api, &shared, &provider, &retry_checkpoints).await;
+        run_catch_up_sweep(CatchUpDeps::new(&api, &shared, &provider)).await;
 
         let saved_checkpoint = *shared
             .last_message_ids
@@ -2667,11 +2686,13 @@ mod catch_up_recovery_tests {
         };
         let retry_checkpoints = HashMap::from([(channel_id, retry_state)]);
 
-        catch_up_missed_messages_inner_with_api(
-            &TestCatchUpDiscordApi::transient_fetch_failure(),
-            &shared,
-            &provider,
-            &retry_checkpoints,
+        run_catch_up_sweep(
+            CatchUpDeps::new(
+                &TestCatchUpDiscordApi::transient_fetch_failure(),
+                &shared,
+                &provider,
+            )
+            .with_retry_checkpoints(&retry_checkpoints),
         )
         .await;
 
@@ -2703,11 +2724,13 @@ mod catch_up_recovery_tests {
         };
         let retry_checkpoints = HashMap::from([(channel_id, retry_state)]);
 
-        catch_up_missed_messages_inner_with_api(
-            &TestCatchUpDiscordApi::unknown_binding(),
-            &shared,
-            &provider,
-            &retry_checkpoints,
+        run_catch_up_sweep(
+            CatchUpDeps::new(
+                &TestCatchUpDiscordApi::unknown_binding(),
+                &shared,
+                &provider,
+            )
+            .with_retry_checkpoints(&retry_checkpoints),
         )
         .await;
 

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -135,7 +135,7 @@ pub(crate) use meeting_orchestrator as meeting;
 // outside the extracted cluster (`maybe_schedule_catch_up_retry_after_queue_drain`
 // here in mod.rs and `catch_up_missed_messages` in runtime_bootstrap recovery).
 pub(in crate::services::discord) use catch_up::{
-    CatchUpRetryState, catch_up_missed_messages, catch_up_missed_messages_inner,
+    CatchUpRetryState, catch_up_missed_messages, catch_up_missed_messages_for_retry,
     should_trigger_catch_up_retry, take_catch_up_retry_checkpoint_after_queue_drain,
 };
 pub(in crate::services::discord) use mailbox_finish::{
@@ -3480,7 +3480,7 @@ fn maybe_schedule_catch_up_retry_after_queue_drain(
             channel_id,
             queue_len_after
         );
-        catch_up_missed_messages_inner(&http, &shared, &provider, &retry_checkpoints).await;
+        catch_up_missed_messages_for_retry(&http, &shared, &provider, &retry_checkpoints).await;
         schedule_deferred_idle_queue_kickoff(
             shared,
             provider,


### PR DESCRIPTION
## 요약
`catch_up.rs`의 4단 래퍼 체인(`_inner`/`_inner_with_api`/`_inner_with_api_and_pending_retry_channels`)을 `CatchUpDeps<'a, A>` 구조체(api/shared/provider/retry_checkpoints/pending_retry_channels)로 평탄화. 4함수→3함수 + 단일 impl `run_catch_up_sweep(deps)`.

## 불변식 (behavior-preserving)
- `run_catch_up_sweep`가 첫 줄에서 구조체 destructure → ~800줄 sweep 본문 byte-for-byte 불변.
- 프로덕션 seam: `CatchUpDeps::new(api, shared, provider)` (빈 retry/pending은 'static LazyLock).
- 테스트 seam 보존: `.with_retry_checkpoints(...)`, `.with_pending_retry_channels(...)`.
- 호출부 변경: mod.rs 1곳(re-export+call, `_inner`→`_for_retry` 리네임). repo-wide grep로 4개 옛 이름 잔여 없음 확인.

## 검증
- fmt/check 클린, test 38 passed, agent-maintenance freshness passed.

Closes #4233

🤖 Generated with [Claude Code](https://claude.com/claude-code)