### PR TITLE
test: isolate delivery record OFF-path runtime

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -10,6 +10,11 @@
 > `QueuedCardPostFailed` referenced lifecycle notice, its outbound-v3 delivery
 > path, dedup identity, and every remaining callsite are unchanged.)
 
+> Last refreshed: 2026-07-11 (#4438 — the test-only default-OFF long-chunk
+> delivery-record check now holds the shared test-environment lock and resolves
+> `AGENTDESK_ROOT_DIR` inside a scoped temp root. Production delivery-record
+> authority, rollout defaults, writers, and outbound callsite coverage are unchanged.)
+
 > #3664 outbound bot-selection note: the outbox drain (`src/server/mod.rs`)
 > now resolves the delivery bot via `message_outbox::delivery_bot_for_target_session`.
 > For a private (DM) session — tmux name `AgentDesk-<provider>-dm-<digits>` with a

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -528,7 +528,7 @@
 | `services::discord::outbound::decision` | `src/services/discord/outbound/decision.rs` | 248 | 248 | 0 |  |
 | `services::discord::outbound::delivery` | `src/services/discord/outbound/delivery.rs` | 1271 | 693 | 578 |  |
 | `services::discord::outbound::delivery_frontier_probe` | `src/services/discord/outbound/delivery_frontier_probe.rs` | 75 | 75 | 0 |  |
-| `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2899 | 1276 | 1623 | giant-file |
+| `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2898 | 1276 | 1622 | giant-file |
 | `services::discord::outbound::manual_delivery` | `src/services/discord/outbound/manual_delivery.rs` | 1176 | 580 | 596 |  |
 | `services::discord::outbound::message` | `src/services/discord/outbound/message.rs` | 426 | 426 | 0 |  |
 | `services::discord::outbound::policy` | `src/services/discord/outbound/policy.rs` | 124 | 124 | 0 |  |

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -2553,11 +2553,13 @@ mod tests {
 
     #[test]
     fn record_long_chunk_terminal_delivery_off_is_noop_3610c() {
-        // The REAL helper end-to-end under the default-OFF shadow flag: it must be a
+        // The REAL helper end-to-end under the forced-OFF shadow flag: it must be a
         // complete no-op (no panic, no write) regardless of the resolved anchor.
-        // (Tests never set AGENTDESK_DELIVERY_RECORD_SHADOW, so the OnceLock reads
-        // OFF; this exercises the helper's own short-circuit through
-        // `shadow_mirror_delivered_frontier`.)
+        // The scoped root holds the crate-wide test-env lock, so both the helper and
+        // the assertions stay inside one throw-away tree and can never inspect the
+        // operator's runtime.
+        let root = IsolatedRoot::new();
+        let _shadow_off = shadow_test_seam::force(false);
         let shared = crate::services::discord::make_shared_data_for_tests();
         // Does not panic; OFF → writes nothing.
         super::record_long_chunk_terminal_delivery(
@@ -2570,8 +2572,16 @@ mod tests {
             "",
         );
         // No durable record was created for either channel under the test root.
-        assert!(read_record(&ProviderKind::Claude, 100_200_300).is_none());
-        assert!(read_record(&ProviderKind::Claude, 900_800_700).is_none());
+        for channel_id in [100_200_300, 900_800_700] {
+            let path = delivery_record_path(&ProviderKind::Claude, channel_id)
+                .expect("isolated delivery-record path");
+            assert!(
+                path.starts_with(root.path()),
+                "delivery-record path escaped isolated root: {}",
+                path.display()
+            );
+            assert!(read_record(&ProviderKind::Claude, channel_id).is_none());
+        }
     }
 
     // ---- #3610 PR-1d: WATCHER legacy long-chunk arm (same-channel) --------------
@@ -2645,33 +2655,22 @@ mod tests {
     /// resolve through this root, so the whole read-authority wiring runs against a
     /// throw-away tree with zero cross-test interference.
     struct IsolatedRoot {
+        _env: crate::config::TestEnvVarGuard,
         _dir: tempfile::TempDir,
-        previous: Option<std::ffi::OsString>,
-        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl IsolatedRoot {
         fn new() -> Self {
-            let lock = crate::config::shared_test_env_lock()
-                .lock()
-                .unwrap_or_else(|error| error.into_inner());
             let dir = tempfile::tempdir().expect("isolated runtime root");
-            let previous = std::env::var_os("AGENTDESK_ROOT_DIR");
-            unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", dir.path()) };
+            let env = crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", dir.path());
             Self {
+                _env: env,
                 _dir: dir,
-                previous,
-                _lock: lock,
             }
         }
-    }
 
-    impl Drop for IsolatedRoot {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-            }
+        fn path(&self) -> &Path {
+            self._dir.path()
         }
     }
 


### PR DESCRIPTION
## Summary

- run the real long-chunk delivery-record OFF-path helper under a scoped temporary `AGENTDESK_ROOT_DIR`
- hold the canonical shared test-environment lock and restore the previous environment value through the existing RAII guard
- force the test-only shadow seam OFF, assert both resolved record paths remain inside the temporary root, and retain the semantic no-record assertions
- keep production delivery-record authority, defaults, writers, and callsites unchanged

## Verification

- standalone `record_long_chunk_terminal_delivery_off_is_noop_3610c`: 3 consecutive runs passed
- containing `delivery_record` suite: 60/60 passed before mutation and 60/60 after restoration
- semantic mutation: inverting the OFF gate compiled, then failed at the test's own `read_record(...).is_none()` assertion with rc 101; restoration returned the focused test to green
- `cargo fmt --all -- --check`
- `cargo check --lib`
- `python3 scripts/generate_inventory_docs.py`
- `python3 scripts/check_agent_maintenance_docs.py`
- `python3 scripts/audit_maintainability.py --check`
- `git diff --check origin/main...HEAD`

Production LoC in `delivery_record.rs` remains 1,276; only test code and required generated/maintenance documentation changed.

Closes #4438
