### PR TITLE
docs(test): #4387 — 테스트 주석을 실제 assert와 일치시킴

### DIFF
--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -2657,7 +2657,7 @@ mod tests {
             &reasons_db
         ));
 
-        // Multiple reasons stay false.
+        // Multiple reasons with a Degraded status still leave fully_recovered=true.
         let reasons_outbox_disk = vec![
             json!("dispatch_outbox_oldest_pending_age:120"),
             json!("disk_low_free_bytes:104857600"),


### PR DESCRIPTION
## 배경

#4387 은 원래 `compute_fully_recovered` 의 `status`/`degraded_reasons` 인자를 "dead args + 거짓 doc comment" 로 지목했으나, 발행자 자진 철회 코멘트로 재스코프됨 — doc comment 와 코드 동작은 정확하고(2fa8cb621 이 warm-pool degradation 무시를 의도적으로 확립), 두 인자는 회귀 가드 테스트의 입력면이므로 유지. 남은 실제 결함은 가드 테스트 `compute_fully_recovered_preserves_recovery_axis_when_runtime_degrades` 내부의 주석 1줄(`// Multiple reasons stay false.`)이 바로 아래 `assert!(…)` (true 단언)와 모순되는 것뿐이며, 이 PR 은 그 주석만 assert 및 테스트 계약에 맞게 수정한다. 동작 변경 없음.

## 변경

- `src/server/routes/health_api.rs` 주석 1줄: `// Multiple reasons stay false.` → `// Multiple reasons with a Degraded status still leave fully_recovered=true.`

## 검증

- `cargo fmt --check` rc=0
- `cargo check --lib` rc=0 (주석만 변경, 컴파일 영향 없음)

Refs #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)