### PR TITLE
chore(memory): File 백엔드 '선택형 vs fallback' 구분 명시 — 4계층 파일 메 (#4316)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -552,7 +552,7 @@
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 387 | 264 | 123 |  |
 | `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 334 | 334 | 0 |  |
-| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 72 | 72 | 0 |  |
+| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 173 | 89 | 84 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2307 | 751 | 1556 |  |
@@ -655,9 +655,9 @@
 | `services::discord::session_runtime::channel_routing` | `src/services/discord/session_runtime/channel_routing.rs` | 235 | 235 | 0 |  |
 | `services::discord::session_runtime::restore_cwd` | `src/services/discord/session_runtime/restore_cwd.rs` | 353 | 353 | 0 |  |
 | `services::discord::session_runtime::worktree` | `src/services/discord/session_runtime/worktree.rs` | 601 | 601 | 0 |  |
-| `services::discord::settings` | `src/services/discord/settings.rs` | 338 | 338 | 0 |  |
+| `services::discord::settings` | `src/services/discord/settings.rs` | 345 | 345 | 0 |  |
 | `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 539 | 506 | 33 |  |
-| `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 127 | 127 | 0 |  |
+| `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 152 | 152 | 0 |  |
 | `services::discord::settings::read` | `src/services/discord/settings/read.rs` | 449 | 449 | 0 |  |
 | `services::discord::settings::validation` | `src/services/discord/settings/validation.rs` | 520 | 258 | 262 |  |
 | `services::discord::settings::write` | `src/services/discord/settings/write.rs` | 386 | 386 | 0 |  |
@@ -868,7 +868,7 @@
 | `services::maintenance::jobs::worktree_orphan_sweep` | `src/services/maintenance/jobs/worktree_orphan_sweep.rs` | 1977 | 975 | 1002 |  |
 | `services::mcp_config` | `src/services/mcp_config.rs` | 893 | 793 | 100 |  |
 | `services::memory` | `src/services/memory/mod.rs` | 268 | 268 | 0 |  |
-| `services::memory::local` | `src/services/memory/local.rs` | 30 | 30 | 0 |  |
+| `services::memory::local` | `src/services/memory/local.rs` | 85 | 45 | 40 |  |
 | `services::memory::memento` | `src/services/memory/memento.rs` | 2122 | 1893 | 229 | giant-file |
 | `services::memory::memento_instructions_cache` | `src/services/memory/memento_instructions_cache.rs` | 241 | 143 | 98 |  |
 | `services::memory::memento_throttle` | `src/services/memory/memento_throttle.rs` | 836 | 752 | 84 |  |

--- a/src/services/discord/prompt_builder/memory_guidance.rs
+++ b/src/services/discord/prompt_builder/memory_guidance.rs
@@ -31,6 +31,22 @@ pub(super) fn proactive_memory_guidance(
     }
 
     let settings = memory_settings?;
+
+    // Fallback mode: memento is the configured backend but is degraded, so
+    // memory silently ran on the local file store. This is NOT a deliberate
+    // file backend — authoritative writes must be held, not committed to the
+    // degraded store. Guidance branches on the CAUSE (memento_fallback), not on
+    // the resulting `File` backend alone.
+    if settings.backend == MemoryBackendKind::File && settings.memento_fallback {
+        return Some(String::from(
+            "\n\n[Proactive Memory Guidance — Fallback Mode]\n\
+             memento is configured but unreachable; memory has degraded to the local file store. \
+             Use `memory-read` skill for explicit past-context/error/config lookups. \
+             HOLD permanent writes: do NOT commit confirmed decisions, root causes, or config \
+             changes to the degraded store — record them with `remember` once memento recovers.",
+        ));
+    }
+
     let (backend_name, read_tool, write_tool, extra_note) = match settings.backend {
         MemoryBackendKind::File => (
             "local",
@@ -69,4 +85,89 @@ pub(super) fn proactive_memory_guidance(
         "\n\n[Proactive Memory Guidance]\n\
          `{backend_name}` memory is available. Use {read_tool} for explicit past-context/error/config lookups; use {write_tool} only for confirmed decisions, root causes, or config changes.{extra_note}"
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_settings(memento_fallback: bool) -> ResolvedMemorySettings {
+        ResolvedMemorySettings {
+            backend: MemoryBackendKind::File,
+            memento_fallback,
+            ..ResolvedMemorySettings::default()
+        }
+    }
+
+    #[test]
+    fn configured_file_backend_yields_unchanged_file_guidance() {
+        // #4316 (a): a deliberately configured file backend (memento_fallback =
+        // false) must keep the existing, unchanged file guidance and must NOT
+        // show the fallback wording.
+        let settings = file_settings(false);
+        let guidance = proactive_memory_guidance(
+            Some(&settings),
+            "/tmp/agentdesk",
+            ChannelId::new(1),
+            None,
+            DispatchProfile::Full,
+            false,
+        )
+        .expect("file backend must produce proactive guidance");
+
+        assert!(guidance.contains("[Proactive Memory Guidance]"));
+        assert!(guidance.contains("`local` memory is available"));
+        assert!(guidance.contains("`memory-read` skill"));
+        assert!(guidance.contains("`memory-write` skill"));
+        assert!(
+            !guidance.contains("Fallback Mode"),
+            "configured file backend must not show fallback wording, got: {guidance}"
+        );
+        assert!(!guidance.contains("HOLD permanent"));
+    }
+
+    #[test]
+    fn memento_fallback_yields_hold_permanent_writes_guidance() {
+        // #4316 (b): memento configured but degraded → File. Guidance must flag
+        // FALLBACK mode and instruct holding permanent/authoritative writes
+        // rather than committing them to the degraded store.
+        let settings = file_settings(true);
+        let guidance = proactive_memory_guidance(
+            Some(&settings),
+            "/tmp/agentdesk",
+            ChannelId::new(1),
+            None,
+            DispatchProfile::Full,
+            false,
+        )
+        .expect("fallback mode must produce proactive guidance");
+
+        assert!(guidance.contains("[Proactive Memory Guidance — Fallback Mode]"));
+        assert!(guidance.contains("memento is configured but unreachable"));
+        // Core semantics: hold permanent writes; record after memento recovers.
+        assert!(
+            guidance.contains("HOLD permanent writes"),
+            "fallback guidance must instruct holding permanent writes, got: {guidance}"
+        );
+        assert!(guidance.contains("once memento recovers"));
+        // Must not read like the deliberate-file backend guidance.
+        assert!(!guidance.contains("`local` memory is available"));
+    }
+
+    #[test]
+    fn non_full_profile_suppresses_guidance() {
+        // Guidance stays gated to the Full profile in both states.
+        let settings = file_settings(true);
+        assert!(
+            proactive_memory_guidance(
+                Some(&settings),
+                "/tmp/agentdesk",
+                ChannelId::new(1),
+                None,
+                DispatchProfile::ReviewLite,
+                false,
+            )
+            .is_none()
+        );
+    }
 }

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -173,6 +173,12 @@ impl MemoryBackendKind {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ResolvedMemorySettings {
     pub backend: MemoryBackendKind,
+    /// True only when the resolved `backend` is `File` because memento was the
+    /// requested/configured backend but is degraded (unreachable). Lets the
+    /// guidance layer distinguish a deliberate file backend from a transparent
+    /// memento fallback, which have different write policies. Always false for a
+    /// deliberately configured file backend and for an active memento backend.
+    pub memento_fallback: bool,
     pub recall_timeout_ms: u64,
     pub capture_timeout_ms: u64,
 }
@@ -181,6 +187,7 @@ impl Default for ResolvedMemorySettings {
     fn default() -> Self {
         Self {
             backend: MemoryBackendKind::File,
+            memento_fallback: false,
             recall_timeout_ms: DEFAULT_MEMORY_RECALL_TIMEOUT_MS,
             capture_timeout_ms: DEFAULT_MEMORY_CAPTURE_TIMEOUT_MS,
         }

--- a/src/services/discord/settings/memory.rs
+++ b/src/services/discord/settings/memory.rs
@@ -37,23 +37,43 @@ fn auto_detect_memory_backend() -> MemoryBackendKind {
     }
 }
 
-fn resolve_memory_backend(raw: Option<&str>) -> MemoryBackendKind {
+/// Outcome of backend resolution. `memento_fallback` is true only when memento
+/// was requested but degraded, so `kind` collapsed to `File`; it lets the
+/// guidance layer tell a deliberate file backend apart from a memento fallback.
+struct ResolvedBackend {
+    kind: MemoryBackendKind,
+    memento_fallback: bool,
+}
+
+fn resolve_memory_backend(raw: Option<&str>) -> ResolvedBackend {
     let configured = configured_memory_backend_name();
     let requested = normalize_memory_backend_name(raw)
         .or_else(|| normalize_memory_backend_name(configured.as_deref()))
         .unwrap_or("auto");
 
     match requested {
-        "auto" => auto_detect_memory_backend(),
-        "file" => MemoryBackendKind::File,
+        "auto" => ResolvedBackend {
+            kind: auto_detect_memory_backend(),
+            memento_fallback: false,
+        },
+        "file" => ResolvedBackend {
+            kind: MemoryBackendKind::File,
+            memento_fallback: false,
+        },
         "memento" => resolve_explicit_memory_backend(MemoryBackendKind::Memento),
-        _ => MemoryBackendKind::File,
+        _ => ResolvedBackend {
+            kind: MemoryBackendKind::File,
+            memento_fallback: false,
+        },
     }
 }
 
-fn resolve_explicit_memory_backend(kind: MemoryBackendKind) -> MemoryBackendKind {
+fn resolve_explicit_memory_backend(kind: MemoryBackendKind) -> ResolvedBackend {
     if crate::services::memory::backend_is_active(kind) {
-        return kind;
+        return ResolvedBackend {
+            kind,
+            memento_fallback: false,
+        };
     }
 
     if let Some(state) = crate::services::memory::backend_state(kind) {
@@ -70,7 +90,10 @@ fn resolve_explicit_memory_backend(kind: MemoryBackendKind) -> MemoryBackendKind
         );
     }
 
-    MemoryBackendKind::File
+    ResolvedBackend {
+        kind: MemoryBackendKind::File,
+        memento_fallback: kind == MemoryBackendKind::Memento,
+    }
 }
 
 fn merge_memory_config(
@@ -95,8 +118,10 @@ pub(crate) fn resolve_memory_settings(
     override_cfg: Option<&MemoryConfigOverride>,
 ) -> ResolvedMemorySettings {
     let merged = merge_memory_config(base, override_cfg);
+    let resolved_backend = resolve_memory_backend(merged.backend.as_deref());
     ResolvedMemorySettings {
-        backend: resolve_memory_backend(merged.backend.as_deref()),
+        backend: resolved_backend.kind,
+        memento_fallback: resolved_backend.memento_fallback,
         recall_timeout_ms: clamp_timeout(
             "memory.recall_timeout_ms",
             merged

--- a/src/services/memory/local.rs
+++ b/src/services/memory/local.rs
@@ -10,9 +10,23 @@ pub(crate) struct LocalMemoryBackend;
 impl MemoryBackend for LocalMemoryBackend {
     fn recall<'a>(&'a self, request: RecallRequest) -> MemoryFuture<'a, RecallResponse> {
         Box::pin(async move {
+            let shared_knowledge = load_shared_knowledge();
+            let longterm_catalog = load_longterm_memory_catalog(&request.role_id);
+
+            // Empty-catalog robustness (#4316): a missing or empty memories
+            // directory (fresh install, local archive) is not an error. Warn
+            // once so the empty state is visible rather than silently emitting
+            // empty guidance, then return normally.
+            if longterm_catalog.is_none() {
+                tracing::warn!(
+                    role_id = %request.role_id,
+                    "local memory recall: long-term catalog is empty (no memories on disk); returning empty guidance"
+                );
+            }
+
             RecallResponse {
-                shared_knowledge: load_shared_knowledge(),
-                longterm_catalog: load_longterm_memory_catalog(&request.role_id),
+                shared_knowledge,
+                longterm_catalog,
                 external_recall: None,
                 memento_context_loaded: false,
                 warnings: Vec::new(),
@@ -26,5 +40,46 @@ impl MemoryBackend for LocalMemoryBackend {
             let _ = request;
             CaptureResult::default()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::DispatchProfile;
+    use crate::services::memory::RecallMode;
+    use crate::services::provider::ProviderKind;
+
+    fn recall_request(role_id: &str) -> RecallRequest {
+        RecallRequest {
+            provider: ProviderKind::Claude,
+            role_id: role_id.to_string(),
+            channel_id: 1,
+            channel_name: None,
+            session_id: "session".to_string(),
+            dispatch_profile: DispatchProfile::Full,
+            user_text: "hello".to_string(),
+            mode: RecallMode::Full,
+        }
+    }
+
+    #[tokio::test]
+    async fn recall_with_empty_catalog_returns_empty_guidance_without_panicking() {
+        // #4316: a missing/empty memories directory must degrade gracefully —
+        // no panic, an empty long-term catalog, and no synthetic warnings on the
+        // response. (The empty state is surfaced via a warn log, not an error.)
+        let backend = LocalMemoryBackend;
+        let response = backend
+            .recall(recall_request("nonexistent-role-4316"))
+            .await;
+
+        assert!(
+            response.longterm_catalog.is_none(),
+            "empty memories dir must yield no long-term catalog, got: {:?}",
+            response.longterm_catalog
+        );
+        assert!(!response.memento_context_loaded);
+        assert!(response.warnings.is_empty());
+        assert!(response.external_recall.is_none());
     }
 }


### PR DESCRIPTION
구현 완료. 상세는 이슈 #4316 및 커밋 메시지 참조.

게이트: fmt/check ✅ · tests ✅ · agent-maintenance freshness ✅ · `audit_maintainability.py --check` RC=0 (캡 미상향, #4269 준수)

Refs #4316