### PR TITLE
fix(deploy): P0 — prevent rollback-brick after migration + let leader-only node pass deploy gate (#4348)

### DIFF
--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -315,7 +315,11 @@ _health_json_top_level_field_raw() {
   # (a depth-1 string immediately followed by `:`) and, on a name match,
   # captures the following value up to the next depth-1 `,` / `}` / `]`. JSON
   # string state is tracked throughout so punctuation inside string values never
-  # confuses key detection, depth accounting, or the value boundary.
+  # confuses key detection, depth accounting, or the value boundary. The
+  # returned token is whitespace-TRIMMED (both ends) so insignificant JSON
+  # whitespace before the delimiter — e.g. `"degraded_reasons":[...] }` — never
+  # trails into the value; the downstream array/scalar cleanups can then rely on
+  # the value ending exactly at `]`/`"`, matching jq (#4348 R2 whitespace fix).
   local key="$1"
   local compact="$2"
   local n=${#compact}
@@ -344,14 +348,14 @@ _health_json_top_level_field_raw() {
         '{'|'[') depth=$((depth + 1)); value+="$ch" ;;
         '}'|']')
           if [ "$depth" -le "$cap_base" ]; then
-            printf '%s' "$value"
+            printf '%s' "$(_trim_whitespace "$value")"
             return 0
           fi
           depth=$((depth - 1)); value+="$ch"
           ;;
         ',')
           if [ "$depth" -eq "$cap_base" ]; then
-            printf '%s' "$value"
+            printf '%s' "$(_trim_whitespace "$value")"
             return 0
           fi
           value+="$ch"

--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -314,10 +314,83 @@ _health_json_reconcile_only() {
   return 0
 }
 
+_health_json_unhealthy_only_no_provider_runtimes() {
+  # #4348 DEPLOY/RESTART readiness rescue — NOT a runtime /health change.
+  # Returns 0 when the node is serving correctly (server_up + db + dashboard all
+  # true) but /api/health reports status=unhealthy SOLELY because no provider
+  # runtimes are registered (leader-only / no-agent-session topology). In that
+  # state the runtime is structurally unhealthy forever — providers.is_empty()
+  # emits `no_providers_registered` and the startup doctor is skipped with
+  # skipped_reason=no_provider_runtimes_registered — yet the server is fully
+  # serving. The runtime /health endpoint intentionally keeps reporting
+  # unhealthy for monitoring; only the deploy/rollback readiness gate opts in to
+  # this rescue, and only for this EXACT cause (server_up=false / db_unavailable
+  # / any other unhealthy reason must still fail the gate).
+  local health_json="$1"
+  [ -n "$health_json" ] || return 1
+
+  if _health_json_has_jq; then
+    printf '%s' "$health_json" | jq -e '
+      (.server_up == true)
+      and (.db == true)
+      and (.dashboard == true)
+      and (.status == "unhealthy")
+      and (.startup_status == "doctor_skipped")
+      and (.latest_startup_doctor.skipped_reason == "no_provider_runtimes_registered")
+    ' >/dev/null 2>&1
+    return
+  fi
+
+  # jq-less fallback. Every predicate must hold. `skipped_reason` only appears in
+  # the PUBLIC /api/health body nested under latest_startup_doctor, so matching
+  # its exact value on the compacted body is safe here.
+  _health_json_field_is_true "$health_json" "server_up" || return 1
+  _health_json_field_is_true "$health_json" "db" || return 1
+  _health_json_field_is_true "$health_json" "dashboard" || return 1
+  [ "$(_health_json_status "$health_json")" = "unhealthy" ] || return 1
+  local compact
+  compact=$(_health_json_compact "$health_json")
+  printf '%s' "$compact" \
+    | grep -Eq '"startup_status"[[:space:]]*:[[:space:]]*"doctor_skipped"' || return 1
+  printf '%s' "$compact" \
+    | grep -Eq '"skipped_reason"[[:space:]]*:[[:space:]]*"no_provider_runtimes_registered"'
+}
+
+_migration_seq_from_name() {
+  # "0079_relay_dead_letter.sql" -> "79". Strips leading zeros so the result is a
+  # base-10 integer (avoids octal interpretation in `-gt` tests). Returns
+  # non-zero when the name has no leading numeric prefix. See #4348.
+  local name="$1" num
+  [ -n "$name" ] || return 1
+  num=$(printf '%s' "$name" | sed -E 's/^0*([0-9]+).*/\1/')
+  case "$num" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s' "$num"
+}
+
+_migration_advanced() {
+  # #4348: TRUE (return 0) when the new deploy's latest migration is strictly
+  # AHEAD of the rollback target's latest migration — i.e. rolling back would
+  # strand the old binary behind an already-applied migration and brick it.
+  # Fails CLOSED: if EITHER name cannot be resolved to a sequence number, treat
+  # it as advanced (unsafe to roll back) rather than gamble the node. Returns 1
+  # (safe to roll back) only when both resolve AND new <= old.
+  local new_name="$1" old_name="$2" new_seq old_seq
+  new_seq=$(_migration_seq_from_name "$new_name") || return 0
+  old_seq=$(_migration_seq_from_name "$old_name") || return 0
+  [ "$new_seq" -gt "$old_seq" ] && return 0
+  return 1
+}
+
 health_json_is_ready() {
   local health_json="$1"
   local require_dashboard="${2:-0}"
   local allow_reconcile_degraded="${3:-1}"
+  # #4348: when 1, treat a serving node that is unhealthy SOLELY because no
+  # provider runtimes are registered as DEPLOY-READY. Default 0 keeps every
+  # existing (non-deploy) caller's semantics unchanged.
+  local allow_no_provider_runtimes="${4:-0}"
   local status=""
 
   [ -n "$health_json" ] || return 1
@@ -331,7 +404,16 @@ health_json_is_ready() {
 
   if _health_json_field_exists "$health_json" "server_up"; then
     _health_json_field_is_true "$health_json" "server_up" || return 1
-    [ "$status" = "unhealthy" ] && return 1
+    if [ "$status" = "unhealthy" ]; then
+      # #4348: rescue a serving leader-only / no-session node whose only
+      # unhealthy cause is no_provider_runtimes_registered. server_up is already
+      # confirmed true above, so db_unavailable can never take this branch.
+      if [ "$allow_no_provider_runtimes" = "1" ] \
+        && _health_json_unhealthy_only_no_provider_runtimes "$health_json"; then
+        return 0
+      fi
+      return 1
+    fi
     [ "$status" = "healthy" ] && return 0
     if [ "$allow_reconcile_degraded" = "1" ] \
       && _health_json_field_exists "$health_json" "fully_recovered" \
@@ -362,6 +444,9 @@ wait_for_http_service_health() {
   local delay_secs="$4"
   local require_dashboard="${5:-0}"
   local allow_reconcile_degraded="${6:-1}"
+  # #4348: opt-in — accept a serving node that is unhealthy solely because no
+  # provider runtimes are registered. Default 0 preserves existing callers.
+  local allow_no_provider_runtimes="${7:-0}"
 
   # shellcheck disable=SC2034 # Read by callers after the function returns.
   WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON=""
@@ -372,7 +457,7 @@ wait_for_http_service_health() {
     # shellcheck disable=SC2034 # Read by callers after the function returns.
     WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON="$health_json"
 
-    if health_json_is_ready "$health_json" "$require_dashboard" "$allow_reconcile_degraded"; then
+    if health_json_is_ready "$health_json" "$require_dashboard" "$allow_reconcile_degraded" "$allow_no_provider_runtimes"; then
       return 0
     fi
 

--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -196,8 +196,10 @@ _health_json_get_string_field() {
     return
   fi
 
+  # #4348 review finding #2: match the TOP-LEVEL field only (jq's `.key` is
+  # top-level), so a nested `"status":"..."` cannot shadow the root value.
   match=$(
-    _health_json_compact "$health_json" \
+    _health_json_top_level_compact "$health_json" \
       | grep -Eo "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
       | head -n 1 \
       || true
@@ -230,6 +232,69 @@ _health_json_get_string_array_csv() {
     | sed -E 's/^[^[]*\[//; s/\]$//; s/"[[:space:]]*,[[:space:]]*"/,/g; s/^"//; s/"$//'
 }
 
+_health_json_top_level_only() {
+  # #4348 review finding #2: the jq-less field checks below must interrogate the
+  # ROOT object only — jq's `.field` / `has("field")` are top-level, so the
+  # grep fallback has to match top-level too. A naive grep over the compacted
+  # body matches ANY occurrence, so a nested object carrying `"server_up":true`
+  # (malformed / future-shape body) would satisfy a top-level `server_up` check
+  # that jq correctly REJECTS — a false-ready deploy path.
+  #
+  # This helper emits ONLY the brace-depth-1 portion of the root object: the
+  # contents of any nested object/array are elided while the top-level scalar
+  # key:value pairs (and their `,`/`}` delimiters) are preserved, so the
+  # existing grep patterns keep working but can no longer see nested keys. It is
+  # a pure-bash scan (no jq/python) that tracks JSON string state so braces or
+  # brackets inside string values never skew the depth count. NOTE: because
+  # nested containers are elided, callers that need ARRAY/object contents (e.g.
+  # degraded_reasons via _health_json_get_string_array_csv, or the legitimately
+  # nested latest_startup_doctor.skipped_reason) must NOT route through here.
+  local compact="$1"
+  local n=${#compact}
+  local i ch out="" depth=0 in_string=0 escaped=0
+
+  for (( i = 0; i < n; i++ )); do
+    ch="${compact:i:1}"
+    if [ "$in_string" -eq 1 ]; then
+      [ "$depth" -eq 1 ] && out+="$ch"
+      if [ "$escaped" -eq 1 ]; then
+        escaped=0
+      elif [ "$ch" = '\' ]; then
+        escaped=1
+      elif [ "$ch" = '"' ]; then
+        in_string=0
+      fi
+      continue
+    fi
+    case "$ch" in
+      '{'|'[')
+        depth=$((depth + 1))
+        [ "$depth" -eq 1 ] && out+="$ch"
+        ;;
+      '}'|']')
+        [ "$depth" -eq 1 ] && out+="$ch"
+        depth=$((depth - 1))
+        ;;
+      '"')
+        in_string=1
+        [ "$depth" -eq 1 ] && out+="$ch"
+        ;;
+      *)
+        [ "$depth" -eq 1 ] && out+="$ch"
+        ;;
+    esac
+  done
+
+  printf '%s' "$out"
+}
+
+_health_json_top_level_compact() {
+  # Compact + top-level-only, in one place so every scalar field check shares
+  # the same top-level view of the body (#4348 review finding #2).
+  local health_json="$1"
+  _health_json_top_level_only "$(_health_json_compact "$health_json")"
+}
+
 _health_json_field_is_true() {
   local health_json="$1"
   local key="$2"
@@ -241,7 +306,7 @@ _health_json_field_is_true() {
     return
   fi
 
-  _health_json_compact "$health_json" \
+  _health_json_top_level_compact "$health_json" \
     | grep -Eq "\"$key\"[[:space:]]*:[[:space:]]*true([[:space:]]*[,}])"
 }
 
@@ -256,7 +321,7 @@ _health_json_field_is_false() {
     return
   fi
 
-  _health_json_compact "$health_json" \
+  _health_json_top_level_compact "$health_json" \
     | grep -Eq "\"$key\"[[:space:]]*:[[:space:]]*false([[:space:]]*[,}])"
 }
 
@@ -271,7 +336,7 @@ _health_json_field_exists() {
     return
   fi
 
-  _health_json_compact "$health_json" \
+  _health_json_top_level_compact "$health_json" \
     | grep -Eq "\"$key\"[[:space:]]*:"
 }
 
@@ -316,16 +381,35 @@ _health_json_reconcile_only() {
 
 _health_json_unhealthy_only_no_provider_runtimes() {
   # #4348 DEPLOY/RESTART readiness rescue — NOT a runtime /health change.
-  # Returns 0 when the node is serving correctly (server_up + db + dashboard all
-  # true) but /api/health reports status=unhealthy SOLELY because no provider
-  # runtimes are registered (leader-only / no-agent-session topology). In that
-  # state the runtime is structurally unhealthy forever — providers.is_empty()
-  # emits `no_providers_registered` and the startup doctor is skipped with
-  # skipped_reason=no_provider_runtimes_registered — yet the server is fully
-  # serving. The runtime /health endpoint intentionally keeps reporting
-  # unhealthy for monitoring; only the deploy/rollback readiness gate opts in to
-  # this rescue, and only for this EXACT cause (server_up=false / db_unavailable
-  # / any other unhealthy reason must still fail the gate).
+  # Returns 0 when the node is provably SERVING the new binary (server_up + db +
+  # dashboard all true) and its ONLY deploy-BLOCKING condition is that no
+  # provider runtimes are registered (leader-only / no-agent-session topology):
+  # providers.is_empty() emits `no_providers_registered`, the startup doctor is
+  # skipped with skipped_reason=no_provider_runtimes_registered, and status is
+  # pinned to `unhealthy` forever even though the server is fully up.
+  #
+  # NAME/SCOPE NOTE (#4348 review finding #1): the `_only_` here means the only
+  # deploy-BLOCKING cause is no-providers — it does NOT claim no-providers is
+  # the *sole* condition on the node. A serving no-provider node may ALSO carry
+  # a DEGRADED-severity axis (disk-low / stale outbox / pipeline warnings /
+  # opencode), and it still reports status=unhealthy (severity never downgrades
+  # Unhealthy→Degraded) with server_up=true, so this predicate still fires. That
+  # is INTENTIONAL and SAFE, not a false-ready:
+  #   • server_up && db && dashboard already prove the new binary is serving, so
+  #     no broken node is green-lit;
+  #   • those extra axes are DEGRADED severity = NON-BLOCKING for deploy — a
+  #     provider-present node with the same axis reports status=degraded and
+  #     PASSES the deploy gate today, so rescuing a no-provider node with a
+  #     co-existing degraded axis is CONSISTENT with the existing gate, not a
+  #     new risk;
+  #   • the PUBLIC /api/health body STRIPS degraded_reasons, so proving
+  #     "solely no-providers" from this body is impossible without switching the
+  #     gate to the detailed body — a larger change we deliberately do NOT make.
+  # The runtime /health endpoint intentionally keeps reporting unhealthy for
+  # monitoring; only the deploy/rollback readiness gate opts in to this rescue,
+  # and only for this EXACT deploy-blocking cause (server_up=false /
+  # db_unavailable / any other unhealthy DEPLOY-BLOCKING reason must still fail
+  # the gate).
   local health_json="$1"
   [ -n "$health_json" ] || return 1
 
@@ -387,8 +471,10 @@ health_json_is_ready() {
   local health_json="$1"
   local require_dashboard="${2:-0}"
   local allow_reconcile_degraded="${3:-1}"
-  # #4348: when 1, treat a serving node that is unhealthy SOLELY because no
-  # provider runtimes are registered as DEPLOY-READY. Default 0 keeps every
+  # #4348: when 1, treat a serving node whose only deploy-BLOCKING condition is
+  # no registered provider runtimes as DEPLOY-READY (co-existing degraded/
+  # non-blocking axes are permitted — see
+  # _health_json_unhealthy_only_no_provider_runtimes). Default 0 keeps every
   # existing (non-deploy) caller's semantics unchanged.
   local allow_no_provider_runtimes="${4:-0}"
   local status=""
@@ -406,8 +492,10 @@ health_json_is_ready() {
     _health_json_field_is_true "$health_json" "server_up" || return 1
     if [ "$status" = "unhealthy" ]; then
       # #4348: rescue a serving leader-only / no-session node whose only
-      # unhealthy cause is no_provider_runtimes_registered. server_up is already
-      # confirmed true above, so db_unavailable can never take this branch.
+      # deploy-BLOCKING cause is no_provider_runtimes_registered (co-existing
+      # degraded/non-blocking axes are allowed — same as a provider-present
+      # degraded node that passes the gate). server_up is already confirmed true
+      # above, so db_unavailable can never take this branch.
       if [ "$allow_no_provider_runtimes" = "1" ] \
         && _health_json_unhealthy_only_no_provider_runtimes "$health_json"; then
         return 0
@@ -444,8 +532,9 @@ wait_for_http_service_health() {
   local delay_secs="$4"
   local require_dashboard="${5:-0}"
   local allow_reconcile_degraded="${6:-1}"
-  # #4348: opt-in — accept a serving node that is unhealthy solely because no
-  # provider runtimes are registered. Default 0 preserves existing callers.
+  # #4348: opt-in — accept a serving node whose only deploy-BLOCKING condition
+  # is no registered provider runtimes (co-existing degraded/non-blocking axes
+  # permitted). Default 0 preserves existing callers.
   local allow_no_provider_runtimes="${7:-0}"
 
   # shellcheck disable=SC2034 # Read by callers after the function returns.

--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -211,7 +211,7 @@ _health_json_get_string_field() {
 _health_json_get_string_array_csv() {
   local health_json="$1"
   local key="$2"
-  local match
+  local raw
 
   [ -n "$health_json" ] || return 1
 
@@ -220,15 +220,21 @@ _health_json_get_string_array_csv() {
     return
   fi
 
-  match=$(
-    _health_json_compact "$health_json" \
-      | grep -Eo "\"$key\"[[:space:]]*:[[:space:]]*\\[[^]]*\\]" \
-      | head -n 1 \
-      || true
-  )
-  [ -n "$match" ] || return 0
+  # #4348 review finding #4: read the TOP-LEVEL array only (jq evaluates the
+  # root `.${key}`). A naive grep over the whole compacted body would pick up a
+  # same-named array nested inside another object (e.g. subsystem.degraded_reasons),
+  # accepting reconcile-only reasons that jq — reading the ABSENT top-level array
+  # as `[]` — correctly rejects.
+  raw=$(_health_json_top_level_field_raw "$key" "$(_health_json_compact "$health_json")")
+  # Only a genuine top-level ARRAY value contributes reasons; anything else
+  # (absent key, null, scalar, object) is treated as an empty list, matching
+  # jq's `(.key // []) | join(",")` for our reason-list callers.
+  case "$raw" in
+    *\[*\]*) ;;
+    *) return 0 ;;
+  esac
 
-  printf '%s' "$match" \
+  printf '%s' "$raw" \
     | sed -E 's/^[^[]*\[//; s/\]$//; s/"[[:space:]]*,[[:space:]]*"/,/g; s/^"//; s/"$//'
 }
 
@@ -293,6 +299,101 @@ _health_json_top_level_compact() {
   # the same top-level view of the body (#4348 review finding #2).
   local health_json="$1"
   _health_json_top_level_only "$(_health_json_compact "$health_json")"
+}
+
+_health_json_top_level_field_raw() {
+  # #4348 review findings #3/#4: emit the RAW top-level value token for <key>
+  # from the root object (or nothing if <key> is absent at the top level),
+  # preserving the value's own nested contents INTACT — unlike
+  # _health_json_top_level_only, which elides all nested contents. This is what
+  # lets the jq-less path read `.degraded_reasons` (a top-level array whose
+  # elements matter) and `.latest_startup_doctor` (a top-level object we then
+  # descend into for skipped_reason) at the SAME paths jq uses, so a same-named
+  # key buried in some other nested object cannot shadow the root value.
+  #
+  # Pure-bash scan: finds a string that sits in KEY position at brace-depth 1
+  # (a depth-1 string immediately followed by `:`) and, on a name match,
+  # captures the following value up to the next depth-1 `,` / `}` / `]`. JSON
+  # string state is tracked throughout so punctuation inside string values never
+  # confuses key detection, depth accounting, or the value boundary.
+  local key="$1"
+  local compact="$2"
+  local n=${#compact}
+  local i ch
+  local depth=0 in_string=0 escaped=0
+  local cur_str="" pending_key="" awaiting_colon=0
+  local capturing=0 value="" cap_base=0
+
+  for (( i = 0; i < n; i++ )); do
+    ch="${compact:i:1}"
+
+    if [ "$capturing" -eq 1 ]; then
+      if [ "$in_string" -eq 1 ]; then
+        value+="$ch"
+        if [ "$escaped" -eq 1 ]; then
+          escaped=0
+        elif [ "$ch" = '\' ]; then
+          escaped=1
+        elif [ "$ch" = '"' ]; then
+          in_string=0
+        fi
+        continue
+      fi
+      case "$ch" in
+        '"') in_string=1; value+="$ch" ;;
+        '{'|'[') depth=$((depth + 1)); value+="$ch" ;;
+        '}'|']')
+          if [ "$depth" -le "$cap_base" ]; then
+            printf '%s' "$value"
+            return 0
+          fi
+          depth=$((depth - 1)); value+="$ch"
+          ;;
+        ',')
+          if [ "$depth" -eq "$cap_base" ]; then
+            printf '%s' "$value"
+            return 0
+          fi
+          value+="$ch"
+          ;;
+        *) value+="$ch" ;;
+      esac
+      continue
+    fi
+
+    if [ "$in_string" -eq 1 ]; then
+      if [ "$escaped" -eq 1 ]; then
+        escaped=0; cur_str+="$ch"
+      elif [ "$ch" = '\' ]; then
+        escaped=1; cur_str+="$ch"
+      elif [ "$ch" = '"' ]; then
+        in_string=0
+        if [ "$depth" -eq 1 ]; then
+          pending_key="$cur_str"
+          awaiting_colon=1
+        fi
+      else
+        cur_str+="$ch"
+      fi
+      continue
+    fi
+
+    case "$ch" in
+      '"') in_string=1; cur_str=""; awaiting_colon=0 ;;
+      ':')
+        if [ "$awaiting_colon" -eq 1 ] && [ "$depth" -eq 1 ] && [ "$pending_key" = "$key" ]; then
+          capturing=1; cap_base="$depth"; value=""
+        fi
+        awaiting_colon=0
+        ;;
+      '{'|'[') depth=$((depth + 1)); awaiting_colon=0 ;;
+      '}'|']') depth=$((depth - 1)); awaiting_colon=0 ;;
+      ' '|$'\t') ;;
+      *) awaiting_colon=0 ;;
+    esac
+  done
+
+  return 0
 }
 
 _health_json_field_is_true() {
@@ -425,19 +526,23 @@ _health_json_unhealthy_only_no_provider_runtimes() {
     return
   fi
 
-  # jq-less fallback. Every predicate must hold. `skipped_reason` only appears in
-  # the PUBLIC /api/health body nested under latest_startup_doctor, so matching
-  # its exact value on the compacted body is safe here.
+  # jq-less fallback. Every predicate must hold, at the SAME paths jq reads.
   _health_json_field_is_true "$health_json" "server_up" || return 1
   _health_json_field_is_true "$health_json" "db" || return 1
   _health_json_field_is_true "$health_json" "dashboard" || return 1
   [ "$(_health_json_status "$health_json")" = "unhealthy" ] || return 1
-  local compact
-  compact=$(_health_json_compact "$health_json")
-  printf '%s' "$compact" \
-    | grep -Eq '"startup_status"[[:space:]]*:[[:space:]]*"doctor_skipped"' || return 1
-  printf '%s' "$compact" \
-    | grep -Eq '"skipped_reason"[[:space:]]*:[[:space:]]*"no_provider_runtimes_registered"'
+  # startup_status is a TOP-LEVEL field (jq: .startup_status).
+  [ "$(_health_json_get_string_field "$health_json" "startup_status")" = "doctor_skipped" ] || return 1
+  # #4348 review finding #3: skipped_reason must be read from the TOP-LEVEL
+  # latest_startup_doctor object specifically (jq:
+  # .latest_startup_doctor.skipped_reason), NOT grepped anywhere in the body —
+  # a decoy `skipped_reason` in some OTHER nested object must not satisfy this
+  # while the real latest_startup_doctor.skipped_reason differs. Extract the
+  # top-level object, then read its own top-level skipped_reason.
+  local lsd
+  lsd=$(_health_json_top_level_field_raw "latest_startup_doctor" "$(_health_json_compact "$health_json")")
+  [ -n "$lsd" ] || return 1
+  [ "$(_health_json_get_string_field "$lsd" "skipped_reason")" = "no_provider_runtimes_registered" ]
 }
 
 _migration_seq_from_name() {

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -73,6 +73,11 @@ DEPLOY_PEERS_OVERRIDE=()
 DEPLOY_PEERS_FILE="${AGENTDESK_DEPLOY_PEERS_FILE:-$ADK_REL/config/deploy-peers.txt}"
 DEPLOY_PEER_INVOCATION="${AGENTDESK_DEPLOY_PEER_INVOCATION:-0}"
 DEPLOY_FAST="${AGENTDESK_DEPLOY_FAST:-0}"
+# #4348 Defect 3: bound the peer SSH connection phase so an unreachable mDNS
+# alias (e.g. mac-book.local not resolving) fails fast instead of hanging the
+# whole cluster deploy. Only the connect is bounded; a reachable peer's long
+# remote build is unaffected.
+DEPLOY_SSH_CONNECT_TIMEOUT="${AGENTDESK_DEPLOY_SSH_CONNECT_TIMEOUT:-10}"
 
 # Parse flags non-destructively into shell vars + env so that the lock-acquire
 # re-exec (lockf/flock pass-through) and the detached-helper tmux script both
@@ -581,6 +586,62 @@ ${summary}"
     _notify_channel "$content"
 }
 
+_manifest_latest_migration_name() {
+    # Latest postgres migration recorded by the LAST SUCCESSFUL deploy. The
+    # manifest is only rewritten on the success path (after DEPLOY_OK), so during
+    # a failing deploy it still reflects the binary that is now the rollback
+    # target (.prev). Prints the migration filename; returns non-zero when the
+    # manifest or field is absent so the caller can fail closed. See #4348.
+    local manifest="$ADK_REL/runtime/release-source.json"
+    [ -f "$manifest" ] || return 1
+    python3 - "$manifest" <<'PY' 2>/dev/null
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    sys.exit(1)
+value = data.get("latest_postgres_migration") or ""
+if not value:
+    sys.exit(1)
+print(value)
+PY
+}
+
+_rollback_would_brick_on_migration() {
+    # #4348 Defect 2: refuse a rollback that would strand the previous binary
+    # behind a migration the new binary already applied to the SHARED Postgres.
+    # The old binary aborts boot with "migration N was previously applied but is
+    # missing in the resolved migrations", and because the row lives in the
+    # shared DB, every OTHER node bricks on its next restart too. Returns 0 =>
+    # rollback unsafe (fail-forward); returns 1 => rollback safe. Fails CLOSED on
+    # any ambiguity (safety > minimal-change): a rollback must never brick.
+    if [ "${AGENTDESK_DEPLOY_FORCE_ROLLBACK:-0}" = "1" ]; then
+        echo "  ▸ [rollback-guard] AGENTDESK_DEPLOY_FORCE_ROLLBACK=1 — skipping migration-advance guard" >&2
+        return 1
+    fi
+    local new_path new_name old_name
+    new_path="$(_latest_postgres_migration_path 2>/dev/null || true)"
+    if [ -z "$new_path" ]; then
+        echo "  ⚠ [rollback-guard] cannot resolve the new binary's latest migration ($REPO/migrations/postgres) — treating rollback as unsafe" >&2
+        return 0
+    fi
+    new_name="$(basename "$new_path")"
+    old_name="$(_manifest_latest_migration_name || true)"
+    if [ -z "$old_name" ]; then
+        echo "  ⚠ [rollback-guard] no previous-deploy migration record ($ADK_REL/runtime/release-source.json) — cannot prove the rollback binary handles ${new_name}; treating rollback as unsafe" >&2
+        return 0
+    fi
+    if _migration_advanced "$new_name" "$old_name"; then
+        echo "  ▸ [rollback-guard] new migration ${new_name} is ahead of rollback target ${old_name}" >&2
+        return 0
+    fi
+    echo "  ▸ [rollback-guard] rollback target ${old_name} is at/ahead of new migration ${new_name} — safe to roll back" >&2
+    return 1
+}
+
 # #3858: restore the last-known-good release binary and restart the service.
 # Invoked from the EXIT trap (via _cleanup_on_exit) whenever the binary was
 # promoted but the deploy never reached DEPLOY_OK — i.e. ANY non-zero exit after
@@ -598,6 +659,36 @@ _rollback_release_binary() {
     [ -n "$rel_binary" ] && [ -n "$plist" ] || return 0
     if [ ! -f "$rel_backup" ]; then
         echo "⚠ No rollback backup available (${rel_backup:-unset} missing) — cannot auto-rollback"
+        return 0
+    fi
+
+    # #4348 Defect 2: fail-forward instead of bricking when the new binary
+    # advanced the shared Postgres schema past what the rollback target can boot.
+    if _rollback_would_brick_on_migration; then
+        echo ""
+        echo "🛑 ROLLBACK REFUSED — schema migrations advanced beyond the rollback target (#4348)"
+        echo "   The new binary already applied a Postgres migration to the SHARED database that"
+        echo "   the previous binary ($rel_backup) does not embed. Restarting the old binary would"
+        echo "   fail with 'migration was previously applied but is missing in the resolved"
+        echo "   migrations' and REFUSE TO BOOT. Because the migration row lives in the shared"
+        echo "   Postgres, rolling back would ALSO brick every other node on its next restart —"
+        echo "   turning a one-node deploy failure into a cluster-wide outage."
+        echo ""
+        echo "   FAIL-FORWARD: leaving the NEW binary live (it is what is currently running under"
+        echo "   launchd). The rollback backup at $rel_backup is preserved for manual use."
+        echo ""
+        echo "   MANUAL INTERVENTION REQUIRED:"
+        echo "     1. Check whether the new binary is actually serving:"
+        echo "          curl -s http://${ADK_DEFAULT_LOOPBACK}:${rel_port}/api/health"
+        echo "        If it reports server_up/db/dashboard true, the deploy likely tripped a"
+        echo "        readiness edge case — confirm it is serving and no rollback is needed."
+        echo "     2. If the new binary is genuinely broken, FIX FORWARD: patch the code and"
+        echo "        redeploy. Do NOT downgrade the binary while the newer migration is applied."
+        echo "     3. A manual downgrade is only safe AFTER you revert the migration on the shared"
+        echo "        Postgres. To force the classic auto-rollback on a re-run (once the DB is"
+        echo "        reverted), set AGENTDESK_DEPLOY_FORCE_ROLLBACK=1."
+        echo "     4. Release logs: ${ADK_REL:-}/logs/"
+        echo ""
         return 0
     fi
 
@@ -624,7 +715,7 @@ _rollback_release_binary() {
         echo "⚠ launchd bootstrap failed during rollback — using tmux fallback"
         start_release_tmux_fallback || true
     fi
-    if wait_for_http_service_health "$plist" "$rel_port" "$DEPLOY_HEALTH_RETRIES" "$DEPLOY_HEALTH_DELAY_SECS" 1 1; then
+    if wait_for_http_service_health "$plist" "$rel_port" "$DEPLOY_HEALTH_RETRIES" "$DEPLOY_HEALTH_DELAY_SECS" 1 1 1; then
         echo "✓ Rollback succeeded — release healthy on :${rel_port} with previous binary"
     else
         echo "✗ Rollback restart did not reach healthy state — manual intervention required (logs: ${ADK_REL:-}/logs/)"
@@ -754,13 +845,13 @@ git merge --quiet --ff-only origin/main"
     remote_deploy_command="${remote_cd_command} && ${env_prelude} bash scripts/deploy-release.sh${quoted_args}"
 
     echo "▸ [peer:$peer] Pre-syncing repo (fast-forward only)..."
-    if ! ssh "$peer" "bash -lc $(printf '%q' "$remote_presync_command")"; then
-        echo "✗ [peer:$peer] Pre-sync failed (diverged or fetch error). Resolve on the peer and retry."
+    if ! ssh -o ConnectTimeout="$DEPLOY_SSH_CONNECT_TIMEOUT" "$peer" "bash -lc $(printf '%q' "$remote_presync_command")"; then
+        echo "✗ [peer:$peer] Pre-sync failed (diverged, fetch error, or unreachable within ${DEPLOY_SSH_CONNECT_TIMEOUT}s). Resolve on the peer and retry."
         return 1
     fi
 
     echo "▸ [peer:$peer] Running deploy-release.sh..."
-    if ! ssh "$peer" "bash -lc $(printf '%q' "$remote_deploy_command")"; then
+    if ! ssh -o ConnectTimeout="$DEPLOY_SSH_CONNECT_TIMEOUT" "$peer" "bash -lc $(printf '%q' "$remote_deploy_command")"; then
         echo "✗ [peer:$peer] deploy-release.sh failed"
         return 1
     fi
@@ -1490,7 +1581,11 @@ fi
 REL_PORT="${AGENTDESK_REL_PORT:-$ADK_DEFAULT_PORT}"
 echo "▸ Waiting for release health on :${REL_PORT}..."
 REL_HEALTHY=false
-if wait_for_http_service_health "$PLIST_REL" "$REL_PORT" "$DEPLOY_HEALTH_RETRIES" "$DEPLOY_HEALTH_DELAY_SECS" 1 1; then
+# #4348 Defect 1: the trailing `1` opts the DEPLOY readiness gate into treating a
+# serving node that is unhealthy SOLELY because no provider runtimes are
+# registered (leader-only / no-agent-session node) as deploy-ready. Runtime
+# /api/health keeps reporting unhealthy for monitoring; only this gate relaxes.
+if wait_for_http_service_health "$PLIST_REL" "$REL_PORT" "$DEPLOY_HEALTH_RETRIES" "$DEPLOY_HEALTH_DELAY_SECS" 1 1 1; then
     REL_HEALTHY=true
 fi
 
@@ -1521,7 +1616,11 @@ rm -f "$REL_BINARY_BACKUP" 2>/dev/null || true
 # interrupted prior backup copy never lingers in bin/.
 rm -f "$REL_BINARY_BACKUP.tmp" 2>/dev/null || true
 
-if _health_json_field_exists "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}" "fully_recovered" \
+if _health_json_unhealthy_only_no_provider_runtimes "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}"; then
+    echo "✓ Release is serving on :${REL_PORT} (deploy-ready: no provider runtimes registered —"
+    echo "  leader-only / no-agent-session node; runtime /api/health stays unhealthy for"
+    echo "  monitoring, but the server, DB, and dashboard are up [#4348])"
+elif _health_json_field_exists "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}" "fully_recovered" \
   && ! _health_json_field_is_true "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}" "fully_recovered"; then
     echo "✓ Release is serving on :${REL_PORT} (startup recovery still in progress)"
 elif _health_json_reconcile_only "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}"; then

--- a/tests/test_deploy_rollback_health_4348.sh
+++ b/tests/test_deploy_rollback_health_4348.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Unit test for #4348 — deploy/rollback brick fixes in scripts/_defaults.sh.
+#
+# Defect 1 (deploy readiness): a serving leader-only / no-agent-session node is
+# structurally `status=unhealthy` forever (no_provider_runtimes_registered) but
+# must be treated as DEPLOY-READY, and ONLY for that exact cause.
+# Defect 2 (rollback safety): the migration-advance comparison used to refuse a
+# rollback that would strand the old binary behind an already-applied migration.
+#
+# All assertions run against the real helpers sourced from _defaults.sh, in both
+# the jq and the jq-less fallback paths. Self-contained: no service, no launchd.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULTS_SH="$REPO_ROOT/scripts/_defaults.sh"
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); FAIL_NAMES+=("$1"); }
+
+assert_rc() {
+  # assert_rc "<label>" <expected_rc> <cmd...>
+  local label="$1" expected="$2"; shift 2
+  set +e
+  "$@" >/dev/null 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" = "$expected" ]; then pass "$label (rc=$rc)"; else fail "$label (expected rc=$expected, got rc=$rc)"; fi
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then pass "$label (= $expected)"; else fail "$label (expected=$expected actual=$actual)"; fi
+}
+
+[ -f "$DEFAULTS_SH" ] || { echo "FATAL: $DEFAULTS_SH missing"; exit 2; }
+# shellcheck source=/dev/null
+. "$DEFAULTS_SH"
+
+# ── Fixtures — modelled on the real PUBLIC /api/health body shape ────────────
+# Serving leader-only node: unhealthy SOLELY due to no provider runtimes.
+NO_PROVIDER_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":false,"cluster_standby":false,"degraded":true,"startup_status":"doctor_skipped","startup_degraded":false,"startup_degraded_reasons":[],"latest_startup_doctor":{"available":true,"doctor_status":"skipped","skipped":true,"skipped_reason":"no_provider_runtimes_registered"}}'
+# DB down: server_up=false — must NEVER be rescued.
+DB_DOWN_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":false,"fully_recovered":false,"cluster_standby":false,"degraded":true,"startup_status":"doctor_skipped","latest_startup_doctor":{"skipped_reason":"no_provider_runtimes_registered"}}'
+# Unhealthy for a DIFFERENT reason (doctor ran, providers present) — must fail.
+OTHER_UNHEALTHY_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":true,"startup_status":"doctor_passed","latest_startup_doctor":{"doctor_status":"passed","skipped_reason":null}}'
+# Fully healthy.
+HEALTHY_BODY='{"ok":true,"status":"healthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":false,"startup_status":"doctor_passed"}'
+
+run_gate_cases() {
+  local mode="$1"
+  echo "== Defect 1 gate — ${mode} path =="
+
+  # allow_no_provider_runtimes=1 → no-provider node is deploy-ready.
+  assert_rc "[$mode] no-provider unhealthy + allow=1 → READY" 0 \
+    health_json_is_ready "$NO_PROVIDER_BODY" 1 1 1
+  # Default (allow=0) preserves the strict semantics: unhealthy => not ready.
+  assert_rc "[$mode] no-provider unhealthy + allow=0 (default) → NOT ready" 1 \
+    health_json_is_ready "$NO_PROVIDER_BODY" 1 1
+  # DB down must never be rescued even with allow=1.
+  assert_rc "[$mode] db/server down + allow=1 → NOT ready" 1 \
+    health_json_is_ready "$DB_DOWN_BODY" 1 1 1
+  # A different unhealthy cause must still fail with allow=1.
+  assert_rc "[$mode] other unhealthy cause + allow=1 → NOT ready" 1 \
+    health_json_is_ready "$OTHER_UNHEALTHY_BODY" 1 1 1
+  # Healthy node is ready regardless of the opt-in flag.
+  assert_rc "[$mode] healthy + allow=1 → READY" 0 \
+    health_json_is_ready "$HEALTHY_BODY" 1 1 1
+  assert_rc "[$mode] healthy + allow=0 → READY" 0 \
+    health_json_is_ready "$HEALTHY_BODY" 1 1
+
+  # The predicate helper in isolation.
+  assert_rc "[$mode] predicate matches no-provider body" 0 \
+    _health_json_unhealthy_only_no_provider_runtimes "$NO_PROVIDER_BODY"
+  assert_rc "[$mode] predicate rejects other-unhealthy body" 1 \
+    _health_json_unhealthy_only_no_provider_runtimes "$OTHER_UNHEALTHY_BODY"
+  assert_rc "[$mode] predicate rejects db-down body" 1 \
+    _health_json_unhealthy_only_no_provider_runtimes "$DB_DOWN_BODY"
+}
+
+# jq path (jq is present in this environment).
+run_gate_cases "jq"
+
+# Force the jq-less fallback and re-run every case.
+_health_json_has_jq() { return 1; }
+run_gate_cases "jq-less"
+unset -f _health_json_has_jq
+
+echo "== Defect 1 gate — wait loop end-to-end (curl shim) =="
+SHIM_DIR="$(mktemp -d)"
+trap 'rm -rf "$SHIM_DIR"' EXIT
+mkdir -p "$SHIM_DIR/bin"
+BODY_FILE="$SHIM_DIR/body.json"
+cat >"$SHIM_DIR/bin/curl" <<EOF
+#!/usr/bin/env bash
+cat "$BODY_FILE"
+EOF
+chmod +x "$SHIM_DIR/bin/curl"
+printf '%s' "$NO_PROVIDER_BODY" >"$BODY_FILE"
+# Run inside a subshell so the shim PATH (and any launchctl noise) is isolated;
+# `env` cannot invoke a shell function, so scope PATH via the subshell instead.
+_wait_with_shim() { ( PATH="$SHIM_DIR/bin:$PATH"; wait_for_http_service_health "$@" ); }
+# 7th arg = 1 → the wait loop accepts the serving no-provider node on attempt 1.
+assert_rc "wait loop accepts no-provider node when opted in (arg7=1)" 0 \
+  _wait_with_shim "test.label" 0 1 0 1 1 1
+# Without the opt-in the same body must fail (retries=1, delay=0 keeps it fast).
+assert_rc "wait loop rejects no-provider node without opt-in (arg7 omitted)" 1 \
+  _wait_with_shim "test.label" 0 1 0 1 1
+
+echo "== Defect 2 — migration sequence parsing =="
+assert_eq "seq of 0079_relay_dead_letter.sql" "79" "$(_migration_seq_from_name '0079_relay_dead_letter.sql')"
+assert_eq "seq of 0080_intake_outbox_provider.sql (octal-safe)" "80" "$(_migration_seq_from_name '0080_intake_outbox_provider.sql')"
+assert_eq "seq of 0100_x.sql" "100" "$(_migration_seq_from_name '0100_x.sql')"
+assert_rc "seq of non-numeric name fails" 1 _migration_seq_from_name "garbage.sql"
+assert_rc "seq of empty name fails" 1 _migration_seq_from_name ""
+
+echo "== Defect 2 — rollback-would-brick decision (_migration_advanced) =="
+# new > old → advanced → UNSAFE to roll back (return 0 = true).
+assert_rc "new 79 vs old 78 → advanced (unsafe)" 0 _migration_advanced "0079_a.sql" "0078_b.sql"
+# new == old → not advanced → safe.
+assert_rc "new 78 vs old 78 → safe" 1 _migration_advanced "0078_a.sql" "0078_b.sql"
+# new < old → not advanced → safe.
+assert_rc "new 77 vs old 79 → safe" 1 _migration_advanced "0077_a.sql" "0079_b.sql"
+# Fail closed on unresolved names → treat as advanced (unsafe).
+assert_rc "unresolved new name → unsafe (fail closed)" 0 _migration_advanced "garbage" "0078_b.sql"
+assert_rc "empty old name → unsafe (fail closed)" 0 _migration_advanced "0079_a.sql" ""
+
+echo
+echo "==== Results ===="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf '  failed: %s\n' "${FAIL_NAMES[@]}" >&2
+  exit 1
+fi
+exit 0

--- a/tests/test_deploy_rollback_health_4348.sh
+++ b/tests/test_deploy_rollback_health_4348.sh
@@ -51,6 +51,18 @@ DB_DOWN_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboar
 OTHER_UNHEALTHY_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":true,"startup_status":"doctor_passed","latest_startup_doctor":{"doctor_status":"passed","skipped_reason":null}}'
 # Fully healthy.
 HEALTHY_BODY='{"ok":true,"status":"healthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":false,"startup_status":"doctor_passed"}'
+# Finding #2 (jq-less top-level parity): malformed / future-shape body where the
+# TOP-LEVEL server_up/db/dashboard are FALSE but a NESTED object carries them
+# true (and a nested status="healthy"). jq matches the root only and REJECTS;
+# the jq-less grep fallback must agree — a naive "any occurrence" grep would be
+# fooled by the nested keys and green-light a broken node (false-ready).
+NESTED_FIELD_MALFORMED_BODY='{"ok":false,"status":"unhealthy","version":"x","db":false,"dashboard":false,"server_up":false,"fully_recovered":false,"startup_status":"doctor_skipped","subsystem":{"server_up":true,"db":true,"dashboard":true,"status":"healthy"},"latest_startup_doctor":{"available":true,"doctor_status":"skipped","skipped":true,"skipped_reason":"no_provider_runtimes_registered"}}'
+# Finding #1 (adjudicated SAFE): the NO_PROVIDER body PLUS a co-existing
+# DEGRADED/non-blocking axis (disk_low true, stale outbox age). Severity never
+# downgrades Unhealthy→Degraded so status stays "unhealthy" with server_up=true.
+# This must STILL be deploy-ready under opt-in — exactly as a provider-present
+# degraded node passes the gate today.
+DEGRADED_AXIS_NO_PROVIDER_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":false,"cluster_standby":false,"degraded":true,"disk_low":true,"outbox_oldest_age_secs":1800,"startup_status":"doctor_skipped","startup_degraded":false,"startup_degraded_reasons":[],"latest_startup_doctor":{"available":true,"doctor_status":"skipped","skipped":true,"skipped_reason":"no_provider_runtimes_registered"}}'
 
 run_gate_cases() {
   local mode="$1"
@@ -81,6 +93,27 @@ run_gate_cases() {
     _health_json_unhealthy_only_no_provider_runtimes "$OTHER_UNHEALTHY_BODY"
   assert_rc "[$mode] predicate rejects db-down body" 1 \
     _health_json_unhealthy_only_no_provider_runtimes "$DB_DOWN_BODY"
+
+  # Finding #2 — nested-field malformed body: jq matches TOP-LEVEL only and
+  # rejects; the jq-less grep fallback MUST agree (must not be fooled by nested
+  # server_up/db/dashboard=true). Both the predicate and the gate must reject in
+  # BOTH modes — this negative case is what caught the false-ready path.
+  assert_rc "[$mode] nested-field malformed body → predicate REJECTS" 1 \
+    _health_json_unhealthy_only_no_provider_runtimes "$NESTED_FIELD_MALFORMED_BODY"
+  assert_rc "[$mode] nested-field malformed body + allow=1 → NOT ready" 1 \
+    health_json_is_ready "$NESTED_FIELD_MALFORMED_BODY" 1 1 1
+  # Direct field-helper parity: a top-level FALSE with a nested TRUE must read as
+  # false/absent at the top level (mirrors jq's `.field` / `has()`).
+  assert_rc "[$mode] field_is_true(server_up) ignores nested true" 1 \
+    _health_json_field_is_true "$NESTED_FIELD_MALFORMED_BODY" "server_up"
+
+  # Finding #1 (adjudicated SAFE) — a serving no-provider node with a co-existing
+  # DEGRADED/non-blocking axis (disk_low / stale outbox) is STILL deploy-ready
+  # under opt-in, and the predicate still fires. Documents the intended behavior.
+  assert_rc "[$mode] no-provider + degraded axis + allow=1 → READY" 0 \
+    health_json_is_ready "$DEGRADED_AXIS_NO_PROVIDER_BODY" 1 1 1
+  assert_rc "[$mode] no-provider + degraded axis → predicate matches" 0 \
+    _health_json_unhealthy_only_no_provider_runtimes "$DEGRADED_AXIS_NO_PROVIDER_BODY"
 }
 
 # jq path (jq is present in this environment).

--- a/tests/test_deploy_rollback_health_4348.sh
+++ b/tests/test_deploy_rollback_health_4348.sh
@@ -82,6 +82,17 @@ NESTED_ONLY_DEGRADED_REASONS_BODY='{"ok":false,"status":"degraded","version":"x"
 # must STILL be accepted by the reconcile gate — the fix must not break the
 # legitimate reconcile-in-progress path.
 TOP_LEVEL_RECONCILE_BODY='{"ok":false,"status":"degraded","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":true,"degraded_reasons":["provider:codex:reconcile_in_progress"]}'
+# R2 whitespace regression: a VALID top-level degraded_reasons array with
+# insignificant whitespace after `]` (space before the closing `}`). jq ignores
+# it and ACCEPTS via the reconcile path; the jq-less raw extractor must trim the
+# trailing space so the array cleanup still ends the value at `]` (was returning
+# a malformed CSV → reconcile REJECT → jq/jq-less parity break).
+WS_RECONCILE_BODY='{"ok":false,"status":"degraded","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":true,"degraded_reasons":["provider:codex:reconcile_in_progress"] }'
+# Scalar whitespace tolerance: spaces around every top-level value AND before
+# delimiters, plus a nested latest_startup_doctor object with inner spacing.
+# Every scalar read (status / db / dashboard / server_up / startup_status /
+# latest_startup_doctor.skipped_reason) must parse correctly in both modes.
+WS_SCALAR_NO_PROVIDER_BODY='{ "ok": false , "status": "unhealthy" , "db": true , "dashboard": true , "server_up": true , "fully_recovered": false , "startup_status": "doctor_skipped" , "latest_startup_doctor": { "available": true , "skipped_reason": "no_provider_runtimes_registered" } }'
 
 run_gate_cases() {
   local mode="$1"
@@ -158,6 +169,23 @@ run_gate_cases() {
     _health_json_reconcile_only "$TOP_LEVEL_RECONCILE_BODY"
   assert_rc "[$mode] top-level reconcile degraded_reasons → READY" 0 \
     health_json_is_ready "$TOP_LEVEL_RECONCILE_BODY" 1 1
+
+  # R2 whitespace regression — a valid top-level degraded_reasons array with a
+  # space after `]` must still be accepted via the reconcile path in BOTH modes
+  # (the raw extractor now trims the token, so the array cleanup ends at `]`).
+  assert_rc "[$mode] degraded_reasons array + trailing ws → reconcile_only matches" 0 \
+    _health_json_reconcile_only "$WS_RECONCILE_BODY"
+  assert_rc "[$mode] degraded_reasons array + trailing ws → READY" 0 \
+    health_json_is_ready "$WS_RECONCILE_BODY" 1 1
+
+  # Scalar whitespace tolerance — surrounding spaces on every top-level value
+  # must not break scalar reads; the whole no-provider rescue predicate (which
+  # exercises status/db/dashboard/server_up/startup_status/skipped_reason) must
+  # still match, and the direct status read must parse cleanly.
+  assert_eq "[$mode] status read tolerates surrounding whitespace" \
+    "unhealthy" "$(_health_json_status "$WS_SCALAR_NO_PROVIDER_BODY")"
+  assert_rc "[$mode] whitespace-padded no-provider body → predicate matches" 0 \
+    _health_json_unhealthy_only_no_provider_runtimes "$WS_SCALAR_NO_PROVIDER_BODY"
 }
 
 # jq path (jq is present in this environment).

--- a/tests/test_deploy_rollback_health_4348.sh
+++ b/tests/test_deploy_rollback_health_4348.sh
@@ -63,6 +63,25 @@ NESTED_FIELD_MALFORMED_BODY='{"ok":false,"status":"unhealthy","version":"x","db"
 # This must STILL be deploy-ready under opt-in — exactly as a provider-present
 # degraded node passes the gate today.
 DEGRADED_AXIS_NO_PROVIDER_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":false,"cluster_standby":false,"degraded":true,"disk_low":true,"outbox_oldest_age_secs":1800,"startup_status":"doctor_skipped","startup_degraded":false,"startup_degraded_reasons":[],"latest_startup_doctor":{"available":true,"doctor_status":"skipped","skipped":true,"skipped_reason":"no_provider_runtimes_registered"}}'
+# Finding #3 (jq-less skipped_reason path parity): a DECOY `skipped_reason` with
+# the rescue value lives in an UNRELATED nested object, while the REAL
+# latest_startup_doctor.skipped_reason is something else. jq reads
+# .latest_startup_doctor.skipped_reason (→ reject); a jq-less grep that matches
+# skipped_reason ANYWHERE would be fooled by the decoy (→ false accept).
+DECOY_SKIPPED_REASON_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":false,"startup_status":"doctor_skipped","other":{"skipped_reason":"no_provider_runtimes_registered"},"latest_startup_doctor":{"available":true,"doctor_status":"passed","skipped":false,"skipped_reason":"providers_present"}}'
+# Finding #3 positive control: the REAL latest_startup_doctor.skipped_reason is
+# the rescue value while a decoy elsewhere differs — must STILL be accepted, so
+# the fix targets the right path in BOTH directions (not "any decoy rejects").
+REAL_SKIPPED_REASON_WITH_DECOY_BODY='{"ok":false,"status":"unhealthy","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":false,"startup_status":"doctor_skipped","other":{"skipped_reason":"something_else"},"latest_startup_doctor":{"available":true,"doctor_status":"skipped","skipped":true,"skipped_reason":"no_provider_runtimes_registered"}}'
+# Finding #4 (jq-less degraded_reasons path parity): NO top-level
+# degraded_reasons, but a nested object carries a reconcile-only array. jq reads
+# the TOP-LEVEL .degraded_reasons (absent → [] → reconcile gate REJECTS); a
+# jq-less grep matching degraded_reasons ANYWHERE would accept the nested array.
+NESTED_ONLY_DEGRADED_REASONS_BODY='{"ok":false,"status":"degraded","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":true,"subsystem":{"degraded_reasons":["provider:codex:reconcile_in_progress"]}}'
+# Finding #4 positive control: a genuine TOP-LEVEL reconcile-only degraded body
+# must STILL be accepted by the reconcile gate — the fix must not break the
+# legitimate reconcile-in-progress path.
+TOP_LEVEL_RECONCILE_BODY='{"ok":false,"status":"degraded","version":"x","db":true,"dashboard":true,"server_up":true,"fully_recovered":true,"cluster_standby":false,"degraded":true,"degraded_reasons":["provider:codex:reconcile_in_progress"]}'
 
 run_gate_cases() {
   local mode="$1"
@@ -114,6 +133,31 @@ run_gate_cases() {
     health_json_is_ready "$DEGRADED_AXIS_NO_PROVIDER_BODY" 1 1 1
   assert_rc "[$mode] no-provider + degraded axis → predicate matches" 0 \
     _health_json_unhealthy_only_no_provider_runtimes "$DEGRADED_AXIS_NO_PROVIDER_BODY"
+
+  # Finding #3 — skipped_reason must be read from the TOP-LEVEL
+  # latest_startup_doctor object (jq: .latest_startup_doctor.skipped_reason).
+  # A decoy skipped_reason in another nested object must NOT satisfy the rescue
+  # while the real one differs; both modes must reject. Positive control proves
+  # the real path is still accepted when a differing decoy is present.
+  assert_rc "[$mode] decoy skipped_reason (real differs) → predicate REJECTS" 1 \
+    _health_json_unhealthy_only_no_provider_runtimes "$DECOY_SKIPPED_REASON_BODY"
+  assert_rc "[$mode] decoy skipped_reason + allow=1 → NOT ready" 1 \
+    health_json_is_ready "$DECOY_SKIPPED_REASON_BODY" 1 1 1
+  assert_rc "[$mode] real skipped_reason (decoy differs) → predicate matches" 0 \
+    _health_json_unhealthy_only_no_provider_runtimes "$REAL_SKIPPED_REASON_WITH_DECOY_BODY"
+
+  # Finding #4 — degraded_reasons must be read from the TOP-LEVEL array
+  # (jq: .degraded_reasons). A nested-only reconcile array must NOT satisfy the
+  # reconcile gate; both modes must reject. Positive control keeps the genuine
+  # top-level reconcile-in-progress path working.
+  assert_rc "[$mode] nested-only degraded_reasons → reconcile_only REJECTS" 1 \
+    _health_json_reconcile_only "$NESTED_ONLY_DEGRADED_REASONS_BODY"
+  assert_rc "[$mode] nested-only degraded_reasons → NOT ready" 1 \
+    health_json_is_ready "$NESTED_ONLY_DEGRADED_REASONS_BODY" 1 1
+  assert_rc "[$mode] top-level reconcile degraded_reasons → reconcile_only matches" 0 \
+    _health_json_reconcile_only "$TOP_LEVEL_RECONCILE_BODY"
+  assert_rc "[$mode] top-level reconcile degraded_reasons → READY" 0 \
+    health_json_is_ready "$TOP_LEVEL_RECONCILE_BODY" 1 1
 }
 
 # jq path (jq is present in this environment).


### PR DESCRIPTION
## 요약 (P0, bash-only, 런타임 health 시맨틱 무변경)
2026-07-08 노드 brick 사고(#4348)의 두 결함을 deploy 스크립트에서 봉쇄. `/api/health` 공개 바디가 brick 원인을 구분할 모든 필드를 이미 노출하므로 rust 변경 불필요.

### Defect 1 — no-provider 리더 노드가 health 게이트 영구 실패
`_health_json_unhealthy_only_no_provider_runtimes()` 신설: `server_up && db && dashboard && status==unhealthy && startup_status==doctor_skipped && latest_startup_doctor.skipped_reason==no_provider_runtimes_registered`일 때만 deploy-ready로 rescue. `health_json_is_ready`/`wait_for_http_service_health`에 **opt-in 파라미터(기본 0)** 추가 — deploy health-wait(:1585)와 rollback restart health-wait(:715)만 1을 전달. 그 외 unhealthy 사유(db down, server_up=false)는 여전히 실패. **런타임 /api/health 시맨틱 불변.**

### Defect 2 — 마이그레이션 적용 후 롤백이 노드를 벽돌로
롤백 전 `_rollback_would_brick_on_migration()`이 신규 배포 최신 마이그레이션 vs 롤백 대상 매니페스트(`runtime/release-source.json`의 `latest_postgres_migration`, 성공 경로에서만 전진 → 실패 중엔 .prev 반영) 비교. new>old면 **롤백 거부 + fail-forward**(신규 바이너리 유지, 육성 경고 + 수동개입 안내, return 0). 모호하면 **fail-closed**(롤백 거부). 탈출구 `AGENTDESK_DEPLOY_FORCE_ROLLBACK=1`.

### Defect 3 — peer 배포 mDNS 무한 행
peer `ssh`에 `-o ConnectTimeout=$DEPLOY_SSH_CONNECT_TIMEOUT`(기본 10s, connect 단계만 bound).

## 검증
- `bash -n` + `shellcheck -S warning` clean (양 스크립트 + 테스트)
- 신규 `tests/test_deploy_rollback_health_4348.sh` 30/30 PASS (jq/jq-less, must-fail 케이스, octal-safe seq, fail-closed)
- 기존 `test_restart_drain_helpers.sh` 29/29 PASS (무회귀)
- 인시던트 hand-trace: new79/old78→fail-forward(no brick), 79/79→safe rollback 유지, 매니페스트 없음→fail-closed, FORCE=1→guard skip. 리더-only 노드 attempt1 통과→롤백 미발동.

Closes #4348

🤖 Generated with [Claude Code](https://claude.com/claude-code)