### PR TITLE
fix(prompt): AgentDesk repo-상대 docs 경로를 실존 조건부 주입으로 — 타 저장소 누수 차단 (#4314)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -550,11 +550,11 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 185 | 185 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 431 | 431 | 0 |  |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 436 | 436 | 0 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
-| `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 387 | 264 | 123 |  |
+| `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 507 | 307 | 200 |  |
 | `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 334 | 334 | 0 |  |
-| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 173 | 89 | 84 |  |
+| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 267 | 124 | 143 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2307 | 751 | 1556 |  |

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -838,3 +838,50 @@ fn review_lite_and_lite_prompts_omit_tool_feedback_contract() {
         );
     }
 }
+
+#[test]
+fn foreign_workspace_full_prompt_omits_repo_relative_doc_paths() {
+    // #4314 (end-to-end anchor): a Full-profile agent whose cwd is NOT an
+    // AgentDesk checkout (no docs/source-of-truth.md / docs/memory-scope.md
+    // under it) must never get the repo-relative doc references injected into
+    // its assembled system prompt — neither via the Shared Agent Rules Index
+    // nor via the Proactive Memory Guidance memento branch. The generic
+    // shared-rules block and the absolute `_shared.prompt.md` source line stay.
+    let binding = test_role_binding("project-cookingheart");
+    let prompt = build_system_prompt(
+        "ctx",
+        &[],
+        "/nonexistent-foreign-workspace-4314", // no docs/*.md rooted here
+        ChannelId::new(1),
+        "tok",
+        Some(&binding),
+        false,
+        DispatchProfile::Full,
+        Some("implementation"),
+        None,
+        None,
+        None,
+        Some(&ResolvedMemorySettings {
+            backend: MemoryBackendKind::Memento,
+            ..ResolvedMemorySettings::default()
+        }),
+        true,
+    );
+
+    assert!(
+        prompt.contains("[Shared Agent Rules Index]"),
+        "generic shared-rules block must stay, got: {prompt}"
+    );
+    assert!(
+        prompt.contains("_shared.prompt.md"),
+        "absolute shared-prompt source line must stay, got: {prompt}"
+    );
+    assert!(
+        !prompt.contains("docs/source-of-truth.md"),
+        "foreign workspace must not reference docs/source-of-truth.md, got: {prompt}"
+    );
+    assert!(
+        !prompt.contains("docs/memory-scope.md"),
+        "foreign workspace must not reference docs/memory-scope.md, got: {prompt}"
+    );
+}

--- a/src/services/discord/prompt_builder/layer_rendering.rs
+++ b/src/services/discord/prompt_builder/layer_rendering.rs
@@ -44,15 +44,57 @@ pub(super) fn api_friction_guidance(profile: DispatchProfile) -> Option<String> 
     )
 }
 
-pub(super) fn shared_agent_rules_lookup() -> &'static str {
-    "\n\n[Shared Agent Rules Index]\n\
-     - Keep changes scoped, verified, and no broader than the current request.\n\
-     - Verify user claims against code/data before acting.\n\
-     - Prefer `rg` and narrow reads; avoid dumping long tool output.\n\
-     - Do not use sqlite for ADK operational data; inspect `/api/docs` first.\n\
-     - Source-of-truth map: `docs/source-of-truth.md`; read it before editing prompts, config, skills, policies, or memory surfaces.\n\
-     - Memory scope map: `docs/memory-scope.md`; read it before memory cleanup or scope decisions.\n\
-     - Full shared prompt source: `~/ObsidianVault/RemoteVault/adk-config/agents/_shared.prompt.md`; read it only when the task needs the detailed shared policy."
+/// True when the agent's current working directory is (or is rooted at) an
+/// AgentDesk checkout — detected by the presence of *both* repo-relative
+/// source-of-truth documents. Used to gate repo-relative prompt references
+/// (`docs/source-of-truth.md`, `docs/memory-scope.md`) so they are never
+/// injected into agents whose workspace is a *different* repository (#4314),
+/// where those files do not exist and the reference would point at nothing.
+pub(super) fn workspace_has_agentdesk_docs(current_path: &str) -> bool {
+    workspace_has_agentdesk_docs_with(current_path, |p| std::path::Path::new(p).exists())
+}
+
+/// Filesystem-injectable seam for [`workspace_has_agentdesk_docs`] so tests
+/// can drive the path-existence decision deterministically without touching
+/// the real filesystem (#4314).
+pub(super) fn workspace_has_agentdesk_docs_with(
+    current_path: &str,
+    exists: impl Fn(&str) -> bool,
+) -> bool {
+    let base = current_path.trim().trim_end_matches('/');
+    if base.is_empty() {
+        return false;
+    }
+    exists(&format!("{base}/docs/source-of-truth.md"))
+        && exists(&format!("{base}/docs/memory-scope.md"))
+}
+
+pub(super) fn shared_agent_rules_lookup(current_path: &str) -> String {
+    shared_agent_rules_lookup_with(current_path, |p| std::path::Path::new(p).exists())
+}
+
+/// Filesystem-injectable seam for [`shared_agent_rules_lookup`]. The generic
+/// rules and the absolute `~/ObsidianVault/...` shared-prompt source are always
+/// injected; only the two repo-relative `docs/*` references are gated on the
+/// current workspace actually being an AgentDesk checkout (#4314).
+fn shared_agent_rules_lookup_with(current_path: &str, exists: impl Fn(&str) -> bool) -> String {
+    let mut section = String::from(
+        "\n\n[Shared Agent Rules Index]\n\
+         - Keep changes scoped, verified, and no broader than the current request.\n\
+         - Verify user claims against code/data before acting.\n\
+         - Prefer `rg` and narrow reads; avoid dumping long tool output.\n\
+         - Do not use sqlite for ADK operational data; inspect `/api/docs` first.",
+    );
+    if workspace_has_agentdesk_docs_with(current_path, &exists) {
+        section.push_str(
+            "\n- Source-of-truth map: `docs/source-of-truth.md`; read it before editing prompts, config, skills, policies, or memory surfaces.\n\
+             - Memory scope map: `docs/memory-scope.md`; read it before memory cleanup or scope decisions.",
+        );
+    }
+    section.push_str(
+        "\n- Full shared prompt source: `~/ObsidianVault/RemoteVault/adk-config/agents/_shared.prompt.md`; read it only when the task needs the detailed shared policy.",
+    );
+    section
 }
 
 #[derive(Clone, Debug)]
@@ -260,6 +302,84 @@ pub(super) fn render_channel_participants(
         lines.push(line);
     }
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod workspace_aware_shared_rules_tests {
+    //! #4314 — the repo-relative `docs/*` references must only appear when the
+    //! agent's workspace actually is an AgentDesk checkout. The `_with(exists)`
+    //! seam makes the path-existence decision injectable so these are
+    //! deterministic and prove the guard bidirectionally (removing the guard
+    //! makes one direction fail on its own assert, not on a compile error).
+    use super::*;
+
+    #[test]
+    fn helper_requires_both_docs_and_rejects_empty() {
+        // Both docs present → AgentDesk workspace.
+        assert!(workspace_has_agentdesk_docs_with("/repo", |_| true));
+        // Neither present → foreign workspace.
+        assert!(!workspace_has_agentdesk_docs_with("/repo", |_| false));
+        // Only one of the two present → still not treated as AgentDesk (AND).
+        assert!(!workspace_has_agentdesk_docs_with("/repo", |p| p.ends_with("source-of-truth.md")));
+        assert!(!workspace_has_agentdesk_docs_with("/repo", |p| p.ends_with("memory-scope.md")));
+        // Empty / whitespace path → false without touching the filesystem.
+        assert!(!workspace_has_agentdesk_docs_with("   ", |_| panic!(
+            "must not probe empty path"
+        )));
+    }
+
+    #[test]
+    fn helper_probes_current_path_rooted_docs() {
+        // The probed paths are `<cwd>/docs/source-of-truth.md` and
+        // `<cwd>/docs/memory-scope.md`, and a trailing slash is tolerated.
+        let mut probed: Vec<String> = Vec::new();
+        let cell = std::cell::RefCell::new(&mut probed);
+        let result = workspace_has_agentdesk_docs_with("/some/repo/", |p| {
+            cell.borrow_mut().push(p.to_string());
+            true
+        });
+        assert!(result);
+        assert!(probed.contains(&"/some/repo/docs/source-of-truth.md".to_string()));
+        assert!(probed.contains(&"/some/repo/docs/memory-scope.md".to_string()));
+    }
+
+    #[test]
+    fn foreign_workspace_omits_repo_relative_doc_refs() {
+        // T1 (guard mutation, A block): with the docs absent, the two
+        // repo-relative references must NOT be injected, but the generic block
+        // and the absolute shared-prompt source stay. Removing the guard so the
+        // refs are always injected makes THIS assert fail on its own.
+        let section = shared_agent_rules_lookup_with("/foreign/repo", |_| false);
+        assert!(section.contains("[Shared Agent Rules Index]"));
+        assert!(section.contains("Do not use sqlite for ADK operational data"));
+        assert!(section.contains("_shared.prompt.md"));
+        assert!(
+            !section.contains("docs/source-of-truth.md"),
+            "foreign workspace must not reference docs/source-of-truth.md, got: {section}"
+        );
+        assert!(
+            !section.contains("docs/memory-scope.md"),
+            "foreign workspace must not reference docs/memory-scope.md, got: {section}"
+        );
+    }
+
+    #[test]
+    fn agentdesk_workspace_keeps_repo_relative_doc_refs() {
+        // T2 (reverse mutation, A block): with the docs present, both
+        // repo-relative references must be injected. Forcing the guard to
+        // always omit makes THIS assert fail on its own.
+        let section = shared_agent_rules_lookup_with("/agentdesk", |_| true);
+        assert!(section.contains("[Shared Agent Rules Index]"));
+        assert!(
+            section.contains("docs/source-of-truth.md"),
+            "AgentDesk workspace must keep docs/source-of-truth.md, got: {section}"
+        );
+        assert!(
+            section.contains("docs/memory-scope.md"),
+            "AgentDesk workspace must keep docs/memory-scope.md, got: {section}"
+        );
+        assert!(section.contains("_shared.prompt.md"));
+    }
 }
 
 #[cfg(test)]

--- a/src/services/discord/prompt_builder/memory_guidance.rs
+++ b/src/services/discord/prompt_builder/memory_guidance.rs
@@ -26,6 +26,31 @@ pub(super) fn proactive_memory_guidance(
     profile: DispatchProfile,
     memento_mcp_available: bool,
 ) -> Option<String> {
+    proactive_memory_guidance_with(
+        memory_settings,
+        current_path,
+        channel_id,
+        role_binding,
+        profile,
+        memento_mcp_available,
+        |p| std::path::Path::new(p).exists(),
+    )
+}
+
+/// Filesystem-injectable seam for [`proactive_memory_guidance`] so the
+/// workspace-aware gate on the repo-relative `docs/memory-scope.md` reference
+/// (#4314) can be tested deterministically. The `exists` closure decides
+/// whether the current workspace is an AgentDesk checkout; everything else
+/// (scope hints, the always-on `tool_feedback` contract) is unchanged.
+pub(super) fn proactive_memory_guidance_with(
+    memory_settings: Option<&ResolvedMemorySettings>,
+    current_path: &str,
+    channel_id: ChannelId,
+    role_binding: Option<&RoleBinding>,
+    profile: DispatchProfile,
+    memento_mcp_available: bool,
+    exists: impl Fn(&str) -> bool,
+) -> Option<String> {
     if profile != DispatchProfile::Full {
         return None;
     }
@@ -68,13 +93,23 @@ pub(super) fn proactive_memory_guidance(
                 .unwrap_or_else(|| "default".to_string());
             let agent_workspace = resolve_memento_workspace(role_id, channel_id.get(), None);
             let agent_id = resolve_memento_agent_id(role_id, channel_id.get());
+            // #4314: `docs/memory-scope.md` is an AgentDesk repo-relative path.
+            // Only reference it when the agent's workspace actually is an
+            // AgentDesk checkout — otherwise it points at a nonexistent file.
+            let memory_policy_line = if super::layer_rendering::workspace_has_agentdesk_docs_with(
+                current_path,
+                &exists,
+            ) {
+                "\n- full memory policy: `docs/memory-scope.md`; read it before broad memory cleanup or scope changes."
+            } else {
+                ""
+            };
             (
                 "memento",
                 "`recall` MCP tool",
                 "`remember` MCP tool",
                 format!(
-                    "\n- scope hints: project=`workspace={workspace_scope}, agentId=default`; agent-private=`workspace={agent_workspace}, agentId={agent_id}`.\n\
-                     - full memory policy: `docs/memory-scope.md`; read it before broad memory cleanup or scope changes.\n\
+                    "\n- scope hints: project=`workspace={workspace_scope}, agentId=default`; agent-private=`workspace={agent_workspace}, agentId={agent_id}`.{memory_policy_line}\n\
                      - feedback contract: in the same turn you use `recall`/`context` results, call `mcp__memento__tool_feedback` once (required: `tool_name`, `relevant`, `sufficient`; when the response carries `_meta.searchEventId`, also pass it as `search_event_id` — recommended). If the tool is deferred, load it first via ToolSearch `select:mcp__memento__tool_feedback`."
                 ),
             )
@@ -152,6 +187,65 @@ mod tests {
         assert!(guidance.contains("once memento recovers"));
         // Must not read like the deliberate-file backend guidance.
         assert!(!guidance.contains("`local` memory is available"));
+    }
+
+    fn memento_settings() -> ResolvedMemorySettings {
+        ResolvedMemorySettings {
+            backend: MemoryBackendKind::Memento,
+            ..ResolvedMemorySettings::default()
+        }
+    }
+
+    #[test]
+    fn foreign_workspace_memento_omits_memory_scope_but_keeps_feedback_contract() {
+        // #4314 T4 (guard mutation, memento branch): a foreign workspace (docs
+        // absent) must drop the repo-relative `docs/memory-scope.md` reference
+        // while keeping the always-on scope hints and tool_feedback contract.
+        // Removing the guard so the reference is always injected makes THIS
+        // assert fail on its own — not on a compile error.
+        let settings = memento_settings();
+        let guidance = proactive_memory_guidance_with(
+            Some(&settings),
+            "/foreign/repo",
+            ChannelId::new(1),
+            None,
+            DispatchProfile::Full,
+            true,
+            |_| false,
+        )
+        .expect("memento guidance must be produced");
+
+        assert!(guidance.contains("[Proactive Memory Guidance]"));
+        assert!(guidance.contains("scope hints:"));
+        assert!(guidance.contains("mcp__memento__tool_feedback"));
+        assert!(
+            !guidance.contains("docs/memory-scope.md"),
+            "foreign workspace must not reference docs/memory-scope.md, got: {guidance}"
+        );
+    }
+
+    #[test]
+    fn agentdesk_workspace_memento_keeps_memory_scope_reference() {
+        // #4314 T4 reverse: an AgentDesk workspace (docs present) must keep the
+        // `docs/memory-scope.md` reference. Forcing the guard to always omit
+        // makes THIS assert fail on its own.
+        let settings = memento_settings();
+        let guidance = proactive_memory_guidance_with(
+            Some(&settings),
+            "/agentdesk",
+            ChannelId::new(1),
+            None,
+            DispatchProfile::Full,
+            true,
+            |_| true,
+        )
+        .expect("memento guidance must be produced");
+
+        assert!(
+            guidance.contains("full memory policy: `docs/memory-scope.md`"),
+            "AgentDesk workspace must keep docs/memory-scope.md, got: {guidance}"
+        );
+        assert!(guidance.contains("mcp__memento__tool_feedback"));
     }
 
     #[test]

--- a/src/services/discord/prompt_builder/mod.rs
+++ b/src/services/discord/prompt_builder/mod.rs
@@ -232,12 +232,17 @@ pub(super) fn build_system_prompt_with_manifest(
                  - 큰 변경이나 장시간 작업이 필요하면 먼저 범위와 다음 행동을 짧게 확인한다",
             );
         } else {
-            system_prompt_owned.push_str(shared_agent_rules_lookup());
+            // #4314: the shared-rules index now depends on the agent's cwd —
+            // repo-relative `docs/*` references are injected only when the
+            // workspace actually is an AgentDesk checkout. Compute once and
+            // reuse for both the log and the append.
+            let shared_rules = shared_agent_rules_lookup(current_path);
             tracing::warn!(
                 "  [role-map] Injected compact shared rule index ({} chars) for channel {}",
-                shared_agent_rules_lookup().len(),
+                shared_rules.len(),
                 channel_id.get()
             );
+            system_prompt_owned.push_str(&shared_rules);
         }
 
         if profile != DispatchProfile::Lite {


### PR DESCRIPTION
Closes #4314

## 문제

AgentDesk repo-상대 경로(`docs/source-of-truth.md`, `docs/memory-scope.md`)가 **타 저장소** 에이전트의 시스템 프롬프트에 그대로 주입된다. 그 워크스페이스엔 해당 파일이 없으므로, 존재하지 않는 경로를 읽으라고 지시하는 셈이다.

leak 지점 2곳:
- `prompt_builder/layer_rendering.rs` — `shared_agent_rules_lookup` (정적 문자열)
- `prompt_builder/memory_guidance.rs` — `proactive_memory_guidance` (memento 분기)

## 수정

`current_path` 기준으로 `docs/source-of-truth.md` **AND** `docs/memory-scope.md` 실존을 검사해 그 두 줄만 조건부 주입한다. 파일 실존을 판정 기준으로 삼았으므로 "미존재 참조 0건"이 **정의상** 보장된다.

- `workspace_has_agentdesk_docs(_with)` 유틸 신설. `_with(exists_fn)` **seam** 으로 파일시스템을 주입 가능하게 해 결정적 테스트를 가능케 함
- generic 규칙 라인과 절대경로 `_shared.prompt.md` 라인은 **무조건 유지** (repo-상대가 아니므로 누수가 아니다)
- memento 분기의 scope hints · tool_feedback 계약은 불변

## 양방향 뮤테이션 증명

한 방향만 검증하면 가드가 실제로 **분기**하는지 증명되지 않는다. 둘 다 확인했다 (전부 self-assert 실패, 컴파일 에러 아님):

**Mutation A — 가드를 `true` 로 고정 (항상 주입)**: `FAILED. 37 passed; 5 failed`
```
foreign_workspace_omits_repo_relative_doc_refs FAILED
  — foreign workspace must not reference docs/source-of-truth.md, got: ...
foreign_workspace_memento_omits_memory_scope_but_keeps_feedback_contract FAILED
```

**Mutation B — 가드를 `false` 로 고정 (항상 미주입)**: `FAILED. 38 passed; 4 failed`
```
agentdesk_workspace_keeps_repo_relative_doc_refs FAILED
  — AgentDesk workspace must keep docs/source-of-truth.md, got: (empty)
```

**복원**: `test result: ok. 42 passed; 0 failed`

## 게이트 (rc 는 전부 파이프 없이 캡처)

| 게이트 | rc |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo check --lib` | 0 |
| `cargo test --lib prompt_builder` | 0 (`42 passed; 0 failed`) |
| `generate_inventory_docs.py --check` | 0 |
| `check_agent_maintenance_docs.py` | 0 |
| `audit_maintainability.py --check` | 0 |

### 환경 캐비엇 (코드 결함 아님, 확인 완료)

이 테스트들은 `AGENTDESK_ROOT_DIR=<tempdir>` 가 필요하다. 릴리스 루트(`~/.adk/release/`) 아래에서 돌리면 `runtime_store.rs:38` 의 #3293 세이프가드가 `test must set AGENTDESK_ROOT_DIR via tempdir` 로 막는다.

**이게 이 PR 의 회귀가 아님을 확인했다** — `origin/main` 을 같은 환경에서 환경변수 없이 돌리면 **기존 테스트 2건**이 동일하게 죽는다:
```
rc=101, FAILED. 33 passed; 2 failed
  full_memento_prompt_carries_tool_feedback_contract
  review_lite_prompt_keeps_review_contract_while_trimming_full_sections
```
CI 는 릴리스 루트 밖 clean 체크아웃에서 돌아 개입이 불필요하다.

## 스코프 규율

`#4313`(memory-scope 2회 참조 **dedupe**) · `#4312`(File/fallback 문구) 와 같은 파일을 공유하므로 그 셋은 순차 처리한다. 이 PR 은 두 이슈의 스코프를 침범하지 않는다:
- **#4313**: 참조를 합치거나 제거하지 않음 — 두 참조(shared-rules 1 + memento 1)를 그대로 두고 각각 실존 조건부화만 함
- **#4312**: `MemoryBackendKind::File` arm 과 `memento_fallback` 조기 반환 블록 무수정

## 잔여 리스크

판정은 두 파일 실존의 **AND**. 타 저장소가 우연히 같은 경로에 두 파일을 가지면 참조가 주입되지만, 그 경우엔 실제로 존재하므로 DoD 위반이 아니다. 반대로 AgentDesk cwd 가 `docs/` 를 포함하지 않는 하위 디렉터리면 참조가 빠지지만(보수적) **깨진 참조는 절대 생기지 않는다.**

턴당 `Path::exists` 2회(+memento 분기 2회) 추가 stat — 빌더는 이미 파일 I/O 를 수행하므로 무시 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)