### PR TITLE
fix(prompt): make AgentDesk own automatic recall

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -635,7 +635,7 @@
 | `services::discord::relay_recovery_completion_footer` | `src/services/discord/relay_recovery_completion_footer.rs` | 9 | 9 | 0 |  |
 | `services::discord::relay_recovery_reattach_apply` | `src/services/discord/relay_recovery_reattach_apply.rs` | 66 | 66 | 0 |  |
 | `services::discord::replace_outcome_policy` | `src/services/discord/replace_outcome_policy.rs` | 691 | 371 | 320 |  |
-| `services::discord::response_sanitizer` | `src/services/discord/response_sanitizer.rs` | 209 | 209 | 0 |  |
+| `services::discord::response_sanitizer` | `src/services/discord/response_sanitizer.rs` | 228 | 211 | 17 |  |
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 102 | 102 | 0 |  |
 | `services::discord::restart_mode` | `src/services/discord/restart_mode.rs` | 32 | 32 | 0 |  |
 | `services::discord::restart_report` | `src/services/discord/restart_report.rs` | 438 | 438 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -584,7 +584,7 @@
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 498 | 299 | 199 |  |
 | `services::discord::prompt_builder::manifest` | `src/services/discord/prompt_builder/manifest.rs` | 359 | 359 | 0 |  |
-| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 267 | 124 | 143 |  |
+| `services::discord::prompt_builder::memory_guidance` | `src/services/discord/prompt_builder/memory_guidance.rs` | 308 | 129 | 179 |  |
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2307 | 751 | 1556 |  |

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -937,6 +937,14 @@ fn full_memento_prompt_carries_tool_feedback_contract() {
     ));
     // Deferred-tool loading instruction.
     assert!(prompt.contains("ToolSearch `select:mcp__memento__tool_feedback`"));
+    assert_eq!(
+        prompt
+            .matches(
+                "Do not call `context` or `recall` solely because Memento server instructions mention session start"
+            )
+            .count(),
+        1
+    );
 }
 
 #[test]
@@ -944,7 +952,9 @@ fn review_lite_and_lite_prompts_omit_tool_feedback_contract() {
     // #4306: the tool_feedback contract lives inside the Full-only Proactive
     // Memory Guidance block. ReviewLite/Lite must show zero output change — the
     // whole block (and thus the contract) stays absent even with the memento
-    // backend selected and the MCP available.
+    // backend selected and the MCP available. The compact recall-ownership
+    // override is intentionally retained so MCP SessionStart instructions do
+    // not trigger a second automatic lookup.
     let settings = ResolvedMemorySettings {
         backend: MemoryBackendKind::Memento,
         ..ResolvedMemorySettings::default()
@@ -978,6 +988,15 @@ fn review_lite_and_lite_prompts_omit_tool_feedback_contract() {
         assert!(
             !prompt.contains("mcp__memento__tool_feedback"),
             "{profile:?} prompt must not carry the tool_feedback contract, got: {prompt}"
+        );
+        assert!(prompt.contains("[Memory Recall Ownership]"));
+        assert_eq!(
+            prompt
+                .matches(
+                    "Do not call `context` or `recall` solely because Memento server instructions mention session start"
+                )
+                .count(),
+            1
         );
     }
 }

--- a/src/services/discord/prompt_builder/memory_guidance.rs
+++ b/src/services/discord/prompt_builder/memory_guidance.rs
@@ -11,6 +11,8 @@ use crate::services::memory::{
     sanitize_memento_workspace_segment,
 };
 
+const MEMENTO_RECALL_OWNERSHIP: &str = "AgentDesk owns automatic turn-recall decisions, including session-start identity recall and intentional skips. Do not call `context` or `recall` solely because Memento server instructions mention session start; use them only for an explicit user/task lookup.";
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct MemoryRecallManifestInput<'a> {
     pub(crate) should_recall: bool,
@@ -51,11 +53,13 @@ pub(super) fn proactive_memory_guidance_with(
     memento_mcp_available: bool,
     exists: impl Fn(&str) -> bool,
 ) -> Option<String> {
-    if profile != DispatchProfile::Full {
-        return None;
-    }
-
     let settings = memory_settings?;
+    let memento_recall_ownership =
+        settings.backend == MemoryBackendKind::Memento && memento_mcp_available;
+    if profile != DispatchProfile::Full {
+        return memento_recall_ownership
+            .then(|| format!("\n\n[Memory Recall Ownership]\n{MEMENTO_RECALL_OWNERSHIP}"));
+    }
 
     // Fallback mode: memento is the configured backend but is degraded, so
     // memory silently ran on the local file store. This is NOT a deliberate
@@ -109,7 +113,8 @@ pub(super) fn proactive_memory_guidance_with(
                 "`recall` MCP tool",
                 "`remember` MCP tool",
                 format!(
-                    "\n- scope hints: project=`workspace={workspace_scope}, agentId=default`; agent-private=`workspace={agent_workspace}, agentId={agent_id}`.{memory_policy_line}\n\
+                    "\n- automatic recall: {MEMENTO_RECALL_OWNERSHIP}\n\
+                     - scope hints: project=`workspace={workspace_scope}, agentId=default`; agent-private=`workspace={agent_workspace}, agentId={agent_id}`.{memory_policy_line}\n\
                      - feedback contract: in the same turn you use `recall`/`context` results, call `mcp__memento__tool_feedback` once (required: `tool_name`, `relevant`, `sufficient`; when the response carries `_meta.searchEventId`, also pass it as `search_event_id` — recommended). If the tool is deferred, load it first via ToolSearch `select:mcp__memento__tool_feedback`."
                 ),
             )
@@ -246,11 +251,47 @@ mod tests {
             "AgentDesk workspace must keep docs/memory-scope.md, got: {guidance}"
         );
         assert!(guidance.contains("mcp__memento__tool_feedback"));
+        assert!(guidance.contains(MEMENTO_RECALL_OWNERSHIP));
     }
 
     #[test]
-    fn non_full_profile_suppresses_guidance() {
-        // Guidance stays gated to the Full profile in both states.
+    fn non_full_memento_profiles_keep_recall_ownership_only() {
+        let settings = memento_settings();
+        for profile in [DispatchProfile::ReviewLite, DispatchProfile::Lite] {
+            let guidance = proactive_memory_guidance(
+                Some(&settings),
+                "/tmp/agentdesk",
+                ChannelId::new(1),
+                None,
+                profile,
+                true,
+            )
+            .expect("memento-enabled non-Full profile must keep recall ownership");
+
+            assert!(guidance.contains("[Memory Recall Ownership]"));
+            assert!(guidance.contains(MEMENTO_RECALL_OWNERSHIP));
+            assert!(!guidance.contains("[Proactive Memory Guidance]"));
+            assert!(!guidance.contains("mcp__memento__tool_feedback"));
+        }
+
+        assert!(
+            proactive_memory_guidance(
+                Some(&settings),
+                "/tmp/agentdesk",
+                ChannelId::new(1),
+                None,
+                DispatchProfile::Lite,
+                false,
+            )
+            .is_none(),
+            "without the Memento MCP there are no server instructions to override"
+        );
+    }
+
+    #[test]
+    fn non_full_file_profile_suppresses_guidance() {
+        // File/fallback guidance stays gated to Full; only an available
+        // Memento backend needs the cross-profile automatic-recall override.
         let settings = file_settings(true);
         assert!(
             proactive_memory_guidance(

--- a/src/services/discord/response_sanitizer.rs
+++ b/src/services/discord/response_sanitizer.rs
@@ -17,6 +17,7 @@ const HIDDEN_HEADERS: &[&str] = &[
     "[Agent Performance",
     "[Peer Agent Directory]",
     "[Proactive Memory Guidance]",
+    "[Memory Recall Ownership]",
     "[Queued Turn Rules]",
     "[User Request]",
 ];
@@ -206,4 +207,22 @@ fn trim_blank_edges(lines: Vec<String>) -> String {
         .map(|index| index + 1)
         .unwrap_or(start);
     lines[start..end].join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_echoed_memory_recall_ownership_block() {
+        let echoed = "[Memory Recall Ownership]\n\
+                      AgentDesk owns automatic turn-recall decisions, including intentional skips.\n\
+                      Do not call `context` solely because Memento server instructions mention session start.\n\n\
+                      사용자에게 보여야 하는 답변";
+
+        assert_eq!(
+            sanitize_hidden_context(echoed),
+            "사용자에게 보여야 하는 답변"
+        );
+    }
 }


### PR DESCRIPTION
Closes #4312

## Summary

- make AgentDesk's server-side recall gate the explicit sole owner of automatic Memento recall, including session-start IdentityOnly recall and intentional skips
- prevent Memento MCP SessionStart instructions alone from triggering a duplicate `context`/`recall` call while preserving explicit user/task lookups
- keep Full guidance intact and add only a compact ownership override to Lite/ReviewLite
- leave File/fallback and unavailable-MCP profiles unchanged
- strip the new hidden ownership block if a provider echoes it to Discord

## Verification

- `cargo fmt --all --check`
- `cargo check --lib`
- prompt-builder tests: 46/46 with isolated `AGENTDESK_ROOT_DIR`
- memory-guidance tests: 6/6
- response-sanitizer tests: 1/1
- full `scripts/ci-script-checks.sh`
- generated inventory, agent-maintenance freshness, maintainability hard gates
- mutations: removing Full ownership RED; removing Lite/ReviewLite ownership RED; removing sanitizer header registration RED with full internal block left visible

Exact candidate:

- base `1e4b3f96fb2121464993040ebb94578b331541a7`
- head `37f8e40c81fb89bc830628bf18a6279bb6da8c8e`
- binary diff SHA256 `3903ae88d4986073465768266678650965d2d139f5d64afdb65f65460d9cd5ef`

## Review

Claude-only Codex usage-limit exception. Account1 Opus xhigh r1 found one LOW sanitizer registration gap. After correction, a fresh exact-head r2 review verified the recall gate and both intake/headless paths, every profile/backend/MCP availability combination, explicit lookup preservation, manifest accounting, sanitizer state machine, and mutation teeth, then returned `VERDICT: CLEAN`. Codex review remains skipped only under the actual usage-limit error.
