### PR TITLE
fix(ops): supervise PG tunnel and alert persistent failures

### DIFF
--- a/scripts/check-portable-paths.py
+++ b/scripts/check-portable-paths.py
@@ -22,6 +22,7 @@ DEFAULT_PATTERNS = (
     "scripts/queue-stability-batch.sh",
     "scripts/setup-hooks.sh",
     "scripts/resolve-python-runner.sh",
+    "scripts/pg_tunnel.sh",
     "scripts/launchd-migrated/*.sh",
     "scripts/launchd-migrated/*.py",
     "scripts/check-portable-paths.py",

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -147,12 +147,12 @@ echo "=== Portable deployable path lint ==="
   tests.test_script_python_policy \
   tests.test_analyze_prs
 
-echo "=== Relay watchdog judgment + wiring tests (#4381) ==="
+echo "=== Relay watchdog + PG tunnel supervisor tests (#4381/#4378) ==="
 # The out-of-band relay watchdog is a deployable Python script; it is not
 # covered by shellcheck (only *.sh) nor by cargo, so this unittest run is its
 # ONLY CI gate. It also pins the deploy/plist wiring so the watchdog cannot
 # silently fall out of the deploy again (the 06-29 relay-gap-watch failure).
-"$PYTHON" -m unittest tests.test_relay_watchdog
+"$PYTHON" -m unittest tests.test_relay_watchdog tests.test_pg_tunnel
 
 echo "=== Generate inventory docs (refresh workspace; gate source-of-truth invariants, #3036) ==="
 # Generic committed markdown freshness drift is warning-only for ordinary PRs

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1821,6 +1821,101 @@ else
     echo "⚠ Relay watchdog staging FAILED (source: $REPO/scripts/relay_watchdog.py)"
 fi
 
+# ── Consumer-owned PostgreSQL SSH tunnel supervisor (#4378) ──────────────────
+# This is deliberately a separate launchd lifetime from dcserver: dcserver may
+# crash-loop while PG is absent (#4379), but the process that restores PG must
+# remain alive.  Like the relay watchdog above, this block is after DEPLOY_OK
+# and entirely fail-open so an ops-side install failure cannot turn a healthy,
+# health-confirmed binary deploy into a rollback or skip peer propagation.
+PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"
+PG_TUNNEL_PLIST_PATH="$HOME/Library/LaunchAgents/$PG_TUNNEL_LABEL.plist"
+PG_TUNNEL_BIN="$ADK_REL/bin/pg-tunnel.sh"
+PG_TUNNEL_CONFIG="$ADK_REL/config/pg-tunnel.env"
+echo "▸ Staging consumer-owned PG tunnel supervisor (#4378)..."
+if install -m 0755 "$REPO/scripts/pg_tunnel.sh" "$PG_TUNNEL_BIN"; then
+    # Machine-local config is the node-identity gate.  It is intentionally not
+    # shipped by the repo: mac-mini and future nodes must never arm a tunnel
+    # pointed back at themselves merely because cluster deploy propagated.
+    if [ -f "$PG_TUNNEL_CONFIG" ]; then
+        _pg_xml_escape() {
+            local s=$1
+            s=${s//&/\&amp;}
+            s=${s//</\&lt;}
+            s=${s//>/\&gt;}
+            s=${s//\"/\&quot;}
+            s=${s//\'/\&apos;}
+            printf '%s' "$s"
+        }
+        _install_pg_tunnel_plist() {
+            local label_x bin_x config_x root_x
+            label_x=$(_pg_xml_escape "$PG_TUNNEL_LABEL") || return 1
+            bin_x=$(_pg_xml_escape "$PG_TUNNEL_BIN") || return 1
+            config_x=$(_pg_xml_escape "$PG_TUNNEL_CONFIG") || return 1
+            root_x=$(_pg_xml_escape "$ADK_REL") || return 1
+            mkdir -p "$HOME/Library/LaunchAgents" || return 1
+            cat > "$PG_TUNNEL_PLIST_PATH.tmp" <<PLIST_EOF || return 1
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$label_x</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$bin_x</string>
+    <string>$config_x</string>
+    <string>-N</string>
+    <string>-T</string>
+    <string>-o</string><string>BatchMode=yes</string>
+    <string>-o</string><string>ConnectTimeout=10</string>
+    <string>-o</string><string>ServerAliveInterval=15</string>
+    <string>-o</string><string>ServerAliveCountMax=3</string>
+    <string>-o</string><string>ExitOnForwardFailure=yes</string>
+    <string>-L</string><string>127.0.0.1:15432:127.0.0.1:5432</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>StandardOutPath</key><string>$root_x/logs/pg-tunnel.launchd.out.log</string>
+  <key>StandardErrorPath</key><string>$root_x/logs/pg-tunnel.launchd.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AGENTDESK_ROOT_DIR</key><string>$root_x</string>
+  </dict>
+</dict>
+</plist>
+PLIST_EOF
+            # Atomic publish: launchd never observes a partially-written XML.
+            mv -f "$PG_TUNNEL_PLIST_PATH.tmp" "$PG_TUNNEL_PLIST_PATH" || return 1
+        }
+        if ! "$PG_TUNNEL_BIN" --check-config "$PG_TUNNEL_CONFIG"; then
+            echo "⚠ PG tunnel config invalid: $PG_TUNNEL_CONFIG — NOT armed"
+            echo "  Required: PG_TUNNEL_SSH_TARGET=mac-mini (or PG_TUNNEL_HOST alias)."
+        elif _install_pg_tunnel_plist; then
+            xattr -d com.apple.quarantine "$PG_TUNNEL_PLIST_PATH" 2>/dev/null || true
+            echo "⚠ PG tunnel deploy prerequisite: on mac-mini, bootout and remove BOTH"
+            echo "  reverse plists (com.agentdesk.macbook-pg-tunnel and"
+            echo "  com.agentdesk.macbook-memento-tunnel) before this job is activated."
+            # bootout+bootstrap (not kickstart): pick up both wrapper and plist.
+            launchctl bootout "$LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" 2>/dev/null || true
+            if launchctl bootstrap "$LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
+                echo "✓ PG tunnel supervisor armed ($PG_TUNNEL_LABEL)"
+            else
+                echo "⚠ PG tunnel bootstrap FAILED — dcserver PG path is unsupervised"
+            fi
+        else
+            rm -f "$PG_TUNNEL_PLIST_PATH.tmp" 2>/dev/null || true
+            echo "⚠ PG tunnel plist write FAILED ($PG_TUNNEL_PLIST_PATH) — not armed"
+            echo "  Deploy continues (fail-open): fix permissions/disk space and redeploy."
+        fi
+    else
+        echo "▸ PG tunnel config absent: $PG_TUNNEL_CONFIG"
+        echo "  Supervisor NOT armed on this node (machine-local node gate)."
+    fi
+else
+    echo "⚠ PG tunnel staging FAILED (source: $REPO/scripts/pg_tunnel.sh)"
+fi
+
 _write_release_source_manifest
 
 echo "═══ Deploy Complete ═══"

--- a/scripts/pg_tunnel.sh
+++ b/scripts/pg_tunnel.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Consumer-owned PostgreSQL tunnel supervisor entrypoint (#4378).
+#
+# launchd owns this foreground process.  The consumer owns the -L forwarding
+# direction so a sleeping/moving mac-book cannot leave a reverse -R process
+# alive-but-useless on mac-mini.  The forwarding endpoints are intentionally
+# fixed: this P1 path must not become coupled to auxiliary tunnels.
+#
+# Machine-local config (deploy passes $ADK_REL/config/pg-tunnel.env):
+#   PG_TUNNEL_SSH_TARGET=mac-mini
+# PG_TUNNEL_HOST is accepted as a backwards-friendly alias.  No config file is
+# shipped in the repository; deploy-release.sh only arms launchd when the local
+# file exists and passes --check-config.
+
+TAKEOVER_PATTERN='^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:'
+EXPECTED_SSH_ARGS=(
+    -N
+    -T
+    -o BatchMode=yes
+    -o ConnectTimeout=10
+    -o ServerAliveInterval=15
+    -o ServerAliveCountMax=3
+    -o ExitOnForwardFailure=yes
+    -L 127.0.0.1:15432:127.0.0.1:5432
+)
+
+die() {
+    echo "pg-tunnel: $*" >&2
+    exit 1
+}
+
+load_config() {
+    local config_path=$1
+    [ -f "$config_path" ] || die "config not found: $config_path"
+    # Operator-owned shell assignments, kept outside the repository.
+    # shellcheck disable=SC1090
+    . "$config_path"
+    PG_TUNNEL_SSH_TARGET="${PG_TUNNEL_SSH_TARGET:-${PG_TUNNEL_HOST:-}}"
+    case "$PG_TUNNEL_SSH_TARGET" in
+        "") die "PG_TUNNEL_SSH_TARGET is required in $config_path" ;;
+        -*) die "PG_TUNNEL_SSH_TARGET must not start with '-'" ;;
+        *[!A-Za-z0-9_.:@-]*)
+            die "PG_TUNNEL_SSH_TARGET contains unsafe characters"
+            ;;
+    esac
+}
+
+still_matching_manual_tunnel() {
+    local pid=$1 command
+    command=$(/bin/ps -p "$pid" -o command= 2>/dev/null || true)
+    [ -n "$command" ] && printf '%s\n' "$command" | /usr/bin/grep -Eq "$TAKEOVER_PATTERN"
+}
+
+take_over_manual_tunnel() {
+    local pids pid attempts
+    pids=$(/usr/bin/pgrep -f "$TAKEOVER_PATTERN" 2>/dev/null || true)
+    [ -n "$pids" ] || return 0
+
+    # pgrep returns one numeric pid per line; intentional whitespace splitting.
+    # shellcheck disable=SC2086
+    for pid in $pids; do
+        case "$pid" in *[!0-9]*|"") continue ;; esac
+        # Re-read the full command immediately before signaling.  This narrows
+        # the PID-reuse window and makes the strict -L endpoint predicate the
+        # final authority; a loose ssh/15432 match must never kill a bystander.
+        still_matching_manual_tunnel "$pid" || continue
+        echo "pg-tunnel: taking over residual manual tunnel pid=$pid" >&2
+        /bin/kill -TERM "$pid" 2>/dev/null || true
+        attempts=0
+        while /bin/kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 25 ]; do
+            /bin/sleep 0.2
+            attempts=$((attempts + 1))
+        done
+        if /bin/kill -0 "$pid" 2>/dev/null && still_matching_manual_tunnel "$pid"; then
+            echo "pg-tunnel: residual pid=$pid ignored TERM; sending KILL" >&2
+            /bin/kill -KILL "$pid" 2>/dev/null || true
+            attempts=0
+            while /bin/kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 10 ]; do
+                /bin/sleep 0.1
+                attempts=$((attempts + 1))
+            done
+            if /bin/kill -0 "$pid" 2>/dev/null && still_matching_manual_tunnel "$pid"; then
+                die "residual manual tunnel pid=$pid did not exit; refusing bind race"
+            fi
+        fi
+    done
+}
+
+validate_ssh_args() {
+    local -a actual=("$@")
+    local i
+    [ "${#actual[@]}" -eq "${#EXPECTED_SSH_ARGS[@]}" ] ||
+        die "refusing non-canonical ssh arguments"
+    for ((i = 0; i < ${#EXPECTED_SSH_ARGS[@]}; i++)); do
+        [ "${actual[$i]}" = "${EXPECTED_SSH_ARGS[$i]}" ] ||
+            die "refusing non-canonical ssh arguments"
+    done
+}
+
+if [ "${1:-}" = "--check-config" ]; then
+    [ "$#" -eq 2 ] || die "usage: $0 --check-config CONFIG"
+    load_config "$2"
+    exit 0
+fi
+
+[ "$#" -ge 1 ] || die "usage: $0 CONFIG SSH_ARGS..."
+CONFIG_PATH=$1
+shift
+load_config "$CONFIG_PATH"
+validate_ssh_args "$@"
+take_over_manual_tunnel
+
+exec /usr/bin/ssh "$@" "$PG_TUNNEL_SSH_TARGET"

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -63,6 +63,15 @@ STATE_OK = "ok"
 STATE_LAGGING = "lagging"  # lost blocks exist, but last good delivery is recent
 STATE_GAP = "gap"  # lost blocks exist AND last good delivery is old → relay down
 
+# Independent PostgreSQL path states (#4378).  `/api/health/detail db=false` is
+# the sole failure trigger; the TCP listener is only a cause discriminator.
+PG_OK = "ok"
+PG_TUNNEL_DOWN = "tunnel_down"
+PG_UPSTREAM_DOWN = "upstream_or_half_dead"
+PG_UNCLASSIFIED_DOWN = "db_down_tunnel_unknown"
+PG_UNKNOWN = "unknown"
+PG_STATE_KEY = "_pg_tunnel"
+
 
 def adk_root() -> Path:
     return Path(os.environ.get("AGENTDESK_ROOT_DIR", str(Path.home() / ".adk/release")))
@@ -127,6 +136,12 @@ class Config:
     # after this many CONSECUTIVE failures instead of skipping forever.
     read_fail_alert_after: int = 5
     dcserver_port: int = 8791
+    # PG must remain end-to-end unhealthy for this long before alerting.  The
+    # default is >3x the supervisor's normal recovery envelope, avoiding noise
+    # while launchd+ssh are doing their job.  Override only for an approved T3
+    # drill; the deploy does not ship machine-local config values.
+    pg_alert_after_secs: int = 300
+    pg_realert_secs: int = 900
 
 
 class ConfigError(Exception):
@@ -170,6 +185,8 @@ def parse_config(raw: dict[str, Any]) -> Config:
         "issue_after_secs",
         "read_fail_alert_after",
         "dcserver_port",
+        "pg_alert_after_secs",
+        "pg_realert_secs",
     ):
         if key in raw:
             # A malformed number must surface as ConfigError, never ValueError:
@@ -184,6 +201,9 @@ def parse_config(raw: dict[str, Any]) -> Config:
                 ) from e
     if "github_repo" in raw:
         kwargs["github_repo"] = str(raw["github_repo"])
+    for key in ("pg_alert_after_secs", "pg_realert_secs"):
+        if key in kwargs and kwargs[key] <= 0:
+            raise ConfigError(f"config field {key!r} must be greater than zero")
     return Config(channels=tuple(channels), **kwargs)
 
 
@@ -320,6 +340,38 @@ class Verdict:
     gap_secs: float
 
 
+@dataclass(frozen=True)
+class PgHealthVerdict:
+    """End-to-end PG health plus the listener-only cause discriminator."""
+
+    state: str
+    db: bool | None
+    tunnel_open: bool | None
+
+
+def evaluate_pg_health(db: object, tunnel_open: bool | None) -> PgHealthVerdict:
+    """Classify without letting a bare TCP listener claim PG is healthy.
+
+    `db is False` from the detailed dcserver health endpoint is the only down
+    signal.  OPEN then means the listener accepted TCP but forwarding or PG is
+    unhealthy (the 07-09 half-dead mode); CLOSED identifies the supervised
+    local tunnel itself.  Missing/malformed health is unknown, never a PG
+    alert, because the dcserver process could be unavailable for another cause.
+    """
+    if db is True:
+        return PgHealthVerdict(PG_OK, True, tunnel_open)
+    if db is not False:
+        return PgHealthVerdict(PG_UNKNOWN, None, tunnel_open)
+    if tunnel_open is False:
+        return PgHealthVerdict(PG_TUNNEL_DOWN, False, False)
+    if tunnel_open is True:
+        return PgHealthVerdict(PG_UPSTREAM_DOWN, False, True)
+    # The classifier being unavailable must not erase the primary db=false
+    # signal; alert with an explicit unknown cause after the same persistence
+    # threshold.
+    return PgHealthVerdict(PG_UNCLASSIFIED_DOWN, False, None)
+
+
 def evaluate(
     blocks: list[tuple[float, str]],
     hay: str,
@@ -401,6 +453,7 @@ class Runtime:
         self.log_path = root / "logs/relay-watchdog.log"
         self.state_path = root / "logs/relay-watchdog.state.json"
         self.deploy_marker = root / "logs/relay-watchdog.deploy-marker"
+        self.dcserver_pg_alert_state = root / "logs/dcserver-pg-alert.state"
 
     def log(self, msg: str) -> None:
         line = f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} {msg}\n"
@@ -476,6 +529,60 @@ class Runtime:
             )
         bot = [m for m in ok_msgs if (m.get("author") or {}).get("bot")]
         return norm(" ".join((m.get("content") or "") for m in bot))
+
+    def pg_health(self) -> PgHealthVerdict:
+        """Probe dcserver's end-to-end DB view, then classify with local TCP.
+
+        Do not use curl `--fail`: the health endpoint can legitimately return a
+        non-2xx status while still carrying the `db=false` JSON we need.
+        """
+        base = f"http://127.0.0.1:{self.cfg.dcserver_port}/api/health/detail"
+        db: object = None
+        try:
+            p = subprocess.run(
+                ["curl", "-sS", "--max-time", "4", base],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if p.returncode == 0 and p.stdout:
+                health = json.loads(p.stdout)
+                if isinstance(health, dict):
+                    db = health.get("db")
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+            pass
+
+        if db is not False:
+            # db=true is authoritative end-to-end health.  A missing/malformed
+            # health response is a dcserver probe failure, not evidence that
+            # the PG tunnel failed, so avoid manufacturing a P1 alert.
+            return evaluate_pg_health(db, None)
+
+        tunnel_open: bool | None
+        try:
+            p = subprocess.run(
+                ["nc", "-z", "-G", "3", "127.0.0.1", "15432"],
+                capture_output=True,
+                timeout=8,
+            )
+            tunnel_open = p.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            tunnel_open = None
+        return evaluate_pg_health(False, tunnel_open)
+
+    def recent_dcserver_pg_alert(self, now: float) -> bool:
+        """Read #4379's successful-alert stamp for one-tick de-duplication.
+
+        The Rust writer stores integer UNIX seconds.  Invalid/future content is
+        fail-open (not recent), matching its own rate-limit semantics so a bad
+        state file can never silence this independent watchdog.
+        """
+        try:
+            sent_at = float(self.dcserver_pg_alert_state.read_text().strip())
+        except (OSError, ValueError):
+            return False
+        elapsed = now - sent_at
+        return 0 <= elapsed < self.cfg.pg_realert_secs
 
     def dcserver_snapshot(self) -> str:
         bits = []
@@ -649,6 +756,115 @@ class Runtime:
 # ── Per-channel tick ───────────────────────────────────────────────────────────
 
 
+def tick_pg_tunnel(rt: Runtime, state: dict[str, Any], now: float) -> None:
+    """Independently monitor the end-to-end PG path once per watchdog tick."""
+    if not rt.cfg.channels:
+        return
+    ch = rt.cfg.channels[0]
+    pgs: dict[str, Any] = state.setdefault(PG_STATE_KEY, {})
+    verdict = rt.pg_health()
+
+    if verdict.state == PG_UNKNOWN:
+        # Unknown is not recovery from an already-alerting incident, but it
+        # breaks a pending "N minutes continuously db=false" interval.
+        if not pgs.get("alerting"):
+            for key in ("unhealthy_since", "dedup_deferred", "dcserver_alert_seen"):
+                pgs.pop(key, None)
+        rt.log("[pg-tunnel] health/detail db unknown — PG timer not advanced")
+        return
+
+    if verdict.state == PG_OK:
+        if pgs.get("alerting"):
+            previous = pgs.get("cause", "unknown")
+            rt.alert(
+                ch,
+                "✅ **PG 경로 복구 (relay watchdog)**\n\n"
+                "`/api/health/detail`에서 `db=true`를 확인했습니다. "
+                f"이전 판정: `{previous}`. PG 터널 장애 알림을 해제합니다.",
+                trigger_turn=False,
+            )
+            rt.log("[pg-tunnel] RECOVERED — db=true, alert state cleared")
+        # Keep last_alert across recovery to enforce the 15-minute anti-flap
+        # cooldown, but clear all incident-local state.
+        for key in (
+            "alerting",
+            "unhealthy_since",
+            "cause",
+            "dedup_deferred",
+            "dcserver_alert_seen",
+        ):
+            pgs.pop(key, None)
+        return
+
+    cause_text = {
+        PG_TUNNEL_DOWN: (
+            "CLOSED — 로컬 127.0.0.1:15432 리스너가 없어 "
+            "SSH -L supervisor 재기동 루프 실패로 판정"
+        ),
+        PG_UPSTREAM_DOWN: (
+            "OPEN — 로컬 리스너는 열렸지만 db=false; "
+            "half-dead SSH 포워딩 또는 upstream PostgreSQL 장애로 판정"
+        ),
+        PG_UNCLASSIFIED_DOWN: (
+            "UNKNOWN — db=false이나 nc 원인 판별자를 실행하지 못함"
+        ),
+    }[verdict.state]
+    pgs["cause"] = verdict.state
+    if "unhealthy_since" not in pgs:
+        pgs["unhealthy_since"] = now
+    unhealthy_for = now - float(pgs["unhealthy_since"])
+    if unhealthy_for < rt.cfg.pg_alert_after_secs:
+        rt.log(
+            f"[pg-tunnel] db=false cause={verdict.state} for "
+            f"{int(unhealthy_for)}s (< {rt.cfg.pg_alert_after_secs}s threshold)"
+        )
+        return
+
+    last_alert = float(pgs.get("last_alert", 0))
+    if now - last_alert < rt.cfg.pg_realert_secs:
+        rt.log(
+            f"[pg-tunnel] db=false persists cause={verdict.state} "
+            "(alert suppressed, cooldown)"
+        )
+        return
+
+    # #4379 may just have emitted its PG-independent boot alert.  Defer only
+    # the FIRST watchdog alert by exactly one tick; the next tick still sends
+    # (with correlation text) so de-duplication can never turn into silence.
+    if not pgs.get("alerting") and not pgs.get("dedup_deferred"):
+        if rt.recent_dcserver_pg_alert(now):
+            pgs["dedup_deferred"] = True
+            pgs["dcserver_alert_seen"] = True
+            rt.log(
+                "[pg-tunnel] dcserver PG boot alert is recent — "
+                "deferring watchdog alert by one tick"
+            )
+            return
+
+    correlation = (
+        "\n\n참고: dcserver 부트 PG 알림이 먼저 발화해 이 알림을 1 tick 보류했습니다."
+        if pgs.get("dcserver_alert_seen")
+        else ""
+    )
+    minutes = max(1, int(unhealthy_for // 60))
+    rt.alert(
+        ch,
+        "🚨 **PG 경로 지속 장애 (relay watchdog)**\n\n"
+        f"`/api/health/detail`의 `db=false`가 **{minutes}분** 지속되었습니다.\n"
+        f"원인 판별: **{cause_text}**.\n\n"
+        f"런타임: {rt.dcserver_snapshot()}"
+        f"{correlation}",
+    )
+    pgs["last_alert"] = now
+    pgs["alerting"] = True
+    pgs.pop("dedup_deferred", None)
+    pgs.pop("dcserver_alert_seen", None)
+    rt.log(
+        f"[pg-tunnel] ALERT db=false cause={verdict.state} "
+        f"duration={int(unhealthy_for)}s"
+    )
+
+
 def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
     cfg = rt.cfg
     cid = ch.channel_id
@@ -795,6 +1011,10 @@ def main() -> int:
         if state is None:
             state = load_state(rt.state_path)
         now = time.time()
+        try:
+            tick_pg_tunnel(rt, state, now)
+        except Exception as e:  # noqa: BLE001 — infra probe must not kill relay checks
+            rt.log(f"[pg-tunnel] tick error: {type(e).__name__}: {e}")
         for ch in cfg.channels:
             try:
                 tick_channel(rt, ch, state, now)

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -1,0 +1,265 @@
+"""Regression tests for the consumer-owned PostgreSQL tunnel (#4378)."""
+
+from __future__ import annotations
+
+import plistlib
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = REPO_ROOT / "scripts/deploy-release.sh"
+WRAPPER = REPO_ROOT / "scripts/pg_tunnel.sh"
+
+
+class WrapperSafetyTests(unittest.TestCase):
+    def test_takeover_pattern_matches_only_exact_local_forward(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        line = next(
+            line for line in text.splitlines() if line.startswith("TAKEOVER_PATTERN=")
+        )
+        pattern = shlex.split(line.split("=", 1)[1])[0]
+
+        matching = [
+            "/usr/bin/ssh -f -N -L 127.0.0.1:15432:127.0.0.1:5432 mac-mini",
+            "ssh -N -o BatchMode=yes -L  127.0.0.1:15432:db:5432 host",
+        ]
+        rejected = [
+            "/usr/bin/ssh -N -R 15432:127.0.0.1:5432 mac-book",
+            "/usr/bin/ssh -N -L 127.0.0.1:15433:127.0.0.1:5432 mac-mini",
+            "/usr/bin/ssh -N -L 0.0.0.0:15432:127.0.0.1:5432 mac-mini",
+            "/usr/bin/ssh -N -L127.0.0.1:15432:127.0.0.1:5432 mac-mini",
+            "python monitor.py ssh -N -L 127.0.0.1:15432:db:5432 host",
+            "/usr/bin/notssh -N -L 127.0.0.1:15432:db:5432 host",
+        ]
+        for command in matching:
+            with self.subTest(command=command):
+                p = subprocess.run(
+                    ["grep", "-Eq", pattern], input=command, text=True
+                )
+                self.assertEqual(p.returncode, 0)
+        for command in rejected:
+            with self.subTest(command=command):
+                p = subprocess.run(
+                    ["grep", "-Eq", pattern], input=command, text=True
+                )
+                self.assertNotEqual(p.returncode, 0)
+
+    def test_pid_is_revalidated_with_same_pattern_before_each_signal(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        self.assertIn("still_matching_manual_tunnel \"$pid\" || continue", text)
+        self.assertIn(
+            'kill -0 "$pid" 2>/dev/null && still_matching_manual_tunnel "$pid"',
+            text,
+        )
+
+    def test_takeover_completes_before_ssh_exec(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        self.assertLess(
+            text.rindex("take_over_manual_tunnel"),
+            text.index('exec /usr/bin/ssh "$@" "$PG_TUNNEL_SSH_TARGET"'),
+        )
+
+    def test_machine_config_requires_safe_ssh_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            good = Path(tmp) / "good.env"
+            good.write_text("PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8")
+            p = subprocess.run(
+                [str(WRAPPER), "--check-config", str(good)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+
+            bad = Path(tmp) / "bad.env"
+            bad.write_text("PG_TUNNEL_SSH_TARGET=-oProxyCommand=bad\n", encoding="utf-8")
+            p = subprocess.run(
+                [str(WRAPPER), "--check-config", str(bad)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(p.returncode, 0)
+
+    def test_wrapper_refuses_noncanonical_launchd_arguments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "pg-tunnel.env"
+            config.write_text("PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8")
+            p = subprocess.run(
+                [str(WRAPPER), str(config), "-N"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("non-canonical ssh arguments", p.stderr)
+
+
+class DeploymentWiringTests(unittest.TestCase):
+    """Pin every load-bearing launchd/deploy invariant individually."""
+
+    @staticmethod
+    def _pg_block() -> str:
+        lines = DEPLOY.read_text(encoding="utf-8").splitlines()
+        start = next(
+            i
+            for i, line in enumerate(lines)
+            if 'PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"' in line
+        )
+        end = next(
+            i for i, line in enumerate(lines) if "PG tunnel staging FAILED" in line
+        )
+        return "\n".join(lines[start : end + 2])
+
+    def test_ci_script_checks_runs_this_suite(self):
+        ci = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")
+        self.assertIn("tests.test_pg_tunnel", ci)
+
+    def test_wrapper_is_registered_for_portable_path_lint(self):
+        checker = (REPO_ROOT / "scripts/check-portable-paths.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('"scripts/pg_tunnel.sh"', checker)
+
+    def test_exit_on_forward_failure_is_pinned(self):
+        self.assertIn(
+            "<string>-o</string><string>ExitOnForwardFailure=yes</string>",
+            self._pg_block(),
+        )
+
+    def test_server_alive_options_are_pinned(self):
+        block = self._pg_block()
+        self.assertIn(
+            "<string>-o</string><string>ServerAliveInterval=15</string>", block
+        )
+        self.assertIn(
+            "<string>-o</string><string>ServerAliveCountMax=3</string>", block
+        )
+
+    def test_connect_timeout_is_pinned(self):
+        self.assertIn(
+            "<string>-o</string><string>ConnectTimeout=10</string>",
+            self._pg_block(),
+        )
+
+    def test_batch_mode_is_pinned(self):
+        self.assertIn(
+            "<string>-o</string><string>BatchMode=yes</string>", self._pg_block()
+        )
+
+    def test_keepalive_and_throttle_are_pinned(self):
+        block = self._pg_block()
+        self.assertIn("<key>KeepAlive</key><true/>", block)
+        self.assertIn("<key>ThrottleInterval</key><integer>10</integer>", block)
+
+    def test_plist_publish_is_atomic_mv(self):
+        block = self._pg_block()
+        self.assertIn('cat > "$PG_TUNNEL_PLIST_PATH.tmp"', block)
+        self.assertIn(
+            'mv -f "$PG_TUNNEL_PLIST_PATH.tmp" "$PG_TUNNEL_PLIST_PATH"', block
+        )
+
+    def test_machine_local_env_gates_bootout_and_bootstrap(self):
+        block = self._pg_block()
+        gate = block.index('if [ -f "$PG_TUNNEL_CONFIG" ]; then')
+        bootout = block.index(
+            'launchctl bootout "$LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL"'
+        )
+        bootstrap = block.index(
+            'launchctl bootstrap "$LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"'
+        )
+        self.assertLess(gate, bootout)
+        self.assertLess(gate, bootstrap)
+        self.assertIn("Supervisor NOT armed on this node", block)
+
+    def test_block_is_after_deploy_ok_and_before_manifest(self):
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        block_at = deploy.index('PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"')
+        self.assertLess(deploy.index("DEPLOY_OK=1"), block_at)
+        self.assertLess(block_at, deploy.index("_write_release_source_manifest", block_at))
+
+    def _run_block(self, adk_rel: Path, home: Path) -> tuple[subprocess.CompletedProcess, Path]:
+        fake_bin = home / "fake-bin"
+        fake_bin.mkdir(parents=True)
+        launchctl_log = home / "launchctl.log"
+        launchctl = fake_bin / "launchctl"
+        launchctl.write_text(
+            '#!/bin/sh\nprintf "%s\\n" "$*" >> "$LAUNCHCTL_LOG"\n',
+            encoding="utf-8",
+        )
+        xattr = fake_bin / "xattr"
+        xattr.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        launchctl.chmod(0o755)
+        xattr.chmod(0o755)
+        script = (
+            "set -euo pipefail\n"
+            f"REPO={shlex.quote(str(REPO_ROOT))}\n"
+            f"ADK_REL={shlex.quote(str(adk_rel))}\n"
+            f"HOME={shlex.quote(str(home))}\n"
+            "LAUNCHD_DOMAIN=gui/999999\n"
+            f"LAUNCHCTL_LOG={shlex.quote(str(launchctl_log))}\n"
+            "export LAUNCHCTL_LOG\n"
+            f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
+            "export PATH\n"
+            + self._pg_block()
+            + "\necho HARNESS-END\n"
+        )
+        p = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, timeout=30
+        )
+        return p, launchctl_log
+
+    def test_generated_plist_is_valid_and_round_trips_metachar_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk & <rel>"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home & <operator>"
+            home.mkdir()
+            p, launchctl_log = self._run_block(adk, home)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("HARNESS-END", p.stdout)
+            self.assertTrue(launchctl_log.is_file())
+
+            plist_path = home / "Library/LaunchAgents/com.agentdesk.pg-tunnel.plist"
+            with plist_path.open("rb") as f:
+                plist = plistlib.load(f)
+            self.assertEqual(plist["ProgramArguments"][0], str(adk / "bin/pg-tunnel.sh"))
+            self.assertEqual(plist["ProgramArguments"][1], str(adk / "config/pg-tunnel.env"))
+            self.assertTrue(plist["KeepAlive"])
+            self.assertEqual(plist["ThrottleInterval"], 10)
+
+    def test_missing_machine_config_does_not_touch_launchd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, launchctl_log = self._run_block(adk, home)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("Supervisor NOT armed on this node", p.stdout)
+            self.assertFalse(launchctl_log.exists())
+
+    def test_invalid_machine_config_does_not_touch_launchd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=-unsafe\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, launchctl_log = self._run_block(adk, home)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("config invalid", p.stdout)
+            self.assertFalse(launchctl_log.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -23,6 +23,12 @@ from unittest import mock
 
 import scripts.relay_watchdog as relay_watchdog
 from scripts.relay_watchdog import (
+    PG_OK,
+    PG_STATE_KEY,
+    PG_TUNNEL_DOWN,
+    PG_UNCLASSIFIED_DOWN,
+    PG_UNKNOWN,
+    PG_UPSTREAM_DOWN,
     STATE_GAP,
     STATE_LAGGING,
     STATE_OK,
@@ -34,6 +40,7 @@ from scripts.relay_watchdog import (
     channel_project_dirs,
     delivered,
     evaluate,
+    evaluate_pg_health,
     load_state,
     main_channel_project_re,
     newest_transcript,
@@ -43,6 +50,7 @@ from scripts.relay_watchdog import (
     project_slug,
     save_state,
     tick_channel,
+    tick_pg_tunnel,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -297,6 +305,31 @@ class EvaluateBoundaryTests(unittest.TestCase):
         self.assertEqual(v.state, STATE_OK)
 
 
+class PgHealthEvaluationTests(unittest.TestCase):
+    def test_db_true_is_authoritative_even_without_listener_probe(self):
+        self.assertEqual(evaluate_pg_health(True, None).state, PG_OK)
+
+    def test_db_false_and_closed_identifies_tunnel_down(self):
+        verdict = evaluate_pg_health(False, False)
+        self.assertEqual(verdict.state, PG_TUNNEL_DOWN)
+        self.assertFalse(verdict.tunnel_open)
+
+    def test_db_false_and_open_identifies_half_dead_or_pg(self):
+        verdict = evaluate_pg_health(False, True)
+        self.assertEqual(verdict.state, PG_UPSTREAM_DOWN)
+        self.assertTrue(verdict.tunnel_open)
+
+    def test_db_false_survives_nc_classifier_failure(self):
+        self.assertEqual(
+            evaluate_pg_health(False, None).state, PG_UNCLASSIFIED_DOWN
+        )
+
+    def test_missing_or_malformed_db_is_unknown_not_down(self):
+        for value in (None, "false", 0, {}, []):
+            with self.subTest(value=value):
+                self.assertEqual(evaluate_pg_health(value, False).state, PG_UNKNOWN)
+
+
 class ConfigTests(unittest.TestCase):
     def test_minimal_config_parses_with_defaults(self):
         cfg = parse_config(
@@ -315,6 +348,8 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(cfg.grace_secs, 600)
         self.assertEqual(cfg.gap_alert_secs, 900)
         self.assertEqual(cfg.github_repo, "")
+        self.assertEqual(cfg.pg_alert_after_secs, 300)
+        self.assertEqual(cfg.pg_realert_secs, 900)
 
     def test_overrides_apply(self):
         cfg = parse_config(
@@ -328,10 +363,14 @@ class ConfigTests(unittest.TestCase):
                     }
                 ],
                 "gap_alert_secs": 1200,
+                "pg_alert_after_secs": 60,
+                "pg_realert_secs": 180,
                 "github_repo": "owner/repo",
             }
         )
         self.assertEqual(cfg.gap_alert_secs, 1200)
+        self.assertEqual(cfg.pg_alert_after_secs, 60)
+        self.assertEqual(cfg.pg_realert_secs, 180)
         self.assertEqual(cfg.github_repo, "owner/repo")
         self.assertEqual(cfg.channels[0].announce_to, "project-agentdesk")
 
@@ -363,6 +402,10 @@ class ConfigTests(unittest.TestCase):
             parse_config({**base, "poll_secs": "bad"})
         with self.assertRaises(ConfigError):
             parse_config({**base, "gap_alert_secs": None})
+        with self.assertRaises(ConfigError):
+            parse_config({**base, "pg_alert_after_secs": 0})
+        with self.assertRaises(ConfigError):
+            parse_config({**base, "pg_realert_secs": -1})
 
     def test_load_config_surfaces_bad_numeric_as_config_error(self):
         # File-level proof that main()'s `except ConfigError` retry path (the
@@ -510,6 +553,59 @@ class StateTests(unittest.TestCase):
             self.assertEqual(load_state(Path(tmp) / "missing.json"), {})
 
 
+class RuntimePgProbeTests(unittest.TestCase):
+    def test_health_detail_db_false_is_classified_by_nc_closed(self):
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            if argv[0] == "curl":
+                return subprocess.CompletedProcess(
+                    argv, 0, stdout='{"db": false}', stderr=""
+                )
+            return subprocess.CompletedProcess(argv, 1, stdout=b"", stderr=b"")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(Config(channels=(TICK_CHANNEL,)), Path(tmp))
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                verdict = rt.pg_health()
+        self.assertEqual(verdict.state, PG_TUNNEL_DOWN)
+        self.assertIn("/api/health/detail", calls[0][-1])
+        self.assertNotIn("-f", calls[0], "non-2xx health JSON must remain readable")
+        self.assertEqual(calls[1][-2:], ["127.0.0.1", "15432"])
+
+    def test_unknown_health_does_not_consult_nc_or_claim_tunnel_down(self):
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, stdout="not-json", stderr="")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(Config(channels=(TICK_CHANNEL,)), Path(tmp))
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                verdict = rt.pg_health()
+        self.assertEqual(verdict.state, PG_UNKNOWN)
+        self.assertEqual(len(calls), 1)
+
+    def test_dcserver_alert_stamp_is_read_fail_open(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(
+                Config(channels=(TICK_CHANNEL,), pg_realert_secs=900), Path(tmp)
+            )
+            rt.dcserver_pg_alert_state.parent.mkdir(parents=True)
+            rt.dcserver_pg_alert_state.write_text("1000", encoding="utf-8")
+            self.assertTrue(rt.recent_dcserver_pg_alert(1899))
+            self.assertFalse(rt.recent_dcserver_pg_alert(1900))
+            self.assertFalse(rt.recent_dcserver_pg_alert(999))
+            rt.dcserver_pg_alert_state.write_text("rolled-back", encoding="utf-8")
+            self.assertFalse(rt.recent_dcserver_pg_alert(1001))
+
+
 TICK_CHANNEL = ChannelConfig(
     channel_id="999",
     sendmessage_key="k",
@@ -543,6 +639,127 @@ class FakeRuntime(Runtime):
     def file_github_issue(self, ch, gap_min: int, lost: int) -> str:
         self.issue_calls += 1
         return f"https://example.test/issues/{self.issue_calls}"
+
+
+class FakePgRuntime(Runtime):
+    def __init__(self, verdict, *, after: int = 300, cooldown: int = 900) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        cfg = Config(
+            channels=(TICK_CHANNEL,),
+            pg_alert_after_secs=after,
+            pg_realert_secs=cooldown,
+        )
+        super().__init__(cfg, Path(self._tmp.name))
+        self.verdict = verdict
+        self.dcserver_recent = False
+        self.alerts: list[tuple[str, bool]] = []
+        self.log_lines: list[str] = []
+
+    def cleanup(self) -> None:
+        self._tmp.cleanup()
+
+    def pg_health(self):
+        return self.verdict
+
+    def recent_dcserver_pg_alert(self, now: float) -> bool:
+        return self.dcserver_recent
+
+    def dcserver_snapshot(self) -> str:
+        return "stub-pg-snapshot"
+
+    def alert(self, ch, body: str, trigger_turn: bool = True) -> None:
+        self.alerts.append((body, trigger_turn))
+
+    def log(self, msg: str) -> None:
+        self.log_lines.append(msg)
+
+
+class TickPgTunnelTests(unittest.TestCase):
+    NOW = 10_000.0
+
+    def make_rt(self, verdict, **kwargs) -> FakePgRuntime:
+        rt = FakePgRuntime(verdict, **kwargs)
+        self.addCleanup(rt.cleanup)
+        return rt
+
+    def test_alerts_only_at_persistence_boundary(self):
+        rt = self.make_rt(evaluate_pg_health(False, False))
+        state: dict = {}
+        tick_pg_tunnel(rt, state, self.NOW)
+        tick_pg_tunnel(rt, state, self.NOW + 299)
+        self.assertEqual(rt.alerts, [])
+        tick_pg_tunnel(rt, state, self.NOW + 300)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("CLOSED", rt.alerts[0][0])
+        self.assertEqual(state[PG_STATE_KEY]["last_alert"], self.NOW + 300)
+
+    def test_open_listener_reports_half_dead_or_upstream(self):
+        rt = self.make_rt(evaluate_pg_health(False, True))
+        state = {PG_STATE_KEY: {"unhealthy_since": self.NOW - 300}}
+        tick_pg_tunnel(rt, state, self.NOW)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("OPEN", rt.alerts[0][0])
+        self.assertIn("half-dead", rt.alerts[0][0])
+
+    def test_realert_cooldown_boundary_is_exact(self):
+        verdict = evaluate_pg_health(False, False)
+        rt = self.make_rt(verdict)
+        state = {
+            PG_STATE_KEY: {
+                "unhealthy_since": self.NOW - 1000,
+                "last_alert": self.NOW - 899,
+                "alerting": True,
+            }
+        }
+        tick_pg_tunnel(rt, state, self.NOW)
+        self.assertEqual(rt.alerts, [])
+        tick_pg_tunnel(rt, state, self.NOW + 1)
+        self.assertEqual(len(rt.alerts), 1)
+
+    def test_recovery_notifies_and_keeps_antiflap_cooldown(self):
+        rt = self.make_rt(evaluate_pg_health(True, None))
+        state = {
+            PG_STATE_KEY: {
+                "unhealthy_since": self.NOW - 600,
+                "last_alert": self.NOW - 60,
+                "alerting": True,
+                "cause": PG_TUNNEL_DOWN,
+            }
+        }
+        tick_pg_tunnel(rt, state, self.NOW)
+        self.assertEqual(len(rt.alerts), 1)
+        body, trigger_turn = rt.alerts[0]
+        self.assertIn("복구", body)
+        self.assertFalse(trigger_turn)
+        self.assertEqual(state[PG_STATE_KEY], {"last_alert": self.NOW - 60})
+
+    def test_recent_dcserver_alert_defers_exactly_one_tick(self):
+        rt = self.make_rt(evaluate_pg_health(False, False))
+        rt.dcserver_recent = True
+        state = {PG_STATE_KEY: {"unhealthy_since": self.NOW - 300}}
+        tick_pg_tunnel(rt, state, self.NOW)
+        self.assertEqual(rt.alerts, [])
+        self.assertTrue(state[PG_STATE_KEY]["dedup_deferred"])
+        tick_pg_tunnel(rt, state, self.NOW + rt.cfg.poll_secs)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("1 tick 보류", rt.alerts[0][0])
+
+    def test_unknown_health_breaks_pending_timer_but_not_active_alert(self):
+        rt = self.make_rt(evaluate_pg_health(None, False))
+        pending = {PG_STATE_KEY: {"unhealthy_since": self.NOW - 299}}
+        tick_pg_tunnel(rt, pending, self.NOW)
+        self.assertNotIn("unhealthy_since", pending[PG_STATE_KEY])
+
+        active = {
+            PG_STATE_KEY: {
+                "unhealthy_since": self.NOW - 1000,
+                "last_alert": self.NOW - 10,
+                "alerting": True,
+            }
+        }
+        tick_pg_tunnel(rt, active, self.NOW)
+        self.assertTrue(active[PG_STATE_KEY]["alerting"])
+        self.assertEqual(rt.alerts, [])
 
 
 class TickChannelTests(unittest.TestCase):
@@ -823,6 +1040,12 @@ class DeploymentWiringTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("tests.test_relay_watchdog", script)
+
+    def test_main_loop_runs_independent_pg_tunnel_tick(self):
+        script = (REPO_ROOT / "scripts/relay_watchdog.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("tick_pg_tunnel(rt, state, now)", script)
 
     def test_deploy_release_ships_watchdog_and_plist(self):
         deploy = (REPO_ROOT / "scripts" / "deploy-release.sh").read_text(


### PR DESCRIPTION
## 설계 요약

07-09 릴레이 유실의 직접 원인은 mac-book의 `127.0.0.1:15432` PG 터널이 수동 프로세스 하나뿐이라 supervisor가 없었던 것이고, 숨은 원인은 mac-mini의 역방향 `-R` launchd 잡이 포트는 살린 채 포워딩이 죽는 유령 supervisor가 된 것입니다.

이 PR은 권고안 (a)를 구현합니다.

- 소비자(mac-book)가 `com.agentdesk.pg-tunnel` launchd 잡으로 foreground `ssh -N -L` 터널을 소유합니다.
- `ConnectTimeout=10`, `ServerAliveInterval=15`, `ServerAliveCountMax=3`, `ExitOnForwardFailure=yes`, `BatchMode=yes`, `KeepAlive=true`, `ThrottleInterval=10`을 모두 고정합니다.
- 래퍼는 `^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:`에 맞는 잔존 터널만 찾고, 같은 정규식으로 PID command를 신호 직전에 재검증한 뒤 TERM → bounded KILL로 인수합니다. 무관한 ssh/15432/역방향 프로세스는 매칭하지 않습니다.
- deploy는 스크립트를 staging한 뒤 plist를 `.tmp`에서 atomic `mv`로 게시하고 bootout+bootstrap합니다. 단, machine-local `$ADK_REL/config/pg-tunnel.env`가 존재하고 `--check-config`를 통과한 노드에서만 arm합니다. 전체 블록은 `DEPLOY_OK=1` 이후 fail-open입니다.
- relay watchdog은 매 tick `/api/health/detail`의 정확한 boolean `db=false`만 장애 1차 신호로 사용합니다. `nc`는 `CLOSED`(터널/supervisor)와 `OPEN`(half-dead 포워딩 또는 upstream PG)을 분류할 뿐 건강 판정으로 승격되지 않습니다.
- `db=false` 기본 5분 지속 시 알림, 15분 재알림 쿨다운, `db=true` 복구 해제 통지를 추가했습니다. `dcserver-pg-alert.state`의 Rust 작성 timestamp를 읽어 최근 부트 알림이 있으면 최초 watchdog 알림만 정확히 1 tick 보류하고 다음 tick에 상관 문구와 함께 보냅니다.
- CI가 `tests.test_pg_tunnel`과 확장된 `tests.test_relay_watchdog`를 실제 실행하도록 `ci-script-checks.sh`에 등록했습니다. Rust 변경은 0줄입니다.

### 권고 설계 대비 구현상 보강

물질적 설계 이탈은 없습니다. 두 가지 방어적 보강만 했습니다.

1. 실제 launchd plist가 SSH 옵션을 소유하고, 래퍼가 전달된 인자열을 canonical 목록과 다시 대조합니다. plist 옵션 누락이 조용히 실행되는 대신 래퍼가 fail-closed로 종료하여 launchd 재시도와 로그로 드러납니다.
2. dcserver 중복 알림 판정은 파일 mtime 대신 Rust가 파일 본문에 쓰는 authoritative UNIX timestamp를 읽습니다. invalid/future 값은 fail-open으로 처리해 손상된 state가 watchdog을 침묵시키지 못합니다.

## ⚠ 배포 런북 — 원격 역방향 supervisor 2종 해체가 선행 조건

**아래 mac-mini 단계가 완료되지 않으면 배포하지 않습니다.** 기존 역방향 잡이 살아 있으면 mac-book:15432를 다시 선점하여 신규 소비자 소유 터널과 경쟁할 수 있습니다. 이 PR 구현·테스트 중에는 아래 명령, 라이브 launchd, 현행 터널 PID, mac-mini에 전혀 접촉하지 않았습니다.

1. 운영자 승인 창에서 mac-mini의 역방향 잡 두 개를 bootout합니다.

   ```bash
   launchctl bootout "gui/$(id -u)/com.agentdesk.macbook-pg-tunnel" || true
   launchctl bootout "gui/$(id -u)/com.agentdesk.macbook-memento-tunnel" || true
   ```

2. 같은 mac-mini에서 두 plist를 제거하고 `launchctl print`/`pgrep`로 재생성되지 않는지 확인합니다.

   ```bash
   rm -f "$HOME/Library/LaunchAgents/com.agentdesk.macbook-pg-tunnel.plist"
   rm -f "$HOME/Library/LaunchAgents/com.agentdesk.macbook-memento-tunnel.plist"
   ```

3. mac-book에 machine-local 설정을 준비합니다. 이 파일은 repo에 커밋하거나 다른 노드로 복제하지 않습니다.

   ```bash
   mkdir -p "$HOME/.adk/release/config"
   printf '%s\n' 'PG_TUNNEL_SSH_TARGET=mac-mini' > "$HOME/.adk/release/config/pg-tunnel.env"
   ```

4. mac-book에서 release deploy를 실행합니다. deploy가 기존 `com.agentdesk.pg-tunnel`을 bootout하고 새 plist를 bootstrap합니다. config가 없거나 invalid면 staging만 하고 arm하지 않으며 건강한 deploy 자체는 성공으로 남습니다.
5. `launchctl print`, `lsof -nP -iTCP:15432 -sTCP:LISTEN`, `/api/health/detail`의 `db=true`, dcserver PID 불변을 확인합니다. 이상 시 신규 잡만 bootout하고 원인을 수정한 뒤 재배포합니다. 역방향 두 잡은 되살리지 않습니다.

## 승인 후 라이브 드릴 절차 (이 PR에서는 실행하지 않음)

### T1 — clean death

1. supervised ssh PID와 dcserver PID를 기록합니다.
2. 터널 PID에 TERM, 이어 별도 반복에서 KILL을 보내고 15432 listener를 폴링합니다.
3. 각 경우 listener가 15초 안에 새 PID로 복구되고, dcserver PID는 바뀌지 않으며, `/api/health/detail db`가 false → true로 listener+5초 안에 돌아오면 PASS입니다.

### T2 — half-dead

1. 터널 PID에 `kill -STOP`을 보내 listener는 유지하되 포워딩을 정지합니다.
2. `nc -z 127.0.0.1 15432`는 OPEN인데 `/api/health/detail`은 `db=false`가 되는지, watchdog 판정이 OPEN/half-dead·upstream인지 확인합니다.
3. 정지한 클라이언트에서는 ServerAlive 자체가 실행되지 않으므로 `kill -KILL`로 종료하고 T1 경로로 복구합니다. 복구 해제 통지와 dcserver PID 불변을 확인합니다.

### T3 — supervisor loop failure alert

1. 승인된 드릴 창에서 `pg_alert_after_secs`만 짧게 설정한 뒤 watchdog을 재시작합니다.
2. `com.agentdesk.pg-tunnel`을 bootout하여 실패를 지속시킵니다.
3. 단축 N분 경계 전 무알림, 경계 후 원인 CLOSED 알림 1회, 15분 쿨다운을 확인합니다. `dcserver-pg-alert.state`가 최근이면 한 tick 보류 후 상관 문구와 함께 발화해야 합니다.
4. plist를 bootstrap해 `db=true` 복구와 해제 통지를 확인하고 기본 300초 설정으로 원복합니다.

### T4 — strict port takeover

1. 신규 supervisor를 먼저 bootout해 포트를 비운 뒤, 정확한 `ssh ... -L 127.0.0.1:15432:...` 수동 터널과 매칭해서는 안 되는 대조 프로세스(`-R 15432`, 다른 bind 주소/포트)를 준비합니다.
2. plist를 다시 bootstrap(이미 로드된 상태라면 kickstart)합니다.
3. 정확한 수동 `-L 127.0.0.1:15432:` 프로세스만 종료되고 대조 프로세스는 생존하며, 신규 supervisor가 정상 bind하면 PASS입니다.

### T5 — 7일 회귀 지표

1. 배포 시각부터 7일간 `dcserver.launchd.stderr.log`의 `pool timed out while waiting for an open connection`과 watchdog PG 판정을 집계합니다.
2. 기준선 6,066회/3일(#4249) 대비 급감, 장기 OPEN+db=false/반복 CLOSED 부재, 릴레이 정상 전달을 확인합니다.
3. 잔존 pool timeout은 터널이 아니라 순수 pool 문제로 #4249에 이관합니다.

## 검증

- `bash -n scripts/pg_tunnel.sh scripts/deploy-release.sh` → `rc=0`
- `shellcheck -S warning scripts/pg_tunnel.sh scripts/deploy-release.sh` → `rc=0`
- 생성 plist `/usr/bin/plutil -lint` (macOS, fake launchctl harness) → `rc=0`
- `/opt/homebrew/bin/python3 -m unittest tests.test_relay_watchdog tests.test_pg_tunnel` → 95 tests, `rc=0`
- `scripts/ci-script-checks.sh` (`PYTHON=/opt/homebrew/bin/python3`) → `rc=0`
- `git diff --check origin/main...HEAD` → `rc=0`

### 커밋 후 뮤테이션 로그

커밋 후 `scripts/deploy-release.sh`의 아래 한 줄만 제거했습니다.

```xml
<string>-o</string><string>ExitOnForwardFailure=yes</string>
```

`/opt/homebrew/bin/python3 -m unittest tests.test_pg_tunnel` 결과:

```text
....F.............
FAIL: test_exit_on_forward_failure_is_pinned
Ran 18 tests
FAILED (failures=1)
rc=1
```

다른 17개 테스트는 통과했습니다. 한 줄 원복 후:

```text
..................
Ran 18 tests
OK
rc=0
```

원복 뒤 커밋 대비 `git diff --exit-code`도 `rc=0`이었습니다.

Refs #4378
