### PR TITLE
chore(maintainability): 분해 후 부모 파일이 테스트 무덤으로 잔존 — pare (#4267)

### DIFF
--- a/docs/generated/maintainability-audit.md
+++ b/docs/generated/maintainability-audit.md
@@ -6,9 +6,9 @@
 
 Automated audit of giant files, route SRP violations, direct Discord sends, service-to-server backflow, manual JSON row mapping, limit/days clamp duplication, git subprocess callsites, legacy SQLite references, source-of-truth alias writes, and namespace size caps. See `scripts/audit_maintainability.py` (#1282).
 
-Hard-gating is **enabled** for 8 checks: `giant_files`, `giant_file_ratchet`, `namespace_size_caps`, `direct_discord_sends`, `manual_json_row_mapping`, `git_subprocess_callsites`, `legacy_sqlite_refs`, `source_of_truth_alias_writes`.
+Hard-gating is **enabled** for 10 checks: `giant_files`, `giant_file_ratchet`, `namespace_size_caps`, `direct_discord_sends`, `direct_discord_reactions`, `footer_view_writes`, `manual_json_row_mapping`, `git_subprocess_callsites`, `legacy_sqlite_refs`, `source_of_truth_alias_writes`.
 
-Baseline no-regression gates are **enabled** for 2 checks: `route_srp_violations`, `service_server_backflow`.
+Baseline no-regression gates are **enabled** for 3 checks: `parent_test_residue`, `route_srp_violations`, `service_server_backflow`.
 
 ## Summary
 
@@ -16,10 +16,13 @@ Baseline no-regression gates are **enabled** for 2 checks: `route_srp_violations
 |---|---:|:--:|:--:|
 | `giant_files` | 0 | YES | no |
 | `giant_file_ratchet` | 0 | YES | no |
+| `parent_test_residue` | 6 | no | YES |
 | `namespace_size_caps` | 0 | YES | no |
-| `route_srp_violations` | 12 | no | YES |
+| `route_srp_violations` | 10 | no | YES |
 | `service_server_backflow` | 0 | no | YES |
 | `direct_discord_sends` | 0 | YES | no |
+| `direct_discord_reactions` | 0 | YES | no |
+| `footer_view_writes` | 0 | YES | no |
 | `manual_json_row_mapping` | 0 | YES | no |
 | `limit_clamp_duplication` | 0 | no | no |
 | `git_subprocess_callsites` | 0 | YES | no |
@@ -38,6 +41,19 @@ Production giants listed in scripts/audit_maintainability_giant_baseline.toml mu
 
 _No findings._
 
+## Parent test residue (`parent_test_residue`)
+
+Decomposition parents whose inline test LoC exceeds 3x their production LoC (files >= 500 raw lines). Migrate stranded tests with the production code; frozen offenders are baselined in scripts/audit_maintainability_config.toml.
+
+| Severity | File | Line | Message |
+|---|---|---:|---|
+| warn | `src/services/discord/inflight.rs` |  | 5451 test LoC vs 590 prod LoC (ratio 9.24x > 3x, 6041 raw); migrate the stranded tests with the decomposed production code |
+| warn | `src/services/discord/inflight/save_store.rs` |  | 730 test LoC vs 235 prod LoC (ratio 3.11x > 3x, 965 raw); migrate the stranded tests with the decomposed production code |
+| warn | `src/services/discord/recovery_engine/manual_rebind/codex_tui_replay.rs` |  | 711 test LoC vs 233 prod LoC (ratio 3.05x > 3x, 944 raw); migrate the stranded tests with the decomposed production code |
+| warn | `src/services/discord/turn_bridge/cancel_finalize_policy.rs` |  | 450 test LoC vs 131 prod LoC (ratio 3.44x > 3x, 581 raw); migrate the stranded tests with the decomposed production code |
+| warn | `src/services/discord/turn_finalizer.rs` |  | 3992 test LoC vs 1048 prod LoC (ratio 3.81x > 3x, 5040 raw); migrate the stranded tests with the decomposed production code |
+| warn | `src/services/discord/turn_finalizer/delivery_lease.rs` |  | 428 test LoC vs 87 prod LoC (ratio 4.92x > 3x, 515 raw); migrate the stranded tests with the decomposed production code |
+
 ## Namespace size caps (`namespace_size_caps`)
 
 Production Rust files under configured namespaces must stay within their per-namespace caps from scripts/audit_maintainability_config.toml.
@@ -53,17 +69,12 @@ Files under src/server/routes/ that mix raw SQL, json!() shaping, and crate::ser
 | warn | `src/server/routes/agents_crud.rs` |  | route file mixes SQL (40), json!() (77), and crate::services calls (7) |
 | warn | `src/server/routes/agents_setup.rs` |  | route file mixes SQL (7), json!() (12), and crate::services calls (2) |
 | warn | `src/server/routes/cron_api.rs` |  | route file mixes SQL (2), json!() (12), and crate::services calls (1) |
-| warn | `src/server/routes/dispatches/thread_reuse.rs` |  | route file mixes SQL (12), json!() (22), and crate::services calls (2) |
 | warn | `src/server/routes/escalation.rs` |  | route file mixes SQL (24), json!() (24), and crate::services calls (3) |
-| warn | `src/server/routes/github.rs` |  | route file mixes SQL (8), json!() (30), and crate::services calls (5) |
-| warn | `src/server/routes/github.rs` |  | route file mixes SQL (8), json!() (34), and crate::services calls (5) |
-| warn | `src/server/routes/health_api.rs` |  | route file mixes SQL (30), json!() (103), and crate::services calls (15) |
-| warn | `src/server/routes/health_api.rs` |  | route file mixes SQL (30), json!() (106), and crate::services calls (17) |
-| warn | `src/server/routes/memory_api.rs` |  | route file mixes SQL (8), json!() (16), and crate::services calls (8) |
+| warn | `src/server/routes/github.rs` |  | route file mixes SQL (6), json!() (44), and crate::services calls (1) |
 | warn | `src/server/routes/memory_api.rs` |  | route file mixes SQL (17), json!() (18), and crate::services calls (7) |
 | warn | `src/server/routes/provider_cli_api.rs` |  | route file mixes SQL (3), json!() (12), and crate::services calls (6) |
 | warn | `src/server/routes/queue_api.rs` |  | route file mixes SQL (4), json!() (15), and crate::services calls (3) |
-| warn | `src/server/routes/review_verdict/verdict_route.rs` |  | route file mixes SQL (5), json!() (19), and crate::services calls (5) |
+| warn | `src/server/routes/review_verdict/verdict_route.rs` |  | route file mixes SQL (5), json!() (20), and crate::services calls (5) |
 | warn | `src/server/routes/stats.rs` |  | route file mixes SQL (32), json!() (10), and crate::services calls (2) |
 
 ## Service/server backflow (`service_server_backflow`)
@@ -75,6 +86,18 @@ _No findings._
 ## Direct Discord send/edit (`direct_discord_sends`)
 
 Direct serenity send_message/edit_message/reply calls outside the outbound queue (src/services/discord/outbound/, message_outbox.rs).
+
+_No findings._
+
+## Direct Discord reactions (`direct_discord_reactions`)
+
+Direct serenity create_reaction/delete_reaction or raw reaction wrapper calls outside reaction_lifecycle.rs and turn_view_reconciler*.
+
+_No findings._
+
+## Footer view writes (`footer_view_writes`)
+
+Completion-footer registry/write calls outside footer_view_reconciler, plus live footer/status-panel write paths that must be allowlisted until S4-b2.
 
 _No findings._
 
@@ -107,3 +130,4 @@ _No findings._
 File-write callsites that touch alias paths listed in docs/source-of-truth.md. Writes should target the canonical path.
 
 _No findings._
+

--- a/scripts/audit_maintainability.py
+++ b/scripts/audit_maintainability.py
@@ -46,6 +46,7 @@ from audit_maintainability.common import REPO_ROOT, Finding  # noqa: E402
 CHECK_MODULES = (
     "audit_maintainability.checks.giant_files",
     "audit_maintainability.checks.giant_file_ratchet",
+    "audit_maintainability.checks.parent_test_residue",
     "audit_maintainability.checks.namespace_size_caps",
     "audit_maintainability.checks.route_srp",
     "audit_maintainability.checks.service_server_backflow",

--- a/scripts/audit_maintainability/checks/parent_test_residue.py
+++ b/scripts/audit_maintainability/checks/parent_test_residue.py
@@ -1,0 +1,220 @@
+"""Check: decomposition parents left as "test graveyards" (#4267).
+
+When a giant file is decomposed its *production* code moves out into new
+children, but its inline ``#[cfg(test)]`` blocks frequently stay behind. The
+parent then keeps almost all of its raw line count as stranded test code —
+opening it still costs the same tokens even though little production logic
+remains, so the AI-readability win of the decomposition evaporates.
+
+The canonical offender is ``src/services/discord/inflight.rs``: after its
+production logic was carved into the ``inflight/`` children it carries only
+590 production LoC but still holds 5451 lines of inline tests (ratio ~9.2x)
+that never migrated with the code.
+
+This check flags production files whose **test-to-prod line ratio exceeds
+``RATIO_THRESHOLD`` (3x)**. It reuses the *exact* production/test line
+accounting that ``giant_files`` already relies on — ``split_prod_test_lines``
+from ``generate_inventory_docs`` plus the shared test-only-module filter — so
+the prod/raw split agrees across every giant surface (#3036) rather than
+introducing a second, divergent parser.
+
+Definitions (all shared with ``giant_files`` / ``giant_file_ratchet``):
+
+* ``prod`` LoC = raw lines minus whole ``#[cfg(test)] mod`` block lines.
+* ``test`` LoC = the lines inside those whole test-gated ``mod`` blocks.
+* ``raw`` LoC = ``prod + test`` = the file's total line count.
+* ratio = ``test / prod``; a file is flagged when ``ratio > 3`` **and** it is
+  genuinely heavy (``raw >= MIN_RAW_LOC``). Files with zero production LoC are
+  skipped: they are pure test modules, not decomposition parents, and the
+  ratio is undefined.
+
+Landing posture — **report-only** (``hard_gate=False``) with a committed
+no-regression ``baseline_gate``, the same shape as ``route_srp_violations`` and
+``service_server_backflow``. Existing graveyards are frozen in the
+``[parent_test_residue]`` table of ``scripts/audit_maintainability_config.toml``
+(each value is the file's current stranded test-LoC ceiling) so CI is not red
+on introduction. The gate fails ``--check`` only when a **new** graveyard
+appears or a frozen file's test residue **grows** past its ceiling. Lower a
+ceiling as tests migrate out; raising one admits more residue and is forbidden
+(#4269) — migrate the tests with the production code instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+from .. import common
+from ..common import Finding
+from . import CheckSpec
+from . import giant_files
+
+CONFIG_REL_PATH = "scripts/audit_maintainability_config.toml"
+
+# A file is a "graveyard" only when its inline tests dwarf its production code.
+RATIO_THRESHOLD = 3.0
+# ...and only when the file is heavy enough that its opening cost actually
+# hurts. Below this raw-LoC floor a high ratio is a small file, not a
+# maintainability concern, so we do not flag it (keeps the signal focused on
+# genuine decomposition parents). Half the 1000-LoC giant threshold.
+MIN_RAW_LOC = 500
+
+_SECTION_RE = re.compile(r"^\[([A-Za-z0-9_.-]+)\]$")
+_ENTRY_RE = re.compile(r'^"([^"]+)"\s*=\s*(\d+)$')
+
+
+def load_residue_baseline(path: Path | None = None) -> dict[str, int]:
+    """Load the ``[parent_test_residue]`` path -> frozen test-LoC ceiling table.
+
+    Uses the same tiny TOML subset as ``namespace_size_caps`` and
+    ``giant_file_ratchet``: a single table of quoted repo-relative paths mapped
+    to positive integer ceilings. Other sections in the shared config file
+    (e.g. ``[namespace_size_caps]``) are ignored.
+    """
+
+    config_path = path or (common.REPO_ROOT / CONFIG_REL_PATH)
+    text = common.read_text(config_path)
+    if not text:
+        return {}
+
+    section: str | None = None
+    baseline: dict[str, int] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        section_match = _SECTION_RE.fullmatch(line)
+        if section_match:
+            section = section_match.group(1)
+            continue
+        if section != "parent_test_residue":
+            continue
+        entry_match = _ENTRY_RE.fullmatch(line)
+        if entry_match:
+            value = int(entry_match.group(2))
+            if value > 0:
+                baseline[entry_match.group(1).strip()] = value
+    return baseline
+
+
+def parent_test_residue() -> list[tuple[str, int, int, float]]:
+    """Return ``(rel, prod, test, ratio)`` for every flagged graveyard file.
+
+    Reuses ``giant_files``' shared accounting: the same test-only-module filter
+    and the same ``split_prod_test_lines`` split used to compute production LoC
+    for the giant-file threshold (#3036), so every surface agrees.
+    """
+
+    test_only = giant_files._test_only_module_files()
+    rows: list[tuple[str, int, int, float]] = []
+    for path in common.production_rust_files():
+        if path in test_only:
+            continue
+        prod, test = giant_files._INVENTORY.split_prod_test_lines(common.read_text(path))
+        raw = prod + test
+        if prod <= 0 or raw < MIN_RAW_LOC:
+            continue
+        ratio = test / prod
+        if ratio > RATIO_THRESHOLD:
+            rows.append((common.rel_posix(path), prod, test, ratio))
+    rows.sort(key=lambda row: -row[3])
+    return rows
+
+
+def _run(allowlist: set[str]) -> Iterable[Finding]:
+    findings: list[Finding] = []
+    for rel, prod, test, ratio in parent_test_residue():
+        if common.is_allowlisted(allowlist, rel):
+            continue
+        raw = prod + test
+        findings.append(
+            Finding(
+                rule="parent_test_residue",
+                severity="warn",
+                file=rel,
+                line=None,
+                message=(
+                    f"{test} test LoC vs {prod} prod LoC "
+                    f"(ratio {ratio:.2f}x > {RATIO_THRESHOLD:.0f}x, {raw} raw); "
+                    f"migrate the stranded tests with the decomposed production code"
+                ),
+                extra={
+                    "prod": str(prod),
+                    "test": str(test),
+                    "raw": str(raw),
+                    "ratio": f"{ratio:.2f}",
+                },
+            )
+        )
+    return findings
+
+
+def _baseline_gate(findings: list[Finding]) -> Iterable[Finding]:
+    """No-regression gate: no new graveyards, and no frozen one may grow.
+
+    ``findings`` is the current ``_run`` output. A finding is a regression when
+    its file is absent from the ``[parent_test_residue]`` baseline (a brand-new
+    graveyard) or when its current test LoC exceeds the frozen ceiling (the
+    residue grew). Files at or below their ceiling — and baseline entries that
+    dropped off the list because tests migrated out — are wins, never failures.
+    """
+
+    baseline = load_residue_baseline()
+    regressions: list[Finding] = []
+    for finding in findings:
+        frozen = baseline.get(finding.file)
+        current_test = int(finding.extra.get("test", "0"))
+        if frozen is None:
+            regressions.append(
+                Finding(
+                    rule="parent_test_residue",
+                    severity="error",
+                    file=finding.file,
+                    line=None,
+                    message=(
+                        f"new parent test residue: {finding.extra.get('test')} test LoC "
+                        f"vs {finding.extra.get('prod')} prod LoC "
+                        f"(ratio {finding.extra.get('ratio')}x). Migrate the tests with "
+                        f"the decomposed production code, or — if the residue is truly "
+                        f"irreducible — seed a reviewed ceiling in {CONFIG_REL_PATH}"
+                    ),
+                    extra={"config": CONFIG_REL_PATH, **finding.extra},
+                )
+            )
+            continue
+        if current_test > frozen:
+            regressions.append(
+                Finding(
+                    rule="parent_test_residue",
+                    severity="error",
+                    file=finding.file,
+                    line=None,
+                    message=(
+                        f"{current_test} test LoC > {frozen} frozen residue ceiling "
+                        f"(the graveyard grew); migrate tests out or lower the ceiling. "
+                        f"Baseline: {CONFIG_REL_PATH}"
+                    ),
+                    extra={
+                        "baseline": str(frozen),
+                        "current": str(current_test),
+                        "config": CONFIG_REL_PATH,
+                    },
+                )
+            )
+    return regressions
+
+
+CHECK = CheckSpec(
+    key="parent_test_residue",
+    title="Parent test residue",
+    description=(
+        "Decomposition parents whose inline test LoC exceeds "
+        f"{RATIO_THRESHOLD:.0f}x their production LoC (files >= {MIN_RAW_LOC} raw "
+        "lines). Migrate stranded tests with the production code; frozen "
+        f"offenders are baselined in {CONFIG_REL_PATH}."
+    ),
+    hard_gate=False,
+    runner=_run,
+    baseline_gate=_baseline_gate,
+)

--- a/scripts/audit_maintainability_config.toml
+++ b/scripts/audit_maintainability_config.toml
@@ -35,3 +35,36 @@
 "src/services/discord/turn_bridge/stream_loop.rs" = 1638 # 2026-07-08 #4230 S6: registered giant-file, plan-marked irreducible stream loop shell (event arms share placeholder/background/transcript/inflight state); tracked in giant_file_registry.toml.
 "src/services/discord/turn_bridge/status_panel.rs" = 700
 "src/services/discord/turn_bridge/voice_completion.rs" = 700
+
+# Frozen test-residue ceilings for the parent_test_residue check (#4267).
+#
+# When a giant file is decomposed its production code moves out but its inline
+# `#[cfg(test)]` blocks often stay behind, leaving a "test graveyard" whose
+# stranded test LoC dwarfs its remaining production LoC. The check flags files
+# whose test/prod ratio exceeds 3x (and that are >= 500 raw LoC). It is
+# report-only with a no-regression baseline: each value below is the file's
+# CURRENT stranded test LoC, frozen so CI is green on introduction. The gate
+# fails only when a NEW graveyard appears or one of these grows past its
+# ceiling. Lower a ceiling as tests migrate out (the fix this check wants);
+# RAISING a ceiling admits more residue and is forbidden (#4269) — migrate the
+# tests with the production code instead.
+[parent_test_residue]
+# The #4267 exemplar: inflight.rs kept its ~5.4k-line inline test module after
+# its production logic was carved into the inflight/ children (ratio ~9.2x).
+# Tracked for migration alongside the #4201 decomposition.
+"src/services/discord/inflight.rs" = 5451
+# turn_finalizer.rs is itself a production giant (1048 prod LoC) carrying a
+# 3992-line inline test module (ratio ~3.8x). Freeze pending test migration.
+"src/services/discord/turn_finalizer.rs" = 3992
+# save_store.rs carries 730 test LoC over 235 prod LoC (ratio ~3.1x) after the
+# inflight/ save-path carve-out; tests to migrate with the store split.
+"src/services/discord/inflight/save_store.rs" = 730
+# codex_tui_replay.rs: 711 test LoC over 233 prod LoC (ratio ~3.0x) left in the
+# recovery_engine manual-rebind carve-out.
+"src/services/discord/recovery_engine/manual_rebind/codex_tui_replay.rs" = 711
+# cancel_finalize_policy.rs: 450 test LoC over 131 prod LoC (ratio ~3.4x) in the
+# turn_bridge cancel/finalize policy carve-out.
+"src/services/discord/turn_bridge/cancel_finalize_policy.rs" = 450
+# delivery_lease.rs: 428 test LoC over 87 prod LoC (ratio ~4.9x) in the
+# turn_finalizer delivery-lease carve-out.
+"src/services/discord/turn_finalizer/delivery_lease.rs" = 428

--- a/tests/test_audit_maintainability.py
+++ b/tests/test_audit_maintainability.py
@@ -49,6 +49,7 @@ from audit_maintainability.checks import (  # noqa: E402
 )
 from audit_maintainability.checks import giant_files  # noqa: E402
 from audit_maintainability.checks import giant_file_ratchet  # noqa: E402
+from audit_maintainability.checks import parent_test_residue  # noqa: E402
 
 
 def _write(root: Path, rel: str, body: str) -> None:
@@ -228,6 +229,105 @@ class GiantFileRatchetCheck(unittest.TestCase):
                 )
             )
         self.assertEqual(hits, [])
+
+
+def _residue_body(prod_lines: int, test_lines: int) -> str:
+    """A Rust source body with ``prod_lines`` production fns plus a whole
+    ``#[cfg(test)] mod tests`` block of ``test_lines`` inner fns.
+
+    ``split_prod_test_lines`` (shared with ``giant_files``) counts the entire
+    ``#[cfg(test)] mod { ... }`` span — attribute line through closing brace —
+    as test LoC, and everything else as production LoC.
+    """
+
+    prod = "".join(f"fn p{i}() {{}}\n" for i in range(prod_lines))
+    inner = "".join(f"    fn t{i}() {{}}\n" for i in range(test_lines))
+    return f"{prod}#[cfg(test)]\nmod tests {{\n{inner}}}\n"
+
+
+class ParentTestResidueCheck(unittest.TestCase):
+    def test_flags_graveyard_but_not_balanced_small_or_pure_test(self) -> None:
+        files = {
+            # ratio ~4.3x, raw ~625 -> flagged
+            "src/services/discord/graveyard.rs": _residue_body(120, 500),
+            # ratio < 1 (test < prod) -> not flagged even though raw is large
+            "src/services/discord/balanced.rs": _residue_body(400, 100),
+            # ratio high but raw < MIN_RAW_LOC (500) -> not flagged (small file)
+            "src/services/discord/tiny.rs": _residue_body(20, 100),
+            # zero production LoC -> pure test module, ratio undefined, skipped
+            "src/services/discord/pure_tests.rs": _residue_body(0, 300),
+        }
+        with _FakeSrcTree(files):
+            hits = list(parent_test_residue.CHECK.runner(set()))
+        self.assertEqual(_files(hits), {"src/services/discord/graveyard.rs"})
+
+    def test_reuses_giant_files_split_accounting(self) -> None:
+        body = _residue_body(120, 500)
+        with _FakeSrcTree({"src/services/discord/graveyard.rs": body}):
+            hits = list(parent_test_residue.CHECK.runner(set()))
+            # The finding's prod/test numbers must equal the exact values the
+            # shared giant_files accounting reports for the same text — i.e. we
+            # reuse split_prod_test_lines, not a second divergent parser.
+            prod, test = giant_files._INVENTORY.split_prod_test_lines(body)
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].extra["prod"], str(prod))
+        self.assertEqual(hits[0].extra["test"], str(test))
+        self.assertGreater(test / prod, parent_test_residue.RATIO_THRESHOLD)
+
+    def test_allowlist_suppresses(self) -> None:
+        body = _residue_body(120, 500)
+        with _FakeSrcTree({"src/services/discord/graveyard.rs": body}):
+            hits = list(
+                parent_test_residue.CHECK.runner({"src/services/discord/graveyard.rs"})
+            )
+        self.assertEqual(hits, [])
+
+    def test_baseline_gate_passes_seeded_offender(self) -> None:
+        body = _residue_body(120, 500)
+        rel = "src/services/discord/graveyard.rs"
+        with _FakeSrcTree({rel: body}) as root:
+            prod, test = giant_files._INVENTORY.split_prod_test_lines(body)
+            _write(
+                root,
+                parent_test_residue.CONFIG_REL_PATH,
+                f"""
+                [parent_test_residue]
+                "{rel}" = {test}
+                """,
+            )
+            hits = list(parent_test_residue.CHECK.runner(set()))
+            gate = list(parent_test_residue.CHECK.baseline_gate(hits))
+        self.assertEqual(_files(hits), {rel})  # still reported
+        self.assertEqual(gate, [])  # but not a regression
+
+    def test_baseline_gate_flags_new_graveyard(self) -> None:
+        body = _residue_body(120, 500)
+        rel = "src/services/discord/graveyard.rs"
+        with _FakeSrcTree({rel: body}):
+            # No [parent_test_residue] config at all -> unseeded -> regression.
+            hits = list(parent_test_residue.CHECK.runner(set()))
+            gate = list(parent_test_residue.CHECK.baseline_gate(hits))
+        self.assertEqual(_files(gate), {rel})
+        self.assertTrue(all(f.severity == "error" for f in gate))
+
+    def test_baseline_gate_flags_grown_residue(self) -> None:
+        body = _residue_body(120, 500)
+        rel = "src/services/discord/graveyard.rs"
+        with _FakeSrcTree({rel: body}) as root:
+            prod, test = giant_files._INVENTORY.split_prod_test_lines(body)
+            # Freeze the ceiling one line BELOW current -> current > ceiling.
+            _write(
+                root,
+                parent_test_residue.CONFIG_REL_PATH,
+                f"""
+                [parent_test_residue]
+                "{rel}" = {test - 1}
+                """,
+            )
+            hits = list(parent_test_residue.CHECK.runner(set()))
+            gate = list(parent_test_residue.CHECK.baseline_gate(hits))
+        self.assertEqual(_files(gate), {rel})
+        self.assertTrue(all(f.severity == "error" for f in gate))
 
 
 class NamespaceSizeCapsCheck(unittest.TestCase):
@@ -717,16 +817,17 @@ class SourceOfTruthAliasCheck(unittest.TestCase):
 
 
 class HarnessCli(unittest.TestCase):
-    def test_runs_all_thirteen_checks_and_emits_yaml_keys(self) -> None:
+    def test_runs_all_fourteen_checks_and_emits_yaml_keys(self) -> None:
         with _FakeSrcTree({"src/main.rs": "fn main() {}\n"}):
             specs = HARNESS.load_check_specs()
-            findings = HARNESS.run_all(specs, {})
+            findings, _ = HARNESS.run_all(specs, {})
             yaml_text = HARNESS.render_yaml(specs, findings)
             json_text = HARNESS.render_json(specs, findings)
             md_text = HARNESS.render_markdown(specs, findings)
         for key in (
             "giant_files",
             "giant_file_ratchet",
+            "parent_test_residue",
             "namespace_size_caps",
             "route_srp_violations",
             "service_server_backflow",
@@ -746,7 +847,7 @@ class HarnessCli(unittest.TestCase):
     def test_markdown_summary_includes_every_registered_check(self) -> None:
         with _FakeSrcTree({"src/main.rs": "fn main() {}\n"}):
             specs = HARNESS.load_check_specs()
-            findings = HARNESS.run_all(specs, {})
+            findings, _ = HARNESS.run_all(specs, {})
             md_text = HARNESS.render_markdown(specs, findings)
 
         summary_keys: list[str] = []
@@ -783,27 +884,28 @@ class HarnessCli(unittest.TestCase):
         )
         self.assertEqual(
             baseline_gated,
-            {"route_srp_violations", "service_server_backflow"},
+            {"route_srp_violations", "service_server_backflow", "parent_test_residue"},
         )
         warning_only = {
             "route_srp_violations",
             "service_server_backflow",
             "limit_clamp_duplication",
+            "parent_test_residue",
         }
         self.assertTrue(all(not spec.hard_gate for spec in specs if spec.key in warning_only))
 
     def test_renderers_report_hard_gate_enabled(self) -> None:
         with _FakeSrcTree({"src/main.rs": "fn main() {}\n"}):
             specs = HARNESS.load_check_specs()
-            findings = HARNESS.run_all(specs, {})
+            findings, _ = HARNESS.run_all(specs, {})
             yaml_text = HARNESS.render_yaml(specs, findings)
             json_payload = json.loads(HARNESS.render_json(specs, findings))
         self.assertIn("hard_gate_enabled: true", yaml_text)
         self.assertIn("hard_gate_count: 10", yaml_text)
-        self.assertIn("baseline_gate_count: 2", yaml_text)
+        self.assertIn("baseline_gate_count: 3", yaml_text)
         self.assertIs(json_payload["hard_gate_enabled"], True)
         self.assertEqual(json_payload["hard_gate_count"], 10)
-        self.assertEqual(json_payload["baseline_gate_count"], 2)
+        self.assertEqual(json_payload["baseline_gate_count"], 3)
 
     def test_check_mode_returns_zero_with_no_findings(self) -> None:
         with _FakeSrcTree({"src/main.rs": "fn main() {}\n"}):


### PR DESCRIPTION
구현 완료. 상세는 이슈 #4267 및 커밋 메시지 참조.

게이트: fmt/check ✅ · tests ✅ · agent-maintenance freshness ✅ · `audit_maintainability.py --check` RC=0 (캡 미상향, #4269 준수)

Refs #4267