### PR TITLE
fix(health): complete W0 shadow stall verdict classification

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -482,8 +482,8 @@
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
 | `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1240 | 972 | 268 |  |
-| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2369 | 975 | 1394 |  |
-| `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 886 | 365 | 521 |  |
+| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2383 | 989 | 1394 |  |
+| `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 1020 | 408 | 612 |  |
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1384 | 627 | 757 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -483,7 +483,7 @@
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
 | `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1240 | 972 | 268 |  |
 | `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2383 | 989 | 1394 |  |
-| `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 1150 | 413 | 737 |  |
+| `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 1289 | 423 | 866 |  |
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1384 | 627 | 757 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -483,7 +483,7 @@
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 226 | 226 | 0 |  |
 | `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1240 | 972 | 268 |  |
 | `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2383 | 989 | 1394 |  |
-| `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 1020 | 408 | 612 |  |
+| `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 1150 | 413 | 737 |  |
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1384 | 627 | 757 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 178 | 138 | 40 |  |
 | `services::discord::idle_detector` | `src/services/discord/idle_detector.rs` | 475 | 401 | 74 |  |

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -266,6 +266,7 @@ pub(super) struct StallWatchdogJudgmentBasis {
     pub(super) turn_age_secs: Option<u64>,
     pub(super) last_relay_age_secs: Option<u64>,
     pub(super) last_outbound_activity_age_secs: Option<u64>,
+    pub(super) restart_grace_active: bool,
 }
 
 impl StallWatchdogJudgmentBasis {
@@ -293,6 +294,11 @@ impl StallWatchdogJudgmentBasis {
             last_outbound_activity_age_secs: unix_millis_age_secs(
                 snapshot.relay_health.last_outbound_activity_ms,
                 now_unix_secs,
+            ),
+            restart_grace_active: super::stall_verdict::restart_grace_active(
+                snapshot.inflight_state_present,
+                now_unix_secs,
+                boot_unix_secs,
             ),
         }
     }
@@ -503,8 +509,12 @@ pub(super) fn log_stall_watchdog_liveness_deferred(
     threshold_secs: u64,
 ) {
     let ts = chrono::Local::now().format("%H:%M:%S");
-    let (shadow_verdict, shadow_reasons) =
-        stall_verdict::judgment_log_fields(snapshot, Some(decision), freshness_secs);
+    let (shadow_verdict, shadow_reasons) = stall_verdict::judgment_log_fields(
+        snapshot,
+        Some(decision),
+        freshness_secs,
+        basis.restart_grace_active,
+    );
     tracing::warn!(
         event = "stall_watchdog_force_cleanup_deferred",
         reason_code = "1446_stall_watchdog",
@@ -580,8 +590,12 @@ pub(super) fn log_stall_watchdog_force_cleanup_judgment(
     let liveness_reasons = decision
         .map(|decision| decision.evidence.reason_codes_csv(freshness_secs))
         .unwrap_or_else(|| "not_evaluated".to_string());
-    let (shadow_verdict, shadow_reasons) =
-        stall_verdict::judgment_log_fields(snapshot, decision, freshness_secs);
+    let (shadow_verdict, shadow_reasons) = stall_verdict::judgment_log_fields(
+        snapshot,
+        decision,
+        freshness_secs,
+        basis.restart_grace_active,
+    );
     tracing::warn!(
         event = "stall_watchdog_force_cleanup_judgment",
         reason_code = "1446_stall_watchdog",

--- a/src/services/discord/health/stall_verdict.rs
+++ b/src/services/discord/health/stall_verdict.rs
@@ -365,13 +365,23 @@ fn classify_runtime_signals_lossy(
         return None;
     }
 
-    let active_turn = if inflight_state_present {
+    // An inflight row is storage evidence, not by itself a live relay. The
+    // production snapshot deliberately reports `active_turn = None` for idle
+    // rebind-origin and ownerless external-input rows, and a terminal-committed
+    // row is completed even if its lingering snapshot still says Foreground.
+    // Only a genuinely active, uncommitted turn makes the ownership bool
+    // authoritative; otherwise preserve unknown instead of inventing a
+    // phantom-attached contradiction from an idle row.
+    let live_relay_present = inflight_state_present
+        && !delivery_committed
+        && !matches!(relay.active_turn, RelayActiveTurn::None);
+    let active_turn = if live_relay_present {
         relay.active_turn
     } else {
         RelayActiveTurn::None
     };
     let idle = !relay.mailbox_has_cancel_token && matches!(active_turn, RelayActiveTurn::None);
-    let watcher_owns_live_relay = inflight_state_present.then_some(relay.watcher_owns_live_relay);
+    let watcher_owns_live_relay = live_relay_present.then_some(relay.watcher_owns_live_relay);
 
     Some(classify_stall(StallSignalSnapshot {
         producer_activity_recent,
@@ -418,7 +428,7 @@ mod tests {
         StallWatchdogLivenessAction, StallWatchdogLivenessDecision, StallWatchdogLivenessEvidence,
     };
     use super::*;
-    use crate::services::discord::inflight::InflightTurnState;
+    use crate::services::discord::inflight::{InflightTurnState, RelayOwnerKind, TurnSource};
     use crate::services::discord::relay_health::RelayStallState;
 
     const FIXTURE_UPDATED_AT: &str = "2026-07-11 12:00:00";
@@ -914,6 +924,135 @@ mod tests {
             vec![
                 StallVerdictReason::FrontierAdvancedRecently,
                 StallVerdictReason::WatcherLiveRelayOwnershipUnknown,
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_health_idle_rebind_inflight_preserves_unknown_watcher_ownership() {
+        let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
+        let now = fixture_updated_at_unix() + freshness as i64 + 10;
+        let mut session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
+        let inflight = session.inflight.as_mut().expect("inflight fixture");
+        inflight.rebind_origin = true;
+        inflight.watcher_owns_live_relay = false;
+
+        // Production `relay_active_turn_from_inflight` maps an idle rebind
+        // origin to None even though its persisted inflight row remains.
+        let mut relay = relay_fixture();
+        relay.active_turn = RelayActiveTurn::None;
+        relay.mailbox_has_cancel_token = false;
+        relay.mailbox_active_user_msg_id = None;
+        relay.pending_discord_callback_msg_id = None;
+        relay.watcher_owns_live_relay = false;
+        relay.desynced = false;
+        relay.last_relay_ts_ms = None;
+
+        let assessment = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now - super::super::recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64 - 1,
+        )
+        .expect("idle rebind-origin row remains observable");
+
+        assert_eq!(assessment.verdict, StallVerdict::ProducerDead);
+        assert_eq!(
+            assessment.reasons,
+            vec![
+                StallVerdictReason::NoPositiveLiveness,
+                StallVerdictReason::WatcherLiveRelayOwnershipUnknown,
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_health_idle_ownerless_external_inflight_preserves_unknown_watcher_ownership() {
+        let now = fixture_updated_at_unix()
+            + crate::services::discord::inflight::INFLIGHT_STALENESS_THRESHOLD_SECS as i64
+            + 1;
+        let mut session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
+        let inflight = session.inflight.as_mut().expect("inflight fixture");
+        inflight.turn_source = TurnSource::ExternalInput;
+        inflight.set_relay_owner_kind(RelayOwnerKind::None);
+        inflight.injected_prompt_message_id = Some(9001);
+        inflight.current_msg_id = 0;
+        inflight.response_sent_offset = 0;
+        inflight.full_response.clear();
+        inflight.last_watcher_relayed_offset = None;
+
+        // Production `relay_active_turn_from_inflight` maps the stale,
+        // ownerless external-input shape to None because its bridge tail is
+        // gone, while the persisted row itself still exists.
+        let mut relay = relay_fixture();
+        relay.active_turn = RelayActiveTurn::None;
+        relay.bridge_current_msg_id = None;
+        relay.mailbox_has_cancel_token = false;
+        relay.mailbox_active_user_msg_id = None;
+        relay.pending_discord_callback_msg_id = None;
+        relay.watcher_owns_live_relay = false;
+        relay.desynced = false;
+        relay.last_relay_ts_ms = None;
+
+        let assessment = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now - super::super::recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64 - 1,
+        )
+        .expect("idle ownerless external-input row remains observable");
+
+        assert_eq!(assessment.verdict, StallVerdict::ProducerDead);
+        assert_eq!(
+            assessment.reasons,
+            vec![
+                StallVerdictReason::NoPositiveLiveness,
+                StallVerdictReason::WatcherLiveRelayOwnershipUnknown,
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_health_terminal_committed_lingering_inflight_is_delivered_idle() {
+        let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
+        let now = fixture_updated_at_unix() + freshness as i64 + 10;
+        let mut session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
+        let inflight = session.inflight.as_mut().expect("inflight fixture");
+        inflight.terminal_delivery_committed = true;
+        inflight.watcher_owns_live_relay = false;
+
+        // Today the production snapshot can still carry Foreground for a
+        // lingering committed row. The W0 adapter must honor the terminal
+        // fence instead of treating that stale shape as a live relay.
+        let mut relay = relay_fixture();
+        relay.active_turn = RelayActiveTurn::Foreground;
+        relay.mailbox_has_cancel_token = false;
+        relay.mailbox_active_user_msg_id = None;
+        relay.pending_discord_callback_msg_id = None;
+        relay.watcher_owns_live_relay = false;
+        relay.desynced = false;
+        relay.last_relay_ts_ms = None;
+
+        let assessment = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now - super::super::recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64 - 1,
+        )
+        .expect("terminal-committed row remains observable");
+
+        assert_eq!(assessment.verdict, StallVerdict::DeliveredIdle);
+        assert_eq!(
+            assessment.reasons,
+            vec![
+                StallVerdictReason::DeliveryCommitted,
+                StallVerdictReason::Idle,
             ]
         );
     }

--- a/src/services/discord/health/stall_verdict.rs
+++ b/src/services/discord/health/stall_verdict.rs
@@ -244,8 +244,8 @@ pub(super) fn restart_grace_active(
 ) -> bool {
     inflight_state_present
         && now_unix_secs >= boot_unix_secs
-        && now_unix_secs.saturating_sub(boot_unix_secs) as u64
-            <= super::recovery::STALL_WATCHDOG_THRESHOLD_SECS
+        && (now_unix_secs.saturating_sub(boot_unix_secs) as u64)
+            < super::recovery::STALL_WATCHDOG_THRESHOLD_SECS
 }
 
 pub(super) fn classify_health_snapshot_lossy(
@@ -275,7 +275,7 @@ fn classify_health_snapshot_at_lossy(
     boot_unix_secs: i64,
 ) -> Option<StallVerdictAssessment> {
     let provider = provider?;
-    let desynced = session.desynced(relay.tmux_alive == Some(true), session.attached);
+    let desynced = relay.desynced;
     if !classification_is_applicable(
         relay,
         session.attached,
@@ -365,17 +365,22 @@ fn classify_runtime_signals_lossy(
         return None;
     }
 
-    let idle =
-        !relay.mailbox_has_cancel_token && matches!(relay.active_turn, RelayActiveTurn::None);
+    let active_turn = if inflight_state_present {
+        relay.active_turn
+    } else {
+        RelayActiveTurn::None
+    };
+    let idle = !relay.mailbox_has_cancel_token && matches!(active_turn, RelayActiveTurn::None);
+    let watcher_owns_live_relay = inflight_state_present.then_some(relay.watcher_owns_live_relay);
 
     Some(classify_stall(StallSignalSnapshot {
         producer_activity_recent,
         frontier_advanced_recently,
         desynced,
         mailbox_cancel_token_present: relay.mailbox_has_cancel_token,
-        active_turn: relay.active_turn,
+        active_turn,
         watcher_attached: relay.watcher_attached,
-        watcher_owns_live_relay: Some(relay.watcher_owns_live_relay),
+        watcher_owns_live_relay,
         producer_known_dead: relay.tmux_alive == Some(false),
         delivery_committed,
         idle,
@@ -829,12 +834,136 @@ mod tests {
     }
 
     #[test]
+    fn raw_health_preserves_relay_desynced_for_restored_owner_without_watcher() {
+        let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
+        let now = fixture_updated_at_unix() + freshness as i64 + 10;
+        let mut session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
+        session.watcher_attached = false;
+        session.capture_lagged = false;
+        let mut relay = relay_fixture();
+        relay.desynced = true;
+        relay.watcher_attached = false;
+        relay.watcher_owner_channel_id = None;
+        relay.watcher_owns_live_relay = true;
+        relay.last_relay_ts_ms = None;
+        assert!(relay.desynced);
+        assert!(!session.desynced(relay.tmux_alive == Some(true), session.attached));
+
+        let assessment = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now - super::super::recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64 - 1,
+        )
+        .expect("restored-owner relay desync remains applicable");
+
+        assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
+        assert_eq!(assessment.reasons, vec![StallVerdictReason::Desynced]);
+    }
+
+    #[test]
+    fn raw_health_attached_watcher_without_inflight_preserves_unknown_ownership() {
+        let now = fixture_updated_at_unix();
+        let session = session_fixture(None, true);
+        let mut relay = relay_fixture();
+        relay.active_turn = RelayActiveTurn::None;
+        relay.bridge_inflight_present = false;
+        relay.bridge_current_msg_id = None;
+        relay.mailbox_has_cancel_token = false;
+        relay.mailbox_active_user_msg_id = None;
+        relay.pending_discord_callback_msg_id = None;
+        relay.watcher_owns_live_relay = false;
+        relay.desynced = false;
+        relay.last_relay_ts_ms = None;
+        assert!(!session.inflight_state_present);
+        assert!(relay.watcher_attached);
+
+        let idle = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now,
+        )
+        .expect("attached idle watcher remains observable");
+        assert_eq!(idle.verdict, StallVerdict::ProducerDead);
+        assert_eq!(
+            idle.reasons,
+            vec![
+                StallVerdictReason::NoPositiveLiveness,
+                StallVerdictReason::WatcherLiveRelayOwnershipUnknown,
+            ]
+        );
+
+        relay.last_relay_ts_ms = Some(now.saturating_mul(1000));
+        let just_completed = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now,
+        )
+        .expect("attached just-completed watcher remains observable");
+        assert_eq!(just_completed.verdict, StallVerdict::ProducerLive);
+        assert_eq!(
+            just_completed.reasons,
+            vec![
+                StallVerdictReason::FrontierAdvancedRecently,
+                StallVerdictReason::WatcherLiveRelayOwnershipUnknown,
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_health_orphan_cancel_token_without_inflight_is_pretripped_desync() {
+        let now = fixture_updated_at_unix();
+        let session = session_fixture(None, false);
+        let mut relay = relay_fixture();
+        relay.active_turn = RelayActiveTurn::Foreground;
+        relay.tmux_session = None;
+        relay.tmux_alive = None;
+        relay.watcher_attached = false;
+        relay.watcher_owner_channel_id = None;
+        relay.watcher_owns_live_relay = false;
+        relay.bridge_inflight_present = false;
+        relay.bridge_current_msg_id = None;
+        relay.mailbox_has_cancel_token = true;
+        relay.mailbox_active_user_msg_id = None;
+        relay.pending_discord_callback_msg_id = None;
+        relay.desynced = false;
+        relay.last_relay_ts_ms = None;
+        assert!(!session.inflight_state_present);
+        assert_eq!(relay.active_turn, RelayActiveTurn::Foreground);
+
+        let assessment = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now,
+        )
+        .expect("orphan cancel token remains applicable");
+
+        assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
+        assert_eq!(
+            assessment.reasons,
+            vec![StallVerdictReason::MailboxCancelTokenPresent]
+        );
+    }
+
+    #[test]
     fn raw_health_fresh_inflight_or_relay_frontier_without_contradiction_is_producer_live() {
         let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
         let timestamp = fixture_updated_at_unix();
         let fresh_now = timestamp + 1;
         let session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
-        let relay = relay_fixture();
+        let mut relay = relay_fixture();
+        relay.desynced = false;
         let fresh_inflight = classify_health_snapshot_at_lossy(
             Some(&ProviderKind::Codex),
             ChannelId::new(42),
@@ -852,6 +981,7 @@ mod tests {
 
         let stale_now = timestamp + freshness as i64 + 10;
         let mut relay = relay_fixture();
+        relay.desynced = false;
         relay.last_relay_ts_ms = Some(stale_now.saturating_mul(1000));
         let fresh_frontier = classify_health_snapshot_at_lossy(
             Some(&ProviderKind::Codex),
@@ -948,7 +1078,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_health_restart_grace_boundary_comes_from_boot_timestamp() {
+    fn raw_health_restart_grace_stops_before_cleanup_boundary() {
         let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
         let threshold = super::super::recovery::STALL_WATCHDOG_THRESHOLD_SECS;
         let now = fixture_updated_at_unix() + freshness as i64 + 10;
@@ -962,24 +1092,24 @@ mod tests {
             &session,
             &relay,
             now,
-            now - threshold as i64,
+            now - threshold as i64 + 1,
         )
         .expect("inside restart grace");
         assert_eq!(inside.verdict, StallVerdict::ProducerLive);
         assert_eq!(inside.reasons, vec![StallVerdictReason::RestartGraceActive]);
 
-        let outside = classify_health_snapshot_at_lossy(
+        let cleanup_boundary = classify_health_snapshot_at_lossy(
             Some(&ProviderKind::Codex),
             ChannelId::new(42),
             &session,
             &relay,
             now,
-            now - threshold as i64 - 1,
+            now - threshold as i64,
         )
-        .expect("outside restart grace remains applicable");
-        assert_eq!(outside.verdict, StallVerdict::ControlPlaneDesync);
+        .expect("cleanup boundary remains applicable");
+        assert_eq!(cleanup_boundary.verdict, StallVerdict::ControlPlaneDesync);
         assert!(
-            !outside
+            !cleanup_boundary
                 .reasons
                 .contains(&StallVerdictReason::RestartGraceActive)
         );

--- a/src/services/discord/health/stall_verdict.rs
+++ b/src/services/discord/health/stall_verdict.rs
@@ -40,7 +40,9 @@ pub(super) struct StallSignalSnapshot {
     pub(super) frontier_advanced_recently: bool,
     pub(super) desynced: bool,
     pub(super) mailbox_cancel_token_present: bool,
-    pub(super) phantom_attached: bool,
+    pub(super) active_turn: RelayActiveTurn,
+    pub(super) watcher_attached: bool,
+    pub(super) watcher_owns_live_relay: Option<bool>,
     pub(super) producer_known_dead: bool,
     pub(super) delivery_committed: bool,
     pub(super) idle: bool,
@@ -57,6 +59,7 @@ pub(super) enum StallVerdictReason {
     Desynced,
     MailboxCancelTokenPresent,
     PhantomAttached,
+    WatcherLiveRelayOwnershipUnknown,
     ProducerKnownDead,
     NoPositiveLiveness,
 }
@@ -72,6 +75,7 @@ impl StallVerdictReason {
             Self::Desynced => "desynced",
             Self::MailboxCancelTokenPresent => "mailbox_cancel_token_present",
             Self::PhantomAttached => "phantom_attached",
+            Self::WatcherLiveRelayOwnershipUnknown => "watcher_live_relay_ownership_unknown",
             Self::ProducerKnownDead => "producer_known_dead",
             Self::NoPositiveLiveness => "no_positive_liveness",
         }
@@ -98,9 +102,10 @@ impl StallVerdictAssessment {
     }
 }
 
-/// Pure W0 classifier. Ordering is intentional: completed idle work and
-/// positive producer evidence outrank every desync symptom; control-plane
-/// contamination outranks a dead-producer fallback.
+/// Pure W0 classifier. Ordering is intentional: completed idle work and the
+/// deployment restart grace are safe terminal/mitigation cases. Outside that
+/// grace, control-plane contradictions outrank producer activity because a
+/// live producer does not prove that its relay path is healthy.
 pub(super) fn classify_stall(signals: StallSignalSnapshot) -> StallVerdictAssessment {
     if signals.delivery_committed && signals.idle {
         return StallVerdictAssessment::new(
@@ -112,6 +117,44 @@ pub(super) fn classify_stall(signals: StallSignalSnapshot) -> StallVerdictAssess
         );
     }
 
+    if signals.restart_grace_active {
+        return StallVerdictAssessment::new(
+            StallVerdict::ProducerLive,
+            vec![StallVerdictReason::RestartGraceActive],
+        );
+    }
+
+    let phantom_attached =
+        signals.watcher_attached && matches!(signals.watcher_owns_live_relay, Some(false));
+    let ownership_unknown = signals.watcher_attached && signals.watcher_owns_live_relay.is_none();
+    let pretripped_token = signals.mailbox_cancel_token_present
+        && matches!(signals.active_turn, RelayActiveTurn::None);
+    let mut control_plane_reasons = Vec::new();
+    if signals.desynced {
+        control_plane_reasons.push(StallVerdictReason::Desynced);
+    }
+    if phantom_attached {
+        control_plane_reasons.push(StallVerdictReason::PhantomAttached);
+    }
+    if pretripped_token {
+        control_plane_reasons.push(StallVerdictReason::MailboxCancelTokenPresent);
+    }
+    if !control_plane_reasons.is_empty() {
+        if signals.producer_activity_recent {
+            control_plane_reasons.push(StallVerdictReason::ProducerActivityRecent);
+        }
+        if signals.frontier_advanced_recently {
+            control_plane_reasons.push(StallVerdictReason::FrontierAdvancedRecently);
+        }
+        if ownership_unknown {
+            control_plane_reasons.push(StallVerdictReason::WatcherLiveRelayOwnershipUnknown);
+        }
+        return StallVerdictAssessment::new(
+            StallVerdict::ControlPlaneDesync,
+            control_plane_reasons,
+        );
+    }
+
     let mut live_reasons = Vec::new();
     if signals.producer_activity_recent {
         live_reasons.push(StallVerdictReason::ProducerActivityRecent);
@@ -119,42 +162,26 @@ pub(super) fn classify_stall(signals: StallSignalSnapshot) -> StallVerdictAssess
     if signals.frontier_advanced_recently {
         live_reasons.push(StallVerdictReason::FrontierAdvancedRecently);
     }
-    if signals.restart_grace_active {
-        live_reasons.push(StallVerdictReason::RestartGraceActive);
+    if ownership_unknown {
+        live_reasons.push(StallVerdictReason::WatcherLiveRelayOwnershipUnknown);
     }
-    if !live_reasons.is_empty() {
+    if signals.producer_activity_recent || signals.frontier_advanced_recently {
         return StallVerdictAssessment::new(StallVerdict::ProducerLive, live_reasons);
     }
 
-    if signals.desynced && (signals.mailbox_cancel_token_present || signals.phantom_attached) {
-        let mut reasons = vec![StallVerdictReason::Desynced];
-        if signals.mailbox_cancel_token_present {
-            reasons.push(StallVerdictReason::MailboxCancelTokenPresent);
-        }
-        if signals.phantom_attached {
-            reasons.push(StallVerdictReason::PhantomAttached);
-        }
-        return StallVerdictAssessment::new(StallVerdict::ControlPlaneDesync, reasons);
-    }
-
     if signals.producer_known_dead {
-        return StallVerdictAssessment::new(
-            StallVerdict::ProducerDead,
-            vec![StallVerdictReason::ProducerKnownDead],
-        );
+        let mut reasons = vec![StallVerdictReason::ProducerKnownDead];
+        if ownership_unknown {
+            reasons.push(StallVerdictReason::WatcherLiveRelayOwnershipUnknown);
+        }
+        return StallVerdictAssessment::new(StallVerdict::ProducerDead, reasons);
     }
 
-    if signals.desynced {
-        return StallVerdictAssessment::new(
-            StallVerdict::ControlPlaneDesync,
-            vec![StallVerdictReason::Desynced],
-        );
+    let mut reasons = vec![StallVerdictReason::NoPositiveLiveness];
+    if ownership_unknown {
+        reasons.push(StallVerdictReason::WatcherLiveRelayOwnershipUnknown);
     }
-
-    StallVerdictAssessment::new(
-        StallVerdict::ProducerDead,
-        vec![StallVerdictReason::NoPositiveLiveness],
-    )
+    StallVerdictAssessment::new(StallVerdict::ProducerDead, reasons)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -192,21 +219,33 @@ fn recent_unix_millis(timestamp_ms: Option<i64>, now_unix_secs: i64, freshness_s
 /// Adapter for the existing watchdog judgment logs. Producer progress comes
 /// only from the evidence already computed for the existing decision; watcher
 /// polling is consumer liveness and is deliberately excluded.
-fn classify_existing_judgment(
+fn classify_existing_judgment_lossy(
     snapshot: &WatcherStateSnapshot,
     decision: Option<&super::stall_liveness::StallWatchdogLivenessDecision>,
     freshness_secs: u64,
+    restart_grace_active: bool,
 ) -> Option<StallVerdictAssessment> {
-    classify_runtime_signals(
+    classify_runtime_signals_lossy(
         &snapshot.relay_health,
         snapshot.attached,
         snapshot.inflight_state_present,
         snapshot.inflight_terminal_delivery_committed,
         decision.is_some_and(|decision| decision.evidence.has_positive_liveness(freshness_secs)),
         false,
-        false,
+        restart_grace_active,
         snapshot.desynced,
     )
+}
+
+pub(super) fn restart_grace_active(
+    inflight_state_present: bool,
+    now_unix_secs: i64,
+    boot_unix_secs: i64,
+) -> bool {
+    inflight_state_present
+        && now_unix_secs >= boot_unix_secs
+        && now_unix_secs.saturating_sub(boot_unix_secs) as u64
+            <= super::recovery::STALL_WATCHDOG_THRESHOLD_SECS
 }
 
 pub(super) fn classify_health_snapshot_lossy(
@@ -273,11 +312,12 @@ fn classify_health_snapshot_at_lossy(
         now_unix_secs,
         super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
     );
-    let restart_grace_active = session.inflight_state_present
-        && now_unix_secs >= boot_unix_secs
-        && now_unix_secs.saturating_sub(boot_unix_secs) as u64
-            <= super::recovery::STALL_WATCHDOG_THRESHOLD_SECS;
-    classify_runtime_signals(
+    let restart_grace_active = restart_grace_active(
+        session.inflight_state_present,
+        now_unix_secs,
+        boot_unix_secs,
+    );
+    classify_runtime_signals_lossy(
         relay,
         session.attached,
         session.inflight_state_present,
@@ -301,10 +341,11 @@ fn classification_is_applicable(
         || desynced
         || relay.mailbox_has_cancel_token
         || channel_session_attached
+        || relay.watcher_attached
 }
 
 #[allow(clippy::too_many_arguments)]
-fn classify_runtime_signals(
+fn classify_runtime_signals_lossy(
     relay: &RelayHealthSnapshot,
     channel_session_attached: bool,
     inflight_state_present: bool,
@@ -324,8 +365,6 @@ fn classify_runtime_signals(
         return None;
     }
 
-    let phantom_attached = channel_session_attached
-        && (relay.watcher_attached_stale || relay.tmux_alive == Some(false));
     let idle =
         !relay.mailbox_has_cancel_token && matches!(relay.active_turn, RelayActiveTurn::None);
 
@@ -334,7 +373,9 @@ fn classify_runtime_signals(
         frontier_advanced_recently,
         desynced,
         mailbox_cancel_token_present: relay.mailbox_has_cancel_token,
-        phantom_attached,
+        active_turn: relay.active_turn,
+        watcher_attached: relay.watcher_attached,
+        watcher_owns_live_relay: Some(relay.watcher_owns_live_relay),
         producer_known_dead: relay.tmux_alive == Some(false),
         delivery_committed,
         idle,
@@ -358,8 +399,10 @@ pub(super) fn judgment_log_fields(
     snapshot: &WatcherStateSnapshot,
     decision: Option<&super::stall_liveness::StallWatchdogLivenessDecision>,
     freshness_secs: u64,
+    restart_grace_active: bool,
 ) -> (&'static str, String) {
-    let assessment = classify_existing_judgment(snapshot, decision, freshness_secs);
+    let assessment =
+        classify_existing_judgment_lossy(snapshot, decision, freshness_secs, restart_grace_active);
     classification_log_fields(assessment.as_ref())
 }
 
@@ -381,7 +424,9 @@ mod tests {
             frontier_advanced_recently: false,
             desynced: false,
             mailbox_cancel_token_present: false,
-            phantom_attached: false,
+            active_turn: RelayActiveTurn::None,
+            watcher_attached: false,
+            watcher_owns_live_relay: None,
             producer_known_dead: false,
             delivery_committed: false,
             idle: false,
@@ -515,20 +560,54 @@ mod tests {
     }
 
     #[test]
-    fn incident_4423_phantom_attached_with_pretripped_token_is_control_plane_desync() {
+    fn incident_4423_runtime_signals_are_control_plane_desync() {
+        let mut relay = relay_fixture();
+        relay.desynced = false;
+        relay.watcher_attached = true;
+        relay.watcher_attached_stale = false;
+        relay.watcher_owns_live_relay = false;
+        relay.mailbox_has_cancel_token = true;
+        relay.tmux_alive = Some(true);
+        relay.last_relay_ts_ms = None;
+
+        let assessment =
+            classify_runtime_signals_lossy(&relay, true, true, false, false, false, false, false)
+                .expect("applicable #4423 runtime signals");
+        assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
+        assert_eq!(
+            assessment.reasons,
+            vec![StallVerdictReason::PhantomAttached]
+        );
+    }
+
+    #[test]
+    fn pretripped_token_without_active_turn_is_control_plane_desync() {
         let assessment = classify_stall(StallSignalSnapshot {
-            desynced: true,
             mailbox_cancel_token_present: true,
-            phantom_attached: true,
+            active_turn: RelayActiveTurn::None,
             ..quiet_signals()
         });
         assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
         assert_eq!(
             assessment.reasons,
+            vec![StallVerdictReason::MailboxCancelTokenPresent]
+        );
+    }
+
+    #[test]
+    fn unknown_watcher_ownership_skips_phantom_rule_and_records_reason() {
+        let assessment = classify_stall(StallSignalSnapshot {
+            producer_activity_recent: true,
+            watcher_attached: true,
+            watcher_owns_live_relay: None,
+            ..quiet_signals()
+        });
+        assert_eq!(assessment.verdict, StallVerdict::ProducerLive);
+        assert_eq!(
+            assessment.reasons,
             vec![
-                StallVerdictReason::Desynced,
-                StallVerdictReason::MailboxCancelTokenPresent,
-                StallVerdictReason::PhantomAttached,
+                StallVerdictReason::ProducerActivityRecent,
+                StallVerdictReason::WatcherLiveRelayOwnershipUnknown,
             ]
         );
     }
@@ -549,16 +628,19 @@ mod tests {
     }
 
     #[test]
-    fn producer_activity_advancing_while_desynced_is_producer_live() {
+    fn producer_activity_advancing_while_desynced_is_control_plane_desync() {
         let assessment = classify_stall(StallSignalSnapshot {
             producer_activity_recent: true,
             desynced: true,
             ..quiet_signals()
         });
-        assert_eq!(assessment.verdict, StallVerdict::ProducerLive);
+        assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
         assert_eq!(
             assessment.reasons,
-            vec![StallVerdictReason::ProducerActivityRecent]
+            vec![
+                StallVerdictReason::Desynced,
+                StallVerdictReason::ProducerActivityRecent,
+            ]
         );
     }
 
@@ -589,7 +671,7 @@ mod tests {
                     desynced: true,
                     ..quiet_signals()
                 },
-                StallVerdict::ProducerLive,
+                StallVerdict::ControlPlaneDesync,
             ),
             (
                 StallSignalSnapshot {
@@ -628,10 +710,11 @@ mod tests {
             &snapshot,
             Some(&decision),
             super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            false,
         );
 
         assert_eq!(verdict, "control_plane_desync");
-        assert_eq!(reasons, "desynced,mailbox_cancel_token_present");
+        assert_eq!(reasons, "desynced");
     }
 
     #[test]
@@ -681,25 +764,52 @@ mod tests {
                 &snapshot,
                 Some(&decision),
                 super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                false,
             );
-            assert_eq!(verdict, "producer_live");
-            assert_eq!(reasons, "producer_activity_recent");
+            assert_eq!(verdict, "control_plane_desync");
+            assert_eq!(reasons, "desynced,producer_activity_recent");
         }
     }
 
     #[test]
-    fn raw_incident_4423_phantom_and_pretripped_token_is_control_plane_desync() {
+    fn judgment_log_fields_honors_restart_grace_before_desync() {
+        let snapshot = watcher_fixture();
+        let decision = liveness_decision(
+            StallWatchdogLivenessAction::Defer { deferral_count: 0 },
+            StallWatchdogLivenessEvidence {
+                runtime_activity_age_secs: Some(1),
+                ..Default::default()
+            },
+        );
+
+        let (verdict, reasons) = judgment_log_fields(
+            &snapshot,
+            Some(&decision),
+            super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            true,
+        );
+
+        assert_eq!(verdict, "producer_live");
+        assert_eq!(reasons, "restart_grace_active");
+    }
+
+    #[test]
+    fn raw_health_incident_4423_signals_are_control_plane_desync() {
         let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
         let now = fixture_updated_at_unix() + freshness as i64 + 10;
         let mut session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
-        // `attached` can come from the inflight tmux owner even when this
-        // channel has no strict watcher binding. Verdict adapters intentionally
-        // use this same channel/session fact as watchdog snapshots.
-        session.watcher_attached = false;
-        session.capture_lagged = true;
+        if let Some(inflight) = session.inflight.as_mut() {
+            inflight.watcher_owns_live_relay = false;
+        }
+        session.capture_lagged = false;
         let mut relay = relay_fixture();
-        relay.watcher_attached = false;
-        relay.tmux_alive = Some(false);
+        relay.desynced = false;
+        relay.watcher_attached = true;
+        relay.watcher_attached_stale = false;
+        relay.watcher_owns_live_relay = false;
+        relay.mailbox_has_cancel_token = true;
+        relay.tmux_alive = Some(true);
+        relay.last_relay_ts_ms = None;
 
         let assessment = classify_health_snapshot_at_lossy(
             Some(&ProviderKind::Codex),
@@ -714,16 +824,12 @@ mod tests {
         assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
         assert_eq!(
             assessment.reasons,
-            vec![
-                StallVerdictReason::Desynced,
-                StallVerdictReason::MailboxCancelTokenPresent,
-                StallVerdictReason::PhantomAttached,
-            ]
+            vec![StallVerdictReason::PhantomAttached]
         );
     }
 
     #[test]
-    fn raw_health_fresh_inflight_or_relay_frontier_is_producer_live() {
+    fn raw_health_fresh_inflight_or_relay_frontier_without_contradiction_is_producer_live() {
         let freshness = super::super::stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS;
         let timestamp = fixture_updated_at_unix();
         let fresh_now = timestamp + 1;
@@ -760,6 +866,34 @@ mod tests {
         assert_eq!(
             fresh_frontier.reasons,
             vec![StallVerdictReason::FrontierAdvancedRecently]
+        );
+    }
+
+    #[test]
+    fn raw_health_fresh_producer_activity_while_desynced_is_control_plane_desync() {
+        let timestamp = fixture_updated_at_unix();
+        let now = timestamp + 1;
+        let mut session = session_fixture(Some(FIXTURE_UPDATED_AT), true);
+        session.capture_lagged = true;
+        let relay = relay_fixture();
+
+        let assessment = classify_health_snapshot_at_lossy(
+            Some(&ProviderKind::Codex),
+            ChannelId::new(42),
+            &session,
+            &relay,
+            now,
+            now - super::super::recovery::STALL_WATCHDOG_THRESHOLD_SECS as i64 - 1,
+        )
+        .expect("applicable desynced producer activity");
+
+        assert_eq!(assessment.verdict, StallVerdict::ControlPlaneDesync);
+        assert_eq!(
+            assessment.reasons,
+            vec![
+                StallVerdictReason::Desynced,
+                StallVerdictReason::ProducerActivityRecent,
+            ]
         );
     }
 


### PR DESCRIPTION
## Context

PR #4431 merged W0 shadow telemetry at intermediate head `3ada07e85`, before correction commit `024ae7826` completed. This follow-up ports the intended residual onto current `main` and keeps #4254 open for separately gated W1/W2 work.

## W0 residual scope

- classify `ControlPlaneDesync` from independent contradictions rather than trusting one derived flag
- preserve produced `relay.desynced`, no-inflight ownership unknown, orphan-token provenance, and the strict restart-grace boundary
- define a live relay as `inflight_present && !terminal_delivery_committed && active_turn != None`
- normalize effective active turn and watcher ownership through that same predicate
- keep idle rebind-origin and stale ownerless `ExternalInput` rows ownership-unknown instead of inventing `phantom_attached`
- map lingering terminal-committed foreground rows to `DeliveredIdle`
- remain shadow-only: no recovery/cleanup predicate, authority, action, budget, or prescription consumes this verdict

## Safety boundary

- no schema, migration, config, or #3016 core-4 file change
- no control-plane recovery/cleanup behavior change
- generated inventory refreshed without cap/baseline relaxation

## Exact-head verification

Exact head: `7919eb4a49421ddc1dc2d61939702e877447f190`

- `cargo test --lib stall_verdict`: 24/24 PASS
- `env -u AGENTDESK_ROOT_DIR cargo test --lib services::discord::health`: 139/139 PASS
- `cargo check --lib` and `cargo fmt --all --check`: PASS
- inventory, maintenance freshness, maintainability, and await-lock ratchet (53/53): PASS
- production-shape regressions cover idle rebind-origin, stale ownerless external input, and terminal-committed lingering rows
- removing the live-relay normalization guard produced three named assertion failures; restored tree passed 12/12
- local = remote branch = PR head; worktree clean

Refs #4254 (W0 residual only; W1/W2 remain open)
