### PR TITLE
fix: persist Claude continuation cutovers

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1120,7 +1120,12 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (1849 lines; +2 from #4091 r6 mandatory env-first lock-order comment at TEST_LOCK; +23 from #4091 r3
+  - `src/services/tui_prompt_dedupe.rs` (1966 lines; +117 from #4423: adopt Claude's
+    actual continuation UUID from a hook payload only through the registered
+    launch UUID and a real sibling transcript; retain the launch UUID as the
+    live hook-routing identity, register the payload alias, require newer mtime
+    for later hops, reset the cursor only on a genuine transition, and reject
+    delayed rewind payloads; +2 from #4091 r6 mandatory env-first lock-order comment at TEST_LOCK; +23 from #4091 r3
     refresh_runtime_binding_activity so live transcript activity extends the
     24h binding-mapping TTL even when the relay offset never advances (the
     exact relay-dead state the anchor protects); shared TUI prompt

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -107,6 +107,6 @@
 | `src/services/routines/discord_log.rs` | 1593 |
 | `src/services/routines/store.rs` | 3505 |
 | `src/services/settings.rs` | 1114 |
-| `src/services/tui_prompt_dedupe.rs` | 1849 |
+| `src/services/tui_prompt_dedupe.rs` | 1966 |
 | `src/services/turn_orchestrator.rs` | 3290 |
 | `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -387,15 +387,15 @@
 | `services::claude_tui::hook_output_guard` | `src/services/claude_tui/hook_output_guard.rs` | 157 | 157 | 0 |  |
 | `services::claude_tui::hook_registry` | `src/services/claude_tui/hook_registry.rs` | 1333 | 718 | 615 |  |
 | `services::claude_tui::hook_relay` | `src/services/claude_tui/hook_relay.rs` | 959 | 498 | 461 |  |
-| `services::claude_tui::hook_server` | `src/services/claude_tui/hook_server.rs` | 1212 | 583 | 629 |  |
+| `services::claude_tui::hook_server` | `src/services/claude_tui/hook_server.rs` | 1365 | 684 | 681 |  |
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
 | `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3358 | 1932 | 1426 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 845 | 553 | 292 |  |
-| `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 431 | 180 | 251 |  |
+| `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 810 | 431 | 379 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
-| `services::claude_tui::transcript_tail` | `src/services/claude_tui/transcript_tail.rs` | 600 | 299 | 301 |  |
+| `services::claude_tui::transcript_tail` | `src/services/claude_tui/transcript_tail.rs` | 651 | 328 | 323 |  |
 | `services::claude_tui::tui_relay` | `src/services/claude_tui/tui_relay.rs` | 1129 | 587 | 542 |  |
 | `services::cluster` | `src/services/cluster/mod.rs` | 32 | 32 | 0 |  |
 | `services::cluster::capability_routing` | `src/services/cluster/capability_routing.rs` | 261 | 261 | 0 |  |
@@ -789,14 +789,14 @@
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |
 | `services::discord::tui_prompt_relay::claude_idle_bridge` | `src/services/discord/tui_prompt_relay/claude_idle_bridge.rs` | 678 | 678 | 0 |  |
-| `services::discord::tui_prompt_relay::claude_idle_runtime` | `src/services/discord/tui_prompt_relay/claude_idle_runtime.rs` | 664 | 628 | 36 |  |
+| `services::discord::tui_prompt_relay::claude_idle_runtime` | `src/services/discord/tui_prompt_relay/claude_idle_runtime.rs` | 979 | 833 | 146 |  |
 | `services::discord::tui_prompt_relay::claude_idle_tail` | `src/services/discord/tui_prompt_relay/claude_idle_tail.rs` | 480 | 480 | 0 |  |
 | `services::discord::tui_prompt_relay::codex_idle_rollout` | `src/services/discord/tui_prompt_relay/codex_idle_rollout.rs` | 613 | 613 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_offset_resolution` | `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` | 100 | 100 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_transcript_scan` | `src/services/discord/tui_prompt_relay/idle_transcript_scan.rs` | 495 | 347 | 148 |  |
 | `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 471 | 471 | 0 |  |
 | `services::discord::tui_prompt_relay::launch_script` | `src/services/discord/tui_prompt_relay/launch_script.rs` | 129 | 107 | 22 |  |
-| `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 994 | 793 | 201 |  |
+| `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 997 | 796 | 201 |  |
 | `services::discord::tui_prompt_relay::relay_ownership` | `src/services/discord/tui_prompt_relay/relay_ownership.rs` | 506 | 506 | 0 |  |
 | `services::discord::tui_prompt_relay::synthetic_orphan_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs` | 326 | 127 | 199 |  |
 | `services::discord::tui_prompt_relay::synthetic_start` | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 2415 | 1078 | 1337 | giant-file |
@@ -1042,7 +1042,7 @@
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 258 | 247 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 100 | 100 | 0 |  |
-| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4192 | 1849 | 2343 | giant-file |
+| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4417 | 1966 | 2451 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2033 | 648 | 1385 |  |
 | `services::tui_turn_state::completion_scan` | `src/services/tui_turn_state/completion_scan.rs` | 360 | 360 | 0 |  |

--- a/src/services/claude_tui/hook_server.rs
+++ b/src/services/claude_tui/hook_server.rs
@@ -196,6 +196,28 @@ struct HookQuery {
     session_id: Option<String>,
 }
 
+fn hook_routing_session_ids(
+    command_session_id: Option<String>,
+    payload_session_id: Option<String>,
+    command_is_registered: bool,
+    payload_is_registered: bool,
+) -> (Option<String>, Option<String>) {
+    match (command_session_id, payload_session_id) {
+        (Some(command), Some(payload))
+            if command != payload && !command_is_registered && payload_is_registered =>
+        {
+            (Some(payload), None)
+        }
+        (Some(command), Some(payload))
+            if command != payload && command_is_registered && payload_is_registered =>
+        {
+            (Some(command), Some(payload))
+        }
+        (Some(command), _) => (Some(command), None),
+        (None, payload) => (payload, None),
+    }
+}
+
 async fn receive_hook(
     State(state): State<HookServerState>,
     Path((provider, event)): Path<(String, String)>,
@@ -210,11 +232,71 @@ async fn receive_hook(
         );
     }
 
-    let session_id = query
-        .session_id
+    let command_session_id = query.session_id.as_deref().and_then(non_empty_string);
+    let observed_payload_session_id = payload_session_id(&payload);
+    if provider == "claude"
+        && let (Some(command_session_id), Some(payload_session_id)) = (
+            command_session_id.as_deref(),
+            observed_payload_session_id.as_deref(),
+        )
+        && command_session_id != payload_session_id
+    {
+        match crate::services::tui_prompt_dedupe::adopt_claude_continuation_session(
+            command_session_id,
+            payload_session_id,
+        ) {
+            Some((tmux_session_name, transcript_path)) => {
+                match crate::services::claude_tui::session::persist_claude_continuation_session(
+                    &tmux_session_name,
+                    payload_session_id,
+                ) {
+                    Ok(changed) => tracing::warn!(
+                        provider,
+                        command_session_id,
+                        payload_session_id,
+                        tmux_session_name,
+                        transcript_path,
+                        persistent_artifacts_changed = changed,
+                        "adopted Claude continuation session from hook payload"
+                    ),
+                    Err(error) => tracing::error!(
+                        provider,
+                        command_session_id,
+                        payload_session_id,
+                        tmux_session_name,
+                        error,
+                        "adopted Claude continuation in memory but failed to persist cutover artifacts"
+                    ),
+                }
+            }
+            None => tracing::debug!(
+                provider,
+                command_session_id,
+                payload_session_id,
+                "Claude hook payload session differs from command identity but no safe runtime binding adoption was available"
+            ),
+        }
+    }
+    // Keep the launch-time query UUID as the hook wait/routing identity while
+    // it is registered; replacing it would strand callers already waiting on
+    // that stable key. After restart or a partial artifact cutover, fall back
+    // to the registered payload UUID so stale settings cannot strand events.
+    let command_is_registered = command_session_id.as_deref().is_some_and(|session_id| {
+        crate::services::tui_prompt_dedupe::provider_session_is_registered(&provider, session_id)
+    });
+    let payload_is_registered = observed_payload_session_id
         .as_deref()
-        .and_then(non_empty_string)
-        .or_else(|| payload_session_id(&payload));
+        .is_some_and(|session_id| {
+            crate::services::tui_prompt_dedupe::provider_session_is_registered(
+                &provider, session_id,
+            )
+        });
+    let (session_id, alias_session_id) = hook_routing_session_ids(
+        command_session_id,
+        observed_payload_session_id,
+        command_is_registered,
+        payload_is_registered,
+    );
     let Some(session_id) = session_id else {
         return (
             StatusCode::BAD_REQUEST,
@@ -271,6 +353,10 @@ async fn receive_hook(
         received_at: Utc::now(),
         payload,
     };
+    let alias_event = alias_session_id.map(|alias_session_id| HookEvent {
+        session_id: alias_session_id,
+        ..event.clone()
+    });
     let event_name = event.kind.as_str().to_string();
     let memento_stop_flush = match event.kind {
         HookEventKind::PostToolUse => {
@@ -402,6 +488,15 @@ async fn receive_hook(
         ) {
             crate::services::claude_tui::hook_registry::global().deliver(key, event.clone());
         }
+        if let Some(alias_event) = alias_event.as_ref()
+            && let Some(key) = crate::services::claude_tui::hook_registry::RegistryKey::new(
+                &alias_event.provider,
+                Some(alias_event.session_id.as_str()),
+                None,
+            )
+        {
+            crate::services::claude_tui::hook_registry::global().deliver(key, alias_event.clone());
+        }
     }
 
     if should_drop_broadcast {
@@ -411,13 +506,19 @@ async fn receive_hook(
             session_id,
             "tui hook event has empty payload or pending memento feedback flush; dropping broadcast"
         );
-    } else if state.event_tx.send(event).is_err() {
-        tracing::debug!(
-            provider,
-            event = event_name,
-            session_id,
-            "tui hook event accepted with no subscribers; event discarded"
-        );
+    } else {
+        let primary_discarded = state.event_tx.send(event).is_err();
+        let alias_discarded = alias_event
+            .map(|alias_event| state.event_tx.send(alias_event).is_err())
+            .unwrap_or(true);
+        if primary_discarded && alias_discarded {
+            tracing::debug!(
+                provider,
+                event = event_name,
+                session_id,
+                "tui hook event accepted with no subscribers; event discarded"
+            );
+        }
     }
 
     let mut body = json!({
@@ -1184,6 +1285,58 @@ mod tests {
         let replayed = global().claim_once(key);
         assert_eq!(replayed.len(), 1, "empty-body Stop must still be buffered");
         assert_eq!(replayed[0].kind, HookEventKind::Stop);
+    }
+
+    #[test]
+    fn mismatched_hook_routes_through_the_registered_side_of_partial_cutover() {
+        assert_eq!(
+            hook_routing_session_ids(
+                Some("stale-command".to_string()),
+                Some("live-payload".to_string()),
+                false,
+                true,
+            )
+            .0
+            .as_deref(),
+            Some("live-payload"),
+            "after restart, a rewritten launch with stale settings must route through the rehydrated payload UUID"
+        );
+        assert_eq!(
+            hook_routing_session_ids(
+                Some("stable-command".to_string()),
+                Some("new-payload".to_string()),
+                true,
+                true,
+            )
+            .0
+            .as_deref(),
+            Some("stable-command"),
+            "while the original waiter is live, its stable command UUID remains authoritative"
+        );
+        assert_eq!(
+            hook_routing_session_ids(
+                Some("rewritten-command".to_string()),
+                Some("old-payload".to_string()),
+                false,
+                true,
+            )
+            .0
+            .as_deref(),
+            Some("old-payload"),
+            "a settings-first partial update must remain routable until launch repair converges"
+        );
+        assert_eq!(
+            hook_routing_session_ids(
+                Some("stable-command".to_string()),
+                Some("new-payload".to_string()),
+                true,
+                true,
+            )
+            .1
+            .as_deref(),
+            Some("new-payload"),
+            "the payload alias must also receive the transition event for waiters created after idle adoption"
+        );
     }
 
     #[test]

--- a/src/services/claude_tui/session.rs
+++ b/src/services/claude_tui/session.rs
@@ -1,4 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{LazyLock, Mutex},
+    time::{Duration, Instant},
+};
 
 use crate::services::claude_tui::hook_bundle::{HookBundleConfig, write_claude_hook_settings};
 use crate::services::process::shell_escape;
@@ -14,6 +21,250 @@ impl ClaudeTuiSessionFiles {
         let _ = std::fs::remove_file(&self.hook_settings_path);
         let _ = std::fs::remove_file(&self.launch_script_path);
     }
+}
+
+#[derive(Debug)]
+struct PersistedContinuationSession {
+    session_id: String,
+    recorded_at: Instant,
+}
+
+static PERSISTED_CONTINUATION_SESSIONS: LazyLock<
+    Mutex<HashMap<String, PersistedContinuationSession>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+const PERSISTED_CONTINUATION_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+fn continuation_persistence_cached(tmux_session_name: &str, session_id: &str) -> bool {
+    let now = Instant::now();
+    let mut persisted = PERSISTED_CONTINUATION_SESSIONS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    persisted.retain(|_, entry| {
+        now.duration_since(entry.recorded_at) <= PERSISTED_CONTINUATION_CACHE_TTL
+    });
+    persisted
+        .get(tmux_session_name)
+        .is_some_and(|entry| entry.session_id == session_id)
+}
+
+fn remember_persisted_continuation(tmux_session_name: &str, session_id: &str) {
+    PERSISTED_CONTINUATION_SESSIONS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(
+            tmux_session_name.to_string(),
+            PersistedContinuationSession {
+                session_id: session_id.to_string(),
+                recorded_at: Instant::now(),
+            },
+        );
+}
+
+/// Persist a Claude continuation cutover into the AgentDesk-owned artifacts
+/// that survive dcserver restarts (#4423).
+///
+/// Claude can keep the live TUI pane while changing the provider session UUID.
+/// Updating only the in-memory transcript binding lets the launch script's old
+/// UUID win again after rehydration. Both artifacts are therefore repaired:
+/// the launch script selects the new transcript on the next pane restart, and
+/// the hook settings address the same identity. A partially completed repair is
+/// accepted and converges on the next call.
+pub(crate) fn persist_claude_continuation_session(
+    tmux_session_name: &str,
+    new_session_id: &str,
+) -> Result<bool, String> {
+    let tmux_session_name = tmux_session_name.trim();
+    let new_session_id = new_session_id.trim();
+    if tmux_session_name.is_empty() {
+        return Err("Claude continuation tmux session name is required".to_string());
+    }
+    if uuid::Uuid::parse_str(new_session_id).is_err() {
+        return Err("Claude continuation session id must be a UUID".to_string());
+    }
+    if continuation_persistence_cached(tmux_session_name, new_session_id) {
+        return Ok(false);
+    }
+    let hook_settings_path = crate::services::tmux_common::resolve_session_temp_path(
+        tmux_session_name,
+        crate::services::tmux_common::CLAUDE_TUI_HOOK_SETTINGS_TEMP_EXT,
+    )
+    .ok_or_else(|| format!("missing Claude hook settings for {tmux_session_name}"))?;
+    let launch_script_path = crate::services::tmux_common::resolve_session_temp_path(
+        tmux_session_name,
+        crate::services::tmux_common::CLAUDE_TUI_LAUNCH_SCRIPT_TEMP_EXT,
+    )
+    .ok_or_else(|| format!("missing Claude launch script for {tmux_session_name}"))?;
+    let changed = persist_claude_continuation_session_files(
+        &ClaudeTuiSessionFiles {
+            hook_settings_path: PathBuf::from(hook_settings_path),
+            launch_script_path: PathBuf::from(launch_script_path),
+        },
+        new_session_id,
+    )?;
+    // Cache only a verified success. Any read/parse/write/rollback failure is
+    // deliberately left uncached so the next mismatched hook retries it.
+    remember_persisted_continuation(tmux_session_name, new_session_id);
+    Ok(changed)
+}
+
+fn uuid_after(content: &str, marker: &str) -> Vec<String> {
+    let mut remainder = content;
+    let mut values = Vec::new();
+    while let Some(index) = remainder.find(marker) {
+        remainder = &remainder[index + marker.len()..];
+        remainder = remainder.strip_prefix('\'').unwrap_or(remainder);
+        let value = &remainder[..remainder
+            .find(|character: char| !(character.is_ascii_hexdigit() || character == '-'))
+            .unwrap_or(remainder.len())];
+        if uuid::Uuid::parse_str(value).is_ok() && !values.iter().any(|existing| existing == value)
+        {
+            values.push(value.to_string());
+        }
+        remainder = &remainder[value.len()..];
+    }
+    values
+}
+
+fn single_artifact_session_id(
+    label: &str,
+    content: &str,
+    markers: &[&str],
+) -> Result<String, String> {
+    let mut values = Vec::new();
+    for marker in markers {
+        for value in uuid_after(content, marker) {
+            if !values.contains(&value) {
+                values.push(value);
+            }
+        }
+    }
+    match values.as_slice() {
+        [value] => Ok(value.clone()),
+        [] => Err(format!(
+            "{label} contains no generated Claude session selector"
+        )),
+        _ => Err(format!(
+            "{label} contains multiple Claude session selectors"
+        )),
+    }
+}
+
+fn atomic_replace_preserving_permissions(path: &Path, data: &str) -> Result<(), String> {
+    let permissions = fs::metadata(path)
+        .map_err(|error| format!("stat {}: {error}", path.display()))?
+        .permissions();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file");
+    let temp_path = path.with_file_name(format!(
+        ".{file_name}.{}.continuation.tmp",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let result = (|| {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+            .map_err(|error| format!("create {}: {error}", temp_path.display()))?;
+        file.write_all(data.as_bytes())
+            .map_err(|error| format!("write {}: {error}", temp_path.display()))?;
+        file.sync_all()
+            .map_err(|error| format!("sync {}: {error}", temp_path.display()))?;
+        fs::set_permissions(&temp_path, permissions)
+            .map_err(|error| format!("chmod {}: {error}", temp_path.display()))?;
+        replace_existing_file(&temp_path, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn replace_existing_file(temp_path: &Path, path: &Path) -> Result<(), String> {
+    fs::rename(temp_path, path).map_err(|error| format!("replace {}: {error}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn replace_existing_file(temp_path: &Path, path: &Path) -> Result<(), String> {
+    // Claude TUI hosting requires tmux and is Unix-only. Keep tests and shared
+    // compilation functional on Windows, where std::fs::rename cannot replace
+    // an existing file, even though that platform cannot execute this path.
+    fs::remove_file(path).map_err(|error| format!("remove {}: {error}", path.display()))?;
+    fs::rename(temp_path, path).map_err(|error| format!("replace {}: {error}", path.display()))
+}
+
+fn persist_claude_continuation_session_files(
+    files: &ClaudeTuiSessionFiles,
+    new_session_id: &str,
+) -> Result<bool, String> {
+    let original_launch = fs::read_to_string(&files.launch_script_path).map_err(|error| {
+        format!(
+            "read Claude launch script {}: {error}",
+            files.launch_script_path.display()
+        )
+    })?;
+    let original_settings = fs::read_to_string(&files.hook_settings_path).map_err(|error| {
+        format!(
+            "read Claude hook settings {}: {error}",
+            files.hook_settings_path.display()
+        )
+    })?;
+    let launch_session_id = single_artifact_session_id(
+        "Claude launch script",
+        &original_launch,
+        &["'--session-id' ", "'--resume' "],
+    )?;
+    serde_json::from_str::<serde_json::Value>(&original_settings)
+        .map_err(|error| format!("Claude hook settings are invalid JSON: {error}"))?;
+    let settings_session_id = single_artifact_session_id(
+        "Claude hook settings",
+        &original_settings,
+        &["--session-id "],
+    )?;
+    // A process crash can leave either artifact one continuation hop ahead of
+    // the other. The caller has already authenticated the live payload against
+    // the tmux binding, so converge each generated selector independently.
+    let launch = (launch_session_id != new_session_id)
+        .then(|| original_launch.replace(&launch_session_id, new_session_id));
+    let settings = (settings_session_id != new_session_id)
+        .then(|| original_settings.replace(&settings_session_id, new_session_id));
+    if launch.is_none() && settings.is_none() {
+        return Ok(false);
+    }
+    if let Some(updated) = settings.as_deref() {
+        serde_json::from_str::<serde_json::Value>(updated)
+            .map_err(|error| format!("updated Claude hook settings are invalid JSON: {error}"))?;
+    }
+    if let Some(updated) = launch.as_deref()
+        && (!updated.contains(new_session_id) || updated.contains(&launch_session_id))
+    {
+        return Err("updated Claude launch script failed session-id validation".to_string());
+    }
+
+    // Repair the launch selector first. If the settings write then fails, put
+    // the original launch script back; either partial ordering is also safe at
+    // runtime because hook_server routes a mismatched payload through whichever
+    // provider UUID is currently registered.
+    if let Some(updated) = launch.as_deref() {
+        atomic_replace_preserving_permissions(&files.launch_script_path, updated)?;
+    }
+    if let Some(updated) = settings.as_deref()
+        && let Err(error) =
+            atomic_replace_preserving_permissions(&files.hook_settings_path, updated)
+    {
+        if launch.is_some()
+            && let Err(rollback_error) =
+                atomic_replace_preserving_permissions(&files.launch_script_path, &original_launch)
+        {
+            return Err(format!(
+                "{error}; additionally failed to roll back Claude launch script: {rollback_error}"
+            ));
+        }
+        return Err(error);
+    }
+    Ok(true)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -389,6 +640,134 @@ mod tests {
 
         assert!(!files.hook_settings_path.exists());
         assert!(!files.launch_script_path.exists());
+    }
+
+    #[test]
+    fn successful_continuation_persistence_is_cached_per_target_uuid() {
+        let tmux = format!("tmux-4423-persist-cache-{}", uuid::Uuid::new_v4());
+        let session = uuid::Uuid::new_v4().to_string();
+        let later_session = uuid::Uuid::new_v4().to_string();
+        assert!(!continuation_persistence_cached(&tmux, &session));
+        remember_persisted_continuation(&tmux, &session);
+        assert!(continuation_persistence_cached(&tmux, &session));
+        assert!(
+            !continuation_persistence_cached(&tmux, &later_session),
+            "a later continuation UUID must still trigger artifact convergence"
+        );
+    }
+
+    #[test]
+    fn continuation_cutover_rewrites_both_artifacts_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let old_session_id = uuid::Uuid::new_v4().to_string();
+        let new_session_id = uuid::Uuid::new_v4().to_string();
+        let files = ClaudeTuiSessionFiles {
+            hook_settings_path: dir.path().join("settings.json"),
+            launch_script_path: dir.path().join("launch.sh"),
+        };
+        let mut config = sample_config();
+        config.session_id = old_session_id.clone();
+        write_claude_hook_settings(
+            &files.hook_settings_path,
+            &HookBundleConfig {
+                endpoint: config.hook_endpoint.clone(),
+                provider: "claude".to_string(),
+                session_id: old_session_id.clone(),
+                agentdesk_exe: config.agentdesk_exe.display().to_string(),
+            },
+        )
+        .unwrap();
+        write_launch_script(
+            &files.launch_script_path,
+            &config,
+            &files.hook_settings_path,
+        )
+        .unwrap();
+
+        assert!(persist_claude_continuation_session_files(&files, &new_session_id).unwrap());
+        let launch = fs::read_to_string(&files.launch_script_path).unwrap();
+        let settings = fs::read_to_string(&files.hook_settings_path).unwrap();
+        assert!(!launch.contains(&old_session_id));
+        assert!(launch.contains(&new_session_id));
+        assert!(!settings.contains(&old_session_id));
+        assert!(settings.contains(&new_session_id));
+        serde_json::from_str::<serde_json::Value>(&settings).unwrap();
+        assert!(
+            !persist_claude_continuation_session_files(&files, &new_session_id).unwrap(),
+            "an already durable cutover must not rewrite artifacts again"
+        );
+
+        let third_session_id = uuid::Uuid::new_v4().to_string();
+        assert!(
+            persist_claude_continuation_session_files(&files, &third_session_id).unwrap(),
+            "a later continuation must advance from the artifact's current UUID, not the original query UUID"
+        );
+        let launch = fs::read_to_string(&files.launch_script_path).unwrap();
+        let settings = fs::read_to_string(&files.hook_settings_path).unwrap();
+        assert!(!launch.contains(&new_session_id));
+        assert!(launch.contains(&third_session_id));
+        assert!(!settings.contains(&new_session_id));
+        assert!(settings.contains(&third_session_id));
+    }
+
+    #[test]
+    fn continuation_cutover_repairs_a_partial_artifact_update() {
+        let dir = tempfile::tempdir().unwrap();
+        let old_session_id = uuid::Uuid::new_v4().to_string();
+        let new_session_id = uuid::Uuid::new_v4().to_string();
+        let files = ClaudeTuiSessionFiles {
+            hook_settings_path: dir.path().join("settings.json"),
+            launch_script_path: dir.path().join("launch.sh"),
+        };
+        fs::write(
+            &files.launch_script_path,
+            format!("exec claude '--resume' '{new_session_id}'\n"),
+        )
+        .unwrap();
+        fs::write(
+            &files.hook_settings_path,
+            serde_json::to_string(&serde_json::json!({
+                "command": format!("agentdesk claude-hook-relay --session-id '{old_session_id}'")
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert!(persist_claude_continuation_session_files(&files, &new_session_id).unwrap());
+        assert!(
+            fs::read_to_string(&files.hook_settings_path)
+                .unwrap()
+                .contains(&new_session_id)
+        );
+        assert!(
+            fs::read_to_string(&files.launch_script_path)
+                .unwrap()
+                .contains(&new_session_id)
+        );
+
+        let later_session_id = uuid::Uuid::new_v4().to_string();
+        fs::write(
+            &files.hook_settings_path,
+            serde_json::to_string(&serde_json::json!({
+                "command": format!("agentdesk claude-hook-relay --session-id '{old_session_id}'")
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            persist_claude_continuation_session_files(&files, &later_session_id).unwrap(),
+            "a later hop must converge even when a prior crash left two older selectors"
+        );
+        assert!(
+            fs::read_to_string(&files.hook_settings_path)
+                .unwrap()
+                .contains(&later_session_id)
+        );
+        assert!(
+            fs::read_to_string(&files.launch_script_path)
+                .unwrap()
+                .contains(&later_session_id)
+        );
     }
 
     #[test]

--- a/src/services/claude_tui/transcript_tail.rs
+++ b/src/services/claude_tui/transcript_tail.rs
@@ -274,6 +274,35 @@ fn claude_transcript_line_timestamp(value: &serde_json::Value) -> Option<DateTim
         .map(|timestamp| timestamp.with_timezone(&Utc))
 }
 
+/// Return the first and last parseable Claude JSONL timestamps. Continuation
+/// discovery uses these semantic activity bounds instead of filesystem mtime
+/// alone so a newer same-cwd transcript cannot steal another session's relay.
+pub(crate) fn claude_transcript_timestamp_bounds(
+    transcript_path: &Path,
+) -> Result<Option<(DateTime<Utc>, DateTime<Utc>)>, String> {
+    let file = std::fs::File::open(transcript_path).map_err(|error| {
+        format!(
+            "read transcript {}: {error}",
+            transcript_path.to_string_lossy()
+        )
+    })?;
+    let reader = std::io::BufReader::new(file);
+    let mut first = None;
+    let mut last = None;
+    for line in reader.lines() {
+        let line = line.map_err(|error| format!("read transcript line: {error}"))?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+        let Some(timestamp) = claude_transcript_line_timestamp(&value) else {
+            continue;
+        };
+        first.get_or_insert(timestamp);
+        last = Some(timestamp);
+    }
+    Ok(first.zip(last))
+}
+
 pub(crate) fn observe_transcript_turn_state(
     transcript_path: &Path,
 ) -> crate::services::tui_turn_state::TuiTurnState {
@@ -507,6 +536,28 @@ mod tests {
 
         let expected = r#"{"type":"assistant"}"#.len() + 1 + "not-json".len() + 1;
         assert_eq!(offset, Some(expected as u64));
+    }
+
+    #[test]
+    fn claude_transcript_timestamp_bounds_ignore_unusable_lines() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            concat!(
+                "not-json\n",
+                "{\"type\":\"system\"}\n",
+                "{\"timestamp\":\"2026-07-10T00:00:01Z\",\"type\":\"user\"}\n",
+                "{\"timestamp\":\"bad\",\"type\":\"assistant\"}\n",
+                "{\"timestamp\":\"2026-07-10T00:00:09Z\",\"type\":\"assistant\"}\n",
+            ),
+        )
+        .unwrap();
+
+        let (first, last) = claude_transcript_timestamp_bounds(file.path())
+            .unwrap()
+            .expect("timestamp bounds");
+        assert_eq!(first.to_rfc3339(), "2026-07-10T00:00:01+00:00");
+        assert_eq!(last.to_rfc3339(), "2026-07-10T00:00:09+00:00");
     }
 
     #[test]

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -157,10 +157,10 @@ pub(super) use self::claude_idle_runtime::resolve_rehydrated_claude_tmux_channel
 #[cfg(unix)]
 use self::claude_idle_runtime::{
     DEAD_ORPHANED_PANE_PROBE_DELAY, DEAD_ORPHANED_PANE_PROBE_SAMPLES,
-    advance_claude_tmux_runtime_binding_offset, claude_tui_rehydrate_start_offset,
-    claude_tui_runtime_binding_matches_launch, resolve_idle_relay_transcript,
-    resolve_rehydrated_tmux_channel_id, resolved_claude_idle_relay_transcript_path,
-    spawn_claude_idle_transcript_relay,
+    advance_claude_tmux_runtime_binding_offset, claude_continuation_binding_supersedes_launch,
+    claude_tui_rehydrate_start_offset, claude_tui_runtime_binding_matches_launch,
+    resolve_idle_relay_transcript, resolve_rehydrated_tmux_channel_id,
+    resolved_claude_idle_relay_transcript_path, spawn_claude_idle_transcript_relay,
 };
 #[cfg(unix)]
 pub(in crate::services::discord) use self::claude_idle_runtime::{

--- a/src/services/discord/tui_prompt_relay/claude_idle_runtime.rs
+++ b/src/services/discord/tui_prompt_relay/claude_idle_runtime.rs
@@ -1,6 +1,84 @@
 use super::*;
 
 #[cfg(unix)]
+const CLAUDE_CONTINUATION_BOUND_STALE_SECS: u64 = 10 * 60;
+
+#[cfg(unix)]
+#[derive(Clone, Debug)]
+struct ClaudeContinuationGrowthObservation {
+    candidate_path: PathBuf,
+    length: u64,
+    observed_at: std::time::Instant,
+}
+
+#[cfg(unix)]
+const CLAUDE_CONTINUATION_GROWTH_WINDOW: Duration = Duration::from_secs(30);
+
+#[cfg(unix)]
+static CLAUDE_CONTINUATION_GROWTH: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, ClaudeContinuationGrowthObservation>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ClaudeContinuationAdoptionFacts {
+    pub(super) bound_stale_for_threshold: bool,
+    pub(super) pane_alive: bool,
+    pub(super) candidate_newer_than_bound: bool,
+    pub(super) candidate_grew_across_samples: bool,
+    pub(super) candidate_starts_after_bound_activity: bool,
+}
+
+#[cfg(unix)]
+pub(super) fn should_adopt_newer_claude_transcript(facts: ClaudeContinuationAdoptionFacts) -> bool {
+    facts.bound_stale_for_threshold
+        && facts.pane_alive
+        && facts.candidate_newer_than_bound
+        && facts.candidate_grew_across_samples
+        && facts.candidate_starts_after_bound_activity
+}
+
+#[cfg(unix)]
+fn observe_claude_continuation_candidate_growth(
+    tmux_session_name: &str,
+    candidate_path: &Path,
+) -> bool {
+    let Ok(length) = std::fs::metadata(candidate_path).map(|metadata| metadata.len()) else {
+        return false;
+    };
+    let mut observations = CLAUDE_CONTINUATION_GROWTH
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let now = std::time::Instant::now();
+    observations.retain(|_, observation| {
+        now.duration_since(observation.observed_at)
+            <= CLAUDE_CONTINUATION_GROWTH_WINDOW.saturating_mul(2)
+    });
+    let grew = observations.get(tmux_session_name).is_some_and(|previous| {
+        previous.candidate_path == candidate_path
+            && length > previous.length
+            && now.duration_since(previous.observed_at) <= CLAUDE_CONTINUATION_GROWTH_WINDOW
+    });
+    observations.insert(
+        tmux_session_name.to_string(),
+        ClaudeContinuationGrowthObservation {
+            candidate_path: candidate_path.to_path_buf(),
+            length,
+            observed_at: now,
+        },
+    );
+    grew
+}
+
+#[cfg(unix)]
+fn clear_claude_continuation_candidate_growth(tmux_session_name: &str) {
+    CLAUDE_CONTINUATION_GROWTH
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(tmux_session_name);
+}
+
+#[cfg(unix)]
 pub(super) fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
     if CLAUDE_IDLE_TRANSCRIPT_RELAY_STARTED.swap(true, Ordering::AcqRel) {
         return;
@@ -261,6 +339,44 @@ pub(super) fn claude_tui_runtime_binding_matches_launch(
 }
 
 #[cfg(unix)]
+pub(super) fn claude_continuation_binding_supersedes_launch(
+    existing: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+    launch: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
+) -> bool {
+    if existing.runtime_kind != RuntimeHandoffKind::ClaudeTui
+        || launch.runtime_kind != RuntimeHandoffKind::ClaudeTui
+        || existing.session_id.is_none()
+        || launch.session_id.is_none()
+        || existing.session_id == launch.session_id
+    {
+        return false;
+    }
+    let existing_path = Path::new(&existing.output_path);
+    let launch_path = Path::new(&launch.output_path);
+    if !existing_path.is_file()
+        || !launch_path.is_file()
+        || transcript_mtime(existing_path) <= transcript_mtime(launch_path)
+    {
+        return false;
+    }
+    let Ok(Some((existing_first, _))) =
+        crate::services::claude_tui::transcript_tail::claude_transcript_timestamp_bounds(
+            existing_path,
+        )
+    else {
+        return false;
+    };
+    let Ok(Some((_, launch_last))) =
+        crate::services::claude_tui::transcript_tail::claude_transcript_timestamp_bounds(
+            launch_path,
+        )
+    else {
+        return false;
+    };
+    existing_first > launch_last
+}
+
+#[cfg(unix)]
 pub(super) fn transcript_mtime(path: &Path) -> std::time::SystemTime {
     std::fs::metadata(path)
         .and_then(|meta| meta.modified())
@@ -349,18 +465,107 @@ pub(super) fn freshest_claude_transcript_for_session(
     tmux_session_name: &str,
     binding: &crate::services::tui_prompt_dedupe::TuiRuntimeBinding,
 ) -> Option<(PathBuf, Option<String>)> {
-    // #2843 multi-session fix: when the bound (launch-script) transcript still
-    // EXISTS, it is the authoritative per-session identity — trust it and do NOT
-    // override with a project-newer file. Picking max-by-mtime across the whole
-    // project dir was wrong for a cwd shared by several Claude sessions: a
-    // *different* session's (or an orphaned older session's) newer transcript
-    // gets pulled in, thrashing the binding against launch rehydration (~5s) and
-    // mis-tailing relay output. The project scan now only fills in when the
-    // bound transcript is genuinely missing (the legitimate stale/rotated-away
-    // case), and even then skips transcripts other live sessions claim.
+    // Existing paths remain authoritative unless all continuation-cutover
+    // evidence agrees. This preserves #2843's shared-cwd anti-steal rule while
+    // closing #4423, where the old transcript remains on disk forever after
+    // Claude compaction moves the live pane to a new UUID.
     let bound_path = PathBuf::from(&binding.output_path);
     if bound_path.exists() {
-        return Some((bound_path, binding.session_id.clone()));
+        // This function runs in the 500ms idle poll. Keep the ordinary
+        // (<10-minute-stale) path to one local stat and return before the
+        // blocking tmux/session inventory and project-directory scan.
+        let now = std::time::SystemTime::now();
+        let bound_mtime = transcript_mtime(&bound_path);
+        let bound_stale_for_threshold = now
+            .duration_since(bound_mtime)
+            .is_ok_and(|age| age.as_secs() >= CLAUDE_CONTINUATION_BOUND_STALE_SECS);
+        if !bound_stale_for_threshold {
+            return Some((bound_path, binding.session_id.clone()));
+        }
+        let claimed_by_other_sessions =
+            other_session_claimed_transcripts(shared, tmux_session_name);
+        let candidate =
+            claude_tui_launch_context(tmux_session_name).and_then(|(cwd, launch_mtime)| {
+                crate::services::claude_tui::transcript_tail::latest_claude_transcript_for_cwd(
+                    &cwd,
+                    launch_mtime,
+                    None,
+                    &claimed_by_other_sessions,
+                )
+            });
+        let Some(candidate_path) = candidate.filter(|candidate| candidate != &bound_path) else {
+            return Some((bound_path, binding.session_id.clone()));
+        };
+        let candidate_mtime = transcript_mtime(&candidate_path);
+        if candidate_mtime <= bound_mtime
+            || !crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name)
+        {
+            return Some((bound_path, binding.session_id.clone()));
+        }
+        let candidate_grew_across_samples =
+            observe_claude_continuation_candidate_growth(tmux_session_name, &candidate_path);
+        if !candidate_grew_across_samples {
+            return Some((bound_path, binding.session_id.clone()));
+        }
+        let candidate_starts_after_bound_activity = match (
+            crate::services::claude_tui::transcript_tail::claude_transcript_timestamp_bounds(
+                &bound_path,
+            ),
+            crate::services::claude_tui::transcript_tail::claude_transcript_timestamp_bounds(
+                &candidate_path,
+            ),
+        ) {
+            (Ok(Some((_, bound_last))), Ok(Some((candidate_first, _)))) => {
+                candidate_first > bound_last
+            }
+            _ => false,
+        };
+        let facts = ClaudeContinuationAdoptionFacts {
+            bound_stale_for_threshold,
+            pane_alive: true,
+            candidate_newer_than_bound: candidate_mtime > bound_mtime,
+            candidate_grew_across_samples,
+            candidate_starts_after_bound_activity,
+        };
+        if !should_adopt_newer_claude_transcript(facts) {
+            return Some((bound_path, binding.session_id.clone()));
+        }
+        let session_id = candidate_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(str::to_string);
+        let Some(candidate_session_id) = session_id.as_deref() else {
+            return Some((bound_path, binding.session_id.clone()));
+        };
+        let Some(bound_session_id) = binding.session_id.as_deref() else {
+            return Some((bound_path, binding.session_id.clone()));
+        };
+        if let Err(error) =
+            crate::services::claude_tui::session::persist_claude_continuation_session(
+                tmux_session_name,
+                candidate_session_id,
+            )
+        {
+            tracing::error!(
+                tmux_session_name,
+                bound_session_id,
+                candidate_session_id,
+                error,
+                "deferred Claude continuation adoption because durable artifact cutover failed"
+            );
+            return Some((bound_path, binding.session_id.clone()));
+        }
+        clear_claude_continuation_candidate_growth(tmux_session_name);
+        tracing::warn!(
+            tmux_session_name,
+            bound_path = %bound_path.display(),
+            candidate_path = %candidate_path.display(),
+            bound_session_id = binding.session_id.as_deref().unwrap_or(""),
+            candidate_session_id = session_id.as_deref().unwrap_or(""),
+            bound_stale_secs = now.duration_since(bound_mtime).map(|age| age.as_secs()).unwrap_or(0),
+            "adopted growing Claude continuation transcript after bounded two-sample proof"
+        );
+        return Some((candidate_path, session_id));
     }
     // Bound transcript is gone — fall back to the freshest project transcript,
     // excluding files that authoritatively belong to other live Claude TUI tmux
@@ -515,6 +720,116 @@ fn transcript_recent_enough_for_binding_refresh(path: &Path) -> bool {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn continuation_adoption_requires_every_safety_fact() {
+        let all = ClaudeContinuationAdoptionFacts {
+            bound_stale_for_threshold: true,
+            pane_alive: true,
+            candidate_newer_than_bound: true,
+            candidate_grew_across_samples: true,
+            candidate_starts_after_bound_activity: true,
+        };
+        assert!(should_adopt_newer_claude_transcript(all));
+
+        for mutate in [
+            |facts: &mut ClaudeContinuationAdoptionFacts| facts.bound_stale_for_threshold = false,
+            |facts: &mut ClaudeContinuationAdoptionFacts| facts.pane_alive = false,
+            |facts: &mut ClaudeContinuationAdoptionFacts| facts.candidate_newer_than_bound = false,
+            |facts: &mut ClaudeContinuationAdoptionFacts| {
+                facts.candidate_grew_across_samples = false
+            },
+            |facts: &mut ClaudeContinuationAdoptionFacts| {
+                facts.candidate_starts_after_bound_activity = false
+            },
+        ] {
+            let mut facts = all;
+            mutate(&mut facts);
+            assert!(!should_adopt_newer_claude_transcript(facts));
+        }
+    }
+
+    #[test]
+    fn continuation_candidate_requires_growth_across_two_samples() {
+        let tmp = tempfile::tempdir().unwrap();
+        let candidate = tmp.path().join("candidate.jsonl");
+        std::fs::write(&candidate, b"first\n").unwrap();
+        let tmux = format!("AgentDesk-claude-4423-growth-{}", std::process::id());
+
+        assert!(!observe_claude_continuation_candidate_growth(
+            &tmux, &candidate
+        ));
+        assert!(!observe_claude_continuation_candidate_growth(
+            &tmux, &candidate
+        ));
+        use std::io::Write;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&candidate)
+            .unwrap()
+            .write_all(b"second\n")
+            .unwrap();
+        assert!(observe_claude_continuation_candidate_growth(
+            &tmux, &candidate
+        ));
+    }
+
+    #[test]
+    fn timestamp_continuation_binding_supersedes_stale_launch_binding() {
+        let tmp = tempfile::tempdir().unwrap();
+        let launch_path = tmp.path().join("old.jsonl");
+        let continuation_path = tmp.path().join("new.jsonl");
+        std::fs::write(
+            &launch_path,
+            concat!(
+                "{\"timestamp\":\"2026-07-10T00:00:01Z\"}\n",
+                "{\"timestamp\":\"2026-07-10T00:00:09Z\"}\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            &continuation_path,
+            concat!(
+                "{\"timestamp\":\"2026-07-10T00:00:10Z\"}\n",
+                "{\"timestamp\":\"2026-07-10T00:00:11Z\"}\n"
+            ),
+        )
+        .unwrap();
+        filetime::set_file_mtime(
+            &launch_path,
+            filetime::FileTime::from_unix_time(1_700_000_000, 0),
+        )
+        .unwrap();
+        filetime::set_file_mtime(
+            &continuation_path,
+            filetime::FileTime::from_unix_time(1_700_000_001, 0),
+        )
+        .unwrap();
+        let binding =
+            |path: &Path, session: &str| crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::ClaudeTui,
+                output_path: path.display().to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: Some(session.to_string()),
+                last_offset: 0,
+                relay_last_offset: None,
+            };
+        let existing = binding(&continuation_path, "new");
+        let launch = binding(&launch_path, "old");
+        assert!(claude_continuation_binding_supersedes_launch(
+            &existing, &launch
+        ));
+
+        std::fs::write(
+            &continuation_path,
+            "{\"timestamp\":\"2026-07-10T00:00:08Z\"}\n",
+        )
+        .unwrap();
+        assert!(!claude_continuation_binding_supersedes_launch(
+            &existing, &launch
+        ));
+    }
 
     #[test]
     fn transcript_binding_refresh_requires_recent_activity() {

--- a/src/services/discord/tui_prompt_relay/rehydration.rs
+++ b/src/services/discord/tui_prompt_relay/rehydration.rs
@@ -248,7 +248,10 @@ pub(super) fn rehydrate_existing_claude_tui_bindings(shared: &Arc<SharedData>) {
             if existing.runtime_kind == RuntimeHandoffKind::ClaudeTui
                 && Path::new(&existing.output_path).exists()
                 && match fresh_binding.as_ref() {
-                    Some(fresh) => claude_tui_runtime_binding_matches_launch(existing, fresh),
+                    Some(fresh) => {
+                        claude_tui_runtime_binding_matches_launch(existing, fresh)
+                            || claude_continuation_binding_supersedes_launch(existing, fresh)
+                    }
                     None => true,
                 }
             {

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
@@ -306,6 +307,10 @@ pub fn provider_session_for_tmux(provider: &str, tmux_session_name: &str) -> Opt
         })
         .max_by_key(|(_, timed)| timed.recorded_at)
         .map(|(promptkey, _)| promptkey.key.clone())
+}
+
+pub(crate) fn provider_session_is_registered(provider: &str, provider_session_id: &str) -> bool {
+    resolve_tmux_session_name(provider, provider_session_id).is_some()
 }
 
 pub fn register_tmux_channel(tmux_session_name: &str, channel_id: u64) {
@@ -730,6 +735,118 @@ pub(crate) fn runtime_binding_for_tmux_session(
         .runtime_by_tmux
         .get(tmux_session_name)
         .map(|entry| entry.value.clone())
+}
+
+/// Adopt the actual Claude session UUID reported inside a hook payload while
+/// retaining the launch-time UUID as a stable hook-routing alias (#4423).
+///
+/// Claude continuation keeps the tmux process and hook command alive but moves
+/// transcript writes to a new `<uuid>.jsonl`.  The hook command therefore still
+/// addresses the old UUID while stdin carries the new one.  This update is
+/// deliberately limited to an existing ClaudeTui binding reached through the
+/// command UUID and to a real sibling transcript file. For a second or later
+/// continuation hop, the candidate must also be newer than the transcript
+/// currently bound to that pane. It never guesses across project directories.
+pub(crate) fn adopt_claude_continuation_session(
+    command_session_id: &str,
+    payload_session_id: &str,
+) -> Option<(String, String)> {
+    let command_session_id = command_session_id.trim();
+    let payload_session_id = payload_session_id.trim();
+    if command_session_id.is_empty()
+        || payload_session_id.is_empty()
+        || command_session_id == payload_session_id
+        || uuid::Uuid::parse_str(payload_session_id).is_err()
+    {
+        return None;
+    }
+
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    let command_key = PromptKey::new("claude", command_session_id);
+    let tmux_session_name = state
+        .tmux_by_provider_session
+        .get(&command_key)?
+        .value
+        .clone();
+    let binding = state.runtime_by_tmux.get(&tmux_session_name)?;
+    if binding.value.runtime_kind != RuntimeHandoffKind::ClaudeTui {
+        return None;
+    }
+    let old_output_path = PathBuf::from(&binding.value.output_path);
+    let new_output_path = old_output_path
+        .parent()?
+        .join(format!("{payload_session_id}.jsonl"));
+    if !new_output_path.is_file() {
+        return None;
+    }
+    if let Some(current_session_id) = binding.value.session_id.as_deref()
+        && current_session_id != command_session_id
+        && current_session_id != payload_session_id
+    {
+        let current_mtime = std::fs::metadata(&old_output_path)
+            .and_then(|metadata| metadata.modified())
+            .ok()?;
+        let candidate_mtime = std::fs::metadata(&new_output_path)
+            .and_then(|metadata| metadata.modified())
+            .ok()?;
+        if candidate_mtime <= current_mtime {
+            return None;
+        }
+    }
+    let new_output_path = new_output_path.display().to_string();
+
+    if binding.value.session_id.as_deref() == Some(payload_session_id)
+        && binding.value.output_path == new_output_path
+    {
+        // Subsequent hooks still carry the launch-time query UUID. Do not reset
+        // the already-adopted continuation cursor to zero on every event.
+        state.tmux_by_provider_session.insert(
+            PromptKey::new("claude", payload_session_id),
+            TimedValue {
+                value: tmux_session_name.clone(),
+                recorded_at: Instant::now(),
+            },
+        );
+        state.tmux_by_provider_session.insert(
+            command_key,
+            TimedValue {
+                value: tmux_session_name.clone(),
+                recorded_at: Instant::now(),
+            },
+        );
+        return Some((tmux_session_name, new_output_path));
+    }
+
+    let binding = state.runtime_by_tmux.get_mut(&tmux_session_name)?;
+    binding.value.output_path = new_output_path.clone();
+    binding.value.relay_output_path = None;
+    binding.value.session_id = Some(payload_session_id.to_string());
+    // Start conservatively at the new transcript head. Stable prompt-entry
+    // identities suppress replay; starting at EOF would silently skip the
+    // continuation boundary that taught us the new UUID.
+    binding.value.last_offset = 0;
+    binding.value.relay_last_offset = None;
+    binding.recorded_at = Instant::now();
+    state.tmux_by_provider_session.insert(
+        PromptKey::new("claude", payload_session_id),
+        TimedValue {
+            value: tmux_session_name.clone(),
+            recorded_at: Instant::now(),
+        },
+    );
+    // The running Claude process can cache the launch-time hook command even
+    // after its settings artifact is rewritten. Keep that observed command
+    // identity newest for future waits until dcserver rehydration establishes
+    // the persisted payload UUID as the sole mapping.
+    state.tmux_by_provider_session.insert(
+        command_key,
+        TimedValue {
+            value: tmux_session_name.clone(),
+            recorded_at: Instant::now(),
+        },
+    );
+    Some((tmux_session_name, new_output_path))
 }
 
 pub(crate) fn refresh_tmux_runtime_binding_activity(
@@ -1897,6 +2014,114 @@ mod tests {
         assert_eq!(
             provider_session_for_tmux("claude", "tmux-relaunch"),
             Some("uuid-new".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_hook_payload_adopts_sibling_continuation_once_without_cursor_reset() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let tmp = tempfile::tempdir().unwrap();
+        let old_session = uuid::Uuid::new_v4().to_string();
+        let new_session = uuid::Uuid::new_v4().to_string();
+        let old_path = tmp.path().join(format!("{old_session}.jsonl"));
+        let new_path = tmp.path().join(format!("{new_session}.jsonl"));
+        std::fs::write(&old_path, b"old\n").unwrap();
+        std::fs::write(&new_path, b"new\n").unwrap();
+        let tmux = format!("tmux-4423-continuation-{}", std::process::id());
+        register_provider_session("claude", &old_session, &tmux);
+        register_tmux_runtime_binding(
+            &tmux,
+            TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::ClaudeTui,
+                output_path: old_path.display().to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: Some(old_session.clone()),
+                last_offset: 99,
+                relay_last_offset: Some(99),
+            },
+        );
+
+        let adopted = adopt_claude_continuation_session(&old_session, &new_session)
+            .expect("safe sibling continuation adoption");
+        assert_eq!(adopted.0, tmux);
+        assert_eq!(adopted.1, new_path.display().to_string());
+        let binding = runtime_binding_for_tmux_session(&tmux).unwrap();
+        assert_eq!(binding.session_id.as_deref(), Some(new_session.as_str()));
+        assert_eq!(binding.output_path, new_path.display().to_string());
+        assert_eq!(binding.last_offset, 0);
+        assert_eq!(
+            provider_session_for_tmux("claude", &tmux).as_deref(),
+            Some(old_session.as_str()),
+            "future waits must keep using the live process's cached hook command UUID"
+        );
+
+        assert!(adopt_claude_continuation_session(&old_session, &new_session).is_some());
+        let mut progressed = runtime_binding_for_tmux_session(&tmux).unwrap();
+        progressed.last_offset = 4;
+        register_tmux_runtime_binding(&tmux, progressed);
+        assert!(adopt_claude_continuation_session(&old_session, &new_session).is_some());
+        assert_eq!(
+            runtime_binding_for_tmux_session(&tmux).unwrap().last_offset,
+            4,
+            "subsequent old-query/new-payload hooks must not rewind the adopted cursor"
+        );
+    }
+
+    #[test]
+    fn claude_hook_payload_can_advance_multiple_continuation_hops_but_not_rewind() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let tmp = tempfile::tempdir().unwrap();
+        let command_session = uuid::Uuid::new_v4().to_string();
+        let first_continuation = uuid::Uuid::new_v4().to_string();
+        let second_continuation = uuid::Uuid::new_v4().to_string();
+        let stale_continuation = uuid::Uuid::new_v4().to_string();
+        let command_path = tmp.path().join(format!("{command_session}.jsonl"));
+        let first_path = tmp.path().join(format!("{first_continuation}.jsonl"));
+        let second_path = tmp.path().join(format!("{second_continuation}.jsonl"));
+        let stale_path = tmp.path().join(format!("{stale_continuation}.jsonl"));
+        for path in [&command_path, &first_path, &second_path, &stale_path] {
+            std::fs::write(path, b"{}\n").unwrap();
+        }
+        filetime::set_file_mtime(&first_path, filetime::FileTime::from_unix_time(20, 0)).unwrap();
+        filetime::set_file_mtime(&second_path, filetime::FileTime::from_unix_time(30, 0)).unwrap();
+        filetime::set_file_mtime(&stale_path, filetime::FileTime::from_unix_time(10, 0)).unwrap();
+        let tmux = format!("tmux-4423-multihop-{}", std::process::id());
+        register_provider_session("claude", &command_session, &tmux);
+        register_tmux_runtime_binding(
+            &tmux,
+            TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::ClaudeTui,
+                output_path: command_path.display().to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: Some(command_session.clone()),
+                last_offset: 7,
+                relay_last_offset: None,
+            },
+        );
+
+        adopt_claude_continuation_session(&command_session, &first_continuation)
+            .expect("first continuation hop");
+        adopt_claude_continuation_session(&command_session, &second_continuation)
+            .expect("newer second continuation hop through cached command UUID");
+        let binding = runtime_binding_for_tmux_session(&tmux).unwrap();
+        assert_eq!(
+            binding.session_id.as_deref(),
+            Some(second_continuation.as_str())
+        );
+        assert!(
+            adopt_claude_continuation_session(&command_session, &stale_continuation).is_none(),
+            "a delayed historical payload must not rewind the current continuation"
+        );
+        assert_eq!(
+            runtime_binding_for_tmux_session(&tmux)
+                .unwrap()
+                .session_id
+                .as_deref(),
+            Some(second_continuation.as_str())
         );
     }
 


### PR DESCRIPTION
Closes #4423

## Summary
- adopt the actual Claude continuation UUID from hook payloads while preserving live waiter aliases
- add a conservative idle fallback gated by stale age, live pane, newer/growing transcript, and semantic timestamp continuity
- persist multi-hop cutovers to AgentDesk launch/settings artifacts and prevent stale rehydration rollback
- avoid hot-loop scans for fresh bindings and cache verified artifact persistence successes

## Verification
- `cargo check -q`
- `cargo test -q continuation_` (36 passed)
- `cargo test -q services::claude_tui::hook_server::tests` (22 passed)
- `cargo test -q services::tui_prompt_dedupe::tests` (75 passed)
- `cargo test -q services::discord::tui_prompt_relay::` (181 passed)
- `python3 scripts/generate_inventory_docs.py --check`
- mutation checks: timestamp continuity, transition alias, and cursor guard each fail their targeted test when removed

## Independent review
- Account 1 Opus xhigh, exact HEAD `579ab48228731f3d70c1b2fed2e882f8aded1c23`
- exact patch SHA-256 `90d0cddf6d9883e2c65a8bc126ef7c818022e0164b1483514647c3f547e24676`
- final `VERDICT: CLEAN` after addressing two hot-loop performance findings
- Fable unavailable under quota policy (all scoped pools unavailable; account 3 above 70% threshold/spend limit)