### PR TITLE
refactor(git): reuse shared tilde path expansion

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -906,7 +906,7 @@
 | `services::git::branch_resolver` | `src/services/git/branch_resolver.rs` | 123 | 123 | 0 |  |
 | `services::git::commit_resolver` | `src/services/git/commit_resolver.rs` | 378 | 357 | 21 |  |
 | `services::git::remote` | `src/services/git/remote.rs` | 16 | 16 | 0 |  |
-| `services::git::repo_resolver` | `src/services/git/repo_resolver.rs` | 283 | 251 | 32 |  |
+| `services::git::repo_resolver` | `src/services/git/repo_resolver.rs` | 272 | 240 | 32 |  |
 | `services::git::runner` | `src/services/git/runner.rs` | 426 | 398 | 28 |  |
 | `services::git::worktree_resolver` | `src/services/git/worktree_resolver.rs` | 467 | 451 | 16 |  |
 | `services::github_issue_creation` | `src/services/github_issue_creation.rs` | 682 | 520 | 162 |  |

--- a/src/services/git/repo_resolver.rs
+++ b/src/services/git/repo_resolver.rs
@@ -57,15 +57,6 @@ pub fn resolve_repo_dir() -> Option<String> {
     legacy.map(|p| p.to_string_lossy().into_owned())
 }
 
-fn expand_tilde(path: &str) -> String {
-    if path == "~" || path.starts_with("~/") {
-        if let Some(expanded) = crate::runtime_layout::expand_user_path(path) {
-            return expanded.to_string_lossy().into_owned();
-        }
-    }
-    path.to_string()
-}
-
 pub(crate) fn looks_like_explicit_repo_path(raw: &str) -> bool {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -130,8 +121,7 @@ fn configured_repo_dir(repo_id: &str) -> Option<String> {
         return None;
     }
 
-    let expanded = expand_tilde(raw);
-    let path = PathBuf::from(expanded);
+    let path = crate::utils::format::expand_tilde_path(raw);
     let resolved = if path.is_relative() {
         base_dir.join(path)
     } else {
@@ -231,8 +221,7 @@ pub fn resolve_repo_dir_for_target(target_repo: Option<&str>) -> Result<Option<S
     };
 
     if looks_like_explicit_repo_path(requested) {
-        let expanded = expand_tilde(requested);
-        let path = PathBuf::from(expanded);
+        let path = crate::utils::format::expand_tilde_path(requested);
         let resolved = if path.is_relative() {
             std::env::current_dir()
                 .map_err(|e| format!("cannot resolve repo path '{}': {}", requested, e))?


### PR DESCRIPTION
## 목표

git repository resolver의 중복 tilde 확장 구현을 제거하고 이미 사용 중인 공용 path helper로 통합해 코드 재사용성과 동작 일관성을 높입니다.

## 쉬운 설명

repo 경로의 `~`를 홈 디렉터리로 바꾸는 코드가 resolver 안에 따로 있었습니다. 같은 규칙을 제공하는 공용 helper를 사용하도록 바꿔, 경로 규칙을 한 곳에서 관리합니다.

## 개선되는 것

- 로컬 `expand_tilde` 함수 9줄을 제거합니다.
- config 기반 repo 경로와 명시적 repo 경로가 공용 `expand_tilde_path`를 재사용합니다.
- 다른 migrate 경로 처리와 동일한 확장 규칙을 사용합니다.
- public API나 config 형식은 바뀌지 않습니다.

## Before → After

| 항목 | Before | After |
|---|---|---|
| tilde 확장 소유권 | repo resolver의 로컬 함수 + 공용 함수 | 공용 함수 한 곳 |
| `~`, `~/...` | runtime layout을 통해 확장 | 동일 |
| `~user/...` 및 일반 경로 | 원문 유지 | 동일 |
| 반환 처리 | String→PathBuf 변환 | helper가 PathBuf 직접 반환 |

## 사이드 이펙트 시뮬레이션

| 입력 | 결과 |
|---|---|
| `~/workspace` | 기존과 동일하게 홈 기준 절대 경로 |
| 상대 경로 | 기존과 동일하게 config/current directory 기준 결합 |
| `~other/path` | 기존과 동일하게 확장하지 않음 |
| HOME 확장 불가 | 기존과 동일하게 원래 경로 유지 |

## 해결한 내용

- `src/services/git/repo_resolver.rs`의 중복 helper 제거
- `configured_repo_dir`와 `resolve_repo_dir_for_target`가 `crate::utils::format::expand_tilde_path` 재사용
- module inventory 재생성

## 검증

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test --lib no_repo_mapping_classification_tests` — 2 passed
- `python3 scripts/generate_inventory_docs.py --check`
- `git diff --check upstream/main...HEAD`
- 최신 upstream `97a4e2888` 기준

- [x] **Scratch file cleanup:** `git status --short`와 `git diff --check` 확인
