### PR TITLE
feat(watchdog): enforce relay coverage invariant

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -56,7 +56,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 # ── Verdict states (pure judgment output, see evaluate()) ─────────────────────
 STATE_OK = "ok"
@@ -71,6 +71,17 @@ PG_UPSTREAM_DOWN = "upstream_or_half_dead"
 PG_UNCLASSIFIED_DOWN = "db_down_tunnel_unknown"
 PG_UNKNOWN = "unknown"
 PG_STATE_KEY = "_pg_tunnel"
+
+# Independent watcher-coverage states (#4408 phase 1).  Coverage is evaluated
+# in parallel with transcript-vs-Discord gap judgment; these states must never
+# suppress or replace STATE_GAP.
+COVERAGE_COVERED = "covered"
+COVERAGE_UNCOVERED = "uncovered"
+COVERAGE_UNKNOWN = "unknown"
+COVERAGE_CONFIRM_TICKS = 2
+
+PG_TOPOLOGY_TUNNEL = "tunnel"
+PG_TOPOLOGY_DIRECT = "direct"
 
 
 def adk_root() -> Path:
@@ -136,6 +147,10 @@ class Config:
     # after this many CONSECUTIVE failures instead of skipping forever.
     read_fail_alert_after: int = 5
     dcserver_port: int = 8791
+    # A direct PostgreSQL node does not expect an SSH -L listener on 15432.
+    # The topology changes only the CLOSED diagnosis text; db=false remains
+    # the sole PG failure signal in either topology.
+    pg_topology: str = PG_TOPOLOGY_TUNNEL
     # PG must remain end-to-end unhealthy for this long before alerting.  The
     # default is >3x the supervisor's normal recovery envelope, avoiding noise
     # while launchd+ssh are doing their job.  Override only for an approved T3
@@ -201,6 +216,12 @@ def parse_config(raw: dict[str, Any]) -> Config:
                 ) from e
     if "github_repo" in raw:
         kwargs["github_repo"] = str(raw["github_repo"])
+    pg_topology = raw.get("pg_topology", PG_TOPOLOGY_TUNNEL)
+    if pg_topology not in (PG_TOPOLOGY_TUNNEL, PG_TOPOLOGY_DIRECT):
+        raise ConfigError(
+            "config field 'pg_topology' must be 'tunnel' or 'direct'"
+        )
+    kwargs["pg_topology"] = pg_topology
     for key in ("pg_alert_after_secs", "pg_realert_secs"):
         if key in kwargs and kwargs[key] <= 0:
             raise ConfigError(f"config field {key!r} must be greater than zero")
@@ -258,16 +279,54 @@ def channel_project_dirs(root: Path, pattern: re.Pattern[str]) -> list[Path]:
         return []
 
 
-def newest_transcript(dirs: list[Path]) -> Path | None:
-    js: list[Path] = []
+@dataclass(frozen=True)
+class TranscriptCandidate:
+    path: Path
+    size: int
+    mtime: float
+
+
+def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
+    candidates: list[TranscriptCandidate] = []
     for d in dirs:
         try:
-            js.extend(d.glob("*.jsonl"))
+            paths = list(d.glob("*.jsonl"))
         except OSError:
             continue
-    if not js:
+        for path in paths:
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            candidates.append(TranscriptCandidate(path, stat.st_size, stat.st_mtime))
+    return candidates
+
+
+def select_watch_transcript(
+    candidates: list[TranscriptCandidate], previous_sizes: Mapping[str, int]
+) -> Path | None:
+    """Choose a transcript by observed growth, falling back to newest mtime.
+
+    A newly discovered candidate has no growth proof yet.  Once a prior size
+    exists, any file that grew wins over a newer-but-stagnant file; mtime and
+    path provide deterministic tie-breaking within the chosen pool.  The
+    caller owns I/O and persistence, keeping this selector pure.
+    """
+    if not candidates:
         return None
-    return max(js, key=lambda f: f.stat().st_mtime)
+    growing = [
+        candidate
+        for candidate in candidates
+        if str(candidate.path) in previous_sizes
+        and candidate.size > previous_sizes[str(candidate.path)]
+    ]
+    pool = growing or candidates
+    return max(pool, key=lambda candidate: (candidate.mtime, str(candidate.path))).path
+
+
+def newest_transcript(dirs: list[Path]) -> Path | None:
+    """Backward-compatible mtime selector for callers without growth state."""
+    return select_watch_transcript(transcript_candidates(dirs), {})
 
 
 # ── Transcript parsing ─────────────────────────────────────────────────────────
@@ -347,6 +406,69 @@ class PgHealthVerdict:
     state: str
     db: bool | None
     tunnel_open: bool | None
+
+
+@dataclass(frozen=True)
+class CoverageVerdict:
+    state: str
+    reason: str
+    consecutive_uncovered: int
+    confirmed: bool
+
+
+@dataclass(frozen=True)
+class WatcherStateProbe:
+    status: int | None
+    attached: bool | None = None
+    desynced: bool | None = None
+
+
+def evaluate_coverage(
+    expected_alive: bool | None,
+    watcher_status: int | None,
+    attached: bool | None,
+    desynced: bool | None,
+    previous_uncovered: int,
+) -> CoverageVerdict:
+    """Pure I2 judgment for expected tmux coverage.
+
+    E is independently enumerated tmux liveness. A is exactly
+    ``attached and not desynced`` from watcher-state. Only E && !A advances
+    confirmation. Transport/schema uncertainty is unknown (never an alert),
+    while an authoritative watcher-state 404 is uncovered. Two consecutive
+    uncovered ticks are required.
+    """
+
+    def uncovered(reason: str) -> CoverageVerdict:
+        consecutive = max(0, previous_uncovered) + 1
+        return CoverageVerdict(
+            COVERAGE_UNCOVERED,
+            reason,
+            consecutive,
+            consecutive >= COVERAGE_CONFIRM_TICKS,
+        )
+
+    if expected_alive is None:
+        return CoverageVerdict(COVERAGE_UNKNOWN, "tmux_enumeration_unknown", 0, False)
+    if expected_alive is False:
+        # The reverse invariant (watcher exists but tmux is dead) belongs to
+        # the stall watchdog; do not manufacture a duplicate alert here.
+        return CoverageVerdict(COVERAGE_COVERED, "tmux_not_expected", 0, False)
+    if watcher_status is None:
+        return CoverageVerdict(COVERAGE_UNKNOWN, "dcserver_unreachable", 0, False)
+    if watcher_status == 404:
+        return uncovered("watcher_state_404")
+    if watcher_status != 200:
+        return CoverageVerdict(
+            COVERAGE_UNKNOWN, f"watcher_state_http_{watcher_status}", 0, False
+        )
+    if attached is True and desynced is False:
+        return CoverageVerdict(COVERAGE_COVERED, "attached", 0, False)
+    if attached is False:
+        return uncovered("detached")
+    if attached is True and desynced is True:
+        return uncovered("attached_but_desynced")
+    return CoverageVerdict(COVERAGE_UNKNOWN, "watcher_state_malformed", 0, False)
 
 
 def evaluate_pg_health(db: object, tunnel_open: bool | None) -> PgHealthVerdict:
@@ -469,6 +591,94 @@ class Runtime:
             return now - self.deploy_marker.stat().st_mtime < self.cfg.deploy_quiet_secs
         except OSError:
             return False
+
+    def live_tmux_sessions(self) -> set[str] | None:
+        """Independently enumerate sessions with at least one live pane.
+
+        This intentionally does not consult SessionRegistry/WatcherSupervisor:
+        I2 must still detect their own discovery or reconcile failures.
+        ``None`` means the independent expectation probe itself is unknown.
+        """
+        try:
+            p = subprocess.run(
+                [
+                    "tmux",
+                    "list-panes",
+                    "-a",
+                    "-F",
+                    "#{session_name}\t#{pane_dead}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if p.returncode != 0:
+            error = (p.stderr or p.stdout).lower()
+            if "no server running" in error or "failed to connect to server" in error:
+                return set()
+            return None
+        live: set[str] = set()
+        parsed = 0
+        for line in p.stdout.splitlines():
+            name, separator, pane_dead = line.partition("\t")
+            if not separator or pane_dead not in ("0", "1"):
+                continue
+            parsed += 1
+            if name and pane_dead == "0":
+                live.add(name)
+        if p.stdout.strip() and parsed == 0:
+            return None
+        return live
+
+    def watcher_state(self, channel_id: str) -> WatcherStateProbe:
+        """Read watcher-state without advancing any relay watermark."""
+        url = (
+            f"http://127.0.0.1:{self.cfg.dcserver_port}/api/channels/"
+            f"{channel_id}/watcher-state"
+        )
+        try:
+            p = subprocess.run(
+                [
+                    "curl",
+                    "-sS",
+                    "--max-time",
+                    "4",
+                    "-w",
+                    "\n%{http_code}",
+                    url,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return WatcherStateProbe(None)
+        if p.returncode != 0:
+            return WatcherStateProbe(None)
+        body, separator, status_text = p.stdout.rpartition("\n")
+        if not separator:
+            return WatcherStateProbe(None)
+        try:
+            status = int(status_text)
+        except ValueError:
+            return WatcherStateProbe(None)
+        if status != 200:
+            return WatcherStateProbe(status)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return WatcherStateProbe(200)
+        if not isinstance(payload, dict):
+            return WatcherStateProbe(200)
+        attached = payload.get("attached")
+        desynced = payload.get("desynced")
+        return WatcherStateProbe(
+            200,
+            attached if isinstance(attached, bool) else None,
+            desynced if isinstance(desynced, bool) else None,
+        )
 
     def discord_haystack(self, channel_id: str) -> str | None:
         try:
@@ -796,11 +1006,18 @@ def tick_pg_tunnel(rt: Runtime, state: dict[str, Any], now: float) -> None:
             pgs.pop(key, None)
         return
 
-    cause_text = {
-        PG_TUNNEL_DOWN: (
+    tunnel_closed_text = (
+        "CLOSED — direct-node topology에서는 127.0.0.1:15432 리스너가 "
+        "필수가 아니므로 SSH -L 장애로 단정하지 않음; direct PostgreSQL "
+        "또는 upstream 경로 장애로 판정"
+        if rt.cfg.pg_topology == PG_TOPOLOGY_DIRECT
+        else (
             "CLOSED — 로컬 127.0.0.1:15432 리스너가 없어 "
             "SSH -L supervisor 재기동 루프 실패로 판정"
-        ),
+        )
+    )
+    cause_text = {
+        PG_TUNNEL_DOWN: tunnel_closed_text,
         PG_UPSTREAM_DOWN: (
             "OPEN — 로컬 리스너는 열렸지만 db=false; "
             "half-dead SSH 포워딩 또는 upstream PostgreSQL 장애로 판정"
@@ -865,15 +1082,120 @@ def tick_pg_tunnel(rt: Runtime, state: dict[str, Any], now: float) -> None:
     )
 
 
+def expected_tmux_session_name(ch: ChannelConfig) -> str:
+    """Canonical session name encoded by the configured worktree family."""
+    return f"AgentDesk-{ch.worktree_prefix}"
+
+
+def tick_coverage(
+    rt: Runtime,
+    ch: ChannelConfig,
+    chs: dict[str, Any],
+    now: float,
+) -> None:
+    """Observe I2 only; never repair, return early from, or suppress gap checks."""
+    expected_name = expected_tmux_session_name(ch)
+    live_sessions = rt.live_tmux_sessions()
+    expected_alive = None if live_sessions is None else expected_name in live_sessions
+    probe = (
+        rt.watcher_state(ch.channel_id)
+        if expected_alive is True
+        else WatcherStateProbe(None)
+    )
+    previous = chs.get("coverage_uncovered_ticks", 0)
+    if not isinstance(previous, int) or isinstance(previous, bool):
+        previous = 0
+    verdict = evaluate_coverage(
+        expected_alive,
+        probe.status,
+        probe.attached,
+        probe.desynced,
+        previous,
+    )
+    if verdict.consecutive_uncovered:
+        chs["coverage_uncovered_ticks"] = verdict.consecutive_uncovered
+    else:
+        chs.pop("coverage_uncovered_ticks", None)
+
+    cid = ch.channel_id
+    if verdict.state == COVERAGE_UNKNOWN:
+        rt.log(f"[{cid}] coverage unknown reason={verdict.reason} — no alert")
+        return
+    if verdict.state == COVERAGE_COVERED:
+        if chs.pop("coverage_alerting", None):
+            rt.log(f"[{cid}] coverage restored for {expected_name}")
+        chs.pop("last_coverage_alert", None)
+        return
+
+    if not verdict.confirmed:
+        rt.log(
+            f"[{cid}] coverage uncovered reason={verdict.reason} "
+            f"confirm={verdict.consecutive_uncovered}/{COVERAGE_CONFIRM_TICKS}"
+        )
+        return
+    raw_last_alert = chs.get("last_coverage_alert", 0)
+    last_alert = (
+        float(raw_last_alert)
+        if isinstance(raw_last_alert, (int, float))
+        and not isinstance(raw_last_alert, bool)
+        else 0.0
+    )
+    if now - last_alert < rt.cfg.realert_secs:
+        rt.log(
+            f"[{cid}] coverage violation persists reason={verdict.reason} "
+            "(alert suppressed, coverage cooldown)"
+        )
+        return
+    rt.alert(
+        ch,
+        "🚨 **릴레이 와쳐 커버리지 불변식 위반**\n\n"
+        f"독립 tmux 열거에서 `{expected_name}` 세션의 live pane을 확인했지만 "
+        f"watcher-state가 **{verdict.reason}** 상태입니다.\n"
+        f"`attached=true && desynced=false`가 아닌 상태가 "
+        f"**{verdict.consecutive_uncovered} tick 연속** 관측되었습니다.\n\n"
+        "워치독은 read-only이며 자동 수리를 수행하지 않습니다.\n"
+        f"런타임: {rt.dcserver_snapshot()}",
+    )
+    chs["last_coverage_alert"] = now
+    chs["coverage_alerting"] = True
+    rt.log(
+        f"[{cid}] COVERAGE ALERT session={expected_name} "
+        f"reason={verdict.reason} ticks={verdict.consecutive_uncovered}"
+    )
+
+
 def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
     cfg = rt.cfg
     cid = ch.channel_id
     chs: dict[str, Any] = state.setdefault(cid, {})
 
+    # I2 is intentionally parallel to gap evaluation (#4424): this helper has
+    # no return value that can short-circuit the existing transcript/haystack
+    # verdict path and it owns a separate alert cooldown key.
+    try:
+        tick_coverage(rt, ch, chs, now)
+    except Exception as e:  # noqa: BLE001 — coverage must never suppress gap checks
+        rt.log(f"[{cid}] coverage tick error: {type(e).__name__}: {e}")
+
     pattern = main_channel_project_re(ch.worktree_root, ch.worktree_prefix)
     dirs = channel_project_dirs(projects_root(), pattern)
-    tr = newest_transcript(dirs)
-    idle = (now - tr.stat().st_mtime) if tr else float("inf")
+    candidates = transcript_candidates(dirs)
+    raw_previous_sizes = chs.get("transcript_sizes", {})
+    previous_sizes = {
+        str(path): size
+        for path, size in (
+            raw_previous_sizes.items()
+            if isinstance(raw_previous_sizes, dict)
+            else ()
+        )
+        if isinstance(size, int) and not isinstance(size, bool) and size >= 0
+    }
+    tr = select_watch_transcript(candidates, previous_sizes)
+    chs["transcript_sizes"] = {
+        str(candidate.path): candidate.size for candidate in candidates
+    }
+    selected = next((candidate for candidate in candidates if candidate.path == tr), None)
+    idle = (now - selected.mtime) if selected else float("inf")
     if idle >= cfg.idle_quiet_secs:
         # Stale transcript: any "gap" is historic, not live. Never alert.
         # (No self-uninstall here — see module docstring.)

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -820,15 +820,20 @@ class Runtime:
                 continue
         else:
             bits.append("health UNREACHABLE")
-        try:
-            p = subprocess.run(
-                ["nc", "-z", "-G", "3", "127.0.0.1", "15432"],
-                capture_output=True,
-                timeout=8,
-            )
-            bits.append("pg-tunnel " + ("OPEN" if p.returncode == 0 else "CLOSED"))
-        except (OSError, subprocess.SubprocessError):
-            bits.append("pg-tunnel UNKNOWN")
+        if self.cfg.pg_topology == PG_TOPOLOGY_DIRECT:
+            bits.append("pg-topology DIRECT (15432 listener not expected)")
+        else:
+            try:
+                p = subprocess.run(
+                    ["nc", "-z", "-G", "3", "127.0.0.1", "15432"],
+                    capture_output=True,
+                    timeout=8,
+                )
+                bits.append(
+                    "pg-tunnel " + ("OPEN" if p.returncode == 0 else "CLOSED")
+                )
+            except (OSError, subprocess.SubprocessError):
+                bits.append("pg-tunnel UNKNOWN")
         try:
             p = subprocess.run(
                 ["/bin/ps", "-axo", "pid=,etime=,command="],
@@ -1026,13 +1031,19 @@ def tick_pg_tunnel(rt: Runtime, state: dict[str, Any], now: float) -> None:
             "UNKNOWN — db=false이나 nc 원인 판별자를 실행하지 못함"
         ),
     }[verdict.state]
-    pgs["cause"] = verdict.state
+    cause_state = (
+        "direct_postgres_down"
+        if rt.cfg.pg_topology == PG_TOPOLOGY_DIRECT
+        and verdict.state == PG_TUNNEL_DOWN
+        else verdict.state
+    )
+    pgs["cause"] = cause_state
     if "unhealthy_since" not in pgs:
         pgs["unhealthy_since"] = now
     unhealthy_for = now - float(pgs["unhealthy_since"])
     if unhealthy_for < rt.cfg.pg_alert_after_secs:
         rt.log(
-            f"[pg-tunnel] db=false cause={verdict.state} for "
+            f"[pg-tunnel] db=false cause={cause_state} for "
             f"{int(unhealthy_for)}s (< {rt.cfg.pg_alert_after_secs}s threshold)"
         )
         return
@@ -1040,7 +1051,7 @@ def tick_pg_tunnel(rt: Runtime, state: dict[str, Any], now: float) -> None:
     last_alert = float(pgs.get("last_alert", 0))
     if now - last_alert < rt.cfg.pg_realert_secs:
         rt.log(
-            f"[pg-tunnel] db=false persists cause={verdict.state} "
+            f"[pg-tunnel] db=false persists cause={cause_state} "
             "(alert suppressed, cooldown)"
         )
         return
@@ -1077,7 +1088,7 @@ def tick_pg_tunnel(rt: Runtime, state: dict[str, Any], now: float) -> None:
     pgs.pop("dedup_deferred", None)
     pgs.pop("dcserver_alert_seen", None)
     rt.log(
-        f"[pg-tunnel] ALERT db=false cause={verdict.state} "
+        f"[pg-tunnel] ALERT db=false cause={cause_state} "
         f"duration={int(unhealthy_for)}s"
     )
 
@@ -1123,14 +1134,27 @@ def tick_coverage(
         return
     if verdict.state == COVERAGE_COVERED:
         if chs.pop("coverage_alerting", None):
-            rt.log(f"[{cid}] coverage restored for {expected_name}")
-        chs.pop("last_coverage_alert", None)
+            if verdict.reason == "tmux_not_expected":
+                rt.log(
+                    f"[{cid}] coverage expectation ended for {expected_name} "
+                    "— tmux session no longer live"
+                )
+            else:
+                rt.log(f"[{cid}] coverage restored for {expected_name}")
+        # Keep last_coverage_alert across recovery as an anti-flap cooldown,
+        # matching the independent PG monitor's persistence semantics.
         return
 
     if not verdict.confirmed:
         rt.log(
             f"[{cid}] coverage uncovered reason={verdict.reason} "
             f"confirm={verdict.consecutive_uncovered}/{COVERAGE_CONFIRM_TICKS}"
+        )
+        return
+    if rt.in_deploy_window(now):
+        rt.log(
+            f"[{cid}] coverage violation reason={verdict.reason} suppressed — "
+            f"deploy window (marker < {rt.cfg.deploy_quiet_secs}s old)"
         )
         return
     raw_last_alert = chs.get("last_coverage_alert", 0)
@@ -1155,6 +1179,7 @@ def tick_coverage(
         f"**{verdict.consecutive_uncovered} tick 연속** 관측되었습니다.\n\n"
         "워치독은 read-only이며 자동 수리를 수행하지 않습니다.\n"
         f"런타임: {rt.dcserver_snapshot()}",
+        trigger_turn=False,
     )
     chs["last_coverage_alert"] = now
     chs["coverage_alerting"] = True

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -787,6 +787,37 @@ class RuntimeCoverageProbeTests(unittest.TestCase):
             probe = self.make_rt().watcher_state("999")
         self.assertEqual(probe, WatcherStateProbe(200, None, None))
 
+    def test_direct_node_snapshot_does_not_report_tunnel_closed(self):
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            if argv[0] == "curl":
+                return subprocess.CompletedProcess(
+                    argv,
+                    0,
+                    stdout='{"db":false,"degraded":true}',
+                    stderr="",
+                )
+            if argv[0] == "/bin/ps":
+                return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+            raise AssertionError(f"unexpected direct-node probe: {argv}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = Runtime(
+                Config(
+                    channels=(TICK_CHANNEL,), pg_topology=PG_TOPOLOGY_DIRECT
+                ),
+                Path(tmp),
+            )
+            with mock.patch.object(
+                relay_watchdog.subprocess, "run", side_effect=fake_run
+            ):
+                snapshot = rt.dcserver_snapshot()
+        self.assertIn("pg-topology DIRECT", snapshot)
+        self.assertNotIn("pg-tunnel CLOSED", snapshot)
+        self.assertFalse(any(call[0] == "nc" for call in calls))
+
 
 TICK_CHANNEL = ChannelConfig(
     channel_id="999",
@@ -911,6 +942,13 @@ class TickPgTunnelTests(unittest.TestCase):
         self.assertIn("CLOSED", rt.alerts[0][0])
         self.assertIn("direct-node topology", rt.alerts[0][0])
         self.assertNotIn("SSH -L supervisor 재기동 루프 실패", rt.alerts[0][0])
+        self.assertEqual(state[PG_STATE_KEY]["cause"], "direct_postgres_down")
+        self.assertTrue(any("cause=direct_postgres_down" in l for l in rt.log_lines))
+
+        rt.verdict = evaluate_pg_health(True, None)
+        tick_pg_tunnel(rt, state, self.NOW + 1)
+        self.assertIn("direct_postgres_down", rt.alerts[1][0])
+        self.assertNotIn("tunnel_down", rt.alerts[1][0])
 
     def test_realert_cooldown_boundary_is_exact(self):
         verdict = evaluate_pg_health(False, False)
@@ -1089,6 +1127,53 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
         self.assertIn("watcher_state_404", rt.alerts[0][0])
         self.assertIn("read-only", rt.alerts[0][0])
+        self.assertFalse(
+            rt.alerts[0][1], "read-only coverage alerts must not trigger a turn"
+        )
+
+    def test_coverage_alert_is_suppressed_during_deploy_window(self):
+        rt = self.make_rt()
+        self.arm_coverage(rt, WatcherStateProbe(404))
+        rt.deploy_marker.touch()
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("last_coverage_alert", state["999"])
+        self.assertTrue(any("deploy window" in l for l in rt.log_lines))
+
+    def test_coverage_recovery_keeps_antiflap_cooldown(self):
+        rt = self.make_rt()
+        self.arm_coverage(rt, WatcherStateProbe(404))
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        first_alert_at = self.now + rt.cfg.poll_secs
+        tick_channel(rt, TICK_CHANNEL, state, first_alert_at)
+        self.assertEqual(len(rt.alerts), 1)
+
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
+        tick_channel(rt, TICK_CHANNEL, state, first_alert_at + rt.cfg.poll_secs)
+        self.assertEqual(state["999"]["last_coverage_alert"], first_alert_at)
+
+        rt.watcher_probe = WatcherStateProbe(404)
+        tick_channel(rt, TICK_CHANNEL, state, first_alert_at + 2 * rt.cfg.poll_secs)
+        tick_channel(rt, TICK_CHANNEL, state, first_alert_at + 3 * rt.cfg.poll_secs)
+        self.assertEqual(
+            len(rt.alerts), 1, "flapping must not bypass the 900s cooldown"
+        )
+
+    def test_tmux_death_ends_expectation_without_claiming_recovery(self):
+        rt = self.make_rt()
+        state = {
+            "999": {
+                "coverage_alerting": True,
+                "last_coverage_alert": self.now - 60,
+                "coverage_uncovered_ticks": 2,
+            }
+        }
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertTrue(any("expectation ended" in l for l in rt.log_lines))
+        self.assertFalse(any("coverage restored" in l for l in rt.log_lines))
+        self.assertEqual(state["999"]["last_coverage_alert"], self.now - 60)
 
     def test_dcserver_unreachable_never_advances_coverage_alert(self):
         rt = self.make_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -23,8 +23,13 @@ from unittest import mock
 
 import scripts.relay_watchdog as relay_watchdog
 from scripts.relay_watchdog import (
+    COVERAGE_CONFIRM_TICKS,
+    COVERAGE_COVERED,
+    COVERAGE_UNCOVERED,
+    COVERAGE_UNKNOWN,
     PG_OK,
     PG_STATE_KEY,
+    PG_TOPOLOGY_DIRECT,
     PG_TUNNEL_DOWN,
     PG_UNCLASSIFIED_DOWN,
     PG_UNKNOWN,
@@ -36,11 +41,15 @@ from scripts.relay_watchdog import (
     Config,
     ConfigError,
     Runtime,
+    TranscriptCandidate,
+    WatcherStateProbe,
     assistant_blocks_from_lines,
     channel_project_dirs,
     delivered,
     evaluate,
+    evaluate_coverage,
     evaluate_pg_health,
+    expected_tmux_session_name,
     load_state,
     main_channel_project_re,
     newest_transcript,
@@ -49,6 +58,7 @@ from scripts.relay_watchdog import (
     parse_transcript_ts,
     project_slug,
     save_state,
+    select_watch_transcript,
     tick_channel,
     tick_pg_tunnel,
 )
@@ -143,6 +153,30 @@ class ProjectDirMatchingTests(unittest.TestCase):
 
 
 class TranscriptResolutionTests(unittest.TestCase):
+    def test_growth_beats_newer_mtime(self):
+        growing = TranscriptCandidate(Path("/tmp/growing.jsonl"), 101, 100.0)
+        newer_stagnant = TranscriptCandidate(
+            Path("/tmp/newer-stagnant.jsonl"), 200, 200.0
+        )
+        selected = select_watch_transcript(
+            [growing, newer_stagnant],
+            {str(growing.path): 100, str(newer_stagnant.path): 200},
+        )
+        self.assertEqual(selected, growing.path)
+
+    def test_no_growth_falls_back_to_newest_mtime(self):
+        older = TranscriptCandidate(Path("/tmp/older.jsonl"), 100, 100.0)
+        newer = TranscriptCandidate(Path("/tmp/newer.jsonl"), 200, 200.0)
+        selected = select_watch_transcript(
+            [older, newer], {str(older.path): 100, str(newer.path): 200}
+        )
+        self.assertEqual(selected, newer.path)
+
+    def test_first_observation_uses_mtime_fallback(self):
+        older = TranscriptCandidate(Path("/tmp/older.jsonl"), 100, 100.0)
+        newer = TranscriptCandidate(Path("/tmp/newer.jsonl"), 1, 200.0)
+        self.assertEqual(select_watch_transcript([older, newer], {}), newer.path)
+
     def test_newest_transcript_ignores_thread_dirs_and_picks_latest(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -305,6 +339,56 @@ class EvaluateBoundaryTests(unittest.TestCase):
         self.assertEqual(v.state, STATE_OK)
 
 
+class CoverageEvaluationTests(unittest.TestCase):
+    def test_live_expected_session_with_healthy_watcher_is_covered(self):
+        verdict = evaluate_coverage(True, 200, True, False, 1)
+        self.assertEqual(verdict.state, COVERAGE_COVERED)
+        self.assertEqual(verdict.consecutive_uncovered, 0)
+        self.assertFalse(verdict.confirmed)
+
+    def test_authoritative_404_confirms_on_exactly_second_tick(self):
+        first = evaluate_coverage(True, 404, None, None, 0)
+        self.assertEqual(first.state, COVERAGE_UNCOVERED)
+        self.assertEqual(first.consecutive_uncovered, 1)
+        self.assertFalse(first.confirmed)
+
+        second = evaluate_coverage(
+            True, 404, None, None, first.consecutive_uncovered
+        )
+        self.assertEqual(second.consecutive_uncovered, COVERAGE_CONFIRM_TICKS)
+        self.assertTrue(second.confirmed)
+
+    def test_dcserver_unreachable_is_unknown_and_resets_confirmation(self):
+        verdict = evaluate_coverage(True, None, None, None, 1)
+        self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
+        self.assertEqual(verdict.reason, "dcserver_unreachable")
+        self.assertEqual(verdict.consecutive_uncovered, 0)
+        self.assertFalse(verdict.confirmed)
+
+    def test_single_detached_tick_never_confirms(self):
+        verdict = evaluate_coverage(True, 200, False, False, 0)
+        self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(verdict.consecutive_uncovered, 1)
+        self.assertFalse(verdict.confirmed)
+
+    def test_attached_but_desynced_is_phantom_coverage(self):
+        verdict = evaluate_coverage(True, 200, True, True, 1)
+        self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(verdict.reason, "attached_but_desynced")
+        self.assertTrue(verdict.confirmed)
+
+    def test_dead_expected_session_is_left_to_stall_watchdog(self):
+        verdict = evaluate_coverage(False, 200, False, True, 1)
+        self.assertEqual(verdict.state, COVERAGE_COVERED)
+        self.assertEqual(verdict.reason, "tmux_not_expected")
+        self.assertFalse(verdict.confirmed)
+
+    def test_malformed_200_is_unknown_not_uncovered(self):
+        verdict = evaluate_coverage(True, 200, None, None, 1)
+        self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
+        self.assertEqual(verdict.consecutive_uncovered, 0)
+
+
 class PgHealthEvaluationTests(unittest.TestCase):
     def test_db_true_is_authoritative_even_without_listener_probe(self):
         self.assertEqual(evaluate_pg_health(True, None).state, PG_OK)
@@ -429,6 +513,29 @@ class ConfigTests(unittest.TestCase):
             )
             with self.assertRaises(ConfigError):
                 relay_watchdog.load_config(p)
+
+
+class PgTopologyConfigTests(unittest.TestCase):
+    BASE = {
+        "channels": [
+            {
+                "channel_id": "123",
+                "sendmessage_key": "k",
+                "worktree_root": WORKTREE_ROOT,
+            }
+        ]
+    }
+
+    def test_topology_defaults_to_tunnel_for_existing_configs(self):
+        self.assertEqual(parse_config(self.BASE).pg_topology, "tunnel")
+
+    def test_direct_topology_is_accepted(self):
+        cfg = parse_config({**self.BASE, "pg_topology": "direct"})
+        self.assertEqual(cfg.pg_topology, PG_TOPOLOGY_DIRECT)
+
+    def test_unknown_topology_is_config_error(self):
+        with self.assertRaises(ConfigError):
+            parse_config({**self.BASE, "pg_topology": "auto"})
 
 
 class DiscordHaystackShapeTests(unittest.TestCase):
@@ -606,6 +713,81 @@ class RuntimePgProbeTests(unittest.TestCase):
             self.assertFalse(rt.recent_dcserver_pg_alert(1001))
 
 
+class RuntimeCoverageProbeTests(unittest.TestCase):
+    def make_rt(self) -> Runtime:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        return Runtime(Config(channels=(TICK_CHANNEL,)), Path(self._tmp.name))
+
+    def test_tmux_enumeration_includes_only_sessions_with_live_panes(self):
+        stdout = (
+            "AgentDesk-claude-adk-cc\t0\n"
+            "AgentDesk-codex-adk-cdx\t1\n"
+            "AgentDesk-mixed\t1\n"
+            "AgentDesk-mixed\t0\n"
+        )
+        completed = subprocess.CompletedProcess(
+            ["tmux"], 0, stdout=stdout, stderr=""
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            sessions = self.make_rt().live_tmux_sessions()
+        self.assertEqual(
+            sessions, {"AgentDesk-claude-adk-cc", "AgentDesk-mixed"}
+        )
+
+    def test_tmux_probe_failure_is_unknown(self):
+        completed = subprocess.CompletedProcess(
+            ["tmux"], 2, stdout="", stderr="permission denied"
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            self.assertIsNone(self.make_rt().live_tmux_sessions())
+
+    def test_no_tmux_server_is_authoritative_empty_set(self):
+        completed = subprocess.CompletedProcess(
+            ["tmux"], 1, stdout="", stderr="no server running on /tmp/tmux"
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            self.assertEqual(self.make_rt().live_tmux_sessions(), set())
+
+    def test_watcher_state_404_is_preserved_as_uncovered_evidence(self):
+        completed = subprocess.CompletedProcess(
+            ["curl"],
+            0,
+            stdout='{"error":"missing"}\n404',
+            stderr="",
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            probe = self.make_rt().watcher_state("999")
+        self.assertEqual(probe, WatcherStateProbe(404))
+
+    def test_watcher_state_unreachable_is_unknown(self):
+        completed = subprocess.CompletedProcess(
+            ["curl"], 7, stdout="\n000", stderr="connect failed"
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            probe = self.make_rt().watcher_state("999")
+        self.assertEqual(probe, WatcherStateProbe(None))
+
+    def test_watcher_state_parses_exact_boolean_contract(self):
+        completed = subprocess.CompletedProcess(
+            ["curl"],
+            0,
+            stdout='{"attached":true,"desynced":false}\n200',
+            stderr="",
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            probe = self.make_rt().watcher_state("999")
+        self.assertEqual(probe, WatcherStateProbe(200, True, False))
+
+    def test_watcher_state_malformed_200_keeps_status_but_not_claims(self):
+        completed = subprocess.CompletedProcess(
+            ["curl"], 0, stdout='{"attached":"true"}\n200', stderr=""
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            probe = self.make_rt().watcher_state("999")
+        self.assertEqual(probe, WatcherStateProbe(200, None, None))
+
+
 TICK_CHANNEL = ChannelConfig(
     channel_id="999",
     sendmessage_key="k",
@@ -623,12 +805,22 @@ class FakeRuntime(Runtime):
         self.log_lines: list[str] = []
         self.haystack: str | None = ""
         self.issue_calls = 0
+        self.live_sessions: set[str] | None = set()
+        self.watcher_probe = WatcherStateProbe(None)
+        self.watcher_calls = 0
 
     def log(self, msg: str) -> None:
         self.log_lines.append(msg)
 
     def discord_haystack(self, channel_id: str) -> str | None:
         return self.haystack
+
+    def live_tmux_sessions(self) -> set[str] | None:
+        return self.live_sessions
+
+    def watcher_state(self, channel_id: str) -> WatcherStateProbe:
+        self.watcher_calls += 1
+        return self.watcher_probe
 
     def dcserver_snapshot(self) -> str:
         return "stub-snapshot"
@@ -642,12 +834,20 @@ class FakeRuntime(Runtime):
 
 
 class FakePgRuntime(Runtime):
-    def __init__(self, verdict, *, after: int = 300, cooldown: int = 900) -> None:
+    def __init__(
+        self,
+        verdict,
+        *,
+        after: int = 300,
+        cooldown: int = 900,
+        topology: str = "tunnel",
+    ) -> None:
         self._tmp = tempfile.TemporaryDirectory()
         cfg = Config(
             channels=(TICK_CHANNEL,),
             pg_alert_after_secs=after,
             pg_realert_secs=cooldown,
+            pg_topology=topology,
         )
         super().__init__(cfg, Path(self._tmp.name))
         self.verdict = verdict
@@ -700,6 +900,17 @@ class TickPgTunnelTests(unittest.TestCase):
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("OPEN", rt.alerts[0][0])
         self.assertIn("half-dead", rt.alerts[0][0])
+
+    def test_direct_node_closed_wording_does_not_blame_ssh_supervisor(self):
+        rt = self.make_rt(
+            evaluate_pg_health(False, False), topology=PG_TOPOLOGY_DIRECT
+        )
+        state = {PG_STATE_KEY: {"unhealthy_since": self.NOW - 300}}
+        tick_pg_tunnel(rt, state, self.NOW)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("CLOSED", rt.alerts[0][0])
+        self.assertIn("direct-node topology", rt.alerts[0][0])
+        self.assertNotIn("SSH -L supervisor 재기동 루프 실패", rt.alerts[0][0])
 
     def test_realert_cooldown_boundary_is_exact(self):
         verdict = evaluate_pg_health(False, False)
@@ -812,6 +1023,126 @@ class TickChannelTests(unittest.TestCase):
         rt = self.make_rt(**cfg_overrides)
         rt.haystack = ""
         return rt
+
+    def arm_coverage(
+        self, rt: FakeRuntime, probe: WatcherStateProbe
+    ) -> None:
+        rt.live_sessions = {expected_tmux_session_name(TICK_CHANNEL)}
+        rt.watcher_probe = probe
+
+    def test_growth_aware_selector_is_wired_into_tick(self):
+        growing = self.proj_dir / "growing.jsonl"
+        stagnant_dir = self.projects / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260710-140500"
+        )
+        stagnant_dir.mkdir()
+        stagnant = stagnant_dir / "stagnant.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        growing.write_text(
+            record(self.now - 2000, "missing from older growing transcript") + "\n",
+            encoding="utf-8",
+        )
+        stagnant.write_text(
+            record(self.now - 2000, "newer stagnant block landed") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(growing, (self.now - 100, self.now - 100))
+        os.utime(stagnant, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("newer stagnant block landed")
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [], "first tick must use mtime fallback")
+
+        with growing.open("a", encoding="utf-8") as f:
+            f.write("\n")
+        # Keep the growing file's mtime older than the stagnant candidate: only
+        # size growth can make it win on the second tick.
+        os.utime(growing, (self.now - 50, self.now - 50))
+        os.utime(stagnant, (self.now, self.now))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+
+    def test_coverage_404_alerts_only_after_two_consecutive_ticks(self):
+        rt = self.make_rt()
+        self.arm_coverage(rt, WatcherStateProbe(404))
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"]["coverage_uncovered_ticks"], 1)
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + rt.cfg.poll_secs)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
+        self.assertIn("watcher_state_404", rt.alerts[0][0])
+        self.assertIn("read-only", rt.alerts[0][0])
+
+    def test_dcserver_unreachable_never_advances_coverage_alert(self):
+        rt = self.make_rt()
+        self.arm_coverage(rt, WatcherStateProbe(None))
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + rt.cfg.poll_secs)
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("coverage_uncovered_ticks", state["999"])
+        self.assertTrue(any("dcserver_unreachable" in l for l in rt.log_lines))
+
+    def test_covered_tick_breaks_uncovered_continuity(self):
+        rt = self.make_rt()
+        self.arm_coverage(rt, WatcherStateProbe(404))
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        rt.watcher_probe = WatcherStateProbe(200, True, False)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        rt.watcher_probe = WatcherStateProbe(404)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"]["coverage_uncovered_ticks"], 1)
+
+    def test_coverage_alert_cannot_suppress_gap_alert_in_same_tick(self):
+        rt = self.gap_rt()
+        self.arm_coverage(rt, WatcherStateProbe(404))
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(len(rt.alerts), 2)
+        bodies = [body for body, _ in rt.alerts]
+        self.assertTrue(any("커버리지 불변식 위반" in body for body in bodies))
+        self.assertTrue(any("릴레이 갭 감지" in body for body in bodies))
+        self.assertIn("last_coverage_alert", state["999"])
+        self.assertIn("last_alert", state["999"])
+
+    def test_coverage_probe_exception_cannot_suppress_gap_alert(self):
+        rt = self.gap_rt()
+        with mock.patch.object(
+            rt, "live_tmux_sessions", side_effect=RuntimeError("probe broke")
+        ):
+            tick_channel(rt, TICK_CHANNEL, {}, self.now)
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertTrue(any("coverage tick error" in l for l in rt.log_lines))
+
+    def test_corrupt_growth_state_fails_open_to_mtime_fallback(self):
+        self.write_transcript([(self.now - 60, "fresh block")])
+        rt = self.make_rt()
+        rt.haystack = norm("fresh block")
+        transcript = self.proj_dir / "s.jsonl"
+        state = {"999": {"transcript_sizes": {str(transcript): "not-an-int"}}}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+        self.assertIsInstance(state["999"]["transcript_sizes"][str(transcript)], int)
 
     # (a) deploy-window suppression — REAL in_deploy_window runs against a real
     # marker file, so replacing it with `return False` fails this test.


### PR DESCRIPTION
## Summary

- Replace mtime-only transcript choice with pure `select_watch_transcript`: files proven to have grown since the prior tick win; otherwise the existing newest-mtime behavior remains.
- Add pure `evaluate_coverage` and independent tmux/API probes for I2. A live deterministic tmux session must have `attached=true && desynced=false`; an uncovered state alerts only after two consecutive ticks.
- Keep coverage judgment isolated from the existing transcript/Discord gap judgment, including separate cooldown state and exception isolation. Coverage cannot suppress a gap alert.
- Add `pg_topology=direct` CLOSED diagnostics without blaming an SSH tunnel on direct-PG nodes.
- Keep the watchdog read-only: coverage alerts use direct Discord delivery and do not trigger a target-agent turn or attempt repair.

## I2 invariant / state transitions

| Independent E (tmux live pane) | watcher-state evidence | Verdict | Counter / action |
| --- | --- | --- | --- |
| unknown | any | `unknown` | reset; no alert |
| false | any | `covered` (`tmux_not_expected`) | reset; reverse/dead-session case remains owned by stall watchdog |
| true | dcserver unreachable, non-200/404, or malformed 200 | `unknown` | reset; no alert |
| true | HTTP 404 | `uncovered` | increment; alert at tick 2 |
| true | 200 + `attached=false` | `uncovered` | increment; alert at tick 2 |
| true | 200 + `attached=true, desynced=true` | `uncovered` (phantom attach) | increment; alert at tick 2 |
| true | 200 + `attached=true, desynced=false` | `covered` | reset; preserve anti-flap alert cooldown |

Confirmed violations are suppressed during the deploy marker window and alert on the first eligible post-window tick. The coverage cooldown key is independent from the existing gap cooldown key.

## Mutation evidence (after implementation commit, then restored)

- m1 growth priority removed: `rc=1`; `test_growth_beats_newer_mtime` and tick wiring both failed by assertion.
- m2 confirmation boundary `>= 2` changed to `> 2`: `rc=1`; pure boundary and two-tick wiring both failed by assertion.
- m3 dcserver unreachable collapsed from `unknown` to `uncovered`: `rc=1`; fail-closed state assertion failed.
- m4 consecutive gate removed: `rc=1`; single-tick pure and wiring assertions both failed.
- Restore: 105 tests `rc=0`; `git diff --exit-code` against the implementation commit `rc=0`.

## Gates (final commit)

- `PATH=/opt/homebrew/bin:$PATH python3 -m unittest tests.test_relay_watchdog` — 109 tests, `rc=0`
- `PATH=/opt/homebrew/bin:$PATH python3 scripts/generate_inventory_docs.py` — `rc=0`
- `PATH=/opt/homebrew/bin:$PATH python3 scripts/check_agent_maintenance_docs.py` — `rc=0`, `agent-maintenance freshness check passed`
- `PATH=/opt/homebrew/bin:$PATH scripts/ci-script-checks.sh` — `rc=0`
- `PATH=/opt/homebrew/bin:$PATH cargo fmt --check` — `rc=0`
- CI reachability verified: `ci-pr.yml` runs `scripts/ci-script-checks.sh`, which directly runs `tests.test_relay_watchdog`.
- Independent Opus adversarial review: first round found five alert-semantics issues; all fixed and final re-review returned `VERDICT: CLEAN`.

## Scope / design

- Changed only `scripts/relay_watchdog.py` and `tests/test_relay_watchdog.py`; no new repository files and no `.rs` changes.
- Material design deviation: none. Review-driven hardening (deploy suppression, anti-flap persistence, non-triggering read-only alert) tightens the recommended fail-closed/read-only behavior.
- I1 selector-binding/Rust work is intentionally excluded because it overlaps #4299 and remains a follow-up PR.

Refs #4408 (phase 1: F+I2; I1 Rust는 후속)
