### PR TITLE
obs(prompt): complete prompt manifest inventory

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -128,10 +128,10 @@
 | `db::meetings` | `src/db/meetings.rs` | 621 | 621 | 0 |  |
 | `db::postgres` | `src/db/postgres.rs` | 2699 | 1280 | 1419 | giant-file |
 | `db::prompt_manifests` | `src/db/prompt_manifests/mod.rs` | 26 | 26 | 0 |  |
-| `db::prompt_manifests::builder` | `src/db/prompt_manifests/builder.rs` | 89 | 89 | 0 |  |
-| `db::prompt_manifests::model` | `src/db/prompt_manifests/model.rs` | 181 | 181 | 0 |  |
+| `db::prompt_manifests::builder` | `src/db/prompt_manifests/builder.rs` | 90 | 90 | 0 |  |
+| `db::prompt_manifests::model` | `src/db/prompt_manifests/model.rs` | 191 | 191 | 0 |  |
 | `db::prompt_manifests::redaction` | `src/db/prompt_manifests/redaction.rs` | 77 | 77 | 0 |  |
-| `db::prompt_manifests::repository` | `src/db/prompt_manifests/repository.rs` | 268 | 268 | 0 |  |
+| `db::prompt_manifests::repository` | `src/db/prompt_manifests/repository.rs` | 275 | 275 | 0 |  |
 | `db::prompt_manifests::retention` | `src/db/prompt_manifests/retention.rs` | 96 | 96 | 0 |  |
 | `db::prompt_manifests::storage_stats` | `src/db/prompt_manifests/storage_stats.rs` | 122 | 122 | 0 |  |
 | `db::relay_dead_letter` | `src/db/relay_dead_letter.rs` | 250 | 133 | 117 |  |
@@ -258,7 +258,7 @@
 | `server::routes::docs::inventory::endpoints::part_02` | `src/server/routes/docs/inventory/endpoints/part_02.rs` | 684 | 684 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_03` | `src/server/routes/docs/inventory/endpoints/part_03.rs` | 646 | 646 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_04` | `src/server/routes/docs/inventory/endpoints/part_04.rs` | 719 | 719 | 0 |  |
-| `server::routes::docs::inventory::endpoints::part_05` | `src/server/routes/docs/inventory/endpoints/part_05.rs` | 719 | 719 | 0 |  |
+| `server::routes::docs::inventory::endpoints::part_05` | `src/server/routes/docs/inventory/endpoints/part_05.rs` | 732 | 732 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_06` | `src/server/routes/docs/inventory/endpoints/part_06.rs` | 749 | 749 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_07` | `src/server/routes/docs/inventory/endpoints/part_07.rs` | 679 | 679 | 0 |  |
 | `server::routes::docs::inventory::endpoints::part_08` | `src/server/routes/docs/inventory/endpoints/part_08.rs` | 739 | 739 | 0 |  |
@@ -450,7 +450,7 @@
 | `services::discord::commands::inspect::query` | `src/services/discord/commands/inspect/query.rs` | 153 | 153 | 0 |  |
 | `services::discord::commands::inspect::render_context` | `src/services/discord/commands/inspect/render_context.rs` | 65 | 65 | 0 |  |
 | `services::discord::commands::inspect::render_last` | `src/services/discord/commands/inspect/render_last.rs` | 54 | 54 | 0 |  |
-| `services::discord::commands::inspect::render_prompt` | `src/services/discord/commands/inspect/render_prompt.rs` | 177 | 177 | 0 |  |
+| `services::discord::commands::inspect::render_prompt` | `src/services/discord/commands/inspect/render_prompt.rs` | 181 | 181 | 0 |  |
 | `services::discord::commands::inspect::render_recovery` | `src/services/discord/commands/inspect/render_recovery.rs` | 60 | 60 | 0 |  |
 | `services::discord::commands::inspect::render_session` | `src/services/discord/commands/inspect/render_session.rs` | 37 | 37 | 0 |  |
 | `services::discord::commands::meeting_cmd` | `src/services/discord/commands/meeting_cmd.rs` | 102 | 102 | 0 |  |
@@ -580,10 +580,10 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 436 | 436 | 0 |  |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 597 | 597 | 0 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 507 | 307 | 200 |  |
-| `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 334 | 334 | 0 |  |
+| `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 359 | 359 | 0 |  |
 | `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 267 | 124 | 143 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
@@ -940,7 +940,7 @@
 | `services::memory::local` | `src/services/memory/local.rs` | 85 | 45 | 40 |  |
 | `services::memory::memento` | `src/services/memory/memento.rs` | 2122 | 1893 | 229 | giant-file |
 | `services::memory::memento_instructions_cache` | `src/services/memory/memento_instructions_cache.rs` | 241 | 143 | 98 |  |
-| `services::memory::memento_throttle` | `src/services/memory/memento_throttle.rs` | 836 | 752 | 84 |  |
+| `services::memory::memento_throttle` | `src/services/memory/memento_throttle.rs` | 884 | 776 | 108 |  |
 | `services::memory::runtime_state` | `src/services/memory/runtime_state.rs` | 315 | 315 | 0 |  |
 | `services::message_outbox` | `src/services/message_outbox.rs` | 1420 | 863 | 557 |  |
 | `services::message_outbox_recovery` | `src/services/message_outbox_recovery.rs` | 166 | 166 | 0 |  |

--- a/migrations/postgres/0088_prompt_manifest_total_input_bytes.sql
+++ b/migrations/postgres/0088_prompt_manifest_total_input_bytes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE prompt_manifests
+    ADD COLUMN IF NOT EXISTS total_input_bytes BIGINT NOT NULL DEFAULT 0;

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -450,6 +450,11 @@
       "path": "migrations/postgres/0087_scheduled_message_launch_commit_and_runtime_defer.sql",
       "sha256": "dffcc1786298a319875f7a1113b7c7d9a3ea538f2111537daef1f13dae0b2877",
       "version": 87
+    },
+    {
+      "path": "migrations/postgres/0088_prompt_manifest_total_input_bytes.sql",
+      "sha256": "0ccba730df1a6df1efd0c0262c81aa21c0cc5607e8b0bd1aeefc6e3fe6f23821",
+      "version": 88
     }
   ],
   "version": 1

--- a/src/db/prompt_manifests/builder.rs
+++ b/src/db/prompt_manifests/builder.rs
@@ -75,6 +75,7 @@ impl PromptManifestBuilder {
             channel_id,
             dispatch_id: self.dispatch_id,
             profile: self.profile,
+            total_input_bytes: 0,
             total_input_tokens_est: 0,
             layer_count: 0,
             layers: self.layers,

--- a/src/db/prompt_manifests/model.rs
+++ b/src/db/prompt_manifests/model.rs
@@ -58,6 +58,8 @@ pub struct PromptManifest {
     pub channel_id: String,
     pub dispatch_id: Option<String>,
     pub profile: Option<String>,
+    #[serde(default)]
+    pub total_input_bytes: i64,
     pub total_input_tokens_est: i64,
     pub layer_count: i64,
     pub layers: Vec<PromptManifestLayer>,
@@ -65,11 +67,19 @@ pub struct PromptManifest {
 
 impl PromptManifest {
     pub fn recompute_totals(&mut self) {
+        self.total_input_bytes = self
+            .layers
+            .iter()
+            .filter(|layer| layer.enabled)
+            .fold(0_i64, |sum, layer| {
+                sum.saturating_add(layer.original_bytes.unwrap_or(layer.chars).max(0))
+            });
         self.total_input_tokens_est = self
             .layers
             .iter()
+            .filter(|layer| layer.enabled)
             .fold(0_i64, |sum, layer| sum.saturating_add(layer.tokens_est));
-        self.layer_count = usize_to_i64(self.layers.len());
+        self.layer_count = usize_to_i64(self.layers.iter().filter(|layer| layer.enabled).count());
     }
 }
 

--- a/src/db/prompt_manifests/repository.rs
+++ b/src/db/prompt_manifests/repository.rs
@@ -50,8 +50,10 @@ async fn save_prompt_manifest_pg(pool: &PgPool, manifest: &PromptManifest) -> Re
     let total_input_tokens_est = manifest
         .layers
         .iter()
+        .filter(|layer| layer.enabled)
         .fold(0_i64, |sum, layer| sum.saturating_add(layer.tokens_est));
-    let layer_count = usize_to_i64(manifest.layers.len());
+    let total_input_bytes = manifest.total_input_bytes.max(0);
+    let layer_count = usize_to_i64(manifest.layers.iter().filter(|layer| layer.enabled).count());
 
     let manifest_id: i64 = sqlx::query_scalar(
         "INSERT INTO prompt_manifests (
@@ -59,14 +61,16 @@ async fn save_prompt_manifest_pg(pool: &PgPool, manifest: &PromptManifest) -> Re
             channel_id,
             dispatch_id,
             profile,
+            total_input_bytes,
             total_input_tokens_est,
             layer_count
-         ) VALUES ($1, $2, $3, $4, $5, $6)
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7)
          ON CONFLICT (turn_id) DO UPDATE SET
             created_at = NOW(),
             channel_id = EXCLUDED.channel_id,
             dispatch_id = EXCLUDED.dispatch_id,
             profile = EXCLUDED.profile,
+            total_input_bytes = EXCLUDED.total_input_bytes,
             total_input_tokens_est = EXCLUDED.total_input_tokens_est,
             layer_count = EXCLUDED.layer_count
          RETURNING id",
@@ -75,6 +79,7 @@ async fn save_prompt_manifest_pg(pool: &PgPool, manifest: &PromptManifest) -> Re
     .bind(channel_id)
     .bind(normalized_opt(manifest.dispatch_id.as_deref()))
     .bind(normalized_opt(manifest.profile.as_deref()))
+    .bind(total_input_bytes)
     .bind(total_input_tokens_est)
     .bind(layer_count)
     .fetch_one(&mut *tx)
@@ -186,6 +191,7 @@ async fn fetch_prompt_manifest_pg(pool: &PgPool, turn_id: &str) -> Result<Option
             channel_id,
             dispatch_id,
             profile,
+            total_input_bytes,
             total_input_tokens_est,
             layer_count
          FROM prompt_manifests
@@ -210,6 +216,7 @@ async fn fetch_prompt_manifest_pg(pool: &PgPool, turn_id: &str) -> Result<Option
         channel_id: row.try_get("channel_id")?,
         dispatch_id: row.try_get("dispatch_id")?,
         profile: row.try_get("profile")?,
+        total_input_bytes: row.try_get("total_input_bytes")?,
         total_input_tokens_est: row.try_get("total_input_tokens_est")?,
         layer_count: row.try_get("layer_count")?,
         layers,

--- a/src/db/prompt_manifests/tests.rs
+++ b/src/db/prompt_manifests/tests.rs
@@ -92,6 +92,7 @@ fn prompt_manifest_builder_separates_content_visibility() {
     assert_eq!(manifest.dispatch_id.as_deref(), Some("dispatch-1"));
     assert_eq!(manifest.profile.as_deref(), Some("project-agentdesk"));
     assert_eq!(manifest.layer_count, 2);
+    assert_eq!(manifest.total_input_bytes, 26);
     assert_eq!(manifest.total_input_tokens_est, 6);
     assert_eq!(
         manifest.layers[0].content_visibility,
@@ -108,6 +109,34 @@ fn prompt_manifest_builder_separates_content_visibility() {
         manifest.layers[1].redacted_preview.as_deref(),
         Some("sensitive user content")
     );
+}
+
+#[test]
+fn prompt_manifest_totals_exclude_disabled_layers() {
+    let manifest = PromptManifestBuilder::new("turn-enabled-only", "channel-1")
+        .content_layer(
+            "enabled",
+            true,
+            Some("test"),
+            Some("present"),
+            PromptContentVisibility::AdkProvided,
+            "12345678",
+        )
+        .content_layer(
+            "disabled",
+            false,
+            Some("test"),
+            Some("absent"),
+            PromptContentVisibility::AdkProvided,
+            "this disabled body must not affect totals",
+        )
+        .build()
+        .expect("manifest");
+
+    assert_eq!(manifest.layers.len(), 2);
+    assert_eq!(manifest.layer_count, 1);
+    assert_eq!(manifest.total_input_bytes, 8);
+    assert_eq!(manifest.total_input_tokens_est, 2);
 }
 
 #[tokio::test]
@@ -152,6 +181,7 @@ async fn prompt_manifest_save_fetch_round_trip_pg() {
     assert_eq!(fetched.id, Some(manifest_id));
     assert_eq!(fetched.turn_id, "turn-round-trip");
     assert_eq!(fetched.channel_id, "1499610614904131594");
+    assert_eq!(fetched.total_input_bytes, manifest.total_input_bytes);
     assert_eq!(fetched.dispatch_id.as_deref(), Some("dispatch-1"));
     assert_eq!(fetched.profile.as_deref(), Some("project-agentdesk"));
     assert_eq!(fetched.layer_count, 2);

--- a/src/server/routes/docs/inventory/endpoints/part_05.rs
+++ b/src/server/routes/docs/inventory/endpoints/part_05.rs
@@ -356,7 +356,20 @@ pub(super) fn endpoints() -> Vec<EndpointDoc> {
         )])
         .with_example(
             json!({"query": {"hours": 24}}),
-            json!({"hours": 24, "calls": [{"hour": "2026-07-08T00:00:00Z", "logical_calls": 12, "dedup_hits": 3}]}),
+            json!({
+                "window_hours": 24,
+                "summary": {"logical_calls": 12, "dedup_hits": 3},
+                "recall_context": {
+                    "full_turns": 8,
+                    "full_bytes": 4096,
+                    "full_average_bytes": 512,
+                    "identity_only_turns": 4,
+                    "identity_only_bytes": 384,
+                    "identity_only_average_bytes": 96,
+                    "identity_only_empty_turns": 1,
+                    "skipped_turns": 2
+                }
+            }),
         ),
         ep(
             "GET",

--- a/src/services/discord/commands/inspect/render_prompt.rs
+++ b/src/services/discord/commands/inspect/render_prompt.rs
@@ -33,7 +33,11 @@ pub(super) fn render_prompt_manifest_report(
     push_kv(
         &mut out,
         "total input estimate",
-        &format!("{} tokens", format_tokens(manifest.total_input_tokens_est)),
+        &format!(
+            "{} bytes / {} tokens",
+            manifest.total_input_bytes,
+            format_tokens(manifest.total_input_tokens_est)
+        ),
     );
     push_kv(
         &mut out,

--- a/src/services/discord/commands/inspect/tests.rs
+++ b/src/services/discord/commands/inspect/tests.rs
@@ -15,6 +15,7 @@ fn test_manifest() -> PromptManifest {
         channel_id: "1".to_string(),
         dispatch_id: None,
         profile: Some("Full".to_string()),
+        total_input_bytes: 1_200,
         total_input_tokens_est: 1_600,
         layer_count: 2,
         layers: vec![

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -84,7 +84,28 @@ fn prompt_manifest_log_records_hash_metadata_without_full_content() {
 
     // Exactly the metadata logged at info level — no full_content field exists.
     let layer_hashes = format!("{:?}", prompt_manifest_layer_hashes(&manifest));
-    assert_eq!(manifest.layers.len(), 3);
+    assert_eq!(manifest.layers.len(), 7);
+    assert_eq!(manifest.layer_count, 6);
+    assert_eq!(
+        manifest.total_input_bytes,
+        i64::try_from(built.system_prompt.len()).unwrap()
+    );
+    for required in [
+        "base_discord",
+        "tool_output_efficiency",
+        "context_compression",
+        "api_friction_guidance",
+        "current_task",
+        "dispatch_contract",
+    ] {
+        assert!(
+            manifest
+                .layers
+                .iter()
+                .any(|layer| layer.enabled && layer.layer_name == required),
+            "missing enabled layer {required}"
+        );
+    }
     assert_eq!(manifest.turn_id, "turn-current-task-test");
     assert!(layer_hashes.contains("dispatch_contract"));
     assert!(layer_hashes.contains(&dispatch_layer.content_sha256));
@@ -113,7 +134,7 @@ fn current_task_dispatch_layer_is_recorded_with_redacted_preview_only() {
 
     assert!(built.system_prompt.contains("[Current Task]"));
     let manifest = built.manifest.expect("prompt manifest");
-    assert_eq!(manifest.layers.len(), 3);
+    assert_eq!(manifest.layers.len(), 7);
     let layer = manifest
         .layers
         .iter()
@@ -132,12 +153,64 @@ fn current_task_dispatch_layer_is_recorded_with_redacted_preview_only() {
     let preview = layer.redacted_preview.as_deref().unwrap();
     assert!(preview.contains("[redacted-email]"));
     assert!(preview.contains("token=***"));
+    assert!(!preview.contains("[Dispatch Contract]"));
     assert!(!preview.contains("user@example.com"));
     assert!(!preview.contains("super-secret-123"));
 
     let serialized = serde_json::to_value(layer).unwrap();
     assert_eq!(serialized["enabled"], true);
     assert_eq!(serialized["full_content"], serde_json::Value::Null);
+}
+
+#[test]
+fn full_prompt_manifest_records_shared_knowledge_and_longterm_catalog() {
+    let binding = test_role_binding("manifest-inventory-agent");
+    let built = build_system_prompt_with_manifest(
+        "ctx",
+        &[],
+        "/tmp",
+        ChannelId::new(1),
+        "tok",
+        Some(&binding),
+        false,
+        DispatchProfile::Full,
+        None,
+        None,
+        Some("[Shared Agent Knowledge]\nimportant invariant"),
+        Some("- memory.md: durable fact"),
+        None,
+        false,
+        None,
+        None,
+        Some("turn-layer-inventory"),
+    );
+
+    let manifest = built.manifest.expect("prompt manifest");
+    for (name, expected_fragment) in [
+        (
+            "base_discord",
+            "You are chatting with a user through Discord.",
+        ),
+        ("shared_knowledge", "important invariant"),
+        ("longterm_catalog", "durable fact"),
+    ] {
+        let layer = manifest
+            .layers
+            .iter()
+            .find(|layer| layer.layer_name == name)
+            .unwrap_or_else(|| panic!("missing {name}"));
+        assert!(layer.enabled, "{name} should describe injected content");
+        let recorded = layer
+            .full_content
+            .as_deref()
+            .or(layer.redacted_preview.as_deref())
+            .expect("recorded content");
+        assert!(recorded.contains(expected_fragment));
+    }
+    assert_eq!(
+        manifest.layer_count as usize,
+        manifest.layers.iter().filter(|layer| layer.enabled).count()
+    );
 }
 
 #[test]
@@ -150,7 +223,7 @@ fn current_task_freeform_layer_uses_discord_message_source() {
     let built = build_prompt_with_manifest_for(&current_task, None);
 
     let manifest = built.manifest.expect("prompt manifest");
-    assert_eq!(manifest.layers.len(), 3);
+    assert_eq!(manifest.layers.len(), 7);
     let layer = manifest
         .layers
         .iter()
@@ -378,6 +451,10 @@ fn build_prompt_manifest_includes_recovery_context_layer() {
     );
 
     let manifest = built.manifest.expect("prompt manifest");
+    assert_eq!(
+        manifest.total_input_bytes,
+        i64::try_from(built.system_prompt.len() + raw_context.len()).unwrap()
+    );
     let layer = manifest
         .layers
         .iter()

--- a/src/services/discord/prompt_builder/manifest.rs
+++ b/src/services/discord/prompt_builder/manifest.rs
@@ -31,6 +31,31 @@ pub(super) const MEMORY_RECALL_LAYER_NAME: &str = "memory_recall";
 pub(super) const MEMORY_RECALL_LAYER_SOURCE: &str = "memento";
 const ADK_PROMPT_MANIFEST_PREVIEW_MAX_BYTES: usize = 200;
 
+pub(super) fn prompt_manifest_layer(
+    layer_name: &str,
+    source: &str,
+    reason: Option<String>,
+    visibility: PromptContentVisibility,
+    content: &str,
+) -> PromptManifestLayer {
+    let enabled = !content.trim().is_empty();
+    let mut layer = PromptManifestLayer::from_content(
+        layer_name,
+        enabled,
+        Some(source),
+        reason,
+        visibility,
+        content.to_string(),
+    );
+    if visibility == PromptContentVisibility::UserDerived {
+        layer.redacted_preview = enabled.then(|| redacted_prompt_manifest_preview(content));
+        layer.full_content = None;
+    } else if !enabled {
+        layer.full_content = None;
+    }
+    layer
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecoveryContextManifestInput<'a> {
     pub(crate) raw_context: &'a str,

--- a/src/services/discord/prompt_builder/mod.rs
+++ b/src/services/discord/prompt_builder/mod.rs
@@ -3,7 +3,7 @@ use super::settings::{
     render_peer_agent_guidance,
 };
 use super::*;
-use crate::db::prompt_manifests::PromptManifest;
+use crate::db::prompt_manifests::{PromptContentVisibility, PromptManifest};
 
 mod dispatch_contract;
 mod layer_rendering;
@@ -14,14 +14,15 @@ pub(crate) use dispatch_contract::CurrentTaskContext;
 pub(crate) use manifest::RecoveryContextManifestInput;
 pub(crate) use memory_guidance::MemoryRecallManifestInput;
 
-use dispatch_contract::render_current_task_section;
+use dispatch_contract::{render_current_task_section, render_dispatch_contract};
 use layer_rendering::{
     agent_performance_prompt_section, api_friction_guidance, context_compression_guidance,
     render_channel_participants, shared_agent_rules_lookup, tool_output_efficiency_guidance,
 };
 use manifest::{
     build_prompt_manifest, current_task_manifest_layer, dispatch_contract_manifest_layer,
-    memory_recall_manifest_layer, recovery_context_manifest_layer, role_prompt_manifest_layer,
+    memory_recall_manifest_layer, prompt_manifest_layer, recovery_context_manifest_layer,
+    role_prompt_manifest_layer,
 };
 use memory_guidance::proactive_memory_guidance;
 
@@ -186,12 +187,38 @@ pub(super) fn build_system_prompt_with_manifest(
         channel_id.get(),
         discord_token_hash(token),
     );
+    prompt_manifest_layers.push(prompt_manifest_layer(
+        "base_discord",
+        "prompt_builder.base_discord",
+        Some(format!(
+            "profile={}",
+            manifest::prompt_manifest_profile(profile)
+        )),
+        PromptContentVisibility::UserDerived,
+        &system_prompt_owned,
+    ));
+    let tool_output_guidance = tool_output_efficiency_guidance();
     system_prompt_owned.push_str("\n\n");
-    system_prompt_owned.push_str(tool_output_efficiency_guidance());
+    system_prompt_owned.push_str(tool_output_guidance);
+    prompt_manifest_layers.push(prompt_manifest_layer(
+        "tool_output_efficiency",
+        "prompt_builder.tool_output_efficiency_guidance",
+        None,
+        PromptContentVisibility::AdkProvided,
+        tool_output_guidance,
+    ));
 
     if profile == DispatchProfile::Full {
+        let compression_guidance = context_compression_guidance();
         system_prompt_owned.push_str("\n\n");
-        system_prompt_owned.push_str(&context_compression_guidance());
+        system_prompt_owned.push_str(&compression_guidance);
+        prompt_manifest_layers.push(prompt_manifest_layer(
+            "context_compression",
+            "prompt_builder.context_compression_guidance",
+            None,
+            PromptContentVisibility::AdkProvided,
+            &compression_guidance,
+        ));
     }
 
     if let Some(binding) = role_binding {
@@ -200,7 +227,7 @@ pub(super) fn build_system_prompt_with_manifest(
         //   review          → read code, post review comment, submit verdict via /api/reviews/verdict
         //   review-decision → read counter-review feedback, submit accept/dispute/dismiss via /api/reviews/decision
         if profile == DispatchProfile::ReviewLite {
-            system_prompt_owned.push_str(&match dispatch_type {
+            let review_rules = match dispatch_type {
                 Some("review-decision") => "\n\n[Review Decision Rules]\n\
                      - 한국어로 소통한다\n\
                      - 카운터 리뷰 피드백을 읽고 accept/dispute/dismiss 중 결정한다\n\
@@ -212,25 +239,48 @@ pub(super) fn build_system_prompt_with_manifest(
                      - 리뷰 결과는 GitHub issue 코멘트로 남긴다\n\
                      - 리뷰 verdict 제출 후 dispatch를 완료한다"
                         .to_string(),
-            });
+            };
+            system_prompt_owned.push_str(&review_rules);
+            prompt_manifest_layers.push(prompt_manifest_layer(
+                "review_rules",
+                "prompt_builder.review_rules",
+                dispatch_type.map(|value| format!("dispatch_type={value}")),
+                PromptContentVisibility::AdkProvided,
+                review_rules.trim_start_matches("\n\n"),
+            ));
 
             // #119: Inject review tuning guidance only for review dispatches (not review-decision).
             // Injecting into review-decision would bias the labeler's accept/dispute/dismiss judgment,
             // contaminating the FP/TP dataset that the guidance itself is derived from.
             if dispatch_type != Some("review-decision") {
                 if let Some(guidance) = load_review_tuning_guidance() {
-                    system_prompt_owned
-                        .push_str("\n\n[Review Tuning — 과거 리뷰 정확도 기반 가이던스]\n");
-                    system_prompt_owned.push_str(&guidance);
+                    let section =
+                        format!("[Review Tuning — 과거 리뷰 정확도 기반 가이던스]\n{guidance}");
+                    system_prompt_owned.push_str("\n\n");
+                    system_prompt_owned.push_str(&section);
+                    prompt_manifest_layers.push(prompt_manifest_layer(
+                        "review_tuning",
+                        "settings.load_review_tuning_guidance",
+                        None,
+                        PromptContentVisibility::AdkProvided,
+                        &section,
+                    ));
                 }
             }
         } else if profile == DispatchProfile::Lite {
-            system_prompt_owned.push_str(
-                "\n\n[Lite Channel Rules]\n\
+            let lite_rules = "[Lite Channel Rules]\n\
                  - 한국어로 간결하게 소통한다\n\
                  - 현재 요청에 필요한 범위만 확인하고 불필요한 파일 탐색을 피한다\n\
-                 - 큰 변경이나 장시간 작업이 필요하면 먼저 범위와 다음 행동을 짧게 확인한다",
-            );
+                 - 큰 변경이나 장시간 작업이 필요하면 먼저 범위와 다음 행동을 짧게 확인한다";
+            system_prompt_owned.push_str("\n\n");
+            system_prompt_owned.push_str(lite_rules);
+            prompt_manifest_layers.push(prompt_manifest_layer(
+                "lite_channel_rules",
+                "prompt_builder.lite_channel_rules",
+                None,
+                PromptContentVisibility::AdkProvided,
+                lite_rules,
+            ));
         } else {
             // #4314: the shared-rules index now depends on the agent's cwd —
             // repo-relative `docs/*` references are injected only when the
@@ -243,6 +293,13 @@ pub(super) fn build_system_prompt_with_manifest(
                 channel_id.get()
             );
             system_prompt_owned.push_str(&shared_rules);
+            prompt_manifest_layers.push(prompt_manifest_layer(
+                "shared_agent_rules",
+                "prompt_builder.shared_agent_rules_lookup",
+                Some(format!("workspace={current_path}")),
+                PromptContentVisibility::AdkProvided,
+                &shared_rules,
+            ));
         }
 
         if profile != DispatchProfile::Lite {
@@ -253,14 +310,22 @@ pub(super) fn build_system_prompt_with_manifest(
                         true,
                         Some(role_prompt.clone()),
                     ));
-                    system_prompt_owned.push_str(
-                        "\n\n[Channel Role Binding]\n\
+                    let role_binding_contract = "[Channel Role Binding]\n\
                          The following role definition is authoritative for this Discord channel.\n\
                          You MUST answer as this role, stay within its scope, and follow its response contract.\n\
                          Do NOT override it with a generic assistant persona or by inferring a different role from repository files,\n\
-                         unless the user explicitly asks you to audit or compare role definitions.\n\n",
-                    );
+                         unless the user explicitly asks you to audit or compare role definitions.";
+                    system_prompt_owned.push_str("\n\n");
+                    system_prompt_owned.push_str(role_binding_contract);
+                    system_prompt_owned.push_str("\n\n");
                     system_prompt_owned.push_str(&role_prompt);
+                    prompt_manifest_layers.push(prompt_manifest_layer(
+                        "role_binding_contract",
+                        "prompt_builder.role_binding_contract",
+                        Some(format!("agent_id={}", binding.role_id)),
+                        PromptContentVisibility::AdkProvided,
+                        role_binding_contract,
+                    ));
                     tracing::warn!(
                         "  [role-map] Applied role '{}' for channel {}",
                         binding.role_id,
@@ -295,6 +360,13 @@ pub(super) fn build_system_prompt_with_manifest(
             {
                 system_prompt_owned.push_str("\n\n");
                 system_prompt_owned.push_str(sak);
+                prompt_manifest_layers.push(prompt_manifest_layer(
+                    "shared_knowledge",
+                    "memory.shared_knowledge",
+                    None,
+                    PromptContentVisibility::AdkProvided,
+                    sak,
+                ));
             }
         }
 
@@ -303,17 +375,39 @@ pub(super) fn build_system_prompt_with_manifest(
             if let Some(catalog) = longterm_catalog
                 && dedupe_tracker.record("longterm_catalog", catalog)
             {
-                system_prompt_owned.push_str(
-                    "\n\n[Long-term Memory]\n\
-                     Available memory files for this agent. Use the Read tool to load full content when needed:\n",
-                );
+                let longterm_contract = "[Long-term Memory]\n\
+                     Available memory files for this agent. Use the Read tool to load full content when needed:";
+                system_prompt_owned.push_str("\n\n");
+                system_prompt_owned.push_str(longterm_contract);
+                system_prompt_owned.push('\n');
                 system_prompt_owned.push_str(catalog);
+                prompt_manifest_layers.push(prompt_manifest_layer(
+                    "longterm_memory_contract",
+                    "prompt_builder.longterm_memory_contract",
+                    None,
+                    PromptContentVisibility::AdkProvided,
+                    longterm_contract,
+                ));
+                prompt_manifest_layers.push(prompt_manifest_layer(
+                    "longterm_catalog",
+                    "memory.longterm_catalog",
+                    None,
+                    PromptContentVisibility::AdkProvided,
+                    catalog,
+                ));
             }
 
             if binding.peer_agents_enabled {
                 if let Some(peer_guidance) = render_peer_agent_guidance(&binding.role_id) {
                     system_prompt_owned.push_str("\n\n");
                     system_prompt_owned.push_str(&peer_guidance);
+                    prompt_manifest_layers.push(prompt_manifest_layer(
+                        "peer_agent_directory",
+                        "settings.render_peer_agent_guidance",
+                        Some(format!("agent_id={}", binding.role_id)),
+                        PromptContentVisibility::AdkProvided,
+                        &peer_guidance,
+                    ));
                 }
             }
         }
@@ -324,6 +418,13 @@ pub(super) fn build_system_prompt_with_manifest(
             // No role binding — still inject SAK (no LTM/peer agents to worry about)
             system_prompt_owned.push_str("\n\n");
             system_prompt_owned.push_str(sak);
+            prompt_manifest_layers.push(prompt_manifest_layer(
+                "shared_knowledge",
+                "memory.shared_knowledge",
+                Some("unbound_channel".to_string()),
+                PromptContentVisibility::AdkProvided,
+                sak,
+            ));
         }
     }
 
@@ -336,28 +437,68 @@ pub(super) fn build_system_prompt_with_manifest(
         memento_mcp_available,
     ) {
         system_prompt_owned.push_str(&memory_guidance);
+        prompt_manifest_layers.push(prompt_manifest_layer(
+            "memory_guidance",
+            "prompt_builder.proactive_memory_guidance",
+            None,
+            PromptContentVisibility::AdkProvided,
+            memory_guidance.trim_start_matches("\n\n"),
+        ));
     }
     if let Some(api_friction_guidance) = api_friction_guidance(profile) {
         system_prompt_owned.push_str(&api_friction_guidance);
+        prompt_manifest_layers.push(prompt_manifest_layer(
+            "api_friction_guidance",
+            "prompt_builder.api_friction_guidance",
+            None,
+            PromptContentVisibility::AdkProvided,
+            api_friction_guidance.trim_start_matches("\n\n"),
+        ));
     }
     if let Some(performance_section) = agent_performance_prompt_section(role_binding, profile) {
         system_prompt_owned.push_str("\n\n");
         system_prompt_owned.push_str(&performance_section);
+        prompt_manifest_layers.push(prompt_manifest_layer(
+            "agent_performance",
+            "prompt_builder.agent_performance_prompt_section",
+            None,
+            PromptContentVisibility::AdkProvided,
+            &performance_section,
+        ));
     }
 
     if queued_turn {
-        system_prompt_owned.push_str(
-            "\n\n[Queued Turn Rules]\n\
+        let queued_rules = "[Queued Turn Rules]\n\
              This user message was queued while another turn was running.\n\
              Treat ONLY the latest queued user message in this turn as actionable.\n\
              Do NOT repeat, combine, or continue prior queued messages unless the latest user message explicitly asks for that.\n\
-             If the latest user message asks for an exact literal output, return exactly that literal output and nothing else.",
-        );
+             If the latest user message asks for an exact literal output, return exactly that literal output and nothing else.";
+        system_prompt_owned.push_str("\n\n");
+        system_prompt_owned.push_str(queued_rules);
+        prompt_manifest_layers.push(prompt_manifest_layer(
+            "queued_turn_rules",
+            "prompt_builder.queued_turn_rules",
+            None,
+            PromptContentVisibility::AdkProvided,
+            queued_rules,
+        ));
     }
     if let Some((task, current_task_section)) = current_task.and_then(|task| {
         render_current_task_section(task, dispatch_type).map(|section| (task, section))
     }) {
-        prompt_manifest_layers.push(current_task_manifest_layer(task, &current_task_section));
+        let current_task_without_contract = render_dispatch_contract(dispatch_type, task)
+            .and_then(|contract| {
+                current_task_section
+                    .strip_suffix(&contract)
+                    .map(str::trim_end)
+                    .filter(|section| *section != "[Current Task]")
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| current_task_section.clone());
+        prompt_manifest_layers.push(current_task_manifest_layer(
+            task,
+            &current_task_without_contract,
+        ));
         system_prompt_owned.push_str("\n\n");
         system_prompt_owned.push_str(&current_task_section);
     }
@@ -405,20 +546,40 @@ pub(super) fn build_system_prompt_with_manifest(
         "prompt build complete"
     );
 
-    let manifest = build_prompt_manifest(
+    let mut manifest = build_prompt_manifest(
         turn_id,
         channel_id,
         profile,
         current_task,
         prompt_manifest_layers,
     );
+    if let Some(prompt_manifest) = manifest.as_mut() {
+        let external_context_bytes = prompt_manifest
+            .layers
+            .iter()
+            .filter(|layer| {
+                layer.enabled
+                    && matches!(
+                        layer.layer_name.as_str(),
+                        manifest::MEMORY_RECALL_LAYER_NAME | manifest::RECOVERY_CONTEXT_LAYER_NAME
+                    )
+            })
+            .fold(0_i64, |sum, layer| {
+                sum.saturating_add(layer.original_bytes.unwrap_or(layer.chars).max(0))
+            });
+        prompt_manifest.total_input_bytes = i64::try_from(system_prompt_owned.len())
+            .unwrap_or(i64::MAX)
+            .saturating_add(external_context_bytes);
+    }
     if let Some(prompt_manifest) = manifest.as_ref() {
         let layer_hashes = prompt_manifest_layer_hashes(prompt_manifest);
         tracing::info!(
             target: "agentdesk.prompt_manifest",
             turn_id = %prompt_manifest.turn_id,
             channel_id = %prompt_manifest.channel_id,
-            layer_count = prompt_manifest.layers.len(),
+            layer_count = prompt_manifest.layer_count,
+            total_input_bytes = prompt_manifest.total_input_bytes,
+            total_input_tokens_est = prompt_manifest.total_input_tokens_est,
             layer_hashes = ?layer_hashes,
             "recorded prompt manifest"
         );

--- a/src/services/memory/memento_throttle.rs
+++ b/src/services/memory/memento_throttle.rs
@@ -684,6 +684,12 @@ pub(crate) fn memento_call_metrics_snapshot(window_hours: usize) -> Value {
         .into_iter()
         .map(|(trigger_type, count)| (trigger_type, json!(count)))
         .collect::<serde_json::Map<String, Value>>();
+    let full_turns = FULL_CONTEXT_TURNS.load(Ordering::Relaxed);
+    let full_bytes = FULL_CONTEXT_BYTES_TOTAL.load(Ordering::Relaxed);
+    let identity_turns = IDENTITY_CONTEXT_TURNS.load(Ordering::Relaxed);
+    let identity_bytes = IDENTITY_CONTEXT_BYTES_TOTAL.load(Ordering::Relaxed);
+    let identity_empty_turns = IDENTITY_EMPTY_CONTEXT_TURNS.load(Ordering::Relaxed);
+    let skipped_turns = SKIPPED_CONTEXT_TURNS.load(Ordering::Relaxed);
 
     json!({
         "generated_at": now.with_timezone(&kst).to_rfc3339(),
@@ -694,8 +700,22 @@ pub(crate) fn memento_call_metrics_snapshot(window_hours: usize) -> Value {
         "searchObservability": {
             "feedback_counts_by_trigger_type": feedback_trigger_json,
         },
+        "recall_context": {
+            "full_turns": full_turns,
+            "full_bytes": full_bytes,
+            "full_average_bytes": average_bytes(full_bytes, full_turns),
+            "identity_only_turns": identity_turns,
+            "identity_only_bytes": identity_bytes,
+            "identity_only_average_bytes": average_bytes(identity_bytes, identity_turns),
+            "identity_only_empty_turns": identity_empty_turns,
+            "skipped_turns": skipped_turns,
+        },
         "hours": hours,
     })
+}
+
+fn average_bytes(total: u64, turns: u64) -> u64 {
+    if turns == 0 { 0 } else { total / turns }
 }
 
 fn normalize_feedback_trigger_type(trigger_type: &str) -> String {
@@ -714,6 +734,7 @@ static FULL_CONTEXT_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
 static FULL_CONTEXT_TURNS: AtomicU64 = AtomicU64::new(0);
 static IDENTITY_CONTEXT_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
 static IDENTITY_CONTEXT_TURNS: AtomicU64 = AtomicU64::new(0);
+static IDENTITY_EMPTY_CONTEXT_TURNS: AtomicU64 = AtomicU64::new(0);
 static SKIPPED_CONTEXT_TURNS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug)]
@@ -732,6 +753,9 @@ pub(crate) fn note_recall_context_size(bucket: RecallSizeBucket, bytes: usize) {
         RecallSizeBucket::IdentityOnly => {
             IDENTITY_CONTEXT_BYTES_TOTAL.fetch_add(bytes as u64, Ordering::Relaxed);
             IDENTITY_CONTEXT_TURNS.fetch_add(1, Ordering::Relaxed);
+            if bytes == 0 {
+                IDENTITY_EMPTY_CONTEXT_TURNS.fetch_add(1, Ordering::Relaxed);
+            }
         }
         RecallSizeBucket::Skipped => {
             SKIPPED_CONTEXT_TURNS.fetch_add(1, Ordering::Relaxed);
@@ -832,5 +856,29 @@ mod forget_ratio_tests {
         // The empty key is normalised to a sentinel; observation still
         // increments forget_count so downstream callers see the signal.
         assert!(snapshot.forget_count >= 1);
+    }
+
+    #[test]
+    fn identity_only_empty_recall_is_exposed_in_stats() {
+        let before =
+            memento_call_metrics_snapshot(1)["recall_context"]["identity_only_empty_turns"]
+                .as_u64()
+                .unwrap_or(0);
+
+        note_recall_context_size(RecallSizeBucket::IdentityOnly, 0);
+
+        let recall_context = memento_call_metrics_snapshot(1)["recall_context"].clone();
+        assert!(
+            recall_context["identity_only_empty_turns"]
+                .as_u64()
+                .unwrap_or(0)
+                >= before.saturating_add(1)
+        );
+        assert!(
+            recall_context["identity_only_turns"].as_u64().unwrap_or(0)
+                >= recall_context["identity_only_empty_turns"]
+                    .as_u64()
+                    .unwrap_or(0)
+        );
     }
 }


### PR DESCRIPTION
Closes #4315

## Summary
- record every injected prompt layer, including base Discord, SAK, LTM, peer directory, role/memory/API/performance/queue contracts
- count only enabled layers and persist exact assembled input bytes via PostgreSQL migration 0088
- expose IdentityOnly empty-recall counts through Memento stats and show byte totals in inspect output

## Verification
- `cargo check`
- prompt builder tests: 22/22
- prompt manifest enabled-only totals + exact system/recovery byte tests
- Memento identity-empty metric test
- inspect tests: 6/6
- full `ci-script-checks.sh`
- generated inventory, migration checksum, maintenance and maintainability gates
- mutations: disabled-layer counting and exact-byte override removal each RED, restored GREEN

## Review
- Account1 Opus xhigh exact-head review: `VERDICT: CLEAN`
- base `83e66477ff83a8f17a8cbca3f0d4c4bcb51cb8a1`
- head `b49bb4f61e7510ed4151360aceb9d5d5f5547298`
- patch SHA256 `71bda93b4cb22772d0494879af0bd8f17460169a620e8fbf6f51516cd93939a9`
- Codex review skipped under the active quota exception; bounded observability scope does not require Fable.