### PR TITLE
test(relay): prove task kind survives restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -633,6 +633,8 @@ src/
 │   │   │   ├── read.rs
 │   │   │   ├── validation.rs
 │   │   │   └── write.rs
+│   │   ├── tmux/
+│   │   │   └── task_notification_kind_restart_roundtrip_tests.rs
 │   │   ├── tmux_placeholder_suppression/
 │   │   │   ├── evidence.rs
 │   │   │   ├── mod.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -154,7 +154,9 @@
     "session ended … start a new session" tmux-death notice and its
     `should_send_session_ended_notice`/`session_ended_notice`/
     `TmuxDeathLifecycleDecision` plumbing).
-  - `src/services/discord/tmux.rs` (1624 lines; +11 from #4380 broadening the
+  - `src/services/discord/tmux.rs` (1624 lines; test-only #4253 wires the
+    deterministic task-notification-kind disk-save/reload/restart roundtrip
+    module, with no production-LoC or runtime behavior change; +11 from #4380 broadening the
     watcher-yield escape hatch (`watcher_should_yield_to_inflight_state`) to honour
     the `readopted_from_inflight` crash re-adopt marker via
     `crash_resume_guard::crash_readopt_live_relay_resume_required`, so a

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -691,7 +691,7 @@
 | `services::discord::subagent_notification_card` | `src/services/discord/subagent_notification_card.rs` | 363 | 264 | 99 |  |
 | `services::discord::task_supervisor` | `src/services/discord/task_supervisor.rs` | 105 | 83 | 22 |  |
 | `services::discord::terminal_ui_obligation` | `src/services/discord/terminal_ui_obligation.rs` | 570 | 507 | 63 |  |
-| `services::discord::tmux` | `src/services/discord/tmux.rs` | 2511 | 1624 | 887 | giant-file |
+| `services::discord::tmux` | `src/services/discord/tmux.rs` | 2515 | 1624 | 891 | giant-file |
 | `services::discord::tmux_error_detect` | `src/services/discord/tmux_error_detect.rs` | 70 | 60 | 10 |  |
 | `services::discord::tmux_kill_policy` | `src/services/discord/tmux_kill_policy.rs` | 637 | 547 | 90 |  |
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 190 | 190 | 0 |  |

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2355,6 +2355,10 @@ mod watcher_stream_progress_tests {
 
 #[cfg(test)]
 mod restored_turn_injected_anchor_tests {
+    mod task_notification_kind_restart_invariant_tests {
+        include!("tmux/task_notification_kind_restart_roundtrip_tests.rs");
+    }
+
     use super::restored_watcher_turn_from_inflight;
     use crate::services::discord::inflight::InflightTurnState;
     use crate::services::provider::ProviderKind;

--- a/src/services/discord/tmux/task_notification_kind_restart_roundtrip_tests.rs
+++ b/src/services/discord/tmux/task_notification_kind_restart_roundtrip_tests.rs
@@ -1,0 +1,83 @@
+use super::super::{
+    restored_watcher_turn_from_inflight, terminal_relay_decision, watcher_stream_seed,
+};
+use crate::services::agent_protocol::TaskNotificationKind;
+use crate::services::discord::inflight::{
+    InflightTurnState, load_inflight_state, save_inflight_state,
+};
+use crate::services::provider::ProviderKind;
+
+#[test]
+fn task_notification_kind_restart_roundtrip_4253() {
+    let runtime_root = tempfile::tempdir().expect("isolated runtime root");
+    let _root_guard =
+        crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", runtime_root.path());
+
+    let provider = ProviderKind::Claude;
+    let channel_id = 1_509_350_493_350_459_253;
+    let tmux_session_name = "AgentDesk-claude-adk-4253-restart-roundtrip";
+    let mut state = InflightTurnState::new(
+        provider.clone(),
+        channel_id,
+        Some("claude-pipe".to_string()),
+        343_742_347_365_974_026,
+        4_253_001,
+        4_253_002,
+        "background task notification".to_string(),
+        Some("session-4253".to_string()),
+        Some(tmux_session_name.to_string()),
+        Some("/tmp/agentdesk-4253-restart-roundtrip.jsonl".to_string()),
+        None,
+        425_300,
+    );
+    state.full_response = "background task completed".to_string();
+    state.task_notification_kind = Some(TaskNotificationKind::Background);
+
+    save_inflight_state(&state).expect("persist background inflight row");
+    drop(state);
+
+    let reloaded = load_inflight_state(&provider, channel_id).expect("reload inflight from disk");
+    assert_eq!(
+        reloaded.task_notification_kind,
+        Some(TaskNotificationKind::Background),
+        "disk reload must retain the background task-notification kind"
+    );
+
+    let restored = restored_watcher_turn_from_inflight(&reloaded, tmux_session_name, true)
+        .expect("matching tmux session and nonzero message id must restore the watcher turn");
+    assert_eq!(
+        restored.task_notification_kind,
+        Some(TaskNotificationKind::Background),
+        "restart restoration must carry the persisted kind"
+    );
+
+    let seed = watcher_stream_seed(Some(restored));
+    assert_eq!(
+        seed.task_notification_kind,
+        Some(TaskNotificationKind::Background),
+        "the restarted watcher stream seed must carry the restored kind"
+    );
+
+    // This is the nearest pure decision called by the restored watcher terminal
+    // path. With no assistant text observed, Background must suppress the
+    // notification; losing the kind to None would incorrectly direct-send it.
+    let terminal = terminal_relay_decision(true, seed.task_notification_kind, false);
+    assert!(
+        terminal.suppressed,
+        "the restart terminal decision must consume Background as a task notification"
+    );
+    assert!(
+        !terminal.should_direct_send,
+        "Background without observed assistant text must not direct-send after restart"
+    );
+
+    let visible_terminal = terminal_relay_decision(true, seed.task_notification_kind, true);
+    assert!(
+        visible_terminal.should_direct_send && !visible_terminal.suppressed,
+        "Background with observed assistant text remains user-visible after restart"
+    );
+    assert!(
+        !visible_terminal.should_tag_monitor_origin,
+        "Background must remain distinct from the monitor-auto-turn kind"
+    );
+}


### PR DESCRIPTION
## Root cause / status

The production feature already exists: `task_notification_kind` is serialized in inflight state, restored into `RestoredWatcherTurn`, seeded into the restarted watcher stream, and consumed by terminal routing. Issue #4253 remained open because there was no deterministic disk-persist/restart regression proof.

## Change

- Construct a real `InflightTurnState` with a nonzero restorable message ID, matching tmux session, and `Background` task kind.
- Save through the real inflight store under an isolated `AGENTDESK_ROOT_DIR` guarded by `TestEnvVarGuard`.
- Drop the original state, reload from disk, and pass it through `restored_watcher_turn_from_inflight` and `watcher_stream_seed`.
- Assert disk, restored turn, stream seed, and terminal relay decisions retain and use `Background`.
- Keep the test in a test-only child of the existing restore tests. The child module name includes `invariant`, so the existing PR/main `cargo test invariant` CI selector executes it.
- Refresh the generated architecture\/module inventory and the migration-sensitive maintenance surface entry required by the new test file. Frozen `tmux.rs` production LoC remains 1624.

## Base / head / ordering

- Original implementation base: `e27667cac6eb9d013ca2b03bfd31f6f5f7f13c4a`
- Final review base after P0 #4433: `e3b1c8d1288160c7fd097ce8dc15b3779577de08`
- Final exact head: `1beef9126f089178796776ecf4548ecfb166ff29`
- Clean rebase completed; the exact named test and all non-Cargo gates were rerun on this head.
- P0 #4433 is merged and cluster-deployed; there is no overlapping #4253 production path.

## Mutation proof

A temporary semantic mutation changed the restored watcher seed assignment to `task_notification_kind: None`.

- Mutated: `cargo test --lib task_notification_kind_restart_roundtrip_4253 -- --nocapture` — rc 101, running 1 test; the test failed at its own assertion with `left: None`, `right: Some(Background)`.
- Restored: the same command — rc 0, running 1 test; 1 passed.

## Gates

Three Cargo builds total were used: mutated exact test, restored exact test, and library check.

- `cargo fmt --all` — rc 0
- `cargo fmt --all --check` — rc 0
- `cargo check --lib` with `CARGO_BUILD_JOBS=5` — rc 0
- Exact named test — rc 0, running 1 test
- Nearby restore/seed tests from the compiled lib test binary — 5 + 1 + 1 passed; the two runtime-root-sensitive filters were run with an isolated `AGENTDESK_ROOT_DIR`
- `python3 scripts/audit_maintainability.py --check` — rc 0
- `python3 scripts/generate_inventory_docs.py` and `--check` — rc 0
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` — rc 0
- `PATH=/opt/homebrew/bin:$PATH bash scripts/ci-script-checks.sh` — rc 0
- `python3 scripts/check_await_holding_lock_ratchet.py` — rc 0, 53/53
- `git diff --check` — rc 0

No production behavior or core-4 file was changed. Independent review is intentionally left to the requested Claude Opus pass.

Closes #4253