### PR TITLE
perf(auto-queue): reduce recovery scans and dispatch clones

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -349,7 +349,7 @@
 | `services::auto_queue::command` | `src/services/auto_queue/command.rs` | 426 | 426 | 0 |  |
 | `services::auto_queue::control_routes` | `src/services/auto_queue/control_routes.rs` | 906 | 854 | 52 |  |
 | `services::auto_queue::dispatch_assignment_command` | `src/services/auto_queue/dispatch_assignment_command.rs` | 101 | 101 | 0 |  |
-| `services::auto_queue::dispatch_command` | `src/services/auto_queue/dispatch_command.rs` | 908 | 908 | 0 |  |
+| `services::auto_queue::dispatch_command` | `src/services/auto_queue/dispatch_command.rs` | 906 | 906 | 0 |  |
 | `services::auto_queue::dispatch_query` | `src/services/auto_queue/dispatch_query.rs` | 93 | 93 | 0 |  |
 | `services::auto_queue::fsm` | `src/services/auto_queue/fsm.rs` | 713 | 693 | 20 |  |
 | `services::auto_queue::order_routes` | `src/services/auto_queue/order_routes.rs` | 295 | 295 | 0 |  |

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -133,9 +133,10 @@ test("auto-queue onTick1min honors stale dispatched runtime config", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
-            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
-            sql.includes(") ASC LIMIT 50");
+            sql.includes("JOIN LATERAL (") &&
+            sql.includes("WHERE e.run_id = r.id AND e.status = 'pending'") &&
+            sql.includes("ORDER BY e.updated_at ASC LIMIT 1") &&
+            sql.includes("ORDER BY oldest_pending.updated_at ASC LIMIT 50");
         },
         result: []
       },
@@ -237,9 +238,10 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
-            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
-            sql.includes(") ASC LIMIT 50");
+            sql.includes("JOIN LATERAL (") &&
+            sql.includes("WHERE e.run_id = r.id AND e.status = 'pending'") &&
+            sql.includes("ORDER BY e.updated_at ASC LIMIT 1") &&
+            sql.includes("ORDER BY oldest_pending.updated_at ASC LIMIT 50");
         },
         result: []
       },
@@ -298,8 +300,10 @@ test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
-            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e");
+            sql.includes("JOIN LATERAL (") &&
+            sql.includes("WHERE e.run_id = r.id AND e.status = 'pending'") &&
+            sql.includes("ORDER BY e.updated_at ASC LIMIT 1") &&
+            sql.includes("ORDER BY oldest_pending.updated_at ASC LIMIT 50");
         },
         result: []
       },
@@ -340,9 +344,10 @@ test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
-            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
-            sql.includes(") ASC LIMIT 50");
+            sql.includes("JOIN LATERAL (") &&
+            sql.includes("WHERE e.run_id = r.id AND e.status = 'pending'") &&
+            sql.includes("ORDER BY e.updated_at ASC LIMIT 1") &&
+            sql.includes("ORDER BY oldest_pending.updated_at ASC LIMIT 50");
         },
         result: [{ id: "run-saturated" }]
       },
@@ -382,9 +387,10 @@ test("auto-queue does not rotate deferred active run activations", () => {
       {
         match(sql) {
           return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
-            sql.includes("WHERE r.status = 'active' AND EXISTS (") &&
-            sql.includes("SELECT MIN(e.updated_at) FROM auto_queue_entries e") &&
-            sql.includes(") ASC LIMIT 50");
+            sql.includes("JOIN LATERAL (") &&
+            sql.includes("WHERE e.run_id = r.id AND e.status = 'pending'") &&
+            sql.includes("ORDER BY e.updated_at ASC LIMIT 1") &&
+            sql.includes("ORDER BY oldest_pending.updated_at ASC LIMIT 50");
         },
         result: [{ id: "run-deferred" }]
       },

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -523,16 +523,19 @@ var autoQueue = {
     // #815: `user_cancelled` entries are deliberately excluded here — they
     // represent an explicit operator stop and must never be resurrected by
     // the tick. Only `pending` entries are re-dispatchable.
+    // The lateral LIMIT 1 lets (run_id, status, updated_at) serve one oldest-row
+    // lookup per run instead of aggregating every pending entry.
     var activeRuns = agentdesk.db.query(
       "SELECT r.id " +
       "FROM auto_queue_runs r " +
-      "WHERE r.status = 'active' AND EXISTS (" +
-      "  SELECT 1 FROM auto_queue_entries e " +
-      "  WHERE e.run_id = r.id AND e.status = 'pending'" +
-      ") ORDER BY (" +
-      "  SELECT MIN(e.updated_at) FROM auto_queue_entries e " +
-      "  WHERE e.run_id = r.id AND e.status = 'pending'" +
-      ") ASC LIMIT 50",
+      "JOIN LATERAL (" +
+      "  SELECT e.updated_at " +
+      "  FROM auto_queue_entries e " +
+      "  WHERE e.run_id = r.id AND e.status = 'pending' " +
+      "  ORDER BY e.updated_at ASC LIMIT 1" +
+      ") oldest_pending ON TRUE " +
+      "WHERE r.status = 'active' " +
+      "ORDER BY oldest_pending.updated_at ASC LIMIT 50",
       []
     );
 

--- a/src/services/auto_queue/dispatch_command.rs
+++ b/src/services/auto_queue/dispatch_command.rs
@@ -642,13 +642,12 @@ pub(super) fn build_group_plan(cards: &[GenerateCandidate]) -> GroupPlan {
         components.entry(root).or_default().push(idx);
     }
 
-    let mut component_roots: Vec<usize> = components.keys().copied().collect();
-    component_roots
-        .sort_by_key(|root| components[root].iter().copied().min().unwrap_or(usize::MAX));
+    let mut component_members: Vec<Vec<usize>> = components.into_values().collect();
+    component_members.sort_by_key(|members| members.iter().copied().min().unwrap_or(usize::MAX));
+    let thread_group_count = component_members.len() as i64;
 
     let mut planned_entries = Vec::with_capacity(n);
-    for (group_num, root) in component_roots.iter().enumerate() {
-        let mut members = components[root].clone();
+    for (group_num, mut members) in component_members.into_iter().enumerate() {
         members.sort_by_key(|idx| planning_sort_key(&cards[*idx], *idx));
         let member_set: HashSet<usize> = members.iter().copied().collect();
 
@@ -815,7 +814,6 @@ pub(super) fn build_group_plan(cards: &[GenerateCandidate]) -> GroupPlan {
         planned.batch_phase = batch_phase_by_idx[planned.card_idx];
     }
 
-    let thread_group_count = component_roots.len() as i64;
     let recommended_parallel_threads = if thread_group_count <= 1 {
         1
     } else {


### PR DESCRIPTION
## 목표

Auto-queue의 주기 복구 조회가 pending entry 전체를 반복 집계하지 않도록 하고, Rust dispatch group 계획에서 component member vector를 불필요하게 복제하지 않도록 최적화합니다. 기존 정렬·그룹 수·dispatch 결과는 그대로 유지합니다.

## 쉬운 설명

Auto-queue가 오래 실행되고 pending 항목이 많아질수록 복구 스캔 비용이 커질 수 있었습니다. 각 run에서 가장 오래된 pending 한 건만 인덱스 친화적으로 찾고, 이미 만든 그룹 목록은 복사하지 않고 소유권으로 소비합니다. 사용자가 보는 큐 순서와 병렬 그룹 결과는 바뀌지 않습니다.

## 개선되는 것

### Fix 1 — 복구 조회의 중복 스캔 제거

- 기존 `EXISTS`와 correlated `MIN(updated_at)` 조합을 `JOIN LATERAL (... ORDER BY updated_at LIMIT 1)`로 바꿉니다.
- run별 oldest pending lookup을 한 번만 수행하고 그 결과로 최대 50개 run을 정렬합니다.

### Fix 2 — dispatch 계획 vector clone 제거

- HashMap의 component vector를 `into_values()`로 소유권 이동합니다.
- 정렬 후 각 member vector를 그대로 소비해 group별 clone을 없앱니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| pending이 많은 active run 스캔 | 존재 확인 후 MIN 집계를 별도 수행 | run별 oldest row 한 건만 lookup |
| component group 계획 | root 목록 생성 후 member vector clone | member vector를 ownership으로 직접 소비 |
| 결과 순서 | 최소 card index 기준 | 동일 기준 유지 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| pending entry가 없는 run | LATERAL inner join 결과에서 제외 | 기존 EXISTS 동작과 동일 |
| 동일 updated_at | DB가 반환한 run 순서를 따름 | 기존 쿼리도 동일한 tie 특성 |
| component member 정렬 | 기존 planning sort key 재사용 | dispatch 결과 불변 |
| group 0개/1개 | 기존 thread count 계산 유지 | 병렬도 계약 불변 |

## 해결한 내용

- `policies/auto-queue.js`: active run oldest-pending 조회를 LATERAL LIMIT 1로 변경
- `policies/__tests__/auto-queue.test.js`: 새 SQL shape와 기존 복구 동작 검증
- `src/services/auto_queue/dispatch_command.rs`: component vector ownership 소비
- 생성 module inventory 동기화

## 검증

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `npm run test:policies` — 181 passed
- `python3 scripts/generate_inventory_docs.py --check`
- `git diff --check`

## 포트 메모

최신 upstream `97a4e2888` 기준으로 리베이스했으며, 예약 메시지 PR과 파일·동작 의존성이 없는 독립 PR입니다.
