### PR TITLE
fix(watchdog): calibrate delivery and selector evidence (#4435)

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -49,6 +49,7 @@ if sys.version_info < MIN_PYTHON:  # pragma: no cover - trivial guard
 
 import calendar
 import json
+import math
 import os
 import re
 import shutil
@@ -89,6 +90,13 @@ SELECTOR_SYNCED = "synced"
 SELECTOR_DIVERGED = "diverged"
 SELECTOR_UNKNOWN = "unknown"
 
+SELECTOR_PATH_PROVIDER_PROJECT = "provider_project"
+SELECTOR_PATH_RUNTIME_MIRROR = "runtime_session_mirror"
+SELECTOR_PATH_UNCOMPARABLE = "uncomparable"
+
+DELIVERED_WATERMARKS_KEY = "delivered_watermarks"
+MAX_DELIVERED_WATERMARKS = 16
+
 PG_TOPOLOGY_TUNNEL = "tunnel"
 PG_TOPOLOGY_DIRECT = "direct"
 
@@ -101,6 +109,44 @@ def projects_root() -> Path:
     return Path(
         os.environ.get("CLAUDE_PROJECTS_ROOT", str(Path.home() / ".claude/projects"))
     )
+
+
+def _lexical_absolute_path(value: str | Path) -> Path | None:
+    """Normalize a path without requiring the target to exist."""
+    try:
+        candidate = Path(value).expanduser()
+    except (TypeError, ValueError, OSError):
+        return None
+    if not candidate.is_absolute():
+        return None
+    return Path(os.path.normpath(str(candidate)))
+
+
+def _is_path_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def classify_selector_path(value: str) -> str:
+    """Classify paths by representation before comparing selector identity.
+
+    Provider project transcripts and AgentDesk runtime-session mirrors can
+    contain the same logical session while intentionally having different
+    paths.  Only two provider-project paths are identity-comparable.
+    """
+    path = _lexical_absolute_path(value)
+    provider_root = _lexical_absolute_path(projects_root())
+    mirror_root = _lexical_absolute_path(adk_root() / "runtime" / "sessions")
+    if path is None or provider_root is None or mirror_root is None:
+        return SELECTOR_PATH_UNCOMPARABLE
+    if _is_path_within(path, mirror_root):
+        return SELECTOR_PATH_RUNTIME_MIRROR
+    if _is_path_within(path, provider_root):
+        return SELECTOR_PATH_PROVIDER_PROJECT
+    return SELECTOR_PATH_UNCOMPARABLE
 
 
 # ── Config ─────────────────────────────────────────────────────────────────────
@@ -359,6 +405,25 @@ def parse_transcript_ts(ts: str) -> float | None:
         return None
 
 
+def is_harness_control_assistant_record(record: object) -> bool:
+    """Whether an assistant JSONL row is a synthetic rate-limit control row.
+
+    The visible banner text is deliberately irrelevant: users and normal
+    assistant responses may legitimately discuss the same words.  Claude marks
+    the non-deliverable harness row with this exact structural tuple instead.
+    """
+    if not isinstance(record, dict):
+        return False
+    message = record.get("message")
+    return (
+        isinstance(message, dict)
+        and message.get("model") == "<synthetic>"
+        and record.get("isApiErrorMessage") is True
+        and record.get("apiErrorStatus") == 429
+        and record.get("error") == "rate_limit"
+    )
+
+
 def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
     """(epoch, text) for every assistant text block in a transcript's lines."""
     out: list[tuple[float, str]] = []
@@ -367,12 +432,19 @@ def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
             r = json.loads(line)
         except (json.JSONDecodeError, TypeError):
             continue
-        if not isinstance(r, dict) or r.get("type") != "assistant":
+        if (
+            not isinstance(r, dict)
+            or r.get("type") != "assistant"
+            or is_harness_control_assistant_record(r)
+        ):
             continue
         epoch = parse_transcript_ts(r.get("timestamp", ""))
         if epoch is None:
             continue
-        for c in (r.get("message") or {}).get("content") or []:
+        message = r.get("message")
+        if not isinstance(message, dict):
+            continue
+        for c in message.get("content") or []:
             if isinstance(c, dict) and c.get("type") == "text":
                 t = (c.get("text") or "").strip()
                 if t:
@@ -522,6 +594,17 @@ def evaluate_selector_sync(
         return SelectorVerdict(SELECTOR_UNKNOWN, "no_transcript", False)
     if bound_output_path == selected_transcript:
         return SelectorVerdict(SELECTOR_SYNCED, "selector_synced", False)
+    bound_kind = classify_selector_path(bound_output_path)
+    selected_kind = classify_selector_path(selected_transcript)
+    if SELECTOR_PATH_RUNTIME_MIRROR in (bound_kind, selected_kind):
+        return SelectorVerdict(
+            SELECTOR_UNKNOWN, "runtime_session_mirror_uncomparable", False
+        )
+    if (
+        bound_kind != SELECTOR_PATH_PROVIDER_PROJECT
+        or selected_kind != SELECTOR_PATH_PROVIDER_PROJECT
+    ):
+        return SelectorVerdict(SELECTOR_UNKNOWN, "selector_paths_uncomparable", False)
     if not f_growing:
         return SelectorVerdict(SELECTOR_SYNCED, "f_not_growing", False)
     return SelectorVerdict(SELECTOR_DIVERGED, "selector_diverged", True)
@@ -568,6 +651,7 @@ def evaluate(
     now: float,
     grace_secs: int,
     gap_alert_secs: int,
+    prior_delivered_ts: float = 0.0,
 ) -> Verdict:
     """Core judgment, ported verbatim from the proven 07-09 logic (#4140→#4178→
     #4181 lineage). The health watermark is the LAST SUCCESSFUL delivery, not
@@ -576,7 +660,17 @@ def evaluate(
     earlier one is still missing. Both conditions — lost blocks exist AND the
     watermark is older than gap_alert_secs — must hold to declare a gap.
     """
-    delivered_ts = max((e for e, t in blocks if delivered(t, hay)), default=0.0)
+    prior = (
+        float(prior_delivered_ts)
+        if _is_finite_nonnegative_number(prior_delivered_ts)
+        else 0.0
+    )
+    current_delivered_ts = max(
+        (e for e, t in blocks if delivered(t, hay)), default=0.0
+    )
+    # Discord reads are bounded.  Absence from today's haystack cannot erase a
+    # delivery confirmed by an earlier tick or process lifetime.
+    delivered_ts = max(prior, current_delivered_ts)
     stale = [(e, t) for e, t in blocks if now - e > grace_secs]
     lost = [(e, t) for e, t in stale if e > delivered_ts and not delivered(t, hay)]
     gap_secs = (now - delivered_ts) if delivered_ts else float("inf")
@@ -597,6 +691,91 @@ def evaluate(
 
 
 # ── Persistent state (survives process restarts; launchd may respawn us) ──────
+
+
+def _is_finite_nonnegative_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and float(value) >= 0.0
+    )
+
+
+def _bounded_delivered_watermarks(
+    entries: Mapping[str, tuple[float, float]], preferred_path: str | None = None
+) -> dict[str, tuple[float, float]]:
+    ordered = sorted(
+        entries.items(),
+        key=lambda item: (
+            -item[1][1],
+            0 if item[0] == preferred_path else 1,
+            item[0],
+        ),
+    )[:MAX_DELIVERED_WATERMARKS]
+    return dict(ordered)
+
+
+def delivered_watermarks(
+    channel_state: Mapping[str, Any],
+) -> dict[str, tuple[float, float]]:
+    """Return validated ``path -> (delivered_ts, updated_at)`` state.
+
+    Malformed legacy/operator-edited state is ignored fail-open.  The returned
+    map is deterministically bounded even if the persisted input was not.
+    """
+    raw = channel_state.get(DELIVERED_WATERMARKS_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    valid: dict[str, tuple[float, float]] = {}
+    for path, entry in raw.items():
+        if not isinstance(path, str) or not path or not isinstance(entry, dict):
+            continue
+        delivered_ts = entry.get("delivered_ts")
+        updated_at = entry.get("updated_at")
+        if not (
+            _is_finite_nonnegative_number(delivered_ts)
+            and _is_finite_nonnegative_number(updated_at)
+        ):
+            continue
+        valid[path] = (float(delivered_ts), float(updated_at))
+    return _bounded_delivered_watermarks(valid)
+
+
+def delivered_watermark_for_path(
+    channel_state: Mapping[str, Any], transcript: str | Path
+) -> float:
+    entry = delivered_watermarks(channel_state).get(str(transcript))
+    return entry[0] if entry is not None else 0.0
+
+
+def advance_delivered_watermark(
+    channel_state: dict[str, Any],
+    transcript: str | Path,
+    delivered_ts: object,
+    now: object,
+) -> bool:
+    """Persist a genuine per-path monotonic delivery advancement."""
+    if not (
+        _is_finite_nonnegative_number(delivered_ts)
+        and _is_finite_nonnegative_number(now)
+    ):
+        return False
+    path = str(transcript)
+    if not path:
+        return False
+    entries = delivered_watermarks(channel_state)
+    prior = entries.get(path, (0.0, 0.0))[0]
+    candidate = float(delivered_ts)
+    if candidate <= prior:
+        return False
+    entries[path] = (candidate, float(now))
+    bounded = _bounded_delivered_watermarks(entries, preferred_path=path)
+    channel_state[DELIVERED_WATERMARKS_KEY] = {
+        key: {"delivered_ts": watermark, "updated_at": updated_at}
+        for key, (watermark, updated_at) in bounded.items()
+    }
+    return True
 
 
 def load_state(path: Path) -> dict[str, Any]:
@@ -1424,7 +1603,19 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     chs["read_failures"] = 0
 
     blocks = assistant_blocks(tr) if tr else []
-    v = evaluate(blocks, hay, now, cfg.grace_secs, cfg.gap_alert_secs)
+    prior_delivered_ts = (
+        delivered_watermark_for_path(chs, tr) if tr is not None else 0.0
+    )
+    v = evaluate(
+        blocks,
+        hay,
+        now,
+        cfg.grace_secs,
+        cfg.gap_alert_secs,
+        prior_delivered_ts,
+    )
+    if tr is not None and v.delivered_ts > prior_delivered_ts:
+        advance_delivered_watermark(chs, tr, v.delivered_ts, now)
 
     if v.state == STATE_GAP:
         if rt.in_deploy_window(now):

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -115,7 +115,7 @@ def _lexical_absolute_path(value: str | Path) -> Path | None:
     """Normalize a path without requiring the target to exist."""
     try:
         candidate = Path(value).expanduser()
-    except (TypeError, ValueError, OSError):
+    except (TypeError, ValueError, OSError, RuntimeError):
         return None
     if not candidate.is_absolute():
         return None
@@ -406,22 +406,17 @@ def parse_transcript_ts(ts: str) -> float | None:
 
 
 def is_harness_control_assistant_record(record: object) -> bool:
-    """Whether an assistant JSONL row is a synthetic rate-limit control row.
+    """Whether an assistant JSONL row is synthetic harness control data.
 
     The visible banner text is deliberately irrelevant: users and normal
-    assistant responses may legitimately discuss the same words.  Claude marks
-    the non-deliverable harness row with this exact structural tuple instead.
+    assistant responses may legitimately discuss the same words. Claude marks
+    every non-deliverable harness-authored assistant row with the synthetic
+    model identity, independent of API status/error shape.
     """
     if not isinstance(record, dict):
         return False
     message = record.get("message")
-    return (
-        isinstance(message, dict)
-        and message.get("model") == "<synthetic>"
-        and record.get("isApiErrorMessage") is True
-        and record.get("apiErrorStatus") == 429
-        and record.get("error") == "rate_limit"
-    )
+    return isinstance(message, dict) and message.get("model") == "<synthetic>"
 
 
 def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
@@ -653,12 +648,13 @@ def evaluate(
     gap_alert_secs: int,
     prior_delivered_ts: float = 0.0,
 ) -> Verdict:
-    """Core judgment, ported verbatim from the proven 07-09 logic (#4140→#4178→
-    #4181 lineage). The health watermark is the LAST SUCCESSFUL delivery, not
-    `any lost`: a historic gap (already reported, already recovered) must not
-    re-alert forever, and relay chunking can deliver a later block while an
-    earlier one is still missing. Both conditions — lost blocks exist AND the
-    watermark is older than gap_alert_secs — must hold to declare a gap.
+    """Core relay-gap judgment descended from the 07-09 logic and subsequently
+    extended through the #4140→#4178→#4181 lineage. The health watermark is the
+    LAST SUCCESSFUL delivery, not `any lost`: a historic gap (already reported,
+    already recovered) must not re-alert forever, and relay chunking can deliver
+    a later block while an earlier one is still missing. Both conditions — lost
+    blocks exist AND the watermark is older than gap_alert_secs — must hold to
+    declare a gap.
     """
     prior = (
         float(prior_delivered_ts)

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -27,6 +27,8 @@ from scripts.relay_watchdog import (
     COVERAGE_COVERED,
     COVERAGE_UNCOVERED,
     COVERAGE_UNKNOWN,
+    DELIVERED_WATERMARKS_KEY,
+    MAX_DELIVERED_WATERMARKS,
     PG_OK,
     PG_STATE_KEY,
     PG_TOPOLOGY_DIRECT,
@@ -46,14 +48,18 @@ from scripts.relay_watchdog import (
     Runtime,
     TranscriptCandidate,
     WatcherStateProbe,
+    advance_delivered_watermark,
     assistant_blocks_from_lines,
     channel_project_dirs,
     delivered,
+    delivered_watermark_for_path,
+    delivered_watermarks,
     evaluate,
     evaluate_coverage,
     evaluate_pg_health,
     evaluate_selector_sync,
     expected_tmux_session_name,
+    is_harness_control_assistant_record,
     load_state,
     main_channel_project_re,
     newest_transcript,
@@ -256,6 +262,40 @@ class TranscriptParsingTests(unittest.TestCase):
         self.assertEqual(len(blocks), 1)
         self.assertEqual(blocks[0][1], "hello world")
 
+    def test_invariant_4435_structural_synthetic_rate_limit_is_excluded(self):
+        record = {
+            "type": "assistant",
+            "timestamp": "2026-07-09T02:00:00Z",
+            "isApiErrorMessage": True,
+            "apiErrorStatus": 429,
+            "error": "rate_limit",
+            "message": {
+                "model": "<synthetic>",
+                "content": [
+                    {"type": "text", "text": "You've hit your session limit"}
+                ],
+            },
+        }
+        self.assertTrue(is_harness_control_assistant_record(record))
+        self.assertEqual(assistant_blocks_from_lines([json.dumps(record)]), [])
+
+    def test_invariant_4435_identical_normal_assistant_text_is_retained(self):
+        record = {
+            "type": "assistant",
+            "timestamp": "2026-07-09T02:00:00Z",
+            "isApiErrorMessage": False,
+            "apiErrorStatus": 200,
+            "message": {
+                "model": "claude-opus-4-1",
+                "content": [
+                    {"type": "text", "text": "You've hit your session limit"}
+                ],
+            },
+        }
+        self.assertFalse(is_harness_control_assistant_record(record))
+        blocks = assistant_blocks_from_lines([json.dumps(record)])
+        self.assertEqual([text for _, text in blocks], ["You've hit your session limit"])
+
 
 class DeliveredTests(unittest.TestCase):
     def test_short_text_requires_exact_normalized_substring(self):
@@ -343,6 +383,33 @@ class EvaluateBoundaryTests(unittest.TestCase):
         v = self._eval([], "")
         self.assertEqual(v.state, STATE_OK)
 
+    def test_invariant_4435_prior_watermark_survives_bounded_haystack_loss(self):
+        anchor = self.NOW - 2000
+        v = evaluate(
+            [(anchor, "previously delivered")],
+            "",
+            self.NOW,
+            self.GRACE,
+            self.GAP,
+            prior_delivered_ts=anchor,
+        )
+        self.assertEqual(v.state, STATE_OK)
+        self.assertEqual(v.lost, 0)
+        self.assertEqual(v.delivered_ts, anchor)
+
+    def test_invariant_4435_older_current_match_cannot_retreat_watermark(self):
+        older = self.NOW - 3000
+        prior = self.NOW - 1000
+        v = evaluate(
+            [(older, "old delivery")],
+            "old delivery",
+            self.NOW,
+            self.GRACE,
+            self.GAP,
+            prior_delivered_ts=prior,
+        )
+        self.assertEqual(v.delivered_ts, prior)
+
 
 class CoverageEvaluationTests(unittest.TestCase):
     def test_live_expected_session_with_healthy_watcher_is_covered(self):
@@ -398,6 +465,10 @@ class SelectorSyncEvaluationTests(unittest.TestCase):
     """Pure I1 judgment (#4408 phase 2): B (watcher-state bound_output_path) vs
     F (growth-aware transcript pick)."""
 
+    @staticmethod
+    def provider_path(name: str) -> str:
+        return str(relay_watchdog.projects_root() / "selector-tests" / name)
+
     def test_absent_bind_is_unknown_fail_closed(self):
         verdict = evaluate_selector_sync(None, "/tmp/f.jsonl", True)
         self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
@@ -417,16 +488,42 @@ class SelectorSyncEvaluationTests(unittest.TestCase):
         self.assertFalse(verdict.diverged)
 
     def test_mismatch_without_growth_is_not_actionable(self):
-        verdict = evaluate_selector_sync("/tmp/b.jsonl", "/tmp/f.jsonl", False)
+        verdict = evaluate_selector_sync(
+            self.provider_path("b.jsonl"), self.provider_path("f.jsonl"), False
+        )
         self.assertEqual(verdict.state, SELECTOR_SYNCED)
         self.assertEqual(verdict.reason, "f_not_growing")
         self.assertFalse(verdict.diverged)
 
     def test_mismatch_with_growing_f_is_diverged(self):
-        verdict = evaluate_selector_sync("/tmp/b.jsonl", "/tmp/f.jsonl", True)
+        verdict = evaluate_selector_sync(
+            self.provider_path("b.jsonl"), self.provider_path("f.jsonl"), True
+        )
         self.assertEqual(verdict.state, SELECTOR_DIVERGED)
         self.assertEqual(verdict.reason, "selector_diverged")
         self.assertTrue(verdict.diverged)
+
+    def test_invariant_4435_runtime_mirror_is_unknown_uncomparable(self):
+        mirror = str(
+            relay_watchdog.adk_root()
+            / "runtime"
+            / "sessions"
+            / "agentdesk-channel.jsonl"
+        )
+        verdict = evaluate_selector_sync(
+            mirror, self.provider_path("f.jsonl"), True
+        )
+        self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
+        self.assertEqual(verdict.reason, "runtime_session_mirror_uncomparable")
+        self.assertFalse(verdict.diverged)
+
+    def test_invariant_4435_arbitrary_unequal_paths_are_not_comparable(self):
+        verdict = evaluate_selector_sync(
+            "/tmp/not-a-provider.jsonl", self.provider_path("f.jsonl"), True
+        )
+        self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
+        self.assertEqual(verdict.reason, "selector_paths_uncomparable")
+        self.assertFalse(verdict.diverged)
 
 
 class SelectorConfirmBoundaryTests(unittest.TestCase):
@@ -717,6 +814,47 @@ class StateTests(unittest.TestCase):
             p.write_text("garbage{", encoding="utf-8")
             self.assertEqual(load_state(p), {})
             self.assertEqual(load_state(Path(tmp) / "missing.json"), {})
+
+    def test_invariant_4435_malformed_watermarks_are_ignored_fail_open(self):
+        state = {
+            DELIVERED_WATERMARKS_KEY: {
+                "/bool": {"delivered_ts": True, "updated_at": 1.0},
+                "/negative": {"delivered_ts": -1.0, "updated_at": 1.0},
+                "/nan": {"delivered_ts": float("nan"), "updated_at": 1.0},
+                "/inf": {"delivered_ts": 1.0, "updated_at": float("inf")},
+                "/not-object": 123,
+                "/valid": {"delivered_ts": 12.5, "updated_at": 13.0},
+            }
+        }
+        self.assertEqual(delivered_watermarks(state), {"/valid": (12.5, 13.0)})
+        self.assertEqual(delivered_watermark_for_path(state, "/nan"), 0.0)
+        self.assertEqual(delivered_watermark_for_path(state, "/valid"), 12.5)
+
+    def test_invariant_4435_watermark_map_is_deterministically_bounded(self):
+        state: dict = {}
+        for index in range(MAX_DELIVERED_WATERMARKS + 1):
+            self.assertTrue(
+                advance_delivered_watermark(
+                    state,
+                    f"/transcript-{index:02}.jsonl",
+                    100.0 + index,
+                    1000.0 + index,
+                )
+            )
+        entries = delivered_watermarks(state)
+        self.assertEqual(len(entries), MAX_DELIVERED_WATERMARKS)
+        self.assertNotIn("/transcript-00.jsonl", entries)
+        self.assertEqual(
+            list(entries)[0],
+            f"/transcript-{MAX_DELIVERED_WATERMARKS:02}.jsonl",
+        )
+
+    def test_invariant_4435_watermark_advancement_is_path_scoped_and_monotonic(self):
+        state: dict = {}
+        self.assertTrue(advance_delivered_watermark(state, "/a.jsonl", 20.0, 30.0))
+        self.assertFalse(advance_delivered_watermark(state, "/a.jsonl", 19.0, 31.0))
+        self.assertEqual(delivered_watermark_for_path(state, "/a.jsonl"), 20.0)
+        self.assertEqual(delivered_watermark_for_path(state, "/b.jsonl"), 0.0)
 
 
 class RuntimePgProbeTests(unittest.TestCase):
@@ -1182,10 +1320,11 @@ class TickChannelTests(unittest.TestCase):
     def test_selector_divergence_alerts_only_after_swap_confirm(self):
         # One delivered block → gap verdict stays OK, isolating the selector path.
         self.write_transcript([(self.now - 30, "delivered block one")])
-        rt = self.make_rt(swap_confirm_secs=1)
+        rt = self.make_rt(swap_confirm_secs=300)
         rt.haystack = norm("delivered block one")
         # dcserver asserts a bind to a DIFFERENT transcript than F (s.jsonl).
-        rt.watcher_probe = WatcherStateProbe(200, True, False, "/tmp/stale-bind.jsonl")
+        stale_bind = str(self.projects / "other-provider" / "stale-bind.jsonl")
+        rt.watcher_probe = WatcherStateProbe(200, True, False, stale_bind)
         state: dict = {}
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
@@ -1196,7 +1335,7 @@ class TickChannelTests(unittest.TestCase):
         )
 
         self._grow_selected_transcript()
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
         self.assertEqual(
             [a for a in rt.alerts if "셀렉터" in a[0]],
             [],
@@ -1205,17 +1344,53 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("selector_diverged_since", state["999"])
 
         self._grow_selected_transcript()
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 300)
+        self.assertEqual(
+            [a for a in rt.alerts if "셀렉터" in a[0]],
+            [],
+            "299 seconds of divergence is still below the boundary",
+        )
+
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 301)
         selector_alerts = [a for a in rt.alerts if "셀렉터 동기화" in a[0]]
         self.assertEqual(len(selector_alerts), 1)
         body, trigger_turn = selector_alerts[0]
-        self.assertIn("/tmp/stale-bind.jsonl", body)
+        self.assertIn(stale_bind, body)
         self.assertIn("/api/inflight/rebind", body)
         self.assertIn("sessions", body)
         self.assertTrue(
             trigger_turn,
             "actionable selector alerts must trigger an agent turn "
             "(send-to-agent handoff), not bot-direct delivery",
+        )
+
+    def test_invariant_4435_runtime_mirror_never_starts_swap_timer_or_alerts(self):
+        self.write_transcript([(self.now - 30, "delivered mirror case")])
+        rt = self.make_rt(swap_confirm_secs=300)
+        rt.haystack = norm("delivered mirror case")
+        mirror = str(
+            relay_watchdog.adk_root()
+            / "runtime"
+            / "sessions"
+            / "agentdesk-999.jsonl"
+        )
+        rt.watcher_probe = WatcherStateProbe(200, True, False, mirror)
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        state["999"]["selector_diverged_since"] = self.now - 1000
+
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertNotIn("selector_diverged_since", state["999"])
+
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 601)
+        self.assertEqual([a for a in rt.alerts if "셀렉터" in a[0]], [])
+        self.assertNotIn("selector_diverged_since", state["999"])
+        self.assertTrue(
+            any("runtime_session_mirror_uncomparable" in line for line in rt.log_lines)
         )
 
     def test_selector_bind_absent_is_fail_closed(self):
@@ -1349,6 +1524,92 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(rt.alerts, [])
         self.assertIsInstance(state["999"]["transcript_sizes"][str(transcript)], int)
+
+    def test_invariant_4435_all_stale_restart_keeps_delivered_anchor(self):
+        anchor = float(int(self.now - 2000))
+        self.write_transcript([(anchor, "old delivered anchor")])
+        transcript = self.proj_dir / "s.jsonl"
+        rt = self.make_rt()
+        rt.haystack = norm("old delivered anchor")
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], transcript), anchor
+        )
+
+        state_path = self.root / "persisted-state.json"
+        save_state(state_path, state)
+        restarted_state = load_state(state_path)
+        restarted = self.make_rt()
+        restarted.haystack = ""
+        tick_channel(restarted, TICK_CHANNEL, restarted_state, self.now + 1)
+
+        self.assertEqual(restarted.alerts, [])
+        self.assertEqual(
+            delivered_watermark_for_path(restarted_state["999"], transcript), anchor
+        )
+        self.assertTrue(any("stale=1 lost=0" in line for line in restarted.log_lines))
+
+    def test_invariant_4435_older_haystack_cannot_regress_persisted_anchor(self):
+        older = float(int(self.now - 3000))
+        newer = float(int(self.now - 1000))
+        self.write_transcript(
+            [(older, "older delivered text"), (newer, "newer delivered text")]
+        )
+        transcript = self.proj_dir / "s.jsonl"
+        rt = self.make_rt()
+        state: dict = {}
+
+        rt.haystack = norm("newer delivered text")
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], transcript), newer
+        )
+
+        rt.haystack = norm("older delivered text")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], transcript), newer
+        )
+
+    def test_invariant_4435_new_transcript_does_not_inherit_old_path_anchor(self):
+        old_anchor = float(int(self.now - 1000))
+        self.write_transcript([(old_anchor, "old path delivered")])
+        old_transcript = self.proj_dir / "s.jsonl"
+        rt = self.make_rt()
+        rt.haystack = norm("old path delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        new_transcript = self.proj_dir / "new.jsonl"
+        new_ts = float(int(self.now - 2000))
+        new_transcript.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(new_ts)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "new path missing"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(new_transcript, (self.now + 1, self.now + 1))
+        rt.haystack = ""
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], old_transcript), old_anchor
+        )
+        self.assertEqual(delivered_watermark_for_path(state["999"], new_transcript), 0.0)
 
     # (a) deploy-window suppression — REAL in_deploy_window runs against a real
     # marker file, so replacing it with `return False` fails this test.

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -279,6 +279,59 @@ class TranscriptParsingTests(unittest.TestCase):
         self.assertTrue(is_harness_control_assistant_record(record))
         self.assertEqual(assistant_blocks_from_lines([json.dumps(record)]), [])
 
+    def test_invariant_4435_all_synthetic_harness_error_shapes_are_excluded(self):
+        cases = [
+            (
+                "server_error_none",
+                {"error": "server_error", "apiErrorStatus": None},
+                "server error",
+            ),
+            (
+                "authentication_failed",
+                {"error": "authentication_failed", "apiErrorStatus": 401},
+                "auth failed",
+            ),
+            (
+                "overloaded_529",
+                {"error": "overloaded", "apiErrorStatus": 529},
+                "overloaded",
+            ),
+            ("unknown_idle_timeout", {"error": "idle_timeout"}, "unknown idle timeout"),
+            (
+                "non_api_no_response",
+                {"isApiErrorMessage": False, "apiErrorStatus": None},
+                "No response requested.",
+            ),
+            (
+                "rate_limit_none",
+                {"error": "rate_limit", "apiErrorStatus": None},
+                "rate limited",
+            ),
+        ]
+        for name, metadata, prose in cases:
+            with self.subTest(name=name):
+                record = {
+                    "type": "assistant",
+                    "timestamp": "2026-07-09T02:00:00Z",
+                    **metadata,
+                    "message": {
+                        "model": "<synthetic>",
+                        "content": [{"type": "text", "text": prose}],
+                    },
+                }
+                self.assertTrue(is_harness_control_assistant_record(record))
+                self.assertEqual(assistant_blocks_from_lines([json.dumps(record)]), [])
+
+                real_record = {
+                    **record,
+                    "message": {**record["message"], "model": "claude-opus-4-1"},
+                }
+                self.assertFalse(is_harness_control_assistant_record(real_record))
+                self.assertEqual(
+                    [text for _, text in assistant_blocks_from_lines([json.dumps(real_record)])],
+                    [prose],
+                )
+
     def test_invariant_4435_identical_normal_assistant_text_is_retained(self):
         record = {
             "type": "assistant",
@@ -520,6 +573,16 @@ class SelectorSyncEvaluationTests(unittest.TestCase):
     def test_invariant_4435_arbitrary_unequal_paths_are_not_comparable(self):
         verdict = evaluate_selector_sync(
             "/tmp/not-a-provider.jsonl", self.provider_path("f.jsonl"), True
+        )
+        self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
+        self.assertEqual(verdict.reason, "selector_paths_uncomparable")
+        self.assertFalse(verdict.diverged)
+
+    def test_invariant_4435_nonexistent_tilde_user_is_unknown_uncomparable(self):
+        verdict = evaluate_selector_sync(
+            "~agentdesk-user-that-does-not-exist-4435/b.jsonl",
+            self.provider_path("f.jsonl"),
+            True,
         )
         self.assertEqual(verdict.state, SELECTOR_UNKNOWN)
         self.assertEqual(verdict.reason, "selector_paths_uncomparable")


### PR DESCRIPTION
## Summary
- persist a bounded path-scoped delivered watermark so bounded Discord history cannot erase prior delivery evidence
- exclude Claude synthetic 429 rate-limit assistant rows by structural JSONL fields while retaining identical normal assistant prose
- treat AgentDesk runtime-session mirrors as selector-identity unknown while preserving 300-second divergence confirmation for comparable provider transcripts

## Verification
- relay watchdog: 132 tests passed
- relay watchdog plus PG tunnel: 150 tests passed
- six behavioral mutations each failed its dedicated assertion, then restored green
- generated inventory, maintenance freshness, maintainability audit, py_compile, diff check, and ci-script-checks passed with rc 0
- no core-4, DB, API, migration, runtime config, cap, or baseline changes

Closes #4435