### PR TITLE
ci: release superseded PR runners (#4467)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,17 +14,17 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Group runs by PR head branch. Only pull_request/workflow_dispatch events
-  # reach here now, so `github.head_ref` is set for PRs; fall back to
-  # `github.ref` for manual dispatch.
-  group: ci-pr-${{ github.head_ref || github.ref }}
-  # cancel-in-progress=false: superseded runs finish instead of being
-  # cancelled. Cancelling them makes the `*_required_context` mirrors below
-  # (which run `if: always()` and FAIL CLOSED on a `cancelled` upstream)
-  # surface spurious `terminated by signal 15` / exit-143 required-check
-  # failures, forcing constant re-runs (#3927). Trade-off: extra runner
-  # minutes on rapid re-pushes; branch protection still gates the HEAD commit.
-  cancel-in-progress: false
+  # A PR number is unique inside the base repository, unlike `head_ref`: two
+  # forks can use the same source branch name and must never cancel each other.
+  # Manual dispatch has no PR payload, so isolate it by the selected ref.
+  group: ci-pr-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  # A newer push makes every result from the older SHA stale, so release its
+  # hosted runners immediately. The `*_required_context` mirrors remain
+  # fail-closed: cancellation may leave failed/cancelled contexts on the OLD
+  # SHA, while branch protection still requires fresh green contexts on the
+  # newest exact HEAD SHA. Manual cancellation of the newest run therefore
+  # remains blocking until that exact SHA is rerun successfully.
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -380,6 +380,13 @@ jobs:
     # on the nightly full macOS/Windows matrix.
     if: needs.changes.outputs.rust_compile == 'true' && needs.changes.outputs.cross_os_rust == 'true'
     runs-on: ${{ matrix.os }}
+    env:
+      # Cross-OS failures need compiler/test diagnostics, not native debug
+      # symbols. Windows spends most of this lane compiling and linking test
+      # harnesses; stripping debuginfo preserves every target and test while
+      # reducing the critical path and peak linker memory.
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     strategy:
       fail-fast: false
       matrix:
@@ -438,6 +445,11 @@ jobs:
       # signal, while fmt/staged clippy and full workspace checks are
       # authoritative in the Ubuntu jobs above.
       - name: cargo check
+        shell: bash
+        env:
+          BASH_ENV: /dev/null
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
         run: cargo check --workspace --all-targets
 
       - name: cargo test (non-PG, targeted subset)
@@ -445,6 +457,10 @@ jobs:
         # known test/runner flakes must not paint the PR red. See #4202/#4423.
         continue-on-error: true
         shell: bash
+        env:
+          BASH_ENV: /dev/null
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
         run: |
           set -euo pipefail
           cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
@@ -547,6 +563,11 @@ jobs:
       PGPORT: "5432"
       PGUSER: postgres
       PGPASSWORD: postgres
+      # Preserve the full serial PostgreSQL suite while reducing cold-link
+      # time and memory exposure on hosted runners. Assertions and panic text
+      # remain available; only native debug symbols are omitted.
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@v4
 
@@ -580,6 +601,11 @@ jobs:
 
       - name: just test-postgres
         timeout-minutes: 20
+        shell: bash
+        env:
+          BASH_ENV: /dev/null
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
         run: just test-postgres
 
       - name: Stop PostgreSQL service

--- a/scripts/check-ci-runner-hardening.sh
+++ b/scripts/check-ci-runner-hardening.sh
@@ -8,10 +8,218 @@ error() {
   fail=1
 }
 
+validate_pr_debug_envs() {
+  if ! command -v ruby >/dev/null 2>&1; then
+    error "ruby is required to validate $pr_workflow structurally"
+    return
+  fi
+
+  # Parse the workflow as YAML instead of slicing it as text. That keeps
+  # quoted job IDs, flow mappings, escaped keys, and sibling job mappings from
+  # satisfying a different job's requirement. Each protected cargo step must
+  # also pin the exact values, disable BASH_ENV startup hooks, and retain the
+  # exact command inventory; all other step-level copies are rejected.
+  if ! ruby - "$pr_workflow" <<'RUBY'
+require "yaml"
+require "json"
+require "digest"
+
+def canonical_yaml(value)
+  case value
+  when Hash
+    value.keys.sort_by(&:to_s).each_with_object({}) do |key, canonical|
+      canonical[key.to_s] = canonical_yaml(value[key])
+    end
+  when Array
+    value.map { |item| canonical_yaml(item) }
+  else
+    value
+  end
+end
+
+path = ARGV.fetch(0)
+begin
+  document = YAML.load_file(path)
+rescue StandardError => error
+  warn "#{path}: cannot parse YAML: #{error.message}"
+  exit 1
+end
+
+jobs = document.is_a?(Hash) ? document["jobs"] : nil
+unless jobs.is_a?(Hash)
+  warn "#{path}: jobs must be a YAML mapping"
+  exit 1
+end
+
+expected_concurrency = {
+  "group" => 'ci-pr-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}',
+  "cancel-in-progress" => true,
+}
+unless document["concurrency"] == expected_concurrency
+  warn "#{path}: top-level concurrency must retain the exact fork-safe cancellation policy"
+  exit 1
+end
+
+targets = {
+  "check_fast_cross_os" => {
+    "label" => "cross-OS job",
+    "name" => 'Fast check + non-PG tests (${{ matrix.os }})',
+    "needs" => "changes",
+    "if" => "needs.changes.outputs.rust_compile == 'true' && needs.changes.outputs.cross_os_rust == 'true'",
+    "runs_on" => '${{ matrix.os }}',
+    "job_sha256" => "86234055c69ae2aaf94b10e968a466dde8761a4dc6433dd3beeb3de300f59a33",
+    "cargo_steps" => {
+      "cargo check" => {
+        "commands" => ["cargo check --workspace --all-targets"],
+        "continue_on_error" => nil,
+        "timeout_minutes" => nil,
+      },
+      "cargo test (non-PG, targeted subset)" => {
+        "commands" => [
+          "set -euo pipefail",
+          "cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1",
+          "cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres",
+          "cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres",
+          "cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres",
+          "cargo test --all-targets stall_recovery -- --skip _pg --skip pg_ --skip postgres",
+          "env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres",
+          "python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres",
+          "cargo test --all-targets routines -- --skip _pg --skip pg_ --skip postgres",
+          "cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres",
+        ],
+        "continue_on_error" => true,
+        "timeout_minutes" => nil,
+      },
+    },
+  },
+  "test_fast" => {
+    "label" => "PostgreSQL job",
+    "name" => "PostgreSQL tests (ubuntu-postgres)",
+    "needs" => "changes",
+    "if" => "needs.changes.outputs.pg_db == 'true'",
+    "runs_on" => "ubuntu-latest",
+    "job_sha256" => "7dd44900af3595344bc0156f378d2bfe8d11c8434adf223f0d76b78817036050",
+    "cargo_steps" => {
+      "just test-postgres" => {
+        "commands" => ["just test-postgres"],
+        "continue_on_error" => nil,
+        "timeout_minutes" => 20,
+      },
+    },
+  },
+}
+keys = %w[CARGO_PROFILE_DEV_DEBUG CARGO_PROFILE_TEST_DEBUG]
+protected_step_env = {
+  "BASH_ENV" => "/dev/null",
+  "CARGO_PROFILE_DEV_DEBUG" => "0",
+  "CARGO_PROFILE_TEST_DEBUG" => "0",
+}
+errors = []
+
+targets.each do |job_id, spec|
+  label = spec.fetch("label")
+  job = jobs[job_id]
+  unless job.is_a?(Hash)
+    errors << "#{label} (#{job_id}) must be a YAML mapping"
+    next
+  end
+
+  job_sha256 = Digest::SHA256.hexdigest(JSON.generate(canonical_yaml(job)))
+  unless job_sha256 == spec.fetch("job_sha256")
+    errors << "#{label} semantic structure or command inventory changed"
+  end
+
+  {
+    "name" => spec.fetch("name"),
+    "needs" => spec.fetch("needs"),
+    "if" => spec.fetch("if"),
+    "runs-on" => spec.fetch("runs_on"),
+  }.each do |field, expected|
+    errors << "#{label} must retain exact #{field}" unless job[field] == expected
+  end
+  errors << "#{label} must not be allowed to continue on error" unless job["continue-on-error"].nil?
+  if job_id == "check_fast_cross_os"
+    strategy = job["strategy"]
+    unless strategy.is_a?(Hash)
+      errors << "#{label} must retain its matrix strategy"
+    else
+      errors << "#{label} matrix must fail independently" unless strategy["fail-fast"] == false
+      errors << "#{label} must retain the Windows matrix" unless strategy.dig("matrix", "os") == ["windows-latest"]
+    end
+  end
+
+  env = job["env"]
+  keys.each do |key|
+    unless env.is_a?(Hash) && env[key] == "0"
+      errors << "#{label} must set job-level #{key} to the string \"0\""
+    end
+
+  end
+
+  expected_steps = spec.fetch("cargo_steps")
+  seen_steps = []
+  Array(job["steps"]).each_with_index do |step, index|
+    next unless step.is_a?(Hash)
+
+    name = step["name"]
+    run = step["run"]
+    step_env = step["env"]
+    if expected_steps.key?(name)
+      step_spec = expected_steps.fetch(name)
+      seen_steps << name
+      unless run.is_a?(String)
+        errors << "#{label} #{name.inspect} must use a shell run block"
+        next
+      end
+      unless step["shell"] == "bash"
+        errors << "#{label} #{name.inspect} must use explicit bash"
+      end
+      errors << "#{label} #{name.inspect} must not be conditionally skipped" unless step["if"].nil?
+      unless step["continue-on-error"] == step_spec.fetch("continue_on_error")
+        errors << "#{label} #{name.inspect} must retain exact continue-on-error policy"
+      end
+      unless step["timeout-minutes"] == step_spec.fetch("timeout_minutes")
+        errors << "#{label} #{name.inspect} must retain exact timeout policy"
+      end
+      unless step_env == protected_step_env
+        errors << "#{label} #{name.inspect} must pin exact step env and disable BASH_ENV"
+      end
+      lines = run.lines.map(&:strip).reject(&:empty?)
+      unless lines == step_spec.fetch("commands")
+        errors << "#{label} #{name.inspect} must retain the exact cargo/test command list"
+      end
+    else
+      forbidden = keys + ["BASH_ENV"]
+      forbidden.each do |key|
+        errors << "#{label} step #{index + 1} must not set #{key}" if step_env.is_a?(Hash) && step_env.key?(key)
+        errors << "#{label} step #{index + 1} must not mutate #{key} at runtime" if run.is_a?(String) && run.include?(key)
+      end
+      if run.is_a?(String) && run.match?(/(^|[[:space:]])cargo[[:space:]]|(^|[[:space:]])just[[:space:]]+test-postgres/)
+        errors << "#{label} step #{index + 1} adds an unprotected cargo/test boundary"
+      end
+    end
+  end
+  expected_steps.each_key do |name|
+    errors << "#{label} must retain exactly one #{name.inspect} step" unless seen_steps.count(name) == 1
+  end
+end
+
+errors.each { |message| warn "#{path}: #{message}" }
+exit(errors.empty? ? 0 : 1)
+RUBY
+  then
+    error "$pr_workflow must preserve target-job debug stripping without step overrides"
+  fi
+}
+
 trusted_workflow=".github/workflows/ci-macos-trusted.yml"
+pr_workflow=".github/workflows/ci-pr.yml"
 
 if [ ! -f "$trusted_workflow" ]; then
   error "missing $trusted_workflow"
+fi
+if [ ! -f "$pr_workflow" ]; then
+  error "missing $pr_workflow"
 fi
 
 for workflow in .github/workflows/*.yml; do
@@ -44,6 +252,13 @@ if [ -f "$trusted_workflow" ]; then
     || error "$trusted_workflow must have a merge_group trigger"
   grep -q 'MACOS_RUNNER_GROUP' "$trusted_workflow" \
     || error "$trusted_workflow must require MACOS_RUNNER_GROUP for self-hosted routing"
+fi
+
+# Superseded PR heads must release hosted runners immediately. Required
+# contexts remain fail-closed on the newest exact SHA; branch protection never
+# consumes the cancelled stale SHA's results.
+if [ -f "$pr_workflow" ]; then
+  validate_pr_debug_envs
 fi
 
 exit "$fail"


### PR DESCRIPTION
## Summary

- cancel superseded PR workflow runs using a fork-safe repository + PR-number concurrency key, with ref fallback for manual dispatch
- preserve every required context and exact test target while disabling native Rust debug symbols only in the Windows cross-OS and PostgreSQL hosted jobs
- validate exact top-level concurrency and canonical whole-job semantic fingerprints for both protected jobs, including strategy, step order/config, exact commands, env, shell, skip/failure policy, and action wiring

## Evidence

- pushing replacement heads live-cancelled stale same-PR workflows, proving supersession
- exact step env fixes both debug values at `"0"` and `BASH_ENV=/dev/null`; every original cargo/just command remains byte-semantically identical
- 34 adversarial classes fail closed: nested concurrency decoys, matrix exclude/include replacement, quoted/hidden extra cargo boundaries, job/step if or continue-on-error, command deletion/reorder/addition, BASH_ENV poisoning, Unicode/flow/cross-job/alias variants, wrong env types/values
- independent canonical SHA recomputation matches both baked job fingerprints; semantically identical flow YAML remains accepted
- hardening, bash syntax, actionlint, diff check and full `scripts/ci-script-checks.sh` GREEN
- exact local dual review: Codex CLEAN + Opus via cswap account1 CLEAN; remote CI launched only after both clean verdicts

Exact candidate: `78a6760653dadf6b7c21773761c7f8c26e2262b6`.

Resolves #4467.
