### PR TITLE
chore(prompt): deduplicate injected policy guidance

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -580,9 +580,9 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 597 | 597 | 0 |  |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 598 | 598 | 0 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
-| `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 507 | 307 | 200 |  |
+| `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 498 | 299 | 199 |  |
 | `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 359 | 359 | 0 |  |
 | `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 267 | 124 | 143 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -56,6 +56,72 @@ fn test_role_binding(role_id: &str) -> RoleBinding {
 }
 
 #[test]
+fn issue_4313_prompt_policy_contract() {
+    let built = build_prompt_with_optional_manifest_for(None, Some("implementation"));
+    let prompt = built.system_prompt;
+
+    assert!(prompt.contains(
+        "If another instruction says to plan first, write a brief plan in plain text and proceed without entering plan mode"
+    ));
+    assert_eq!(
+        prompt.matches("inspect `GET /api/docs`").count(),
+        1,
+        "the runtime prompt must have one canonical docs-first API order: {prompt}"
+    );
+    assert!(prompt.contains("docs override guessed CLI/source patterns"));
+    assert!(prompt.contains("Constrain output before invoking a tool"));
+    assert!(!prompt.contains("summarize the result instead of pasting raw output"));
+    assert!(!prompt.contains("10 lines"));
+    assert!(prompt.contains("one standalone `API_FRICTION: {...}` final-response line"));
+    assert!(prompt.contains("provider-managed automatic compaction uses its own contract"));
+    assert!(!prompt.contains("docs/memory-scope.md"));
+    assert!(
+        prompt.len() < 3_053,
+        "fixed Full prompt must shrink from the measured 3,053-byte baseline, got {}",
+        prompt.len()
+    );
+}
+
+#[test]
+fn issue_4313_agentdesk_prompt_has_single_policy_owner() {
+    let runtime_root = tempfile::tempdir().expect("runtime root");
+    let _runtime_guard = crate::config::set_agentdesk_root_for_test(runtime_root.path());
+    let binding = test_role_binding("project-agentdesk");
+    let prompt = build_system_prompt(
+        "ctx",
+        &[],
+        env!("CARGO_MANIFEST_DIR"),
+        ChannelId::new(1),
+        "tok",
+        Some(&binding),
+        false,
+        DispatchProfile::Full,
+        Some("implementation"),
+        None,
+        None,
+        None,
+        Some(&ResolvedMemorySettings {
+            backend: MemoryBackendKind::Memento,
+            ..ResolvedMemorySettings::default()
+        }),
+        true,
+    );
+
+    for (needle, owner) in [
+        ("inspect `GET /api/docs`", "ADK API Usage"),
+        ("targeted `rg`", "Tool Output Efficiency"),
+        ("docs/memory-scope.md", "Proactive Memory Guidance"),
+    ] {
+        assert_eq!(
+            prompt.matches(needle).count(),
+            1,
+            "{needle} must be owned once by {owner}: {prompt}"
+        );
+    }
+    assert!(prompt.contains("docs/source-of-truth.md"));
+}
+
+#[test]
 fn prompt_manifest_log_records_hash_metadata_without_full_content() {
     // The `info!("recorded prompt manifest", ...)` call logs the manifest's
     // `turn_id`/`channel_id`/`layer_count` plus the `?layer_hashes` field whose

--- a/src/services/discord/prompt_builder/layer_rendering.rs
+++ b/src/services/discord/prompt_builder/layer_rendering.rs
@@ -16,30 +16,25 @@ pub(super) const STALE_TOOL_RESULT_PLACEHOLDER_EXAMPLE: &str =
 pub(super) fn context_compression_guidance() -> String {
     format!(
         "[Context Compression]\n\
-         When conversation compaction happens (`/compact`, automatic compaction, or equivalent summarization), \
-         rewrite prior context using these sections in order: {CONTEXT_COMPRESSION_SECTION_ORDER}.\n\
-         - Keep each section short, factual, and focused on the latest state.\n\
-         - Preserve unresolved blockers, assumptions, failures, and the latest user intent.\n\
-         - In `Files`, list only files that still matter and why they matter.\n\
-         - Replace stale tool chatter, raw logs, and old command output with placeholders like {STALE_TOOL_RESULT_PLACEHOLDER_EXAMPLE}.\n\
-         - Prefer outcomes and follow-up implications over verbatim output, and drop already-resolved repetition once summarized."
+         Only when asked to write a continuation summary (`/compact`, handoff, recovery), use \
+         {CONTEXT_COMPRESSION_SECTION_ORDER}; provider-managed automatic compaction uses its own contract.\n\
+         - Preserve latest intent, progress, decisions, unresolved blockers/failures, relevant files, and next action.\n\
+         - Replace raw logs and stale tool chatter with {STALE_TOOL_RESULT_PLACEHOLDER_EXAMPLE}; omit resolved repetition."
     )
 }
 
 pub(super) fn tool_output_efficiency_guidance() -> &'static str {
     "[Tool Output Efficiency]\n\
-     Large tool results persist in context and increase cost for every subsequent turn.\n\
-     - Bash/Read: If output would exceed 10 lines, summarize the result instead of pasting raw output\n\
-     - Bash: Use LIMIT clauses for SQL, pipe to head/grep for filtering, avoid tail with large line counts\n\
-     - Read: Use offset/limit to read specific sections; do not read entire files when a section is enough\n\
-     - Grep: Set head_limit, use narrow glob/type filters, avoid broad patterns that match hundreds of lines\n\
-     - Prefer targeted queries over exhaustive dumps"
+     Constrain output before invoking a tool; a post-hoc summary cannot reclaim dumped context.\n\
+     - Bash: use SQL LIMIT, targeted `rg`, or `head`; avoid broad grep and large tail counts\n\
+     - Read/Grep: narrow ranges, globs, types, and head limits; do not dump whole files\n\
+     - Keep only task-relevant output"
 }
 
 pub(super) fn api_friction_guidance(profile: DispatchProfile) -> Option<String> {
     (profile == DispatchProfile::Full).then_some(
         "\n\n[ADK API Usage]\n\
-         Before ADK API work, inspect `GET /api/docs` or `GET /api/docs/{category}`. If docs are missing/wrong, do not use sqlite fallback; report one `API_FRICTION: {...}` marker with endpoint, summary, workaround, and suggested_fix. The runtime stores valid markers under Memento `topic=api-friction` when Memento is configured."
+         Before ADK API work, inspect `GET /api/docs` or `GET /api/docs/{category}`; docs override guessed CLI/source patterns. If missing or wrong, do not use sqlite fallback. Emit one standalone `API_FRICTION: {...}` final-response line with endpoint, friction_type, summary, workaround, and suggested_fix; runtime extracts it before delivery."
             .to_string(),
     )
 }
@@ -81,14 +76,11 @@ fn shared_agent_rules_lookup_with(current_path: &str, exists: impl Fn(&str) -> b
     let mut section = String::from(
         "\n\n[Shared Agent Rules Index]\n\
          - Keep changes scoped, verified, and no broader than the current request.\n\
-         - Verify user claims against code/data before acting.\n\
-         - Prefer `rg` and narrow reads; avoid dumping long tool output.\n\
-         - Do not use sqlite for ADK operational data; inspect `/api/docs` first.",
+         - Verify user claims against code/data before acting.",
     );
     if workspace_has_agentdesk_docs_with(current_path, &exists) {
         section.push_str(
-            "\n- Source-of-truth map: `docs/source-of-truth.md`; read it before editing prompts, config, skills, policies, or memory surfaces.\n\
-             - Memory scope map: `docs/memory-scope.md`; read it before memory cleanup or scope decisions.",
+            "\n- Source-of-truth map: `docs/source-of-truth.md`; read it before editing prompts, config, skills, policies, or memory surfaces.",
         );
     }
     section.push_str(
@@ -351,7 +343,7 @@ mod workspace_aware_shared_rules_tests {
         // refs are always injected makes THIS assert fail on its own.
         let section = shared_agent_rules_lookup_with("/foreign/repo", |_| false);
         assert!(section.contains("[Shared Agent Rules Index]"));
-        assert!(section.contains("Do not use sqlite for ADK operational data"));
+        assert!(section.contains("Keep changes scoped, verified"));
         assert!(section.contains("_shared.prompt.md"));
         assert!(
             !section.contains("docs/source-of-truth.md"),
@@ -365,8 +357,10 @@ mod workspace_aware_shared_rules_tests {
 
     #[test]
     fn agentdesk_workspace_keeps_repo_relative_doc_refs() {
-        // T2 (reverse mutation, A block): with the docs present, both
-        // repo-relative references must be injected. Forcing the guard to
+        // T2 (reverse mutation, A block): with the docs present, the
+        // source-of-truth reference must be injected. Memory policy is owned
+        // by Proactive Memory Guidance, so the index must not duplicate it.
+        // Forcing the guard to
         // always omit makes THIS assert fail on its own.
         let section = shared_agent_rules_lookup_with("/agentdesk", |_| true);
         assert!(section.contains("[Shared Agent Rules Index]"));
@@ -374,10 +368,7 @@ mod workspace_aware_shared_rules_tests {
             section.contains("docs/source-of-truth.md"),
             "AgentDesk workspace must keep docs/source-of-truth.md, got: {section}"
         );
-        assert!(
-            section.contains("docs/memory-scope.md"),
-            "AgentDesk workspace must keep docs/memory-scope.md, got: {section}"
-        );
+        assert!(!section.contains("docs/memory-scope.md"));
         assert!(section.contains("_shared.prompt.md"));
     }
 }

--- a/src/services/discord/prompt_builder/mod.rs
+++ b/src/services/discord/prompt_builder/mod.rs
@@ -177,6 +177,7 @@ pub(super) fn build_system_prompt_with_manifest(
          - Keep messages concise and scannable on mobile. Prefer short paragraphs and bullet points.\n\
          - Avoid decorative separators or long horizontal lines.\n\n\
          This Discord channel does not support interactive prompts. Do NOT call AskUserQuestion, EnterPlanMode, or ExitPlanMode. \
+         If another instruction says to plan first, write a brief plan in plain text and proceed without entering plan mode. \
          Ask in plain text if you need clarification.\n\n\
          Message author prefix: Direct user messages are prefixed as `[User: NAME (ID: N)]`; use that marker to distinguish speakers in shared channels.\n\n\
          Reply context: When a user message includes a [Reply context] tag, the user is responding to the **replied-to message**, \


### PR DESCRIPTION
Closes #4313

## Summary

- reconcile upstream plan-first instructions with Discord's no-interactive-mode contract
- make Tool Output Efficiency the sole owner of pre-invocation output bounding and ADK API Usage the sole owner of docs-first/sqlite guidance
- remove the duplicate memory-scope reference from Shared Agent Rules while preserving it exactly once for AgentDesk Memento prompts
- clarify API_FRICTION placement/required fields and provider-owned automatic compaction
- reduce the representative fixed Full prompt from 3,053 to 2,689 bytes (-364, -11.9%)

## Verification

- `cargo fmt --all --check`
- `cargo check --lib`
- prompt-builder tests: 45/45 (with isolated `AGENTDESK_ROOT_DIR` required by the existing role-prompt tests)
- #4313 focused tests: 2/2
- workspace-aware shared-rules tests: 4/4
- `scripts/ci-script-checks.sh`
- generated inventory, agent-maintenance freshness, and maintainability hard gates
- mutations: removing plan reconciliation RED; reintroducing duplicate memory-scope RED; restored candidate GREEN

Exact candidate:

- base `8c6834c79e18ae64fe036bcc5f94a6f194454dc4`
- head `4191c051320b2aa2efae5c7ff6067a0d621b4940`
- binary diff SHA256 `abbefa8bb691059dbcf81ac35b5adba260822859db92ba5f58f2105cafa64563`

## Review

Claude-only Codex usage-limit exception: account1 Opus xhigh independently reviewed the exact head and returned `VERDICT: CLEAN`. It verified prompt ownership across profile/backend/workspace combinations, API_FRICTION parser/docs alignment, test teeth, byte reduction, and generated inventory accounting. Codex review is skipped only because the CLI is under an actual usage-limit error until July 18.
