### PR TITLE
feat(ops): productionize out-of-band relay watchdog (#4381)

### DIFF
--- a/scripts/check-portable-paths.py
+++ b/scripts/check-portable-paths.py
@@ -25,6 +25,7 @@ DEFAULT_PATTERNS = (
     "scripts/launchd-migrated/*.sh",
     "scripts/launchd-migrated/*.py",
     "scripts/check-portable-paths.py",
+    "scripts/relay_watchdog.py",
     "scripts/operator-init-portable.py",
     "scripts/portable-operator-migration-dry-run.py",
     "policies/**/*",

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -147,6 +147,13 @@ echo "=== Portable deployable path lint ==="
   tests.test_script_python_policy \
   tests.test_analyze_prs
 
+echo "=== Relay watchdog judgment + wiring tests (#4381) ==="
+# The out-of-band relay watchdog is a deployable Python script; it is not
+# covered by shellcheck (only *.sh) nor by cargo, so this unittest run is its
+# ONLY CI gate. It also pins the deploy/plist wiring so the watchdog cannot
+# silently fall out of the deploy again (the 06-29 relay-gap-watch failure).
+"$PYTHON" -m unittest tests.test_relay_watchdog
+
 echo "=== Generate inventory docs (refresh workspace; gate source-of-truth invariants, #3036) ==="
 # Generic committed markdown freshness drift is warning-only for ordinary PRs
 # and is refreshed by the weekly regen-docs workflow. This CI invocation writes

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1707,8 +1707,16 @@ echo "▸ Installing out-of-band relay watchdog (#4381)..."
 if install -m 0755 "$REPO/scripts/relay_watchdog.py" "$WATCHDOG_BIN"; then
     if [ -f "$WATCHDOG_CONFIG" ]; then
         WATCHDOG_PYTHON="$(command -v python3 || echo /usr/bin/python3)"
-        mkdir -p "$HOME/Library/LaunchAgents"
-        cat > "$WATCHDOG_PLIST_PATH" <<PLIST_EOF
+        # INVARIANT: the ENTIRE watchdog block is fail-open. We are past
+        # DEPLOY_OK, so any failure here (permissions, full disk, launchd)
+        # must degrade to a loud ⚠ warning and let the script continue —
+        # aborting would poison the exit code of a HEALTHY deploy and skip
+        # _write_release_source_manifest / _deploy_to_all_peers below.
+        # The function body runs from an `if` guard, so `set -e` is suspended
+        # inside it; every step therefore carries its own `|| return 1`.
+        _install_relay_watchdog_plist() {
+            mkdir -p "$HOME/Library/LaunchAgents" || return 1
+            cat > "$WATCHDOG_PLIST_PATH.tmp" <<PLIST_EOF || return 1
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -1729,13 +1737,23 @@ if install -m 0755 "$REPO/scripts/relay_watchdog.py" "$WATCHDOG_BIN"; then
 </dict>
 </plist>
 PLIST_EOF
-        xattr -d com.apple.quarantine "$WATCHDOG_PLIST_PATH" 2>/dev/null || true
-        # bootout+bootstrap (not kickstart) so a script/plist change is picked up.
-        launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
-        if launchctl bootstrap "$LAUNCHD_DOMAIN" "$WATCHDOG_PLIST_PATH"; then
-            echo "✓ Relay watchdog armed ($WATCHDOG_LABEL)"
+            # Atomic publish: launchd never sees a half-written plist, and an
+            # interrupted write leaves only the .tmp (cleaned by the caller).
+            mv -f "$WATCHDOG_PLIST_PATH.tmp" "$WATCHDOG_PLIST_PATH" || return 1
+        }
+        if _install_relay_watchdog_plist; then
+            xattr -d com.apple.quarantine "$WATCHDOG_PLIST_PATH" 2>/dev/null || true
+            # bootout+bootstrap (not kickstart) so a script/plist change is picked up.
+            launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
+            if launchctl bootstrap "$LAUNCHD_DOMAIN" "$WATCHDOG_PLIST_PATH"; then
+                echo "✓ Relay watchdog armed ($WATCHDOG_LABEL)"
+            else
+                echo "⚠ Relay watchdog bootstrap FAILED — relay gaps will go unwatched"
+            fi
         else
-            echo "⚠ Relay watchdog bootstrap FAILED — relay gaps will go unwatched"
+            rm -f "$WATCHDOG_PLIST_PATH.tmp" 2>/dev/null || true
+            echo "⚠ Relay watchdog plist write FAILED ($WATCHDOG_PLIST_PATH) — not armed"
+            echo "  Deploy continues (fail-open): fix permissions/disk space and redeploy."
         fi
     else
         echo "⚠ Relay watchdog config missing: $WATCHDOG_CONFIG"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1714,25 +1714,47 @@ if install -m 0755 "$REPO/scripts/relay_watchdog.py" "$WATCHDOG_BIN"; then
         # _write_release_source_manifest / _deploy_to_all_peers below.
         # The function body runs from an `if` guard, so `set -e` is suspended
         # inside it; every step therefore carries its own `|| return 1`.
+        #
+        # Runtime python preflight: relay_watchdog.py declares MIN_PYTHON=3.10
+        # and exits 1 below it. If `command -v python3` resolved to the macOS
+        # system 3.9, arming the plist would put KeepAlive into a silent ~30s
+        # crash-loop — refuse to arm instead (r4 review, PR #4399).
+        _xml_escape() {
+            # Plist bodies are XML: raw &, <, > (and quotes, for safety) in an
+            # operator path would render the plist plutil-invalid and the
+            # watchdog silently unarmed (r4 review, PR #4399).
+            local s=$1
+            s=${s//&/\&amp;}
+            s=${s//</\&lt;}
+            s=${s//>/\&gt;}
+            s=${s//\"/\&quot;}
+            s=${s//\'/\&apos;}
+            printf '%s' "$s"
+        }
         _install_relay_watchdog_plist() {
+            local label_x python_x bin_x root_x
+            label_x=$(_xml_escape "$WATCHDOG_LABEL") || return 1
+            python_x=$(_xml_escape "$WATCHDOG_PYTHON") || return 1
+            bin_x=$(_xml_escape "$WATCHDOG_BIN") || return 1
+            root_x=$(_xml_escape "$ADK_REL") || return 1
             mkdir -p "$HOME/Library/LaunchAgents" || return 1
             cat > "$WATCHDOG_PLIST_PATH.tmp" <<PLIST_EOF || return 1
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key><string>$WATCHDOG_LABEL</string>
+  <key>Label</key><string>$label_x</string>
   <key>ProgramArguments</key>
-  <array><string>$WATCHDOG_PYTHON</string><string>$WATCHDOG_BIN</string></array>
+  <array><string>$python_x</string><string>$bin_x</string></array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>30</integer>
-  <key>StandardOutPath</key><string>$ADK_REL/logs/relay-watchdog.launchd.out.log</string>
-  <key>StandardErrorPath</key><string>$ADK_REL/logs/relay-watchdog.launchd.err.log</string>
+  <key>StandardOutPath</key><string>$root_x/logs/relay-watchdog.launchd.out.log</string>
+  <key>StandardErrorPath</key><string>$root_x/logs/relay-watchdog.launchd.err.log</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>AGENTDESK_ROOT_DIR</key><string>$ADK_REL</string>
+    <key>AGENTDESK_ROOT_DIR</key><string>$root_x</string>
   </dict>
 </dict>
 </plist>
@@ -1741,7 +1763,11 @@ PLIST_EOF
             # interrupted write leaves only the .tmp (cleaned by the caller).
             mv -f "$WATCHDOG_PLIST_PATH.tmp" "$WATCHDOG_PLIST_PATH" || return 1
         }
-        if _install_relay_watchdog_plist; then
+        if ! "$WATCHDOG_PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+            echo "⚠ Relay watchdog requires python3 >= 3.10 (MIN_PYTHON in relay_watchdog.py);"
+            echo "  resolved runner: $WATCHDOG_PYTHON — NOT armed (arming would KeepAlive-crash-loop)."
+            echo "  Install a newer python3 (e.g. brew install python) and redeploy."
+        elif _install_relay_watchdog_plist; then
             xattr -d com.apple.quarantine "$WATCHDOG_PLIST_PATH" 2>/dev/null || true
             # bootout+bootstrap (not kickstart) so a script/plist change is picked up.
             launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1379,6 +1379,11 @@ xattr -d com.apple.provenance "$STAGED_BINARY" 2>/dev/null || true
 sign_binary_with_fallback "$STAGED_BINARY"
 _clean_release_build_cache_after_staging
 
+# #4381: a deploy restarts dcserver, so a short relay gap is EXPECTED here.
+# Touch the marker the out-of-band relay watchdog checks; while it is fresh
+# (deploy_quiet_secs) the watchdog logs instead of alerting.
+touch "$ADK_REL/logs/relay-watchdog.deploy-marker" 2>/dev/null || true
+
 # Stop release — wait for process to actually die (flock release)
 echo "▸ Stopping release..."
 LOCK_FILE="$ADK_REL/runtime/dcserver.lock"
@@ -1686,6 +1691,60 @@ elif _health_json_reconcile_only "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}"; 
     echo "✓ Release is serving on :${REL_PORT} (provider reconcile in progress)"
 else
     echo "✓ Release is healthy on :${REL_PORT}"
+fi
+
+# ── Out-of-band relay watchdog (#4381) ────────────────────────────────────────
+# Deliberately OUTSIDE dcserver's launchd job: the watchdog must survive exactly
+# the failures it watches for (dcserver crash-looping on PG loss, #4379). The
+# repo is the source of truth — the machine-local prototype (and the 06-29
+# relay-gap-watch before it) evaporated because nothing deployed it. Runs after
+# DEPLOY_OK on purpose: a failed deploy leaves the previous watchdog untouched.
+WATCHDOG_LABEL="com.agentdesk.relay-watchdog"
+WATCHDOG_PLIST_PATH="$HOME/Library/LaunchAgents/$WATCHDOG_LABEL.plist"
+WATCHDOG_BIN="$ADK_REL/bin/relay-watchdog.py"
+WATCHDOG_CONFIG="$ADK_REL/config/relay-watchdog.json"
+echo "▸ Installing out-of-band relay watchdog (#4381)..."
+if install -m 0755 "$REPO/scripts/relay_watchdog.py" "$WATCHDOG_BIN"; then
+    if [ -f "$WATCHDOG_CONFIG" ]; then
+        WATCHDOG_PYTHON="$(command -v python3 || echo /usr/bin/python3)"
+        mkdir -p "$HOME/Library/LaunchAgents"
+        cat > "$WATCHDOG_PLIST_PATH" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$WATCHDOG_LABEL</string>
+  <key>ProgramArguments</key>
+  <array><string>$WATCHDOG_PYTHON</string><string>$WATCHDOG_BIN</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>30</integer>
+  <key>StandardOutPath</key><string>$ADK_REL/logs/relay-watchdog.launchd.out.log</string>
+  <key>StandardErrorPath</key><string>$ADK_REL/logs/relay-watchdog.launchd.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AGENTDESK_ROOT_DIR</key><string>$ADK_REL</string>
+  </dict>
+</dict>
+</plist>
+PLIST_EOF
+        xattr -d com.apple.quarantine "$WATCHDOG_PLIST_PATH" 2>/dev/null || true
+        # bootout+bootstrap (not kickstart) so a script/plist change is picked up.
+        launchctl bootout "$LAUNCHD_DOMAIN/$WATCHDOG_LABEL" 2>/dev/null || true
+        if launchctl bootstrap "$LAUNCHD_DOMAIN" "$WATCHDOG_PLIST_PATH"; then
+            echo "✓ Relay watchdog armed ($WATCHDOG_LABEL)"
+        else
+            echo "⚠ Relay watchdog bootstrap FAILED — relay gaps will go unwatched"
+        fi
+    else
+        echo "⚠ Relay watchdog config missing: $WATCHDOG_CONFIG"
+        echo "  Watchdog NOT armed on this node. Channel ids are operator config"
+        echo "  (never hardcoded in the repo); create the config — see the"
+        echo "  scripts/relay_watchdog.py docstring — then redeploy."
+    fi
+else
+    echo "⚠ Relay watchdog staging FAILED (source: $REPO/scripts/relay_watchdog.py)"
 fi
 
 _write_release_source_manifest

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -442,11 +442,23 @@ class Runtime:
             return None
         if not isinstance(msgs, list):
             return None
-        bot = [
-            m
-            for m in msgs
-            if isinstance(m, dict) and (m.get("author") or {}).get("bot")
-        ]
+        dict_msgs = [m for m in msgs if isinstance(m, dict)]
+        if msgs and not dict_msgs:
+            # A NON-EMPTY payload with ZERO parseable entries is schema drift,
+            # not an empty channel: silently skipping them all would yield ''
+            # — a "successful" read that never increments read_failures and
+            # bypasses the watchdog-blind escalation (r5 review, PR #4399).
+            # An empty list ([]) stays a normal empty channel.
+            return None
+        skipped = len(msgs) - len(dict_msgs)
+        if skipped:
+            # Mixed payload: partial data beats blindness, but schema drift
+            # must still leave a trace.
+            self.log(
+                f"discord read: skipped {skipped} non-object message "
+                f"entries (schema drift?)"
+            )
+        bot = [m for m in dict_msgs if (m.get("author") or {}).get("bot")]
         return norm(" ".join((m.get("content") or "") for m in bot))
 
     def dcserver_snapshot(self) -> str:

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+"""Out-of-band Discord relay gap watchdog (#4381).
+
+Why out-of-band: the in-band relay audit runs INSIDE the agent whose relay is
+being watched, so when the relay dies its findings cannot reach the user either.
+On 2026-07-09 that produced 2h07m of silence, 1h34m of it AFTER the agent
+announced "relay recovered" on the strength of a dcserver health check it never
+cross-checked against actual delivery.
+
+This process compares the SOURCE (the agent's own session transcript under
+`~/.claude/projects/<slug>/*.jsonl`) against the RELAY (what actually landed in
+Discord via `agentdesk discord read`) and alerts through paths that do NOT
+traverse the turn-relay being watched:
+
+  primary : `agentdesk send-to-agent --from system` (announce bot) — trips the
+            target agent's intake_gate and TRIGGERS A TURN, so the agent is
+            woken to investigate rather than only the human being notified.
+  fallback: `agentdesk discord-sendmessage` — posts with the bot token directly
+            and needs nothing but the token. On 2026-07-09 it was the ONLY path
+            that survived the outage.
+
+Absence is the thing being detected, so reading Discord alone can never find it.
+
+Deployment (owned by `scripts/deploy-release.sh`):
+  script : staged to   $ADK_REL/bin/relay-watchdog.py
+  launchd: ~/Library/LaunchAgents/com.agentdesk.relay-watchdog.plist
+           (RunAtLoad + KeepAlive; independent of dcserver — dcserver dying is
+           precisely the moment this must stay alive, see #4379/#4381)
+  config : $ADK_REL/config/relay-watchdog.json (machine-local, deploy-preserved;
+           channel ids are OPERATOR CONFIG, never hardcoded here)
+
+There is deliberately NO self-expiry / self-uninstall: the 07-09 prototype's
+TTL+idle self-destruction nearly removed the watchdog on a FALSE idle reading
+(it was tailing a dead worktree's transcript). Production lifetime is owned by
+the deploy, not by the process itself.
+"""
+
+from __future__ import annotations
+
+import sys
+
+MIN_PYTHON = (3, 10)
+if sys.version_info < MIN_PYTHON:  # pragma: no cover - trivial guard
+    sys.stderr.write(
+        "relay_watchdog requires Python %d.%d+ (found %s)\n"
+        % (*MIN_PYTHON, sys.version.split()[0])
+    )
+    raise SystemExit(1)
+
+import calendar
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ── Verdict states (pure judgment output, see evaluate()) ─────────────────────
+STATE_OK = "ok"
+STATE_LAGGING = "lagging"  # lost blocks exist, but last good delivery is recent
+STATE_GAP = "gap"  # lost blocks exist AND last good delivery is old → relay down
+
+
+def adk_root() -> Path:
+    return Path(os.environ.get("AGENTDESK_ROOT_DIR", str(Path.home() / ".adk/release")))
+
+
+def projects_root() -> Path:
+    return Path(
+        os.environ.get("CLAUDE_PROJECTS_ROOT", str(Path.home() / ".claude/projects"))
+    )
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ChannelConfig:
+    """One watched Discord channel and the worktree family that relays to it."""
+
+    channel_id: str
+    # Key for `agentdesk discord-sendmessage --key` (bot-token direct post).
+    sendmessage_key: str
+    # Absolute path whose Claude-project slug prefixes this channel's session
+    # project dirs, e.g. "$HOME/.adk/release/worktrees".
+    worktree_root: str
+    # Worktree basename prefix, e.g. "claude-adk-cc". Only
+    # `<prefix>-<YYYYMMDD>-<HHMMSS>` worktrees belong to this channel.
+    worktree_prefix: str = "claude-adk-cc"
+    # Agent id to wake via the announce bot; empty disables the turn-trigger
+    # primary and alerts go straight to discord-sendmessage.
+    announce_to: str = ""
+    announce_channel_kind: str = "cc"
+
+
+@dataclass(frozen=True)
+class Config:
+    channels: tuple[ChannelConfig, ...] = ()
+    poll_secs: int = 120
+    # A block younger than this may simply not be relayed yet: the relay flushes
+    # on turn/tool boundaries and edits messages in place, so a block can sit
+    # unposted for minutes during a long tool call. First live catch
+    # (2026-07-09 05:30Z) was a FALSE POSITIVE at 300s.
+    grace_secs: int = 600
+    # ...and the relay is only declared DOWN when the LAST SUCCESSFUL delivery
+    # is this old. Both conditions must hold. Calibration: the 07-09 outage ran
+    # 2h07m, so 15m catches it early while a normal batching delay (<10m
+    # observed) never trips it.
+    gap_alert_secs: int = 900
+    # Re-alert cadence once a gap is confirmed and still unresolved.
+    realert_secs: int = 900
+    # Transcript older than this ⇒ no live session; a stale gap is not a live
+    # gap. Never alert on it.
+    idle_quiet_secs: int = 2 * 3600
+    # Deploys restart dcserver, so short gaps during a deploy window are
+    # expected. deploy-release.sh touches the marker file when it stops the
+    # release service; alerts are suppressed while the marker is fresh.
+    deploy_quiet_secs: int = 900
+    # A gap persisting this long gets a GitHub issue auto-filed (what the
+    # 06-29 relay-gap-watch did for #3893). Requires github_repo.
+    issue_after_secs: int = 1800
+    github_repo: str = ""  # e.g. "owner/AgentDesk"; empty disables auto-issue
+    # `discord read` failing is itself a signal (the prober is blind); alert
+    # after this many CONSECUTIVE failures instead of skipping forever.
+    read_fail_alert_after: int = 5
+    dcserver_port: int = 8791
+
+
+class ConfigError(Exception):
+    pass
+
+
+def parse_config(raw: dict[str, Any]) -> Config:
+    channels_raw = raw.get("channels")
+    if not isinstance(channels_raw, list) or not channels_raw:
+        raise ConfigError("config must define a non-empty 'channels' list")
+    channels: list[ChannelConfig] = []
+    for i, ch in enumerate(channels_raw):
+        if not isinstance(ch, dict):
+            raise ConfigError(f"channels[{i}] must be an object")
+        try:
+            channel_id = str(ch["channel_id"])
+            sendmessage_key = str(ch["sendmessage_key"])
+        except KeyError as e:
+            raise ConfigError(f"channels[{i}] missing required key: {e}") from e
+        worktree_root = str(
+            ch.get("worktree_root", str(adk_root() / "worktrees"))
+        )
+        channels.append(
+            ChannelConfig(
+                channel_id=channel_id,
+                sendmessage_key=sendmessage_key,
+                worktree_root=worktree_root,
+                worktree_prefix=str(ch.get("worktree_prefix", "claude-adk-cc")),
+                announce_to=str(ch.get("announce_to", "")),
+                announce_channel_kind=str(ch.get("announce_channel_kind", "cc")),
+            )
+        )
+    kwargs: dict[str, Any] = {}
+    for key in (
+        "poll_secs",
+        "grace_secs",
+        "gap_alert_secs",
+        "realert_secs",
+        "idle_quiet_secs",
+        "deploy_quiet_secs",
+        "issue_after_secs",
+        "read_fail_alert_after",
+        "dcserver_port",
+    ):
+        if key in raw:
+            kwargs[key] = int(raw[key])
+    if "github_repo" in raw:
+        kwargs["github_repo"] = str(raw["github_repo"])
+    return Config(channels=tuple(channels), **kwargs)
+
+
+def load_config(path: Path) -> Config:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise ConfigError(f"config file not found: {path}") from e
+    except (OSError, json.JSONDecodeError) as e:
+        raise ConfigError(f"config file unreadable/invalid JSON: {path}: {e}") from e
+    if not isinstance(raw, dict):
+        raise ConfigError(f"config root must be a JSON object: {path}")
+    return parse_config(raw)
+
+
+# ── Project-dir resolution (the 07-09 hotfix, productionized) ─────────────────
+
+
+def project_slug(path: str) -> str:
+    """Claude Code project-dir slug for an absolute path: `/` and `.` → `-`.
+
+    e.g. /Users/me/.adk/release/worktrees → -Users-me--adk-release-worktrees
+    """
+    return re.sub(r"[/.]", "-", path)
+
+
+def main_channel_project_re(worktree_root: str, worktree_prefix: str) -> re.Pattern[str]:
+    """Regex matching ONLY this channel's main-session project dirs.
+
+    Two hard-won invariants (2026-07-09 incident, #4381):
+
+    1. NEVER pin a project dir (or session UUID). The worktree changes every
+       session family; a watchdog tailing a dead worktree's transcript reports
+       `lost=0` forever while the live session goes unwatched. The prototype
+       hardcoded a 06-29 dir and was blind for 5 hours. Resolve on every tick.
+
+    2. EXCLUDE thread sessions. Thread worktrees carry an extra `-t<thread_id>-`
+       segment (`<prefix>-t123…-<date>-<time>`) and relay to a DIFFERENT Discord
+       channel — comparing their transcripts against this channel's messages
+       would manufacture false LOST blocks. Only `<prefix>-<YYYYMMDD>-<HHMMSS>`
+       matches; the `t…` segment fails the `\\d{8}` requirement by construction.
+       Guarded by tests/test_relay_watchdog.py::ProjectDirMatchingTests.
+    """
+    prefix = project_slug(worktree_root.rstrip("/")) + "-" + worktree_prefix + "-"
+    return re.compile("^" + re.escape(prefix) + r"\d{8}-\d{6}$")
+
+
+def channel_project_dirs(root: Path, pattern: re.Pattern[str]) -> list[Path]:
+    try:
+        return [d for d in root.iterdir() if d.is_dir() and pattern.match(d.name)]
+    except OSError:
+        return []
+
+
+def newest_transcript(dirs: list[Path]) -> Path | None:
+    js: list[Path] = []
+    for d in dirs:
+        try:
+            js.extend(d.glob("*.jsonl"))
+        except OSError:
+            continue
+    if not js:
+        return None
+    return max(js, key=lambda f: f.stat().st_mtime)
+
+
+# ── Transcript parsing ─────────────────────────────────────────────────────────
+
+
+def parse_transcript_ts(ts: str) -> float | None:
+    """Transcript timestamps are UTC ISO-8601. Use timegm, NOT
+    `mktime(...) - time.timezone`: mktime interprets the tuple as LOCAL time and
+    `timezone` ignores DST (`altzone` applies then), so the prototype was off by
+    an hour during DST."""
+    try:
+        return float(calendar.timegm(time.strptime(ts[:19], "%Y-%m-%dT%H:%M:%S")))
+    except (ValueError, TypeError):
+        return None
+
+
+def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
+    """(epoch, text) for every assistant text block in a transcript's lines."""
+    out: list[tuple[float, str]] = []
+    for line in lines:
+        try:
+            r = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(r, dict) or r.get("type") != "assistant":
+            continue
+        epoch = parse_transcript_ts(r.get("timestamp", ""))
+        if epoch is None:
+            continue
+        for c in (r.get("message") or {}).get("content") or []:
+            if isinstance(c, dict) and c.get("type") == "text":
+                t = (c.get("text") or "").strip()
+                if t:
+                    out.append((epoch, t))
+    return out
+
+
+def assistant_blocks(transcript: Path) -> list[tuple[float, str]]:
+    try:
+        with transcript.open(encoding="utf-8") as f:
+            return assistant_blocks_from_lines(f)
+    except OSError:
+        return []
+
+
+# ── Delivery matching + judgment (pure) ────────────────────────────────────────
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def delivered(text: str, hay: str) -> bool:
+    """3 probes (head/middle/tail); ≥1 hit counts as delivered, because the
+    relay chunks long blocks across messages and edits messages in place."""
+    n = norm(text)
+    if len(n) < 60:
+        return n in hay
+    probes = [n[:60], n[len(n) // 2 : len(n) // 2 + 50], n[-60:]]
+    return any(p and p in hay for p in probes)
+
+
+@dataclass(frozen=True)
+class Verdict:
+    state: str
+    blocks: int
+    stale: int
+    lost: int
+    delivered_ts: float
+    gap_secs: float
+
+
+def evaluate(
+    blocks: list[tuple[float, str]],
+    hay: str,
+    now: float,
+    grace_secs: int,
+    gap_alert_secs: int,
+) -> Verdict:
+    """Core judgment, ported verbatim from the proven 07-09 logic (#4140→#4178→
+    #4181 lineage). The health watermark is the LAST SUCCESSFUL delivery, not
+    `any lost`: a historic gap (already reported, already recovered) must not
+    re-alert forever, and relay chunking can deliver a later block while an
+    earlier one is still missing. Both conditions — lost blocks exist AND the
+    watermark is older than gap_alert_secs — must hold to declare a gap.
+    """
+    delivered_ts = max((e for e, t in blocks if delivered(t, hay)), default=0.0)
+    stale = [(e, t) for e, t in blocks if now - e > grace_secs]
+    lost = [(e, t) for e, t in stale if e > delivered_ts and not delivered(t, hay)]
+    gap_secs = (now - delivered_ts) if delivered_ts else float("inf")
+    if lost and gap_secs > gap_alert_secs:
+        state = STATE_GAP
+    elif lost:
+        state = STATE_LAGGING
+    else:
+        state = STATE_OK
+    return Verdict(
+        state=state,
+        blocks=len(blocks),
+        stale=len(stale),
+        lost=len(lost),
+        delivered_ts=delivered_ts,
+        gap_secs=gap_secs,
+    )
+
+
+# ── Persistent state (survives process restarts; launchd may respawn us) ──────
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=1, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+# ── Runtime side (subprocess/IO); kept thin so judgment stays pure ─────────────
+
+
+class Runtime:
+    def __init__(self, cfg: Config, root: Path) -> None:
+        self.cfg = cfg
+        self.root = root
+        self.agentdesk = str(root / "bin/agentdesk")
+        self.log_path = root / "logs/relay-watchdog.log"
+        self.state_path = root / "logs/relay-watchdog.state.json"
+        self.deploy_marker = root / "logs/relay-watchdog.deploy-marker"
+
+    def log(self, msg: str) -> None:
+        line = f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n"
+        try:
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+            with self.log_path.open("a", encoding="utf-8") as f:
+                f.write(line)
+        except OSError:
+            sys.stderr.write(line)
+
+    def in_deploy_window(self, now: float) -> bool:
+        try:
+            return now - self.deploy_marker.stat().st_mtime < self.cfg.deploy_quiet_secs
+        except OSError:
+            return False
+
+    def discord_haystack(self, channel_id: str) -> str | None:
+        try:
+            p = subprocess.run(
+                [self.agentdesk, "discord", "read", channel_id, "--limit", "100"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if p.returncode != 0:
+                return None
+            d = json.loads(p.stdout)
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+            return None
+        msgs = d if isinstance(d, list) else d.get("messages", d.get("data", []))
+        bot = [m for m in msgs if (m.get("author") or {}).get("bot")]
+        return norm(" ".join((m.get("content") or "") for m in bot))
+
+    def dcserver_snapshot(self) -> str:
+        bits = []
+        # /api/health/detail, NOT /api/health: the public projection strips live
+        # `degraded_reasons` and exposes only startup_degraded_reasons, which do
+        # not drive `degraded` — reading it misattributes the cause (#4382).
+        base = f"http://127.0.0.1:{self.cfg.dcserver_port}/api/health"
+        for url, tag in ((base + "/detail", "health/detail"), (base, "health")):
+            try:
+                p = subprocess.run(
+                    ["curl", "-sf", "--max-time", "4", url],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if p.returncode == 0 and p.stdout:
+                    h = json.loads(p.stdout)
+                    b = f"{tag} db={h.get('db')} degraded={h.get('degraded')}"
+                    reasons = h.get("degraded_reasons")
+                    if reasons:
+                        b += f" reasons={','.join(str(r) for r in reasons)[:200]}"
+                    bits.append(b)
+                    break
+            except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+                continue
+        else:
+            bits.append("health UNREACHABLE")
+        try:
+            p = subprocess.run(
+                ["nc", "-z", "-G", "3", "127.0.0.1", "15432"],
+                capture_output=True,
+                timeout=8,
+            )
+            bits.append("pg-tunnel " + ("OPEN" if p.returncode == 0 else "CLOSED"))
+        except (OSError, subprocess.SubprocessError):
+            bits.append("pg-tunnel UNKNOWN")
+        try:
+            p = subprocess.run(
+                ["/bin/ps", "-axo", "pid=,etime=,command="],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            for line in p.stdout.splitlines():
+                if "agentdesk" in line and "dcserver" in line and "grep" not in line:
+                    pid, etime = line.split(None, 2)[:2]
+                    bits.append(f"dcserver pid={pid} uptime={etime}")
+                    break
+            else:
+                bits.append("dcserver NOT RUNNING")
+        except (OSError, subprocess.SubprocessError, ValueError):
+            bits.append("dcserver UNKNOWN")
+        return " | ".join(bits)
+
+    def alert(self, ch: ChannelConfig, body: str, trigger_turn: bool = True) -> None:
+        """Deliver an alert OUT OF BAND (never through the watched turn relay).
+
+        Primary: announce bot (`send-to-agent --from system`). Trips the target
+        agent's intake_gate and TRIGGERS A TURN; a wedged mailbox queues it (📬)
+        instead of dropping it. `--start-turn` is NOT used because it 409s on
+        exactly the busy mailbox we are alerting about. `--from` must be
+        `system` (LOOPBACK_ONLY; other labels are rejected by send_gate).
+        `--expect-reply` MUST be `false`: `true` appends a reply contract
+        targeting `--to system`, which has no Discord channel binding — an
+        unfulfillable contract. expect_reply only selects that appended text;
+        `false` still wakes the agent (verified 2026-07-09).
+
+        But send-to-agent requires a live PG pool, so when Postgres is down —
+        precisely the failure that killed dcserver on 2026-07-09 — this path
+        dies too. Fallback: `discord-sendmessage`, bot-token direct, proven the
+        only survivor of the 07-09 outage. Never let a fancier primary silently
+        swallow the alert.
+        """
+        if trigger_turn and ch.announce_to:
+            try:
+                p = subprocess.run(
+                    [
+                        self.agentdesk,
+                        "send-to-agent",
+                        "--from",
+                        "system",
+                        "--to",
+                        ch.announce_to,
+                        "--channel-kind",
+                        ch.announce_channel_kind,
+                        "--expect-reply",
+                        "false",
+                        "--message",
+                        body,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                if p.returncode == 0:
+                    self.log("alert delivered via announce bot (turn trigger)")
+                    return
+                self.log(
+                    f"announce bot failed rc={p.returncode}: "
+                    f"{(p.stderr or p.stdout)[:160]!r}; falling back"
+                )
+            except (OSError, subprocess.SubprocessError) as e:
+                self.log(f"announce bot error: {e}; falling back")
+        try:
+            p = subprocess.run(
+                [
+                    self.agentdesk,
+                    "discord-sendmessage",
+                    "--channel",
+                    ch.channel_id,
+                    "--key",
+                    ch.sendmessage_key,
+                    "--message",
+                    body,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=45,
+            )
+            self.log(f"alert delivered via discord-sendmessage rc={p.returncode}")
+        except (OSError, subprocess.SubprocessError) as e:
+            self.log(f"discord-sendmessage error: {e}")
+
+    def file_github_issue(self, ch: ChannelConfig, gap_min: int, lost: int) -> str:
+        """Auto-file a GitHub issue for a persistent gap (06-29 relay-gap-watch
+        behavior, see #3893). Best-effort: failure is logged, never fatal."""
+        gh = shutil.which("gh") or "/opt/homebrew/bin/gh"
+        title = (
+            f"[auto][relay-watchdog] relay gap on channel {ch.channel_id}: "
+            f"{lost} undelivered blocks, {gap_min}m since last delivery"
+        )
+        body = (
+            f"Filed automatically by the out-of-band relay watchdog (#4381).\n\n"
+            f"- channel: `{ch.channel_id}`\n"
+            f"- undelivered assistant blocks: **{lost}**\n"
+            f"- minutes since last successful delivery: **{gap_min}**\n"
+            f"- runtime snapshot: {self.dcserver_snapshot()}\n\n"
+            f"The watchdog compares session transcripts against delivered "
+            f"Discord messages; see `scripts/relay_watchdog.py`."
+        )
+        try:
+            p = subprocess.run(
+                [
+                    gh,
+                    "issue",
+                    "create",
+                    "--repo",
+                    self.cfg.github_repo,
+                    "--title",
+                    title,
+                    "--body",
+                    body,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if p.returncode == 0:
+                url = p.stdout.strip().splitlines()[-1] if p.stdout.strip() else ""
+                self.log(f"auto-filed issue: {url}")
+                return url
+            self.log(
+                f"gh issue create failed rc={p.returncode}: "
+                f"{(p.stderr or p.stdout)[:160]!r}"
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            self.log(f"gh issue create error: {e}")
+        return ""
+
+
+# ── Per-channel tick ───────────────────────────────────────────────────────────
+
+
+def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
+    cfg = rt.cfg
+    cid = ch.channel_id
+    chs: dict[str, Any] = state.setdefault(cid, {})
+
+    pattern = main_channel_project_re(ch.worktree_root, ch.worktree_prefix)
+    dirs = channel_project_dirs(projects_root(), pattern)
+    tr = newest_transcript(dirs)
+    idle = (now - tr.stat().st_mtime) if tr else float("inf")
+    if idle >= cfg.idle_quiet_secs:
+        # Stale transcript: any "gap" is historic, not live. Never alert.
+        # (No self-uninstall here — see module docstring.)
+        rt.log(f"[{cid}] idle {int(min(idle, 86400 * 365) // 60)}m — no live session, skipping")
+        return
+
+    hay = rt.discord_haystack(cid)
+    if hay is None:
+        # A blind prober is itself a signal: persistent read failure means we
+        # cannot vouch for the relay at all. Alert after N consecutive misses.
+        fails = int(chs.get("read_failures", 0)) + 1
+        chs["read_failures"] = fails
+        rt.log(f"[{cid}] discord read failed ({fails} consecutive); skipping tick")
+        if fails >= cfg.read_fail_alert_after and now - float(
+            chs.get("last_alert", 0)
+        ) >= cfg.realert_secs:
+            rt.alert(
+                ch,
+                f"🚨 **릴레이 워치독 자체 실명 감지**\n\n"
+                f"`agentdesk discord read`가 **{fails}회 연속 실패** — 워치독이 "
+                f"릴레이 상태를 검증할 수 없는 상태입니다 (이것 자체가 신호).\n\n"
+                f"런타임: {rt.dcserver_snapshot()}",
+            )
+            chs["last_alert"] = now
+        return
+    chs["read_failures"] = 0
+
+    blocks = assistant_blocks(tr) if tr else []
+    v = evaluate(blocks, hay, now, cfg.grace_secs, cfg.gap_alert_secs)
+
+    if v.state == STATE_GAP:
+        if rt.in_deploy_window(now):
+            rt.log(
+                f"[{cid}] gap lost={v.lost} suppressed — deploy window "
+                f"(marker < {cfg.deploy_quiet_secs}s old)"
+            )
+            return
+        gap_min = int(v.gap_secs // 60) if v.delivered_ts else 999
+        if not chs.get("gap_since"):
+            chs["gap_since"] = now
+        if (
+            cfg.github_repo
+            and not chs.get("issue_url")
+            and now - float(chs["gap_since"]) >= cfg.issue_after_secs
+        ):
+            url = rt.file_github_issue(ch, gap_min, v.lost)
+            if url:
+                chs["issue_url"] = url
+        if now - float(chs.get("last_alert", 0)) >= cfg.realert_secs:
+            issue_line = (
+                f"\n자동 등록 이슈: {chs['issue_url']}" if chs.get("issue_url") else ""
+            )
+            rt.alert(
+                ch,
+                f"🚨 **릴레이 갭 감지 (out-of-band 워치독)**\n\n"
+                f"소스(세션 트랜스크립트)에는 있는데 Discord에 도착하지 않은 "
+                f"assistant 블록 **{v.lost}건**.\n"
+                f"마지막 정상 도달 이후 **{gap_min}분** 경과.\n\n"
+                f"런타임: {rt.dcserver_snapshot()}{issue_line}\n\n"
+                f"이 알림은 turn-relay 경로가 아니라 out-of-band로 직접 나갑니다 — "
+                f"릴레이가 죽어도 도착합니다.",
+            )
+            chs["last_alert"] = now
+            chs["alerting"] = True
+            rt.log(f"[{cid}] ALERT lost={v.lost} gap_min={gap_min}")
+        else:
+            rt.log(f"[{cid}] gap persists lost={v.lost} (alert suppressed, cooldown)")
+    elif v.state == STATE_LAGGING:
+        rt.log(
+            f"[{cid}] lagging lost={v.lost} gap={int(v.gap_secs)}s "
+            f"(< {cfg.gap_alert_secs}s alert threshold — relay batching, not down)"
+        )
+    else:
+        if chs.get("alerting"):
+            # Auto-clear: tell the same audience the gap resolved, then reset.
+            rt.alert(
+                ch,
+                f"✅ **릴레이 갭 해소 (out-of-band 워치독)**\n\n"
+                f"미도달 블록 0건으로 복구 확인. "
+                f"(감시 재개; 이전 알림은 무시해도 됩니다)"
+                + (
+                    f"\n자동 등록 이슈 확인 필요: {chs['issue_url']}"
+                    if chs.get("issue_url")
+                    else ""
+                ),
+                trigger_turn=False,
+            )
+            rt.log(f"[{cid}] RECOVERED — alert state cleared")
+        chs.pop("alerting", None)
+        chs.pop("gap_since", None)
+        chs.pop("issue_url", None)
+        rt.log(f"[{cid}] ok blocks={v.blocks} stale={v.stale} lost=0")
+
+
+# ── Main loop ──────────────────────────────────────────────────────────────────
+
+
+def config_path() -> Path:
+    return Path(
+        os.environ.get(
+            "RELAY_WATCHDOG_CONFIG", str(adk_root() / "config/relay-watchdog.json")
+        )
+    )
+
+
+def main() -> int:
+    root = adk_root()
+    cfg: Config | None = None
+    rt: Runtime | None = None
+    last_cfg_err = ""
+    while True:
+        try:
+            cfg = load_config(config_path())
+        except ConfigError as e:
+            # KeepAlive would crash-loop us; instead poll for config to appear.
+            msg = f"config error: {e} — retrying in 600s"
+            if msg != last_cfg_err:
+                Runtime(Config(), root).log(msg)
+                last_cfg_err = msg
+            time.sleep(600)
+            continue
+        last_cfg_err = ""
+        if rt is None or rt.cfg != cfg:
+            rt = Runtime(cfg, root)
+            rt.log(
+                f"watchdog armed channels={[c.channel_id for c in cfg.channels]} "
+                f"poll={cfg.poll_secs}s grace={cfg.grace_secs}s "
+                f"gap_alert={cfg.gap_alert_secs}s"
+            )
+        state = load_state(rt.state_path)
+        now = time.time()
+        for ch in cfg.channels:
+            try:
+                tick_channel(rt, ch, state, now)
+            except Exception as e:  # noqa: BLE001 — one channel must not kill the loop
+                rt.log(f"[{ch.channel_id}] tick error: {type(e).__name__}: {e}")
+        save_state(rt.state_path, state)
+        time.sleep(cfg.poll_secs)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -362,6 +362,25 @@ def save_state(path: Path, state: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
+def save_state_guarded(rt: "Runtime", state: dict[str, Any]) -> None:
+    """Persist state, but NEVER die on a write failure (r2 review, PR #4399).
+
+    Same "KeepAlive would crash-loop us" invariant as the config-retry loop in
+    main(): if a disk-full/unwritable-logs OSError killed the process here,
+    launchd (KeepAlive, ThrottleInterval=30) would respawn it every ~30s with
+    EMPTY in-memory state. The alert goes out BEFORE the save, so each respawn
+    would forget last_alert and re-alert — a live gap becomes an ~2/min alert
+    storm, amplified by announce-triggered agent turns; gap_since would also
+    never persist, so the auto-issue threshold could never fire. Log and
+    continue: the caller keeps the SAME dict across ticks, so cooldown state
+    survives in memory and persistence resumes when the disk does.
+    """
+    try:
+        save_state(rt.state_path, state)
+    except OSError as e:
+        rt.log(f"state save failed ({e}); continuing with in-memory state")
+
+
 # ── Runtime side (subprocess/IO); kept thin so judgment stays pure ─────────────
 
 
@@ -696,6 +715,10 @@ def main() -> int:
     root = adk_root()
     cfg: Config | None = None
     rt: Runtime | None = None
+    # Loaded from disk ONCE (per Runtime), then kept in memory across ticks so
+    # cooldown/issue-dedup state survives even while saves fail — see
+    # save_state_guarded().
+    state: dict[str, Any] | None = None
     last_cfg_err = ""
     while True:
         try:
@@ -711,19 +734,21 @@ def main() -> int:
         last_cfg_err = ""
         if rt is None or rt.cfg != cfg:
             rt = Runtime(cfg, root)
+            state = None
             rt.log(
                 f"watchdog armed channels={[c.channel_id for c in cfg.channels]} "
                 f"poll={cfg.poll_secs}s grace={cfg.grace_secs}s "
                 f"gap_alert={cfg.gap_alert_secs}s"
             )
-        state = load_state(rt.state_path)
+        if state is None:
+            state = load_state(rt.state_path)
         now = time.time()
         for ch in cfg.channels:
             try:
                 tick_channel(rt, ch, state, now)
             except Exception as e:  # noqa: BLE001 — one channel must not kill the loop
                 rt.log(f"[{ch.channel_id}] tick error: {type(e).__name__}: {e}")
-        save_state(rt.state_path, state)
+        save_state_guarded(rt, state)
         time.sleep(cfg.poll_secs)
 
 

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -442,23 +442,39 @@ class Runtime:
             return None
         if not isinstance(msgs, list):
             return None
-        dict_msgs = [m for m in msgs if isinstance(m, dict)]
-        if msgs and not dict_msgs:
+        def well_formed(m: object) -> bool:
+            # A parseable entry is a dict whose `author` is a dict (or absent)
+            # and whose `content` is a string (or absent). Malformed dicts
+            # (`{"author": "bot"}`, non-string content) would raise
+            # AttributeError/TypeError below — surfacing as a generic tick
+            # error that BYPASSES the read_failures escalation, the exact
+            # failure class r4/r5 closed for non-dict shapes (r6 review,
+            # PR #4399).
+            if not isinstance(m, dict):
+                return False
+            author = m.get("author")
+            if author is not None and not isinstance(author, dict):
+                return False
+            content = m.get("content")
+            return content is None or isinstance(content, str)
+
+        ok_msgs = [m for m in msgs if well_formed(m)]
+        if msgs and not ok_msgs:
             # A NON-EMPTY payload with ZERO parseable entries is schema drift,
             # not an empty channel: silently skipping them all would yield ''
             # — a "successful" read that never increments read_failures and
             # bypasses the watchdog-blind escalation (r5 review, PR #4399).
             # An empty list ([]) stays a normal empty channel.
             return None
-        skipped = len(msgs) - len(dict_msgs)
+        skipped = len(msgs) - len(ok_msgs)
         if skipped:
             # Mixed payload: partial data beats blindness, but schema drift
             # must still leave a trace.
             self.log(
-                f"discord read: skipped {skipped} non-object message "
+                f"discord read: skipped {skipped} malformed message "
                 f"entries (schema drift?)"
             )
-        bot = [m for m in dict_msgs if (m.get("author") or {}).get("bot")]
+        bot = [m for m in ok_msgs if (m.get("author") or {}).get("bot")]
         return norm(" ".join((m.get("content") or "") for m in bot))
 
     def dcserver_snapshot(self) -> str:

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -172,7 +172,16 @@ def parse_config(raw: dict[str, Any]) -> Config:
         "dcserver_port",
     ):
         if key in raw:
-            kwargs[key] = int(raw[key])
+            # A malformed number must surface as ConfigError, never ValueError:
+            # main()'s retry loop only catches ConfigError, and anything else
+            # would kill the process → KeepAlive crash-loop every ~30s until an
+            # operator notices (r4 review, PR #4399).
+            try:
+                kwargs[key] = int(raw[key])
+            except (ValueError, TypeError) as e:
+                raise ConfigError(
+                    f"config field {key!r} must be an integer, got {raw[key]!r}"
+                ) from e
     if "github_repo" in raw:
         kwargs["github_repo"] = str(raw["github_repo"])
     return Config(channels=tuple(channels), **kwargs)
@@ -421,8 +430,23 @@ class Runtime:
             d = json.loads(p.stdout)
         except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
             return None
-        msgs = d if isinstance(d, list) else d.get("messages", d.get("data", []))
-        bot = [m for m in msgs if (m.get("author") or {}).get("bot")]
+        # Shape-validate: rc=0 with VALID but non-list/dict JSON (`null`, a bare
+        # number/string) must join the read-failure path (return None) — an
+        # AttributeError here would skip the read_failures escalation and leave
+        # the prober silently blind (r4 review, PR #4399).
+        if isinstance(d, list):
+            msgs = d
+        elif isinstance(d, dict):
+            msgs = d.get("messages", d.get("data", []))
+        else:
+            return None
+        if not isinstance(msgs, list):
+            return None
+        bot = [
+            m
+            for m in msgs
+            if isinstance(m, dict) and (m.get("author") or {}).get("bot")
+        ]
         return norm(" ".join((m.get("content") or "") for m in bot))
 
     def dcserver_snapshot(self) -> str:

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -444,8 +444,41 @@ class DiscordHaystackShapeTests(unittest.TestCase):
             '[null, 7, {"author": {"bot": true}, "content": "hello  world"}]'
         )
         self.assertEqual(out, "hello world")
-        self.assertIn("skipped 2 non-object message entries", log)
+        self.assertIn("skipped 2 malformed message entries", log)
         self.assertIn("schema drift", log)
+
+    # r6 review (PR #4399): entries that ARE dicts but carry a non-dict
+    # `author` (`{"author": "bot"}` → AttributeError) or a non-string
+    # `content` (TypeError at join) used to raise instead of classifying —
+    # a generic tick error that bypassed the read_failures escalation, the
+    # same failure class r4/r5 closed for non-dict shapes.
+    def test_all_malformed_dict_entries_is_read_failure_not_exception(self):
+        for stdout in (
+            '[{"author": "bot", "content": "x"}]',
+            '[{"author": {"bot": true}, "content": [1, 2]}]',
+            '[{"author": "bot"}, {"author": {"bot": true}, "content": 7}]',
+        ):
+            with self.subTest(stdout=stdout):
+                self.assertIsNone(self._haystack_for(stdout))
+
+    def test_malformed_dict_entry_mixed_with_valid_is_skipped_with_trace(self):
+        out, log = self._probe(
+            '[{"author": "bot", "content": "bad"},'
+            ' {"author": {"bot": true}, "content": "good"}]'
+        )
+        self.assertEqual(out, "good")
+        self.assertIn("skipped 1 malformed message entries", log)
+        self.assertIn("schema drift", log)
+
+    def test_absent_author_and_absent_content_stay_well_formed(self):
+        # A dict entry missing `author`/`content` was always tolerated (a
+        # non-bot or empty message) — r6 must not reclassify it as drift.
+        out, log = self._probe(
+            '[{}, {"author": {"bot": true}, "content": "ok"},'
+            ' {"author": {"bot": true}}]'
+        )
+        self.assertEqual(out, "ok")
+        self.assertNotIn("schema drift", log)
 
     def test_valid_shapes_still_parse(self):
         self.assertEqual(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -394,7 +394,9 @@ class DiscordHaystackShapeTests(unittest.TestCase):
     — read_failures never incremented, so the 'watchdog blind' escalation was
     silently skipped. Such shapes must join the read-failure path (None)."""
 
-    def _haystack_for(self, stdout: str) -> "str | None":
+    def _probe(self, stdout: str) -> "tuple[str | None, str]":
+        """Returns (haystack result, watchdog log contents)."""
+
         def fake_run(argv, **kwargs):
             return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
 
@@ -403,7 +405,15 @@ class DiscordHaystackShapeTests(unittest.TestCase):
             with mock.patch.object(
                 relay_watchdog.subprocess, "run", side_effect=fake_run
             ):
-                return rt.discord_haystack("999")
+                out = rt.discord_haystack("999")
+            try:
+                log = rt.log_path.read_text(encoding="utf-8")
+            except OSError:
+                log = ""
+        return out, log
+
+    def _haystack_for(self, stdout: str) -> "str | None":
+        return self._probe(stdout)[0]
 
     def test_valid_but_non_collection_json_is_read_failure(self):
         for stdout in ("null", "123", '"str"'):
@@ -413,11 +423,29 @@ class DiscordHaystackShapeTests(unittest.TestCase):
     def test_dict_with_non_list_messages_is_read_failure(self):
         self.assertIsNone(self._haystack_for('{"messages": 5}'))
 
-    def test_non_dict_entries_are_skipped_not_fatal(self):
-        out = self._haystack_for(
+    # r5 review (PR #4399): a NON-EMPTY list with zero dict entries used to
+    # collapse to '' — a "successful" empty read that never incremented
+    # read_failures, bypassing the watchdog-blind escalation. It must be a
+    # read failure (None).
+    def test_all_malformed_entries_is_read_failure(self):
+        self.assertIsNone(self._haystack_for("[null, 7]"))
+
+    def test_all_malformed_entries_in_dict_wrapper_is_read_failure(self):
+        self.assertIsNone(self._haystack_for('{"messages": [null, 7]}'))
+
+    def test_empty_list_is_a_normal_empty_channel(self):
+        out, log = self._probe("[]")
+        self.assertEqual(out, "")
+        self.assertNotIn("schema drift", log)
+
+    def test_mixed_entries_parse_dicts_and_log_schema_drift(self):
+        # Partial data beats blindness, but the drift must leave a trace.
+        out, log = self._probe(
             '[null, 7, {"author": {"bot": true}, "content": "hello  world"}]'
         )
         self.assertEqual(out, "hello world")
+        self.assertIn("skipped 2 non-object message entries", log)
+        self.assertIn("schema drift", log)
 
     def test_valid_shapes_still_parse(self):
         self.assertEqual(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -13,17 +13,23 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 import time
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest import mock
 
+import scripts.relay_watchdog as relay_watchdog
 from scripts.relay_watchdog import (
     STATE_GAP,
     STATE_LAGGING,
     STATE_OK,
+    ChannelConfig,
+    Config,
     ConfigError,
+    Runtime,
     assistant_blocks_from_lines,
     channel_project_dirs,
     delivered,
@@ -36,6 +42,7 @@ from scripts.relay_watchdog import (
     parse_transcript_ts,
     project_slug,
     save_state,
+    tick_channel,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -356,6 +363,267 @@ class StateTests(unittest.TestCase):
             self.assertEqual(load_state(Path(tmp) / "missing.json"), {})
 
 
+TICK_CHANNEL = ChannelConfig(
+    channel_id="999",
+    sendmessage_key="k",
+    worktree_root=WORKTREE_ROOT,
+)
+
+
+class FakeRuntime(Runtime):
+    """Runtime with every subprocess/network edge stubbed; tick_channel logic
+    (including the REAL in_deploy_window file check) runs unmodified."""
+
+    def __init__(self, cfg: Config, root: Path) -> None:
+        super().__init__(cfg, root)
+        self.alerts: list[tuple[str, bool]] = []
+        self.log_lines: list[str] = []
+        self.haystack: str | None = ""
+        self.issue_calls = 0
+
+    def log(self, msg: str) -> None:
+        self.log_lines.append(msg)
+
+    def discord_haystack(self, channel_id: str) -> str | None:
+        return self.haystack
+
+    def dcserver_snapshot(self) -> str:
+        return "stub-snapshot"
+
+    def alert(self, ch, body: str, trigger_turn: bool = True) -> None:
+        self.alerts.append((body, trigger_turn))
+
+    def file_github_issue(self, ch, gap_min: int, lost: int) -> str:
+        self.issue_calls += 1
+        return f"https://example.test/issues/{self.issue_calls}"
+
+
+class TickChannelTests(unittest.TestCase):
+    """Orchestration-level behavior: suppression windows, cooldown, recovery,
+    issue dedup, read-failure escalation. These exercise tick_channel itself —
+    the pure-judgment tests above cannot catch a broken wiring of it (adversarial
+    review finding on PR #4399: neutering in_deploy_window left 35/35 green)."""
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        (self.root / "logs").mkdir()
+        self.projects = self.root / "projects"
+        self.proj_dir = self.projects / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-140500"
+        )
+        self.proj_dir.mkdir(parents=True)
+        env = mock.patch.dict(
+            os.environ, {"CLAUDE_PROJECTS_ROOT": str(self.projects)}
+        )
+        env.start()
+        self.addCleanup(env.stop)
+        self.now = time.time()
+
+    def write_transcript(self, blocks: list[tuple[float, str]]) -> None:
+        lines = []
+        for epoch, text in blocks:
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": ts,
+                        "message": {"content": [{"type": "text", "text": text}]},
+                    }
+                )
+            )
+        (self.proj_dir / "s.jsonl").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    def make_rt(self, **cfg_overrides) -> FakeRuntime:
+        cfg = Config(channels=(TICK_CHANNEL,), **cfg_overrides)
+        return FakeRuntime(cfg, self.root)
+
+    def gap_rt(self, **cfg_overrides) -> FakeRuntime:
+        # One stale undelivered block, nothing ever delivered → GAP verdict.
+        self.write_transcript([(self.now - 2000, "never delivered block")])
+        rt = self.make_rt(**cfg_overrides)
+        rt.haystack = ""
+        return rt
+
+    # (a) deploy-window suppression — REAL in_deploy_window runs against a real
+    # marker file, so replacing it with `return False` fails this test.
+    def test_fresh_deploy_marker_suppresses_gap_alert(self):
+        rt = self.gap_rt()
+        # Positive control first: without a marker the same scenario alerts.
+        tick_channel(rt, TICK_CHANNEL, {}, self.now)
+        self.assertEqual(len(rt.alerts), 1, "control: gap must alert sans marker")
+
+        rt2 = self.gap_rt()
+        rt2.deploy_marker.touch()
+        state: dict = {}
+        tick_channel(rt2, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt2.alerts, [], "fresh deploy marker must suppress alerts")
+        self.assertTrue(any("deploy window" in l for l in rt2.log_lines))
+        self.assertNotIn("last_alert", state.get("999", {}))
+
+    def test_stale_deploy_marker_does_not_suppress(self):
+        rt = self.gap_rt()
+        rt.deploy_marker.touch()
+        old = self.now - rt.cfg.deploy_quiet_secs - 1
+        os.utime(rt.deploy_marker, (old, old))
+        tick_channel(rt, TICK_CHANNEL, {}, self.now)
+        self.assertEqual(len(rt.alerts), 1)
+
+    # (b) cooldown / re-alert boundary
+    def test_cooldown_suppresses_realert_until_boundary(self):
+        rt = self.gap_rt()
+        state = {"999": {"last_alert": self.now - (rt.cfg.realert_secs - 1)}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+        self.assertTrue(any("cooldown" in l for l in rt.log_lines))
+
+        rt2 = self.gap_rt()
+        state2 = {"999": {"last_alert": self.now - rt2.cfg.realert_secs}}
+        tick_channel(rt2, TICK_CHANNEL, state2, self.now)
+        self.assertEqual(len(rt2.alerts), 1)
+        self.assertEqual(state2["999"]["last_alert"], self.now)
+        self.assertTrue(state2["999"]["alerting"])
+
+    # (c) recovery auto-clear
+    def test_recovery_sends_notice_and_clears_alert_state(self):
+        self.write_transcript([(self.now - 2000, "landed fine in discord")])
+        rt = self.make_rt()
+        rt.haystack = norm("landed fine in discord")
+        state = {
+            "999": {
+                "alerting": True,
+                "gap_since": self.now - 3000,
+                "issue_url": "https://example.test/issues/7",
+                "last_alert": self.now - 60,
+            }
+        }
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(len(rt.alerts), 1)
+        body, trigger_turn = rt.alerts[0]
+        self.assertIn("해소", body)
+        self.assertIn("https://example.test/issues/7", body)
+        self.assertFalse(trigger_turn, "recovery notice must not trigger a turn")
+        for cleared in ("alerting", "gap_since", "issue_url"):
+            self.assertNotIn(cleared, state["999"])
+
+    def test_ok_without_prior_alert_sends_nothing(self):
+        self.write_transcript([(self.now - 2000, "landed fine in discord")])
+        rt = self.make_rt()
+        rt.haystack = norm("landed fine in discord")
+        tick_channel(rt, TICK_CHANNEL, {}, self.now)
+        self.assertEqual(rt.alerts, [])
+
+    # (d) persistent-gap issue auto-filing is deduplicated
+    def test_persistent_gap_files_issue_exactly_once(self):
+        rt = self.gap_rt(github_repo="owner/repo")
+        state = {"999": {"gap_since": self.now - rt.cfg.issue_after_secs - 1}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.issue_calls, 1)
+        self.assertEqual(state["999"]["issue_url"], "https://example.test/issues/1")
+        self.assertIn("https://example.test/issues/1", rt.alerts[0][0])
+
+        # Second tick, gap still open: issue_url in state must prevent a dupe.
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(rt.issue_calls, 1, "issue must be filed exactly once")
+
+    def test_no_github_repo_configured_files_nothing(self):
+        rt = self.gap_rt()  # github_repo defaults to ""
+        state = {"999": {"gap_since": self.now - rt.cfg.issue_after_secs - 1}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.issue_calls, 0)
+
+    # (e) consecutive discord-read failures escalate to an alert
+    def test_read_failure_threshold_escalates(self):
+        self.write_transcript([(self.now - 60, "fresh block")])
+        rt = self.make_rt()
+        rt.haystack = None  # discord read failing
+        state = {"999": {"read_failures": rt.cfg.read_fail_alert_after - 2}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [], "below threshold must only log")
+        self.assertEqual(
+            state["999"]["read_failures"], rt.cfg.read_fail_alert_after - 1
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(len(rt.alerts), 1, "threshold reached must alert")
+        self.assertIn("연속 실패", rt.alerts[0][0])
+        self.assertEqual(state["999"]["last_alert"], self.now)
+
+    def test_read_success_resets_failure_counter(self):
+        self.write_transcript([(self.now - 60, "fresh block")])
+        rt = self.make_rt()
+        rt.haystack = norm("fresh block")
+        state = {"999": {"read_failures": 4}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(state["999"]["read_failures"], 0)
+
+
+class AlertFallbackTests(unittest.TestCase):
+    """(f) Runtime.alert delivery chain: announce-bot primary, bot-token
+    fallback. The fallback is the only path proven to survive the 07-09 outage;
+    a broken handoff would silently swallow the alert."""
+
+    CH = ChannelConfig(
+        channel_id="999",
+        sendmessage_key="key123",
+        worktree_root=WORKTREE_ROOT,
+        announce_to="project-agentdesk",
+    )
+
+    def _run_alert(self, announce_rc: int) -> list[list[str]]:
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            rc = announce_rc if "send-to-agent" in argv else 0
+            return subprocess.CompletedProcess(argv, rc, stdout="", stderr="boom")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(Config(channels=(self.CH,)), Path(tmp))
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                rt.alert(self.CH, "alert body")
+        return calls
+
+    def test_announce_failure_falls_back_to_sendmessage(self):
+        calls = self._run_alert(announce_rc=1)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("send-to-agent", calls[0])
+        # The unfulfillable-contract guard: --expect-reply must be false.
+        self.assertIn("--expect-reply", calls[0])
+        self.assertEqual(calls[0][calls[0].index("--expect-reply") + 1], "false")
+        self.assertIn("discord-sendmessage", calls[1])
+        self.assertIn("key123", calls[1])
+
+    def test_announce_success_skips_fallback(self):
+        calls = self._run_alert(announce_rc=0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("send-to-agent", calls[0])
+
+    def test_no_announce_target_goes_straight_to_sendmessage(self):
+        ch = ChannelConfig(
+            channel_id="999", sendmessage_key="key123", worktree_root=WORKTREE_ROOT
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(Config(channels=(ch,)), Path(tmp))
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                rt.alert(ch, "alert body")
+        self.assertEqual(len(calls), 1)
+        self.assertIn("discord-sendmessage", calls[0])
+
+
 class DeploymentWiringTests(unittest.TestCase):
     """#4372 lesson: a test that CI never runs is a graveyard, and a script the
     deploy never ships evaporates (the 06-29 relay-gap-watch, the 07-09
@@ -373,6 +641,11 @@ class DeploymentWiringTests(unittest.TestCase):
         )
         self.assertIn("scripts/relay_watchdog.py", deploy)
         self.assertIn("com.agentdesk.relay-watchdog", deploy)
+        # Fail-open invariant (adversarial review, PR #4399): the watchdog block
+        # runs after DEPLOY_OK, so a plist write failure must warn and continue
+        # — never abort a healthy deploy or skip manifest/peer propagation.
+        self.assertIn("_install_relay_watchdog_plist", deploy)
+        self.assertIn("Relay watchdog plist write FAILED", deploy)
         # Deploy-window suppression contract: deploy must touch the marker the
         # watchdog checks before restarting dcserver.
         self.assertIn("relay-watchdog.deploy-marker", deploy)

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1,0 +1,388 @@
+"""Unit tests for scripts/relay_watchdog.py (#4381).
+
+These nail the judgment logic that the 2026-07-09 incident proved must never
+regress silently:
+
+- project-dir resolution is DYNAMIC (no pinned worktree/session) and EXCLUDES
+  thread sessions, which relay to a different channel;
+- the LOST/GAP verdict uses the last-good-delivery watermark with grace and
+  gap-alert boundaries exactly as calibrated during the incident.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.relay_watchdog import (
+    STATE_GAP,
+    STATE_LAGGING,
+    STATE_OK,
+    ConfigError,
+    assistant_blocks_from_lines,
+    channel_project_dirs,
+    delivered,
+    evaluate,
+    load_state,
+    main_channel_project_re,
+    newest_transcript,
+    norm,
+    parse_config,
+    parse_transcript_ts,
+    project_slug,
+    save_state,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+WORKTREE_ROOT = "/Users/alice/.adk/release/worktrees"
+PREFIX = "claude-adk-cc"
+
+
+def make_re():
+    return main_channel_project_re(WORKTREE_ROOT, PREFIX)
+
+
+class ProjectSlugTests(unittest.TestCase):
+    def test_slashes_and_dots_become_dashes(self):
+        self.assertEqual(
+            project_slug("/Users/alice/.adk/release/worktrees"),
+            "-Users-alice--adk-release-worktrees",
+        )
+
+
+class ProjectDirMatchingTests(unittest.TestCase):
+    """The 07-09 hotfix invariants. If these fail, the watchdog either goes
+    blind (pinned dir) or manufactures false LOST blocks (thread sessions)."""
+
+    def test_main_channel_worktree_matches(self):
+        self.assertIsNotNone(
+            make_re().match(
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-140500"
+            )
+        )
+
+    def test_thread_session_dirs_are_excluded(self):
+        # INVARIANT (#4381): thread worktrees (`<prefix>-t<thread_id>-…`) relay
+        # to a DIFFERENT Discord channel. Comparing their transcripts against
+        # the main channel's messages would manufacture false LOST blocks, so
+        # they must NEVER match the main-channel pattern.
+        self.assertIsNone(
+            make_re().match(
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-"
+                "t1391234567890123456-20260709-140500"
+            )
+        )
+
+    def test_short_thread_segment_is_still_excluded(self):
+        self.assertIsNone(
+            make_re().match(
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-t1-20260709-140500"
+            )
+        )
+
+    def test_other_prefix_families_are_excluded(self):
+        self.assertIsNone(
+            make_re().match(
+                "-Users-alice--adk-release-worktrees-codex-adk-20260709-140500"
+            )
+        )
+
+    def test_suffix_noise_is_excluded(self):
+        self.assertIsNone(
+            make_re().match(
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-140500-x"
+            )
+        )
+
+    def test_non_worktree_project_dirs_are_excluded(self):
+        self.assertIsNone(make_re().match("-Users-alice-src-someproject"))
+
+    def test_date_time_shape_is_required(self):
+        # Not 8-digit date / 6-digit time → not a main-channel worktree.
+        self.assertIsNone(
+            make_re().match(
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-2026079-140500"
+            )
+        )
+
+    def test_pattern_is_derived_from_home_not_hardcoded(self):
+        # Portability (#4381): the operator username must come from the given
+        # worktree root, never be baked into the module.
+        pattern = main_channel_project_re("/Users/bob/.adk/release/worktrees", PREFIX)
+        self.assertIsNotNone(
+            pattern.match(
+                "-Users-bob--adk-release-worktrees-claude-adk-cc-20260709-140500"
+            )
+        )
+        self.assertIsNone(
+            pattern.match(
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-140500"
+            )
+        )
+
+
+class TranscriptResolutionTests(unittest.TestCase):
+    def test_newest_transcript_ignores_thread_dirs_and_picks_latest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            main_old = root / (
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-20260629-120235"
+            )
+            main_new = root / (
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-140500"
+            )
+            thread = root / (
+                "-Users-alice--adk-release-worktrees-claude-adk-cc-"
+                "t139123-20260710-000000"
+            )
+            for d in (main_old, main_new, thread):
+                d.mkdir()
+            old = main_old / "a.jsonl"
+            new = main_new / "b.jsonl"
+            threads = thread / "c.jsonl"
+            for f in (old, new, threads):
+                f.write_text("{}\n", encoding="utf-8")
+            now = time.time()
+            os.utime(old, (now - 300, now - 300))
+            os.utime(new, (now - 100, now - 100))
+            # The thread transcript is the NEWEST file overall; it must still
+            # lose because thread dirs are filtered out before mtime ranking.
+            os.utime(threads, (now, now))
+
+            dirs = channel_project_dirs(root, make_re())
+            self.assertEqual(
+                sorted(d.name for d in dirs),
+                sorted([main_old.name, main_new.name]),
+            )
+            self.assertEqual(newest_transcript(dirs), new)
+
+    def test_no_dirs_yields_none(self):
+        self.assertIsNone(newest_transcript([]))
+
+
+class TimestampTests(unittest.TestCase):
+    def test_transcript_timestamps_parse_as_utc(self):
+        # `mktime(...) - time.timezone` (the prototype) breaks under DST; the
+        # parse must be pure UTC regardless of local timezone.
+        expected = datetime(2026, 7, 9, 2, 57, 18, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(parse_transcript_ts("2026-07-09T02:57:18.123Z"), expected)
+
+    def test_garbage_timestamp_is_none(self):
+        self.assertIsNone(parse_transcript_ts("not-a-timestamp"))
+        self.assertIsNone(parse_transcript_ts(""))
+
+
+class TranscriptParsingTests(unittest.TestCase):
+    def test_extracts_only_assistant_text_blocks(self):
+        lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-09T02:00:00Z",
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "hello world"},
+                            {"type": "tool_use", "name": "Bash"},
+                            {"type": "text", "text": "   "},
+                        ]
+                    },
+                }
+            ),
+            json.dumps({"type": "user", "timestamp": "2026-07-09T02:00:01Z"}),
+            "not json at all",
+            json.dumps({"type": "assistant", "message": {"content": []}}),
+        ]
+        blocks = assistant_blocks_from_lines(lines)
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0][1], "hello world")
+
+
+class DeliveredTests(unittest.TestCase):
+    def test_short_text_requires_exact_normalized_substring(self):
+        self.assertTrue(delivered("done!", norm("prefix done! suffix")))
+        self.assertFalse(delivered("done!", norm("prefix nope suffix")))
+
+    def test_whitespace_is_normalized(self):
+        self.assertTrue(delivered("a  b\n\nc", "x a b c y"))
+
+    def test_chunked_delivery_counts_via_any_probe(self):
+        text = ("H" * 80) + ("M" * 80) + ("T" * 80)
+        # Only the tail chunk landed (relay chunking/edit): still delivered.
+        self.assertTrue(delivered(text, "T" * 80))
+        self.assertFalse(delivered(text, "Z" * 200))
+
+
+class EvaluateBoundaryTests(unittest.TestCase):
+    """LOST/GAP boundaries. GRACE=600/GAP=900 were calibrated live on 07-09."""
+
+    GRACE = 600
+    GAP = 900
+    NOW = 1_800_000_000.0
+
+    def _eval(self, blocks, hay):
+        return evaluate(blocks, hay, self.NOW, self.GRACE, self.GAP)
+
+    def test_all_delivered_is_ok(self):
+        v = self._eval([(self.NOW - 2000, "alpha block")], "alpha block")
+        self.assertEqual(v.state, STATE_OK)
+        self.assertEqual(v.lost, 0)
+
+    def test_young_undelivered_block_is_within_grace(self):
+        # The relay flushes on turn/tool boundaries; a block younger than GRACE
+        # is not evidence of anything (07-09 05:30Z false positive at 300s).
+        v = self._eval([(self.NOW - self.GRACE, "undelivered")], "")
+        self.assertEqual(v.stale, 0)
+        self.assertEqual(v.state, STATE_OK)
+
+    def test_block_one_second_past_grace_is_stale(self):
+        v = self._eval([(self.NOW - self.GRACE - 1, "undelivered block here")], "")
+        self.assertEqual(v.stale, 1)
+        self.assertEqual(v.lost, 1)
+
+    def test_historic_gap_before_watermark_never_realerts(self):
+        # A lost block OLDER than the last successful delivery is a historic,
+        # already-recovered gap — the watermark must silence it forever.
+        lost_old = (self.NOW - 5000, "vanished long ago")
+        delivered_new = (self.NOW - 120, "this one landed fine")
+        v = self._eval([lost_old, delivered_new], "this one landed fine")
+        self.assertEqual(v.lost, 0)
+        self.assertEqual(v.state, STATE_OK)
+
+    def test_block_sharing_the_watermark_timestamp_is_not_lost(self):
+        # `e > delivered_ts` is strict: an undelivered block with the SAME
+        # second-resolution timestamp as the delivered watermark block does not
+        # count as lost (transcripts often stamp adjacent blocks identically).
+        ts = self.NOW - 2000
+        v = self._eval(
+            [(ts, "delivered payload"), (ts, "missing payload")],
+            "delivered payload",
+        )
+        self.assertEqual(v.lost, 0)
+        self.assertEqual(v.state, STATE_OK)
+
+    def test_lost_with_recent_watermark_is_lagging_not_gap(self):
+        delivered_block = (self.NOW - self.GAP, "delivered payload")
+        lost_block = (self.NOW - self.GRACE - 60, "missing payload")
+        v = self._eval([delivered_block, lost_block], "delivered payload")
+        self.assertEqual(v.lost, 1)
+        # gap_secs == GAP exactly: strictly-greater is required to alert.
+        self.assertEqual(v.state, STATE_LAGGING)
+
+    def test_lost_with_old_watermark_is_gap(self):
+        delivered_block = (self.NOW - self.GAP - 1, "delivered payload")
+        lost_block = (self.NOW - self.GRACE - 60, "missing payload")
+        v = self._eval([delivered_block, lost_block], "delivered payload")
+        self.assertEqual(v.state, STATE_GAP)
+
+    def test_no_delivery_ever_with_stale_lost_is_gap(self):
+        v = self._eval([(self.NOW - 4000, "never arrived")], "")
+        self.assertEqual(v.state, STATE_GAP)
+        self.assertEqual(v.gap_secs, float("inf"))
+
+    def test_no_blocks_is_ok(self):
+        v = self._eval([], "")
+        self.assertEqual(v.state, STATE_OK)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_minimal_config_parses_with_defaults(self):
+        cfg = parse_config(
+            {
+                "channels": [
+                    {
+                        "channel_id": "123",
+                        "sendmessage_key": "discord_abc",
+                        "worktree_root": WORKTREE_ROOT,
+                    }
+                ]
+            }
+        )
+        self.assertEqual(cfg.channels[0].channel_id, "123")
+        self.assertEqual(cfg.channels[0].worktree_prefix, "claude-adk-cc")
+        self.assertEqual(cfg.grace_secs, 600)
+        self.assertEqual(cfg.gap_alert_secs, 900)
+        self.assertEqual(cfg.github_repo, "")
+
+    def test_overrides_apply(self):
+        cfg = parse_config(
+            {
+                "channels": [
+                    {
+                        "channel_id": "123",
+                        "sendmessage_key": "k",
+                        "worktree_root": WORKTREE_ROOT,
+                        "announce_to": "project-agentdesk",
+                    }
+                ],
+                "gap_alert_secs": 1200,
+                "github_repo": "owner/repo",
+            }
+        )
+        self.assertEqual(cfg.gap_alert_secs, 1200)
+        self.assertEqual(cfg.github_repo, "owner/repo")
+        self.assertEqual(cfg.channels[0].announce_to, "project-agentdesk")
+
+    def test_empty_channels_is_an_error(self):
+        with self.assertRaises(ConfigError):
+            parse_config({"channels": []})
+        with self.assertRaises(ConfigError):
+            parse_config({})
+
+    def test_missing_required_channel_key_is_an_error(self):
+        with self.assertRaises(ConfigError):
+            parse_config({"channels": [{"channel_id": "123"}]})
+
+
+class StateTests(unittest.TestCase):
+    def test_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "state.json"
+            save_state(p, {"123": {"last_alert": 1.0, "alerting": True}})
+            self.assertEqual(
+                load_state(p), {"123": {"last_alert": 1.0, "alerting": True}}
+            )
+
+    def test_corrupt_state_yields_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "state.json"
+            p.write_text("garbage{", encoding="utf-8")
+            self.assertEqual(load_state(p), {})
+            self.assertEqual(load_state(Path(tmp) / "missing.json"), {})
+
+
+class DeploymentWiringTests(unittest.TestCase):
+    """#4372 lesson: a test that CI never runs is a graveyard, and a script the
+    deploy never ships evaporates (the 06-29 relay-gap-watch, the 07-09
+    prototype). Pin the wiring itself."""
+
+    def test_ci_script_checks_runs_this_suite(self):
+        script = (REPO_ROOT / "scripts" / "ci-script-checks.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("tests.test_relay_watchdog", script)
+
+    def test_deploy_release_ships_watchdog_and_plist(self):
+        deploy = (REPO_ROOT / "scripts" / "deploy-release.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("scripts/relay_watchdog.py", deploy)
+        self.assertIn("com.agentdesk.relay-watchdog", deploy)
+        # Deploy-window suppression contract: deploy must touch the marker the
+        # watchdog checks before restarting dcserver.
+        self.assertIn("relay-watchdog.deploy-marker", deploy)
+
+    def test_watchdog_is_portable_path_linted(self):
+        checker = (REPO_ROOT / "scripts" / "check-portable-paths.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("scripts/relay_watchdog.py", checker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -345,6 +345,92 @@ class ConfigTests(unittest.TestCase):
         with self.assertRaises(ConfigError):
             parse_config({"channels": [{"channel_id": "123"}]})
 
+    # r4 review (PR #4399): a non-numeric numeric field raised bare ValueError,
+    # which main()'s retry loop does not catch → process death → KeepAlive
+    # crash-loop every ~30s. It must surface as ConfigError so main() logs and
+    # retries instead of dying.
+    def test_non_numeric_field_is_config_error_not_valueerror(self):
+        base = {
+            "channels": [
+                {
+                    "channel_id": "123",
+                    "sendmessage_key": "k",
+                    "worktree_root": WORKTREE_ROOT,
+                }
+            ]
+        }
+        with self.assertRaises(ConfigError):
+            parse_config({**base, "poll_secs": "bad"})
+        with self.assertRaises(ConfigError):
+            parse_config({**base, "gap_alert_secs": None})
+
+    def test_load_config_surfaces_bad_numeric_as_config_error(self):
+        # File-level proof that main()'s `except ConfigError` retry path (the
+        # crash-loop avoidance) covers the exact config an operator could typo.
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "relay-watchdog.json"
+            p.write_text(
+                json.dumps(
+                    {
+                        "channels": [
+                            {
+                                "channel_id": "123",
+                                "sendmessage_key": "k",
+                                "worktree_root": WORKTREE_ROOT,
+                            }
+                        ],
+                        "poll_secs": "bad",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(ConfigError):
+                relay_watchdog.load_config(p)
+
+
+class DiscordHaystackShapeTests(unittest.TestCase):
+    """r4 review (PR #4399): `agentdesk discord read` returning rc=0 with VALID
+    but non-list/dict JSON (`null`, a bare number/string) raised AttributeError
+    — read_failures never incremented, so the 'watchdog blind' escalation was
+    silently skipped. Such shapes must join the read-failure path (None)."""
+
+    def _haystack_for(self, stdout: str) -> "str | None":
+        def fake_run(argv, **kwargs):
+            return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(Config(channels=(TICK_CHANNEL,)), Path(tmp))
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                return rt.discord_haystack("999")
+
+    def test_valid_but_non_collection_json_is_read_failure(self):
+        for stdout in ("null", "123", '"str"'):
+            with self.subTest(stdout=stdout):
+                self.assertIsNone(self._haystack_for(stdout))
+
+    def test_dict_with_non_list_messages_is_read_failure(self):
+        self.assertIsNone(self._haystack_for('{"messages": 5}'))
+
+    def test_non_dict_entries_are_skipped_not_fatal(self):
+        out = self._haystack_for(
+            '[null, 7, {"author": {"bot": true}, "content": "hello  world"}]'
+        )
+        self.assertEqual(out, "hello world")
+
+    def test_valid_shapes_still_parse(self):
+        self.assertEqual(
+            self._haystack_for('[{"author": {"bot": true}, "content": "ok"}]'),
+            "ok",
+        )
+        self.assertEqual(
+            self._haystack_for(
+                '{"messages": [{"author": {"bot": true}, "content": "ok"}]}'
+            ),
+            "ok",
+        )
+
 
 class StateTests(unittest.TestCase):
     def test_round_trip(self):
@@ -560,6 +646,25 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(state["999"]["read_failures"], 0)
 
+    # r4 review (PR #4399), end-to-end for the AttributeError defect: with the
+    # REAL discord_haystack wired in, `discord read` printing `null` (rc=0,
+    # valid JSON) must increment read_failures instead of crashing the tick.
+    def test_null_discord_json_increments_read_failures(self):
+        self.write_transcript([(self.now - 60, "fresh block")])
+        rt = self.make_rt()
+        rt.discord_haystack = Runtime.discord_haystack.__get__(rt)
+
+        def fake_run(argv, **kwargs):
+            return subprocess.CompletedProcess(argv, 0, stdout="null", stderr="")
+
+        state: dict = {}
+        with mock.patch.object(
+            relay_watchdog.subprocess, "run", side_effect=fake_run
+        ):
+            tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(state["999"]["read_failures"], 1)
+        self.assertTrue(any("discord read failed" in l for l in rt.log_lines))
+
     # r2 review (PR #4399): save_state was the only unguarded call in the main
     # loop. A disk-full/unwritable-logs OSError there kills the process; the
     # plist's KeepAlive+ThrottleInterval=30 respawns it every ~30s with empty
@@ -678,6 +783,80 @@ class DeploymentWiringTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("scripts/relay_watchdog.py", checker)
+
+    @staticmethod
+    def _watchdog_block() -> str:
+        """Extract the actual watchdog install block from deploy-release.sh so
+        the harness below executes the SHIPPED code, not a copy."""
+        lines = (
+            (REPO_ROOT / "scripts" / "deploy-release.sh")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+        start = next(
+            i
+            for i, l in enumerate(lines)
+            if 'WATCHDOG_LABEL="com.agentdesk.relay-watchdog"' in l
+        )
+        # The block's final `fi` is the line after the staging-FAILED warning.
+        end = next(
+            i for i, l in enumerate(lines) if "Relay watchdog staging FAILED" in l
+        )
+        return "\n".join(lines[start : end + 2])
+
+    def _run_block(self, block: str, adk_rel: Path, home: Path):
+        import shlex
+
+        script = (
+            "set -euo pipefail\n"
+            f"REPO={shlex.quote(str(REPO_ROOT))}\n"
+            f"ADK_REL={shlex.quote(str(adk_rel))}\n"
+            f"HOME={shlex.quote(str(home))}\n"
+            # Nonexistent domain: bootstrap must fail (fail-open ⚠ path) rather
+            # than loading a test plist into the developer's real launchd.
+            "LAUNCHD_DOMAIN=gui/999999\n" + block + "\necho HARNESS-END\n"
+        )
+        return subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, timeout=60
+        )
+
+    # r4 review (PR #4399): plist values were raw-interpolated into the XML
+    # heredoc, so an operator path containing &, <, or > produced an invalid
+    # plist and a silently unarmed watchdog.
+    def test_generated_plist_survives_xml_metachars_in_paths(self):
+        import plistlib
+
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk & <rel>"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config" / "relay-watchdog.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            (home / "Library").mkdir(parents=True)
+
+            p = self._run_block(self._watchdog_block(), adk, home)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("HARNESS-END", p.stdout, "fail-open must reach the end")
+
+            plist_path = (
+                home / "Library/LaunchAgents/com.agentdesk.relay-watchdog.plist"
+            )
+            self.assertTrue(plist_path.is_file(), p.stdout + p.stderr)
+            with plist_path.open("rb") as f:
+                data = plistlib.load(f)  # raises on invalid XML → test fails
+            # Escaping must round-trip: the parsed values are the RAW paths.
+            self.assertEqual(
+                data["ProgramArguments"][1], str(adk / "bin/relay-watchdog.py")
+            )
+            self.assertEqual(
+                data["EnvironmentVariables"]["AGENTDESK_ROOT_DIR"], str(adk)
+            )
+            self.assertEqual(
+                data["StandardOutPath"],
+                str(adk / "logs/relay-watchdog.launchd.out.log"),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -560,6 +560,29 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(state["999"]["read_failures"], 0)
 
+    # r2 review (PR #4399): save_state was the only unguarded call in the main
+    # loop. A disk-full/unwritable-logs OSError there kills the process; the
+    # plist's KeepAlive+ThrottleInterval=30 respawns it every ~30s with empty
+    # in-memory state, and since the alert fires BEFORE the save, the cooldown
+    # evaporates on each restart → ~2 alerts/min storm during a live gap
+    # (amplified by announce-triggered agent turns), while gap_since never
+    # persists so the auto-issue threshold can never fire.
+    def test_unwritable_state_dir_does_not_kill_process_or_break_cooldown(self):
+        rt = self.gap_rt()
+        logs = self.root / "logs"
+        self.addCleanup(os.chmod, logs, 0o755)
+        os.chmod(logs, 0o555)  # every state save now raises OSError
+        state: dict = {}
+        # Three tick+save rounds sharing the SAME in-memory dict, exactly like
+        # main(). An unguarded OSError escapes the loop and fails this test.
+        for i in range(3):
+            tick_channel(rt, TICK_CHANNEL, state, self.now + i)
+            relay_watchdog.save_state_guarded(rt, state)
+        self.assertEqual(
+            len(rt.alerts), 1, "cooldown must survive failed state saves"
+        )
+        self.assertTrue(any("state save failed" in l for l in rt.log_lines))
+
 
 class AlertFallbackTests(unittest.TestCase):
     """(f) Runtime.alert delivery chain: announce-bot primary, bot-token


### PR DESCRIPTION
## 요약

07-09 사고(릴레이 2h07m 무음, 두 번 다 사용자가 먼저 발견) 대응으로 띄운 머신 로컬 프로토타입(`~/.adk/release/bin/relay-watchdog.py`)을 레포로 편입하고, 배포가 수명을 소유하도록 프로덕션화한다.

## 핫픽스 통합 경위

라이브 프로토타입에는 레포에 없는 핫픽스가 이미 적용돼 있었다 (이슈 코멘트 "5시간째 눈이 멀어 있었다" 참조). 라이브 파일을 **읽기만** 하여 레포 산출물에 통합했다 (라이브 파일 자체는 미수정):

1. **하드코딩된 6월 29일자 `PROJECT_DIR` 제거** → 매 tick 동적 발견. 프로덕션 버전은 사용자명까지 하드코딩하지 않도록 `worktree_root`(설정) + `$HOME`에서 프로젝트 슬러그를 유도한다 (`project_slug()` → `main_channel_project_re()`).
2. **thread 세션(`-t<id>-` 세그먼트) 제외 불변식** — thread 워크트리는 다른 채널로 릴레이되므로 메인 채널 메시지와 대조하면 가짜 LOST를 제조한다. `main_channel_project_re()` docstring에 명문화 + `ProjectDirMatchingTests`로 고정.
3. 판정 로직(last-good-delivery 워터마크 + grace/gap 2조건)은 **재설계 없이 그대로 이식** (#4140→#4178→#4181 계보).

## 이슈 요구사항 반영

- 레포가 source of truth: `scripts/relay_watchdog.py` → 배포 시 `$ADK_REL/bin/relay-watchdog.py`로 스테이징
- `deploy-release.sh`가 plist(`com.agentdesk.relay-watchdog`, RunAtLoad+KeepAlive, dcserver 독립) 설치/갱신 + bootout/bootstrap
- 채널 목록 설정화: `$ADK_REL/config/relay-watchdog.json` (머신 로컬, 배포 보존; 채널 id 하드코딩 전면 제거)
- 갭 확정 1회 알림 + 15분 쿨다운 재알림 + **복구 시 자동 해제 알림**
- 알림 본문 런타임 스냅샷: `/api/health/detail`의 `degraded_reasons` 우선(#4382), pg 터널, dcserver pid/uptime
- 갭 지속(기본 30분) 시 GitHub 이슈 자동 등록 (06-29 relay-gap-watch 복원)
- 자멸 로직(TTL/idle self-uninstall) 제거 — 수명은 deploy가 소유
- 코멘트 반영: `--expect-reply false` 계약, announce 우선 + `discord-sendmessage` 폴백, DST-안전 UTC 파싱(`calendar.timegm`), discord read 연속 실패 자체를 알림 신호로 승격, 배포창(deploy marker) 오탐 억제

## 테스트 / CI

- `tests/test_relay_watchdog.py` — 35 케이스: 프로젝트 디렉토리 매칭/thread 제외 불변식, LOST/GAP 판정 경계(grace 경계, 워터마크 동시각 동률, 역사적 갭 침묵, lagging↔gap 경계), 설정 파싱, 상태 라운드트립, **배포·CI 배선 핀**(#4372 교훈: 안 도는 테스트/배포 안 되는 스크립트 방지)
- CI: `scripts/ci-script-checks.sh`에 `python3 -m unittest tests.test_relay_watchdog` 스텝 추가 — `ci-pr.yml`의 `scripts` job(Script checks)과 `ci-main.yml`이 실행. 로컬 전체 `ci-script-checks.sh` rc=0 확인.
- E2E 스모크(스텁 agentdesk + 가짜 트랜스크립트): GAP 알림/쿨다운/복구 해제/배포창 억제/설정 부재 재시도 모두 실측 확인. plist 산출물 `plutil -lint` OK.

## 게이트

- `ci-script-checks.sh` rc=0 (shellcheck, portable-paths, inventory --check, audit --check 포함)
- `generate_inventory_docs.py` rc=0 / `check_agent_maintenance_docs.py` freshness passed
- `audit_maintainability.py --check` rc=0

Refs #4381



## Known limitations (r2 리뷰 관찰, 스코프 외 — 후속 처리 대상)

- **O1 — `discord read --limit 100` 창 밀림**: 매우 긴 턴에서 delivered 블록이 최근 100개 메시지 창 밖으로 밀리면 워터마크가 과거로 후퇴해 false GAP 가능. (프로토타입에서 계승된 알려진 오탐 지점; 이슈 코멘트 "알려진 잔여 오탐 지점" 참조)
- **O2 — read-failure 알림의 복구 통지 부재**: `discord read` 연속 실패 승격 알림은 갭 알림과 달리 복구 시 자동 해제 통지를 보내지 않는다 (카운터만 리셋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
