### PR TITLE
fix(routines): stop deploy from deleting operator routines; clear stale pause_reason

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -109,7 +109,7 @@
 | `src/services/qwen.rs` | 2198 |
 | `src/services/routines/agent_executor.rs` | 2021 |
 | `src/services/routines/discord_log.rs` | 1589 |
-| `src/services/routines/store.rs` | 3684 |
+| `src/services/routines/store.rs` | 3687 |
 | `src/services/settings.rs` | 1114 |
 | `src/services/tui_prompt_dedupe.rs` | 1849 |
 | `src/services/turn_orchestrator.rs` | 3290 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -956,7 +956,7 @@
 | `services::routines::runtime` | `src/services/routines/runtime.rs` | 1046 | 870 | 176 |  |
 | `services::routines::runtime_config` | `src/services/routines/runtime_config.rs` | 133 | 64 | 69 |  |
 | `services::routines::session_control` | `src/services/routines/session_control.rs` | 1065 | 899 | 166 |  |
-| `services::routines::store` | `src/services/routines/store.rs` | 4428 | 3684 | 744 | giant-file |
+| `services::routines::store` | `src/services/routines/store.rs` | 4431 | 3687 | 744 | giant-file |
 | `services::service_error` | `src/services/service_error.rs` | 1 | 1 | 0 |  |
 | `services::session_activity` | `src/services/session_activity.rs` | 354 | 275 | 79 |  |
 | `services::session_backend` | `src/services/session_backend.rs` | 1078 | 667 | 411 |  |

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -888,6 +888,28 @@ git merge --quiet --ff-only origin/main"
         return 1
     fi
 
+    # Operator-private routines are excluded from the repo (.gitignore:50), so the
+    # peer's own `git fetch` above cannot deliver them. Push them before the peer
+    # deploys: leadership can move between nodes, and the routine runtime is a
+    # LeaderOnly worker that resolves `script_ref` against the local disk. A node
+    # missing these files fails every routine row with "routine script ... is not
+    # loaded". No --delete: the peer may hold routines this node does not.
+    if [ -d "$ADK_REL/routines" ]; then
+        local peer_adk_rel
+        if ! peer_adk_rel="$(ssh -o ConnectTimeout="$DEPLOY_SSH_CONNECT_TIMEOUT" "$peer" \
+            'bash -lc '"$(printf '%q' 'echo "${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"')"'')"; then
+            echo "✗ [peer:$peer] could not resolve remote AGENTDESK_ROOT_DIR"
+            return 1
+        fi
+        peer_adk_rel="$(printf '%s' "$peer_adk_rel" | tr -d '\r')"
+        echo "▸ [peer:$peer] Syncing operator routine scripts..."
+        if ! rsync -a -e "ssh -o ConnectTimeout=$DEPLOY_SSH_CONNECT_TIMEOUT" \
+            "$ADK_REL/routines/" "$peer:$peer_adk_rel/routines/"; then
+            echo "✗ [peer:$peer] routine script sync failed"
+            return 1
+        fi
+    fi
+
     echo "▸ [peer:$peer] Running deploy-release.sh..."
     if ! ssh -o ConnectTimeout="$DEPLOY_SSH_CONNECT_TIMEOUT" "$peer" "bash -lc $(printf '%q' "$remote_deploy_command")"; then
         echo "✗ [peer:$peer] deploy-release.sh failed"
@@ -1221,7 +1243,15 @@ if [ -d "$REPO/routines" ]; then
     ROUTINES_STAGED="$ADK_REL/routines.new"
     rm -rf "$ROUTINES_STAGED"
     mkdir -p "$ROUTINES_STAGED"
-    rsync -a --delete "$REPO/routines/" "$ROUTINES_STAGED/"
+    # Operator-private routines (.gitignore:50) live only under $ADK_REL/routines,
+    # never in the repo. Seed the staging dir with them first so the repo overlay
+    # below cannot delete a routine whose row still exists in `routines`; the
+    # runtime would then fail it with "routine script ... is not loaded".
+    if [ -d "$ADK_REL/routines" ]; then
+        rsync -a "$ADK_REL/routines/" "$ROUTINES_STAGED/"
+    fi
+    # Engine-owned routines win on conflict. No --delete: see above.
+    rsync -a "$REPO/routines/" "$ROUTINES_STAGED/"
 else
     echo "⚠ Routines source missing: $REPO/routines"
     echo "  Skipping routine staging — existing $ADK_REL/routines/ will be retained."

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -909,6 +909,7 @@ impl RoutineStore {
             r#"
             UPDATE routines
             SET status = 'enabled',
+                pause_reason = NULL,
                 updated_at = NOW()
             WHERE id = $1
               AND status = 'paused'
@@ -2605,6 +2606,7 @@ impl RoutineStore {
                     r#"
                     UPDATE routines
                     SET status = 'enabled',
+                        pause_reason = NULL,
                         updated_at = NOW()
                     WHERE id = $1
                       AND status = 'paused'
@@ -2623,6 +2625,7 @@ impl RoutineStore {
                 r#"
                 UPDATE routines
                 SET status = 'enabled',
+                    pause_reason = NULL,
                     next_due_at = $2,
                     updated_at = NOW()
                 WHERE id = $1


### PR DESCRIPTION
## 문제

릴리스의 모든 루틴(8/8)이 실패하고 있었다. 두 개의 독립된 결함이 겹쳤다.

### 1. 배포가 운영자 루틴을 삭제한다 (근본 원인)

`deploy-release.sh`는 `$ADK_REL/routines`를 `$REPO/routines` 내용으로 통째 교체했다 (`rsync --delete` → `routines.new` → `mv`). 그런데 운영자 루틴 21개는 `.gitignore:50`에 의해 **의도적으로 untracked**다. 따라서 배포가 도는 노드마다 해당 스크립트가 삭제됐다.

루틴 런타임은 `LeaderOnly` 워커(`worker_registry.rs:551`)이고 `script_ref`를 **로컬 디스크** 기준으로 해석한다. mac-mini는 이미 21개를 모두 잃은 상태였고, 리더십이 mac-mini로 넘어가자 모든 루틴 행이 `routine script ... is not loaded`로 실패했다. migrated 계열은 추가로 `pause_reason=migration_invalid`로 자가 정지했다.

로더 카운트가 증거다: mac-book `count=25` vs mac-mini `count=5`.

### 2. resume이 `pause_reason`을 남긴다

`resume_routine` / `auto_resume_failure_paused_routine`이 `status='enabled'`만 쓰고 `pause_reason`을 비우지 않아, enabled 행이 계속 `migration_invalid`를 보고했다. 모든 pause 경로가 이 컬럼을 덮어쓰므로 오동작은 없었지만, 행 상태가 자기모순이라 트리아지 때 정상 루틴이 고장난 것처럼 보인다.

## 변경

- **staging**: `routines.new`를 라이브 디렉토리로 먼저 채운 뒤 리포를 오버레이한다. 충돌 시 리포가 이기고, `--delete`가 없으므로 아무것도 삭제되지 않는다.
- **peer**: peer의 `git fetch`는 untracked 파일을 전달할 수 없고 리더십은 어느 노드로든 이동할 수 있으므로, peer가 배포를 실행하기 **전에** 운영자 루틴을 rsync로 전파한다.
- **store**: 두 resume 경로 모두 `pause_reason = NULL`로 정리한다.

## 검증

- 병합 시맨틱 샌드박스 검증: 운영자 루틴 보존 + 리포 오버레이 우선
- `bash -n`, `shellcheck -S error`, `scripts/ci-script-checks.sh` → `rc=0`
- `cargo fmt --check`, `cargo check --lib` → clean
- `cargo test --lib routines` → 164 passed
- docs 게이트: `agent-maintenance freshness check passed`

라이브 복구도 함께 수행했다. 리더를 맥북으로 전환하고(`leader_only_workers_started: True`, active 7) 루틴 스크립트를 mac-mini에 동기화했다. `routine script registry initialized count=25`를 확인했고, paused 4개를 resume해 8/8이 `enabled` + 유효한 `next_due_at`을 가진다. `resume_routine`은 `validate_migrated_launchd_activation`을 호출하고 실패 시 에러를 반환하므로, HTTP 200은 migrated 검증을 실제로 통과했다는 뜻이다.

stale 행 6개는 백필했다. 불변식 `pause_reason IS NOT NULL iff status='paused'` 위반 = 0.

## 주의

`pause_reason`을 지울 수 있는 API 표면이 없어 백필은 psql 직접 실행으로 처리했다. `PATCH /api/routines/{id}`는 이 컬럼을 받지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)