### PR TITLE
fix(discord): retain final footer target after failed edit

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -681,7 +681,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2830 | 861 | 1969 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2927 | 861 | 2066 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1637 | 904 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |

--- a/src/services/discord/footer_view_reconciler/registry.rs
+++ b/src/services/discord/footer_view_reconciler/registry.rs
@@ -526,7 +526,7 @@ fn completion_footer_record_edit_result_with_block(
         }
     }
 
-    if remove_after_edit {
+    if remove_after_edit && edited {
         guard.remove(&channel_id.get());
         return true;
     }

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -1729,6 +1729,103 @@ mod tests {
     }
 
     #[test]
+    fn completion_footer_failed_final_edit_keeps_target_then_retry_commits_4025() {
+        let channel_id = ChannelId::new(4_025_001);
+        let message_id = MessageId::new(4_025_101);
+        footer_registry::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_background_task(channel_id);
+        let _ = footer_registry::register_completion_footer_target(
+            channel_id,
+            message_id,
+            &ProviderKind::Claude,
+            1_800_000_000,
+            "Final answer",
+            None,
+            true,
+        );
+        shared.ui.placeholder_live_events.push_status_event(
+            channel_id,
+            StatusEvent::BackgroundTaskEnd {
+                tool_use_id: format!("tool-{}", channel_id.get()),
+                success: true,
+            },
+        );
+
+        let failed_edit = footer_registry::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠸",
+            1_800_000_001,
+        )
+        .expect("final terminal refresh should target the registered message");
+        assert_eq!(failed_edit.message_id, message_id);
+        assert!(failed_edit.text.contains("Bash Run background codex ✓"));
+        assert!(failed_edit.remove_after_edit);
+
+        assert!(
+            footer_registry::completion_footer_record_edit_result_for_edit(
+                shared.as_ref(),
+                channel_id,
+                &failed_edit,
+                false,
+            )
+        );
+        assert!(
+            footer_registry::completion_footer_has_registered_target(channel_id),
+            "failed final edit must retain its retry target"
+        );
+        assert_eq!(
+            footer_registry::completion_footer_registered_failure_count(channel_id),
+            Some(1),
+            "failed final edit must count toward the existing retry cap"
+        );
+        let retained = shared.ui.placeholder_live_events.render_completion_footer(
+            channel_id,
+            &ProviderKind::Claude,
+            "⠼",
+        );
+        assert!(
+            retained
+                .block
+                .as_deref()
+                .is_some_and(|block| block.contains("Bash Run background codex ✓")),
+            "failed delivery must not evict the terminal slot"
+        );
+
+        let retry = footer_registry::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠼",
+            1_800_000_002,
+        )
+        .expect("failed final edit should remain available for retry");
+        assert_eq!(retry.message_id, failed_edit.message_id);
+        assert_eq!(retry.text, failed_edit.text);
+        assert!(retry.remove_after_edit);
+
+        assert!(
+            footer_registry::completion_footer_record_edit_result_for_edit(
+                shared.as_ref(),
+                channel_id,
+                &retry,
+                true,
+            )
+        );
+        assert!(!footer_registry::completion_footer_has_registered_target(
+            channel_id
+        ));
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_live_events
+                .render_completion_footer(channel_id, &ProviderKind::Claude, "⠴")
+                .block,
+            None,
+            "terminal slot must be evicted only after successful recorded delivery"
+        );
+    }
+
+    #[test]
     fn completion_footer_evicts_all_terminal_marks_delivered_by_one_edit() {
         let channel_id = ChannelId::new(3_391_103);
         footer_registry::completion_footer_forget_registered_target(channel_id);


### PR DESCRIPTION
## Summary

- Fixes only the residual B2 defect: a failed final completion-footer edit no longer unregisters the retry target.
- Changes the final-removal predicate from `remove_after_edit` to `remove_after_edit && edited`.
- Adds one focused regression through the existing public/test helper path, covering failed final delivery, retry retention, failure accounting, terminal-slot retention, same-message/content retry, successful removal, and post-success terminal eviction.

## Scope and exact SHAs

- Implementation base: `afdb1509c8d61d99963e51a456559f630e573dda` (exact `origin/main` fetched before worktree creation).
- Final exact head: `e5c309b67b31ac0b3389b90294a046431ecf63cb`.
- Final review base: `e3b1c8d1288160c7fd097ce8dc15b3779577de08`; clean rebase completed after the P0 outbox merge, with generated inventory revalidated.
- Branch: `fix/4025-footer-final-edit-retry`.
- Changed files:
  - `src/services/discord/footer_view_reconciler/registry.rs`
  - `src/services/discord/single_message_panel.rs`
  - `docs/generated/module-inventory.md` (generator-only count update)
- Final diff: 3 files, 99 insertions, 2 deletions.
- Production inventory remains within policy: registry 624 prod LoC; single-message panel 861 prod LoC. Core-4 files are unchanged.

## Deterministic RED/GREEN proof

- Pre-fix RED on the old predicate: exact one-test selection ran 1 test and failed at `failed final edit must retain its retry target`; Cargo rc `101`. Log: `/tmp/adk-4025-evidence/01-pre-fix-red.log`.
- Fixed GREEN: the same exact selection ran 1 test and passed; rc `0`. Logs: `/tmp/adk-4025-evidence/02-focused-green.log`, `/tmp/adk-4025-evidence/25-final-focused-green.log`.
- Mutation proof from clean committed code: temporarily restored only `if remove_after_edit`; exact selection visibly ran 1 test and failed at the same semantic retention assertion; Cargo rc `101`. Restored `&& edited`; the same exact selection ran 1 test and passed; rc `0`. Logs: `/tmp/adk-4025-evidence/06-mutation-red.log`, `/tmp/adk-4025-evidence/07-mutation-restored-green.log`.

## Neighbor and containing regressions

- `completion_footer_failed_delivery_retries_terminal_mark`: 1 passed, rc `0`.
- `stale_edit_result_cannot_remove_newer_footer_target_3717`: 1 passed, rc `0`.
- `completion_footer_consecutive_edit_failures_evict_registered_target`: 1 passed, rc `0`.
- Final neighbor logs: `/tmp/adk-4025-evidence/22-final-neighbor-failed-delivery.log`, `23-final-neighbor-stale-identity.log`, `24-final-neighbor-failure-cap.log`.
- `cargo test --lib completion_footer_ -- --nocapture`: 58 passed, rc `0`. Log: `/tmp/adk-4025-evidence/21-completion-footer-containing-tests.log`.
- An exploratory full `single_message_panel::tests` run produced 63 passed / 1 unrelated failure, rc `101`, in `footer_rollover_reservation_is_bound_by_panel_budget_s3`. The exact same test fails alone on the untouched implementation base with rc `101`, proving it is pre-existing and outside this B2 scope. Logs: `/tmp/adk-4025-evidence/20-single-message-panel-module-tests.log`, `/tmp/adk-4025-evidence/26-base-rollover-test.log`.

## Repository gates

| Gate | rc | Evidence |
| --- | ---: | --- |
| `cargo fmt` | 0 | `08-cargo-fmt.log` |
| `cargo fmt --check` | 0 | `09-cargo-fmt-check.log` |
| `cargo check --lib` | 0 | `15-cargo-check-lib.log` |
| focused final test | 0 | `25-final-focused-green.log` |
| 58 completion-footer containing tests | 0 | `21-completion-footer-containing-tests.log` |
| `python3 scripts/audit_maintainability.py --check` | 0 | `11-audit-maintainability.log` |
| `python3 scripts/generate_inventory_docs.py` (final post-rustfmt generation) | 0 | `17-regenerate-inventory-after-fmt.log` |
| `python3 scripts/check_agent_maintenance_docs.py` | 0 | `18-check-agent-maintenance-docs-final.log` |
| `python3 scripts/check_hotfile_ratchet.py` | 0 | `13-check-hotfile-ratchet.log` |
| `python3 scripts/check_await_holding_lock_ratchet.py` | 0 | `14-check-await-lock-ratchet.log` |
| `PATH=/opt/homebrew/bin:$PATH bash scripts/ci-script-checks.sh` | 0 | `19-ci-script-checks-final.log` |
| final `git diff --check` / scope / core-4 checks | 0 | clean local verification |

Every Cargo launch was preceded by exact `pgrep -x cargo` / `pgrep -x rustc` counts below the three-build cap; concurrent launches used `CARGO_BUILD_JOBS=5`.

## Preserved behavior

- Stale owner/message identity guards are unchanged.
- The existing three-consecutive-failure cap is unchanged and covered.
- Failed edits do not update committed text/block state.
- Terminal slots still evict only on `edited && recorded`.
- WIP-warning behavior and warning send count are untouched.
- No timer, worker, queue, sweeper, scheduler, first-time/no-target correction, forced-cleanup correction, migration, config, API, or persistence change.

## Issue classification

B1 and B3 are obsolete after the #4046 restructuring, and E16 was already fixed. This PR fixes only the surviving B2 footer-registry retry defect.

Closes #4025