### PR TITLE
fix(watchdog): retain selected transcript across idle touches (#4435)

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -122,12 +122,15 @@ GAP_OWNER_TRANSCRIPTS_KEY = "gap_owner_transcripts"
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
+MAX_GAP_OWNER_TRANSCRIPTS = MAX_PENDING_TRANSCRIPTS + 1
 MAX_RETIRED_TRANSCRIPTS = 32
-# Every pending transcript can hold independent delivery authority in addition
-# to the selected non-pending transcript.  The watermark cap must fit and pin
-# that whole active set; otherwise an old-but-live pending path can be replayed
-# after unrelated paths refresh their watermarks.
-MAX_DELIVERED_WATERMARKS = MAX_PENDING_TRANSCRIPTS + 1
+# Selected, pending, and unresolved GAP-owner transcripts each retain
+# independent delivery authority.  The watermark cap must fit their full
+# deduplicated worst-case union; otherwise a recovered GAP owner's newly
+# advanced watermark can be evicted before bounded Discord history rolls off.
+MAX_DELIVERED_WATERMARKS = (
+    1 + MAX_PENDING_TRANSCRIPTS + MAX_GAP_OWNER_TRANSCRIPTS
+)
 TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
 
 PG_TOPOLOGY_TUNNEL = "tunnel"
@@ -506,7 +509,7 @@ def _open_regular_file_beneath_parent(
         opened = descriptor
         descriptor = -1
         return opened
-    except (OSError, TypeError, ValueError, UnicodeError):
+    except (OSError, NotImplementedError, TypeError, ValueError, UnicodeError):
         return None
     finally:
         if descriptor >= 0:
@@ -707,7 +710,7 @@ def _validated_gap_owner_transcripts(
     legacy = channel_state.get(GAP_TRANSCRIPT_KEY)
     if isinstance(legacy, str) and legacy and legacy not in owners:
         owners.append(legacy)
-    return owners[: MAX_PENDING_TRANSCRIPTS + 1]
+    return owners[:MAX_GAP_OWNER_TRANSCRIPTS]
 
 
 def _store_gap_owner_transcripts(
@@ -717,7 +720,7 @@ def _store_gap_owner_transcripts(
     for path in owners:
         if isinstance(path, str) and path and path not in bounded:
             bounded.append(path)
-    bounded = bounded[: MAX_PENDING_TRANSCRIPTS + 1]
+    bounded = bounded[:MAX_GAP_OWNER_TRANSCRIPTS]
     if bounded:
         channel_state[GAP_OWNER_TRANSCRIPTS_KEY] = bounded
     else:
@@ -1313,6 +1316,17 @@ def _bounded_delivered_watermarks(
     return dict(ordered)
 
 
+def _delivered_watermark_authority_paths(
+    channel_state: Mapping[str, Any],
+) -> list[str]:
+    """Return every bounded path that still owns delivery authority."""
+    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+    authorities = [selected] if isinstance(selected, str) and selected else []
+    authorities.extend(_validated_pending_transcripts(channel_state))
+    authorities.extend(_validated_gap_owner_transcripts(channel_state))
+    return list(dict.fromkeys(authorities))
+
+
 def delivered_watermarks(
     channel_state: Mapping[str, Any],
 ) -> dict[str, tuple[float, float]]:
@@ -1336,10 +1350,10 @@ def delivered_watermarks(
         ):
             continue
         valid[path] = (float(delivered_ts), float(updated_at))
-    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
-    pinned = [selected] if isinstance(selected, str) and selected else []
-    pinned.extend(_validated_pending_transcripts(channel_state))
-    return _bounded_delivered_watermarks(valid, pinned_paths=pinned)
+    return _bounded_delivered_watermarks(
+        valid,
+        pinned_paths=_delivered_watermark_authority_paths(channel_state),
+    )
 
 
 def delivered_watermark_for_path(
@@ -1370,11 +1384,10 @@ def advance_delivered_watermark(
     if candidate <= prior:
         return False
     entries[path] = (candidate, float(now))
-    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
-    pinned = [selected] if isinstance(selected, str) and selected else []
-    pinned.extend(_validated_pending_transcripts(channel_state))
     bounded = _bounded_delivered_watermarks(
-        entries, preferred_path=path, pinned_paths=pinned
+        entries,
+        preferred_path=path,
+        pinned_paths=_delivered_watermark_authority_paths(channel_state),
     )
     channel_state[DELIVERED_WATERMARKS_KEY] = {
         key: {"delivered_ts": watermark, "updated_at": updated_at}

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -959,12 +959,18 @@ def _refresh_recovered_gap_guards(
             reclaimed.append(path)
             continue
         if presence == RECOVERED_GAP_PATH_PRESENT:
-            refreshed[path] = (size, confirmed_at, now, None)
+            refreshed[path] = (size, confirmed_at, max(last_seen_at, now), None)
             continue
         if presence == RECOVERED_GAP_PATH_AMBIGUOUS:
             # Ambiguity breaks proof of continuous absence. Never expire a
             # replay floor because a directory read, stat, or file type was
             # unsafe to interpret.
+            refreshed[path] = (size, confirmed_at, last_seen_at, None)
+            continue
+        if last_seen_at > now:
+            # A wall-clock rollback cannot establish elapsed absence. Keep the
+            # floor armed until time catches up and a fresh absence interval
+            # can be observed.
             refreshed[path] = (size, confirmed_at, last_seen_at, None)
             continue
         missing_since = absent_since
@@ -3295,7 +3301,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         recovered_gap_guards, admitted = _upsert_recovered_gap_guard(
             recovered_gap_guards,
             path,
-            candidate.size,
+            read_cache[path].observed_size,
             now,
         )
         if not admitted and recovering_gap_owner:

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -99,6 +99,7 @@ SELECTOR_UNKNOWN = "unknown"
 SELECTOR_PATH_PROVIDER_PROJECT = "provider_project"
 SELECTOR_PATH_RUNTIME_MIRROR = "runtime_session_mirror"
 SELECTOR_PATH_UNCOMPARABLE = "uncomparable"
+SELECTOR_DIVERGED_TRANSCRIPT_KEY = "selector_diverged_transcript"
 
 DELIVERED_WATERMARKS_KEY = "delivered_watermarks"
 SELECTED_TRANSCRIPT_KEY = "selected_transcript"
@@ -113,7 +114,11 @@ PENDING_TRANSCRIPT_OVERFLOW_KEY = "pending_transcript_overflow"
 LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY = (
     "last_pending_transcript_overflow_alert"
 )
+LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY = (
+    "last_pending_transcript_retirement_alert"
+)
 GAP_TRANSCRIPT_KEY = "gap_transcript"
+GAP_OWNER_TRANSCRIPTS_KEY = "gap_owner_transcripts"
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
@@ -395,6 +400,68 @@ def _regular_file_stat_without_symlink(path: Path) -> os.stat_result | None:
     return path_stat
 
 
+def _same_file_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def _open_regular_file_beneath_parent(
+    path: Path, flags: int
+) -> int | None:
+    """Open one pinned regular file without re-resolving a swapped parent.
+
+    ``O_NOFOLLOW`` on a path string protects only its final component.  Open
+    and identity-pin the parent directory first, then use openat(dirfd,
+    basename) and verify both descriptors against their nofollow prechecks.
+    Any unsupported platform or race fails closed.
+    """
+    if not getattr(os, "O_DIRECTORY", 0) or not getattr(os, "O_NOFOLLOW", 0):
+        return None
+    try:
+        expected_parent = path.parent.stat(follow_symlinks=False)
+        expected_file = path.stat(follow_symlinks=False)
+    except (OSError, ValueError, UnicodeError):
+        return None
+    if not stat_mode.S_ISDIR(expected_parent.st_mode) or not stat_mode.S_ISREG(
+        expected_file.st_mode
+    ):
+        return None
+
+    parent_descriptor = -1
+    descriptor = -1
+    try:
+        parent_flags = (
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        parent_descriptor = os.open(path.parent, parent_flags)
+        opened_parent = os.fstat(parent_descriptor)
+        if not stat_mode.S_ISDIR(opened_parent.st_mode) or not _same_file_identity(
+            expected_parent, opened_parent
+        ):
+            return None
+        descriptor = os.open(path.name, flags, dir_fd=parent_descriptor)
+        opened_file = os.fstat(descriptor)
+        if not stat_mode.S_ISREG(opened_file.st_mode) or not _same_file_identity(
+            expected_file, opened_file
+        ):
+            return None
+        opened = descriptor
+        descriptor = -1
+        return opened
+    except (OSError, TypeError, ValueError, UnicodeError):
+        return None
+    finally:
+        for opened in (descriptor, parent_descriptor):
+            if opened >= 0:
+                try:
+                    os.close(opened)
+                except OSError:
+                    pass
+
+
 @dataclass(frozen=True)
 class TranscriptCandidate:
     path: Path
@@ -516,13 +583,31 @@ def _validated_pending_transcripts(channel_state: Mapping[str, Any]) -> list[str
     return pending[:MAX_PENDING_TRANSCRIPTS]
 
 
+def _read_failure_authority_paths(
+    channel_state: Mapping[str, Any], pending_paths: list[str]
+) -> set[str]:
+    """Paths whose consecutive read-failure counter must survive this tick.
+
+    Selected and unresolved GAP-owner transcripts have independent evaluation
+    authority in addition to the bounded pending queue.  Folding either into a
+    full 32-path queue would evict an existing authority, so pin their counters
+    separately while leaving the pending cap unchanged.
+    """
+    authorities = set(pending_paths)
+    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+    if isinstance(selected, str) and selected:
+        authorities.add(selected)
+    authorities.update(_validated_gap_owner_transcripts(channel_state))
+    return authorities
+
+
 def _validated_pending_failures(
     channel_state: Mapping[str, Any], pending_paths: list[str]
 ) -> dict[str, int]:
     raw = channel_state.get(PENDING_TRANSCRIPT_FAILURES_KEY, {})
     if not isinstance(raw, dict):
         return {}
-    pending = set(pending_paths)
+    pending = _read_failure_authority_paths(channel_state, pending_paths)
     return {
         path: failures
         for path, failures in raw.items()
@@ -548,6 +633,37 @@ def _validated_pending_since(
         )
         for path in pending_paths
     }
+
+
+def _validated_gap_owner_transcripts(
+    channel_state: Mapping[str, Any],
+) -> list[str]:
+    """Return bounded unresolved GAP owners, including the legacy singleton."""
+    owners: list[str] = []
+    raw = channel_state.get(GAP_OWNER_TRANSCRIPTS_KEY, [])
+    if isinstance(raw, list):
+        for path in raw:
+            if isinstance(path, str) and path and path not in owners:
+                owners.append(path)
+    legacy = channel_state.get(GAP_TRANSCRIPT_KEY)
+    if isinstance(legacy, str) and legacy and legacy not in owners:
+        owners.append(legacy)
+    return owners[: MAX_PENDING_TRANSCRIPTS + 1]
+
+
+def _store_gap_owner_transcripts(
+    channel_state: dict[str, Any], owners: list[str]
+) -> list[str]:
+    bounded: list[str] = []
+    for path in owners:
+        if isinstance(path, str) and path and path not in bounded:
+            bounded.append(path)
+    bounded = bounded[: MAX_PENDING_TRANSCRIPTS + 1]
+    if bounded:
+        channel_state[GAP_OWNER_TRANSCRIPTS_KEY] = bounded
+    else:
+        channel_state.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
+    return bounded
 
 
 def _bounded_retired_transcripts(
@@ -808,8 +924,6 @@ def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
 
 
 def assistant_blocks(transcript: Path) -> TranscriptReadResult:
-    if _regular_file_stat_without_symlink(transcript) is None:
-        return TranscriptReadResult([], "UnsafePath")
     flags = (
         os.O_RDONLY
         | getattr(os, "O_CLOEXEC", 0)
@@ -818,7 +932,10 @@ def assistant_blocks(transcript: Path) -> TranscriptReadResult:
     )
     descriptor = -1
     try:
-        descriptor = os.open(transcript, flags)
+        opened = _open_regular_file_beneath_parent(transcript, flags)
+        if opened is None:
+            return TranscriptReadResult([], "UnsafePath")
+        descriptor = opened
         if not stat_mode.S_ISREG(os.fstat(descriptor).st_mode):
             return TranscriptReadResult([], "UnsafePath")
         if fcntl is not None and getattr(os, "O_NONBLOCK", 0):
@@ -1878,19 +1995,38 @@ def tick_selector_sync(
     gap or coverage state machines.
     """
     cid = ch.channel_id
-    if not f_growing or not selected_transcript:
-        # No growing live transcript to compare against — a mismatch is not
-        # actionable, and any pending divergence window is stale.  Skip the HTTP
-        # probe entirely (matches tick_coverage's probe-only-when-needed shape).
+    if not selected_transcript:
         chs.pop("selector_diverged_since", None)
+        chs.pop(SELECTOR_DIVERGED_TRANSCRIPT_KEY, None)
+        return
+    selected_path = str(selected_transcript)
+    window_path = chs.get(SELECTOR_DIVERGED_TRANSCRIPT_KEY)
+    if not f_growing:
+        # A quiet/tool-only tick supplies no new F evidence.  It must not erase
+        # a previously proven divergence for the same selection; otherwise one
+        # normal long tool call resets the 300s confirmation forever.  A changed
+        # selection does invalidate the old window.
+        if (
+            isinstance(chs.get("selector_diverged_since"), (int, float))
+            and not isinstance(chs.get("selector_diverged_since"), bool)
+            and window_path == selected_path
+        ):
+            rt.log(
+                f"[{cid}] selector-sync quiet; retained divergence window "
+                f"F={selected_path}"
+            )
+            return
+        chs.pop("selector_diverged_since", None)
+        chs.pop(SELECTOR_DIVERGED_TRANSCRIPT_KEY, None)
         return
 
     probe = rt.watcher_state(cid)
     bound = probe.bound_output_path if probe.status == 200 else None
-    verdict = evaluate_selector_sync(bound, str(selected_transcript), f_growing)
+    verdict = evaluate_selector_sync(bound, selected_path, f_growing)
 
     if not verdict.diverged:
         chs.pop("selector_diverged_since", None)
+        chs.pop(SELECTOR_DIVERGED_TRANSCRIPT_KEY, None)
         if verdict.state == SELECTOR_UNKNOWN:
             # Fail-closed: old server without the field, JSON null, or dcserver
             # unreachable → never alarm on an unknown bind.
@@ -1900,11 +2036,16 @@ def tick_selector_sync(
         return
 
     raw_since = chs.get("selector_diverged_since")
-    if isinstance(raw_since, (int, float)) and not isinstance(raw_since, bool):
+    if (
+        window_path == selected_path
+        and isinstance(raw_since, (int, float))
+        and not isinstance(raw_since, bool)
+    ):
         since = float(raw_since)
     else:
         since = now
     chs["selector_diverged_since"] = since
+    chs[SELECTOR_DIVERGED_TRANSCRIPT_KEY] = selected_path
     age = now - since
     if not selector_divergence_confirmed(verdict.diverged, age, rt.cfg.swap_confirm_secs):
         rt.log(
@@ -1955,12 +2096,28 @@ def tick_selector_sync(
 def _alert_pending_retirement(
     rt: Runtime,
     ch: ChannelConfig,
+    channel_state: dict[str, Any],
     paths: list[str],
+    now: float,
     *,
     reason: str,
-) -> None:
+) -> bool:
     if not paths:
-        return
+        return False
+    raw_last_alert = channel_state.get(
+        LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY, 0.0
+    )
+    last_alert = (
+        float(raw_last_alert)
+        if _is_finite_nonnegative_number(raw_last_alert)
+        else 0.0
+    )
+    if now - last_alert < rt.cfg.realert_secs:
+        rt.log(
+            f"[{ch.channel_id}] transcript-retirement-alert suppressed "
+            f"reason={reason} count={len(paths)} cooldown"
+        )
+        return False
     if reason == "idle":
         title = "릴레이 트랜스크립트 평가 권한 만료"
         detail = (
@@ -1981,6 +2138,8 @@ def _alert_pending_retirement(
         f"🚨 **{title}**\n\n{detail}\n\n{sample}\n\n"
         f"런타임: {rt.dcserver_snapshot()}",
     )
+    channel_state[LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY] = now
+    return True
 
 
 def _clear_gap_alert_without_recovery(
@@ -1991,20 +2150,35 @@ def _clear_gap_alert_without_recovery(
 ) -> bool:
     retired = set(authority_paths)
     gap_path = channel_state.get(GAP_TRANSCRIPT_KEY)
-    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
-    if (
-        isinstance(gap_path, str)
-        and gap_path
-        and gap_path not in retired
-    ) or (
-        not isinstance(gap_path, str)
-        and isinstance(selected, str)
-        and selected
-        and selected not in retired
-    ):
+    previous_owners = _validated_gap_owner_transcripts(channel_state)
+    retained_owners = [path for path in previous_owners if path not in retired]
+    gap_state_open = bool(
+        previous_owners
+        or channel_state.get("alerting")
+        or channel_state.get("gap_since")
+        or channel_state.get("issue_url")
+    )
+    if not retained_owners and gap_state_open:
+        # Legacy singleton state may not yet have the owner set.  Preserve any
+        # still-live selected/pending authority until this tick evaluates it;
+        # only an explicit OK verdict may claim recovery.
+        selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+        fallback = (
+            [selected] if isinstance(selected, str) and selected else []
+        ) + _validated_pending_transcripts(channel_state)
+        retained_owners = [path for path in fallback if path not in retired]
+    retained_owners = _store_gap_owner_transcripts(
+        channel_state, retained_owners
+    )
+    if retained_owners:
+        if gap_path not in retained_owners:
+            selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+            channel_state[GAP_TRANSCRIPT_KEY] = (
+                selected if selected in retained_owners else retained_owners[0]
+            )
         rt.log(
             f"[{channel_id}] unrelated transcript retirement preserved live "
-            "gap authority"
+            f"gap authority owners={len(retained_owners)}"
         )
         return False
     if channel_state.get("alerting"):
@@ -2016,6 +2190,7 @@ def _clear_gap_alert_without_recovery(
     channel_state.pop("gap_since", None)
     channel_state.pop("issue_url", None)
     channel_state.pop(GAP_TRANSCRIPT_KEY, None)
+    channel_state.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
     return True
 
 
@@ -2038,7 +2213,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     candidates = transcript_candidates(dirs)
     previous_sizes = _validated_transcript_sizes(chs)
     previous_seen_at = _validated_transcript_seen_at(chs, previous_sizes, now)
-    known_state_initialized = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)
+    known_state_persisted = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)
     known_at = _validated_transcript_known_at(chs, now)
     pending_paths = _validated_pending_transcripts(chs)
     pending_failures = _validated_pending_failures(chs, pending_paths)
@@ -2088,6 +2263,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         or retired_transcripts
         or (isinstance(previous_selected, str) and previous_selected)
     )
+    # Upgrade boundary: pre-known_at state already has a selected/size/
+    # watermark authority.  Its first post-upgrade unseen path is still a true
+    # first observation; otherwise an unreadable debut is labelled
+    # unproven_stale once, persisted as known, then skipped forever.
+    known_state_initialized = known_state_persisted or tracking_initialized
     bootstrapped_from_watermark = False
     candidate_paths = {str(candidate.path) for candidate in candidates}
     selectable_candidate_paths = {
@@ -2335,10 +2515,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     else:
         chs.pop(PENDING_TRANSCRIPT_OVERFLOW_KEY, None)
     pending_paths = bounded_pending_paths
+    failure_authorities = _read_failure_authority_paths(chs, pending_paths)
     pending_failures = {
         path: failures
         for path, failures in pending_failures.items()
-        if path in set(pending_paths)
+        if path in failure_authorities
     }
     pending_since = {
         path: pending_since.get(path, now) for path in pending_paths
@@ -2408,7 +2589,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"[{cid}] transcript-pending-expired count={len(expired_pending_paths)}"
         )
         _alert_pending_retirement(
-            rt, ch, expired_pending_paths, reason="idle"
+            rt, ch, chs, expired_pending_paths, now, reason="idle"
         )
         _clear_gap_alert_without_recovery(
             rt, chs, cid, expired_pending_paths
@@ -2431,21 +2612,24 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         rt.log(f"[{cid}] selector-sync tick error: {type(e).__name__}: {e}")
 
     pending_set = set(pending_paths)
+    gap_owner_paths = _validated_gap_owner_transcripts(chs)
+    gap_owner_set = set(gap_owner_paths)
     evaluation_candidates: list[TranscriptCandidate] = []
     if selected is not None:
         evaluation_candidates.append(selected)
-    for path in pending_paths:
-        candidate = next(
-            (candidate for candidate in candidates if str(candidate.path) == path),
-            None,
-        )
+    for path in [*pending_paths, *gap_owner_paths]:
+        candidate = candidate_by_path.get(path)
         if candidate is not None and candidate not in evaluation_candidates:
             evaluation_candidates.append(candidate)
     active_candidates: list[TranscriptCandidate] = []
     for candidate in evaluation_candidates:
         path = str(candidate.path)
         idle = now - candidate.mtime
-        if path not in pending_set and idle >= cfg.idle_quiet_secs:
+        if (
+            path not in pending_set
+            and path not in gap_owner_set
+            and idle >= cfg.idle_quiet_secs
+        ):
             rt.log(
                 f"[{cid}] idle {int(min(idle, 86400 * 365) // 60)}m "
                 f"path={path} — no live session, skipping"
@@ -2495,13 +2679,13 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 )
             else:
                 rt.log(f"[{cid}] transcript-read-incomplete path={path}")
-            owns_read_authority = path in pending_set or (
-                selected is not None and candidate.path == selected.path
+            owns_read_authority = (
+                path in pending_set
+                or path in gap_owner_set
+                or (selected is not None and candidate.path == selected.path)
             )
             if owns_read_authority:
-                if path not in remaining_pending:
-                    remaining_pending.append(path)
-                    pending_since.setdefault(path, now)
+                if path not in pending_set and path not in pending_failures:
                     rt.log(
                         f"[{cid}] transcript-selected-read-failure-tracked "
                         f"path={path}"
@@ -2546,7 +2730,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 f"state={verdict.state} lost={verdict.lost} "
                 f"fresh_undelivered={fresh_undelivered}"
             )
-            if verdict.state == STATE_OK and fresh_undelivered == 0:
+            if (
+                verdict.state == STATE_OK
+                and fresh_undelivered == 0
+                and read_result.blocks
+            ):
                 remaining_pending = [
                     pending for pending in remaining_pending if pending != path
                 ]
@@ -2556,10 +2744,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         set(merged_sizes) | candidate_paths | set(pending_since),
     )
     chs[PENDING_TRANSCRIPTS_KEY] = remaining_pending
+    failure_authorities = _read_failure_authority_paths(chs, remaining_pending)
     pending_failures = {
         path: failures
         for path, failures in pending_failures.items()
-        if path in set(remaining_pending)
+        if path in failure_authorities
     }
     pending_since = {
         path: pending_since.get(path, now) for path in remaining_pending
@@ -2586,7 +2775,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             f"count={len(escalated_pending_paths)}"
         )
         _alert_pending_retirement(
-            rt, ch, escalated_pending_paths, reason="read_failure"
+            rt,
+            ch,
+            chs,
+            escalated_pending_paths,
+            now,
+            reason="read_failure",
         )
         _clear_gap_alert_without_recovery(
             rt, chs, cid, escalated_pending_paths
@@ -2612,6 +2806,29 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ),
     )
     verdict_path = str(verdict_candidate.path)
+    previous_gap_owners = _validated_gap_owner_transcripts(chs)
+    evaluated_paths = {str(candidate.path) for candidate, _ in evaluated}
+    incident_open = bool(
+        previous_gap_owners
+        or chs.get("alerting")
+        or chs.get("gap_since")
+        or chs.get("issue_url")
+    )
+    next_gap_owners = [
+        path for path in previous_gap_owners if path not in evaluated_paths
+    ]
+    for candidate, verdict in evaluated:
+        path = str(candidate.path)
+        unresolved = verdict.state == STATE_GAP or (
+            incident_open and verdict.state == STATE_LAGGING
+        )
+        if unresolved and path not in next_gap_owners:
+            next_gap_owners.append(path)
+    next_gap_owners = _store_gap_owner_transcripts(chs, next_gap_owners)
+    if next_gap_owners and chs.get(GAP_TRANSCRIPT_KEY) not in next_gap_owners:
+        chs[GAP_TRANSCRIPT_KEY] = (
+            verdict_path if verdict_path in next_gap_owners else next_gap_owners[0]
+        )
     if unreadable_paths and v.state == STATE_OK:
         rt.log(
             f"[{cid}] transcript-verdict-incomplete "
@@ -2619,14 +2836,28 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         )
         return
     if retired_pending_paths and v.state == STATE_OK:
-        if _clear_gap_alert_without_recovery(
-            rt, chs, cid, retired_pending_paths
-        ):
-            rt.log(
-                f"[{cid}] transcript-verdict-unresolved-retirement "
-                f"retired={len(retired_pending_paths)}"
-            )
-            return
+        if not next_gap_owners:
+            if chs.get("alerting"):
+                rt.log(
+                    f"[{cid}] alert state transitioned to unresolved transcript "
+                    "escalation — no clean recovery claimed"
+                )
+            chs.pop("alerting", None)
+            chs.pop("gap_since", None)
+            chs.pop("issue_url", None)
+            chs.pop(GAP_TRANSCRIPT_KEY, None)
+            chs.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
+        rt.log(
+            f"[{cid}] transcript-verdict-unresolved-retirement "
+            f"retired={len(retired_pending_paths)}"
+        )
+        return
+    if next_gap_owners and v.state == STATE_OK:
+        rt.log(
+            f"[{cid}] transcript-verdict-incomplete "
+            f"unresolved_gap_owners={len(next_gap_owners)}"
+        )
+        return
 
     if v.state == STATE_GAP:
         chs[GAP_TRANSCRIPT_KEY] = verdict_path
@@ -2697,6 +2928,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         chs.pop("gap_since", None)
         chs.pop("issue_url", None)
         chs.pop(GAP_TRANSCRIPT_KEY, None)
+        chs.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
         rt.log(
             f"[{cid}] ok path={verdict_path} blocks={v.blocks} "
             f"stale={v.stale} lost=0"

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -119,19 +119,27 @@ LAST_PENDING_TRANSCRIPT_RETIREMENT_ALERT_KEY = (
 )
 GAP_TRANSCRIPT_KEY = "gap_transcript"
 GAP_OWNER_TRANSCRIPTS_KEY = "gap_owner_transcripts"
+RECOVERED_GAP_GUARDS_KEY = "recovered_gap_replay_guards"
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
 MAX_GAP_OWNER_TRANSCRIPTS = MAX_PENDING_TRANSCRIPTS + 1
+MAX_RECOVERED_GAP_GUARDS = MAX_KNOWN_TRANSCRIPTS
 MAX_RETIRED_TRANSCRIPTS = 32
-# Selected, pending, and unresolved GAP-owner transcripts each retain
-# independent delivery authority.  The watermark cap must fit their full
-# deduplicated worst-case union; otherwise a recovered GAP owner's newly
-# advanced watermark can be evicted before bounded Discord history rolls off.
+# Selected, pending, unresolved GAP-owner, and recovered replay-guard paths
+# each retain independent delivery authority. The watermark cap fits their
+# full deduplicated worst-case union. Recovered guards follow the same bounded
+# path-lifecycle budget as known transcripts: a guard is reclaimed only after
+# one full history TTL of definite absence. If their store is full, recovery
+# stays open rather than evicting an older replay floor.
 MAX_DELIVERED_WATERMARKS = (
-    1 + MAX_PENDING_TRANSCRIPTS + MAX_GAP_OWNER_TRANSCRIPTS
+    1
+    + MAX_PENDING_TRANSCRIPTS
+    + MAX_GAP_OWNER_TRANSCRIPTS
+    + MAX_RECOVERED_GAP_GUARDS
 )
 TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
+RECOVERED_GAP_GUARD_TTL_SECS = TRANSCRIPT_HISTORY_TTL_SECS
 
 PG_TOPOLOGY_TUNNEL = "tunnel"
 PG_TOPOLOGY_DIRECT = "direct"
@@ -446,7 +454,9 @@ def _open_regular_file_beneath_parent(
     except ValueError:
         return None
     components = relative.parts
-    if not components or any(component in ("", ".", "..") for component in components):
+    if not components or any(
+        component in ("", ".", "..") for component in components
+    ):
         return None
 
     directory_descriptors: list[int] = []
@@ -470,7 +480,10 @@ def _open_regular_file_beneath_parent(
             return None
         root_descriptor = os.open(normalized_root, directory_flags)
         directory_descriptors.append(root_descriptor)
-        opened_root = os.fstat(root_descriptor)
+        try:
+            opened_root = os.fstat(root_descriptor)
+        except OSError:
+            return RECOVERED_GAP_PATH_AMBIGUOUS
         if not stat_mode.S_ISDIR(opened_root.st_mode) or not _same_file_identity(
             expected_root, opened_root
         ):
@@ -487,7 +500,10 @@ def _open_regular_file_beneath_parent(
                 component, directory_flags, dir_fd=parent_descriptor
             )
             directory_descriptors.append(child_descriptor)
-            opened_directory = os.fstat(child_descriptor)
+            try:
+                opened_directory = os.fstat(child_descriptor)
+            except OSError:
+                return RECOVERED_GAP_PATH_AMBIGUOUS
             if not stat_mode.S_ISDIR(
                 opened_directory.st_mode
             ) or not _same_file_identity(expected_directory, opened_directory):
@@ -650,16 +666,17 @@ def _read_failure_authority_paths(
 ) -> set[str]:
     """Paths whose consecutive read-failure counter must survive this tick.
 
-    Selected and unresolved GAP-owner transcripts have independent evaluation
-    authority in addition to the bounded pending queue.  Folding either into a
-    full 32-path queue would evict an existing authority, so pin their counters
-    separately while leaving the pending cap unchanged.
+    Selected, unresolved GAP-owner, and recovered replay-guard transcripts have
+    independent evaluation authority in addition to the bounded pending queue.
+    Folding any into a full 32-path queue would evict an existing authority, so
+    pin their counters separately while leaving the pending cap unchanged.
     """
     authorities = set(pending_paths)
     selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
     if isinstance(selected, str) and selected:
         authorities.add(selected)
     authorities.update(_validated_gap_owner_transcripts(channel_state))
+    authorities.update(_validated_recovered_gap_guards(channel_state))
     return authorities
 
 
@@ -726,6 +743,268 @@ def _store_gap_owner_transcripts(
     else:
         channel_state.pop(GAP_OWNER_TRANSCRIPTS_KEY, None)
     return bounded
+
+
+def _validated_recovered_gap_guards(
+    channel_state: Mapping[str, Any],
+) -> dict[str, tuple[int, float, float, float | None]]:
+    """Return bounded recovered replay guards with absence lifecycle state."""
+    raw = channel_state.get(RECOVERED_GAP_GUARDS_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    guards: dict[str, tuple[int, float, float, float | None]] = {}
+    for path, entry in raw.items():
+        if len(guards) >= MAX_RECOVERED_GAP_GUARDS:
+            break
+        if not isinstance(path, str) or not path or not isinstance(entry, dict):
+            continue
+        size = entry.get("size")
+        confirmed_at = entry.get("confirmed_at")
+        last_seen_at = entry.get("last_seen_at")
+        absent_since = entry.get("absent_since")
+        if (
+            isinstance(size, int)
+            and not isinstance(size, bool)
+            and size >= 0
+            and _is_finite_nonnegative_number(confirmed_at)
+            and _is_finite_nonnegative_number(last_seen_at)
+            and (
+                absent_since is None
+                or (
+                    _is_finite_nonnegative_number(absent_since)
+                    and float(absent_since) >= float(last_seen_at)
+                )
+            )
+        ):
+            guards[path] = (
+                size,
+                float(confirmed_at),
+                float(last_seen_at),
+                None if absent_since is None else float(absent_since),
+            )
+    return guards
+
+
+def _store_recovered_gap_guards(
+    channel_state: dict[str, Any],
+    guards: Mapping[str, tuple[int, float, float, float | None]],
+) -> None:
+    bounded = dict(list(guards.items())[:MAX_RECOVERED_GAP_GUARDS])
+    if bounded:
+        channel_state[RECOVERED_GAP_GUARDS_KEY] = {
+            path: {
+                "size": size,
+                "confirmed_at": confirmed_at,
+                "last_seen_at": last_seen_at,
+                "absent_since": absent_since,
+            }
+            for path, (
+                size,
+                confirmed_at,
+                last_seen_at,
+                absent_since,
+            ) in bounded.items()
+        }
+    else:
+        channel_state.pop(RECOVERED_GAP_GUARDS_KEY, None)
+
+
+RECOVERED_GAP_PATH_PRESENT = "present"
+RECOVERED_GAP_PATH_ABSENT = "absent"
+RECOVERED_GAP_PATH_AMBIGUOUS = "ambiguous"
+RECOVERED_GAP_PATH_INVALID = "invalid"
+
+
+def _recovered_gap_path_presence_beneath_root(
+    path: Path, trusted_root: Path
+) -> str:
+    """Prove path presence/absence beneath a no-follow descriptor root."""
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    nofollow_flag = getattr(os, "O_NOFOLLOW", 0)
+    nonblock_flag = getattr(os, "O_NONBLOCK", 0)
+    if not directory_flag or not nofollow_flag or not nonblock_flag:
+        return RECOVERED_GAP_PATH_AMBIGUOUS
+    normalized_path = _lexical_absolute_path(path)
+    normalized_root = _lexical_absolute_path(trusted_root)
+    if (
+        normalized_path is None
+        or normalized_root is None
+        or normalized_path != path
+        or normalized_root != trusted_root
+    ):
+        return RECOVERED_GAP_PATH_INVALID
+    try:
+        relative = normalized_path.relative_to(normalized_root)
+    except ValueError:
+        return RECOVERED_GAP_PATH_INVALID
+    components = relative.parts
+    if not components or any(component in ("", ".", "..") for component in components):
+        return RECOVERED_GAP_PATH_INVALID
+
+    descriptors: list[int] = []
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | directory_flag
+        | nofollow_flag
+        | nonblock_flag
+    )
+    try:
+        try:
+            expected_root = normalized_root.stat(follow_symlinks=False)
+            if not stat_mode.S_ISDIR(expected_root.st_mode):
+                return RECOVERED_GAP_PATH_AMBIGUOUS
+            root_descriptor = os.open(normalized_root, directory_flags)
+        except (OSError, NotImplementedError, TypeError, ValueError, UnicodeError):
+            return RECOVERED_GAP_PATH_AMBIGUOUS
+        descriptors.append(root_descriptor)
+        opened_root = os.fstat(root_descriptor)
+        if not stat_mode.S_ISDIR(opened_root.st_mode) or not _same_file_identity(
+            expected_root, opened_root
+        ):
+            return RECOVERED_GAP_PATH_AMBIGUOUS
+
+        for component in components[:-1]:
+            parent_descriptor = descriptors[-1]
+            try:
+                expected_directory = os.stat(
+                    component,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return RECOVERED_GAP_PATH_ABSENT
+            except (OSError, NotImplementedError, TypeError, ValueError):
+                return RECOVERED_GAP_PATH_AMBIGUOUS
+            if not stat_mode.S_ISDIR(expected_directory.st_mode):
+                return RECOVERED_GAP_PATH_AMBIGUOUS
+            try:
+                child_descriptor = os.open(
+                    component, directory_flags, dir_fd=parent_descriptor
+                )
+            except (OSError, NotImplementedError, TypeError, ValueError):
+                return RECOVERED_GAP_PATH_AMBIGUOUS
+            descriptors.append(child_descriptor)
+            opened_directory = os.fstat(child_descriptor)
+            if not stat_mode.S_ISDIR(
+                opened_directory.st_mode
+            ) or not _same_file_identity(expected_directory, opened_directory):
+                return RECOVERED_GAP_PATH_AMBIGUOUS
+
+        try:
+            leaf = os.stat(
+                components[-1],
+                dir_fd=descriptors[-1],
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return RECOVERED_GAP_PATH_ABSENT
+        except (OSError, NotImplementedError, TypeError, ValueError):
+            return RECOVERED_GAP_PATH_AMBIGUOUS
+        return (
+            RECOVERED_GAP_PATH_PRESENT
+            if stat_mode.S_ISREG(leaf.st_mode)
+            else RECOVERED_GAP_PATH_AMBIGUOUS
+        )
+    finally:
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _recovered_gap_path_presence(
+    value: str,
+    discovered_paths: set[str],
+    project_root: Path,
+    pattern: re.Pattern[str],
+) -> str:
+    """Classify a guarded path without treating discovery/I/O errors as absence."""
+    if value in discovered_paths:
+        return RECOVERED_GAP_PATH_PRESENT
+    path = _lexical_absolute_path(value)
+    root = _lexical_absolute_path(project_root)
+    if (
+        path is None
+        or root is None
+        or str(path) != value
+        or path.suffix != ".jsonl"
+        or path.parent.parent != root
+        or pattern.fullmatch(path.parent.name) is None
+    ):
+        return RECOVERED_GAP_PATH_INVALID
+    return _recovered_gap_path_presence_beneath_root(
+        path,
+        root,
+    )
+
+
+def _refresh_recovered_gap_guards(
+    guards: Mapping[str, tuple[int, float, float, float | None]],
+    discovered_paths: set[str],
+    protected_paths: set[str],
+    project_root: Path,
+    pattern: re.Pattern[str],
+    now: float,
+) -> tuple[dict[str, tuple[int, float, float, float | None]], list[str]]:
+    """Advance guard lifecycles and reclaim only continuously absent paths."""
+    refreshed: dict[str, tuple[int, float, float, float | None]] = {}
+    reclaimed: list[str] = []
+    for path, (size, confirmed_at, last_seen_at, absent_since) in guards.items():
+        presence = _recovered_gap_path_presence(
+            path, discovered_paths, project_root, pattern
+        )
+        if presence == RECOVERED_GAP_PATH_INVALID:
+            reclaimed.append(path)
+            continue
+        if presence == RECOVERED_GAP_PATH_PRESENT:
+            refreshed[path] = (size, confirmed_at, now, None)
+            continue
+        if presence == RECOVERED_GAP_PATH_AMBIGUOUS:
+            # Ambiguity breaks proof of continuous absence. Never expire a
+            # replay floor because a directory read, stat, or file type was
+            # unsafe to interpret.
+            refreshed[path] = (size, confirmed_at, last_seen_at, None)
+            continue
+        missing_since = absent_since
+        if missing_since is None or missing_since > now:
+            missing_since = now
+        if (
+            path not in protected_paths
+            and now - missing_since >= RECOVERED_GAP_GUARD_TTL_SECS
+        ):
+            reclaimed.append(path)
+            continue
+        refreshed[path] = (size, confirmed_at, last_seen_at, missing_since)
+    return refreshed, reclaimed
+
+
+def _upsert_recovered_gap_guard(
+    guards: Mapping[str, tuple[int, float, float, float | None]],
+    path: str,
+    size: int,
+    confirmed_at: float,
+) -> tuple[dict[str, tuple[int, float, float, float | None]], bool]:
+    """Re-arm one guard, refusing new admission when the bound is full."""
+    updated = dict(guards)
+    if (
+        not path
+        or not isinstance(size, int)
+        or isinstance(size, bool)
+        or size < 0
+        or not _is_finite_nonnegative_number(confirmed_at)
+    ):
+        return updated, False
+    if path not in updated and len(updated) >= MAX_RECOVERED_GAP_GUARDS:
+        return updated, False
+    updated[path] = (
+        size,
+        float(confirmed_at),
+        float(confirmed_at),
+        None,
+    )
+    return updated, True
 
 
 def _bounded_retired_transcripts(
@@ -1324,6 +1603,7 @@ def _delivered_watermark_authority_paths(
     authorities = [selected] if isinstance(selected, str) and selected else []
     authorities.extend(_validated_pending_transcripts(channel_state))
     authorities.extend(_validated_gap_owner_transcripts(channel_state))
+    authorities.extend(_validated_recovered_gap_guards(channel_state))
     return list(dict.fromkeys(authorities))
 
 
@@ -1394,6 +1674,61 @@ def advance_delivered_watermark(
         for key, (watermark, updated_at) in bounded.items()
     }
     return True
+
+
+def _forget_reclaimed_recovered_gap_lifecycles(
+    channel_state: dict[str, Any], paths: list[str]
+) -> None:
+    """Drop all replay identity for guards proven absent for one full TTL."""
+    reclaimed = set(paths)
+    if not reclaimed:
+        return
+
+    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+    if isinstance(selected, str) and selected in reclaimed:
+        channel_state.pop(SELECTED_TRANSCRIPT_KEY, None)
+
+    for key in (
+        TRANSCRIPT_SIZES_KEY,
+        TRANSCRIPT_SEEN_AT_KEY,
+        TRANSCRIPT_KNOWN_AT_KEY,
+        PENDING_TRANSCRIPT_FAILURES_KEY,
+        PENDING_TRANSCRIPT_SINCE_KEY,
+        RETIRED_TRANSCRIPTS_KEY,
+    ):
+        raw = channel_state.get(key)
+        if not isinstance(raw, dict):
+            continue
+        retained = {path: entry for path, entry in raw.items() if path not in reclaimed}
+        if retained:
+            channel_state[key] = retained
+        else:
+            channel_state.pop(key, None)
+
+    raw_pending = channel_state.get(PENDING_TRANSCRIPTS_KEY)
+    if isinstance(raw_pending, list):
+        retained_pending = [path for path in raw_pending if path not in reclaimed]
+        if retained_pending:
+            channel_state[PENDING_TRANSCRIPTS_KEY] = retained_pending
+        else:
+            channel_state.pop(PENDING_TRANSCRIPTS_KEY, None)
+
+    watermarks = {
+        path: entry
+        for path, entry in delivered_watermarks(channel_state).items()
+        if path not in reclaimed
+    }
+    if watermarks:
+        bounded = _bounded_delivered_watermarks(
+            watermarks,
+            pinned_paths=_delivered_watermark_authority_paths(channel_state),
+        )
+        channel_state[DELIVERED_WATERMARKS_KEY] = {
+            path: {"delivered_ts": delivered_ts, "updated_at": updated_at}
+            for path, (delivered_ts, updated_at) in bounded.items()
+        }
+    else:
+        channel_state.pop(DELIVERED_WATERMARKS_KEY, None)
 
 
 def load_state(path: Path) -> dict[str, Any]:
@@ -2291,6 +2626,26 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     project_root = projects_root()
     dirs = channel_project_dirs(project_root, pattern)
     candidates = transcript_candidates(dirs)
+    discovered_paths = {str(candidate.path) for candidate in candidates}
+    pending_paths = _validated_pending_transcripts(chs)
+    protected_guard_paths = set(pending_paths) | set(
+        _validated_gap_owner_transcripts(chs)
+    )
+    recovered_gap_guards, reclaimed_guard_paths = _refresh_recovered_gap_guards(
+        _validated_recovered_gap_guards(chs),
+        discovered_paths,
+        protected_guard_paths,
+        project_root,
+        pattern,
+        now,
+    )
+    _store_recovered_gap_guards(chs, recovered_gap_guards)
+    if reclaimed_guard_paths:
+        _forget_reclaimed_recovered_gap_lifecycles(chs, reclaimed_guard_paths)
+        rt.log(
+            f"[{cid}] recovered-gap-guard-reclaimed "
+            f"count={len(reclaimed_guard_paths)}"
+        )
     previous_sizes = _validated_transcript_sizes(chs)
     previous_seen_at = _validated_transcript_seen_at(chs, previous_sizes, now)
     known_state_persisted = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)
@@ -2333,13 +2688,18 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     persisted_selected = previous_selected
     watermarks = delivered_watermarks(chs)
     known_before = (
-        set(known_at) | set(previous_sizes) | set(watermarks) | retired_paths
+        set(known_at)
+        | set(previous_sizes)
+        | set(watermarks)
+        | set(recovered_gap_guards)
+        | retired_paths
     )
 
     tracking_initialized = bool(
         previous_sizes
         or pending_paths
         or watermarks
+        or recovered_gap_guards
         or retired_transcripts
         or (isinstance(previous_selected, str) and previous_selected)
     )
@@ -2365,7 +2725,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 previous_selected,
                 project_root,
                 pattern,
-                set(previous_sizes) | set(watermarks),
+                set(previous_sizes) | set(watermarks) | set(recovered_gap_guards),
             )
         )
         if rechecked is not None:
@@ -2402,13 +2762,15 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     ):
         previous_selected = None
     selection_sizes = dict(previous_sizes)
+    for path, (size, _, _, _) in recovered_gap_guards.items():
+        selection_sizes.setdefault(path, size)
     live_debut_paths: list[str] = []
     if tracking_initialized:
         debut_candidates = sorted(
             (
                 candidate
                 for candidate in selectable_candidates
-                if str(candidate.path) not in previous_sizes
+                if str(candidate.path) not in selection_sizes
             ),
             key=lambda candidate: (-candidate.mtime, str(candidate.path)),
         )
@@ -2477,7 +2839,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     semantic_growth_paths: set[str] = set()
     for candidate in selectable_candidates:
         path = str(candidate.path)
-        prior_size = previous_sizes.get(path)
+        guard = recovered_gap_guards.get(path)
+        prior_size = guard[0] if guard is not None else previous_sizes.get(path)
         if prior_size is None or candidate.size <= prior_size:
             continue
         read_result = read_candidate(candidate)
@@ -2488,10 +2851,19 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ):
             semantic_growth_paths.add(path)
         elif read_result.error is None and not read_result.incomplete_tail:
+            if guard is not None:
+                _, confirmed_at, last_seen_at, absent_since = guard
+                recovered_gap_guards[path] = (
+                    max(prior_size, read_result.observed_size),
+                    confirmed_at,
+                    last_seen_at,
+                    absent_since,
+                )
             rt.log(
                 f"[{cid}] transcript-growth-ignored reason=non-semantic "
                 f"path={path}"
             )
+    _store_recovered_gap_guards(chs, recovered_gap_guards)
     tr, selection_reason = select_watch_transcript_with_reason(
         selectable_candidates,
         selection_sizes,
@@ -2533,6 +2905,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             else []
         )
         + pending_paths
+        + list(recovered_gap_guards)
         + [
             str(candidate.path)
             for candidate in sorted(
@@ -2694,10 +3067,15 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     pending_set = set(pending_paths)
     gap_owner_paths = _validated_gap_owner_transcripts(chs)
     gap_owner_set = set(gap_owner_paths)
+    recovered_guard_paths = list(_validated_recovered_gap_guards(chs))
+    recovered_guard_set = set(recovered_guard_paths)
     evaluation_candidates: list[TranscriptCandidate] = []
     if selected is not None:
         evaluation_candidates.append(selected)
-    for path in [*pending_paths, *gap_owner_paths]:
+    growing_guard_paths = [
+        path for path in recovered_guard_paths if path in semantic_growth_paths
+    ]
+    for path in [*pending_paths, *gap_owner_paths, *growing_guard_paths]:
         candidate = candidate_by_path.get(path)
         if candidate is not None and candidate not in evaluation_candidates:
             evaluation_candidates.append(candidate)
@@ -2708,6 +3086,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if (
             path not in pending_set
             and path not in gap_owner_set
+            and path not in recovered_guard_set
             and idle >= cfg.idle_quiet_secs
         ):
             rt.log(
@@ -2745,6 +3124,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     chs["read_failures"] = 0
 
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
+    fresh_undelivered_by_path: dict[str, int] = {}
     unreadable_paths: list[str] = []
     escalated_pending_paths: list[str] = []
     remaining_pending = list(pending_paths)
@@ -2762,6 +3142,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             owns_read_authority = (
                 path in pending_set
                 or path in gap_owner_set
+                or path in recovered_guard_set
                 or (selected is not None and candidate.path == selected.path)
             )
             if owns_read_authority:
@@ -2804,6 +3185,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             and epoch > verdict.delivered_ts
             and not delivered(text, hay)
         )
+        fresh_undelivered_by_path[path] = fresh_undelivered
         if path in pending_set:
             rt.log(
                 f"[{cid}] transcript-debut-eval path={path} "
@@ -2894,6 +3276,32 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         or chs.get("gap_since")
         or chs.get("issue_url")
     )
+    recovered_gap_guards = _validated_recovered_gap_guards(chs)
+    rejected_recoveries: list[str] = []
+    for candidate, verdict in evaluated:
+        path = str(candidate.path)
+        owns_guard = path in recovered_gap_guards
+        recovering_gap_owner = path in previous_gap_owners
+        if verdict.state != STATE_OK or not (owns_guard or recovering_gap_owner):
+            continue
+        if fresh_undelivered_by_path.get(path, 0) > 0:
+            if recovering_gap_owner:
+                rejected_recoveries.append(path)
+            continue
+        if delivered_watermark_for_path(chs, path) <= 0:
+            if recovering_gap_owner:
+                rejected_recoveries.append(path)
+            continue
+        recovered_gap_guards, admitted = _upsert_recovered_gap_guard(
+            recovered_gap_guards,
+            path,
+            candidate.size,
+            now,
+        )
+        if not admitted and recovering_gap_owner:
+            rejected_recoveries.append(path)
+    _store_recovered_gap_guards(chs, recovered_gap_guards)
+
     next_gap_owners = [
         path for path in previous_gap_owners if path not in evaluated_paths
     ]
@@ -2904,6 +3312,14 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         )
         if unresolved and path not in next_gap_owners:
             next_gap_owners.append(path)
+    for path in rejected_recoveries:
+        if path not in next_gap_owners:
+            next_gap_owners.append(path)
+    if rejected_recoveries:
+        rt.log(
+            f"[{cid}] recovered-gap-guard-capacity-blocked "
+            f"count={len(rejected_recoveries)} — recovery remains open"
+        )
     next_gap_owners = _store_gap_owner_transcripts(chs, next_gap_owners)
     if next_gap_owners and chs.get(GAP_TRANSCRIPT_KEY) not in next_gap_owners:
         chs[GAP_TRANSCRIPT_KEY] = (

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -483,7 +483,7 @@ def _open_regular_file_beneath_parent(
         try:
             opened_root = os.fstat(root_descriptor)
         except OSError:
-            return RECOVERED_GAP_PATH_AMBIGUOUS
+            return None
         if not stat_mode.S_ISDIR(opened_root.st_mode) or not _same_file_identity(
             expected_root, opened_root
         ):
@@ -503,7 +503,7 @@ def _open_regular_file_beneath_parent(
             try:
                 opened_directory = os.fstat(child_descriptor)
             except OSError:
-                return RECOVERED_GAP_PATH_AMBIGUOUS
+                return None
             if not stat_mode.S_ISDIR(
                 opened_directory.st_mode
             ) or not _same_file_identity(expected_directory, opened_directory):
@@ -858,7 +858,10 @@ def _recovered_gap_path_presence_beneath_root(
         except (OSError, NotImplementedError, TypeError, ValueError, UnicodeError):
             return RECOVERED_GAP_PATH_AMBIGUOUS
         descriptors.append(root_descriptor)
-        opened_root = os.fstat(root_descriptor)
+        try:
+            opened_root = os.fstat(root_descriptor)
+        except OSError:
+            return RECOVERED_GAP_PATH_AMBIGUOUS
         if not stat_mode.S_ISDIR(opened_root.st_mode) or not _same_file_identity(
             expected_root, opened_root
         ):
@@ -885,7 +888,10 @@ def _recovered_gap_path_presence_beneath_root(
             except (OSError, NotImplementedError, TypeError, ValueError):
                 return RECOVERED_GAP_PATH_AMBIGUOUS
             descriptors.append(child_descriptor)
-            opened_directory = os.fstat(child_descriptor)
+            try:
+                opened_directory = os.fstat(child_descriptor)
+            except OSError:
+                return RECOVERED_GAP_PATH_AMBIGUOUS
             if not stat_mode.S_ISDIR(
                 opened_directory.st_mode
             ) or not _same_file_identity(expected_directory, opened_directory):

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -53,6 +53,7 @@ import math
 import os
 import re
 import shutil
+import stat as stat_mode
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -99,12 +100,14 @@ MAX_DELIVERED_WATERMARKS = 16
 SELECTED_TRANSCRIPT_KEY = "selected_transcript"
 TRANSCRIPT_SIZES_KEY = "transcript_sizes"
 TRANSCRIPT_SEEN_AT_KEY = "transcript_seen_at"
+TRANSCRIPT_KNOWN_AT_KEY = "transcript_known_at"
 PENDING_TRANSCRIPTS_KEY = "pending_transcripts"
 PENDING_TRANSCRIPT_OVERFLOW_KEY = "pending_transcript_overflow"
 LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY = (
     "last_pending_transcript_overflow_alert"
 )
 MAX_TRANSCRIPT_HISTORY = 64
+MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
 TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
 
@@ -347,9 +350,35 @@ def main_channel_project_re(worktree_root: str, worktree_prefix: str) -> re.Patt
 
 def channel_project_dirs(root: Path, pattern: re.Pattern[str]) -> list[Path]:
     try:
-        return [d for d in root.iterdir() if d.is_dir() and pattern.match(d.name)]
+        entries = list(root.iterdir())
     except OSError:
         return []
+    return [
+        entry
+        for entry in entries
+        if _directory_without_symlink(entry) and pattern.match(entry.name)
+    ]
+
+
+def _directory_without_symlink(path: Path) -> bool:
+    try:
+        path_stat = path.stat(follow_symlinks=False)
+    except (OSError, ValueError, UnicodeError):
+        return False
+    return stat_mode.S_ISDIR(path_stat.st_mode)
+
+
+def _regular_file_stat_without_symlink(path: Path) -> os.stat_result | None:
+    try:
+        parent_stat = path.parent.stat(follow_symlinks=False)
+        path_stat = path.stat(follow_symlinks=False)
+    except (OSError, ValueError, UnicodeError):
+        return None
+    if not stat_mode.S_ISDIR(parent_stat.st_mode):
+        return None
+    if not stat_mode.S_ISREG(path_stat.st_mode):
+        return None
+    return path_stat
 
 
 @dataclass(frozen=True)
@@ -357,6 +386,12 @@ class TranscriptCandidate:
     path: Path
     size: int
     mtime: float
+
+
+@dataclass(frozen=True)
+class TranscriptReadResult:
+    blocks: list[tuple[float, str]]
+    error: str | None = None
 
 
 def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
@@ -367,11 +402,12 @@ def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
         except OSError:
             continue
         for path in paths:
-            try:
-                stat = path.stat()
-            except OSError:
+            path_stat = _regular_file_stat_without_symlink(path)
+            if path_stat is None:
                 continue
-            candidates.append(TranscriptCandidate(path, stat.st_size, stat.st_mtime))
+            candidates.append(
+                TranscriptCandidate(path, path_stat.st_size, path_stat.st_mtime)
+            )
     return candidates
 
 
@@ -400,11 +436,10 @@ def recheck_selected_transcript(
         or pattern.fullmatch(path.parent.name) is None
     ):
         return None
-    try:
-        stat = path.stat()
-    except (OSError, ValueError, UnicodeError):
+    path_stat = _regular_file_stat_without_symlink(path)
+    if path_stat is None:
         return None
-    return TranscriptCandidate(path, stat.st_size, stat.st_mtime)
+    return TranscriptCandidate(path, path_stat.st_size, path_stat.st_mtime)
 
 
 def _validated_transcript_sizes(channel_state: Mapping[str, Any]) -> dict[str, int]:
@@ -434,6 +469,22 @@ def _validated_transcript_seen_at(
             else now
         )
         for path in sizes
+    }
+
+
+def _validated_transcript_known_at(
+    channel_state: Mapping[str, Any], now: float
+) -> dict[str, float]:
+    raw = channel_state.get(TRANSCRIPT_KNOWN_AT_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        path: float(seen_at)
+        for path, seen_at in raw.items()
+        if isinstance(path, str)
+        and path
+        and _is_finite_nonnegative_number(seen_at)
+        and now - float(seen_at) <= TRANSCRIPT_HISTORY_TTL_SECS
     }
 
 
@@ -497,6 +548,34 @@ def _bounded_pending_transcripts(
         if path in history_paths and path not in pending:
             pending.append(path)
     return pending[:MAX_PENDING_TRANSCRIPTS]
+
+
+def _bounded_transcript_known_at(
+    known_at: Mapping[str, float], now: float, priority_paths: list[str]
+) -> dict[str, float]:
+    priority = {
+        path: index
+        for index, path in enumerate(dict.fromkeys(priority_paths))
+    }
+    entries = [
+        (path, float(seen_at))
+        for path, seen_at in known_at.items()
+        if isinstance(path, str)
+        and path
+        and _is_finite_nonnegative_number(seen_at)
+        and (
+            path in priority
+            or now - float(seen_at) <= TRANSCRIPT_HISTORY_TTL_SECS
+        )
+    ]
+    entries.sort(
+        key=lambda entry: (
+            priority.get(entry[0], len(priority)),
+            -entry[1],
+            entry[0],
+        )
+    )
+    return dict(entries[:MAX_KNOWN_TRANSCRIPTS])
 
 
 def select_watch_transcript(
@@ -628,12 +707,27 @@ def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
     return out
 
 
-def assistant_blocks(transcript: Path) -> list[tuple[float, str]]:
+def assistant_blocks(transcript: Path) -> TranscriptReadResult:
+    if _regular_file_stat_without_symlink(transcript) is None:
+        return TranscriptReadResult([], "UnsafePath")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
     try:
-        with transcript.open(encoding="utf-8") as f:
-            return assistant_blocks_from_lines(f)
-    except (OSError, UnicodeError):
-        return []
+        descriptor = os.open(transcript, flags)
+        if not stat_mode.S_ISREG(os.fstat(descriptor).st_mode):
+            return TranscriptReadResult([], "UnsafePath")
+        stream = os.fdopen(descriptor, "r", encoding="utf-8")
+        descriptor = -1
+        with stream as f:
+            return TranscriptReadResult(assistant_blocks_from_lines(f))
+    except (OSError, UnicodeError, ValueError) as exc:
+        return TranscriptReadResult([], type(exc).__name__)
+    finally:
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
 
 
 # ── Delivery matching + judgment (pure) ────────────────────────────────────────
@@ -1727,9 +1821,20 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     candidates = transcript_candidates(dirs)
     previous_sizes = _validated_transcript_sizes(chs)
     previous_seen_at = _validated_transcript_seen_at(chs, previous_sizes, now)
+    known_state_initialized = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)
+    known_at = _validated_transcript_known_at(chs, now)
     pending_paths = _validated_pending_transcripts(chs)
     previous_selected = chs.get(SELECTED_TRANSCRIPT_KEY)
     watermarks = delivered_watermarks(chs)
+    known_before = set(known_at) | set(previous_sizes) | set(watermarks)
+    read_cache: dict[str, TranscriptReadResult] = {}
+
+    def read_candidate(candidate: TranscriptCandidate) -> TranscriptReadResult:
+        path = str(candidate.path)
+        if path not in read_cache:
+            read_cache[path] = assistant_blocks(candidate.path)
+        return read_cache[path]
+
     tracking_initialized = bool(
         previous_sizes
         or pending_paths
@@ -1772,6 +1877,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if watermarked_candidates and len(watermarked_candidates) == len(candidates):
             previous_selected = max(watermarked_candidates)[1]
             bootstrapped_from_watermark = True
+    selection_sizes = dict(previous_sizes)
     if tracking_initialized:
         debut_candidates = sorted(
             (
@@ -1790,14 +1896,40 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                     f"[{cid}] transcript-debut-skip reason=idle "
                     f"idle_min={int(min(idle, 86400 * 365) // 60)} path={path}"
                 )
+                selection_sizes[path] = candidate.size
                 continue
+            read_result = read_candidate(candidate)
+            content_is_recent = any(
+                now - epoch < cfg.idle_quiet_secs
+                for epoch, _ in read_result.blocks
+            )
+            first_observation = known_state_initialized and path not in known_before
+            first_observation_without_readable_history = first_observation and (
+                read_result.error is not None or not read_result.blocks
+            )
+            if not content_is_recent and not first_observation_without_readable_history:
+                reason = (
+                    "known_stale_content"
+                    if path in known_before
+                    else "unproven_stale_content"
+                )
+                rt.log(f"[{cid}] transcript-debut-skip reason={reason} path={path}")
+                selection_sizes[path] = candidate.size
+                continue
+            if first_observation_without_readable_history:
+                selection_sizes[path] = candidate.size
             live_debut_paths.append(path)
         live_debut_set = set(live_debut_paths)
         pending_paths = live_debut_paths + [
             path for path in pending_paths if path not in live_debut_set
         ]
+    if bootstrapped_from_watermark:
+        for candidate in candidates:
+            path = str(candidate.path)
+            if path in watermarks:
+                selection_sizes.setdefault(path, candidate.size)
     tr, selection_reason = select_watch_transcript_with_reason(
-        candidates, previous_sizes, previous_selected
+        candidates, selection_sizes, previous_selected
     )
     if bootstrapped_from_watermark and selection_reason == "sticky":
         selection_reason = "watermark_bootstrap"
@@ -1831,6 +1963,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 watermarks.items(), key=lambda item: (-item[1][1], item[0])
             )
         ]
+    )
+    merged_known_at = dict(known_at)
+    for candidate in candidates:
+        merged_known_at[str(candidate.path)] = now
+    merged_known_at = _bounded_transcript_known_at(
+        merged_known_at, now, priority_paths
     )
     merged_sizes, merged_seen_at = _bounded_transcript_history(
         merged_sizes, merged_seen_at, now, priority_paths
@@ -1875,6 +2013,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     pending_paths = bounded_pending_paths
     chs[TRANSCRIPT_SIZES_KEY] = merged_sizes
     chs[TRANSCRIPT_SEEN_AT_KEY] = merged_seen_at
+    chs[TRANSCRIPT_KNOWN_AT_KEY] = merged_known_at
     chs[PENDING_TRANSCRIPTS_KEY] = pending_paths
     selected = next((candidate for candidate in candidates if candidate.path == tr), None)
     # I1 selector sync (#4408 phase 2): compare the dcserver's asserted relay
@@ -1937,12 +2076,21 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     chs["read_failures"] = 0
 
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
+    read_error_paths: list[str] = []
     remaining_pending = list(pending_paths)
     for candidate in active_candidates:
         path = str(candidate.path)
+        read_result = read_candidate(candidate)
+        if read_result.error is not None:
+            rt.log(
+                f"[{cid}] transcript-read-error path={path} "
+                f"error={read_result.error}"
+            )
+            read_error_paths.append(path)
+            continue
         prior_delivered_ts = delivered_watermark_for_path(chs, candidate.path)
         verdict = evaluate(
-            assistant_blocks(candidate.path),
+            read_result.blocks,
             hay,
             now,
             cfg.grace_secs,
@@ -1953,12 +2101,20 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             advance_delivered_watermark(
                 chs, candidate.path, verdict.delivered_ts, now
             )
+        fresh_undelivered = sum(
+            1
+            for epoch, text in read_result.blocks
+            if now - epoch <= cfg.grace_secs
+            and epoch > verdict.delivered_ts
+            and not delivered(text, hay)
+        )
         if path in pending_set:
             rt.log(
                 f"[{cid}] transcript-debut-eval path={path} "
-                f"state={verdict.state} lost={verdict.lost}"
+                f"state={verdict.state} lost={verdict.lost} "
+                f"fresh_undelivered={fresh_undelivered}"
             )
-            if path == str(tr) or verdict.state == STATE_OK:
+            if verdict.state == STATE_OK and fresh_undelivered == 0:
                 remaining_pending = [
                     pending for pending in remaining_pending if pending != path
                 ]
@@ -1966,6 +2122,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     chs[PENDING_TRANSCRIPTS_KEY] = _bounded_pending_transcripts(
         remaining_pending, set(merged_sizes)
     )
+    if not evaluated:
+        return
     state_rank = {STATE_OK: 0, STATE_LAGGING: 1, STATE_GAP: 2}
     verdict_candidate, v = max(
         evaluated,
@@ -1978,6 +2136,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ),
     )
     verdict_path = str(verdict_candidate.path)
+    if read_error_paths and v.state == STATE_OK:
+        rt.log(
+            f"[{cid}] transcript-verdict-incomplete "
+            f"read_errors={len(read_error_paths)}"
+        )
+        return
 
     if v.state == STATE_GAP:
         if rt.in_deploy_window(now):

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -101,7 +101,6 @@ SELECTOR_PATH_RUNTIME_MIRROR = "runtime_session_mirror"
 SELECTOR_PATH_UNCOMPARABLE = "uncomparable"
 
 DELIVERED_WATERMARKS_KEY = "delivered_watermarks"
-MAX_DELIVERED_WATERMARKS = 16
 SELECTED_TRANSCRIPT_KEY = "selected_transcript"
 TRANSCRIPT_SIZES_KEY = "transcript_sizes"
 TRANSCRIPT_SEEN_AT_KEY = "transcript_seen_at"
@@ -114,10 +113,16 @@ PENDING_TRANSCRIPT_OVERFLOW_KEY = "pending_transcript_overflow"
 LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY = (
     "last_pending_transcript_overflow_alert"
 )
+GAP_TRANSCRIPT_KEY = "gap_transcript"
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
 MAX_RETIRED_TRANSCRIPTS = 32
+# Every pending transcript can hold independent delivery authority in addition
+# to the selected non-pending transcript.  The watermark cap must fit and pin
+# that whole active set; otherwise an old-but-live pending path can be replayed
+# after unrelated paths refresh their watermarks.
+MAX_DELIVERED_WATERMARKS = MAX_PENDING_TRANSCRIPTS + 1
 TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
 
 PG_TOPOLOGY_TUNNEL = "tunnel"
@@ -402,6 +407,8 @@ class TranscriptReadResult:
     blocks: list[tuple[float, str]]
     error: str | None = None
     incomplete_tail: bool = False
+    semantic_end_offset: int = 0
+    observed_size: int = 0
 
 
 def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
@@ -670,18 +677,21 @@ def select_watch_transcript(
     candidates: list[TranscriptCandidate],
     previous_sizes: Mapping[str, int],
     previous_selected: str | Path | None = None,
+    semantic_growth_paths: set[str] | None = None,
 ) -> Path | None:
-    """Choose by observed growth, then retain the previously selected path.
+    """Choose by semantic growth, then retain the previous selected path.
 
-    A newly discovered candidate has no growth proof yet.  Once a prior size
-    exists, any file that grew wins over a newer-but-stagnant file; mtime and
-    path provide deterministic tie-breaking within the growing pool.  Without
-    growth, a still-present previous selection is sticky: mtime-only touches on
-    an old continuation transcript are not evidence that it became live again.
-    The caller owns I/O and persistence, keeping this selector pure.
+    The caller proves growth by finding a newly appended, timestamped,
+    deliverable assistant block beyond the prior byte baseline.  Raw bytes,
+    metadata rows, blank lines, and mtime touches never grant selection
+    authority.  The caller owns I/O and persistence, keeping this selector
+    pure.
     """
     return select_watch_transcript_with_reason(
-        candidates, previous_sizes, previous_selected
+        candidates,
+        previous_sizes,
+        previous_selected,
+        semantic_growth_paths,
     )[0]
 
 
@@ -689,14 +699,16 @@ def select_watch_transcript_with_reason(
     candidates: list[TranscriptCandidate],
     previous_sizes: Mapping[str, int],
     previous_selected: object = None,
+    semantic_growth_paths: set[str] | None = None,
 ) -> tuple[Path | None, str]:
     if not candidates:
         return None, "no_candidates"
+    semantic_growth_paths = semantic_growth_paths or set()
     growing = [
         candidate
         for candidate in candidates
         if str(candidate.path) in previous_sizes
-        and candidate.size > previous_sizes[str(candidate.path)]
+        and str(candidate.path) in semantic_growth_paths
     ]
     if growing:
         selected = max(
@@ -736,7 +748,7 @@ def select_watch_transcript_with_reason(
 
 def newest_transcript(dirs: list[Path]) -> Path | None:
     """Backward-compatible mtime selector for callers without growth state."""
-    return select_watch_transcript(transcript_candidates(dirs), {})
+    return select_watch_transcript(transcript_candidates(dirs), {}, None, set())
 
 
 # ── Transcript parsing ─────────────────────────────────────────────────────────
@@ -816,19 +828,31 @@ def assistant_blocks(transcript: Path) -> TranscriptReadResult:
                 fcntl.F_SETFL,
                 current_flags & ~getattr(os, "O_NONBLOCK", 0),
             )
-        stream = os.fdopen(descriptor, "r", encoding="utf-8")
+        stream = os.fdopen(descriptor, "rb")
         descriptor = -1
         with stream as f:
-            lines = f.readlines()
+            raw_lines = f.readlines()
+            lines = [line.decode("utf-8") for line in raw_lines]
             incomplete_tail = False
-            if lines and not lines[-1].endswith("\n"):
+            if raw_lines and not raw_lines[-1].endswith(b"\n"):
                 try:
                     json.loads(lines[-1])
                 except (json.JSONDecodeError, TypeError):
                     incomplete_tail = True
+            blocks: list[tuple[float, str]] = []
+            semantic_end_offset = 0
+            byte_offset = 0
+            for raw_line, line in zip(raw_lines, lines):
+                line_blocks = assistant_blocks_from_lines([line])
+                blocks.extend(line_blocks)
+                byte_offset += len(raw_line)
+                if line_blocks:
+                    semantic_end_offset = byte_offset
             return TranscriptReadResult(
-                assistant_blocks_from_lines(lines),
+                blocks,
                 incomplete_tail=incomplete_tail,
+                semantic_end_offset=semantic_end_offset,
+                observed_size=byte_offset,
             )
     except (OSError, UnicodeError, ValueError) as exc:
         return TranscriptReadResult([], type(exc).__name__)
@@ -1086,12 +1110,17 @@ def _is_finite_nonnegative_number(value: object) -> bool:
 def _bounded_delivered_watermarks(
     entries: Mapping[str, tuple[float, float]],
     preferred_path: str | None = None,
-    pinned_path: str | None = None,
+    pinned_paths: list[str] | None = None,
 ) -> dict[str, tuple[float, float]]:
+    pinned = {
+        path: index
+        for index, path in enumerate(dict.fromkeys(pinned_paths or []))
+        if path
+    }
     ordered = sorted(
         entries.items(),
         key=lambda item: (
-            0 if item[0] == pinned_path else 1,
+            pinned.get(item[0], len(pinned)),
             -item[1][1],
             0 if item[0] == preferred_path else 1,
             item[0],
@@ -1124,8 +1153,9 @@ def delivered_watermarks(
             continue
         valid[path] = (float(delivered_ts), float(updated_at))
     selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
-    pinned = selected if isinstance(selected, str) and selected else None
-    return _bounded_delivered_watermarks(valid, pinned_path=pinned)
+    pinned = [selected] if isinstance(selected, str) and selected else []
+    pinned.extend(_validated_pending_transcripts(channel_state))
+    return _bounded_delivered_watermarks(valid, pinned_paths=pinned)
 
 
 def delivered_watermark_for_path(
@@ -1157,9 +1187,10 @@ def advance_delivered_watermark(
         return False
     entries[path] = (candidate, float(now))
     selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
-    pinned = selected if isinstance(selected, str) and selected else None
+    pinned = [selected] if isinstance(selected, str) and selected else []
+    pinned.extend(_validated_pending_transcripts(channel_state))
     bounded = _bounded_delivered_watermarks(
-        entries, preferred_path=path, pinned_path=pinned
+        entries, preferred_path=path, pinned_paths=pinned
     )
     channel_state[DELIVERED_WATERMARKS_KEY] = {
         key: {"delivered_ts": watermark, "updated_at": updated_at}
@@ -1953,8 +1984,29 @@ def _alert_pending_retirement(
 
 
 def _clear_gap_alert_without_recovery(
-    rt: Runtime, channel_state: dict[str, Any], channel_id: str
-) -> None:
+    rt: Runtime,
+    channel_state: dict[str, Any],
+    channel_id: str,
+    authority_paths: list[str],
+) -> bool:
+    retired = set(authority_paths)
+    gap_path = channel_state.get(GAP_TRANSCRIPT_KEY)
+    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+    if (
+        isinstance(gap_path, str)
+        and gap_path
+        and gap_path not in retired
+    ) or (
+        not isinstance(gap_path, str)
+        and isinstance(selected, str)
+        and selected
+        and selected not in retired
+    ):
+        rt.log(
+            f"[{channel_id}] unrelated transcript retirement preserved live "
+            "gap authority"
+        )
+        return False
     if channel_state.get("alerting"):
         rt.log(
             f"[{channel_id}] alert state transitioned to unresolved transcript "
@@ -1963,6 +2015,8 @@ def _clear_gap_alert_without_recovery(
     channel_state.pop("alerting", None)
     channel_state.pop("gap_since", None)
     channel_state.pop("issue_url", None)
+    channel_state.pop(GAP_TRANSCRIPT_KEY, None)
+    return True
 
 
 def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
@@ -1990,11 +2044,26 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     pending_failures = _validated_pending_failures(chs, pending_paths)
     pending_since = _validated_pending_since(chs, pending_paths, now)
     retired_transcripts = _validated_retired_transcripts(chs)
+    read_cache: dict[str, TranscriptReadResult] = {}
+
+    def read_candidate(candidate: TranscriptCandidate) -> TranscriptReadResult:
+        path = str(candidate.path)
+        if path not in read_cache:
+            read_cache[path] = assistant_blocks(candidate.path)
+        return read_cache[path]
+
     reactivated_paths: list[str] = []
     for candidate in candidates:
         path = str(candidate.path)
         retired = retired_transcripts.get(path)
-        if retired is not None and candidate.size != retired[0]:
+        if retired is None or candidate.size <= retired[0]:
+            continue
+        read_result = read_candidate(candidate)
+        if (
+            read_result.error is None
+            and not read_result.incomplete_tail
+            and read_result.semantic_end_offset > retired[0]
+        ):
             retired_transcripts.pop(path, None)
             reactivated_paths.append(path)
             rt.log(f"[{cid}] transcript-retired-reactivated path={path}")
@@ -2011,13 +2080,6 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     known_before = (
         set(known_at) | set(previous_sizes) | set(watermarks) | retired_paths
     )
-    read_cache: dict[str, TranscriptReadResult] = {}
-
-    def read_candidate(candidate: TranscriptCandidate) -> TranscriptReadResult:
-        path = str(candidate.path)
-        if path not in read_cache:
-            read_cache[path] = assistant_blocks(candidate.path)
-        return read_cache[path]
 
     tracking_initialized = bool(
         previous_sizes
@@ -2056,7 +2118,13 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         path
         for path in pending_paths
         if path in candidate_paths
-        or now - previous_seen_at.get(path, 0.0) <= TRANSCRIPT_HISTORY_TTL_SECS
+        or now
+        - (
+            previous_seen_at[path]
+            if path in previous_seen_at
+            else pending_since.get(path, 0.0)
+        )
+        <= TRANSCRIPT_HISTORY_TTL_SECS
     ]
     tracked_anchor_missing = (
         isinstance(persisted_selected, str)
@@ -2146,8 +2214,29 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             path = str(candidate.path)
             if path in watermarks:
                 selection_sizes.setdefault(path, candidate.size)
+    semantic_growth_paths: set[str] = set()
+    for candidate in selectable_candidates:
+        path = str(candidate.path)
+        prior_size = previous_sizes.get(path)
+        if prior_size is None or candidate.size <= prior_size:
+            continue
+        read_result = read_candidate(candidate)
+        if (
+            read_result.error is None
+            and not read_result.incomplete_tail
+            and read_result.semantic_end_offset > prior_size
+        ):
+            semantic_growth_paths.add(path)
+        elif read_result.error is None and not read_result.incomplete_tail:
+            rt.log(
+                f"[{cid}] transcript-growth-ignored reason=non-semantic "
+                f"path={path}"
+            )
     tr, selection_reason = select_watch_transcript_with_reason(
-        selectable_candidates, selection_sizes, previous_selected
+        selectable_candidates,
+        selection_sizes,
+        previous_selected,
+        semantic_growth_paths,
     )
     if bootstrapped_from_watermark and selection_reason == "sticky":
         selection_reason = (
@@ -2163,14 +2252,18 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     for candidate in candidates:
         path = str(candidate.path)
         read_result = read_cache.get(path)
-        if path not in previous_sizes and read_result is not None and (
+        if read_result is not None and (
             read_result.error is not None or read_result.incomplete_tail
         ):
-            # A torn/unreadable debut has not established a trustworthy growth
-            # baseline.  Its pending authority, not a committed size, carries
-            # it into the next tick for a complete read.
+            # A torn/unreadable path has not established a trustworthy growth
+            # baseline.  Preserve the last complete baseline so continuous raw
+            # bytes cannot reset pending age or manufacture later activity.
             continue
-        merged_sizes[path] = candidate.size
+        merged_sizes[path] = (
+            read_result.observed_size
+            if read_result is not None
+            else candidate.size
+        )
         merged_seen_at[path] = now
     priority_paths = (
         ([str(tr)] if tr is not None else [])
@@ -2204,7 +2297,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         merged_sizes, merged_seen_at, now, priority_paths
     )
     bounded_pending_paths = _bounded_pending_transcripts(
-        pending_paths, set(merged_sizes) | candidate_paths
+        pending_paths,
+        set(merged_sizes) | candidate_paths | set(pending_since),
     )
     bounded_pending_set = set(bounded_pending_paths)
     dropped_pending_paths = [
@@ -2250,15 +2344,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         path: pending_since.get(path, now) for path in pending_paths
     }
     for path in pending_paths:
-        candidate = next(
-            (candidate for candidate in candidates if str(candidate.path) == path),
-            None,
-        )
-        if (
-            candidate is not None
-            and path in previous_sizes
-            and candidate.size > previous_sizes[path]
-        ):
+        if path in semantic_growth_paths:
             pending_since[path] = now
     chs[TRANSCRIPT_SIZES_KEY] = merged_sizes
     chs[TRANSCRIPT_SEEN_AT_KEY] = merged_seen_at
@@ -2279,7 +2365,10 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         last_activity = (
             candidate.mtime
             if candidate is not None
-            else previous_seen_at.get(path, 0.0)
+            else max(
+                previous_seen_at.get(path, 0.0),
+                pending_since.get(path, now),
+            )
         )
         pending_age = now - pending_since.get(path, now)
         if (
@@ -2321,7 +2410,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         _alert_pending_retirement(
             rt, ch, expired_pending_paths, reason="idle"
         )
-        _clear_gap_alert_without_recovery(rt, chs, cid)
+        _clear_gap_alert_without_recovery(
+            rt, chs, cid, expired_pending_paths
+        )
         if tr is not None and str(tr) in expired:
             chs.pop(SELECTED_TRANSCRIPT_KEY, None)
             tr = None
@@ -2332,8 +2423,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     # so it can never short-circuit or suppress the gap verdict below.
     f_growing = (
         selected is not None
-        and str(selected.path) in previous_sizes
-        and selected.size > previous_sizes[str(selected.path)]
+        and str(selected.path) in semantic_growth_paths
     )
     try:
         tick_selector_sync(rt, ch, chs, tr, f_growing, now)
@@ -2364,7 +2454,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         active_candidates.append(candidate)
     if not active_candidates:
         if retired_pending_paths:
-            _clear_gap_alert_without_recovery(rt, chs, cid)
+            _clear_gap_alert_without_recovery(
+                rt, chs, cid, retired_pending_paths
+            )
         return
 
     hay = rt.discord_haystack(cid)
@@ -2403,7 +2495,17 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 )
             else:
                 rt.log(f"[{cid}] transcript-read-incomplete path={path}")
-            if path in pending_set:
+            owns_read_authority = path in pending_set or (
+                selected is not None and candidate.path == selected.path
+            )
+            if owns_read_authority:
+                if path not in remaining_pending:
+                    remaining_pending.append(path)
+                    pending_since.setdefault(path, now)
+                    rt.log(
+                        f"[{cid}] transcript-selected-read-failure-tracked "
+                        f"path={path}"
+                    )
                 failures = pending_failures.get(path, 0) + 1
                 pending_failures[path] = failures
                 if failures >= cfg.read_fail_alert_after:
@@ -2450,7 +2552,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 ]
         evaluated.append((candidate, verdict))
     remaining_pending = _bounded_pending_transcripts(
-        remaining_pending, set(merged_sizes) | candidate_paths
+        remaining_pending,
+        set(merged_sizes) | candidate_paths | set(pending_since),
     )
     chs[PENDING_TRANSCRIPTS_KEY] = remaining_pending
     pending_failures = {
@@ -2485,13 +2588,17 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         _alert_pending_retirement(
             rt, ch, escalated_pending_paths, reason="read_failure"
         )
-        _clear_gap_alert_without_recovery(rt, chs, cid)
+        _clear_gap_alert_without_recovery(
+            rt, chs, cid, escalated_pending_paths
+        )
         if tr is not None and str(tr) in escalated:
             chs.pop(SELECTED_TRANSCRIPT_KEY, None)
             tr = None
     if not evaluated:
         if retired_pending_paths:
-            _clear_gap_alert_without_recovery(rt, chs, cid)
+            _clear_gap_alert_without_recovery(
+                rt, chs, cid, retired_pending_paths
+            )
         return
     state_rank = {STATE_OK: 0, STATE_LAGGING: 1, STATE_GAP: 2}
     verdict_candidate, v = max(
@@ -2512,14 +2619,17 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         )
         return
     if retired_pending_paths and v.state == STATE_OK:
-        _clear_gap_alert_without_recovery(rt, chs, cid)
-        rt.log(
-            f"[{cid}] transcript-verdict-unresolved-retirement "
-            f"retired={len(retired_pending_paths)}"
-        )
-        return
+        if _clear_gap_alert_without_recovery(
+            rt, chs, cid, retired_pending_paths
+        ):
+            rt.log(
+                f"[{cid}] transcript-verdict-unresolved-retirement "
+                f"retired={len(retired_pending_paths)}"
+            )
+            return
 
     if v.state == STATE_GAP:
+        chs[GAP_TRANSCRIPT_KEY] = verdict_path
         if rt.in_deploy_window(now):
             rt.log(
                 f"[{cid}] gap lost={v.lost} suppressed — deploy window "
@@ -2586,6 +2696,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         chs.pop("alerting", None)
         chs.pop("gap_since", None)
         chs.pop("issue_url", None)
+        chs.pop(GAP_TRANSCRIPT_KEY, None)
         rt.log(
             f"[{cid}] ok path={verdict_path} blocks={v.blocks} "
             f"stale={v.stale} lost=0"

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -97,6 +97,12 @@ SELECTOR_PATH_UNCOMPARABLE = "uncomparable"
 DELIVERED_WATERMARKS_KEY = "delivered_watermarks"
 MAX_DELIVERED_WATERMARKS = 16
 SELECTED_TRANSCRIPT_KEY = "selected_transcript"
+TRANSCRIPT_SIZES_KEY = "transcript_sizes"
+TRANSCRIPT_SEEN_AT_KEY = "transcript_seen_at"
+PENDING_TRANSCRIPTS_KEY = "pending_transcripts"
+MAX_TRANSCRIPT_HISTORY = 64
+MAX_PENDING_TRANSCRIPTS = 32
+TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
 
 PG_TOPOLOGY_TUNNEL = "tunnel"
 PG_TOPOLOGY_DIRECT = "direct"
@@ -392,9 +398,101 @@ def recheck_selected_transcript(
         return None
     try:
         stat = path.stat()
-    except OSError:
+    except (OSError, ValueError, UnicodeError):
         return None
     return TranscriptCandidate(path, stat.st_size, stat.st_mtime)
+
+
+def _validated_transcript_sizes(channel_state: Mapping[str, Any]) -> dict[str, int]:
+    raw = channel_state.get(TRANSCRIPT_SIZES_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        path: size
+        for path, size in raw.items()
+        if isinstance(path, str)
+        and path
+        and isinstance(size, int)
+        and not isinstance(size, bool)
+        and size >= 0
+    }
+
+
+def _validated_transcript_seen_at(
+    channel_state: Mapping[str, Any], sizes: Mapping[str, int], now: float
+) -> dict[str, float]:
+    raw = channel_state.get(TRANSCRIPT_SEEN_AT_KEY, {})
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        path: (
+            float(raw[path])
+            if path in raw and _is_finite_nonnegative_number(raw[path])
+            else now
+        )
+        for path in sizes
+    }
+
+
+def _validated_pending_transcripts(channel_state: Mapping[str, Any]) -> list[str]:
+    raw = channel_state.get(PENDING_TRANSCRIPTS_KEY, [])
+    if not isinstance(raw, list):
+        return []
+    pending: list[str] = []
+    for path in raw:
+        if isinstance(path, str) and path and path not in pending:
+            pending.append(path)
+    return pending[:MAX_PENDING_TRANSCRIPTS]
+
+
+def _bounded_transcript_history(
+    sizes: Mapping[str, int],
+    seen_at: Mapping[str, float],
+    now: float,
+    priority_paths: list[str],
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Bound path baselines without dropping a transiently undiscovered path."""
+    priority = {
+        path: index
+        for index, path in enumerate(dict.fromkeys(priority_paths))
+    }
+    entries: list[tuple[str, int, float]] = []
+    for path, size in sizes.items():
+        if not isinstance(path, str) or not path:
+            continue
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            continue
+        observed_at = seen_at.get(path, now)
+        if not _is_finite_nonnegative_number(observed_at):
+            observed_at = now
+        observed_at = float(observed_at)
+        if (
+            path not in priority
+            and now - observed_at > TRANSCRIPT_HISTORY_TTL_SECS
+        ):
+            continue
+        entries.append((path, size, observed_at))
+    entries.sort(
+        key=lambda entry: (
+            priority.get(entry[0], len(priority)),
+            -entry[2],
+            entry[0],
+        )
+    )
+    bounded = entries[:MAX_TRANSCRIPT_HISTORY]
+    return (
+        {path: size for path, size, _ in bounded},
+        {path: observed_at for path, _, observed_at in bounded},
+    )
+
+
+def _bounded_pending_transcripts(
+    paths: list[str], history_paths: set[str]
+) -> list[str]:
+    pending: list[str] = []
+    for path in paths:
+        if path in history_paths and path not in pending:
+            pending.append(path)
+    return pending[:MAX_PENDING_TRANSCRIPTS]
 
 
 def select_watch_transcript(
@@ -1623,18 +1721,17 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     project_root = projects_root()
     dirs = channel_project_dirs(project_root, pattern)
     candidates = transcript_candidates(dirs)
-    raw_previous_sizes = chs.get("transcript_sizes", {})
-    previous_sizes = {
-        str(path): size
-        for path, size in (
-            raw_previous_sizes.items()
-            if isinstance(raw_previous_sizes, dict)
-            else ()
-        )
-        if isinstance(size, int) and not isinstance(size, bool) and size >= 0
-    }
+    previous_sizes = _validated_transcript_sizes(chs)
+    previous_seen_at = _validated_transcript_seen_at(chs, previous_sizes, now)
+    pending_paths = _validated_pending_transcripts(chs)
     previous_selected = chs.get(SELECTED_TRANSCRIPT_KEY)
     watermarks = delivered_watermarks(chs)
+    tracking_initialized = bool(
+        previous_sizes
+        or pending_paths
+        or watermarks
+        or (isinstance(previous_selected, str) and previous_selected)
+    )
     bootstrapped_from_watermark = False
     candidate_paths = {str(candidate.path) for candidate in candidates}
     if (
@@ -1651,6 +1748,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             candidates.append(rechecked)
             candidate_paths.add(str(rechecked.path))
             rt.log(f"[{cid}] transcript-recheck recovered path={rechecked.path}")
+    pending_paths = [
+        path
+        for path in pending_paths
+        if path in candidate_paths
+        or now - previous_seen_at.get(path, 0.0) <= TRANSCRIPT_HISTORY_TTL_SECS
+    ]
     if (
         not isinstance(previous_selected, str)
         or not previous_selected
@@ -1665,6 +1768,19 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if watermarked_candidates and len(watermarked_candidates) == len(candidates):
             previous_selected = max(watermarked_candidates)[1]
             bootstrapped_from_watermark = True
+    if tracking_initialized:
+        debut_candidates = sorted(
+            (
+                candidate
+                for candidate in candidates
+                if str(candidate.path) not in previous_sizes
+            ),
+            key=lambda candidate: (candidate.mtime, str(candidate.path)),
+        )
+        for candidate in debut_candidates:
+            path = str(candidate.path)
+            if path not in pending_paths:
+                pending_paths.append(path)
     tr, selection_reason = select_watch_transcript_with_reason(
         candidates, previous_sizes, previous_selected
     )
@@ -1673,11 +1789,41 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     if tr is not None:
         chs[SELECTED_TRANSCRIPT_KEY] = str(tr)
     rt.log(f"[{cid}] transcript-select reason={selection_reason} path={tr}")
-    chs["transcript_sizes"] = (
-        {str(candidate.path): candidate.size for candidate in candidates}
-        if candidates
-        else previous_sizes
+    merged_sizes = dict(previous_sizes)
+    merged_seen_at = dict(previous_seen_at)
+    for candidate in candidates:
+        path = str(candidate.path)
+        merged_sizes[path] = candidate.size
+        merged_seen_at[path] = now
+    priority_paths = (
+        ([str(tr)] if tr is not None else [])
+        + (
+            [previous_selected]
+            if isinstance(previous_selected, str) and previous_selected
+            else []
+        )
+        + pending_paths
+        + [
+            str(candidate.path)
+            for candidate in sorted(
+                candidates,
+                key=lambda candidate: (-candidate.mtime, str(candidate.path)),
+            )
+        ]
+        + [
+            path
+            for path, _ in sorted(
+                watermarks.items(), key=lambda item: (-item[1][1], item[0])
+            )
+        ]
     )
+    merged_sizes, merged_seen_at = _bounded_transcript_history(
+        merged_sizes, merged_seen_at, now, priority_paths
+    )
+    pending_paths = _bounded_pending_transcripts(pending_paths, set(merged_sizes))
+    chs[TRANSCRIPT_SIZES_KEY] = merged_sizes
+    chs[TRANSCRIPT_SEEN_AT_KEY] = merged_seen_at
+    chs[PENDING_TRANSCRIPTS_KEY] = pending_paths
     selected = next((candidate for candidate in candidates if candidate.path == tr), None)
     # I1 selector sync (#4408 phase 2): compare the dcserver's asserted relay
     # bind (B) against F. Parallel to gap/coverage — its own cooldown key, wrapped
@@ -1691,11 +1837,30 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         tick_selector_sync(rt, ch, chs, tr, f_growing, now)
     except Exception as e:  # noqa: BLE001 — selector sync must never suppress gap checks
         rt.log(f"[{cid}] selector-sync tick error: {type(e).__name__}: {e}")
-    idle = (now - selected.mtime) if selected else float("inf")
-    if idle >= cfg.idle_quiet_secs:
-        # Stale transcript: any "gap" is historic, not live. Never alert.
-        # (No self-uninstall here — see module docstring.)
-        rt.log(f"[{cid}] idle {int(min(idle, 86400 * 365) // 60)}m — no live session, skipping")
+
+    pending_set = set(pending_paths)
+    evaluation_candidates: list[TranscriptCandidate] = []
+    if selected is not None:
+        evaluation_candidates.append(selected)
+    for path in pending_paths:
+        candidate = next(
+            (candidate for candidate in candidates if str(candidate.path) == path),
+            None,
+        )
+        if candidate is not None and candidate not in evaluation_candidates:
+            evaluation_candidates.append(candidate)
+    active_candidates: list[TranscriptCandidate] = []
+    for candidate in evaluation_candidates:
+        path = str(candidate.path)
+        idle = now - candidate.mtime
+        if path not in pending_set and idle >= cfg.idle_quiet_secs:
+            rt.log(
+                f"[{cid}] idle {int(min(idle, 86400 * 365) // 60)}m "
+                f"path={path} — no live session, skipping"
+            )
+            continue
+        active_candidates.append(candidate)
+    if not active_candidates:
         return
 
     hay = rt.discord_haystack(cid)
@@ -1719,20 +1884,48 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         return
     chs["read_failures"] = 0
 
-    blocks = assistant_blocks(tr) if tr else []
-    prior_delivered_ts = (
-        delivered_watermark_for_path(chs, tr) if tr is not None else 0.0
+    evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
+    remaining_pending = list(pending_paths)
+    for candidate in active_candidates:
+        path = str(candidate.path)
+        prior_delivered_ts = delivered_watermark_for_path(chs, candidate.path)
+        verdict = evaluate(
+            assistant_blocks(candidate.path),
+            hay,
+            now,
+            cfg.grace_secs,
+            cfg.gap_alert_secs,
+            prior_delivered_ts,
+        )
+        if verdict.delivered_ts > prior_delivered_ts:
+            advance_delivered_watermark(
+                chs, candidate.path, verdict.delivered_ts, now
+            )
+        if path in pending_set:
+            rt.log(
+                f"[{cid}] transcript-debut-eval path={path} "
+                f"state={verdict.state} lost={verdict.lost}"
+            )
+            if path == str(tr) or verdict.state == STATE_OK:
+                remaining_pending = [
+                    pending for pending in remaining_pending if pending != path
+                ]
+        evaluated.append((candidate, verdict))
+    chs[PENDING_TRANSCRIPTS_KEY] = _bounded_pending_transcripts(
+        remaining_pending, set(merged_sizes)
     )
-    v = evaluate(
-        blocks,
-        hay,
-        now,
-        cfg.grace_secs,
-        cfg.gap_alert_secs,
-        prior_delivered_ts,
+    state_rank = {STATE_OK: 0, STATE_LAGGING: 1, STATE_GAP: 2}
+    verdict_candidate, v = max(
+        evaluated,
+        key=lambda item: (
+            state_rank[item[1].state],
+            item[1].gap_secs,
+            item[1].lost,
+            item[0].mtime,
+            str(item[0].path),
+        ),
     )
-    if tr is not None and v.delivered_ts > prior_delivered_ts:
-        advance_delivered_watermark(chs, tr, v.delivered_ts, now)
+    verdict_path = str(verdict_candidate.path)
 
     if v.state == STATE_GAP:
         if rt.in_deploy_window(now):
@@ -1768,12 +1961,18 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             )
             chs["last_alert"] = now
             chs["alerting"] = True
-            rt.log(f"[{cid}] ALERT lost={v.lost} gap_min={gap_min}")
+            rt.log(
+                f"[{cid}] ALERT path={verdict_path} lost={v.lost} gap_min={gap_min}"
+            )
         else:
-            rt.log(f"[{cid}] gap persists lost={v.lost} (alert suppressed, cooldown)")
+            rt.log(
+                f"[{cid}] gap persists path={verdict_path} lost={v.lost} "
+                "(alert suppressed, cooldown)"
+            )
     elif v.state == STATE_LAGGING:
         rt.log(
-            f"[{cid}] lagging lost={v.lost} gap={int(v.gap_secs)}s "
+            f"[{cid}] lagging path={verdict_path} lost={v.lost} "
+            f"gap={int(v.gap_secs)}s "
             f"(< {cfg.gap_alert_secs}s alert threshold — relay batching, not down)"
         )
     else:
@@ -1795,7 +1994,10 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         chs.pop("alerting", None)
         chs.pop("gap_since", None)
         chs.pop("issue_url", None)
-        rt.log(f"[{cid}] ok blocks={v.blocks} stale={v.stale} lost=0")
+        rt.log(
+            f"[{cid}] ok path={verdict_path} blocks={v.blocks} "
+            f"stale={v.stale} lost=0"
+        )
 
 
 # ── Main loop ──────────────────────────────────────────────────────────────────

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -60,6 +60,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback; regular files ignore it
+    fcntl = None  # type: ignore[assignment]
+
 # ── Verdict states (pure judgment output, see evaluate()) ─────────────────────
 STATE_OK = "ok"
 STATE_LAGGING = "lagging"  # lost blocks exist, but last good delivery is recent
@@ -102,6 +107,9 @@ TRANSCRIPT_SIZES_KEY = "transcript_sizes"
 TRANSCRIPT_SEEN_AT_KEY = "transcript_seen_at"
 TRANSCRIPT_KNOWN_AT_KEY = "transcript_known_at"
 PENDING_TRANSCRIPTS_KEY = "pending_transcripts"
+PENDING_TRANSCRIPT_FAILURES_KEY = "pending_transcript_failures"
+PENDING_TRANSCRIPT_SINCE_KEY = "pending_transcript_since"
+RETIRED_TRANSCRIPTS_KEY = "retired_transcripts"
 PENDING_TRANSCRIPT_OVERFLOW_KEY = "pending_transcript_overflow"
 LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY = (
     "last_pending_transcript_overflow_alert"
@@ -109,6 +117,7 @@ LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY = (
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_KNOWN_TRANSCRIPTS = 256
 MAX_PENDING_TRANSCRIPTS = 32
+MAX_RETIRED_TRANSCRIPTS = 32
 TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
 
 PG_TOPOLOGY_TUNNEL = "tunnel"
@@ -392,6 +401,7 @@ class TranscriptCandidate:
 class TranscriptReadResult:
     blocks: list[tuple[float, str]]
     error: str | None = None
+    incomplete_tail: bool = False
 
 
 def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
@@ -497,6 +507,84 @@ def _validated_pending_transcripts(channel_state: Mapping[str, Any]) -> list[str
         if isinstance(path, str) and path and path not in pending:
             pending.append(path)
     return pending[:MAX_PENDING_TRANSCRIPTS]
+
+
+def _validated_pending_failures(
+    channel_state: Mapping[str, Any], pending_paths: list[str]
+) -> dict[str, int]:
+    raw = channel_state.get(PENDING_TRANSCRIPT_FAILURES_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    pending = set(pending_paths)
+    return {
+        path: failures
+        for path, failures in raw.items()
+        if path in pending
+        and isinstance(failures, int)
+        and not isinstance(failures, bool)
+        and failures > 0
+    }
+
+
+def _validated_pending_since(
+    channel_state: Mapping[str, Any], pending_paths: list[str], now: float
+) -> dict[str, float]:
+    raw = channel_state.get(PENDING_TRANSCRIPT_SINCE_KEY, {})
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        path: (
+            float(raw[path])
+            if path in raw
+            and _is_finite_nonnegative_number(raw[path])
+            and float(raw[path]) <= now
+            else now
+        )
+        for path in pending_paths
+    }
+
+
+def _bounded_retired_transcripts(
+    entries: Mapping[str, tuple[int, float]],
+) -> dict[str, tuple[int, float]]:
+    ordered = sorted(
+        entries.items(), key=lambda item: (-item[1][1], item[0])
+    )[:MAX_RETIRED_TRANSCRIPTS]
+    return dict(ordered)
+
+
+def _validated_retired_transcripts(
+    channel_state: Mapping[str, Any],
+) -> dict[str, tuple[int, float]]:
+    raw = channel_state.get(RETIRED_TRANSCRIPTS_KEY, {})
+    if not isinstance(raw, dict):
+        return {}
+    valid: dict[str, tuple[int, float]] = {}
+    for path, entry in raw.items():
+        if not isinstance(path, str) or not path or not isinstance(entry, dict):
+            continue
+        size = entry.get("size")
+        retired_at = entry.get("retired_at")
+        if (
+            isinstance(size, int)
+            and not isinstance(size, bool)
+            and size >= 0
+            and _is_finite_nonnegative_number(retired_at)
+        ):
+            valid[path] = (size, float(retired_at))
+    return _bounded_retired_transcripts(valid)
+
+
+def _store_retired_transcripts(
+    channel_state: dict[str, Any], entries: Mapping[str, tuple[int, float]]
+) -> None:
+    bounded = _bounded_retired_transcripts(entries)
+    if bounded:
+        channel_state[RETIRED_TRANSCRIPTS_KEY] = {
+            path: {"size": size, "retired_at": retired_at}
+            for path, (size, retired_at) in bounded.items()
+        }
+    else:
+        channel_state.pop(RETIRED_TRANSCRIPTS_KEY, None)
 
 
 def _bounded_transcript_history(
@@ -710,16 +798,38 @@ def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
 def assistant_blocks(transcript: Path) -> TranscriptReadResult:
     if _regular_file_stat_without_symlink(transcript) is None:
         return TranscriptReadResult([], "UnsafePath")
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
     descriptor = -1
     try:
         descriptor = os.open(transcript, flags)
         if not stat_mode.S_ISREG(os.fstat(descriptor).st_mode):
             return TranscriptReadResult([], "UnsafePath")
+        if fcntl is not None and getattr(os, "O_NONBLOCK", 0):
+            current_flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+            fcntl.fcntl(
+                descriptor,
+                fcntl.F_SETFL,
+                current_flags & ~getattr(os, "O_NONBLOCK", 0),
+            )
         stream = os.fdopen(descriptor, "r", encoding="utf-8")
         descriptor = -1
         with stream as f:
-            return TranscriptReadResult(assistant_blocks_from_lines(f))
+            lines = f.readlines()
+            incomplete_tail = False
+            if lines and not lines[-1].endswith("\n"):
+                try:
+                    json.loads(lines[-1])
+                except (json.JSONDecodeError, TypeError):
+                    incomplete_tail = True
+            return TranscriptReadResult(
+                assistant_blocks_from_lines(lines),
+                incomplete_tail=incomplete_tail,
+            )
     except (OSError, UnicodeError, ValueError) as exc:
         return TranscriptReadResult([], type(exc).__name__)
     finally:
@@ -974,11 +1084,14 @@ def _is_finite_nonnegative_number(value: object) -> bool:
 
 
 def _bounded_delivered_watermarks(
-    entries: Mapping[str, tuple[float, float]], preferred_path: str | None = None
+    entries: Mapping[str, tuple[float, float]],
+    preferred_path: str | None = None,
+    pinned_path: str | None = None,
 ) -> dict[str, tuple[float, float]]:
     ordered = sorted(
         entries.items(),
         key=lambda item: (
+            0 if item[0] == pinned_path else 1,
             -item[1][1],
             0 if item[0] == preferred_path else 1,
             item[0],
@@ -1010,7 +1123,9 @@ def delivered_watermarks(
         ):
             continue
         valid[path] = (float(delivered_ts), float(updated_at))
-    return _bounded_delivered_watermarks(valid)
+    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+    pinned = selected if isinstance(selected, str) and selected else None
+    return _bounded_delivered_watermarks(valid, pinned_path=pinned)
 
 
 def delivered_watermark_for_path(
@@ -1041,7 +1156,11 @@ def advance_delivered_watermark(
     if candidate <= prior:
         return False
     entries[path] = (candidate, float(now))
-    bounded = _bounded_delivered_watermarks(entries, preferred_path=path)
+    selected = channel_state.get(SELECTED_TRANSCRIPT_KEY)
+    pinned = selected if isinstance(selected, str) and selected else None
+    bounded = _bounded_delivered_watermarks(
+        entries, preferred_path=path, pinned_path=pinned
+    )
     channel_state[DELIVERED_WATERMARKS_KEY] = {
         key: {"delivered_ts": watermark, "updated_at": updated_at}
         for key, (watermark, updated_at) in bounded.items()
@@ -1802,6 +1921,50 @@ def tick_selector_sync(
     )
 
 
+def _alert_pending_retirement(
+    rt: Runtime,
+    ch: ChannelConfig,
+    paths: list[str],
+    *,
+    reason: str,
+) -> None:
+    if not paths:
+        return
+    if reason == "idle":
+        title = "릴레이 트랜스크립트 평가 권한 만료"
+        detail = (
+            "세션 활동이 idle 한계를 넘겨 더 이상 live GAP으로 반복 평가하지 "
+            "않습니다. 미도달 여부가 해결됐다고 주장하는 복구 알림은 보내지 않습니다."
+        )
+    else:
+        title = "릴레이 트랜스크립트 평가 불능 에스컬레이션"
+        detail = (
+            "연속 읽기 실패 한계를 넘어 해당 pending 권한을 격리했습니다. 정상으로 "
+            "판정한 것이 아니며 원본 트랜스크립트 점검이 필요합니다."
+        )
+    sample = "\n".join(f"- `{path}`" for path in paths[:3])
+    if len(paths) > 3:
+        sample += f"\n- 외 {len(paths) - 3}개"
+    rt.alert(
+        ch,
+        f"🚨 **{title}**\n\n{detail}\n\n{sample}\n\n"
+        f"런타임: {rt.dcserver_snapshot()}",
+    )
+
+
+def _clear_gap_alert_without_recovery(
+    rt: Runtime, channel_state: dict[str, Any], channel_id: str
+) -> None:
+    if channel_state.get("alerting"):
+        rt.log(
+            f"[{channel_id}] alert state transitioned to unresolved transcript "
+            "escalation — no clean recovery claimed"
+        )
+    channel_state.pop("alerting", None)
+    channel_state.pop("gap_since", None)
+    channel_state.pop("issue_url", None)
+
+
 def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: float) -> None:
     cfg = rt.cfg
     cid = ch.channel_id
@@ -1824,9 +1987,30 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     known_state_initialized = isinstance(chs.get(TRANSCRIPT_KNOWN_AT_KEY), dict)
     known_at = _validated_transcript_known_at(chs, now)
     pending_paths = _validated_pending_transcripts(chs)
+    pending_failures = _validated_pending_failures(chs, pending_paths)
+    pending_since = _validated_pending_since(chs, pending_paths, now)
+    retired_transcripts = _validated_retired_transcripts(chs)
+    reactivated_paths: list[str] = []
+    for candidate in candidates:
+        path = str(candidate.path)
+        retired = retired_transcripts.get(path)
+        if retired is not None and candidate.size != retired[0]:
+            retired_transcripts.pop(path, None)
+            reactivated_paths.append(path)
+            rt.log(f"[{cid}] transcript-retired-reactivated path={path}")
+    _store_retired_transcripts(chs, retired_transcripts)
+    retired_paths = set(retired_transcripts)
+    selectable_candidates = [
+        candidate
+        for candidate in candidates
+        if str(candidate.path) not in retired_paths
+    ]
     previous_selected = chs.get(SELECTED_TRANSCRIPT_KEY)
+    persisted_selected = previous_selected
     watermarks = delivered_watermarks(chs)
-    known_before = set(known_at) | set(previous_sizes) | set(watermarks)
+    known_before = (
+        set(known_at) | set(previous_sizes) | set(watermarks) | retired_paths
+    )
     read_cache: dict[str, TranscriptReadResult] = {}
 
     def read_candidate(candidate: TranscriptCandidate) -> TranscriptReadResult:
@@ -1839,23 +2023,34 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         previous_sizes
         or pending_paths
         or watermarks
+        or retired_transcripts
         or (isinstance(previous_selected, str) and previous_selected)
     )
     bootstrapped_from_watermark = False
     candidate_paths = {str(candidate.path) for candidate in candidates}
+    selectable_candidate_paths = {
+        str(candidate.path) for candidate in selectable_candidates
+    }
     if (
         not isinstance(previous_selected, str)
-        or previous_selected not in candidate_paths
+        or previous_selected not in selectable_candidate_paths
     ):
-        rechecked = recheck_selected_transcript(
-            previous_selected,
-            project_root,
-            pattern,
-            set(previous_sizes) | set(watermarks),
+        rechecked = (
+            None
+            if isinstance(previous_selected, str)
+            and previous_selected in retired_paths
+            else recheck_selected_transcript(
+                previous_selected,
+                project_root,
+                pattern,
+                set(previous_sizes) | set(watermarks),
+            )
         )
         if rechecked is not None:
             candidates.append(rechecked)
+            selectable_candidates.append(rechecked)
             candidate_paths.add(str(rechecked.path))
+            selectable_candidate_paths.add(str(rechecked.path))
             rt.log(f"[{cid}] transcript-recheck recovered path={rechecked.path}")
     pending_paths = [
         path
@@ -1863,31 +2058,32 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if path in candidate_paths
         or now - previous_seen_at.get(path, 0.0) <= TRANSCRIPT_HISTORY_TTL_SECS
     ]
+    tracked_anchor_missing = (
+        isinstance(persisted_selected, str)
+        and persisted_selected in known_before
+        and persisted_selected not in selectable_candidate_paths
+    )
     if (
         not isinstance(previous_selected, str)
         or not previous_selected
-        or (candidate_paths and previous_selected not in candidate_paths)
+        or previous_selected in retired_paths
+        or (
+            selectable_candidate_paths
+            and previous_selected not in selectable_candidate_paths
+        )
     ):
         previous_selected = None
-        watermarked_candidates = [
-            (watermarks[str(candidate.path)][1], str(candidate.path))
-            for candidate in candidates
-            if str(candidate.path) in watermarks
-        ]
-        if watermarked_candidates and len(watermarked_candidates) == len(candidates):
-            previous_selected = max(watermarked_candidates)[1]
-            bootstrapped_from_watermark = True
     selection_sizes = dict(previous_sizes)
+    live_debut_paths: list[str] = []
     if tracking_initialized:
         debut_candidates = sorted(
             (
                 candidate
-                for candidate in candidates
+                for candidate in selectable_candidates
                 if str(candidate.path) not in previous_sizes
             ),
             key=lambda candidate: (-candidate.mtime, str(candidate.path)),
         )
-        live_debut_paths: list[str] = []
         for candidate in debut_candidates:
             path = str(candidate.path)
             idle = now - candidate.mtime
@@ -1923,16 +2119,42 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         pending_paths = live_debut_paths + [
             path for path in pending_paths if path not in live_debut_set
         ]
+        for path in live_debut_paths:
+            pending_since.setdefault(path, now)
+    if reactivated_paths:
+        reactivated_set = set(reactivated_paths)
+        pending_paths = reactivated_paths + [
+            path for path in pending_paths if path not in reactivated_set
+        ]
+        for path in reactivated_paths:
+            pending_failures.pop(path, None)
+            pending_since[path] = now
+    watermarked_candidates = [
+        (watermarks[str(candidate.path)][1], str(candidate.path))
+        for candidate in selectable_candidates
+        if str(candidate.path) in watermarks
+    ]
+    if previous_selected is None and watermarked_candidates:
+        all_candidates_watermarked = len(watermarked_candidates) == len(
+            selectable_candidates
+        )
+        if all_candidates_watermarked or tracked_anchor_missing:
+            previous_selected = max(watermarked_candidates)[1]
+            bootstrapped_from_watermark = True
     if bootstrapped_from_watermark:
-        for candidate in candidates:
+        for candidate in selectable_candidates:
             path = str(candidate.path)
             if path in watermarks:
                 selection_sizes.setdefault(path, candidate.size)
     tr, selection_reason = select_watch_transcript_with_reason(
-        candidates, selection_sizes, previous_selected
+        selectable_candidates, selection_sizes, previous_selected
     )
     if bootstrapped_from_watermark and selection_reason == "sticky":
-        selection_reason = "watermark_bootstrap"
+        selection_reason = (
+            "watermark_anchor_recovery"
+            if tracked_anchor_missing
+            else "watermark_bootstrap"
+        )
     if tr is not None:
         chs[SELECTED_TRANSCRIPT_KEY] = str(tr)
     rt.log(f"[{cid}] transcript-select reason={selection_reason} path={tr}")
@@ -1940,6 +2162,14 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     merged_seen_at = dict(previous_seen_at)
     for candidate in candidates:
         path = str(candidate.path)
+        read_result = read_cache.get(path)
+        if path not in previous_sizes and read_result is not None and (
+            read_result.error is not None or read_result.incomplete_tail
+        ):
+            # A torn/unreadable debut has not established a trustworthy growth
+            # baseline.  Its pending authority, not a committed size, carries
+            # it into the next tick for a complete read.
+            continue
         merged_sizes[path] = candidate.size
         merged_seen_at[path] = now
     priority_paths = (
@@ -1974,7 +2204,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         merged_sizes, merged_seen_at, now, priority_paths
     )
     bounded_pending_paths = _bounded_pending_transcripts(
-        pending_paths, set(merged_sizes)
+        pending_paths, set(merged_sizes) | candidate_paths
     )
     bounded_pending_set = set(bounded_pending_paths)
     dropped_pending_paths = [
@@ -2011,10 +2241,91 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     else:
         chs.pop(PENDING_TRANSCRIPT_OVERFLOW_KEY, None)
     pending_paths = bounded_pending_paths
+    pending_failures = {
+        path: failures
+        for path, failures in pending_failures.items()
+        if path in set(pending_paths)
+    }
+    pending_since = {
+        path: pending_since.get(path, now) for path in pending_paths
+    }
+    for path in pending_paths:
+        candidate = next(
+            (candidate for candidate in candidates if str(candidate.path) == path),
+            None,
+        )
+        if (
+            candidate is not None
+            and path in previous_sizes
+            and candidate.size > previous_sizes[path]
+        ):
+            pending_since[path] = now
     chs[TRANSCRIPT_SIZES_KEY] = merged_sizes
     chs[TRANSCRIPT_SEEN_AT_KEY] = merged_seen_at
     chs[TRANSCRIPT_KNOWN_AT_KEY] = merged_known_at
     chs[PENDING_TRANSCRIPTS_KEY] = pending_paths
+    if pending_failures:
+        chs[PENDING_TRANSCRIPT_FAILURES_KEY] = pending_failures
+    else:
+        chs.pop(PENDING_TRANSCRIPT_FAILURES_KEY, None)
+    if pending_since:
+        chs[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
+    else:
+        chs.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
+    candidate_by_path = {str(candidate.path): candidate for candidate in candidates}
+    expired_pending_paths: list[str] = []
+    for path in pending_paths:
+        candidate = candidate_by_path.get(path)
+        last_activity = (
+            candidate.mtime
+            if candidate is not None
+            else previous_seen_at.get(path, 0.0)
+        )
+        pending_age = now - pending_since.get(path, now)
+        if (
+            now - last_activity >= cfg.idle_quiet_secs
+            or pending_age >= cfg.idle_quiet_secs
+        ):
+            expired_pending_paths.append(path)
+    if expired_pending_paths:
+        expired = set(expired_pending_paths)
+        for path in expired_pending_paths:
+            candidate = candidate_by_path.get(path)
+            size = candidate.size if candidate is not None else merged_sizes.get(path)
+            if isinstance(size, int) and not isinstance(size, bool) and size >= 0:
+                retired_transcripts[path] = (size, now)
+        _store_retired_transcripts(chs, retired_transcripts)
+        pending_paths = [path for path in pending_paths if path not in expired]
+        pending_failures = {
+            path: failures
+            for path, failures in pending_failures.items()
+            if path not in expired
+        }
+        pending_since = {
+            path: since
+            for path, since in pending_since.items()
+            if path not in expired
+        }
+        chs[PENDING_TRANSCRIPTS_KEY] = pending_paths
+        if pending_failures:
+            chs[PENDING_TRANSCRIPT_FAILURES_KEY] = pending_failures
+        else:
+            chs.pop(PENDING_TRANSCRIPT_FAILURES_KEY, None)
+        if pending_since:
+            chs[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
+        else:
+            chs.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
+        rt.log(
+            f"[{cid}] transcript-pending-expired count={len(expired_pending_paths)}"
+        )
+        _alert_pending_retirement(
+            rt, ch, expired_pending_paths, reason="idle"
+        )
+        _clear_gap_alert_without_recovery(rt, chs, cid)
+        if tr is not None and str(tr) in expired:
+            chs.pop(SELECTED_TRANSCRIPT_KEY, None)
+            tr = None
+    retired_pending_paths = list(expired_pending_paths)
     selected = next((candidate for candidate in candidates if candidate.path == tr), None)
     # I1 selector sync (#4408 phase 2): compare the dcserver's asserted relay
     # bind (B) against F. Parallel to gap/coverage — its own cooldown key, wrapped
@@ -2052,6 +2363,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             continue
         active_candidates.append(candidate)
     if not active_candidates:
+        if retired_pending_paths:
+            _clear_gap_alert_without_recovery(rt, chs, cid)
         return
 
     hay = rt.discord_haystack(cid)
@@ -2076,18 +2389,35 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     chs["read_failures"] = 0
 
     evaluated: list[tuple[TranscriptCandidate, Verdict]] = []
-    read_error_paths: list[str] = []
+    unreadable_paths: list[str] = []
+    escalated_pending_paths: list[str] = []
     remaining_pending = list(pending_paths)
     for candidate in active_candidates:
         path = str(candidate.path)
         read_result = read_candidate(candidate)
-        if read_result.error is not None:
-            rt.log(
-                f"[{cid}] transcript-read-error path={path} "
-                f"error={read_result.error}"
-            )
-            read_error_paths.append(path)
+        if read_result.error is not None or read_result.incomplete_tail:
+            if read_result.error is not None:
+                rt.log(
+                    f"[{cid}] transcript-read-error path={path} "
+                    f"error={read_result.error}"
+                )
+            else:
+                rt.log(f"[{cid}] transcript-read-incomplete path={path}")
+            if path in pending_set:
+                failures = pending_failures.get(path, 0) + 1
+                pending_failures[path] = failures
+                if failures >= cfg.read_fail_alert_after:
+                    remaining_pending = [
+                        pending
+                        for pending in remaining_pending
+                        if pending != path
+                    ]
+                    pending_failures.pop(path, None)
+                    escalated_pending_paths.append(path)
+                    continue
+            unreadable_paths.append(path)
             continue
+        pending_failures.pop(path, None)
         prior_delivered_ts = delivered_watermark_for_path(chs, candidate.path)
         verdict = evaluate(
             read_result.blocks,
@@ -2119,10 +2449,49 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                     pending for pending in remaining_pending if pending != path
                 ]
         evaluated.append((candidate, verdict))
-    chs[PENDING_TRANSCRIPTS_KEY] = _bounded_pending_transcripts(
-        remaining_pending, set(merged_sizes)
+    remaining_pending = _bounded_pending_transcripts(
+        remaining_pending, set(merged_sizes) | candidate_paths
     )
+    chs[PENDING_TRANSCRIPTS_KEY] = remaining_pending
+    pending_failures = {
+        path: failures
+        for path, failures in pending_failures.items()
+        if path in set(remaining_pending)
+    }
+    pending_since = {
+        path: pending_since.get(path, now) for path in remaining_pending
+    }
+    if pending_failures:
+        chs[PENDING_TRANSCRIPT_FAILURES_KEY] = pending_failures
+    else:
+        chs.pop(PENDING_TRANSCRIPT_FAILURES_KEY, None)
+    if pending_since:
+        chs[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
+    else:
+        chs.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
+    if escalated_pending_paths:
+        retired_pending_paths.extend(escalated_pending_paths)
+        escalated = set(escalated_pending_paths)
+        for path in escalated_pending_paths:
+            candidate = candidate_by_path.get(path)
+            size = candidate.size if candidate is not None else merged_sizes.get(path)
+            if isinstance(size, int) and not isinstance(size, bool) and size >= 0:
+                retired_transcripts[path] = (size, now)
+        _store_retired_transcripts(chs, retired_transcripts)
+        rt.log(
+            f"[{cid}] transcript-pending-escalated "
+            f"count={len(escalated_pending_paths)}"
+        )
+        _alert_pending_retirement(
+            rt, ch, escalated_pending_paths, reason="read_failure"
+        )
+        _clear_gap_alert_without_recovery(rt, chs, cid)
+        if tr is not None and str(tr) in escalated:
+            chs.pop(SELECTED_TRANSCRIPT_KEY, None)
+            tr = None
     if not evaluated:
+        if retired_pending_paths:
+            _clear_gap_alert_without_recovery(rt, chs, cid)
         return
     state_rank = {STATE_OK: 0, STATE_LAGGING: 1, STATE_GAP: 2}
     verdict_candidate, v = max(
@@ -2136,10 +2505,17 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ),
     )
     verdict_path = str(verdict_candidate.path)
-    if read_error_paths and v.state == STATE_OK:
+    if unreadable_paths and v.state == STATE_OK:
         rt.log(
             f"[{cid}] transcript-verdict-incomplete "
-            f"read_errors={len(read_error_paths)}"
+            f"read_errors={len(unreadable_paths)}"
+        )
+        return
+    if retired_pending_paths and v.state == STATE_OK:
+        _clear_gap_alert_without_recovery(rt, chs, cid)
+        rt.log(
+            f"[{cid}] transcript-verdict-unresolved-retirement "
+            f"retired={len(retired_pending_paths)}"
         )
         return
 

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -365,6 +365,38 @@ def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
     return candidates
 
 
+def recheck_selected_transcript(
+    value: object,
+    project_root: Path,
+    pattern: re.Pattern[str],
+    tracked_paths: set[str],
+) -> TranscriptCandidate | None:
+    """Recover a tracked selection omitted by a partial directory listing.
+
+    Only an exact, absolute provider-project path already present in persisted
+    size/watermark state is eligible.  This keeps malformed state from gaining
+    sticky authority while a direct stat closes the transient discovery gap.
+    """
+    if not isinstance(value, str) or not value or value not in tracked_paths:
+        return None
+    path = _lexical_absolute_path(value)
+    root = _lexical_absolute_path(project_root)
+    if (
+        path is None
+        or root is None
+        or str(path) != value
+        or path.suffix != ".jsonl"
+        or path.parent.parent != root
+        or pattern.fullmatch(path.parent.name) is None
+    ):
+        return None
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return TranscriptCandidate(path, stat.st_size, stat.st_mtime)
+
+
 def select_watch_transcript(
     candidates: list[TranscriptCandidate],
     previous_sizes: Mapping[str, int],
@@ -413,6 +445,19 @@ def select_watch_transcript_with_reason(
             None,
         )
         if retained is not None:
+            unseen_newer = [
+                candidate
+                for candidate in candidates
+                if candidate.path != retained.path
+                and str(candidate.path) not in previous_sizes
+                and candidate.mtime > retained.mtime
+            ]
+            if unseen_newer:
+                selected = max(
+                    unseen_newer,
+                    key=lambda candidate: (candidate.mtime, str(candidate.path)),
+                )
+                return selected.path, "unseen_newer"
             return retained.path, "sticky"
     selected = max(
         candidates, key=lambda candidate: (candidate.mtime, str(candidate.path))
@@ -1575,7 +1620,8 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         rt.log(f"[{cid}] coverage tick error: {type(e).__name__}: {e}")
 
     pattern = main_channel_project_re(ch.worktree_root, ch.worktree_prefix)
-    dirs = channel_project_dirs(projects_root(), pattern)
+    project_root = projects_root()
+    dirs = channel_project_dirs(project_root, pattern)
     candidates = transcript_candidates(dirs)
     raw_previous_sizes = chs.get("transcript_sizes", {})
     previous_sizes = {
@@ -1588,21 +1634,35 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         if isinstance(size, int) and not isinstance(size, bool) and size >= 0
     }
     previous_selected = chs.get(SELECTED_TRANSCRIPT_KEY)
+    watermarks = delivered_watermarks(chs)
     bootstrapped_from_watermark = False
     candidate_paths = {str(candidate.path) for candidate in candidates}
+    if (
+        not isinstance(previous_selected, str)
+        or previous_selected not in candidate_paths
+    ):
+        rechecked = recheck_selected_transcript(
+            previous_selected,
+            project_root,
+            pattern,
+            set(previous_sizes) | set(watermarks),
+        )
+        if rechecked is not None:
+            candidates.append(rechecked)
+            candidate_paths.add(str(rechecked.path))
+            rt.log(f"[{cid}] transcript-recheck recovered path={rechecked.path}")
     if (
         not isinstance(previous_selected, str)
         or not previous_selected
         or (candidate_paths and previous_selected not in candidate_paths)
     ):
         previous_selected = None
-        watermarks = delivered_watermarks(chs)
         watermarked_candidates = [
             (watermarks[str(candidate.path)][1], str(candidate.path))
             for candidate in candidates
             if str(candidate.path) in watermarks
         ]
-        if watermarked_candidates:
+        if watermarked_candidates and len(watermarked_candidates) == len(candidates):
             previous_selected = max(watermarked_candidates)[1]
             bootstrapped_from_watermark = True
     tr, selection_reason = select_watch_transcript_with_reason(
@@ -1613,9 +1673,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     if tr is not None:
         chs[SELECTED_TRANSCRIPT_KEY] = str(tr)
     rt.log(f"[{cid}] transcript-select reason={selection_reason} path={tr}")
-    chs["transcript_sizes"] = {
-        str(candidate.path): candidate.size for candidate in candidates
-    }
+    chs["transcript_sizes"] = (
+        {str(candidate.path): candidate.size for candidate in candidates}
+        if candidates
+        else previous_sizes
+    )
     selected = next((candidate for candidate in candidates if candidate.path == tr), None)
     # I1 selector sync (#4408 phase 2): compare the dcserver's asserted relay
     # bind (B) against F. Parallel to gap/coverage — its own cooldown key, wrapped

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1589,7 +1589,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     }
     previous_selected = chs.get(SELECTED_TRANSCRIPT_KEY)
     bootstrapped_from_watermark = False
-    if not isinstance(previous_selected, str) or not previous_selected:
+    candidate_paths = {str(candidate.path) for candidate in candidates}
+    if (
+        not isinstance(previous_selected, str)
+        or not previous_selected
+        or (candidate_paths and previous_selected not in candidate_paths)
+    ):
         previous_selected = None
         watermarks = delivered_watermarks(chs)
         watermarked_candidates = [

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -405,44 +405,99 @@ def _same_file_identity(left: os.stat_result, right: os.stat_result) -> bool:
 
 
 def _open_regular_file_beneath_parent(
-    path: Path, flags: int
+    path: Path, flags: int, trusted_root: Path
 ) -> int | None:
-    """Open one pinned regular file without re-resolving a swapped parent.
+    """Open one regular file beneath a pinned, explicitly trusted root.
 
-    ``O_NOFOLLOW`` on a path string protects only its final component.  Open
-    and identity-pin the parent directory first, then use openat(dirfd,
-    basename) and verify both descriptors against their nofollow prechecks.
-    Any unsupported platform or race fails closed.
+    A final-component ``O_NOFOLLOW`` is insufficient: after discovery an
+    attacker can rename an ancestor such as the provider ``projects`` root and
+    replace it with a symlink to an outside, same-shaped tree.  Pin the trusted
+    root, then resolve *every* descendant directory with ``openat`` plus
+    ``O_NOFOLLOW|O_DIRECTORY``.  The trusted root itself must be an absolute,
+    non-symlink directory; symlinks above that explicit trust boundary retain
+    their normal platform semantics (notably macOS ``/var`` -> ``/private/var``).
+
+    Every pre-open identity is revalidated against the resulting descriptor.
+    The final open is nonblocking so a raced FIFO/device cannot hang the
+    watchdog before its regular-file ``fstat`` gate.  Unsupported platforms,
+    malformed paths, and every race fail closed, with all intermediate file
+    descriptors released.
     """
-    if not getattr(os, "O_DIRECTORY", 0) or not getattr(os, "O_NOFOLLOW", 0):
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    nofollow_flag = getattr(os, "O_NOFOLLOW", 0)
+    nonblock_flag = getattr(os, "O_NONBLOCK", 0)
+    if not directory_flag or not nofollow_flag or not nonblock_flag:
         return None
-    try:
-        expected_parent = path.parent.stat(follow_symlinks=False)
-        expected_file = path.stat(follow_symlinks=False)
-    except (OSError, ValueError, UnicodeError):
-        return None
-    if not stat_mode.S_ISDIR(expected_parent.st_mode) or not stat_mode.S_ISREG(
-        expected_file.st_mode
+
+    normalized_path = _lexical_absolute_path(path)
+    normalized_root = _lexical_absolute_path(trusted_root)
+    if (
+        normalized_path is None
+        or normalized_root is None
+        or normalized_path != path
+        or normalized_root != trusted_root
     ):
         return None
-
-    parent_descriptor = -1
-    descriptor = -1
     try:
-        parent_flags = (
-            os.O_RDONLY
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_DIRECTORY", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-            | getattr(os, "O_NONBLOCK", 0)
-        )
-        parent_descriptor = os.open(path.parent, parent_flags)
-        opened_parent = os.fstat(parent_descriptor)
-        if not stat_mode.S_ISDIR(opened_parent.st_mode) or not _same_file_identity(
-            expected_parent, opened_parent
+        relative = normalized_path.relative_to(normalized_root)
+    except ValueError:
+        return None
+    components = relative.parts
+    if not components or any(component in ("", ".", "..") for component in components):
+        return None
+
+    directory_descriptors: list[int] = []
+    descriptor = -1
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | directory_flag
+        | nofollow_flag
+        | nonblock_flag
+    )
+    file_flags = (
+        flags
+        | getattr(os, "O_CLOEXEC", 0)
+        | nofollow_flag
+        | nonblock_flag
+    )
+    try:
+        expected_root = normalized_root.stat(follow_symlinks=False)
+        if not stat_mode.S_ISDIR(expected_root.st_mode):
+            return None
+        root_descriptor = os.open(normalized_root, directory_flags)
+        directory_descriptors.append(root_descriptor)
+        opened_root = os.fstat(root_descriptor)
+        if not stat_mode.S_ISDIR(opened_root.st_mode) or not _same_file_identity(
+            expected_root, opened_root
         ):
             return None
-        descriptor = os.open(path.name, flags, dir_fd=parent_descriptor)
+
+        for component in components[:-1]:
+            parent_descriptor = directory_descriptors[-1]
+            expected_directory = os.stat(
+                component, dir_fd=parent_descriptor, follow_symlinks=False
+            )
+            if not stat_mode.S_ISDIR(expected_directory.st_mode):
+                return None
+            child_descriptor = os.open(
+                component, directory_flags, dir_fd=parent_descriptor
+            )
+            directory_descriptors.append(child_descriptor)
+            opened_directory = os.fstat(child_descriptor)
+            if not stat_mode.S_ISDIR(
+                opened_directory.st_mode
+            ) or not _same_file_identity(expected_directory, opened_directory):
+                return None
+
+        parent_descriptor = directory_descriptors[-1]
+        filename = components[-1]
+        expected_file = os.stat(
+            filename, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if not stat_mode.S_ISREG(expected_file.st_mode):
+            return None
+        descriptor = os.open(filename, file_flags, dir_fd=parent_descriptor)
         opened_file = os.fstat(descriptor)
         if not stat_mode.S_ISREG(opened_file.st_mode) or not _same_file_identity(
             expected_file, opened_file
@@ -454,12 +509,16 @@ def _open_regular_file_beneath_parent(
     except (OSError, TypeError, ValueError, UnicodeError):
         return None
     finally:
-        for opened in (descriptor, parent_descriptor):
-            if opened >= 0:
-                try:
-                    os.close(opened)
-                except OSError:
-                    pass
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        for opened_directory in reversed(directory_descriptors):
+            try:
+                os.close(opened_directory)
+            except OSError:
+                pass
 
 
 @dataclass(frozen=True)
@@ -923,7 +982,9 @@ def assistant_blocks_from_lines(lines) -> list[tuple[float, str]]:
     return out
 
 
-def assistant_blocks(transcript: Path) -> TranscriptReadResult:
+def assistant_blocks(
+    transcript: Path, trusted_root: Path | None = None
+) -> TranscriptReadResult:
     flags = (
         os.O_RDONLY
         | getattr(os, "O_CLOEXEC", 0)
@@ -932,7 +993,13 @@ def assistant_blocks(transcript: Path) -> TranscriptReadResult:
     )
     descriptor = -1
     try:
-        opened = _open_regular_file_beneath_parent(transcript, flags)
+        # Provider transcripts have shape ``projects/<session>/<uuid>.jsonl``;
+        # the projects directory is the narrowest stable trust boundary that
+        # still lets the component walk reject a swapped session directory.
+        # Production passes it explicitly; the derived value keeps this helper
+        # fail-closed and useful for focused tests.
+        root = trusted_root if trusted_root is not None else transcript.parent.parent
+        opened = _open_regular_file_beneath_parent(transcript, flags, root)
         if opened is None:
             return TranscriptReadResult([], "UnsafePath")
         descriptor = opened
@@ -2224,7 +2291,7 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     def read_candidate(candidate: TranscriptCandidate) -> TranscriptReadResult:
         path = str(candidate.path)
         if path not in read_cache:
-            read_cache[path] = assistant_blocks(candidate.path)
+            read_cache[path] = assistant_blocks(candidate.path, project_root)
         return read_cache[path]
 
     reactivated_paths: list[str] = []

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -100,6 +100,10 @@ SELECTED_TRANSCRIPT_KEY = "selected_transcript"
 TRANSCRIPT_SIZES_KEY = "transcript_sizes"
 TRANSCRIPT_SEEN_AT_KEY = "transcript_seen_at"
 PENDING_TRANSCRIPTS_KEY = "pending_transcripts"
+PENDING_TRANSCRIPT_OVERFLOW_KEY = "pending_transcript_overflow"
+LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY = (
+    "last_pending_transcript_overflow_alert"
+)
 MAX_TRANSCRIPT_HISTORY = 64
 MAX_PENDING_TRANSCRIPTS = 32
 TRANSCRIPT_HISTORY_TTL_SECS = 7 * 24 * 60 * 60
@@ -628,7 +632,7 @@ def assistant_blocks(transcript: Path) -> list[tuple[float, str]]:
     try:
         with transcript.open(encoding="utf-8") as f:
             return assistant_blocks_from_lines(f)
-    except OSError:
+    except (OSError, UnicodeError):
         return []
 
 
@@ -1775,12 +1779,23 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 for candidate in candidates
                 if str(candidate.path) not in previous_sizes
             ),
-            key=lambda candidate: (candidate.mtime, str(candidate.path)),
+            key=lambda candidate: (-candidate.mtime, str(candidate.path)),
         )
+        live_debut_paths: list[str] = []
         for candidate in debut_candidates:
             path = str(candidate.path)
-            if path not in pending_paths:
-                pending_paths.append(path)
+            idle = now - candidate.mtime
+            if idle >= cfg.idle_quiet_secs:
+                rt.log(
+                    f"[{cid}] transcript-debut-skip reason=idle "
+                    f"idle_min={int(min(idle, 86400 * 365) // 60)} path={path}"
+                )
+                continue
+            live_debut_paths.append(path)
+        live_debut_set = set(live_debut_paths)
+        pending_paths = live_debut_paths + [
+            path for path in pending_paths if path not in live_debut_set
+        ]
     tr, selection_reason = select_watch_transcript_with_reason(
         candidates, previous_sizes, previous_selected
     )
@@ -1820,7 +1835,44 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     merged_sizes, merged_seen_at = _bounded_transcript_history(
         merged_sizes, merged_seen_at, now, priority_paths
     )
-    pending_paths = _bounded_pending_transcripts(pending_paths, set(merged_sizes))
+    bounded_pending_paths = _bounded_pending_transcripts(
+        pending_paths, set(merged_sizes)
+    )
+    bounded_pending_set = set(bounded_pending_paths)
+    dropped_pending_paths = [
+        path for path in pending_paths if path not in bounded_pending_set
+    ]
+    if dropped_pending_paths:
+        chs[PENDING_TRANSCRIPT_OVERFLOW_KEY] = {
+            "at": now,
+            "dropped": len(dropped_pending_paths),
+            "kept": len(bounded_pending_paths),
+        }
+        rt.log(
+            f"[{cid}] transcript-debut-overflow "
+            f"kept={len(bounded_pending_paths)} "
+            f"dropped={len(dropped_pending_paths)}"
+        )
+        last_overflow_alert = chs.get(
+            LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY, 0.0
+        )
+        if not _is_finite_nonnegative_number(last_overflow_alert):
+            last_overflow_alert = 0.0
+        if now - float(last_overflow_alert) >= cfg.realert_secs:
+            rt.alert(
+                ch,
+                "🚨 **릴레이 트랜스크립트 평가 큐 포화**\n\n"
+                f"한 번의 감시 틱에서 보존 가능한 신규 트랜스크립트 "
+                f"**{len(bounded_pending_paths)}개**를 초과해 "
+                f"**{len(dropped_pending_paths)}개**의 평가 권한을 유지하지 "
+                "못했습니다. 최신 후보를 우선 보존했지만 평가 커버리지가 "
+                "불완전하므로 정상 상태로 간주할 수 없습니다.\n\n"
+                f"런타임: {rt.dcserver_snapshot()}",
+            )
+            chs[LAST_PENDING_TRANSCRIPT_OVERFLOW_ALERT_KEY] = now
+    else:
+        chs.pop(PENDING_TRANSCRIPT_OVERFLOW_KEY, None)
+    pending_paths = bounded_pending_paths
     chs[TRANSCRIPT_SIZES_KEY] = merged_sizes
     chs[TRANSCRIPT_SEEN_AT_KEY] = merged_seen_at
     chs[PENDING_TRANSCRIPTS_KEY] = pending_paths

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -96,6 +96,7 @@ SELECTOR_PATH_UNCOMPARABLE = "uncomparable"
 
 DELIVERED_WATERMARKS_KEY = "delivered_watermarks"
 MAX_DELIVERED_WATERMARKS = 16
+SELECTED_TRANSCRIPT_KEY = "selected_transcript"
 
 PG_TOPOLOGY_TUNNEL = "tunnel"
 PG_TOPOLOGY_DIRECT = "direct"
@@ -365,25 +366,58 @@ def transcript_candidates(dirs: list[Path]) -> list[TranscriptCandidate]:
 
 
 def select_watch_transcript(
-    candidates: list[TranscriptCandidate], previous_sizes: Mapping[str, int]
+    candidates: list[TranscriptCandidate],
+    previous_sizes: Mapping[str, int],
+    previous_selected: str | Path | None = None,
 ) -> Path | None:
-    """Choose a transcript by observed growth, falling back to newest mtime.
+    """Choose by observed growth, then retain the previously selected path.
 
     A newly discovered candidate has no growth proof yet.  Once a prior size
     exists, any file that grew wins over a newer-but-stagnant file; mtime and
-    path provide deterministic tie-breaking within the chosen pool.  The
-    caller owns I/O and persistence, keeping this selector pure.
+    path provide deterministic tie-breaking within the growing pool.  Without
+    growth, a still-present previous selection is sticky: mtime-only touches on
+    an old continuation transcript are not evidence that it became live again.
+    The caller owns I/O and persistence, keeping this selector pure.
     """
+    return select_watch_transcript_with_reason(
+        candidates, previous_sizes, previous_selected
+    )[0]
+
+
+def select_watch_transcript_with_reason(
+    candidates: list[TranscriptCandidate],
+    previous_sizes: Mapping[str, int],
+    previous_selected: object = None,
+) -> tuple[Path | None, str]:
     if not candidates:
-        return None
+        return None, "no_candidates"
     growing = [
         candidate
         for candidate in candidates
         if str(candidate.path) in previous_sizes
         and candidate.size > previous_sizes[str(candidate.path)]
     ]
-    pool = growing or candidates
-    return max(pool, key=lambda candidate: (candidate.mtime, str(candidate.path))).path
+    if growing:
+        selected = max(
+            growing, key=lambda candidate: (candidate.mtime, str(candidate.path))
+        )
+        return selected.path, "growth"
+    prior = (
+        str(previous_selected)
+        if isinstance(previous_selected, (str, Path)) and str(previous_selected)
+        else None
+    )
+    if prior is not None:
+        retained = next(
+            (candidate for candidate in candidates if str(candidate.path) == prior),
+            None,
+        )
+        if retained is not None:
+            return retained.path, "sticky"
+    selected = max(
+        candidates, key=lambda candidate: (candidate.mtime, str(candidate.path))
+    )
+    return selected.path, "prior_missing" if prior is not None else "bootstrap"
 
 
 def newest_transcript(dirs: list[Path]) -> Path | None:
@@ -1553,7 +1587,27 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         )
         if isinstance(size, int) and not isinstance(size, bool) and size >= 0
     }
-    tr = select_watch_transcript(candidates, previous_sizes)
+    previous_selected = chs.get(SELECTED_TRANSCRIPT_KEY)
+    bootstrapped_from_watermark = False
+    if not isinstance(previous_selected, str) or not previous_selected:
+        previous_selected = None
+        watermarks = delivered_watermarks(chs)
+        watermarked_candidates = [
+            (watermarks[str(candidate.path)][1], str(candidate.path))
+            for candidate in candidates
+            if str(candidate.path) in watermarks
+        ]
+        if watermarked_candidates:
+            previous_selected = max(watermarked_candidates)[1]
+            bootstrapped_from_watermark = True
+    tr, selection_reason = select_watch_transcript_with_reason(
+        candidates, previous_sizes, previous_selected
+    )
+    if bootstrapped_from_watermark and selection_reason == "sticky":
+        selection_reason = "watermark_bootstrap"
+    if tr is not None:
+        chs[SELECTED_TRANSCRIPT_KEY] = str(tr)
+    rt.log(f"[{cid}] transcript-select reason={selection_reason} path={tr}")
     chs["transcript_sizes"] = {
         str(candidate.path): candidate.size for candidate in candidates
     }

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -402,6 +402,31 @@ class TranscriptRecheckTests(unittest.TestCase):
             [],
         )
 
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "FIFO unavailable on this platform")
+    def test_fifo_swap_before_open_is_rejected_without_blocking(self):
+        """A non-regular swap must not block before the descriptor fstat."""
+        fifo = self.project / "swapped.jsonl"
+        os.mkfifo(fifo)
+        probe = (
+            "from pathlib import Path\n"
+            "from unittest import mock\n"
+            "import scripts.relay_watchdog as rw\n"
+            f"with mock.patch.object(rw, '_regular_file_stat_without_symlink', "
+            f"return_value=rw.os.stat({str(self.transcript)!r})):\n"
+            f"    result = rw.assistant_blocks(Path({str(fifo)!r}))\n"
+            "raise SystemExit(0 if result.error == 'UnsafePath' else 1)\n"
+        )
+        try:
+            completed = subprocess.run(
+                [os.environ.get("PYTHON", "python3"), "-c", probe],
+                cwd=REPO_ROOT,
+                timeout=2,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("assistant_blocks blocked opening a FIFO swapped after precheck")
+        self.assertEqual(completed.returncode, 0)
+
 
 class TimestampTests(unittest.TestCase):
     def test_transcript_timestamps_parse_as_utc(self):
@@ -1095,6 +1120,22 @@ class StateTests(unittest.TestCase):
         self.assertFalse(advance_delivered_watermark(state, "/a.jsonl", 19.0, 31.0))
         self.assertEqual(delivered_watermark_for_path(state, "/a.jsonl"), 20.0)
         self.assertEqual(delivered_watermark_for_path(state, "/b.jsonl"), 0.0)
+
+    def test_invariant_4435_selected_watermark_is_pinned_under_cap_pressure(self):
+        selected = "/z-selected.jsonl"
+        state: dict = {SELECTED_TRANSCRIPT_KEY: selected}
+        self.assertTrue(advance_delivered_watermark(state, selected, 50.0, 100.0))
+        for index in range(MAX_DELIVERED_WATERMARKS):
+            self.assertTrue(
+                advance_delivered_watermark(
+                    state,
+                    f"/a-{index:02d}.jsonl",
+                    60.0 + index,
+                    100.0,
+                )
+            )
+        self.assertEqual(len(delivered_watermarks(state)), MAX_DELIVERED_WATERMARKS)
+        self.assertEqual(delivered_watermark_for_path(state, selected), 50.0)
 
 
 class RuntimePgProbeTests(unittest.TestCase):
@@ -2705,6 +2746,286 @@ class TickChannelTests(unittest.TestCase):
         )
         self.assertEqual(
             len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+
+    def test_invariant_4435_truncated_debut_stays_pending_until_completed(self):
+        current = self.proj_dir / "current.jsonl"
+        final = self.proj_dir / "torn-final.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        anchor = float(int(self.now - 1000))
+        current.write_text(record(anchor, "current delivered") + "\n", encoding="utf-8")
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        final_record = record(self.now - 2000, "completed final was never relayed")
+        final.write_text(final_record[:-9], encoding="utf-8")
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(anchor + 1, "current growth delivered") + "\n")
+        os.utime(final, (self.now + 1, self.now + 1))
+        os.utime(current, (self.now + 2, self.now + 2))
+        rt.haystack = norm("current delivered current growth delivered")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+
+        self.assertIn(str(final), state["999"]["pending_transcripts"])
+        self.assertNotIn(
+            str(final),
+            state["999"]["transcript_sizes"],
+            "an incomplete debut must not commit a safe growth baseline",
+        )
+        self.assertTrue(
+            any(
+                f"transcript-read-incomplete path={final}" in line
+                for line in rt.log_lines
+            )
+        )
+
+        final.write_text(final_record + "\n", encoding="utf-8")
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(anchor + 2, "current second growth delivered") + "\n")
+        os.utime(final, (self.now + 4, self.now + 4))
+        os.utime(current, (self.now + 5, self.now + 5))
+        rt.haystack = norm(
+            "current delivered current growth delivered current second growth delivered"
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 6)
+
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+        self.assertTrue(
+            any(
+                f"transcript-debut-eval path={final} state=gap" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_invariant_4435_corrupt_pending_escalates_once_then_unwedges(self):
+        current = self.proj_dir / "current.jsonl"
+        malformed = self.proj_dir / "permanently-malformed.jsonl"
+        anchor = float(int(self.now - 1000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(record(anchor, "current delivered") + "\n", encoding="utf-8")
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt(read_fail_alert_after=3)
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        malformed.write_bytes(b"\xff\n")
+        os.utime(malformed, (self.now + 1, self.now + 1))
+        state["999"]["alerting"] = True
+        state["999"]["gap_since"] = self.now - 60
+
+        for offset in range(2, 5):
+            tick_channel(rt, TICK_CHANNEL, state, self.now + offset)
+
+        escalation_alerts = [
+            body for body, _ in rt.alerts if "평가 불능 에스컬레이션" in body
+        ]
+        self.assertEqual(len(escalation_alerts), 1)
+        self.assertNotIn(str(malformed), state["999"]["pending_transcripts"])
+        self.assertFalse(state["999"].get("alerting", False))
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 5)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 불능 에스컬레이션" in body]),
+            1,
+        )
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_invariant_4435_stale_pending_gap_expires_without_realert_loop(self):
+        current = self.proj_dir / "current.jsonl"
+        missed = self.proj_dir / "missed-final.jsonl"
+        anchor = float(int(self.now - 1000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(record(anchor, "current delivered") + "\n", encoding="utf-8")
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        missed.write_text(
+            record(self.now - 2000, "dead session final missing") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(missed, (self.now + 1, self.now + 1))
+        rt.haystack = norm("current delivered")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(missed))
+
+        expiry = self.now + 3 + rt.cfg.idle_quiet_secs + 1
+        # Metadata-only activity is not content authority and must not extend
+        # the pending lifetime indefinitely.
+        os.utime(missed, (expiry, expiry))
+        tick_channel(rt, TICK_CHANNEL, state, expiry)
+        tick_channel(rt, TICK_CHANNEL, state, expiry + rt.cfg.realert_secs + 1)
+
+        self.assertNotIn(str(missed), state["999"]["pending_transcripts"])
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 권한 만료" in body]), 1
+        )
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_invariant_4435_deleted_anchor_uses_watermark_over_touched_dead_path(self):
+        deleted_anchor = self.proj_dir / "deleted-current.jsonl"
+        safe = self.proj_dir / "safe-watermarked.jsonl"
+        dead = self.proj_dir / "touched-dead.jsonl"
+        unwatermarked = self.proj_dir / "unwatermarked-stale.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        safe.write_text(record(anchor, "safe delivered anchor") + "\n", encoding="utf-8")
+        dead.write_text(
+            "\n".join(
+                record(anchor - 1000 + index, f"historic missing block {index}")
+                for index in range(490)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        unwatermarked.write_text("{}\n", encoding="utf-8")
+        os.utime(safe, (self.now - 100, self.now - 100))
+        os.utime(unwatermarked, (self.now - 1, self.now - 1))
+        os.utime(dead, (self.now, self.now))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(deleted_anchor),
+                "transcript_sizes": {
+                    str(deleted_anchor): 10,
+                    str(safe): safe.stat().st_size,
+                    str(dead): dead.stat().st_size,
+                },
+                "transcript_seen_at": {
+                    str(deleted_anchor): self.now - 1,
+                    str(safe): self.now - 1,
+                    str(dead): self.now - 1,
+                },
+                "transcript_known_at": {
+                    str(deleted_anchor): self.now - 1,
+                    str(safe): self.now - 1,
+                    str(dead): self.now - 1,
+                },
+            }
+        }
+        advance_delivered_watermark(state["999"], safe, anchor, self.now - 1)
+        rt = self.make_rt()
+        rt.haystack = ""
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(safe))
+        self.assertTrue(
+            any(
+                "transcript-select reason=watermark_anchor_recovery" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_invariant_4435_selected_anchor_survives_many_delivered_debuts(self):
+        current = self.proj_dir / "z-current.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(record(anchor, "selected delivered") + "\n", encoding="utf-8")
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("selected delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        delivered_texts = ["selected delivered", "selected growth delivered"]
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(anchor + 1, "selected growth delivered") + "\n")
+        for index in range(MAX_DELIVERED_WATERMARKS):
+            path = self.proj_dir / f"a-{index:02d}.jsonl"
+            text = f"delivered debut {index}"
+            path.write_text(
+                record(self.now - 1900 + index, text) + "\n", encoding="utf-8"
+            )
+            os.utime(path, (self.now + 1, self.now + 1))
+            delivered_texts.append(text)
+        os.utime(current, (self.now + 2, self.now + 2))
+        rt.haystack = norm(" ".join(delivered_texts))
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], current), anchor + 1
+        )
+        self.assertEqual(len(delivered_watermarks(state["999"])), MAX_DELIVERED_WATERMARKS)
+
+        rt.haystack = ""
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 0
         )
 
     def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -175,6 +175,7 @@ class TranscriptResolutionTests(unittest.TestCase):
         selected = select_watch_transcript(
             [growing, newer_stagnant],
             {str(growing.path): 100, str(newer_stagnant.path): 200},
+            semantic_growth_paths={str(growing.path)},
         )
         self.assertEqual(selected, growing.path)
 
@@ -1137,6 +1138,32 @@ class StateTests(unittest.TestCase):
         self.assertEqual(len(delivered_watermarks(state)), MAX_DELIVERED_WATERMARKS)
         self.assertEqual(delivered_watermark_for_path(state, selected), 50.0)
 
+    def test_invariant_4435_all_active_pending_watermarks_are_pinned(self):
+        selected = "/selected.jsonl"
+        pending = [
+            f"/pending-{index:02d}.jsonl"
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS)
+        ]
+        state: dict = {
+            SELECTED_TRANSCRIPT_KEY: selected,
+            "pending_transcripts": pending,
+        }
+        for index, path in enumerate([selected, *pending]):
+            self.assertTrue(
+                advance_delivered_watermark(state, path, 10.0 + index, 20.0)
+            )
+        for index in range(MAX_DELIVERED_WATERMARKS + 5):
+            advance_delivered_watermark(
+                state,
+                f"/unrelated-{index:02d}.jsonl",
+                100.0 + index,
+                1000.0 + index,
+            )
+
+        retained = delivered_watermarks(state)
+        self.assertEqual(len(retained), MAX_DELIVERED_WATERMARKS)
+        self.assertTrue(set([selected, *pending]) <= set(retained))
+
 
 class RuntimePgProbeTests(unittest.TestCase):
     def test_health_detail_db_false_is_classified_by_nc_closed(self):
@@ -1546,13 +1573,13 @@ class TickChannelTests(unittest.TestCase):
         rt.live_sessions = {expected_tmux_session_name(TICK_CHANNEL)}
         rt.watcher_probe = probe
 
-    def test_growth_aware_selector_is_wired_into_tick(self):
-        growing = self.proj_dir / "growing.jsonl"
+    def test_metadata_only_growth_cannot_steal_live_selection(self):
+        stale_compact = self.proj_dir / "stale-compact.jsonl"
         stagnant_dir = self.projects / (
             "-Users-alice--adk-release-worktrees-claude-adk-cc-20260710-140500"
         )
         stagnant_dir.mkdir()
-        stagnant = stagnant_dir / "stagnant.jsonl"
+        current = stagnant_dir / "current.jsonl"
 
         def record(epoch: float, text: str) -> str:
             return json.dumps(
@@ -1565,34 +1592,77 @@ class TickChannelTests(unittest.TestCase):
                 }
             )
 
-        growing.write_text(
-            record(self.now - 2000, "missing from older growing transcript") + "\n",
+        stale_compact.write_text(
+            "".join(
+                record(self.now - 3000 - index, f"old missing block {index}") + "\n"
+                for index in range(490)
+            ),
             encoding="utf-8",
         )
-        stagnant.write_text(
-            record(self.now - 2000, "newer stagnant block landed") + "\n",
+        current.write_text(
+            record(self.now - 30, "current live block landed") + "\n",
             encoding="utf-8",
         )
-        os.utime(growing, (self.now - 100, self.now - 100))
-        os.utime(stagnant, (self.now, self.now))
+        os.utime(stale_compact, (self.now - 100, self.now - 100))
+        os.utime(current, (self.now, self.now))
         rt = self.make_rt()
-        rt.haystack = norm("newer stagnant block landed")
+        rt.haystack = norm("current live block landed")
         state: dict = {}
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(rt.alerts, [], "first tick must use mtime fallback")
-        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(stagnant))
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
 
-        with growing.open("a", encoding="utf-8") as f:
-            f.write("\n")
-        # Keep the growing file's mtime older than the stagnant candidate: only
-        # size growth can make it win on the second tick.
-        os.utime(growing, (self.now - 50, self.now - 50))
-        os.utime(stagnant, (self.now, self.now))
+        with stale_compact.open("a", encoding="utf-8") as f:
+            f.write("\n" + json.dumps({"type": "queue-operation"}) + "\n")
+        # This is the live #4435 recurrence: compact/dead transcript metadata
+        # grows and gets a fresh mtime, but no deliverable assistant row exists.
+        os.utime(stale_compact, (self.now + 1, self.now + 1))
         tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
-        self.assertEqual(len(rt.alerts), 1)
-        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
-        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(growing))
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertTrue(
+            any(
+                f"transcript-growth-ignored reason=non-semantic path={stale_compact}"
+                in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_timestamped_assistant_growth_can_switch_selection(self):
+        prior = self.proj_dir / "prior.jsonl"
+        current_dir = self.projects / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260710-140500"
+        )
+        current_dir.mkdir()
+        current = current_dir / "current.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        prior.write_text(record(self.now - 60, "prior delivered") + "\n", encoding="utf-8")
+        current.write_text(record(self.now - 30, "current delivered") + "\n", encoding="utf-8")
+        os.utime(prior, (self.now - 100, self.now - 100))
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("prior delivered current delivered semantic growth delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        with prior.open("a", encoding="utf-8") as stream:
+            stream.write(record(self.now + 1, "semantic growth delivered") + "\n")
+        os.utime(prior, (self.now - 50, self.now - 50))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(prior))
         self.assertTrue(
             any("transcript-select reason=growth" in line for line in rt.log_lines)
         )
@@ -1600,7 +1670,20 @@ class TickChannelTests(unittest.TestCase):
     def _grow_selected_transcript(self) -> None:
         tr = self.proj_dir / "s.jsonl"
         with tr.open("a", encoding="utf-8") as f:
-            f.write("\n")
+            f.write(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": time.strftime(
+                            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.now)
+                        ),
+                        "message": {
+                            "content": [{"type": "text", "text": "selector growth"}]
+                        },
+                    }
+                )
+                + "\n"
+            )
         os.utime(tr, (self.now, self.now))
 
     def test_selector_divergence_alerts_only_after_swap_confirm(self):
@@ -2794,6 +2877,17 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+        with mock.patch.object(
+            relay_watchdog, "transcript_candidates", return_value=[]
+        ):
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        self.assertIn(
+            str(final),
+            state["999"]["pending_transcripts"],
+            "a torn debut must retain authority across a discovery miss",
+        )
+        self.assertNotIn(str(final), state["999"]["transcript_sizes"])
+
         final.write_text(final_record + "\n", encoding="utf-8")
         with current.open("a", encoding="utf-8") as stream:
             stream.write(record(anchor + 2, "current second growth delivered") + "\n")
@@ -2842,6 +2936,7 @@ class TickChannelTests(unittest.TestCase):
         os.utime(malformed, (self.now + 1, self.now + 1))
         state["999"]["alerting"] = True
         state["999"]["gap_since"] = self.now - 60
+        state["999"][relay_watchdog.GAP_TRANSCRIPT_KEY] = str(malformed)
 
         for offset in range(2, 5):
             tick_channel(rt, TICK_CHANNEL, state, self.now + offset)
@@ -2854,12 +2949,57 @@ class TickChannelTests(unittest.TestCase):
         self.assertFalse(state["999"].get("alerting", False))
         self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
 
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 5)
+        for offset in range(5, 9):
+            with malformed.open("ab") as stream:
+                stream.write(b"\xff")
+            os.utime(malformed, (self.now + offset, self.now + offset))
+            tick_channel(rt, TICK_CHANNEL, state, self.now + offset)
         self.assertEqual(
             len([body for body, _ in rt.alerts if "평가 불능 에스컬레이션" in body]),
             1,
         )
+        self.assertIn(
+            str(malformed), state["999"]["retired_transcripts"]
+        )
         self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_invariant_4435_selected_read_failure_escalates_and_quarantines(self):
+        selected = self.proj_dir / "selected.jsonl"
+        anchor = float(int(self.now - 30))
+        selected.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "selected delivered"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt(read_fail_alert_after=3)
+        rt.haystack = norm("selected delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        with selected.open("ab") as stream:
+            stream.write(b"\xff\n")
+        for offset in range(1, 4):
+            os.utime(selected, (self.now + offset, self.now + offset))
+            tick_channel(rt, TICK_CHANNEL, state, self.now + offset)
+
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 불능 에스컬레이션" in body]),
+            1,
+        )
+        self.assertIn(str(selected), state["999"]["retired_transcripts"])
+        self.assertNotEqual(
+            state["999"].get(SELECTED_TRANSCRIPT_KEY), str(selected)
+        )
 
     def test_invariant_4435_stale_pending_gap_expires_without_realert_loop(self):
         current = self.proj_dir / "current.jsonl"
@@ -2911,6 +3051,44 @@ class TickChannelTests(unittest.TestCase):
             len([body for body, _ in rt.alerts if "평가 권한 만료" in body]), 1
         )
         self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_invariant_4435_unrelated_pending_retirement_preserves_live_gap(self):
+        rt = self.gap_rt()
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+        selected = chs[SELECTED_TRANSCRIPT_KEY]
+        self.assertTrue(chs.get("alerting"))
+        self.assertEqual(chs[relay_watchdog.GAP_TRANSCRIPT_KEY], selected)
+        chs["issue_url"] = "https://example.test/issues/existing"
+        original_gap_since = chs["gap_since"]
+
+        unrelated = self.proj_dir / "unrelated-pending.jsonl"
+        unrelated.write_text("{}\n", encoding="utf-8")
+        os.utime(unrelated, (self.now, self.now))
+        chs["transcript_sizes"][str(unrelated)] = unrelated.stat().st_size
+        chs["transcript_seen_at"][str(unrelated)] = self.now
+        chs["pending_transcripts"] = [str(unrelated)]
+        chs["pending_transcript_since"] = {
+            str(unrelated): self.now - rt.cfg.idle_quiet_secs - 1
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        self.assertTrue(chs.get("alerting"))
+        self.assertEqual(chs["gap_since"], original_gap_since)
+        self.assertEqual(
+            chs["issue_url"], "https://example.test/issues/existing"
+        )
+        self.assertEqual(chs[relay_watchdog.GAP_TRANSCRIPT_KEY], selected)
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+        self.assertTrue(
+            any(
+                "unrelated transcript retirement preserved live gap authority"
+                in line
+                for line in rt.log_lines
+            )
+        )
 
     def test_invariant_4435_deleted_anchor_uses_watermark_over_touched_dead_path(self):
         deleted_anchor = self.proj_dir / "deleted-current.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -68,6 +68,7 @@ from scripts.relay_watchdog import (
     parse_config,
     parse_transcript_ts,
     project_slug,
+    recheck_selected_transcript,
     save_state,
     select_watch_transcript,
     select_watch_transcript_with_reason,
@@ -259,6 +260,104 @@ class TranscriptResolutionTests(unittest.TestCase):
 
     def test_no_dirs_yields_none(self):
         self.assertIsNone(newest_transcript([]))
+
+
+class TranscriptRecheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.pattern = make_re()
+        self.project = self.root / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-140500"
+        )
+        self.project.mkdir()
+        self.transcript = self.project / "valid.jsonl"
+        self.transcript.write_text("{}\n", encoding="utf-8")
+
+    def test_untracked_valid_shaped_path_is_rejected(self):
+        self.assertIsNone(
+            recheck_selected_transcript(
+                str(self.transcript), self.root, self.pattern, set()
+            )
+        )
+
+    def test_tracked_noncanonical_path_is_rejected(self):
+        value = str(
+            self.root
+            / self.project.name
+            / ".."
+            / self.project.name
+            / self.transcript.name
+        )
+        self.assertIsNone(
+            recheck_selected_transcript(value, self.root, self.pattern, {value})
+        )
+
+    def test_tracked_path_outside_root_or_deeper_nested_is_rejected(self):
+        other_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(other_tmp.cleanup)
+        other_root = Path(other_tmp.name)
+        outside_project = other_root / self.project.name
+        outside_project.mkdir()
+        outside = outside_project / "outside.jsonl"
+        outside.write_text("{}\n", encoding="utf-8")
+
+        nested_project = self.root / "extra" / self.project.name
+        nested_project.mkdir(parents=True)
+        nested = nested_project / "nested.jsonl"
+        nested.write_text("{}\n", encoding="utf-8")
+
+        for value in (str(outside), str(nested)):
+            with self.subTest(value=value):
+                self.assertIsNone(
+                    recheck_selected_transcript(
+                        value, self.root, self.pattern, {value}
+                    )
+                )
+
+    def test_tracked_wrong_suffix_is_rejected(self):
+        wrong = self.project / "wrong.txt"
+        wrong.write_text("{}\n", encoding="utf-8")
+        self.assertIsNone(
+            recheck_selected_transcript(
+                str(wrong), self.root, self.pattern, {str(wrong)}
+            )
+        )
+
+    def test_tracked_pattern_mismatch_is_rejected(self):
+        wrong_project = self.root / "not-a-channel-project"
+        wrong_project.mkdir()
+        wrong = wrong_project / "wrong.jsonl"
+        wrong.write_text("{}\n", encoding="utf-8")
+        self.assertIsNone(
+            recheck_selected_transcript(
+                str(wrong), self.root, self.pattern, {str(wrong)}
+            )
+        )
+
+    def test_valid_tracked_existing_path_is_recovered(self):
+        candidate = recheck_selected_transcript(
+            str(self.transcript),
+            self.root,
+            self.pattern,
+            {str(self.transcript)},
+        )
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.path, self.transcript)
+        self.assertEqual(candidate.size, self.transcript.stat().st_size)
+
+    def test_malformed_tracked_path_stat_errors_are_rejected(self):
+        for name in ("bad\0.jsonl", "bad\ud800.jsonl"):
+            value = str(self.project / name)
+            with self.subTest(name=repr(name)):
+                try:
+                    candidate = recheck_selected_transcript(
+                        value, self.root, self.pattern, {value}
+                    )
+                except (OSError, ValueError, UnicodeError) as exc:
+                    self.fail(f"malformed persisted path escaped recheck: {exc!r}")
+                self.assertIsNone(candidate)
 
 
 class TimestampTests(unittest.TestCase):
@@ -1849,6 +1948,258 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(touched_old))
         self.assertTrue(
             any("transcript-select reason=bootstrap" in line for line in rt.log_lines)
+        )
+
+    def test_invariant_4435_partial_discovery_preserves_nonselected_baseline(self):
+        current = self.proj_dir / "current.jsonl"
+        historical = self.proj_dir / "historical.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(anchor, "confirmed current") + "\n", encoding="utf-8"
+        )
+        historical.write_text(
+            record(anchor - 1000, "historic missing") + "\n", encoding="utf-8"
+        )
+        os.utime(historical, (self.now - 100, self.now - 100))
+        os.utime(current, (self.now, self.now))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(current),
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    str(historical): historical.stat().st_size,
+                },
+            }
+        }
+        advance_delivered_watermark(state["999"], current, anchor, self.now - 1)
+        rt = self.make_rt()
+        rt.haystack = norm("confirmed current")
+        current_only = TranscriptCandidate(
+            current, current.stat().st_size, current.stat().st_mtime
+        )
+
+        with mock.patch.object(
+            relay_watchdog, "transcript_candidates", return_value=[current_only]
+        ):
+            tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertIn(str(historical), state["999"]["transcript_sizes"])
+        self.assertEqual(
+            state["999"]["transcript_sizes"][str(historical)],
+            historical.stat().st_size,
+        )
+
+        os.utime(historical, (self.now + 1, self.now + 1))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertTrue(
+            any("transcript-select reason=sticky" in line for line in rt.log_lines)
+        )
+
+    def test_invariant_4435_transcript_history_is_bounded(self):
+        current = self.proj_dir / "current.jsonl"
+        current.write_text("{}\n", encoding="utf-8")
+        fresh = {
+            f"/missing/fresh-{index}.jsonl": index
+            for index in range(relay_watchdog.MAX_TRANSCRIPT_HISTORY + 10)
+        }
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(current),
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    **fresh,
+                },
+                "transcript_seen_at": {
+                    str(current): self.now,
+                    **{path: self.now - 1 for path in fresh},
+                },
+            }
+        }
+
+        tick_channel(self.make_rt(), TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(
+            len(state["999"]["transcript_sizes"]),
+            relay_watchdog.MAX_TRANSCRIPT_HISTORY,
+        )
+        self.assertIn(str(current), state["999"]["transcript_sizes"])
+        self.assertTrue(set(fresh) & set(state["999"]["transcript_sizes"]))
+
+    def test_invariant_4435_transcript_history_evicts_stale_missing(self):
+        current = self.proj_dir / "current.jsonl"
+        current.write_text("{}\n", encoding="utf-8")
+        stale_at = self.now - relay_watchdog.TRANSCRIPT_HISTORY_TTL_SECS - 1
+        stale = {
+            f"/missing/history-{index}.jsonl": index for index in range(3)
+        }
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(current),
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    **stale,
+                },
+                "transcript_seen_at": {
+                    str(current): self.now,
+                    **{path: stale_at for path in stale},
+                },
+                "pending_transcripts": [next(iter(stale))],
+            }
+        }
+
+        tick_channel(self.make_rt(), TICK_CHANNEL, state, self.now)
+
+        self.assertFalse(set(stale) & set(state["999"]["transcript_sizes"]))
+        self.assertEqual(state["999"]["pending_transcripts"], [])
+
+    def test_invariant_4435_pending_debut_queue_is_bounded_on_read_failure(self):
+        current = self.proj_dir / "current.jsonl"
+        current.write_text("{}\n", encoding="utf-8")
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(current),
+                "transcript_sizes": {str(current): current.stat().st_size},
+            }
+        }
+        for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 5):
+            (self.proj_dir / f"debut-{index:02d}.jsonl").write_text(
+                "{}\n", encoding="utf-8"
+            )
+        rt = self.make_rt()
+        rt.haystack = None
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(
+            len(state["999"]["pending_transcripts"]),
+            relay_watchdog.MAX_PENDING_TRANSCRIPTS,
+        )
+
+    def test_invariant_4435_debut_queue_evaluates_all_while_growth_stays_selected(
+        self,
+    ):
+        current = self.proj_dir / "current.jsonl"
+        missed = self.proj_dir / "missed-final.jsonl"
+        delivered_new = self.proj_dir / "delivered-final.jsonl"
+        current_ts = float(int(self.now - 1000))
+        missed_ts = float(int(self.now - 2000))
+        delivered_ts = float(int(self.now - 1500))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(current_ts, "current delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(current_ts + 1, "current growth delivered") + "\n")
+        missed.write_text(
+            record(missed_ts, "missed final block") + "\n", encoding="utf-8"
+        )
+        delivered_new.write_text(
+            record(delivered_ts, "new final delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(missed, (self.now - 2, self.now - 2))
+        os.utime(delivered_new, (self.now - 1, self.now - 1))
+        os.utime(current, (self.now + 1, self.now + 1))
+        rt.haystack = norm(
+            "current delivered current growth delivered new final delivered"
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertTrue(
+            any("transcript-select reason=growth" in line for line in rt.log_lines)
+        )
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        for path in (missed, delivered_new):
+            self.assertTrue(
+                any(
+                    f"transcript-debut-eval path={path}" in line
+                    for line in rt.log_lines
+                )
+            )
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], delivered_new), delivered_ts
+        )
+        self.assertEqual(delivered_watermark_for_path(state["999"], missed), 0.0)
+        self.assertEqual(state["999"]["pending_transcripts"], [str(missed)])
+
+    def test_invariant_4435_debut_survives_blind_tick_until_first_evaluation(self):
+        current = self.proj_dir / "current.jsonl"
+        missed = self.proj_dir / "missed-after-blind-tick.jsonl"
+        current_ts = float(int(self.now - 1000))
+        missed_ts = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(current_ts, "current delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        missed.write_text(
+            record(missed_ts, "missed during blind tick") + "\n", encoding="utf-8"
+        )
+        os.utime(missed, (self.now - 1, self.now - 1))
+        rt.haystack = None
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertIn(str(missed), state["999"]["pending_transcripts"])
+
+        rt.haystack = norm("current delivered")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertTrue(
+            any(
+                f"transcript-debut-eval path={missed}" in line
+                for line in rt.log_lines
+            )
         )
 
     def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -403,6 +403,52 @@ class TranscriptRecheckTests(unittest.TestCase):
             [],
         )
 
+    def test_parent_symlink_swap_before_open_cannot_escape_dirfd(self):
+        outside_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_tmp.cleanup)
+        outside_project = Path(outside_tmp.name) / self.project.name
+        outside_project.mkdir()
+        outside = outside_project / self.transcript.name
+        outside.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-11T07:00:00Z",
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "escaped-parent-read"}
+                        ]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        moved_project = self.root / "original-project-after-swap"
+        real_open = relay_watchdog.os.open
+        swapped = False
+
+        def swap_parent_then_open(path, flags, *args, **kwargs):
+            nonlocal swapped
+            if not swapped and Path(path) in (self.project, self.transcript):
+                swapped = True
+                self.project.rename(moved_project)
+                self.project.symlink_to(outside_project, target_is_directory=True)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch.object(
+            relay_watchdog.os, "open", side_effect=swap_parent_then_open
+        ):
+            result = relay_watchdog.assistant_blocks(self.transcript)
+
+        self.assertTrue(swapped, "test must swap after nofollow prechecks")
+        self.assertEqual(result.error, "UnsafePath")
+        self.assertEqual(
+            result.blocks,
+            [],
+            "a path-string reopen must never read through the swapped parent",
+        )
+
     @unittest.skipUnless(hasattr(os, "mkfifo"), "FIFO unavailable on this platform")
     def test_fifo_swap_before_open_is_rejected_without_blocking(self):
         """A non-regular swap must not block before the descriptor fstat."""
@@ -1734,6 +1780,39 @@ class TickChannelTests(unittest.TestCase):
             "(send-to-agent handoff), not bot-direct delivery",
         )
 
+    def test_selector_quiet_tool_tick_preserves_divergence_window(self):
+        self.write_transcript([(self.now - 30, "delivered selector anchor")])
+        rt = self.make_rt(swap_confirm_secs=300)
+        rt.haystack = norm("delivered selector anchor")
+        stale_bind = str(self.projects / "other-provider" / "stale-bind.jsonl")
+        rt.watcher_probe = WatcherStateProbe(200, True, False, stale_bind)
+        state: dict = {}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self._grow_selected_transcript()
+        first_divergence = self.now + 1
+        tick_channel(rt, TICK_CHANNEL, state, first_divergence)
+        self.assertEqual(
+            state["999"].get("selector_diverged_since"), first_divergence
+        )
+
+        # A normal long tool phase has no new assistant text.  It pauses F
+        # evidence but must not erase the already-proven stuck-bind window.
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 200)
+        self.assertEqual(
+            state["999"].get("selector_diverged_since"), first_divergence
+        )
+        self.assertTrue(
+            any("retained divergence window" in line for line in rt.log_lines)
+        )
+
+        self._grow_selected_transcript()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 301)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "셀렉터 동기화" in body]),
+            1,
+        )
+
     def test_invariant_4435_runtime_mirror_never_starts_swap_timer_or_alerts(self):
         self.write_transcript([(self.now - 30, "delivered mirror case")])
         rt = self.make_rt(swap_confirm_secs=300)
@@ -3051,6 +3130,169 @@ class TickChannelTests(unittest.TestCase):
             state["999"].get(SELECTED_TRANSCRIPT_KEY), str(selected)
         )
 
+    def test_invariant_4435_full_pending_cap_keeps_selected_failure_authority(self):
+        selected = self.proj_dir / "selected-cap-anchor.jsonl"
+        anchor = float(int(self.now - 30))
+        selected.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "cap anchor landed"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt(read_fail_alert_after=4)
+        rt.haystack = norm("cap anchor landed")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(selected))
+
+        pending: list[str] = []
+        for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS):
+            path = self.proj_dir / f"pending-corrupt-{index:02d}.jsonl"
+            path.write_bytes(b"\xff\n")
+            os.utime(path, (self.now + 1, self.now + 1))
+            pending.append(str(path))
+        with selected.open("ab") as stream:
+            stream.write(b"\xff\n")
+        os.utime(selected, (self.now + 1, self.now + 1))
+        state["999"]["pending_transcripts"] = pending
+        state["999"]["pending_transcript_since"] = {
+            path: self.now + 1 for path in pending
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        chs = state["999"]
+        self.assertEqual(
+            len(chs["pending_transcripts"]),
+            relay_watchdog.MAX_PENDING_TRANSCRIPTS,
+        )
+        self.assertNotIn(
+            str(selected),
+            chs["pending_transcripts"],
+            "selected owns a separate failure slot, not pending capacity",
+        )
+        self.assertEqual(
+            chs.get("pending_transcript_failures", {}).get(str(selected)), 1
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertEqual(
+            state["999"].get("pending_transcript_failures", {}).get(str(selected)),
+            2,
+            "a full cap must not reset the established selection each tick",
+        )
+
+    def test_invariant_4435_legacy_without_known_at_tracks_torn_debut(self):
+        selected = self.proj_dir / "legacy-selected.jsonl"
+        torn = self.proj_dir / "legacy-new-torn.jsonl"
+        anchor = float(int(self.now - 30))
+        selected.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "legacy landed"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        torn.write_text('{"type":"assistant"', encoding="utf-8")
+        os.utime(selected, (self.now - 1, self.now - 1))
+        os.utime(torn, (self.now, self.now))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(selected),
+                "transcript_sizes": {str(selected): selected.stat().st_size},
+            }
+        }
+        rt = self.make_rt(read_fail_alert_after=3)
+        rt.haystack = norm("legacy landed")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        chs = state["999"]
+        self.assertIn(str(torn), chs["pending_transcripts"])
+        self.assertEqual(chs["pending_transcript_failures"][str(torn)], 1)
+        self.assertIn("transcript_known_at", chs)
+        self.assertFalse(
+            any("unproven_stale_content" in line for line in rt.log_lines)
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(
+            state["999"]["pending_transcript_failures"][str(torn)], 2
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertIn(str(torn), state["999"]["retired_transcripts"])
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 불능" in body]), 1
+        )
+
+    def test_invariant_4435_zero_assistant_debut_keeps_pending_authority(self):
+        current = self.proj_dir / "zero-block-current.jsonl"
+        debut = self.proj_dir / "zero-block-debut.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(self.now - 30, "zero block anchor landed") + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt()
+        rt.haystack = norm("zero block anchor landed")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        debut.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.now + 1)
+                    ),
+                    "message": {"content": "prompt only"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(debut, (self.now + 1, self.now + 1))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertIn(
+            str(debut),
+            state["999"]["pending_transcripts"],
+            "vacuous OK without one assistant block cannot consume debut authority",
+        )
+
+        with debut.open("a", encoding="utf-8") as stream:
+            stream.write(record(self.now - 2000, "later semantic block missing") + "\n")
+        os.utime(debut, (self.now + 3, self.now + 3))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+
     def test_invariant_4435_stale_pending_gap_expires_without_realert_loop(self):
         current = self.proj_dir / "current.jsonl"
         missed = self.proj_dir / "missed-final.jsonl"
@@ -3102,6 +3344,68 @@ class TickChannelTests(unittest.TestCase):
         )
         self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
 
+    def test_invariant_4435_retirement_alerts_share_realert_cooldown(self):
+        current = self.proj_dir / "retirement-current.jsonl"
+        current.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.now - 30)
+                    ),
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "retirement anchor landed"}
+                        ]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt()
+        rt.haystack = norm("retirement anchor landed")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+
+        def arm_expired(name: str, tick_at: float) -> None:
+            path = self.proj_dir / name
+            path.write_text("{}\n", encoding="utf-8")
+            os.utime(path, (tick_at, tick_at))
+            chs["transcript_sizes"][str(path)] = path.stat().st_size
+            chs["transcript_seen_at"][str(path)] = tick_at
+            chs["transcript_known_at"][str(path)] = tick_at
+            chs["pending_transcripts"] = [str(path)]
+            chs["pending_transcript_since"] = {
+                str(path): tick_at - rt.cfg.idle_quiet_secs - 1
+            }
+
+        first_tick = self.now + 1
+        arm_expired("retire-one.jsonl", first_tick)
+        tick_channel(rt, TICK_CHANNEL, state, first_tick)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 권한 만료" in body]), 1
+        )
+
+        arm_expired("retire-two.jsonl", first_tick + 1)
+        tick_channel(rt, TICK_CHANNEL, state, first_tick + 1)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 권한 만료" in body]),
+            1,
+            "a new crash-loop transcript inside cooldown must not spam",
+        )
+        self.assertTrue(
+            any("retirement-alert suppressed" in line for line in rt.log_lines)
+        )
+
+        boundary = first_tick + rt.cfg.realert_secs
+        arm_expired("retire-three.jsonl", boundary)
+        tick_channel(rt, TICK_CHANNEL, state, boundary)
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 권한 만료" in body]), 2
+        )
+
     def test_invariant_4435_unrelated_pending_retirement_preserves_live_gap(self):
         rt = self.gap_rt()
         state: dict = {}
@@ -3139,6 +3443,128 @@ class TickChannelTests(unittest.TestCase):
                 for line in rt.log_lines
             )
         )
+
+    def test_invariant_4435_young_debut_cannot_false_recover_prior_gap_owner(self):
+        owner = self.proj_dir / "gap-owner-a.jsonl"
+        debut = self.proj_dir / "young-debut-b.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner.write_text(
+            record(self.now - 2000, "owner A remains missing") + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt()
+        rt.haystack = ""
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+        self.assertTrue(chs.get("alerting"))
+        self.assertIn(
+            str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY]
+        )
+        original_gap_since = chs["gap_since"]
+        chs["issue_url"] = "https://example.test/issues/owner-a"
+
+        debut.write_text(
+            record(self.now + 1, "young B not delivered yet") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(debut, (self.now + 1, self.now + 1))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertTrue(chs.get("alerting"))
+        self.assertEqual(chs["gap_since"], original_gap_since)
+        self.assertEqual(
+            chs["issue_url"], "https://example.test/issues/owner-a"
+        )
+        self.assertEqual(chs[relay_watchdog.GAP_TRANSCRIPT_KEY], str(owner))
+        self.assertIn(
+            str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY]
+        )
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_invariant_4435_retiring_one_of_two_gap_owners_keeps_incident_clock(self):
+        owner_a = self.proj_dir / "multi-gap-a.jsonl"
+        owner_b = self.proj_dir / "multi-gap-b.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner_a.write_text(
+            record(self.now - 2000, "multi gap A missing") + "\n",
+            encoding="utf-8",
+        )
+        owner_b.write_text(
+            record(self.now - 3000, "multi gap B missing") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(owner_a, (self.now, self.now))
+        os.utime(owner_b, (self.now + 1, self.now + 1))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(owner_a),
+                "transcript_sizes": {
+                    str(owner_a): owner_a.stat().st_size,
+                    str(owner_b): owner_b.stat().st_size,
+                },
+                "transcript_seen_at": {
+                    str(owner_a): self.now,
+                    str(owner_b): self.now,
+                },
+                "transcript_known_at": {
+                    str(owner_a): self.now,
+                    str(owner_b): self.now,
+                },
+                "pending_transcripts": [str(owner_b)],
+                "pending_transcript_since": {str(owner_b): self.now},
+            }
+        }
+        rt = self.make_rt()
+        rt.haystack = ""
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        chs = state["999"]
+        self.assertEqual(chs[relay_watchdog.GAP_TRANSCRIPT_KEY], str(owner_b))
+        self.assertEqual(
+            set(chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY]),
+            {str(owner_a), str(owner_b)},
+        )
+        original_gap_since = chs["gap_since"]
+        chs["issue_url"] = "https://example.test/issues/multi-gap"
+        chs["pending_transcript_since"][str(owner_b)] = (
+            self.now - rt.cfg.idle_quiet_secs - 1
+        )
+
+        os.utime(owner_a, (self.now + 3, self.now + 3))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+
+        self.assertTrue(chs.get("alerting"))
+        self.assertEqual(chs["gap_since"], original_gap_since)
+        self.assertEqual(
+            chs["issue_url"], "https://example.test/issues/multi-gap"
+        )
+        self.assertEqual(chs[relay_watchdog.GAP_TRANSCRIPT_KEY], str(owner_a))
+        self.assertEqual(
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY], [str(owner_a)]
+        )
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
 
     def test_invariant_4435_deleted_anchor_uses_watermark_over_touched_dead_path(self):
         deleted_anchor = self.proj_dir / "deleted-current.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -361,6 +361,32 @@ class TranscriptRecheckTests(unittest.TestCase):
                     self.fail(f"malformed persisted path escaped recheck: {exc!r}")
                 self.assertIsNone(candidate)
 
+    def test_directory_fstat_errors_fail_closed_as_unsafe_paths(self):
+        real_fstat = relay_watchdog.os.fstat
+        for failing_directory_index in (1, 2):
+            with self.subTest(failing_directory_index=failing_directory_index):
+                directory_calls = 0
+
+                def fail_selected_directory_fstat(descriptor):
+                    nonlocal directory_calls
+                    opened = real_fstat(descriptor)
+                    if stat.S_ISDIR(opened.st_mode):
+                        directory_calls += 1
+                        if directory_calls == failing_directory_index:
+                            raise OSError("injected directory fstat failure")
+                    return opened
+
+                with mock.patch.object(
+                    relay_watchdog.os,
+                    "fstat",
+                    side_effect=fail_selected_directory_fstat,
+                ):
+                    result = relay_watchdog.assistant_blocks(self.transcript)
+
+                self.assertEqual(directory_calls, failing_directory_index)
+                self.assertEqual(result.blocks, [])
+                self.assertEqual(result.error, "UnsafePath")
+
     def test_symlink_escape_is_rejected_across_recheck_discovery_and_read(self):
         other_tmp = tempfile.TemporaryDirectory()
         self.addCleanup(other_tmp.cleanup)
@@ -4368,6 +4394,70 @@ class TickChannelTests(unittest.TestCase):
         self.assertFalse(
             any("recovered-gap-guard-reclaimed" in line for line in rt.log_lines)
         )
+
+    def test_invariant_4435_guard_directory_fstat_errors_keep_floor_and_tick_running(self):
+        selected = self.proj_dir / "fstat-selected.jsonl"
+        selected.write_text("{}\n", encoding="utf-8")
+        hidden_project = self.projects / (
+            "-Users-alice--adk-release-worktrees-claude-adk-cc-20260709-150500"
+        )
+        hidden_project.mkdir()
+        target = hidden_project / "fstat-hidden-recovered.jsonl"
+        target.write_text("{}\n", encoding="utf-8")
+        path = str(target)
+        real_fstat = relay_watchdog.os.fstat
+
+        for failing_directory_index in (1, 2):
+            with self.subTest(failing_directory_index=failing_directory_index):
+                state = {
+                    "999": {
+                        relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                            path: {
+                                "size": target.stat().st_size,
+                                "confirmed_at": self.now,
+                                "last_seen_at": self.now,
+                                "absent_since": None,
+                            }
+                        },
+                        DELIVERED_WATERMARKS_KEY: {
+                            path: {
+                                "delivered_ts": self.now - 2000,
+                                "updated_at": self.now,
+                            }
+                        },
+                    }
+                }
+                directory_calls = 0
+
+                def fail_selected_directory_fstat(descriptor):
+                    nonlocal directory_calls
+                    opened = real_fstat(descriptor)
+                    if stat.S_ISDIR(opened.st_mode):
+                        directory_calls += 1
+                        if directory_calls == failing_directory_index:
+                            raise OSError("injected recovered-guard directory fstat failure")
+                    return opened
+
+                with (
+                    mock.patch.object(
+                        relay_watchdog,
+                        "channel_project_dirs",
+                        return_value=[self.proj_dir],
+                    ),
+                    mock.patch.object(
+                        relay_watchdog.os,
+                        "fstat",
+                        side_effect=fail_selected_directory_fstat,
+                    ),
+                ):
+                    tick_channel(self.make_rt(), TICK_CHANNEL, state, self.now + 1)
+
+                chs = state["999"]
+                guard = relay_watchdog._validated_recovered_gap_guards(chs)[path]
+                self.assertGreaterEqual(directory_calls, failing_directory_index)
+                self.assertIsNone(guard[3])
+                self.assertGreater(delivered_watermark_for_path(chs, target), 0.0)
+                self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(selected))
 
     def test_invariant_4435_unchanged_guards_are_not_parsed_and_metadata_settles(self):
         selected = self.proj_dir / "guard-perf-selected.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -587,6 +587,24 @@ class TranscriptRecheckTests(unittest.TestCase):
         self.assertEqual(relative.error, "UnsafePath")
         self.assertEqual(escaped.error, "UnsafePath")
 
+    def test_component_open_not_implemented_fails_closed(self):
+        real_open = relay_watchdog.os.open
+
+        def unsupported_openat(path, flags, *args, **kwargs):
+            if kwargs.get("dir_fd") is not None:
+                raise NotImplementedError("dir_fd is unavailable")
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch.object(
+            relay_watchdog.os, "open", side_effect=unsupported_openat
+        ):
+            result = relay_watchdog.assistant_blocks(
+                self.transcript, trusted_root=self.root
+            )
+
+        self.assertEqual(result.error, "UnsafePath")
+        self.assertEqual(result.blocks, [])
+
     @unittest.skipUnless(hasattr(os, "mkfifo"), "FIFO unavailable on this platform")
     def test_fifo_swap_before_open_is_rejected_without_blocking(self):
         """A non-regular swap must not block before the descriptor fstat."""
@@ -610,6 +628,43 @@ class TranscriptRecheckTests(unittest.TestCase):
             )
         except subprocess.TimeoutExpired:
             self.fail("assistant_blocks blocked opening a FIFO swapped after precheck")
+        self.assertEqual(completed.returncode, 0)
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "FIFO unavailable on this platform")
+    def test_regular_to_fifo_race_between_stat_and_open_is_nonblocking(self):
+        """Swap after the final lstat; O_NONBLOCK must make fstat rejection bounded."""
+        raced = self.project / "raced-after-stat.jsonl"
+        raced.write_text("{}\n", encoding="utf-8")
+        probe = (
+            "import os\n"
+            "from pathlib import Path\n"
+            "from unittest import mock\n"
+            "import scripts.relay_watchdog as rw\n"
+            f"target = Path({str(raced)!r})\n"
+            f"trusted = Path({str(self.root)!r})\n"
+            "real_open = rw.os.open\n"
+            "swapped = False\n"
+            "def swap_then_open(path, flags, *args, **kwargs):\n"
+            "    global swapped\n"
+            "    if (not swapped and kwargs.get('dir_fd') is not None "
+            "and os.fspath(path) == target.name):\n"
+            "        target.unlink()\n"
+            "        os.mkfifo(target)\n"
+            "        swapped = True\n"
+            "    return real_open(path, flags, *args, **kwargs)\n"
+            "with mock.patch.object(rw.os, 'open', side_effect=swap_then_open):\n"
+            "    result = rw.assistant_blocks(target, trusted_root=trusted)\n"
+            "raise SystemExit(0 if swapped and result.error == 'UnsafePath' else 1)\n"
+        )
+        try:
+            completed = subprocess.run(
+                [os.environ.get("PYTHON", "python3"), "-c", probe],
+                cwd=REPO_ROOT,
+                timeout=2,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("regular-to-FIFO race blocked at final open without O_NONBLOCK")
         self.assertEqual(completed.returncode, 0)
 
 
@@ -1347,6 +1402,71 @@ class StateTests(unittest.TestCase):
         retained = delivered_watermarks(state)
         self.assertEqual(len(retained), MAX_DELIVERED_WATERMARKS)
         self.assertTrue(set([selected, *pending]) <= set(retained))
+
+    def test_invariant_4435_watermark_cap_fits_full_authority_union(self):
+        selected = "/selected.jsonl"
+        pending = [
+            f"/pending-{index:02d}.jsonl"
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS)
+        ]
+        gap_owners = [
+            f"/gap-owner-{index:02d}.jsonl"
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1)
+        ]
+        authorities = [selected, *pending, *gap_owners]
+        unrelated = "/unrelated-newer.jsonl"
+        state = {
+            SELECTED_TRANSCRIPT_KEY: selected,
+            relay_watchdog.PENDING_TRANSCRIPTS_KEY: pending,
+            relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: gap_owners,
+            DELIVERED_WATERMARKS_KEY: {
+                path: {"delivered_ts": 10.0 + index, "updated_at": 100.0}
+                for index, path in enumerate(authorities)
+            }
+            | {
+                unrelated: {
+                    "delivered_ts": 999.0,
+                    "updated_at": 999.0,
+                }
+            },
+        }
+
+        retained = delivered_watermarks(state)
+
+        self.assertEqual(
+            MAX_DELIVERED_WATERMARKS,
+            1
+            + relay_watchdog.MAX_PENDING_TRANSCRIPTS
+            + (relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1),
+        )
+        self.assertEqual(len(retained), MAX_DELIVERED_WATERMARKS)
+        self.assertTrue(set(authorities) <= set(retained))
+        self.assertNotIn(unrelated, retained)
+
+    def test_invariant_4435_gap_owner_validation_stays_deduped_and_bounded(self):
+        valid = [
+            f"/owner-{index:02d}.jsonl"
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 5)
+        ]
+        state = {
+            relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: [
+                valid[0],
+                "",
+                None,
+                True,
+                valid[0],
+                *valid[1:],
+            ],
+            relay_watchdog.GAP_TRANSCRIPT_KEY: valid[-1],
+        }
+
+        owners = relay_watchdog._validated_gap_owner_transcripts(state)
+
+        self.assertEqual(
+            owners,
+            valid[: relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1],
+        )
+        self.assertEqual(len(owners), len(set(owners)))
 
 
 class RuntimePgProbeTests(unittest.TestCase):
@@ -3795,7 +3915,7 @@ class TickChannelTests(unittest.TestCase):
         delivered_texts = ["selected delivered", "selected growth delivered"]
         with current.open("a", encoding="utf-8") as stream:
             stream.write(record(anchor + 1, "selected growth delivered") + "\n")
-        for index in range(MAX_DELIVERED_WATERMARKS):
+        for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS):
             path = self.proj_dir / f"a-{index:02d}.jsonl"
             text = f"delivered debut {index}"
             path.write_text(
@@ -3812,13 +3932,128 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(
             delivered_watermark_for_path(state["999"], current), anchor + 1
         )
-        self.assertEqual(len(delivered_watermarks(state["999"])), MAX_DELIVERED_WATERMARKS)
+        self.assertEqual(
+            len(delivered_watermarks(state["999"])),
+            relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1,
+        )
 
         rt.haystack = ""
         tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
         self.assertEqual(
             len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 0
         )
+
+    def test_invariant_4435_full_cap_gap_owner_recovery_survives_haystack_rolloff(self):
+        anchor = float(int(self.now - 2000))
+        selected = self.proj_dir / "selected-empty.jsonl"
+        pending = [
+            self.proj_dir / f"pending-empty-{index:02d}.jsonl"
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS)
+        ]
+        target = self.proj_dir / "zz-recovered-gap-owner.jsonl"
+        other_owners = [
+            self.proj_dir / f"gap-owner-{index:02d}.jsonl"
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS)
+        ]
+        gap_owners = [target, *other_owners]
+
+        def record(text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        selected.write_text("{}\n", encoding="utf-8")
+        for path in pending:
+            path.write_text("{}\n", encoding="utf-8")
+        owner_texts: dict[str, str] = {}
+        for index, path in enumerate(gap_owners):
+            text = f"delivered full-cap gap owner {index:02d}"
+            owner_texts[str(path)] = text
+            path.write_text(record(text) + "\n", encoding="utf-8")
+        for path in [selected, *pending, *other_owners]:
+            os.utime(path, (self.now, self.now))
+        # Keep the target in bounded transcript history while the 66 authority
+        # paths are present; it is the sole file left for the rolloff tick.
+        os.utime(target, (self.now + 1, self.now + 1))
+
+        paths = [selected, *pending, *gap_owners]
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(selected),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {
+                    str(path): path.stat().st_size for path in paths
+                },
+                relay_watchdog.TRANSCRIPT_SEEN_AT_KEY: {
+                    str(path): self.now for path in paths
+                },
+                relay_watchdog.TRANSCRIPT_KNOWN_AT_KEY: {
+                    str(path): self.now for path in paths
+                },
+                relay_watchdog.PENDING_TRANSCRIPTS_KEY: [
+                    str(path) for path in pending
+                ],
+                relay_watchdog.PENDING_TRANSCRIPT_SINCE_KEY: {
+                    str(path): self.now for path in pending
+                },
+                relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: [
+                    str(path) for path in gap_owners
+                ],
+                relay_watchdog.GAP_TRANSCRIPT_KEY: str(target),
+                DELIVERED_WATERMARKS_KEY: {
+                    str(path): {
+                        "delivered_ts": anchor - 1,
+                        "updated_at": self.now,
+                    }
+                    for path in [selected, *pending]
+                }
+                | {
+                    "/unrelated-newer.jsonl": {
+                        "delivered_ts": anchor - 1,
+                        "updated_at": self.now + 100,
+                    }
+                },
+                "alerting": True,
+                "gap_since": self.now - 2000,
+                "last_alert": self.now - 10_000,
+            }
+        }
+        rt = self.make_rt()
+        rt.haystack = norm(" ".join(owner_texts.values()))
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        chs = state["999"]
+
+        self.assertFalse(chs.get("alerting", False))
+        self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
+        self.assertEqual(
+            delivered_watermark_for_path(chs, target),
+            anchor,
+            "a recovered GAP owner must retain its delivery authority at full cap",
+        )
+        self.assertEqual(len(delivered_watermarks(chs)), MAX_DELIVERED_WATERMARKS)
+
+        for path in [selected, *pending, *other_owners]:
+            path.unlink()
+        rt.haystack = ""  # bounded Discord history has rolled off the delivery
+        prior_gap_alerts = len(
+            [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+
+        self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(target))
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]),
+            prior_gap_alerts,
+            "haystack rolloff must not re-alert a delivery already confirmed",
+        )
+        self.assertFalse(chs.get("alerting", False))
 
     def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(
         self,

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2202,6 +2202,210 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+    def test_invariant_4435_history_cap_evictees_do_not_redebut_when_idle(self):
+        current = self.proj_dir / "current.jsonl"
+        current_ts = float(int(self.now - 1000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(current_ts, "current delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        idle_at = self.now - rt.cfg.idle_quiet_secs - 60
+        dead_paths: list[Path] = []
+        for index in range(relay_watchdog.MAX_TRANSCRIPT_HISTORY + 8):
+            dead = self.proj_dir / f"dead-{index:03d}.jsonl"
+            dead.write_text(
+                record(self.now - 3000 - index, f"historic missing {index}") + "\n",
+                encoding="utf-8",
+            )
+            os.utime(dead, (idle_at - index, idle_at - index))
+            dead_paths.append(dead)
+
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(rt.alerts, [])
+        retained = set(state["999"]["transcript_sizes"])
+        evicted = [path for path in dead_paths if str(path) not in retained]
+        self.assertGreater(len(evicted), 0)
+
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(current_ts + 1, "current growth delivered") + "\n")
+        live_debut = self.proj_dir / "live-final.jsonl"
+        live_debut.write_text(
+            record(self.now - 2000, "live final missing") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(live_debut, (self.now + 1, self.now + 1))
+        os.utime(current, (self.now + 2, self.now + 2))
+        rt.haystack = norm("current delivered current growth delivered")
+        log_start = len(rt.log_lines)
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+
+        second_tick_logs = rt.log_lines[log_start:]
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+        self.assertTrue(
+            any(
+                f"transcript-debut-eval path={live_debut}" in line
+                for line in second_tick_logs
+            )
+        )
+        for path in evicted:
+            self.assertFalse(
+                any(
+                    f"transcript-debut-eval path={path}" in line
+                    for line in second_tick_logs
+                ),
+                f"idle history evictee regained debut authority: {path}",
+            )
+
+    def test_invariant_4435_malformed_pending_does_not_abort_healthy_selected(self):
+        current = self.proj_dir / "current.jsonl"
+        malformed = self.proj_dir / "malformed.jsonl"
+        current_ts = float(int(self.now - 1000))
+        grown_ts = current_ts + 1
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(current_ts, "current delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(grown_ts, "healthy selected growth") + "\n")
+        malformed.write_bytes(b"\xff\n")
+        os.utime(malformed, (self.now + 1, self.now + 1))
+        os.utime(current, (self.now + 2, self.now + 2))
+        rt.haystack = norm("current delivered healthy selected growth")
+
+        try:
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        except UnicodeError as exc:
+            self.fail(f"malformed pending transcript aborted channel tick: {exc!r}")
+
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], current), grown_ts
+        )
+        self.assertNotIn(str(malformed), state["999"]["pending_transcripts"])
+        self.assertEqual(rt.alerts, [])
+        self.assertTrue(
+            any(
+                f"transcript-debut-eval path={malformed} state=ok" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_invariant_4435_pending_overflow_keeps_newest_and_alerts(self):
+        current = self.proj_dir / "current.jsonl"
+        current_ts = float(int(self.now - 1000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(current_ts, "current delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        debuts: list[Path] = []
+        delivered_texts: list[str] = []
+        for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 5):
+            path = self.proj_dir / f"overflow-{index:02d}.jsonl"
+            text = f"overflow debut {index}"
+            path.write_text(
+                record(self.now - 2000 - index, text) + "\n", encoding="utf-8"
+            )
+            os.utime(
+                path,
+                (self.now + 1 + index / 100, self.now + 1 + index / 100),
+            )
+            debuts.append(path)
+            delivered_texts.append(text)
+        newest = debuts[-1]
+        oldest = debuts[0]
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(current_ts + 1, "current growth delivered") + "\n")
+        os.utime(current, (self.now + 2, self.now + 2))
+        rt.haystack = None
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+
+        pending = state["999"]["pending_transcripts"]
+        self.assertEqual(len(pending), relay_watchdog.MAX_PENDING_TRANSCRIPTS)
+        self.assertIn(str(newest), pending)
+        self.assertNotIn(str(oldest), pending)
+        self.assertEqual(
+            state["999"]["pending_transcript_overflow"]["dropped"], 5
+        )
+        self.assertTrue(
+            any(
+                "transcript-debut-overflow kept=32 dropped=5" in line
+                for line in rt.log_lines
+            )
+        )
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 큐 포화" in body]), 1
+        )
+
+        rt.haystack = norm(
+            "current delivered current growth delivered "
+            + " ".join(delivered_texts[:-1])
+        )
+        log_start = len(rt.log_lines)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+
+        self.assertTrue(
+            any(
+                f"transcript-debut-eval path={newest}" in line
+                for line in rt.log_lines[log_start:]
+            )
+        )
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+
     def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(
         self,
     ):

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1649,6 +1649,9 @@ class TickChannelTests(unittest.TestCase):
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(previous))
+        self.assertEqual(
+            state["999"]["transcript_sizes"], {str(previous): 100}
+        )
         self.assertTrue(
             any("transcript-select reason=no_candidates" in line for line in rt.log_lines)
         )
@@ -1740,7 +1743,7 @@ class TickChannelTests(unittest.TestCase):
             any("transcript-select reason=sticky" in line for line in restarted.log_lines)
         )
 
-    def test_invariant_4435_existing_watermark_bootstraps_sticky_selection(self):
+    def test_invariant_4435_newest_updated_watermark_bootstraps_selection(self):
         current = self.proj_dir / "current.jsonl"
         touched_old = self.proj_dir / "old.jsonl"
         anchor = float(int(self.now - 2000))
@@ -1773,6 +1776,9 @@ class TickChannelTests(unittest.TestCase):
                 }
             }
         }
+        advance_delivered_watermark(
+            state["999"], touched_old, anchor - 100, self.now - 2
+        )
         advance_delivered_watermark(state["999"], current, anchor, self.now - 1)
 
         rt = self.make_rt()
@@ -1787,7 +1793,65 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
-    def test_invariant_4435_invalid_persisted_selection_allows_watermark_bootstrap(
+    def test_invariant_4435_partial_discovery_rechecks_tracked_selection(self):
+        current = self.proj_dir / "current.jsonl"
+        touched_old = self.proj_dir / "old.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(anchor, "confirmed current") + "\n", encoding="utf-8"
+        )
+        touched_old.write_text(
+            record(anchor - 1000, "historic old") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now - 100, self.now - 100))
+        os.utime(touched_old, (self.now, self.now))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(current),
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    str(touched_old): touched_old.stat().st_size,
+                },
+            }
+        }
+        advance_delivered_watermark(state["999"], current, anchor, self.now - 1)
+        rt = self.make_rt()
+        rt.haystack = norm("confirmed current historic old")
+        partial = TranscriptCandidate(
+            touched_old, touched_old.stat().st_size, touched_old.stat().st_mtime
+        )
+
+        with mock.patch.object(
+            relay_watchdog, "transcript_candidates", return_value=[partial]
+        ):
+            tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertTrue(
+            any("transcript-recheck recovered" in line for line in rt.log_lines)
+        )
+
+        current.unlink()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(touched_old))
+        self.assertTrue(
+            any("transcript-select reason=bootstrap" in line for line in rt.log_lines)
+        )
+
+    def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(
         self,
     ):
         current = self.proj_dir / "current.jsonl"
@@ -1828,15 +1892,65 @@ class TickChannelTests(unittest.TestCase):
         advance_delivered_watermark(state["999"], current, anchor, self.now - 1)
 
         rt = self.make_rt()
+        rt.haystack = norm("confirmed current historic missing output")
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
         self.assertEqual(rt.alerts, [])
-        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(touched_old))
         self.assertTrue(
             any(
-                "transcript-select reason=watermark_bootstrap" in line
+                "transcript-select reason=bootstrap" in line
                 for line in rt.log_lines
             )
+        )
+
+    def test_invariant_4435_partial_watermark_coverage_cannot_hide_newer_gap(self):
+        delivered_old = self.proj_dir / "delivered-old.jsonl"
+        missed_newer = self.proj_dir / "missed-newer.jsonl"
+        old_anchor = float(int(self.now - 3000))
+        missed_ts = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        delivered_old.write_text(
+            record(old_anchor, "delivered old") + "\n", encoding="utf-8"
+        )
+        missed_newer.write_text(
+            record(missed_ts, "stale missed final block") + "\n", encoding="utf-8"
+        )
+        os.utime(delivered_old, (self.now - 100, self.now - 100))
+        os.utime(missed_newer, (self.now, self.now))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: "relative/corrupt-selection.jsonl",
+                "transcript_sizes": {
+                    str(delivered_old): delivered_old.stat().st_size,
+                    str(missed_newer): missed_newer.stat().st_size,
+                },
+            }
+        }
+        advance_delivered_watermark(
+            state["999"], delivered_old, old_anchor, self.now - 1
+        )
+        rt = self.make_rt()
+        rt.haystack = norm("delivered old")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(missed_newer))
+        self.assertTrue(
+            any("transcript-select reason=bootstrap" in line for line in rt.log_lines)
         )
 
     def test_invariant_4435_older_haystack_cannot_regress_persisted_anchor(self):
@@ -1862,7 +1976,7 @@ class TickChannelTests(unittest.TestCase):
             delivered_watermark_for_path(state["999"], transcript), newer
         )
 
-    def test_invariant_4435_new_transcript_does_not_inherit_old_path_anchor(self):
+    def test_invariant_4435_unseen_newer_transcript_wins_without_growth_baseline(self):
         old_anchor = float(int(self.now - 1000))
         self.write_transcript([(old_anchor, "old path delivered")])
         old_transcript = self.proj_dir / "s.jsonl"
@@ -1891,16 +2005,12 @@ class TickChannelTests(unittest.TestCase):
         os.utime(new_transcript, (self.now + 1, self.now + 1))
         rt.haystack = ""
         tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
-        self.assertEqual(rt.alerts, [])
-        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(old_transcript))
-
-        with new_transcript.open("a", encoding="utf-8") as stream:
-            stream.write("\n")
-        os.utime(new_transcript, (self.now + 2, self.now + 2))
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
-
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(new_transcript))
+        self.assertTrue(
+            any("transcript-select reason=unseen_newer" in line for line in rt.log_lines)
+        )
         self.assertEqual(
             delivered_watermark_for_path(state["999"], old_transcript), old_anchor
         )

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -4495,7 +4495,7 @@ class TickChannelTests(unittest.TestCase):
             }
         }
         delivered_epoch = float(int(self.now - 2000))
-        missing_epoch = float(int(self.now - 1900))
+        missing_epoch = float(int(self.now))
         with delivered_path.open("a", encoding="utf-8") as stream:
             stream.write(record(delivered_epoch, "new delivered A") + "\n")
         with missing_path.open("a", encoding="utf-8") as stream:
@@ -4517,13 +4517,22 @@ class TickChannelTests(unittest.TestCase):
             delivered_watermark_for_path(chs, delivered_path), delivered_epoch
         )
         self.assertEqual(delivered_watermark_for_path(chs, missing_path), anchor)
+        self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
+        self.assertFalse(chs.get("alerting", False))
+
+        stale_tick = self.now + rt.cfg.grace_secs + 2
+        rt.haystack = ""
+        tick_channel(rt, TICK_CHANNEL, state, stale_tick)
+        save_state(state_path, state)
+        state = load_state(state_path)
+        chs = state["999"]
         self.assertIn(
             str(missing_path), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY]
         )
         self.assertTrue(chs.get("alerting"))
 
         rt.haystack = norm("new missing B")
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        tick_channel(rt, TICK_CHANNEL, state, stale_tick + 1)
         chs = state["999"]
         self.assertFalse(chs.get("alerting", False))
         self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
@@ -4592,6 +4601,121 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn(str(owner_b), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
         self.assertTrue(chs.get("alerting"))
         self.assertEqual(chs["gap_since"], original_gap_since)
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+
+    def test_invariant_4435_sequential_recovery_churn_exceeds_one_gap_wave(self):
+        anchor = float(int(self.now - 2000))
+
+        def record(text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        state: dict = {"999": {}}
+        state_path = self.root / "sequential-recovery-state.json"
+        rt = self.make_rt()
+        recovery_count = relay_watchdog.MAX_GAP_OWNER_TRANSCRIPTS + 1
+        for index in range(recovery_count):
+            path = self.proj_dir / f"sequential-recovered-{index:03d}.jsonl"
+            text = f"sequential delivered recovery {index:03d}"
+            path.write_text(record(text) + "\n", encoding="utf-8")
+            tick_at = self.now + index + 1
+            os.utime(path, (tick_at, tick_at))
+            chs = state["999"]
+            chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY] = [str(path)]
+            chs[relay_watchdog.GAP_TRANSCRIPT_KEY] = str(path)
+            chs["alerting"] = True
+            chs["gap_since"] = self.now - 5000
+            chs["last_alert"] = self.now
+            rt.haystack = norm(text)
+
+            tick_channel(rt, TICK_CHANNEL, state, tick_at)
+            save_state(state_path, state)
+            state = load_state(state_path)
+            guards = relay_watchdog._validated_recovered_gap_guards(state["999"])
+            self.assertIn(str(path), guards)
+            self.assertEqual(len(guards), index + 1)
+            self.assertFalse(state["999"].get("alerting", False))
+
+        self.assertGreater(
+            len(relay_watchdog._validated_recovered_gap_guards(state["999"])),
+            relay_watchdog.MAX_GAP_OWNER_TRANSCRIPTS,
+        )
+        self.assertFalse(
+            any("recovered-gap-guard-capacity-blocked" in line for line in rt.log_lines)
+        )
+
+    def test_invariant_4435_full_recovered_guard_store_blocks_false_recovery(self):
+        anchor = float(int(self.now - 2000))
+        owner = self.proj_dir / "full-store-owner.jsonl"
+        owner.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "owner delivered"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        guards = {
+            str(self.proj_dir / f"absent-full-guard-{index:03d}.jsonl"): {
+                "size": 1,
+                "confirmed_at": self.now,
+                "last_seen_at": self.now,
+                "absent_since": None,
+            }
+            for index in range(relay_watchdog.MAX_RECOVERED_GAP_GUARDS)
+        }
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(owner),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {
+                    str(owner): owner.stat().st_size
+                },
+                relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: [str(owner)],
+                relay_watchdog.GAP_TRANSCRIPT_KEY: str(owner),
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: guards,
+                DELIVERED_WATERMARKS_KEY: {
+                    str(owner): {
+                        "delivered_ts": anchor - 1,
+                        "updated_at": self.now,
+                    }
+                },
+                "alerting": True,
+                "gap_since": self.now - 5000,
+                "last_alert": self.now,
+            }
+        }
+        rt = self.make_rt()
+        rt.haystack = norm("owner delivered")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        state_path = self.root / "full-store-state.json"
+        save_state(state_path, state)
+        state = load_state(state_path)
+        chs = state["999"]
+
+        self.assertEqual(
+            len(relay_watchdog._validated_recovered_gap_guards(chs)),
+            relay_watchdog.MAX_RECOVERED_GAP_GUARDS,
+        )
+        self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
+        self.assertTrue(chs.get("alerting"))
+        self.assertTrue(
+            any("recovered-gap-guard-capacity-blocked" in line for line in rt.log_lines)
+        )
         self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
 
     def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1659,7 +1659,7 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
         self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(replacement))
         self.assertTrue(
-            any("transcript-select reason=prior_missing" in line for line in rt.log_lines)
+            any("transcript-select reason=bootstrap" in line for line in rt.log_lines)
         )
 
     def test_invariant_4435_all_stale_restart_keeps_delivered_anchor(self):
@@ -1771,6 +1771,58 @@ class TickChannelTests(unittest.TestCase):
                     str(current): current.stat().st_size,
                     str(touched_old): touched_old.stat().st_size,
                 }
+            }
+        }
+        advance_delivered_watermark(state["999"], current, anchor, self.now - 1)
+
+        rt = self.make_rt()
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertTrue(
+            any(
+                "transcript-select reason=watermark_bootstrap" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_invariant_4435_invalid_persisted_selection_allows_watermark_bootstrap(
+        self,
+    ):
+        current = self.proj_dir / "current.jsonl"
+        touched_old = self.proj_dir / "old.jsonl"
+        anchor = float(int(self.now - 2000))
+        current.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "confirmed current"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        touched_old.write_text(
+            current.read_text(encoding="utf-8").replace(
+                "confirmed current", "historic missing output"
+            ),
+            encoding="utf-8",
+        )
+        os.utime(current, (self.now - 100, self.now - 100))
+        os.utime(touched_old, (self.now, self.now))
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: "relative/stale-selection.jsonl",
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    str(touched_old): touched_old.stat().st_size,
+                },
             }
         }
         advance_delivered_watermark(state["999"], current, anchor, self.now - 1)

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1413,12 +1413,25 @@ class StateTests(unittest.TestCase):
             f"/gap-owner-{index:02d}.jsonl"
             for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1)
         ]
-        authorities = [selected, *pending, *gap_owners]
+        recovered = [
+            f"/recovered-{index:03d}.jsonl"
+            for index in range(relay_watchdog.MAX_RECOVERED_GAP_GUARDS)
+        ]
+        authorities = [selected, *pending, *gap_owners, *recovered]
         unrelated = "/unrelated-newer.jsonl"
         state = {
             SELECTED_TRANSCRIPT_KEY: selected,
             relay_watchdog.PENDING_TRANSCRIPTS_KEY: pending,
             relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: gap_owners,
+            relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                path: {
+                    "size": index,
+                    "confirmed_at": 100.0,
+                    "last_seen_at": 100.0,
+                    "absent_since": None,
+                }
+                for index, path in enumerate(recovered)
+            },
             DELIVERED_WATERMARKS_KEY: {
                 path: {"delivered_ts": 10.0 + index, "updated_at": 100.0}
                 for index, path in enumerate(authorities)
@@ -1437,7 +1450,8 @@ class StateTests(unittest.TestCase):
             MAX_DELIVERED_WATERMARKS,
             1
             + relay_watchdog.MAX_PENDING_TRANSCRIPTS
-            + (relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1),
+            + (relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1)
+            + relay_watchdog.MAX_RECOVERED_GAP_GUARDS,
         )
         self.assertEqual(len(retained), MAX_DELIVERED_WATERMARKS)
         self.assertTrue(set(authorities) <= set(retained))
@@ -1467,6 +1481,65 @@ class StateTests(unittest.TestCase):
             valid[: relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1],
         )
         self.assertEqual(len(owners), len(set(owners)))
+
+    def test_invariant_4435_recovered_guard_validation_is_strict_and_bounded(self):
+        valid = {
+            f"/guard-{index:03d}.jsonl": {
+                "size": index,
+                "confirmed_at": 10.0,
+                "last_seen_at": 11.0,
+                "absent_since": None,
+            }
+            for index in range(relay_watchdog.MAX_RECOVERED_GAP_GUARDS + 5)
+        }
+        state = {
+            relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                "/bad-bool.jsonl": {
+                    "size": True,
+                    "confirmed_at": 10.0,
+                    "last_seen_at": 11.0,
+                    "absent_since": None,
+                },
+                "/bad-clock.jsonl": {
+                    "size": 1,
+                    "confirmed_at": 10.0,
+                    "last_seen_at": 20.0,
+                    "absent_since": 19.0,
+                },
+                **valid,
+            }
+        }
+
+        guards = relay_watchdog._validated_recovered_gap_guards(state)
+
+        self.assertEqual(len(guards), relay_watchdog.MAX_RECOVERED_GAP_GUARDS)
+        self.assertNotIn("/bad-bool.jsonl", guards)
+        self.assertNotIn("/bad-clock.jsonl", guards)
+
+    def test_invariant_4435_recovered_guard_capacity_outlives_one_gap_wave(self):
+        guards: dict = {}
+        for index in range(relay_watchdog.MAX_GAP_OWNER_TRANSCRIPTS + 1):
+            guards, admitted = relay_watchdog._upsert_recovered_gap_guard(
+                guards, f"/guard-{index:03d}.jsonl", index, 100.0 + index
+            )
+            self.assertTrue(admitted)
+        self.assertGreater(
+            len(guards), relay_watchdog.MAX_GAP_OWNER_TRANSCRIPTS
+        )
+
+        for index in range(
+            len(guards), relay_watchdog.MAX_RECOVERED_GAP_GUARDS
+        ):
+            guards, admitted = relay_watchdog._upsert_recovered_gap_guard(
+                guards, f"/guard-{index:03d}.jsonl", index, 100.0 + index
+            )
+            self.assertTrue(admitted)
+        before = dict(guards)
+        guards, admitted = relay_watchdog._upsert_recovered_gap_guard(
+            guards, "/overflow.jsonl", 1, 999.0
+        )
+        self.assertFalse(admitted)
+        self.assertEqual(guards, before)
 
 
 class RuntimePgProbeTests(unittest.TestCase):
@@ -3957,12 +4030,12 @@ class TickChannelTests(unittest.TestCase):
         ]
         gap_owners = [target, *other_owners]
 
-        def record(text: str) -> str:
+        def record(text: str, epoch: float = anchor) -> str:
             return json.dumps(
                 {
                     "type": "assistant",
                     "timestamp": time.strftime(
-                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
                     ),
                     "message": {"content": [{"type": "text", "text": text}]},
                 }
@@ -4025,8 +4098,14 @@ class TickChannelTests(unittest.TestCase):
         }
         rt = self.make_rt()
         rt.haystack = norm(" ".join(owner_texts.values()))
+        state_path = self.root / "post-recovery-state.json"
+
+        def restart(current_state: dict) -> dict:
+            save_state(state_path, current_state)
+            return load_state(state_path)
 
         tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        state = restart(state)
         chs = state["999"]
 
         self.assertFalse(chs.get("alerting", False))
@@ -4036,16 +4115,56 @@ class TickChannelTests(unittest.TestCase):
             anchor,
             "a recovered GAP owner must retain its delivery authority at full cap",
         )
-        self.assertEqual(len(delivered_watermarks(chs)), MAX_DELIVERED_WATERMARKS)
+        self.assertEqual(
+            len(delivered_watermarks(chs)),
+            len({str(path) for path in [selected, *pending, *gap_owners]}) + 1,
+        )
 
-        for path in [selected, *pending, *other_owners]:
+        growth_text = "delivered growth after GAP recovery"
+        with target.open("a", encoding="utf-8") as stream:
+            stream.write(record(growth_text, anchor + 1) + "\n")
+        os.utime(target, (self.now + 3, self.now + 3))
+        rt.haystack = norm(growth_text)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        state = restart(state)
+        chs = state["999"]
+        self.assertEqual(delivered_watermark_for_path(chs, target), anchor + 1)
+        self.assertEqual(
+            relay_watchdog._validated_recovered_gap_guards(chs)[str(target)][0],
+            target.stat().st_size,
+        )
+
+        # Recovery clears GAP-owner state. Exercise the actual review finding:
+        # two later full debut waves create enough newer watermarks to evict an
+        # ex-owner unless recovery transferred it to durable replay authority.
+        pressure_paths: list[Path] = []
+        for wave in range(2):
+            wave_texts: list[str] = []
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS):
+                path = self.proj_dir / f"wave-{wave}-{index:02d}.jsonl"
+                text = f"delivered pressure wave {wave} item {index:02d}"
+                path.write_text(record(text) + "\n", encoding="utf-8")
+                os.utime(path, (self.now + 4 + wave, self.now + 4 + wave))
+                pressure_paths.append(path)
+                wave_texts.append(text)
+            rt.haystack = norm(" ".join(wave_texts))
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 4 + wave)
+            state = restart(state)
+            chs = state["999"]
+            self.assertEqual(
+                delivered_watermark_for_path(chs, target),
+                anchor + 1,
+                f"post-recovery pressure wave {wave} evicted replay authority",
+            )
+
+        for path in [selected, *pending, *other_owners, *pressure_paths]:
             path.unlink()
         rt.haystack = ""  # bounded Discord history has rolled off the delivery
         prior_gap_alerts = len(
             [body for body, _ in rt.alerts if "릴레이 갭 감지" in body]
         )
 
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 6)
 
         self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(target))
         self.assertEqual(
@@ -4054,6 +4173,426 @@ class TickChannelTests(unittest.TestCase):
             "haystack rolloff must not re-alert a delivery already confirmed",
         )
         self.assertFalse(chs.get("alerting", False))
+
+    def test_invariant_4435_recovered_guard_absence_ttl_starts_new_lifecycle(self):
+        anchor = float(int(self.now - 2000))
+        target = self.proj_dir / "absent-recovered.jsonl"
+        target.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "old lifecycle"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        path = str(target)
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: path,
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {path: target.stat().st_size},
+                relay_watchdog.TRANSCRIPT_SEEN_AT_KEY: {path: self.now},
+                relay_watchdog.TRANSCRIPT_KNOWN_AT_KEY: {path: self.now},
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    path: {
+                        "size": target.stat().st_size,
+                        "confirmed_at": self.now,
+                        "last_seen_at": self.now,
+                        "absent_since": None,
+                    }
+                },
+                DELIVERED_WATERMARKS_KEY: {
+                    path: {"delivered_ts": anchor, "updated_at": self.now}
+                },
+            }
+        }
+        state_path = self.root / "absence-lifecycle.json"
+
+        def restart(current_state: dict) -> dict:
+            save_state(state_path, current_state)
+            return load_state(state_path)
+
+        target.unlink()
+        rt = self.make_rt()
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        state = restart(state)
+        guard = relay_watchdog._validated_recovered_gap_guards(state["999"])[path]
+        self.assertEqual(guard[3], self.now + 1)
+
+        before_expiry = (
+            self.now + 1 + relay_watchdog.RECOVERED_GAP_GUARD_TTL_SECS - 1
+        )
+        tick_channel(rt, TICK_CHANNEL, state, before_expiry)
+        state = restart(state)
+        self.assertIn(
+            path, relay_watchdog._validated_recovered_gap_guards(state["999"])
+        )
+        self.assertEqual(delivered_watermark_for_path(state["999"], path), anchor)
+
+        after_expiry = before_expiry + 2
+        tick_channel(rt, TICK_CHANNEL, state, after_expiry)
+        state = restart(state)
+        chs = state["999"]
+        self.assertNotIn(
+            path, relay_watchdog._validated_recovered_gap_guards(chs)
+        )
+        self.assertEqual(delivered_watermark_for_path(chs, path), 0.0)
+        self.assertNotIn(path, chs.get(relay_watchdog.TRANSCRIPT_SIZES_KEY, {}))
+        self.assertTrue(
+            any("recovered-gap-guard-reclaimed" in line for line in rt.log_lines)
+        )
+
+        # Reuse after the proven-absence boundary is a new path lifecycle. The
+        # old delivery floor must not authenticate its stale content.
+        target.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "old lifecycle"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(target, (after_expiry + 1, after_expiry + 1))
+        rt.haystack = ""
+        tick_channel(rt, TICK_CHANNEL, state, after_expiry + 1)
+        self.assertTrue(state["999"].get("alerting"))
+        self.assertEqual(state["999"][relay_watchdog.GAP_TRANSCRIPT_KEY], path)
+
+    def test_invariant_4435_present_recovered_guard_does_not_expire(self):
+        anchor = float(int(self.now - 2000))
+        selected = self.proj_dir / "present-selected.jsonl"
+        target = self.proj_dir / "present-recovered.jsonl"
+        selected.write_text("{}\n", encoding="utf-8")
+        target.write_text("{}\n", encoding="utf-8")
+        target_path = str(target)
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(selected),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {
+                    str(selected): selected.stat().st_size,
+                    target_path: target.stat().st_size,
+                },
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    target_path: {
+                        "size": target.stat().st_size,
+                        "confirmed_at": self.now,
+                        "last_seen_at": self.now,
+                        "absent_since": None,
+                    }
+                },
+                DELIVERED_WATERMARKS_KEY: {
+                    target_path: {
+                        "delivered_ts": anchor,
+                        "updated_at": self.now,
+                    }
+                },
+            }
+        }
+        state_path = self.root / "present-lifecycle.json"
+        save_state(state_path, state)
+        state = load_state(state_path)
+        tick_at = self.now + relay_watchdog.RECOVERED_GAP_GUARD_TTL_SECS + 1
+
+        tick_channel(self.make_rt(), TICK_CHANNEL, state, tick_at)
+
+        guard = relay_watchdog._validated_recovered_gap_guards(state["999"])[
+            target_path
+        ]
+        self.assertEqual(guard[1], self.now)
+        self.assertEqual(guard[2], tick_at)
+        self.assertIsNone(guard[3])
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], target_path), anchor
+        )
+
+    def test_invariant_4435_ancestor_symlink_is_ambiguous_not_absent(self):
+        target = self.proj_dir / "hidden-recovered.jsonl"
+        target.write_text("{}\n", encoding="utf-8")
+        path = str(target)
+        state = {
+            "999": {
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    path: {
+                        "size": target.stat().st_size,
+                        "confirmed_at": self.now,
+                        "last_seen_at": self.now,
+                        "absent_since": None,
+                    }
+                },
+                DELIVERED_WATERMARKS_KEY: {
+                    path: {
+                        "delivered_ts": self.now - 2000,
+                        "updated_at": self.now,
+                    }
+                },
+            }
+        }
+        hidden = self.projects / "hidden-real-project"
+        decoy = self.projects / "decoy-project"
+        self.proj_dir.rename(hidden)
+        decoy.mkdir()
+        self.proj_dir.symlink_to(decoy, target_is_directory=True)
+        state_path = self.root / "symlink-lifecycle.json"
+        rt = self.make_rt()
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        save_state(state_path, state)
+        state = load_state(state_path)
+        tick_channel(
+            rt,
+            TICK_CHANNEL,
+            state,
+            self.now + relay_watchdog.RECOVERED_GAP_GUARD_TTL_SECS + 2,
+        )
+
+        guard = relay_watchdog._validated_recovered_gap_guards(state["999"])[path]
+        self.assertIsNone(guard[3])
+        self.assertGreater(
+            delivered_watermark_for_path(state["999"], path), 0.0
+        )
+        self.assertFalse(
+            any("recovered-gap-guard-reclaimed" in line for line in rt.log_lines)
+        )
+
+    def test_invariant_4435_unchanged_guards_are_not_parsed_and_metadata_settles(self):
+        selected = self.proj_dir / "guard-perf-selected.jsonl"
+        selected.write_text("{}\n", encoding="utf-8")
+        guards: dict[str, dict] = {}
+        sizes = {str(selected): selected.stat().st_size}
+        watermarks: dict[str, dict] = {}
+        paths: list[Path] = []
+        for index in range(relay_watchdog.MAX_RECOVERED_GAP_GUARDS):
+            path = self.proj_dir / f"guard-perf-{index:03d}.jsonl"
+            path.write_text("{}\n", encoding="utf-8")
+            paths.append(path)
+            sizes[str(path)] = path.stat().st_size
+            guards[str(path)] = {
+                "size": path.stat().st_size,
+                "confirmed_at": self.now,
+                "last_seen_at": self.now,
+                "absent_since": None,
+            }
+            watermarks[str(path)] = {
+                "delivered_ts": self.now - 2000,
+                "updated_at": self.now,
+            }
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(selected),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: sizes,
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: guards,
+                DELIVERED_WATERMARKS_KEY: watermarks,
+            }
+        }
+        rt = self.make_rt()
+
+        with mock.patch.object(
+            relay_watchdog,
+            "assistant_blocks",
+            wraps=relay_watchdog.assistant_blocks,
+        ) as parse:
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        self.assertEqual(
+            [str(call.args[0]) for call in parse.call_args_list], [str(selected)]
+        )
+
+        target = paths[0]
+        with target.open("a", encoding="utf-8") as stream:
+            stream.write('{"type":"progress","message":"metadata only"}\n')
+        os.utime(target, (self.now + 2, self.now + 2))
+        with mock.patch.object(
+            relay_watchdog,
+            "assistant_blocks",
+            wraps=relay_watchdog.assistant_blocks,
+        ) as parse:
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        parsed = [str(call.args[0]) for call in parse.call_args_list]
+        self.assertEqual(parsed.count(str(target)), 1)
+        self.assertEqual(parsed.count(str(selected)), 1)
+        guard = relay_watchdog._validated_recovered_gap_guards(state["999"])[
+            str(target)
+        ]
+        self.assertEqual(guard[0], target.stat().st_size)
+        self.assertEqual(guard[1], self.now)
+
+        state_path = self.root / "guard-perf-state.json"
+        save_state(state_path, state)
+        state = load_state(state_path)
+        with mock.patch.object(
+            relay_watchdog,
+            "assistant_blocks",
+            wraps=relay_watchdog.assistant_blocks,
+        ) as parse:
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertEqual(
+            [str(call.args[0]) for call in parse.call_args_list], [str(selected)]
+        )
+
+    def test_invariant_4435_simultaneous_guard_growth_checks_every_growing_path(self):
+        anchor = float(int(self.now - 4000))
+        selected = self.proj_dir / "multi-growth-selected.jsonl"
+        delivered_path = self.proj_dir / "multi-growth-delivered.jsonl"
+        missing_path = self.proj_dir / "multi-growth-missing.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        selected.write_text("{}\n", encoding="utf-8")
+        delivered_path.write_text(
+            record(anchor, "old delivered A") + "\n", encoding="utf-8"
+        )
+        missing_path.write_text(
+            record(anchor, "old delivered B") + "\n", encoding="utf-8"
+        )
+        old_sizes = {
+            str(delivered_path): delivered_path.stat().st_size,
+            str(missing_path): missing_path.stat().st_size,
+        }
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(selected),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {
+                    str(selected): selected.stat().st_size,
+                    **old_sizes,
+                },
+                relay_watchdog.RECOVERED_GAP_GUARDS_KEY: {
+                    path: {
+                        "size": old_sizes[path],
+                        "confirmed_at": self.now - 100,
+                        "last_seen_at": self.now - 100,
+                        "absent_since": None,
+                    }
+                    for path in old_sizes
+                },
+                DELIVERED_WATERMARKS_KEY: {
+                    path: {
+                        "delivered_ts": anchor,
+                        "updated_at": self.now - 100,
+                    }
+                    for path in old_sizes
+                },
+            }
+        }
+        delivered_epoch = float(int(self.now - 2000))
+        missing_epoch = float(int(self.now - 1900))
+        with delivered_path.open("a", encoding="utf-8") as stream:
+            stream.write(record(delivered_epoch, "new delivered A") + "\n")
+        with missing_path.open("a", encoding="utf-8") as stream:
+            stream.write(record(missing_epoch, "new missing B") + "\n")
+        os.utime(delivered_path, (self.now, self.now))
+        os.utime(missing_path, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("new delivered A")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        state_path = self.root / "multi-growth-state.json"
+        save_state(state_path, state)
+        state = load_state(state_path)
+        chs = state["999"]
+        guards = relay_watchdog._validated_recovered_gap_guards(chs)
+        self.assertEqual(guards[str(delivered_path)][0], delivered_path.stat().st_size)
+        self.assertEqual(guards[str(missing_path)][0], old_sizes[str(missing_path)])
+        self.assertEqual(
+            delivered_watermark_for_path(chs, delivered_path), delivered_epoch
+        )
+        self.assertEqual(delivered_watermark_for_path(chs, missing_path), anchor)
+        self.assertIn(
+            str(missing_path), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY]
+        )
+        self.assertTrue(chs.get("alerting"))
+
+        rt.haystack = norm("new missing B")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        chs = state["999"]
+        self.assertFalse(chs.get("alerting", False))
+        self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
+        self.assertEqual(
+            relay_watchdog._validated_recovered_gap_guards(chs)[str(missing_path)][
+                0
+            ],
+            missing_path.stat().st_size,
+        )
+
+    def test_invariant_4435_multi_owner_partial_recovery_keeps_incident_open(self):
+        anchor = float(int(self.now - 2000))
+        owner_a = self.proj_dir / "partial-owner-a.jsonl"
+        owner_b = self.proj_dir / "partial-owner-b.jsonl"
+
+        def record(text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner_a.write_text(record("partial delivered A") + "\n", encoding="utf-8")
+        owner_b.write_text(record("partial missing B") + "\n", encoding="utf-8")
+        owners = [str(owner_a), str(owner_b)]
+        original_gap_since = self.now - 5000
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(owner_a),
+                relay_watchdog.TRANSCRIPT_SIZES_KEY: {
+                    str(owner_a): owner_a.stat().st_size,
+                    str(owner_b): owner_b.stat().st_size,
+                },
+                relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY: owners,
+                relay_watchdog.GAP_TRANSCRIPT_KEY: str(owner_a),
+                DELIVERED_WATERMARKS_KEY: {
+                    path: {
+                        "delivered_ts": anchor - 1,
+                        "updated_at": self.now - 100,
+                    }
+                    for path in owners
+                },
+                "alerting": True,
+                "gap_since": original_gap_since,
+                "last_alert": self.now,
+            }
+        }
+        rt = self.make_rt()
+        rt.haystack = norm("partial delivered A")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+        state_path = self.root / "partial-recovery-state.json"
+        save_state(state_path, state)
+        state = load_state(state_path)
+        chs = state["999"]
+        self.assertIn(
+            str(owner_a), relay_watchdog._validated_recovered_gap_guards(chs)
+        )
+        self.assertNotIn(
+            str(owner_a), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY]
+        )
+        self.assertIn(str(owner_b), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
+        self.assertTrue(chs.get("alerting"))
+        self.assertEqual(chs["gap_since"], original_gap_since)
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
 
     def test_invariant_4435_invalid_persisted_selection_is_ignored_before_fallback(
         self,

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -2909,6 +2909,56 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+    def test_invariant_4435_torn_debut_miss_reentry_still_escalates(self):
+        current = self.proj_dir / "current.jsonl"
+        torn = self.proj_dir / "torn-unreadable.jsonl"
+        anchor = float(int(self.now - 30))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(anchor, "current delivered") + "\n", encoding="utf-8"
+        )
+        rt = self.make_rt(read_fail_alert_after=3)
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        torn.write_text('{"type":"assistant"', encoding="utf-8")
+        os.utime(torn, (self.now + 1, self.now + 1))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(
+            state["999"]["pending_transcript_failures"][str(torn)], 1
+        )
+
+        with mock.patch.object(
+            relay_watchdog, "transcript_candidates", return_value=[]
+        ):
+            tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertIn(str(torn), state["999"]["pending_transcripts"])
+        self.assertEqual(
+            state["999"]["pending_transcript_failures"][str(torn)], 1
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 4)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 5)
+
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "평가 불능 에스컬레이션" in body]),
+            1,
+        )
+        self.assertIn(str(torn), state["999"]["retired_transcripts"])
+        self.assertNotIn(str(torn), state["999"]["pending_transcripts"])
+
     def test_invariant_4435_corrupt_pending_escalates_once_then_unwedges(self):
         current = self.proj_dir / "current.jsonl"
         malformed = self.proj_dir / "permanently-malformed.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1637,6 +1637,31 @@ class TickChannelTests(unittest.TestCase):
             any("transcript-select reason=bootstrap" in line for line in rt.log_lines)
         )
 
+    def test_invariant_4435_empty_discovery_tick_retains_previous_selection(self):
+        previous = self.proj_dir / "temporarily-hidden.jsonl"
+        state = {
+            "999": {
+                SELECTED_TRANSCRIPT_KEY: str(previous),
+                "transcript_sizes": {str(previous): 100},
+            }
+        }
+        rt = self.make_rt()
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(previous))
+        self.assertTrue(
+            any("transcript-select reason=no_candidates" in line for line in rt.log_lines)
+        )
+
+        replacement = self.proj_dir / "replacement.jsonl"
+        replacement.write_text("{}\n", encoding="utf-8")
+        os.utime(replacement, (self.now + 1, self.now + 1))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(replacement))
+        self.assertTrue(
+            any("transcript-select reason=prior_missing" in line for line in rt.log_lines)
+        )
+
     def test_invariant_4435_all_stale_restart_keeps_delivered_anchor(self):
         anchor = float(int(self.now - 2000))
         self.write_transcript([(anchor, "old delivered anchor")])

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -359,6 +359,49 @@ class TranscriptRecheckTests(unittest.TestCase):
                     self.fail(f"malformed persisted path escaped recheck: {exc!r}")
                 self.assertIsNone(candidate)
 
+    def test_symlink_escape_is_rejected_across_recheck_discovery_and_read(self):
+        other_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(other_tmp.cleanup)
+        outside = Path(other_tmp.name) / "outside.jsonl"
+        outside.write_text("{}\n", encoding="utf-8")
+        linked = self.project / "linked.jsonl"
+        try:
+            linked.symlink_to(outside)
+        except OSError as exc:
+            self.skipTest(f"symlink unavailable: {exc}")
+
+        self.assertIsNone(
+            recheck_selected_transcript(
+                str(linked), self.root, self.pattern, {str(linked)}
+            )
+        )
+        self.assertNotIn(
+            linked,
+            [
+                candidate.path
+                for candidate in relay_watchdog.transcript_candidates([self.project])
+            ],
+        )
+        self.assertIsNotNone(relay_watchdog.assistant_blocks(linked).error)
+        with mock.patch.object(
+            relay_watchdog,
+            "_regular_file_stat_without_symlink",
+            return_value=outside.stat(),
+        ):
+            self.assertIsNotNone(
+                relay_watchdog.assistant_blocks(linked).error,
+                "descriptor open must reject a symlink swapped in after precheck",
+            )
+
+        discovery_root = self.root / "discovery"
+        discovery_root.mkdir()
+        linked_project = discovery_root / self.project.name
+        linked_project.symlink_to(self.project, target_is_directory=True)
+        self.assertEqual(
+            channel_project_dirs(discovery_root, self.pattern),
+            [],
+        )
+
 
 class TimestampTests(unittest.TestCase):
     def test_transcript_timestamps_parse_as_utc(self):
@@ -1892,6 +1935,101 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+    def test_invariant_4435_watermark_only_restart_ignores_mtime_override(self):
+        current = self.proj_dir / "current.jsonl"
+        touched_old = self.proj_dir / "old.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(anchor, "confirmed current") + "\n", encoding="utf-8"
+        )
+        touched_old.write_text(
+            record(anchor - 100, "old delivered") + "\n", encoding="utf-8"
+        )
+        os.utime(current, (self.now - 100, self.now - 100))
+        os.utime(touched_old, (self.now, self.now))
+        state = {"999": {}}
+        advance_delivered_watermark(
+            state["999"], touched_old, anchor - 100, self.now - 2
+        )
+        advance_delivered_watermark(
+            state["999"], current, anchor, self.now - 1
+        )
+        rt = self.make_rt()
+        rt.haystack = norm("confirmed current old delivered")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
+
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(rt.alerts, [])
+        self.assertTrue(
+            any(
+                "transcript-select reason=watermark_bootstrap" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_invariant_4435_watermark_bootstrap_yields_to_positive_growth(self):
+        current = self.proj_dir / "current.jsonl"
+        growing = self.proj_dir / "growing.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(anchor, "current delivered") + "\n", encoding="utf-8"
+        )
+        growing.write_text(
+            record(anchor - 100, "growing delivered") + "\n", encoding="utf-8"
+        )
+        state = {
+            "999": {
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    str(growing): growing.stat().st_size,
+                }
+            }
+        }
+        with growing.open("a", encoding="utf-8") as stream:
+            stream.write(record(anchor + 1, "positive growth delivered") + "\n")
+        advance_delivered_watermark(
+            state["999"], growing, anchor - 100, self.now - 2
+        )
+        advance_delivered_watermark(
+            state["999"], current, anchor, self.now - 1
+        )
+        rt = self.make_rt()
+        rt.haystack = norm(
+            "current delivered growing delivered positive growth delivered"
+        )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(growing))
+        self.assertTrue(
+            any("transcript-select reason=growth" in line for line in rt.log_lines)
+        )
+
     def test_invariant_4435_partial_discovery_rechecks_tracked_selection(self):
         current = self.proj_dir / "current.jsonl"
         touched_old = self.proj_dir / "old.jsonl"
@@ -2078,7 +2216,21 @@ class TickChannelTests(unittest.TestCase):
         }
         for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 5):
             (self.proj_dir / f"debut-{index:02d}.jsonl").write_text(
-                "{}\n", encoding="utf-8"
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": time.strftime(
+                            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.now - 1)
+                        ),
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": f"debut {index}"}
+                            ]
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
             )
         rt = self.make_rt()
         rt.haystack = None
@@ -2202,6 +2354,145 @@ class TickChannelTests(unittest.TestCase):
             )
         )
 
+    def test_invariant_4435_fresh_debut_stays_pending_until_mature_verdict(self):
+        current = self.proj_dir / "current.jsonl"
+        final = self.proj_dir / "swap-final.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(self.now - 1000, "current delivered") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        final.write_text(
+            record(self.now + 60, "swap final never relayed") + "\n",
+            encoding="utf-8",
+        )
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(self.now + 61, "current growth delivered") + "\n")
+        os.utime(final, (self.now + 60, self.now + 60))
+        os.utime(current, (self.now + 61, self.now + 61))
+        rt.haystack = norm("current delivered current growth delivered")
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 120)
+
+        self.assertIn(str(final), state["999"]["pending_transcripts"])
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 0
+        )
+        self.assertTrue(
+            any(
+                f"transcript-debut-eval path={final} state=ok" in line
+                and "fresh_undelivered=1" in line
+                for line in rt.log_lines
+            )
+        )
+
+        with current.open("a", encoding="utf-8") as stream:
+            stream.write(record(self.now + 899, "current keepalive delivered") + "\n")
+        os.utime(current, (self.now + 900, self.now + 900))
+        rt.haystack = norm(
+            "current delivered current growth delivered current keepalive delivered"
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 900)
+
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 1
+        )
+        self.assertIn(str(final), state["999"]["pending_transcripts"])
+        self.assertEqual(
+            sum(
+                1
+                for line in rt.log_lines
+                if f"transcript-debut-eval path={final}" in line
+            ),
+            2,
+        )
+
+    def test_invariant_4435_touched_known_history_evictee_cannot_redebut(self):
+        current = self.proj_dir / "current.jsonl"
+        historic = self.proj_dir / "historic-old.jsonl"
+        day = 24 * 60 * 60
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        historic.write_text(
+            "\n".join(
+                record(self.now - 3 * day + index, f"historic block {index}")
+                for index in range(490)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.utime(historic, (self.now - 3 * day, self.now - 3 * day))
+        for index in range(relay_watchdog.MAX_TRANSCRIPT_HISTORY):
+            recent = self.proj_dir / f"recent-{index:03d}.jsonl"
+            recent.write_text("{}\n", encoding="utf-8")
+            os.utime(
+                recent,
+                (self.now - 5000 - index, self.now - 5000 - index),
+            )
+        current.write_text(
+            record(self.now - 1000, "current delivered") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(current, (self.now, self.now))
+        rt = self.make_rt()
+        rt.haystack = norm("current delivered")
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        self.assertNotIn(str(historic), state["999"]["transcript_sizes"])
+        self.assertIn("transcript_known_at", state["999"])
+        self.assertIn(str(historic), state["999"]["transcript_known_at"])
+
+        os.utime(historic, (self.now + 100, self.now + 100))
+        log_start = len(rt.log_lines)
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 120)
+
+        second_tick_logs = rt.log_lines[log_start:]
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(
+            len([body for body, _ in rt.alerts if "릴레이 갭 감지" in body]), 0
+        )
+        self.assertNotIn(str(historic), state["999"]["pending_transcripts"])
+        self.assertFalse(
+            any(
+                f"transcript-debut-eval path={historic}" in line
+                for line in second_tick_logs
+            )
+        )
+        self.assertTrue(
+            any(
+                f"transcript-debut-skip reason=known_stale_content path={historic}"
+                in line
+                for line in second_tick_logs
+            )
+        )
+
     def test_invariant_4435_history_cap_evictees_do_not_redebut_when_idle(self):
         current = self.proj_dir / "current.jsonl"
         current_ts = float(int(self.now - 1000))
@@ -2306,6 +2597,8 @@ class TickChannelTests(unittest.TestCase):
         malformed.write_bytes(b"\xff\n")
         os.utime(malformed, (self.now + 1, self.now + 1))
         os.utime(current, (self.now + 2, self.now + 2))
+        state["999"]["alerting"] = True
+        state["999"]["gap_since"] = self.now - 60
         rt.haystack = norm("current delivered healthy selected growth")
 
         try:
@@ -2316,11 +2609,19 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(
             delivered_watermark_for_path(state["999"], current), grown_ts
         )
-        self.assertNotIn(str(malformed), state["999"]["pending_transcripts"])
+        self.assertIn(str(malformed), state["999"]["pending_transcripts"])
         self.assertEqual(rt.alerts, [])
+        self.assertTrue(state["999"]["alerting"])
         self.assertTrue(
             any(
-                f"transcript-debut-eval path={malformed} state=ok" in line
+                f"transcript-read-error path={malformed} error=UnicodeDecodeError"
+                in line
+                for line in rt.log_lines
+            )
+        )
+        self.assertFalse(
+            any(
+                f"transcript-debut-eval path={malformed}" in line
                 for line in rt.log_lines
             )
         )

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1839,6 +1839,13 @@ class TickChannelTests(unittest.TestCase):
         os.utime(new_transcript, (self.now + 1, self.now + 1))
         rt.haystack = ""
         tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(old_transcript))
+
+        with new_transcript.open("a", encoding="utf-8") as stream:
+            stream.write("\n")
+        os.utime(new_transcript, (self.now + 2, self.now + 2))
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
 
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("릴레이 갭 감지", rt.alerts[0][0])

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -4086,10 +4086,13 @@ class TickChannelTests(unittest.TestCase):
                     for path in [selected, *pending]
                 }
                 | {
-                    "/unrelated-newer.jsonl": {
+                    f"/unrelated-newer-{index:03d}.jsonl": {
                         "delivered_ts": anchor - 1,
                         "updated_at": self.now + 100,
                     }
+                    for index in range(
+                        relay_watchdog.MAX_RECOVERED_GAP_GUARDS
+                    )
                 },
                 "alerting": True,
                 "gap_since": self.now - 2000,
@@ -4116,8 +4119,7 @@ class TickChannelTests(unittest.TestCase):
             "a recovered GAP owner must retain its delivery authority at full cap",
         )
         self.assertEqual(
-            len(delivered_watermarks(chs)),
-            len({str(path) for path in [selected, *pending, *gap_owners]}) + 1,
+            len(delivered_watermarks(chs)), MAX_DELIVERED_WATERMARKS
         )
 
         growth_text = "delivered growth after GAP recovery"
@@ -4140,7 +4142,7 @@ class TickChannelTests(unittest.TestCase):
         pressure_paths: list[Path] = []
         for wave in range(2):
             wave_texts: list[str] = []
-            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS):
+            for index in range(relay_watchdog.MAX_PENDING_TRANSCRIPTS + 1):
                 path = self.proj_dir / f"wave-{wave}-{index:02d}.jsonl"
                 text = f"delivered pressure wave {wave} item {index:02d}"
                 path.write_text(record(text) + "\n", encoding="utf-8")

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -37,6 +37,7 @@ from scripts.relay_watchdog import (
     PG_UNKNOWN,
     PG_UPSTREAM_DOWN,
     SELECTOR_DIVERGED,
+    SELECTED_TRANSCRIPT_KEY,
     SELECTOR_SYNCED,
     SELECTOR_UNKNOWN,
     STATE_GAP,
@@ -69,6 +70,7 @@ from scripts.relay_watchdog import (
     project_slug,
     save_state,
     select_watch_transcript,
+    select_watch_transcript_with_reason,
     selector_divergence_confirmed,
     tick_channel,
     tick_pg_tunnel,
@@ -182,6 +184,39 @@ class TranscriptResolutionTests(unittest.TestCase):
             [older, newer], {str(older.path): 100, str(newer.path): 200}
         )
         self.assertEqual(selected, newer.path)
+
+    def test_invariant_4435_no_growth_retains_previous_selection(self):
+        current = TranscriptCandidate(Path("/tmp/current.jsonl"), 100, 100.0)
+        touched_old = TranscriptCandidate(Path("/tmp/old.jsonl"), 200, 200.0)
+        selected, reason = select_watch_transcript_with_reason(
+            [current, touched_old],
+            {str(current.path): 100, str(touched_old.path): 200},
+            str(current.path),
+        )
+        self.assertEqual(selected, current.path)
+        self.assertEqual(reason, "sticky")
+
+    def test_invariant_4435_missing_previous_selection_bootstraps_newest(self):
+        older = TranscriptCandidate(Path("/tmp/older.jsonl"), 100, 100.0)
+        newer = TranscriptCandidate(Path("/tmp/newer.jsonl"), 200, 200.0)
+        selected, reason = select_watch_transcript_with_reason(
+            [older, newer],
+            {str(older.path): 100, str(newer.path): 200},
+            "/tmp/disappeared.jsonl",
+        )
+        self.assertEqual(selected, newer.path)
+        self.assertEqual(reason, "prior_missing")
+
+    def test_invariant_4435_corrupt_previous_selection_fails_open(self):
+        older = TranscriptCandidate(Path("/tmp/older.jsonl"), 100, 100.0)
+        newer = TranscriptCandidate(Path("/tmp/newer.jsonl"), 200, 200.0)
+        selected, reason = select_watch_transcript_with_reason(
+            [older, newer],
+            {str(older.path): 100, str(newer.path): 200},
+            True,
+        )
+        self.assertEqual(selected, newer.path)
+        self.assertEqual(reason, "bootstrap")
 
     def test_first_observation_uses_mtime_fallback(self):
         older = TranscriptCandidate(Path("/tmp/older.jsonl"), 100, 100.0)
@@ -1363,6 +1398,7 @@ class TickChannelTests(unittest.TestCase):
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(rt.alerts, [], "first tick must use mtime fallback")
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(stagnant))
 
         with growing.open("a", encoding="utf-8") as f:
             f.write("\n")
@@ -1373,6 +1409,10 @@ class TickChannelTests(unittest.TestCase):
         tick_channel(rt, TICK_CHANNEL, state, self.now + 1)
         self.assertEqual(len(rt.alerts), 1)
         self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(growing))
+        self.assertTrue(
+            any("transcript-select reason=growth" in line for line in rt.log_lines)
+        )
 
     def _grow_selected_transcript(self) -> None:
         tr = self.proj_dir / "s.jsonl"
@@ -1583,10 +1623,19 @@ class TickChannelTests(unittest.TestCase):
         rt = self.make_rt()
         rt.haystack = norm("fresh block")
         transcript = self.proj_dir / "s.jsonl"
-        state = {"999": {"transcript_sizes": {str(transcript): "not-an-int"}}}
+        state = {
+            "999": {
+                "transcript_sizes": {str(transcript): "not-an-int"},
+                SELECTED_TRANSCRIPT_KEY: True,
+            }
+        }
         tick_channel(rt, TICK_CHANNEL, state, self.now)
         self.assertEqual(rt.alerts, [])
         self.assertIsInstance(state["999"]["transcript_sizes"][str(transcript)], int)
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(transcript))
+        self.assertTrue(
+            any("transcript-select reason=bootstrap" in line for line in rt.log_lines)
+        )
 
     def test_invariant_4435_all_stale_restart_keeps_delivered_anchor(self):
         anchor = float(int(self.now - 2000))
@@ -1613,6 +1662,105 @@ class TickChannelTests(unittest.TestCase):
             delivered_watermark_for_path(restarted_state["999"], transcript), anchor
         )
         self.assertTrue(any("stale=1 lost=0" in line for line in restarted.log_lines))
+
+    def test_invariant_4435_restart_ignores_old_transcript_mtime_only_touch(self):
+        current = self.proj_dir / "current.jsonl"
+        touched_old = self.proj_dir / "old.jsonl"
+        anchor = float(int(self.now - 2000))
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        current.write_text(
+            record(anchor, "confirmed current delivery") + "\n", encoding="utf-8"
+        )
+        touched_old.write_text(
+            record(anchor - 1000, "historic missing output") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(touched_old, (self.now - 100, self.now - 100))
+        os.utime(current, (self.now, self.now))
+
+        first = self.make_rt()
+        first.haystack = norm("confirmed current delivery")
+        state: dict = {}
+        tick_channel(first, TICK_CHANNEL, state, self.now)
+        self.assertEqual(first.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertEqual(
+            delivered_watermark_for_path(state["999"], current), anchor
+        )
+
+        state_path = self.root / "sticky-state.json"
+        save_state(state_path, state)
+        restarted_state = load_state(state_path)
+        os.utime(touched_old, (self.now + 1, self.now + 1))
+
+        restarted = self.make_rt()
+        restarted.haystack = ""
+        tick_channel(restarted, TICK_CHANNEL, restarted_state, self.now + 2)
+        self.assertEqual(restarted.alerts, [])
+        self.assertEqual(
+            restarted_state["999"][SELECTED_TRANSCRIPT_KEY], str(current)
+        )
+        self.assertTrue(
+            any("transcript-select reason=sticky" in line for line in restarted.log_lines)
+        )
+
+    def test_invariant_4435_existing_watermark_bootstraps_sticky_selection(self):
+        current = self.proj_dir / "current.jsonl"
+        touched_old = self.proj_dir / "old.jsonl"
+        anchor = float(int(self.now - 2000))
+        current.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(anchor)
+                    ),
+                    "message": {
+                        "content": [{"type": "text", "text": "confirmed current"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        touched_old.write_text(
+            current.read_text(encoding="utf-8").replace("confirmed current", "old"),
+            encoding="utf-8",
+        )
+        os.utime(current, (self.now - 100, self.now - 100))
+        os.utime(touched_old, (self.now, self.now))
+        state = {
+            "999": {
+                "transcript_sizes": {
+                    str(current): current.stat().st_size,
+                    str(touched_old): touched_old.stat().st_size,
+                }
+            }
+        }
+        advance_delivered_watermark(state["999"], current, anchor, self.now - 1)
+
+        rt = self.make_rt()
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertEqual(state["999"][SELECTED_TRANSCRIPT_KEY], str(current))
+        self.assertTrue(
+            any(
+                "transcript-select reason=watermark_bootstrap" in line
+                for line in rt.log_lines
+            )
+        )
 
     def test_invariant_4435_older_haystack_cannot_regress_persisted_anchor(self):
         older = float(int(self.now - 3000))

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
 import tempfile
 import time
@@ -430,7 +431,7 @@ class TranscriptRecheckTests(unittest.TestCase):
 
         def swap_parent_then_open(path, flags, *args, **kwargs):
             nonlocal swapped
-            if not swapped and Path(path) in (self.project, self.transcript):
+            if not swapped and os.fspath(path) == self.project.name:
                 swapped = True
                 self.project.rename(moved_project)
                 self.project.symlink_to(outside_project, target_is_directory=True)
@@ -448,6 +449,143 @@ class TranscriptRecheckTests(unittest.TestCase):
             [],
             "a path-string reopen must never read through the swapped parent",
         )
+
+    def test_projects_root_symlink_swap_after_discovery_cannot_escape(self):
+        """Pin every ancestor below the trusted root, not just file.parent."""
+        trusted_home = self.root / "trusted-home"
+        projects_root = trusted_home / "projects"
+        project = projects_root / self.project.name
+        project.mkdir(parents=True)
+        transcript = project / "ancestor-swap.jsonl"
+        transcript.write_text("{}\n", encoding="utf-8")
+        candidates = relay_watchdog.transcript_candidates([project])
+        self.assertEqual([candidate.path for candidate in candidates], [transcript])
+
+        outside_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_tmp.cleanup)
+        outside_projects = Path(outside_tmp.name) / "projects"
+        outside_project = outside_projects / project.name
+        outside_project.mkdir(parents=True)
+        outside = outside_project / transcript.name
+        outside.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-11T07:00:00Z",
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "escaped-ancestor-read"}
+                        ]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        moved_projects = trusted_home / "projects-after-discovery"
+        projects_root.rename(moved_projects)
+        projects_root.symlink_to(outside_projects, target_is_directory=True)
+
+        # Independent semantic mutation oracle: the old immediate-parent-only
+        # implementation follows the swapped projects ancestor and reads the
+        # outside same-shaped transcript.  Keep this proof local to the test;
+        # the production helper below must reject the exact same filesystem.
+        def narrow_parent_only_open(path, flags, _trusted_root):
+            expected_parent = path.parent.stat(follow_symlinks=False)
+            expected_file = path.stat(follow_symlinks=False)
+            parent_fd = os.open(
+                path.parent,
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_NONBLOCK", 0),
+            )
+            descriptor = -1
+            try:
+                opened_parent = os.fstat(parent_fd)
+                if not relay_watchdog._same_file_identity(
+                    expected_parent, opened_parent
+                ):
+                    return None
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+                opened_file = os.fstat(descriptor)
+                if not stat.S_ISREG(opened_file.st_mode) or not (
+                    relay_watchdog._same_file_identity(expected_file, opened_file)
+                ):
+                    return None
+                opened = descriptor
+                descriptor = -1
+                return opened
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                os.close(parent_fd)
+
+        with mock.patch.object(
+            relay_watchdog,
+            "_open_regular_file_beneath_parent",
+            side_effect=narrow_parent_only_open,
+        ):
+            legacy_result = relay_watchdog.assistant_blocks(
+                transcript, trusted_root=projects_root
+            )
+        self.assertEqual(
+            [text for _, text in legacy_result.blocks], ["escaped-ancestor-read"]
+        )
+
+        result = relay_watchdog.assistant_blocks(
+            transcript, trusted_root=projects_root
+        )
+        self.assertEqual(result.error, "UnsafePath")
+        self.assertEqual(result.blocks, [])
+
+    def test_trusted_root_boundary_allows_symlink_only_above_it(self):
+        """The explicit root may live below a legitimate platform symlink."""
+        real_home = self.root / "real-home"
+        real_projects = real_home / "projects"
+        real_project = real_projects / self.project.name
+        real_project.mkdir(parents=True)
+        transcript_name = "trusted-boundary.jsonl"
+        (real_project / transcript_name).write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-11T07:00:00Z",
+                    "message": {
+                        "content": [{"type": "text", "text": "trusted-read"}]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        alias_home = self.root / "home-alias"
+        alias_home.symlink_to(real_home, target_is_directory=True)
+        alias_projects = alias_home / "projects"
+        alias_transcript = alias_projects / real_project.name / transcript_name
+
+        result = relay_watchdog.assistant_blocks(
+            alias_transcript, trusted_root=alias_projects
+        )
+
+        self.assertIsNone(result.error)
+        self.assertEqual([text for _, text in result.blocks], ["trusted-read"])
+
+    def test_component_open_requires_absolute_path_beneath_trusted_root(self):
+        relative = relay_watchdog.assistant_blocks(
+            Path("relative.jsonl"), trusted_root=self.root
+        )
+        outside_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_tmp.cleanup)
+        outside = Path(outside_tmp.name) / "outside.jsonl"
+        outside.write_text("{}\n", encoding="utf-8")
+        escaped = relay_watchdog.assistant_blocks(
+            outside, trusted_root=self.root
+        )
+
+        self.assertEqual(relative.error, "UnsafePath")
+        self.assertEqual(escaped.error, "UnsafePath")
 
     @unittest.skipUnless(hasattr(os, "mkfifo"), "FIFO unavailable on this platform")
     def test_fifo_swap_before_open_is_rejected_without_blocking(self):


### PR DESCRIPTION
## Summary

- persist and validate per-channel selected transcript plus path-scoped delivery authority
- cut over only on timestamped deliverable assistant semantic growth; raw bytes, metadata, blank lines, and mtime touches cannot steal selection
- retain bounded debut/discovery state across partial listings, torn reads, and selected-path read failures
- anchor reads beneath the trusted projects root with component-by-component `openat(O_NOFOLLOW|O_DIRECTORY)` traversal and a nonblocking final open
- pin the complete selected + pending + unresolved-GAP-owner delivery authority union
- after a GAP owner recovers, transfer its watermark into a persistent replay guard so later watermark pressure and Discord haystack rolloff cannot manufacture the same GAP again
- bound recovered guards to the known-path lifecycle budget (256), and reclaim a guard plus every path-scoped identity only after one full TTL of descriptor-proven continuous absence
- treat present, unreadable, unsafe-type, raced, or ancestor-symlink paths as ambiguous and keep them pinned; a reclaimed path reappears as a new lifecycle
- evaluate recovered guards only when selected/pending/unresolved or when safe parsing proves semantic growth; unchanged guards add no full-transcript reads
- advance metadata-only observation baselines without advancing delivery confirmation, while delivered growth rearms and undelivered growth remains observable through grace to GAP
- recover multi-owner incidents partially and fail closed when the recovered-guard store is full instead of evicting an older replay floor
- absorb root/session directory fstat I/O failures without type confusion or channel-tick aborts: transcript reads fail closed as UnsafePath, recovered-guard checks stay AMBIGUOUS and retain their replay floor

## Root cause and boundary

The post-#4441 `lost=490` recurrence was a selection cutover: a compact-dead transcript received nonsemantic activity and regained selector authority without a path watermark. The first fix made semantic assistant completion—not raw file activity—the selector authority.

The next exact-head review reproduced a full-cap authority bug: GAP owners were evaluated but their new watermark could be evicted because the old cap covered only selected + pending paths. That was fixed by pinning the complete unresolved authority union.

The latest exact-head review reproduced a later lifecycle bug: successful recovery cleared `gap_owner_transcripts`, so the recovered path stopped owning pin authority. Two later delivered-debut waves could evict its watermark; after other files disappeared and bounded Discord history rolled off, the already-delivered transcript was selected and emitted a false GAP again.

This head gives recovery its own bounded lifecycle authority. The watermark cap equals the full deduplicated worst-case union:

`1 selected + 32 pending + 33 unresolved GAP owners + 256 recovered guards = 322`.

TTL reclamation is deliberately stricter than cache expiry. The watchdog pins the projects root descriptor and walks every descendant without following symlinks. Only continuous, securely proven absence starts and completes the TTL. Any unsafe ancestor, symlink, special file, permission/read error, race, or clock rollback preserves the guard. At the boundary, guard, watermark, selection, size/seen/known baselines, pending failure state, and retirement identity are removed together, so a reused path is evaluated as a new lifecycle.

## Exact-head verification

Exact head: `5f7fa71fa2043986371c537e5102c6bfe9aeac1d`

- stacked on prior fix head `024c0ac78c026a6087cf633943ed8078c908b565`
- authenticated post-recovery eviction reproduction: RED (`/tmp/4452-codex-post-recovery-eviction-red.log`, sha256 `20723931e51c9b935db7f18b4d57284d10683dd4be261a3fee516a057b2afa8d`)
- production two-wave regression before lifecycle fix: RED (`/tmp/4452-post-recovery-two-wave-red.log`, sha256 `a1810b6b8f1f7caedabdbb9bbd6d335e3ce7a343089ab7f2f89c7fe08c0a5cb3`)
- all #4435 focused invariants: 66/66 PASS (`/tmp/4452-lifecycle-focused-green.log`, sha256 `08d3658bf7c76f0c80b7f98425fff77c8f3654a92c0425e5cb4e202cff9ac8ea`)
- Opus root/child directory-fstat regression before fix: RED, 2 tests / 4 errors (/tmp/review-4452-opus-fstat-red.log, sha256 7f9ae088d1cae1b9f64bc231289233483a3e6ebb8ae7e1979c33f768a00cc652)
- Opus directory-fstat focused regressions: 2/2 PASS (/tmp/review-4452-opus-fstat-focused-green.log, sha256 4fa97a130469613a9f8f60c565d7446402f7e4468675956f2bf2b72c30069e12)
- full relay-watchdog + PostgreSQL tunnel suite: 222/222 PASS (/tmp/review-4452-opus-watchdog-pg-green.log, sha256 49de738107b09dc30967827187adecf4bb85c405c5c85df16efab2c19ea6c417)
- PATH=/opt/homebrew/bin:$PATH PYTHON=/opt/homebrew/bin/python3 scripts/ci-script-checks.sh: PASS, rc=0 (/tmp/review-4452-opus-script-ci-green.log, sha256 60e9cef0534d452dc5036b6bdaca4d5aa2a1cf1f93e9ab3dc78e17144801c9ce)
- env -u AGENTDESK_ROOT_DIR just check: PASS, rc=0 (/tmp/review-4452-opus-just-check-green.log, sha256 06f8afc59e83780678e0565b0fa5b177b620ea4730f73d9fed6808923645c796)
- pycompile, inventory generation, maintenance freshness/line-count, maintainability, hotfile, inflight blind-save, and diff gates: PASS (/tmp/review-4452-opus-nonbuild-green.log, sha256 75a806c24efcaf1be60709a5acdcd74ce53440d474f8090eb5a3dc1d429d383f)

### Semantic mutation proof (all expected RED, then restored)

- reintroduce the string return from the transcript opener: RED, 1 test / 2 errors (/tmp/review-4452-opus-mutation-open-fstat-contract-red.log, sha256 0df90383136b1c4d1b66e408f126304ed248520ca54e26ef0913f7f9aa6d18d0)
- remove recovered-guard directory-fstat absorption: RED, 1 test / 2 errors (/tmp/review-4452-opus-mutation-guard-fstat-absorption-red.log, sha256 dfc94ae7a470116c6636ae93b1d50a236f7b35c9e1a00b6d686dff23f3843099)

- remove recovered-guard watermark pin: RED (`/tmp/4452-mutation-watermark-pin-red.log`, sha256 `76f035d31848983a83e400728add817919cf214eb9d25c6b63f34c152271e168`)
- omit semantically growing guards from evaluation: RED (`/tmp/4452-mutation-growth-queue-red.log`, sha256 `9e0c3fcee4b7c219c63e59ede197c4e4897d68af7f950ab38a9802f61b72b9d7`)
- remove metadata-only observation advancement: RED (`/tmp/4452-mutation-metadata-baseline-red.log`, sha256 `504293a40990785596304b23d84993c2ba59956086639e75e672a03ba5ffc212`)
- prevent absence-TTL lifecycle reclamation: RED (`/tmp/4452-mutation-lifecycle-reclaim-red.log`, sha256 `5f7c567c5c976e0912a2f587d026df70e9bc33475cf36f4cc424d3add4bbb292`)
- replace descriptor-anchored absence proof with ancestor-following `lstat`: RED (`/tmp/4452-mutation-ancestor-symlink-red.log`, sha256 `d79b5c49877f8d12b8c648e34605628d9c1378d7776c54031c1a71afd13c2768`)
- evict an existing guard when the lifecycle store is full: RED (`/tmp/4452-mutation-full-store-red.log`, sha256 `2cb2a2c15f5764249e1447845771950f75878cad2cc4b1af7ab8320c0e365ee5`)

Covered production shapes include restart after every lifecycle phase, delivered growth followed by two full pressure waves and haystack rolloff, fresh-undelivered growth maturing into GAP, simultaneous multi-guard growth, partial multi-owner recovery, >33 sequential recoveries, full-store fail-closed behavior, present-path TTL retention, missing-path TTL reclamation/reuse, malformed/over-cap persistence, unchanged-256-guard read count, metadata-only settling, and ancestor-symlink ambiguity for a full TTL.

Local branch, remote branch, and PR head are pinned to the exact SHA above; the worktree is clean. GitHub CI is triggered for this head.

Refs #4435
