### PR TITLE
fix(ci-scripts): await_holding_lock ratchet가 추적 파일만 세도록 — gitignored worktree 사본 제외 (#4376)

### DIFF
--- a/scripts/check_await_holding_lock_ratchet.py
+++ b/scripts/check_await_holding_lock_ratchet.py
@@ -15,6 +15,7 @@ diff edit and should carry justification — it is not the normal path.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -35,8 +36,35 @@ BASELINE = 53  # +16 (#4091 r7 batch-4): crate-wide test env-lock isolation swee
 ALLOW_RE = re.compile(r"#\[allow\([^)]*\bclippy::await_holding_lock\b")
 
 
+def _tracked_rs_files(repo_root: Path) -> list[Path]:
+    """Return the repo's git-tracked `*.rs` files (as absolute paths).
+
+    Enumerating with `git ls-files` instead of `repo_root.rglob("*.rs")` is what
+    keeps the count independent of the developer's local checkout (#4376). A
+    worktree-based dev environment leaves gitignored `.claude/worktrees/<id>/`
+    clones — each a full `src/` copy — sitting in the repo root. A raw rglob
+    walks into them and counts every suppression site once per nested worktree,
+    so a developer with active worktrees is always locally red (e.g. 1027 vs
+    baseline 53) while CI (a fresh, worktree-free checkout) stays green. Tracked
+    files are exactly what CI sees; `target/`, `node_modules/`, and the worktree
+    clones are gitignored/untracked and drop out automatically, so the old
+    `"target" in rel.parts` special-case is no longer needed.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", "*.rs"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [repo_root / rel for rel in result.stdout.split("\0") if rel]
+
+
 def count_allows(repo_root: Path) -> tuple[int, list[str]]:
     """Count real `#[allow(clippy::await_holding_lock)]` attributes.
+
+    Only git-tracked `*.rs` files are scanned (see `_tracked_rs_files`), so the
+    result matches CI regardless of local worktree clones (#4376).
 
     Best-effort source scan: full-line comments are skipped and trailing line
     comments are stripped so prose mentioning the lint (e.g. lib.rs guidance)
@@ -47,10 +75,8 @@ def count_allows(repo_root: Path) -> tuple[int, list[str]]:
     """
     total = 0
     locations: list[str] = []
-    for path in sorted(repo_root.rglob("*.rs")):
+    for path in sorted(_tracked_rs_files(repo_root)):
         rel = path.relative_to(repo_root)
-        if "target" in rel.parts:
-            continue
         for lineno, line in enumerate(
             path.read_text(encoding="utf-8").splitlines(), start=1
         ):

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -60,6 +60,7 @@ echo "=== Policy DB capability manifest guard (#3734) ==="
 
 echo "=== await_holding_lock ratchet guard ==="
 "$PYTHON" scripts/check_await_holding_lock_ratchet.py
+"$PYTHON" -m unittest tests.test_await_holding_lock_ratchet
 
 echo "=== Hotfile LOC ratchet guard (#3565) ==="
 "$PYTHON" scripts/check_hotfile_ratchet.py
@@ -107,7 +108,7 @@ fi
 
 echo "=== Check hardcoded port/path drift ==="
 grep -rn '8791\|8799' --include='*.rs' --include='*.js' --include='*.yaml' --include='*.json' \
-  --exclude-dir=target --exclude-dir=.git --exclude-dir=node_modules \
+  --exclude-dir=target --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.claude \
   | grep -v 'Cargo.lock' \
   | grep -v '// port' \
   | grep -v '# port' || true
@@ -115,7 +116,7 @@ grep -rn '8791\|8799' --include='*.rs' --include='*.js' --include='*.yaml' --inc
 echo ""
 echo "=== Checking hardcoded home paths (informational; see #100) ==="
 if grep -rn 'env!("HOME")' --include='*.rs' \
-  --exclude-dir=target --exclude-dir=.git 2>/dev/null; then
+  --exclude-dir=target --exclude-dir=.git --exclude-dir=.claude 2>/dev/null; then
   echo "NOTE: env!(\"HOME\") found; tracked in #100"
 else
   echo "OK: No env!(\"HOME\") found"

--- a/tests/test_await_holding_lock_ratchet.py
+++ b/tests/test_await_holding_lock_ratchet.py
@@ -1,0 +1,168 @@
+"""Self-tests for scripts/check_await_holding_lock_ratchet.py (#4376).
+
+Covers the counting contract after the #4376 fix that switched file enumeration
+from `repo_root.rglob("*.rs")` to `git ls-files`:
+ (a) only git-tracked `*.rs` files are counted — a gitignored worktree clone
+     (`.claude/worktrees/<id>/src/…`) planted next to a tracked file must NOT
+     inflate the count (the bug: a worktree dev's local run counted every
+     suppression once per nested clone, e.g. 1027 vs baseline 53, so they were
+     always locally red while CI — a fresh, clone-free checkout — stayed green);
+ (b) full-line and trailing `//` comments mentioning the lint are stripped;
+ (c) the FAIL/NOTE/OK exit branches;
+ (d) the live repo agrees with the frozen BASELINE.
+
+The (a) tests are the mutation guard: reverting `count_allows` to
+`sorted(repo_root.rglob("*.rs"))` makes them count the gitignored clone and fail
+by assertion (not by import/compile error).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_await_holding_lock_ratchet.py"
+
+_spec = importlib.util.spec_from_file_location("check_await_holding_lock_ratchet", SCRIPT)
+ratchet = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ratchet)
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+# One real suppression site. Indented as rustfmt would leave an attribute.
+ALLOW = "    #[allow(clippy::await_holding_lock)]\n"
+
+# A tracked production file with exactly ONE suppression.
+TRACKED_RS = (
+    "async fn holds() {\n"
+    + ALLOW
+    + "    let _g = LOCK.lock().unwrap();\n"
+    + "    do_async().await;\n"
+    + "}\n"
+)
+
+
+class TrackedFileScopeTests(unittest.TestCase):
+    """git ls-files enumeration: only tracked files count (#4376)."""
+
+    def _count_in_git_repo(self, builder) -> tuple[int, list[str]]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _git(root, "init", "-q")
+            # The worktree clones the bug is about live under `.claude/`, which
+            # AgentDesk gitignores; mirror that so they are untracked here too.
+            _write(root, ".gitignore", ".claude/\n")
+            builder(root)
+            _git(root, "add", "-A")
+            return ratchet.count_allows(root)
+
+    def test_gitignored_worktree_clone_is_not_counted(self):
+        # The core #4376 regression: a tracked file with ONE suppression, plus a
+        # gitignored `.claude/worktrees/<id>/src` clone of it. Only the tracked
+        # copy may count — the clone is exactly what `git ls-files` (vs rglob)
+        # drops. Reverting to rglob counts the clone and fails this assert.
+        def build(root: Path) -> None:
+            _write(root, "src/services/discord/a.rs", TRACKED_RS)
+            _write(root, ".claude/worktrees/wt1/src/services/discord/a.rs", TRACKED_RS)
+
+        total, locs = self._count_in_git_repo(build)
+        self.assertEqual(total, 1, locs)
+        self.assertEqual(len(locs), 1)
+        self.assertTrue(all(".claude" not in loc for loc in locs), locs)
+        self.assertTrue(locs[0].startswith("src/"), locs)
+
+    def test_many_gitignored_clones_do_not_multiply_the_count(self):
+        # Reproduces the "N worktrees -> Nx count" inflation shape directly:
+        # five clones of a single tracked site must still count as one.
+        def build(root: Path) -> None:
+            _write(root, "src/a.rs", TRACKED_RS)
+            for i in range(5):
+                _write(root, f".claude/worktrees/wt{i}/src/a.rs", TRACKED_RS)
+
+        total, _locs = self._count_in_git_repo(build)
+        self.assertEqual(total, 1)
+
+    def test_full_line_and_trailing_comments_not_counted(self):
+        # (b) prose mentioning the lint (full-line `//`, doc `///`, and trailing
+        # `//`) is stripped; only the real attribute counts.
+        body = (
+            "// #[allow(clippy::await_holding_lock)] in a comment must NOT count\n"
+            "/// doc: #[allow(clippy::await_holding_lock)] must NOT count\n"
+            "async fn f() {\n"
+            "    let _ = 1; // #[allow(clippy::await_holding_lock)] trailing, NOT counted\n"
+            + ALLOW
+            + "    g().await;\n"
+            "}\n"
+        )
+        total, locs = self._count_in_git_repo(lambda r: _write(r, "src/b.rs", body))
+        self.assertEqual(total, 1, locs)
+
+
+class ExitBranchTests(unittest.TestCase):
+    """FAIL/NOTE/OK branches, isolated from the real tree via mocking."""
+
+    def _run_main(self, current: int, baseline: int) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(ratchet, "BASELINE", baseline), mock.patch.object(
+            ratchet, "count_allows", return_value=(current, ["a.rs:1"] * current)
+        ), redirect_stdout(out), redirect_stderr(err):
+            code = ratchet.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_over_baseline_fails(self):
+        code, _out, err = self._run_main(current=54, baseline=53)
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL", err)
+
+    def test_below_baseline_notes_and_passes(self):
+        code, out, _err = self._run_main(current=52, baseline=53)
+        self.assertEqual(code, 0)
+        self.assertIn("NOTE", out)
+        self.assertIn("Lower BASELINE to 52", out)
+
+    def test_at_baseline_ok(self):
+        code, out, _err = self._run_main(current=53, baseline=53)
+        self.assertEqual(code, 0)
+        self.assertIn("OK", out)
+
+
+class LiveRepoBaselineTests(unittest.TestCase):
+    def test_live_repo_matches_baseline(self):
+        # The real tree matches the frozen BASELINE via git ls-files enumeration,
+        # independent of any local `.claude/worktrees` clones.
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"OK: {ratchet.BASELINE}", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4376

## 문제

`scripts/check_await_holding_lock_ratchet.py` 의 `count_allows()` 가 `repo_root.rglob("*.rs")` 로 레포 루트를 통째로 훑는다. 그래서 gitignore된 `.claude/worktrees/` 의 `src/` 사본까지 세어, worktree를 쓰는 개발자는 로컬에서 **항상 red** 였다 (실측 1027 vs baseline 53).

CI는 fresh checkout이라 사본이 없어 green — **로컬 전용 버그**이고, 그래서 오래 살아남았다.

## 수정

파일 열거를 `git ls-files -z -- '*.rs'` 기반 헬퍼 `_tracked_rs_files()` 로 교체해 **git 추적 파일만** 센다. 사본이 몇 개가 있든 카운트가 baseline 53에 수렴한다.

**BASELINE은 올리지 않았다** (#4269 준수). 이 버그의 해법은 baseline을 실측에 맞추는 게 아니라 스캔 대상에서 worktree를 올바르게 제외하는 것이다. `git ls-files` 로 바꾸자 카운트가 자동으로 53이 됐다.

`"target" in rel.parts` 특수처리는 `git ls-files` 가 이미 무시하므로 삭제했다.

부수적으로 `ci-script-checks.sh` 의 grep 2곳에 `--exclude-dir=.claude` 를 추가했다 (비게이팅, 노이즈 제거).

## 검증

gitignored 경로에 `.rs` 사본을 심어 수정 전/후를 실증했다.

| | 카운트 | rc |
|---|---|---|
| 수정 전 (`rglob`) | 55 > baseline 53 | 1 (red), FAIL 목록에 `.claude/worktrees/...` 경로 노출 |
| 수정 후 (`git ls-files`) | 53 == baseline 53 | 0 (green) |

**뮤테이션 증명** — `git ls-files` 를 `rglob` 으로 되돌리면 신규 테스트가 자기 assert로 실패한다 (임포트/컴파일 에러 아님):
```
FAILED (failures=3)   # AssertionError ×3
Ran 7 tests
```
복원하면 `Ran 7 tests ... OK`.

**신규 테스트가 CI에서 실제로 실행된다** — 이 레포엔 `tests/*.sh` 스위트가 존재하는데 CI가 한 번도 실행하지 않던 전례(#4372)가 있어 확인했다:
- `scripts/ci-script-checks.sh:63` → `python -m unittest tests.test_await_holding_lock_ratchet`
- `.github/workflows/ci-pr.yml:742` / `ci-main.yml:254` → `run: ./scripts/ci-script-checks.sh`

Rust 0줄 변경 → module-inventory / change-surfaces 라인수 게이트 · DB migration 무관. #3016 핫파일 미접촉.

## 신규 테스트 (7건)

임시 git 레포 기반 — gitignored 사본 미집계 2건(뮤테이션 가드), 주석 스트립 회귀 1건, FAIL/NOTE/OK 분기 3건, 라이브 레포 baseline 일치 1건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)