### PR TITLE
fix(voice): surface TTS/STT failures — retry once + text fallback, structured early-return warns (#4238)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -803,7 +803,7 @@
 | `services::discord::voice_acknowledgement` | `src/services/discord/voice_acknowledgement.rs` | 61 | 61 | 0 |  |
 | `services::discord::voice_background_driver` | `src/services/discord/voice_background_driver.rs` | 234 | 199 | 35 |  |
 | `services::discord::voice_barge_in` | `src/services/discord/voice_barge_in.rs` | 5153 | 2905 | 2248 | giant-file |
-| `services::discord::voice_barge_in::final_result_playback` | `src/services/discord/voice_barge_in/final_result_playback.rs` | 248 | 248 | 0 |  |
+| `services::discord::voice_barge_in::final_result_playback` | `src/services/discord/voice_barge_in/final_result_playback.rs` | 362 | 362 | 0 |  |
 | `services::discord::voice_barge_in::foreground_decision` | `src/services/discord/voice_barge_in/foreground_decision.rs` | 242 | 242 | 0 |  |
 | `services::discord::voice_barge_in::live_cut_playback` | `src/services/discord/voice_barge_in/live_cut_playback.rs` | 160 | 160 | 0 |  |
 | `services::discord::voice_barge_in::progress_playback` | `src/services/discord/voice_barge_in/progress_playback.rs` | 505 | 505 | 0 |  |
@@ -999,8 +999,8 @@
 | `voice::commands` | `src/voice/commands.rs` | 860 | 548 | 312 |  |
 | `voice::config` | `src/voice/config.rs` | 627 | 392 | 235 |  |
 | `voice::flight` | `src/voice/flight.rs` | 252 | 138 | 114 |  |
-| `voice::metrics` | `src/voice/metrics.rs` | 438 | 336 | 102 |  |
-| `voice::progress` | `src/voice/progress.rs` | 448 | 353 | 95 |  |
+| `voice::metrics` | `src/voice/metrics.rs` | 455 | 353 | 102 |  |
+| `voice::progress` | `src/voice/progress.rs` | 472 | 365 | 107 |  |
 | `voice::prompt` | `src/voice/prompt.rs` | 823 | 540 | 283 |  |
 | `voice::receiver` | `src/voice/receiver.rs` | 1592 | 1108 | 484 | giant-file |
 | `voice::runtime_boundary` | `src/voice/runtime_boundary.rs` | 281 | 212 | 69 |  |

--- a/src/services/discord/voice_barge_in/final_result_playback.rs
+++ b/src/services/discord/voice_barge_in/final_result_playback.rs
@@ -120,6 +120,14 @@ impl VoiceBargeInRuntime {
             // Voice #10: drop the partial latency record so the next turn
             // doesn't inherit stale stt/agent ms.
             crate::voice::metrics::discard(channel_id.get());
+            // #4238: this path is reached only for a voice-sourced turn, so a
+            // missing TTS runtime means the user spoke and gets no spoken reply
+            // — make the silent early return observable.
+            tracing::warn!(
+                channel_id = channel_id.get(),
+                reason = "no_tts_runtime",
+                "voice final TTS playback skipped: TTS runtime not configured"
+            );
             return;
         };
         let language = self.spoken_result_language().await;
@@ -132,6 +140,13 @@ impl VoiceBargeInRuntime {
         let spoken = spoken_result_only_with_limit(answer, &language, spoken_result_max_chars);
         if spoken.trim().is_empty() {
             crate::voice::metrics::discard(channel_id.get());
+            // #4238: the agent produced an answer but it sanitized to nothing
+            // speakable; surface the reason instead of returning silently.
+            tracing::warn!(
+                channel_id = channel_id.get(),
+                reason = "empty_spoken_text",
+                "voice final TTS playback skipped: answer sanitized to empty spoken text"
+            );
             return;
         }
 
@@ -141,17 +156,22 @@ impl VoiceBargeInRuntime {
             .map(|entry| *entry.value())
         else {
             crate::voice::metrics::discard(channel_id.get());
-            tracing::debug!(
+            // #4238: promote from debug — a voice turn with no registered guild
+            // means the spoken reply is dropped; operators need to see why.
+            tracing::warn!(
                 channel_id = channel_id.get(),
+                reason = "no_voice_guild",
                 "voice final TTS playback skipped: no registered voice guild"
             );
             return;
         };
         let Some(ctx) = shared.http.cached_serenity_ctx.get() else {
             crate::voice::metrics::discard(channel_id.get());
-            tracing::debug!(
+            // #4238: promote from debug for the same reason as above.
+            tracing::warn!(
                 channel_id = channel_id.get(),
                 guild_id = guild_id.get(),
+                reason = "no_serenity_context",
                 "voice final TTS playback skipped: no serenity context"
             );
             return;
@@ -161,6 +181,7 @@ impl VoiceBargeInRuntime {
             tracing::warn!(
                 channel_id = channel_id.get(),
                 guild_id = guild_id.get(),
+                reason = "songbird_manager_missing",
                 "voice final TTS playback skipped: songbird manager missing"
             );
             return;
@@ -177,33 +198,77 @@ impl VoiceBargeInRuntime {
         .await
         else {
             crate::voice::metrics::discard(channel_id.get());
+            // #4238: `connected_voice_call` already warns for the zombie-driver
+            // case (#4236); emit a site-level warn with a uniform `reason` so
+            // the "no call handle at all" case is observable too.
+            tracing::warn!(
+                channel_id = channel_id.get(),
+                guild_id = guild_id.get(),
+                reason = "no_connected_voice_call",
+                "voice final TTS playback skipped: no connected voice call"
+            );
             return;
         };
 
         let runtime = self.clone();
+        let shared = shared.clone();
         let (playback_id, cancellation) = self.start_spoken_result_playback(channel_id);
         let playback_cancellation = cancellation.clone();
         let register_cancellation = cancellation.clone();
         tokio::spawn(async move {
             let runtime_for_track = runtime.clone();
-            let register_track = move |track| {
-                runtime_for_track.reset_after_playback_start_with_owner(
-                    channel_id,
-                    Arc::new(track),
-                    register_cancellation.clone(),
-                    Some(playback_id),
-                );
+            // #4238: track whether any chunk actually reached the channel so the
+            // retry below never replays audio the user already heard.
+            let played_any = Arc::new(AtomicBool::new(false));
+            let register_track = {
+                let played_any = played_any.clone();
+                move |track| {
+                    played_any.store(true, Ordering::Relaxed);
+                    runtime_for_track.reset_after_playback_start_with_owner(
+                        channel_id,
+                        Arc::new(track),
+                        register_cancellation.clone(),
+                        Some(playback_id),
+                    );
+                }
             };
 
-            let result = play_chunked_with_prefetch(
-                call_lock,
-                tts,
-                spoken,
+            let mut result = play_chunked_with_prefetch(
+                call_lock.clone(),
+                tts.clone(),
+                spoken.clone(),
                 DEFAULT_TTS_CHUNK_MAX_CHARS,
-                playback_cancellation,
-                register_track,
+                playback_cancellation.clone(),
+                register_track.clone(),
             )
             .await;
+
+            // #4238: TTS synth/playback failures used to be swallowed with only
+            // a `warn!`. Retry ONCE, but ONLY when the failure happened before
+            // any audio reached the channel — retrying after a partial play
+            // would double up the chunks the user already heard. Cancellation
+            // (user barge-in / teardown) surfaces as `Ok`, so an `Err` here is a
+            // genuine failure; the cancel-flag guard still avoids retrying into
+            // a call that is being torn down.
+            if let Some(first_error) = result.as_ref().err().map(ToString::to_string) {
+                if !played_any.load(Ordering::Relaxed) && !playback_cancellation.is_cancelled() {
+                    tracing::warn!(
+                        error = %first_error,
+                        channel_id = channel_id.get(),
+                        guild_id = guild_id.get(),
+                        "voice final TTS playback failed before any audio; retrying once (#4238)"
+                    );
+                    result = play_chunked_with_prefetch(
+                        call_lock,
+                        tts,
+                        spoken,
+                        DEFAULT_TTS_CHUNK_MAX_CHARS,
+                        playback_cancellation.clone(),
+                        register_track,
+                    )
+                    .await;
+                }
+            }
 
             runtime.clear_playback_if_owner(channel_id, playback_id);
             runtime.clear_spoken_result_playback_if_current(channel_id, playback_id);
@@ -241,8 +306,57 @@ impl VoiceBargeInRuntime {
                         guild_id = guild_id.get(),
                         "voice final TTS chunked playback failed"
                     );
+                    // #4238: the spoken reply is lost (retry already spent, or a
+                    // partial play failed and a replay would double audio). Post
+                    // a one-shot text fallback so the answer is not silently
+                    // dropped. This is the terminal failure arm and runs at most
+                    // once per playback, so it cannot loop. Skip on cancellation
+                    // (deliberate stop / teardown — no failure to report).
+                    if !playback_cancellation.is_cancelled() {
+                        runtime
+                            .post_voice_playback_failure_notice(&shared, channel_id)
+                            .await;
+                    }
                 }
             }
         });
+    }
+
+    /// #4238: post a one-shot text fallback to the routing channel after a
+    /// spoken-result playback fails past its retry. Reuses the exact send path
+    /// the progress-text mirror uses (`serenity_http_or_token_fallback` +
+    /// `rate_limit_wait` + `http::send_channel_message`) so no new send surface
+    /// is introduced. Called only from the terminal `Err` arm above, so it fires
+    /// at most once per failed playback.
+    async fn post_voice_playback_failure_notice(
+        &self,
+        shared: &Arc<SharedData>,
+        channel_id: ChannelId,
+    ) {
+        let Some(http) = shared.serenity_http_or_token_fallback() else {
+            tracing::warn!(
+                channel_id = channel_id.get(),
+                "voice TTS failure text fallback skipped: no Discord HTTP client"
+            );
+            return;
+        };
+        let language = self.spoken_result_language().await;
+        let content = crate::voice::progress::playback_failure_notice(&language);
+        super::rate_limit_wait(shared, channel_id).await;
+        match super::http::send_channel_message(&http, channel_id, content).await {
+            Ok(_) => {
+                tracing::warn!(
+                    channel_id = channel_id.get(),
+                    "voice TTS playback failed; posted text fallback notice (#4238)"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    channel_id = channel_id.get(),
+                    "voice TTS failure text fallback send failed"
+                );
+            }
+        }
     }
 }

--- a/src/voice/metrics.rs
+++ b/src/voice/metrics.rs
@@ -230,6 +230,13 @@ impl SttOutcome {
             Self::VolumeDetectFailed => "volumedetect_failed",
         }
     }
+
+    /// #4238: genuine STT failures worth an operator `warn!`, as opposed to the
+    /// benign `LowVolumeSkipped` (the silence gate firing on a quiet utterance,
+    /// which is the common expected case and must not spam the log).
+    fn is_failure(self) -> bool {
+        matches!(self, Self::EmptyAfterRetry | Self::VolumeDetectFailed)
+    }
 }
 
 fn stt_outcome_registry() -> &'static Mutex<HashMap<&'static str, u64>> {
@@ -252,6 +259,16 @@ pub fn record_stt_outcome(outcome: SttOutcome) {
             Some("voice"),
             json!({ "outcome": outcome.as_str() }),
         );
+        // #4238: the metric counter alone was invisible to operators watching
+        // logs. Surface genuine STT failures as a structured `warn!` so a
+        // recovery-worthy regression (whisper returning empty, volume pre-pass
+        // failing) is observable, not just silently tallied.
+        if outcome.is_failure() {
+            tracing::warn!(
+                outcome = outcome.as_str(),
+                "voice STT turn failed to yield a usable transcript (#4238)"
+            );
+        }
     }
 }
 

--- a/src/voice/progress.rs
+++ b/src/voice/progress.rs
@@ -243,6 +243,18 @@ pub(crate) fn idle_notice(language: &str) -> &'static str {
     }
 }
 
+/// #4238: user-facing text fallback when spoken-result TTS playback fails
+/// (after the single retry). Voice failures used to be swallowed with only a
+/// `warn!`, so the caller heard nothing and had no idea the answer was ready.
+/// This points them at the text response instead.
+pub(crate) fn playback_failure_notice(language: &str) -> &'static str {
+    if is_english(language) {
+        "Voice playback failed — check the text response instead."
+    } else {
+        "음성 재생에 실패했어. 텍스트로 확인해줘."
+    }
+}
+
 pub(crate) fn next_idle_notice_delay(current: Duration) -> Duration {
     let next = current.mul_f64(PROGRESS_IDLE_NOTICE_MULTIPLIER);
     next.min(PROGRESS_IDLE_NOTICE_MAX)
@@ -428,6 +440,18 @@ mod tests {
             None
         );
         assert_eq!(parse_verbose_progress_command("진행 상황 알려줘"), None);
+    }
+
+    #[test]
+    fn playback_failure_notice_is_localized() {
+        assert_eq!(
+            playback_failure_notice("ko"),
+            "음성 재생에 실패했어. 텍스트로 확인해줘."
+        );
+        assert_eq!(
+            playback_failure_notice("en"),
+            "Voice playback failed — check the text response instead."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약
TTS 합성/재생 실패가 `warn!`만 남기고 조용히 삼켜지던 문제(#4238) 해소.

## 변경
- **TTS retry + 폴백**: 청크 재생 실패 시 1회 재시도 → 재실패하면 라우팅 채널에 1회성 로컬라이즈 텍스트 고지(`음성 재생에 실패했어. 텍스트로 확인해줘.`). 기존 progress-text mirror의 send 경로 그대로 재사용(`serenity_http_or_token_fallback` + `rate_limit_wait` + `send_channel_message`) — 새 send surface 미도입. 문구는 `voice::progress::playback_failure_notice`(기존 `is_english()` 게이팅 스타일).
- **오디오 중복 방지**: `register_track` 콜백에서 뒤집는 `AtomicBool played_any`로 **채널에 오디오가 이미 도달했으면 재시도 안 함** → 부분 재생 후 실패는 곧장 텍스트 폴백(들은 오디오 재생 없음).
- **취소 인지**: barge-in/teardown 취소 시 고지 생략(`playback_cancellation.is_cancelled()`).
- **early-return 6건 구조화 승격**: no_tts_runtime/empty_spoken_text/no_voice_guild/no_serenity_context/songbird_manager_missing/no_connected_voice_call → `warn!(channel_id, reason)` 필드(#4219 방향). **제어흐름 불변**.
- **STT**: `record_stt_outcome`이 실질 실패(empty_after_retry/volumedetect_failed)에 구조화 warn. benign `low_volume_skipped`는 제외(스팸 방지).

## 검증
- fmt/check 클린, 신규 테스트 `playback_failure_notice_is_localized` 통과.
- 브랜치 352 passed/3 failed vs clean base 351/3 — **동일 3건이 origin/main에서도 재현**(git stash로 증명), 전부 `runtime_store.rs:38` #3293 env-isolation flake. 본 변경 무관.
- agent-maintenance freshness passed. **audit_maintainability --check RC=0** (namespace_size_caps 0, 하드게이트 위반 없음).

## 리스크
- 폴백 루프 없음(terminal Err arm에서 1회, 재진입 없음). 스팸 낮음(2회 실패+비취소 시에만).

Closes #4238

🤖 Generated with [Claude Code](https://claude.com/claude-code)