### PR TITLE
fix(watchdog): exempt proven foreground desync snapshots

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -86,6 +86,11 @@ COVERAGE_COVERED = "covered"
 COVERAGE_UNCOVERED = "uncovered"
 COVERAGE_UNKNOWN = "unknown"
 COVERAGE_CONFIRM_TICKS = 2
+# A foreground turn must show an outbound/relay write inside this window before
+# a transient watcher-state desync can be treated as covered.  Ten minutes
+# matches the watchdog's calibrated delivery grace while still letting a
+# genuinely stalled foreground turn resume normal two-tick escalation.
+COVERAGE_ACTIVITY_FRESH_SECS = 10 * 60
 
 # Independent selector-sync states (#4408 phase 2, I1).  Compares the dcserver's
 # asserted relay bind (B = watcher-state `bound_output_path`) against the
@@ -1387,6 +1392,29 @@ class CoverageVerdict:
 
 
 @dataclass(frozen=True)
+class CoverageActivityVerdict:
+    state: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CoverageActivityProbe:
+    """Exact watcher-state fields that can corroborate a foreground stream."""
+
+    relay_stall_state: str | None = None
+    active_turn: str | None = None
+    queue_depth: int | None = None
+    tmux_alive: bool | None = None
+    watcher_attached: bool | None = None
+    watcher_attached_stale: bool | None = None
+    watcher_owns_live_relay: bool | None = None
+    last_outbound_activity_ms: int | None = None
+    last_relay_ts_ms: int | None = None
+    desynced: bool | None = None
+    malformed: bool = False
+
+
+@dataclass(frozen=True)
 class SelectorVerdict:
     state: str
     reason: str
@@ -1405,6 +1433,256 @@ class WatcherStateProbe:
     # is bound to (`bound_output_path`). `None` means an old server without the
     # field, a JSON null, or a non-200 response — all fail-closed to no alarm.
     bound_output_path: str | None = None
+    # #4458: derived foreground/liveness evidence from top-level
+    # `relay_stall_state` plus nested `relay_health`. `None` is a legacy server
+    # with neither field and preserves the pre-#4458 desync behavior.
+    relay_activity: CoverageActivityProbe | None = None
+
+
+def parse_watcher_state_probe(
+    status: int | None, payload: object
+) -> WatcherStateProbe:
+    """Pure, exact-type parser for the watcher-state response contract."""
+    if status != 200:
+        return WatcherStateProbe(status)
+    if not isinstance(payload, Mapping):
+        return WatcherStateProbe(200)
+
+    attached_raw = payload.get("attached")
+    desynced_raw = payload.get("desynced")
+    bound_output_path = payload.get("bound_output_path")
+    attached = attached_raw if isinstance(attached_raw, bool) else None
+    desynced = desynced_raw if isinstance(desynced_raw, bool) else None
+    bound = bound_output_path if isinstance(bound_output_path, str) else None
+
+    has_activity_schema = (
+        "relay_stall_state" in payload or "relay_health" in payload
+    )
+    if not has_activity_schema:
+        return WatcherStateProbe(200, attached, desynced, bound)
+
+    malformed = False
+    stall_raw = payload.get("relay_stall_state")
+    if stall_raw is None:
+        relay_stall_state = None
+    elif isinstance(stall_raw, str) and stall_raw:
+        relay_stall_state = stall_raw
+    else:
+        relay_stall_state = None
+        malformed = True
+
+    relay_raw = payload.get("relay_health")
+    if not isinstance(relay_raw, Mapping):
+        return WatcherStateProbe(
+            200,
+            attached,
+            desynced,
+            bound,
+            CoverageActivityProbe(
+                relay_stall_state=relay_stall_state,
+                malformed=True,
+            ),
+        )
+
+    def string_field(key: str) -> tuple[str | None, bool]:
+        if key not in relay_raw:
+            return None, False
+        value = relay_raw.get(key)
+        if isinstance(value, str) and value:
+            return value, False
+        return None, True
+
+    def bool_field(
+        key: str, *, nullable: bool = False
+    ) -> tuple[bool | None, bool]:
+        if key not in relay_raw:
+            return None, False
+        value = relay_raw.get(key)
+        if isinstance(value, bool):
+            return value, False
+        if value is None and nullable:
+            return None, False
+        return None, True
+
+    def int_field(
+        key: str, *, nullable: bool = False
+    ) -> tuple[int | None, bool]:
+        if key not in relay_raw:
+            return None, False
+        value = relay_raw.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value, False
+        if value is None and nullable:
+            return None, False
+        return None, True
+
+    active_turn, bad_active_turn = string_field("active_turn")
+    queue_depth, bad_queue_depth = int_field("queue_depth")
+    tmux_alive, bad_tmux_alive = bool_field("tmux_alive", nullable=True)
+    watcher_attached, bad_watcher_attached = bool_field("watcher_attached")
+    watcher_attached_stale, bad_watcher_attached_stale = bool_field(
+        "watcher_attached_stale"
+    )
+    watcher_owns_live_relay, bad_watcher_owns_live_relay = bool_field(
+        "watcher_owns_live_relay"
+    )
+    last_outbound_activity_ms, bad_last_outbound_activity_ms = int_field(
+        "last_outbound_activity_ms", nullable=True
+    )
+    last_relay_ts_ms, bad_last_relay_ts_ms = int_field(
+        "last_relay_ts_ms", nullable=True
+    )
+    relay_desynced, bad_relay_desynced = bool_field("desynced")
+    malformed = malformed or any(
+        (
+            bad_active_turn,
+            bad_queue_depth,
+            bad_tmux_alive,
+            bad_watcher_attached,
+            bad_watcher_attached_stale,
+            bad_watcher_owns_live_relay,
+            bad_last_outbound_activity_ms,
+            bad_last_relay_ts_ms,
+            bad_relay_desynced,
+        )
+    )
+    return WatcherStateProbe(
+        200,
+        attached,
+        desynced,
+        bound,
+        CoverageActivityProbe(
+            relay_stall_state=relay_stall_state,
+            active_turn=active_turn,
+            queue_depth=queue_depth,
+            tmux_alive=tmux_alive,
+            watcher_attached=watcher_attached,
+            watcher_attached_stale=watcher_attached_stale,
+            watcher_owns_live_relay=watcher_owns_live_relay,
+            last_outbound_activity_ms=last_outbound_activity_ms,
+            last_relay_ts_ms=last_relay_ts_ms,
+            desynced=relay_desynced,
+            malformed=malformed,
+        ),
+    )
+
+
+def evaluate_active_foreground_coverage(
+    activity: CoverageActivityProbe | None,
+    now_ms: object,
+    freshness_secs: object = COVERAGE_ACTIVITY_FRESH_SECS,
+) -> CoverageActivityVerdict:
+    """Prove that an attached desync is a live foreground streaming snapshot."""
+    if activity is None:
+        # Legacy watcher-state: retain the original attached+desynced failure.
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_schema_absent"
+        )
+
+    # Explicit negative evidence always wins over partial/malformed positive
+    # evidence. These are real coverage failures, not parser uncertainty.
+    if (
+        activity.relay_stall_state is not None
+        and activity.relay_stall_state != "active_foreground_stream"
+    ):
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "relay_stall_state_not_active_foreground"
+        )
+    if activity.active_turn is not None and activity.active_turn != "foreground":
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_turn_not_foreground"
+        )
+    if activity.queue_depth is not None and activity.queue_depth != 0:
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_queue_not_empty"
+        )
+    if activity.tmux_alive is False:
+        return CoverageActivityVerdict(COVERAGE_UNCOVERED, "tmux_not_alive")
+    if activity.watcher_attached is False:
+        return CoverageActivityVerdict(COVERAGE_UNCOVERED, "watcher_detached")
+    if activity.watcher_attached_stale is True:
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "watcher_attachment_stale"
+        )
+    if activity.watcher_owns_live_relay is False:
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "watcher_does_not_own_live_relay"
+        )
+    if activity.desynced is False:
+        return CoverageActivityVerdict(
+            COVERAGE_UNKNOWN, "watcher_state_desync_inconsistent"
+        )
+
+    active_hint = (
+        activity.relay_stall_state == "active_foreground_stream"
+        or activity.active_turn == "foreground"
+    )
+    required_evidence_missing = any(
+        field is None
+        for field in (
+            activity.relay_stall_state,
+            activity.active_turn,
+            activity.queue_depth,
+            activity.tmux_alive,
+            activity.watcher_attached,
+            activity.watcher_attached_stale,
+            activity.watcher_owns_live_relay,
+            activity.desynced,
+        )
+    )
+    if activity.malformed or required_evidence_missing:
+        return CoverageActivityVerdict(
+            COVERAGE_UNKNOWN, "active_foreground_evidence_incomplete"
+        )
+    if not active_hint:
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_not_observed"
+        )
+    if not (
+        activity.relay_stall_state == "active_foreground_stream"
+        and activity.active_turn == "foreground"
+        and activity.queue_depth == 0
+        and activity.tmux_alive is True
+        and activity.watcher_attached is True
+        and activity.watcher_attached_stale is False
+        and activity.watcher_owns_live_relay is True
+        and activity.desynced is True
+    ):
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_evidence_rejected"
+        )
+
+    if not (
+        _is_finite_nonnegative_number(now_ms)
+        and _is_finite_nonnegative_number(freshness_secs)
+        and float(freshness_secs) > 0
+    ):
+        return CoverageActivityVerdict(
+            COVERAGE_UNKNOWN, "active_foreground_clock_unknown"
+        )
+    timestamps = [
+        timestamp
+        for timestamp in (
+            activity.last_outbound_activity_ms,
+            activity.last_relay_ts_ms,
+        )
+        if isinstance(timestamp, int)
+        and not isinstance(timestamp, bool)
+        and timestamp > 0
+    ]
+    if not timestamps:
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_activity_absent"
+        )
+    freshest = max(timestamps)
+    age_ms = float(now_ms) - freshest
+    if age_ms <= 0 or age_ms < float(freshness_secs) * 1000:
+        return CoverageActivityVerdict(
+            COVERAGE_COVERED, "active_foreground_recent_activity"
+        )
+    return CoverageActivityVerdict(
+        COVERAGE_UNCOVERED, "active_foreground_activity_stale"
+    )
 
 
 def evaluate_coverage(
@@ -1413,14 +1691,18 @@ def evaluate_coverage(
     attached: bool | None,
     desynced: bool | None,
     previous_uncovered: int,
+    relay_activity: CoverageActivityProbe | None = None,
+    now_ms: object = None,
+    activity_freshness_secs: object = COVERAGE_ACTIVITY_FRESH_SECS,
 ) -> CoverageVerdict:
     """Pure I2 judgment for expected tmux coverage.
 
-    E is independently enumerated tmux liveness. A is exactly
-    ``attached and not desynced`` from watcher-state. Only E && !A advances
-    confirmation. Transport/schema uncertainty is unknown (never an alert),
-    while an authoritative watcher-state 404 is uncovered. Two consecutive
-    uncovered ticks are required.
+    E is independently enumerated tmux liveness. A is normally
+    ``attached and not desynced`` from watcher-state; #4458 also accepts an
+    exact, fresh active-foreground relay proof while the snapshot is transiently
+    desynced. Only E && !A advances confirmation. Transport/schema uncertainty
+    is unknown (never an alert), while an authoritative watcher-state 404 is
+    uncovered. Two consecutive uncovered ticks are required.
     """
 
     def uncovered(reason: str) -> CoverageVerdict:
@@ -1451,6 +1733,19 @@ def evaluate_coverage(
     if attached is False:
         return uncovered("detached")
     if attached is True and desynced is True:
+        activity_verdict = evaluate_active_foreground_coverage(
+            relay_activity,
+            now_ms,
+            activity_freshness_secs,
+        )
+        if activity_verdict.state == COVERAGE_COVERED:
+            return CoverageVerdict(
+                COVERAGE_COVERED, activity_verdict.reason, 0, False
+            )
+        if activity_verdict.state == COVERAGE_UNKNOWN:
+            return CoverageVerdict(
+                COVERAGE_UNKNOWN, activity_verdict.reason, 0, False
+            )
         return uncovered("attached_but_desynced")
     return CoverageVerdict(COVERAGE_UNKNOWN, "watcher_state_malformed", 0, False)
 
@@ -1882,17 +2177,7 @@ class Runtime:
             payload = json.loads(body)
         except json.JSONDecodeError:
             return WatcherStateProbe(200)
-        if not isinstance(payload, dict):
-            return WatcherStateProbe(200)
-        attached = payload.get("attached")
-        desynced = payload.get("desynced")
-        bound_output_path = payload.get("bound_output_path")
-        return WatcherStateProbe(
-            200,
-            attached if isinstance(attached, bool) else None,
-            desynced if isinstance(desynced, bool) else None,
-            bound_output_path if isinstance(bound_output_path, str) else None,
-        )
+        return parse_watcher_state_probe(200, payload)
 
     def discord_haystack(self, channel_id: str) -> str | None:
         try:
@@ -2336,6 +2621,8 @@ def tick_coverage(
         probe.attached,
         probe.desynced,
         previous,
+        probe.relay_activity,
+        int(now * 1000),
     )
     if verdict.consecutive_uncovered:
         chs["coverage_uncovered_ticks"] = verdict.consecutive_uncovered

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1610,7 +1610,7 @@ def evaluate_active_foreground_coverage(
         )
     if activity.desynced is False:
         return CoverageActivityVerdict(
-            COVERAGE_UNKNOWN, "watcher_state_desync_inconsistent"
+            COVERAGE_UNCOVERED, "watcher_state_desync_inconsistent"
         )
 
     active_hint = (
@@ -1632,7 +1632,7 @@ def evaluate_active_foreground_coverage(
     )
     if activity.malformed or required_evidence_missing:
         return CoverageActivityVerdict(
-            COVERAGE_UNKNOWN, "active_foreground_evidence_incomplete"
+            COVERAGE_UNCOVERED, "active_foreground_evidence_incomplete"
         )
     if not active_hint:
         return CoverageActivityVerdict(
@@ -1658,7 +1658,7 @@ def evaluate_active_foreground_coverage(
         and float(freshness_secs) > 0
     ):
         return CoverageActivityVerdict(
-            COVERAGE_UNKNOWN, "active_foreground_clock_unknown"
+            COVERAGE_UNCOVERED, "active_foreground_clock_unknown"
         )
     timestamps = [
         timestamp
@@ -1700,9 +1700,11 @@ def evaluate_coverage(
     E is independently enumerated tmux liveness. A is normally
     ``attached and not desynced`` from watcher-state; #4458 also accepts an
     exact, fresh active-foreground relay proof while the snapshot is transiently
-    desynced. Only E && !A advances confirmation. Transport/schema uncertainty
-    is unknown (never an alert), while an authoritative watcher-state 404 is
-    uncovered. Two consecutive uncovered ticks are required.
+    desynced. Only E && !A advances confirmation. Core watcher-state transport/
+    schema uncertainty is unknown, but optional activity evidence can only prove
+    the exception; incomplete or malformed activity never weakens an otherwise
+    authoritative attached+desynced failure. An authoritative watcher-state 404
+    is uncovered. Two consecutive uncovered ticks are required.
     """
 
     def uncovered(reason: str) -> CoverageVerdict:
@@ -1742,10 +1744,8 @@ def evaluate_coverage(
             return CoverageVerdict(
                 COVERAGE_COVERED, activity_verdict.reason, 0, False
             )
-        if activity_verdict.state == COVERAGE_UNKNOWN:
-            return CoverageVerdict(
-                COVERAGE_UNKNOWN, activity_verdict.reason, 0, False
-            )
+        # Supplemental activity is a one-way exception proof. Any outcome
+        # other than exact COVERED retains the original desync invariant.
         return uncovered("attached_but_desynced")
     return CoverageVerdict(COVERAGE_UNKNOWN, "watcher_state_malformed", 0, False)
 

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1660,23 +1660,45 @@ def evaluate_active_foreground_coverage(
         return CoverageActivityVerdict(
             COVERAGE_UNCOVERED, "active_foreground_clock_unknown"
         )
-    timestamps = [
-        timestamp
-        for timestamp in (
-            activity.last_outbound_activity_ms,
-            activity.last_relay_ts_ms,
+    now_value = float(now_ms)
+    freshness_ms = float(freshness_secs) * 1000
+    if not math.isfinite(freshness_ms):
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_clock_unknown"
         )
-        if isinstance(timestamp, int)
-        and not isinstance(timestamp, bool)
-        and timestamp > 0
-    ]
+    timestamps: list[float] = []
+    for raw_timestamp in (
+        activity.last_outbound_activity_ms,
+        activity.last_relay_ts_ms,
+    ):
+        if not (
+            isinstance(raw_timestamp, int)
+            and not isinstance(raw_timestamp, bool)
+            and raw_timestamp > 0
+        ):
+            continue
+        try:
+            timestamp = float(raw_timestamp)
+        except (OverflowError, ValueError):
+            return CoverageActivityVerdict(
+                COVERAGE_UNCOVERED, "active_foreground_activity_invalid"
+            )
+        if not math.isfinite(timestamp):
+            return CoverageActivityVerdict(
+                COVERAGE_UNCOVERED, "active_foreground_activity_invalid"
+            )
+        timestamps.append(timestamp)
     if not timestamps:
         return CoverageActivityVerdict(
             COVERAGE_UNCOVERED, "active_foreground_activity_absent"
         )
     freshest = max(timestamps)
-    age_ms = float(now_ms) - freshest
-    if age_ms <= 0 or age_ms < float(freshness_secs) * 1000:
+    age_ms = now_value - freshest
+    if age_ms < 0:
+        return CoverageActivityVerdict(
+            COVERAGE_UNCOVERED, "active_foreground_activity_future"
+        )
+    if age_ms < freshness_ms:
         return CoverageActivityVerdict(
             COVERAGE_COVERED, "active_foreground_recent_activity"
         )
@@ -1872,12 +1894,13 @@ def evaluate(
 
 
 def _is_finite_nonnegative_number(value: object) -> bool:
-    return (
-        isinstance(value, (int, float))
-        and not isinstance(value, bool)
-        and math.isfinite(float(value))
-        and float(value) >= 0.0
-    )
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        numeric = float(value)
+    except (OverflowError, ValueError):
+        return False
+    return math.isfinite(numeric) and numeric >= 0.0
 
 
 def _bounded_delivered_watermarks(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1041,8 +1041,68 @@ class CoverageEvaluationTests(unittest.TestCase):
         self.assertEqual(boundary.state, COVERAGE_UNCOVERED)
         self.assertEqual(boundary.reason, "active_foreground_activity_stale")
 
+    def test_future_activity_timestamp_cannot_suppress_desync(self):
+        activity = self.active_foreground(
+            last_outbound_activity_ms=self.NOW_MS + 1,
+            last_relay_ts_ms=None,
+        )
+        activity_verdict = evaluate_active_foreground_coverage(
+            activity,
+            self.NOW_MS,
+        )
+        self.assertEqual(activity_verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(
+            activity_verdict.reason,
+            "active_foreground_activity_future",
+        )
+
+        coverage_verdict = evaluate_coverage(
+            True,
+            200,
+            True,
+            True,
+            1,
+            activity,
+            self.NOW_MS,
+        )
+        self.assertEqual(coverage_verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(coverage_verdict.reason, "attached_but_desynced")
+        self.assertTrue(coverage_verdict.confirmed)
+
+    def test_oversized_activity_timestamp_fails_closed_without_throwing(self):
+        activity = self.active_foreground(
+            last_outbound_activity_ms=10**400,
+            last_relay_ts_ms=None,
+        )
+        activity_verdict = evaluate_active_foreground_coverage(
+            activity,
+            self.NOW_MS,
+        )
+        self.assertEqual(activity_verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(
+            activity_verdict.reason,
+            "active_foreground_activity_invalid",
+        )
+
+        coverage_verdict = evaluate_coverage(
+            True,
+            200,
+            True,
+            True,
+            1,
+            activity,
+            self.NOW_MS,
+        )
+        self.assertEqual(coverage_verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(coverage_verdict.reason, "attached_but_desynced")
+        self.assertTrue(coverage_verdict.confirmed)
+
     def test_invalid_freshness_clock_cannot_suppress_desync(self):
-        for now_ms, freshness_secs in ((None, 60), (self.NOW_MS, 0)):
+        for now_ms, freshness_secs in (
+            (None, 60),
+            (self.NOW_MS, 0),
+            (10**400, 60),
+        ):
             with self.subTest(now_ms=now_ms, freshness_secs=freshness_secs):
                 verdict = evaluate_coverage(
                     True,
@@ -2006,6 +2066,63 @@ class RuntimeCoverageProbeTests(unittest.TestCase):
             probe.relay_activity,
             CoverageEvaluationTests.active_foreground(),
         )
+
+    def test_production_activity_clock_anomalies_fail_closed(self):
+        cases = (
+            (
+                "future",
+                CoverageEvaluationTests.NOW_MS + 1,
+                "active_foreground_activity_future",
+            ),
+            (
+                "oversized",
+                10**400,
+                "active_foreground_activity_invalid",
+            ),
+        )
+        for name, timestamp, reason in cases:
+            with self.subTest(name=name):
+                completed = subprocess.CompletedProcess(
+                    ["curl"],
+                    0,
+                    stdout=(
+                        json.dumps(
+                            WatcherStateParserTests.payload(
+                                last_outbound_activity_ms=timestamp,
+                                last_relay_ts_ms=None,
+                            )
+                        )
+                        + "\n200"
+                    ),
+                    stderr="",
+                )
+                with mock.patch.object(
+                    relay_watchdog.subprocess,
+                    "run",
+                    return_value=completed,
+                ):
+                    probe = self.make_rt().watcher_state("999")
+                activity_verdict = evaluate_active_foreground_coverage(
+                    probe.relay_activity,
+                    CoverageEvaluationTests.NOW_MS,
+                )
+                self.assertEqual(activity_verdict.state, COVERAGE_UNCOVERED)
+                self.assertEqual(activity_verdict.reason, reason)
+                coverage_verdict = evaluate_coverage(
+                    True,
+                    probe.status,
+                    probe.attached,
+                    probe.desynced,
+                    1,
+                    probe.relay_activity,
+                    CoverageEvaluationTests.NOW_MS,
+                )
+                self.assertEqual(coverage_verdict.state, COVERAGE_UNCOVERED)
+                self.assertEqual(
+                    coverage_verdict.reason,
+                    "attached_but_desynced",
+                )
+                self.assertTrue(coverage_verdict.confirmed)
 
     def test_watcher_state_malformed_200_keeps_status_but_not_claims(self):
         completed = subprocess.CompletedProcess(

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -1041,6 +1041,23 @@ class CoverageEvaluationTests(unittest.TestCase):
         self.assertEqual(boundary.state, COVERAGE_UNCOVERED)
         self.assertEqual(boundary.reason, "active_foreground_activity_stale")
 
+    def test_invalid_freshness_clock_cannot_suppress_desync(self):
+        for now_ms, freshness_secs in ((None, 60), (self.NOW_MS, 0)):
+            with self.subTest(now_ms=now_ms, freshness_secs=freshness_secs):
+                verdict = evaluate_coverage(
+                    True,
+                    200,
+                    True,
+                    True,
+                    1,
+                    self.active_foreground(),
+                    now_ms,
+                    freshness_secs,
+                )
+                self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+                self.assertEqual(verdict.reason, "attached_but_desynced")
+                self.assertTrue(verdict.confirmed)
+
     def test_explicit_stall_evidence_never_uses_foreground_bypass(self):
         cases = {
             "queue": {"queue_depth": 1},
@@ -1077,7 +1094,7 @@ class CoverageEvaluationTests(unittest.TestCase):
                 self.assertEqual(verdict.reason, "attached_but_desynced")
                 self.assertTrue(verdict.confirmed)
 
-    def test_partial_or_malformed_active_schema_is_unknown(self):
+    def test_partial_or_malformed_active_schema_cannot_suppress_desync(self):
         partial = CoverageActivityProbe(
             relay_stall_state="active_foreground_stream",
             active_turn="foreground",
@@ -1094,10 +1111,14 @@ class CoverageEvaluationTests(unittest.TestCase):
                     activity,
                     self.NOW_MS,
                 )
-                self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
-                self.assertEqual(verdict.consecutive_uncovered, 0)
+                self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+                self.assertEqual(verdict.reason, "attached_but_desynced")
+                self.assertEqual(
+                    verdict.consecutive_uncovered, COVERAGE_CONFIRM_TICKS
+                )
+                self.assertTrue(verdict.confirmed)
 
-    def test_nested_desync_disagreement_is_unknown(self):
+    def test_nested_desync_disagreement_cannot_suppress_top_level_desync(self):
         verdict = evaluate_coverage(
             True,
             200,
@@ -1107,8 +1128,9 @@ class CoverageEvaluationTests(unittest.TestCase):
             self.active_foreground(desynced=False),
             self.NOW_MS,
         )
-        self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
-        self.assertEqual(verdict.reason, "watcher_state_desync_inconsistent")
+        self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(verdict.reason, "attached_but_desynced")
+        self.assertTrue(verdict.confirmed)
 
     def test_active_evidence_cannot_override_detached_or_404(self):
         activity = self.active_foreground()
@@ -1216,7 +1238,7 @@ class WatcherStateParserTests(unittest.TestCase):
         self.assertIsNone(probe.relay_activity.watcher_attached_stale)
         self.assertIsNone(probe.relay_activity.last_outbound_activity_ms)
 
-    def test_partial_active_schema_is_preserved_as_unknown_evidence(self):
+    def test_partial_active_schema_preserves_legacy_desync_detection(self):
         probe = parse_watcher_state_probe(
             200,
             {
@@ -1235,8 +1257,9 @@ class WatcherStateParserTests(unittest.TestCase):
             probe.relay_activity,
             self.NOW_MS,
         )
-        self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
-        self.assertEqual(verdict.consecutive_uncovered, 0)
+        self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+        self.assertEqual(verdict.reason, "attached_but_desynced")
+        self.assertTrue(verdict.confirmed)
 
     def test_legacy_schema_retains_original_desync_detection(self):
         probe = parse_watcher_state_probe(
@@ -2561,6 +2584,25 @@ class TickChannelTests(unittest.TestCase):
         self.assertNotIn("coverage_uncovered_ticks", state["999"])
         self.assertNotIn("last_coverage_alert", state["999"])
 
+    def test_back_to_back_foreground_churn_never_accumulates_confirmation(self):
+        rt = self.make_rt()
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        for tick_index in range(10):
+            tick_at = self.now + tick_index * rt.cfg.poll_secs
+            self.arm_coverage(
+                rt,
+                self.active_foreground_probe(
+                    last_outbound_activity_ms=int(tick_at * 1000) - 1,
+                    last_relay_ts_ms=int(tick_at * 1000) - 2,
+                ),
+            )
+            tick_channel(rt, TICK_CHANNEL, state, tick_at)
+            self.assertNotIn("coverage_uncovered_ticks", state["999"])
+
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("last_coverage_alert", state["999"])
+
     def test_stale_foreground_desync_still_confirms_coverage_alert(self):
         rt = self.make_rt()
         stale_ms = int(self.now * 1000) - COVERAGE_ACTIVITY_FRESH_SECS * 1000
@@ -2579,7 +2621,7 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
         self.assertIn("attached_but_desynced", rt.alerts[0][0])
 
-    def test_partial_foreground_schema_resets_confirmation_as_unknown(self):
+    def test_partial_foreground_schema_cannot_suppress_coverage_alert(self):
         rt = self.make_rt()
         self.arm_coverage(
             rt,
@@ -2597,14 +2639,32 @@ class TickChannelTests(unittest.TestCase):
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
-        self.assertEqual(rt.alerts, [])
-        self.assertNotIn("coverage_uncovered_ticks", state["999"])
-        self.assertTrue(
-            any(
-                "active_foreground_evidence_incomplete" in line
-                for line in rt.log_lines
-            )
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+        self.assertEqual(
+            state["999"]["coverage_uncovered_ticks"], COVERAGE_CONFIRM_TICKS
         )
+
+    def test_active_foreground_evidence_cannot_suppress_detached_alert(self):
+        rt = self.make_rt()
+        probe = self.active_foreground_probe()
+        self.arm_coverage(
+            rt,
+            WatcherStateProbe(
+                status=200,
+                attached=False,
+                desynced=True,
+                relay_activity=probe.relay_activity,
+            ),
+        )
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
+        self.assertIn("detached", rt.alerts[0][0])
 
     def test_active_foreground_coverage_cannot_suppress_transcript_gap(self):
         rt = self.gap_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 import scripts.relay_watchdog as relay_watchdog
 from scripts.relay_watchdog import (
+    COVERAGE_ACTIVITY_FRESH_SECS,
     COVERAGE_CONFIRM_TICKS,
     COVERAGE_COVERED,
     COVERAGE_UNCOVERED,
@@ -47,6 +48,7 @@ from scripts.relay_watchdog import (
     ChannelConfig,
     Config,
     ConfigError,
+    CoverageActivityProbe,
     Runtime,
     TranscriptCandidate,
     WatcherStateProbe,
@@ -57,6 +59,7 @@ from scripts.relay_watchdog import (
     delivered_watermark_for_path,
     delivered_watermarks,
     evaluate,
+    evaluate_active_foreground_coverage,
     evaluate_coverage,
     evaluate_pg_health,
     evaluate_selector_sync,
@@ -67,6 +70,7 @@ from scripts.relay_watchdog import (
     newest_transcript,
     norm,
     parse_config,
+    parse_watcher_state_probe,
     parse_transcript_ts,
     project_slug,
     recheck_selected_transcript,
@@ -933,6 +937,25 @@ class EvaluateBoundaryTests(unittest.TestCase):
 
 
 class CoverageEvaluationTests(unittest.TestCase):
+    NOW_MS = 1_800_000_000_000
+
+    @classmethod
+    def active_foreground(cls, **overrides) -> CoverageActivityProbe:
+        fields = {
+            "relay_stall_state": "active_foreground_stream",
+            "active_turn": "foreground",
+            "queue_depth": 0,
+            "tmux_alive": True,
+            "watcher_attached": True,
+            "watcher_attached_stale": False,
+            "watcher_owns_live_relay": True,
+            "last_outbound_activity_ms": cls.NOW_MS - 1,
+            "last_relay_ts_ms": cls.NOW_MS - 2,
+            "desynced": True,
+        }
+        fields.update(overrides)
+        return CoverageActivityProbe(**fields)
+
     def test_live_expected_session_with_healthy_watcher_is_covered(self):
         verdict = evaluate_coverage(True, 200, True, False, 1)
         self.assertEqual(verdict.state, COVERAGE_COVERED)
@@ -970,6 +993,140 @@ class CoverageEvaluationTests(unittest.TestCase):
         self.assertEqual(verdict.reason, "attached_but_desynced")
         self.assertTrue(verdict.confirmed)
 
+    def test_recent_active_foreground_stream_covers_transient_desync(self):
+        verdict = evaluate_coverage(
+            True,
+            200,
+            True,
+            True,
+            1,
+            self.active_foreground(),
+            self.NOW_MS,
+        )
+        self.assertEqual(verdict.state, COVERAGE_COVERED)
+        self.assertEqual(verdict.reason, "active_foreground_recent_activity")
+        self.assertEqual(verdict.consecutive_uncovered, 0)
+        self.assertFalse(verdict.confirmed)
+
+    def test_relay_timestamp_is_valid_freshness_fallback(self):
+        verdict = evaluate_active_foreground_coverage(
+            self.active_foreground(
+                last_outbound_activity_ms=None,
+                last_relay_ts_ms=self.NOW_MS - 1,
+            ),
+            self.NOW_MS,
+        )
+        self.assertEqual(verdict.state, COVERAGE_COVERED)
+
+    def test_activity_freshness_boundary_is_strict(self):
+        inside = evaluate_active_foreground_coverage(
+            self.active_foreground(
+                last_outbound_activity_ms=(
+                    self.NOW_MS - COVERAGE_ACTIVITY_FRESH_SECS * 1000 + 1
+                ),
+                last_relay_ts_ms=None,
+            ),
+            self.NOW_MS,
+        )
+        boundary = evaluate_active_foreground_coverage(
+            self.active_foreground(
+                last_outbound_activity_ms=(
+                    self.NOW_MS - COVERAGE_ACTIVITY_FRESH_SECS * 1000
+                ),
+                last_relay_ts_ms=None,
+            ),
+            self.NOW_MS,
+        )
+        self.assertEqual(inside.state, COVERAGE_COVERED)
+        self.assertEqual(boundary.state, COVERAGE_UNCOVERED)
+        self.assertEqual(boundary.reason, "active_foreground_activity_stale")
+
+    def test_explicit_stall_evidence_never_uses_foreground_bypass(self):
+        cases = {
+            "queue": {"queue_depth": 1},
+            "dead tmux": {"tmux_alive": False},
+            "detached nested watcher": {"watcher_attached": False},
+            "stale attachment": {"watcher_attached_stale": True},
+            "lost live relay ownership": {"watcher_owns_live_relay": False},
+            "relay-dead classifier": {
+                "relay_stall_state": "tmux_alive_relay_dead"
+            },
+            "no activity": {
+                "last_outbound_activity_ms": None,
+                "last_relay_ts_ms": None,
+            },
+            "stale activity": {
+                "last_outbound_activity_ms": (
+                    self.NOW_MS - COVERAGE_ACTIVITY_FRESH_SECS * 1000
+                ),
+                "last_relay_ts_ms": None,
+            },
+        }
+        for name, overrides in cases.items():
+            with self.subTest(name=name):
+                verdict = evaluate_coverage(
+                    True,
+                    200,
+                    True,
+                    True,
+                    1,
+                    self.active_foreground(**overrides),
+                    self.NOW_MS,
+                )
+                self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+                self.assertEqual(verdict.reason, "attached_but_desynced")
+                self.assertTrue(verdict.confirmed)
+
+    def test_partial_or_malformed_active_schema_is_unknown(self):
+        partial = CoverageActivityProbe(
+            relay_stall_state="active_foreground_stream",
+            active_turn="foreground",
+        )
+        malformed = self.active_foreground(malformed=True)
+        for activity in (partial, malformed):
+            with self.subTest(activity=activity):
+                verdict = evaluate_coverage(
+                    True,
+                    200,
+                    True,
+                    True,
+                    1,
+                    activity,
+                    self.NOW_MS,
+                )
+                self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
+                self.assertEqual(verdict.consecutive_uncovered, 0)
+
+    def test_nested_desync_disagreement_is_unknown(self):
+        verdict = evaluate_coverage(
+            True,
+            200,
+            True,
+            True,
+            1,
+            self.active_foreground(desynced=False),
+            self.NOW_MS,
+        )
+        self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
+        self.assertEqual(verdict.reason, "watcher_state_desync_inconsistent")
+
+    def test_active_evidence_cannot_override_detached_or_404(self):
+        activity = self.active_foreground()
+        detached = evaluate_coverage(
+            True, 200, False, True, 1, activity, self.NOW_MS
+        )
+        missing = evaluate_coverage(
+            True, 404, None, None, 1, activity, self.NOW_MS
+        )
+        self.assertEqual((detached.state, detached.reason), (
+            COVERAGE_UNCOVERED,
+            "detached",
+        ))
+        self.assertEqual((missing.state, missing.reason), (
+            COVERAGE_UNCOVERED,
+            "watcher_state_404",
+        ))
+
     def test_dead_expected_session_is_left_to_stall_watchdog(self):
         verdict = evaluate_coverage(False, 200, False, True, 1)
         self.assertEqual(verdict.state, COVERAGE_COVERED)
@@ -980,6 +1137,129 @@ class CoverageEvaluationTests(unittest.TestCase):
         verdict = evaluate_coverage(True, 200, None, None, 1)
         self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
         self.assertEqual(verdict.consecutive_uncovered, 0)
+
+
+class WatcherStateParserTests(unittest.TestCase):
+    NOW_MS = CoverageEvaluationTests.NOW_MS
+
+    @classmethod
+    def payload(cls, **relay_overrides) -> dict:
+        relay_health = {
+            "active_turn": "foreground",
+            "queue_depth": 0,
+            "tmux_alive": True,
+            "watcher_attached": True,
+            "watcher_attached_stale": False,
+            "watcher_owns_live_relay": True,
+            "last_outbound_activity_ms": cls.NOW_MS - 1,
+            "last_relay_ts_ms": cls.NOW_MS - 2,
+            "desynced": True,
+        }
+        relay_health.update(relay_overrides)
+        return {
+            "attached": True,
+            "desynced": True,
+            "bound_output_path": "/tmp/live.jsonl",
+            "relay_stall_state": "active_foreground_stream",
+            "relay_health": relay_health,
+        }
+
+    def test_parses_actual_active_foreground_schema(self):
+        probe = parse_watcher_state_probe(200, self.payload())
+        self.assertEqual(
+            probe,
+            WatcherStateProbe(
+                200,
+                True,
+                True,
+                "/tmp/live.jsonl",
+                CoverageActivityProbe(
+                    relay_stall_state="active_foreground_stream",
+                    active_turn="foreground",
+                    queue_depth=0,
+                    tmux_alive=True,
+                    watcher_attached=True,
+                    watcher_attached_stale=False,
+                    watcher_owns_live_relay=True,
+                    last_outbound_activity_ms=self.NOW_MS - 1,
+                    last_relay_ts_ms=self.NOW_MS - 2,
+                    desynced=True,
+                ),
+            ),
+        )
+
+    def test_nullable_activity_timestamps_are_valid_schema(self):
+        probe = parse_watcher_state_probe(
+            200,
+            self.payload(
+                last_outbound_activity_ms=None,
+                last_relay_ts_ms=self.NOW_MS - 1,
+            ),
+        )
+        self.assertIsNotNone(probe.relay_activity)
+        self.assertFalse(probe.relay_activity.malformed)
+        self.assertIsNone(probe.relay_activity.last_outbound_activity_ms)
+        self.assertEqual(probe.relay_activity.last_relay_ts_ms, self.NOW_MS - 1)
+
+    def test_exact_types_reject_bool_integer_and_string_boolean(self):
+        probe = parse_watcher_state_probe(
+            200,
+            self.payload(
+                queue_depth=True,
+                watcher_attached_stale="false",
+                last_outbound_activity_ms="1800000000000",
+            ),
+        )
+        self.assertIsNotNone(probe.relay_activity)
+        self.assertTrue(probe.relay_activity.malformed)
+        self.assertIsNone(probe.relay_activity.queue_depth)
+        self.assertIsNone(probe.relay_activity.watcher_attached_stale)
+        self.assertIsNone(probe.relay_activity.last_outbound_activity_ms)
+
+    def test_partial_active_schema_is_preserved_as_unknown_evidence(self):
+        probe = parse_watcher_state_probe(
+            200,
+            {
+                "attached": True,
+                "desynced": True,
+                "relay_stall_state": "active_foreground_stream",
+                "relay_health": {"active_turn": "foreground"},
+            },
+        )
+        verdict = evaluate_coverage(
+            True,
+            probe.status,
+            probe.attached,
+            probe.desynced,
+            1,
+            probe.relay_activity,
+            self.NOW_MS,
+        )
+        self.assertEqual(verdict.state, COVERAGE_UNKNOWN)
+        self.assertEqual(verdict.consecutive_uncovered, 0)
+
+    def test_legacy_schema_retains_original_desync_detection(self):
+        probe = parse_watcher_state_probe(
+            200, {"attached": True, "desynced": True}
+        )
+        self.assertIsNone(probe.relay_activity)
+        verdict = evaluate_coverage(
+            True,
+            probe.status,
+            probe.attached,
+            probe.desynced,
+            1,
+            probe.relay_activity,
+            self.NOW_MS,
+        )
+        self.assertEqual(verdict.state, COVERAGE_UNCOVERED)
+        self.assertTrue(verdict.confirmed)
+
+    def test_non_mapping_and_non_200_never_invent_activity(self):
+        self.assertEqual(parse_watcher_state_probe(200, []), WatcherStateProbe(200))
+        self.assertEqual(
+            parse_watcher_state_probe(404, self.payload()), WatcherStateProbe(404)
+        )
 
 
 class SelectorSyncEvaluationTests(unittest.TestCase):
@@ -1687,6 +1967,23 @@ class RuntimeCoverageProbeTests(unittest.TestCase):
             probe = self.make_rt().watcher_state("999")
         self.assertEqual(probe, WatcherStateProbe(200, True, False))
 
+    def test_watcher_state_wires_production_active_foreground_shape(self):
+        completed = subprocess.CompletedProcess(
+            ["curl"],
+            0,
+            stdout=json.dumps(WatcherStateParserTests.payload()) + "\n200",
+            stderr="",
+        )
+        with mock.patch.object(relay_watchdog.subprocess, "run", return_value=completed):
+            probe = self.make_rt().watcher_state("999")
+        self.assertEqual(probe.status, 200)
+        self.assertTrue(probe.attached)
+        self.assertTrue(probe.desynced)
+        self.assertEqual(
+            probe.relay_activity,
+            CoverageEvaluationTests.active_foreground(),
+        )
+
     def test_watcher_state_malformed_200_keeps_status_but_not_claims(self):
         completed = subprocess.CompletedProcess(
             ["curl"], 0, stdout='{"attached":"true"}\n200', stderr=""
@@ -1976,6 +2273,27 @@ class TickChannelTests(unittest.TestCase):
         rt.live_sessions = {expected_tmux_session_name(TICK_CHANNEL)}
         rt.watcher_probe = probe
 
+    def active_foreground_probe(self, **overrides) -> WatcherStateProbe:
+        fields = {
+            "relay_stall_state": "active_foreground_stream",
+            "active_turn": "foreground",
+            "queue_depth": 0,
+            "tmux_alive": True,
+            "watcher_attached": True,
+            "watcher_attached_stale": False,
+            "watcher_owns_live_relay": True,
+            "last_outbound_activity_ms": int(self.now * 1000) - 1,
+            "last_relay_ts_ms": int(self.now * 1000) - 2,
+            "desynced": True,
+        }
+        fields.update(overrides)
+        return WatcherStateProbe(
+            status=200,
+            attached=True,
+            desynced=True,
+            relay_activity=CoverageActivityProbe(**fields),
+        )
+
     def test_metadata_only_growth_cannot_steal_live_selection(self):
         stale_compact = self.proj_dir / "stale-compact.jsonl"
         stagnant_dir = self.projects / (
@@ -2231,6 +2549,74 @@ class TickChannelTests(unittest.TestCase):
             "actionable coverage alerts must trigger an agent turn "
             "(send-to-agent handoff), not bot-direct delivery",
         )
+
+    def test_active_foreground_desync_does_not_advance_coverage_confirmation(self):
+        rt = self.make_rt()
+        self.arm_coverage(rt, self.active_foreground_probe())
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("coverage_uncovered_ticks", state["999"])
+        self.assertNotIn("last_coverage_alert", state["999"])
+
+    def test_stale_foreground_desync_still_confirms_coverage_alert(self):
+        rt = self.make_rt()
+        stale_ms = int(self.now * 1000) - COVERAGE_ACTIVITY_FRESH_SECS * 1000
+        self.arm_coverage(
+            rt,
+            self.active_foreground_probe(
+                last_outbound_activity_ms=stale_ms,
+                last_relay_ts_ms=None,
+            ),
+        )
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
+        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+
+    def test_partial_foreground_schema_resets_confirmation_as_unknown(self):
+        rt = self.make_rt()
+        self.arm_coverage(
+            rt,
+            WatcherStateProbe(
+                status=200,
+                attached=True,
+                desynced=True,
+                relay_activity=CoverageActivityProbe(
+                    relay_stall_state="active_foreground_stream",
+                    active_turn="foreground",
+                ),
+            ),
+        )
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("coverage_uncovered_ticks", state["999"])
+        self.assertTrue(
+            any(
+                "active_foreground_evidence_incomplete" in line
+                for line in rt.log_lines
+            )
+        )
+
+    def test_active_foreground_coverage_cannot_suppress_transcript_gap(self):
+        rt = self.gap_rt()
+        self.arm_coverage(rt, self.active_foreground_probe())
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertEqual(len(rt.alerts), 1)
+        self.assertIn("릴레이 갭 감지", rt.alerts[0][0])
+        self.assertNotIn("last_coverage_alert", state["999"])
+        self.assertIn("last_alert", state["999"])
 
     def test_coverage_alert_is_suppressed_during_deploy_window(self):
         rt = self.make_rt()


### PR DESCRIPTION
Closes #4458.

## What changed

- Parse the production watcher-state activity contract from top-level `relay_stall_state` and nested `relay_health` with exact types.
- Treat `attached=true && desynced=true` as covered only for a complete active-foreground proof: foreground stream, empty queue, live tmux, attached/non-stale watcher, live-relay ownership, nested desync agreement, and activity strictly newer than 10 minutes.
- Keep the exception one-way: detached/404, explicit negative evidence, stale/missing activity, malformed/partial schemas, nested disagreement, and invalid clocks remain uncovered. Legacy payload behavior is unchanged.
- Keep coverage evaluation parallel to transcript `STATE_GAP`; foreground coverage cannot suppress lost-message detection.

## Review follow-up

Independent Fable and Opus reviews of prior head `93dc88102123090d8d483e349e441c32c60508b8` both found the same two invalid-clock defects:

- Future activity timestamps were accepted as fresh.
- Arbitrary-size JSON integers could raise `OverflowError` and skip the coverage tick.

The follow-up rejects negative ages, guards integer conversion and non-finite windows, hardens numeric validation, and adds direct plus production-shaped JSON regressions. Prior review log SHA-256: Fable `2fa581966b206d1a4708781af4cada658d86684d115e363c5a184a2a3ec7202c`; Opus `d2514ec6fcdafc88792d142abcf10eb33d803674b43a4e1d6731d30d65fa5527`.

## Exact integration boundary

- Base/main: `0dbbee0354db53ec7774bccfe47db2d03cc40daf`.
- PR head: `a360c649a757e0d501cb35476b9cc4859f4984bb`.
- Only the three intended #4458 commits are present; generated inventory docs were regenerated and unchanged.
- #4452 directory-`fstat` fail-closed behavior and its boundary tests remain intact.

## Verification on exact head

- Focused #4458 + #4452 boundary suite: **43/43 GREEN** (`685d101a48c2a5500b1ac284d00ed694d533891e69b0a8f913e9c4195dfcbff4`).
- Full watchdog + PG supervisor suite: **246/246 GREEN** (`7e4992de311ac567a6f53f088726afb2b427f2da4d21003603198e5a8562f600`).
- `scripts/ci-script-checks.sh`: **GREEN** (`c5f2d62690795bbfa8fbf4ce91f2478db99f22593c0265e9049bc3c1964dec73`).
- Clean-env `just check`: **GREEN** (`907235892a87cbd0582686b47f1ca774eb1478d3215dead69ab12833125071a8`).
- Non-build/docs/ratchet gates: **GREEN** (`fe2d8fe9d7c3ea807501710b18d016f581567097e0979976be0b4bce89cf7213`).

## Semantic mutation evidence

- Remove future timestamp rejection: **RED**, both direct and production-shape tests fail (`46b41ed840b4cdf2e6808b864ebedb5ecef5b49d2a42ec061f210eabb85a6f78`).
- Remove oversized-integer exception guard: **RED**, both direct and production-shape tests error (`39ad89456926d70e6c5dc99d490e28ac194ffa6b3edc8403e4e6ee3f70cf2359`).

## Fresh exact-head review

- Opus (slot 2): **VERDICT: CLEAN**, SHA-256 `f2c8d39ddc40e817e9f1e3fb18d1180293a3105433af391e4b76295b103cd2b9`.
- Fable (slot 1): unavailable due session limit, no verdict; log SHA-256 `6e8179c10d058a3f4c88cb5cf05315eb30e8db0cfbced5cb30cd431d1a1613dc`.

Per review fallback policy, exact-head Opus CLEAN substitutes for unavailable/no-verdict Fable.
