### PR TITLE
Fix #4430 Fable recovery follow-up findings

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -138,6 +138,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
           python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
@@ -262,6 +263,7 @@ jobs:
           nice -n 10 cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          nice -n 10 env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           nice -n 10 cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -444,6 +444,7 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+          env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
           python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -581,7 +581,7 @@
 | `services::discord::recovery_engine::manual_rebind::adoption` | `src/services/discord/recovery_engine/manual_rebind/adoption.rs` | 304 | 95 | 209 |  |
 | `services::discord::recovery_engine::manual_rebind::codex_tui_replay` | `src/services/discord/recovery_engine/manual_rebind/codex_tui_replay.rs` | 944 | 233 | 711 |  |
 | `services::discord::recovery_engine::manual_rebind_output_path` | `src/services/discord/recovery_engine/manual_rebind_output_path.rs` | 562 | 352 | 210 |  |
-| `services::discord::recovery_engine::manual_rebind_override` | `src/services/discord/recovery_engine/manual_rebind_override.rs` | 306 | 196 | 110 |  |
+| `services::discord::recovery_engine::manual_rebind_override` | `src/services/discord/recovery_engine/manual_rebind_override.rs` | 551 | 251 | 300 |  |
 | `services::discord::recovery_engine::output_path_detect` | `src/services/discord/recovery_engine/output_path_detect.rs` | 177 | 177 | 0 |  |
 | `services::discord::recovery_engine::phase_policy` | `src/services/discord/recovery_engine/phase_policy.rs` | 370 | 179 | 191 |  |
 | `services::discord::recovery_engine::rebind_runtime` | `src/services/discord/recovery_engine/rebind_runtime.rs` | 2091 | 972 | 1119 |  |
@@ -601,9 +601,9 @@
 | `services::discord::relay_health` | `src/services/discord/relay_health.rs` | 305 | 185 | 120 |  |
 | `services::discord::relay_owner_observability` | `src/services/discord/relay_owner_observability.rs` | 458 | 343 | 115 |  |
 | `services::discord::relay_recovery` | `src/services/discord/relay_recovery.rs` | 3328 | 1471 | 1857 | giant-file |
-| `services::discord::relay_recovery_auto_heal_apply` | `src/services/discord/relay_recovery_auto_heal_apply.rs` | 208 | 114 | 94 |  |
-| `services::discord::relay_recovery_auto_heal_attempts` | `src/services/discord/relay_recovery_auto_heal_attempts.rs` | 260 | 195 | 65 |  |
-| `services::discord::relay_recovery_auto_heal_confirm` | `src/services/discord/relay_recovery_auto_heal_confirm.rs` | 191 | 142 | 49 |  |
+| `services::discord::relay_recovery_auto_heal_apply` | `src/services/discord/relay_recovery_auto_heal_apply.rs` | 262 | 127 | 135 |  |
+| `services::discord::relay_recovery_auto_heal_attempts` | `src/services/discord/relay_recovery_auto_heal_attempts.rs` | 374 | 220 | 154 |  |
+| `services::discord::relay_recovery_auto_heal_confirm` | `src/services/discord/relay_recovery_auto_heal_confirm.rs` | 312 | 167 | 145 |  |
 | `services::discord::relay_recovery_completion_footer` | `src/services/discord/relay_recovery_completion_footer.rs` | 9 | 9 | 0 |  |
 | `services::discord::replace_outcome_policy` | `src/services/discord/replace_outcome_policy.rs` | 691 | 371 | 320 |  |
 | `services::discord::response_sanitizer` | `src/services/discord/response_sanitizer.rs` | 177 | 177 | 0 |  |

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ test-non-pg:
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres
+    env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
     python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
     cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -82,6 +82,9 @@ echo "=== PR infrastructure failure rerun classifier (#4392) ==="
 echo "=== CI timeout wrapper tests (#4413) ==="
 "$PYTHON" -m unittest tests.test_ci_timeout
 
+echo "=== Relay recovery targeted-lane wiring contract (#4423) ==="
+"$PYTHON" -m unittest tests.test_relay_recovery_ci_wiring
+
 echo "=== Scratch file guard ==="
 FAIL=0
 for scratch_file in plan.md scratch.md scratch.txt scratch.sh scratchpad.md scratchpad.txt scratchpad.sh sql_test.rs test_scratch.rs plan.txt pr-body.md test.sh test.sql; do

--- a/src/services/discord/recovery_engine/manual_rebind_override.rs
+++ b/src/services/discord/recovery_engine/manual_rebind_override.rs
@@ -23,6 +23,11 @@ impl ManualRebindOverrides {
             .map(str::trim)
             .map(validate_session_id)
             .transpose()?;
+        validate_claude_override_coherence(
+            provider,
+            output_path.as_deref(),
+            session_id.as_deref(),
+        )?;
         Ok(Self {
             output_path,
             session_id,
@@ -111,19 +116,44 @@ fn validate_output_path(provider: &ProviderKind, output_path: &str) -> Result<St
     if !metadata.is_file() {
         return Err("output_path override must be a regular file".to_string());
     }
-    if provider == &ProviderKind::Claude && !is_under_claude_projects_dir(&canonical) {
-        return Err(
-            "Claude output_path override must be under a Claude projects directory".to_string(),
-        );
+    if !is_under_allowed_output_root(provider, &canonical) {
+        let error = match provider {
+            ProviderKind::Claude => {
+                "Claude output_path override must be under a Claude projects directory".to_string()
+            }
+            _ => format!(
+                "{} output_path override must be under an allowed session directory",
+                provider.as_str()
+            ),
+        };
+        return Err(error);
     }
     Ok(canonical.display().to_string())
 }
 
-fn is_under_claude_projects_dir(path: &Path) -> bool {
-    claude_projects_dir_candidates()
+fn is_under_allowed_output_root(provider: &ProviderKind, path: &Path) -> bool {
+    allowed_output_roots(provider)
         .into_iter()
         .filter_map(|root| std::fs::canonicalize(root).ok())
         .any(|root| path.starts_with(root))
+}
+
+fn allowed_output_roots(provider: &ProviderKind) -> Vec<PathBuf> {
+    match provider {
+        ProviderKind::Claude => claude_projects_dir_candidates(),
+        ProviderKind::Codex => {
+            crate::services::codex_tui::rollout_tail::default_codex_sessions_dir()
+                .into_iter()
+                .chain(crate::services::tmux_common::persistent_sessions_dir())
+                .collect()
+        }
+        ProviderKind::Gemini | ProviderKind::OpenCode | ProviderKind::Qwen => {
+            crate::services::tmux_common::persistent_sessions_dir()
+                .into_iter()
+                .collect()
+        }
+        ProviderKind::Unsupported(_) => Vec::new(),
+    }
 }
 
 fn claude_projects_dir_candidates() -> Vec<PathBuf> {
@@ -148,6 +178,31 @@ fn claude_session_id_from_path(provider: &ProviderKind, output_path: &str) -> Op
     }
     let stem = Path::new(output_path).file_stem()?.to_str()?;
     uuid::Uuid::parse_str(stem).ok().map(|_| stem.to_string())
+}
+
+fn validate_claude_override_coherence(
+    provider: &ProviderKind,
+    output_path: Option<&str>,
+    session_id: Option<&str>,
+) -> Result<(), String> {
+    if provider != &ProviderKind::Claude {
+        return Ok(());
+    }
+    let (Some(output_path), Some(session_id)) = (output_path, session_id) else {
+        return Ok(());
+    };
+    let path_session_id = Path::new(output_path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| uuid::Uuid::parse_str(stem).ok());
+    let supplied_session_id = uuid::Uuid::parse_str(session_id)
+        .expect("validated session_id override must remain a UUID");
+    if path_session_id != Some(supplied_session_id) {
+        return Err(
+            "Claude output_path transcript UUID must match session_id override".to_string(),
+        );
+    }
+    Ok(())
 }
 
 pub(super) async fn upsert_rebind_session_id_override(
@@ -198,23 +253,6 @@ pub(super) async fn upsert_rebind_session_id_override(
 mod tests {
     use super::*;
 
-    struct EnvGuard(Option<std::ffi::OsString>);
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", value) },
-                None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
-            }
-        }
-    }
-
-    fn set_claude_home(path: &Path) -> EnvGuard {
-        let previous = std::env::var_os("CLAUDE_CONFIG_DIR");
-        unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", path) };
-        EnvGuard(previous)
-    }
-
     #[test]
     fn health_rebind_override_rejects_missing_and_non_regular_paths() {
         let root = tempfile::tempdir().expect("override root");
@@ -245,11 +283,8 @@ mod tests {
 
     #[test]
     fn health_rebind_override_rejects_claude_path_outside_projects() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
         let root = tempfile::tempdir().expect("Claude home");
-        let _env = set_claude_home(root.path());
+        let _env = crate::config::TestEnvVarGuard::set_path("CLAUDE_CONFIG_DIR", root.path());
         let outside = root.path().join("outside.jsonl");
         std::fs::write(&outside, b"{}\n").expect("outside transcript");
 
@@ -276,12 +311,9 @@ mod tests {
     }
 
     #[test]
-    fn health_rebind_override_accepts_claude_projects_file_and_canonicalizes_it() {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+    fn health_rebind_override_accepts_parsed_equal_claude_path_and_session_id() {
         let root = tempfile::tempdir().expect("Claude home");
-        let _env = set_claude_home(root.path());
+        let _env = crate::config::TestEnvVarGuard::set_path("CLAUDE_CONFIG_DIR", root.path());
         let project = root.path().join("projects/-tmp-agentdesk");
         std::fs::create_dir_all(&project).expect("project dir");
         let transcript = project.join("4c474e5d-37e7-4b6a-bcf7-d68854a31c49.jsonl");
@@ -290,7 +322,7 @@ mod tests {
         let overrides = ManualRebindOverrides::validated(
             &ProviderKind::Claude,
             Some(transcript.to_str().expect("utf8 path")),
-            Some("4c474e5d-37e7-4b6a-bcf7-d68854a31c49"),
+            Some("4C474E5D-37E7-4B6A-BCF7-D68854A31C49"),
         )
         .expect("valid override");
         assert_eq!(
@@ -301,6 +333,219 @@ mod tests {
                     .to_str()
                     .expect("utf8 path")
             )
+        );
+        assert_eq!(
+            overrides.session_id(),
+            Some("4C474E5D-37E7-4B6A-BCF7-D68854A31C49")
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_preserves_claude_path_only_and_session_only_forms() {
+        let root = tempfile::tempdir().expect("Claude home");
+        let _env = crate::config::TestEnvVarGuard::set_path("CLAUDE_CONFIG_DIR", root.path());
+        let project = root.path().join("projects/-tmp-agentdesk");
+        std::fs::create_dir_all(&project).expect("project dir");
+        let transcript = project.join("4c474e5d-37e7-4b6a-bcf7-d68854a31c49.jsonl");
+        std::fs::write(&transcript, b"{}\n").expect("transcript");
+
+        let path_only = ManualRebindOverrides::validated(
+            &ProviderKind::Claude,
+            Some(transcript.to_str().expect("utf8 path")),
+            None,
+        )
+        .expect("path-only Claude override");
+        assert!(path_only.output_path().is_some());
+        assert!(path_only.session_id().is_none());
+
+        let session_only = ManualRebindOverrides::validated(
+            &ProviderKind::Claude,
+            None,
+            Some("5d585f6e-48e8-497c-94bc-16e9369e32c6"),
+        )
+        .expect("session-only Claude override");
+        assert!(session_only.output_path().is_none());
+        assert_eq!(
+            session_only.session_id(),
+            Some("5d585f6e-48e8-497c-94bc-16e9369e32c6")
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_rejects_mismatched_claude_path_and_session_id() {
+        let root = tempfile::tempdir().expect("Claude home");
+        let _env = crate::config::TestEnvVarGuard::set_path("CLAUDE_CONFIG_DIR", root.path());
+        let project = root.path().join("projects/-tmp-agentdesk");
+        std::fs::create_dir_all(&project).expect("project dir");
+        let transcript = project.join("4c474e5d-37e7-4b6a-bcf7-d68854a31c49.jsonl");
+        std::fs::write(&transcript, b"{}\n").expect("transcript");
+
+        let error = ManualRebindOverrides::validated(
+            &ProviderKind::Claude,
+            Some(transcript.to_str().expect("utf8 path")),
+            Some("5d585f6e-48e8-497c-94bc-16e9369e32c6"),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "Claude output_path transcript UUID must match session_id override"
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_accepts_codex_rollout_under_canonical_sessions_dir() {
+        let root = tempfile::tempdir().expect("Codex home");
+        let _env = crate::config::TestEnvVarGuard::set_path("CODEX_HOME", root.path());
+        let sessions = root.path().join("sessions/2026/07/11");
+        std::fs::create_dir_all(&sessions).expect("sessions dir");
+        let rollout = sessions.join("rollout-valid.jsonl");
+        std::fs::write(&rollout, b"{}\n").expect("rollout");
+
+        let overrides = ManualRebindOverrides::validated(
+            &ProviderKind::Codex,
+            Some(rollout.to_str().expect("utf8 path")),
+            None,
+        )
+        .expect("in-root Codex rollout");
+        assert_eq!(
+            overrides.output_path(),
+            Some(
+                std::fs::canonicalize(rollout)
+                    .expect("canonical rollout")
+                    .to_str()
+                    .expect("utf8 path")
+            )
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_rejects_codex_rollout_outside_canonical_sessions_dir() {
+        let root = tempfile::tempdir().expect("Codex home");
+        let _env = crate::config::TestEnvVarGuard::set_path("CODEX_HOME", root.path());
+        std::fs::create_dir_all(root.path().join("sessions")).expect("sessions dir");
+        let outside = root.path().join("outside.jsonl");
+        std::fs::write(&outside, b"{}\n").expect("outside rollout");
+
+        let error = ManualRebindOverrides::validated(
+            &ProviderKind::Codex,
+            Some(outside.to_str().expect("utf8 path")),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "codex output_path override must be under an allowed session directory"
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_accepts_codex_persistent_wrapper_output() {
+        let root = tempfile::tempdir().expect("AgentDesk root");
+        let _env = crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", root.path());
+        let sessions = crate::services::tmux_common::persistent_sessions_dir()
+            .expect("persistent sessions root");
+        std::fs::create_dir_all(&sessions).expect("persistent sessions dir");
+        let output = sessions.join("codex-wrapper.jsonl");
+        std::fs::write(&output, b"{}\n").expect("wrapper output");
+
+        let overrides = ManualRebindOverrides::validated(
+            &ProviderKind::Codex,
+            Some(output.to_str().expect("utf8 path")),
+            None,
+        )
+        .expect("Codex wrapper output under persistent root");
+        assert_eq!(
+            overrides.output_path(),
+            std::fs::canonicalize(output)
+                .expect("canonical wrapper output")
+                .to_str()
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_other_providers_require_persistent_root() {
+        let root = tempfile::tempdir().expect("AgentDesk root");
+        let _env = crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", root.path());
+        let sessions = crate::services::tmux_common::persistent_sessions_dir()
+            .expect("persistent sessions root");
+        std::fs::create_dir_all(&sessions).expect("persistent sessions dir");
+        let wrapper_output = sessions.join("wrapper.jsonl");
+        let outside = root.path().join("outside.jsonl");
+        std::fs::write(&wrapper_output, b"{}\n").expect("wrapper output");
+        std::fs::write(&outside, b"{}\n").expect("outside output");
+
+        for provider in [
+            ProviderKind::Gemini,
+            ProviderKind::OpenCode,
+            ProviderKind::Qwen,
+        ] {
+            ManualRebindOverrides::validated(
+                &provider,
+                Some(wrapper_output.to_str().expect("utf8 path")),
+                None,
+            )
+            .unwrap_or_else(|error| panic!("{} persistent output: {error}", provider.as_str()));
+            assert_eq!(
+                ManualRebindOverrides::validated(
+                    &provider,
+                    Some(outside.to_str().expect("utf8 path")),
+                    None,
+                )
+                .unwrap_err(),
+                format!(
+                    "{} output_path override must be under an allowed session directory",
+                    provider.as_str()
+                )
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn health_rebind_override_rejects_symlink_escape_from_allowed_root() {
+        let root = tempfile::tempdir().expect("Codex home");
+        let _env = crate::config::TestEnvVarGuard::set_path("CODEX_HOME", root.path());
+        let sessions = root.path().join("sessions");
+        std::fs::create_dir_all(&sessions).expect("sessions dir");
+        let outside = root.path().join("outside.jsonl");
+        let escaped = sessions.join("escaped.jsonl");
+        std::fs::write(&outside, b"{}\n").expect("outside output");
+        std::os::unix::fs::symlink(&outside, &escaped).expect("escape symlink");
+
+        assert_eq!(
+            ManualRebindOverrides::validated(
+                &ProviderKind::Codex,
+                Some(escaped.to_str().expect("utf8 path")),
+                None,
+            )
+            .unwrap_err(),
+            "codex output_path override must be under an allowed session directory"
+        );
+    }
+
+    #[test]
+    fn health_rebind_override_fails_closed_when_allowed_root_is_missing() {
+        let root = tempfile::tempdir().expect("isolated root");
+        let missing_runtime_root = root.path().join("missing-runtime-root");
+        let _env =
+            crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", &missing_runtime_root);
+        let output = root.path().join("gemini.jsonl");
+        std::fs::write(&output, b"{}\n").expect("output");
+        assert!(
+            allowed_output_roots(&ProviderKind::Gemini)
+                .into_iter()
+                .all(|candidate| std::fs::canonicalize(candidate).is_err()),
+            "test requires every allowed root to be unavailable"
+        );
+
+        assert_eq!(
+            ManualRebindOverrides::validated(
+                &ProviderKind::Gemini,
+                Some(output.to_str().expect("utf8 path")),
+                None,
+            )
+            .unwrap_err(),
+            "gemini output_path override must be under an allowed session directory"
         );
     }
 }

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -615,13 +615,13 @@ fn relay_recovery_status_counts_as_applied(status: &'static str) -> bool {
             | "reattached_watcher"
             | "reuse_existing_live_watcher"
             | "reattach_confirm_startup_grace"
+            | "reattach_confirm_emission_in_flight"
             | "cleared_idle_tmux_stale_turn"
             | "scheduled_pending_queue_drain"
     )
 }
 
-/// #3277 verify-2 (Defect D follow-up): report the reattach apply HONESTLY.
-/// `rebind_inflight_for_channel` routes through the single-watcher claim
+/// #3277 verify-2: `rebind_inflight_for_channel` reports apply honestly through the claim
 /// (`claim_or_reuse_watcher`, source `"recovery_restore_inflight"`), which
 /// REPLACES a cancelled / heartbeat-stale / paused / output-path-changed
 /// same-session incumbent (`find_watcher_by_tmux_session` folds

--- a/src/services/discord/relay_recovery_auto_heal_apply.rs
+++ b/src/services/discord/relay_recovery_auto_heal_apply.rs
@@ -63,29 +63,7 @@ pub(super) async fn apply_relay_recovery_plan(
         chrono::Utc::now().timestamp(),
     )
     .await;
-    match confirmation {
-        ReattachConfirmation::StartupGrace => {
-            apply_result.status = "reattach_confirm_startup_grace";
-            release_auto_heal_attempt(&key);
-        }
-        ReattachConfirmation::Failed => {
-            apply_result.status = "reattach_confirm_failed";
-            apply_result.reattach_error = Some(
-                "spawned watcher did not confirm heartbeat or relay-frontier progress".to_string(),
-            );
-            record_auto_heal_confirm_failure(&key, now_ms);
-        }
-        ReattachConfirmation::NotRequired | ReattachConfirmation::Confirmed => {
-            if matches!(
-                apply_result.status,
-                "rebind_failed" | "provider_unavailable"
-            ) {
-                refund_auto_heal_attempt(&key, now_ms);
-            } else {
-                commit_auto_heal_attempt(&key);
-            }
-        }
-    }
+    settle_auto_heal_confirmation(&mut apply_result, confirmation, &key, now_ms);
     decision.auto_heal.remaining_attempts =
         remaining_auto_heal_attempts(&key, now_ms, decision.auto_heal.max_attempts_per_window);
     let applied = relay_recovery_status_counts_as_applied(apply_result.status);
@@ -112,6 +90,41 @@ pub(super) async fn apply_relay_recovery_plan(
     }
 }
 
+fn settle_auto_heal_confirmation(
+    apply_result: &mut RelayRecoveryApplyResult,
+    confirmation: ReattachConfirmation,
+    key: &str,
+    now_ms: i64,
+) {
+    match confirmation {
+        ReattachConfirmation::StartupGrace => {
+            apply_result.status = "reattach_confirm_startup_grace";
+            release_auto_heal_attempt(&key);
+        }
+        ReattachConfirmation::RelayEmissionInFlight => {
+            apply_result.status = "reattach_confirm_emission_in_flight";
+            release_auto_heal_attempt(&key);
+        }
+        ReattachConfirmation::Failed => {
+            apply_result.status = "reattach_confirm_failed";
+            apply_result.reattach_error = Some(
+                "spawned watcher did not confirm heartbeat or relay-frontier progress".to_string(),
+            );
+            record_auto_heal_confirm_failure(&key, now_ms);
+        }
+        ReattachConfirmation::NotRequired | ReattachConfirmation::Confirmed => {
+            if matches!(
+                apply_result.status,
+                "rebind_failed" | "provider_unavailable"
+            ) {
+                refund_auto_heal_attempt(&key, now_ms);
+            } else {
+                commit_auto_heal_attempt(&key);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -119,7 +132,8 @@ mod tests {
     use poise::serenity_prelude::{ChannelId, MessageId, UserId};
 
     use super::super::auto_heal_attempts::{
-        auto_heal_test_lock, clear_auto_heal_attempts_for_tests,
+        auto_heal_key, auto_heal_test_lock, clear_auto_heal_attempts_for_tests,
+        reserve_auto_heal_attempt,
     };
     use super::*;
     use crate::services::provider::CancelToken;
@@ -135,6 +149,46 @@ mod tests {
                 MessageId::new(message),
             )
             .await
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_recovery_emission_in_flight_releases_budget_without_success_or_backoff() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let key = auto_heal_key(
+            "codex",
+            4_423_302,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+        );
+        assert_eq!(reserve_auto_heal_attempt(&key, 1_000, 1), Ok(0));
+        let mut apply_result = RelayRecoveryApplyResult {
+            status: "reattached_watcher",
+            removed_thread_proofs: 0,
+            removed_mailbox_token: false,
+            post_mailbox_has_cancel_token: None,
+            post_mailbox_queue_depth: None,
+            reattach_watcher_spawned: Some(true),
+            reattach_watcher_replaced: Some(false),
+            reattach_initial_offset: Some(0),
+            reattach_error: None,
+        };
+
+        settle_auto_heal_confirmation(
+            &mut apply_result,
+            ReattachConfirmation::RelayEmissionInFlight,
+            &key,
+            2_000,
+        );
+
+        assert_eq!(apply_result.status, "reattach_confirm_emission_in_flight");
+        assert!(apply_result.reattach_error.is_none());
+        assert!(relay_recovery_status_counts_as_applied(apply_result.status));
+        assert_eq!(
+            reserve_auto_heal_attempt(&key, 3_000, 1),
+            Ok(0),
+            "in-flight relay must release the reservation without failure backoff"
         );
     }
 

--- a/src/services/discord/relay_recovery_auto_heal_attempts.rs
+++ b/src/services/discord/relay_recovery_auto_heal_attempts.rs
@@ -10,6 +10,30 @@ pub(super) const AUTO_HEAL_DEAD_FRONTIER_REATTACH_MAX_ATTEMPTS_PER_WINDOW: u32 =
 pub(super) const AUTO_HEAL_REFUND_BACKOFF_THRESHOLD: u32 = 3;
 const AUTO_HEAL_MAX_REFUND_BACKOFF_EXPONENT: u32 = 4;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AutoHealBudgetLane {
+    Manual,
+    Internal,
+}
+
+impl AutoHealBudgetLane {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+impl RelayRecoveryApplySource {
+    fn budget_lane(self) -> AutoHealBudgetLane {
+        match self {
+            Self::Manual => AutoHealBudgetLane::Manual,
+            Self::ProbeAutoHeal | Self::StallWatchdog => AutoHealBudgetLane::Internal,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct AttemptWindow {
     window_start_ms: i64,
@@ -66,7 +90,7 @@ pub(super) fn auto_heal_key(
         provider,
         channel_id,
         action.as_str(),
-        source.as_str()
+        source.budget_lane().as_str()
     )
 }
 
@@ -134,8 +158,9 @@ pub(super) fn refund_auto_heal_attempt(key: &str, now_ms: i64) {
     window.retry_not_before_ms = Some(now_ms.saturating_add(expanded_window_secs * 1000));
 }
 
-/// A startup-graced, not-yet-confirmed spawn is neither success nor failure.
-/// Release only the reservation and preserve the current failure episode.
+/// A startup-graced or actively-emitting, not-yet-confirmed spawn is neither
+/// success nor failure. Release only the reservation and preserve the current
+/// failure episode.
 pub(super) fn release_auto_heal_attempt(key: &str) {
     let mut attempts = auto_heal_attempts()
         .lock()
@@ -204,6 +229,95 @@ mod tests {
             RelayRecoveryActionKind::ReattachWatcher,
             RelayRecoveryApplySource::ProbeAutoHeal,
         )
+    }
+
+    #[test]
+    fn relay_recovery_internal_sources_share_budget_lane_manual_is_distinct() {
+        let probe = auto_heal_key(
+            "codex",
+            4_423_102,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+        );
+        let watchdog = auto_heal_key(
+            "codex",
+            4_423_102,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::StallWatchdog,
+        );
+        let manual = auto_heal_key(
+            "codex",
+            4_423_102,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::Manual,
+        );
+
+        assert_eq!(
+            probe, watchdog,
+            "internal actors must share one budget lane"
+        );
+        assert_ne!(manual, probe, "manual budget must remain operator-only");
+    }
+
+    #[tokio::test]
+    async fn relay_recovery_probe_exhaustion_blocks_watchdog_but_not_manual() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let probe = auto_heal_key(
+            "codex",
+            4_423_103,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+        );
+        let watchdog = auto_heal_key(
+            "codex",
+            4_423_103,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::StallWatchdog,
+        );
+        let manual = auto_heal_key(
+            "codex",
+            4_423_103,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::Manual,
+        );
+
+        assert_eq!(reserve_auto_heal_attempt(&probe, 1_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&watchdog, 2_000, 1),
+            Err("auto_heal_rate_limited"),
+            "probe and watchdog must consume the same internal budget"
+        );
+        assert_eq!(
+            reserve_auto_heal_attempt(&manual, 2_000, 1),
+            Ok(0),
+            "internal exhaustion must not consume the manual budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_recovery_manual_exhaustion_does_not_block_internal_budget() {
+        let _guard = auto_heal_test_lock().lock().await;
+        clear_auto_heal_attempts_for_tests();
+        let manual = auto_heal_key(
+            "codex",
+            4_423_104,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::Manual,
+        );
+        let internal = auto_heal_key(
+            "codex",
+            4_423_104,
+            RelayRecoveryActionKind::ReattachWatcher,
+            RelayRecoveryApplySource::ProbeAutoHeal,
+        );
+
+        assert_eq!(reserve_auto_heal_attempt(&manual, 1_000, 1), Ok(0));
+        assert_eq!(
+            reserve_auto_heal_attempt(&internal, 2_000, 1),
+            Ok(0),
+            "manual exhaustion must not consume the internal budget"
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/relay_recovery_auto_heal_confirm.rs
+++ b/src/services/discord/relay_recovery_auto_heal_confirm.rs
@@ -16,6 +16,14 @@ pub(super) enum ReattachConfirmation {
     NotRequired,
     Confirmed,
     StartupGrace,
+    RelayEmissionInFlight,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SpawnedWatcherConfirmation {
+    Confirmed,
+    RelayEmissionInFlight,
     Failed,
 }
 
@@ -41,7 +49,7 @@ pub(super) async fn classify_reattach_confirmation(
     {
         return ReattachConfirmation::NotRequired;
     }
-    let confirmed = match decision.affected.tmux_session.as_deref() {
+    let probe_result = match decision.affected.tmux_session.as_deref() {
         Some(tmux_session) if !tmux_session.is_empty() => {
             confirm_spawned_watcher(
                 shared,
@@ -51,22 +59,27 @@ pub(super) async fn classify_reattach_confirmation(
             )
             .await
         }
-        _ => false,
+        _ => SpawnedWatcherConfirmation::Failed,
     };
-    confirmation_after_probe(confirmed, process_started_at_unix, now_unix)
+    confirmation_after_probe(probe_result, process_started_at_unix, now_unix)
 }
 
 fn confirmation_after_probe(
-    confirmed: bool,
+    probe_result: SpawnedWatcherConfirmation,
     process_started_at_unix: i64,
     now_unix: i64,
 ) -> ReattachConfirmation {
-    if confirmed {
-        ReattachConfirmation::Confirmed
-    } else if startup_confirm_grace_active(process_started_at_unix, now_unix) {
-        ReattachConfirmation::StartupGrace
-    } else {
-        ReattachConfirmation::Failed
+    match probe_result {
+        SpawnedWatcherConfirmation::Confirmed => ReattachConfirmation::Confirmed,
+        SpawnedWatcherConfirmation::RelayEmissionInFlight => {
+            ReattachConfirmation::RelayEmissionInFlight
+        }
+        SpawnedWatcherConfirmation::Failed
+            if startup_confirm_grace_active(process_started_at_unix, now_unix) =>
+        {
+            ReattachConfirmation::StartupGrace
+        }
+        SpawnedWatcherConfirmation::Failed => ReattachConfirmation::Failed,
     }
 }
 
@@ -79,30 +92,42 @@ async fn confirm_spawned_watcher(
     channel_id: u64,
     tmux_session: &str,
     baseline_frontier: u64,
-) -> bool {
+) -> SpawnedWatcherConfirmation {
     let Some(probe) = spawned_watcher_probe(shared, ChannelId::new(channel_id), tmux_session)
     else {
-        return false;
+        return SpawnedWatcherConfirmation::Failed;
     };
     let deadline = Instant::now() + AUTO_HEAL_CONFIRM_TIMEOUT;
     let mut heartbeat_stable_since = None;
     loop {
         if shared.committed_relay_offset(ChannelId::new(channel_id)) > baseline_frontier {
-            return true;
+            return SpawnedWatcherConfirmation::Confirmed;
         }
         if !spawned_watcher_still_current(shared, &probe) {
-            return false;
+            return SpawnedWatcherConfirmation::Failed;
         }
         if probe.heartbeat.load(Ordering::Acquire) > probe.baseline_heartbeat_ms {
             let stable_since = heartbeat_stable_since.get_or_insert_with(Instant::now);
             if stable_since.elapsed() >= AUTO_HEAL_CONFIRM_STABLE_FOR {
-                return true;
+                return SpawnedWatcherConfirmation::Confirmed;
             }
         }
         if Instant::now() >= deadline {
-            return false;
+            return confirmation_at_deadline(shared, ChannelId::new(channel_id), &probe);
         }
         tokio::time::sleep(AUTO_HEAL_CONFIRM_POLL).await;
+    }
+}
+
+fn confirmation_at_deadline(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    probe: &SpawnedWatcherProbe,
+) -> SpawnedWatcherConfirmation {
+    if spawned_watcher_still_current(shared, probe) && shared.relay_emission_in_flight(channel_id) {
+        SpawnedWatcherConfirmation::RelayEmissionInFlight
+    } else {
+        SpawnedWatcherConfirmation::Failed
     }
 }
 
@@ -172,19 +197,115 @@ mod tests {
             heartbeat.store(101, Ordering::Release);
         });
 
-        assert!(confirm_spawned_watcher(&shared, channel.get(), tmux_session, 0).await);
+        assert_eq!(
+            confirm_spawned_watcher(&shared, channel.get(), tmux_session, 0).await,
+            SpawnedWatcherConfirmation::Confirmed
+        );
         advance.await.expect("heartbeat task");
+    }
+
+    #[test]
+    fn relay_recovery_same_watcher_emission_in_flight_is_not_confirmation_failure() {
+        let shared = make_shared_data_for_tests();
+        let channel = ChannelId::new(4_423_202);
+        let tmux_session = "AgentDesk-codex-4423-emitting";
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        let probe = spawned_watcher_probe(&shared, channel, tmux_session).expect("watcher probe");
+        shared
+            .tmux_relay_coord(channel)
+            .relay_slot
+            .store(128, Ordering::Release);
+
+        assert_eq!(
+            confirmation_at_deadline(&shared, channel, &probe),
+            SpawnedWatcherConfirmation::RelayEmissionInFlight
+        );
+    }
+
+    #[test]
+    fn relay_recovery_same_watcher_without_emission_fails_at_deadline() {
+        let shared = make_shared_data_for_tests();
+        let channel = ChannelId::new(4_423_203);
+        let tmux_session = "AgentDesk-codex-4423-not-emitting";
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        let probe = spawned_watcher_probe(&shared, channel, tmux_session).expect("watcher probe");
+
+        assert_eq!(
+            confirmation_at_deadline(&shared, channel, &probe),
+            SpawnedWatcherConfirmation::Failed
+        );
+    }
+
+    #[test]
+    fn relay_recovery_cancelled_watcher_fails_even_with_channel_emission() {
+        let shared = make_shared_data_for_tests();
+        let channel = ChannelId::new(4_423_204);
+        let tmux_session = "AgentDesk-codex-4423-cancelled-emitting";
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        let probe = spawned_watcher_probe(&shared, channel, tmux_session).expect("watcher probe");
+        probe.cancel.store(true, Ordering::Release);
+        shared
+            .tmux_relay_coord(channel)
+            .relay_slot
+            .store(128, Ordering::Release);
+
+        assert_eq!(
+            confirmation_at_deadline(&shared, channel, &probe),
+            SpawnedWatcherConfirmation::Failed
+        );
+    }
+
+    #[test]
+    fn relay_recovery_replaced_watcher_fails_even_with_channel_emission() {
+        let shared = make_shared_data_for_tests();
+        let channel = ChannelId::new(4_423_205);
+        let tmux_session = "AgentDesk-codex-4423-replaced-emitting";
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        let probe = spawned_watcher_probe(&shared, channel, tmux_session).expect("watcher probe");
+        shared.tmux_watchers.insert(
+            channel,
+            watcher_handle(tmux_session, Arc::new(AtomicI64::new(100))),
+        );
+        shared
+            .tmux_relay_coord(channel)
+            .relay_slot
+            .store(128, Ordering::Release);
+
+        assert_eq!(
+            confirmation_at_deadline(&shared, channel, &probe),
+            SpawnedWatcherConfirmation::Failed
+        );
     }
 
     #[test]
     fn relay_recovery_restart_first_turn_gets_at_least_120_second_grace() {
         let started_at = 10_000;
         assert_eq!(
-            confirmation_after_probe(false, started_at, started_at + 119),
+            confirmation_after_probe(
+                SpawnedWatcherConfirmation::Failed,
+                started_at,
+                started_at + 119
+            ),
             ReattachConfirmation::StartupGrace
         );
         assert_eq!(
-            confirmation_after_probe(false, started_at, started_at + 120),
+            confirmation_after_probe(
+                SpawnedWatcherConfirmation::Failed,
+                started_at,
+                started_at + 120
+            ),
             ReattachConfirmation::Failed
         );
     }

--- a/tests/test_relay_recovery_ci_wiring.py
+++ b/tests/test_relay_recovery_ci_wiring.py
@@ -1,0 +1,41 @@
+"""Contract tests for the non-PG relay-recovery execution proof."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELAY_RECOVERY_COMMAND = (
+    "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- "
+    "--skip _pg --skip pg_ --skip postgres"
+)
+
+
+class RelayRecoveryCiWiringTest(unittest.TestCase):
+    def test_relay_recovery_filter_wired_into_every_targeted_non_pg_lane(self) -> None:
+        expected_counts = {
+            "justfile": 1,
+            ".github/workflows/ci-pr.yml": 1,
+            ".github/workflows/ci-macos-trusted.yml": 2,
+        }
+        for relative_path, expected_count in expected_counts.items():
+            with self.subTest(path=relative_path):
+                text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+                self.assertEqual(
+                    text.count(RELAY_RECOVERY_COMMAND),
+                    expected_count,
+                    f"{relative_path} must run the relay_recovery non-PG filter "
+                    f"in all {expected_count} targeted lane(s)",
+                )
+
+    def test_ci_script_checks_runs_relay_recovery_wiring_contract(self) -> None:
+        script = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")
+        self.assertIn(
+            '"$PYTHON" -m unittest tests.test_relay_recovery_ci_wiring', script
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_relay_recovery_ci_wiring.py
+++ b/tests/test_relay_recovery_ci_wiring.py
@@ -13,6 +13,17 @@ RELAY_RECOVERY_COMMAND = (
 )
 
 
+def count_executable_relay_recovery_commands(text: str) -> int:
+    executable_lines = {
+        RELAY_RECOVERY_COMMAND,
+        f"nice -n 10 {RELAY_RECOVERY_COMMAND}",
+    }
+    return sum(
+        line.strip() in executable_lines
+        for line in text.splitlines()
+    )
+
+
 class RelayRecoveryCiWiringTest(unittest.TestCase):
     def test_relay_recovery_filter_wired_into_every_targeted_non_pg_lane(self) -> None:
         expected_counts = {
@@ -24,11 +35,22 @@ class RelayRecoveryCiWiringTest(unittest.TestCase):
             with self.subTest(path=relative_path):
                 text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
                 self.assertEqual(
-                    text.count(RELAY_RECOVERY_COMMAND),
+                    count_executable_relay_recovery_commands(text),
                     expected_count,
                     f"{relative_path} must run the relay_recovery non-PG filter "
                     f"in all {expected_count} targeted lane(s)",
                 )
+
+    def test_commented_or_echoed_commands_do_not_count_as_executable_wiring(self) -> None:
+        fixture = "\n".join(
+            (
+                f"# {RELAY_RECOVERY_COMMAND}",
+                f"    {RELAY_RECOVERY_COMMAND}",
+                f"    nice -n 10 {RELAY_RECOVERY_COMMAND}",
+                f'    echo "{RELAY_RECOVERY_COMMAND}"',
+            )
+        )
+        self.assertEqual(count_executable_relay_recovery_commands(fixture), 2)
 
     def test_ci_script_checks_runs_relay_recovery_wiring_contract(self) -> None:
         script = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- **F2 — CI execution proof:** run the non-PG `relay_recovery` lib filter in `justfile`, the PR direct lane, and both trusted macOS targeted lanes; protect the mirrors with a named Python contract test wired into `ci-script-checks.sh`.
- **F3 — slow live emission:** classify a same-handle/current-watcher channel emission as `reattach_confirm_emission_in_flight`, release the reservation neutrally, count the validly-started action as applied for redrive, and preserve failure behavior for missing, cancelled, or replaced watchers.
- **F4 — budget lanes:** keep source telemetry unchanged while mapping `ProbeAutoHeal` and `StallWatchdog` to one typed internal lane and `Manual` to a separate operator lane.
- **F5a — Claude coherence:** require a supplied Claude transcript UUID stem and session-id override to parse to the same UUID before runtime state or DB upsert.
- **F5b — provider roots:** use one canonical allowed-root contract: Claude projects roots; Codex TUI sessions plus AgentDesk persistent sessions; Gemini/OpenCode/Qwen persistent sessions only. Canonical file/root checks reject outside paths, symlink escapes, and unavailable-root cases while preserving wrapper JSONL overrides.

No migration or attempt-cap increase. The #3016 core-4 files remain untouched, and `relay_recovery.rs` remains at its prior production size.

## Exact rebase

- base: `e27667cac6eb9d013ca2b03bfd31f6f5f7f13c4a` (PR #4431 merged W0)
- head: `c1bc7ff78e369d0e4d90be01143d831f09704545`
- one implementation commit replayed cleanly; generated inventory regenerated/checked on the final base with no post-rebase diff
- diff: 11 files, 689 insertions, 85 deletions

## Validation on rebased head

- `cargo fmt --all -- --check`: rc=0
- `cargo check --lib`: rc=0
- `cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres`: rc=0, 48 passed
- `env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres`: rc=0, 205 passed
- `python3 -m unittest tests.test_relay_recovery_ci_wiring`: rc=0, 2 passed
- maintainability, inventory freshness, maintenance-doc freshness, `ci-script-checks.sh`, and await-lock ratchet: rc=0; await-lock 53/53

The first local health invocation inherited the live AgentDesk shell value `AGENTDESK_ROOT_DIR=~/.adk/release`; the existing #3293 safety assertion correctly rejected access to the live runtime root. Re-running with the same isolated environment used by review/CI (`env -u AGENTDESK_ROOT_DIR`) passed 205/205. No production change was made for this harness-only rejection.

## Mutation proofs

- F3: negate the same-handle emission guard → named test rc=101 (`Failed` vs `RelayEmissionInFlight`); restored test 1/1 passed.
- F4: give `StallWatchdog` a raw-source key → named equality test rc=101 (`internal` vs `stall_watchdog`).
- F5a: remove the Claude coherence call → mismatch test rc=101 because `unwrap_err()` received `Ok`.
- F5b: bypass Codex containment → outside-root test rc=101 because `unwrap_err()` received `Ok`.
- All inverse patches restored exactly; aggregate restored suites passed before rebase and all impacted suites passed again after rebase.

## Fable review round

Exact-head Fable review of `a04d27537` verified F2/F3/F4/F5a/F5b runtime behavior and four independent mutations, but returned `ISSUES` for one LOW CI-contract weakness: the Python wiring test counted raw command text even when the line was commented out.

Fix commit `c1bc7ff78` now counts only exact executable command lines (plain or the approved `nice -n 10` form) and rejects commented or echoed decoys. Proof:

- focused unit contract: 3/3 passed
- comment the live justfile command: focused contract failed semantically with 0 vs 1; restored 3/3 passed
- Python compile and full `ci-script-checks.sh`: rc=0

Fresh independent exact-head Claude Fable review and current-head CI are pending. No CLEAN claim is made here.

Refs #4423
