### PR TITLE
fix(inventory): classify test-only child modules

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -7,9 +7,10 @@
 - Giant-file threshold: `>= 1000` production lines
 - Giant files: `96`
 
-> `Prod` excludes lines inside `#[cfg(test)] mod` blocks; the
-> giant-file flag tracks `Prod` so inline test fixtures do not freeze a
-> module (#3036). `Lines` is the raw total for reference.
+> `Prod` excludes lines inside `#[cfg(test)] mod` blocks and whole
+> files reached only through test-only module declarations; the
+> giant-file flag tracks `Prod` so test fixtures do not freeze a module
+> (#3036/#4394). `Lines` is the raw total for reference.
 
 ## Namespace Summary
 
@@ -303,8 +304,8 @@
 | `server::routes::skills_api` | `src/server/routes/skills_api.rs` | 684 | 684 | 0 |  |
 | `server::routes::stats` | `src/server/routes/stats.rs` | 722 | 589 | 133 |  |
 | `server::routes::termination_events` | `src/server/routes/termination_events.rs` | 152 | 152 | 0 |  |
-| `server::routes::tests::preflight_harness::types` | `src/server/routes/tests/preflight_harness/types.rs` | 217 | 217 | 0 |  |
-| `server::routes::tests::preflight_harness::validation` | `src/server/routes/tests/preflight_harness/validation.rs` | 260 | 260 | 0 |  |
+| `server::routes::tests::preflight_harness::types` | `src/server/routes/tests/preflight_harness/types.rs` | 217 | 0 | 217 |  |
+| `server::routes::tests::preflight_harness::validation` | `src/server/routes/tests/preflight_harness/validation.rs` | 260 | 0 | 260 |  |
 | `server::routes::v1` | `src/server/routes/v1.rs` | 1857 | 1857 | 0 | giant-file |
 | `server::routes::voice_config` | `src/server/routes/voice_config.rs` | 463 | 393 | 70 |  |
 | `server::state` | `src/server/state.rs` | 11 | 11 | 0 |  |
@@ -497,7 +498,7 @@
 | `services::discord::inflight::removal` | `src/services/discord/inflight/removal.rs` | 465 | 465 | 0 |  |
 | `services::discord::inflight::save_store` | `src/services/discord/inflight/save_store.rs` | 966 | 236 | 730 |  |
 | `services::discord::inflight::save_store::identity_gate` | `src/services/discord/inflight/save_store/identity_gate.rs` | 1284 | 999 | 285 |  |
-| `services::discord::inflight::stall_recovery_tests::flake_isolation_4361` | `src/services/discord/inflight/stall_recovery_tests/flake_isolation_4361.rs` | 289 | 289 | 0 |  |
+| `services::discord::inflight::stall_recovery_tests::flake_isolation_4361` | `src/services/discord/inflight/stall_recovery_tests/flake_isolation_4361.rs` | 289 | 0 | 289 |  |
 | `services::discord::inflight::store` | `src/services/discord/inflight/store.rs` | 402 | 351 | 51 |  |
 | `services::discord::inflight::watcher_state` | `src/services/discord/inflight/watcher_state.rs` | 365 | 365 | 0 |  |
 | `services::discord::inflight_heartbeat_sweeper` | `src/services/discord/inflight_heartbeat_sweeper.rs` | 299 | 264 | 35 |  |

--- a/scripts/audit_maintainability/checks/giant_files.py
+++ b/scripts/audit_maintainability/checks/giant_files.py
@@ -55,40 +55,17 @@ _INVENTORY = _load_inventory_generator()
 def _test_only_module_files() -> set[Path]:
     """Files reached only through a test-gated parent ``mod`` declaration.
 
-    Mirrors ``generate_inventory_docs.test_only_module_files`` but iterates the
-    audit's (patchable) ``common.production_rust_files`` so the production/test
-    split — including cross-file test-only subtrees — stays consistent (#3036).
+    Delegates to ``generate_inventory_docs.test_only_module_files`` while
+    passing the audit's patchable file iterators. This keeps generator, audit,
+    and ratchet on one test-only module graph instead of maintaining a parser
+    mirror here (#3036/#4394).
     """
 
-    files = list(production_rust_files())
-    test_targets: set[Path] = set()
-    prod_targets: set[Path] = set()
-    for path in files:
-        text = read_text(path)
-        for match in _INVENTORY._MOD_DECL_RE.finditer(text):
-            predicate = match.group("predicate")
-            requires_test = predicate is not None and _INVENTORY.cfg_requires_test(
-                predicate
-            )
-            base = path.parent
-            for child in (base / f"{match.group('name')}.rs", base / match.group("name") / "mod.rs"):
-                (test_targets if requires_test else prod_targets).add(child.resolve())
-
-    test_only_dirs: list[Path] = []
-    test_only_files: set[Path] = set()
-    for target in test_targets - prod_targets:
-        if target.name == "mod.rs":
-            test_only_dirs.append(target.parent)
-        test_only_files.add(target)
-
-    result: set[Path] = set()
-    for path in files:
-        resolved = path.resolve()
-        if resolved in test_only_files or any(
-            directory in resolved.parents for directory in test_only_dirs
-        ):
-            result.add(path)
-    return result
+    return _INVENTORY.test_only_module_files(
+        production_files=production_rust_files(),
+        all_files=common.all_rust_files(),
+        read_text_fn=read_text,
+    )
 
 
 def giant_production_loc() -> dict[str, int]:

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -166,6 +166,9 @@ echo "=== Generate inventory docs (refresh workspace; gate source-of-truth invar
 # duplicate downstream inventory refresh PRs.
 "$PYTHON" scripts/generate_inventory_docs.py --check
 
+echo "=== Inventory prod/test split regression tests (#4394) ==="
+"$PYTHON" -m unittest tests.test_inventory_giant_split
+
 echo "=== API docs coverage gate (#3719) ==="
 "$PYTHON" scripts/check_api_docs_coverage.py
 "$PYTHON" -m unittest tests.test_api_docs_coverage

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -8,6 +8,7 @@ import re
 import sys
 from collections import Counter
 from dataclasses import dataclass
+from typing import Callable, Iterable
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -177,6 +178,14 @@ class WorkerEntry:
     notes: str
 
 
+@dataclass(frozen=True)
+class ModuleFileDeclaration:
+    parent: Path
+    name: str
+    child_paths: tuple[Path, ...]
+    requires_test: bool
+
+
 class ParseError(RuntimeError):
     pass
 
@@ -223,7 +232,10 @@ def split_prod_test_lines(text: str) -> tuple[int, int]:
 
 
 def rel_posix(path: Path) -> str:
-    return path.relative_to(REPO_ROOT).as_posix()
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
 
 
 def offset_to_line(text: str, offset: int) -> int:
@@ -234,9 +246,17 @@ def is_test_file(path: Path) -> bool:
     return path.name.endswith("_tests.rs") or path.name in TEST_FILE_NAMES
 
 
+def all_rust_files() -> list[Path]:
+    if not SRC_ROOT.is_dir():
+        return []
+    return sorted(path for path in SRC_ROOT.rglob("*.rs") if path.is_file())
+
+
 def production_rust_files() -> list[Path]:
     return sorted(
-        path for path in SRC_ROOT.rglob("*.rs") if path.is_file() and not is_test_file(path)
+        path
+        for path in SRC_ROOT.rglob("*.rs")
+        if path.is_file() and not is_test_file(path)
     )
 
 
@@ -650,21 +670,117 @@ def resolve_function_source(
     return None
 
 
-# `mod <name>;` file-module declaration, capturing any preceding `#[cfg(...)]`.
+# File-module and inline-module declarations, capturing immediately preceding
+# attributes in any order. The test-only module graph uses this for `#[cfg]`,
+# `#[path]`, and inline test-module context; the older `_MOD_DECL_RE` name is
+# kept as an alias for callers/tests that intentionally inspect this parser.
 _MOD_DECL_RE = re.compile(
-    r"(?:#\[cfg\((?P<predicate>[^]]*?)\)\]\s*)?"
-    r"(?:pub(?:\([^)]*\))?\s+)?mod\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*;"
+    r"(?P<attrs>(?:\s*#\[[^\]]*\]\s*)*)"
+    r"(?:pub(?:\([^)]*\))?\s+)?mod\s+"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*"
+    r"(?P<kind>[{;])",
+    re.MULTILINE,
 )
+_CFG_ATTR_RE = re.compile(r"#\[\s*cfg\((?P<predicate>[^]]*?)\)\s*\]")
+_PATH_ATTR_RE = re.compile(r'#\[\s*path\s*=\s*"(?P<path>[^"]+)"\s*\]')
 
 
-def _declared_child_paths(parent: Path, name: str) -> list[Path]:
+@dataclass(frozen=True)
+class _InlineModuleContext:
+    end: int
+    module_dir: Path
+    requires_test: bool
+
+
+def _attrs_require_test(attrs: str) -> bool:
+    return any(
+        cfg_requires_test(match.group("predicate"))
+        for match in _CFG_ATTR_RE.finditer(attrs)
+    )
+
+
+def _path_attr(attrs: str) -> str | None:
+    match = _PATH_ATTR_RE.search(attrs)
+    return match.group("path") if match else None
+
+
+def _file_module_dir(parent: Path) -> Path:
+    if parent.name in {"lib.rs", "main.rs", "mod.rs"}:
+        return parent.parent
+    return parent.parent / parent.stem
+
+
+def _declared_child_paths(
+    parent: Path,
+    name: str,
+    *,
+    base: Path | None = None,
+    path_attr: str | None = None,
+) -> tuple[Path, ...]:
     """Resolve the file(s) a `mod <name>;` declaration in ``parent`` points to."""
 
-    base = parent.parent
-    return [base / f"{name}.rs", base / name / "mod.rs"]
+    if path_attr is not None:
+        return ((parent.parent / path_attr).resolve(),)
+    base = base or _file_module_dir(parent)
+    return ((base / f"{name}.rs").resolve(), (base / name / "mod.rs").resolve())
 
 
-def test_only_module_files() -> set[Path]:
+def _module_file_declarations(
+    parent: Path,
+    text: str,
+    *,
+    parent_requires_test: bool = False,
+) -> list[ModuleFileDeclaration]:
+    declarations: list[ModuleFileDeclaration] = []
+    contexts: list[_InlineModuleContext] = []
+    for match in _MOD_DECL_RE.finditer(text):
+        start = match.start()
+        contexts = [context for context in contexts if start < context.end]
+        inherited_test = parent_requires_test or any(
+            context.requires_test for context in contexts
+        )
+        attrs = match.group("attrs") or ""
+        requires_test = inherited_test or _attrs_require_test(attrs)
+        name = match.group("name")
+
+        if match.group("kind") == "{":
+            try:
+                _body, end = scan_balanced(text, match.end() - 1, "{", "}")
+            except ParseError:
+                continue
+            base = contexts[-1].module_dir if contexts else _file_module_dir(parent)
+            contexts.append(
+                _InlineModuleContext(
+                    end=end,
+                    module_dir=base / name,
+                    requires_test=requires_test,
+                )
+            )
+            continue
+
+        base = contexts[-1].module_dir if contexts else _file_module_dir(parent)
+        declarations.append(
+            ModuleFileDeclaration(
+                parent=parent,
+                name=name,
+                child_paths=_declared_child_paths(
+                    parent,
+                    name,
+                    base=base,
+                    path_attr=_path_attr(attrs),
+                ),
+                requires_test=requires_test,
+            )
+        )
+    return declarations
+
+
+def test_only_module_files(
+    production_files: Iterable[Path] | None = None,
+    *,
+    all_files: Iterable[Path] | None = None,
+    read_text_fn: Callable[[Path], str] = read_text,
+) -> set[Path]:
     """Files whose module is declared *only* under a test-requiring cfg.
 
     A file like ``src/server/routes/routes_tests/common.rs`` carries no
@@ -675,32 +791,55 @@ def test_only_module_files() -> set[Path]:
     test context (e.g. ``src/db/schema.rs``) stays production.
     """
 
-    test_targets: set[Path] = set()
-    prod_targets: set[Path] = set()
-    for path in production_rust_files():
-        text = read_text(path)
-        for match in _MOD_DECL_RE.finditer(text):
-            predicate = match.group("predicate")
-            requires_test = predicate is not None and cfg_requires_test(predicate)
-            for child in _declared_child_paths(path, match.group("name")):
-                (test_targets if requires_test else prod_targets).add(child.resolve())
-
-    test_only_dirs: list[Path] = []
-    test_only_files: set[Path] = set()
-    for target in test_targets - prod_targets:
-        if target.name == "mod.rs":
-            test_only_dirs.append(target.parent)
-        test_only_files.add(target)
+    prod_file_items = list(production_files or production_rust_files())
+    prod_by_resolved = {path.resolve(): path for path in prod_file_items}
+    prod_files = list(prod_by_resolved)
+    source_files = [path.resolve() for path in (all_files or all_rust_files())]
+    prod_file_set = set(prod_files)
+    declarations_by_parent: dict[Path, list[ModuleFileDeclaration]] = {}
+    for path in source_files:
+        try:
+            text = read_text_fn(path)
+        except (OSError, UnicodeDecodeError):
+            continue
+        declarations_by_parent[path] = _module_file_declarations(
+            path,
+            text,
+            parent_requires_test=is_test_file(path),
+        )
 
     result: set[Path] = set()
-    for path in production_rust_files():
-        resolved = path.resolve()
-        if resolved in test_only_files:
-            result.add(path)
-            continue
-        if any(directory in resolved.parents for directory in test_only_dirs):
-            result.add(path)
-    return result
+    while True:
+        test_targets: set[Path] = set()
+        prod_targets: set[Path] = set()
+        for parent, declarations in declarations_by_parent.items():
+            parent_is_test = is_test_file(parent) or parent in result
+            for declaration in declarations:
+                target_set = (
+                    test_targets
+                    if (parent_is_test or declaration.requires_test)
+                    else prod_targets
+                )
+                target_set.update(declaration.child_paths)
+
+        test_only_dirs = [
+            target.parent
+            for target in (test_targets - prod_targets)
+            if target.name == "mod.rs"
+        ]
+        next_result: set[Path] = set()
+        direct_test_only = test_targets - prod_targets
+        for path in prod_files:
+            if path in direct_test_only or any(
+                directory in path.parents for directory in test_only_dirs
+            ):
+                next_result.add(path)
+
+        if next_result == result:
+            return {
+                prod_by_resolved[path] for path in next_result if path in prod_file_set
+            }
+        result = next_result
 
 
 def collect_modules() -> list[ModuleEntry]:
@@ -1390,9 +1529,10 @@ def render_module_inventory(entries: list[ModuleEntry]) -> str:
         f"- Giant-file threshold: `>= {GIANT_FILE_THRESHOLD}` production lines",
         f"- Giant files: `{giant_count}`",
         "",
-        "> `Prod` excludes lines inside `#[cfg(test)] mod` blocks; the",
-        "> giant-file flag tracks `Prod` so inline test fixtures do not freeze a",
-        "> module (#3036). `Lines` is the raw total for reference.",
+        "> `Prod` excludes lines inside `#[cfg(test)] mod` blocks and whole",
+        "> files reached only through test-only module declarations; the",
+        "> giant-file flag tracks `Prod` so test fixtures do not freeze a module",
+        "> (#3036/#4394). `Lines` is the raw total for reference.",
         "",
         "## Namespace Summary",
         "",

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -720,7 +720,8 @@ def _declared_child_paths(
     """Resolve the file(s) a `mod <name>;` declaration in ``parent`` points to."""
 
     if path_attr is not None:
-        return ((parent.parent / path_attr).resolve(),)
+        path_base = base if base is not None else parent.parent
+        return ((path_base / path_attr).resolve(),)
     base = base or _file_module_dir(parent)
     return ((base / f"{name}.rs").resolve(), (base / name / "mod.rs").resolve())
 
@@ -758,7 +759,7 @@ def _module_file_declarations(
             )
             continue
 
-        base = contexts[-1].module_dir if contexts else _file_module_dir(parent)
+        base = contexts[-1].module_dir if contexts else None
         declarations.append(
             ModuleFileDeclaration(
                 parent=parent,

--- a/tests/test_inventory_giant_split.py
+++ b/tests/test_inventory_giant_split.py
@@ -443,6 +443,117 @@ class TestOnlySubtreeTest(unittest.TestCase):
         self.assertNotIn("src/db/schema.rs", test_only)
         self.assertIn("src/db/schema_extra.rs", test_only)
 
+    def test_inline_cfg_test_mod_file_child_uses_inline_module_base(self) -> None:
+        # Gap A / #4394: a file module declared inside an inline cfg(test) mod is
+        # test-only, and Rust resolves it under <parent-stem>/<inline-mod>/.
+        files = {
+            "src/services/discord/inflight.rs": (
+                """
+                pub fn production_surface() {}
+
+                #[cfg(test)]
+                mod stall_recovery_tests {
+                    mod flake_isolation_4361;
+                }
+                """
+            ),
+            "src/services/discord/inflight/stall_recovery_tests/flake_isolation_4361.rs": (
+                "pub fn helper() {}\n"
+            ),
+            "src/services/discord/flake_isolation_4361.rs": (
+                "pub fn wrong_old_base_must_stay_prod() {}\n"
+            ),
+        }
+        with self._with_src(files):
+            test_only = {GEN.rel_posix(p) for p in GEN.test_only_module_files()}
+            modules = {entry.file_path: entry for entry in GEN.collect_modules()}
+        self.assertIn(
+            "src/services/discord/inflight/stall_recovery_tests/flake_isolation_4361.rs",
+            test_only,
+        )
+        self.assertNotIn("src/services/discord/flake_isolation_4361.rs", test_only)
+        child = modules[
+            "src/services/discord/inflight/stall_recovery_tests/flake_isolation_4361.rs"
+        ]
+        self.assertEqual((child.prod_line_count, child.test_line_count), (0, 1))
+        self.assertEqual(child.prod_line_count + child.test_line_count, child.line_count)
+
+    def test_test_named_parent_file_declarations_seed_test_only_children(self) -> None:
+        # Gap B / #4394: *_tests.rs files are excluded from inventory rows, but
+        # their child file modules must still seed the test-only graph.
+        files = {
+            "src/server/routes/tests/auto_queue_preflight_harness_tests.rs": (
+                """
+                #[path = "preflight_harness/types.rs"]
+                mod types;
+                #[path = "preflight_harness/validation.rs"]
+                mod validation;
+                """
+            ),
+            "src/server/routes/tests/preflight_harness/types.rs": "pub fn ty() {}\n",
+            "src/server/routes/tests/preflight_harness/validation.rs": (
+                "pub fn validate() {}\n"
+            ),
+        }
+        with self._with_src(files):
+            test_only = {GEN.rel_posix(p) for p in GEN.test_only_module_files()}
+            modules = {entry.file_path: entry for entry in GEN.collect_modules()}
+        self.assertIn("src/server/routes/tests/preflight_harness/types.rs", test_only)
+        self.assertIn("src/server/routes/tests/preflight_harness/validation.rs", test_only)
+        self.assertNotIn("src/server/routes/tests/auto_queue_preflight_harness_tests.rs", modules)
+        for rel in (
+            "src/server/routes/tests/preflight_harness/types.rs",
+            "src/server/routes/tests/preflight_harness/validation.rs",
+        ):
+            row = modules[rel]
+            self.assertEqual(row.prod_line_count, 0)
+            self.assertEqual(row.test_line_count, row.line_count)
+
+    def test_path_attribute_order_resolves_test_only_targets(self) -> None:
+        # Gap C / #4394: #[path] can appear before or after #[cfg(test)].
+        # Without parsing the attr blob, these support files fall back to the
+        # wrong default module path and remain production.
+        files = {
+            "src/lib.rs": (
+                """
+                #[cfg(test)]
+                #[path = "support/cfg_then_path.rs"]
+                mod cfg_then_path;
+
+                #[path = "support/path_then_cfg.rs"]
+                #[cfg(all(test, feature = "fixture"))]
+                mod path_then_cfg;
+                """
+            ),
+            "src/support/cfg_then_path.rs": "pub fn a() {}\n",
+            "src/support/path_then_cfg.rs": "pub fn b() {}\n",
+        }
+        with self._with_src(files):
+            test_only = {GEN.rel_posix(p) for p in GEN.test_only_module_files()}
+        self.assertIn("src/support/cfg_then_path.rs", test_only)
+        self.assertIn("src/support/path_then_cfg.rs", test_only)
+
+    def test_non_test_path_declaration_keeps_child_production(self) -> None:
+        files = {
+            "src/lib.rs": (
+                """
+                #[cfg(test)]
+                #[path = "shared.rs"]
+                mod shared_for_tests;
+
+                #[path = "shared.rs"]
+                mod shared_for_prod;
+                """
+            ),
+            "src/shared.rs": "pub fn shared() {}\n",
+        }
+        with self._with_src(files):
+            test_only = {GEN.rel_posix(p) for p in GEN.test_only_module_files()}
+            modules = {entry.file_path: entry for entry in GEN.collect_modules()}
+        self.assertNotIn("src/shared.rs", test_only)
+        self.assertEqual(modules["src/shared.rs"].prod_line_count, 1)
+        self.assertEqual(modules["src/shared.rs"].test_line_count, 0)
+
 
 class RegistryParseTest(unittest.TestCase):
     def test_strip_comment_keeps_hash_inside_string(self) -> None:

--- a/tests/test_inventory_giant_split.py
+++ b/tests/test_inventory_giant_split.py
@@ -533,6 +533,30 @@ class TestOnlySubtreeTest(unittest.TestCase):
         self.assertIn("src/support/cfg_then_path.rs", test_only)
         self.assertIn("src/support/path_then_cfg.rs", test_only)
 
+    def test_inline_cfg_test_path_attr_uses_inline_module_base(self) -> None:
+        # Gap A x C / #4394: inside an inline mod, #[path] is relative to the
+        # inline module base, not to the parent file directory.
+        files = {
+            "src/widget.rs": (
+                """
+                pub fn production_surface() {}
+
+                #[cfg(test)]
+                mod tests {
+                    #[path = "harness_support.rs"]
+                    mod harness_support;
+                }
+                """
+            ),
+            "src/widget/tests/harness_support.rs": "pub fn helper() {}\n",
+        }
+        with self._with_src(files):
+            test_only = {GEN.rel_posix(p) for p in GEN.test_only_module_files()}
+            modules = {entry.file_path: entry for entry in GEN.collect_modules()}
+        self.assertIn("src/widget/tests/harness_support.rs", test_only)
+        row = modules["src/widget/tests/harness_support.rs"]
+        self.assertEqual((row.prod_line_count, row.test_line_count), (0, 1))
+
     def test_non_test_path_declaration_keeps_child_production(self) -> None:
         files = {
             "src/lib.rs": (


### PR DESCRIPTION
## Summary
- Fixes gap A: file modules declared inside inline `#[cfg(test)] mod { ... }` now inherit test-only context and use the Rust 2018 inline-module child base (`<parent-stem>/<inline-mod>/...`).
- Fixes gap B: `*_tests.rs` / `tests.rs` parents are scanned as test-only declaration roots even though they remain excluded from inventory rows.
- Fixes gap C: module declaration attributes are parsed as a blob, so `#[path = ...]` works before or after `#[cfg(...)]`.
- `audit_maintainability.checks.giant_files` now delegates its test-only module set to `generate_inventory_docs.test_only_module_files(...)`, preserving patchable audit file iterators while removing the duplicated parser.
- Adds `tests.test_inventory_giant_split` to `scripts/ci-script-checks.sh` so the new fixtures run in CI.
- Regenerates `docs/generated/module-inventory.md`; exactly 3 rows flip prod -> test: `preflight_harness/types.rs` (217), `preflight_harness/validation.rs` (260), `flake_isolation_4361.rs` (289). No registry/baseline changes were needed.

## Invariants / Gates
- I1 `prod + test == raw`: `/tmp/4394-invariants.log`, `I1_bad_split_count=0`, rc=0.
- I2 no prod increases: `/tmp/4394-invariants.log`, `I2_prod_increase_count=0`, rc=0.
- I3 generator/audit share the test-only set: audit delegates to generator; focused audit unittest rc=0.
- I4 non-test declaration keeps child prod: `test_non_test_path_declaration_keeps_child_production`, included in `tests.test_inventory_giant_split`, rc=0.
- I5 orphan/unreachable behavior: unchanged collection model; only declared test-only descendants are reclassified, and existing prod sibling guard remains in the gap A fixture.
- I6 gates:
  - `python3 scripts/generate_inventory_docs.py --check` rc=0.
  - `python3 scripts/audit_maintainability.py --check` rc=0.
  - `python3 scripts/check_agent_maintenance_docs.py --line-count-gate` rc=0.
  - `python3 -m unittest tests.test_inventory_giant_split` rc=0.
  - `PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh` rc=0. Note: bare `bash scripts/ci-script-checks.sh` failed before checks on this host because `/Applications/Xcode-16.4.0.app/.../python3` is Python 3.9.6; the script documents the supported `PYTHON=` override.

## Mutation Proof
- Gap A guard removed (`module_dir=base / name` -> `module_dir=base`): `tests.test_inventory_giant_split.TestOnlySubtreeTest.test_inline_cfg_test_mod_file_child_uses_inline_module_base` rc=1, assertion failure (`flake_isolation_4361.rs` not found in test-only set).
- Gap B guard removed (`all_files` scan -> production files only): `test_test_named_parent_file_declarations_seed_test_only_children` rc=1, assertion failure (`preflight_harness/types.rs` not found).
- Gap C guard removed (`_path_attr` returns `None`): `test_path_attribute_order_resolves_test_only_targets` rc=1, assertion failure (`support/cfg_then_path.rs` not found).
- Restored committed source and reran `python3 -m unittest tests.test_inventory_giant_split` rc=0.

## Design
Adopted the issue comment's option A in scoped form: one generator-owned module declaration graph plus audit delegation. No design deviation. The implementation adds fixed-point propagation for test-only parent files instead of keeping audit's previous mirror.

Refs #4394