### PR TITLE
fix(recovery): gate watcher claim helper on Unix

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -594,7 +594,7 @@
 | `services::discord::recovery_engine::completion_delivery` | `src/services/discord/recovery_engine/completion_delivery.rs` | 814 | 312 | 502 |  |
 | `services::discord::recovery_engine::crash_resume_guard` | `src/services/discord/recovery_engine/crash_resume_guard.rs` | 368 | 176 | 192 |  |
 | `services::discord::recovery_engine::jsonl_extract` | `src/services/discord/recovery_engine/jsonl_extract.rs` | 137 | 137 | 0 |  |
-| `services::discord::recovery_engine::manual_rebind` | `src/services/discord/recovery_engine/manual_rebind/mod.rs` | 1421 | 995 | 426 |  |
+| `services::discord::recovery_engine::manual_rebind` | `src/services/discord/recovery_engine/manual_rebind/mod.rs` | 1423 | 997 | 426 |  |
 | `services::discord::recovery_engine::manual_rebind::adoption` | `src/services/discord/recovery_engine/manual_rebind/adoption.rs` | 304 | 95 | 209 |  |
 | `services::discord::recovery_engine::manual_rebind::codex_tui_replay` | `src/services/discord/recovery_engine/manual_rebind/codex_tui_replay.rs` | 1362 | 363 | 999 |  |
 | `services::discord::recovery_engine::manual_rebind::episode_handoff` | `src/services/discord/recovery_engine/manual_rebind/episode_handoff.rs` | 154 | 154 | 0 |  |

--- a/src/services/discord/recovery_engine/manual_rebind/mod.rs
+++ b/src/services/discord/recovery_engine/manual_rebind/mod.rs
@@ -24,7 +24,9 @@ use std::sync::{Mutex, OnceLock};
 mod adoption;
 mod codex_tui_replay;
 mod episode_handoff;
+#[cfg(unix)]
 mod watcher_claim;
+#[cfg(unix)]
 use watcher_claim::claim_rebind_watcher;
 
 pub(crate) use self::adoption::{

--- a/tests/test_manual_rebind_platform_guard.py
+++ b/tests/test_manual_rebind_platform_guard.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANUAL_REBIND = (
+    ROOT / "src/services/discord/recovery_engine/manual_rebind/mod.rs"
+).read_text(encoding="utf-8")
+
+
+class ManualRebindPlatformGuardTests(unittest.TestCase):
+    def test_unix_only_watcher_claim_helper_stays_cfg_gated(self) -> None:
+        self.assertIn("#[cfg(unix)]\nmod watcher_claim;", MANUAL_REBIND)
+        self.assertIn(
+            "#[cfg(unix)]\nuse watcher_claim::claim_rebind_watcher;",
+            MANUAL_REBIND,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 배경

`manual_rebind::watcher_claim`은 Unix 전용 `discord::tmux` 모듈의 watcher claim 함수를 사용하지만 모듈 선언과 import가 모든 플랫폼에서 컴파일되고 있었습니다. 이 때문에 최신 `main`의 Windows full check가 `could not find tmux in super`로 실패합니다.

## 변경 사항

- `watcher_claim` 모듈 선언을 `#[cfg(unix)]`로 제한
- 해당 helper import도 동일하게 `#[cfg(unix)]`로 제한
- 실제 호출부는 이미 `#[cfg(unix)]` 블록 안에 있어 비 Unix 동작에는 영향 없음
- Unix 조건부 컴파일 wiring이 제거되지 않도록 구조 회귀 테스트 추가

## 검증

- `python3 -m unittest tests.test_manual_rebind_platform_guard`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --all-targets`
- PR CI의 Windows full check (test 경로 변경으로 cross-OS lane 실행)

## 위험도

낮음. Unix 전용 구현의 컴파일 범위를 실제 사용 범위와 일치시키는 조건부 컴파일 보정이며 런타임 로직은 변경하지 않습니다.