### PR TITLE
fix(catch-up): never re-collect our own restart-gap notice (#4443)

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -15,7 +15,7 @@
 | `src/server/maintenance.rs` | 1119 | server-runtime | 2026-10-31 | #3909 |
 | `src/server/worker_registry.rs` | 1278 | server-runtime | 2026-08-31 | #3739 |
 | `src/services/codex_tui/rollout_tail.rs` | 1329 | discord-relay | 2026-10-31 | #3843 |
-| `src/services/discord/catch_up.rs` | 1691 | discord-relay | 2026-10-31 | #3405 |
+| `src/services/discord/catch_up.rs` | 1716 | discord-relay | 2026-10-31 | #3405 |
 | `src/services/discord/health/recovery.rs` | 2694 | discord-relay | 2026-10-31 | #3839 |
 | `src/services/discord/idle_recap.rs` | 1374 | discord-relay | 2026-08-31 | #3405 |
 | `src/services/discord/outbound/delivery_record.rs` | 1276 | discord-relay | 2026-10-31 | #3405 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -421,7 +421,7 @@
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 1079 | 652 | 427 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
-| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 2961 | 1691 | 1270 | giant-file |
+| `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 3064 | 1716 | 1348 | giant-file |
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 48 | 48 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 121 | 121 | 0 |  |

--- a/src/services/discord/catch_up.rs
+++ b/src/services/discord/catch_up.rs
@@ -664,6 +664,11 @@ pub(in crate::services::discord) fn classify_catch_up_message(
     if existing_ids.contains(&msg.message_id) {
         return CatchUpClassification::Duplicate;
     }
+    if is_restart_gap_notice(msg.author_is_bot, &msg.trimmed_text) {
+        // #4443: checked BEFORE TooOld so aged notices skip the drop/DLQ/
+        // re-notice path entirely (see is_restart_gap_notice).
+        return CatchUpClassification::SelfAuthored;
+    }
     if msg.age_secs > max_age_secs {
         return CatchUpClassification::TooOld;
     }
@@ -685,6 +690,20 @@ pub(in crate::services::discord) fn classify_catch_up_message(
 /// #4260: max entries listed in the aggregate too-old notice before we
 /// summarize the remainder as "… 외 N건" (keep the card compact).
 const CATCH_UP_TOO_OLD_NOTICE_MAX_ITEMS: usize = 10;
+
+/// #4443: leading marker of the aggregate restart-gap notice. Shared between
+/// the notice builder and the catch-up classifiers so a reworded notice cannot
+/// silently break the self-recollection guard.
+const CATCH_UP_TOO_OLD_NOTICE_PREFIX: &str = "⚠️ 재시작 공백으로";
+
+/// #4443: true when a message is our own restart-gap notice reposted through
+/// an allowed sender bot. Both catch-up phases must classify these out:
+/// re-collecting one nests it inside the next notice (one level per restart,
+/// every channel) and phase2 would hand a young one to the agent as input.
+/// Prefix + bot-author scoped so a human quoting the marker still recovers.
+fn is_restart_gap_notice(author_is_bot: bool, text: &str) -> bool {
+    author_is_bot && text.starts_with(CATCH_UP_TOO_OLD_NOTICE_PREFIX)
+}
 
 /// #4260: one message dropped as too-old during a catch-up scan, captured for
 /// the per-channel aggregate "재시작 공백" notice (silent-loss vector 1).
@@ -718,7 +737,7 @@ fn catch_up_too_old_notice(drops: &[CatchUpTooOldDrop]) -> Option<String> {
         return None;
     }
     let mut body = format!(
-        "⚠️ 재시작 공백으로 {}건이 5분 초과로 미처리되었습니다. 필요하면 다시 보내주세요:",
+        "{CATCH_UP_TOO_OLD_NOTICE_PREFIX} {}건이 5분 초과로 미처리되었습니다. 필요하면 다시 보내주세요:",
         drops.len()
     );
     for drop in drops.iter().take(CATCH_UP_TOO_OLD_NOTICE_MAX_ITEMS) {
@@ -1498,6 +1517,12 @@ async fn run_catch_up_sweep<A: CatchUpDiscordApi + ?Sized>(deps: CatchUpDeps<'_,
                 stats.skipped += 1;
                 continue;
             }
+            if is_restart_gap_notice(msg.author.bot, text) {
+                // #4443: phase2's 10-minute window would otherwise hand a
+                // young notice straight to the agent after every deploy.
+                stats.skipped += 1;
+                continue;
+            }
             let mid = msg.id.get();
             if !is_allowed_turn_sender(
                 &allowed_bot_ids_phase2,
@@ -1703,10 +1728,11 @@ mod catch_up_recovery_tests {
         catch_up_remaining_queue_capacity, catch_up_too_old_notice, catch_up_too_old_snippet,
         classify_catch_up_message, classify_phase2_enqueue_commit,
         collect_catch_up_retry_pending_channels, consume_catch_up_retry_state_for_scan,
-        insert_configured_catch_up_candidate, merge_catch_up_retry_checkpoint,
-        parse_catch_up_scan_pace, phase2_retry_after_checkpoint, prune_stale_checkpoint_files,
-        rearm_catch_up_retry_after_defer, rearm_catch_up_retry_after_fetch_failure,
-        run_catch_up_sweep, should_fetch_older_recent_page, should_pace_before_scan,
+        insert_configured_catch_up_candidate, is_restart_gap_notice,
+        merge_catch_up_retry_checkpoint, parse_catch_up_scan_pace, phase2_retry_after_checkpoint,
+        prune_stale_checkpoint_files, rearm_catch_up_retry_after_defer,
+        rearm_catch_up_retry_after_fetch_failure, run_catch_up_sweep,
+        should_fetch_older_recent_page, should_pace_before_scan,
         take_catch_up_retry_checkpoint_after_queue_drain,
     };
     use crate::services::turn_orchestrator::{
@@ -2100,6 +2126,83 @@ mod catch_up_recovery_tests {
         assert_eq!(
             classify_catch_up_message(&view, Some(owner_user_id), &existing, 300, &[], None),
             CatchUpClassification::SelfAuthored
+        );
+    }
+
+    #[test]
+    fn restart_gap_notice_from_allowed_bot_is_never_recollected() {
+        // #4443: the aggregate restart-gap notice is posted through an
+        // allowed sender bot. Re-collecting it as TooOld quoted it inside the
+        // next notice — one more nesting level per restart, spammed to every
+        // channel. The guard must fire BEFORE the TooOld branch (no DLQ, no
+        // drop entry) and regardless of age.
+        let notice_bot_id = 1481522187197218816;
+        let current_bot_id = 9001;
+        let notice_text = catch_up_too_old_notice(&[CatchUpTooOldDrop {
+            author_id: notice_bot_id,
+            snippet: "⚠️ 재시작 공백으로 1건이 5분 초과로 미처리되었습니다…".to_string(),
+        }])
+        .expect("non-empty drops produce a notice");
+        let mut view = CatchUpMessageView {
+            message_id: 1504813049431724099,
+            author_id: notice_bot_id,
+            author_is_bot: true,
+            is_processable_kind: true,
+            age_secs: 3600, // far beyond max_age — would be TooOld without the guard
+            trimmed_text: notice_text,
+        };
+        let existing = HashSet::new();
+
+        assert_eq!(
+            classify_catch_up_message(
+                &view,
+                Some(current_bot_id),
+                &existing,
+                300,
+                &[notice_bot_id],
+                None
+            ),
+            CatchUpClassification::SelfAuthored,
+            "aged notice must be classified out before the TooOld drop path"
+        );
+        view.age_secs = 60;
+        assert_eq!(
+            classify_catch_up_message(
+                &view,
+                Some(current_bot_id),
+                &existing,
+                300,
+                &[notice_bot_id],
+                None
+            ),
+            CatchUpClassification::SelfAuthored,
+            "young notice must not be recovered as a turn input either"
+        );
+
+        // Shared predicate (also wired into the phase2 enqueue loop):
+        assert!(is_restart_gap_notice(true, &view.trimmed_text));
+        assert!(
+            !is_restart_gap_notice(false, &view.trimmed_text),
+            "human-authored text is never a notice"
+        );
+        assert!(
+            !is_restart_gap_notice(true, "PM triage: pick up #42"),
+            "ordinary allowed-bot traffic must stay recoverable"
+        );
+
+        // A human message that merely mentions the marker mid-text still
+        // recovers — the guard is prefix + bot-author scoped.
+        let human = CatchUpMessageView {
+            message_id: 1504813049431724100,
+            author_id: 343742347365974026,
+            author_is_bot: false,
+            is_processable_kind: true,
+            age_secs: 60,
+            trimmed_text: "어제 '⚠️ 재시작 공백으로' 카드 왜 떴어?".to_string(),
+        };
+        assert_eq!(
+            classify_catch_up_message(&human, Some(current_bot_id), &existing, 300, &[], None),
+            CatchUpClassification::Recover
         );
     }
 


### PR DESCRIPTION
## 문제 (P0, 사용자 보고)
재시작 공백 공지가 allowed 봇 발신이라 다음 재시작 catch-up 스캔이 공지 자체를 미처리 메시지로 재수거 → dead-letter + 새 공지에 인용. 재시작 세대마다 한 겹씩 중첩 증식, 전 채널 도배 (오늘 재시작 3회로 표면화).

## 수정
- `CATCH_UP_TOO_OLD_NOTICE_PREFIX` const 추출 — 공지 빌더와 가드가 공유 (문구 변경 시 가드가 조용히 깨지는 것 방지).
- `is_restart_gap_notice(author_is_bot, text)` 공통 술어: 분류기(classify_catch_up_message)에서 **TooOld 분기보다 먼저** SelfAuthored로 조기 배제(수거/DLQ/재공지 모두 차단), phase2 enqueue 루프에서도 skip(젊은 공지가 턴 입력으로 넘어가는 것 차단).
- prefix+bot-author 스코프 — 사람이 본문에 마커를 인용한 메시지는 정상 수거 (테스트로 고정).

## 검증
- `cargo test --lib catch_up` 39 passed (rc=0) — 신규 테스트: aged 공지 배제 / young 공지 배제 / 술어 3케이스 / 사람 인용 메시지 Recover 유지.
- 뮤테이션 증명: 술어를 false로 무력화 → 자기 assert FAIL(rc=101, 'aged notice must be classified out before the TooOld drop path') → 원복 rc=0.
- fmt --check / check --lib / audit --check / inventory+freshness passed / ci-script-checks 전부 rc=0.
- #3016 핫파일 무접촉, 캡/baseline 무변경.

Refs #4443, #4260 (공지 도입 커밋 계보)

🤖 Generated with [Claude Code](https://claude.com/claude-code)