### PR TITLE
ci: reject root verify.sh scratch files

### DIFF
--- a/scripts/analyze_prs.py
+++ b/scripts/analyze_prs.py
@@ -194,6 +194,7 @@ def is_scratch_file_path(path):
         "test.sh",
         "test.sql",
         "test_scratch.rs",
+        "verify.sh",
     }
     if path in root_scratch_files:
         return True

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -95,7 +95,7 @@ echo "=== Relay recovery targeted-lane wiring contract (#4423) ==="
 
 echo "=== Scratch file guard ==="
 FAIL=0
-for scratch_file in plan.md scratch.md scratch.txt scratch.sh scratchpad.md scratchpad.txt scratchpad.sh sql_test.rs test_scratch.rs plan.txt pr-body.md test.sh test.sql; do
+for scratch_file in plan.md scratch.md scratch.txt scratch.sh scratchpad.md scratchpad.txt scratchpad.sh sql_test.rs test_scratch.rs plan.txt pr-body.md test.sh test.sql verify.sh; do
   if [ -f "$scratch_file" ]; then
     echo "ERROR: Scratch file detected in repository root: $scratch_file"
     FAIL=1

--- a/tests/test_analyze_prs.py
+++ b/tests/test_analyze_prs.py
@@ -377,6 +377,7 @@ class PrAnalyzerScratchPathTests(unittest.TestCase):
         self.assertTrue(is_scratch_file_path("scratchpad.sh"))
         self.assertTrue(is_scratch_file_path("scratch-check.sql"))
         self.assertTrue(is_scratch_file_path("test_cli.rs"))
+        self.assertTrue(is_scratch_file_path("verify.sh"))
 
     def test_checked_in_scripts_and_migrations_are_not_scratch(self):
         self.assertFalse(is_scratch_file_path("scripts/deploy-release.sh"))
@@ -394,6 +395,7 @@ class CiScriptScratchGuardTests(unittest.TestCase):
         script = Path("scripts/ci-script-checks.sh").read_text()
 
         self.assertIn("scratch.sh", script)
+        self.assertIn("verify.sh", script)
         self.assertIn("scratchpad.sh", script)
         self.assertIn("scratch[._-]*.sh", script)
         self.assertIn("scratchpad[._-]*.sh", script)


### PR DESCRIPTION
## 목표

로컬 검증용으로 흔히 만들어지는 루트 `verify.sh`가 실수로 커밋·PR에 포함되는 것을 CI와 PR 분석기 양쪽에서 차단합니다.

## 쉬운 설명

임시 검증 스크립트 이름이 `verify.sh`인 경우 기존 scratch-file 목록에 걸리지 않았습니다. 이제 저장소 루트의 해당 파일을 임시 파일로 판정해 체크인 누락 청소를 자동으로 잡습니다.

## 개선되는 것

- PR 분석기가 루트 `verify.sh`를 scratch file로 분류합니다.
- CI scratch guard도 같은 파일을 직접 차단합니다.
- 두 경로가 동일 계약을 지키는지 regression test로 고정합니다.

## Before → After

| 상황 | Before | After |
|---|---|---|
| 루트 `verify.sh` 포함 | scratch 검사 통과 가능 | PR 분석·CI 모두 탐지 |
| `scripts/`의 정식 스크립트 | 허용 | 그대로 허용 |
| 기존 scratch 이름 | 차단 | 그대로 차단 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 결과 |
|---|---|
| 개발자가 루트에 임시 `verify.sh` 생성 | 커밋 전에 CI가 명확히 실패 |
| 정식 검증 스크립트를 추가해야 함 | `scripts/` 아래 의미 있는 이름으로 추가 가능 |
| 기존 저장소 상태 | 루트 `verify.sh`가 없어 통과 |
| PR analyzer와 shell guard drift | 단위 테스트가 두 목록의 포함 여부를 고정 |

## 해결한 내용

- `scripts/analyze_prs.py` scratch 목록에 `verify.sh` 추가
- `scripts/ci-script-checks.sh` 루트 파일 guard에 동일 항목 추가
- `tests/test_analyze_prs.py` regression assertions 추가

## 검증

- `python3 -m unittest tests.test_analyze_prs` — 52 passed
- `AGENTDESK_MIGRATION_GUARD_BASE_REF=upstream/main ./scripts/ci-script-checks.sh` — 전체 통과
- `git diff --check upstream/main...HEAD`
- 최신 upstream `97a4e2888` 기준

- [x] **Scratch file cleanup:** `git status --short`와 `git diff --check` 확인
