### PR TITLE
fix(panel): close ALL parallel subagents in a batched tool_result record (#4396)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -542,10 +542,10 @@
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
-| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 794 | 794 | 0 |  |
+| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 780 | 780 | 0 |  |
 | `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 749 | 749 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_panel` | `src/services/discord/placeholder_live_events/subagent_panel.rs` | 104 | 104 | 0 |  |
-| `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 481 | 306 | 175 |  |
+| `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 531 | 356 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 399 | 399 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -587,7 +587,7 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
     let record_summary = if any_block_aggregate {
         None
     } else {
-        subagent_completion_from_record(value)
+        super::subagent_rollout::subagent_completion_from_record(value)
     };
     let record_summary_owner_idx = record_summary.as_ref().and_then(|_| {
         blocks.iter().position(|block| {
@@ -621,7 +621,7 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
             // This block's OWN aggregate (batched case), keyed by THIS block's
             // tool_use_id; else the legacy record-level aggregate on the first
             // id-bearing block.
-            let block_completion = subagent_completion_from_record(block);
+            let block_completion = super::subagent_rollout::subagent_completion_from_record(block);
             let completion = block_completion.or_else(|| {
                 if Some(idx) == record_summary_owner_idx {
                     record_summary.clone()
@@ -652,26 +652,12 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                 ];
             }
 
-            status_events_from_tool_result(None, is_error)
+            // #4396: an id-bearing block with NO aggregate still closes an
+            // exactly-id-matched subagent slot (see the helper's docs).
+            super::subagent_rollout::idful_tool_result_close_events(block, is_error)
+                .unwrap_or_else(|| status_events_from_tool_result(None, is_error))
         })
         .collect()
-}
-
-/// Builds the subagent [`SubagentSummary`](crate::services::agent_protocol::SubagentSummary)
-/// from a JSON object's `toolUseResult` aggregate — an individual `tool_result`
-/// block (batched) or the whole `user` record (legacy single). `None` for
-/// ordinary results. #3086 P1: live hot path — in-stream aggregate only (no disk
-/// IO); the prior synchronous rollout `read_to_string` was removed.
-fn subagent_completion_from_record(
-    value: &Value,
-) -> Option<(
-    crate::services::agent_protocol::SubagentSummary,
-    Option<String>,
-    Option<String>,
-)> {
-    let (summary, agent_id) = super::subagent_rollout::summary_from_tool_use_result(value)?;
-    let desc = super::subagent_rollout::description_from_tool_use_result(value);
-    Some((summary, agent_id, desc))
 }
 
 fn system_status_events(value: &Value) -> Vec<StatusEvent> {

--- a/src/services/discord/placeholder_live_events/subagent_rollout.rs
+++ b/src/services/discord/placeholder_live_events/subagent_rollout.rs
@@ -100,6 +100,56 @@ pub(super) fn description_from_tool_use_result(value: &Value) -> Option<String> 
         .map(str::to_string)
 }
 
+/// Builds the subagent [`SubagentSummary`] `(summary, agent_id, desc)` triple
+/// from a JSON object's `toolUseResult` aggregate — an individual `tool_result`
+/// block (batched) or the whole `user` record (legacy single). `None` for
+/// ordinary results. #3086 P1: live hot path — in-stream aggregate only (no disk
+/// IO); the prior synchronous rollout `read_to_string` was removed.
+pub(super) fn subagent_completion_from_record(
+    value: &Value,
+) -> Option<(SubagentSummary, Option<String>, Option<String>)> {
+    let (summary, agent_id) = summary_from_tool_use_result(value)?;
+    let desc = description_from_tool_use_result(value);
+    Some((summary, agent_id, desc))
+}
+
+/// #4396: terminal events for an id-bearing `tool_result` block that carries NO
+/// aggregate; `None` for an id-less block (the caller's plain-`ToolEnd` path).
+///
+/// A batched record carries ONE record-level `toolUseResult` aggregate, owned
+/// by the first id-bearing block — the OTHER parallel Tasks' results used to
+/// fall through to a bare `ToolEnd`, leaving their slots permanently unfinished
+/// (no footer ✓/✗, and the #4367 live filter never hides them). The record does
+/// not name the block's tool, so emit a summary-less id-bearing `SubagentEnd`
+/// and let the panel decide: it applies an id-bearing end ONLY on an exact
+/// `tool_use_id` match against a slot a real Task launch opened (agent_id/desc
+/// are `None`, so the #4177 fallback cannot fire) — an ordinary tool's result
+/// id matches no subagent slot and is a no-op. `ack_only: !is_error` mirrors
+/// `status_events_from_tool_result_with_id`: a successful BACKGROUND launch ack
+/// must not finalize its still-running slot, while a foreground completion (or
+/// a failed launch) finalizes.
+pub(super) fn idful_tool_result_close_events(
+    block: &Value,
+    is_error: bool,
+) -> Option<Vec<StatusEvent>> {
+    let id = block
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())?;
+    Some(vec![
+        StatusEvent::ToolEnd { success: !is_error },
+        StatusEvent::SubagentEnd {
+            success: !is_error,
+            agent_id: None,
+            desc: None,
+            tool_use_id: Some(id.to_string()),
+            summary: None,
+            ack_only: !is_error,
+        },
+    ])
+}
+
 /// #3920: `true` when a parent-transcript `tool_result`/`user` record (or a
 /// batched per-block `tool_result`) is an ASYNC subagent LAUNCH acknowledgment
 /// — `toolUseResult.isAsync == true` or `toolUseResult.status == "async_launched"`.

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4515,6 +4515,93 @@ fn status_panel_batched_multi_subagent_summaries_land_on_own_slots() {
     );
 }
 
+// #4396: a single batched `user` record may complete N parallel subagents while
+// carrying only ONE record-level `toolUseResult` aggregate (no per-block
+// aggregates). The aggregate is owned by the FIRST id-bearing block; the other
+// Task results must STILL close their slots (summary-less `SubagentEnd`), not
+// fall through to a bare `ToolEnd` that leaves them permanently unfinished —
+// the exact #4396 symptom: no footer ✓/✗ and the #4367 live filter never hides
+// them. An unrelated ordinary tool result batched into the same record must
+// stay a no-op (its id matches no subagent slot).
+#[test]
+fn status_panel_batched_record_level_aggregate_closes_all_parallel_subagents() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4396);
+
+    // Three subagents launched in parallel.
+    for (subagent_type, desc, id) in [
+        ("alpha", "Scout A", "toolu_4396_a"),
+        ("beta", "Scout B", "toolu_4396_b"),
+        ("gamma", "Scout C", "toolu_4396_c"),
+    ] {
+        events.push_status_events(
+            channel_id,
+            status_events_from_tool_use_with_id(
+                "Task",
+                &json!({"subagent_type": subagent_type, "description": desc}).to_string(),
+                Some(id),
+            ),
+        );
+    }
+
+    // ONE `user` record batches ALL THREE Task results (plus an unrelated
+    // ordinary tool result) with only a RECORD-level aggregate.
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "user",
+            "message": {
+                "content": [
+                    { "type": "tool_result", "tool_use_id": "toolu_4396_a", "is_error": false },
+                    { "type": "tool_result", "tool_use_id": "toolu_4396_b", "is_error": false },
+                    { "type": "tool_result", "tool_use_id": "toolu_4396_c", "is_error": false },
+                    { "type": "tool_result", "tool_use_id": "toolu_4396_bash", "is_error": false }
+                ]
+            },
+            "toolUseResult": {
+                "agentId": "aalpha4396000000",
+                "totalToolUseCount": 7,
+                "totalTokens": 4200,
+                "totalDurationMs": 21_000
+            }
+        })),
+    );
+
+    // Every parallel subagent is terminal: the completion footer marks ALL
+    // THREE ✓ (the record aggregate's Done summary belongs to the first
+    // id-bearing block only).
+    let footer = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let block = footer
+        .block
+        .expect("completed subagents should render in the completion footer");
+    for needle in ["alpha Scout A", "beta Scout B", "gamma Scout C"] {
+        let line = footer_line_containing(&block, needle);
+        assert!(
+            line.contains('✓'),
+            "every batched parallel subagent must be marked done, got: {line}"
+        );
+    }
+    assert!(
+        footer_line_containing(&block, "alpha Scout A").contains("Done (7 tools"),
+        "record-level aggregate belongs to the first id-bearing block, got: {block}"
+    );
+    // The unrelated ordinary tool result must not fabricate a subagent entry.
+    assert_eq!(
+        block.matches('✓').count(),
+        3,
+        "exactly the three launched subagents close — no ghost from the \
+         unrelated tool result, got: {block}"
+    );
+
+    // #4367 live filter: all three are terminal, so the live panel hides the
+    // whole Subagents section (this is what stayed stuck before the fix).
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(
+        !rendered.contains("Subagents"),
+        "all-terminal subagents must vanish from the live panel, got: {rendered}"
+    );
+}
+
 // #3086 P1 #1: a summary-bearing `SubagentEnd` whose `tool_use_id` matches NO
 // tracked slot must be dropped, not mis-routed to the last unfinished slot.
 #[test]


### PR DESCRIPTION
## 루트 커즈 (#4396 지점 1)

JSONL 배치 `user` 레코드는 레코드 최상위에 `toolUseResult` 누적 요약을 **1개만** 싣는다. `user_status_events`는 이를 첫 id-보유 `tool_result` 블록에만 귀속(`record_summary_owner_idx`)하므로, 병렬 서브에이전트 N건이 한 레코드로 배치 완료되면 첫 1건만 `SubagentEnd`를 받고 나머지는 `status_events_from_tool_result(None, ..)`로 떨어져 `ToolEnd`만 방출했다. 결과: `slot.finished` 영구 미세팅 → 완료 푸터 ✓/✗ 0개 + #4367 라이브 필터 무력화(완료된 서브에이전트가 라이브 패널에 잔존).

## 수정

- `subagent_rollout::idful_tool_result_close_events` (신규): 요약(aggregate) 없는 **id-보유** `tool_result` 블록에 대해 `ToolEnd` + summary-없는 id-보유 `SubagentEnd`를 방출. id-없는 블록은 기존 plain-`ToolEnd` 경로 유지.
- `user_status_events`의 최종 fallback이 이 헬퍼를 경유.

## 판별 안전성 논증 (일반 툴 회귀 없음)

`user` 레코드는 블록의 툴 이름을 싣지 않으므로 방출 측에서는 Task 여부를 판별할 수 없다. 판별은 하류 `StatusPanelState::apply`의 기존 id-정확 매칭이 수행한다:

- id-보유 `SubagentEnd`는 **실제 Task 런치가 연 슬롯과 `tool_use_id` 정확 일치**할 때만 적용된다 (#3084/#4177 계약). 일반 툴(Bash/Read 등)의 result id는 어떤 서브에이전트 슬롯에도 등록된 적이 없어 no-op.
- `agent_id`/`desc`를 `None`으로 방출하므로 #4177 unique-fallback 매칭도 발화 불가.
- `ack_only: !is_error`는 기존 `status_events_from_tool_result_with_id`의 런치-ack 의미론을 그대로 미러: 성공한 background 런치 ack는 슬롯을 finalize하지 않고(실완료는 task-notification), foreground 완료·실패 런치는 finalize.
- async 런치 ack(`isAsync`/`async_launched`)는 이 fallback보다 앞선 `async_launch_promote_events`가 선점 처리 (기존 그대로).
- 타 소비자 검증: `task_notification_success_completion_visible_in_snapshot`(mod.rs)은 id-슬롯 매칭 술어라 무영향, `slot_rehydration`은 Start 이벤트만 소비, 이벤트는 전부 `push_status_event → apply`로만 흐름을 확인함.
- 기존 테스트 `status_panel_subagent_summary_attaches_only_to_matching_slot`이 "배치 내 무관 툴 결과 no-op" 경로를 계속 가드 (195/195 통과).

## 네임스페이스 캡 (#4269 — 캡 인상 없음)

`status_events.rs`는 794줄 캡에 정확히 차 있어, 신규 헬퍼와 (이미 subagent_rollout 함수들의 얇은 래퍼였던) `subagent_completion_from_record`를 `subagent_rollout.rs`(캡 700, 최종 531줄)로 이동. `status_events.rs`는 780줄로 캡 아래. `audit_maintainability --check` rc=0.

## 테스트 / 뮤테이션 증명

신규 회귀 테스트 `status_panel_batched_record_level_aggregate_closes_all_parallel_subagents`: Task 3건 병렬 런치 → 레코드-레벨 aggregate만 실은 배치 레코드(무관 툴 결과 1건 포함) → 3건 전원 푸터 ✓(요약은 owner 블록만), ✓ 정확히 3개(고스트 없음), 라이브 패널 Subagents 섹션 소거.

뮤테이션 증명 — 가드(fallback 헬퍼 경유)를 원래의 `status_events_from_tool_result(None, is_error)`로 되돌리면:

```
test ... status_panel_batched_record_level_aggregate_closes_all_parallel_subagents ... FAILED
panicked at tests.rs:4579: every batched parallel subagent must be marked done, got: └ beta Scout B ⠸
test result: FAILED. 0 passed; 1 failed
```

복원 시:

```
test result: ok. 1 passed; 0 failed
(모듈 전체) test result: ok. 195 passed; 0 failed
```

## 게이트

- `cargo fmt --check` rc=0
- `cargo check --lib` rc=0
- `cargo test --lib placeholder_live_events` rc=0 (195 passed)
- `generate_inventory_docs.py` rc=0 → `check_agent_maintenance_docs.py` rc=0 ("freshness check passed")
- `audit_maintainability.py --check` rc=0

지점 2(task-notification id-less 드롭 + TTL 스위퍼)는 범위 밖 — 후속 라운드.

Refs #4396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
