### PR TITLE
chore(cli): remove unreachable manual help helpers (#4225)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 25 | 25 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1205 | 960 | 245 |  |
+| `cli::args` | `src/cli/args.rs` | 1350 | 960 | 390 |  |
 | `cli::client` | `src/cli/client.rs` | 2732 | 2474 | 258 | giant-file |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1667 | 1667 | 0 | giant-file |
 | `cli::dcserver_pg_bootstrap` | `src/cli/dcserver_pg_bootstrap.rs` | 913 | 455 | 458 |  |
@@ -80,7 +80,7 @@
 | `cli::provider_cli` | `src/cli/provider_cli/mod.rs` | 1039 | 1039 | 0 | giant-file |
 | `cli::query` | `src/cli/query.rs` | 462 | 379 | 83 |  |
 | `cli::run` | `src/cli/run.rs` | 839 | 792 | 47 |  |
-| `cli::utils` | `src/cli/utils.rs` | 581 | 473 | 108 |  |
+| `cli::utils` | `src/cli/utils.rs` | 510 | 402 | 108 |  |
 | `compat` | `src/compat/mod.rs` | 39 | 39 | 0 |  |
 | `compat::legacy_db_paths` | `src/compat/legacy_db_paths.rs` | 12 | 12 | 0 |  |
 | `compat::legacy_tmp_paths` | `src/compat/legacy_tmp_paths.rs` | 27 | 27 | 0 |  |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -961,7 +961,152 @@ pub(crate) fn parse() -> ParseOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::{Parser, error::ErrorKind};
+    use clap::{CommandFactory, Parser, error::ErrorKind};
+
+    #[test]
+    fn top_level_command_name_snapshot_preserves_public_cli_surface() {
+        let mut command = Cli::command();
+        command.build();
+        let actual = command
+            .get_subcommands()
+            .map(|command| command.get_name())
+            .collect::<Vec<_>>();
+        let expected = vec![
+            "dcserver",
+            "init",
+            "reconfigure",
+            "emit-launchd-plist",
+            "restart-dcserver",
+            "discord-sendfile",
+            "discord-sendmessage",
+            "discord-senddm",
+            "send",
+            "send-to-agent",
+            "review-verdict",
+            "review-decision",
+            "review-recover-target",
+            "docs",
+            "auto-queue",
+            "force-kill",
+            "github-sync",
+            "monitoring",
+            "intake-outbox",
+            "discord",
+            "card",
+            "cherry-merge",
+            #[cfg(unix)]
+            "tmux-wrapper",
+            #[cfg(unix)]
+            "codex-tmux-wrapper",
+            #[cfg(unix)]
+            "qwen-tmux-wrapper",
+            "claude-hook-relay",
+            "codex-hook-relay",
+            "reset-tmux",
+            "ismcptool",
+            "addmcptool",
+            "install-memento-session-hook",
+            "status",
+            "cards",
+            "dispatch",
+            "resume",
+            "advance",
+            "queue",
+            "query",
+            "phase",
+            "deploy",
+            "agents",
+            "diag",
+            "config",
+            "api",
+            "terminations",
+            "doctor",
+            "migrate",
+            "provider-cli",
+            "show",
+            "health",
+            "machine-compare",
+            "activity",
+            "help",
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn clap_help_and_version_remain_successful_authoritative_outputs() {
+        for flag in ["-h", "--help"] {
+            let Err(error) = Cli::try_parse_from(["agentdesk", flag]) else {
+                panic!("{flag} must render help instead of running a command");
+            };
+            assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+            assert_eq!(error.exit_code(), 0);
+            let rendered = error.to_string();
+            assert!(rendered.contains("AI agent orchestration platform"));
+            assert!(rendered.contains("Usage: agentdesk"));
+            assert!(rendered.contains("Commands:"));
+            assert!(rendered.contains("discord-sendmessage"));
+            assert!(rendered.contains("provider-cli"));
+        }
+
+        let Err(error) = Cli::try_parse_from(["agentdesk", "help"]) else {
+            panic!("help subcommand must render help instead of running a command");
+        };
+        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+        assert_eq!(error.exit_code(), 0);
+
+        for flag in ["-V", "--version"] {
+            let Err(error) = Cli::try_parse_from(["agentdesk", flag]) else {
+                panic!("{flag} must render version instead of running a command");
+            };
+            assert_eq!(error.kind(), ErrorKind::DisplayVersion);
+            assert_eq!(error.exit_code(), 0);
+            assert_eq!(
+                error.to_string().trim(),
+                format!("agentdesk {}", env!("CARGO_PKG_VERSION"))
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_launchd_and_provider_value_aliases_still_parse() {
+        let legacy = rewrite_legacy_args(vec![
+            "agentdesk".to_string(),
+            "--emit-launchd-plist".to_string(),
+            "--flavor".to_string(),
+            "release".to_string(),
+        ]);
+        let canonical = vec![
+            "agentdesk".to_string(),
+            "emit-launchd-plist".to_string(),
+            "--flavor".to_string(),
+            "release".to_string(),
+        ];
+        assert_eq!(legacy, canonical);
+        assert!(matches!(
+            Cli::try_parse_from(legacy)
+                .expect("legacy launchd spelling should parse")
+                .command,
+            Some(Commands::EmitLaunchdPlist(_))
+        ));
+
+        let provider_alias = Cli::try_parse_from([
+            "agentdesk",
+            "restart-dcserver",
+            "--report-channel-id",
+            "42",
+            "--report-provider",
+            "open-code",
+        ])
+        .expect("open-code provider alias should parse");
+        assert!(matches!(
+            provider_alias.command,
+            Some(Commands::RestartDcserver {
+                report_provider: Some(ReportProvider::OpenCode),
+                ..
+            })
+        ));
+    }
 
     #[test]
     fn send_to_agent_requires_expect_reply() {

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,58 +1,3 @@
-#![allow(dead_code)]
-
-use super::VERSION;
-
-pub fn print_help() {
-    println!("AgentDesk {} - AI agent orchestration platform", VERSION);
-    println!();
-    println!("USAGE:");
-    println!("    agentdesk <COMMAND>");
-    println!();
-    println!("COMMANDS:");
-    println!("    -h, --help              Print help information");
-    println!("    -v, --version           Print version information");
-    println!(
-        "    dcserver [TOKEN]        Start Discord bot server(s); without TOKEN uses configured Discord bots"
-    );
-    println!(
-        "    restart-dcserver [--report-channel-id <ID> --report-provider <claude|codex|gemini|opencode|qwen> [--report-message-id <ID>]]"
-    );
-    println!("    discord-sendfile <PATH> --channel <ID> --key <HASH>");
-    println!("    discord-sendmessage --channel <ID> --message <TEXT> [--key <HASH>]");
-    println!("    discord-senddm --user <ID> --message <TEXT> [--key <HASH>]");
-    println!(
-        "    send-to-agent --from <AGENT> --to <AGENT> --message <TEXT> --expect-reply <true|false> [--channel-kind cc|cdx] [--no-prefix]"
-    );
-    println!("    reset-tmux              Kill all AgentDesk-* tmux sessions");
-    println!(
-        "    ismcptool <TOOL>...     Check if MCP tool(s) are registered in .claude/settings.json (CWD)"
-    );
-    println!(
-        "    addmcptool <TOOL>...    Add MCP tool permission(s) to .claude/settings.json (CWD)"
-    );
-    println!();
-}
-
-pub fn print_version() {
-    println!("AgentDesk {}", VERSION);
-}
-
-pub fn handle_base64(encoded: &str) {
-    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-    match BASE64.decode(encoded) {
-        Ok(decoded) => {
-            if let Ok(text) = String::from_utf8(decoded) {
-                print!("{}", text);
-            } else {
-                std::process::exit(1);
-            }
-        }
-        Err(_) => {
-            std::process::exit(1);
-        }
-    }
-}
-
 pub fn handle_ismcptool(tool_names: &[String]) {
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
@@ -453,22 +398,6 @@ fn clean_agentdesk_tmp_files() -> usize {
         }
     }
     count
-}
-
-pub fn migrate_config_dir() {
-    if let Some(home) = dirs::home_dir() {
-        let old_dir = home.join(".cokacdir");
-        let new_dir = home.join(".adk");
-        if old_dir.exists() && !new_dir.exists() {
-            if let Err(e) = std::fs::rename(&old_dir, &new_dir) {
-                eprintln!("Warning: failed to migrate ~/.cokacdir to ~/.adk: {}", e);
-            }
-        }
-    }
-}
-
-pub fn print_goodbye_message() {
-    println!("AgentDesk process ended.");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of #4225

## Summary
- Remove five zero-call helpers from the private CLI module: print_help, print_version, handle_base64, migrate_config_dir, and print_goodbye_message.
- Remove the file-wide dead_code allowance while retaining all four live utility handlers and their dispatch call sites.
- Add a built-Clap top-level command snapshot plus help, version, generated help subcommand, and explicit alias parser coverage.

The old migrate_config_dir helper is safe to remove because it is private-module code with zero callers and no current .cokacdir path remains in the repository. This does not claim that runtime_layout implements the same directory rename.

## Compatibility
- Public commands and generated help command remain unchanged.
- Help and version remain successful Clap display outcomes with exit code 0.
- Legacy --emit-launchd-plist, open-code, and starter-message aliases remain accepted.

## Verification
- Independent frozen audit: CLEAN.
- cargo test cli::args::tests --lib: 15 passed.
- cargo test cli::utils::memento_hook_install_tests --lib: 4 passed.
- Five compiled semantic mutations were each rejected by the intended assertion and exactly restored.
- cargo fmt --check and git diff --check passed.

This is a draft checkpoint only. The broader command-tree consolidation in #4225 remains open.