### PR TITLE
fix(test): guard shared env lock reentry

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -138,6 +138,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
@@ -261,6 +262,7 @@ jobs:
           nice -n 10 cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -441,6 +441,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -81,7 +81,7 @@
 | `compat` | `src/compat/mod.rs` | 39 | 39 | 0 |  |
 | `compat::legacy_db_paths` | `src/compat/legacy_db_paths.rs` | 12 | 12 | 0 |  |
 | `compat::legacy_tmp_paths` | `src/compat/legacy_tmp_paths.rs` | 27 | 27 | 0 |  |
-| `config` | `src/config.rs` | 3065 | 2723 | 342 | giant-file |
+| `config` | `src/config.rs` | 3118 | 2723 | 395 | giant-file |
 | `config_live_reload` | `src/config_live_reload.rs` | 966 | 525 | 441 |  |
 | `crate` | `src/main.rs` | 7 | 7 | 0 |  |
 | `credential` | `src/credential.rs` | 212 | 59 | 153 |  |
@@ -465,7 +465,7 @@
 | `services::discord::health::headless_turn` | `src/services/discord/health/headless_turn.rs` | 369 | 369 | 0 |  |
 | `services::discord::health::mailbox` | `src/services/discord/health/mailbox.rs` | 111 | 111 | 0 |  |
 | `services::discord::health::provider_probe` | `src/services/discord/health/provider_probe.rs` | 246 | 193 | 53 |  |
-| `services::discord::health::recovery` | `src/services/discord/health/recovery.rs` | 5594 | 2750 | 2844 | giant-file |
+| `services::discord::health::recovery` | `src/services/discord/health/recovery.rs` | 5535 | 2750 | 2785 | giant-file |
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ test-non-pg:
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+    python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
     cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
 test-postgres:

--- a/scripts/ci-timeout.py
+++ b/scripts/ci-timeout.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Run a command with a wall-clock timeout and return 124 on expiry."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: ci-timeout.py SECONDS COMMAND [ARG...]", file=sys.stderr)
+        return 2
+
+    try:
+        timeout = float(sys.argv[1])
+    except ValueError:
+        print(f"invalid timeout seconds: {sys.argv[1]!r}", file=sys.stderr)
+        return 2
+
+    command = sys.argv[2:]
+    proc = subprocess.Popen(command, start_new_session=True)
+    try:
+        return proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait()
+        return 124
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config.rs
+++ b/src/config.rs
@@ -2976,8 +2976,39 @@ pub(crate) fn shared_test_env_lock() -> &'static std::sync::Mutex<()> {
 }
 
 #[cfg(test)]
+pub(crate) mod test_env_lock {
+    thread_local! {
+        static SHARED_TEST_ENV_LOCK_HELD: std::cell::Cell<bool> =
+            const { std::cell::Cell::new(false) };
+    }
+
+    pub(crate) struct SharedTestEnvLockGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for SharedTestEnvLockGuard {
+        fn drop(&mut self) {
+            SHARED_TEST_ENV_LOCK_HELD.with(|held| held.set(false));
+        }
+    }
+
+    pub(crate) fn acquire_shared_test_env_lock() -> SharedTestEnvLockGuard {
+        SHARED_TEST_ENV_LOCK_HELD.with(|held| {
+            if held.get() {
+                panic!("shared_test_env_lock re-entry detected before mutex acquisition");
+            }
+            held.set(true);
+        });
+        let lock = super::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        SharedTestEnvLockGuard { _lock: lock }
+    }
+}
+
+#[cfg(test)]
 pub(crate) struct TestEnvVarGuard {
-    _lock: Option<std::sync::MutexGuard<'static, ()>>,
+    _lock: Option<test_env_lock::SharedTestEnvLockGuard>,
     key: &'static str,
     previous: Option<std::ffi::OsString>,
 }
@@ -2985,9 +3016,7 @@ pub(crate) struct TestEnvVarGuard {
 #[cfg(test)]
 impl TestEnvVarGuard {
     pub(crate) fn set_path(key: &'static str, value: &std::path::Path) -> Self {
-        let lock = shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let lock = test_env_lock::acquire_shared_test_env_lock();
         let previous = std::env::var_os(key);
         unsafe { std::env::set_var(key, value) };
         Self {
@@ -3061,5 +3090,29 @@ mod remote_settings_tests {
             settings.remote_profiles.is_empty(),
             "remote profiles are not loaded from AgentDesk config; use the #2193 remote_hosts ADR"
         );
+    }
+}
+
+#[cfg(test)]
+mod shared_test_env_lock_tests {
+    #[test]
+    fn acquire_shared_test_env_lock_panics_on_same_thread_reentry_before_deadlock() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let _lock = super::test_env_lock::acquire_shared_test_env_lock();
+            let reentry = std::panic::catch_unwind(|| {
+                let _nested = super::test_env_lock::acquire_shared_test_env_lock();
+            });
+            tx.send(reentry.is_err()).expect("send reentry result");
+        });
+
+        let panicked = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("same-thread reentry must panic before waiting on the mutex");
+        assert!(
+            panicked,
+            "same-thread reentry should fail before attempting the mutex lock"
+        );
+        handle.join().expect("reentry proof thread should finish");
     }
 }

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -2926,6 +2926,7 @@ mod stall_watchdog_pure_tests {
         preserve_cancel_should_skip_provider_interrupt_for_idle_tui,
         revalidate_and_clear_explicit_background_inflight,
     };
+    use crate::config::TestEnvVarGuard;
     use crate::services::discord::inflight::{
         self, GuardedClearOutcome, GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState,
         RelayOwnerKind,
@@ -2935,29 +2936,6 @@ mod stall_watchdog_pure_tests {
     use crate::services::provider::ProviderKind;
     use chrono::TimeZone;
     use poise::serenity_prelude::ChannelId;
-    use std::ffi::OsString;
-
-    struct EnvVarReset {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarReset {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarReset {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
 
     fn test_ledger_identity(chunks: &[String]) -> LeakRecoveryLedgerIdentity {
         LeakRecoveryLedgerIdentity {
@@ -3125,11 +3103,12 @@ mod stall_watchdog_pure_tests {
 
     #[test]
     fn chunk_ledger_survives_restart_and_resumes_tail_without_live_fetch() {
-        let _guard = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("temp runtime root");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let chunks: Vec<String> = (0..64).map(|index| format!("chunk-{index}")).collect();
         let identity = test_ledger_identity(&chunks);
 
@@ -3151,11 +3130,12 @@ mod stall_watchdog_pure_tests {
 
     #[test]
     fn chunk_ledger_records_send_failure_boundary_without_offset_loss() {
-        let _guard = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("temp runtime root");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let chunks: Vec<String> = (0..5).map(|index| format!("chunk-{index}")).collect();
         let identity = test_ledger_identity(&chunks);
 
@@ -3174,11 +3154,12 @@ mod stall_watchdog_pure_tests {
 
     #[test]
     fn chunk_ledger_ignores_stale_identity_or_changed_confirmed_chunk() {
-        let _guard = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("temp runtime root");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let chunks = vec!["chunk-0".to_string(), "chunk-1".to_string()];
         let identity = test_ledger_identity(&chunks);
 
@@ -3218,11 +3199,12 @@ mod stall_watchdog_pure_tests {
         // `full_response`, moving `byte_end` and appending chunk fingerprints. The
         // already-confirmed prefix (whose fingerprints are byte-identical) must
         // remain confirmed so recovery never re-sends already-delivered chunks.
-        let _guard = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("temp runtime root");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
 
         let chunks = vec!["chunk-0".to_string(), "chunk-1".to_string()];
         let identity = test_ledger_identity(&chunks);
@@ -3267,11 +3249,12 @@ mod stall_watchdog_pure_tests {
 
     #[test]
     fn leak_recovery_offset_patch_preserves_concurrent_relay_watermark_update() {
-        let _guard = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("temp runtime root");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
 
         let provider = ProviderKind::Codex;
         let channel_id = ChannelId::new(4_111_001);
@@ -3336,11 +3319,12 @@ mod stall_watchdog_pure_tests {
 
     #[test]
     fn explicit_background_watchdog_abort_preserves_new_identity_after_snapshot() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
 
         let provider = ProviderKind::Claude;
         let channel_id = ChannelId::new(4_019_230_001);
@@ -3385,11 +3369,12 @@ mod stall_watchdog_pure_tests {
 
     #[test]
     fn idle_tmux_stale_turn_clear_preserves_fresh_inflight_after_finish_window() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
 
         let provider = ProviderKind::Claude;
         let channel_id = ChannelId::new(4_030_601);
@@ -4307,34 +4292,12 @@ mod stall_watchdog_pure_tests {
 #[cfg(test)]
 mod stall_watchdog_auto_heal_tests {
     use super::super::HealthRegistry;
+    use crate::config::TestEnvVarGuard;
     use crate::services::provider::{CancelToken, ProviderKind};
     use poise::serenity_prelude::{ChannelId, MessageId, UserId};
-    use std::ffi::OsString;
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
     use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64};
-
-    struct EnvVarReset {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarReset {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarReset {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
 
     struct IdleTmuxCandidateHookGuard {
         previous: Option<super::IdleTmuxStaleTurnInflightCandidateHook>,
@@ -4515,11 +4478,12 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn idle_tmux_stale_turn_clear_refusal_preserves_mailbox_and_session() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let shared = super::super::super::make_shared_data_for_tests();
@@ -4576,11 +4540,12 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn idle_tmux_stale_turn_guarded_finish_preserves_new_mailbox_claim() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let shared = super::super::super::make_shared_data_for_tests();
@@ -4657,11 +4622,12 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn idle_tmux_stale_turn_guarded_finish_preserves_new_same_id_mailbox_claim() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let shared = super::super::super::make_shared_data_for_tests();
@@ -4737,11 +4703,12 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn idle_tmux_stale_turn_tail_recheck_preserves_mailbox_after_precheck_passed() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let shared = super::super::super::make_shared_data_for_tests();
@@ -4797,11 +4764,12 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn force_clean_guarded_finish_preserves_new_same_id_mailbox_claim() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Codex;
         let mut registry = HealthRegistry::new();
         registry.started_at_unix =
@@ -4903,11 +4871,12 @@ mod stall_watchdog_auto_heal_tests {
 
     #[tokio::test]
     async fn stall_watchdog_cleanup_releases_residual_orphan_pending_token() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Codex;
         let registry = HealthRegistry::new();
         let shared = super::super::super::make_shared_data_for_tests();
@@ -4979,38 +4948,9 @@ mod hard_stop_completion_event_tests {
     use tracing_subscriber::fmt::MakeWriter;
 
     use super::super::HealthRegistry;
+    use crate::config::TestEnvVarGuard;
     use crate::services::provider::{CancelToken, ProviderKind};
     use crate::services::turn_orchestrator::{Intervention, InterventionMode};
-
-    struct EnvVarReset {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarReset {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let lock = crate::config::shared_test_env_lock()
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner());
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self {
-                _lock: lock,
-                key,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvVarReset {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
 
     #[derive(Clone)]
     struct CapturingWriter {
@@ -5086,7 +5026,7 @@ mod hard_stop_completion_event_tests {
     #[tokio::test(flavor = "current_thread")]
     async fn providerless_hard_stop_with_runtime_publishes_completion_event_for_pending_queue() {
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", tempdir.path());
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let shared = super::super::super::make_shared_data_for_tests();
@@ -5135,7 +5075,7 @@ mod hard_stop_completion_event_tests {
     #[tokio::test(flavor = "current_thread")]
     async fn providerless_stale_repair_uses_strict_per_runtime_mailbox_ownership() {
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", tempdir.path());
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let first = super::super::super::make_shared_data_for_tests();
@@ -5232,11 +5172,12 @@ mod hard_stop_completion_event_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn providerless_strict_repair_ignores_empty_mailbox_created_by_snapshot_scan() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
         let provider = ProviderKind::Claude;
         let registry = HealthRegistry::new();
         let first = super::super::super::make_shared_data_for_tests();
@@ -5345,7 +5286,7 @@ mod hard_stop_completion_event_tests {
     #[tokio::test(flavor = "current_thread")]
     async fn unresolvable_raw_hard_stop_warns_about_potentially_stranded_pending_queue() {
         let tempdir = tempfile::tempdir().expect("runtime root tempdir");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", tempdir.path());
         let provider = ProviderKind::Claude;
         let shared = super::super::super::make_shared_data_for_tests();
         let channel = ChannelId::new(4_048_240);


### PR DESCRIPTION
## Defect map

`health::recovery` had three local `EnvVarReset` copies. The hard-stop completion copy acquired `shared_test_env_lock()` internally, while `providerless_strict_repair_ignores_empty_mailbox_created_by_snapshot_scan` already held the same non-reentrant mutex before calling it. That exact double acquisition caused the providerless health test to hang and held the lock for the rest of the health suite.

## Approach

- Added a test-only `config::test_env_lock::acquire_shared_test_env_lock()` wrapper with a thread-local reentry flag. Same-thread reentry panics before attempting the mutex.
- Moved `TestEnvVarGuard::set_path` onto that wrapper and kept `set_path_after_shared_test_env_lock` for callers that already hold the wrapper guard.
- Removed the three copied `EnvVarReset` helpers from `health::recovery` tests and converted the 14 externally locked env mutations to `set_path_after_shared_test_env_lock`; lock-free env mutations use `set_path`.
- Added `scripts/ci-timeout.py` so Linux and macOS CI both get finite failure instead of depending on GNU `timeout` availability.

Design deviation: no core deviation from the issue design. The only extension is using a portable Python timeout wrapper for CI/macOS trusted instead of assuming `timeout` exists on every runner.

## Pre/post logs

- Pre repro: `timeout 120 env -u AGENTDESK_ROOT_DIR cargo test --lib providerless_strict_repair_ignores_empty_mailbox` -> `rc=124` (`/tmp/adk4404-pre-providerless.log`). Local macOS used an equivalent shell timeout shim because GNU `timeout` is not installed.
- Post focused repro: `python3 scripts/ci-timeout.py 120 env -u AGENTDESK_ROOT_DIR cargo test --lib providerless_strict_repair_ignores_empty_mailbox` -> `rc=0` (`/tmp/adk4404-final-post-providerless.log`).
- Health default: `python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres` -> `rc=0` (`/tmp/adk4404-final-health-default.log`).
- Health single-thread: same command plus `--test-threads=1` -> `rc=0` (`/tmp/adk4404-final-health-test-threads-1.log`).

## Mutation proof

- Guard branch removed mutant: reentry proof test failed by its own 2s deadline, `rc=101`; log shows `same-thread reentry must panic before waiting on the mutex: Timeout` (`/tmp/adk4404-mutant-reentry-guard-removed-300.log`).
- Restored guard: same proof test passed, `rc=0` (`/tmp/adk4404-mutant-restored-reentry-test-300.log`).

## Gates

- `cargo fmt` -> `rc=0`; `cargo fmt --check` -> `rc=0`.
- `cargo check --lib` -> `rc=0` (`/tmp/adk4404-final-cargo-check-lib.log`).
- `python3 scripts/generate_inventory_docs.py` -> `rc=0`; `python3 scripts/check_agent_maintenance_docs.py` -> `rc=0`, `agent-maintenance freshness check passed`.
- `PATH=/opt/homebrew/bin:$PATH PYTHON=/opt/homebrew/bin/python3 bash scripts/ci-script-checks.sh` -> `rc=0` (`/tmp/adk4404-final-ci-script-checks.log`).
- Existing targeted subset with `env -u AGENTDESK_ROOT_DIR` for local parity: transition/auto_queue/cancel/review_decision/stall_recovery/health/routines/invariant -> `rc=0` (`/tmp/adk4404-final-existing-targeted-subset-envu.log`).

## CI integration

- `justfile test-non-pg` now runs the health suite through the timeout wrapper.
- `.github/workflows/ci-pr.yml` targeted non-PG step runs the same health suite.
- `.github/workflows/ci-macos-trusted.yml` hosted and self-hosted targeted blocks run the same health suite; self-hosted keeps `nice -n 10`.

Prod line delta is 0: `docs/generated/module-inventory.md` keeps `src/config.rs` prod at 2723 and `src/services/discord/health/recovery.rs` prod at 2750; only test LoC changed. No #3016 hotfiles touched.

Refs #4404