### PR TITLE
fix(discord): Tasks 라이브 패널을 in-progress만 표시 (완료 즉시 숨김) (#4093)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -533,17 +533,17 @@
 | `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 649 | 649 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
-| `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 548 | 548 | 0 |  |
+| `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 544 | 544 | 0 |  |
 | `services::discord::placeholder_live_events::context_panel` | `src/services/discord/placeholder_live_events/context_panel.rs` | 72 | 72 | 0 |  |
 | `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 187 | 86 | 101 |  |
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
 | `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 794 | 794 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 794 | 794 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 804 | 804 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 481 | 306 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
-| `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 348 | 348 | 0 |  |
+| `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 368 | 368 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 185 | 185 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -540,10 +540,10 @@
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
 | `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 794 | 794 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 804 | 804 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 787 | 787 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 481 | 306 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
-| `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 368 | 368 | 0 |  |
+| `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 392 | 392 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 185 | 185 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |

--- a/src/services/discord/placeholder_live_events/completion_footer.rs
+++ b/src/services/discord/placeholder_live_events/completion_footer.rs
@@ -522,15 +522,11 @@ pub(in crate::services::discord) fn live_panel_compaction_counts(
     provider: &ProviderKind,
 ) -> (usize, usize) {
     let collapsed = |total: usize| total.saturating_sub(LIVE_PANEL_TERMINAL_RENDER_CAP);
-    let tasks_collapsed = collapsed(
-        snapshot
-            .tasks
-            .iter()
-            .rev()
-            .take(STATUS_PANEL_TASK_LIMIT)
-            .filter(|slot| task_tool_slot_is_terminal(slot))
-            .count(),
-    );
+    // #4093: the live render now hides terminal (completed/failed) task slots
+    // entirely, so no terminal task line ever reaches the live compaction — the
+    // Tasks section can no longer be collapsed. Mirror that here so the
+    // observability count stays honest.
+    let tasks_collapsed = 0;
     let subagents_collapsed = if matches!(provider, ProviderKind::Codex) {
         0
     } else {

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -3,9 +3,8 @@ use crate::services::provider::ProviderKind;
 
 use super::common::{
     EVENT_LINE_MAX_CHARS, STATUS_PANEL_MAX_CHARS, STATUS_PANEL_SUBAGENT_LIMIT,
-    STATUS_PANEL_TASK_LIMIT, STATUS_PANEL_TODO_LIMIT, STATUS_PANEL_WORKFLOW_LIMIT,
-    escape_status_panel_markdown, normalize_summary, sanitized_tool_name, truncate_chars,
-    truncate_chars_with_marker,
+    STATUS_PANEL_TODO_LIMIT, STATUS_PANEL_WORKFLOW_LIMIT, escape_status_panel_markdown,
+    normalize_summary, sanitized_tool_name, truncate_chars, truncate_chars_with_marker,
 };
 use super::completion_footer::compact_live_panel_terminal_lines;
 use super::context_panel::{ContextPanelSnapshot, render_context_panel_line};
@@ -14,9 +13,9 @@ use super::status_events::{is_schedule_wakeup_tool, parse_eta_secs};
 use super::subagent_summary::render_subagent_done_summary;
 use super::task_panel::{
     STUCK_BACKGROUND_TASK_TTL, TaskPanelSnapshot, TaskToolSlot, finish_background_task_tool_slot,
-    force_abort_stuck_background_task_slots, render_task_panel_line, render_task_tool_slot,
-    take_slot_ordinal, task_tool_slot_is_in_progress, task_tool_slot_is_unfinished_background,
-    upsert_background_task_tool_slot, upsert_task_tool_slot,
+    force_abort_stuck_background_task_slots, render_live_tasks_section, render_task_panel_line,
+    take_slot_ordinal, task_tool_slot_is_unfinished_background, upsert_background_task_tool_slot,
+    upsert_task_tool_slot,
 };
 use super::workflow_panel::{
     WorkflowAgentSlot, WorkflowSlot, render_workflow_slot, trim_workflow_slot, trim_workflows,
@@ -590,26 +589,10 @@ pub(super) fn render_status_panel(
 
     // #3983 item 5a: the compact 🖥️ Recent + host block is removed from the footer
     // (the terminal echo is retired from the status panel entirely).
-    if !snapshot.tasks.is_empty() {
-        // #4093: render ONLY in-progress tasks — completed/failed rows are hidden
-        // immediately and statusless foreground dispatches are excluded — so
-        // finished work no longer masks active work until it falls out of the
-        // 10-slot window. Filtering BEFORE `.take` keeps the cap semantics (up to
-        // 10 of the FILTERED in-progress tasks) and preserves newest-first order.
-        let lines = snapshot
-            .tasks
-            .iter()
-            .rev()
-            .filter(|slot| task_tool_slot_is_in_progress(slot))
-            .take(STATUS_PANEL_TASK_LIMIT)
-            .map(render_task_tool_slot)
-            .collect::<Vec<_>>();
-        let lines = compact_live_panel_terminal_lines(&lines).map_or(lines, |(out, _)| out); // #3404 cap
-        // Omit the Tasks section entirely when nothing is in progress so no
-        // dangling `Tasks` header is rendered over an empty body.
-        if !lines.is_empty() {
-            sections.push(format!("Tasks\n{}", lines.join("\n")));
-        }
+    // #4093: the in-progress-only Tasks section (filter + #3404 compaction +
+    // empty-section guard) lives in `task_panel::render_live_tasks_section`.
+    if let Some(section) = render_live_tasks_section(&snapshot.tasks) {
+        sections.push(section);
     }
 
     if !matches!(provider, ProviderKind::Codex) && !snapshot.subagents.is_empty() {

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -15,8 +15,8 @@ use super::subagent_summary::render_subagent_done_summary;
 use super::task_panel::{
     STUCK_BACKGROUND_TASK_TTL, TaskPanelSnapshot, TaskToolSlot, finish_background_task_tool_slot,
     force_abort_stuck_background_task_slots, render_task_panel_line, render_task_tool_slot,
-    take_slot_ordinal, task_tool_slot_is_unfinished_background, upsert_background_task_tool_slot,
-    upsert_task_tool_slot,
+    take_slot_ordinal, task_tool_slot_is_in_progress, task_tool_slot_is_unfinished_background,
+    upsert_background_task_tool_slot, upsert_task_tool_slot,
 };
 use super::workflow_panel::{
     WorkflowAgentSlot, WorkflowSlot, render_workflow_slot, trim_workflow_slot, trim_workflows,
@@ -591,15 +591,25 @@ pub(super) fn render_status_panel(
     // #3983 item 5a: the compact 🖥️ Recent + host block is removed from the footer
     // (the terminal echo is retired from the status panel entirely).
     if !snapshot.tasks.is_empty() {
+        // #4093: render ONLY in-progress tasks — completed/failed rows are hidden
+        // immediately and statusless foreground dispatches are excluded — so
+        // finished work no longer masks active work until it falls out of the
+        // 10-slot window. Filtering BEFORE `.take` keeps the cap semantics (up to
+        // 10 of the FILTERED in-progress tasks) and preserves newest-first order.
         let lines = snapshot
             .tasks
             .iter()
             .rev()
+            .filter(|slot| task_tool_slot_is_in_progress(slot))
             .take(STATUS_PANEL_TASK_LIMIT)
             .map(render_task_tool_slot)
             .collect::<Vec<_>>();
         let lines = compact_live_panel_terminal_lines(&lines).map_or(lines, |(out, _)| out); // #3404 cap
-        sections.push(format!("Tasks\n{}", lines.join("\n")));
+        // Omit the Tasks section entirely when nothing is in progress so no
+        // dangling `Tasks` header is rendered over an empty body.
+        if !lines.is_empty() {
+            sections.push(format!("Tasks\n{}", lines.join("\n")));
+        }
     }
 
     if !matches!(provider, ProviderKind::Codex) && !snapshot.subagents.is_empty() {

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -320,6 +320,26 @@ pub(super) fn task_tool_slot_is_terminal(slot: &TaskToolSlot) -> bool {
     task_tool_terminal_marker(slot.status.as_deref()).is_some()
 }
 
+/// #4093: a task slot is "in progress" — the only kind the LIVE Tasks panel now
+/// renders — iff it is NOT terminal (carries no ✓/✗ mark). Terminal slots
+/// (completed / failed) are hidden immediately so finished work no longer masks
+/// active work until it falls out of the 10-slot window.
+///
+/// `status == None` is treated as IN PROGRESS, not "done": a freshly-created
+/// foreground task (e.g. `TaskCreate`) carries no status until its first update,
+/// and a background (bash) slot keeps `status == None` for its whole running
+/// life until the terminal notification sets `completed`/`failed`. Excluding
+/// `None` would hide brand-new and long-running tasks mid-flight, so the filter
+/// keys on terminal-ness alone.
+///
+/// This gates the LIVE panel only. The completion footer deliberately still
+/// renders terminal slots — its ✓/✗ turn-end result summary and the #3391
+/// delivered-terminal eviction both depend on completed rows being emitted — so
+/// it must not use this predicate.
+pub(super) fn task_tool_slot_is_in_progress(slot: &TaskToolSlot) -> bool {
+    !task_tool_slot_is_terminal(slot)
+}
+
 /// #3391: stable slot identity for delivered-terminal eviction. Background
 /// tasks key on their `tool_use_id`, Task-tool slots on their `task_id`, and
 /// any slot lacking both falls back to the never-reused `ordinal`. The ordinal

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -340,6 +340,30 @@ pub(super) fn task_tool_slot_is_in_progress(slot: &TaskToolSlot) -> bool {
     !task_tool_slot_is_terminal(slot)
 }
 
+/// #4093: renders the LIVE status panel's `Tasks` section for `tasks`, or `None`
+/// when nothing should render. Only in-progress slots are shown (completed /
+/// failed rows are hidden so they can never mask active work), newest first,
+/// capped at `STATUS_PANEL_TASK_LIMIT` over the FILTERED set, then run through
+/// the #3404 terminal-slot compaction. Returns `None` when no in-progress task
+/// survives so the caller emits no dangling `Tasks` header. Colocated here (not
+/// in `status_panel.rs`) so task-slot rendering concerns live with the task-slot
+/// model; the completion footer keeps its own terminal-aware task rendering.
+pub(super) fn render_live_tasks_section(tasks: &[TaskToolSlot]) -> Option<String> {
+    if tasks.is_empty() {
+        return None;
+    }
+    let lines = tasks
+        .iter()
+        .rev()
+        .filter(|slot| task_tool_slot_is_in_progress(slot))
+        .take(super::common::STATUS_PANEL_TASK_LIMIT)
+        .map(render_task_tool_slot)
+        .collect::<Vec<_>>();
+    let lines = super::completion_footer::compact_live_panel_terminal_lines(&lines)
+        .map_or(lines, |(out, _)| out); // #3404 cap
+    (!lines.is_empty()).then(|| format!("Tasks\n{}", lines.join("\n")))
+}
+
 /// #3391: stable slot identity for delivered-terminal eviction. Background
 /// tasks key on their `tool_use_id`, Task-tool slots on their `task_id`, and
 /// any slot lacking both falls back to the never-reused `ordinal`. The ordinal

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1984,11 +1984,13 @@ fn background_bash_notification_finalizes_only_exact_tool_use_id() {
         ),
     );
 
-    let done = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    let done_line = done
-        .lines()
-        .find(|line| line.contains("Bash Launch codex for voice S2"))
-        .unwrap_or_else(|| panic!("background Bash task slot missing in: {done}"));
+    // #4093: completed tasks are hidden from the live panel, so verify the ✓ on
+    // the completion footer, which still renders terminal marks.
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let done_block = done
+        .block
+        .expect("completed background task should render in the completion footer");
+    let done_line = footer_line_containing(&done_block, "Bash Launch codex for voice S2");
     assert!(
         done_line.contains('✓'),
         "matching notification must mark ✓: {done_line}"
@@ -2023,11 +2025,14 @@ fn background_bash_failed_notification_marks_task_failed() {
         ),
     );
 
-    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    let line = rendered
-        .lines()
-        .find(|line| line.contains("Bash Deploy release runtime"))
-        .unwrap_or_else(|| panic!("background Bash task slot missing in: {rendered}"));
+    // #4093: the live panel now HIDES terminal (failed) tasks, so verify the ✗
+    // finalization on the completion footer — the surface that still renders the
+    // terminal result summary.
+    let rendered = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let block = rendered
+        .block
+        .expect("failed background task should render in the completion footer");
+    let line = footer_line_containing(&block, "Bash Deploy release runtime");
     assert!(
         line.contains('✗'),
         "failed notification must mark ✗: {line}"
@@ -2116,11 +2121,13 @@ fn background_bash_record_reconstruction_ack_does_not_finalize_then_notification
         ),
     );
 
-    let done = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    let done_line = done
-        .lines()
-        .find(|line| line.contains("Bash Launch codex for SharedData S4"))
-        .unwrap_or_else(|| panic!("background Bash task slot missing in: {done}"));
+    // #4093: completed tasks are hidden from the live panel; verify the flipped
+    // ✓ on the completion footer, which still renders terminal marks.
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let done_block = done
+        .block
+        .expect("reconstructed completed task should render in the completion footer");
+    let done_line = footer_line_containing(&done_block, "Bash Launch codex for SharedData S4");
     assert!(
         done_line.contains('✓'),
         "matching reconstructed notification must flip ✓: {done_line}"
@@ -5298,13 +5305,37 @@ fn status_panel_taskupdate_updates_existing_task_by_id() {
         ),
     );
 
+    // #4093: a `completed` task is hidden from the live panel, so the in-place
+    // update (TaskUpdate mutates the existing slot rather than appending a new
+    // one) is verified via state. The single slot carries the merged fields:
+    // the latest name, the TaskCreate summary (TaskUpdate sent none), and the
+    // new terminal status. Scope the guard so it is dropped before the render
+    // below re-locks the same channel entry (the mutex is not reentrant).
+    {
+        let status_entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("status panel state");
+        let guard = status_entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(
+            guard.tasks.len(),
+            1,
+            "TaskUpdate must update the existing slot by id, not append"
+        );
+        let slot = &guard.tasks[0];
+        assert_eq!(slot.task_id.as_deref(), Some("task-1"));
+        assert_eq!(slot.summary.as_deref(), Some("Wire Tasks panel"));
+        assert_eq!(slot.status.as_deref(), Some("completed"));
+    }
+
+    // And the completed task is absent from the live panel per #4093.
     let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    let task_lines = rendered
-        .lines()
-        .filter(|line| line.starts_with("└ Task"))
-        .collect::<Vec<_>>();
-    assert_eq!(task_lines.len(), 1, "rendered:\n{rendered}");
-    assert!(rendered.contains("TaskUpdate task-1 · Wire Tasks panel · completed"));
+    assert!(
+        !rendered.contains("Wire Tasks panel"),
+        "completed task must not render in the live panel: {rendered}"
+    );
 }
 
 #[test]
@@ -6552,14 +6583,15 @@ fn rehydration_bound_skips_records_before_compact_boundary() {
 
 const LIVE_CAP: usize = super::completion_footer::LIVE_PANEL_TERMINAL_RENDER_CAP;
 
-// #3404 fail-on-base: during a long turn the LIVE panel accumulated EVERY
-// completed Task forever; the running entry and even the section budget got
-// starved. Compaction keeps only the most recent `LIVE_CAP` completions plus all
-// running entries and collapses the rest into a `… (+N completed)` summary. On
-// HEAD (no compaction) all completed lines render and no summary line exists, so
-// this fails.
+// #4093 (supersedes #3404 for the Tasks section): during a long turn the LIVE
+// panel used to accumulate completed Tasks — #3404 capped the display at
+// `LIVE_CAP` completions plus a `… (+N completed)` summary. #4093 goes further:
+// completed Task slots are hidden from the live panel entirely so they can never
+// mask or crowd out in-progress work, while every running entry and the section
+// header stay. (The completion footer still renders the ✓ result summary, and
+// the #3404 compaction primitive still governs the Subagents section.)
 #[test]
-fn live_panel_compacts_completed_tasks_keeping_running_and_header() {
+fn live_panel_hides_completed_tasks_keeping_running_and_header() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_404_001);
     let completed = LIVE_CAP + 4;
@@ -6571,24 +6603,24 @@ fn live_panel_compacts_completed_tasks_keeping_running_and_header() {
     push_background_bash_task(&events, channel_id, "Still running", "toolu_3404_run");
 
     let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    let rendered_done = panel.matches('✓').count();
     assert_eq!(
-        rendered_done, LIVE_CAP,
-        "live panel must cap rendered completions at {LIVE_CAP}: {panel}"
+        panel.matches('✓').count(),
+        0,
+        "live panel must hide all completed tasks: {panel}"
     );
-    let collapsed = completed - LIVE_CAP;
     assert!(
-        panel.contains(&format!("… (+{collapsed} completed)")),
-        "older completions must collapse into a summary: {panel}"
+        !panel.contains("completed)"),
+        "no compaction summary when completed tasks are hidden: {panel}"
     );
     assert!(panel.contains("Tasks"), "Tasks header survives: {panel}");
     assert!(
         panel.contains("Still running"),
-        "the running entry is never capped: {panel}"
+        "the running entry is always shown: {panel}"
     );
-    // The most recent completion stays visible; the oldest is collapsed away.
-    assert!(panel.contains(&format!("Completed job {:02}", completed - 1)));
-    assert!(!panel.contains("Completed job 00"));
+    assert!(
+        !panel.contains("Completed job"),
+        "no completed task line renders in the live panel: {panel}"
+    );
 }
 
 // #3404 fail-on-base: the bug's headline symptom — a long backlog of completed
@@ -6682,10 +6714,11 @@ fn live_panel_compaction_preserves_state_for_footer_eviction() {
     );
 }
 
-// #3404: a small backlog at or under the cap renders verbatim (no summary line,
-// no behavior change for short turns).
+// #4093 (supersedes #3404 for the Tasks section): even a small backlog of
+// completed tasks (at or under the old compaction cap) is now hidden entirely —
+// no ✓ marks and no `… (+N completed)` summary render in the live panel.
 #[test]
-fn live_panel_no_compaction_under_cap() {
+fn live_panel_hides_completed_tasks_even_under_cap() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_404_004);
     for i in 0..LIVE_CAP {
@@ -6694,10 +6727,14 @@ fn live_panel_no_compaction_under_cap() {
         complete_background_bash_task(&events, channel_id, &id);
     }
     let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
-    assert_eq!(panel.matches('✓').count(), LIVE_CAP);
+    assert_eq!(
+        panel.matches('✓').count(),
+        0,
+        "completed tasks are hidden from the live panel: {panel}"
+    );
     assert!(
         !panel.contains("completed)"),
-        "no summary under cap: {panel}"
+        "no summary when completed tasks are hidden: {panel}"
     );
 }
 


### PR DESCRIPTION
## 요약
Discord 라이브 상태판의 Tasks 섹션에서 완료 항목을 즉시 숨김. `task_tool_slot_is_in_progress = !is_terminal` predicate를 `.take(LIMIT)` **이전**에 적용(라이브 패널만), newest-first·10캡 유지, 0건 시 섹션 생략(dangling 헤더 없음).

## 이슈 문구 대비 의도적 이탈 2건 (근거)
1. **completion footer는 미필터**: footer는 턴-종료 결과 요약 → 필터 시 #3391 delivered-terminal-eviction(9 spec 테스트) + #3086 완료 요약 파괴. 완료를 숨기는 완료 보고는 오류이므로 라이브 패널만 게이팅.
2. **status=None 미제외**: 테스트가 None=진행중임을 증명(방금 생성된 TaskCreate는 첫 업데이트 전까지 무status, 실행 중 background bash도 terminal 통지 전까지 None). None 제외 시 신규·장기 태스크가 숨겨짐 → predicate는 terminal-ness만으로 판정.

## 검증
- placeholder_live_events 196 passed, fmt/check 클린, agent-maintenance passed.
- 빈 리스트 렌더 안전(섹션 생략), Subagents 섹션·rehydration·notification predicate는 미필터(전량 필요).

Closes #4093

🤖 Generated with [Claude Code](https://claude.com/claude-code)