### PR TITLE
fix(handoff): route required replies away from unroutable pseudo-sources (#4383)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -411,7 +411,7 @@
 | `services::discord` | `src/services/discord/mod.rs` | 5549 | 4165 | 1384 | giant-file |
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 981 | 855 | 126 |  |
-| `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 928 | 574 | 354 |  |
+| `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 1079 | 652 | 427 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
 | `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2961 | 1691 | 1270 | giant-file |

--- a/src/services/discord/agent_handoff.rs
+++ b/src/services/discord/agent_handoff.rs
@@ -193,29 +193,78 @@ impl AgentHandoffError {
     }
 }
 
+/// How the receiver can reach the requester when a reply is required (#4383).
+///
+/// Watchdogs and routines hand off under pseudo-source ids (`system`) that carry
+/// no Discord channel binding. Telling their receiver to run `send-to-agent --to
+/// system` yields `agent not found: system`, so the contract must route those
+/// replies back to the channel the handoff landed on instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ReplyRoute {
+    /// Requester resolves to a mailbox — reply via `send-to-agent`.
+    Mailbox,
+    /// Requester has no mailbox — report into the handoff's own channel.
+    ChannelOnly,
+}
+
+/// Whether `agent_id` is a routable reply target: registered *and* resolving to
+/// at least one Discord mailbox. Mirrors the reachability predicate
+/// [`send_agent_handoff`] applies to `to_agent_id`, so a contract that promises
+/// `send-to-agent` only ever names an id that command can actually deliver to.
+///
+/// A query failure propagates rather than defaulting to a route: both callers
+/// have already proven the pool healthy by loading `to_agent_id`'s bindings, so
+/// an error here is a real anomaly, and guessing would reintroduce the very
+/// class of bug this check exists to prevent — a contract that misdirects.
+async fn resolve_reply_route(
+    pg_pool: &PgPool,
+    agent_id: &str,
+) -> Result<ReplyRoute, AgentHandoffError> {
+    let routable = crate::db::agents::load_agent_channel_bindings_pg(pg_pool, agent_id.trim())
+        .await
+        .map_err(|error| {
+            AgentHandoffError::internal(format!("query reply-target channels: {error}"))
+        })?
+        .and_then(|bindings| bindings.primary_channel())
+        .is_some();
+    Ok(if routable {
+        ReplyRoute::Mailbox
+    } else {
+        ReplyRoute::ChannelOnly
+    })
+}
+
 /// Reply-expectation contract (#3620 follow-up) appended to the end of a handoff
 /// body. `true` → 회신 필수 (the receiver must report back to the requester),
 /// `false` → 회신 불필요 (no callback expected). Kept aligned with the role
 /// response-contract: replies follow the request's callback info + channel rules.
-fn reply_expectation_contract(from_agent_id: &str, expect_reply: bool) -> String {
-    if expect_reply {
-        format!(
+fn reply_expectation_contract(
+    from_agent_id: &str,
+    expect_reply: bool,
+    reply_route: ReplyRoute,
+) -> String {
+    match (expect_reply, reply_route) {
+        (true, ReplyRoute::Mailbox) => format!(
             "──────────\n📨 **회신 필수 계약**: 이 핸드오프는 회신을 요구합니다. 작업/검토를 마치면 결과·결론을 요청자 `{from_agent_id}`에게 반드시 회신하세요. 회신은 `agentdesk send-to-agent --from <self> --to {from_agent_id} --message \"...\" --expect-reply false` 로 보냅니다(현재 요청의 callback 정보·채널 규칙 우선)."
-        )
-    } else {
-        "──────────\n📭 **회신 불필요 계약**: 이 핸드오프는 회신을 요구하지 않습니다. 별도 보고 없이 처리하세요(중대한 이슈를 발견한 경우에만 자율적으로 회신).".to_string()
+        ),
+        (true, ReplyRoute::ChannelOnly) => format!(
+            "──────────\n📨 **회신 필수 계약**: 이 핸드오프는 회신을 요구합니다. 작업/검토를 마치면 결과·결론을 반드시 보고하세요. 단 요청자 `{from_agent_id}`는 메일박스가 없어 `send-to-agent`로 회신할 수 없습니다 — 이 핸드오프가 도착한 채널에 결과를 보고하세요."
+        ),
+        (false, _) => "──────────\n📭 **회신 불필요 계약**: 이 핸드오프는 회신을 요구하지 않습니다. 별도 보고 없이 처리하세요(중대한 이슈를 발견한 경우에만 자율적으로 회신).".to_string(),
     }
 }
 
 /// Build the handoff body. When `expect_reply` is `Some`, a reply-expectation
 /// contract is appended to the end of the message; `None` keeps the legacy
-/// behavior (no contract) for backward compatibility.
+/// behavior (no contract) for backward compatibility. `reply_route` decides how
+/// a required reply is addressed and is ignored otherwise.
 pub(crate) fn build_agent_handoff_content(
     from_agent_id: &str,
     to_agent_id: &str,
     message: &str,
     prefix: bool,
     expect_reply: Option<bool>,
+    reply_route: ReplyRoute,
 ) -> String {
     let mut content = if prefix {
         format!("[{from_agent_id} → {to_agent_id} 핸드오프]\n\n{message}")
@@ -224,7 +273,11 @@ pub(crate) fn build_agent_handoff_content(
     };
     if let Some(expect_reply) = expect_reply {
         content.push_str("\n\n");
-        content.push_str(&reply_expectation_contract(from_agent_id, expect_reply));
+        content.push_str(&reply_expectation_contract(
+            from_agent_id,
+            expect_reply,
+            reply_route,
+        ));
     }
     content
 }
@@ -272,8 +325,19 @@ pub(crate) async fn send_agent_handoff(
         ));
     };
 
-    let content =
-        build_agent_handoff_content(from_agent_id, to_agent_id, message, prefix, expect_reply);
+    let reply_route = if expect_reply == Some(true) {
+        resolve_reply_route(pg_pool, from_agent_id).await?
+    } else {
+        ReplyRoute::Mailbox
+    };
+    let content = build_agent_handoff_content(
+        from_agent_id,
+        to_agent_id,
+        message,
+        prefix,
+        expect_reply,
+        reply_route,
+    );
     let target = format!("channel:{channel_id}");
     let (status, response_body) = health::send_message_with_backends(
         registry,
@@ -365,6 +429,7 @@ fn resolve_agent_handoff_turn_target(
     channel_kind: AgentHandoffChannelKind,
     prefix: bool,
     expect_reply: Option<bool>,
+    reply_route: ReplyRoute,
 ) -> Result<AgentHandoffTurnTarget, AgentHandoffError> {
     let from_agent_id = from_agent_id.trim();
     if from_agent_id.is_empty() {
@@ -410,8 +475,14 @@ fn resolve_agent_handoff_turn_target(
         )));
     };
 
-    let content =
-        build_agent_handoff_content(from_agent_id, to_agent_id, prompt, prefix, expect_reply);
+    let content = build_agent_handoff_content(
+        from_agent_id,
+        to_agent_id,
+        prompt,
+        prefix,
+        expect_reply,
+        reply_route,
+    );
 
     Ok(AgentHandoffTurnTarget {
         to_agent_id: to_agent_id.to_string(),
@@ -469,6 +540,12 @@ pub(crate) async fn start_agent_handoff_turn(
         .map_err(|error| AgentHandoffError::internal(format!("query agent channels: {error}")))?
         .ok_or_else(|| AgentHandoffError::agent_not_found(to_agent_id_trimmed))?;
 
+    let reply_route = if expect_reply == Some(true) {
+        resolve_reply_route(pg_pool, from_agent_id).await?
+    } else {
+        ReplyRoute::Mailbox
+    };
+
     let target = resolve_agent_handoff_turn_target(
         &bindings,
         from_agent_id,
@@ -477,6 +554,7 @@ pub(crate) async fn start_agent_handoff_turn(
         channel_kind,
         prefix,
         expect_reply,
+        reply_route,
     )?;
 
     let result = health::start_headless_agent_turn(
@@ -602,11 +680,25 @@ mod tests {
     #[test]
     fn handoff_prefix_can_be_enabled_or_disabled() {
         assert_eq!(
-            build_agent_handoff_content("project-agentdesk", "adk-dashboard", "hello", true, None),
+            build_agent_handoff_content(
+                "project-agentdesk",
+                "adk-dashboard",
+                "hello",
+                true,
+                None,
+                ReplyRoute::Mailbox
+            ),
             "[project-agentdesk → adk-dashboard 핸드오프]\n\nhello"
         );
         assert_eq!(
-            build_agent_handoff_content("project-agentdesk", "adk-dashboard", "hello", false, None),
+            build_agent_handoff_content(
+                "project-agentdesk",
+                "adk-dashboard",
+                "hello",
+                false,
+                None,
+                ReplyRoute::Mailbox
+            ),
             "hello"
         );
     }
@@ -615,22 +707,72 @@ mod tests {
     fn handoff_reply_expectation_appends_contract() {
         // None → no contract (backward compatible).
         assert_eq!(
-            build_agent_handoff_content("a", "b", "hi", false, None),
+            build_agent_handoff_content("a", "b", "hi", false, None, ReplyRoute::Mailbox),
             "hi"
         );
         // Some(true) → 회신 필수 contract referencing the requester.
-        let required = build_agent_handoff_content("a", "b", "hi", false, Some(true));
+        let required =
+            build_agent_handoff_content("a", "b", "hi", false, Some(true), ReplyRoute::Mailbox);
         assert!(required.starts_with("hi\n\n"));
         assert!(required.contains("회신 필수 계약"));
         assert!(required.contains("`a`"));
         // Some(false) → 회신 불필요 contract.
-        let not_required = build_agent_handoff_content("a", "b", "hi", false, Some(false));
+        let not_required =
+            build_agent_handoff_content("a", "b", "hi", false, Some(false), ReplyRoute::Mailbox);
         assert!(not_required.starts_with("hi\n\n"));
         assert!(not_required.contains("회신 불필요 계약"));
         // Contract appends after the prefix envelope too.
-        let prefixed = build_agent_handoff_content("a", "b", "hi", true, Some(true));
+        let prefixed =
+            build_agent_handoff_content("a", "b", "hi", true, Some(true), ReplyRoute::Mailbox);
         assert!(prefixed.starts_with("[a → b 핸드오프]\n\nhi\n\n"));
         assert!(prefixed.contains("회신 필수 계약"));
+    }
+
+    /// #4383: a pseudo-source requester (`system`) has no mailbox, so the
+    /// required-reply contract must never emit `send-to-agent --to system` —
+    /// running it yields `agent not found: system`.
+    #[test]
+    fn required_reply_to_unroutable_requester_avoids_send_to_agent() {
+        let contract = build_agent_handoff_content(
+            "system",
+            "project-agentdesk",
+            "check the relay",
+            false,
+            Some(true),
+            ReplyRoute::ChannelOnly,
+        );
+        assert!(contract.contains("회신 필수 계약"));
+        assert!(contract.contains("`system`"));
+        // The contract may *name* send-to-agent to explain why it is unusable,
+        // but must never hand the receiver a runnable `--to system` command.
+        assert!(!contract.contains("--to system"));
+        assert!(!contract.contains("--expect-reply"));
+        assert!(contract.contains("이 핸드오프가 도착한 채널"));
+    }
+
+    /// A routable requester keeps the executable `send-to-agent` instruction.
+    #[test]
+    fn required_reply_to_routable_requester_keeps_send_to_agent() {
+        let contract = build_agent_handoff_content(
+            "project-agentdesk",
+            "adk-dashboard",
+            "review this",
+            false,
+            Some(true),
+            ReplyRoute::Mailbox,
+        );
+        assert!(contract.contains("--to project-agentdesk"));
+        assert!(contract.contains("--expect-reply false"));
+    }
+
+    /// `expect_reply=false` renders the same 회신 불필요 contract regardless of
+    /// how the requester would have been reached.
+    #[test]
+    fn reply_route_is_ignored_when_reply_not_expected() {
+        let mailbox = reply_expectation_contract("system", false, ReplyRoute::Mailbox);
+        let channel_only = reply_expectation_contract("system", false, ReplyRoute::ChannelOnly);
+        assert_eq!(mailbox, channel_only);
+        assert!(mailbox.contains("회신 불필요 계약"));
     }
 
     #[test]
@@ -695,6 +837,7 @@ mod tests {
             AgentHandoffChannelKind::Cdx,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .expect("cdx binding resolves");
         assert_eq!(target.to_agent_id, "adk-dashboard");
@@ -718,6 +861,7 @@ mod tests {
             AgentHandoffChannelKind::Cc,
             false,
             None,
+            ReplyRoute::Mailbox,
         )
         .expect("cc binding resolves");
         assert_eq!(target.content, "raw prompt");
@@ -736,6 +880,7 @@ mod tests {
             AgentHandoffChannelKind::Cc,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .expect("falls back to the agent's primary channel");
         assert_eq!(target.channel_id, "222");
@@ -762,6 +907,7 @@ mod tests {
             AgentHandoffChannelKind::Cc,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .expect("codex primary-only binding resolves");
         assert_eq!(target.channel_id, "1495040912361914399");
@@ -786,6 +932,7 @@ mod tests {
             AgentHandoffChannelKind::Cdx,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .expect("explicit cc-only fallback resolves via Claude");
         assert_eq!(target.channel_id, "1495040912361914400");
@@ -810,6 +957,7 @@ mod tests {
             AgentHandoffChannelKind::Cdx,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .expect("opencode mailbox resolves via primary channel");
         assert_eq!(target.channel_id, "1495040912361914398");
@@ -827,6 +975,7 @@ mod tests {
             AgentHandoffChannelKind::Cc,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::UNPROCESSABLE_ENTITY);
@@ -842,6 +991,7 @@ mod tests {
             AgentHandoffChannelKind::Cc,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::BAD_REQUEST);
@@ -858,6 +1008,7 @@ mod tests {
             AgentHandoffChannelKind::Cc,
             true,
             None,
+            ReplyRoute::Mailbox,
         )
         .unwrap_err();
         assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Closes #4383

## 문제

`--expect-reply true` 핸드오프는 수신 에이전트에게 다음 회신 명령을 지시한다:

```
agentdesk send-to-agent --from <self> --to {from_agent_id} --message "..." --expect-reply false
```

`from_agent_id` 가 라우팅 가능한지 아무도 검증하지 않는다. 워치독/루틴은 `--from system` 으로 보내는데 `system` 은 Discord 채널 바인딩이 없다. 결과:

```
$ agentdesk send-to-agent --from project-agentdesk --to system --message "..." --expect-reply false
Error: agent not found: system
```

계약이 구조적으로 이행 불가능하다.

이미 릴리스 런타임의 `relay-watchdog.py` 가 이 결함을 발견하고 `--expect-reply false` 로 우회하고 있었다 (`"MUST be false. --expect-reply true makes agent_handoff.rs append a contract telling the agent to reply via send-to-agent --to system ... The contract is unfulfillable by construction. Verified 2026-07-09"`). 이 PR은 우회가 아니라 원인을 고친다.

## 수정

- `ReplyRoute { Mailbox, ChannelOnly }` 도입.
- `resolve_reply_route()` 가 `from_agent_id` 의 도달 가능성을 확인한다 — 에이전트 레지스트리에 존재하고 메일박스가 1개 이상 해석될 것. `send_agent_handoff()` 가 이미 `to_agent_id` 에 적용하던 것과 동일한 predicate (`primary_channel().is_some()`) 라, `send-to-agent` 를 약속하는 계약은 그 명령이 실제로 배달 가능한 id만 지목하게 된다.
- 메일박스가 없으면 계약 문구를 "이 핸드오프가 도착한 채널에 보고하라" 로 대체한다. 실행 불가능한 명령은 더 이상 emit 되지 않는다.
- 조회 실패는 route 를 추측하지 않고 전파한다. 두 호출자 모두 직전에 `to_agent_id` 바인딩을 로드해 pool 건전성을 이미 입증했으므로 여기서의 에러는 진짜 이상 신호이고, 추측은 이 검사가 막으려는 "잘못 지시하는 계약" 을 그대로 재도입한다.

`system` 을 라우팅 대상으로 등록하는 대안은 택하지 않았다. pseudo-source 는 늘어날 것이고, 실행 불가능한 명령을 지시하는 계약 문구 자체가 결함이다.

announce 경로(`send_agent_handoff`)와 turn-trigger 경로(`start_agent_handoff_turn`, #3556) 모두 `build_agent_handoff_content()` 를 공유하므로 함께 고쳐진다. `expect_reply != Some(true)` 이면 DB 조회를 건너뛴다.

## 검증

- `cargo test --lib agent_handoff` — **23 passed, 0 failed**. 신규 3건:
  - `required_reply_to_unroutable_requester_avoids_send_to_agent` — `system` 계약에 실행 가능한 `--to system` / `--expect-reply` 가 없음을 확인. (초안에서 `!contains("send-to-agent")` 로 과하게 조인 어서션이 실패했다 — 새 문구는 "send-to-agent 로 회신할 수 없다" 고 *설명* 하므로 이름 자체는 등장한다. 실제 불변식인 "실행 가능한 명령 미포함" 으로 교정했다.)
  - `required_reply_to_routable_requester_keeps_send_to_agent` — 정상 에이전트는 기존 `--to <id>` 지시를 유지.
  - `reply_route_is_ignored_when_reply_not_expected` — `expect_reply=false` 는 route 와 무관하게 동일 문구.
- `cargo fmt --all --check` 클린, `cargo check --workspace --all-targets` 에러 0.
- docs 게이트: `generate_inventory_docs.py` → `check_agent_maintenance_docs.py` = `agent-maintenance freshness check passed`. `module-inventory.md` 라인수 갱신 동봉 (prod 652줄, giant threshold 미만).
- 라이브 전제 확인: `agentdesk agents` 상 `system` 은 미등록(`registered=False`), `project-agentdesk` 는 등록됨 → 각각 `ChannelOnly` / `Mailbox` 로 해석된다.

Discord 로 실제 핸드오프를 쏘는 e2e 는 채널에 메시지가 나가고 턴을 트리거하므로 수행하지 않았다. 배포 후 `--from system --expect-reply true` 1회로 확인 가능하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)