### PR TITLE
fix(relay): stop redrive-reclaim self-destruction loop

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1269 | 564 | 705 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1428 | 610 | 818 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1534 | 611 | 923 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1624 | 654 | 970 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
@@ -706,7 +706,7 @@
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
 | `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 599 | 574 | 25 |  |
-| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 324 | 133 | 191 |  |
+| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 320 | 133 | 187 |  |
 | `services::discord::tmux_watcher::post_stream_exit` | `src/services/discord/tmux_watcher/post_stream_exit.rs` | 254 | 254 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 146 | 100 | 46 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1250 | 565 | 685 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1269 | 564 | 705 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
@@ -705,8 +705,8 @@
 | `services::discord::tmux_watcher::loop_poll_prologue` | `src/services/discord/tmux_watcher/loop_poll_prologue.rs` | 609 | 609 | 0 |  |
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
-| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 597 | 572 | 25 |  |
-| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 313 | 133 | 180 |  |
+| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 599 | 574 | 25 |  |
+| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 324 | 133 | 191 |  |
 | `services::discord::tmux_watcher::post_stream_exit` | `src/services/discord/tmux_watcher/post_stream_exit.rs` | 254 | 254 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 146 | 100 | 46 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 626 | 307 | 319 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1070 | 495 | 575 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
@@ -705,8 +705,8 @@
 | `services::discord::tmux_watcher::loop_poll_prologue` | `src/services/discord/tmux_watcher/loop_poll_prologue.rs` | 609 | 609 | 0 |  |
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
-| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 598 | 598 | 0 |  |
-| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 106 | 106 | 0 |  |
+| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 596 | 571 | 25 |  |
+| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 306 | 126 | 180 |  |
 | `services::discord::tmux_watcher::post_stream_exit` | `src/services/discord/tmux_watcher/post_stream_exit.rs` | 254 | 254 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 146 | 100 | 46 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1177 | 526 | 651 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1250 | 565 | 685 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
@@ -706,7 +706,7 @@
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
 | `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 597 | 572 | 25 |  |
-| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 307 | 127 | 180 |  |
+| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 313 | 133 | 180 |  |
 | `services::discord::tmux_watcher::post_stream_exit` | `src/services/discord/tmux_watcher/post_stream_exit.rs` | 254 | 254 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 146 | 100 | 46 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1428 | 610 | 818 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1534 | 611 | 923 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1624 | 654 | 970 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1732 | 666 | 1066 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -470,7 +470,7 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1070 | 495 | 575 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1177 | 526 | 651 |  |
 | `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
@@ -705,8 +705,8 @@
 | `services::discord::tmux_watcher::loop_poll_prologue` | `src/services/discord/tmux_watcher/loop_poll_prologue.rs` | 609 | 609 | 0 |  |
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 238 | 238 | 0 |  |
-| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 596 | 571 | 25 |  |
-| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 306 | 126 | 180 |  |
+| `services::discord::tmux_watcher::panel_decisions` | `src/services/discord/tmux_watcher/panel_decisions.rs` | 597 | 572 | 25 |  |
+| `services::discord::tmux_watcher::placeholder_reclaim` | `src/services/discord/tmux_watcher/placeholder_reclaim.rs` | 307 | 127 | 180 |  |
 | `services::discord::tmux_watcher::post_stream_exit` | `src/services/discord/tmux_watcher/post_stream_exit.rs` | 254 | 254 | 0 |  |
 | `services::discord::tmux_watcher::prompt_observe` | `src/services/discord/tmux_watcher/prompt_observe.rs` | 109 | 109 | 0 |  |
 | `services::discord::tmux_watcher::provider_session_persistence` | `src/services/discord/tmux_watcher/provider_session_persistence.rs` | 146 | 100 | 46 |  |

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -46,16 +46,22 @@ impl RedriveEpisode {
     ) -> Option<(InflightTurnIdentity, Option<String>)> {
         let previous = self.identity.as_ref()?;
         let post_identity = InflightTurnIdentity::from_state(post);
-        let same_nonce = self.turn_nonce.is_some() && self.turn_nonce == post.turn_nonce;
+        let previous_nonce = self.turn_nonce.as_deref().filter(|nonce| !nonce.is_empty());
+        let post_nonce = post.turn_nonce.as_deref().filter(|nonce| !nonce.is_empty());
+        let same_nonce = previous_nonce.is_some() && previous_nonce == post_nonce;
         let same_managed_turn = previous.user_msg_id != 0
             && previous.user_msg_id == post_identity.user_msg_id
             && previous.started_at == post_identity.started_at
             && previous.tmux_session_name == post_identity.tmux_session_name;
         let synthetic_rebind = post.rebind_origin
             && post_identity.user_msg_id == 0
-            && previous.tmux_session_name == post_identity.tmux_session_name;
+            && previous.tmux_session_name == post_identity.tmux_session_name
+            && !matches!(
+                post.turn_source,
+                crate::services::discord::inflight::TurnSource::MonitorTriggered
+            );
         (same_nonce || same_managed_turn || synthetic_rebind)
-            .then_some((post_identity, post.turn_nonce.clone()))
+            .then_some((post_identity, post_nonce.map(str::to_string)))
     }
 }
 
@@ -66,6 +72,7 @@ struct RedriveAttemptState {
     last_attempt_unix: i64,
     capped_alarm_emitted: bool,
     retry_not_before_unix: Option<i64>,
+    shield_started_at_millis: Option<i64>,
 }
 
 impl RedriveAttemptState {
@@ -76,6 +83,7 @@ impl RedriveAttemptState {
             last_attempt_unix: now_unix,
             capped_alarm_emitted: false,
             retry_not_before_unix: None,
+            shield_started_at_millis: None,
         }
     }
 }
@@ -113,7 +121,7 @@ impl SharedData {
                         .as_ref()
                         .is_some_and(|identity| identity.matches_state(state))
                 })
-                .and_then(|state| state.turn_nonce);
+                .and_then(|state| state.turn_nonce.filter(|nonce| !nonce.is_empty()));
         RedriveEpisode {
             frontier: snapshot.last_relay_offset,
             identity: snapshot.inflight_identity.clone(),
@@ -179,12 +187,14 @@ impl SharedData {
         now_unix: i64,
         reattached: bool,
     ) -> RedriveAttemptDecision {
+        let now_millis = chrono::Utc::now().timestamp_millis();
         let key = self.redrive_key(provider, channel_id);
         let mut state = REDRIVE_ATTEMPTS
             .get_mut(&key)
             .expect("redrive success must follow an admitted attempt");
         state.attempts += 1;
         let first_attempt_of_episode = state.attempts == 1;
+        let shield_started_at_millis = *state.shield_started_at_millis.get_or_insert(now_millis);
         state.last_attempt_unix = now_unix;
         state.retry_not_before_unix = None;
         if reattached {
@@ -222,7 +232,8 @@ impl SharedData {
                 identity: owner_inflight
                     .as_ref()
                     .map(InflightTurnIdentity::from_state),
-                turn_nonce: owner_inflight.and_then(|post| post.turn_nonce),
+                turn_nonce: owner_inflight
+                    .and_then(|post| post.turn_nonce.filter(|nonce| !nonce.is_empty())),
                 reconnect_count: self
                     .tmux_relay_coord(shield_channel_id)
                     .reconnect_count
@@ -231,15 +242,15 @@ impl SharedData {
         };
         drop(state);
 
-        let now_millis = chrono::Utc::now().timestamp_millis();
         let mut shield = REDRIVE_PLACEHOLDER_SHIELDS
             .entry(self.redrive_key(provider, shield_channel_id))
-            .or_insert_with(|| (episode.clone(), now_millis));
+            .or_insert_with(|| (episode.clone(), shield_started_at_millis));
         if first_attempt_of_episode {
-            *shield = (episode, now_millis);
+            shield.0 = episode;
         } else if shield_channel_id == channel_id {
             shield.0 = episode;
         }
+        shield.1 = shield_started_at_millis;
         decision
     }
 
@@ -399,42 +410,36 @@ impl HealthRegistry {
             return Ok(false);
         }
 
-        let watcher_owner_channel_id = snapshot
-            .watcher_owner_channel_id
-            .map(ChannelId::new)
-            .unwrap_or(channel_id);
-        let (applied, reattached, noop_cooldown_secs, shield_channel_id) =
-            if nudge_existing_watcher_for_backlog(
-                &shared,
+        let (applied, reattached, noop_cooldown_secs) = if nudge_existing_watcher_for_backlog(
+            &shared,
+            provider,
+            &snapshot,
+            channel_id,
+            now_unix_secs,
+        ) {
+            (true, false, None)
+        } else {
+            if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
+                return Ok(false);
+            }
+            let response = relay_recovery::auto_apply_relay_recovery_for_shared(
+                self,
+                shared.clone(),
                 provider,
-                &snapshot,
-                channel_id,
-                now_unix_secs,
-            ) {
-                (true, false, None, watcher_owner_channel_id)
-            } else {
-                if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
-                    return Ok(false);
-                }
-                let response = relay_recovery::auto_apply_relay_recovery_for_shared(
-                    self,
-                    shared.clone(),
-                    provider,
-                    channel_id.get(),
-                    RelayRecoveryActionKind::ReattachWatcher,
-                    RelayRecoveryApplySource::ProbeAutoHeal,
-                )
-                .await?;
-                let shield_channel_id =
-                    redrive_shield_channel_after_reattach(&shared, &snapshot, channel_id);
-                (
-                    response.applied,
-                    true,
-                    Some(response.decision.auto_heal.window_secs),
-                    shield_channel_id,
-                )
-            };
+                channel_id.get(),
+                RelayRecoveryActionKind::ReattachWatcher,
+                RelayRecoveryApplySource::ProbeAutoHeal,
+            )
+            .await?;
+            (
+                response.applied,
+                true,
+                Some(response.decision.auto_heal.window_secs),
+            )
+        };
         if applied {
+            let shield_channel_id =
+                redrive_shield_channel_for_action(&shared, &snapshot, channel_id, reattached);
             let committed = shared.commit_redrive_success(
                 provider,
                 channel_id,
@@ -450,11 +455,18 @@ impl HealthRegistry {
     }
 }
 
-fn redrive_shield_channel_after_reattach(
+fn redrive_shield_channel_for_action(
     shared: &SharedData,
     snapshot: &WatcherStateSnapshot,
     fallback_channel_id: ChannelId,
+    reattached: bool,
 ) -> ChannelId {
+    if !reattached {
+        return snapshot
+            .watcher_owner_channel_id
+            .map(ChannelId::new)
+            .unwrap_or(fallback_channel_id);
+    }
     snapshot
         .tmux_session
         .as_deref()
@@ -1204,6 +1216,64 @@ mod tests {
     }
 
     #[test]
+    fn redrive_self_reattach_identity_rejects_unrelated_synthetic_turns_4299() {
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(4_299_008);
+        let tmux_session = "AgentDesk-codex-4299-synthetic-identity";
+        let output_path = "/tmp/agentdesk-4299-synthetic-identity.jsonl";
+        let mut previous = synthetic_rebind_state(
+            &provider,
+            channel_id,
+            tmux_session,
+            output_path,
+            "2026-06-12 00:00:01",
+            128,
+        );
+        previous.turn_nonce = Some("previous-turn".to_string());
+        let episode = RedriveEpisode {
+            frontier: 128,
+            identity: Some(InflightTurnIdentity::from_state(&previous)),
+            turn_nonce: previous.turn_nonce.clone(),
+            reconnect_count: 0,
+        };
+
+        let mut monitor = synthetic_rebind_state(
+            &provider,
+            channel_id,
+            tmux_session,
+            output_path,
+            "2026-06-12 00:00:02",
+            129,
+        );
+        monitor.turn_nonce = Some("monitor-turn".to_string());
+        monitor.turn_source = crate::services::discord::inflight::TurnSource::MonitorTriggered;
+        assert_eq!(
+            episode.self_reattach_identity(&monitor),
+            None,
+            "a monitor auto-turn is a successor, not reattach's synthetic row"
+        );
+
+        let mut explicit_rebind = monitor.clone();
+        explicit_rebind.turn_source =
+            crate::services::discord::inflight::TurnSource::ExternalAdopted;
+        assert!(
+            episode.self_reattach_identity(&explicit_rebind).is_some(),
+            "an explicit synthetic rebind must still be absorbed"
+        );
+
+        let mut empty_nonce_episode = episode;
+        empty_nonce_episode.turn_nonce = Some(String::new());
+        let mut empty_nonce_successor = previous;
+        empty_nonce_successor.turn_nonce = Some(String::new());
+        empty_nonce_successor.rebind_origin = false;
+        assert_eq!(
+            empty_nonce_episode.self_reattach_identity(&empty_nonce_successor),
+            None,
+            "empty nonce values are absent and must never authenticate a turn"
+        );
+    }
+
+    #[test]
     fn redrive_cap_resets_only_for_progress_identity_or_watcher_4299() {
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
@@ -1377,11 +1447,10 @@ mod tests {
             base + 4_000_030,
         );
         assert_eq!(second.attempt, Some(2));
-        let key = shared.redrive_key(&provider, channel_id);
-        REDRIVE_PLACEHOLDER_SHIELDS
-            .get_mut(&key)
+        let first_shield_started = shared
+            .redrive_placeholder_shield_context(&provider, channel_id)
             .expect("first reattach records shield")
-            .1 = 1_234;
+            .0;
         rebound.started_at = "2026-06-12 00:00:02".to_string();
         rebound.updated_at = rebound.started_at.clone();
         rebound.turn_start_offset = Some(snapshot.last_relay_offset + 1);
@@ -1405,7 +1474,10 @@ mod tests {
         let (shield_started, _, shield_identity) = shared
             .redrive_placeholder_shield_context(&provider, channel_id)
             .expect("self-reattach must preserve shield");
-        assert_eq!(shield_started, 1_234, "self-reattach must not extend 900s");
+        assert_eq!(
+            shield_started, first_shield_started,
+            "self-reattach must not extend 900s"
+        );
         assert_eq!(shield_identity, Some(second_rebound_identity.clone()));
         let mut twice_reattached = self_reattached.clone();
         twice_reattached.reconnect_count = 1;
@@ -1519,8 +1591,16 @@ mod tests {
         let mut snapshot = backlog_snapshot(channel_id, tmux_session, output_path, 128, 301_613);
         snapshot.watcher_owner_channel_id = Some(owner_channel_id.get());
         snapshot.relay_health.watcher_owner_channel_id = Some(owner_channel_id.get());
+        let stale_snapshot_owner = ChannelId::new(4_299_007);
+        let mut routing_snapshot = snapshot.clone();
+        routing_snapshot.watcher_owner_channel_id = Some(stale_snapshot_owner.get());
         assert_eq!(
-            redrive_shield_channel_after_reattach(&shared, &snapshot, channel_id),
+            redrive_shield_channel_for_action(&shared, &routing_snapshot, channel_id, false,),
+            stale_snapshot_owner,
+            "a nudge must shield the owner captured by its snapshot"
+        );
+        assert_eq!(
+            redrive_shield_channel_for_action(&shared, &routing_snapshot, channel_id, true),
             owner_channel_id,
             "reuse-existing reattach must shield the incumbent watcher owner"
         );
@@ -1548,6 +1628,19 @@ mod tests {
                 1_234,
             ),
         );
+        let request_key = shared.redrive_key(&provider, channel_id);
+        REDRIVE_PLACEHOLDER_SHIELDS.insert(
+            request_key,
+            (
+                RedriveEpisode {
+                    frontier: snapshot.last_relay_offset,
+                    identity: snapshot.inflight_identity.clone(),
+                    turn_nonce: None,
+                    reconnect_count: snapshot.reconnect_count,
+                },
+                5_678,
+            ),
+        );
         let base = 1_820_000_000;
         assert_eq!(
             gated_nudge(
@@ -1563,18 +1656,14 @@ mod tests {
             gated_nudge(&shared, &provider, &snapshot, channel_id, base),
             (true, Some(1))
         );
+        let episode_started = shared
+            .redrive_placeholder_shield_context(&provider, owner_channel_id)
+            .expect("first attempt re-arms the owner shield")
+            .0;
         assert_ne!(
-            shared
-                .redrive_placeholder_shield_context(&provider, owner_channel_id)
-                .expect("first attempt re-arms the owner shield")
-                .0,
-            1_234,
+            episode_started, 1_234,
             "the first action of a new request episode must replace a stale owner shield"
         );
-        REDRIVE_PLACEHOLDER_SHIELDS
-            .get_mut(&owner_key)
-            .expect("first owner nudge records a shield")
-            .1 = 1_234;
 
         shared
             .tmux_relay_coord(owner_channel_id)
@@ -1598,7 +1687,10 @@ mod tests {
         let (shield_started, frontier_at_first_nudge, shield_identity) = shared
             .redrive_placeholder_shield_context(&provider, owner_channel_id)
             .expect("owner shield survives the request-channel episode");
-        assert_eq!(shield_started, 1_234, "repeat nudge must not extend 900s");
+        assert_eq!(
+            shield_started, episode_started,
+            "repeat nudge must not extend 900s"
+        );
         assert_eq!(
             frontier_at_first_nudge, 0,
             "owner progress must not move the frozen first-nudge frontier"
@@ -1612,6 +1704,22 @@ mod tests {
         assert!(
             shared.committed_relay_offset(owner_channel_id) > frontier_at_first_nudge,
             "owner progress must restore reclaim against the frozen shield snapshot"
+        );
+
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(&provider, channel_id, &snapshot, base + 90)
+                .attempt,
+            Some(3)
+        );
+        shared.commit_redrive_success(&provider, channel_id, channel_id, base + 90, true);
+        assert_eq!(
+            shared
+                .redrive_placeholder_shield_context(&provider, channel_id)
+                .expect("shield follows a mid-episode owner move")
+                .0,
+            episode_started,
+            "a shield-key move must retain the first action's 900s anchor"
         );
 
         REDRIVE_PLACEHOLDER_SHIELDS.remove(&owner_key);

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -28,6 +28,7 @@ type RedriveKey = (String, String, u64);
 struct RedriveEpisode {
     frontier: u64,
     identity: Option<InflightTurnIdentity>,
+    turn_nonce: Option<String>,
     reconnect_count: u64,
 }
 
@@ -35,19 +36,26 @@ impl RedriveEpisode {
     fn resets(&self, previous: &Self) -> bool {
         self.frontier > previous.frontier
             || (self.identity.is_some() && self.identity != previous.identity)
+            || (self.turn_nonce.is_some() && self.turn_nonce != previous.turn_nonce)
             || self.reconnect_count != previous.reconnect_count
     }
 
-    fn self_reattach_identity(&self, post: &InflightTurnState) -> Option<InflightTurnIdentity> {
+    fn self_reattach_identity(
+        &self,
+        post: &InflightTurnState,
+    ) -> Option<(InflightTurnIdentity, Option<String>)> {
         let previous = self.identity.as_ref()?;
         let post_identity = InflightTurnIdentity::from_state(post);
-        let same_turn = previous.user_msg_id == post_identity.user_msg_id
+        let same_nonce = self.turn_nonce.is_some() && self.turn_nonce == post.turn_nonce;
+        let same_managed_turn = previous.user_msg_id != 0
+            && previous.user_msg_id == post_identity.user_msg_id
             && previous.started_at == post_identity.started_at
             && previous.tmux_session_name == post_identity.tmux_session_name;
         let synthetic_rebind = post.rebind_origin
             && post_identity.user_msg_id == 0
             && previous.tmux_session_name == post_identity.tmux_session_name;
-        (same_turn || synthetic_rebind).then_some(post_identity)
+        (same_nonce || same_managed_turn || synthetic_rebind)
+            .then_some((post_identity, post.turn_nonce.clone()))
     }
 }
 
@@ -92,10 +100,24 @@ impl SharedData {
         )
     }
 
-    fn redrive_episode(snapshot: &WatcherStateSnapshot) -> RedriveEpisode {
+    fn redrive_episode(
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        snapshot: &WatcherStateSnapshot,
+    ) -> RedriveEpisode {
+        let turn_nonce =
+            crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
+                .filter(|state| {
+                    snapshot
+                        .inflight_identity
+                        .as_ref()
+                        .is_some_and(|identity| identity.matches_state(state))
+                })
+                .and_then(|state| state.turn_nonce);
         RedriveEpisode {
             frontier: snapshot.last_relay_offset,
             identity: snapshot.inflight_identity.clone(),
+            turn_nonce,
             reconnect_count: snapshot.reconnect_count,
         }
     }
@@ -108,7 +130,7 @@ impl SharedData {
         now_unix: i64,
     ) -> RedriveAttemptDecision {
         let key = self.redrive_key(provider, channel_id);
-        let episode = Self::redrive_episode(snapshot);
+        let episode = Self::redrive_episode(provider, channel_id, snapshot);
         let mut state = REDRIVE_ATTEMPTS
             .entry(key)
             .or_insert_with(|| RedriveAttemptState::new(episode.clone(), now_unix));
@@ -175,9 +197,10 @@ impl SharedData {
             }
             if let Some(post) =
                 crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
-                && let Some(identity) = state.episode.self_reattach_identity(&post)
+                && let Some((identity, turn_nonce)) = state.episode.self_reattach_identity(&post)
             {
                 state.episode.identity = Some(identity);
+                state.episode.turn_nonce = turn_nonce;
             }
         }
         let emit_capped_alarm =
@@ -190,13 +213,16 @@ impl SharedData {
         let episode = if shield_channel_id == channel_id {
             state.episode.clone()
         } else {
+            let owner_inflight = crate::services::discord::inflight::load_inflight_state(
+                provider,
+                shield_channel_id.get(),
+            );
             RedriveEpisode {
                 frontier: self.committed_relay_offset(shield_channel_id),
-                identity: crate::services::discord::inflight::load_inflight_state(
-                    provider,
-                    shield_channel_id.get(),
-                )
-                .map(|post| InflightTurnIdentity::from_state(&post)),
+                identity: owner_inflight
+                    .as_ref()
+                    .map(InflightTurnIdentity::from_state),
+                turn_nonce: owner_inflight.and_then(|post| post.turn_nonce),
                 reconnect_count: self
                     .tmux_relay_coord(shield_channel_id)
                     .reconnect_count
@@ -209,10 +235,9 @@ impl SharedData {
         let mut shield = REDRIVE_PLACEHOLDER_SHIELDS
             .entry(self.redrive_key(provider, shield_channel_id))
             .or_insert_with(|| (episode.clone(), now_millis));
-        if first_attempt_of_episode && episode.resets(&shield.0) {
-            shield.1 = now_millis;
-        }
-        if first_attempt_of_episode || shield_channel_id == channel_id {
+        if first_attempt_of_episode {
+            *shield = (episode, now_millis);
+        } else if shield_channel_id == channel_id {
             shield.0 = episode;
         }
         decision
@@ -400,11 +425,13 @@ impl HealthRegistry {
                     RelayRecoveryApplySource::ProbeAutoHeal,
                 )
                 .await?;
+                let shield_channel_id =
+                    redrive_shield_channel_after_reattach(&shared, &snapshot, channel_id);
                 (
                     response.applied,
                     true,
                     Some(response.decision.auto_heal.window_secs),
-                    channel_id,
+                    shield_channel_id,
                 )
             };
         if applied {
@@ -421,6 +448,22 @@ impl HealthRegistry {
         }
         Ok(applied)
     }
+}
+
+fn redrive_shield_channel_after_reattach(
+    shared: &SharedData,
+    snapshot: &WatcherStateSnapshot,
+    fallback_channel_id: ChannelId,
+) -> ChannelId {
+    snapshot
+        .tmux_session
+        .as_deref()
+        .and_then(|tmux_session| {
+            shared
+                .tmux_watchers
+                .owner_channel_for_tmux_session(tmux_session)
+        })
+        .unwrap_or(fallback_channel_id)
 }
 
 fn trace_redrive_cap_if_needed(
@@ -1379,22 +1422,44 @@ mod tests {
             Some(3),
             "a self-induced identity rewrite without reconnect must not reset the cap episode"
         );
-        twice_reattached
-            .inflight_identity
-            .as_mut()
-            .expect("twice-reattached identity")
-            .user_msg_id = 9_999;
+        let mut same_second_successor = synthetic_rebind_state(
+            &provider,
+            channel_id,
+            tmux_session,
+            output_path,
+            &rebound.started_at,
+            snapshot.last_relay_offset + 2,
+        );
+        same_second_successor.rebind_origin = false;
+        crate::services::discord::inflight::save_inflight_state(&same_second_successor)
+            .expect("persist same-second TUI successor identity");
+        assert_eq!(
+            shared.commit_redrive_success(
+                &provider,
+                channel_id,
+                channel_id,
+                base + 4_000_090,
+                true,
+            ),
+            RedriveAttemptDecision {
+                attempt: Some(3),
+                emit_capped_alarm: false,
+            }
+        );
+        let mut successor_snapshot = twice_reattached;
+        successor_snapshot.inflight_identity =
+            Some(InflightTurnIdentity::from_state(&same_second_successor));
         assert_eq!(
             shared
                 .redrive_attempt_decision(
                     &provider,
                     channel_id,
-                    &twice_reattached,
+                    &successor_snapshot,
                     base + 4_000_091,
                 )
                 .attempt,
             Some(1),
-            "a real successor turn identity must still reset the episode"
+            "a same-second user-id-zero successor must still reset the episode"
         );
         crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
@@ -1454,6 +1519,11 @@ mod tests {
         let mut snapshot = backlog_snapshot(channel_id, tmux_session, output_path, 128, 301_613);
         snapshot.watcher_owner_channel_id = Some(owner_channel_id.get());
         snapshot.relay_health.watcher_owner_channel_id = Some(owner_channel_id.get());
+        assert_eq!(
+            redrive_shield_channel_after_reattach(&shared, &snapshot, channel_id),
+            owner_channel_id,
+            "reuse-existing reattach must shield the incumbent watcher owner"
+        );
         let first_owner = synthetic_rebind_state(
             &provider,
             owner_channel_id,
@@ -1465,6 +1535,19 @@ mod tests {
         crate::services::discord::inflight::save_inflight_state(&first_owner)
             .expect("persist first owner identity");
         let first_owner_identity = InflightTurnIdentity::from_state(&first_owner);
+        let owner_key = shared.redrive_key(&provider, owner_channel_id);
+        REDRIVE_PLACEHOLDER_SHIELDS.insert(
+            owner_key.clone(),
+            (
+                RedriveEpisode {
+                    frontier: 0,
+                    identity: Some(first_owner_identity.clone()),
+                    turn_nonce: first_owner.turn_nonce.clone(),
+                    reconnect_count: 0,
+                },
+                1_234,
+            ),
+        );
         let base = 1_820_000_000;
         assert_eq!(
             gated_nudge(
@@ -1480,7 +1563,14 @@ mod tests {
             gated_nudge(&shared, &provider, &snapshot, channel_id, base),
             (true, Some(1))
         );
-        let owner_key = shared.redrive_key(&provider, owner_channel_id);
+        assert_ne!(
+            shared
+                .redrive_placeholder_shield_context(&provider, owner_channel_id)
+                .expect("first attempt re-arms the owner shield")
+                .0,
+            1_234,
+            "the first action of a new request episode must replace a stale owner shield"
+        );
         REDRIVE_PLACEHOLDER_SHIELDS
             .get_mut(&owner_key)
             .expect("first owner nudge records a shield")

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -14,7 +14,9 @@ use crate::services::provider::ProviderKind;
 
 // Delay after each admitted attempt. The sixth (960s) is the terminal capped
 // horizon from the issue contract; no seventh action is admitted. Consequently
-// the six actual action times are cumulative +0/+30/+90/+210/+450/+930.
+// the six actual action times are cumulative +0/+30/+90/+210/+450/+930. The
+// hard placeholder shield expires at +900, so the final action intentionally
+// runs under the reclaim semantics restored by that bound.
 const REDRIVE_BACKOFF_SECS: [i64; 6] = [30, 60, 120, 240, 480, 960];
 const REDRIVE_MAX_NO_PROGRESS_ATTEMPTS: u8 = 6;
 const _: () = assert!(REDRIVE_BACKOFF_SECS.len() == REDRIVE_MAX_NO_PROGRESS_ATTEMPTS as usize);
@@ -33,11 +35,6 @@ impl RedriveEpisode {
         self.frontier > previous.frontier
             || (self.identity.is_some() && self.identity != previous.identity)
             || self.reconnect_count != previous.reconnect_count
-    }
-
-    fn refreshes_shield(&self, previous: &Self) -> bool {
-        self.frontier > previous.frontier
-            || (self.identity.is_some() && self.identity != previous.identity)
     }
 }
 
@@ -106,7 +103,8 @@ impl SharedData {
             *state = RedriveAttemptState::new(episode, now_unix);
         }
         if state.attempts >= REDRIVE_MAX_NO_PROGRESS_ATTEMPTS {
-            debug_assert_eq!(REDRIVE_BACKOFF_SECS[usize::from(state.attempts - 1)], 960);
+            debug_assert_eq!(state.attempts, REDRIVE_MAX_NO_PROGRESS_ATTEMPTS);
+            debug_assert_eq!(REDRIVE_BACKOFF_SECS[REDRIVE_BACKOFF_SECS.len() - 1], 960);
             let emit_capped_alarm = !state.capped_alarm_emitted;
             state.capped_alarm_emitted = true;
             return RedriveAttemptDecision {
@@ -150,6 +148,7 @@ impl SharedData {
             .get_mut(&key)
             .expect("redrive success must follow an admitted attempt");
         state.attempts += 1;
+        let first_attempt_of_episode = state.attempts == 1;
         state.last_attempt_unix = now_unix;
         state.retry_not_before_unix = None;
         if reattached {
@@ -175,7 +174,7 @@ impl SharedData {
         let mut shield = REDRIVE_PLACEHOLDER_SHIELDS
             .entry(key)
             .or_insert_with(|| (episode.clone(), now_millis));
-        if episode.refreshes_shield(&shield.0) {
+        if first_attempt_of_episode {
             *shield = (episode, now_millis);
         } else {
             shield.0 = episode;
@@ -1166,6 +1165,11 @@ mod tests {
 
         let mut next_watcher = next_identity.clone();
         next_watcher.reconnect_count += 1;
+        let key = shared.redrive_key(&provider, channel_id);
+        REDRIVE_PLACEHOLDER_SHIELDS
+            .get_mut(&key)
+            .expect("the previous episode records a shield")
+            .1 = 1_234;
         assert_eq!(
             shared
                 .redrive_attempt_decision(&provider, channel_id, &next_watcher, base + 3_000_000,),
@@ -1174,6 +1178,21 @@ mod tests {
                 emit_capped_alarm: false,
             },
             "replacing the live watcher instance must re-arm the episode"
+        );
+        assert_eq!(
+            shared.commit_redrive_success(&provider, channel_id, base + 3_000_000, false,),
+            RedriveAttemptDecision {
+                attempt: Some(1),
+                emit_capped_alarm: false,
+            }
+        );
+        assert_ne!(
+            shared
+                .redrive_placeholder_shield_context(&provider, channel_id)
+                .expect("watcher replacement starts a new shield")
+                .0,
+            1_234,
+            "an external watcher replacement must refresh the shield start"
         );
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
 

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -172,13 +172,12 @@ impl SharedData {
                 .load(Ordering::Acquire);
             if current == state.episode.reconnect_count.saturating_add(1) {
                 state.episode.reconnect_count = current;
-                if let Some(post) = crate::services::discord::inflight::load_inflight_state(
-                    provider,
-                    channel_id.get(),
-                ) && let Some(identity) = state.episode.self_reattach_identity(&post)
-                {
-                    state.episode.identity = Some(identity);
-                }
+            }
+            if let Some(post) =
+                crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
+                && let Some(identity) = state.episode.self_reattach_identity(&post)
+            {
+                state.episode.identity = Some(identity);
             }
         }
         let emit_capped_alarm =
@@ -213,7 +212,9 @@ impl SharedData {
         if first_attempt_of_episode && episode.resets(&shield.0) {
             shield.1 = now_millis;
         }
-        shield.0 = episode;
+        if first_attempt_of_episode || shield_channel_id == channel_id {
+            shield.0 = episode;
+        }
         decision
     }
 
@@ -1344,10 +1345,6 @@ mod tests {
         crate::services::discord::inflight::save_inflight_state(&rebound)
             .expect("persist second self-reattach identity");
         let second_rebound_identity = InflightTurnIdentity::from_state(&rebound);
-        shared
-            .tmux_relay_coord(channel_id)
-            .reconnect_count
-            .store(2, Ordering::Release);
         assert_eq!(
             shared.commit_redrive_success(
                 &provider,
@@ -1360,7 +1357,7 @@ mod tests {
                 attempt: Some(2),
                 emit_capped_alarm: false,
             },
-            "redrive's own reattach must advance the same capped episode"
+            "a reuse-existing reattach must advance the same capped episode"
         );
         let (shield_started, _, shield_identity) = shared
             .redrive_placeholder_shield_context(&provider, channel_id)
@@ -1368,7 +1365,7 @@ mod tests {
         assert_eq!(shield_started, 1_234, "self-reattach must not extend 900s");
         assert_eq!(shield_identity, Some(second_rebound_identity.clone()));
         let mut twice_reattached = self_reattached.clone();
-        twice_reattached.reconnect_count = 2;
+        twice_reattached.reconnect_count = 1;
         twice_reattached.inflight_identity = Some(second_rebound_identity);
         assert_eq!(
             shared
@@ -1380,7 +1377,7 @@ mod tests {
                 )
                 .attempt,
             Some(3),
-            "self-induced rebind identity replacement must not reset the cap episode"
+            "a self-induced identity rewrite without reconnect must not reset the cap episode"
         );
         twice_reattached
             .inflight_identity
@@ -1423,6 +1420,115 @@ mod tests {
             Some(1),
             "a no-op cooldown must not consume the first real attempt"
         );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+    }
+
+    #[test]
+    fn redrive_owner_shield_freezes_first_episode_snapshot_4299() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tmp.path(),
+        );
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(4_299_005);
+        let owner_channel_id = ChannelId::new(4_299_006);
+        let tmux_session = "AgentDesk-codex-4299-owner-shield";
+        let output_path = "/tmp/agentdesk-4299-owner-shield.jsonl";
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        shared.tmux_watchers.insert(
+            owner_channel_id,
+            watcher_handle(
+                tmux_session,
+                output_path,
+                Arc::new(Mutex::new(None)),
+                Arc::new(AtomicBool::new(true)),
+            ),
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+        REDRIVE_PLACEHOLDER_SHIELDS.remove(&shared.redrive_key(&provider, owner_channel_id));
+
+        let mut snapshot = backlog_snapshot(channel_id, tmux_session, output_path, 128, 301_613);
+        snapshot.watcher_owner_channel_id = Some(owner_channel_id.get());
+        snapshot.relay_health.watcher_owner_channel_id = Some(owner_channel_id.get());
+        let first_owner = synthetic_rebind_state(
+            &provider,
+            owner_channel_id,
+            tmux_session,
+            output_path,
+            "2026-06-12 00:00:01",
+            0,
+        );
+        crate::services::discord::inflight::save_inflight_state(&first_owner)
+            .expect("persist first owner identity");
+        let first_owner_identity = InflightTurnIdentity::from_state(&first_owner);
+        let base = 1_820_000_000;
+        assert_eq!(
+            gated_nudge(
+                &shared,
+                &provider,
+                &snapshot,
+                channel_id,
+                base - stall_liveness::STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64,
+            ),
+            (false, None)
+        );
+        assert_eq!(
+            gated_nudge(&shared, &provider, &snapshot, channel_id, base),
+            (true, Some(1))
+        );
+        let owner_key = shared.redrive_key(&provider, owner_channel_id);
+        REDRIVE_PLACEHOLDER_SHIELDS
+            .get_mut(&owner_key)
+            .expect("first owner nudge records a shield")
+            .1 = 1_234;
+
+        shared
+            .tmux_relay_coord(owner_channel_id)
+            .confirmed_end_offset
+            .store(64, Ordering::Release);
+        let second_owner = synthetic_rebind_state(
+            &provider,
+            owner_channel_id,
+            tmux_session,
+            output_path,
+            "2026-06-12 00:00:02",
+            64,
+        );
+        crate::services::discord::inflight::save_inflight_state(&second_owner)
+            .expect("persist successor owner identity");
+        let second_owner_identity = InflightTurnIdentity::from_state(&second_owner);
+        assert_eq!(
+            gated_nudge(&shared, &provider, &snapshot, channel_id, base + 30),
+            (true, Some(2))
+        );
+        let (shield_started, frontier_at_first_nudge, shield_identity) = shared
+            .redrive_placeholder_shield_context(&provider, owner_channel_id)
+            .expect("owner shield survives the request-channel episode");
+        assert_eq!(shield_started, 1_234, "repeat nudge must not extend 900s");
+        assert_eq!(
+            frontier_at_first_nudge, 0,
+            "owner progress must not move the frozen first-nudge frontier"
+        );
+        assert_eq!(shield_identity, Some(first_owner_identity));
+        assert_ne!(
+            shield_identity,
+            Some(second_owner_identity),
+            "a successor owner turn must not be absorbed into the old shield"
+        );
+        assert!(
+            shared.committed_relay_offset(owner_channel_id) > frontier_at_first_nudge,
+            "owner progress must restore reclaim against the frozen shield snapshot"
+        );
+
+        REDRIVE_PLACEHOLDER_SHIELDS.remove(&owner_key);
+        if let Some((_, handle)) = shared.tmux_watchers.remove(&owner_channel_id) {
+            handle.cancel.store(true, Ordering::Release);
+        }
+        crate::services::discord::inflight::clear_inflight_state(&provider, owner_channel_id.get());
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
     }
 }

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -6,6 +6,7 @@ use poise::serenity_prelude::ChannelId;
 use super::snapshot::WatcherStateSnapshot;
 use super::{HealthRegistry, stall_liveness};
 use crate::services::discord::SharedData;
+use crate::services::discord::inflight::{InflightTurnIdentity, InflightTurnState};
 use crate::services::discord::relay_health::RelayStallState;
 use crate::services::discord::relay_recovery::{
     self, RelayRecoveryActionKind, RelayRecoveryApplySource, RelayRecoveryError,
@@ -26,7 +27,7 @@ type RedriveKey = (String, String, u64);
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RedriveEpisode {
     frontier: u64,
-    identity: Option<crate::services::discord::inflight::InflightTurnIdentity>,
+    identity: Option<InflightTurnIdentity>,
     reconnect_count: u64,
 }
 
@@ -35,6 +36,18 @@ impl RedriveEpisode {
         self.frontier > previous.frontier
             || (self.identity.is_some() && self.identity != previous.identity)
             || self.reconnect_count != previous.reconnect_count
+    }
+
+    fn self_reattach_identity(&self, post: &InflightTurnState) -> Option<InflightTurnIdentity> {
+        let previous = self.identity.as_ref()?;
+        let post_identity = InflightTurnIdentity::from_state(post);
+        let same_turn = previous.user_msg_id == post_identity.user_msg_id
+            && previous.started_at == post_identity.started_at
+            && previous.tmux_session_name == post_identity.tmux_session_name;
+        let synthetic_rebind = post.rebind_origin
+            && post_identity.user_msg_id == 0
+            && previous.tmux_session_name == post_identity.tmux_session_name;
+        (same_turn || synthetic_rebind).then_some(post_identity)
     }
 }
 
@@ -140,6 +153,7 @@ impl SharedData {
         &self,
         provider: &ProviderKind,
         channel_id: ChannelId,
+        shield_channel_id: ChannelId,
         now_unix: i64,
         reattached: bool,
     ) -> RedriveAttemptDecision {
@@ -158,6 +172,15 @@ impl SharedData {
                 .load(Ordering::Acquire);
             if current == state.episode.reconnect_count.saturating_add(1) {
                 state.episode.reconnect_count = current;
+                if let Some(post) =
+                    crate::services::discord::inflight::load_inflight_state(
+                        provider,
+                        channel_id.get(),
+                    )
+                    && let Some(identity) = state.episode.self_reattach_identity(&post)
+                {
+                    state.episode.identity = Some(identity);
+                }
             }
         }
         let emit_capped_alarm =
@@ -167,18 +190,32 @@ impl SharedData {
             attempt: Some(state.attempts),
             emit_capped_alarm,
         };
-        let episode = state.episode.clone();
+        let episode = if shield_channel_id == channel_id {
+            state.episode.clone()
+        } else {
+            RedriveEpisode {
+                frontier: self.committed_relay_offset(shield_channel_id),
+                identity: crate::services::discord::inflight::load_inflight_state(
+                    provider,
+                    shield_channel_id.get(),
+                )
+                .map(|post| InflightTurnIdentity::from_state(&post)),
+                reconnect_count: self
+                    .tmux_relay_coord(shield_channel_id)
+                    .reconnect_count
+                    .load(Ordering::Acquire),
+            }
+        };
         drop(state);
 
         let now_millis = chrono::Utc::now().timestamp_millis();
         let mut shield = REDRIVE_PLACEHOLDER_SHIELDS
-            .entry(key)
+            .entry(self.redrive_key(provider, shield_channel_id))
             .or_insert_with(|| (episode.clone(), now_millis));
-        if first_attempt_of_episode {
-            *shield = (episode, now_millis);
-        } else {
-            shield.0 = episode;
+        if first_attempt_of_episode && episode.resets(&shield.0) {
+            shield.1 = now_millis;
         }
+        shield.0 = episode;
         decision
     }
 
@@ -338,14 +375,18 @@ impl HealthRegistry {
             return Ok(false);
         }
 
-        let (applied, reattached, noop_cooldown_secs) = if nudge_existing_watcher_for_backlog(
+        let watcher_owner_channel_id = snapshot
+            .watcher_owner_channel_id
+            .map(ChannelId::new)
+            .unwrap_or(channel_id);
+        let (applied, reattached, noop_cooldown_secs, shield_channel_id) = if nudge_existing_watcher_for_backlog(
             &shared,
             provider,
             &snapshot,
             channel_id,
             now_unix_secs,
         ) {
-            (true, false, None)
+            (true, false, None, watcher_owner_channel_id)
         } else {
             if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
                 return Ok(false);
@@ -363,11 +404,17 @@ impl HealthRegistry {
                 response.applied,
                 true,
                 Some(response.decision.auto_heal.window_secs),
+                channel_id,
             )
         };
         if applied {
-            let committed =
-                shared.commit_redrive_success(provider, channel_id, now_unix_secs, reattached);
+            let committed = shared.commit_redrive_success(
+                provider,
+                channel_id,
+                shield_channel_id,
+                now_unix_secs,
+                reattached,
+            );
             trace_redrive_cap_if_needed(provider, channel_id, &snapshot, committed);
         } else if let Some(cooldown_secs) = noop_cooldown_secs {
             shared.note_redrive_noop(provider, channel_id, now_unix_secs, cooldown_secs);
@@ -658,6 +705,34 @@ mod tests {
                 stale_thread_proof: false,
             },
         }
+    }
+
+    fn synthetic_rebind_state(
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        tmux_session: &str,
+        output_path: &str,
+        started_at: &str,
+        last_offset: u64,
+    ) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            provider.clone(),
+            channel_id.get(),
+            None,
+            0,
+            0,
+            0,
+            "/api/inflight/rebind".to_string(),
+            None,
+            Some(tmux_session.to_string()),
+            Some(output_path.to_string()),
+            None,
+            last_offset,
+        );
+        state.started_at = started_at.to_string();
+        state.updated_at = started_at.to_string();
+        state.rebind_origin = true;
+        state
     }
 
     #[test]
@@ -957,7 +1032,17 @@ mod tests {
         let nudged =
             nudge_existing_watcher_for_backlog(shared, provider, snapshot, channel_id, now);
         if nudged {
-            let committed = shared.commit_redrive_success(provider, channel_id, now, false);
+            let shield_channel_id = snapshot
+                .watcher_owner_channel_id
+                .map(ChannelId::new)
+                .unwrap_or(channel_id);
+            let committed = shared.commit_redrive_success(
+                provider,
+                channel_id,
+                shield_channel_id,
+                now,
+                false,
+            );
             trace_redrive_cap_if_needed(provider, channel_id, snapshot, committed);
             assert_eq!(committed.attempt, Some(reserved_attempt));
             return (true, committed.attempt);
@@ -1065,7 +1150,13 @@ mod tests {
             );
             assert!(!reserved.emit_capped_alarm);
             assert_eq!(
-                shared.commit_redrive_success(provider, channel_id, base + elapsed, false),
+                shared.commit_redrive_success(
+                    provider,
+                    channel_id,
+                    channel_id,
+                    base + elapsed,
+                    false,
+                ),
                 RedriveAttemptDecision {
                     attempt: Some(expected as u8 + 1),
                     emit_capped_alarm: expected == 5,
@@ -1079,6 +1170,11 @@ mod tests {
         let _env_lock = crate::config::shared_test_env_lock()
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tmp.path(),
+        );
         let provider = ProviderKind::Codex;
         let channel_id = ChannelId::new(4_299_002);
         let tmux_session = "AgentDesk-codex-4299-reset";
@@ -1180,7 +1276,13 @@ mod tests {
             "replacing the live watcher instance must re-arm the episode"
         );
         assert_eq!(
-            shared.commit_redrive_success(&provider, channel_id, base + 3_000_000, false,),
+            shared.commit_redrive_success(
+                &provider,
+                channel_id,
+                channel_id,
+                base + 3_000_000,
+                false,
+            ),
             RedriveAttemptDecision {
                 attempt: Some(1),
                 emit_capped_alarm: false,
@@ -1199,12 +1301,29 @@ mod tests {
         let first =
             shared.redrive_attempt_decision(&provider, channel_id, &snapshot, base + 4_000_000);
         assert_eq!(first.attempt, Some(1));
+        let mut rebound = synthetic_rebind_state(
+            &provider,
+            channel_id,
+            tmux_session,
+            output_path,
+            "2026-06-12 00:00:01",
+            snapshot.last_relay_offset,
+        );
+        crate::services::discord::inflight::save_inflight_state(&rebound)
+            .expect("persist first self-reattach identity");
+        let first_rebound_identity = InflightTurnIdentity::from_state(&rebound);
         shared
             .tmux_relay_coord(channel_id)
             .reconnect_count
             .store(1, Ordering::Release);
         assert_eq!(
-            shared.commit_redrive_success(&provider, channel_id, base + 4_000_000, true,),
+            shared.commit_redrive_success(
+                &provider,
+                channel_id,
+                channel_id,
+                base + 4_000_000,
+                true,
+            ),
             RedriveAttemptDecision {
                 attempt: Some(1),
                 emit_capped_alarm: false,
@@ -1212,6 +1331,7 @@ mod tests {
         );
         let mut self_reattached = snapshot.clone();
         self_reattached.reconnect_count = 1;
+        self_reattached.inflight_identity = Some(first_rebound_identity);
         let second = shared.redrive_attempt_decision(
             &provider,
             channel_id,
@@ -1224,12 +1344,24 @@ mod tests {
             .get_mut(&key)
             .expect("first reattach records shield")
             .1 = 1_234;
+        rebound.started_at = "2026-06-12 00:00:02".to_string();
+        rebound.updated_at = rebound.started_at.clone();
+        rebound.turn_start_offset = Some(snapshot.last_relay_offset + 1);
+        crate::services::discord::inflight::save_inflight_state(&rebound)
+            .expect("persist second self-reattach identity");
+        let second_rebound_identity = InflightTurnIdentity::from_state(&rebound);
         shared
             .tmux_relay_coord(channel_id)
             .reconnect_count
             .store(2, Ordering::Release);
         assert_eq!(
-            shared.commit_redrive_success(&provider, channel_id, base + 4_000_030, true),
+            shared.commit_redrive_success(
+                &provider,
+                channel_id,
+                channel_id,
+                base + 4_000_030,
+                true,
+            ),
             RedriveAttemptDecision {
                 attempt: Some(2),
                 emit_capped_alarm: false,
@@ -1240,7 +1372,40 @@ mod tests {
             .redrive_placeholder_shield_context(&provider, channel_id)
             .expect("self-reattach must preserve shield");
         assert_eq!(shield_started, 1_234, "self-reattach must not extend 900s");
-        assert_eq!(shield_identity, snapshot.inflight_identity);
+        assert_eq!(shield_identity, Some(second_rebound_identity.clone()));
+        let mut twice_reattached = self_reattached.clone();
+        twice_reattached.reconnect_count = 2;
+        twice_reattached.inflight_identity = Some(second_rebound_identity);
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(
+                    &provider,
+                    channel_id,
+                    &twice_reattached,
+                    base + 4_000_090,
+                )
+                .attempt,
+            Some(3),
+            "self-induced rebind identity replacement must not reset the cap episode"
+        );
+        twice_reattached
+            .inflight_identity
+            .as_mut()
+            .expect("twice-reattached identity")
+            .user_msg_id = 9_999;
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(
+                    &provider,
+                    channel_id,
+                    &twice_reattached,
+                    base + 4_000_091,
+                )
+                .attempt,
+            Some(1),
+            "a real successor turn identity must still reset the episode"
+        );
+        crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
 
         assert_eq!(

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, LazyLock};
 
 use poise::serenity_prelude::ChannelId;
 
@@ -11,6 +11,142 @@ use crate::services::discord::relay_recovery::{
     self, RelayRecoveryActionKind, RelayRecoveryApplySource, RelayRecoveryError,
 };
 use crate::services::provider::ProviderKind;
+
+const REDRIVE_BACKOFF_SECS: [i64; 6] = [30, 60, 120, 240, 480, 960];
+const REDRIVE_MAX_NO_PROGRESS_ATTEMPTS: u8 = 6;
+
+type RedriveKey = (String, String, u64);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RedriveEpisode {
+    frontier: u64,
+    identity: Option<crate::services::discord::inflight::InflightTurnIdentity>,
+    reconnect_count: u64,
+}
+
+impl RedriveEpisode {
+    fn resets(&self, previous: &Self) -> bool {
+        self.frontier > previous.frontier
+            || self.identity != previous.identity
+            || self.reconnect_count != previous.reconnect_count
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RedriveAttemptState {
+    episode: RedriveEpisode,
+    attempts: u8,
+    last_attempt_unix: i64,
+    capped_alarm_emitted: bool,
+    shield_started_unix: Option<i64>,
+}
+
+impl RedriveAttemptState {
+    fn new(episode: RedriveEpisode, now_unix: i64) -> Self {
+        Self {
+            episode,
+            attempts: 0,
+            last_attempt_unix: now_unix,
+            capped_alarm_emitted: false,
+            shield_started_unix: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RedriveAttemptDecision {
+    attempt: Option<u8>,
+    emit_capped_alarm: bool,
+}
+
+static REDRIVE_ATTEMPTS: LazyLock<dashmap::DashMap<RedriveKey, RedriveAttemptState>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+impl SharedData {
+    fn redrive_key(&self, provider: &ProviderKind, channel_id: ChannelId) -> RedriveKey {
+        (
+            self.token_hash.clone(),
+            provider.as_str().to_string(),
+            channel_id.get(),
+        )
+    }
+
+    fn redrive_episode(snapshot: &WatcherStateSnapshot) -> RedriveEpisode {
+        RedriveEpisode {
+            frontier: snapshot.last_relay_offset,
+            identity: snapshot.inflight_identity.clone(),
+            reconnect_count: snapshot.reconnect_count,
+        }
+    }
+
+    fn redrive_attempt_decision(
+        &self,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        snapshot: &WatcherStateSnapshot,
+        now_unix: i64,
+    ) -> RedriveAttemptDecision {
+        let key = self.redrive_key(provider, channel_id);
+        let episode = Self::redrive_episode(snapshot);
+        let mut state = REDRIVE_ATTEMPTS
+            .entry(key)
+            .or_insert_with(|| RedriveAttemptState::new(episode.clone(), now_unix));
+        if episode.resets(&state.episode) {
+            *state = RedriveAttemptState::new(episode, now_unix);
+        }
+        if state.attempts >= REDRIVE_MAX_NO_PROGRESS_ATTEMPTS {
+            let emit_capped_alarm = !state.capped_alarm_emitted;
+            state.capped_alarm_emitted = true;
+            return RedriveAttemptDecision {
+                attempt: None,
+                emit_capped_alarm,
+            };
+        }
+        if state.attempts > 0 {
+            let delay = REDRIVE_BACKOFF_SECS[usize::from(state.attempts - 1)];
+            if now_unix.saturating_sub(state.last_attempt_unix).max(0) < delay {
+                return RedriveAttemptDecision {
+                    attempt: None,
+                    emit_capped_alarm: false,
+                };
+            }
+        }
+        state.attempts += 1;
+        state.last_attempt_unix = now_unix;
+        let emit_capped_alarm = state.attempts == REDRIVE_MAX_NO_PROGRESS_ATTEMPTS;
+        state.capped_alarm_emitted |= emit_capped_alarm;
+        RedriveAttemptDecision {
+            attempt: Some(state.attempts),
+            emit_capped_alarm,
+        }
+    }
+
+    fn record_redrive_placeholder_shield(
+        &self,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        now_unix: i64,
+    ) {
+        let key = self.redrive_key(provider, channel_id);
+        if let Some(mut state) = REDRIVE_ATTEMPTS.get_mut(&key) {
+            state.shield_started_unix.get_or_insert(now_unix);
+        }
+    }
+
+    pub(in crate::services::discord) fn redrive_placeholder_shield_context(
+        &self,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+    ) -> Option<(i64, u64)> {
+        REDRIVE_ATTEMPTS
+            .get(&self.redrive_key(provider, channel_id))
+            .and_then(|state| {
+                state
+                    .shield_started_unix
+                    .map(|started| (started, state.episode.frontier))
+            })
+    }
+}
 
 pub(super) async fn apply_watchdog_orphan_token_cleanup(
     registry: &HealthRegistry,
@@ -103,39 +239,91 @@ async fn redrive_undelivered_backlog(
     shared: Arc<SharedData>,
     channel_id: ChannelId,
 ) -> Result<bool, RelayRecoveryError> {
-    let Some(snapshot) = registry
-        .snapshot_watcher_state_for_shared(provider, shared.clone(), channel_id.get())
+    registry
+        .redrive_undelivered_backlog_at(
+            provider,
+            shared,
+            channel_id,
+            chrono::Utc::now().timestamp(),
+        )
         .await
-    else {
-        return Ok(false);
-    };
+}
 
-    let now_unix_secs = chrono::Utc::now().timestamp();
-    if !should_redrive_undelivered_backlog(provider, channel_id, &snapshot, now_unix_secs) {
-        return Ok(false);
-    }
-    if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
-        return Ok(false);
-    }
+impl HealthRegistry {
+    pub(in crate::services::discord) async fn redrive_undelivered_backlog_at(
+        &self,
+        provider: &ProviderKind,
+        shared: Arc<SharedData>,
+        channel_id: ChannelId,
+        now_unix_secs: i64,
+    ) -> Result<bool, RelayRecoveryError> {
+        let Some(snapshot) = self
+            .snapshot_watcher_state_for_shared(provider, shared.clone(), channel_id.get())
+            .await
+        else {
+            return Ok(false);
+        };
 
-    if nudge_existing_watcher_for_backlog(&shared, provider, &snapshot, channel_id, now_unix_secs) {
-        return Ok(true);
-    }
-    if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
-        return Ok(false);
-    }
+        if !should_redrive_undelivered_backlog(provider, channel_id, &snapshot, now_unix_secs) {
+            return Ok(false);
+        }
+        if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
+            return Ok(false);
+        }
+        let attempt =
+            shared.redrive_attempt_decision(provider, channel_id, &snapshot, now_unix_secs);
+        trace_redrive_cap_if_needed(provider, channel_id, &snapshot, attempt);
+        if attempt.attempt.is_none() {
+            return Ok(false);
+        }
 
-    let response = relay_recovery::auto_apply_relay_recovery_for_shared(
-        registry,
-        shared,
-        provider,
-        channel_id.get(),
-        RelayRecoveryActionKind::ReattachWatcher,
-        RelayRecoveryApplySource::ProbeAutoHeal,
-    )
-    .await?;
+        let applied = if nudge_existing_watcher_for_backlog(
+            &shared,
+            provider,
+            &snapshot,
+            channel_id,
+            now_unix_secs,
+        ) {
+            true
+        } else {
+            if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
+                return Ok(false);
+            }
+            relay_recovery::auto_apply_relay_recovery_for_shared(
+                self,
+                shared.clone(),
+                provider,
+                channel_id.get(),
+                RelayRecoveryActionKind::ReattachWatcher,
+                RelayRecoveryApplySource::ProbeAutoHeal,
+            )
+            .await?
+            .applied
+        };
+        if applied {
+            shared.record_redrive_placeholder_shield(provider, channel_id, now_unix_secs);
+        }
+        Ok(applied)
+    }
+}
 
-    Ok(response.applied)
+fn trace_redrive_cap_if_needed(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &WatcherStateSnapshot,
+    decision: RedriveAttemptDecision,
+) {
+    if decision.emit_capped_alarm {
+        tracing::error!(
+            target: "agentdesk::discord::relay_recovery",
+            event = "redrive_no_progress_capped",
+            provider = provider.as_str(),
+            channel_id = channel_id.get(),
+            last_relay_offset = snapshot.last_relay_offset,
+            attempts = REDRIVE_MAX_NO_PROGRESS_ATTEMPTS,
+            "redrive stopped after the no-progress attempt cap"
+        );
+    }
 }
 
 fn has_live_undelivered_backlog(snapshot: &WatcherStateSnapshot) -> bool {
@@ -307,10 +495,12 @@ fn trace_orphan_auto_heal_error(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{self, Write};
     use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
 
     use crate::services::discord::relay_health::{RelayActiveTurn, RelayHealthSnapshot};
+    use tracing_subscriber::fmt::MakeWriter;
 
     use super::*;
 
@@ -362,7 +552,12 @@ mod tests {
             has_pending_queue: false,
             mailbox_active_user_msg_id: Some(9001),
             inflight_terminal_delivery_committed: false,
-            inflight_identity: None,
+            inflight_identity: Some(crate::services::discord::inflight::InflightTurnIdentity {
+                user_msg_id: 9001,
+                started_at: "2026-06-12 00:00:00".to_string(),
+                tmux_session_name: Some(tmux_session.to_string()),
+                turn_start_offset: Some(last_relay_offset),
+            }),
             inflight_finalizer_turn_id: None,
             inflight_output_path: Some(output_path.to_string()),
             relay_stall_state: RelayStallState::TmuxAliveRelayDead,
@@ -622,5 +817,254 @@ mod tests {
             channel_id,
             Some(tmux_session),
         );
+    }
+
+    #[derive(Clone)]
+    struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_errors<R>(run: impl FnOnce() -> R) -> (R, String) {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::ERROR)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(CapturingWriter(buffer.clone()))
+            .finish();
+        let result = tracing::subscriber::with_default(subscriber, run);
+        let output = String::from_utf8_lossy(&buffer.lock().unwrap()).into_owned();
+        (result, output)
+    }
+
+    fn clear_redrive_test_state(
+        shared: &SharedData,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        tmux_session: &str,
+    ) {
+        let key = shared.redrive_key(provider, channel_id);
+        REDRIVE_ATTEMPTS.remove(&key);
+        stall_liveness::clear_stall_watchdog_liveness_state(
+            provider,
+            channel_id,
+            Some(tmux_session),
+        );
+    }
+
+    fn gated_nudge(
+        shared: &SharedData,
+        provider: &ProviderKind,
+        snapshot: &WatcherStateSnapshot,
+        channel_id: ChannelId,
+        now: i64,
+    ) -> (bool, Option<u8>) {
+        if !should_redrive_undelivered_backlog(provider, channel_id, snapshot, now) {
+            return (false, None);
+        }
+        let decision = shared.redrive_attempt_decision(provider, channel_id, snapshot, now);
+        trace_redrive_cap_if_needed(provider, channel_id, snapshot, decision);
+        let Some(attempt) = decision.attempt else {
+            return (false, None);
+        };
+        let nudged =
+            nudge_existing_watcher_for_backlog(shared, provider, snapshot, channel_id, now);
+        if nudged {
+            shared.record_redrive_placeholder_shield(provider, channel_id, now);
+        }
+        (nudged, Some(attempt))
+    }
+
+    #[test]
+    fn redrive_frozen_backlog_backs_off_and_caps_once_4299() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(4_299_001);
+        let tmux_session = "AgentDesk-codex-4299-green";
+        let output_path = "/tmp/agentdesk-4299-green.jsonl";
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let resume_offset = Arc::new(Mutex::new(None));
+        let turn_delivered = Arc::new(AtomicBool::new(true));
+        shared.tmux_watchers.insert(
+            channel_id,
+            watcher_handle(tmux_session, output_path, resume_offset, turn_delivered),
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+
+        let snapshot = backlog_snapshot(channel_id, tmux_session, output_path, 128, 301_613);
+        let base = 1_800_000_000;
+        assert_eq!(
+            gated_nudge(
+                &shared,
+                &provider,
+                &snapshot,
+                channel_id,
+                base - stall_liveness::STALL_WATCHDOG_BACKLOG_NO_PROGRESS_GRACE_SECS as i64,
+            ),
+            (false, None)
+        );
+        let ((mut nudge_times, mut attempts), logs) = capture_errors(|| {
+            let mut nudge_times = Vec::new();
+            let mut attempts = Vec::new();
+            for pass in 0..20 {
+                let elapsed = i64::from(pass) * 30;
+                let (nudged, attempt) =
+                    gated_nudge(&shared, &provider, &snapshot, channel_id, base + elapsed);
+                if nudged {
+                    nudge_times.push(elapsed);
+                    attempts.push(attempt.expect("a successful nudge is an admitted attempt"));
+                }
+            }
+            (nudge_times, attempts)
+        });
+        let ((sixth_nudge, sixth_attempt), sixth_logs) =
+            capture_errors(|| gated_nudge(&shared, &provider, &snapshot, channel_id, base + 930));
+        if sixth_nudge {
+            nudge_times.push(930);
+            attempts.push(sixth_attempt.expect("sixth nudge must carry attempt ordinal"));
+        }
+        let (_, capped_logs) = capture_errors(|| {
+            for elapsed in [960, 1_890, 86_400] {
+                assert_eq!(
+                    gated_nudge(&shared, &provider, &snapshot, channel_id, base + elapsed),
+                    (false, None),
+                    "time alone must never re-arm a capped episode"
+                );
+            }
+        });
+        let alarm_count = logs.matches("redrive_no_progress_capped").count()
+            + sixth_logs.matches("redrive_no_progress_capped").count()
+            + capped_logs.matches("redrive_no_progress_capped").count();
+        assert_eq!(REDRIVE_BACKOFF_SECS, [30, 60, 120, 240, 480, 960]);
+        assert_eq!(
+            nudge_times,
+            [0, 30, 90, 210, 450, 930],
+            "exponential schedule must be cumulative and capped after six attempts"
+        );
+        assert_eq!(
+            attempts,
+            [1, 2, 3, 4, 5, 6],
+            "counter must advance once per pass"
+        );
+        assert_eq!(
+            alarm_count, 1,
+            "the capped error event must fire exactly once"
+        );
+        eprintln!(
+            "#4299 GREEN: N=20 + cap tick, nudge_times={nudge_times:?}, alarm_count={alarm_count}"
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+    }
+
+    fn drive_attempt_state_to_cap(
+        shared: &SharedData,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        snapshot: &WatcherStateSnapshot,
+        base: i64,
+    ) {
+        for (expected, elapsed) in [0, 30, 90, 210, 450, 930].into_iter().enumerate() {
+            assert_eq!(
+                shared.redrive_attempt_decision(provider, channel_id, snapshot, base + elapsed),
+                RedriveAttemptDecision {
+                    attempt: Some(expected as u8 + 1),
+                    emit_capped_alarm: expected == 5,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn redrive_cap_resets_only_for_progress_identity_or_watcher_4299() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(4_299_002);
+        let tmux_session = "AgentDesk-codex-4299-reset";
+        let output_path = "/tmp/agentdesk-4299-reset.jsonl";
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        shared.tmux_watchers.insert(
+            channel_id,
+            watcher_handle(
+                tmux_session,
+                output_path,
+                Arc::new(Mutex::new(None)),
+                Arc::new(AtomicBool::new(true)),
+            ),
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+
+        let snapshot = backlog_snapshot(channel_id, tmux_session, output_path, 128, 301_613);
+        let base = 1_810_000_000;
+        drive_attempt_state_to_cap(&shared, &provider, channel_id, &snapshot, base);
+        stall_liveness::gc_stall_watchdog_liveness_state(
+            base + stall_liveness::STALL_LIVENESS_STATE_TTL_SECS as i64 + 1,
+        );
+        assert_eq!(
+            shared.redrive_attempt_decision(&provider, channel_id, &snapshot, base + 10 * 86_400,),
+            RedriveAttemptDecision {
+                attempt: None,
+                emit_capped_alarm: false
+            },
+            "elapsed time and liveness-state GC must not re-arm capped redrive"
+        );
+
+        let mut progressed = snapshot.clone();
+        progressed.last_relay_offset += 1;
+        progressed.relay_health.last_relay_offset += 1;
+        drive_attempt_state_to_cap(
+            &shared,
+            &provider,
+            channel_id,
+            &progressed,
+            base + 1_000_000,
+        );
+
+        let mut next_identity = progressed.clone();
+        next_identity
+            .inflight_identity
+            .as_mut()
+            .expect("test snapshot identity")
+            .turn_start_offset = Some(9_999_999);
+        drive_attempt_state_to_cap(
+            &shared,
+            &provider,
+            channel_id,
+            &next_identity,
+            base + 2_000_000,
+        );
+
+        let mut next_watcher = next_identity.clone();
+        next_watcher.reconnect_count += 1;
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(&provider, channel_id, &next_watcher, base + 3_000_000,),
+            RedriveAttemptDecision {
+                attempt: Some(1),
+                emit_capped_alarm: false,
+            },
+            "replacing the live watcher instance must re-arm the episode"
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
     }
 }

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -12,8 +12,12 @@ use crate::services::discord::relay_recovery::{
 };
 use crate::services::provider::ProviderKind;
 
+// Delay after each admitted attempt. The sixth (960s) is the terminal capped
+// horizon from the issue contract; no seventh action is admitted. Consequently
+// the six actual action times are cumulative +0/+30/+90/+210/+450/+930.
 const REDRIVE_BACKOFF_SECS: [i64; 6] = [30, 60, 120, 240, 480, 960];
 const REDRIVE_MAX_NO_PROGRESS_ATTEMPTS: u8 = 6;
+const _: () = assert!(REDRIVE_BACKOFF_SECS.len() == REDRIVE_MAX_NO_PROGRESS_ATTEMPTS as usize);
 
 type RedriveKey = (String, String, u64);
 
@@ -27,7 +31,7 @@ struct RedriveEpisode {
 impl RedriveEpisode {
     fn resets(&self, previous: &Self) -> bool {
         self.frontier > previous.frontier
-            || self.identity != previous.identity
+            || (self.identity.is_some() && self.identity != previous.identity)
             || self.reconnect_count != previous.reconnect_count
     }
 }
@@ -38,7 +42,6 @@ struct RedriveAttemptState {
     attempts: u8,
     last_attempt_unix: i64,
     capped_alarm_emitted: bool,
-    shield_started_unix: Option<i64>,
 }
 
 impl RedriveAttemptState {
@@ -48,7 +51,6 @@ impl RedriveAttemptState {
             attempts: 0,
             last_attempt_unix: now_unix,
             capped_alarm_emitted: false,
-            shield_started_unix: None,
         }
     }
 }
@@ -60,6 +62,8 @@ struct RedriveAttemptDecision {
 }
 
 static REDRIVE_ATTEMPTS: LazyLock<dashmap::DashMap<RedriveKey, RedriveAttemptState>> =
+    LazyLock::new(dashmap::DashMap::new);
+static REDRIVE_PLACEHOLDER_SHIELDS: LazyLock<dashmap::DashMap<RedriveKey, (RedriveEpisode, i64)>> =
     LazyLock::new(dashmap::DashMap::new);
 
 impl SharedData {
@@ -95,6 +99,7 @@ impl SharedData {
             *state = RedriveAttemptState::new(episode, now_unix);
         }
         if state.attempts >= REDRIVE_MAX_NO_PROGRESS_ATTEMPTS {
+            debug_assert_eq!(REDRIVE_BACKOFF_SECS[usize::from(state.attempts - 1)], 960);
             let emit_capped_alarm = !state.capped_alarm_emitted;
             state.capped_alarm_emitted = true;
             return RedriveAttemptDecision {
@@ -111,26 +116,52 @@ impl SharedData {
                 };
             }
         }
-        state.attempts += 1;
-        state.last_attempt_unix = now_unix;
-        let emit_capped_alarm = state.attempts == REDRIVE_MAX_NO_PROGRESS_ATTEMPTS;
-        state.capped_alarm_emitted |= emit_capped_alarm;
         RedriveAttemptDecision {
-            attempt: Some(state.attempts),
-            emit_capped_alarm,
+            attempt: Some(state.attempts + 1),
+            emit_capped_alarm: false,
         }
     }
 
-    fn record_redrive_placeholder_shield(
+    fn commit_redrive_success(
         &self,
         provider: &ProviderKind,
         channel_id: ChannelId,
         now_unix: i64,
-    ) {
+        reattached: bool,
+    ) -> RedriveAttemptDecision {
         let key = self.redrive_key(provider, channel_id);
-        if let Some(mut state) = REDRIVE_ATTEMPTS.get_mut(&key) {
-            state.shield_started_unix.get_or_insert(now_unix);
+        let mut state = REDRIVE_ATTEMPTS
+            .get_mut(&key)
+            .expect("redrive success must follow an admitted attempt");
+        state.attempts += 1;
+        state.last_attempt_unix = now_unix;
+        if reattached {
+            let current = self
+                .tmux_relay_coord(channel_id)
+                .reconnect_count
+                .load(Ordering::Acquire);
+            if current == state.episode.reconnect_count.saturating_add(1) {
+                state.episode.reconnect_count = current;
+            }
         }
+        let emit_capped_alarm =
+            state.attempts == REDRIVE_MAX_NO_PROGRESS_ATTEMPTS && !state.capped_alarm_emitted;
+        state.capped_alarm_emitted |= emit_capped_alarm;
+        let decision = RedriveAttemptDecision {
+            attempt: Some(state.attempts),
+            emit_capped_alarm,
+        };
+        let episode = state.episode.clone();
+        drop(state);
+
+        let now_millis = chrono::Utc::now().timestamp_millis();
+        let mut shield = REDRIVE_PLACEHOLDER_SHIELDS
+            .entry(key)
+            .or_insert_with(|| (episode.clone(), now_millis));
+        if episode.resets(&shield.0) {
+            *shield = (episode, now_millis);
+        }
+        decision
     }
 
     pub(in crate::services::discord) fn redrive_placeholder_shield_context(
@@ -138,13 +169,9 @@ impl SharedData {
         provider: &ProviderKind,
         channel_id: ChannelId,
     ) -> Option<(i64, u64)> {
-        REDRIVE_ATTEMPTS
+        REDRIVE_PLACEHOLDER_SHIELDS
             .get(&self.redrive_key(provider, channel_id))
-            .and_then(|state| {
-                state
-                    .shield_started_unix
-                    .map(|started| (started, state.episode.frontier))
-            })
+            .map(|shield| (shield.1, shield.0.frontier))
     }
 }
 
@@ -277,14 +304,14 @@ impl HealthRegistry {
             return Ok(false);
         }
 
-        let applied = if nudge_existing_watcher_for_backlog(
+        let (applied, reattached) = if nudge_existing_watcher_for_backlog(
             &shared,
             provider,
             &snapshot,
             channel_id,
             now_unix_secs,
         ) {
-            true
+            (true, false)
         } else {
             if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
                 return Ok(false);
@@ -299,9 +326,13 @@ impl HealthRegistry {
             )
             .await?
             .applied
+            .then_some((true, true))
+            .unwrap_or((false, true))
         };
         if applied {
-            shared.record_redrive_placeholder_shield(provider, channel_id, now_unix_secs);
+            let committed =
+                shared.commit_redrive_success(provider, channel_id, now_unix_secs, reattached);
+            trace_redrive_cap_if_needed(provider, channel_id, &snapshot, committed);
         }
         Ok(applied)
     }
@@ -862,6 +893,7 @@ mod tests {
     ) {
         let key = shared.redrive_key(provider, channel_id);
         REDRIVE_ATTEMPTS.remove(&key);
+        REDRIVE_PLACEHOLDER_SHIELDS.remove(&key);
         stall_liveness::clear_stall_watchdog_liveness_state(
             provider,
             channel_id,
@@ -881,15 +913,18 @@ mod tests {
         }
         let decision = shared.redrive_attempt_decision(provider, channel_id, snapshot, now);
         trace_redrive_cap_if_needed(provider, channel_id, snapshot, decision);
-        let Some(attempt) = decision.attempt else {
+        let Some(reserved_attempt) = decision.attempt else {
             return (false, None);
         };
         let nudged =
             nudge_existing_watcher_for_backlog(shared, provider, snapshot, channel_id, now);
         if nudged {
-            shared.record_redrive_placeholder_shield(provider, channel_id, now);
+            let committed = shared.commit_redrive_success(provider, channel_id, now, false);
+            trace_redrive_cap_if_needed(provider, channel_id, snapshot, committed);
+            assert_eq!(committed.attempt, Some(reserved_attempt));
+            return (true, committed.attempt);
         }
-        (nudged, Some(attempt))
+        (false, None)
     }
 
     #[test]
@@ -983,8 +1018,16 @@ mod tests {
         base: i64,
     ) {
         for (expected, elapsed) in [0, 30, 90, 210, 450, 930].into_iter().enumerate() {
+            let reserved =
+                shared.redrive_attempt_decision(provider, channel_id, snapshot, base + elapsed);
             assert_eq!(
-                shared.redrive_attempt_decision(provider, channel_id, snapshot, base + elapsed),
+                reserved.attempt,
+                Some(expected as u8 + 1),
+                "the next ordinal must be reserved without consuming it"
+            );
+            assert!(!reserved.emit_capped_alarm);
+            assert_eq!(
+                shared.commit_redrive_success(provider, channel_id, base + elapsed, false),
                 RedriveAttemptDecision {
                     attempt: Some(expected as u8 + 1),
                     emit_capped_alarm: expected == 5,
@@ -1016,6 +1059,20 @@ mod tests {
 
         let snapshot = backlog_snapshot(channel_id, tmux_session, output_path, 128, 301_613);
         let base = 1_810_000_000;
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(&provider, channel_id, &snapshot, base - 20_000,)
+                .attempt,
+            Some(1)
+        );
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(&provider, channel_id, &snapshot, base - 10_000,)
+                .attempt,
+            Some(1),
+            "a TOCTOU-suppressed action must not consume its reservation"
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
         drive_attempt_state_to_cap(&shared, &provider, channel_id, &snapshot, base);
         stall_liveness::gc_stall_watchdog_liveness_state(
             base + stall_liveness::STALL_LIVENESS_STATE_TTL_SECS as i64 + 1,
@@ -1027,6 +1084,20 @@ mod tests {
                 emit_capped_alarm: false
             },
             "elapsed time and liveness-state GC must not re-arm capped redrive"
+        );
+        let mut missing_identity = snapshot.clone();
+        missing_identity.inflight_identity = None;
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(
+                    &provider,
+                    channel_id,
+                    &missing_identity,
+                    base + 11 * 86_400,
+                )
+                .attempt,
+            None,
+            "identity disappearance is not a replacement and must not re-arm"
         );
 
         let mut progressed = snapshot.clone();
@@ -1064,6 +1135,42 @@ mod tests {
                 emit_capped_alarm: false,
             },
             "replacing the live watcher instance must re-arm the episode"
+        );
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+
+        let first =
+            shared.redrive_attempt_decision(&provider, channel_id, &snapshot, base + 4_000_000);
+        assert_eq!(first.attempt, Some(1));
+        shared
+            .tmux_relay_coord(channel_id)
+            .reconnect_count
+            .store(1, Ordering::Release);
+        assert_eq!(
+            shared.commit_redrive_success(&provider, channel_id, base + 4_000_000, true,),
+            RedriveAttemptDecision {
+                attempt: Some(1),
+                emit_capped_alarm: false,
+            }
+        );
+        let mut self_reattached = snapshot.clone();
+        self_reattached.reconnect_count = 1;
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(
+                    &provider,
+                    channel_id,
+                    &self_reattached,
+                    base + 4_000_030,
+                )
+                .attempt,
+            Some(2),
+            "redrive's own reattach must advance the same capped episode"
+        );
+        assert!(
+            shared
+                .redrive_placeholder_shield_context(&provider, channel_id)
+                .is_some(),
+            "self-reattach re-baselining must not erase the reclaim shield"
         );
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
     }

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -172,12 +172,10 @@ impl SharedData {
                 .load(Ordering::Acquire);
             if current == state.episode.reconnect_count.saturating_add(1) {
                 state.episode.reconnect_count = current;
-                if let Some(post) =
-                    crate::services::discord::inflight::load_inflight_state(
-                        provider,
-                        channel_id.get(),
-                    )
-                    && let Some(identity) = state.episode.self_reattach_identity(&post)
+                if let Some(post) = crate::services::discord::inflight::load_inflight_state(
+                    provider,
+                    channel_id.get(),
+                ) && let Some(identity) = state.episode.self_reattach_identity(&post)
                 {
                     state.episode.identity = Some(identity);
                 }
@@ -379,34 +377,35 @@ impl HealthRegistry {
             .watcher_owner_channel_id
             .map(ChannelId::new)
             .unwrap_or(channel_id);
-        let (applied, reattached, noop_cooldown_secs, shield_channel_id) = if nudge_existing_watcher_for_backlog(
-            &shared,
-            provider,
-            &snapshot,
-            channel_id,
-            now_unix_secs,
-        ) {
-            (true, false, None, watcher_owner_channel_id)
-        } else {
-            if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
-                return Ok(false);
-            }
-            let response = relay_recovery::auto_apply_relay_recovery_for_shared(
-                self,
-                shared.clone(),
+        let (applied, reattached, noop_cooldown_secs, shield_channel_id) =
+            if nudge_existing_watcher_for_backlog(
+                &shared,
                 provider,
-                channel_id.get(),
-                RelayRecoveryActionKind::ReattachWatcher,
-                RelayRecoveryApplySource::ProbeAutoHeal,
-            )
-            .await?;
-            (
-                response.applied,
-                true,
-                Some(response.decision.auto_heal.window_secs),
+                &snapshot,
                 channel_id,
-            )
-        };
+                now_unix_secs,
+            ) {
+                (true, false, None, watcher_owner_channel_id)
+            } else {
+                if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
+                    return Ok(false);
+                }
+                let response = relay_recovery::auto_apply_relay_recovery_for_shared(
+                    self,
+                    shared.clone(),
+                    provider,
+                    channel_id.get(),
+                    RelayRecoveryActionKind::ReattachWatcher,
+                    RelayRecoveryApplySource::ProbeAutoHeal,
+                )
+                .await?;
+                (
+                    response.applied,
+                    true,
+                    Some(response.decision.auto_heal.window_secs),
+                    channel_id,
+                )
+            };
         if applied {
             let committed = shared.commit_redrive_success(
                 provider,
@@ -1036,13 +1035,8 @@ mod tests {
                 .watcher_owner_channel_id
                 .map(ChannelId::new)
                 .unwrap_or(channel_id);
-            let committed = shared.commit_redrive_success(
-                provider,
-                channel_id,
-                shield_channel_id,
-                now,
-                false,
-            );
+            let committed =
+                shared.commit_redrive_success(provider, channel_id, shield_channel_id, now, false);
             trace_redrive_cap_if_needed(provider, channel_id, snapshot, committed);
             assert_eq!(committed.attempt, Some(reserved_attempt));
             return (true, committed.attempt);

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -34,6 +34,11 @@ impl RedriveEpisode {
             || (self.identity.is_some() && self.identity != previous.identity)
             || self.reconnect_count != previous.reconnect_count
     }
+
+    fn refreshes_shield(&self, previous: &Self) -> bool {
+        self.frontier > previous.frontier
+            || (self.identity.is_some() && self.identity != previous.identity)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -42,6 +47,7 @@ struct RedriveAttemptState {
     attempts: u8,
     last_attempt_unix: i64,
     capped_alarm_emitted: bool,
+    retry_not_before_unix: Option<i64>,
 }
 
 impl RedriveAttemptState {
@@ -51,6 +57,7 @@ impl RedriveAttemptState {
             attempts: 0,
             last_attempt_unix: now_unix,
             capped_alarm_emitted: false,
+            retry_not_before_unix: None,
         }
     }
 }
@@ -107,6 +114,15 @@ impl SharedData {
                 emit_capped_alarm,
             };
         }
+        if state
+            .retry_not_before_unix
+            .is_some_and(|not_before| now_unix < not_before)
+        {
+            return RedriveAttemptDecision {
+                attempt: None,
+                emit_capped_alarm: false,
+            };
+        }
         if state.attempts > 0 {
             let delay = REDRIVE_BACKOFF_SECS[usize::from(state.attempts - 1)];
             if now_unix.saturating_sub(state.last_attempt_unix).max(0) < delay {
@@ -135,6 +151,7 @@ impl SharedData {
             .expect("redrive success must follow an admitted attempt");
         state.attempts += 1;
         state.last_attempt_unix = now_unix;
+        state.retry_not_before_unix = None;
         if reattached {
             let current = self
                 .tmux_relay_coord(channel_id)
@@ -158,20 +175,38 @@ impl SharedData {
         let mut shield = REDRIVE_PLACEHOLDER_SHIELDS
             .entry(key)
             .or_insert_with(|| (episode.clone(), now_millis));
-        if episode.resets(&shield.0) {
+        if episode.refreshes_shield(&shield.0) {
             *shield = (episode, now_millis);
+        } else {
+            shield.0 = episode;
         }
         decision
+    }
+
+    fn note_redrive_noop(
+        &self,
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+        now_unix: i64,
+        cooldown_secs: i64,
+    ) {
+        if let Some(mut state) = REDRIVE_ATTEMPTS.get_mut(&self.redrive_key(provider, channel_id)) {
+            state.retry_not_before_unix = Some(now_unix.saturating_add(cooldown_secs.max(30)));
+        }
     }
 
     pub(in crate::services::discord) fn redrive_placeholder_shield_context(
         &self,
         provider: &ProviderKind,
         channel_id: ChannelId,
-    ) -> Option<(i64, u64)> {
+    ) -> Option<(
+        i64,
+        u64,
+        Option<crate::services::discord::inflight::InflightTurnIdentity>,
+    )> {
         REDRIVE_PLACEHOLDER_SHIELDS
             .get(&self.redrive_key(provider, channel_id))
-            .map(|shield| (shield.1, shield.0.frontier))
+            .map(|shield| (shield.1, shield.0.frontier, shield.0.identity.clone()))
     }
 }
 
@@ -304,19 +339,19 @@ impl HealthRegistry {
             return Ok(false);
         }
 
-        let (applied, reattached) = if nudge_existing_watcher_for_backlog(
+        let (applied, reattached, noop_cooldown_secs) = if nudge_existing_watcher_for_backlog(
             &shared,
             provider,
             &snapshot,
             channel_id,
             now_unix_secs,
         ) {
-            (true, false)
+            (true, false, None)
         } else {
             if redrive_should_yield_to_live_relay(&shared, channel_id, &snapshot) {
                 return Ok(false);
             }
-            relay_recovery::auto_apply_relay_recovery_for_shared(
+            let response = relay_recovery::auto_apply_relay_recovery_for_shared(
                 self,
                 shared.clone(),
                 provider,
@@ -324,15 +359,19 @@ impl HealthRegistry {
                 RelayRecoveryActionKind::ReattachWatcher,
                 RelayRecoveryApplySource::ProbeAutoHeal,
             )
-            .await?
-            .applied
-            .then_some((true, true))
-            .unwrap_or((false, true))
+            .await?;
+            (
+                response.applied,
+                true,
+                Some(response.decision.auto_heal.window_secs),
+            )
         };
         if applied {
             let committed =
                 shared.commit_redrive_success(provider, channel_id, now_unix_secs, reattached);
             trace_redrive_cap_if_needed(provider, channel_id, &snapshot, committed);
+        } else if let Some(cooldown_secs) = noop_cooldown_secs {
+            shared.note_redrive_noop(provider, channel_id, now_unix_secs, cooldown_secs);
         }
         Ok(applied)
     }
@@ -1154,23 +1193,57 @@ mod tests {
         );
         let mut self_reattached = snapshot.clone();
         self_reattached.reconnect_count = 1;
+        let second = shared.redrive_attempt_decision(
+            &provider,
+            channel_id,
+            &self_reattached,
+            base + 4_000_030,
+        );
+        assert_eq!(second.attempt, Some(2));
+        let key = shared.redrive_key(&provider, channel_id);
+        REDRIVE_PLACEHOLDER_SHIELDS
+            .get_mut(&key)
+            .expect("first reattach records shield")
+            .1 = 1_234;
+        shared
+            .tmux_relay_coord(channel_id)
+            .reconnect_count
+            .store(2, Ordering::Release);
         assert_eq!(
-            shared
-                .redrive_attempt_decision(
-                    &provider,
-                    channel_id,
-                    &self_reattached,
-                    base + 4_000_030,
-                )
-                .attempt,
-            Some(2),
+            shared.commit_redrive_success(&provider, channel_id, base + 4_000_030, true),
+            RedriveAttemptDecision {
+                attempt: Some(2),
+                emit_capped_alarm: false,
+            },
             "redrive's own reattach must advance the same capped episode"
         );
-        assert!(
+        let (shield_started, _, shield_identity) = shared
+            .redrive_placeholder_shield_context(&provider, channel_id)
+            .expect("self-reattach must preserve shield");
+        assert_eq!(shield_started, 1_234, "self-reattach must not extend 900s");
+        assert_eq!(shield_identity, snapshot.inflight_identity);
+        clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
+
+        assert_eq!(
             shared
-                .redrive_placeholder_shield_context(&provider, channel_id)
-                .is_some(),
-            "self-reattach re-baselining must not erase the reclaim shield"
+                .redrive_attempt_decision(&provider, channel_id, &snapshot, base + 5_000_000,)
+                .attempt,
+            Some(1)
+        );
+        shared.note_redrive_noop(&provider, channel_id, base + 5_000_000, 600);
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(&provider, channel_id, &snapshot, base + 5_000_599,)
+                .attempt,
+            None,
+            "no-op recovery calls must honor the response cooldown"
+        );
+        assert_eq!(
+            shared
+                .redrive_attempt_decision(&provider, channel_id, &snapshot, base + 5_000_600,)
+                .attempt,
+            Some(1),
+            "a no-op cooldown must not consume the first real attempt"
         );
         clear_redrive_test_state(&shared, &provider, channel_id, tmux_session);
     }

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -487,6 +487,7 @@ pub(super) fn watcher_should_reclaim_orphan_turn_placeholder(
 }
 
 const REDRIVE_PLACEHOLDER_SHIELD_MILLIS: i64 = 900_000;
+const REDRIVE_PLACEHOLDER_CLOCK_SKEW_MILLIS: i64 = 5_000;
 
 pub(super) fn redrive_shielded_placeholder(
     nudged_at_millis: i64,
@@ -494,7 +495,8 @@ pub(super) fn redrive_shielded_placeholder(
     frontier_not_advanced: bool,
     now_millis: i64,
 ) -> bool {
-    message_created_at_millis >= nudged_at_millis
+    message_created_at_millis.saturating_add(REDRIVE_PLACEHOLDER_CLOCK_SKEW_MILLIS)
+        >= nudged_at_millis
         && frontier_not_advanced
         && now_millis.saturating_sub(nudged_at_millis).max(0) < REDRIVE_PLACEHOLDER_SHIELD_MILLIS
 }
@@ -582,7 +584,7 @@ mod redrive_placeholder_shield_tests {
             "post-nudge placeholder at a frozen frontier must be preserved inside 900s"
         );
         assert!(
-            !redrive_shielded_placeholder(nudged_at, nudged_at - 1, true, nudged_at + 1),
+            !redrive_shielded_placeholder(nudged_at, nudged_at - 5_001, true, nudged_at + 1),
             "a pre-nudge orphan must retain the existing reclaim semantics"
         );
         assert!(

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -2,57 +2,16 @@
 
 use super::*;
 
-/// #3016 S3 (the A2 / phase-5 enabler): the fresh-idle finalize DECISION,
-/// factored out of the production watcher loop so the EXACT production routing is
-/// unit-testable end-to-end (the enclosing `tmux_output_watcher_with_restore` is
-/// not). It fuses two independent disambiguators:
+/// #3016 S3 fresh-idle finalize decision, extracted so the production routing is
+/// unit-testable. Structural completion is authoritative: `Done` finalizes even
+/// with empty text, `PausedLive` defers, and non-JSONL `Unknown` uses the proven
+/// pane-idle fallback (empty `Unknown` retains the 1800s safety backstop).
 ///
-///   1. The STRUCTURAL completion signal (`CompletionSignal`, S1) — the
-///      authority that finally distinguishes "turn done" from "paused-live",
-///      which the old flag-only path could not:
-///        * `Done`       — a structural JSONL terminator is proven on disk
-///                         (Claude `result`/`system`, Codex `turn.completed`).
-///                         Even when the committed response text is EMPTY/
-///                         suppressed, this is a genuine completed turn → finalize.
-///        * `PausedLive` — NO terminator (Busy/Inconclusive): paused at a
-///                         selector / permission prompt, a subagent still running,
-///                         or a long silent tool call. NEVER finalize → defer.
-///        * `Unknown`    — non-JSONL runtime (LegacyTmuxWrapper / ProcessBackend /
-///                         ClaudeEAdapter, or a non-JSONL provider): the transcript
-///                         probe cannot speak, so the pane-idle proxy is the sole
-///                         terminal authority. #3016 phase-5b1 routes `Unknown` to
-///                         the SAME finalize path as `Done` (flag-independent): the
-///                         fresh-idle gate already PROVES pane idle (it only fires
-///                         after `watcher_session_ready_for_input` — the SAME
-///                         `FallbackPaneReadiness` predicate the 5a far-backstop
-///                         uses for `Unknown` — held
-///                         over the idle timeout), so finalizing promptly here is
-///                         behaviour-equivalent to the old `mailbox_finalize_owed`
-///                         flag (owed was ~always true at this arm), without the
-///                         1800s far-backstop latency.
-///
-///   2. The A2-banked wrong-turn-race defenses (only relevant once the signal
-///      says we *would* finalize): a follow-up turn can claim the same session
-///      during the cleanup `.await`s, so before the destructive clear we
-///        * `AbortFollowupTookOver` — `paused_now || epoch_changed` (the SAME
-///          predicate as the canonical pause/epoch guard at tmux.rs:7806, but
-///          evaluated HERE because this branch `continue`s before that guard
-///          would run); and
-///        * `SkipStale` — the PINNED pre-cleanup snapshot is a NEWER turn that
-///          began AT/AFTER this committed range (`committed_completion_is_stale_for_newer_turn`,
-///          or `pinned_finalize_user_msg_id == 0`). Finalizing would release the
-///          follow-up; skip and preserve inflight.
-///
-/// The two combine so that the defer decision keys on the STRUCTURAL TERMINATOR,
-/// not on response emptiness — which is the fix for the contradiction that killed
-/// the first A2 attempt (the old defer guard deferred `delegated && empty`, the
-/// SAME condition as the empty completion it wanted to finalize, so finalize was
-/// unreachable). Here an empty-but-TERMINATED completion routes to `Finalize`.
-///
-/// Degenerate-empty-offset safety: a genuine current-turn fresh idle always has
-/// `turn_start_offset < current_offset` (`FreshIdle` requires `output_ever_grew`,
-/// and the watcher resumes at `turn_start_offset`), so the pinned id is its real,
-/// non-zero id and `SkipStale` cannot misfire on the current turn.
+/// Before a destructive clear, the A2 race guards preserve a follow-up that took
+/// the session during cleanup: pause/epoch change yields `AbortFollowupTookOver`,
+/// while a pinned newer turn yields `SkipStale`. Thus response emptiness never
+/// contradicts a proven terminator, and a current fresh-idle turn's non-zero
+/// pinned identity cannot be mistaken for a stale follow-up.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FreshIdleFinalizeDecision {
     /// `PausedLive` (no terminator) — defer; preserve inflight, keep waiting.
@@ -526,6 +485,19 @@ pub(super) fn watcher_should_reclaim_orphan_turn_placeholder(
         )
 }
 
+const REDRIVE_PLACEHOLDER_SHIELD_SECS: i64 = 900;
+
+pub(super) fn redrive_shielded_placeholder(
+    nudged_at_unix: i64,
+    message_created_at_unix: i64,
+    frontier_not_advanced: bool,
+    now_unix: i64,
+) -> bool {
+    message_created_at_unix >= nudged_at_unix
+        && frontier_not_advanced
+        && now_unix.saturating_sub(nudged_at_unix).max(0) < REDRIVE_PLACEHOLDER_SHIELD_SECS
+}
+
 /// #3107 (CHANGE 3): pure decision for the `load_inflight_state == None` arm of
 /// `watcher_external_input_turn_abandoned`. A missing inflight is abandonment
 /// ONLY when the pane is not actively streaming; an actively-streaming pane is a
@@ -596,3 +568,29 @@ pub(super) fn watcher_external_input_completion_footer_suppressed(
 #[cfg(test)]
 #[path = "panel_decisions_tests.rs"]
 mod completion_footer_suppression_tests;
+
+#[cfg(test)]
+mod redrive_placeholder_shield_tests {
+    use super::redrive_shielded_placeholder;
+
+    #[test]
+    fn redrive_placeholder_shield_truth_table_4299() {
+        let nudged_at = 1_800_000_000;
+        assert!(
+            redrive_shielded_placeholder(nudged_at, nudged_at + 1, true, nudged_at + 899),
+            "post-nudge placeholder at a frozen frontier must be preserved inside 900s"
+        );
+        assert!(
+            !redrive_shielded_placeholder(nudged_at, nudged_at - 1, true, nudged_at + 1),
+            "a pre-nudge orphan must retain the existing reclaim semantics"
+        );
+        assert!(
+            !redrive_shielded_placeholder(nudged_at, nudged_at + 1, true, nudged_at + 900),
+            "the shield must expire at its hard 900s bound"
+        );
+        assert!(
+            !redrive_shielded_placeholder(nudged_at, nudged_at + 1, false, nudged_at + 1),
+            "frontier progress must restore the existing reclaim semantics"
+        );
+    }
+}

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -11,7 +11,8 @@ use super::*;
 /// the session during cleanup: pause/epoch change yields `AbortFollowupTookOver`,
 /// while a pinned newer turn yields `SkipStale`. Thus response emptiness never
 /// contradicts a proven terminator, and a current fresh-idle turn's non-zero
-/// pinned identity cannot be mistaken for a stale follow-up.
+/// pinned identity cannot be mistaken for a stale follow-up: `FreshIdle` requires
+/// output growth, so `turn_start_offset < current_offset` for the current turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FreshIdleFinalizeDecision {
     /// `PausedLive` (no terminator) — defer; preserve inflight, keep waiting.
@@ -485,17 +486,17 @@ pub(super) fn watcher_should_reclaim_orphan_turn_placeholder(
         )
 }
 
-const REDRIVE_PLACEHOLDER_SHIELD_SECS: i64 = 900;
+const REDRIVE_PLACEHOLDER_SHIELD_MILLIS: i64 = 900_000;
 
 pub(super) fn redrive_shielded_placeholder(
-    nudged_at_unix: i64,
-    message_created_at_unix: i64,
+    nudged_at_millis: i64,
+    message_created_at_millis: i64,
     frontier_not_advanced: bool,
-    now_unix: i64,
+    now_millis: i64,
 ) -> bool {
-    message_created_at_unix >= nudged_at_unix
+    message_created_at_millis >= nudged_at_millis
         && frontier_not_advanced
-        && now_unix.saturating_sub(nudged_at_unix).max(0) < REDRIVE_PLACEHOLDER_SHIELD_SECS
+        && now_millis.saturating_sub(nudged_at_millis).max(0) < REDRIVE_PLACEHOLDER_SHIELD_MILLIS
 }
 
 /// #3107 (CHANGE 3): pure decision for the `load_inflight_state == None` arm of
@@ -575,9 +576,9 @@ mod redrive_placeholder_shield_tests {
 
     #[test]
     fn redrive_placeholder_shield_truth_table_4299() {
-        let nudged_at = 1_800_000_000;
+        let nudged_at = 1_800_000_000_000;
         assert!(
-            redrive_shielded_placeholder(nudged_at, nudged_at + 1, true, nudged_at + 899),
+            redrive_shielded_placeholder(nudged_at, nudged_at + 1, true, nudged_at + 899_999),
             "post-nudge placeholder at a frozen frontier must be preserved inside 900s"
         );
         assert!(
@@ -585,7 +586,7 @@ mod redrive_placeholder_shield_tests {
             "a pre-nudge orphan must retain the existing reclaim semantics"
         );
         assert!(
-            !redrive_shielded_placeholder(nudged_at, nudged_at + 1, true, nudged_at + 900),
+            !redrive_shielded_placeholder(nudged_at, nudged_at + 1, true, nudged_at + 900_000),
             "the shield must expire at its hard 900s bound"
         );
         assert!(

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -252,20 +252,19 @@ mod redrive_reclaim_e2e_tests {
                     }
                 }
                 if placeholder_msg_id.is_some() {
-                    assert!(
-                        !reclaim_orphan_external_input_placeholder(
-                            &http,
-                            &shared,
-                            channel_id,
-                            &mut placeholder_msg_id,
-                            &mut restored,
-                            &mut last_edit_text,
-                            &provider,
-                            &tmux_session,
-                        )
-                        .await,
-                        "shielded reclaim must preserve and defer"
-                    );
+                    let reclaimed = reclaim_orphan_external_input_placeholder(
+                        &http,
+                        &shared,
+                        channel_id,
+                        &mut placeholder_msg_id,
+                        &mut restored,
+                        &mut last_edit_text,
+                        &provider,
+                        &tmux_session,
+                    )
+                    .await;
+                    deletes += usize::from(reclaimed);
+                    assert!(!reclaimed, "shielded reclaim must preserve and defer");
                     let preserved_msg_id = placeholder_msg_id
                         .expect("shielded reclaim must preserve the placeholder id");
                     assert!(
@@ -277,9 +276,6 @@ mod redrive_reclaim_e2e_tests {
                         ),
                         "shield must return before delete and durable-retry enqueue"
                     );
-                    if placeholder_msg_id.is_none() {
-                        deletes += 1;
-                    }
                 }
             }
             assert!(

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -266,6 +266,17 @@ mod redrive_reclaim_e2e_tests {
                         .await,
                         "shielded reclaim must preserve and defer"
                     );
+                    let preserved_msg_id = placeholder_msg_id
+                        .expect("shielded reclaim must preserve the placeholder id");
+                    assert!(
+                        !crate::services::discord::status_panel_orphan_store::is_queued(
+                            &provider,
+                            &shared.token_hash,
+                            channel_id.get(),
+                            preserved_msg_id.get(),
+                        ),
+                        "shield must return before delete and durable-retry enqueue"
+                    );
                     if placeholder_msg_id.is_none() {
                         deletes += 1;
                     }

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -43,6 +43,25 @@ pub(super) async fn reclaim_orphan_external_input_placeholder(
     let Some(msg_id) = *placeholder_msg_id else {
         return true;
     };
+    if let Some((nudged_at_unix, frontier_at_nudge)) =
+        shared.redrive_placeholder_shield_context(provider, channel_id)
+        && super::panel_decisions::redrive_shielded_placeholder(
+            nudged_at_unix,
+            msg_id.created_at().unix_timestamp(),
+            shared.committed_relay_offset(channel_id) <= frontier_at_nudge,
+            chrono::Utc::now().timestamp(),
+        )
+    {
+        tracing::debug!(
+            target: "agentdesk::discord::relay_recovery",
+            event = "redrive_placeholder_reclaim_shielded",
+            channel_id = channel_id.get(),
+            message_id = msg_id.get(),
+            frontier_at_nudge,
+            "redrive-created placeholder preserved while the frontier is frozen"
+        );
+        return false;
+    }
     let outcome = delete_nonterminal_placeholder(
         http,
         channel_id,
@@ -103,4 +122,185 @@ pub(super) async fn reclaim_orphan_external_input_placeholder(
         msg_id.get()
     );
     true
+}
+
+#[cfg(all(test, unix))]
+mod redrive_reclaim_e2e_tests {
+    use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    fn message_id_at(unix_secs: i64, sequence: u64) -> serenity::MessageId {
+        const DISCORD_EPOCH_MS: i64 = 1_420_070_400_000;
+        let discord_ms = u64::try_from(unix_secs * 1_000 - DISCORD_EPOCH_MS)
+            .expect("test timestamp after Discord epoch");
+        serenity::MessageId::new((discord_ms << 22) | sequence)
+    }
+
+    #[test]
+    fn live_tmux_redrive_reclaim_cycle_terminates_4299() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            tmp.path(),
+        );
+        if !crate::services::platform::tmux::is_available() {
+            eprintln!("skipping #4299 redrive/reclaim E2E: tmux is not available");
+            return;
+        }
+
+        let provider = ProviderKind::Codex;
+        let channel_id = ChannelId::new(4_299_004);
+        let tmux_session = format!("AgentDesk-codex-e2e4299-{}", std::process::id());
+        let created =
+            crate::services::platform::tmux::create_session(&tmux_session, None, "sleep 60")
+                .expect("create tmux session");
+        assert!(created.status.success(), "live tmux session must start");
+        let output_path = tmp.path().join("frozen-backlog.jsonl");
+        std::fs::write(&output_path, vec![b'x'; 4_096]).expect("stage transcript backlog");
+        let output_path = output_path.display().to_string();
+        let base = chrono::Utc::now().timestamp();
+        let user_msg_id = message_id_at(base - 60, 1).get();
+        let mut inflight = crate::services::discord::inflight::InflightTurnState::new(
+            provider.clone(),
+            channel_id.get(),
+            None,
+            77,
+            user_msg_id,
+            0,
+            "stale foreground".to_string(),
+            None,
+            Some(tmux_session.clone()),
+            Some(output_path.clone()),
+            None,
+            0,
+        );
+        inflight.turn_source = crate::services::discord::inflight::TurnSource::Managed;
+        assert!(
+            crate::services::discord::inflight::save_inflight_state_if_absent(&inflight)
+                .expect("persist stale foreground row")
+        );
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let resume_offset = Arc::new(Mutex::new(None));
+        shared.tmux_watchers.insert(
+            channel_id,
+            crate::services::discord::TmuxWatcherHandle {
+                tmux_session_name: tmux_session.clone(),
+                output_path: output_path.clone(),
+                paused: Arc::new(AtomicBool::new(false)),
+                resume_offset: resume_offset.clone(),
+                cancel: Arc::new(AtomicBool::new(false)),
+                pause_epoch: Arc::new(AtomicU64::new(0)),
+                turn_delivered: Arc::new(AtomicBool::new(true)),
+                last_heartbeat_ts_ms: Arc::new(AtomicI64::new(
+                    crate::services::discord::tmux_watcher_now_ms(),
+                )),
+            },
+        );
+        let registry = crate::services::discord::health::HealthRegistry::new();
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let (create_count, delete_count, nudge_count) = runtime.block_on(async {
+            const BACKLOG_GRACE_SECS: i64 = 180;
+            assert!(
+                !registry
+                    .redrive_undelivered_backlog_at(
+                        &provider,
+                        shared.clone(),
+                        channel_id,
+                        base - BACKLOG_GRACE_SECS,
+                    )
+                    .await
+                    .expect("prime redrive observation")
+            );
+            let mut placeholder_msg_id = None;
+            let mut restored = false;
+            let mut last_edit_text = String::new();
+            let mut creates = 0;
+            let mut deletes = 0;
+            let mut nudges = 0;
+            for pass in 0..20 {
+                let nudged = registry
+                    .redrive_undelivered_backlog_at(
+                        &provider,
+                        shared.clone(),
+                        channel_id,
+                        base + i64::from(pass) * 30,
+                    )
+                    .await
+                    .expect("redrive pass");
+                if nudged {
+                    nudges += 1;
+                    if placeholder_msg_id.is_none() {
+                        placeholder_msg_id = Some(message_id_at(base + 1, 2));
+                        creates += 1;
+                    }
+                }
+                if placeholder_msg_id.is_some() {
+                    assert!(
+                        !reclaim_orphan_external_input_placeholder(
+                            &http,
+                            &shared,
+                            channel_id,
+                            &mut placeholder_msg_id,
+                            &mut restored,
+                            &mut last_edit_text,
+                            &provider,
+                            &tmux_session,
+                        )
+                        .await,
+                        "shielded reclaim must preserve and defer"
+                    );
+                    if placeholder_msg_id.is_none() {
+                        deletes += 1;
+                    }
+                }
+            }
+            assert!(
+                registry
+                    .redrive_undelivered_backlog_at(
+                        &provider,
+                        shared.clone(),
+                        channel_id,
+                        base + 930,
+                    )
+                    .await
+                    .expect("sixth redrive pass")
+            );
+            nudges += 1;
+            assert!(
+                !registry
+                    .redrive_undelivered_backlog_at(
+                        &provider,
+                        shared.clone(),
+                        channel_id,
+                        base + 1_890,
+                    )
+                    .await
+                    .expect("capped redrive pass")
+            );
+            (creates, deletes, nudges)
+        });
+
+        assert_eq!(create_count, 1, "the shield must force placeholder reuse");
+        assert_eq!(
+            delete_count, 0,
+            "no post-nudge placeholder may churn inside 900s"
+        );
+        assert_eq!(nudge_count, 6, "redrive must stop permanently at the cap");
+        assert_eq!(*resume_offset.lock().unwrap(), Some(0));
+        if let Some((_, handle)) = shared.tmux_watchers.remove(&channel_id) {
+            handle.cancel.store(true, Ordering::Release);
+        }
+        crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
+        let _ = crate::services::platform::tmux::kill_session(&tmux_session, "#4299 E2E cleanup");
+    }
 }

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -27,8 +27,9 @@ pub(super) fn drop_placeholder_orphan_record(
 /// the local id for an in-turn retry + enqueues a durable record; committed /
 /// permanent failure drops the handles and compare-and-clears the persisted
 /// `current_msg_id` (#3077 pattern) so a later segment cannot edit the stale id.
-/// The return value is NOT wired into finalize decisions (panel defer semantics
-/// #3003 r5/r12 unchanged).
+/// `false` preserves the local handle for retry. The fresh-idle no-result caller
+/// also treats it as a bounded finalize deferral; a redrive shield deliberately
+/// uses that non-destructive path for at most 900s.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn reclaim_orphan_external_input_placeholder(
     http: &Arc<serenity::Http>,
@@ -43,13 +44,13 @@ pub(super) async fn reclaim_orphan_external_input_placeholder(
     let Some(msg_id) = *placeholder_msg_id else {
         return true;
     };
-    if let Some((nudged_at_unix, frontier_at_nudge)) =
+    if let Some((nudged_at_millis, frontier_at_nudge)) =
         shared.redrive_placeholder_shield_context(provider, channel_id)
         && super::panel_decisions::redrive_shielded_placeholder(
-            nudged_at_unix,
-            msg_id.created_at().unix_timestamp(),
+            nudged_at_millis,
+            msg_id.created_at().timestamp_millis(),
             shared.committed_relay_offset(channel_id) <= frontier_at_nudge,
-            chrono::Utc::now().timestamp(),
+            chrono::Utc::now().timestamp_millis(),
         )
     {
         tracing::debug!(

--- a/src/services/discord/tmux_watcher/placeholder_reclaim.rs
+++ b/src/services/discord/tmux_watcher/placeholder_reclaim.rs
@@ -44,8 +44,14 @@ pub(super) async fn reclaim_orphan_external_input_placeholder(
     let Some(msg_id) = *placeholder_msg_id else {
         return true;
     };
-    if let Some((nudged_at_millis, frontier_at_nudge)) =
+    if let Some((nudged_at_millis, frontier_at_nudge, shield_identity)) =
         shared.redrive_placeholder_shield_context(provider, channel_id)
+        && shield_identity.is_some()
+        && shield_identity
+            == crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
+                .map(|state| {
+                    crate::services::discord::inflight::InflightTurnIdentity::from_state(&state)
+                })
         && super::panel_decisions::redrive_shielded_placeholder(
             nudged_at_millis,
             msg_id.created_at().timestamp_millis(),
@@ -241,7 +247,7 @@ mod redrive_reclaim_e2e_tests {
                 if nudged {
                     nudges += 1;
                     if placeholder_msg_id.is_none() {
-                        placeholder_msg_id = Some(message_id_at(base + 1, 2));
+                        placeholder_msg_id = Some(message_id_at(base + 300, 2));
                         creates += 1;
                     }
                 }


### PR DESCRIPTION
## 요약

- **사이클 절단점 1 — redrive cap:** frozen frontier episode를 성공한 action 기준으로만 계수하고 `30/60/120/240/480/960s` 지수 backoff를 적용합니다. 실제 action 시각은 누적 `+0/+30/+90/+210/+450/+930s`, 상한은 6회이며 `redrive_no_progress_capped` error는 정확히 1회만 발화합니다.
- **사이클 절단점 2 — reclaim shield:** 성공한 redrive 뒤 생성된 동일-turn placeholder를 frontier가 정지한 동안 reclaim 내부에서 보존합니다. 함수 시그니처와 `tmux_watcher.rs` 호출부는 무변경이며 hard 상한은 900초입니다.
- capped episode의 재무장은 committed frontier 진전, 실제 inflight identity 교체, 외부 watcher generation 교체만 허용합니다. 시간 경과, identity 소멸, redrive 자신의 self-reattach/rebind는 재무장하지 않습니다.
- stale foreground row 입양/정리 arm은 구현하지 않았습니다. live-turn 강탈 위험이 있는 판정모델 변경은 #4254 범위로 유지합니다.

## 교차검토 반영

- 성공한 action 뒤에만 attempt를 commit하여 live-relay TOCTOU, recovery error, `applied=false` no-op이 cap을 소비하지 않게 했습니다.
- self-reattach의 정확히 `+1` reconnect generation과 같은-turn/synthetic-rebind identity 갱신을 episode에 re-baseline하여 attempt-1 무한 루프를 막았습니다. 실제 후속 turn identity는 계속 정상 재무장합니다.
- reclaim shield를 현재 inflight full identity에 결속했고, watcher owner 채널에 기록해 owner/request 채널이 다른 경우에도 실제 placeholder를 보호합니다.
- shield 시작 밀리초는 첫 successful action에 고정됩니다. 반복 nudge/self-reattach는 hard 900초를 연장하지 않으며, 외부 watcher 교체만 새 episode로 갱신합니다.
- Fresh Opus round-5에서 발견한 두 gap도 닫았습니다. `reuse_existing_live_watcher`처럼 reconnect generation이 오르지 않고 identity만 rewrite되는 self-reattach도 같은 episode에 흡수하며, owner≠request 채널 shield의 frontier/identity는 첫 successful action snapshot에 고정해 이후 owner 진전/후속 turn을 old shield가 따라가지 않게 했습니다.
- Fresh Opus round-6 후속 지적도 닫았습니다. reattach 적용 뒤 registry의 실제 watcher owner를 재도출해 shield key로 사용하고, stable `turn_nonce`로 same-second user-id-zero 후속 turn과 self-rebind를 구별합니다. 새 request episode 첫 action은 같은 owner에 stale shield entry가 있어도 timestamp/frontier/identity를 함께 재무장합니다.
- Fresh Opus round-7 잔여도 닫았습니다. episode의 첫 successful action 밀리초를 attempt state에 고정해 shield key가 B→A로 이동해도 같은 900초 anchor를 쓰며, nudge/reattach owner 선택은 하나의 production selector로 합쳤습니다. MonitorTriggered row와 빈 nonce는 self-reattach 인증에서 제외합니다.

## RED / GREEN

- **T1 RED (수정 전):** `/private/tmp/adk4299-t1-red.log`, `rc=0`, `N=20 frozen passes`, `nudge_count=20` — 요구치 `>=17/20`을 충족하며 무한 재시도를 실증했습니다.
- **GREEN (최종 HEAD `a25a4b000facd2c1f2a420e90d361f8e9e3ef52c`):** `/private/tmp/adk4299-r8-targeted.log`, `rc=0`, redrive 10/10. T1/T2, owner/key-switch/nonce/monitor regressions, live tmux T4가 skip 없이 통과했습니다. T1은 `nudge_times=[0,30,90,210,450,930]`, alarm 1회; T4는 create=1/delete=0/nudge=6입니다.

## 뮤테이션 증명

커밋된 clean HEAD에서 각 변이를 하나씩 적용하고 해당 테스트의 자기 assert가 실패한 뒤 즉시 원복했습니다. 모두 컴파일 오류가 아닌 `rc=101` assertion failure이며 마지막 `git diff --exit-code=0`입니다.

| 변이 | 로그 | rc | 검출 assertion |
|---|---|---:|---|
| T1 ① counter increment 제거 | `/private/tmp/adk4299-r6-mut-t1-counter.log` | 101 | committed ordinal `Some(0) != Some(1)` |
| T1 ② 지수 index 제거(30s 고정) | `/private/tmp/adk4299-r6-mut-t1-backoff.log` | 101 | `[0,30,60,90,120,150] != [0,30,90,210,450,930]` |
| T1 ③ once-flag 기록 제거 | `/private/tmp/adk4299-r6-mut-t1-alarm-once.log` | 101 | alarm count `2 != 1` |
| T3 ① created-after-nudge 제거 | `/private/tmp/adk4299-r6-mut-t3-created-after.log` | 101 | pre-nudge orphan reclaim 의미론 |
| T3 ② 900s expiry 제거 | `/private/tmp/adk4299-r6-mut-t3-expiry.log` | 101 | hard 900s expiry |
| T3 ③ frontier-frozen 제거 | `/private/tmp/adk4299-r6-mut-t3-frontier.log` | 101 | progress restores reclaim |

추가 교차검토 guard mutation도 모두 `rc=101`입니다.

- reconnect 증가 없는 self-reattach identity 흡수 제거: `/private/tmp/adk4299-r6-mut-identity-without-reconnect.log` — T2의 shield identity 자기 assert FAIL.
- owner first-snapshot freeze 제거: `/private/tmp/adk4299-r6-mut-owner-shield-freeze.log` — owner frontier `64 != 0` 자기 assert FAIL.
- post-reattach live-owner 재도출 제거: `/private/tmp/adk4299-r7-mut-reattach-owner-key.log` — owner `A != B` 자기 assert FAIL.
- user-id-zero same-turn heuristic 재허용: `/private/tmp/adk4299-r7-mut-same-second-nonce.log` — same-second successor `None != Some(1)` 자기 assert FAIL.
- stale owner shield 첫-attempt 재무장 제거: `/private/tmp/adk4299-r7-mut-stale-owner-rearm.log` — timestamp `1234 == 1234` 자기 assert FAIL.
- episode anchor write 제거: `/private/tmp/adk4299-r8-mut-episode-anchor.log` — stale timestamp `1234 == 1234` 자기 assert FAIL.
- selector nudge/reattach arm 반전: `/private/tmp/adk4299-r8-mut-selector-arm.log` — nudge owner `B != C` 자기 assert FAIL.
- MonitorTriggered 제외 제거: `/private/tmp/adk4299-r8-mut-monitor-exclusion.log` — monitor identity `Some(...) != None` 자기 assert FAIL.
- empty-nonce 정규화 제거: `/private/tmp/adk4299-r8-mut-empty-nonce.log` — empty nonce identity `Some(...) != None` 자기 assert FAIL.

## 게이트 rc

| 게이트 | rc | 증거 |
|---|---:|---|
| `cargo fmt` | 0 | `/private/tmp/adk4299-r8-fmt.log` |
| `cargo fmt --check` | 0 | `/private/tmp/adk4299-r8-fmt-check.log` |
| `cargo check --lib` | 0 | `/private/tmp/adk4299-r8-check-lib.log` |
| `env -u AGENTDESK_ROOT_DIR cargo test --lib health && cargo test --lib tmux_watcher` | 0 | `/private/tmp/adk4299-r8-gate-tests.log` — 174/174, 277/277 |
| `python3 scripts/audit_maintainability.py --check` | 0 | `/private/tmp/adk4299-r8-audit.log`; cap/baseline 인상 없음 |
| `python3 scripts/generate_inventory_docs.py` | 0 | `/private/tmp/adk4299-r8-generate.log` |
| `python3 scripts/check_agent_maintenance_docs.py` | 0 | `/private/tmp/adk4299-r8-maintenance.log`; `agent-maintenance freshness check passed` |
| `PATH=/opt/homebrew/bin:$PATH ./scripts/ci-script-checks.sh` | 0 | `/private/tmp/adk4299-r8-ci-script-checks.log` |
| `python3 scripts/check_await_holding_lock_ratchet.py` | 0 | `/private/tmp/adk4299-r8-await-lock-ratchet.log`; 53/53 |

## 변경 표면 / 설계 배치 차이

- 제품 코드는 `relay_auto_heal.rs`, `placeholder_reclaim.rs`, `panel_decisions.rs`만 변경했습니다. 파생 `module-inventory.md`를 갱신했습니다.
- 설계의 ledger 배치 제안과 달리 attempt/shield state는 유일한 redrive action owner인 `relay_auto_heal.rs`에 함께 두었습니다. `stall_liveness.rs`는 giant 경계(당시 965 prod LoC)를 건드리지 않고 기존 frozen-frontier 관측만 유지합니다.
- snapshot 관측 필드는 설계상 선택 항목이라 생략했습니다.
- 금지 표면 `turn_bridge/*`, 부모 `tmux_watcher.rs`, `inflight.rs`는 변경하지 않았습니다. cap/baseline 및 `await_holding_lock=53` ratchet도 인상하지 않았습니다.

Refs #4299
