### PR TITLE
docs(contract): relay-state-contract file:line 참조를 심볼 앵커로 전환 + PR 게이트 드리프트 체크 (#4268)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -43,6 +43,12 @@ jobs:
       pg_db: ${{ steps.filter.outputs.pg_db }}
       rust_or_policy: ${{ steps.filter.outputs.rust_or_policy }}
       rust_compile: ${{ steps.filter.outputs.rust_compile }}
+      # True when a relay-state-contract anchor file, the contract doc, or the
+      # sync gate itself changed. Used to run the compile-existence half
+      # (`check_fast`, which compiles the `relay_state_contract_refs` blocks) even
+      # on a `ci_relax_safe` branch — the doc<->code anchor binding must never be
+      # accepted on a relax branch without the compiler having verified it (#4268).
+      relay_contract: ${{ steps.filter.outputs.relay_contract }}
       # True when a Rust-compile change touches paths OUTSIDE the relay
       # stabilization surface, i.e. it actually needs cross-OS verification.
       # Relay-only PRs (src/services/discord/**, tests/e2e/**) leave this
@@ -142,6 +148,23 @@ jobs:
               # (src/services/routines/loader.rs); adding/removing/renaming
               # a routine script can break the asserted file list.
               - 'routines/**'
+            # relay_contract: the doc<->code binding surface for the #4268
+            # contract symbol-ref gate. When any of these change, the
+            # compile-existence half (check_fast, which compiles the
+            # `relay_state_contract_refs` blocks so a renamed/removed contract
+            # symbol fails to compile) MUST run regardless of `ci_relax_safe` —
+            # otherwise a relax branch (the one most likely to move relay code)
+            # could edit the anchors/doc and merge with the compiler proof off.
+            # Keep this list in sync with REFERENCE_SOURCE_MODULES in
+            # scripts/check_contract_symbol_refs.py.
+            relay_contract:
+              - 'docs/relay-state-contract.md'
+              - 'scripts/check_contract_symbol_refs.py'
+              - 'tests/test_contract_symbol_refs.py'
+              - 'src/services/discord/inflight/store.rs'
+              - 'src/services/discord/turn_bridge/terminal_delivery.rs'
+              - 'src/services/discord/tmux_watcher/liveness.rs'
+              - 'src/services/discord/router/message_handler/watchdog.rs'
             # rust_compile is a narrower subset of rust_or_policy: only paths
             # whose change can plausibly alter Rust binary output (and therefore
             # require cross-OS verification on macOS/Windows). Pure JS policy,
@@ -253,10 +276,17 @@ jobs:
   # Ubuntu Rust lane: canonical fast check. Gated on the broad rust_or_policy
   # filter so a `policies/*.js`, `scripts/*.sh`, `.github/workflows/**`, or
   # Node package change still gets a Rust check on Linux.
+  #
+  # The `relay_contract == 'true'` OR-clause forces this lane to run even on a
+  # `ci_relax_safe` branch when a #4268 contract anchor file, the contract doc,
+  # or the sync gate changed: this job compiles the `relay_state_contract_refs`
+  # blocks, which is the ONLY thing that proves each contract symbol still
+  # exists. A relax branch must not be able to edit those anchors and merge with
+  # the compiler proof skipped. Unrelated relax PRs keep the speedup.
   check_fast:
     name: Fast check + non-PG tests (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.rust_or_policy == 'true' && needs.changes.outputs.ci_relax_safe != 'true'
+    if: (needs.changes.outputs.rust_or_policy == 'true' && needs.changes.outputs.ci_relax_safe != 'true') || needs.changes.outputs.relay_contract == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -439,8 +469,22 @@ jobs:
           UPSTREAM_RESULT: ${{ needs.check_fast.result }}
         run: ./scripts/required-check-mirror.sh
 
+      # On a relax branch that touched the relay-contract binding surface,
+      # check_fast was forced to run (see its `if`). Its result MUST gate the
+      # merge here — otherwise the relax echo below would swallow a real
+      # compile-existence failure (#4268).
+      - name: Relay-contract fast check mirror (always, #4268)
+        if: ${{ needs.changes.outputs.ci_relax_safe == 'true' && needs.changes.outputs.relay_contract == 'true' }}
+        env:
+          CHANGED_PATHS_RESULT: ${{ needs.changes.result }}
+          FILTER_NAME: relay_contract
+          FILTER_OUTPUT: ${{ needs.changes.outputs.relay_contract }}
+          UPSTREAM_JOB_NAME: check_fast
+          UPSTREAM_RESULT: ${{ needs.check_fast.result }}
+        run: ./scripts/required-check-mirror.sh
+
       - name: Relaxed fast check mirror for TUI relay stabilization
-        if: ${{ needs.changes.outputs.ci_relax_safe == 'true' }}
+        if: ${{ needs.changes.outputs.ci_relax_safe == 'true' && needs.changes.outputs.relay_contract != 'true' }}
         run: echo "PR Rust CI temporarily relaxed for TUI relay stabilization; verify locally on macOS before merge."
 
   fast_targeted_tests_required_context:
@@ -758,6 +802,24 @@ jobs:
       # the monotonic blind-write ceiling in force for every branch, no skip gate.
       - name: Inflight blind-save ratchet (always, #4259)
         run: python3 scripts/check_inflight_blind_save_ratchet.py
+
+      # Contract symbol-ref doc<->code sync check (#4268) runs UNCONDITIONALLY,
+      # same as the ratchets above: it must NOT inherit the `ci_relax_safe` skip
+      # on "Run script checks". It verifies that docs/relay-state-contract.md's
+      # `sym:` anchors exactly match the references parsed from the
+      # `relay_state_contract_refs` blocks that `cargo check --all-targets`
+      # compiles to prove those symbols exist. The `tui-relay-stabilization`
+      # branch is the one most likely to move that relay code, i.e. exactly when
+      # a stale anchor is most dangerous, so this sync check stays in force for
+      # every branch. Its COMPILE-EXISTENCE counterpart (the `check_fast` job) is
+      # NOT unconditional on its own — it inherits the `ci_relax_safe` skip — so
+      # the `relay_contract` path filter force-runs `check_fast` whenever any
+      # anchor file / the contract doc / this gate changes, closing that gap on
+      # relax branches. Both halves are therefore in force together.
+      - name: Contract symbol-ref sync gate (always, #4268)
+        run: |
+          python3 scripts/check_contract_symbol_refs.py
+          python3 -m unittest tests.test_contract_symbol_refs
 
       - name: Upload maintainability audit artifact
         if: always()

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -497,7 +497,7 @@
 | `services::discord::inflight::save_store` | `src/services/discord/inflight/save_store.rs` | 966 | 236 | 730 |  |
 | `services::discord::inflight::save_store::identity_gate` | `src/services/discord/inflight/save_store/identity_gate.rs` | 1151 | 991 | 160 |  |
 | `services::discord::inflight::stall_recovery_tests::flake_isolation_4361` | `src/services/discord/inflight/stall_recovery_tests/flake_isolation_4361.rs` | 289 | 289 | 0 |  |
-| `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 350 | 350 | 0 |  |
+| `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 402 | 351 | 51 |  |
 | `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 365 | 365 | 0 |  |
 | `services::discord::inflight_heartbeat_sweeper` | `src/services/discord/inflight_heartbeat_sweeper.rs` | 299 | 264 | 35 |  |
 | `services::discord::internal_api` | `src/services/discord/internal_api.rs` | 723 | 723 | 0 |  |
@@ -629,7 +629,7 @@
 | `services::discord::router::message_handler::turn_lifecycle` | `src/services/discord/router/message_handler/turn_lifecycle.rs` | 183 | 183 | 0 |  |
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
 | `services::discord::router::message_handler::voice_announcement_scope` | `src/services/discord/router/message_handler/voice_announcement_scope.rs` | 125 | 73 | 52 |  |
-| `services::discord::router::message_handler::watchdog` | `src/services/discord/router/message_handler/watchdog.rs` | 1228 | 959 | 269 |  |
+| `services::discord::router::message_handler::watchdog` | `src/services/discord/router/message_handler/watchdog.rs` | 1255 | 960 | 295 |  |
 | `services::discord::router::response_format` | `src/services/discord/router/response_format.rs` | 430 | 351 | 79 |  |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 130 | 130 | 0 |  |
 | `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 522 | 522 | 0 |  |
@@ -699,7 +699,7 @@
 | `services::discord::tmux_watcher::controller_heartbeat` | `src/services/discord/tmux_watcher/controller_heartbeat.rs` | 34 | 34 | 0 |  |
 | `services::discord::tmux_watcher::entry` | `src/services/discord/tmux_watcher/entry.rs` | 33 | 33 | 0 |  |
 | `services::discord::tmux_watcher::jsonl_rotation` | `src/services/discord/tmux_watcher/jsonl_rotation.rs` | 78 | 78 | 0 |  |
-| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 666 | 515 | 151 |  |
+| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 694 | 516 | 178 |  |
 | `services::discord::tmux_watcher::loop_poll_prologue` | `src/services/discord/tmux_watcher/loop_poll_prologue.rs` | 609 | 609 | 0 |  |
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
@@ -782,7 +782,7 @@
 | `services::discord::turn_bridge::streaming_edit_text` | `src/services/discord/turn_bridge/streaming_edit_text.rs` | 619 | 219 | 400 |  |
 | `services::discord::turn_bridge::task_notification_lifecycle` | `src/services/discord/turn_bridge/task_notification_lifecycle.rs` | 221 | 104 | 117 |  |
 | `services::discord::turn_bridge::terminal_controller_cutover` | `src/services/discord/turn_bridge/terminal_controller_cutover.rs` | 1838 | 960 | 878 |  |
-| `services::discord::turn_bridge::terminal_delivery` | `src/services/discord/turn_bridge/terminal_delivery.rs` | 1979 | 737 | 1242 |  |
+| `services::discord::turn_bridge::terminal_delivery` | `src/services/discord/turn_bridge/terminal_delivery.rs` | 2002 | 738 | 1264 |  |
 | `services::discord::turn_bridge::terminal_outcome_delivery` | `src/services/discord/turn_bridge/terminal_outcome_delivery.rs` | 1669 | 1669 | 0 | giant-file |
 | `services::discord::turn_bridge::tmux_runtime` | `src/services/discord/turn_bridge/tmux_runtime.rs` | 1267 | 983 | 284 |  |
 | `services::discord::turn_bridge::tmux_runtime::interrupt_policy` | `src/services/discord/turn_bridge/tmux_runtime/interrupt_policy.rs` | 374 | 225 | 149 |  |

--- a/docs/relay-state-contract.md
+++ b/docs/relay-state-contract.md
@@ -17,17 +17,81 @@ If you change relay ownership, every invariant below must continue to hold.
 A regression here is a user-visible relay miss / duplicate, so keep the
 checks loud (debug_assert + observability record) instead of silent.
 
+### Reference format
+
+Code anchors below are **symbol-path references**, not `file:line` (which
+decomposition silently breaks — #4268). Each machine-checkable anchor is an
+inline `sym:` span, e.g. (this fenced example is illustrative and is NOT itself
+checked, so it cannot pad the anchor set):
+
+```
+sym:<module>::<path>::<Symbol>
+```
+
+Paths are written from `src/services/discord/`. The gate is enforced in two
+halves, each by the tool that can actually prove its half:
+
+- **Existence is proven by the compiler.** Every `sym:` anchor here has a
+  matching real reference in a `#[cfg(test)] mod relay_state_contract_refs`
+  block (in `inflight/store.rs`, `turn_bridge/terminal_delivery.rs`,
+  `tmux_watcher/liveness.rs`, and `router/message_handler/watchdog.rs` — split
+  by module visibility). A reference is a `use <path> as _;` (functions/items),
+  a `let _ = <Type>::<assoc_fn>;` (associated functions), or a
+  `let _ = |x: &<Type>| { let _ = &x.<field>; };` (fields — `use` cannot name a
+  field). Each fails to **compile** if its symbol is renamed, moved, or removed,
+  and `cargo check --workspace --all-targets` (a required CI gate) compiles those
+  blocks. So a rename trips CI regardless of raw strings, macros, or cfg — the
+  compiler is the source of truth for existence. The block's cfg gate and every
+  attribute inside it are checked against byte-exact whitelists (no cfg parser):
+  the gate must be `#[cfg(test)]` or `#[cfg(all(test, unix))]`, and the only
+  attribute allowed inside the block is `#[test]`. `unix` is allowed because the
+  only required PR Rust compile is `check_fast` (matrix `os: [ubuntu-latest]`,
+  where `cfg(unix)` is true), so that required job compiles the block; the
+  windows lane is advisory/non-required and skipped for relay-only changes, so a
+  windows/non-ubuntu gate would run in no required job. The `pause_epoch`
+  producer is `#[cfg(unix)]`, so its anchor block is `#[cfg(all(test, unix))]`.
+  Anything else fails loudly — a feature/non-test or non-ubuntu block gate, a
+  malformed cfg, or an item-level `#[cfg(feature = "never")]` on a reference that
+  would drop it from the compile while the block survives.
+- **Doc↔code agreement is proven by `scripts/check_contract_symbol_refs.py`**,
+  which does only a cheap exact set comparison: the distinct `sym:` anchors here
+  must equal the distinct anchors the checker **parses out of the reference
+  expressions themselves** (resolving `super::` / `crate::services::discord::` to
+  the paths above). It parses no Rust definitions and reads no comments, so there
+  is nothing for a text bypass to exploit. It runs in
+  `scripts/ci-script-checks.sh` and as an unconditional `ci-pr.yml` step (a
+  relax-safe branch must not skip a contract gate).
+
+When you move contract code, update the `sym:` anchor here **and** its
+compiler-checked reference together.
+
+**How the two halves stay on together in CI.** The set-comparison half is an
+unconditional `ci-pr.yml` step. The compile-existence half is the `check_fast`
+job, which by itself inherits the `ci_relax_safe` skip; so a `relay_contract`
+path filter (the four anchor files, this doc, and the gate script) force-runs
+`check_fast` whenever the doc↔code binding surface changes, even on a relax
+branch. Editing an anchor or this doc therefore always runs both halves.
+
+**There is no more "mislabeled comment" gap.** Earlier revisions carried a
+`// sym:` label next to each reference and the checker counted the label, so a
+comment could name a symbol the code did not actually reference (and a label
+could outlive a deleted reference). The anchor name is now derived from the
+reference the compiler checks, so no comment is trusted and none exists: comment
+out or `use super::*;`-replace a reference and its anchor disappears, tripping
+the set comparison.
+
 ---
 
 ## I1. `response_sent_offset` is bounded and monotonic
 
 - Definition: `InflightTurnState::response_sent_offset`
-  (`src/services/discord/inflight.rs:50`).
-- Producer: both `turn_bridge`
-  (`src/services/discord/turn_bridge/mod.rs:1505-1511`, terminal save sites)
-  and `watcher` mutate this through `save_inflight_state`.
+  (`sym:inflight::model::InflightTurnState::response_sent_offset`).
+- Producer: both `turn_bridge` and `watcher` mutate this through the durable
+  save writer `save_inflight_state`
+  (`sym:inflight::save_store::save_inflight_state`) at their terminal save
+  sites.
 - Validation: `validate_inflight_state_for_save`
-  (`src/services/discord/inflight.rs:318-368`).
+  (`sym:inflight::store::validate_inflight_state_for_save`).
 - Invariant keys:
   - `response_sent_offset_in_bounds` — must stay within `full_response.len()`
     and land on a UTF-8 char boundary.
@@ -39,10 +103,16 @@ checks loud (debug_assert + observability record) instead of silent.
 
 ## I2. `current_msg_id` rollover has a single source of truth
 
-- Definition: `InflightTurnState::current_msg_id`.
+- Definition: `InflightTurnState::current_msg_id`
+  (`sym:inflight::model::InflightTurnState::current_msg_id`).
 - Producer:
-  - `turn_bridge` rolls over at `src/services/discord/turn_bridge/mod.rs:1505-1511`.
-  - `watcher` rolls over at `src/services/discord/tmux.rs:4513-4526`.
+  - `turn_bridge` rolls the placeholder over in the `spawn_turn_bridge`
+    streaming task (`sym:turn_bridge::spawn_turn_bridge`); `spawn_turn_bridge`
+    itself resolves/pins the initial `current_msg_id`, and the streaming child
+    fns it drives write each subsequent rollover.
+  - `watcher` pins/rolls its `current_msg_id` in
+    `reacquire_watcher_inflight_for_active_stream`
+    (`sym:tmux_watcher::liveness::reacquire_watcher_inflight_for_active_stream`).
 - Invariant: when both owners observe the same `inflight` snapshot, they
   must agree on which `MessageId` is the active streaming placeholder.
   After a rollover one of the owners writes the new id back into
@@ -56,11 +126,11 @@ checks loud (debug_assert + observability record) instead of silent.
 ## I3. `last_watcher_relayed_offset` is idempotent across watcher replacement
 
 - Definition: `InflightTurnState::last_watcher_relayed_offset`
-  (`src/services/discord/inflight.rs:81`).
-- Consumer: watcher startup at
-  `src/services/discord/tmux.rs:3759-3766` initialises its in-memory
-  `last_relayed_offset` from this value so a replacement watcher does not
-  re-emit content the previous watcher already sent.
+  (`sym:inflight::model::InflightTurnState::last_watcher_relayed_offset`).
+- Consumer: watcher startup in `tmux_output_watcher_with_restore`
+  (`sym:tmux_watcher::tmux_output_watcher_with_restore`) initialises its
+  in-memory `last_relayed_offset` from this value so a replacement watcher does
+  not re-emit content the previous watcher already sent.
 - Invariant: a watcher that restarts at offset `O` must not relay any
   bytes whose start offset is `< O`. Equivalently, replaying the same
   output buffer twice must result in zero new Discord messages.
@@ -71,10 +141,16 @@ checks loud (debug_assert + observability record) instead of silent.
 ## I4. `confirmed-end` watermark has a single owner per turn end
 
 - Definition: `tmux_relay_confirmed_end` watermark, written by both:
-  - `turn_bridge::advance_tmux_relay_confirmed_end`
-    (`src/services/discord/turn_bridge/mod.rs:302-335`, called at
-    `1871-1876 / 1906-1911 / 2233-2238`),
-  - `watcher` self-confirm at `src/services/discord/tmux.rs:5618-5629`.
+  - `turn_bridge` via `advance_tmux_relay_confirmed_end`
+    (`sym:turn_bridge::terminal_delivery::advance_tmux_relay_confirmed_end`),
+    called from `deliver_short_replace_via_controller`
+    (`sym:turn_bridge::terminal_controller_cutover::deliver_short_replace_via_controller`),
+    `deliver_long_chunks_via_controller`
+    (`sym:turn_bridge::terminal_controller_cutover::deliver_long_chunks_via_controller`),
+    and the lease-commit path `BridgeDeliveryLease::commit_and_advance`
+    (`sym:turn_bridge::terminal_delivery::BridgeDeliveryLease::commit_and_advance`);
+  - `watcher` self-confirm via `advance_watcher_confirmed_end`
+    (`sym:tmux::advance_watcher_confirmed_end`).
 - Invariant: at the end of a single turn there is exactly one writer of
   the confirmed-end watermark for that turn. The `single-relay-owner`
   migration's first observable contract change is that this writer is
@@ -85,14 +161,35 @@ checks loud (debug_assert + observability record) instead of silent.
 
 ## I5. duplicate-suppression protocol (`turn_delivered` / `resume_offset` / `pause_epoch`)
 
-- Definition: shared atomic flags created in
-  `src/services/discord/mod.rs:457-472`.
-- Producer (current): `turn_bridge` writes
-  `turn_delivered` / `resume_offset` / `pause_epoch` at
-  `src/services/discord/turn_bridge/mod.rs:2261-2295`.
-- Consumer: `watcher` checks at
-  `src/services/discord/tmux.rs:3792-3808` (resume guard) and the late
-  guard at `4987-5023`.
+- Definition: shared atomic flags held on the `TmuxWatcherHandle`
+  (`sym:TmuxWatcherHandle::turn_delivered`, `sym:TmuxWatcherHandle::resume_offset`,
+  `sym:TmuxWatcherHandle::pause_epoch`).
+- Producers (per field — these three flags do **not** share one writer; the
+  earlier "single producer `run_terminal_outcome_delivery`" claim was wrong and
+  is corrected here per #4268 r3):
+  - `turn_delivered` is set true by two producers: the bridge in-band terminal
+    delivery path `run_terminal_outcome_delivery`
+    (`sym:turn_bridge::terminal_outcome_delivery::run_terminal_outcome_delivery`)
+    and the watcher terminal-commit epilogue `run_terminal_commit_epilogue`
+    (`sym:tmux_watcher::terminal_commit_epilogue::run_terminal_commit_epilogue`).
+    (It is additionally *cleared* to false on the handoff/reset and auto-heal
+    paths, and by the watcher after it consumes the flag; those resets are not
+    producers of the delivered signal.)
+  - `resume_offset` is written (as the "already delivered in-band up to here"
+    marker) by the completion postlude `run_completion_postlude`
+    (`sym:turn_bridge::completion_postlude::run_completion_postlude`) and the
+    runtime-handoff loop `handle_runtime_handoff_loop_message`
+    (`sym:turn_bridge::runtime_handoff_loop::handle_runtime_handoff_loop_message`).
+    These are the primary terminal/handoff producers; the busy-turn handoff,
+    finalize-epilogue, and auto-heal paths also seed it, and the watcher clears
+    it on consume.
+  - `pause_epoch` has exactly one production writer, and it is **not** in
+    `turn_bridge`: the watchdog increments it when it opens a pause window, in
+    `attach_paused_turn_watcher_inner`
+    (`sym:router::message_handler::watchdog::attach_paused_turn_watcher_inner`).
+- Consumer: `watcher` checks these in `poll_watcher_output_or_continue`
+  (`sym:tmux_watcher::loop_poll_prologue::poll_watcher_output_or_continue`),
+  which owns both the resume guard and the late guard.
 - Invariant: this is **not** lifecycle metadata — it is an active
   duplicate-suppression handshake. After a `pause` window closes the
   watcher must not relay any byte in `[resume_offset_seen,
@@ -113,24 +210,28 @@ plan.
 ## I6. `last_offset` watermark is owner-gated and monotonic per turn (#3017)
 
 - Definition: `InflightTurnState::last_offset`
-  (`src/services/discord/inflight.rs`).
+  (`sym:inflight::model::InflightTurnState::last_offset`).
 - Producers (the three writers #3017 unifies):
-  - `turn_bridge` in-memory `inflight_state.last_offset = …` then
-    `save_inflight_state` (`src/services/discord/turn_bridge/mod.rs`).
+  - `turn_bridge` sets in-memory `inflight_state.last_offset = …` then calls
+    the durable writer `save_inflight_state`
+    (`sym:inflight::save_store::save_inflight_state`).
   - `watcher` via the same `save_inflight_state` durable writer.
-  - standby JSONL relay via
+  - standby JSONL relay (from `standby_relay`) via
     `refresh_inflight_last_offset_if_matches_identity`
-    (`src/services/discord/standby_relay.rs` →
-    `refresh_inflight_last_offset_if_matches_identity_in_root`).
+    (`sym:inflight::clear_store::refresh_inflight_last_offset_if_matches_identity`
+    → `sym:inflight::clear_store::refresh_inflight_last_offset_if_matches_identity_in_root`).
 - Validation:
   - ENFORCING in the standby/refresh path
     (`refresh_inflight_last_offset_if_matches_identity_in_root`): the
     write is skipped (returns `false`, on-disk state unchanged) when
     (a) the caller is not the live relay owner
-    (`effective_relay_owner_kind()`), or
+    (`effective_relay_owner_kind()`,
+    `sym:inflight::model::InflightTurnState::effective_relay_owner_kind`), or
     (b) `last_offset` would move backwards for the SAME turn identity.
   - OBSERVE-ONLY on the bridge/watcher save path
-    (`validate_inflight_state_for_save`): a backward `last_offset` for
+    (`validate_inflight_state_for_save`,
+    `sym:inflight::store::validate_inflight_state_for_save`): a backward
+    `last_offset` for
     the same turn identity records the violation + `debug_assert` but
     does not drop the write, so a legit fresh-turn reset can still
     persist.

--- a/scripts/check_contract_symbol_refs.py
+++ b/scripts/check_contract_symbol_refs.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+
+"""Doc<->code sync gate for relay-state contract symbol anchors (#4268).
+
+Background: ``docs/relay-state-contract.md`` used ``file:line`` hard references
+that module decomposition silently broke. Symbol-path references fixed the line
+drift, but a *text* gate that judged whether a Rust symbol still exists kept
+losing to raw strings, macros, cfg-gated items, and trait/impl matching — every
+round found a new regex bypass. Judging Rust definitions with regex is the wrong
+tool.
+
+Round-3 review found the deeper hole: the previous version derived the Rust
+anchor SET from ``// sym:`` *comments*. A comment is not compiled, so you could
+comment out (or ``use super::*;``-replace) the real reference and keep the
+``// sym:`` label — the set comparison still passed and ``cargo check`` no longer
+proved anything. The label and the compiled reference were unbound.
+
+This gate closes that: it parses the anchor set **from the compiler-checked code
+itself**, never from comments. There are no ``// sym:`` labels anymore.
+
+* **Existence is proven by the compiler.** Each anchor is a real Rust reference
+  inside a ``#[cfg(test)] mod relay_state_contract_refs`` block:
+
+  - ``use <path> as _;`` for functions/items,
+  - ``let _ = <Type>::<assoc_fn>;`` for associated functions,
+  - ``let _ = |x: &<Type>| { let _ = &x.<field>; };`` for fields (``use`` cannot
+    name a field).
+
+  Each fails to COMPILE if its symbol is renamed/moved/removed.
+  ``cargo check --workspace --all-targets`` — an already-required CI gate —
+  compiles those blocks, so the compiler is the source of truth for existence.
+  Raw strings, macros, and cfg items cannot fool a real compile.
+
+* **The anchor NAME is parsed from that same code**, not a comment. The parser
+  reads the ``use`` path / field expression, resolves ``super::`` /
+  ``crate::services::discord::`` to the canonical doc path, and that resolved
+  path is the anchor. Comment out the reference and the anchor vanishes with it;
+  the set comparison then fails. There is no label left to lie.
+
+* **Block cfg and item attributes are byte-exact whitelists, not parsed.** The
+  block's gate must be one of ``_ALLOWED_ANCHOR_CFGS`` (``#[cfg(test)]`` or
+  ``#[cfg(all(test, unix))]``) and every attribute INSIDE the block must be
+  ``#[test]`` (``_ALLOWED_ITEM_ATTRS``). ``unix`` is allowed because the only
+  required PR Rust compile is ``check_fast`` (ubuntu-latest), where ``cfg(unix)``
+  is true, so that required job compiles the block. Anything else fails loudly —
+  a windows/non-ubuntu gate (compiled by no required job), a malformed cfg, or an
+  item-level ``#[cfg(feature = "never")]`` that would drop one reference while
+  the block survives. There is no cfg grammar/evaluator: this PR's history is
+  that every added cfg parser sprouted a new bypass within a round, so we removed
+  interpretation and enumerate the exact allowed spellings instead.
+
+* **All Rust-source matching runs on comment/string-stripped text** (r6).
+  ``_strip_comments_and_strings`` blanks ``//`` comments, nested ``/* */``
+  comments, and (raw) string literals with same-length whitespace before block
+  discovery, the attribute walk, and reference matching. So a comment cannot
+  break the attribute walk (rustc attaches attributes through comments/blank
+  lines — an illegal cfg hidden above a comment is still collected and fails), a
+  fake block inside a raw string/block comment cannot shadow the real one, and a
+  block-commented reference stops counting as an anchor (set mismatch, loud
+  FAIL).
+
+* **Doc<->code agreement is proven here** by a cheap, exact set comparison: the
+  distinct ``sym:`` anchors in the doc must equal the distinct anchors parsed
+  from the reference blocks. This script never parses Rust *definitions*, only
+  the reference expressions, so there is nothing for a raw string / macro / cfg
+  to bypass.
+
+The round-2 "mislabeled comment" limitation is GONE: the anchor is now the
+symbol the code actually references, so a wrong label is impossible — there is
+no label.
+
+Threat model (r7 — read before "hardening" this further): this gate defends
+against DRIFT and honest mistakes — decomposition moves, renames, accidental
+comment-outs, refactors that nest the anchor module under a cfg'd parent. It
+does NOT defend against a deliberate in-repo saboteur: anyone who can commit
+adversarial Rust (macro decoys, lexer traps) can just as easily edit this
+checker, the whitelists, or the doc itself, so an in-repo gate cannot beat an
+in-repo attacker even in principle. Do not grow this checker to chase such
+constructs; see PR #4388's seven review rounds for why every added parser layer
+became new attack surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DISCORD_ROOT = REPO_ROOT / "src" / "services" / "discord"
+
+DEFAULT_DOC = REPO_ROOT / "docs" / "relay-state-contract.md"
+
+# Rust files hosting a `#[cfg(test)] mod relay_state_contract_refs` block, mapped
+# to the module path (from `src/services/discord/`) of the FILE that hosts the
+# block — i.e. the parent module of `relay_state_contract_refs`. `super::` inside
+# the block resolves to this path; each extra `super::` drops one trailing
+# component. Blocks are split by visibility island: many contract symbols are
+# `pub(super)`/private and are only nameable from within their own module
+# subtree, so the references are co-located there rather than in one central
+# module.
+REFERENCE_SOURCE_MODULES: dict[str, tuple[str, ...]] = {
+    "inflight/store.rs": ("inflight", "store"),
+    "turn_bridge/terminal_delivery.rs": ("turn_bridge", "terminal_delivery"),
+    "tmux_watcher/liveness.rs": ("tmux_watcher", "liveness"),
+    "router/message_handler/watchdog.rs": ("router", "message_handler", "watchdog"),
+}
+
+DEFAULT_REFERENCE_SOURCES: tuple[Path, ...] = tuple(
+    DISCORD_ROOT / rel for rel in REFERENCE_SOURCE_MODULES
+)
+
+# Absolute-path prefix that names items from the discord crate root. Stripped so
+# `crate::services::discord::tmux::advance_watcher_confirmed_end` yields the doc
+# anchor `tmux::advance_watcher_confirmed_end`.
+CRATE_PREFIX: tuple[str, ...] = ("crate", "services", "discord")
+
+# Distinct-anchor floor (defense in depth). Set comparison already fails if the
+# doc and code diverge, but a synchronized gutting of BOTH to a couple of anchors
+# would compare "equal" while covering nothing — the floor rejects that. Never
+# lower this (#4269).
+MIN_CONTRACT_ANCHORS = 20
+
+ANCHOR_MOD_NAME = "relay_state_contract_refs"
+
+# Doc anchors: inline `sym:PATH` code spans. The `<`-free character class means a
+# placeholder like `sym:<module>::<Symbol>` in prose is never captured.
+DOC_ANCHOR_RE = re.compile(r"`sym:([A-Za-z0-9_:]+)`")
+
+# --- Rust reference-expression forms (parsed from CODE, never from comments) ---
+# A `//`-prefixed line can never match any of these (they all require `use`/`let`
+# as the first token), so comments are structurally incapable of being anchors.
+#
+# `use <path> as _;` — functions/items.
+_USE_RE = re.compile(r"^\s*use\s+([A-Za-z0-9_:]+)\s+as\s+_\s*;", re.MULTILINE)
+# `let _ = |x: &<Type>| { let _ = &x.<field>; };` — fields (rustfmt may wrap it
+# across lines, hence DOTALL). Compiler-enforces field existence.
+_FIELD_RE = re.compile(
+    r"let\s+_\s*=\s*\|\s*\w+\s*:\s*&\s*([A-Za-z0-9_:]+)\s*\|\s*\{"
+    r"\s*let\s+_\s*=\s*&\s*\w+\.([A-Za-z0-9_]+)\s*;\s*\}",
+    re.DOTALL,
+)
+# `let _ = <Type>::<assoc_fn>;` — associated functions (`use` cannot name them).
+# Must run AFTER the field regex has been stripped so it never swallows a closure.
+_ASSOC_RE = re.compile(r"^\s*let\s+_\s*=\s*([A-Za-z0-9_:]+)\s*;", re.MULTILINE)
+
+# Up to 3 leading spaces still opens a fenced block (CommonMark); 4 would be an
+# indented code block instead, handled separately below.
+_FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+
+_MOD_RE = re.compile(rf"^(\s*)mod\s+{ANCHOR_MOD_NAME}\b")
+
+# Char literal for the stripper (r7): quote + (escape sequence incl. \u{…}/\xNN
+# or one non-quote/non-backslash char) + quote. Anything else after `'` is a
+# lifetime and is NOT consumed.
+_CHAR_LIT_RE = re.compile(r"'(?:\\(?:u\{[0-9a-fA-F_]{1,6}\}|x[0-9a-fA-F]{2}|.)|[^'\\\n])'")
+_ATTR_RE = re.compile(r"^\s*#\!?\[(.*)\]\s*$")
+# Detects an attribute line by its START (`#[` / `#![`), so it catches an item
+# attribute whether on its own line or inline before an item.
+_ATTR_START_RE = re.compile(r"^\s*#!?\[")
+
+# The ONLY cfg forms an anchor block's gate may take, matched BYTE-EXACT after
+# strip() — no grammar, no parser. A converged lesson of this PR (#4268) is that
+# every added cfg parser sprouts a new bypass within a round (regex, then
+# recursive-descent, then an evaluator), while removing interpretation holds.
+# `unix` is allowed because the only REQUIRED PR Rust compile is `check_fast`
+# (ci-pr.yml matrix `os: [ubuntu-latest]`), where `cfg(unix)` is true, so that
+# required job compiles the block and a vanished symbol fails it. A windows-only
+# or non-ubuntu gate would compile in NO required job (the windows lane is
+# advisory and skipped for relay-only changes), silently disabling the proof. If
+# a required windows test lane is ever added, extend this set in the same commit
+# that wires it. `all(test, target_os = "linux")` and friends are deliberately
+# NOT here: one canonical spelling per gate keeps the policy readable.
+_ALLOWED_ANCHOR_CFGS = frozenset(
+    {
+        "#[cfg(test)]",
+        "#[cfg(all(test, unix))]",
+    }
+)
+
+# Inside a block, the ONLY attribute an item may carry is `#[test]` (the
+# `contract_symbols_exist` wrapper). An item-level cfg — e.g.
+# `#[cfg(feature = "never")]` on a `use super::X as _;` — keeps the block alive
+# (so a block-cfg check passes) while dropping that ONE reference from the
+# required compile, so a vanished symbol raises no E0432. Whitelisting item
+# attributes to `#[test]` seals that hole (#4268 r5).
+_ALLOWED_ITEM_ATTRS = frozenset({"#[test]"})
+
+
+@dataclass(frozen=True)
+class ContractRefReport:
+    doc_anchors: frozenset[str]
+    rust_anchors: frozenset[str]
+    errors: tuple[str, ...]
+    min_anchors: int
+
+    @property
+    def missing_in_code(self) -> frozenset[str]:
+        """Doc anchors with no compiler-checked reference."""
+        return frozenset(self.doc_anchors - self.rust_anchors)
+
+    @property
+    def missing_in_doc(self) -> frozenset[str]:
+        """Compiler-checked references not documented as `sym:` anchors."""
+        return frozenset(self.rust_anchors - self.doc_anchors)
+
+    @property
+    def distinct_count(self) -> int:
+        return min(len(self.doc_anchors), len(self.rust_anchors))
+
+    @property
+    def below_floor(self) -> bool:
+        return self.distinct_count < self.min_anchors
+
+    def is_clean(self) -> bool:
+        return not (
+            self.errors
+            or self.missing_in_code
+            or self.missing_in_doc
+            or self.below_floor
+        )
+
+
+def extract_doc_anchors(text: str) -> set[str]:
+    """Distinct `sym:` anchors from doc prose, excluding ALL code blocks.
+
+    Both fenced (``` / ~~~) and indented (4-space / tab, CommonMark-opened after
+    a blank line) code blocks are skipped, so an example anchor placed in either
+    kind of block cannot inflate the anchor set.
+    """
+
+    anchors: set[str] = set()
+    in_fence = False
+    in_indent_code = False
+    prev_blank = True  # start of document behaves like "after a blank line"
+    for line in text.splitlines():
+        is_blank = line.strip() == ""
+
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            prev_blank = False
+            continue
+        if in_fence:
+            prev_blank = is_blank
+            continue
+
+        indented = line.startswith("    ") or line.startswith("\t")
+        if in_indent_code:
+            if is_blank or indented:
+                prev_blank = is_blank
+                continue
+            in_indent_code = False
+        if not is_blank and indented and prev_blank:
+            in_indent_code = True
+            prev_blank = False
+            continue
+
+        prev_blank = is_blank
+        if is_blank:
+            continue
+        for match in DOC_ANCHOR_RE.finditer(line):
+            anchors.add(match.group(1))
+    return anchors
+
+
+def _resolve_symbol(path: str, module_base: tuple[str, ...]) -> str:
+    """Resolve a Rust reference path to its canonical doc-anchor path.
+
+    `super::X`  (from a `relay_state_contract_refs` block whose parent module is
+    `module_base`) -> `<module_base>::X`; every extra leading `super::` drops one
+    trailing component of `module_base`. `crate::services::discord::X` -> `X`.
+    """
+
+    segs = path.split("::")
+    if segs[0] == "crate":
+        if tuple(segs[: len(CRATE_PREFIX)]) != CRATE_PREFIX:
+            raise ValueError(
+                f"anchor path {path!r} is crate-absolute but not under "
+                f"{'::'.join(CRATE_PREFIX)}"
+            )
+        return "::".join(segs[len(CRATE_PREFIX) :])
+    if segs[0] == "super":
+        supers = 0
+        while supers < len(segs) and segs[supers] == "super":
+            supers += 1
+        keep = len(module_base) - (supers - 1)
+        if keep < 0:
+            raise ValueError(
+                f"anchor path {path!r} has more super:: hops than the host "
+                f"module {'::'.join(module_base)} has components"
+            )
+        return "::".join(list(module_base[:keep]) + segs[supers:])
+    # A bare path (no super/crate prefix) is assumed already canonical.
+    return path
+
+
+def _strip_comments_and_strings(text: str) -> str:
+    """Lexer preprocessing (#4268 r6): blank out comments and string literals so
+    every downstream match runs on code the compiler actually sees.
+
+    Replaces `// …` line comments, `/* … */` block comments (NESTED — Rust block
+    comments nest, so a depth counter, not a find), `"…"` strings (with `\\`
+    escape handling), and raw strings `r"…"` / `r#"…"#` (any hash count — the
+    closer is `"` plus exactly the opening hash run) with same-length whitespace,
+    preserving newlines so line structure survives. Char literals (`'a'`, `'"'`,
+    `'\\''`, `'\\u{1F600}'`) are blanked too — a quote char left unlexed desyncs
+    the string state and can hide a following attribute line (#4268 r7). A lone
+    `'` that does not complete a char literal is a lifetime and stays as code.
+
+    Without this pass the checker matched raw text: a comment line broke the
+    attribute walk (hiding an illegal cfg above it), a fake block inside a raw
+    string/block comment could shadow the real one, and a block-commented `use`
+    still counted as an anchor.
+    """
+
+    out = list(text)
+    n = len(text)
+
+    def blank(a: int, b: int) -> None:
+        for k in range(a, min(b, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    i = 0
+    while i < n:
+        # Literal prefix (r8): a `b`/`c` at token start before a char/string/raw
+        # opener is part of the token (`b'x'`, `b"…"`, `br#"…"#`, `c"…"`,
+        # `cr"…"`). Fold it into the blanked span — r7 lexed only the bare
+        # `'x'`/`"…"`, leaving a stray prefix letter that downstream regexes
+        # collected as a phantom anchor symbol.
+        pfx = 0
+        if (
+            text[i] in ("b", "c")
+            and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == "_"))
+            and i + 1 < n
+            and (
+                text[i + 1] in ("'", '"')
+                or (text[i + 1] == "r" and i + 2 < n and text[i + 2] in ('"', "#"))
+            )
+        ):
+            pfx = 1
+        p = i + pfx
+        ch = text[p]
+        nxt = text[p + 1] if p + 1 < n else ""
+        if ch == "/" and nxt == "/":
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            blank(i, j)
+            i = j
+        elif ch == "/" and nxt == "*":
+            depth = 1
+            j = i + 2
+            while j < n and depth:
+                if text.startswith("/*", j):
+                    depth += 1
+                    j += 2
+                elif text.startswith("*/", j):
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            blank(i, j)  # unterminated comment blanks to EOF (fail-closed)
+            i = j
+        elif ch == "r" and nxt in ('"', "#"):
+            j = p + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                closer = '"' + "#" * hashes
+                k = text.find(closer, j + 1)
+                k = n if k == -1 else k + len(closer)
+                blank(i, k)
+                i = k
+            else:
+                i += 1  # raw identifier like r#fn — not a string, leave it
+        elif ch == '"':
+            j = p + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                elif text[j] == '"':
+                    j += 1
+                    break
+                else:
+                    j += 1
+            blank(i, j)
+            i = j
+        elif ch == "'":
+            # Char literal (standard Rust lexing): `'` + (escape or one non-`'`
+            # char) + `'` — blank it so a quote inside (`'"'`) cannot desync the
+            # string state (r7). No match => lifetime (`'a`), leave as code.
+            m = _CHAR_LIT_RE.match(text, p)
+            if m:
+                blank(i, m.end())
+                i = m.end()
+            else:
+                i += 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _find_anchor_block(text: str, rel: str) -> tuple[str | None, list[str]]:
+    """Return (block_body, errors) for the single `relay_state_contract_refs`
+    module in `text`, verifying its cfg gate is one of ``_ALLOWED_ANCHOR_CFGS``
+    (byte-exact) and that no item inside carries a disallowed attribute.
+    `text` must already be comment/string-stripped (see
+    ``_strip_comments_and_strings``); ``extract_rust_anchors`` does this."""
+
+    lines = text.splitlines()
+    errors: list[str] = []
+    # Uniqueness (r7): exactly ONE declaration per host file. Two or more means a
+    # decoy exists (e.g. an unexpanded macro_rules! transcriber) and first-match
+    # adoption could validate the wrong one; zero means the host lost its block.
+    mod_matches = [
+        (idx, m) for idx, line in enumerate(lines) if (m := _MOD_RE.match(line))
+    ]
+    if not mod_matches:
+        errors.append(f"{rel}: no `mod {ANCHOR_MOD_NAME}` block found")
+        return None, errors
+    if len(mod_matches) > 1:
+        errors.append(
+            f"{rel}: `mod {ANCHOR_MOD_NAME}` appears {len(mod_matches)} times "
+            f"(lines {[idx + 1 for idx, _ in mod_matches]}); it must appear "
+            f"exactly once per host file — a duplicate is a decoy the checker "
+            f"could validate instead of the real block (#4268 r7)"
+        )
+        return None, errors
+    mod_line_idx, mod_match = mod_matches[0]
+    # Top-level (r7): an indented declaration is nested inside another item and
+    # can inherit an ancestor cfg (e.g. `#[cfg(feature = "never")] mod parent`)
+    # that silently disables the compiler proof.
+    if mod_match.group(1) != "":
+        errors.append(
+            f"{rel}: `mod {ANCHOR_MOD_NAME}` is indented (nested) — the anchor "
+            f"module must be declared at file top level; nesting can inherit an "
+            f"ancestor cfg that silently disables the compiler proof (#4268 r7)"
+        )
+        return None, errors
+
+    # The contiguous attribute line(s) directly above `mod` must be exactly one
+    # whitelisted cfg gate — byte-exact, no parsing. Rust attaches attributes
+    # through blank lines and comments, and comments are already blanked by the
+    # stripper, so skipping whitespace-only lines here walks exactly the lines
+    # rustc walks: a `#[cfg(feature = "never")]` hidden above a comment (or a
+    # `#[cfg_attr(…)]` above a blank line) IS collected and fails the whitelist.
+    attrs_above: list[str] = []
+    j = mod_line_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if _ATTR_RE.match(lines[j]):
+            attrs_above.append(stripped)
+            j -= 1
+            continue
+        break
+    if len(attrs_above) != 1 or attrs_above[0] not in _ALLOWED_ANCHOR_CFGS:
+        errors.append(
+            f"{rel}: `mod {ANCHOR_MOD_NAME}` must be gated by exactly one of "
+            f"{sorted(_ALLOWED_ANCHOR_CFGS)} (byte-exact after strip), found "
+            f"{attrs_above} — any other cfg (feature/non-test, malformed, or a "
+            f"platform gate false on the required ubuntu compile) can drop the "
+            f"block from every required CI job and silently disable the proof"
+        )
+
+    # Brace-match the module body. Comments and strings are already blanked by
+    # the stripper, so every brace counted here is a real code brace.
+    depth = 0
+    started = False
+    body: list[str] = []
+    for line in lines[mod_line_idx:]:
+        opens = line.count("{")
+        closes = line.count("}")
+        if started:
+            body.append(line)
+        depth += opens - closes
+        if opens and not started:
+            started = True
+        if started and depth <= 0:
+            break
+    if not started or depth > 0:
+        errors.append(f"{rel}: could not brace-match `mod {ANCHOR_MOD_NAME}` body")
+        return None, errors
+    # Drop the trailing closing-brace line captured by the loop.
+    content = body[:-1] if body else []
+
+    # Item-level attribute whitelist. Only `#[test]` may appear inside the block;
+    # an item-level cfg (e.g. `#[cfg(feature = "never")]` on a `use`) would keep
+    # the block alive but silently drop that reference from the required compile,
+    # so a vanished symbol raises no E0432. Match by attribute START so an inline
+    # `#[cfg(...)] use ...;` is caught too.
+    for content_line in content:
+        if _ATTR_START_RE.match(content_line) and content_line.strip() not in _ALLOWED_ITEM_ATTRS:
+            errors.append(
+                f"{rel}: disallowed attribute {content_line.strip()!r} inside "
+                f"`mod {ANCHOR_MOD_NAME}` — only {sorted(_ALLOWED_ITEM_ATTRS)} is "
+                f"permitted. An item-level cfg can silently drop a reference from "
+                f"the required compile while the block still exists (#4268 r5)."
+            )
+
+    return "\n".join(content), errors
+
+
+def extract_rust_anchors(text: str, module_base: tuple[str, ...], rel: str = "") -> tuple[set[str], list[str]]:
+    """Parse the anchor set from the compiler-checked reference block in `text`.
+
+    The text is first comment/string-stripped (r6), so block discovery, the
+    attribute walk, and reference matching all see only the code the compiler
+    sees: a fake block in a raw string vanishes, a comment cannot hide an
+    attribute, and a commented-out reference stops counting. Anchors come from
+    `use`/field/assoc-fn expressions only. Returns (anchors, errors).
+    """
+
+    anchors: set[str] = set()
+    errors: list[str] = []
+    text = _strip_comments_and_strings(text)
+    body, block_errors = _find_anchor_block(text, rel)
+    errors.extend(block_errors)
+    if body is None:
+        return anchors, errors
+
+    def resolve(path: str, kind: str) -> None:
+        try:
+            anchors.add(_resolve_symbol(path, module_base))
+        except ValueError as exc:
+            errors.append(f"{rel}: {kind} {exc}")
+
+    # Fields first, then strip them so the assoc-fn regex cannot swallow a
+    # closure that happens to start `let _ =`.
+    residual = body
+    for match in _FIELD_RE.finditer(body):
+        type_path, field = match.group(1), match.group(2)
+        resolve(f"{type_path}::{field}", "field")
+    residual = _FIELD_RE.sub("", body)
+    for match in _USE_RE.finditer(residual):
+        resolve(match.group(1), "use")
+    for match in _ASSOC_RE.finditer(residual):
+        resolve(match.group(1), "assoc-fn")
+    return anchors, errors
+
+
+def build_report(
+    *,
+    doc_anchors: set[str] | None = None,
+    rust_anchors: set[str] | None = None,
+    doc: Path = DEFAULT_DOC,
+    rust_sources: dict[Path, tuple[str, ...]] | None = None,
+    min_anchors: int = MIN_CONTRACT_ANCHORS,
+) -> ContractRefReport:
+    errors: list[str] = []
+
+    if doc_anchors is None:
+        if doc.is_file():
+            doc_anchors = extract_doc_anchors(doc.read_text(encoding="utf-8"))
+        else:
+            doc_anchors = set()
+            errors.append(f"contract doc is missing: {_rel(doc)}")
+
+    if rust_anchors is None:
+        if rust_sources is None:
+            rust_sources = {
+                DISCORD_ROOT / rel: base
+                for rel, base in REFERENCE_SOURCE_MODULES.items()
+            }
+        rust_anchors = set()
+        for source, module_base in rust_sources.items():
+            if source.is_file():
+                found, src_errors = extract_rust_anchors(
+                    source.read_text(encoding="utf-8"), module_base, _rel(source)
+                )
+                rust_anchors |= found
+                errors.extend(src_errors)
+            else:
+                errors.append(f"reference source is missing: {_rel(source)}")
+
+    return ContractRefReport(
+        doc_anchors=frozenset(doc_anchors),
+        rust_anchors=frozenset(rust_anchors),
+        errors=tuple(errors),
+        min_anchors=min_anchors,
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def format_report(report: ContractRefReport) -> str:
+    if report.is_clean():
+        return (
+            f"contract symbol-ref check passed "
+            f"({len(report.doc_anchors)} anchors, doc<->code in sync)"
+        )
+
+    lines = ["Contract symbol-ref drift detected:"]
+    for error in report.errors:
+        lines.append(f"  - {error}")
+    for anchor in sorted(report.missing_in_code):
+        lines.append(
+            f"  - `sym:{anchor}` is documented but has no compiler-checked "
+            f"reference in a `{ANCHOR_MOD_NAME}` block"
+        )
+    for anchor in sorted(report.missing_in_doc):
+        lines.append(
+            f"  - `{anchor}` is referenced in code but not documented as a "
+            f"`sym:` anchor in the contract"
+        )
+    if report.below_floor:
+        lines.append(
+            f"  - only {report.distinct_count} distinct anchors "
+            f"(floor is {report.min_anchors}); contract anchors look gutted"
+        )
+    lines.append("")
+    lines.append(
+        "Fix: keep the `sym:` anchors in docs/relay-state-contract.md and the "
+        f"compiler-checked references in the `{ANCHOR_MOD_NAME}` blocks in exact "
+        "1:1 correspondence. The reference blocks are what `cargo check "
+        "--all-targets` compiles to prove each symbol still exists; the anchor "
+        "name is parsed from the reference expression, not from any comment."
+    )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Contract symbol-ref sync gate (#4268).")
+    parser.add_argument("--doc", type=Path, default=DEFAULT_DOC, help="Contract doc path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    report = build_report(doc=args.doc)
+    print(format_report(report))
+    return 0 if report.is_clean() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -163,6 +163,20 @@ echo "=== API docs coverage gate (#3719) ==="
 "$PYTHON" scripts/check_api_docs_coverage.py
 "$PYTHON" -m unittest tests.test_api_docs_coverage
 
+echo "=== Contract symbol-ref doc<->code sync gate (#4268) ==="
+# docs/relay-state-contract.md anchors code with `sym:` symbol paths. This check
+# verifies the doc's `sym:` anchors exactly match the references PARSED FROM THE
+# CODE in the relay_state_contract_refs blocks (use / field / assoc-fn forms,
+# never comments) — it does NOT judge whether a symbol exists. Symbol EXISTENCE
+# is proven by the compiler: those reference blocks fail
+# `cargo check --workspace --all-targets` (a required gate) if a symbol is
+# renamed/moved/removed. Splitting it this way is what killed the regex-bypass
+# game (raw strings / macros / cfg can't fool a real compile), and deriving the
+# anchor set from the compiled code (not `// sym:` comments) is what killed the
+# r3 comment-decoupling bypass.
+"$PYTHON" scripts/check_contract_symbol_refs.py
+"$PYTHON" -m unittest tests.test_contract_symbol_refs
+
 echo "=== Agent maintenance freshness gate (warn, #1432; LoC hard-gate, #3036) ==="
 # --warning-only keeps the #1432 freshness/touch rollout non-fatal, while
 # --line-count-gate hard-fails on change-surfaces.md production-LoC drift, ghost

--- a/src/services/discord/inflight/store.rs
+++ b/src/services/discord/inflight/store.rs
@@ -348,3 +348,55 @@ pub(super) fn persist_under_lock_preserving_updated_at(
 ) -> Result<(), String> {
     persist_under_lock_inner(root, path, state, caller, false)
 }
+
+#[cfg(test)]
+mod relay_state_contract_refs {
+    //! #4268 — relay-state contract symbol anchors for the `inflight`
+    //! state/store (compiler-checked existence).
+    //!
+    //! Every statement below is a real reference that fails to COMPILE if its
+    //! symbol is renamed, moved, or removed, so `cargo check --workspace
+    //! --all-targets` (a required CI gate) is the source of truth for whether
+    //! each contract symbol still exists.
+    //! `scripts/check_contract_symbol_refs.py` parses the anchor SET from these
+    //! reference expressions — never from comments — and checks it equals the
+    //! `sym:` anchors in `docs/relay-state-contract.md`.
+    //!
+    //! There are deliberately no `// sym:` labels: the anchor name is derived
+    //! from the reference the compiler checks (`use` path / field expression), so
+    //! commenting out or `use super::*;`-replacing a reference removes its anchor
+    //! and the set comparison fails — no comment can name a symbol the code does
+    //! not actually reference. The block cfg gate and the attributes inside are
+    //! byte-exact whitelists in the checker (no cfg parser): the gate must be
+    //! `#[cfg(test)]` or `#[cfg(all(test, unix))]` (the latter for a `#[cfg(unix)]`
+    //! symbol — see the watchdog block), and the only attribute allowed inside is
+    //! `#[test]`. This blocks a feature/non-ubuntu block gate AND an item-level
+    //! cfg on a reference, either of which would drop a symbol from the required
+    //! compile and silently disable the proof.
+    //!
+    //! Hosted here (not in `inflight.rs`) because several referenced items are
+    //! `pub(super)` within the `inflight` subtree and are only nameable from
+    //! inside it, while `inflight.rs` is a frozen test-residue file whose ceiling
+    //! must not grow (#4269). This whole module is `#[cfg(test)]`, so it is test
+    //! LoC and adds no production surface.
+    #[test]
+    fn contract_symbols_exist() {
+        let _ = |s: &super::super::model::InflightTurnState| {
+            let _ = &s.response_sent_offset;
+        };
+        let _ = |s: &super::super::model::InflightTurnState| {
+            let _ = &s.current_msg_id;
+        };
+        let _ = |s: &super::super::model::InflightTurnState| {
+            let _ = &s.last_offset;
+        };
+        let _ = |s: &super::super::model::InflightTurnState| {
+            let _ = &s.last_watcher_relayed_offset;
+        };
+        let _ = super::super::model::InflightTurnState::effective_relay_owner_kind;
+        use super::super::clear_store::refresh_inflight_last_offset_if_matches_identity as _;
+        use super::super::clear_store::refresh_inflight_last_offset_if_matches_identity_in_root as _;
+        use super::super::save_store::save_inflight_state as _;
+        use super::validate_inflight_state_for_save as _;
+    }
+}

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -956,6 +956,33 @@ fn attach_paused_turn_watcher_inner(
     watcher_owner_channel_id
 }
 
+#[cfg(all(test, unix))]
+mod relay_state_contract_refs {
+    //! #4268 — relay-state contract symbol anchor for the `pause_epoch` producer
+    //! (compiler-checked existence). `attach_paused_turn_watcher_inner` is the
+    //! sole production writer of `TmuxWatcherHandle::pause_epoch` (invariant I5),
+    //! and it is a private fn nameable only from within `watchdog`, so its anchor
+    //! lives here rather than in the central blocks.
+    //!
+    //! Gated `all(test, unix)` (not plain `test`): `attach_paused_turn_watcher_inner`
+    //! is itself `#[cfg(unix)]`, so on windows test builds it is compiled out and
+    //! a plain `#[cfg(test)]` anchor referencing it fails to compile (E0432,
+    //! #4268 r3 / #4394). Matching its platform gate makes the anchor and the
+    //! symbol appear/disappear together. `unix` is true on the required ubuntu
+    //! `check_fast` compile, so that required job still compiles this block and
+    //! proves the symbol exists. `#[cfg(all(test, unix))]` is one of the two
+    //! byte-exact cfg spellings the checker whitelists (the other is
+    //! `#[cfg(test)]`); a windows-only gate is rejected because no required job
+    //! compiles it.
+    //!
+    //! See the header on `inflight::store::relay_state_contract_refs` for the
+    //! contract, the CI wiring, and why there are no `// sym:` labels.
+    #[test]
+    fn contract_symbols_exist() {
+        use super::attach_paused_turn_watcher_inner as _;
+    }
+}
+
 #[cfg(test)]
 mod timeout_notice_tests {
     use super::*;

--- a/src/services/discord/tmux_watcher/liveness.rs
+++ b/src/services/discord/tmux_watcher/liveness.rs
@@ -664,3 +664,31 @@ fn user_message_prompt_text(message: &serde_json::Value) -> Option<String> {
 fn non_empty_prompt_text(text: &str) -> Option<String> {
     (!text.trim().is_empty()).then(|| text.to_string())
 }
+
+#[cfg(test)]
+mod relay_state_contract_refs {
+    //! #4268 — relay-state contract symbol anchors for the watcher/`tmux` sites
+    //! (compiler-checked existence). These live here because several of the fns
+    //! are `pub(super)` to `tmux_watcher` and are only nameable from within that
+    //! subtree. See the header on `inflight::store::relay_state_contract_refs`
+    //! for the contract, the CI wiring, and why there are no `// sym:` labels.
+    #[test]
+    fn contract_symbols_exist() {
+        use super::super::loop_poll_prologue::poll_watcher_output_or_continue as _;
+        use super::super::tmux_output_watcher_with_restore as _;
+        use super::reacquire_watcher_inflight_for_active_stream as _;
+        use crate::services::discord::tmux::advance_watcher_confirmed_end as _;
+        // I5 turn_delivered producer: the watcher terminal-commit epilogue path.
+        use super::super::terminal_commit_epilogue::run_terminal_commit_epilogue as _;
+        // I5 duplicate-suppression handshake fields on TmuxWatcherHandle.
+        let _ = |h: &crate::services::discord::TmuxWatcherHandle| {
+            let _ = &h.turn_delivered;
+        };
+        let _ = |h: &crate::services::discord::TmuxWatcherHandle| {
+            let _ = &h.resume_offset;
+        };
+        let _ = |h: &crate::services::discord::TmuxWatcherHandle| {
+            let _ = &h.pause_epoch;
+        };
+    }
+}

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -1977,3 +1977,26 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod relay_state_contract_refs {
+    //! #4268 — relay-state contract symbol anchors for the `turn_bridge`
+    //! producer sites (compiler-checked existence). These live here rather than
+    //! in a single central module because the referenced fns are `pub(super)` to
+    //! `turn_bridge` and are only nameable from within the `turn_bridge` subtree.
+    //! See the header on `inflight::store::relay_state_contract_refs` for the
+    //! contract, the CI wiring, and why there are no `// sym:` labels.
+    #[test]
+    fn contract_symbols_exist() {
+        use super::super::spawn_turn_bridge as _;
+        use super::advance_tmux_relay_confirmed_end as _;
+        let _ = super::BridgeDeliveryLease::commit_and_advance;
+        use super::super::terminal_controller_cutover::deliver_long_chunks_via_controller as _;
+        use super::super::terminal_controller_cutover::deliver_short_replace_via_controller as _;
+        // I5 turn_delivered producer: the in-band terminal-outcome delivery path.
+        use super::super::terminal_outcome_delivery::run_terminal_outcome_delivery as _;
+        // I5 resume_offset producers: completion postlude + runtime-handoff loop.
+        use super::super::completion_postlude::run_completion_postlude as _;
+        use super::super::runtime_handoff_loop::handle_runtime_handoff_loop_message as _;
+    }
+}

--- a/tests/test_contract_symbol_refs.py
+++ b/tests/test_contract_symbol_refs.py
@@ -1,0 +1,575 @@
+"""Unit tests for scripts/check_contract_symbol_refs.py (#4268).
+
+The checker's job is ONLY the doc<->code set comparison; symbol EXISTENCE is
+proven by the compiler (`cargo check --all-targets` on the
+`relay_state_contract_refs` reference blocks). Round 3 moved the anchor SET from
+`// sym:` *comments* to the compiler-checked reference expressions themselves, so
+these tests target: doc-anchor extraction, the code-derived Rust-anchor parser
+(use / field / assoc-fn forms + `super::`/`crate::` resolution), the exact-cfg
+gate, the set comparison, and the distinct-anchor floor. Each round-2/round-3
+false-pass has a dedicated reproduction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_contract_symbol_refs.py"
+
+_SPEC = importlib.util.spec_from_file_location("check_contract_symbol_refs", SCRIPT_PATH)
+CHECKER = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = CHECKER
+_SPEC.loader.exec_module(CHECKER)
+
+INFLIGHT_BASE = ("inflight", "store")
+
+
+def _block(body: str, cfg: str = "#[cfg(test)]") -> str:
+    """Wrap reference statements in a `relay_state_contract_refs` module."""
+    return textwrap.dedent(
+        f"""
+        {cfg}
+        mod relay_state_contract_refs {{
+            #[test]
+            fn contract_symbols_exist() {{
+        {textwrap.indent(textwrap.dedent(body), " " * 8)}
+            }}
+        }}
+        """
+    )
+
+
+class ExtractDocAnchorsTest(unittest.TestCase):
+    def test_inline_anchors_extracted_distinct(self) -> None:
+        text = textwrap.dedent(
+            """
+            - Definition `sym:inflight::model::InflightTurnState::response_sent_offset`.
+            - Prose backtick ignored: `save_inflight_state`.
+            - Repeat `sym:inflight::model::InflightTurnState::response_sent_offset` again.
+            - Other `sym:turn_bridge::spawn_turn_bridge`.
+            """
+        )
+        self.assertEqual(
+            CHECKER.extract_doc_anchors(text),
+            {
+                "inflight::model::InflightTurnState::response_sent_offset",
+                "turn_bridge::spawn_turn_bridge",
+            },
+        )
+
+    def test_defect2_fenced_block_anchors_excluded(self) -> None:
+        text = textwrap.dedent(
+            """
+            Real `sym:a::b::Kept`.
+
+            ```
+            `sym:a::b::FencedExample`
+            ```
+
+            ~~~
+            `sym:a::b::TildeFenced`
+            ~~~
+            """
+        )
+        self.assertEqual(CHECKER.extract_doc_anchors(text), {"a::b::Kept"})
+
+    def test_defect2_indented_block_anchors_excluded(self) -> None:
+        text = (
+            "Real `sym:a::b::Kept`.\n"
+            "\n"
+            "    `sym:a::b::SpaceIndented`\n"
+            "\n"
+            "\t`sym:a::b::TabIndented`\n"
+        )
+        self.assertEqual(CHECKER.extract_doc_anchors(text), {"a::b::Kept"})
+
+    def test_list_continuation_anchors_are_not_treated_as_code(self) -> None:
+        text = (
+            "- Definition: `InflightTurnState::x`\n"
+            "    (`sym:inflight::model::InflightTurnState::x`).\n"
+        )
+        self.assertEqual(
+            CHECKER.extract_doc_anchors(text),
+            {"inflight::model::InflightTurnState::x"},
+        )
+
+    def test_angle_bracket_placeholder_ignored(self) -> None:
+        self.assertEqual(CHECKER.extract_doc_anchors("`sym:<module>::<Symbol>`"), set())
+
+
+class ResolveSymbolTest(unittest.TestCase):
+    def test_single_super_keeps_host_module(self) -> None:
+        self.assertEqual(
+            CHECKER._resolve_symbol("super::validate_inflight_state_for_save", INFLIGHT_BASE),
+            "inflight::store::validate_inflight_state_for_save",
+        )
+
+    def test_double_super_drops_one_component(self) -> None:
+        self.assertEqual(
+            CHECKER._resolve_symbol("super::super::save_store::save_inflight_state", INFLIGHT_BASE),
+            "inflight::save_store::save_inflight_state",
+        )
+
+    def test_crate_prefix_stripped(self) -> None:
+        self.assertEqual(
+            CHECKER._resolve_symbol(
+                "crate::services::discord::tmux::advance_watcher_confirmed_end", INFLIGHT_BASE
+            ),
+            "tmux::advance_watcher_confirmed_end",
+        )
+
+    def test_too_many_supers_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            CHECKER._resolve_symbol("super::super::super::super::x", INFLIGHT_BASE)
+
+
+class CfgGateTest(unittest.TestCase):
+    """Byte-exact block-cfg whitelist + item-attribute whitelist (r5). No parser:
+    the checker enumerates the exact allowed cfg spellings and the exact allowed
+    in-block attribute (`#[test]`)."""
+
+    _REF = "use super::validate_inflight_state_for_save as _;\n"
+
+    def _errors(self, *, cfg: str = "#[cfg(test)]", body: str | None = None):
+        _, errors = CHECKER.extract_rust_anchors(
+            _block(body if body is not None else self._REF, cfg=cfg), INFLIGHT_BASE, "store.rs"
+        )
+        return errors
+
+    def test_accepted_block_cfgs(self) -> None:
+        # The only two whitelisted gates. `unix` is allowed only because the
+        # required PR compile (check_fast) is ubuntu-latest.
+        for cfg in ("#[cfg(test)]", "#[cfg(all(test, unix))]"):
+            self.assertEqual(self._errors(cfg=cfg), [], cfg)
+
+    def test_rejected_block_cfgs(self) -> None:
+        for cfg in (
+            "#[cfg(all(test, windows))]",              # no required job compiles it
+            "#[cfg(all(test, not(unix)))]",            # false on required ubuntu
+            '#[cfg(all(test, target_os = "freebsd"))]',
+            '#[cfg(all(test, target_feature = "avx2"))]',
+            "#[cfg(all(test, target_os = linux))]",    # malformed (unquoted)
+            '#[cfg(all(test, target_os = "linux))]',   # malformed (unterminated)
+            '#[cfg(all(test, feature = "never"))]',    # feature can be off everywhere
+            "#[cfg(not(test))]",                       # production-only
+            "#[cfg(any(test, unix))]",                 # compiles without test
+            '#[cfg(all(test, target_os = "linux"))]',  # off-whitelist spelling (intended)
+            "#[cfg(unix)]",                            # no test
+        ):
+            self.assertTrue(self._errors(cfg=cfg), cfg)
+
+    def test_item_level_attribute_on_reference_is_rejected(self) -> None:
+        # The r5 hole: an item-level cfg keeps the block alive (block-cfg check
+        # passes) but drops that ONE reference from the required compile.
+        for attr in (
+            '#[cfg(feature = "never")]',
+            "#[cfg(unix)]",
+            "#[cfg(not(test))]",
+        ):
+            body = f"{attr}\nuse super::validate_inflight_state_for_save as _;\n"
+            errors = self._errors(cfg="#[cfg(test)]", body=body)
+            self.assertTrue(any("item-level cfg" in e for e in errors), (attr, errors))
+
+
+class StripperTest(unittest.TestCase):
+    def test_strips_preserve_length_and_newlines(self) -> None:
+        src = 'let a = 1; // note\nlet s = "x{y}\\"z";\n/* multi\nline */ let b = 2;\n'
+        out = CHECKER._strip_comments_and_strings(src)
+        self.assertEqual(len(out), len(src))
+        self.assertEqual(out.count("\n"), src.count("\n"))
+        self.assertNotIn("note", out)
+        self.assertNotIn("x{y}", out)
+        self.assertNotIn("multi", out)
+        self.assertIn("let a = 1;", out)
+        self.assertIn("let b = 2;", out)
+
+    def test_nested_block_comments(self) -> None:
+        src = "/* outer /* inner */ still comment */ let x = 1;"
+        out = CHECKER._strip_comments_and_strings(src)
+        self.assertNotIn("still comment", out)
+        self.assertIn("let x = 1;", out)
+
+    def test_raw_strings_with_hashes(self) -> None:
+        src = 'let s = r#"has "quote" and #[cfg(test)] mod fake {}"#; let y = 2;'
+        out = CHECKER._strip_comments_and_strings(src)
+        self.assertNotIn("mod fake", out)
+        self.assertNotIn("#[cfg(test)]", out)
+        self.assertIn("let y = 2;", out)
+
+    def test_raw_identifier_not_treated_as_string(self) -> None:
+        src = "use super::r#fn as _;"
+        self.assertEqual(CHECKER._strip_comments_and_strings(src), src)
+
+
+class R6CommentEvasionTest(unittest.TestCase):
+    """The three r6 holes: raw-text matching let comments/strings defeat the
+    attribute walk, block discovery, and reference counting."""
+
+    _GOOD_BODY = (
+        "    #[test]\n"
+        "    fn contract_symbols_exist() {\n"
+        "        use super::validate_inflight_state_for_save as _;\n"
+        "    }\n"
+    )
+
+    def _mod(self, attr_stack: str, cfg: str = "#[cfg(test)]") -> str:
+        return f"{attr_stack}{cfg}\nmod relay_state_contract_refs {{\n{self._GOOD_BODY}}}\n"
+
+    def test_r6_attr_hidden_above_line_comment_is_collected(self) -> None:
+        # rustc attaches BOTH attrs to the mod (comments are transparent); the
+        # checker must too, and fail the len==1 whitelist.
+        text = self._mod('#[cfg(feature = "never")]\n// innocuous comment\n')
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("must be gated" in e for e in errors), errors)
+
+    def test_r6_attr_hidden_above_block_comment_is_collected(self) -> None:
+        text = self._mod('#[cfg(feature = "never")]\n/* spacer */\n')
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("must be gated" in e for e in errors), errors)
+
+    def test_r6_cfg_attr_above_blank_line_is_collected(self) -> None:
+        text = self._mod('#[cfg_attr(test, cfg(feature = "never"))]\n\n')
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("must be gated" in e for e in errors), errors)
+
+    def test_r6_fake_block_in_raw_string_does_not_shadow_real_block(self) -> None:
+        fake = (
+            'const FAKE: &str = r#"\n'
+            "#[cfg(test)]\n"
+            "mod relay_state_contract_refs {\n"
+            "    #[test]\n"
+            "    fn contract_symbols_exist() {\n"
+            "        use super::validate_inflight_state_for_save as _;\n"
+            "    }\n"
+            "}\n"
+            '"#;\n'
+        )
+        text = fake + self._mod("", cfg="#[cfg(all(test, unix, windows))]")
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("must be gated" in e for e in errors), errors)
+
+    def test_r6_fake_block_in_block_comment_does_not_shadow_real_block(self) -> None:
+        fake = (
+            "/*\n"
+            "#[cfg(test)]\n"
+            "mod relay_state_contract_refs {\n"
+            "    fn contract_symbols_exist() {}\n"
+            "}\n"
+            "*/\n"
+        )
+        text = fake + self._mod("", cfg='#[cfg(all(test, feature = "never"))]')
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("must be gated" in e for e in errors), errors)
+
+    def test_r6_block_commented_use_is_not_an_anchor(self) -> None:
+        body = "/*\nuse super::validate_inflight_state_for_save as _;\n*/\n"
+        anchors, errors = CHECKER.extract_rust_anchors(
+            _block(body), INFLIGHT_BASE, "x.rs"
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(anchors, set())
+
+
+class R7StructuralSealTest(unittest.TestCase):
+    """r7 seals: char-literal lexing, block uniqueness, top-level declaration."""
+
+    _GOOD = (
+        "#[cfg(test)]\n"
+        "mod relay_state_contract_refs {\n"
+        "    #[test]\n"
+        "    fn contract_symbols_exist() {\n"
+        "        use super::validate_inflight_state_for_save as _;\n"
+        "    }\n"
+        "}\n"
+    )
+
+    def test_r7_char_literal_blanked_lifetime_kept(self) -> None:
+        src = "let q = '\"'; let e = '\\''; fn f<'a>(x: &'a str) {}"
+        out = CHECKER._strip_comments_and_strings(src)
+        self.assertNotIn("'\"'", out)
+        self.assertNotIn("'\\''", out)
+        self.assertIn("<'a>", out)
+        self.assertIn("&'a str", out)
+        self.assertEqual(len(out), len(src))
+
+    def test_r7_char_trap_cannot_hide_item_attr(self) -> None:
+        # codex R7-1: `'"'` desyncs a naive string state so the attr line lands
+        # "inside a string" and is blanked. With char literals lexed, the attr
+        # survives stripping and the item-attr whitelist rejects it.
+        body = (
+            "let _q = '\"';\n"
+            '#[cfg(feature = "never")] // "\n'
+            "use super::validate_inflight_state_for_save as _;\n"
+        )
+        _, errors = CHECKER.extract_rust_anchors(_block(body), INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("disallowed attribute" in e for e in errors), errors)
+
+    def test_r8_byte_and_c_literal_prefixes_fully_blanked(self) -> None:
+        # codex R8-1: r7 lexed only the bare `'x'` of `b'x'`, leaving a stray
+        # `b` that _ASSOC_RE collected as a phantom `b` anchor (false-positive
+        # rc=1 on an honest byte-literal edit). The prefix letter is part of
+        # the Rust token and must be blanked with the literal.
+        for src in (
+            "let _ = b'x';",
+            'let _ = b"hi";',
+            'let _ = br#"hi"#;',
+            'let _ = c"hi";',
+            'let _ = cr#"hi"#;',
+        ):
+            out = CHECKER._strip_comments_and_strings(src)
+            self.assertEqual(out, "let _ =" + " " * (len(src) - 8) + ";", src)
+        # Token-start guard: an identifier ending in `b` is not a prefix, and a
+        # lone `b` in expression position stays code.
+        for keep in ("blob_b = 1", "x < b && b < y", "fn r#fn() {}"):
+            self.assertEqual(CHECKER._strip_comments_and_strings(keep), keep)
+
+    def test_r8_byte_char_in_anchor_block_makes_no_phantom_anchor(self) -> None:
+        # End-to-end shape of codex R8-1: an honest `let _ = b'x';` line inside
+        # the anchor block must not add a `b` symbol to the extracted anchors.
+        body = (
+            "let _ = b'x';\n"
+            "use super::validate_inflight_state_for_save as _;\n"
+        )
+        anchors, errors = CHECKER.extract_rust_anchors(
+            _block(body), INFLIGHT_BASE, "x.rs"
+        )
+        base = "::".join(INFLIGHT_BASE)
+        self.assertEqual(errors, [], errors)
+        # Exact set: under the r7 lexer the stray prefix produced a bare `b`
+        # anchor here (and rc=1 in the full doc<->code comparison).
+        self.assertEqual(anchors, {f"{base}::validate_inflight_state_for_save"})
+
+    def test_r7_macro_decoy_duplicate_declaration_fails(self) -> None:
+        # codex R7-2: an unexpanded macro_rules! transcriber holds a decoy block;
+        # uniqueness (exactly one declaration per file) rejects it regardless of
+        # which one a first-match scan would have adopted.
+        decoy = (
+            "macro_rules! decoy {\n"
+            "    () => {\n"
+            "mod relay_state_contract_refs {\n"
+            "    fn contract_symbols_exist() {}\n"
+            "}\n"
+            "    };\n"
+            "}\n"
+        )
+        _, errors = CHECKER.extract_rust_anchors(decoy + self._GOOD, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("exactly once" in e for e in errors), errors)
+
+    def test_r7_nested_under_cfg_parent_fails_top_level(self) -> None:
+        # codex R7-3: a disabled ancestor (`#[cfg(feature = "never")] mod parent`)
+        # compiles the whole subtree out; the immediate cfg looked fine. Any
+        # nesting (indentation) is rejected.
+        text = (
+            '#[cfg(feature = "never")]\n'
+            "mod parent {\n"
+            "    #[cfg(test)]\n"
+            "    mod relay_state_contract_refs {\n"
+            "        #[test]\n"
+            "        fn contract_symbols_exist() {\n"
+            "            use super::super::validate_inflight_state_for_save as _;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("top level" in e for e in errors), errors)
+
+    def test_r7_plain_nesting_without_cfg_also_fails(self) -> None:
+        # The honest-mistake variant: a refactor tucks the anchor module inside
+        # another module with no cfg at all — still rejected (top-level rule).
+        text = (
+            "mod parent {\n"
+            "    #[cfg(test)]\n"
+            "    mod relay_state_contract_refs {\n"
+            "        #[test]\n"
+            "        fn contract_symbols_exist() {\n"
+            "            use super::super::validate_inflight_state_for_save as _;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        _, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("top level" in e for e in errors), errors)
+
+
+class ExtractRustAnchorsTest(unittest.TestCase):
+    def test_use_field_and_assoc_forms_parsed_from_code(self) -> None:
+        body = """
+        let _ = |s: &super::super::model::InflightTurnState| {
+            let _ = &s.response_sent_offset;
+        };
+        let _ = super::super::model::InflightTurnState::effective_relay_owner_kind;
+        use super::super::save_store::save_inflight_state as _;
+        use super::validate_inflight_state_for_save as _;
+        """
+        anchors, errors = CHECKER.extract_rust_anchors(_block(body), INFLIGHT_BASE, "store.rs")
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            anchors,
+            {
+                "inflight::model::InflightTurnState::response_sent_offset",
+                "inflight::model::InflightTurnState::effective_relay_owner_kind",
+                "inflight::save_store::save_inflight_state",
+                "inflight::store::validate_inflight_state_for_save",
+            },
+        )
+
+    def test_defect1_commented_out_reference_drops_its_anchor(self) -> None:
+        # r3 core defect: a `//`-commented reference must NOT be counted (the
+        # compiler no longer checks it). The anchor vanishes with the code.
+        body = """
+        use super::super::save_store::save_inflight_state as _;
+        // use super::validate_inflight_state_for_save as _;
+        """
+        anchors, errors = CHECKER.extract_rust_anchors(_block(body), INFLIGHT_BASE, "store.rs")
+        self.assertEqual(errors, [])
+        self.assertEqual(anchors, {"inflight::save_store::save_inflight_state"})
+
+    def test_defect1_glob_use_is_not_an_anchor(self) -> None:
+        # Replacing a real reference with `use super::*;` (which compiles) must
+        # drop the anchor so the set comparison fails.
+        body = "use super::*;\n"
+        anchors, errors = CHECKER.extract_rust_anchors(_block(body), INFLIGHT_BASE, "store.rs")
+        self.assertEqual(errors, [])
+        self.assertEqual(anchors, set())
+
+    def test_defect1_missing_cfg_is_rejected(self) -> None:
+        body = "use super::validate_inflight_state_for_save as _;\n"
+        # Build a block with no cfg attribute at all.
+        text = (
+            "mod relay_state_contract_refs {\n"
+            "    #[test]\n"
+            "    fn contract_symbols_exist() {\n"
+            f"        {body}"
+            "    }\n"
+            "}\n"
+        )
+        anchors, errors = CHECKER.extract_rust_anchors(text, INFLIGHT_BASE, "store.rs")
+        self.assertTrue(any("cfg(test)" in e for e in errors), errors)
+
+    def test_missing_block_is_an_error(self) -> None:
+        anchors, errors = CHECKER.extract_rust_anchors("fn unrelated() {}\n", INFLIGHT_BASE, "x.rs")
+        self.assertTrue(any("no `mod relay_state_contract_refs`" in e for e in errors), errors)
+
+
+class ReportTest(unittest.TestCase):
+    def _report(self, doc: set[str], code: set[str], min_anchors: int = 3):
+        return CHECKER.build_report(
+            doc_anchors=doc, rust_anchors=code, min_anchors=min_anchors
+        )
+
+    def test_clean_when_sets_equal_and_above_floor(self) -> None:
+        anchors = {"a::A", "b::B", "c::C"}
+        report = self._report(anchors, set(anchors))
+        self.assertTrue(report.is_clean(), CHECKER.format_report(report))
+
+    def test_doc_anchor_without_code_reference_is_flagged(self) -> None:
+        report = self._report({"a::A", "b::B", "c::C", "d::Extra"}, {"a::A", "b::B", "c::C"})
+        self.assertFalse(report.is_clean())
+        self.assertIn("d::Extra", report.missing_in_code)
+
+    def test_code_reference_without_doc_anchor_is_flagged(self) -> None:
+        report = self._report({"a::A", "b::B", "c::C"}, {"a::A", "b::B", "c::C", "z::Extra"})
+        self.assertFalse(report.is_clean())
+        self.assertIn("z::Extra", report.missing_in_doc)
+
+    def test_synchronized_gutting_below_floor_is_flagged(self) -> None:
+        report = self._report({"a::A", "b::B"}, {"a::A", "b::B"}, min_anchors=20)
+        self.assertFalse(report.is_clean())
+        self.assertTrue(report.below_floor)
+
+    def test_missing_doc_file_is_flagged(self) -> None:
+        report = CHECKER.build_report(
+            doc=REPO_ROOT / "does-not-exist.md",
+            rust_anchors={"a::A"},
+            min_anchors=1,
+        )
+        self.assertFalse(report.is_clean())
+
+    def test_missing_rust_source_is_flagged(self) -> None:
+        report = CHECKER.build_report(
+            doc_anchors={"a::A"},
+            rust_sources={REPO_ROOT / "nope.rs": ("x",)},
+            min_anchors=1,
+        )
+        self.assertFalse(report.is_clean())
+
+
+class WiringTest(unittest.TestCase):
+    def test_checker_invoked_by_ci_script_checks(self) -> None:
+        script = (REPO_ROOT / "scripts" / "ci-script-checks.sh").read_text(encoding="utf-8")
+        self.assertIn('"$PYTHON" scripts/check_contract_symbol_refs.py', script)
+        self.assertIn('"$PYTHON" -m unittest tests.test_contract_symbol_refs', script)
+
+    def test_sync_gate_unconditional_in_ci_pr(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci-pr.yml").read_text(
+            encoding="utf-8"
+        )
+        marker = "- name: Contract symbol-ref sync gate (always, #4268)"
+        self.assertIn(marker, workflow)
+        start = workflow.index(marker)
+        nxt = workflow.find("\n      - name:", start + len(marker))
+        step = workflow[start : nxt if nxt != -1 else len(workflow)]
+        self.assertIn("scripts/check_contract_symbol_refs.py", step)
+        self.assertNotIn("ci_relax_safe", step)
+        self.assertNotIn("if:", step)
+
+    def test_compile_existence_gate_is_a_required_ci_job(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci-pr.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("cargo check --workspace --all-targets", workflow)
+
+    def test_defect2_relay_contract_forces_check_fast_on_relax_branch(self) -> None:
+        # The compile-existence half (check_fast) must run even when
+        # ci_relax_safe is true, if a relay-contract anchor file / doc changed.
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci-pr.yml").read_text(
+            encoding="utf-8"
+        )
+        # A relay_contract path filter and output exist.
+        self.assertIn("relay_contract:", workflow)
+        self.assertIn(
+            "relay_contract: ${{ steps.filter.outputs.relay_contract }}", workflow
+        )
+        # check_fast's gate ORs in relay_contract so the relax skip is bypassed.
+        self.assertIn(
+            "|| needs.changes.outputs.relay_contract == 'true'", workflow
+        )
+        # The anchor host files are covered by the filter.
+        for host in (
+            "src/services/discord/inflight/store.rs",
+            "src/services/discord/turn_bridge/terminal_delivery.rs",
+            "src/services/discord/tmux_watcher/liveness.rs",
+            "src/services/discord/router/message_handler/watchdog.rs",
+            "docs/relay-state-contract.md",
+        ):
+            self.assertIn(host, workflow)
+        # The required-context mirror gates the forced run (no silent relax echo).
+        self.assertIn("Relay-contract fast check mirror (always, #4268)", workflow)
+
+
+class IntegrationTest(unittest.TestCase):
+    def test_repo_doc_and_code_anchors_in_sync(self) -> None:
+        report = CHECKER.build_report()
+        self.assertTrue(report.is_clean(), CHECKER.format_report(report))
+        self.assertGreaterEqual(len(report.doc_anchors), CHECKER.MIN_CONTRACT_ANCHORS)
+        self.assertEqual(report.doc_anchors, report.rust_anchors)
+
+    def test_every_reference_source_declares_anchors(self) -> None:
+        for rel, base in CHECKER.REFERENCE_SOURCE_MODULES.items():
+            source = CHECKER.DISCORD_ROOT / rel
+            anchors, errors = CHECKER.extract_rust_anchors(
+                source.read_text(encoding="utf-8"), base, rel
+            )
+            self.assertEqual(errors, [], f"{rel}: {errors}")
+            self.assertTrue(anchors, f"no anchors parsed from {rel}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4268

## 문제

`docs/relay-state-contract.md` 의 `file:line` 하드 참조가 모듈 분해로 **전부 깨졌다.** 직접 대조한 실측:

| 문서 참조 | 실제 |
|---|---|
| `tmux.rs:3759` · `:4513` · `:4987` · `:5618` | `tmux.rs` 는 **2458줄** — 전부 EOF 초과 (watcher 코드는 `tmux_watcher.rs` 로 이동) |
| `turn_bridge/mod.rs:1871~2295` | 해당 파일은 **1691줄** — 초과 |
| `inflight.rs:50` · `:81` · `:318-368` | `inflight/model.rs:157` · `:265` · `inflight/store.rs:92` 로 이동 |
| `mod.rs:457-472` ("atomic flags") | 실제로는 `status_update_interval` (atomic flags 는 906-914 / 1269-1272) |

16건(15 distinct) **100% 붕괴**. 계약 문서가 가리키는 곳에 계약이 없다.

## 수정

`file:line` → `` `sym:` `` 심볼 경로 앵커로 전환하고, 드리프트를 **CI가 실제로 막도록** 체크를 추가했다.

- `docs/relay-state-contract.md` — 16건 전부 전환 (+ file-only 3건 표준화). 잔여 `.rs:NNN` = **0**, `sym:` 앵커 25개
- `scripts/check_contract_symbol_refs.py` (신규) — `sym:` 앵커를 소스로 해석해 심볼 정의 존재를 검증. 순수 텍스트, cargo 불요
- `scripts/ci-script-checks.sh:170-171` — 체커 + unittest 실행
- `tests/test_contract_symbol_refs.py` (신규, 15건)

## ⚠️ 이슈 제목의 "nightly" 를 따르지 않았다

`ci-nightly.yml` 은 `ci-script-checks.sh` 를 **호출하지 않는다.** nightly 에 붙였으면 체크는 존재하되 **PR 을 하나도 못 막았을 것**이다.

그래서 `ci-script-checks.sh` 에 붙였다 — 이 스크립트는 `ci-pr.yml:742` 와 `ci-main.yml:254` 의 **필수 게이트**에서 돈다. 형제 선례 `check_api_docs_coverage.py`(#3719/#4226) 와 동일 위치·구조다.

"체크를 썼다"와 "CI 가 그 체크를 돌린다"는 다른 명제다 — 이 레포엔 `tests/*.sh` 스위트가 존재하는데 CI 가 한 번도 실행하지 않던 전례(#4372)가 있다. 그래서 `test_contract_symbol_refs.WiringTest` 가 **"스크립트가 실제로 체커를 호출하는지"를 테스트로 고정**한다.

## 검증

게이트 rc 는 전부 파이프 없이 캡처했다.

| 게이트 | rc |
|---|---|
| `check_contract_symbol_refs.py` | 0 (`contract symbol-ref check passed (25 references)`) |
| `ci-script-checks.sh` | 0 |
| `python -m unittest tests.test_contract_symbol_refs` | 0 (`Ran 15 tests ... OK`) |

**뮤테이션 증명** (자기 finding / 비영 rc 로 실패 — 임포트·문법 에러 아님):

1. 존재하지 않는 심볼 앵커를 심음 → **rc=1**
   ```
   docs/relay-state-contract.md:24: symbol(s) `response_sent_offset_ZZZ_BOGUS`
     not defined in src/services/discord/inflight/model.rs
   ```
2. `sym:` 앵커를 **전부 제거** → **rc=1**. 게이트가 아무것도 검사하지 않으면서 조용히 통과하는 no-op 상태를 차단한다 (#4372 교훈).
3. 복원 → **rc=0**

## 설계 결정

- 앵커 sigil 을 `` `sym:...` `` 로 둬서 프로즈 백틱(`record_invariant_check` 같은)과 구분. 체커는 이 단일 패턴만 파싱한다.
- base 는 `src/services/discord/`, `crate::` 접두는 `src/` 부터 해석.
- 파일 해석: "가장 긴 모듈 프리픽스 → `.rs`/`mod.rs`, 실패 시 루트 `mod.rs` 폴백" — `TmuxWatcherHandle::field`(mod.rs), `inflight::model::Struct::field`, `tmux::fn` 을 모두 커버.

## 스코프

핫파일(`turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, `turn_finalizer.rs`)은 문서가 **참조만** 하며 수정하지 않았다. Rust 0줄.

**후속 이슈 대상 (보고만)**: 같은 `file:line` 패턴이 `docs/invariants.md`(50건), `docs/agent-maintenance/multinode-transition.md`(97건), `discord-outbound-migration.md`(65건), `docs/design/3089-turn-output-controller.md`(33건) 에도 있다. 스코프 규율상 이번엔 `relay-state-contract.md` 만 처리했다. 성격이 가장 유사한 건 `docs/invariants.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)