### PR TITLE
fix(placeholder): preserve workflow completion task ids

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -543,14 +543,14 @@
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 321 | 321 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
-| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 792 | 792 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 780 | 780 | 0 |  |
+| `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 791 | 791 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 774 | 774 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_panel` | `src/services/discord/placeholder_live_events/subagent_panel.rs` | 368 | 318 | 50 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 531 | 356 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 399 | 399 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
-| `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 185 | 185 | 0 |  |
+| `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 436 | 436 | 0 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -180,7 +180,7 @@ fn status_events_from_task_notification_with_metadata(
     status: &str,
     summary: &str,
     tool_use_id: Option<&str>,
-    agent_id: Option<&str>,
+    notification_task_id: Option<&str>,
 ) -> Vec<StatusEvent> {
     let mut events = Vec::new();
     match kind {
@@ -188,6 +188,7 @@ fn status_events_from_task_notification_with_metadata(
         "subagent" => {
             let summary = first_content_line(summary);
             let desc = subagent_desc_from_notification_summary(&summary);
+            let agent_id = clean_status_key(notification_task_id);
             if !summary.is_empty() {
                 events.push(match tool_use_id {
                     Some(tool_use_id) => StatusEvent::SubagentActivity {
@@ -200,7 +201,7 @@ fn status_events_from_task_notification_with_metadata(
             if notification_is_terminal(status) {
                 events.push(StatusEvent::SubagentEnd {
                     success: !notification_is_error(status),
-                    agent_id: clean_status_key(agent_id),
+                    agent_id,
                     desc,
                     tool_use_id: tool_use_id.map(str::to_string),
                     summary: None,
@@ -223,7 +224,7 @@ fn status_events_from_task_notification_with_metadata(
             // !is_error), like the subagent/background arms — running emits nothing.
             if notification_is_terminal(status) {
                 events.push(StatusEvent::WorkflowEnd {
-                    task_id: None,
+                    task_id: clean_status_key(notification_task_id),
                     success: !notification_is_error(status),
                     summary: Some(first_content_line(summary)).filter(|value| !value.is_empty()),
                 });
@@ -260,9 +261,7 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
         return Vec::new();
     }
     let kind = parsed.kind();
-    let agent_id = (kind == "subagent")
-        .then(|| parsed.task_id.as_deref())
-        .flatten();
+    let notification_task_id = parsed.task_id.as_deref();
     // #4338 rework (codex r1): the harness XML-escapes the free-form `<summary>`
     // prose in the injected envelope; when the notify card is footer-suppressed
     // this bridge is the summary's only visible surface (panel slot text), so
@@ -280,7 +279,7 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
         status,
         &summary,
         parsed.tool_use_id.as_deref(),
-        agent_id,
+        notification_task_id,
     );
     // #3393 finding 1 (XML-scoped), narrowed by #4396 point 2: drop an id-less
     // terminal `SubagentEnd` only when it ALSO carries no fallback key. With an

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -19,8 +19,8 @@ use super::task_panel::{
     upsert_task_tool_slot,
 };
 use super::workflow_panel::{
-    WorkflowAgentSlot, WorkflowSlot, render_workflow_slot, trim_workflow_slot, trim_workflows,
-    upsert_workflow_agent, upsert_workflow_phase, workflow_status_label,
+    WorkflowAgentSlot, WorkflowSlot, apply_workflow_end, render_workflow_slot, trim_workflow_slot,
+    trim_workflows, upsert_workflow_agent, upsert_workflow_phase, workflow_status_label,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -516,17 +516,11 @@ impl StatusPanelState {
                 success,
                 summary,
             } => {
-                {
-                    let slot = self.workflow_slot_mut(task_id);
-                    if let Some(summary) = summary.filter(|value| !value.trim().is_empty()) {
-                        slot.recent = Some(normalize_summary(&summary));
+                if apply_workflow_end(&mut self.workflows, task_id, success, summary) {
+                    trim_workflows(&mut self.workflows);
+                    if matches!(self.status, DerivedStatus::WorkflowRunning { .. }) {
+                        self.status = DerivedStatus::Running;
                     }
-                    slot.finished = Some(success);
-                    trim_workflow_slot(slot);
-                }
-                trim_workflows(&mut self.workflows);
-                if matches!(self.status, DerivedStatus::WorkflowRunning { .. }) {
-                    self.status = DerivedStatus::Running;
                 }
             }
             StatusEvent::TurnCompleted {

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6808,6 +6808,239 @@ fn idless_end_after_eviction_with_new_agent_id_still_respects_desc_tombstone() {
     );
 }
 
+// #4407 codex repro: a late workflow-A completion XML must not close the only
+// live workflow-B slot just because the completion reached the bridge without
+// a usable id. Main closes wf-b here; the fixed path preserves wf-a's task-id
+// and appends a separate finished wf-a slot.
+#[test]
+fn issue_4407_workflow_xml_completion_with_mismatched_task_id_never_closes_live_workflow() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_407_001);
+
+    events.push_status_event(
+        channel_id,
+        StatusEvent::WorkflowStart {
+            task_id: Some("wf-b".to_string()),
+            name: Some("workflow B".to_string()),
+        },
+    );
+
+    let raw = "<task-notification><task-id>wf-a</task-id><status>completed</status>\
+        <summary>Dynamic workflow \"workflow A\" completed</summary></task-notification>";
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_xml_for_footer_mode(raw, true),
+    );
+
+    let entry = events
+        .status_by_channel
+        .get(&channel_id)
+        .expect("status panel state");
+    let guard = entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wf_b = guard
+        .workflows
+        .iter()
+        .find(|slot| slot.task_id.as_deref() == Some("wf-b"))
+        .unwrap_or_else(|| panic!("live wf-b slot missing: {:?}", guard.workflows));
+    assert_eq!(
+        wf_b.finished, None,
+        "late wf-a completion XML must not close live wf-b: {:?}",
+        guard.workflows
+    );
+    assert!(
+        guard
+            .workflows
+            .iter()
+            .any(|slot| slot.task_id.as_deref() == Some("wf-a") && slot.finished == Some(true)),
+        "late wf-a completion must render as its own finished slot: {:?}",
+        guard.workflows
+    );
+}
+
+#[test]
+fn issue_4407_workflow_end_matching_rules_preserve_legacy_and_current_paths() {
+    let events = PlaceholderLiveEvents::default();
+
+    for (channel, status, success) in [(4_407_002, "completed", true), (4_407_003, "failed", false)]
+    {
+        let channel_id = ChannelId::new(channel);
+        events.push_status_event(
+            channel_id,
+            StatusEvent::WorkflowStart {
+                task_id: Some("wf-same".to_string()),
+                name: Some("workflow same".to_string()),
+            },
+        );
+        let raw = format!(
+            "<task-notification><task-id>wf-same</task-id><status>{status}</status>\
+            <summary>Dynamic workflow \"workflow same\" {status}</summary></task-notification>"
+        );
+        events.push_status_events(
+            channel_id,
+            status_events_from_task_notification_xml_for_footer_mode(&raw, true),
+        );
+        let entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("status panel state");
+        let guard = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(
+            guard.workflows.len(),
+            1,
+            "same-id end must not add a ghost slot"
+        );
+        assert_eq!(guard.workflows[0].finished, Some(success));
+    }
+
+    let legacy_channel = ChannelId::new(4_407_004);
+    events.push_status_event(
+        legacy_channel,
+        StatusEvent::WorkflowStart {
+            task_id: None,
+            name: Some("legacy workflow".to_string()),
+        },
+    );
+    events.push_status_event(
+        legacy_channel,
+        StatusEvent::WorkflowEnd {
+            task_id: None,
+            success: true,
+            summary: None,
+        },
+    );
+    let legacy_entry = events
+        .status_by_channel
+        .get(&legacy_channel)
+        .expect("status panel state");
+    let legacy = legacy_entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(
+        legacy.workflows[0].finished,
+        Some(true),
+        "id-less legacy end must still close the unique id-less slot"
+    );
+
+    let adopt_channel = ChannelId::new(4_407_005);
+    events.push_status_event(
+        adopt_channel,
+        StatusEvent::WorkflowStart {
+            task_id: None,
+            name: Some("adopted workflow".to_string()),
+        },
+    );
+    events.push_status_event(
+        adopt_channel,
+        StatusEvent::WorkflowEnd {
+            task_id: Some("wf-adopted".to_string()),
+            success: true,
+            summary: None,
+        },
+    );
+    let adopt_entry = events
+        .status_by_channel
+        .get(&adopt_channel)
+        .expect("status panel state");
+    let adopt = adopt_entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(adopt.workflows.len(), 1, "adopt must close in place");
+    assert_eq!(adopt.workflows[0].task_id.as_deref(), Some("wf-adopted"));
+    assert_eq!(adopt.workflows[0].finished, Some(true));
+}
+
+#[test]
+fn issue_4407_idless_workflow_end_for_unique_id_bearing_slot_drops_without_status_transition() {
+    use std::{
+        io::{self, Write},
+        sync::{Arc, Mutex},
+    };
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(4_407_006);
+    events.push_status_event(
+        channel_id,
+        StatusEvent::WorkflowStart {
+            task_id: Some("wf-live".to_string()),
+            name: Some("live workflow".to_string()),
+        },
+    );
+
+    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_ansi(false)
+        .without_time()
+        .with_writer(CapturingWriter {
+            buffer: buffer.clone(),
+        })
+        .finish();
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        events.push_status_event(
+            channel_id,
+            StatusEvent::WorkflowEnd {
+                task_id: None,
+                success: true,
+                summary: Some("legacy completion".to_string()),
+            },
+        );
+    }
+
+    let entry = events
+        .status_by_channel
+        .get(&channel_id)
+        .expect("status panel state");
+    let guard = entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert_eq!(
+        guard.workflows.len(),
+        1,
+        "drop must not add a ghost workflow"
+    );
+    assert_eq!(guard.workflows[0].task_id.as_deref(), Some("wf-live"));
+    assert_eq!(
+        guard.workflows[0].finished, None,
+        "id-less end must not close the only id-bearing workflow"
+    );
+    assert!(
+        matches!(guard.status, DerivedStatus::WorkflowRunning { .. }),
+        "drop must not transition WorkflowRunning back to Running: {:?}",
+        guard.status
+    );
+    let logs = String::from_utf8(buffer.lock().unwrap().clone()).expect("utf8 logs");
+    assert!(
+        logs.contains("#4407: dropped id-less WorkflowEnd"),
+        "drop must be logged, got: {logs}"
+    );
+}
+
 // #3393 finding 3: a workflow `<task-notification>` XML with a NON-terminal
 // status (e.g. running) must NOT emit `WorkflowEnd`; terminal statuses still map
 // success via `!is_error`, consistent with the subagent/background arms.
@@ -6828,9 +7061,14 @@ fn task_notification_xml_workflow_gates_workflow_end_on_terminal_status() {
     let completed_events =
         status_events_from_task_notification_xml_for_footer_mode(completed, true);
     assert!(
-        completed_events
-            .iter()
-            .any(|e| matches!(e, StatusEvent::WorkflowEnd { success: true, .. })),
+        completed_events.iter().any(|e| matches!(
+            e,
+            StatusEvent::WorkflowEnd {
+                task_id: Some(task_id),
+                success: true,
+                ..
+            } if task_id == "wf2"
+        )),
         "status=completed workflow XML must emit WorkflowEnd{{success:true}}: {completed_events:?}"
     );
 
@@ -6838,9 +7076,14 @@ fn task_notification_xml_workflow_gates_workflow_end_on_terminal_status() {
         <summary>Dynamic workflow \"probe\" failed</summary></task-notification>";
     let failed_events = status_events_from_task_notification_xml_for_footer_mode(failed, true);
     assert!(
-        failed_events
-            .iter()
-            .any(|e| matches!(e, StatusEvent::WorkflowEnd { success: false, .. })),
+        failed_events.iter().any(|e| matches!(
+            e,
+            StatusEvent::WorkflowEnd {
+                task_id: Some(task_id),
+                success: false,
+                ..
+            } if task_id == "wf3"
+        )),
         "status=failed workflow XML must emit WorkflowEnd{{success:false}}: {failed_events:?}"
     );
 }

--- a/src/services/discord/placeholder_live_events/workflow_panel.rs
+++ b/src/services/discord/placeholder_live_events/workflow_panel.rs
@@ -82,6 +82,91 @@ pub(super) fn workflow_status_label(slot: &WorkflowSlot) -> String {
         .unwrap_or_else(|| "workflow".to_string())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkflowEndTarget {
+    Existing(usize),
+    NewSlot,
+    Drop,
+}
+
+pub(super) fn workflow_end_target(
+    slots: &[WorkflowSlot],
+    task_id: Option<&str>,
+) -> WorkflowEndTarget {
+    match task_id {
+        Some(task_id) => {
+            if let Some(index) = slots
+                .iter()
+                .position(|slot| slot.task_id.as_deref() == Some(task_id))
+            {
+                return WorkflowEndTarget::Existing(index);
+            }
+            if slots.len() == 1 && slots[0].task_id.is_none() && slots[0].finished.is_none() {
+                WorkflowEndTarget::Existing(0)
+            } else {
+                WorkflowEndTarget::NewSlot
+            }
+        }
+        None => match slots {
+            [slot] if slot.task_id.is_none() => WorkflowEndTarget::Existing(0),
+            [slot] if slot.task_id.is_some() => WorkflowEndTarget::Drop,
+            _ => WorkflowEndTarget::NewSlot,
+        },
+    }
+}
+
+pub(super) fn apply_workflow_end(
+    slots: &mut Vec<WorkflowSlot>,
+    task_id: Option<String>,
+    success: bool,
+    summary: Option<String>,
+) -> bool {
+    match workflow_end_target(slots, task_id.as_deref()) {
+        WorkflowEndTarget::Existing(index) => {
+            let slot = &mut slots[index];
+            if slot.task_id.is_none() {
+                slot.task_id = task_id;
+            }
+            finish_workflow_slot(slot, success, summary);
+            true
+        }
+        WorkflowEndTarget::NewSlot => {
+            slots.push(WorkflowSlot {
+                task_id,
+                name: None,
+                phases: Vec::new(),
+                agents: Vec::new(),
+                recent: None,
+                finished: None,
+            });
+            finish_workflow_slot(
+                slots.last_mut().expect("workflow just pushed"),
+                success,
+                summary,
+            );
+            true
+        }
+        WorkflowEndTarget::Drop => {
+            tracing::info!(
+                live_task_id = slots
+                    .first()
+                    .and_then(|slot| slot.task_id.as_deref())
+                    .unwrap_or(""),
+                "#4407: dropped id-less WorkflowEnd for the only id-bearing workflow slot"
+            );
+            false
+        }
+    }
+}
+
+fn finish_workflow_slot(slot: &mut WorkflowSlot, success: bool, summary: Option<String>) {
+    if let Some(summary) = summary.filter(|value| !value.trim().is_empty()) {
+        slot.recent = Some(normalize_summary(&summary));
+    }
+    slot.finished = Some(success);
+    trim_workflow_slot(slot);
+}
+
 fn workflow_agent_label(agent: &WorkflowAgentSlot) -> String {
     agent
         .phase_title


### PR DESCRIPTION
## Summary

Refs #4407.

Workflow `<task-notification>` XML already parses `<task-id>`, but the live-panel bridge only forwarded that id for `kind=subagent`. For `kind=workflow`, it emitted `WorkflowEnd { task_id: None }`; `status_panel` then treated `None` with a single workflow slot as "close the only slot", so a late `wf-a` completion could close live `wf-b`.

This PR:
- preserves the parsed XML task id for workflow `WorkflowEnd`.
- moves WorkflowEnd targeting into `workflow_panel`.
- drops ambiguous `None` End against a unique id-bearing workflow slot, logging the drop and leaving `WorkflowRunning` unchanged.
- keeps legacy/current paths intact.

## Matching Rules

| End task_id | Slot state | Result |
|---|---|---|
| `Some(id)` | matching id exists | close existing slot |
| `Some(id)` | no match + unique id-less unfinished slot | close in place and adopt id |
| `Some(id)` | otherwise | push new finished slot |
| `None` | unique id-less slot | close existing slot |
| `None` | unique id-bearing slot | drop + info log, no Running transition |
| `None` | zero or 2+ slots | push new finished slot |

## Main FAIL Proof

Added the codex repro test before implementation:

`env -u AGENTDESK_ROOT_DIR cargo test --lib workflow_xml_completion_with_mismatched_task_id_never_closes_live_workflow > /tmp/adk-4407-main-fail.log 2>&1; echo "rc=$?"`

Result on origin/main baseline code with only the test added:

```text
rc=101
test ...workflow_xml_completion_with_mismatched_task_id_never_closes_live_workflow ... FAILED
assertion `left == right` failed: late wf-a completion XML must not close live wf-b:
[WorkflowSlot { task_id: Some("wf-b"), ... finished: Some(true) }]
left: Some(true)
right: None
```

## Fixed PASS Proof

`env -u AGENTDESK_ROOT_DIR cargo test --lib issue_4407 > /tmp/adk-4407-focused-tests.log 2>&1; echo "rc=$?"`

```text
rc=0
running 3 tests
...issue_4407_workflow_end_matching_rules_preserve_legacy_and_current_paths ... ok
...issue_4407_workflow_xml_completion_with_mismatched_task_id_never_closes_live_workflow ... ok
...issue_4407_idless_workflow_end_for_unique_id_bearing_slot_drops_without_status_transition ... ok
test result: ok. 3 passed
```

`env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events > /tmp/adk-4407-placeholder-live-events.log 2>&1; echo "rc=$?"`

```text
rc=0
test result: ok. 209 passed; 0 failed
```

## Mutation Proof

After committing, removed the `None + unique id-bearing slot => Drop` arm and reran:

`env -u AGENTDESK_ROOT_DIR cargo test --lib issue_4407_idless_workflow_end_for_unique_id_bearing_slot_drops_without_status_transition > /tmp/adk-4407-mutation-drop-removed.log 2>&1; echo "rc=$?"`

```text
rc=101
test ...issue_4407_idless_workflow_end_for_unique_id_bearing_slot_drops_without_status_transition ... FAILED
assertion `left == right` failed: drop must not add a ghost workflow
left: 2
right: 1
```

This is a test assertion failure, not a compile failure.

## Gates

- `cargo fmt`: rc=0
- `cargo fmt --check`: rc=0
- `cargo check --lib`: rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib placeholder_live_events`: rc=0, 209 passed
- `python3 scripts/audit_maintainability.py --check`: rc=0
- `python3 scripts/generate_inventory_docs.py`: rc=0
- `python3 scripts/check_agent_maintenance_docs.py`: rc=0, `agent-maintenance freshness check passed`

## Caps / Baselines

No cap or baseline was raised.

- `status_events.rs`: 792 -> 791 lines
- `status_panel.rs`: 780 -> 774 lines
- `workflow_panel.rs`: 185 -> 270 lines
- maintainability audit rc=0

## Design Divergence

No semantic divergence from the issue design. Implementation packaging differs slightly: WorkflowEnd matching and apply/finish logic live in `workflow_panel.rs`, keeping `status_panel.rs` below its namespace cap without any admission.

## Hotfiles

No #3016/#3565 hotfiles touched.
