### PR TITLE
fix(discord): preserve session banner claim across turn cleanup

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -555,7 +555,7 @@
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3467 | 1180 | 2287 | giant-file |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 686 | 424 | 262 |  |
 | `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 941 | 573 | 368 |  |
-| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 647 | 647 | 0 |  |
+| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 654 | 654 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |
@@ -565,7 +565,7 @@
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
 | `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 791 | 791 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 774 | 774 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 787 | 787 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_panel` | `src/services/discord/placeholder_live_events/subagent_panel.rs` | 368 | 318 | 50 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 531 | 356 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -130,7 +130,14 @@ impl PlaceholderLiveEvents {
                 // entry alive when it carries one even with no footer residuals,
                 // otherwise the whole entry (and the anchor) would be dropped here
                 // before the turn renders its request link.
-                has_residuals || guard.request_user_msg_id.is_some()
+                // #4451: the one-shot session-banner claim is likewise scoped to
+                // the live session, not the turn. A 30s recovery redrive performs
+                // this cleanup while the same session is still alive, so retain
+                // the entry until a full channel clear or a new identity replaces
+                // the claim.
+                has_residuals
+                    || guard.request_user_msg_id.is_some()
+                    || guard.has_session_banner_claim()
             });
         if !keep_entry {
             self.status_by_channel.remove(&channel_id);

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -218,9 +218,22 @@ impl StatusPanelState {
             // #3391: carry the counter so a residual ordinal is never reissued.
             next_slot_ordinal: self.next_slot_ordinal,
             request_user_msg_id: self.request_user_msg_id, // #3811: survive turn reset
+            // #4451: this claim is session-scoped, not turn-scoped. The health
+            // redrive path can run ordinary turn cleanup every 30 seconds while
+            // the same tmux/provider session remains alive. Dropping the claim
+            // here re-posted the same one-shot banner on every redrive.
+            session_banner_emitted_key: self.session_banner_emitted_key.clone(),
             ..StatusPanelState::default()
         };
         has_residuals
+    }
+
+    /// #4451: a claimed session banner is durable turn bookkeeping. Keep the
+    /// channel state entry across ordinary turn cleanup even when it carries no
+    /// footer residuals or request anchor, otherwise removing the entry would
+    /// discard the preserved claim immediately.
+    pub(super) fn has_session_banner_claim(&self) -> bool {
+        self.session_banner_emitted_key.is_some()
     }
 
     pub(super) fn apply(&mut self, event: StatusEvent) {

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1580,6 +1580,76 @@ fn session_banner_reemits_once_on_new_session_boundary() {
     );
 }
 
+/// #4451 — stall-watchdog recovery can perform the normal turn cleanup every
+/// 30 seconds while the tmux/provider session remains alive. That cleanup must
+/// not discard the session-scoped banner claim and re-post the same banner on
+/// every lifecycle refresh.
+#[test]
+fn session_banner_claim_survives_repeated_turn_cleanup_redrive() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(44_510);
+    let instance_key = "AgentDesk-codex-ch4451#stable-spawn";
+    let details = json!({
+        "provider_session_id": "session-stable",
+        "tmux_reused": true
+    });
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_some(),
+        "the live session gets its initial one-shot banner"
+    );
+
+    // Match the incident's repeated 30-second cleanup/redrive cadence. Each
+    // refresh restores the same lifecycle snapshot after turn-local state was
+    // cleared; none may re-arm the already-claimed session banner.
+    for redrive in 1..=12 {
+        events.clear_channel_preserving_footer_residuals(channel_id);
+        let _ = events.set_session_panel_lifecycle_event(
+            channel_id,
+            Some(instance_key),
+            "session_resumed",
+            &details,
+        );
+        assert!(
+            events
+                .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+                .is_none(),
+            "same-session redrive #{redrive} must not re-post the banner"
+        );
+    }
+
+    // The retained claim must not suppress a genuine new session identity.
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some("AgentDesk-codex-ch4451#new-spawn"),
+        "session_fresh",
+        &json!({
+            "provider_session_id": "session-new",
+            "tmux_reused": false
+        }),
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_some(),
+        "a genuine new session identity still re-arms the banner"
+    );
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_none(),
+        "the new session remains one-shot"
+    );
+}
+
 /// #3983 item4 — with no live tmux marker (`session_instance_key == None`) the
 /// dedup falls back to the provider session id, so a headless session still
 /// banners exactly once and a genuinely different provider session re-arms it.

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1650,6 +1650,301 @@ fn session_banner_claim_survives_repeated_turn_cleanup_redrive() {
     );
 }
 
+#[test]
+fn issue_4451_full_channel_clear_drops_the_session_banner_claim() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(44_511);
+    let instance_key = "AgentDesk-codex-ch4451#full-clear";
+    let details = json!({
+        "provider_session_id": "session-full-clear",
+        "tmux_reused": true
+    });
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_some()
+    );
+
+    events.clear_channel(channel_id);
+    assert!(
+        events.status_by_channel.get(&channel_id).is_none(),
+        "a full generation clear must remove the channel-scoped claim"
+    );
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_some(),
+        "after a full clear the next lifecycle snapshot owns a fresh claim"
+    );
+}
+
+#[test]
+fn issue_4451_turn_reset_preserves_only_claim_not_stale_panel_content() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(44_512);
+    let instance_key = "AgentDesk-claude-ch4451#claim-only";
+    let details = json!({
+        "provider_session_id": "session-claim-only",
+        "tmux_reused": true
+    });
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_some()
+    );
+    events.set_task_panel_info(
+        channel_id,
+        TaskPanelInfo {
+            dispatch_id: "dispatch-stale-4451",
+            card_id: Some("CARD-4451"),
+            dispatch_type: Some("issue"),
+            owner_instance_id: Some("mac-book-release"),
+            card_title: Some("stale task 4451"),
+            dispatch_title: None,
+            github_issue_number: Some(4451),
+        },
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use(
+            "TodoWrite",
+            &json!({
+                "todos": [{"content": "stale todo 4451", "status": "in_progress"}]
+            })
+            .to_string(),
+        ),
+    );
+    events.push_status_event(
+        channel_id,
+        StatusEvent::WorkflowStart {
+            task_id: Some("workflow-stale-4451".to_string()),
+            name: Some("stale workflow 4451".to_string()),
+        },
+    );
+    let before = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(before.contains("stale task 4451"));
+    assert!(before.contains("stale todo 4451"));
+    assert!(before.contains("stale workflow 4451"));
+
+    events.clear_channel_preserving_footer_residuals(channel_id);
+    {
+        let entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("the session-scoped banner claim keeps the entry alive");
+        let guard = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            guard.session.is_none(),
+            "turn reset must drop the stale session snapshot"
+        );
+        assert!(
+            guard.task.is_none(),
+            "turn reset must drop stale task metadata"
+        );
+        assert!(
+            guard.workflows.is_empty(),
+            "turn reset must drop stale workflow slots: {:?}",
+            guard.workflows
+        );
+    }
+    let after = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(
+        !after.contains("stale task 4451"),
+        "stale task survived: {after}"
+    );
+    assert!(
+        !after.contains("stale todo 4451"),
+        "stale todo survived: {after}"
+    );
+    assert!(
+        !after.contains("stale workflow 4451"),
+        "stale workflow survived: {after}"
+    );
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_none(),
+        "clearing turn-local content must not clear the same-session banner claim"
+    );
+}
+
+#[test]
+fn issue_4451_same_identity_detail_churn_after_reset_stays_suppressed() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(44_513);
+    let instance_key = "AgentDesk-codex-ch4451#detail-churn";
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &json!({
+            "provider_session_id": "session-detail-churn",
+            "tmux_reused": true,
+            "recovery_message_count": 1
+        }),
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_some()
+    );
+
+    events.clear_channel_preserving_footer_residuals(channel_id);
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &json!({
+            "provider_session_id": "session-detail-churn",
+            "tmux_reused": false,
+            "recovery_message_count": 99
+        }),
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Codex)
+            .is_none(),
+        "render-only detail churn must not mint a new identity after turn cleanup"
+    );
+}
+
+#[test]
+fn issue_4451_provider_session_fallback_survives_turn_reset() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(44_514);
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        None,
+        "session_resumed",
+        &json!({"provider_session_id": "fallback-A", "tmux_reused": true}),
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_some()
+    );
+
+    events.clear_channel_preserving_footer_residuals(channel_id);
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        None,
+        "session_resumed",
+        &json!({"provider_session_id": "fallback-A", "tmux_reused": false}),
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_none(),
+        "the provider-session fallback key must survive ordinary turn cleanup"
+    );
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        None,
+        "session_resumed",
+        &json!({"provider_session_id": "fallback-B", "tmux_reused": true}),
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_some(),
+        "a genuinely different fallback provider session must still re-arm"
+    );
+}
+
+#[test]
+fn issue_4451_banner_retention_does_not_retain_wrong_terminal_task_slot() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(44_515);
+    let instance_key = "AgentDesk-claude-ch4451#task-isolation";
+    let details = json!({
+        "provider_session_id": "session-task-isolation",
+        "tmux_reused": true
+    });
+
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_some()
+    );
+    for (tool_use_id, summary) in [
+        ("toolu_4451_target", "target terminal 4451"),
+        ("toolu_4451_decoy", "decoy terminal 4451"),
+    ] {
+        push_background_bash_task(&events, channel_id, summary, tool_use_id);
+        complete_background_bash_task(&events, channel_id, tool_use_id);
+    }
+
+    events.evict_delivered_terminal_footer_tasks(channel_id, &[bg_task_id("toolu_4451_target")]);
+    let exact_after = events
+        .render_completion_footer(channel_id, &ProviderKind::Claude, "⠸")
+        .block
+        .expect("the non-target terminal slot must remain before turn cleanup");
+    assert!(!exact_after.contains("target terminal 4451"));
+    assert!(
+        exact_after.contains("decoy terminal 4451"),
+        "exact tool-id eviction must not remove the decoy: {exact_after}"
+    );
+
+    events.clear_channel_preserving_footer_residuals(channel_id);
+    assert!(
+        events
+            .render_completion_footer(channel_id, &ProviderKind::Claude, "⠼")
+            .block
+            .is_none(),
+        "a terminal decoy must not survive merely because the banner claim keeps the entry alive"
+    );
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        Some(instance_key),
+        "session_resumed",
+        &details,
+    ));
+    assert!(
+        events
+            .claim_session_banner_line(channel_id, &ProviderKind::Claude)
+            .is_none(),
+        "task cleanup must remain isolated from the same-session banner claim"
+    );
+}
+
 /// #3983 item4 — with no live tmux marker (`session_instance_key == None`) the
 /// dedup falls back to the provider session id, so a headless session still
 /// banners exactly once and a genuinely different provider session re-arms it.


### PR DESCRIPTION
## Summary

- preserve the one-shot session banner claim across ordinary turn cleanup/redrive
- retain an otherwise-empty live-event entry only while it carries that session-scoped claim
- keep full channel teardown and genuine session-identity changes able to re-arm the banner
- prove the retained claim does not retain stale task/todo/workflow/session/terminal-task content

## Root cause and scope

Historical evidence showed the same live tmux/provider session being redriven at the observed 30-second cadence. `reset_turn_content_preserving_unfinished_footer_residuals` rebuilt `StatusPanelState` with defaults, dropping `session_banner_emitted_key`; `clear_channel_preserving_footer_residuals` then removed the otherwise-empty entry. The next lifecycle refresh for the same identity could claim and post the banner again.

This fixes that same-session reset path. It intentionally does not suppress a genuinely different session identity. If a separate recovery defect ever creates a new spawn nonce every 30 seconds, that is a distinct recovery-loop issue rather than banner deduplication.

## Verification

- `cargo test services::discord::placeholder_live_events::tests --lib --quiet` — 187 passed
- `cargo test session_banner --lib --quiet` — 7 passed
- `cargo test issue_4451 --lib --quiet` — 5 passed
- `cargo check`
- `cargo fmt --all -- --check`
- `python3.14 scripts/generate_inventory_docs.py --check`
- `PATH=/opt/homebrew/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/ci-script-checks.sh`
- `git diff --check origin/main...HEAD`

Mutation checks independently failed on their own assertions and were restored green:

- remove the preserved banner-key copy
- remove the retained-entry predicate
- retain stale task state during turn cleanup

Exact review target:

- base: `d58fb8d8e8ce019468c7240600d0be0991e44869`
- head: `98e31d9dbb90c5e23f400eabcafcebf3d836160a`
- binary diff SHA256: `9c6166fa0ee6bfd3104a643a3a8a49b967e03e874dec3dfc0be005173f1aac21`

Independent account1 Opus maximum-depth review: `VERDICT: CLEAN`. Codex review omitted under the active quota exception; this bounded UI-state fix does not require the Fable tier.

Closes #4451
