### PR TITLE
feat(health,watchdog): surface bound selector + I1 sync invariant (#4408 phase 2)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -252,7 +252,7 @@
 | `server::routes::docs::inventory::endpoints::part_04` | `src/server/routes/docs/inventory/endpoints/part_04.rs` | 719 | 719 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_05` | `src/server/routes/docs/inventory/endpoints/part_05.rs` | 719 | 719 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_06` | `src/server/routes/docs/inventory/endpoints/part_06.rs` | 749 | 749 | 0 |  |
-| `server::routes::docs::inventory::endpoints::part_07` | `src/server/routes/docs/inventory/endpoints/part_07.rs` | 671 | 671 | 0 |  |
+| `server::routes::docs::inventory::endpoints::part_07` | `src/server/routes/docs/inventory/endpoints/part_07.rs` | 679 | 679 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_08` | `src/server/routes/docs/inventory/endpoints/part_08.rs` | 739 | 739 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_09` | `src/server/routes/docs/inventory/endpoints/part_09.rs` | 113 | 113 | 0 |  |
 | `server::routes::docs::taxonomy` | `src/server/routes/docs/taxonomy.rs` | 256 | 256 | 0 |  |
@@ -471,13 +471,13 @@
 | `services::discord::health::recovery::leak_recovery_ledger` | `src/services/discord/health/recovery/leak_recovery_ledger.rs` | 370 | 370 | 0 |  |
 | `services::discord::health::recovery::watchdog_decisions` | `src/services/discord/health/recovery/watchdog_decisions.rs` | 296 | 296 | 0 |  |
 | `services::discord::health::redaction` | `src/services/discord/health/redaction.rs` | 33 | 23 | 10 |  |
-| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1732 | 666 | 1066 |  |
-| `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 268 | 101 | 167 |  |
+| `services::discord::health::relay_auto_heal` | `src/services/discord/health/relay_auto_heal.rs` | 1734 | 666 | 1068 |  |
+| `services::discord::health::relay_dead_reattach` | `src/services/discord/health/relay_dead_reattach.rs` | 270 | 101 | 169 |  |
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
-| `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1071 | 893 | 178 |  |
-| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2357 | 965 | 1392 |  |
-| `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1382 | 627 | 755 |  |
+| `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1231 | 963 | 268 |  |
+| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2359 | 965 | 1394 |  |
+| `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1384 | 627 | 757 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |
 | `services::discord::idle_recap` | `src/services/discord/idle_recap.rs` | 2586 | 1374 | 1212 | giant-file |
@@ -615,7 +615,7 @@
 | `services::discord::router::intake_gate::node_override_routing` | `src/services/discord/router/intake_gate/node_override_routing.rs` | 63 | 63 | 0 |  |
 | `services::discord::router::intake_gate::queue_effects` | `src/services/discord/router/intake_gate/queue_effects.rs` | 953 | 745 | 208 |  |
 | `services::discord::router::intake_gate::reaction_remove` | `src/services/discord/router/intake_gate/reaction_remove.rs` | 226 | 226 | 0 |  |
-| `services::discord::router::intake_gate::stale_turn` | `src/services/discord/router/intake_gate/stale_turn.rs` | 630 | 283 | 347 |  |
+| `services::discord::router::intake_gate::stale_turn` | `src/services/discord/router/intake_gate/stale_turn.rs` | 632 | 283 | 349 |  |
 | `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 832 | 474 | 358 |  |
 | `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 83 | 83 | 0 |  |
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1247,9 +1247,9 @@ def tick_coverage(
         f"watcher-state가 **{verdict.reason}** 상태입니다.\n"
         f"`attached=true && desynced=false`가 아닌 상태가 "
         f"**{verdict.consecutive_uncovered} tick 연속** 관측되었습니다.\n\n"
-        "워치독은 read-only이며 자동 수리를 수행하지 않습니다.\n"
+        "워치독은 read-only이며 자동 수리를 수행하지 않습니다 — 이 알람을 받은 "
+        "에이전트가 조치해야 합니다.\n"
         f"런타임: {rt.dcserver_snapshot()}",
-        trigger_turn=False,
     )
     chs["last_coverage_alert"] = now
     chs["coverage_alerting"] = True
@@ -1341,9 +1341,9 @@ def tick_selector_sync(
         "1. `sessions` 테이블에서 해당 채널 행의 output_path/session_id를 성장 중인 "
         "트랜스크립트로 `UPDATE`.\n"
         "2. `POST /api/inflight/rebind` 로 inflight 바인딩을 성장 중인 트랜스크립트로 재지정.\n\n"
-        "워치독은 read-only이며 자동 수리를 수행하지 않습니다.\n"
+        "워치독은 read-only이며 자동 수리를 수행하지 않습니다 — 이 알람을 받은 "
+        "에이전트가 조치해야 합니다.\n"
         f"런타임: {rt.dcserver_snapshot()}",
-        trigger_turn=False,
     )
     chs["last_selector_alert"] = now
     chs["selector_alerting"] = True

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -80,6 +80,15 @@ COVERAGE_UNCOVERED = "uncovered"
 COVERAGE_UNKNOWN = "unknown"
 COVERAGE_CONFIRM_TICKS = 2
 
+# Independent selector-sync states (#4408 phase 2, I1).  Compares the dcserver's
+# asserted relay bind (B = watcher-state `bound_output_path`) against the
+# watchdog's own growth-aware transcript pick (F).  Fail-closed: a missing/null
+# bind is UNKNOWN and never an alarm.  Evaluated in parallel with the gap and
+# coverage judgments; it must never suppress or replace either.
+SELECTOR_SYNCED = "synced"
+SELECTOR_DIVERGED = "diverged"
+SELECTOR_UNKNOWN = "unknown"
+
 PG_TOPOLOGY_TUNNEL = "tunnel"
 PG_TOPOLOGY_DIRECT = "direct"
 
@@ -157,6 +166,12 @@ class Config:
     # drill; the deploy does not ship machine-local config values.
     pg_alert_after_secs: int = 300
     pg_realert_secs: int = 900
+    # #4408 phase-2 (I1): a selector divergence (dcserver bound to a different
+    # transcript than the one actually growing) must persist at least this long
+    # before it alarms, so a legitimate post-swap rebind lag — the server still
+    # briefly bound to the pre-swap transcript — is not misread as a stuck relay
+    # tail. The deploy does not ship machine-local overrides.
+    swap_confirm_secs: int = 300
 
 
 class ConfigError(Exception):
@@ -202,6 +217,7 @@ def parse_config(raw: dict[str, Any]) -> Config:
         "dcserver_port",
         "pg_alert_after_secs",
         "pg_realert_secs",
+        "swap_confirm_secs",
     ):
         if key in raw:
             # A malformed number must surface as ConfigError, never ValueError:
@@ -222,7 +238,7 @@ def parse_config(raw: dict[str, Any]) -> Config:
             "config field 'pg_topology' must be 'tunnel' or 'direct'"
         )
     kwargs["pg_topology"] = pg_topology
-    for key in ("pg_alert_after_secs", "pg_realert_secs"):
+    for key in ("pg_alert_after_secs", "pg_realert_secs", "swap_confirm_secs"):
         if key in kwargs and kwargs[key] <= 0:
             raise ConfigError(f"config field {key!r} must be greater than zero")
     return Config(channels=tuple(channels), **kwargs)
@@ -417,10 +433,24 @@ class CoverageVerdict:
 
 
 @dataclass(frozen=True)
+class SelectorVerdict:
+    state: str
+    reason: str
+    # Raw B != F with F growing, independent of the swap-confirm age gate.  The
+    # caller persists a divergence-start timestamp keyed off this flag, then
+    # applies :func:`selector_divergence_confirmed` before alarming.
+    diverged: bool
+
+
+@dataclass(frozen=True)
 class WatcherStateProbe:
     status: int | None
     attached: bool | None = None
     desynced: bool | None = None
+    # #4408 phase-2 (I1): the transcript path the dcserver asserts its relay tail
+    # is bound to (`bound_output_path`). `None` means an old server without the
+    # field, a JSON null, or a non-200 response — all fail-closed to no alarm.
+    bound_output_path: str | None = None
 
 
 def evaluate_coverage(
@@ -469,6 +499,44 @@ def evaluate_coverage(
     if attached is True and desynced is True:
         return uncovered("attached_but_desynced")
     return CoverageVerdict(COVERAGE_UNKNOWN, "watcher_state_malformed", 0, False)
+
+
+def evaluate_selector_sync(
+    bound_output_path: str | None,
+    selected_transcript: str | None,
+    f_growing: bool,
+) -> "SelectorVerdict":
+    """Pure I1 judgment: does the dcserver's asserted relay bind match F?
+
+    ``B`` is ``bound_output_path`` from watcher-state; ``F`` is the watchdog's
+    own growth-aware transcript pick.  A missing/null ``B`` means an old server
+    that does not expose the bind — fail closed to UNKNOWN, never an alarm.  When
+    ``F`` is not growing there is no proof ``F`` is the live transcript, so a
+    mismatch is not actionable.  A raw divergence (``diverged``) is ``B != F``
+    with ``F`` growing; the time-based swap-confirm gate is applied separately by
+    :func:`selector_divergence_confirmed` so the caller can persist the window.
+    """
+    if bound_output_path is None:
+        return SelectorVerdict(SELECTOR_UNKNOWN, "bound_output_path_absent", False)
+    if not selected_transcript:
+        return SelectorVerdict(SELECTOR_UNKNOWN, "no_transcript", False)
+    if bound_output_path == selected_transcript:
+        return SelectorVerdict(SELECTOR_SYNCED, "selector_synced", False)
+    if not f_growing:
+        return SelectorVerdict(SELECTOR_SYNCED, "f_not_growing", False)
+    return SelectorVerdict(SELECTOR_DIVERGED, "selector_diverged", True)
+
+
+def selector_divergence_confirmed(
+    diverged: bool, divergence_age_secs: float, swap_confirm_secs: int
+) -> bool:
+    """A raw selector divergence only alarms after it persists ``swap_confirm_secs``.
+
+    During a legitimate transcript swap the server can still be bound to the
+    pre-swap transcript for a moment while it rebinds; gating on the divergence
+    age prevents that transient from being misread as a stuck relay tail.
+    """
+    return diverged and divergence_age_secs >= swap_confirm_secs
 
 
 def evaluate_pg_health(db: object, tunnel_open: bool | None) -> PgHealthVerdict:
@@ -674,10 +742,12 @@ class Runtime:
             return WatcherStateProbe(200)
         attached = payload.get("attached")
         desynced = payload.get("desynced")
+        bound_output_path = payload.get("bound_output_path")
         return WatcherStateProbe(
             200,
             attached if isinstance(attached, bool) else None,
             desynced if isinstance(desynced, bool) else None,
+            bound_output_path if isinstance(bound_output_path, str) else None,
         )
 
     def discord_haystack(self, channel_id: str) -> str | None:
@@ -1189,6 +1259,99 @@ def tick_coverage(
     )
 
 
+def tick_selector_sync(
+    rt: Runtime,
+    ch: ChannelConfig,
+    chs: dict[str, Any],
+    selected_transcript: Path | None,
+    f_growing: bool,
+    now: float,
+) -> None:
+    """Observe I1 (selector sync) only; never repair or suppress gap/I2 checks.
+
+    B is the dcserver's asserted relay bind (``bound_output_path`` from
+    watcher-state).  F is the watchdog's own growth-aware transcript pick.  When
+    the server is bound to a different transcript than the one actually growing
+    and stays diverged past ``swap_confirm_secs``, the relay tail is stuck on a
+    dead transcript (the #4423 selector-swap blind spot) → out-of-band alarm.
+    Owns a private ``selector_*`` cooldown/window key so it cannot perturb the
+    gap or coverage state machines.
+    """
+    cid = ch.channel_id
+    if not f_growing or not selected_transcript:
+        # No growing live transcript to compare against — a mismatch is not
+        # actionable, and any pending divergence window is stale.  Skip the HTTP
+        # probe entirely (matches tick_coverage's probe-only-when-needed shape).
+        chs.pop("selector_diverged_since", None)
+        return
+
+    probe = rt.watcher_state(cid)
+    bound = probe.bound_output_path if probe.status == 200 else None
+    verdict = evaluate_selector_sync(bound, str(selected_transcript), f_growing)
+
+    if not verdict.diverged:
+        chs.pop("selector_diverged_since", None)
+        if verdict.state == SELECTOR_UNKNOWN:
+            # Fail-closed: old server without the field, JSON null, or dcserver
+            # unreachable → never alarm on an unknown bind.
+            rt.log(f"[{cid}] selector-sync unknown reason={verdict.reason} — no alert")
+        elif chs.pop("selector_alerting", None):
+            rt.log(f"[{cid}] selector-sync restored (B==F) reason={verdict.reason}")
+        return
+
+    raw_since = chs.get("selector_diverged_since")
+    if isinstance(raw_since, (int, float)) and not isinstance(raw_since, bool):
+        since = float(raw_since)
+    else:
+        since = now
+    chs["selector_diverged_since"] = since
+    age = now - since
+    if not selector_divergence_confirmed(verdict.diverged, age, rt.cfg.swap_confirm_secs):
+        rt.log(
+            f"[{cid}] selector-sync diverged B={bound!r} F={selected_transcript} "
+            f"age={int(age)}s (< {rt.cfg.swap_confirm_secs}s swap-confirm — not yet alarmed)"
+        )
+        return
+    if rt.in_deploy_window(now):
+        rt.log(
+            f"[{cid}] selector-sync divergence suppressed — deploy window "
+            f"(marker < {rt.cfg.deploy_quiet_secs}s old)"
+        )
+        return
+    raw_last_alert = chs.get("last_selector_alert", 0)
+    last_alert = (
+        float(raw_last_alert)
+        if isinstance(raw_last_alert, (int, float)) and not isinstance(raw_last_alert, bool)
+        else 0.0
+    )
+    if now - last_alert < rt.cfg.realert_secs:
+        rt.log(
+            f"[{cid}] selector-sync divergence persists B={bound!r} "
+            "(alert suppressed, selector cooldown)"
+        )
+        return
+    rt.alert(
+        ch,
+        "🚨 **릴레이 셀렉터 동기화 불변식 위반 (I1)**\n\n"
+        f"dcserver는 릴레이 tail을 `{bound}`에 바인딩하고 있으나, 실제로 성장 중인 "
+        f"트랜스크립트는 `{selected_transcript}` 입니다.\n"
+        f"이 불일치가 **{int(age)}초**(swap-confirm {rt.cfg.swap_confirm_secs}s 초과) 지속 — "
+        "세션 스왑 후 릴레이 tail이 죽은 트랜스크립트에 고착된 상태입니다 (#4423 blind spot).\n\n"
+        "복구 런북 (#4423):\n"
+        "1. `sessions` 테이블에서 해당 채널 행의 output_path/session_id를 성장 중인 "
+        "트랜스크립트로 `UPDATE`.\n"
+        "2. `POST /api/inflight/rebind` 로 inflight 바인딩을 성장 중인 트랜스크립트로 재지정.\n\n"
+        "워치독은 read-only이며 자동 수리를 수행하지 않습니다.\n"
+        f"런타임: {rt.dcserver_snapshot()}",
+        trigger_turn=False,
+    )
+    chs["last_selector_alert"] = now
+    chs["selector_alerting"] = True
+    rt.log(
+        f"[{cid}] SELECTOR ALERT B={bound!r} F={selected_transcript} age={int(age)}s"
+    )
+
+
 def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
     cfg = rt.cfg
     cid = ch.channel_id
@@ -1220,6 +1383,18 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         str(candidate.path): candidate.size for candidate in candidates
     }
     selected = next((candidate for candidate in candidates if candidate.path == tr), None)
+    # I1 selector sync (#4408 phase 2): compare the dcserver's asserted relay
+    # bind (B) against F. Parallel to gap/coverage — its own cooldown key, wrapped
+    # so it can never short-circuit or suppress the gap verdict below.
+    f_growing = (
+        selected is not None
+        and str(selected.path) in previous_sizes
+        and selected.size > previous_sizes[str(selected.path)]
+    )
+    try:
+        tick_selector_sync(rt, ch, chs, tr, f_growing, now)
+    except Exception as e:  # noqa: BLE001 — selector sync must never suppress gap checks
+        rt.log(f"[{cid}] selector-sync tick error: {type(e).__name__}: {e}")
     idle = (now - selected.mtime) if selected else float("inf")
     if idle >= cfg.idle_quiet_secs:
         # Stale transcript: any "gap" is historic, not live. Never alert.

--- a/src/server/routes/docs/inventory/endpoints/part_07.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_07.rs
@@ -597,7 +597,13 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
              #1133 enriched diagnostics (omitted when source is absent): \
              inflight_started_at, inflight_updated_at, inflight_user_msg_id, \
              inflight_current_msg_id, watcher_owner_channel_id, tmux_session_alive \
-             (PID check via `tmux has-session`), mailbox_active_user_msg_id. Returns \
+             (PID check via `tmux has-session`), mailbox_active_user_msg_id. \
+             #4408 phase-2 (I1, omitted when unknown): bound_output_path and \
+             bound_session_id expose the transcript path / provider session the \
+             relay tail is actually bound to (inflight `output_path`/`session_id` \
+             first, else the in-memory tmux runtime binding's relay path), so an \
+             out-of-band watchdog can compare the server's asserted selector \
+             against its own growth-aware transcript pick. Returns \
              404 when no watcher / inflight / mailbox engagement exists for the channel.",
         )
         .with_params([("id", path_param("Discord channel ID (numeric)"))])
@@ -622,6 +628,8 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
                 "tmux_session_alive": true,
                 "has_pending_queue": false,
                 "mailbox_active_user_msg_id": 9001,
+                "bound_output_path": "/tmp/rollout.jsonl",
+                "bound_session_id": "session-1",
             }),
         ),
         ep(

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -722,6 +722,8 @@ mod tests {
             tmux_session_alive: Some(true),
             has_pending_queue: false,
             mailbox_active_user_msg_id: Some(9001),
+            bound_output_path: None,
+            bound_session_id: None,
             inflight_terminal_delivery_committed: false,
             inflight_identity: Some(crate::services::discord::inflight::InflightTurnIdentity {
                 user_msg_id: 9001,

--- a/src/services/discord/health/relay_dead_reattach.rs
+++ b/src/services/discord/health/relay_dead_reattach.rs
@@ -134,6 +134,8 @@ mod tests {
             tmux_session_alive: Some(true),
             has_pending_queue: false,
             mailbox_active_user_msg_id: Some(1),
+            bound_output_path: None,
+            bound_session_id: None,
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -87,6 +87,22 @@ pub struct WatcherStateSnapshot {
     /// mailbox is idle (no active turn).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mailbox_active_user_msg_id: Option<u64>,
+    /// #4408 phase-2 (I1): the transcript path the dcserver actually binds its
+    /// relay tail to. Resolved with per-field precedence — a live inflight row's
+    /// persisted `output_path` wins; otherwise the in-memory tmux runtime
+    /// binding's `relay_output_path` (a sync single-shot lookup, never held
+    /// across an await). Lets the out-of-band watchdog compare the server's
+    /// asserted selector (B) against its own growth-aware transcript pick (F).
+    /// `null`/absent means neither source is known, so the watchdog fails closed
+    /// instead of alarming on an unknown bind. See `resolve_bound_selector`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bound_output_path: Option<String>,
+    /// #4408 phase-2 (I1): the provider session the bound transcript belongs to,
+    /// resolved from the inflight row's `session_id` first, else the runtime
+    /// binding. Read-only; the side-effecting claude-session-id GET (which
+    /// advances a watermark) is intentionally never consulted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bound_session_id: Option<String>,
     /// #3126: `true` when the in-flight row records a turn whose terminal
     /// assistant response has already been committed
     /// (`InflightTurnState::terminal_delivery_committed`). A row with this set
@@ -184,6 +200,39 @@ fn ownerless_external_input_inflight_is_idle(
     inflight: Option<&discord::inflight::InflightTurnState>,
 ) -> bool {
     inflight.is_some_and(discord::inflight::ownerless_external_input_inflight_is_stale)
+}
+
+/// #4408 phase-2 (I1): resolve the transcript path / provider session the relay
+/// tail is bound to, surfaced on `watcher-state` so the out-of-band watchdog can
+/// compare the server's asserted selector (B) against its own growth-aware
+/// transcript pick (F).
+///
+/// Precedence is per field: a live inflight row's persisted `output_path` /
+/// `session_id` win because they are the authoritative binding; when the inflight
+/// row is absent — or leaves a field blank — we fall back to the in-memory tmux
+/// runtime binding's `relay_output_path` / `session_id`. Both inputs come from
+/// sync single-shot lookups that never straddle an await (so no
+/// `await_holding_lock` allow is introduced), and the side-effecting
+/// claude-session-id GET path is intentionally NOT consulted. A field is `None`
+/// when neither source knows it, so serialization omits it and the watchdog fails
+/// closed instead of alarming on an unknown bind.
+fn resolve_bound_selector(
+    inflight_output_path: Option<&str>,
+    inflight_session_id: Option<&str>,
+    binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
+) -> (Option<String>, Option<String>) {
+    fn non_blank(value: Option<&str>) -> Option<String> {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    }
+
+    let bound_output_path = non_blank(inflight_output_path)
+        .or_else(|| non_blank(binding.map(|binding| binding.relay_output_path())));
+    let bound_session_id = non_blank(inflight_session_id)
+        .or_else(|| non_blank(binding.and_then(|binding| binding.session_id.as_deref())));
+    (bound_output_path, bound_session_id)
 }
 
 fn relay_active_turn_from_inflight(
@@ -549,6 +598,25 @@ async fn watcher_state_snapshot_for_shared(
     });
     let relay_stall_state = RelayStallClassifier::classify(&relay_health);
     trace_relay_health_classification(&relay_health, relay_stall_state);
+    // #4408 phase-2 (I1): resolve the relay tail's bound transcript/session. The
+    // runtime binding is a sync single-shot lookup (its Mutex guard is released
+    // inside the call and never held across the awaits above/below), so this adds
+    // no `await_holding_lock` allow.
+    let tmux_runtime_binding = session
+        .tmux_session
+        .as_deref()
+        .and_then(crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session);
+    let (bound_output_path, bound_session_id) = resolve_bound_selector(
+        session
+            .inflight
+            .as_ref()
+            .and_then(|state| state.output_path.as_deref()),
+        session
+            .inflight
+            .as_ref()
+            .and_then(|state| state.session_id.as_deref()),
+        tmux_runtime_binding.as_ref(),
+    );
     Some(WatcherStateSnapshot {
         provider: provider_name.to_string(),
         attached: session.attached,
@@ -568,6 +636,8 @@ async fn watcher_state_snapshot_for_shared(
         tmux_session_alive,
         has_pending_queue,
         mailbox_active_user_msg_id,
+        bound_output_path,
+        bound_session_id,
         inflight_terminal_delivery_committed: session.inflight_terminal_delivery_committed(),
         inflight_identity: session
             .inflight
@@ -900,11 +970,13 @@ mod tests {
 
     use super::{
         HealthRegistry, build_health_snapshot, rebind_origin_inflight_is_idle,
-        relay_active_turn_from_inflight,
+        relay_active_turn_from_inflight, resolve_bound_selector,
     };
+    use crate::services::agent_protocol::RuntimeHandoffKind;
     use crate::services::discord::inflight::InflightTurnState;
     use crate::services::discord::relay_health::RelayActiveTurn;
     use crate::services::provider::{CancelToken, ProviderKind};
+    use crate::services::tui_prompt_dedupe::TuiRuntimeBinding;
     use chrono::TimeZone;
 
     const AGENTDESK_ROOT_DIR_ENV: &str = "AGENTDESK_ROOT_DIR";
@@ -982,6 +1054,94 @@ mod tests {
             RelayActiveTurn::None,
             "restart recovery can resurrect a cancel token for the stale row, but not the lost bridge tail"
         );
+    }
+
+    /// #4408 phase-2 (I1) case 1 (inflight): a live inflight row's persisted
+    /// `output_path`/`session_id` are authoritative and win over any runtime
+    /// binding, so B reflects the turn's own bind.
+    #[test]
+    fn bound_selector_prefers_inflight_over_binding() {
+        let binding = TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: "/tmp/binding-primary.jsonl".to_string(),
+            relay_output_path: Some("/tmp/binding-relay.jsonl".to_string()),
+            input_fifo_path: None,
+            session_id: Some("binding-session".to_string()),
+            last_offset: 0,
+            relay_last_offset: None,
+        };
+        let (bound_output_path, bound_session_id) = resolve_bound_selector(
+            Some("/tmp/inflight.jsonl"),
+            Some("inflight-session"),
+            Some(&binding),
+        );
+        assert_eq!(bound_output_path.as_deref(), Some("/tmp/inflight.jsonl"));
+        assert_eq!(bound_session_id.as_deref(), Some("inflight-session"));
+    }
+
+    /// #4408 phase-2 (I1) case 2 (binding-only): with no inflight row the bind
+    /// falls back to the in-memory runtime binding's `relay_output_path`/
+    /// `session_id`. This is the m5 mutation target — deleting the server-side
+    /// binding fallback in `resolve_bound_selector` collapses B to `None` here
+    /// and this assertion FAILs.
+    #[test]
+    fn bound_selector_falls_back_to_runtime_binding() {
+        let binding = TuiRuntimeBinding {
+            runtime_kind: RuntimeHandoffKind::ClaudeTui,
+            output_path: "/tmp/binding-primary.jsonl".to_string(),
+            relay_output_path: Some("/tmp/binding-relay.jsonl".to_string()),
+            input_fifo_path: None,
+            session_id: Some("binding-session".to_string()),
+            last_offset: 0,
+            relay_last_offset: None,
+        };
+        let (bound_output_path, bound_session_id) =
+            resolve_bound_selector(None, None, Some(&binding));
+        assert_eq!(
+            bound_output_path.as_deref(),
+            Some("/tmp/binding-relay.jsonl")
+        );
+        assert_eq!(bound_session_id.as_deref(), Some("binding-session"));
+    }
+
+    /// #4408 phase-2 (I1) case 3 (neither): with no inflight row and no runtime
+    /// binding both fields are `None`, so `skip_serializing_if` omits them from
+    /// the `watcher-state` JSON and the watchdog reads B as absent (fail-closed).
+    #[test]
+    fn bound_selector_absent_when_no_source_and_omitted_from_json() {
+        #[derive(serde::Serialize)]
+        struct BoundFieldsProbe {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            bound_output_path: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            bound_session_id: Option<String>,
+        }
+
+        let (bound_output_path, bound_session_id) = resolve_bound_selector(None, None, None);
+        assert!(bound_output_path.is_none());
+        assert!(bound_session_id.is_none());
+        let omitted = serde_json::to_value(BoundFieldsProbe {
+            bound_output_path,
+            bound_session_id,
+        })
+        .expect("serialize omitted bound selector");
+        assert!(omitted.get("bound_output_path").is_none());
+        assert!(omitted.get("bound_session_id").is_none());
+
+        // A resolved value IS emitted under the same attribute (blank-guarded).
+        let (bound_output_path, bound_session_id) =
+            resolve_bound_selector(Some("/tmp/live.jsonl"), Some("   "), None);
+        let emitted = serde_json::to_value(BoundFieldsProbe {
+            bound_output_path,
+            bound_session_id,
+        })
+        .expect("serialize present bound selector");
+        assert_eq!(
+            emitted.get("bound_output_path").and_then(|v| v.as_str()),
+            Some("/tmp/live.jsonl")
+        );
+        // A whitespace-only session id is treated as absent, not an empty bind.
+        assert!(emitted.get("bound_session_id").is_none());
     }
 
     #[tokio::test]

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -1070,6 +1070,8 @@ mod tests {
             tmux_session_alive: Some(true),
             has_pending_queue: false,
             mailbox_active_user_msg_id: Some(9001),
+            bound_output_path: None,
+            bound_session_id: None,
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/health/watcher_respawn.rs
+++ b/src/services/discord/health/watcher_respawn.rs
@@ -666,6 +666,8 @@ mod tests {
             tmux_session_alive: tmux_alive,
             has_pending_queue: false,
             mailbox_active_user_msg_id: mailbox_active,
+            bound_output_path: None,
+            bound_session_id: None,
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/src/services/discord/router/intake_gate/stale_turn.rs
+++ b/src/services/discord/router/intake_gate/stale_turn.rs
@@ -407,6 +407,8 @@ mod thread_guard_stale_pure_tests {
             tmux_session_alive,
             has_pending_queue: false,
             mailbox_active_user_msg_id: Some(user_msg_id),
+            bound_output_path: None,
+            bound_session_id: None,
             inflight_terminal_delivery_committed: false,
             inflight_identity: None,
             inflight_finalizer_turn_id: None,

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -34,6 +34,9 @@ from scripts.relay_watchdog import (
     PG_UNCLASSIFIED_DOWN,
     PG_UNKNOWN,
     PG_UPSTREAM_DOWN,
+    SELECTOR_DIVERGED,
+    SELECTOR_SYNCED,
+    SELECTOR_UNKNOWN,
     STATE_GAP,
     STATE_LAGGING,
     STATE_OK,
@@ -49,6 +52,7 @@ from scripts.relay_watchdog import (
     evaluate,
     evaluate_coverage,
     evaluate_pg_health,
+    evaluate_selector_sync,
     expected_tmux_session_name,
     load_state,
     main_channel_project_re,
@@ -59,6 +63,7 @@ from scripts.relay_watchdog import (
     project_slug,
     save_state,
     select_watch_transcript,
+    selector_divergence_confirmed,
     tick_channel,
     tick_pg_tunnel,
 )
@@ -389,6 +394,55 @@ class CoverageEvaluationTests(unittest.TestCase):
         self.assertEqual(verdict.consecutive_uncovered, 0)
 
 
+class SelectorSyncEvaluationTests(unittest.TestCase):
+    """Pure I1 judgment (#4408 phase 2): B (watcher-state bound_output_path) vs
+    F (growth-aware transcript pick)."""
+
+    def test_absent_bind_is_unknown_fail_closed(self):
+        verdict = evaluate_selector_sync(None, "/tmp/f.jsonl", True)
+        self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
+        self.assertEqual(verdict.reason, "bound_output_path_absent")
+        self.assertFalse(verdict.diverged)
+
+    def test_no_transcript_is_unknown(self):
+        verdict = evaluate_selector_sync("/tmp/b.jsonl", None, True)
+        self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
+        self.assertEqual(verdict.reason, "no_transcript")
+        self.assertFalse(verdict.diverged)
+
+    def test_matching_bind_is_synced(self):
+        verdict = evaluate_selector_sync("/tmp/f.jsonl", "/tmp/f.jsonl", True)
+        self.assertEqual(verdict.state, SELECTOR_SYNCED)
+        self.assertEqual(verdict.reason, "selector_synced")
+        self.assertFalse(verdict.diverged)
+
+    def test_mismatch_without_growth_is_not_actionable(self):
+        verdict = evaluate_selector_sync("/tmp/b.jsonl", "/tmp/f.jsonl", False)
+        self.assertEqual(verdict.state, SELECTOR_SYNCED)
+        self.assertEqual(verdict.reason, "f_not_growing")
+        self.assertFalse(verdict.diverged)
+
+    def test_mismatch_with_growing_f_is_diverged(self):
+        verdict = evaluate_selector_sync("/tmp/b.jsonl", "/tmp/f.jsonl", True)
+        self.assertEqual(verdict.state, SELECTOR_DIVERGED)
+        self.assertEqual(verdict.reason, "selector_diverged")
+        self.assertTrue(verdict.diverged)
+
+
+class SelectorConfirmBoundaryTests(unittest.TestCase):
+    """Mutation-2 target: removing the swap-confirm age gate in
+    ``selector_divergence_confirmed`` makes the below-threshold case FAIL."""
+
+    def test_below_swap_confirm_is_not_confirmed(self):
+        self.assertFalse(selector_divergence_confirmed(True, 299.0, 300))
+
+    def test_exactly_at_swap_confirm_is_confirmed(self):
+        self.assertTrue(selector_divergence_confirmed(True, 300.0, 300))
+
+    def test_not_diverged_never_confirms(self):
+        self.assertFalse(selector_divergence_confirmed(False, 10_000.0, 300))
+
+
 class PgHealthEvaluationTests(unittest.TestCase):
     def test_db_true_is_authoritative_even_without_listener_probe(self):
         self.assertEqual(evaluate_pg_health(True, None).state, PG_OK)
@@ -434,6 +488,7 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(cfg.github_repo, "")
         self.assertEqual(cfg.pg_alert_after_secs, 300)
         self.assertEqual(cfg.pg_realert_secs, 900)
+        self.assertEqual(cfg.swap_confirm_secs, 300)
 
     def test_overrides_apply(self):
         cfg = parse_config(
@@ -449,12 +504,14 @@ class ConfigTests(unittest.TestCase):
                 "gap_alert_secs": 1200,
                 "pg_alert_after_secs": 60,
                 "pg_realert_secs": 180,
+                "swap_confirm_secs": 45,
                 "github_repo": "owner/repo",
             }
         )
         self.assertEqual(cfg.gap_alert_secs, 1200)
         self.assertEqual(cfg.pg_alert_after_secs, 60)
         self.assertEqual(cfg.pg_realert_secs, 180)
+        self.assertEqual(cfg.swap_confirm_secs, 45)
         self.assertEqual(cfg.github_repo, "owner/repo")
         self.assertEqual(cfg.channels[0].announce_to, "project-agentdesk")
 
@@ -490,6 +547,8 @@ class ConfigTests(unittest.TestCase):
             parse_config({**base, "pg_alert_after_secs": 0})
         with self.assertRaises(ConfigError):
             parse_config({**base, "pg_realert_secs": -1})
+        with self.assertRaises(ConfigError):
+            parse_config({**base, "swap_confirm_secs": 0})
 
     def test_load_config_surfaces_bad_numeric_as_config_error(self):
         # File-level proof that main()'s `except ConfigError` retry path (the
@@ -1113,6 +1172,64 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+
+    def _grow_selected_transcript(self) -> None:
+        tr = self.proj_dir / "s.jsonl"
+        with tr.open("a", encoding="utf-8") as f:
+            f.write("\n")
+        os.utime(tr, (self.now, self.now))
+
+    def test_selector_divergence_alerts_only_after_swap_confirm(self):
+        # One delivered block → gap verdict stays OK, isolating the selector path.
+        self.write_transcript([(self.now - 30, "delivered block one")])
+        rt = self.make_rt(swap_confirm_secs=1)
+        rt.haystack = norm("delivered block one")
+        # dcserver asserts a bind to a DIFFERENT transcript than F (s.jsonl).
+        rt.watcher_probe = WatcherStateProbe(200, True, False, "/tmp/stale-bind.jsonl")
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(
+            [a for a in rt.alerts if "셀렉터" in a[0]],
+            [],
+            "first tick has no growth proof; selector probe is skipped",
+        )
+
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(
+            [a for a in rt.alerts if "셀렉터" in a[0]],
+            [],
+            "a divergence within the swap-confirm window is not alarmed",
+        )
+        self.assertIn("selector_diverged_since", state["999"])
+
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        selector_alerts = [a for a in rt.alerts if "셀렉터 동기화" in a[0]]
+        self.assertEqual(len(selector_alerts), 1)
+        body, trigger_turn = selector_alerts[0]
+        self.assertIn("/tmp/stale-bind.jsonl", body)
+        self.assertIn("/api/inflight/rebind", body)
+        self.assertIn("sessions", body)
+        self.assertFalse(
+            trigger_turn, "read-only selector alerts must not trigger a turn"
+        )
+
+    def test_selector_bind_absent_is_fail_closed(self):
+        self.write_transcript([(self.now - 30, "delivered block one")])
+        rt = self.make_rt(swap_confirm_secs=1)
+        rt.haystack = norm("delivered block one")
+        # Old server: HTTP 200 but no bound_output_path field → probe carries None.
+        rt.watcher_probe = WatcherStateProbe(200, True, False, None)
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 100)
+
+        self.assertEqual([a for a in rt.alerts if "셀렉터" in a[0]], [])
+        self.assertNotIn("selector_diverged_since", state["999"])
 
     def test_coverage_404_alerts_only_after_two_consecutive_ticks(self):
         rt = self.make_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1212,8 +1212,10 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("/tmp/stale-bind.jsonl", body)
         self.assertIn("/api/inflight/rebind", body)
         self.assertIn("sessions", body)
-        self.assertFalse(
-            trigger_turn, "read-only selector alerts must not trigger a turn"
+        self.assertTrue(
+            trigger_turn,
+            "actionable selector alerts must trigger an agent turn "
+            "(send-to-agent handoff), not bot-direct delivery",
         )
 
     def test_selector_bind_absent_is_fail_closed(self):
@@ -1244,8 +1246,10 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
         self.assertIn("watcher_state_404", rt.alerts[0][0])
         self.assertIn("read-only", rt.alerts[0][0])
-        self.assertFalse(
-            rt.alerts[0][1], "read-only coverage alerts must not trigger a turn"
+        self.assertTrue(
+            rt.alerts[0][1],
+            "actionable coverage alerts must trigger an agent turn "
+            "(send-to-agent handoff), not bot-direct delivery",
         )
 
     def test_coverage_alert_is_suppressed_during_deploy_window(self):


### PR DESCRIPTION
## #4408 phase-2: I1 selector 동기화

설계(이슈 코멘트 §2-a) 이행:
- **snapshot.rs**: WatcherStateSnapshot에 `bound_output_path`/`bound_session_id` 직렬화 필드 추가 — inflight output_path 우선, 없으면 runtime binding relay_output_path 폴백. sync Mutex 단발 조회(await 무접촉, ratchet 53 유지). 부작용 있는 claude-session-id 경로 미사용.
- **relay_watchdog.py**: I1 판정 — B(watcher-state bound_output_path) vs F(성장-인지 선택) 대조, B≠F && F 성장 && 발산 지속 ≥ swap_confirm_secs(300s)에서만 알람(#4423 런북 문구 포함). B 부재(구버전 서버) → unknown, 알람 금지(fail-closed). 기존 gap/I2 비간섭(키 분리).

## 검증
- 게이트: cargo fmt --check / cargo check --lib / cargo test --lib health (173 passed) / python unittest 전체 OK / audit --check findings 0 / inventory+maintenance docs passed / ci-script-checks rc=0 — 전부 rc=0.
- 뮤테이션 (커밋 후 적용→FAIL 확인→원복):
  - m1 서버측 binding 폴백 제거 → `bound_selector_falls_back_to_runtime_binding` 자기 assert FAIL (rc=101)
  - m2 swap-confirm 경계 `>=`→`>` → `test_exactly_at_swap_confirm_is_confirmed` AssertionError FAIL
- 구현 경위: opus 서브에이전트가 본 구현(be06b3a2) 후 한도로 중단 → 오케스트레이터(Fable)가 뮤테이션 검증·게이트·PR 마무리. 리뷰는 교차 원칙상 codex로 진행 예정.

Refs #4408 (phase 2: I1)