### PR TITLE
fix(test): harden shared env lock and CI timeout

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -82,7 +82,7 @@
 | `compat` | `src/compat/mod.rs` | 39 | 39 | 0 |  |
 | `compat::legacy_db_paths` | `src/compat/legacy_db_paths.rs` | 12 | 12 | 0 |  |
 | `compat::legacy_tmp_paths` | `src/compat/legacy_tmp_paths.rs` | 27 | 27 | 0 |  |
-| `config` | `src/config.rs` | 3118 | 2723 | 395 | giant-file |
+| `config` | `src/config.rs` | 3122 | 2723 | 399 | giant-file |
 | `config_live_reload` | `src/config_live_reload.rs` | 966 | 525 | 441 |  |
 | `crate` | `src/main.rs` | 7 | 7 | 0 |  |
 | `credential` | `src/credential.rs` | 212 | 59 | 153 |  |
@@ -475,7 +475,7 @@
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
 | `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1071 | 893 | 178 |  |
-| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2381 | 965 | 1416 |  |
+| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2357 | 965 | 1392 |  |
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1382 | 627 | 755 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |
@@ -580,7 +580,7 @@
 | `services::discord::recovery_engine::output_path_detect` | `src/services/discord/recovery_engine/output_path_detect.rs` | 177 | 177 | 0 |  |
 | `services::discord::recovery_engine::phase_policy` | `src/services/discord/recovery_engine/phase_policy.rs` | 370 | 179 | 191 |  |
 | `services::discord::recovery_engine::rebind_runtime` | `src/services/discord/recovery_engine/rebind_runtime.rs` | 2091 | 972 | 1119 |  |
-| `services::discord::recovery_engine::restore_inflight` | `src/services/discord/recovery_engine/restore_inflight.rs` | 2404 | 2313 | 91 | giant-file |
+| `services::discord::recovery_engine::restore_inflight` | `src/services/discord/recovery_engine/restore_inflight.rs` | 2382 | 2313 | 69 | giant-file |
 | `services::discord::recovery_engine::restore_persist_outcome` | `src/services/discord/recovery_engine/restore_persist_outcome.rs` | 102 | 102 | 0 |  |
 | `services::discord::recovery_engine::routing_orphan` | `src/services/discord/recovery_engine/routing_orphan.rs` | 218 | 146 | 72 |  |
 | `services::discord::recovery_engine::runtime` | `src/services/discord/recovery_engine/runtime.rs` | 558 | 265 | 293 |  |

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -79,6 +79,9 @@ echo "=== CI runner hardening guard ==="
 echo "=== PR infrastructure failure rerun classifier (#4392) ==="
 ./scripts/ci/infra-failure-rerun.sh --self-test
 
+echo "=== CI timeout wrapper tests (#4413) ==="
+"$PYTHON" -m unittest tests.test_ci_timeout
+
 echo "=== Scratch file guard ==="
 FAIL=0
 for scratch_file in plan.md scratch.md scratch.txt scratch.sh scratchpad.md scratchpad.txt scratchpad.sh sql_test.rs test_scratch.rs plan.txt pr-body.md test.sh test.sql; do

--- a/scripts/ci-timeout.py
+++ b/scripts/ci-timeout.py
@@ -8,6 +8,67 @@ import signal
 import subprocess
 import sys
 
+TERMINATION_GRACE_SECONDS = 5
+
+
+class _ForwardedSignal(Exception):
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = signum
+
+
+def _send_process_signal(
+    proc: subprocess.Popen[bytes], signum: int, *, force: bool = False
+) -> None:
+    """Signal the child process group, or its process on platforms without killpg."""
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(proc.pid, signal.SIGKILL if force else signum)
+        elif force:
+            proc.kill()
+        else:
+            proc.terminate()
+    except ProcessLookupError:
+        pass
+
+
+def _wait_after_signal(proc: subprocess.Popen[bytes]) -> None:
+    try:
+        proc.wait(timeout=TERMINATION_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        _send_process_signal(proc, signal.SIGTERM, force=True)
+        proc.wait()
+
+
+def _terminate_and_wait(proc: subprocess.Popen[bytes]) -> None:
+    _send_process_signal(proc, signal.SIGTERM)
+    _wait_after_signal(proc)
+
+
+def run_command(timeout: float, command: list[str]) -> int:
+    proc = subprocess.Popen(command, start_new_session=True)
+    previous_handlers: dict[int, signal.Handlers] = {}
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        _send_process_signal(proc, signum)
+        raise _ForwardedSignal(signum)
+
+    try:
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            previous_handlers[signum] = signal.signal(signum, forward_signal)
+
+        try:
+            return proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _terminate_and_wait(proc)
+            return 124
+        except _ForwardedSignal as forwarded:
+            _wait_after_signal(proc)
+            return 128 + forwarded.signum
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
 
 def main() -> int:
     if len(sys.argv) < 3:
@@ -20,24 +81,7 @@ def main() -> int:
         print(f"invalid timeout seconds: {sys.argv[1]!r}", file=sys.stderr)
         return 2
 
-    command = sys.argv[2:]
-    proc = subprocess.Popen(command, start_new_session=True)
-    try:
-        return proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(proc.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            proc.wait()
-        return 124
+    return run_command(timeout, sys.argv[2:])
 
 
 if __name__ == "__main__":

--- a/src/config.rs
+++ b/src/config.rs
@@ -2977,6 +2977,10 @@ pub(crate) fn shared_test_env_lock() -> &'static std::sync::Mutex<()> {
 
 #[cfg(test)]
 pub(crate) mod test_env_lock {
+    //! Canonical acquisition path for the shared test-environment mutex.
+    //! New test sites must use `acquire_shared_test_env_lock`; directly locking
+    //! `shared_test_env_lock` is forbidden.
+
     thread_local! {
         static SHARED_TEST_ENV_LOCK_HELD: std::cell::Cell<bool> =
             const { std::cell::Cell::new(false) };

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -965,7 +965,6 @@ fn is_recent_age(age_secs: Option<u64>, freshness_secs: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
     use std::io::{self, Write};
     use std::sync::{Arc, Mutex};
 
@@ -976,30 +975,6 @@ mod tests {
     use crate::services::discord::relay_health::{RelayHealthSnapshot, RelayStallState};
 
     use super::*;
-
-    /// Restores an env var to its prior value on drop (mirrors the helper in the
-    /// sibling `recovery.rs` test module).
-    struct EnvVarReset {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarReset {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarReset {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
 
     /// The liveness evidence path reaches `latest_runtime_activity_unix_nanos`,
     /// which trips the #3293 runtime-store guard when `AGENTDESK_ROOT_DIR` points
@@ -1014,15 +989,16 @@ mod tests {
     /// still holding the lock.
     #[must_use]
     fn isolated_runtime_root() -> (
-        EnvVarReset,
+        crate::config::TestEnvVarGuard,
         tempfile::TempDir,
-        std::sync::MutexGuard<'static, ()>,
+        crate::config::test_env_lock::SharedTestEnvLockGuard,
     ) {
-        let lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
+        let lock = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let dir = tempfile::tempdir().expect("temp runtime root");
-        let env = EnvVarReset::set("AGENTDESK_ROOT_DIR", dir.path());
+        let env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            dir.path(),
+        );
         (env, dir, lock)
     }
 

--- a/src/services/discord/recovery_engine/restore_inflight.rs
+++ b/src/services/discord/recovery_engine/restore_inflight.rs
@@ -2317,37 +2317,15 @@ mod tests {
         self, GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState, RelayOwnerKind,
     };
     use crate::services::provider::ProviderKind;
-    use std::ffi::OsString;
-
-    struct EnvVarReset {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarReset {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarReset {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
 
     #[test]
     fn restore_rollout_output_path_patch_preserves_concurrent_relay_fields() {
-        let _guard = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _guard = crate::config::test_env_lock::acquire_shared_test_env_lock();
         let tempdir = tempfile::tempdir().expect("temp runtime root");
-        let _env = EnvVarReset::set("AGENTDESK_ROOT_DIR", tempdir.path());
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tempdir.path(),
+        );
 
         let provider = ProviderKind::Codex;
         let channel_id = 4_111_002;

--- a/tests/test_ci_timeout.py
+++ b/tests/test_ci_timeout.py
@@ -1,0 +1,82 @@
+import importlib.util
+import signal
+import subprocess
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "ci-timeout.py"
+SPEC = importlib.util.spec_from_file_location("ci_timeout", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+ci_timeout = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ci_timeout)
+
+
+class FakeProcess:
+    def __init__(self, timeout_count: int) -> None:
+        self.pid = 4413
+        self.terminate = mock.Mock()
+        self.kill = mock.Mock()
+        self.timeout_count = timeout_count
+        self.wait_calls = 0
+
+    def wait(self, timeout=None):
+        self.wait_calls += 1
+        if self.wait_calls <= self.timeout_count:
+            raise subprocess.TimeoutExpired("cargo test", timeout)
+        return 0
+
+
+class CiTimeoutTests(unittest.TestCase):
+    def test_killpg_fallback_terminates_then_kills_after_grace_period(self):
+        proc = FakeProcess(timeout_count=2)
+
+        with (
+            mock.patch.object(ci_timeout, "os", types.SimpleNamespace()),
+            mock.patch.object(ci_timeout.subprocess, "Popen", return_value=proc),
+            mock.patch.object(ci_timeout.signal, "signal", return_value=signal.SIG_DFL),
+        ):
+            return_code = ci_timeout.run_command(30, ["cargo", "test"])
+
+        proc.terminate.assert_called_once_with()
+        proc.kill.assert_called_once_with()
+        self.assertEqual(proc.wait_calls, 3)
+        self.assertEqual(return_code, 124)
+
+    def test_sigterm_and_sigint_are_forwarded_with_shell_return_code(self):
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            with self.subTest(signum=signum):
+                installed_handlers = {}
+
+                def install_handler(installed_signum, handler):
+                    previous = installed_handlers.get(installed_signum, signal.SIG_DFL)
+                    installed_handlers[installed_signum] = handler
+                    return previous
+
+                wait_results = [
+                    lambda timeout: installed_handlers[signum](signum, None),
+                    -signum,
+                ]
+
+                def next_wait(timeout=None):
+                    result = wait_results.pop(0)
+                    return result(timeout) if callable(result) else result
+
+                proc = mock.Mock(pid=4413)
+                proc.wait = mock.Mock(side_effect=next_wait)
+
+                with (
+                    mock.patch.object(ci_timeout.signal, "signal", side_effect=install_handler),
+                    mock.patch.object(ci_timeout.subprocess, "Popen", return_value=proc),
+                    mock.patch.object(ci_timeout, "_send_process_signal") as send_signal,
+                ):
+                    return_code = ci_timeout.run_command(30, ["cargo", "test"])
+
+                send_signal.assert_called_once_with(proc, signum)
+                self.assertEqual(return_code, 128 + signum)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the remaining `EnvVarReset` copies in `stall_liveness` and `restore_inflight`, using the canonical `TestEnvVarGuard` while preserving environment-restore-before-lock-release drop order
- migrate both scoped raw shared-env mutex acquisitions to `acquire_shared_test_env_lock()` and document that new direct-lock sites are forbidden
- harden `ci-timeout.py` with a `hasattr(os, "killpg")` Windows fallback (`terminate()` then `kill()`), plus SIGTERM/SIGINT forwarding and shell-style 128+signal return codes
- add focused timeout-wrapper unit tests and wire them into `ci-script-checks.sh`

## Why

The two local reset helpers retained the helper-drift class addressed by #4404, while raw mutex acquisition bypassed same-thread re-entry detection. The timeout wrapper also raised on Windows expiry and did not forward CI cancellation signals, leaving cargo children at risk of becoming orphaned.

## Validation

- `env -u AGENTDESK_ROOT_DIR cargo test --lib stall_liveness` — rc=0
- `env -u AGENTDESK_ROOT_DIR cargo test --lib restore_inflight` — rc=0
- `/opt/homebrew/bin/python3 -m unittest tests.test_ci_timeout tests.test_relay_watchdog` — rc=0
- `/opt/homebrew/bin/python3 scripts/generate_inventory_docs.py --check` — rc=0
- `/opt/homebrew/bin/python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` — rc=0 (`agent-maintenance freshness check passed`)
- `PATH=/opt/homebrew/bin:$PATH PYTHON=/opt/homebrew/bin/python3 ./scripts/ci-script-checks.sh` — rc=0
- `cargo fmt --all -- --check` — rc=0

Generated inventory confirms production LoC is unchanged for all Rust files touched by the implementation.

## Mutation proof

After committing, the `hasattr(os, "killpg")` fallback branches were temporarily removed. Running

`/opt/homebrew/bin/python3 -m unittest tests.test_ci_timeout.CiTimeoutTests.test_killpg_fallback_terminates_then_kills_after_grace_period`

returned rc=1 at its own assertion:

`AssertionError: Expected 'mock' to be called once. Called 0 times.`

The fallback was restored, the same test returned rc=0, and the worktree is clean.

Refs #4413
