### PR TITLE
chore(cli): deprecate legacy Discord send commands

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -586,3 +586,5 @@ changing runtime behavior.
 > Last refreshed: 2026-07-06 (#4115 r5 — classify_transport_failure's permanent-failure WARN routes the error text through strip_watcher_send_failure_class_marker so structured class markers stay out of operator logs; log hygiene only, no delivery verb / API / callsite coverage change.)
 
 > Last refreshed: 2026-07-08 (#4218 — tracing log field key rename only across outbound (`channel =` -> `channel_id =` / shorthand); no delivery verb / API / callsite coverage change.)
+
+> Last refreshed: 2026-07-13 (#4225 S2 — routed `send` target grammar is shared by CLI help, resolver failures, and API errors; unsupported colon-prefixed targets are rejected before alias lookup. No outbound delivery verb, transport, or callsite coverage change.)

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 25 | 25 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1350 | 960 | 390 |  |
+| `cli::args` | `src/cli/args.rs` | 1523 | 971 | 552 |  |
 | `cli::client` | `src/cli/client.rs` | 2732 | 2474 | 258 | giant-file |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1667 | 1667 | 0 | giant-file |
 | `cli::dcserver_pg_bootstrap` | `src/cli/dcserver_pg_bootstrap.rs` | 913 | 455 | 458 |  |
@@ -553,7 +553,7 @@
 | `services::discord::outbound::result` | `src/services/discord/outbound/result.rs` | 161 | 161 | 0 |  |
 | `services::discord::outbound::send_api` | `src/services/discord/outbound/send_api.rs` | 591 | 295 | 296 |  |
 | `services::discord::outbound::send_gate` | `src/services/discord/outbound/send_gate.rs` | 555 | 349 | 206 |  |
-| `services::discord::outbound::send_target` | `src/services/discord/outbound/send_target.rs` | 193 | 144 | 49 |  |
+| `services::discord::outbound::send_target` | `src/services/discord/outbound/send_target.rs` | 263 | 153 | 110 |  |
 | `services::discord::outbound::send_to_agent` | `src/services/discord/outbound/send_to_agent.rs` | 157 | 93 | 64 |  |
 | `services::discord::outbound::serenity_reference` | `src/services/discord/outbound/serenity_reference.rs` | 149 | 149 | 0 |  |
 | `services::discord::outbound::source_registry` | `src/services/discord/outbound/source_registry.rs` | 247 | 159 | 88 |  |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -39,7 +39,10 @@ pub(crate) enum Commands {
         #[arg(long)]
         report_message_id: Option<u64>,
     },
-    /// Send a file to a Discord channel
+    /// Deprecated: send a file to a Discord channel
+    #[command(
+        after_help = "Deprecated compatibility command. The routed `send` command does not currently accept file attachments, so keep using this command until an attachment-capable replacement is available."
+    )]
     DiscordSendfile {
         /// File path to send
         path: String,
@@ -50,7 +53,10 @@ pub(crate) enum Commands {
         #[arg(long)]
         key: String,
     },
-    /// Send a message to a Discord channel
+    /// Deprecated: send a message to a Discord channel
+    #[command(
+        after_help = "Deprecated compatibility command. With `--key`, this command selects that one configured bot token; without `--key`, it tries configured bot tokens sequentially until one succeeds. For a role-mapped channel with a configured bot runtime, migrate to `agentdesk send --target channel:<id> --content <TEXT>`. Routed `send` instead requires role-map authorization and selects one `--bot` runtime (default: announce), so it does not preserve this command's token selection or sequential fallback. Keep using this compatibility command when those routing requirements do not match the current delivery."
+    )]
     DiscordSendmessage {
         /// Discord channel ID
         #[arg(long)]
@@ -58,11 +64,14 @@ pub(crate) enum Commands {
         /// Message text
         #[arg(long)]
         message: String,
-        /// Authentication key hash (optional; falls back to AGENTDESK_TOKEN env or configured Discord bots)
+        /// Authentication key hash (optional; without it, configured bot tokens are tried sequentially until one succeeds)
         #[arg(long)]
         key: Option<String>,
     },
-    /// Send a direct message to a Discord user
+    /// Deprecated: send a direct message to a Discord user
+    #[command(
+        after_help = "Deprecated compatibility command. With `--key`, this command selects that one configured bot token; without `--key`, it tries configured bot tokens sequentially until one succeeds. Routed `send` instead requires a role-map-authorized channel or agent target and selects one configured `--bot` runtime (default: announce); it does not preserve this token fallback, target a Discord user, or create a DM. Keep using this command until a supported replacement is available."
+    )]
     DiscordSenddm {
         /// Discord user ID
         #[arg(long)]
@@ -70,14 +79,16 @@ pub(crate) enum Commands {
         /// Message text
         #[arg(long)]
         message: String,
-        /// Authentication key hash (optional; falls back to AGENTDESK_TOKEN env or configured Discord bots)
+        /// Authentication key hash (optional; without it, configured bot tokens are tried sequentially until one succeeds)
         #[arg(long)]
         key: Option<String>,
     },
     /// Send a routed Discord message without HTTP server dependency
     Send {
-        /// Target route such as channel:<id>, user:<id>, role:<name>
-        #[arg(long)]
+        #[arg(
+            long,
+            help = crate::services::discord::outbound::send_target::SEND_TARGET_CONTRACT
+        )]
         target: String,
         /// Source label recorded in the send envelope
         #[arg(long)]
@@ -1066,6 +1077,168 @@ mod tests {
                 format!("agentdesk {}", env!("CARGO_PKG_VERSION"))
             );
         }
+    }
+
+    #[test]
+    fn legacy_flat_discord_send_commands_still_parse_unchanged() {
+        let file = Cli::try_parse_from([
+            "agentdesk",
+            "discord-sendfile",
+            "/tmp/report.txt",
+            "--channel",
+            "42",
+            "--key",
+            "key-hash",
+        ])
+        .expect("legacy file send should still parse");
+        assert!(matches!(
+            file.command,
+            Some(Commands::DiscordSendfile {
+                path,
+                channel: 42,
+                key,
+            }) if path == "/tmp/report.txt" && key == "key-hash"
+        ));
+
+        let channel = Cli::try_parse_from([
+            "agentdesk",
+            "discord-sendmessage",
+            "--channel",
+            "42",
+            "--message",
+            "hello channel",
+        ])
+        .expect("legacy channel send should still parse");
+        assert!(matches!(
+            channel.command,
+            Some(Commands::DiscordSendmessage {
+                channel: 42,
+                message,
+                key: None,
+            }) if message == "hello channel"
+        ));
+
+        let dm = Cli::try_parse_from([
+            "agentdesk",
+            "discord-senddm",
+            "--user",
+            "43",
+            "--message",
+            "hello user",
+        ])
+        .expect("legacy DM send should still parse");
+        assert!(matches!(
+            dm.command,
+            Some(Commands::DiscordSenddm {
+                user: 43,
+                message,
+                key: None,
+            }) if message == "hello user"
+        ));
+    }
+
+    #[test]
+    fn legacy_flat_discord_send_help_matches_routed_send_contract() {
+        fn help_for(command: &str) -> String {
+            let Err(error) = Cli::try_parse_from(["agentdesk", command, "--help"]) else {
+                panic!("{command} --help must render help instead of running the command");
+            };
+            assert_eq!(error.kind(), ErrorKind::DisplayHelp, "{command}");
+            assert_eq!(error.exit_code(), 0, "{command}");
+            error.to_string()
+        }
+
+        fn assert_legacy_token_contract(help: &str, command: &str) -> String {
+            let help = help.split_whitespace().collect::<Vec<_>>().join(" ");
+            for required in [
+                "With `--key`",
+                "one configured bot token",
+                "without `--key`",
+                "configured bot tokens",
+                "sequentially until one succeeds",
+            ] {
+                assert!(
+                    help.contains(required),
+                    "{command} help must disclose {required}: {help}"
+                );
+            }
+            assert!(
+                !help.contains("AGENTDESK_TOKEN"),
+                "{command} must not claim an environment-token fallback it does not implement: {help}"
+            );
+            help
+        }
+
+        let command = Cli::command();
+        let send_target_help = command
+            .find_subcommand("send")
+            .expect("send subcommand")
+            .get_arguments()
+            .find(|argument| argument.get_id().as_str() == "target")
+            .and_then(|argument| argument.get_help())
+            .map(ToString::to_string);
+        assert_eq!(
+            send_target_help.as_deref(),
+            Some(crate::services::discord::outbound::send_target::SEND_TARGET_CONTRACT),
+            "Clap target help must be sourced from the resolver-owned contract"
+        );
+
+        let send = help_for("send");
+        for supported_route in ["channel:<id>", "channel:<name>", "agent:<roleId>"] {
+            assert!(
+                send.contains(supported_route),
+                "routed send help must advertise {supported_route}: {send}"
+            );
+        }
+        assert!(
+            !send.contains("user:<id>"),
+            "unsupported user route: {send}"
+        );
+        assert!(
+            !send.contains("role:<name>"),
+            "unsupported role route: {send}"
+        );
+
+        let channel = help_for("discord-sendmessage");
+        assert!(channel.contains("Deprecated"), "{channel}");
+        let channel_contract = assert_legacy_token_contract(&channel, "discord-sendmessage");
+        assert!(
+            channel_contract.contains("selects one `--bot` runtime")
+                && channel_contract.contains("does not preserve")
+                && channel_contract.contains("sequential fallback"),
+            "routed send must remain explicitly non-equivalent to legacy token fallback: {channel_contract}"
+        );
+        for migration_token in ["agentdesk", "channel:<id>", "--content"] {
+            assert!(
+                channel.contains(migration_token),
+                "channel migration must include {migration_token}: {channel}"
+            );
+        }
+        for required_caveat in ["role-map", "--bot", "--key", "compatibility"] {
+            assert!(
+                channel.contains(required_caveat),
+                "channel migration must disclose {required_caveat}: {channel}"
+            );
+        }
+
+        let dm = help_for("discord-senddm");
+        assert!(dm.contains("Deprecated"), "{dm}");
+        let dm_contract = assert_legacy_token_contract(&dm, "discord-senddm");
+        assert!(
+            dm_contract.contains("selects one configured `--bot` runtime")
+                && dm_contract.contains("does not preserve this token fallback"),
+            "routed send must not be presented as a DM token-fallback replacement: {dm_contract}"
+        );
+        for unsupported_or_gated in ["role-map", "--bot", "--key", "DM", "compatibility"] {
+            assert!(
+                dm.contains(unsupported_or_gated),
+                "DM compatibility help must disclose {unsupported_or_gated}: {dm}"
+            );
+        }
+
+        let file = help_for("discord-sendfile");
+        assert!(file.contains("Deprecated"), "{file}");
+        assert!(file.contains("attachments"), "{file}");
     }
 
     #[test]

--- a/src/services/discord/outbound/send_api.rs
+++ b/src/services/discord/outbound/send_api.rs
@@ -497,7 +497,7 @@ mod handle_send_contract_tests {
         assert_eq!(body["ok"], false);
         assert_eq!(
             body["error"],
-            "invalid target format (use channel:<id>, channel:<name>, or agent:<roleId>)"
+            super::super::send_target::SEND_TARGET_CONTRACT
         );
     }
 

--- a/src/services/discord/outbound/send_target.rs
+++ b/src/services/discord/outbound/send_target.rs
@@ -5,6 +5,12 @@
 use poise::serenity_prelude::ChannelId;
 use sqlx::PgPool;
 
+/// Canonical public contract for the routed `send` target grammar.
+///
+/// CLI help and resolver errors share this text so they cannot advertise
+/// prefixes that the parser does not implement.
+pub(crate) const SEND_TARGET_CONTRACT: &str = "Target must be channel:<id>, channel:<name>, or agent:<roleId>; bare channel IDs/names are accepted for compatibility.";
+
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum SendTargetResolutionError {
     BadRequest(&'static str),
@@ -26,9 +32,7 @@ fn parse_agent_target(target: &str) -> Result<Option<&str>, SendTargetResolution
     };
     let agent_id = agent_id_raw.trim();
     if agent_id.is_empty() {
-        return Err(SendTargetResolutionError::BadRequest(
-            "invalid target format (use channel:<id>, channel:<name>, or agent:<roleId>)",
-        ));
+        return Err(SendTargetResolutionError::BadRequest(SEND_TARGET_CONTRACT));
     }
     Ok(Some(agent_id))
 }
@@ -118,10 +122,15 @@ pub(super) async fn routine_thread_parent_hint(
 }
 
 fn resolve_channel_target(target: &str) -> Result<u64, SendTargetResolutionError> {
-    let channel_target = target.strip_prefix("channel:").unwrap_or(target);
-    parse_channel_target_value(channel_target).ok_or(SendTargetResolutionError::BadRequest(
-        "invalid target format (use channel:<id>, channel:<name>, or agent:<roleId>)",
-    ))
+    let channel_target = match target.strip_prefix("channel:") {
+        Some(channel_target) => channel_target,
+        None if target.contains(':') => {
+            return Err(SendTargetResolutionError::BadRequest(SEND_TARGET_CONTRACT));
+        }
+        None => target,
+    };
+    parse_channel_target_value(channel_target)
+        .ok_or(SendTargetResolutionError::BadRequest(SEND_TARGET_CONTRACT))
 }
 
 pub(super) async fn resolve_send_target_channel_id_with_backends(
@@ -148,7 +157,10 @@ mod send_target_parse_tests {
     //! branches (`parse_channel_target_value` / `parse_agent_target`) before
     //! the health.rs directory decomposition.
 
-    use super::{SendTargetResolutionError, parse_agent_target, parse_channel_target_value};
+    use super::{
+        SEND_TARGET_CONTRACT, SendTargetResolutionError, parse_agent_target,
+        parse_channel_target_value, resolve_channel_target,
+    };
 
     #[test]
     fn numeric_channel_target_parses_after_trimming() {
@@ -177,9 +189,7 @@ mod send_target_parse_tests {
     fn agent_target_with_empty_id_is_bad_request() {
         assert_eq!(
             parse_agent_target("agent:   "),
-            Err(SendTargetResolutionError::BadRequest(
-                "invalid target format (use channel:<id>, channel:<name>, or agent:<roleId>)",
-            ))
+            Err(SendTargetResolutionError::BadRequest(SEND_TARGET_CONTRACT))
         );
     }
 
@@ -189,5 +199,65 @@ mod send_target_parse_tests {
             parse_agent_target("agent: backend-dev "),
             Ok(Some("backend-dev"))
         );
+    }
+
+    #[test]
+    fn published_target_contract_matches_parser_prefixes() {
+        let root_result = tempfile::tempdir();
+        assert!(
+            root_result.is_ok(),
+            "create temporary AgentDesk root for target contract test: {:?}",
+            root_result.as_ref().err()
+        );
+        let Some(root) = root_result.ok() else {
+            return;
+        };
+        let _root_guard = crate::config::set_agentdesk_root_for_test(root.path());
+        let config_dir = root.path().join("config");
+        assert!(
+            std::fs::create_dir_all(&config_dir).is_ok(),
+            "create target contract test config directory"
+        );
+        assert!(
+            std::fs::write(
+                config_dir.join("role_map.json"),
+                serde_json::json!({
+                    "byChannelName": {
+                        "supported-alias": { "channelId": "4225000" },
+                        "user:4225": { "channelId": "4225001" },
+                        "role:backend-dev": { "channelId": "4225002" }
+                    },
+                    "byChannelId": {}
+                })
+                .to_string(),
+            )
+            .is_ok(),
+            "write alias-collision role map"
+        );
+
+        assert_eq!(resolve_channel_target("channel:123"), Ok(123));
+        assert_eq!(resolve_channel_target("123"), Ok(123));
+        assert_eq!(
+            resolve_channel_target("channel:supported-alias"),
+            Ok(4225000)
+        );
+        assert_eq!(resolve_channel_target("supported-alias"), Ok(4225000));
+        assert_eq!(
+            parse_agent_target("agent:backend-dev"),
+            Ok(Some("backend-dev"))
+        );
+
+        for unsupported in ["user:4225", "role:backend-dev"] {
+            assert_eq!(
+                resolve_channel_target(unsupported),
+                Err(SendTargetResolutionError::BadRequest(SEND_TARGET_CONTRACT)),
+                "unsupported target prefix must not be advertised: {unsupported}"
+            );
+        }
+        assert!(SEND_TARGET_CONTRACT.contains("channel:<id>"));
+        assert!(SEND_TARGET_CONTRACT.contains("channel:<name>"));
+        assert!(SEND_TARGET_CONTRACT.contains("agent:<roleId>"));
+        assert!(!SEND_TARGET_CONTRACT.contains("user:<id>"));
+        assert!(!SEND_TARGET_CONTRACT.contains("role:<name>"));
     }
 }


### PR DESCRIPTION
Part of #4225.

This second contained CLI slice keeps the legacy flat Discord send commands working while making their help honest and steering compatible callers toward routed `agentdesk send`.

Changes:
- add deprecation/migration guidance for `discord-sendmessage`, `discord-senddm`, and `discord-sendfile`;
- share one resolver-owned routed-send target grammar across Clap help and API errors;
- categorically reject unsupported colon prefixes before channel-alias lookup;
- document the real legacy token behavior (`--key` selects one configured bot; otherwise configured bot tokens are tried sequentially) and its non-equivalence to routed `--bot` + role-map authorization;
- add rendered-help and real alias-collision regressions.

Verification:
- focused Cargo: help 1/1, send-target parser 6/6, missing-target API 1/1;
- unsupported target-contract advertisement mutation: 2 RED, restored;
- colon-prefix alias-guard removal mutation: RED, restored;
- rustfmt, inventory generator/check, maintenance docs, and git diff checks: GREEN.

This remains a Draft until fresh exact-SHA Codex gpt-5.5/xhigh and account2 Opus/xhigh reviews plus CI are green.

