### PR TITLE
fix(config): expose runtime blob values to QuickJS policies

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1847,7 +1847,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/dispatched_sessions.rs` (1650; #4091 r2 adds the two-sample
   growth-evidence selector cross-check wiring, claude_tui transcript-mtime
   runtime-activity anchors, and the flip-back window guard), and
-  `src/services/settings.rs` (1114) — service-layer route support surfaces
+  `src/services/settings.rs` (1067) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
 - `src/services/dispatches/outbox_route.rs` (1173) — dispatch outbox route
@@ -1943,7 +1943,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   live-activity guard anchor, and log kill/skip timing decisions; +4 from #3795
   replacing inline session-key split errors with central `SessionIdentity`
   helper calls and explicit legacy/namespaced error messages.)
-- `src/services/settings.rs` (1114) — settings domain service extracted from
+- `src/services/settings.rs` (1067) — settings domain service extracted from
   the route layer in #1519. Keep follow-up changes bugfix-only unless the file
   is split further.
 - `src/services/routines/{store.rs (2844), migrated.rs (1286),

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -106,7 +106,7 @@
 | `src/services/routines/agent_executor.rs` | 2021 |
 | `src/services/routines/discord_log.rs` | 1593 |
 | `src/services/routines/store.rs` | 3505 |
-| `src/services/settings.rs` | 1114 |
+| `src/services/settings.rs` | 1067 |
 | `src/services/tui_prompt_dedupe.rs` | 1966 |
 | `src/services/turn_orchestrator.rs` | 3290 |
 | `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -163,7 +163,7 @@
 | `engine::ops::auto_queue_ops` | `src/engine/ops/auto_queue_ops.rs` | 662 | 662 | 0 |  |
 | `engine::ops::cards_ops` | `src/engine/ops/cards_ops.rs` | 448 | 448 | 0 |  |
 | `engine::ops::ci_recovery_ops` | `src/engine/ops/ci_recovery_ops.rs` | 347 | 347 | 0 |  |
-| `engine::ops::config_ops` | `src/engine/ops/config_ops.rs` | 59 | 59 | 0 |  |
+| `engine::ops::config_ops` | `src/engine/ops/config_ops.rs` | 473 | 108 | 365 |  |
 | `engine::ops::db_ops` | `src/engine/ops/db_ops.rs` | 1640 | 1212 | 428 | giant-file |
 | `engine::ops::dispatch_ops` | `src/engine/ops/dispatch_ops.rs` | 364 | 364 | 0 |  |
 | `engine::ops::dm_reply_ops` | `src/engine/ops/dm_reply_ops.rs` | 376 | 376 | 0 |  |
@@ -1034,7 +1034,7 @@
 | `services::session_backend::terminal_usage` | `src/services/session_backend/terminal_usage.rs` | 212 | 106 | 106 |  |
 | `services::session_forwarding` | `src/services/session_forwarding.rs` | 493 | 315 | 178 |  |
 | `services::session_selector_validity` | `src/services/session_selector_validity.rs` | 395 | 149 | 246 |  |
-| `services::settings` | `src/services/settings.rs` | 1273 | 1114 | 159 | giant-file |
+| `services::settings` | `src/services/settings.rs` | 1491 | 1067 | 424 | giant-file |
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |

--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -107,13 +107,68 @@ test("auto-queue finds a free path from backlog to the nearest dispatchable stat
   assert.deepEqual(toPlain(path), ["requested"]);
 });
 
+test("auto-queue stale terminal statuses accept normalized strings and arrays", () => {
+  const stringConfig = loadPolicy("policies/lib/auto-queue-config.js", {
+    config: {
+      staleDispatchedTerminalStatuses: " failed,expired,FAILED,bad-status "
+    }
+  }).module;
+  const arrayConfig = loadPolicy("policies/lib/auto-queue-config.js", {
+    config: {
+      staleDispatchedTerminalStatuses: ["FAILED", "expired", "failed", "bad-status"]
+    }
+  }).module;
+
+  assert.deepEqual(toPlain(stringConfig.staleDispatchedTerminalStatuses()), ["failed", "expired"]);
+  assert.deepEqual(toPlain(arrayConfig.staleDispatchedTerminalStatuses()), ["failed", "expired"]);
+});
+
+test("auto-queue stale recovery switches accept only explicit booleans", () => {
+  const validValues = [
+    [true, true],
+    ["true", true],
+    [false, false],
+    ["false", false]
+  ];
+  const readers = [
+    ["staleDispatchedRecoverNullDispatch", "staleDispatchedRecoverNullDispatch"],
+    ["staleDispatchedRecoverMissingDispatch", "staleDispatchedRecoverMissingDispatch"]
+  ];
+
+  for (const [key, reader] of readers) {
+    for (const [configured, expected] of validValues) {
+      const module = loadPolicy("policies/lib/auto-queue-config.js", {
+        config: { [key]: configured }
+      }).module;
+      assert.equal(module[reader](), expected, `${key}=${JSON.stringify(configured)}`);
+    }
+  }
+});
+
+test("auto-queue stale recovery switches fail safely on malformed values", () => {
+  const malformedValues = [null, undefined, [], {}, 0, 1, "TRUE", "FALSE", "yes", ""];
+  const readers = [
+    ["staleDispatchedRecoverNullDispatch", "staleDispatchedRecoverNullDispatch"],
+    ["staleDispatchedRecoverMissingDispatch", "staleDispatchedRecoverMissingDispatch"]
+  ];
+
+  for (const [key, reader] of readers) {
+    for (const configured of malformedValues) {
+      const module = loadPolicy("policies/lib/auto-queue-config.js", {
+        config: { [key]: configured }
+      }).module;
+      assert.equal(module[reader](), true, `${key}=${JSON.stringify(configured)}`);
+    }
+  }
+});
+
 test("auto-queue onTick1min honors stale dispatched runtime config", () => {
   const recordedFailures = [];
   const { policy } = loadPolicy("policies/auto-queue.js", {
     config: {
       maxEntryRetries: 7,
       staleDispatchedGraceMin: 5,
-      staleDispatchedTerminalStatuses: "failed,expired",
+      staleDispatchedTerminalStatuses: ["failed", "expired", "FAILED", "bad-status"],
       staleDispatchedRecoverNullDispatch: false,
       staleDispatchedRecoverMissingDispatch: true
     },

--- a/policies/lib/auto-queue-config.js
+++ b/policies/lib/auto-queue-config.js
@@ -23,24 +23,33 @@ function configuredStaleDispatchedGraceMinutes() {
 
 function configuredStaleDispatchedTerminalStatuses() {
   var configured = agentdesk.config.get("staleDispatchedTerminalStatuses");
-  var raw = typeof configured === "string" ? configured : "cancelled,failed";
-  var statuses = raw
-    .split(",")
+  var rawStatuses = Array.isArray(configured)
+    ? configured
+    : (typeof configured === "string" ? configured.split(",") : ["cancelled", "failed"]);
+  var seen = Object.create(null);
+  var statuses = rawStatuses
     .map(function(status) { return String(status || "").trim().toLowerCase(); })
-    .filter(function(status) { return /^[a-z_]+$/.test(status); });
+    .filter(function(status) {
+      if (!/^[a-z_]+$/.test(status) || seen[status]) return false;
+      seen[status] = true;
+      return true;
+    });
   return statuses.length > 0 ? statuses : ["cancelled", "failed"];
 }
 
+function configuredSafeRuntimeBool(key) {
+  var configured = agentdesk.config.get(key);
+  if (configured === true || configured === "true") return true;
+  if (configured === false || configured === "false") return false;
+  return true;
+}
+
 function configuredStaleDispatchedRecoverNullDispatch() {
-  var configured = agentdesk.config.get("staleDispatchedRecoverNullDispatch");
-  if (configured === null || configured === undefined) return true;
-  return configured === true || configured === "true";
+  return configuredSafeRuntimeBool("staleDispatchedRecoverNullDispatch");
 }
 
 function configuredStaleDispatchedRecoverMissingDispatch() {
-  var configured = agentdesk.config.get("staleDispatchedRecoverMissingDispatch");
-  if (configured === null || configured === undefined) return true;
-  return configured === true || configured === "true";
+  return configuredSafeRuntimeBool("staleDispatchedRecoverMissingDispatch");
 }
 
 function staleDispatchedRecoveryConditionsSql() {

--- a/src/engine/ops/config_ops.rs
+++ b/src/engine/ops/config_ops.rs
@@ -3,11 +3,13 @@ use sqlx::PgPool;
 
 // ── Config ops ───────────────────────────────────────────────────
 
+const RUNTIME_CONFIG_BLOB_KEY: &str = "runtime-config";
+
 pub(super) fn register_config_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let config_obj = Object::new(ctx.clone())?;
 
-    // __config_get_raw(key) → JSON string: "null" or "\"value\""
+    // __config_get_raw(key) → serialized JSON consumed by the JS wrapper below.
     let pg_c = pg_pool;
     config_obj.set(
         "__get_raw",
@@ -40,20 +42,432 @@ pub(super) fn register_config_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) 
 }
 
 fn config_get_raw_pg(pool: &PgPool, key: &str) -> String {
+    if key == RUNTIME_CONFIG_BLOB_KEY {
+        return "null".to_string();
+    }
+
     let key = key.to_string();
     crate::utils::async_bridge::block_on_pg_result(
         pool,
         move |bridge_pool| async move {
-            let value = sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
-                .bind(&key)
-                .fetch_optional(&bridge_pool)
-                .await
-                .map_err(|error| format!("load postgres kv_meta {key}: {error}"))?;
-            Ok(value
-                .and_then(|value| serde_json::to_string(&value).ok())
-                .unwrap_or_else(|| "null".to_string()))
+            let scalar =
+                sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+                    .bind(&key)
+                    .fetch_optional(&bridge_pool)
+                    .await
+                    .map_err(|error| format!("load postgres kv_meta {key}: {error}"))?;
+
+            let runtime_config = if should_load_runtime_config(&key, scalar.as_deref()) {
+                sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+                    .bind(RUNTIME_CONFIG_BLOB_KEY)
+                    .fetch_optional(&bridge_pool)
+                    .await
+                    .map_err(|error| format!("load postgres runtime-config for {key}: {error}"))?
+            } else {
+                None
+            };
+
+            Ok(resolve_config_get_raw(
+                &key,
+                scalar.as_deref(),
+                runtime_config.as_deref(),
+            ))
         },
         |_error| "null".to_string(),
     )
-    .unwrap_or_else(|value| value)
+    .unwrap_or_else(|_error| "null".to_string())
+}
+
+fn should_load_runtime_config(key: &str, scalar: Option<&str>) -> bool {
+    key != RUNTIME_CONFIG_BLOB_KEY
+        && scalar.is_none()
+        && crate::services::settings::is_runtime_config_key(key)
+}
+
+fn resolve_config_get_raw(key: &str, scalar: Option<&str>, runtime_config: Option<&str>) -> String {
+    if key == RUNTIME_CONFIG_BLOB_KEY {
+        return "null".to_string();
+    }
+    if let Some(value) = scalar {
+        return serde_json::to_string(value).unwrap_or_else(|_| "null".to_string());
+    }
+    if !crate::services::settings::is_runtime_config_key(key) {
+        return "null".to_string();
+    }
+
+    runtime_config
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| {
+            value
+                .as_object()
+                .and_then(|values| values.get(key))
+                .and_then(|value| serde_json::to_string(value).ok())
+        })
+        .unwrap_or_else(|| "null".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDatabase {
+        admin_url: String,
+        database_name: String,
+        database_url: String,
+    }
+
+    impl TestDatabase {
+        async fn create() -> Self {
+            let admin_url = crate::dispatch::test_support::postgres_admin_database_url();
+            let database_name = format!("agentdesk_config_ops_{}", uuid::Uuid::new_v4().simple());
+            let database_url = format!(
+                "{}/{}",
+                crate::dispatch::test_support::postgres_base_database_url(),
+                database_name
+            );
+            crate::db::postgres::create_test_database(
+                &admin_url,
+                &database_name,
+                "config ops pg tests",
+            )
+            .await
+            .expect("create config ops postgres test db");
+            Self {
+                admin_url,
+                database_name,
+                database_url,
+            }
+        }
+
+        async fn drop(self) {
+            crate::db::postgres::drop_test_database(
+                &self.admin_url,
+                &self.database_name,
+                "config ops pg tests",
+            )
+            .await
+            .expect("drop config ops postgres test db");
+        }
+    }
+
+    #[test]
+    fn config_get_raw_queries_runtime_blob_only_for_allowlisted_scalar_misses() {
+        assert!(!should_load_runtime_config("maxEntryRetries", Some("9")));
+        assert!(should_load_runtime_config("maxEntryRetries", None));
+        assert!(!should_load_runtime_config(RUNTIME_CONFIG_BLOB_KEY, None));
+        assert!(!should_load_runtime_config("privateBlobField", None));
+    }
+
+    #[test]
+    fn config_get_raw_never_exposes_the_reserved_runtime_blob_key() {
+        let runtime_blob = r#"{"maxEntryRetries":7}"#;
+
+        assert_eq!(
+            resolve_config_get_raw(
+                RUNTIME_CONFIG_BLOB_KEY,
+                Some(runtime_blob),
+                Some(runtime_blob)
+            ),
+            "null"
+        );
+    }
+
+    #[test]
+    fn config_get_raw_keeps_scalar_string_semantics_and_precedence() {
+        let runtime_blob = r#"{"review_enabled":true,"maxEntryRetries":7}"#;
+
+        assert_eq!(
+            resolve_config_get_raw("review_enabled", Some("false"), Some(runtime_blob)),
+            r#""false""#,
+            "existing CONFIG_KEYS scalars must still reach JS as strings"
+        );
+        assert_eq!(
+            resolve_config_get_raw("maxEntryRetries", Some("9"), Some(runtime_blob)),
+            r#""9""#,
+            "a legacy runtime scalar must win over the blob"
+        );
+    }
+
+    #[test]
+    fn config_get_raw_preserves_runtime_blob_json_types() {
+        let runtime_blob = r#"{
+            "staleDispatchedRecoverNullDispatch": false,
+            "maxEntryRetries": 7,
+            "staleDispatchedTerminalStatuses": "failed,expired"
+        }"#;
+        let array_blob = r#"{
+            "staleDispatchedTerminalStatuses": ["failed", "expired"]
+        }"#;
+
+        assert_eq!(
+            resolve_config_get_raw(
+                "staleDispatchedRecoverNullDispatch",
+                None,
+                Some(runtime_blob)
+            ),
+            "false"
+        );
+        assert_eq!(
+            resolve_config_get_raw("maxEntryRetries", None, Some(runtime_blob)),
+            "7"
+        );
+        assert_eq!(
+            resolve_config_get_raw("staleDispatchedTerminalStatuses", None, Some(runtime_blob)),
+            r#""failed,expired""#
+        );
+        assert_eq!(
+            resolve_config_get_raw("staleDispatchedTerminalStatuses", None, Some(array_blob)),
+            r#"["failed","expired"]"#
+        );
+    }
+
+    #[test]
+    fn config_get_raw_runtime_blob_fallback_is_allowlisted_and_fail_closed() {
+        assert_eq!(
+            resolve_config_get_raw(
+                "privateBlobField",
+                None,
+                Some(r#"{"privateBlobField":"secret"}"#)
+            ),
+            "null"
+        );
+        assert_eq!(
+            resolve_config_get_raw("maxEntryRetries", None, Some("not-json")),
+            "null"
+        );
+        assert_eq!(
+            resolve_config_get_raw("maxEntryRetries", None, Some("[]")),
+            "null"
+        );
+        assert_eq!(
+            resolve_config_get_raw("maxEntryRetries", None, Some("{}")),
+            "null"
+        );
+        assert_eq!(
+            resolve_config_get_raw("maxEntryRetries", None, None),
+            "null"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn policy_engine_config_get_query_error_fails_closed_with_live_postgres() {
+        let database = TestDatabase::create().await;
+        let pool =
+            crate::db::postgres::connect_test_pool(&database.database_url, "config ops pg tests")
+                .await
+                .expect("connect config ops postgres test db");
+
+        let test_result: Result<(String, i32, bool), String> = async {
+            sqlx::query("CREATE TABLE kv_meta (key TEXT PRIMARY KEY, value TEXT)")
+                .execute(&pool)
+                .await
+                .map_err(|error| format!("create config ops kv_meta table: {error}"))?;
+            sqlx::query("INSERT INTO kv_meta (key, value) VALUES ($1, $2)")
+                .bind("review_enabled")
+                .bind("false")
+                .execute(&pool)
+                .await
+                .map_err(|error| format!("seed config ops scalar: {error}"))?;
+
+            let mut config = crate::config::Config::default();
+            config.policies.dir = std::path::PathBuf::from("/nonexistent");
+            config.policies.hot_reload = false;
+            let engine = crate::engine::PolicyEngine::new_with_pg(&config, Some(pool.clone()))
+                .map_err(|error| format!("build config ops PolicyEngine: {error}"))?;
+            let before: String = engine
+                .eval_js(r#"agentdesk.config.get("review_enabled")"#)
+                .map_err(|error| {
+                    format!("evaluate pre-error scalar through PolicyEngine: {error}")
+                })?;
+
+            sqlx::query("DROP TABLE kv_meta")
+                .execute(&pool)
+                .await
+                .map_err(|error| format!("drop config ops kv_meta table: {error}"))?;
+            let connection_probe = sqlx::query_scalar::<_, i32>("SELECT 1")
+                .fetch_one(&pool)
+                .await
+                .map_err(|error| format!("probe live postgres after kv_meta drop: {error}"))?;
+            let query_error_is_null = engine
+                .eval_js::<bool>(r#"agentdesk.config.get("review_enabled") === null"#)
+                .map_err(|error| {
+                    format!("evaluate query-error config get through PolicyEngine: {error}")
+                })?;
+
+            Ok((before, connection_probe, query_error_is_null))
+        }
+        .await;
+
+        pool.close().await;
+        database.drop().await;
+
+        let (before, connection_probe, query_error_is_null) =
+            test_result.expect("complete query-error config get contract");
+        assert_eq!(
+            before, "false",
+            "valid scalar semantics must remain unchanged"
+        );
+        assert_eq!(
+            connection_probe, 1,
+            "the PostgreSQL connection must remain live"
+        );
+        assert!(
+            query_error_is_null,
+            "a kv_meta query error must become JS null instead of invalid JSON"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn policy_engine_config_get_preserves_types_precedence_and_fail_closed_contract() {
+        let database = TestDatabase::create().await;
+        let pool =
+            crate::db::postgres::connect_test_pool(&database.database_url, "config ops pg tests")
+                .await
+                .expect("connect config ops postgres test db");
+        sqlx::query("CREATE TABLE kv_meta (key TEXT PRIMARY KEY, value TEXT)")
+            .execute(&pool)
+            .await
+            .expect("create config ops kv_meta table");
+        sqlx::query("INSERT INTO kv_meta (key, value) VALUES ($1, $2), ($3, $4), ($5, $6)")
+            .bind(RUNTIME_CONFIG_BLOB_KEY)
+            .bind(
+                r#"{
+                    "maxEntryRetries": 7,
+                    "maxRetries": 6,
+                    "staleDispatchedTerminalStatuses": "failed,expired",
+                    "staleDispatchedRecoverNullDispatch": false,
+                    "reviewReminderMin": null,
+                    "privateBlobField": "secret"
+                }"#,
+            )
+            .bind("maxEntryRetries")
+            .bind("9")
+            .bind("review_enabled")
+            .bind("false")
+            .execute(&pool)
+            .await
+            .expect("seed config ops kv_meta values");
+
+        let mut config = crate::config::Config::default();
+        config.policies.dir = std::path::PathBuf::from("/nonexistent");
+        config.policies.hot_reload = false;
+        let engine = crate::engine::PolicyEngine::new_with_pg(&config, Some(pool.clone()))
+            .expect("build config ops PolicyEngine");
+
+        let initial_json: String = engine
+            .eval_js(
+                r#"JSON.stringify({
+                    scalar: agentdesk.config.get("review_enabled"),
+                    precedence: agentdesk.config.get("maxEntryRetries"),
+                    boolValue: agentdesk.config.get("staleDispatchedRecoverNullDispatch"),
+                    intValue: agentdesk.config.get("maxRetries"),
+                    stringValue: agentdesk.config.get("staleDispatchedTerminalStatuses"),
+                    nullValue: agentdesk.config.get("reviewReminderMin"),
+                    miss: agentdesk.config.get("githubRepoCacheSec"),
+                    unknown: agentdesk.config.get("privateBlobField"),
+                    reserved: agentdesk.config.get("runtime-config")
+                })"#,
+            )
+            .expect("evaluate config get initial values through PolicyEngine");
+        let initial: serde_json::Value =
+            serde_json::from_str(&initial_json).expect("parse PolicyEngine config result");
+        assert_eq!(
+            initial,
+            serde_json::json!({
+                "scalar": "false",
+                "precedence": "9",
+                "boolValue": false,
+                "intValue": 6,
+                "stringValue": "failed,expired",
+                "nullValue": null,
+                "miss": null,
+                "unknown": null,
+                "reserved": null
+            })
+        );
+
+        sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+            .bind("maxEntryRetries")
+            .execute(&pool)
+            .await
+            .expect("delete legacy runtime scalar");
+        sqlx::query("UPDATE kv_meta SET value = $1 WHERE key = $2")
+            .bind(
+                r#"{
+                    "maxEntryRetries": 7,
+                    "staleDispatchedTerminalStatuses": ["failed", "expired"]
+                }"#,
+            )
+            .bind(RUNTIME_CONFIG_BLOB_KEY)
+            .execute(&pool)
+            .await
+            .expect("write array runtime-config");
+        let array_json: String = engine
+            .eval_js(
+                r#"JSON.stringify({
+                    blobAfterScalarRemoval: agentdesk.config.get("maxEntryRetries"),
+                    arrayValue: agentdesk.config.get("staleDispatchedTerminalStatuses")
+                })"#,
+            )
+            .expect("evaluate config get array values through PolicyEngine");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&array_json).expect("parse array result"),
+            serde_json::json!({
+                "blobAfterScalarRemoval": 7,
+                "arrayValue": ["failed", "expired"]
+            })
+        );
+
+        sqlx::query("UPDATE kv_meta SET value = $1 WHERE key = $2")
+            .bind("not-json")
+            .bind(RUNTIME_CONFIG_BLOB_KEY)
+            .execute(&pool)
+            .await
+            .expect("write malformed runtime-config");
+        assert_eq!(
+            engine
+                .eval_js::<String>(
+                    r#"JSON.stringify({
+                        known: agentdesk.config.get("maxEntryRetries"),
+                        scalar: agentdesk.config.get("review_enabled"),
+                        reserved: agentdesk.config.get("runtime-config")
+                    })"#
+                )
+                .expect("evaluate malformed blob through PolicyEngine"),
+            r#"{"known":null,"scalar":"false","reserved":null}"#
+        );
+        sqlx::query("UPDATE kv_meta SET value = $1 WHERE key = $2")
+            .bind("[]")
+            .bind(RUNTIME_CONFIG_BLOB_KEY)
+            .execute(&pool)
+            .await
+            .expect("write non-object runtime-config");
+        assert!(
+            engine
+                .eval_js::<bool>(r#"agentdesk.config.get("maxEntryRetries") === null"#)
+                .expect("evaluate non-object blob through PolicyEngine")
+        );
+
+        sqlx::query("UPDATE kv_meta SET value = $1 WHERE key = $2")
+            .bind(r#"{"maxEntryRetries":55}"#)
+            .bind(RUNTIME_CONFIG_BLOB_KEY)
+            .execute(&pool)
+            .await
+            .expect("restore valid runtime-config before query error check");
+        assert!(
+            engine
+                .eval_js::<bool>(r#"agentdesk.config.get("maxEntryRetries") === 55"#)
+                .expect("evaluate pre-error runtime-config through PolicyEngine"),
+            "the pre-error query must prove the configured value is readable"
+        );
+        pool.close().await;
+        database.drop().await;
+        assert!(
+            engine
+                .eval_js::<bool>(r#"agentdesk.config.get("maxEntryRetries") === null"#)
+                .expect("evaluate closed-pool query through PolicyEngine"),
+            "database errors must preserve the fail-closed JS contract"
+        );
+        drop(engine);
+    }
 }

--- a/src/services/settings.rs
+++ b/src/services/settings.rs
@@ -51,6 +51,11 @@ const RUNTIME_CONFIG_KEYS: &[&str] = &[
     "dispatchRateLimitGateEnabled",
     "dispatchRateLimitGateDangerPct",
 ];
+
+pub(crate) fn is_runtime_config_key(key: &str) -> bool {
+    RUNTIME_CONFIG_KEYS.contains(&key)
+}
+
 pub(crate) const RUNTIME_CONFIG_EXPLICIT_KEYS_META: &str = "__runtimeConfigExplicitKeys";
 
 /// Known individual `kv_meta` config keys surfaced to the dashboard and policy helpers.
@@ -458,10 +463,10 @@ impl SettingsService {
             let marked = with_explicit_runtime_config_keys(values.clone());
             let value_str = serde_json::to_string(&Value::Object(marked.clone()))
                 .unwrap_or_else(|_| "{}".to_string());
-            write_runtime_config_pg_async(pool, &value_str, &marked).await?;
+            write_runtime_config_pg_async(pool, &value_str).await?;
         } else {
             let value_str = serde_json::to_string(&body).unwrap_or_else(|_| "{}".to_string());
-            upsert_runtime_config_value_pg_async(pool, &value_str).await?;
+            write_runtime_config_pg_async(pool, &value_str).await?;
         }
         Ok(SettingsOkResponse::ok())
     }
@@ -673,94 +678,63 @@ async fn load_pg_kv_values(pool: &sqlx::PgPool) -> ServiceResult<HashMap<String,
     Ok(values)
 }
 
-async fn upsert_runtime_config_value_pg_async(
-    pool: &sqlx::PgPool,
-    value_str: &str,
-) -> ServiceResult<()> {
-    sqlx::query(
-        "INSERT INTO kv_meta (key, value, expires_at)
-         VALUES ($1, $2, NULL)
-         ON CONFLICT (key) DO UPDATE
-             SET value = EXCLUDED.value,
-                 expires_at = EXCLUDED.expires_at",
-    )
-    .bind("runtime-config")
-    .bind(value_str)
-    .execute(pool)
-    .await
-    .map_err(|error| {
-        ServiceError::internal(format!("{error}"))
-            .with_code(ErrorCode::Database)
-            .with_operation("put_runtime_config.upsert_runtime_config_pg")
-    })?;
-    Ok(())
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuntimeConfigKvWrite {
+    UpsertBlob(String),
+    DeleteScalar(&'static str),
 }
 
-async fn write_runtime_config_pg_async(
-    pool: &sqlx::PgPool,
-    value_str: &str,
-    values: &Map<String, Value>,
-) -> ServiceResult<()> {
+fn runtime_config_write_plan(value: String) -> Vec<RuntimeConfigKvWrite> {
+    std::iter::once(RuntimeConfigKvWrite::UpsertBlob(value))
+        .chain(
+            RUNTIME_CONFIG_KEYS
+                .iter()
+                .copied()
+                .map(RuntimeConfigKvWrite::DeleteScalar),
+        )
+        .collect()
+}
+
+async fn write_runtime_config_pg_async(pool: &sqlx::PgPool, value_str: &str) -> ServiceResult<()> {
     let mut tx = pool.begin().await.map_err(|error| {
         ServiceError::internal(format!("begin runtime-config tx: {error}"))
             .with_code(ErrorCode::Database)
             .with_operation("put_runtime_config.begin_pg_tx")
     })?;
 
-    sqlx::query(
-        "INSERT INTO kv_meta (key, value, expires_at)
-         VALUES ($1, $2, NULL)
-         ON CONFLICT (key) DO UPDATE
-             SET value = EXCLUDED.value,
-                 expires_at = EXCLUDED.expires_at",
-    )
-    .bind("runtime-config")
-    .bind(value_str)
-    .execute(&mut *tx)
-    .await
-    .map_err(|error| {
-        ServiceError::internal(format!("{error}"))
-            .with_code(ErrorCode::Database)
-            .with_operation("put_runtime_config.upsert_runtime_config_pg")
-    })?;
-
-    for key in RUNTIME_CONFIG_KEYS {
-        sqlx::query("DELETE FROM kv_meta WHERE key = $1")
-            .bind(*key)
-            .execute(&mut *tx)
-            .await
-            .map_err(|error| {
-                ServiceError::internal(format!("{error}"))
-                    .with_code(ErrorCode::Database)
-                    .with_operation("put_runtime_config.delete_scalar_pg")
-                    .with_context("key", key)
-            })?;
-    }
-
-    for (key, value) in values {
-        if !RUNTIME_CONFIG_KEYS.contains(&key.as_str()) {
-            continue;
+    for write in runtime_config_write_plan(value_str.to_string()) {
+        match write {
+            RuntimeConfigKvWrite::UpsertBlob(value) => {
+                sqlx::query(
+                    "INSERT INTO kv_meta (key, value, expires_at)
+                     VALUES ($1, $2, NULL)
+                     ON CONFLICT (key) DO UPDATE
+                         SET value = EXCLUDED.value,
+                             expires_at = EXCLUDED.expires_at",
+                )
+                .bind("runtime-config")
+                .bind(value)
+                .execute(&mut *tx)
+                .await
+                .map_err(|error| {
+                    ServiceError::internal(format!("{error}"))
+                        .with_code(ErrorCode::Database)
+                        .with_operation("put_runtime_config.upsert_runtime_config_pg")
+                })?;
+            }
+            RuntimeConfigKvWrite::DeleteScalar(key) => {
+                sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+                    .bind(key)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|error| {
+                        ServiceError::internal(format!("{error}"))
+                            .with_code(ErrorCode::Database)
+                            .with_operation("put_runtime_config.delete_scalar_pg")
+                            .with_context("key", key)
+                    })?;
+            }
         }
-        let Some(text) = runtime_scalar_to_string(value) else {
-            continue;
-        };
-        sqlx::query(
-            "INSERT INTO kv_meta (key, value, expires_at)
-             VALUES ($1, $2, NULL)
-             ON CONFLICT (key) DO UPDATE
-                 SET value = EXCLUDED.value,
-                     expires_at = EXCLUDED.expires_at",
-        )
-        .bind(key)
-        .bind(&text)
-        .execute(&mut *tx)
-        .await
-        .map_err(|error| {
-            ServiceError::internal(format!("{error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("put_runtime_config.upsert_scalar_pg")
-                .with_context("key", key)
-        })?;
     }
 
     tx.commit().await.map_err(|error| {
@@ -953,26 +927,13 @@ fn with_explicit_runtime_config_keys(mut values: Map<String, Value>) -> Map<Stri
     values
 }
 
-fn runtime_scalar_to_string(value: &Value) -> Option<String> {
-    match value {
-        Value::String(text) => Some(text.clone()),
-        Value::Number(number) => Some(number.to_string()),
-        Value::Bool(flag) => Some(flag.to_string()),
-        _ => None,
-    }
-}
-
 fn write_runtime_config_pg(
     pg_pool: &sqlx::PgPool,
     values: &Map<String, Value>,
 ) -> ServiceResult<()> {
     let value_str =
         serde_json::to_string(&Value::Object(values.clone())).unwrap_or_else(|_| "{}".to_string());
-    let scalar_values = values
-        .iter()
-        .filter(|(key, _)| RUNTIME_CONFIG_KEYS.contains(&key.as_str()))
-        .filter_map(|(key, value)| runtime_scalar_to_string(value).map(|text| (key.clone(), text)))
-        .collect::<Vec<_>>();
+    let write_plan = runtime_config_write_plan(value_str);
 
     crate::utils::async_bridge::block_on_pg_result(
         pg_pool,
@@ -982,40 +943,32 @@ fn write_runtime_config_pg(
                 .await
                 .map_err(|error| format!("begin runtime-config pg tx: {error}"))?;
 
-            sqlx::query(
-                "INSERT INTO kv_meta (key, value, expires_at)
-                 VALUES ($1, $2, NULL)
-                 ON CONFLICT (key) DO UPDATE
-                     SET value = EXCLUDED.value,
-                         expires_at = EXCLUDED.expires_at",
-            )
-            .bind("runtime-config")
-            .bind(&value_str)
-            .execute(&mut *tx)
-            .await
-            .map_err(|error| format!("upsert pg runtime-config: {error}"))?;
-
-            for key in RUNTIME_CONFIG_KEYS {
-                sqlx::query("DELETE FROM kv_meta WHERE key = $1")
-                    .bind(*key)
-                    .execute(&mut *tx)
-                    .await
-                    .map_err(|error| format!("delete pg runtime-config scalar {key}: {error}"))?;
-            }
-
-            for (key, text) in scalar_values {
-                sqlx::query(
-                    "INSERT INTO kv_meta (key, value, expires_at)
-                     VALUES ($1, $2, NULL)
-                     ON CONFLICT (key) DO UPDATE
-                         SET value = EXCLUDED.value,
-                             expires_at = EXCLUDED.expires_at",
-                )
-                .bind(&key)
-                .bind(&text)
-                .execute(&mut *tx)
-                .await
-                .map_err(|error| format!("upsert pg runtime-config scalar {key}: {error}"))?;
+            for write in write_plan {
+                match write {
+                    RuntimeConfigKvWrite::UpsertBlob(value) => {
+                        sqlx::query(
+                            "INSERT INTO kv_meta (key, value, expires_at)
+                             VALUES ($1, $2, NULL)
+                             ON CONFLICT (key) DO UPDATE
+                                 SET value = EXCLUDED.value,
+                                     expires_at = EXCLUDED.expires_at",
+                        )
+                        .bind("runtime-config")
+                        .bind(value)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|error| format!("upsert pg runtime-config: {error}"))?;
+                    }
+                    RuntimeConfigKvWrite::DeleteScalar(key) => {
+                        sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+                            .bind(key)
+                            .execute(&mut *tx)
+                            .await
+                            .map_err(|error| {
+                                format!("delete pg runtime-config scalar {key}: {error}")
+                            })?;
+                    }
+                }
             }
 
             tx.commit()
@@ -1116,6 +1069,111 @@ fn seeded_runtime_config_map(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    struct TestDatabase {
+        admin_url: String,
+        database_name: String,
+        database_url: String,
+    }
+
+    impl TestDatabase {
+        async fn create() -> Self {
+            let admin_url = crate::dispatch::test_support::postgres_admin_database_url();
+            let database_name = format!("agentdesk_settings_{}", uuid::Uuid::new_v4().simple());
+            let database_url = format!(
+                "{}/{}",
+                crate::dispatch::test_support::postgres_base_database_url(),
+                database_name
+            );
+            crate::db::postgres::create_test_database(
+                &admin_url,
+                &database_name,
+                "settings runtime-config pg tests",
+            )
+            .await
+            .expect("create settings postgres test db");
+            Self {
+                admin_url,
+                database_name,
+                database_url,
+            }
+        }
+
+        async fn connect(&self) -> sqlx::PgPool {
+            let pool = crate::db::postgres::connect_test_pool(
+                &self.database_url,
+                "settings runtime-config pg tests",
+            )
+            .await
+            .expect("connect settings postgres test db");
+            sqlx::query(
+                "CREATE TABLE kv_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT,
+                    expires_at TIMESTAMPTZ
+                )",
+            )
+            .execute(&pool)
+            .await
+            .expect("create settings kv_meta table");
+            pool
+        }
+
+        async fn drop(self) {
+            crate::db::postgres::drop_test_database(
+                &self.admin_url,
+                &self.database_name,
+                "settings runtime-config pg tests",
+            )
+            .await
+            .expect("drop settings postgres test db");
+        }
+    }
+
+    async fn upsert_test_kv(pool: &sqlx::PgPool, key: &str, value: &str) {
+        sqlx::query(
+            "INSERT INTO kv_meta (key, value, expires_at)
+             VALUES ($1, $2, NULL)
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|error| panic!("upsert test kv_meta {key}: {error}"));
+    }
+
+    async fn seed_runtime_scalar_mirrors(pool: &sqlx::PgPool) {
+        for key in RUNTIME_CONFIG_KEYS {
+            upsert_test_kv(pool, key, &format!("legacy-{key}")).await;
+        }
+    }
+
+    async fn assert_runtime_blob_and_no_mirrors(pool: &sqlx::PgPool, expected: &Value) {
+        let blob = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM kv_meta WHERE key = 'runtime-config'",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("load authoritative runtime-config blob");
+        assert_eq!(
+            serde_json::from_str::<Value>(&blob).expect("parse authoritative runtime-config blob"),
+            *expected
+        );
+
+        for key in RUNTIME_CONFIG_KEYS {
+            let scalar =
+                sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+                    .bind(key)
+                    .fetch_optional(pool)
+                    .await
+                    .unwrap_or_else(|error| panic!("load runtime scalar {key}: {error}"));
+            assert_eq!(
+                scalar, None,
+                "legacy runtime scalar {key} must stay deleted"
+            );
+        }
+    }
 
     #[test]
     fn settings_response_dtos_serialize_existing_contract_fields() {
@@ -1269,5 +1327,165 @@ mod tests {
             keys.is_empty(),
             "full saved runtime-config values are not explicit unless the metadata says so"
         );
+    }
+
+    #[test]
+    fn runtime_config_key_lookup_exposes_only_known_value_keys() {
+        assert!(is_runtime_config_key("maxEntryRetries"));
+        assert!(is_runtime_config_key("staleDispatchedRecoverNullDispatch"));
+        assert!(!is_runtime_config_key("runtime-config"));
+        assert!(!is_runtime_config_key(RUNTIME_CONFIG_EXPLICIT_KEYS_META));
+        assert!(!is_runtime_config_key("privateBlobField"));
+    }
+
+    #[test]
+    fn runtime_config_write_plan_has_one_blob_authority_and_cleanup_only() {
+        let plan = runtime_config_write_plan(r#"{"maxEntryRetries":7}"#.to_string());
+
+        assert_eq!(
+            plan.first(),
+            Some(&RuntimeConfigKvWrite::UpsertBlob(
+                r#"{"maxEntryRetries":7}"#.to_string()
+            ))
+        );
+        assert_eq!(plan.len(), RUNTIME_CONFIG_KEYS.len() + 1);
+        assert!(
+            plan[1..]
+                .iter()
+                .all(|write| matches!(write, RuntimeConfigKvWrite::DeleteScalar(_)))
+        );
+        for key in RUNTIME_CONFIG_KEYS {
+            assert!(plan.contains(&RuntimeConfigKvWrite::DeleteScalar(*key)));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn put_runtime_config_object_and_non_object_keep_only_blob_authority() {
+        let database = TestDatabase::create().await;
+        let pool = database.connect().await;
+        upsert_test_kv(&pool, "runtime-config", r#"{"old":true}"#).await;
+        seed_runtime_scalar_mirrors(&pool).await;
+        let service = SettingsService::new(
+            Some(pool.clone()),
+            Arc::new(crate::config::Config::default()),
+        );
+
+        service
+            .put_runtime_config(json!({
+                "maxEntryRetries": 7,
+                "staleDispatchedRecoverNullDispatch": false,
+                "staleDispatchedTerminalStatuses": ["failed", "expired"]
+            }))
+            .await
+            .expect("write object runtime-config through SettingsService");
+        assert_runtime_blob_and_no_mirrors(
+            &pool,
+            &json!({
+                "maxEntryRetries": 7,
+                "staleDispatchedRecoverNullDispatch": false,
+                "staleDispatchedTerminalStatuses": ["failed", "expired"],
+                "__runtimeConfigExplicitKeys": []
+            }),
+        )
+        .await;
+
+        seed_runtime_scalar_mirrors(&pool).await;
+        service
+            .put_runtime_config(json!(["non-object", 7, false]))
+            .await
+            .expect("write non-object runtime-config through SettingsService");
+        assert_runtime_blob_and_no_mirrors(&pool, &json!(["non-object", 7, false])).await;
+
+        drop(service);
+        pool.close().await;
+        database.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn startup_runtime_config_writer_keeps_blob_authority_without_mirror_reinsertion() {
+        let database = TestDatabase::create().await;
+        let pool = database.connect().await;
+        upsert_test_kv(&pool, "runtime-config", r#"{"maxEntryRetries":99}"#).await;
+        seed_runtime_scalar_mirrors(&pool).await;
+
+        seed_runtime_config_defaults_pg(&pool, &crate::config::Config::default())
+            .await
+            .expect("seed runtime-config through startup sync writer");
+
+        assert_runtime_blob_and_no_mirrors(&pool, &json!({"maxEntryRetries": 99})).await;
+
+        pool.close().await;
+        database.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn runtime_config_delete_failure_rolls_back_blob_and_every_mirror() {
+        let database = TestDatabase::create().await;
+        let pool = database.connect().await;
+        let old_blob = r#"{"maxEntryRetries":4,"marker":"old"}"#;
+        upsert_test_kv(&pool, "runtime-config", old_blob).await;
+        seed_runtime_scalar_mirrors(&pool).await;
+        sqlx::query(
+            r#"
+            CREATE FUNCTION reject_runtime_scalar_delete() RETURNS trigger AS $$
+            BEGIN
+                IF OLD.key = 'maxEntryRetries' THEN
+                    RAISE EXCEPTION 'injected runtime scalar delete failure';
+                END IF;
+                RETURN OLD;
+            END;
+            $$ LANGUAGE plpgsql;
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("install runtime scalar delete fault function");
+        sqlx::query(
+            "CREATE TRIGGER reject_runtime_scalar_delete_trigger
+             BEFORE DELETE ON kv_meta
+             FOR EACH ROW EXECUTE FUNCTION reject_runtime_scalar_delete()",
+        )
+        .execute(&pool)
+        .await
+        .expect("install runtime scalar delete fault trigger");
+        let service = SettingsService::new(
+            Some(pool.clone()),
+            Arc::new(crate::config::Config::default()),
+        );
+
+        service
+            .put_runtime_config(json!({"maxEntryRetries": 12}))
+            .await
+            .expect_err("injected delete failure must abort runtime-config write");
+
+        let blob = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM kv_meta WHERE key = 'runtime-config'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load blob after rollback");
+        assert_eq!(
+            blob, old_blob,
+            "blob upsert must roll back with mirror deletes"
+        );
+        for key in RUNTIME_CONFIG_KEYS {
+            let scalar =
+                sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+                    .bind(key)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap_or_else(|load_error| {
+                        panic!("load runtime scalar {key} after rollback: {load_error}")
+                    });
+            assert_eq!(
+                scalar,
+                format!("legacy-{key}"),
+                "runtime scalar {key} must survive transaction rollback"
+            );
+        }
+
+        drop(service);
+        pool.close().await;
+        database.drop().await;
     }
 }


### PR DESCRIPTION
Closes #4487

## Summary

- preserve scalar-first `config.get` compatibility while falling back to allowlisted keys in the `runtime-config` blob
- make the blob the single write authority by atomically deleting legacy scalar mirrors in both runtime-config writers
- preserve native JSON types through PostgreSQL → PolicyEngine → QuickJS, including terminal-status arrays and safe recovery-boolean parsing
- fail closed for reserved/unknown keys, malformed or non-object blobs, query errors, and malformed recovery flags

## Verification

- Rust config-op tests: 6/6
- Rust settings tests: 12/12
- Node policy suite: 184/184
- four compiled/behavior mutations went RED, then exact restore
- independent frozen-WIP audit: `VERDICT: CLEAN`
- `cargo fmt --all -- --check`
- `git diff --check`
- generated inventory docs regenerated and `--check` clean

Exact candidate: `f2428267750f18a621ac04d77a1da9b7de7fe15c`

Fresh exact-SHA Codex and account2 Opus reviews are required before merge.