### PR TITLE
fix(voice): make barge-in stop/cancel atomic — always fire CancellationToken (#4241)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -994,7 +994,7 @@
 | `utils::wip_detect` | `src/utils/wip_detect.rs` | 237 | 106 | 131 |  |
 | `voice` | `src/voice/mod.rs` | 21 | 21 | 0 |  |
 | `voice::announce_meta` | `src/voice/announce_meta.rs` | 1979 | 1001 | 978 | giant-file |
-| `voice::barge_in` | `src/voice/barge_in.rs` | 937 | 592 | 345 |  |
+| `voice::barge_in` | `src/voice/barge_in.rs` | 995 | 598 | 397 |  |
 | `voice::cancel_tombstone` | `src/voice/cancel_tombstone.rs` | 274 | 147 | 127 |  |
 | `voice::commands` | `src/voice/commands.rs` | 860 | 548 | 312 |  |
 | `voice::config` | `src/voice/config.rs` | 627 | 392 | 235 |  |

--- a/src/voice/barge_in.rs
+++ b/src/voice/barge_in.rs
@@ -157,8 +157,14 @@ impl LiveBargeInMonitor {
             return Ok(None);
         }
 
-        player.stop()?;
+        // #4241: track-stop and task-cancel must be atomic. Capture the stop
+        // result and always fire `cancel()` before propagating, so a failing
+        // `stop()` can never swallow the playback task's cancel signal. The stop
+        // error is still surfaced (not logged-and-continued) to preserve the
+        // existing `?` propagation contract for non-Finished errors.
+        let stop_result = player.stop();
         cancellation.cancel();
+        stop_result?;
         self.triggered = true;
 
         Ok(Some(LiveBargeInCut {
@@ -599,6 +605,7 @@ mod tests {
     struct MockPlayer {
         stops: AtomicUsize,
         already_finished: bool,
+        fails: bool,
     }
 
     impl MockPlayer {
@@ -606,6 +613,17 @@ mod tests {
             Self {
                 stops: AtomicUsize::new(0),
                 already_finished: true,
+                fails: false,
+            }
+        }
+
+        /// `stop()` returns a real (non-Finished) error to exercise the #4241
+        /// atomicity path where the cancel token must still flip.
+        fn failing() -> Self {
+            Self {
+                stops: AtomicUsize::new(0),
+                already_finished: false,
+                fails: true,
             }
         }
     }
@@ -613,7 +631,9 @@ mod tests {
     impl BargeInPlayerStop for MockPlayer {
         fn stop(&self) -> Result<()> {
             self.stops.fetch_add(1, Ordering::SeqCst);
-            if self.already_finished {
+            if self.fails {
+                map_track_stop_result(Err(songbird::tracks::ControlError::Dropped))
+            } else if self.already_finished {
                 map_track_stop_result(Err(songbird::tracks::ControlError::Finished))
             } else {
                 Ok(())
@@ -932,6 +952,44 @@ mod tests {
             player.stops.load(Ordering::SeqCst),
             1,
             "stop() must not be invoked again after the first cut, even on Finished"
+        );
+    }
+
+    /// Regression test for #4241 — track-stop and task-cancel must be atomic.
+    /// When songbird `TrackHandle::stop` returns a real (non-Finished) error,
+    /// `observe_pcm` must STILL flip the cancellation token (so the playback
+    /// task's cancel signal is never lost) while still surfacing the stop error
+    /// to the caller rather than swallowing it.
+    #[test]
+    fn live_monitor_cancels_even_when_stop_fails() {
+        let player = MockPlayer::failing();
+        let cancellation = CancellationToken::new();
+        let mut monitor = LiveBargeInMonitor::new(BargeInSensitivity::Normal);
+        let loud = stereo_pcm(&[16_384, -16_384, 16_384, -16_384]);
+
+        // Frame 1: candidate gauge ticks up but the trigger threshold is not met.
+        assert!(
+            monitor
+                .observe_pcm(&loud, &player, &cancellation)
+                .unwrap()
+                .is_none()
+        );
+        assert!(!cancellation.is_cancelled());
+        assert_eq!(player.stops.load(Ordering::SeqCst), 0);
+
+        // Frame 2: trigger fires. `stop()` returns a real error, but the cancel
+        // token MUST already be flipped before the error propagates.
+        let error = monitor
+            .observe_pcm(&loud, &player, &cancellation)
+            .expect_err("stop() error must be surfaced, not swallowed");
+        assert!(
+            cancellation.is_cancelled(),
+            "cancel() must fire even when stop() errors (#4241 atomicity)"
+        );
+        assert_eq!(player.stops.load(Ordering::SeqCst), 1);
+        assert!(
+            format!("{error}").contains("failed to stop songbird playback track"),
+            "stop error must still be surfaced, got: {error}"
         );
     }
 }


### PR DESCRIPTION
## 요약
`LiveBargeInMonitor::observe_pcm`이 `player.stop()?` 후 `cancellation.cancel()`를 호출해, stop()이 에러 반환 시 `?`로 조기반환되어 **취소 토큰이 미발화**(재생 태스크 취소 신호 유실)되던 버그(#4241) 수정.

## 변경
```rust
let stop_result = player.stop();
cancellation.cancel();   // stop() 결과와 무관하게 항상 발화
stop_result?;            // stop 에러는 여전히 전파 (삼키지 않음)
self.triggered = true;   // ? 뒤 유지 → 에러 시 triggered=false, 기존 행위 불변
```
만성 재발 테마(#2250/#2335/#2374/#2403/#3911)의 이 stop→cancel 순서 결함 해소.

## 검증
- 회귀 테스트 `live_monitor_cancels_even_when_stop_fails`: stop()이 real error 시 (a) cancellation 발화 확인 (b) 에러 여전히 전파 확인.
- fmt/check 클린, `voice::barge_in` 19/19, `voice_barge_in` 모듈 74/74, agent-maintenance passed.
- CancellationToken::cancel() 멱등 → double-cancel 무해. stop(TrackHandle)와 token은 독립 객체라 순서 의존 없음.

## 참고
- pre-existing #3293 env-isolation flake(`post_synthesis_handoff_cancel`, AGENTDESK_ROOT_DIR 미설정 시 sibling 의존)는 본 변경 무관.

Closes #4241

🤖 Generated with [Claude Code](https://claude.com/claude-code)