### PR TITLE
test(relay): add executable W1-A authority contract

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -58,6 +58,10 @@ echo "=== Alert dedupe/authority/routing wiring contract (#4448/#4449) ==="
 echo "=== State/lint hardening guard ==="
 "$PYTHON" scripts/audit_state_lint_hardening.py
 
+echo "=== Relay W1-A executable contract (#4254) ==="
+PYTHONDONTWRITEBYTECODE=1 "$PYTHON" -m unittest discover \
+  -s scripts/relay_w1a/tests -p 'test_*.py'
+
 echo "=== Policy DB capability manifest guard (#3734) ==="
 "$PYTHON" scripts/check_policy_db_capabilities.py --no-silent-growth \
   --require-manifest policies/timeouts/active-monitor.cap.yaml \

--- a/scripts/relay_w1a/README.md
+++ b/scripts/relay_w1a/README.md
@@ -48,6 +48,13 @@ Discord evidence ids remain typed decimal strings; arbitrary values are never
 coerced. Marker uniqueness is derived from actual source bytes independently of
 nullable range metadata.
 
+`commit_dispositions` and `advance_committed_frontier` are side-effect-free, so
+their Discord message-id uniqueness checks cover only the dispositions supplied
+in that call. They do not claim process-global or durable uniqueness. Cross-batch
+reconciliation must provide the evidence oracle with every disposition and
+Discord observation in the externally pinned audit extent; the oracle rejects a
+message id reused anywhere in that extent.
+
 ## Fixtures and tests
 
 `fixtures/incidents.json` contains the authority matrix, executable ledger and

--- a/scripts/relay_w1a/README.md
+++ b/scripts/relay_w1a/README.md
@@ -63,11 +63,11 @@ message id reused anywhere in that extent.
 
 ## Fixtures and tests
 
-`fixtures/incidents.json` contains the authority matrix, executable ledger and
-backpressure fault cases, the continuous #4104 E-22
-`Missing -> ReappearedSame -> PresentStable` sequence, and a complete oracle
-example with separately supplied pins. The suite invokes the model for every
-fault fixture; fixture names alone are not treated as evidence.
+`fixtures/incidents.json` contains the authority matrix, isolated executable
+ledger and backpressure fault cases, and a complete oracle example with
+separately supplied pins. The test suite constructs the continuous #4104 E-22
+`Missing -> ReappearedSame -> PresentStable` sequence directly. It invokes the
+model for every fault fixture; fixture names alone are not treated as evidence.
 
 Run the isolated standard-library suite from the repository root:
 

--- a/scripts/relay_w1a/README.md
+++ b/scripts/relay_w1a/README.md
@@ -28,6 +28,12 @@ safe queue disposition, and action-time reprobe. Unknown enum values, stale or
 future clocks, impossible `u64` counters/frontiers, missing anchors, and
 unrecognized ledger states fail closed.
 
+`PRESENT_STABLE` preserves the ledger's episode, source id, and source
+generation exactly; it cannot introduce a successor identity. A successor must
+be reported as `REPLACED`, and reusing the same source id requires a strictly
+greater generation even when the episode key changes. A genuinely different
+source may start at the same valid generation.
+
 ## Oracle inputs
 
 An evidence bundle is not self-authenticating. `validate_evidence_bundle`

--- a/scripts/relay_w1a/README.md
+++ b/scripts/relay_w1a/README.md
@@ -1,0 +1,69 @@
+# #4254 standalone W1-A executable contract
+
+This directory is intentionally independent of the AgentDesk Rust module tree.
+It is a side-effect-free executable specification, not runtime recovery
+authority.
+
+## Contract boundaries
+
+The model covers four fail-closed contracts:
+
+- stall authority uses typed, episode-bound evidence; silence, elapsed time,
+  repeated repair failure, and the compatibility boolean termination flag never
+  prove producer death;
+- repair accounting uses an exact attempt CAS and a `Reserved -> EffectPending
+  -> Settled` ledger. An unresolved reservation or effect cannot be overwritten
+  or replayed, and only a delivery-effect proof can rearm a same-episode circuit;
+- bounded batching durably disposes every source range as delivered,
+  summarized, or policy-omitted. Oversized tool bulk advances a bounded prefix
+  and exposes an explicit suffix instead of requiring the whole group to fit;
+- reconciliation recomputes range, expected-body, Discord-body, marker, and
+  committed-frontier facts from external pins and actual UTF-8 source bytes.
+
+`DeliveryProof` pins the episode, source id and generation, durable anchor,
+source and committed frontiers, typed queue disposition, and action-time clock.
+The observation and proof must agree at settlement time. `TerminationProof`
+additionally pins the exact termination id, finalizer commit, stopped watcher,
+safe queue disposition, and action-time reprobe. Unknown enum values, stale or
+future clocks, impossible `u64` counters/frontiers, missing anchors, and
+unrecognized ledger states fail closed.
+
+## Oracle inputs
+
+An evidence bundle is not self-authenticating. `validate_evidence_bundle`
+requires these inputs from outside the bundle:
+
+- the exact manifest/schema/template pin;
+- actual source id and actual source bytes;
+- Discord channel id and exclusive message-id cutoff.
+
+The oracle accepts only raw UTF-8 byte coordinates, exact disposition/reason
+pairs, contiguous non-duplicated ranges, a durable advancing anchor, complete
+Discord revision history after the cutoff, and unrelated-session evidence from
+both Claude and Codex. Declared source hashes, markers, normalized bodies,
+expected-body hashes, and frontiers are always recomputed or cross-checked.
+Every serialized disposition carries both its aggregate `source_sha256` and an
+ordered `source_range_sha256s` list, including multi-range tool summaries.
+Discord evidence ids remain typed decimal strings; arbitrary values are never
+coerced. Marker uniqueness is derived from actual source bytes independently of
+nullable range metadata.
+
+## Fixtures and tests
+
+`fixtures/incidents.json` contains the authority matrix, executable ledger and
+backpressure fault cases, the continuous #4104 E-22
+`Missing -> ReappearedSame -> PresentStable` sequence, and a complete oracle
+example with separately supplied pins. The suite invokes the model for every
+fault fixture; fixture names alone are not treated as evidence.
+
+Run the isolated standard-library suite from the repository root:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+  -s scripts/relay_w1a/tests -p 'test_*.py' -v
+```
+
+Production wiring remains blocked on the dependency and sole-writer gates in
+the corrected #4254 V2 design. Files in this directory must never import
+AgentDesk runtime modules or perform network, Discord, tmux, process, or
+filesystem-state mutation.

--- a/scripts/relay_w1a/fixtures/incidents.json
+++ b/scripts/relay_w1a/fixtures/incidents.json
@@ -1,0 +1,426 @@
+{
+  "schema_version": 1,
+  "authority_cases": [
+    {
+      "name": "4178_source_live_delivery_frozen",
+      "observation": {
+        "episode_key": "ep-4178",
+        "continuity": "present_stable",
+        "queue": "active",
+        "source_progress": true,
+        "control_contradiction": true
+      },
+      "expected_candidate": "control_plane_desync",
+      "expected_action": "repair_control_plane",
+      "expected_spend": true
+    },
+    {
+      "name": "quiet_is_not_death",
+      "observation": {
+        "episode_key": "ep-quiet",
+        "continuity": "present_stable",
+        "queue": "active"
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "failed_repairs_are_not_death",
+      "observation": {
+        "episode_key": "ep-no-effect",
+        "continuity": "present_stable",
+        "queue": "active",
+        "failed_repairs": 2
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "five_hour_live_source_is_not_dead",
+      "observation": {
+        "episode_key": "ep-five-hours",
+        "continuity": "present_stable",
+        "queue": "active",
+        "source_progress": true
+      },
+      "expected_candidate": "producer_live",
+      "expected_action": "observe",
+      "expected_spend": false
+    },
+    {
+      "name": "malformed_clock_is_inconclusive",
+      "observation": {
+        "episode_key": "ep-clock",
+        "continuity": "present_stable",
+        "queue": "active",
+        "clock_valid": false,
+        "source_progress": true
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "4485_affirmative_death_with_terminal_queue",
+      "observation": {
+        "episode_key": "ep-4485",
+        "source_id": "source-4485",
+        "source_generation": 3,
+        "durable_anchor": "anchor-4485",
+        "observed_at": {
+          "wall_ms": 1000,
+          "boot_id": "boot-4485",
+          "monotonic_ms": 10
+        },
+        "continuity": "present_stable",
+        "queue": "terminal",
+        "termination_proof": {
+          "episode_key": "ep-4485",
+          "source_id": "source-4485",
+          "source_generation": 3,
+          "durable_anchor": "anchor-4485",
+          "queue": "terminal",
+          "termination_id": "termination-4485",
+          "finalizer_committed": true,
+          "watcher_stopped": true,
+          "action_reprobe_at": {
+            "wall_ms": 1000,
+            "boot_id": "boot-4485",
+            "monotonic_ms": 10
+          }
+        }
+      },
+      "expected_candidate": "producer_dead",
+      "expected_action": "delegate_exact_termination",
+      "expected_spend": false
+    },
+    {
+      "name": "4485_death_proof_with_active_queue_fails_closed",
+      "observation": {
+        "episode_key": "ep-4485-active",
+        "source_id": "source-4485-active",
+        "source_generation": 4,
+        "durable_anchor": "anchor-4485-active",
+        "observed_at": {
+          "wall_ms": 2000,
+          "boot_id": "boot-4485",
+          "monotonic_ms": 20
+        },
+        "continuity": "present_stable",
+        "queue": "active",
+        "termination_proof": {
+          "episode_key": "ep-4485-active",
+          "source_id": "source-4485-active",
+          "source_generation": 4,
+          "durable_anchor": "anchor-4485-active",
+          "queue": "active",
+          "termination_id": "termination-4485-active",
+          "finalizer_committed": true,
+          "watcher_stopped": true,
+          "action_reprobe_at": {
+            "wall_ms": 2000,
+            "boot_id": "boot-4485",
+            "monotonic_ms": 20
+          }
+        }
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "4247_unknown_queue_inhibits_repair_and_death",
+      "observation": {
+        "episode_key": "ep-4247",
+        "continuity": "present_stable",
+        "queue": "unknown",
+        "source_progress": true,
+        "control_contradiction": true
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "4104_inflight_missing_is_inconclusive",
+      "observation": {
+        "episode_key": "ep-4104",
+        "continuity": "missing",
+        "queue": "active",
+        "source_progress": true,
+        "control_contradiction": true
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "4104_same_row_reappeared_needs_stability",
+      "observation": {
+        "episode_key": "ep-4104",
+        "continuity": "reappeared_same",
+        "queue": "active",
+        "source_progress": true,
+        "control_contradiction": true
+      },
+      "expected_candidate": null,
+      "expected_action": "none",
+      "expected_spend": false
+    },
+    {
+      "name": "delivered_terminal_typed_idle",
+      "observation": {
+        "episode_key": "ep-idle",
+        "continuity": "present_stable",
+        "queue": "idle",
+        "terminal_delivery_committed": true,
+        "typed_idle": true
+      },
+      "expected_candidate": "delivered_idle",
+      "expected_action": "observe",
+      "expected_spend": false
+    }
+  ],
+  "fault_cases": [
+    {
+      "name": "reserved_crash_is_cancelled_without_spend",
+      "operation": "recover_reserved",
+      "input": {"episode": "fixture-reserved", "source": 100, "delivered": 10},
+      "expected": {"changed": true, "state": "settled", "attempts_spent": 0, "must_reprobe": false}
+    },
+    {
+      "name": "effect_pending_crash_requires_reprobe",
+      "operation": "recover_pending",
+      "input": {"episode": "fixture-pending", "source": 100, "delivered": 10},
+      "expected": {"changed": false, "state": "effect_pending", "attempts_spent": 1, "must_reprobe": true}
+    },
+    {
+      "name": "source_only_progress_does_not_rearm",
+      "operation": "circuit_rearm",
+      "input": {"episode": "fixture-source-only", "delivered_after": 10},
+      "expected": {"changed": false, "reason": "same_episode_circuit_open", "lifetime_no_effect_count": 2}
+    },
+    {
+      "name": "delivery_progress_rearms_same_episode",
+      "operation": "circuit_rearm",
+      "input": {"episode": "fixture-delivery", "delivered_after": 11},
+      "expected": {"changed": true, "reason": "reserved_without_spend", "lifetime_no_effect_count": 0}
+    },
+    {
+      "name": "4104_missing_pending_freezes_without_retry",
+      "operation": "pending_continuity",
+      "input": {"episode": "fixture-4104", "continuity": "missing"},
+      "expected": {"changed": false, "must_reprobe": true, "state": "effect_pending", "attempts_spent": 1}
+    },
+    {
+      "name": "clock_rollback_fails_closed",
+      "operation": "clock_transition",
+      "input": {
+        "previous": {"wall_ms": 10000, "boot_id": "boot-a", "monotonic_ms": 500},
+        "current": {"wall_ms": 9999, "boot_id": "boot-a", "monotonic_ms": 499},
+        "trusted_now": {"wall_ms": 10000, "boot_id": "boot-a", "monotonic_ms": 500},
+        "max_future_skew_ms": 100
+      },
+      "expected": {"allowed": false}
+    },
+    {
+      "name": "future_schema_fails_closed",
+      "operation": "load_ledger",
+      "input": {"raw": "{\"schema_version\":2}"},
+      "expected": {"fail_closed": true, "reason": "future_or_unknown_schema"}
+    },
+    {
+      "name": "corrupt_record_fails_closed",
+      "operation": "load_ledger",
+      "input": {"raw": "{"},
+      "expected": {"fail_closed": true, "reason": "corrupt_json"}
+    },
+    {
+      "name": "oversized_assistant_range_does_not_advance",
+      "operation": "plan_single_range",
+      "input": {"kind": "assistant_text", "body_bytes": 100, "max_items": 4, "max_bytes": 50},
+      "expected": {"processed_end": 0, "blocked_reason": "high_value_range_requires_utf8_safe_split", "dispositions": 0}
+    },
+    {
+      "name": "tool_bulk_summary_advances_after_commit",
+      "operation": "plan_single_range",
+      "input": {"kind": "tool_bulk", "body_bytes": 500, "max_items": 1, "max_bytes": 300},
+      "expected": {"processed_end": 500, "blocked_reason": null, "dispositions": 1, "committed_frontier": 500}
+    }
+  ],
+  "oracle_pinned_inputs": {
+    "pinned_manifest": {
+      "schema_version": 1,
+      "run_id": "run4254",
+      "case_id": "high-volume",
+      "provider": "codex",
+      "channel_id": "1479671301387059200",
+      "base_sha": "b9026baf724b35d2acd9db6bccc8895fab07a902",
+      "binary_sha": "1111111111111111111111111111111111111111",
+      "policy_version": "relay-target-v1",
+      "normalization_version": "discord-body-v1",
+      "actual_source_id": "rollout-019f4254",
+      "source_generation": 7,
+      "coordinate_space": "raw_utf8_bytes",
+      "source_start": 0,
+      "source_end": 123,
+      "durable_frontier_before": 0,
+      "durable_anchor_before": "anchor-4254-0",
+      "durable_anchor_after": "anchor-4254-123",
+      "bot_author_id": "424254",
+      "discord_after_message_id": "999",
+      "started_at": "2026-07-13T10:00:00Z",
+      "discord_complete": true
+    },
+    "actual_source_id": "rollout-019f4254",
+    "actual_source_utf8": "[ADK-E2E:run4254:high-volume:1:BEGIN]answer-one[ADK-E2E:run4254:high-volume:2:END]tool-output:xxxxxxxxxxxxxxxcontrol-record",
+    "discord_channel_id": "1479671301387059200",
+    "discord_after_message_id": "999"
+  },
+  "oracle_good_bundle": {
+    "manifest": {
+      "schema_version": 1,
+      "run_id": "run4254",
+      "case_id": "high-volume",
+      "provider": "codex",
+      "channel_id": "1479671301387059200",
+      "base_sha": "b9026baf724b35d2acd9db6bccc8895fab07a902",
+      "binary_sha": "1111111111111111111111111111111111111111",
+      "policy_version": "relay-target-v1",
+      "normalization_version": "discord-body-v1",
+      "actual_source_id": "rollout-019f4254",
+      "source_generation": 7,
+      "coordinate_space": "raw_utf8_bytes",
+      "source_start": 0,
+      "source_end": 123,
+      "durable_frontier_before": 0,
+      "durable_anchor_before": "anchor-4254-0",
+      "durable_anchor_after": "anchor-4254-123",
+      "bot_author_id": "424254",
+      "discord_after_message_id": "999",
+      "started_at": "2026-07-13T10:00:00Z",
+      "discord_complete": true
+    },
+    "source_ranges": [
+      {
+        "range_id": "r1",
+        "start": 0,
+        "end": 47,
+        "kind": "assistant_text",
+        "sha256": "b13978d97291ab50c695ca9767556eefa2e22facd60df0524421c6312bcd0b51",
+        "marker": "[ADK-E2E:run4254:high-volume:1:BEGIN]",
+        "marker_in_source": true
+      },
+      {
+        "range_id": "r2",
+        "start": 47,
+        "end": 109,
+        "kind": "tool_bulk",
+        "sha256": "8eeb58ba99884c0c203135d0fd2635297cf42161a88a8cb2d19ec4ae1ee23143",
+        "marker": "[ADK-E2E:run4254:high-volume:2:END]",
+        "marker_in_source": true
+      },
+      {
+        "range_id": "r3",
+        "start": 109,
+        "end": 123,
+        "kind": "control",
+        "sha256": "19dc6803cbc0d8f302c6cb9c2634bc150bc119a0255058aa4fc388e5c40d12c5",
+        "marker": null
+      }
+    ],
+    "dispositions": [
+      {
+        "range_ids": ["r1"],
+        "kind": "delivered",
+        "policy_reason": "assistant_text_must_deliver",
+        "source_sha256": "b13978d97291ab50c695ca9767556eefa2e22facd60df0524421c6312bcd0b51",
+        "source_range_sha256s": ["b13978d97291ab50c695ca9767556eefa2e22facd60df0524421c6312bcd0b51"],
+        "discord_message_ids": ["1001"],
+        "expected_body_sha256": "b13978d97291ab50c695ca9767556eefa2e22facd60df0524421c6312bcd0b51",
+        "committed": true
+      },
+      {
+        "range_ids": ["r2"],
+        "kind": "summarized",
+        "policy_reason": "relay-target-v1:tool_bulk_overflow",
+        "source_sha256": "8eeb58ba99884c0c203135d0fd2635297cf42161a88a8cb2d19ec4ae1ee23143",
+        "source_range_sha256s": ["8eeb58ba99884c0c203135d0fd2635297cf42161a88a8cb2d19ec4ae1ee23143"],
+        "discord_message_ids": ["1002"],
+        "expected_body_sha256": "38fae5215b6d510bdf8b8d194dcb73bfc9beadab5613aba9a982788dd585a95a",
+        "committed": true
+      },
+      {
+        "range_ids": ["r3"],
+        "kind": "omitted_policy",
+        "policy_reason": "relay-target-v1:control",
+        "source_sha256": "19dc6803cbc0d8f302c6cb9c2634bc150bc119a0255058aa4fc388e5c40d12c5",
+        "source_range_sha256s": ["19dc6803cbc0d8f302c6cb9c2634bc150bc119a0255058aa4fc388e5c40d12c5"],
+        "discord_message_ids": [],
+        "expected_body_sha256": null,
+        "committed": true
+      }
+    ],
+    "discord_observations": [
+      {
+        "message_id": "1001",
+        "channel_id": "1479671301387059200",
+        "author_id": "424254",
+        "observed_at": "2026-07-13T10:00:01Z",
+        "edited_at": null,
+        "revision_index": 0,
+        "message_role": "relay_body",
+        "raw_body": "[ADK-E2E:run4254:high-volume:1:BEGIN]answer-one",
+        "normalized_body": "[ADK-E2E:run4254:high-volume:1:BEGIN]answer-one"
+      },
+      {
+        "message_id": "1002",
+        "channel_id": "1479671301387059200",
+        "author_id": "424254",
+        "observed_at": "2026-07-13T10:00:02Z",
+        "edited_at": null,
+        "revision_index": 0,
+        "message_role": "relay_body",
+        "raw_body": "[AgentDesk summary policy=relay-target-v1 range=47:109 records=1 raw_bytes=62 sha256=8eeb58ba99884c0c203135d0fd2635297cf42161a88a8cb2d19ec4ae1ee23143 markers=[ADK-E2E:run4254:high-volume:2:END]]",
+        "normalized_body": "[AgentDesk summary policy=relay-target-v1 range=47:109 records=1 raw_bytes=62 sha256=8eeb58ba99884c0c203135d0fd2635297cf42161a88a8cb2d19ec4ae1ee23143 markers=[ADK-E2E:run4254:high-volume:2:END]]"
+      },
+      {
+        "message_id": "1003",
+        "channel_id": "1479671301387059200",
+        "author_id": "424254",
+        "observed_at": "2026-07-13T10:00:02Z",
+        "edited_at": null,
+        "revision_index": 0,
+        "message_role": "panel",
+        "raw_body": "working",
+        "normalized_body": "working"
+      }
+    ],
+    "delivery_observation": {
+      "source_id": "rollout-019f4254",
+      "source_generation": 7,
+      "committed_frontier": 123,
+      "durable_anchor": "anchor-4254-123"
+    },
+    "unrelated_sessions": [
+      {
+        "channel_id": "1479671298497183835",
+        "provider": "claude",
+        "identity_complete": true,
+        "observed_at": "2026-07-13T10:00:03Z",
+        "relay_gap": false,
+        "regression": false
+      },
+      {
+        "channel_id": "1479671301387059111",
+        "provider": "codex",
+        "identity_complete": true,
+        "observed_at": "2026-07-13T10:00:03Z",
+        "relay_gap": false,
+        "regression": false
+      }
+    ]
+  }
+}

--- a/scripts/relay_w1a/model.py
+++ b/scripts/relay_w1a/model.py
@@ -123,13 +123,15 @@ class Assessment:
     may_spend_automatic_action: bool
 
 
-def assess(observation: Observation) -> Assessment:
-    """Return the fail-closed authoritative assessment for one observation."""
+def _observation_contract_error(observation: Observation) -> str | None:
+    """Validate typed fields shared by every observation-consuming entrypoint."""
 
+    if not isinstance(observation, Observation):
+        return "observation_not_typed"
     if not isinstance(observation.continuity, InflightContinuity):
-        return _inconclusive("continuity_not_typed")
+        return "continuity_not_typed"
     if not isinstance(observation.queue, QueueDisposition):
-        return _inconclusive("queue_not_typed")
+        return "queue_not_typed"
     if any(
         not isinstance(value, bool)
         for value in (
@@ -143,7 +145,16 @@ def assess(observation: Observation) -> Assessment:
             observation.typed_idle,
         )
     ):
-        return _inconclusive("observation_bool_not_typed")
+        return "observation_bool_not_typed"
+    return None
+
+
+def assess(observation: Observation) -> Assessment:
+    """Return the fail-closed authoritative assessment for one observation."""
+
+    contract_error = _observation_contract_error(observation)
+    if contract_error is not None:
+        return _inconclusive(contract_error)
     if not observation.identity_complete or not observation.episode_key:
         return _inconclusive("missing_identity")
     if not observation.clock_valid:
@@ -363,6 +374,14 @@ class LedgerTransition:
     must_reprobe: bool = False
 
 
+def _unknown_ledger_state_transition(
+    record: LedgerRecord | None,
+) -> LedgerTransition | None:
+    if record is not None and not isinstance(record.state, LedgerState):
+        return LedgerTransition(record, False, 0, "ledger_state_not_typed", True)
+    return None
+
+
 def _delivery_proof_error(
     proof: DeliveryProof | None,
     observation: Observation,
@@ -372,6 +391,12 @@ def _delivery_proof_error(
 ) -> str | None:
     if proof is None:
         return "delivery_proof_required"
+    if not isinstance(proof, DeliveryProof):
+        return "delivery_proof_malformed"
+    if not isinstance(proof.identity_complete, bool) or not isinstance(
+        proof.clock_valid, bool
+    ):
+        return "delivery_proof_bool_not_typed"
     if (
         not isinstance(proof.queue, QueueDisposition)
         or not isinstance(observation.queue, QueueDisposition)
@@ -450,8 +475,9 @@ def reserve_attempt(
     delivery_proof: DeliveryProof,
     now: ClockStamp,
 ) -> LedgerTransition:
-    if record is not None and not isinstance(record.state, LedgerState):
-        return LedgerTransition(record, False, 0, "ledger_state_not_typed", True)
+    unknown_state = _unknown_ledger_state_transition(record)
+    if unknown_state is not None:
+        return unknown_state
     if (
         record is not None
         and record.state in {LedgerState.RESERVED, LedgerState.EFFECT_PENDING}
@@ -533,6 +559,9 @@ def reserve_attempt(
 def mark_effect_pending(
     record: LedgerRecord, *, attempt_id: str, now: ClockStamp
 ) -> LedgerTransition:
+    unknown_state = _unknown_ledger_state_transition(record)
+    if unknown_state is not None:
+        return unknown_state
     if attempt_id != record.attempt_id:
         return LedgerTransition(record, False, 0, "attempt_cas_mismatch", True)
     if record.state is not LedgerState.RESERVED:
@@ -556,9 +585,16 @@ def recover_after_crash(
     *,
     attempt_id: str | None = None,
 ) -> LedgerTransition:
+    unknown_state = _unknown_ledger_state_transition(record)
+    if unknown_state is not None:
+        return unknown_state
     if attempt_id != record.attempt_id:
         return LedgerTransition(record, False, 0, "attempt_cas_mismatch", True)
     if record.state is LedgerState.RESERVED:
+        if observation is not None:
+            contract_error = _observation_contract_error(observation)
+            if contract_error is not None:
+                return LedgerTransition(record, False, 0, contract_error, True)
         if (
             observation is None
             or observation.episode_key != record.episode_key
@@ -590,12 +626,16 @@ def settle_effect(
     now: ClockStamp,
     backoff_ms: int = 600_000,
 ) -> LedgerTransition:
+    unknown_state = _unknown_ledger_state_transition(record)
+    if unknown_state is not None:
+        return unknown_state
     if attempt_id != record.attempt_id:
         return LedgerTransition(record, False, 0, "attempt_cas_mismatch", True)
     if record.state is not LedgerState.EFFECT_PENDING:
         return LedgerTransition(record, False, 0, "not_effect_pending")
-    if not isinstance(observation.continuity, InflightContinuity):
-        return LedgerTransition(record, False, 0, "continuity_not_typed", True)
+    contract_error = _observation_contract_error(observation)
+    if contract_error is not None:
+        return LedgerTransition(record, False, 0, contract_error, True)
     if observation.continuity in {
         InflightContinuity.MISSING,
         InflightContinuity.REAPPEARED_SAME,
@@ -603,17 +643,20 @@ def settle_effect(
         return LedgerTransition(record, False, 0, "inflight_continuity_inconclusive", True)
     if not clock_allows_transition(record.clock_stamp, now):
         return LedgerTransition(record, False, 0, "clock_fail_closed", True)
-    same_episode_source_identity = (
+    same_episode_and_source = (
         observation.episode_key == record.episode_key
         and observation.source_id == record.source_id
-        and observation.source_generation == record.source_generation
     )
     if (
         observation.continuity is InflightContinuity.REPLACED
-        and same_episode_source_identity
+        and same_episode_and_source
+        and isinstance(observation.source_generation, int)
+        and not isinstance(observation.source_generation, bool)
+        and 0 <= observation.source_generation <= MAX_U64
+        and observation.source_generation <= record.source_generation
     ):
         return LedgerTransition(
-            record, False, 0, "replacement_identity_inconclusive", True
+            record, False, 0, "replacement_generation_not_advanced", True
         )
     if observation.episode_key != record.episode_key or (
         observation.continuity is InflightContinuity.REPLACED
@@ -1049,6 +1092,8 @@ def commit_dispositions(
     plan: BatchPlan,
     discord_ids: Mapping[int, Sequence[str]],
 ) -> tuple[PlannedDisposition, ...]:
+    """Commit a plan, enforcing Discord id uniqueness within this call only."""
+
     if not isinstance(discord_ids, Mapping):
         raise ValueError("Discord ids must be an index mapping")
     for index in discord_ids:
@@ -1081,7 +1126,7 @@ def commit_dispositions(
         elif ids:
             raise ValueError("policy omission cannot claim a Discord message")
         if any(message_id in used_message_ids for message_id in ids):
-            raise ValueError("Discord message ids must be globally unique")
+            raise ValueError("Discord message ids must be unique within this call")
         used_message_ids.update(ids)
         committed.append(
             replace(disposition, committed=True, discord_message_ids=ids)
@@ -1114,6 +1159,8 @@ def serialize_planned_disposition(disposition: PlannedDisposition) -> dict[str, 
 def advance_committed_frontier(
     current: int, dispositions: Sequence[PlannedDisposition]
 ) -> int:
+    """Advance one supplied sequence; id uniqueness is scoped to this call."""
+
     if (
         isinstance(current, bool)
         or not isinstance(current, int)
@@ -1188,7 +1235,7 @@ def advance_committed_frontier(
             DispositionKind.SUMMARIZED,
         }:
             if message_ids[0] in seen_message_ids:
-                raise ValueError("Discord message ids must be globally unique")
+                raise ValueError("Discord message ids must be unique within this call")
             seen_message_ids.add(message_ids[0])
         if not disposition.committed:
             pending_seen = True

--- a/scripts/relay_w1a/model.py
+++ b/scripts/relay_w1a/model.py
@@ -18,6 +18,7 @@ from typing import Any, Iterable, Mapping, Sequence
 SCHEMA_VERSION = 1
 MAX_U64 = (1 << 64) - 1
 DEFAULT_MAX_FUTURE_SKEW_MS = 300_000
+TOOL_SUMMARY_INLINE_MARKER_MAX_BYTES = 240
 MARKER_RE = re.compile(
     r"^\[ADK-E2E:(?P<run>[^:\]]+):(?P<case>[^:\]]+):"
     r"(?P<sequence>[0-9]+):(?P<edge>BEGIN|END)\]$"
@@ -129,6 +130,20 @@ def assess(observation: Observation) -> Assessment:
         return _inconclusive("continuity_not_typed")
     if not isinstance(observation.queue, QueueDisposition):
         return _inconclusive("queue_not_typed")
+    if any(
+        not isinstance(value, bool)
+        for value in (
+            observation.identity_complete,
+            observation.clock_valid,
+            observation.affirmative_termination,
+            observation.source_progress,
+            observation.delivery_progress,
+            observation.control_contradiction,
+            observation.terminal_delivery_committed,
+            observation.typed_idle,
+        )
+    ):
+        return _inconclusive("observation_bool_not_typed")
     if not observation.identity_complete or not observation.episode_key:
         return _inconclusive("missing_identity")
     if not observation.clock_valid:
@@ -155,7 +170,9 @@ def assess(observation: Observation) -> Assessment:
         proof_matches = (
             isinstance(proof.queue, QueueDisposition)
             and isinstance(observation.queue, QueueDisposition)
+            and isinstance(proof.identity_complete, bool)
             and proof.identity_complete
+            and isinstance(proof.clock_valid, bool)
             and proof.clock_valid
             and isinstance(proof.episode_key, str)
             and bool(proof.episode_key)
@@ -175,7 +192,9 @@ def assess(observation: Observation) -> Assessment:
             and _clock_stamp_well_formed(proof.action_reprobe_at)
             and isinstance(proof.termination_id, str)
             and bool(proof.termination_id)
+            and isinstance(proof.finalizer_committed, bool)
             and proof.finalizer_committed
+            and isinstance(proof.watcher_stopped, bool)
             and proof.watcher_stopped
         )
         if not proof_matches:
@@ -431,6 +450,8 @@ def reserve_attempt(
     delivery_proof: DeliveryProof,
     now: ClockStamp,
 ) -> LedgerTransition:
+    if record is not None and not isinstance(record.state, LedgerState):
+        return LedgerTransition(record, False, 0, "ledger_state_not_typed", True)
     if (
         record is not None
         and record.state in {LedgerState.RESERVED, LedgerState.EFFECT_PENDING}
@@ -582,6 +603,18 @@ def settle_effect(
         return LedgerTransition(record, False, 0, "inflight_continuity_inconclusive", True)
     if not clock_allows_transition(record.clock_stamp, now):
         return LedgerTransition(record, False, 0, "clock_fail_closed", True)
+    same_episode_source_identity = (
+        observation.episode_key == record.episode_key
+        and observation.source_id == record.source_id
+        and observation.source_generation == record.source_generation
+    )
+    if (
+        observation.continuity is InflightContinuity.REPLACED
+        and same_episode_source_identity
+    ):
+        return LedgerTransition(
+            record, False, 0, "replacement_identity_inconclusive", True
+        )
     if observation.episode_key != record.episode_key or (
         observation.continuity is InflightContinuity.REPLACED
     ):
@@ -978,11 +1011,7 @@ def plan_bounded_batch(
             if candidate_raw_bytes > source_scan_budget and prefix:
                 break
             candidate_prefix = [*prefix, candidate]
-            candidate_summary = _tool_summary(
-                candidate_prefix,
-                policy_version,
-                max_bytes=available_bytes,
-            )
+            candidate_summary = _tool_summary(candidate_prefix, policy_version)
             if len(candidate_summary.encode("utf-8")) > available_bytes:
                 break
             prefix = candidate_prefix
@@ -1031,6 +1060,7 @@ def commit_dispositions(
         ):
             raise ValueError("Discord id mapping index is invalid")
     committed: list[PlannedDisposition] = []
+    used_message_ids: set[str] = set()
     for index, disposition in enumerate(plan.dispositions):
         if not isinstance(disposition.kind, DispositionKind):
             raise ValueError("unknown disposition kind")
@@ -1050,6 +1080,9 @@ def commit_dispositions(
                 )
         elif ids:
             raise ValueError("policy omission cannot claim a Discord message")
+        if any(message_id in used_message_ids for message_id in ids):
+            raise ValueError("Discord message ids must be globally unique")
+        used_message_ids.update(ids)
         committed.append(
             replace(disposition, committed=True, discord_message_ids=ids)
         )
@@ -1090,6 +1123,7 @@ def advance_committed_frontier(
         raise ValueError("invalid current frontier")
     frontier = current
     seen_ranges: set[str] = set()
+    seen_message_ids: set[str] = set()
     pending_seen = False
     for disposition in dispositions:
         if (
@@ -1149,6 +1183,13 @@ def advance_committed_frontier(
         if any(range_id in seen_ranges for range_id in disposition.range_ids):
             raise ValueError("duplicate disposition range id")
         seen_ranges.update(disposition.range_ids)
+        if disposition.committed and disposition.kind in {
+            DispositionKind.DELIVERED,
+            DispositionKind.SUMMARIZED,
+        }:
+            if message_ids[0] in seen_message_ids:
+                raise ValueError("Discord message ids must be globally unique")
+            seen_message_ids.add(message_ids[0])
         if not disposition.committed:
             pending_seen = True
             continue
@@ -1226,9 +1267,16 @@ def _hash_ranges(ranges: Iterable[SourceRange]) -> str:
 def _tool_summary(
     ranges: Sequence[SourceRange],
     policy_version: str,
-    *,
-    max_bytes: int | None = None,
 ) -> str:
+    return _tool_summary_contract(ranges, policy_version)[0]
+
+
+def _tool_summary_contract(
+    ranges: Sequence[SourceRange],
+    policy_version: str,
+) -> tuple[str, bool]:
+    """Return the canonical summary body and whether markers use digest form."""
+
     raw_bytes = sum(len(entry.raw) for entry in ranges)
     markers = [entry.marker for entry in ranges if entry.marker]
     marker_suffix = "" if not markers else " markers=" + ",".join(markers)
@@ -1237,14 +1285,20 @@ def _tool_summary(
         f"range={ranges[0].start}:{ranges[-1].end} records={len(ranges)} "
         f"raw_bytes={raw_bytes} sha256={_hash_ranges(ranges)}{marker_suffix}]"
     )
-    if max_bytes is None or len(summary.encode("utf-8")) <= max_bytes or not markers:
-        return summary
+    if (
+        len(summary.encode("utf-8")) <= TOOL_SUMMARY_INLINE_MARKER_MAX_BYTES
+        or not markers
+    ):
+        return summary, False
     marker_digest = hashlib.sha256("\n".join(markers).encode("utf-8")).hexdigest()
     return (
-        f"[AgentDesk summary policy={policy_version} "
-        f"range={ranges[0].start}:{ranges[-1].end} records={len(ranges)} "
-        f"raw_bytes={raw_bytes} sha256={_hash_ranges(ranges)} "
-        f"marker_count={len(markers)} marker_sha256={marker_digest}]"
+        (
+            f"[AgentDesk summary policy={policy_version} "
+            f"range={ranges[0].start}:{ranges[-1].end} records={len(ranges)} "
+            f"raw_bytes={raw_bytes} sha256={_hash_ranges(ranges)} "
+            f"marker_count={len(markers)} marker_sha256={marker_digest}]"
+        ),
+        True,
     )
 
 
@@ -1529,17 +1583,9 @@ def validate_evidence_bundle(
                 errors.append("discord_revision_gap")
         final_messages[message_id] = ordered[-1]
 
-    for marker in markers:
-        marker_count = sum(
-            str(message.get("normalized_body", "")).count(marker)
-            for message in final_messages.values()
-            if message.get("message_role") == "relay_body"
-        )
-        if marker_count != 1:
-            errors.append(f"marker_count:{marker}:{marker_count}")
-
     range_owners: dict[str, int] = {}
     used_message_ids: set[str] = set()
+    digest_summary_markers: set[str] = set()
     committed_spans: list[tuple[int, int]] = []
     pending_seen = False
     for index, disposition in enumerate(dispositions):
@@ -1606,8 +1652,11 @@ def validate_evidence_bundle(
         if disposition.get("source_range_sha256s") != expected_hashes:
             errors.append("disposition_source_hashes_mismatch")
 
+        digest_marker_summary = False
         if kind is DispositionKind.SUMMARIZED:
-            expected_body = _tool_summary(entries, policy)
+            expected_body, digest_marker_summary = _tool_summary_contract(
+                entries, policy
+            )
         elif kind is DispositionKind.DELIVERED:
             expected_body = "".join(entry.body for entry in entries)
         else:
@@ -1627,6 +1676,10 @@ def validate_evidence_bundle(
         if not committed:
             pending_seen = True
             continue
+        if digest_marker_summary and source_kinds == {RangeKind.TOOL_BULK}:
+            digest_summary_markers.update(
+                entry.marker for entry in entries if entry.marker is not None
+            )
         if pending_seen:
             errors.append("committed_disposition_after_pending_suffix")
         span = (entries[0].start, entries[-1].end)
@@ -1665,6 +1718,16 @@ def validate_evidence_bundle(
                 errors.append("discord_body_hash_mismatch")
         elif ids:
             errors.append("omission_has_discord_message")
+
+    for marker in markers:
+        marker_count = sum(
+            str(message.get("normalized_body", "")).count(marker)
+            for message in final_messages.values()
+            if message.get("message_role") == "relay_body"
+        )
+        expected_marker_count = 0 if marker in digest_summary_markers else 1
+        if marker_count != expected_marker_count:
+            errors.append(f"marker_count:{marker}:{marker_count}")
 
     if set(range_owners) != set(source_by_id):
         errors.append("source_range_without_disposition")

--- a/scripts/relay_w1a/model.py
+++ b/scripts/relay_w1a/model.py
@@ -1,0 +1,1726 @@
+"""Executable, side-effect-free W1-A contract for AgentDesk issue #4254.
+
+This module deliberately imports no AgentDesk runtime code.  It models the
+authority, recovery-ledger, bounded-disposition, and source-to-Discord oracle
+rules that later production wiring must preserve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+MAX_U64 = (1 << 64) - 1
+DEFAULT_MAX_FUTURE_SKEW_MS = 300_000
+MARKER_RE = re.compile(
+    r"^\[ADK-E2E:(?P<run>[^:\]]+):(?P<case>[^:\]]+):"
+    r"(?P<sequence>[0-9]+):(?P<edge>BEGIN|END)\]$"
+)
+MARKER_SCAN_RE = re.compile(
+    r"\[ADK-E2E:[^:\]\r\n]+:[^:\]\r\n]+:[0-9]+:(?:BEGIN|END)\]"
+)
+
+
+class Verdict(str, Enum):
+    PRODUCER_LIVE = "producer_live"
+    CONTROL_PLANE_DESYNC = "control_plane_desync"
+    PRODUCER_DEAD = "producer_dead"
+    DELIVERED_IDLE = "delivered_idle"
+
+
+class AllowedAction(str, Enum):
+    NONE = "none"
+    OBSERVE = "observe"
+    REPAIR_CONTROL_PLANE = "repair_control_plane"
+    DELEGATE_EXACT_TERMINATION = "delegate_exact_termination"
+
+
+class InflightContinuity(str, Enum):
+    PRESENT_STABLE = "present_stable"
+    MISSING = "missing"
+    REAPPEARED_SAME = "reappeared_same"
+    REPLACED = "replaced"
+
+
+class QueueDisposition(str, Enum):
+    ACTIVE = "active"
+    IDLE = "idle"
+    TERMINAL = "terminal"
+    RETRYABLE = "retryable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ClockStamp:
+    wall_ms: int
+    boot_id: str
+    monotonic_ms: int
+
+
+@dataclass(frozen=True)
+class DeliveryProof:
+    episode_key: str
+    source_id: str
+    source_generation: int
+    durable_anchor: str
+    source_frontier: int
+    committed_frontier: int
+    queue: QueueDisposition
+    observed_at: ClockStamp
+    identity_complete: bool = True
+    clock_valid: bool = True
+
+
+@dataclass(frozen=True)
+class TerminationProof:
+    episode_key: str
+    source_id: str
+    source_generation: int
+    durable_anchor: str
+    queue: QueueDisposition
+    termination_id: str
+    finalizer_committed: bool
+    watcher_stopped: bool
+    action_reprobe_at: ClockStamp
+    identity_complete: bool = True
+    clock_valid: bool = True
+
+
+@dataclass(frozen=True)
+class Observation:
+    episode_key: str | None
+    source_id: str | None = None
+    source_generation: int | None = None
+    durable_anchor: str | None = None
+    observed_at: ClockStamp | None = None
+    identity_complete: bool = True
+    clock_valid: bool = True
+    continuity: InflightContinuity = InflightContinuity.PRESENT_STABLE
+    queue: QueueDisposition = QueueDisposition.ACTIVE
+    termination_proof: TerminationProof | None = None
+    # Compatibility-only input. A boolean can never prove ProducerDead.
+    affirmative_termination: bool = False
+    source_progress: bool = False
+    delivery_progress: bool = False
+    control_contradiction: bool = False
+    terminal_delivery_committed: bool = False
+    typed_idle: bool = False
+    failed_repairs: int = 0
+
+
+@dataclass(frozen=True)
+class Assessment:
+    candidate: Verdict | None
+    action: AllowedAction
+    reason: str
+    may_spend_automatic_action: bool
+
+
+def assess(observation: Observation) -> Assessment:
+    """Return the fail-closed authoritative assessment for one observation."""
+
+    if not isinstance(observation.continuity, InflightContinuity):
+        return _inconclusive("continuity_not_typed")
+    if not isinstance(observation.queue, QueueDisposition):
+        return _inconclusive("queue_not_typed")
+    if not observation.identity_complete or not observation.episode_key:
+        return _inconclusive("missing_identity")
+    if not observation.clock_valid:
+        return _inconclusive("invalid_clock")
+    if observation.continuity is InflightContinuity.MISSING:
+        return _inconclusive("inflight_missing_4104")
+    if observation.continuity is InflightContinuity.REAPPEARED_SAME:
+        return _inconclusive("inflight_reappeared_stability_window_4104")
+    if observation.continuity is InflightContinuity.REPLACED:
+        return _inconclusive("episode_replaced")
+    if observation.queue in {QueueDisposition.RETRYABLE, QueueDisposition.UNKNOWN}:
+        return _inconclusive("queue_not_authoritative_4247")
+
+    if observation.terminal_delivery_committed and observation.typed_idle:
+        return Assessment(
+            Verdict.DELIVERED_IDLE,
+            AllowedAction.OBSERVE,
+            "terminal_delivery_and_typed_idle",
+            False,
+        )
+
+    if observation.termination_proof is not None:
+        proof = observation.termination_proof
+        proof_matches = (
+            isinstance(proof.queue, QueueDisposition)
+            and isinstance(observation.queue, QueueDisposition)
+            and proof.identity_complete
+            and proof.clock_valid
+            and isinstance(proof.episode_key, str)
+            and bool(proof.episode_key)
+            and isinstance(proof.source_id, str)
+            and bool(proof.source_id)
+            and isinstance(proof.source_generation, int)
+            and not isinstance(proof.source_generation, bool)
+            and 0 <= proof.source_generation <= MAX_U64
+            and isinstance(proof.durable_anchor, str)
+            and bool(proof.durable_anchor)
+            and proof.episode_key == observation.episode_key
+            and proof.source_id == observation.source_id
+            and proof.source_generation == observation.source_generation
+            and proof.durable_anchor == observation.durable_anchor
+            and proof.queue is observation.queue
+            and proof.action_reprobe_at == observation.observed_at
+            and _clock_stamp_well_formed(proof.action_reprobe_at)
+            and isinstance(proof.termination_id, str)
+            and bool(proof.termination_id)
+            and proof.finalizer_committed
+            and proof.watcher_stopped
+        )
+        if not proof_matches:
+            return _inconclusive("termination_proof_identity_or_reprobe_mismatch")
+        if proof.queue in {QueueDisposition.TERMINAL, QueueDisposition.IDLE}:
+            return Assessment(
+                Verdict.PRODUCER_DEAD,
+                AllowedAction.DELEGATE_EXACT_TERMINATION,
+                "episode_bound_termination_and_safe_queue_disposition",
+                False,
+            )
+        return _inconclusive("termination_proof_but_queue_still_active")
+
+    if observation.control_contradiction and (
+        observation.source_progress or observation.delivery_progress
+    ):
+        return Assessment(
+            Verdict.CONTROL_PLANE_DESYNC,
+            AllowedAction.REPAIR_CONTROL_PLANE,
+            "live_progress_with_control_contradiction",
+            True,
+        )
+    if observation.source_progress or observation.delivery_progress:
+        return Assessment(
+            Verdict.PRODUCER_LIVE,
+            AllowedAction.OBSERVE,
+            "affirmative_progress",
+            False,
+        )
+
+    # Silence, age, and failed repairs are deliberately not death proof.
+    if observation.failed_repairs:
+        return _inconclusive("failed_repairs_are_not_death_proof")
+    return _inconclusive("no_affirmative_evidence")
+
+
+def _inconclusive(reason: str) -> Assessment:
+    return Assessment(None, AllowedAction.NONE, reason, False)
+
+
+class LedgerState(str, Enum):
+    RESERVED = "reserved"
+    EFFECT_PENDING = "effect_pending"
+    SETTLED = "settled"
+
+
+class LedgerOutcome(str, Enum):
+    VERIFIED_DELIVERY_PROGRESS = "verified_delivery_progress"
+    VERIFIED_CONTROL_REPAIR = "verified_control_repair"
+    NO_PROGRESS = "no_progress"
+    SUPERSEDED = "superseded"
+    INCONCLUSIVE = "inconclusive"
+    FAILED = "failed"
+
+
+def clock_allows_transition(
+    previous: ClockStamp,
+    current: ClockStamp,
+    *,
+    trusted_now: ClockStamp | None = None,
+    max_future_skew_ms: int = DEFAULT_MAX_FUTURE_SKEW_MS,
+) -> bool:
+    """Validate time only as an eligibility guard, never as liveness proof."""
+
+    values = (
+        previous.wall_ms,
+        previous.monotonic_ms,
+        current.wall_ms,
+        current.monotonic_ms,
+    )
+    if (
+        any(
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < 0
+            or value > MAX_U64
+            for value in values
+        )
+        or not isinstance(previous.boot_id, str)
+        or not previous.boot_id
+        or not isinstance(current.boot_id, str)
+        or not current.boot_id
+        or isinstance(max_future_skew_ms, bool)
+        or not isinstance(max_future_skew_ms, int)
+        or max_future_skew_ms < 0
+        or max_future_skew_ms > MAX_U64
+    ):
+        return False
+    if trusted_now is not None:
+        trusted_values = (trusted_now.wall_ms, trusted_now.monotonic_ms)
+        if (
+            any(
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or value < 0
+                or value > MAX_U64
+                for value in trusted_values
+            )
+            or not isinstance(trusted_now.boot_id, str)
+            or not trusted_now.boot_id
+            or trusted_now.wall_ms > MAX_U64 - max_future_skew_ms
+            or trusted_now.monotonic_ms > MAX_U64 - max_future_skew_ms
+            or previous.wall_ms > trusted_now.wall_ms + max_future_skew_ms
+            or current.wall_ms > trusted_now.wall_ms + max_future_skew_ms
+            or (
+                previous.boot_id == trusted_now.boot_id
+                and previous.monotonic_ms
+                > trusted_now.monotonic_ms + max_future_skew_ms
+            )
+            or (
+                current.boot_id == trusted_now.boot_id
+                and current.monotonic_ms
+                > trusted_now.monotonic_ms + max_future_skew_ms
+            )
+        ):
+            return False
+    if current.wall_ms < previous.wall_ms:
+        return False
+    if previous.boot_id == current.boot_id:
+        return current.monotonic_ms >= previous.monotonic_ms
+    # Across boots, monotonic values are incomparable; nondecreasing wall time
+    # is only a conservative eligibility guard and never liveness evidence.
+    return True
+
+
+def _clock_stamp_well_formed(stamp: ClockStamp | None) -> bool:
+    if stamp is None or not isinstance(stamp.boot_id, str) or not stamp.boot_id:
+        return False
+    return all(
+        not isinstance(value, bool)
+        and isinstance(value, int)
+        and 0 <= value <= MAX_U64
+        for value in (stamp.wall_ms, stamp.monotonic_ms)
+    )
+
+
+@dataclass(frozen=True)
+class LedgerRecord:
+    schema_version: int
+    attempt_id: str
+    episode_key: str
+    source_id: str
+    source_generation: int
+    durable_anchor: str
+    baseline_source: int
+    baseline_delivered: int
+    state: LedgerState
+    outcome: LedgerOutcome
+    failure_streak: int
+    lifetime_no_effect_count: int
+    attempts_spent: int
+    retry_not_before_ms: int | None
+    clock_stamp: ClockStamp
+
+    @property
+    def circuit_open(self) -> bool:
+        return self.lifetime_no_effect_count >= 2
+
+
+@dataclass(frozen=True)
+class LedgerTransition:
+    record: LedgerRecord | None
+    changed: bool
+    spent_delta: int
+    reason: str
+    must_reprobe: bool = False
+
+
+def _delivery_proof_error(
+    proof: DeliveryProof | None,
+    observation: Observation,
+    *,
+    now: ClockStamp,
+    record: LedgerRecord | None = None,
+) -> str | None:
+    if proof is None:
+        return "delivery_proof_required"
+    if (
+        not isinstance(proof.queue, QueueDisposition)
+        or not isinstance(observation.queue, QueueDisposition)
+        or not isinstance(proof.episode_key, str)
+        or not proof.episode_key
+        or not isinstance(proof.source_id, str)
+        or not proof.source_id
+        or not isinstance(proof.durable_anchor, str)
+        or not proof.durable_anchor
+        or isinstance(proof.source_generation, bool)
+        or not isinstance(proof.source_generation, int)
+        or isinstance(proof.source_frontier, bool)
+        or not isinstance(proof.source_frontier, int)
+        or isinstance(proof.committed_frontier, bool)
+        or not isinstance(proof.committed_frontier, int)
+        or not _clock_stamp_well_formed(proof.observed_at)
+    ):
+        return "delivery_proof_malformed"
+    if (
+        not proof.identity_complete
+        or not proof.clock_valid
+        or not observation.identity_complete
+        or not observation.clock_valid
+    ):
+        return "delivery_proof_identity_or_clock_invalid"
+    if (
+        proof.episode_key != observation.episode_key
+        or proof.source_id != observation.source_id
+        or proof.source_generation != observation.source_generation
+        or proof.durable_anchor != observation.durable_anchor
+        or proof.queue is not observation.queue
+    ):
+        return "delivery_proof_observation_mismatch"
+    if proof.queue in {QueueDisposition.RETRYABLE, QueueDisposition.UNKNOWN}:
+        return "delivery_proof_queue_inconclusive"
+    if proof.observed_at != now:
+        return "delivery_proof_not_action_time"
+    if observation.observed_at != now or not _clock_stamp_well_formed(
+        observation.observed_at
+    ):
+        return "delivery_observation_not_action_time"
+    integers = (
+        proof.source_generation,
+        proof.source_frontier,
+        proof.committed_frontier,
+    )
+    if (
+        any(value < 0 or value > MAX_U64 for value in integers)
+        or proof.committed_frontier > proof.source_frontier
+    ):
+        return "delivery_proof_malformed"
+    if record is not None:
+        if (
+            proof.episode_key != record.episode_key
+            or proof.source_id != record.source_id
+            or proof.source_generation != record.source_generation
+        ):
+            return "delivery_proof_record_identity_mismatch"
+        if proof.source_frontier < record.baseline_source:
+            return "delivery_source_frontier_regressed"
+        if proof.committed_frontier < record.baseline_delivered:
+            return "delivery_frontier_regressed"
+        advanced = proof.committed_frontier > record.baseline_delivered
+        if advanced and proof.durable_anchor == record.durable_anchor:
+            return "delivery_anchor_did_not_advance"
+        if advanced != observation.delivery_progress:
+            return "delivery_progress_claim_mismatch"
+    return None
+
+
+def reserve_attempt(
+    record: LedgerRecord | None,
+    observation: Observation,
+    *,
+    attempt_id: str,
+    delivery_proof: DeliveryProof,
+    now: ClockStamp,
+) -> LedgerTransition:
+    if (
+        record is not None
+        and record.state in {LedgerState.RESERVED, LedgerState.EFFECT_PENDING}
+    ):
+        return LedgerTransition(
+            record,
+            False,
+            0,
+            "attempt_unresolved_requires_exact_reprobe",
+            True,
+        )
+    assessment = assess(observation)
+    if not assessment.may_spend_automatic_action:
+        return LedgerTransition(record, False, 0, assessment.reason)
+    if not isinstance(attempt_id, str) or not attempt_id:
+        return LedgerTransition(record, False, 0, "attempt_id_missing")
+
+    proof_error = _delivery_proof_error(delivery_proof, observation, now=now)
+    if proof_error is not None:
+        return LedgerTransition(record, False, 0, proof_error, True)
+
+    if record is not None:
+        if not clock_allows_transition(record.clock_stamp, now):
+            return LedgerTransition(record, False, 0, "clock_fail_closed")
+        if record.episode_key == observation.episode_key:
+            if attempt_id == record.attempt_id:
+                return LedgerTransition(record, False, 0, "attempt_id_reused")
+            proof_error = _delivery_proof_error(
+                delivery_proof, observation, now=now, record=record
+            )
+            if proof_error is not None:
+                return LedgerTransition(record, False, 0, proof_error, True)
+            if delivery_proof.committed_frontier > record.baseline_delivered:
+                record = replace(
+                    record,
+                    durable_anchor=delivery_proof.durable_anchor,
+                    baseline_delivered=delivery_proof.committed_frontier,
+                    baseline_source=delivery_proof.source_frontier,
+                    failure_streak=0,
+                    lifetime_no_effect_count=0,
+                    retry_not_before_ms=None,
+                    outcome=LedgerOutcome.VERIFIED_DELIVERY_PROGRESS,
+                    clock_stamp=now,
+                )
+            elif record.circuit_open:
+                # Source-only progress is intentionally ignored here.
+                return LedgerTransition(record, False, 0, "same_episode_circuit_open")
+            if (
+                record.retry_not_before_ms is not None
+                and now.wall_ms < record.retry_not_before_ms
+            ):
+                return LedgerTransition(record, False, 0, "backoff_active")
+        else:
+            record = None
+
+    failure_streak = 0 if record is None else record.failure_streak
+    lifetime_no_effect_count = 0 if record is None else record.lifetime_no_effect_count
+    attempts_spent = 0 if record is None else record.attempts_spent
+    reserved = LedgerRecord(
+        schema_version=SCHEMA_VERSION,
+        attempt_id=attempt_id,
+        episode_key=observation.episode_key or "",
+        source_id=delivery_proof.source_id,
+        source_generation=delivery_proof.source_generation,
+        durable_anchor=delivery_proof.durable_anchor,
+        baseline_source=delivery_proof.source_frontier,
+        baseline_delivered=delivery_proof.committed_frontier,
+        state=LedgerState.RESERVED,
+        outcome=LedgerOutcome.INCONCLUSIVE,
+        failure_streak=failure_streak,
+        lifetime_no_effect_count=lifetime_no_effect_count,
+        attempts_spent=attempts_spent,
+        retry_not_before_ms=None,
+        clock_stamp=now,
+    )
+    return LedgerTransition(reserved, True, 0, "reserved_without_spend")
+
+
+def mark_effect_pending(
+    record: LedgerRecord, *, attempt_id: str, now: ClockStamp
+) -> LedgerTransition:
+    if attempt_id != record.attempt_id:
+        return LedgerTransition(record, False, 0, "attempt_cas_mismatch", True)
+    if record.state is not LedgerState.RESERVED:
+        return LedgerTransition(record, False, 0, "not_reserved")
+    if not clock_allows_transition(record.clock_stamp, now):
+        return LedgerTransition(record, False, 0, "clock_fail_closed")
+    if record.attempts_spent >= MAX_U64:
+        return LedgerTransition(record, False, 0, "attempt_counter_overflow", True)
+    pending = replace(
+        record,
+        state=LedgerState.EFFECT_PENDING,
+        attempts_spent=record.attempts_spent + 1,
+        clock_stamp=now,
+    )
+    return LedgerTransition(pending, True, 1, "effect_boundary_crossed")
+
+
+def recover_after_crash(
+    record: LedgerRecord,
+    observation: Observation | None = None,
+    *,
+    attempt_id: str | None = None,
+) -> LedgerTransition:
+    if attempt_id != record.attempt_id:
+        return LedgerTransition(record, False, 0, "attempt_cas_mismatch", True)
+    if record.state is LedgerState.RESERVED:
+        if (
+            observation is None
+            or observation.episode_key != record.episode_key
+            or observation.source_id != record.source_id
+            or observation.source_generation != record.source_generation
+            or observation.durable_anchor != record.durable_anchor
+            or observation.continuity is not InflightContinuity.PRESENT_STABLE
+            or not observation.identity_complete
+            or not observation.clock_valid
+        ):
+            return LedgerTransition(record, False, 0, "reserved_requires_reprobe", True)
+        cancelled = replace(
+            record,
+            state=LedgerState.SETTLED,
+            outcome=LedgerOutcome.INCONCLUSIVE,
+        )
+        return LedgerTransition(cancelled, True, 0, "reserved_action_not_invoked")
+    if record.state is LedgerState.EFFECT_PENDING:
+        return LedgerTransition(record, False, 0, "pending_requires_reprobe", True)
+    return LedgerTransition(record, False, 0, "already_settled")
+
+
+def settle_effect(
+    record: LedgerRecord,
+    observation: Observation,
+    *,
+    attempt_id: str,
+    delivery_proof: DeliveryProof | None,
+    now: ClockStamp,
+    backoff_ms: int = 600_000,
+) -> LedgerTransition:
+    if attempt_id != record.attempt_id:
+        return LedgerTransition(record, False, 0, "attempt_cas_mismatch", True)
+    if record.state is not LedgerState.EFFECT_PENDING:
+        return LedgerTransition(record, False, 0, "not_effect_pending")
+    if not isinstance(observation.continuity, InflightContinuity):
+        return LedgerTransition(record, False, 0, "continuity_not_typed", True)
+    if observation.continuity in {
+        InflightContinuity.MISSING,
+        InflightContinuity.REAPPEARED_SAME,
+    }:
+        return LedgerTransition(record, False, 0, "inflight_continuity_inconclusive", True)
+    if not clock_allows_transition(record.clock_stamp, now):
+        return LedgerTransition(record, False, 0, "clock_fail_closed", True)
+    if observation.episode_key != record.episode_key or (
+        observation.continuity is InflightContinuity.REPLACED
+    ):
+        successor_identity_valid = (
+            observation.identity_complete
+            and observation.clock_valid
+            and isinstance(observation.continuity, InflightContinuity)
+            and isinstance(observation.queue, QueueDisposition)
+            and observation.queue
+            not in {QueueDisposition.RETRYABLE, QueueDisposition.UNKNOWN}
+            and isinstance(observation.episode_key, str)
+            and bool(observation.episode_key)
+            and isinstance(observation.source_id, str)
+            and bool(observation.source_id)
+            and isinstance(observation.source_generation, int)
+            and not isinstance(observation.source_generation, bool)
+            and 0 <= observation.source_generation <= MAX_U64
+            and isinstance(observation.durable_anchor, str)
+            and bool(observation.durable_anchor)
+            and observation.observed_at == now
+            and _clock_stamp_well_formed(observation.observed_at)
+        )
+        if not successor_identity_valid:
+            return LedgerTransition(record, False, 0, "successor_identity_inconclusive", True)
+        settled = replace(
+            record,
+            state=LedgerState.SETTLED,
+            outcome=LedgerOutcome.SUPERSEDED,
+            clock_stamp=now,
+        )
+        return LedgerTransition(settled, True, 0, "successor_untouched")
+    proof_error = _delivery_proof_error(
+        delivery_proof, observation, now=now, record=record
+    )
+    if proof_error is not None:
+        return LedgerTransition(record, False, 0, proof_error, True)
+    assert delivery_proof is not None
+    if delivery_proof.committed_frontier > record.baseline_delivered:
+        settled = replace(
+            record,
+            state=LedgerState.SETTLED,
+            outcome=LedgerOutcome.VERIFIED_DELIVERY_PROGRESS,
+            durable_anchor=delivery_proof.durable_anchor,
+            baseline_source=delivery_proof.source_frontier,
+            baseline_delivered=delivery_proof.committed_frontier,
+            failure_streak=0,
+            lifetime_no_effect_count=0,
+            retry_not_before_ms=None,
+            clock_stamp=now,
+        )
+        return LedgerTransition(settled, True, 0, "delivery_progress_rearms")
+
+    # Source growth without delivery is still a no-effect repair.
+    if (
+        isinstance(backoff_ms, bool)
+        or not isinstance(backoff_ms, int)
+        or backoff_ms < 0
+        or backoff_ms > MAX_U64
+        or now.wall_ms > MAX_U64 - backoff_ms
+        or record.failure_streak >= MAX_U64
+        or record.lifetime_no_effect_count >= MAX_U64
+    ):
+        return LedgerTransition(record, False, 0, "backoff_clock_overflow", True)
+    settled = replace(
+        record,
+        state=LedgerState.SETTLED,
+        outcome=LedgerOutcome.NO_PROGRESS,
+        baseline_source=delivery_proof.source_frontier,
+        failure_streak=record.failure_streak + 1,
+        lifetime_no_effect_count=record.lifetime_no_effect_count + 1,
+        retry_not_before_ms=now.wall_ms + backoff_ms,
+        clock_stamp=now,
+    )
+    return LedgerTransition(settled, True, 0, "no_delivery_progress")
+
+
+@dataclass(frozen=True)
+class LedgerLoad:
+    record: LedgerRecord | None
+    fail_closed: bool
+    reason: str
+
+
+def load_ledger_json(
+    raw: str,
+    *,
+    trusted_now: ClockStamp,
+    max_future_skew_ms: int = DEFAULT_MAX_FUTURE_SKEW_MS,
+) -> LedgerLoad:
+    try:
+        data = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return LedgerLoad(None, True, "corrupt_json")
+    if not isinstance(data, dict):
+        return LedgerLoad(None, True, "record_not_object")
+    version = data.get("schema_version")
+    if isinstance(version, bool) or (version is not None and not isinstance(version, int)):
+        return LedgerLoad(None, True, "malformed_record")
+    if version is None or version == 0:
+        return LedgerLoad(None, True, "legacy_inconclusive")
+    if version != SCHEMA_VERSION:
+        return LedgerLoad(None, True, "future_or_unknown_schema")
+    try:
+        clock = data["clock_stamp"]
+        record = LedgerRecord(
+            schema_version=version,
+            attempt_id=_required_text(data, "attempt_id"),
+            episode_key=_required_text(data, "episode_key"),
+            source_id=_required_text(data, "source_id"),
+            source_generation=_nonnegative_int(data, "source_generation"),
+            durable_anchor=_required_text(data, "durable_anchor"),
+            baseline_source=_nonnegative_int(data, "baseline_source"),
+            baseline_delivered=_nonnegative_int(data, "baseline_delivered"),
+            state=LedgerState(data["state"]),
+            outcome=LedgerOutcome(data["outcome"]),
+            failure_streak=_nonnegative_int(data, "failure_streak"),
+            lifetime_no_effect_count=_nonnegative_int(data, "lifetime_no_effect_count"),
+            attempts_spent=_nonnegative_int(data, "attempts_spent"),
+            retry_not_before_ms=(
+                None
+                if data.get("retry_not_before_ms") is None
+                else _nonnegative_int(data, "retry_not_before_ms")
+            ),
+            clock_stamp=ClockStamp(
+                wall_ms=_nonnegative_int(clock, "wall_ms"),
+                boot_id=_required_text(clock, "boot_id"),
+                monotonic_ms=_nonnegative_int(clock, "monotonic_ms"),
+            ),
+        )
+    except (KeyError, TypeError, ValueError):
+        return LedgerLoad(None, True, "malformed_record")
+    if not clock_allows_transition(
+        record.clock_stamp,
+        trusted_now,
+        trusted_now=trusted_now,
+        max_future_skew_ms=max_future_skew_ms,
+    ):
+        return LedgerLoad(None, True, "clock_fail_closed")
+    if not _ledger_semantics_valid(record):
+        return LedgerLoad(None, True, "semantic_invariant_violation")
+    return LedgerLoad(record, False, "valid")
+
+
+def _required_text(data: Mapping[str, Any], key: str) -> str:
+    value = data[key]
+    if not isinstance(value, str) or not value:
+        raise ValueError(key)
+    return value
+
+
+def _nonnegative_int(data: Mapping[str, Any], key: str) -> int:
+    value = data[key]
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > MAX_U64
+    ):
+        raise ValueError(key)
+    return value
+
+
+def _ledger_semantics_valid(record: LedgerRecord) -> bool:
+    if record.baseline_delivered > record.baseline_source:
+        return False
+    if record.failure_streak > record.lifetime_no_effect_count:
+        return False
+    if record.lifetime_no_effect_count > record.attempts_spent:
+        return False
+    if record.state is LedgerState.RESERVED:
+        return (
+            record.outcome is LedgerOutcome.INCONCLUSIVE
+            and record.retry_not_before_ms is None
+        )
+    if record.state is LedgerState.EFFECT_PENDING:
+        return (
+            record.outcome is LedgerOutcome.INCONCLUSIVE
+            # mark_effect_pending spends one action before any corresponding
+            # no-effect settlement can be counted.
+            and record.attempts_spent > record.lifetime_no_effect_count
+            and record.retry_not_before_ms is None
+        )
+    if record.outcome is LedgerOutcome.INCONCLUSIVE:
+        # The only settled inconclusive transition cancels an uninvoked
+        # reservation, so it cannot retain a retry deadline.
+        return record.retry_not_before_ms is None
+    if record.outcome is LedgerOutcome.NO_PROGRESS:
+        return (
+            record.attempts_spent >= 1
+            and record.failure_streak >= 1
+            and record.lifetime_no_effect_count >= 1
+            and record.retry_not_before_ms is not None
+            and record.retry_not_before_ms >= record.clock_stamp.wall_ms
+        )
+    if record.outcome in {
+        LedgerOutcome.VERIFIED_DELIVERY_PROGRESS,
+        LedgerOutcome.VERIFIED_CONTROL_REPAIR,
+    }:
+        return (
+            record.attempts_spent >= 1
+            and record.failure_streak == 0
+            and record.lifetime_no_effect_count == 0
+            and record.retry_not_before_ms is None
+        )
+    if record.outcome is LedgerOutcome.SUPERSEDED:
+        return (
+            record.attempts_spent > record.lifetime_no_effect_count
+            and record.retry_not_before_ms is None
+        )
+    if record.outcome is LedgerOutcome.FAILED:
+        # A terminal action failure is a no-effect settlement and must carry
+        # the same spent-attempt, failure-count, and retry evidence.
+        return (
+            record.attempts_spent >= 1
+            and record.failure_streak >= 1
+            and record.lifetime_no_effect_count >= 1
+            and record.retry_not_before_ms is not None
+            and record.retry_not_before_ms >= record.clock_stamp.wall_ms
+        )
+    return False
+
+
+class RangeKind(str, Enum):
+    ASSISTANT_TEXT = "assistant_text"
+    TOOL_BULK = "tool_bulk"
+    CONTROL = "control"
+
+
+class DispositionKind(str, Enum):
+    DELIVERED = "delivered"
+    SUMMARIZED = "summarized"
+    OMITTED_POLICY = "omitted_policy"
+
+
+@dataclass(frozen=True)
+class SourceRange:
+    range_id: str
+    start: int
+    end: int
+    kind: RangeKind
+    body: str
+    marker: str | None = None
+
+    @property
+    def raw(self) -> bytes:
+        return self.body.encode("utf-8")
+
+
+@dataclass(frozen=True)
+class PlannedDisposition:
+    range_ids: tuple[str, ...]
+    start: int
+    end: int
+    kind: DispositionKind
+    source_sha256: str
+    source_range_sha256s: tuple[str, ...]
+    expected_body: str
+    policy_reason: str
+    committed: bool = False
+    discord_message_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BatchPlan:
+    dispositions: tuple[PlannedDisposition, ...]
+    processed_end: int
+    admitted_items: int
+    admitted_bytes: int
+    blocked_reason: str | None
+
+
+def plan_bounded_batch(
+    ranges: Sequence[SourceRange],
+    *,
+    start_cursor: int,
+    max_pending_items: int,
+    max_pending_bytes: int,
+    policy_version: str = "relay-target-v1",
+) -> BatchPlan:
+    bounds = (start_cursor, max_pending_items, max_pending_bytes)
+    if any(
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > MAX_U64
+        for value in bounds
+    ):
+        raise ValueError("u64 bounds required")
+    if max_pending_items == 0 or max_pending_bytes == 0:
+        raise ValueError("positive bounds required")
+    if (
+        not isinstance(policy_version, str)
+        or re.fullmatch(r"[A-Za-z0-9._-]+", policy_version) is None
+    ):
+        raise ValueError("policy version required")
+    _validate_source_ranges(ranges, start_cursor)
+    dispositions: list[PlannedDisposition] = []
+    used_items = 0
+    used_bytes = 0
+    cursor = start_cursor
+    index = 0
+    blocked: str | None = None
+
+    while index < len(ranges):
+        item = ranges[index]
+        if item.kind is RangeKind.ASSISTANT_TEXT:
+            size = len(item.raw)
+            if size > max_pending_bytes:
+                blocked = "high_value_range_requires_utf8_safe_split"
+                break
+            if used_items + 1 > max_pending_items or used_bytes + size > max_pending_bytes:
+                blocked = "bounded_window_full"
+                break
+            dispositions.append(
+                PlannedDisposition(
+                    (item.range_id,),
+                    item.start,
+                    item.end,
+                    DispositionKind.DELIVERED,
+                    _hash_ranges([item]),
+                    (_hash_ranges([item]),),
+                    item.body,
+                    "assistant_text_must_deliver",
+                )
+            )
+            used_items += 1
+            used_bytes += size
+            cursor = item.end
+            index += 1
+            continue
+
+        if item.kind is RangeKind.CONTROL:
+            if used_items + 1 > max_pending_items:
+                blocked = "bounded_window_full"
+                break
+            dispositions.append(
+                PlannedDisposition(
+                    (item.range_id,),
+                    item.start,
+                    item.end,
+                    DispositionKind.OMITTED_POLICY,
+                    _hash_ranges([item]),
+                    (_hash_ranges([item]),),
+                    "",
+                    f"{policy_version}:control",
+                )
+            )
+            used_items += 1
+            cursor = item.end
+            index += 1
+            continue
+
+        group_start = index
+        raw_size = 0
+        while index < len(ranges) and ranges[index].kind is RangeKind.TOOL_BULK:
+            raw_size += len(ranges[index].raw)
+            index += 1
+        group_end = index
+        group_count = group_end - group_start
+        raw_items_fit = (
+            used_items + group_count <= max_pending_items
+            and used_bytes + raw_size <= max_pending_bytes
+        )
+        if raw_items_fit:
+            for entry in ranges[group_start:group_end]:
+                dispositions.append(
+                    PlannedDisposition(
+                        (entry.range_id,),
+                        entry.start,
+                        entry.end,
+                        DispositionKind.DELIVERED,
+                        _hash_ranges([entry]),
+                        (_hash_ranges([entry]),),
+                        entry.body,
+                        f"{policy_version}:tool_within_bound",
+                    )
+                )
+                used_items += 1
+                used_bytes += len(entry.raw)
+                cursor = entry.end
+            continue
+
+        if used_items + 1 > max_pending_items:
+            index = group_start
+            blocked = "bounded_window_full"
+            break
+        available_bytes = max_pending_bytes - used_bytes
+        source_scan_budget = max_pending_bytes * max_pending_items
+        prefix: list[SourceRange] = []
+        prefix_raw_bytes = 0
+        summary = ""
+        for candidate in ranges[group_start:group_end]:
+            candidate_raw_bytes = prefix_raw_bytes + len(candidate.raw)
+            if candidate_raw_bytes > source_scan_budget and prefix:
+                break
+            candidate_prefix = [*prefix, candidate]
+            candidate_summary = _tool_summary(
+                candidate_prefix,
+                policy_version,
+                max_bytes=available_bytes,
+            )
+            if len(candidate_summary.encode("utf-8")) > available_bytes:
+                break
+            prefix = candidate_prefix
+            prefix_raw_bytes = candidate_raw_bytes
+            summary = candidate_summary
+        if not prefix:
+            index = group_start
+            blocked = "tool_summary_exceeds_window"
+            break
+        summary_size = len(summary.encode("utf-8"))
+        dispositions.append(
+            PlannedDisposition(
+                tuple(entry.range_id for entry in prefix),
+                prefix[0].start,
+                prefix[-1].end,
+                DispositionKind.SUMMARIZED,
+                _hash_ranges(prefix),
+                tuple(_hash_ranges([entry]) for entry in prefix),
+                summary,
+                f"{policy_version}:tool_bulk_overflow",
+            )
+        )
+        used_items += 1
+        used_bytes += summary_size
+        cursor = prefix[-1].end
+        index = group_start + len(prefix)
+        if index < group_end:
+            blocked = "bounded_tool_bulk_suffix"
+            break
+
+    return BatchPlan(tuple(dispositions), cursor, used_items, used_bytes, blocked)
+
+
+def commit_dispositions(
+    plan: BatchPlan,
+    discord_ids: Mapping[int, Sequence[str]],
+) -> tuple[PlannedDisposition, ...]:
+    if not isinstance(discord_ids, Mapping):
+        raise ValueError("Discord ids must be an index mapping")
+    for index in discord_ids:
+        if (
+            isinstance(index, bool)
+            or not isinstance(index, int)
+            or index < 0
+            or index >= len(plan.dispositions)
+        ):
+            raise ValueError("Discord id mapping index is invalid")
+    committed: list[PlannedDisposition] = []
+    for index, disposition in enumerate(plan.dispositions):
+        if not isinstance(disposition.kind, DispositionKind):
+            raise ValueError("unknown disposition kind")
+        raw_ids = discord_ids.get(index, ())
+        if (
+            not isinstance(raw_ids, Sequence)
+            or isinstance(raw_ids, (str, bytes, bytearray))
+        ):
+            raise ValueError("Discord ids must be a sequence")
+        ids = tuple(raw_ids)
+        if any(not _discord_message_id_valid(value) for value in ids):
+            raise ValueError("Discord message id is invalid")
+        if disposition.kind in {DispositionKind.DELIVERED, DispositionKind.SUMMARIZED}:
+            if len(ids) != 1 or any(not value for value in ids):
+                raise ValueError(
+                    "exactly one Discord id required for delivered/summary disposition"
+                )
+        elif ids:
+            raise ValueError("policy omission cannot claim a Discord message")
+        committed.append(
+            replace(disposition, committed=True, discord_message_ids=ids)
+        )
+    return tuple(committed)
+
+
+def serialize_planned_disposition(disposition: PlannedDisposition) -> dict[str, Any]:
+    """Serialize the planner contract in the exact shape consumed by the oracle."""
+
+    if not isinstance(disposition.kind, DispositionKind):
+        raise ValueError("unknown disposition kind")
+    return {
+        "range_ids": list(disposition.range_ids),
+        "kind": disposition.kind.value,
+        "policy_reason": disposition.policy_reason,
+        "source_sha256": disposition.source_sha256,
+        "source_range_sha256s": list(disposition.source_range_sha256s),
+        "discord_message_ids": list(disposition.discord_message_ids),
+        "expected_body_sha256": (
+            normalized_body_sha256([disposition.expected_body])
+            if disposition.kind
+            in {DispositionKind.DELIVERED, DispositionKind.SUMMARIZED}
+            else None
+        ),
+        "committed": disposition.committed,
+    }
+
+
+def advance_committed_frontier(
+    current: int, dispositions: Sequence[PlannedDisposition]
+) -> int:
+    if (
+        isinstance(current, bool)
+        or not isinstance(current, int)
+        or current < 0
+        or current > MAX_U64
+    ):
+        raise ValueError("invalid current frontier")
+    frontier = current
+    seen_ranges: set[str] = set()
+    pending_seen = False
+    for disposition in dispositions:
+        if (
+            not isinstance(disposition.kind, DispositionKind)
+            or not isinstance(disposition.committed, bool)
+        ):
+            raise ValueError("unknown disposition or commit state")
+        reason = disposition.policy_reason
+        reason_valid = False
+        if isinstance(reason, str):
+            if disposition.kind is DispositionKind.DELIVERED:
+                reason_valid = reason == "assistant_text_must_deliver" or bool(
+                    re.fullmatch(r"[A-Za-z0-9._-]+:tool_within_bound", reason)
+                )
+            elif disposition.kind is DispositionKind.SUMMARIZED:
+                reason_valid = bool(
+                    re.fullmatch(r"[A-Za-z0-9._-]+:tool_bulk_overflow", reason)
+                )
+            else:
+                reason_valid = bool(
+                    re.fullmatch(r"[A-Za-z0-9._-]+:control", reason)
+                )
+        if not reason_valid:
+            raise ValueError("invalid disposition policy reason")
+        message_ids = disposition.discord_message_ids
+        if disposition.committed and disposition.kind in {
+            DispositionKind.DELIVERED,
+            DispositionKind.SUMMARIZED,
+        }:
+            if (
+                not isinstance(message_ids, tuple)
+                or len(message_ids) != 1
+                or not _discord_message_id_valid(message_ids[0])
+            ):
+                raise ValueError("committed delivery lacks Discord evidence")
+        elif message_ids:
+            raise ValueError("disposition has invalid Discord evidence")
+        if (
+            isinstance(disposition.start, bool)
+            or not isinstance(disposition.start, int)
+            or isinstance(disposition.end, bool)
+            or not isinstance(disposition.end, int)
+            or disposition.start < 0
+            or disposition.end <= disposition.start
+            or disposition.end > MAX_U64
+        ):
+            raise ValueError("invalid disposition range")
+        if (
+            not isinstance(disposition.range_ids, tuple)
+            or not disposition.range_ids
+            or any(
+                not isinstance(range_id, str) or not range_id
+                for range_id in disposition.range_ids
+            )
+        ):
+            raise ValueError("invalid disposition range ids")
+        if any(range_id in seen_ranges for range_id in disposition.range_ids):
+            raise ValueError("duplicate disposition range id")
+        seen_ranges.update(disposition.range_ids)
+        if not disposition.committed:
+            pending_seen = True
+            continue
+        if pending_seen:
+            raise ValueError("committed disposition after pending suffix")
+        if disposition.start < frontier:
+            raise ValueError("duplicate or overlapping committed span")
+        if disposition.start > frontier:
+            raise ValueError("committed frontier gap")
+        frontier = disposition.end
+    return frontier
+
+
+def _validate_source_ranges(ranges: Sequence[SourceRange], start_cursor: int) -> None:
+    cursor = start_cursor
+    seen: set[str] = set()
+    for entry in ranges:
+        if (
+            not isinstance(entry.range_id, str)
+            or not entry.range_id
+            or entry.range_id in seen
+        ):
+            raise ValueError("duplicate range id")
+        seen.add(entry.range_id)
+        if (
+            not isinstance(entry.kind, RangeKind)
+            or isinstance(entry.start, bool)
+            or not isinstance(entry.start, int)
+            or isinstance(entry.end, bool)
+            or not isinstance(entry.end, int)
+            or entry.start < 0
+            or entry.end > MAX_U64
+            or entry.start != cursor
+            or entry.end <= entry.start
+        ):
+            raise ValueError("source ranges must be contiguous and nonempty")
+        if entry.end - entry.start != len(entry.raw):
+            raise ValueError("cursor range must equal UTF-8 byte length")
+        if entry.marker is not None and (
+            not isinstance(entry.marker, str)
+            or MARKER_RE.fullmatch(entry.marker) is None
+        ):
+            raise ValueError("invalid E2E marker")
+        if entry.marker is not None and entry.marker not in entry.body:
+            raise ValueError("E2E marker must be present in its source range")
+        cursor = entry.end
+    marker_counts: dict[str, int] = {}
+    for marker in MARKER_SCAN_RE.findall("".join(entry.body for entry in ranges)):
+        marker_counts[marker] = marker_counts.get(marker, 0) + 1
+    if any(count > 1 for count in marker_counts.values()):
+        raise ValueError("duplicate E2E marker in actual source")
+
+
+def _discord_message_id_valid(value: Any) -> bool:
+    if not isinstance(value, str) or re.fullmatch(r"[0-9]+", value) is None:
+        return False
+    if value.startswith("0"):
+        return False
+    maximum = str(MAX_U64)
+    return (
+        len(value) < len(maximum)
+        or (len(value) == len(maximum) and value <= maximum)
+    )
+
+
+def _hash_ranges(ranges: Iterable[SourceRange]) -> str:
+    digest = hashlib.sha256()
+    for entry in ranges:
+        raw = entry.raw
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+    return digest.hexdigest()
+
+
+def _tool_summary(
+    ranges: Sequence[SourceRange],
+    policy_version: str,
+    *,
+    max_bytes: int | None = None,
+) -> str:
+    raw_bytes = sum(len(entry.raw) for entry in ranges)
+    markers = [entry.marker for entry in ranges if entry.marker]
+    marker_suffix = "" if not markers else " markers=" + ",".join(markers)
+    summary = (
+        f"[AgentDesk summary policy={policy_version} "
+        f"range={ranges[0].start}:{ranges[-1].end} records={len(ranges)} "
+        f"raw_bytes={raw_bytes} sha256={_hash_ranges(ranges)}{marker_suffix}]"
+    )
+    if max_bytes is None or len(summary.encode("utf-8")) <= max_bytes or not markers:
+        return summary
+    marker_digest = hashlib.sha256("\n".join(markers).encode("utf-8")).hexdigest()
+    return (
+        f"[AgentDesk summary policy={policy_version} "
+        f"range={ranges[0].start}:{ranges[-1].end} records={len(ranges)} "
+        f"raw_bytes={raw_bytes} sha256={_hash_ranges(ranges)} "
+        f"marker_count={len(markers)} marker_sha256={marker_digest}]"
+    )
+
+
+def normalized_body_sha256(texts: Sequence[str]) -> str:
+    digest = hashlib.sha256()
+    for text in texts:
+        raw = text.encode("utf-8")
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+    return digest.hexdigest()
+
+
+def validate_evidence_bundle(
+    bundle: Mapping[str, Any],
+    *,
+    pinned_manifest: Mapping[str, Any],
+    actual_source_id: str,
+    actual_source_bytes: bytes,
+    discord_channel_id: str,
+    discord_after_message_id: str,
+) -> list[str]:
+    """Recompute the oracle from external pins and actual source bytes."""
+
+    errors: list[str] = []
+    manifest = bundle.get("manifest")
+    ranges = bundle.get("source_ranges")
+    dispositions = bundle.get("dispositions")
+    messages = bundle.get("discord_observations")
+    delivery = bundle.get("delivery_observation")
+    unrelated = bundle.get("unrelated_sessions")
+    if not all(
+        [
+            isinstance(manifest, dict),
+            isinstance(ranges, list),
+            isinstance(dispositions, list),
+            isinstance(messages, list),
+            isinstance(delivery, dict),
+            isinstance(unrelated, list),
+            isinstance(pinned_manifest, Mapping),
+            isinstance(actual_source_bytes, bytes),
+            isinstance(actual_source_id, str),
+            isinstance(discord_channel_id, str),
+            isinstance(discord_after_message_id, str),
+        ]
+    ):
+        return ["bundle_shape_invalid"]
+
+    required_manifest = {
+        "schema_version",
+        "run_id",
+        "case_id",
+        "provider",
+        "channel_id",
+        "base_sha",
+        "binary_sha",
+        "policy_version",
+        "normalization_version",
+        "actual_source_id",
+        "source_generation",
+        "coordinate_space",
+        "source_start",
+        "source_end",
+        "durable_frontier_before",
+        "durable_anchor_before",
+        "durable_anchor_after",
+        "discord_complete",
+        "bot_author_id",
+        "discord_after_message_id",
+        "started_at",
+    }
+    if set(manifest) != required_manifest or set(pinned_manifest) != required_manifest:
+        errors.append("manifest_fields_or_schema_mismatch")
+        return errors
+    if manifest != dict(pinned_manifest):
+        errors.append("manifest_not_externally_pinned")
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        errors.append("manifest_schema_unknown")
+    if manifest["provider"] not in ("claude", "codex"):
+        errors.append("manifest_provider_unknown")
+    if (
+        isinstance(manifest["source_generation"], bool)
+        or not isinstance(manifest["source_generation"], int)
+        or not 0 <= manifest["source_generation"] <= MAX_U64
+    ):
+        errors.append("manifest_source_generation_invalid")
+    if not all(
+        isinstance(manifest[key], str) and manifest[key]
+        for key in (
+            "run_id",
+            "case_id",
+            "policy_version",
+            "actual_source_id",
+            "durable_anchor_before",
+            "durable_anchor_after",
+            "started_at",
+        )
+    ):
+        errors.append("manifest_text_identity_invalid")
+    if manifest["durable_anchor_before"] == manifest["durable_anchor_after"]:
+        errors.append("manifest_durable_anchor_did_not_advance")
+    for key in ("channel_id", "bot_author_id", "discord_after_message_id"):
+        if not _discord_message_id_valid(manifest[key]):
+            errors.append("manifest_discord_id_invalid")
+    for key in ("base_sha", "binary_sha"):
+        value = manifest[key]
+        if (
+            not isinstance(value, str)
+            or len(value) != 40
+            or any(character not in "0123456789abcdef" for character in value)
+        ):
+            errors.append("manifest_git_sha_invalid")
+    if manifest["coordinate_space"] != "raw_utf8_bytes":
+        errors.append("coordinate_space_unknown")
+    if manifest["normalization_version"] != "discord-body-v1":
+        errors.append("normalization_version_unknown")
+    if manifest["discord_complete"] is not True:
+        errors.append("discord_fetch_incomplete")
+    if (
+        manifest["actual_source_id"] != actual_source_id
+        or manifest["channel_id"] != discord_channel_id
+        or manifest["discord_after_message_id"] != discord_after_message_id
+    ):
+        errors.append("external_source_or_discord_scope_mismatch")
+    source_start = manifest["source_start"]
+    source_end = manifest["source_end"]
+    durable_frontier_before = manifest["durable_frontier_before"]
+    if (
+        isinstance(source_start, bool)
+        or not isinstance(source_start, int)
+        or isinstance(source_end, bool)
+        or not isinstance(source_end, int)
+        or source_start < 0
+        or source_end <= source_start
+        or source_end > MAX_U64
+        or source_end - source_start != len(actual_source_bytes)
+    ):
+        errors.append("actual_source_extent_mismatch")
+        return errors
+    if (
+        isinstance(durable_frontier_before, bool)
+        or not isinstance(durable_frontier_before, int)
+        or durable_frontier_before < 0
+        or durable_frontier_before > MAX_U64
+        or durable_frontier_before != source_start
+    ):
+        errors.append("manifest_durable_frontier_invalid")
+        return errors
+
+    source_by_id: dict[str, SourceRange] = {}
+    source_order: list[str] = []
+    source_hashes: dict[str, str] = {}
+    cursor = source_start
+    actual_markers = MARKER_SCAN_RE.findall(
+        actual_source_bytes.decode("utf-8", errors="replace")
+    )
+    actual_marker_counts: dict[str, int] = {}
+    for marker in actual_markers:
+        actual_marker_counts[marker] = actual_marker_counts.get(marker, 0) + 1
+    if any(count > 1 for count in actual_marker_counts.values()):
+        errors.append("source_marker_duplicate")
+    markers: dict[str, str] = {}
+    declared_markers: set[str] = set()
+    for entry in ranges:
+        if not isinstance(entry, dict):
+            errors.append("source_range_invalid")
+            continue
+        range_id = entry.get("range_id")
+        if not isinstance(range_id, str) or not range_id or range_id in source_by_id:
+            errors.append("source_range_id_duplicate_or_invalid")
+            continue
+        start = entry.get("start")
+        end = entry.get("end")
+        if (
+            isinstance(start, bool)
+            or not isinstance(start, int)
+            or isinstance(end, bool)
+            or not isinstance(end, int)
+            or end <= start
+            or start < source_start
+            or end > source_end
+        ):
+            errors.append("source_range_empty_or_invalid")
+            continue
+        if start != cursor:
+            errors.append("source_range_gap_or_order")
+        cursor = end
+        try:
+            kind = RangeKind(entry.get("kind"))
+        except (TypeError, ValueError):
+            errors.append("source_range_kind_unknown")
+            continue
+        raw = actual_source_bytes[start - source_start : end - source_start]
+        try:
+            body = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            errors.append("source_range_not_utf8")
+            continue
+        marker = entry.get("marker")
+        if marker is not None:
+            match = MARKER_RE.fullmatch(marker) if isinstance(marker, str) else None
+            if (
+                match is None
+                or match.group("run") != manifest["run_id"]
+                or match.group("case") != manifest["case_id"]
+            ):
+                errors.append("source_marker_invalid")
+            elif marker in declared_markers:
+                errors.append("source_marker_duplicate")
+            else:
+                declared_markers.add(marker)
+            if not isinstance(marker, str) or marker not in body:
+                errors.append("source_marker_bytes_mismatch")
+            if entry.get("marker_in_source") is not True:
+                errors.append("source_marker_not_witnessed")
+        elif entry.get("marker_in_source") not in {None, False}:
+            errors.append("source_marker_not_witnessed")
+        model_range = SourceRange(range_id, start, end, kind, body, marker)
+        digest = _hash_ranges([model_range])
+        if entry.get("sha256") != digest:
+            errors.append("source_range_hash_mismatch")
+        source_by_id[range_id] = model_range
+        source_hashes[range_id] = digest
+        source_order.append(range_id)
+    if cursor != source_end:
+        errors.append("source_end_mismatch")
+    for marker in actual_marker_counts:
+        match = MARKER_RE.fullmatch(marker)
+        if (
+            match is None
+            or match.group("run") != manifest["run_id"]
+            or match.group("case") != manifest["case_id"]
+        ):
+            errors.append("source_marker_invalid")
+        if marker not in declared_markers:
+            errors.append("source_marker_metadata_missing")
+        markers[marker] = "actual_source"
+
+    message_revisions: dict[str, list[Mapping[str, Any]]] = {}
+    cutoff_valid = _discord_message_id_valid(discord_after_message_id)
+    for message in messages:
+        if not isinstance(message, dict) or not isinstance(message.get("message_id"), str):
+            errors.append("discord_message_invalid")
+            continue
+        message_id = message["message_id"]
+        if (
+            not _discord_message_id_valid(message_id)
+            or not cutoff_valid
+            or (
+                _discord_message_id_valid(message_id)
+                and cutoff_valid
+                and int(message_id) <= int(discord_after_message_id)
+            )
+        ):
+            errors.append("discord_message_outside_cutoff")
+        if message.get("channel_id") != discord_channel_id:
+            errors.append("discord_message_channel_mismatch")
+        raw_body = message.get("raw_body")
+        if not isinstance(raw_body, str):
+            errors.append("discord_raw_body_missing")
+        else:
+            if manifest["normalization_version"] == "discord-body-v1":
+                normalized = _normalize_discord_body(
+                    raw_body, manifest["normalization_version"]
+                )
+                if message.get("normalized_body") != normalized:
+                    errors.append("discord_normalization_mismatch")
+        message_revisions.setdefault(message_id, []).append(message)
+    final_messages: dict[str, Mapping[str, Any]] = {}
+    for message_id, revisions in message_revisions.items():
+        revision_indexes = [item.get("revision_index") for item in revisions]
+        if any(
+            isinstance(value, bool) or not isinstance(value, int)
+            for value in revision_indexes
+        ):
+            errors.append("discord_revision_gap")
+            ordered = revisions
+        else:
+            ordered = sorted(revisions, key=lambda item: item["revision_index"])
+            if [item["revision_index"] for item in ordered] != list(
+                range(len(ordered))
+            ):
+                errors.append("discord_revision_gap")
+        final_messages[message_id] = ordered[-1]
+
+    for marker in markers:
+        marker_count = sum(
+            str(message.get("normalized_body", "")).count(marker)
+            for message in final_messages.values()
+            if message.get("message_role") == "relay_body"
+        )
+        if marker_count != 1:
+            errors.append(f"marker_count:{marker}:{marker_count}")
+
+    range_owners: dict[str, int] = {}
+    used_message_ids: set[str] = set()
+    committed_spans: list[tuple[int, int]] = []
+    pending_seen = False
+    for index, disposition in enumerate(dispositions):
+        if not isinstance(disposition, dict):
+            errors.append("disposition_invalid")
+            continue
+        range_ids = disposition.get("range_ids")
+        if (
+            not isinstance(range_ids, list)
+            or not range_ids
+            or any(not isinstance(range_id, str) for range_id in range_ids)
+        ):
+            errors.append("disposition_range_ids_invalid")
+            continue
+        entries: list[SourceRange] = []
+        indexes: list[int] = []
+        for range_id in range_ids:
+            if range_id in range_owners:
+                errors.append("source_range_multiple_dispositions")
+            range_owners[range_id] = index
+            entry = source_by_id.get(range_id)
+            if entry is None:
+                errors.append("disposition_unknown_range")
+            else:
+                entries.append(entry)
+                indexes.append(source_order.index(range_id))
+        if not entries:
+            continue
+        if indexes != list(range(indexes[0], indexes[0] + len(indexes))):
+            errors.append("disposition_ranges_noncontiguous_or_reordered")
+        try:
+            kind = DispositionKind(disposition.get("kind"))
+        except (TypeError, ValueError):
+            errors.append("disposition_kind_unknown")
+            continue
+        source_kinds = {entry.kind for entry in entries}
+        policy = manifest["policy_version"]
+        expected_reason: str | None = None
+        if kind is DispositionKind.DELIVERED and source_kinds == {
+            RangeKind.ASSISTANT_TEXT
+        }:
+            expected_reason = "assistant_text_must_deliver"
+        elif kind is DispositionKind.DELIVERED and source_kinds == {RangeKind.TOOL_BULK}:
+            expected_reason = f"{policy}:tool_within_bound"
+        elif kind is DispositionKind.SUMMARIZED and source_kinds == {
+            RangeKind.TOOL_BULK
+        }:
+            expected_reason = f"{policy}:tool_bulk_overflow"
+        elif kind is DispositionKind.OMITTED_POLICY and source_kinds == {
+            RangeKind.CONTROL
+        }:
+            expected_reason = f"{policy}:control"
+        if expected_reason is None or disposition.get("policy_reason") != expected_reason:
+            errors.append("disposition_policy_mismatch")
+        if RangeKind.ASSISTANT_TEXT in source_kinds and kind is not DispositionKind.DELIVERED:
+            errors.append("assistant_text_not_delivered")
+        if kind is DispositionKind.OMITTED_POLICY and source_kinds != {RangeKind.CONTROL}:
+            errors.append("noncontrol_policy_omission")
+        if kind is DispositionKind.SUMMARIZED and source_kinds != {RangeKind.TOOL_BULK}:
+            errors.append("summary_not_tool_bulk")
+        expected_hashes = [source_hashes[entry.range_id] for entry in entries]
+        if disposition.get("source_sha256") != _hash_ranges(entries):
+            errors.append("disposition_source_hash_mismatch")
+        if disposition.get("source_range_sha256s") != expected_hashes:
+            errors.append("disposition_source_hashes_mismatch")
+
+        if kind is DispositionKind.SUMMARIZED:
+            expected_body = _tool_summary(entries, policy)
+        elif kind is DispositionKind.DELIVERED:
+            expected_body = "".join(entry.body for entry in entries)
+        else:
+            expected_body = ""
+        expected_body_hash = (
+            normalized_body_sha256([expected_body])
+            if kind in {DispositionKind.DELIVERED, DispositionKind.SUMMARIZED}
+            else None
+        )
+        if disposition.get("expected_body_sha256") != expected_body_hash:
+            errors.append("expected_body_hash_not_recomputed")
+
+        committed = disposition.get("committed")
+        if not isinstance(committed, bool):
+            errors.append("disposition_commit_state_invalid")
+            continue
+        if not committed:
+            pending_seen = True
+            continue
+        if pending_seen:
+            errors.append("committed_disposition_after_pending_suffix")
+        span = (entries[0].start, entries[-1].end)
+        if span in committed_spans or any(
+            span[0] < existing[1] and existing[0] < span[1]
+            for existing in committed_spans
+        ):
+            errors.append("duplicate_or_overlapping_committed_span")
+        committed_spans.append(span)
+        ids = disposition.get("discord_message_ids", [])
+        if not isinstance(ids, list):
+            errors.append("disposition_message_ids_invalid")
+            continue
+        if kind in {DispositionKind.DELIVERED, DispositionKind.SUMMARIZED}:
+            if len(ids) != 1:
+                errors.append("committed_delivery_requires_one_message_id")
+                continue
+            message_id = ids[0]
+            if not _discord_message_id_valid(message_id):
+                errors.append("discord_message_id_invalid")
+                continue
+            if message_id in used_message_ids:
+                errors.append("discord_message_reused")
+            used_message_ids.add(message_id)
+            message = final_messages.get(message_id)
+            if message is None:
+                errors.append("discord_message_not_observed")
+                continue
+            if message.get("author_id") != manifest["bot_author_id"]:
+                errors.append("discord_message_author_mismatch")
+            if message.get("message_role") != "relay_body":
+                errors.append("discord_message_wrong_role")
+            if normalized_body_sha256(
+                [str(message.get("normalized_body", ""))]
+            ) != expected_body_hash:
+                errors.append("discord_body_hash_mismatch")
+        elif ids:
+            errors.append("omission_has_discord_message")
+
+    if set(range_owners) != set(source_by_id):
+        errors.append("source_range_without_disposition")
+    committed_frontier = durable_frontier_before
+    for start, end in committed_spans:
+        if start != committed_frontier:
+            errors.append("committed_frontier_gap_or_order")
+            break
+        committed_frontier = end
+    if (
+        delivery.get("source_id") != actual_source_id
+        or delivery.get("source_generation") != manifest["source_generation"]
+    ):
+        errors.append("delivery_source_identity_mismatch")
+    durable_anchor = delivery.get("durable_anchor")
+    if not isinstance(durable_anchor, str) or not durable_anchor:
+        errors.append("durable_anchor_missing")
+    elif durable_anchor != manifest["durable_anchor_after"]:
+        errors.append("durable_anchor_not_externally_pinned")
+    delivered_frontier = delivery.get("committed_frontier")
+    if (
+        isinstance(delivered_frontier, bool)
+        or not isinstance(delivered_frontier, int)
+        or delivered_frontier < 0
+        or delivered_frontier > MAX_U64
+        or delivered_frontier != committed_frontier
+    ):
+        errors.append("durable_frontier_mismatch")
+    if committed_frontier != source_end:
+        errors.append("pending_source_suffix")
+
+    providers: set[str] = set()
+    for entry in unrelated:
+        if not isinstance(entry, dict):
+            errors.append("unrelated_session_evidence_invalid")
+            continue
+        provider = entry.get("provider")
+        if provider not in ("claude", "codex"):
+            errors.append("unrelated_provider_unknown")
+            continue
+        providers.add(provider)
+        if (
+            entry.get("channel_id") == discord_channel_id
+            or entry.get("identity_complete") is not True
+            or not isinstance(entry.get("observed_at"), str)
+            or not entry.get("observed_at")
+        ):
+            errors.append("unrelated_session_evidence_invalid")
+        if entry.get("relay_gap") is not False or entry.get("regression") is not False:
+            errors.append("unrelated_session_regression")
+    if providers != {"claude", "codex"}:
+        errors.append("unrelated_provider_evidence_missing")
+    return errors
+
+
+def _normalize_discord_body(raw_body: str, version: str) -> str:
+    if version != "discord-body-v1":
+        raise ValueError("unknown normalization version")
+    return raw_body.replace("\r\n", "\n")

--- a/scripts/relay_w1a/model.py
+++ b/scripts/relay_w1a/model.py
@@ -146,6 +146,11 @@ def _observation_contract_error(observation: Observation) -> str | None:
         )
     ):
         return "observation_bool_not_typed"
+    if observation.source_generation is not None and (
+        type(observation.source_generation) is not int
+        or not 0 <= observation.source_generation <= MAX_U64
+    ):
+        return "observation_source_generation_not_typed_or_out_of_range"
     return None
 
 
@@ -178,6 +183,8 @@ def assess(observation: Observation) -> Assessment:
 
     if observation.termination_proof is not None:
         proof = observation.termination_proof
+        if not isinstance(proof, TerminationProof):
+            return _inconclusive("termination_proof_not_typed")
         proof_matches = (
             isinstance(proof.queue, QueueDisposition)
             and isinstance(observation.queue, QueueDisposition)

--- a/scripts/relay_w1a/model.py
+++ b/scripts/relay_w1a/model.py
@@ -643,24 +643,25 @@ def settle_effect(
         return LedgerTransition(record, False, 0, "inflight_continuity_inconclusive", True)
     if not clock_allows_transition(record.clock_stamp, now):
         return LedgerTransition(record, False, 0, "clock_fail_closed", True)
-    same_episode_and_source = (
-        observation.episode_key == record.episode_key
+
+    stable_identity_matches = (
+        isinstance(observation.episode_key, str)
+        and observation.episode_key == record.episode_key
+        and isinstance(observation.source_id, str)
         and observation.source_id == record.source_id
-    )
-    if (
-        observation.continuity is InflightContinuity.REPLACED
-        and same_episode_and_source
         and isinstance(observation.source_generation, int)
         and not isinstance(observation.source_generation, bool)
-        and 0 <= observation.source_generation <= MAX_U64
-        and observation.source_generation <= record.source_generation
+        and observation.source_generation == record.source_generation
+    )
+    if (
+        observation.continuity is InflightContinuity.PRESENT_STABLE
+        and not stable_identity_matches
     ):
         return LedgerTransition(
-            record, False, 0, "replacement_generation_not_advanced", True
+            record, False, 0, "continuity_identity_mismatch", True
         )
-    if observation.episode_key != record.episode_key or (
-        observation.continuity is InflightContinuity.REPLACED
-    ):
+
+    if observation.continuity is InflightContinuity.REPLACED:
         successor_identity_valid = (
             observation.identity_complete
             and observation.clock_valid
@@ -682,6 +683,13 @@ def settle_effect(
         )
         if not successor_identity_valid:
             return LedgerTransition(record, False, 0, "successor_identity_inconclusive", True)
+        if (
+            observation.source_id == record.source_id
+            and observation.source_generation <= record.source_generation
+        ):
+            return LedgerTransition(
+                record, False, 0, "replacement_generation_not_advanced", True
+            )
         settled = replace(
             record,
             state=LedgerState.SETTLED,

--- a/scripts/relay_w1a/tests/test_model.py
+++ b/scripts/relay_w1a/tests/test_model.py
@@ -424,6 +424,58 @@ class AuthorityFixtureTests(unittest.TestCase):
                 self.assertIsNone(result.candidate)
                 self.assertEqual(result.action, AllowedAction.NONE)
 
+    def test_all_observation_and_termination_flags_require_strict_booleans(self) -> None:
+        now = ClockStamp(6_000, "boot-strict-bool", 60)
+        proof = TerminationProof(
+            episode_key="ep-strict-bool",
+            source_id="source-strict-bool",
+            source_generation=1,
+            durable_anchor="anchor-strict-bool",
+            queue=QueueDisposition.TERMINAL,
+            termination_id="termination-strict-bool",
+            finalizer_committed=True,
+            watcher_stopped=True,
+            action_reprobe_at=now,
+        )
+        observation = Observation(
+            episode_key=proof.episode_key,
+            source_id=proof.source_id,
+            source_generation=proof.source_generation,
+            durable_anchor=proof.durable_anchor,
+            observed_at=now,
+            queue=proof.queue,
+            termination_proof=proof,
+        )
+        self.assertEqual(assess(observation).candidate, Verdict.PRODUCER_DEAD)
+
+        for field in (
+            "identity_complete",
+            "clock_valid",
+            "affirmative_termination",
+            "source_progress",
+            "delivery_progress",
+            "control_contradiction",
+            "terminal_delivery_committed",
+            "typed_idle",
+        ):
+            with self.subTest(owner="observation", field=field):
+                result = assess(replace(observation, **{field: "false"}))
+                self.assertIsNone(result.candidate)
+                self.assertEqual(result.action, AllowedAction.NONE)
+
+        for field in (
+            "finalizer_committed",
+            "watcher_stopped",
+            "identity_complete",
+            "clock_valid",
+        ):
+            with self.subTest(owner="termination_proof", field=field):
+                result = assess(
+                    replace(observation, termination_proof=replace(proof, **{field: "false"}))
+                )
+                self.assertIsNone(result.candidate)
+                self.assertEqual(result.action, AllowedAction.NONE)
+
 
 class LedgerFaultTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -620,6 +672,68 @@ class LedgerFaultTests(unittest.TestCase):
         )
         self.assertTrue(complete.changed)
         self.assertEqual(complete.record.outcome, LedgerOutcome.SUPERSEDED)
+
+    def test_replaced_continuity_without_successor_identity_cannot_supersede_or_rearm(
+        self,
+    ) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        replaced_same_identity = settle_effect(
+            pending,
+            repair_observation(
+                pending.episode_key,
+                continuity=InflightContinuity.REPLACED,
+                source_id=pending.source_id,
+                source_generation=pending.source_generation,
+                durable_anchor="anchor-rebound-but-not-successor",
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertFalse(replaced_same_identity.changed)
+        self.assertTrue(replaced_same_identity.must_reprobe)
+        self.assertEqual(replaced_same_identity.record, pending)
+
+        reserve_now = ClockStamp(1_000_101, "boot-a", 10_101)
+        replacement_attempt = reserve_attempt(
+            replaced_same_identity.record,
+            repair_observation(
+                pending.episode_key,
+                durable_anchor=pending.durable_anchor,
+                observed_at=reserve_now,
+            ),
+            attempt_id="attempt-after-false-replacement",
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=reserve_now,
+                source_frontier=pending.baseline_source,
+                committed_frontier=pending.baseline_delivered,
+                durable_anchor=pending.durable_anchor,
+            ),
+            now=reserve_now,
+        )
+        self.assertFalse(replacement_attempt.changed)
+        self.assertTrue(replacement_attempt.must_reprobe)
+        self.assertEqual(replacement_attempt.record, pending)
+
+        actual_successor = settle_effect(
+            pending,
+            repair_observation(
+                pending.episode_key,
+                continuity=InflightContinuity.REPLACED,
+                source_id=pending.source_id,
+                source_generation=pending.source_generation + 1,
+                durable_anchor="anchor-successor",
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertTrue(actual_successor.changed)
+        self.assertEqual(actual_successor.record.outcome, LedgerOutcome.SUPERSEDED)
 
     def test_delivery_proof_requires_generation_and_anchor_advance(self) -> None:
         _, pending = self._reserve_and_mark()
@@ -1057,6 +1171,32 @@ class LedgerFaultTests(unittest.TestCase):
         self.assertFalse(overflow.changed)
         self.assertEqual(overflow.reason, "backoff_clock_overflow")
 
+    def test_reserve_attempt_rejects_unknown_in_memory_ledger_state(self) -> None:
+        reserved, _ = self._reserve_and_mark()
+        unknown = replace(reserved, state="future-ledger-state")
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        transition = reserve_attempt(
+            unknown,
+            repair_observation(
+                unknown.episode_key,
+                durable_anchor=unknown.durable_anchor,
+                observed_at=now,
+            ),
+            attempt_id="attempt-after-unknown-state",
+            delivery_proof=delivery_proof(
+                unknown.episode_key,
+                now=now,
+                source_frontier=unknown.baseline_source,
+                committed_frontier=unknown.baseline_delivered,
+                durable_anchor=unknown.durable_anchor,
+            ),
+            now=now,
+        )
+        self.assertFalse(transition.changed)
+        self.assertTrue(transition.must_reprobe)
+        self.assertEqual(transition.record, unknown)
+        self.assertEqual(transition.reason, "ledger_state_not_typed")
+
     def test_corrupt_future_and_legacy_ledger_fail_closed(self) -> None:
         for raw, reason in (
             ("{", "corrupt_json"),
@@ -1287,6 +1427,28 @@ class BackpressureTests(unittest.TestCase):
                         0,
                         [replace(committed[0], discord_message_ids=(invalid_id,))],
                     )
+
+    def test_commit_and_frontier_require_globally_unique_discord_message_ids(
+        self,
+    ) -> None:
+        first = SourceRange("a", 0, 3, RangeKind.ASSISTANT_TEXT, "one")
+        second = SourceRange("b", 3, 6, RangeKind.ASSISTANT_TEXT, "two")
+        plan = plan_bounded_batch(
+            [first, second],
+            start_cursor=0,
+            max_pending_items=2,
+            max_pending_bytes=10,
+        )
+        with self.assertRaisesRegex(ValueError, "globally unique"):
+            commit_dispositions(plan, {0: ["8001"], 1: ["8001"]})
+
+        committed = commit_dispositions(plan, {0: ["8001"], 1: ["8002"]})
+        duplicate_at_frontier = (
+            committed[0],
+            replace(committed[1], discord_message_ids=("8001",)),
+        )
+        with self.assertRaisesRegex(ValueError, "globally unique"):
+            advance_committed_frontier(0, duplicate_at_frontier)
 
     def test_planner_rejects_actual_duplicate_marker_without_metadata(self) -> None:
         marker = "[ADK-E2E:run:case:1:BEGIN]"
@@ -1612,6 +1774,126 @@ class EvidenceOracleTests(unittest.TestCase):
         bundle["discord_observations"][1]["raw_body"] = body
         bundle["discord_observations"][1]["normalized_body"] = body
         self.assertEqual(self.validate(bundle), [])
+
+    def test_digest_marker_summary_uses_same_canonical_body_hash_in_oracle(
+        self,
+    ) -> None:
+        ranges = []
+        cursor = 0
+        for sequence in range(1, 5):
+            marker = f"[ADK-E2E:digest-run:digest-case:{sequence}:END]"
+            entry = SourceRange(
+                f"tool-{sequence}",
+                cursor,
+                cursor + len(marker.encode("utf-8")),
+                RangeKind.TOOL_BULK,
+                marker,
+                marker,
+            )
+            ranges.append(entry)
+            cursor = entry.end
+
+        plan = plan_bounded_batch(
+            ranges,
+            start_cursor=0,
+            max_pending_items=1,
+            max_pending_bytes=250,
+        )
+        self.assertIsNone(plan.blocked_reason)
+        self.assertEqual(len(plan.dispositions), 1)
+        self.assertIn("marker_count=4", plan.dispositions[0].expected_body)
+        self.assertIn("marker_sha256=", plan.dispositions[0].expected_body)
+        committed = commit_dispositions(plan, {0: ["9001"]})
+        serialized = serialize_planned_disposition(committed[0])
+
+        source_bytes = "".join(entry.body for entry in ranges).encode("utf-8")
+        manifest = {
+            "schema_version": 1,
+            "run_id": "digest-run",
+            "case_id": "digest-case",
+            "provider": "claude",
+            "channel_id": "4254",
+            "base_sha": "a" * 40,
+            "binary_sha": "b" * 40,
+            "policy_version": "relay-target-v1",
+            "normalization_version": "discord-body-v1",
+            "actual_source_id": "source-digest",
+            "source_generation": 7,
+            "coordinate_space": "raw_utf8_bytes",
+            "source_start": 0,
+            "source_end": len(source_bytes),
+            "durable_frontier_before": 0,
+            "durable_anchor_before": "anchor-before",
+            "durable_anchor_after": "anchor-after",
+            "discord_complete": True,
+            "bot_author_id": "424254",
+            "discord_after_message_id": "9000",
+            "started_at": "2026-07-13T10:00:00Z",
+        }
+        bundle = {
+            "manifest": manifest,
+            "source_ranges": [
+                {
+                    "range_id": entry.range_id,
+                    "start": entry.start,
+                    "end": entry.end,
+                    "kind": entry.kind.value,
+                    "sha256": committed[0].source_range_sha256s[index],
+                    "marker": entry.marker,
+                    "marker_in_source": True,
+                }
+                for index, entry in enumerate(ranges)
+            ],
+            "dispositions": [serialized],
+            "discord_observations": [
+                {
+                    "message_id": "9001",
+                    "channel_id": "4254",
+                    "author_id": "424254",
+                    "observed_at": "2026-07-13T10:00:01Z",
+                    "edited_at": None,
+                    "revision_index": 0,
+                    "message_role": "relay_body",
+                    "raw_body": committed[0].expected_body,
+                    "normalized_body": committed[0].expected_body,
+                }
+            ],
+            "delivery_observation": {
+                "source_id": "source-digest",
+                "source_generation": 7,
+                "durable_anchor": "anchor-after",
+                "committed_frontier": len(source_bytes),
+            },
+            "unrelated_sessions": [
+                {
+                    "provider": "claude",
+                    "channel_id": "4255",
+                    "identity_complete": True,
+                    "observed_at": "2026-07-13T10:00:02Z",
+                    "relay_gap": False,
+                    "regression": False,
+                },
+                {
+                    "provider": "codex",
+                    "channel_id": "4256",
+                    "identity_complete": True,
+                    "observed_at": "2026-07-13T10:00:03Z",
+                    "relay_gap": False,
+                    "regression": False,
+                },
+            ],
+        }
+        self.assertEqual(
+            validate_evidence_bundle(
+                bundle,
+                pinned_manifest=manifest,
+                actual_source_id="source-digest",
+                actual_source_bytes=source_bytes,
+                discord_channel_id="4254",
+                discord_after_message_id="9000",
+            ),
+            [],
+        )
 
     def test_source_gap_is_rejected(self) -> None:
         broken = copy.deepcopy(self.good)

--- a/scripts/relay_w1a/tests/test_model.py
+++ b/scripts/relay_w1a/tests/test_model.py
@@ -409,6 +409,74 @@ class AuthorityFixtureTests(unittest.TestCase):
             with self.subTest(mutant=mutant):
                 self.assertIsNone(assess(observe(mutant)).candidate)
 
+    def test_observation_generation_requires_exact_u64_before_termination_authority(
+        self,
+    ) -> None:
+        now = ClockStamp(5_100, "boot-generation", 51)
+        proof = TerminationProof(
+            episode_key="ep-generation",
+            source_id="source-generation",
+            source_generation=1,
+            durable_anchor="anchor-generation",
+            queue=QueueDisposition.TERMINAL,
+            termination_id="termination-generation",
+            finalizer_committed=True,
+            watcher_stopped=True,
+            action_reprobe_at=now,
+        )
+
+        def observe(source_generation) -> Observation:
+            return Observation(
+                episode_key=proof.episode_key,
+                source_id=proof.source_id,
+                source_generation=source_generation,
+                durable_anchor=proof.durable_anchor,
+                observed_at=now,
+                queue=proof.queue,
+                termination_proof=proof,
+            )
+
+        valid = assess(observe(1))
+        self.assertEqual(valid.candidate, Verdict.PRODUCER_DEAD)
+        self.assertEqual(valid.action, AllowedAction.DELEGATE_EXACT_TERMINATION)
+
+        missing = assess(observe(None))
+        self.assertIsNone(missing.candidate)
+        self.assertEqual(missing.action, AllowedAction.NONE)
+
+        for case, source_generation in (
+            ("bool", True),
+            ("float", 1.0),
+            ("negative", -1),
+            ("overflow", MAX_U64 + 1),
+        ):
+            with self.subTest(case=case):
+                result = assess(observe(source_generation))
+                self.assertIsNone(result.candidate)
+                self.assertEqual(result.action, AllowedAction.NONE)
+                self.assertFalse(result.may_spend_automatic_action)
+                self.assertEqual(
+                    result.reason,
+                    "observation_source_generation_not_typed_or_out_of_range",
+                )
+
+    def test_untyped_termination_proof_is_inconclusive_without_exception(self) -> None:
+        base = Observation(
+            episode_key="ep-untyped-proof",
+            source_id="source-untyped-proof",
+            source_generation=1,
+            durable_anchor="anchor-untyped-proof",
+            observed_at=ClockStamp(5_200, "boot-untyped-proof", 52),
+            queue=QueueDisposition.TERMINAL,
+        )
+        for proof in ({"termination_id": "self-declared"}, "terminated"):
+            with self.subTest(proof=proof):
+                result = assess(replace(base, termination_proof=proof))
+                self.assertIsNone(result.candidate)
+                self.assertEqual(result.action, AllowedAction.NONE)
+                self.assertFalse(result.may_spend_automatic_action)
+                self.assertEqual(result.reason, "termination_proof_not_typed")
+
     def test_untyped_observation_enums_never_authorize_an_action(self) -> None:
         base = Observation(
             episode_key="ep-untyped",
@@ -1047,6 +1115,352 @@ class LedgerFaultTests(unittest.TestCase):
                 self.assertTrue(transition.must_reprobe)
                 self.assertEqual(transition.record, pending)
                 self.assertEqual(transition.reason, "delivery_proof_bool_not_typed")
+
+    def test_observation_generation_contract_guards_all_ledger_entrypoints(
+        self,
+    ) -> None:
+        reserved, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        expected_reason = (
+            "observation_source_generation_not_typed_or_out_of_range"
+        )
+
+        def observation(source_generation) -> Observation:
+            return replace(
+                repair_observation(
+                    reserved.episode_key,
+                    durable_anchor=reserved.durable_anchor,
+                    observed_at=now,
+                ),
+                source_generation=source_generation,
+            )
+
+        proof = delivery_proof(
+            reserved.episode_key,
+            now=now,
+            source_frontier=reserved.baseline_source,
+            committed_frontier=reserved.baseline_delivered,
+            durable_anchor=reserved.durable_anchor,
+        )
+
+        for case, source_generation in (
+            ("bool", True),
+            ("float", 1.0),
+            ("negative", -1),
+            ("overflow", MAX_U64 + 1),
+        ):
+            malformed = observation(source_generation)
+
+            with self.subTest(case=case, entrypoint="reserve"):
+                transition = reserve_attempt(
+                    None,
+                    malformed,
+                    attempt_id=f"invalid-generation-{case}",
+                    delivery_proof=proof,
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertFalse(transition.must_reprobe)
+                self.assertIsNone(transition.record)
+                self.assertEqual(transition.reason, expected_reason)
+
+            with self.subTest(case=case, entrypoint="recover"):
+                transition = recover_after_crash(
+                    reserved,
+                    malformed,
+                    attempt_id=reserved.attempt_id,
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, reserved)
+                self.assertEqual(transition.reason, expected_reason)
+
+            with self.subTest(case=case, entrypoint="settle"):
+                transition = settle_effect(
+                    pending,
+                    malformed,
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=proof,
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, pending)
+                self.assertEqual(transition.reason, expected_reason)
+
+        missing = observation(None)
+        missing_reserve = reserve_attempt(
+            None,
+            missing,
+            attempt_id="missing-generation",
+            delivery_proof=proof,
+            now=now,
+        )
+        self.assertFalse(missing_reserve.changed)
+        self.assertTrue(missing_reserve.must_reprobe)
+        self.assertIsNone(missing_reserve.record)
+
+        missing_recover = recover_after_crash(
+            reserved,
+            missing,
+            attempt_id=reserved.attempt_id,
+        )
+        self.assertFalse(missing_recover.changed)
+        self.assertTrue(missing_recover.must_reprobe)
+        self.assertEqual(missing_recover.record, reserved)
+
+        missing_settle = settle_effect(
+            pending,
+            missing,
+            attempt_id=pending.attempt_id,
+            delivery_proof=proof,
+            now=now,
+        )
+        self.assertFalse(missing_settle.changed)
+        self.assertTrue(missing_settle.must_reprobe)
+        self.assertEqual(missing_settle.record, pending)
+
+        valid = observation(1)
+        valid_reserve = reserve_attempt(
+            None,
+            valid,
+            attempt_id="valid-generation",
+            delivery_proof=proof,
+            now=now,
+        )
+        self.assertTrue(valid_reserve.changed, valid_reserve.reason)
+        self.assertEqual(valid_reserve.reason, "reserved_without_spend")
+
+        valid_recover = recover_after_crash(
+            reserved,
+            valid,
+            attempt_id=reserved.attempt_id,
+        )
+        self.assertTrue(valid_recover.changed, valid_recover.reason)
+        self.assertFalse(valid_recover.must_reprobe)
+        self.assertEqual(valid_recover.reason, "reserved_action_not_invoked")
+
+        valid_settle = settle_effect(
+            pending,
+            valid,
+            attempt_id=pending.attempt_id,
+            delivery_proof=proof,
+            now=now,
+        )
+        self.assertTrue(valid_settle.changed, valid_settle.reason)
+        self.assertFalse(valid_settle.must_reprobe)
+        self.assertEqual(valid_settle.reason, "no_delivery_progress")
+
+    def test_reserve_rejects_reused_attempt_and_proof_record_identity_mismatch(
+        self,
+    ) -> None:
+        reserved, _ = self._reserve_and_mark()
+        settled = replace(reserved, state=LedgerState.SETTLED)
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+
+        reused = reserve_attempt(
+            settled,
+            repair_observation(
+                settled.episode_key,
+                durable_anchor=settled.durable_anchor,
+                observed_at=now,
+            ),
+            attempt_id=settled.attempt_id,
+            delivery_proof=delivery_proof(
+                settled.episode_key,
+                now=now,
+                source_frontier=settled.baseline_source,
+                committed_frontier=settled.baseline_delivered,
+                durable_anchor=settled.durable_anchor,
+            ),
+            now=now,
+        )
+        self.assertFalse(reused.changed)
+        self.assertEqual(reused.record, settled)
+        self.assertEqual(reused.reason, "attempt_id_reused")
+
+        rebound_observation = repair_observation(
+            settled.episode_key,
+            source_generation=settled.source_generation + 1,
+            durable_anchor=settled.durable_anchor,
+            observed_at=now,
+        )
+        mismatched = reserve_attempt(
+            settled,
+            rebound_observation,
+            attempt_id="attempt-rebound",
+            delivery_proof=delivery_proof(
+                settled.episode_key,
+                now=now,
+                source_frontier=settled.baseline_source,
+                committed_frontier=settled.baseline_delivered,
+                source_generation=settled.source_generation + 1,
+                durable_anchor=settled.durable_anchor,
+            ),
+            now=now,
+        )
+        self.assertFalse(mismatched.changed)
+        self.assertTrue(mismatched.must_reprobe)
+        self.assertEqual(mismatched.record, settled)
+        self.assertEqual(mismatched.reason, "delivery_proof_record_identity_mismatch")
+
+    def test_reserve_honors_backoff_before_creating_a_new_attempt(self) -> None:
+        _, pending = self._reserve_and_mark()
+        settled = self._settle_pending(
+            pending,
+            source=pending.baseline_source,
+            delivered=pending.baseline_delivered,
+            wall=1_000_010,
+            mono=10_010,
+        ).record
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        self.assertGreater(settled.retry_not_before_ms, now.wall_ms)
+        blocked = reserve_attempt(
+            settled,
+            repair_observation(
+                settled.episode_key,
+                durable_anchor=settled.durable_anchor,
+                observed_at=now,
+            ),
+            attempt_id="attempt-during-backoff",
+            delivery_proof=delivery_proof(
+                settled.episode_key,
+                now=now,
+                source_frontier=settled.baseline_source,
+                committed_frontier=settled.baseline_delivered,
+                durable_anchor=settled.durable_anchor,
+            ),
+            now=now,
+        )
+        self.assertFalse(blocked.changed)
+        self.assertEqual(blocked.record, settled)
+        self.assertEqual(blocked.reason, "backoff_active")
+
+    def test_reserve_rejects_each_record_frontier_regression_and_progress_lie(
+        self,
+    ) -> None:
+        reserved, _ = self._reserve_and_mark()
+        settled = replace(reserved, state=LedgerState.SETTLED)
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        cases = (
+            (
+                "source_frontier",
+                settled.baseline_source - 1,
+                settled.baseline_delivered,
+                settled.durable_anchor,
+                False,
+                "delivery_source_frontier_regressed",
+            ),
+            (
+                "delivery_frontier",
+                settled.baseline_source,
+                settled.baseline_delivered - 1,
+                "anchor-regressed",
+                False,
+                "delivery_frontier_regressed",
+            ),
+            (
+                "progress_claim",
+                settled.baseline_source + 1,
+                settled.baseline_delivered + 1,
+                "anchor-advanced",
+                False,
+                "delivery_progress_claim_mismatch",
+            ),
+        )
+        for case, source, delivered, anchor, claimed_progress, reason in cases:
+            observation = repair_observation(
+                settled.episode_key,
+                durable_anchor=anchor,
+                observed_at=now,
+                delivery_progress=claimed_progress,
+            )
+            transition = reserve_attempt(
+                settled,
+                observation,
+                attempt_id=f"attempt-{case}",
+                delivery_proof=delivery_proof(
+                    settled.episode_key,
+                    now=now,
+                    source_frontier=source,
+                    committed_frontier=delivered,
+                    durable_anchor=anchor,
+                ),
+                now=now,
+            )
+            with self.subTest(case=case):
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, settled)
+                self.assertEqual(transition.reason, reason)
+
+    def test_settle_rejects_inconclusive_delivery_queue_before_state_change(
+        self,
+    ) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        observation = repair_observation(
+            pending.episode_key,
+            durable_anchor=pending.durable_anchor,
+            observed_at=now,
+            queue=QueueDisposition.RETRYABLE,
+        )
+        transition = settle_effect(
+            pending,
+            observation,
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=pending.baseline_source,
+                committed_frontier=pending.baseline_delivered,
+                durable_anchor=pending.durable_anchor,
+                queue=QueueDisposition.RETRYABLE,
+            ),
+            now=now,
+        )
+        self.assertFalse(transition.changed)
+        self.assertTrue(transition.must_reprobe)
+        self.assertEqual(transition.record, pending)
+        self.assertEqual(transition.reason, "delivery_proof_queue_inconclusive")
+
+    def test_successor_settlement_requires_safe_queue_and_action_time_reprobe(
+        self,
+    ) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        cases = (
+            (
+                "queue",
+                QueueDisposition.RETRYABLE,
+                now,
+            ),
+            (
+                "action_time",
+                QueueDisposition.ACTIVE,
+                ClockStamp(now.wall_ms - 1, now.boot_id, now.monotonic_ms - 1),
+            ),
+        )
+        for case, queue, observed_at in cases:
+            transition = settle_effect(
+                pending,
+                repair_observation(
+                    "ep-successor-guard",
+                    continuity=InflightContinuity.REPLACED,
+                    source_generation=pending.source_generation + 1,
+                    durable_anchor="anchor-successor-guard",
+                    observed_at=observed_at,
+                    queue=queue,
+                ),
+                attempt_id=pending.attempt_id,
+                delivery_proof=None,
+                now=now,
+            )
+            with self.subTest(case=case):
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, pending)
+                self.assertEqual(transition.reason, "successor_identity_inconclusive")
 
     def test_delivery_proof_requires_generation_and_anchor_advance(self) -> None:
         _, pending = self._reserve_and_mark()
@@ -1961,6 +2375,67 @@ class EvidenceOracleTests(unittest.TestCase):
 
     def test_good_bundle_reconciles_source_dispositions_discord_and_frontier(self) -> None:
         self.assertEqual(self.validate(self.good), [])
+
+    def test_oracle_load_bearing_known_answer_guards(self) -> None:
+        external_scope_errors = validate_evidence_bundle(
+            self.good,
+            pinned_manifest=self.pins["pinned_manifest"],
+            actual_source_id="other-external-source",
+            actual_source_bytes=self.pins["actual_source_utf8"].encode("utf-8"),
+            discord_channel_id=self.pins["discord_channel_id"],
+            discord_after_message_id=self.pins["discord_after_message_id"],
+        )
+        self.assertIn(
+            "external_source_or_discord_scope_mismatch", external_scope_errors
+        )
+
+        delivery_identity = copy.deepcopy(self.good)
+        delivery_identity["delivery_observation"]["source_id"] = "other-source"
+        self.assertIn(
+            "delivery_source_identity_mismatch", self.validate(delivery_identity)
+        )
+
+        anchor_bundle = copy.deepcopy(self.good)
+        anchor_pins = copy.deepcopy(self.pins["pinned_manifest"])
+        unchanged_anchor = anchor_bundle["manifest"]["durable_anchor_before"]
+        anchor_bundle["manifest"]["durable_anchor_after"] = unchanged_anchor
+        anchor_bundle["delivery_observation"]["durable_anchor"] = unchanged_anchor
+        anchor_pins["durable_anchor_after"] = unchanged_anchor
+        anchor_errors = validate_evidence_bundle(
+            anchor_bundle,
+            pinned_manifest=anchor_pins,
+            actual_source_id=self.pins["actual_source_id"],
+            actual_source_bytes=self.pins["actual_source_utf8"].encode("utf-8"),
+            discord_channel_id=self.pins["discord_channel_id"],
+            discord_after_message_id=self.pins["discord_after_message_id"],
+        )
+        self.assertIn("manifest_durable_anchor_did_not_advance", anchor_errors)
+
+        normalization = copy.deepcopy(self.good)
+        normalization["discord_observations"][0]["raw_body"] += "mutant"
+        self.assertIn("discord_normalization_mismatch", self.validate(normalization))
+
+        wrong_role = copy.deepcopy(self.good)
+        wrong_role["discord_observations"][0]["message_role"] = "panel"
+        self.assertIn("discord_message_wrong_role", self.validate(wrong_role))
+
+        declared_body_hash = copy.deepcopy(self.good)
+        declared_body_hash["dispositions"][0]["expected_body_sha256"] = "0" * 64
+        self.assertIn(
+            "expected_body_hash_not_recomputed", self.validate(declared_body_hash)
+        )
+
+        source_end = copy.deepcopy(self.good)
+        source_end["source_ranges"] = source_end["source_ranges"][:-1]
+        source_end["dispositions"] = source_end["dispositions"][:-1]
+        self.assertIn("source_end_mismatch", self.validate(source_end))
+
+        frontier_gap = copy.deepcopy(self.good)
+        frontier_gap["dispositions"][0], frontier_gap["dispositions"][1] = (
+            frontier_gap["dispositions"][1],
+            frontier_gap["dispositions"][0],
+        )
+        self.assertIn("committed_frontier_gap_or_order", self.validate(frontier_gap))
 
     def test_missing_discord_message_is_rejected(self) -> None:
         broken = copy.deepcopy(self.good)

--- a/scripts/relay_w1a/tests/test_model.py
+++ b/scripts/relay_w1a/tests/test_model.py
@@ -650,7 +650,11 @@ class LedgerFaultTests(unittest.TestCase):
         now = ClockStamp(1_000_100, "boot-a", 10_100)
         incomplete = settle_effect(
             pending,
-            Observation(episode_key="ep-successor", observed_at=None),
+            Observation(
+                episode_key="ep-successor",
+                continuity=InflightContinuity.REPLACED,
+                observed_at=None,
+            ),
             attempt_id=pending.attempt_id,
             delivery_proof=None,
             now=now,
@@ -664,6 +668,7 @@ class LedgerFaultTests(unittest.TestCase):
             repair_observation(
                 "ep-successor",
                 continuity=InflightContinuity.REPLACED,
+                source_generation=pending.source_generation + 1,
                 observed_at=now,
             ),
             attempt_id=pending.attempt_id,
@@ -778,6 +783,143 @@ class LedgerFaultTests(unittest.TestCase):
         self.assertEqual(
             new_source_same_generation.record.outcome, LedgerOutcome.SUPERSEDED
         )
+
+    def test_successor_generation_and_continuity_cannot_be_laundered_by_episode(
+        self,
+    ) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+
+        for generation in (pending.source_generation - 1, pending.source_generation):
+            with self.subTest(continuity="replaced", generation=generation):
+                stale = settle_effect(
+                    pending,
+                    repair_observation(
+                        "ep-successor",
+                        continuity=InflightContinuity.REPLACED,
+                        source_id=pending.source_id,
+                        source_generation=generation,
+                        durable_anchor="anchor-stale-successor",
+                        observed_at=now,
+                    ),
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=None,
+                    now=now,
+                )
+                self.assertFalse(stale.changed)
+                self.assertTrue(stale.must_reprobe)
+                self.assertEqual(stale.record, pending)
+                self.assertEqual(stale.reason, "replacement_generation_not_advanced")
+
+            with self.subTest(continuity="present_stable", generation=generation):
+                mismatched = settle_effect(
+                    pending,
+                    repair_observation(
+                        "ep-successor",
+                        continuity=InflightContinuity.PRESENT_STABLE,
+                        source_id=pending.source_id,
+                        source_generation=generation,
+                        durable_anchor="anchor-stable-mismatch",
+                        observed_at=now,
+                    ),
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=None,
+                    now=now,
+                )
+                self.assertFalse(mismatched.changed)
+                self.assertTrue(mismatched.must_reprobe)
+                self.assertEqual(mismatched.record, pending)
+                self.assertEqual(mismatched.reason, "continuity_identity_mismatch")
+
+        for field, value in (
+            ("source_id", "source-mismatched"),
+            ("source_generation", pending.source_generation + 1),
+        ):
+            with self.subTest(continuity="present_stable", field=field):
+                mismatched = settle_effect(
+                    pending,
+                    replace(
+                        repair_observation(
+                            pending.episode_key,
+                            continuity=InflightContinuity.PRESENT_STABLE,
+                            source_id=pending.source_id,
+                            source_generation=pending.source_generation,
+                            durable_anchor=pending.durable_anchor,
+                            observed_at=now,
+                        ),
+                        **{field: value},
+                    ),
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=None,
+                    now=now,
+                )
+                self.assertFalse(mismatched.changed)
+                self.assertTrue(mismatched.must_reprobe)
+                self.assertEqual(mismatched.record, pending)
+                self.assertEqual(mismatched.reason, "continuity_identity_mismatch")
+
+        same_source_new_generation = settle_effect(
+            pending,
+            repair_observation(
+                "ep-successor",
+                continuity=InflightContinuity.REPLACED,
+                source_id=pending.source_id,
+                source_generation=pending.source_generation + 1,
+                durable_anchor="anchor-new-generation",
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertTrue(same_source_new_generation.changed)
+        self.assertEqual(
+            same_source_new_generation.record.outcome, LedgerOutcome.SUPERSEDED
+        )
+
+        new_source_same_generation = settle_effect(
+            pending,
+            repair_observation(
+                "ep-successor",
+                continuity=InflightContinuity.REPLACED,
+                source_id="source-successor",
+                source_generation=pending.source_generation,
+                durable_anchor="anchor-new-source",
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertTrue(new_source_same_generation.changed)
+        self.assertEqual(
+            new_source_same_generation.record.outcome, LedgerOutcome.SUPERSEDED
+        )
+
+        stable_identity = settle_effect(
+            pending,
+            repair_observation(
+                pending.episode_key,
+                continuity=InflightContinuity.PRESENT_STABLE,
+                source_id=pending.source_id,
+                source_generation=pending.source_generation,
+                durable_anchor=pending.durable_anchor,
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=pending.baseline_source,
+                committed_frontier=pending.baseline_delivered,
+                source_id=pending.source_id,
+                source_generation=pending.source_generation,
+                durable_anchor=pending.durable_anchor,
+            ),
+            now=now,
+        )
+        self.assertTrue(stable_identity.changed)
+        self.assertEqual(stable_identity.record.outcome, LedgerOutcome.NO_PROGRESS)
 
     def test_ledger_entrypoints_reject_truthy_string_boolean_flags(self) -> None:
         reserved, pending = self._reserve_and_mark()
@@ -946,7 +1088,7 @@ class LedgerFaultTests(unittest.TestCase):
         )
         self.assertFalse(wrong_generation.changed)
         self.assertEqual(
-            wrong_generation.reason, "delivery_proof_record_identity_mismatch"
+            wrong_generation.reason, "continuity_identity_mismatch"
         )
 
     def test_delivery_proof_requires_action_time_observation_and_possible_frontier(self) -> None:

--- a/scripts/relay_w1a/tests/test_model.py
+++ b/scripts/relay_w1a/tests/test_model.py
@@ -1,0 +1,1816 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from model import (  # noqa: E402
+    AllowedAction,
+    ClockStamp,
+    DeliveryProof,
+    DispositionKind,
+    InflightContinuity,
+    LedgerOutcome,
+    LedgerState,
+    MAX_U64,
+    Observation,
+    QueueDisposition,
+    RangeKind,
+    SourceRange,
+    TerminationProof,
+    Verdict,
+    advance_committed_frontier,
+    assess,
+    clock_allows_transition,
+    commit_dispositions,
+    load_ledger_json,
+    mark_effect_pending,
+    normalized_body_sha256,
+    plan_bounded_batch,
+    recover_after_crash,
+    reserve_attempt,
+    serialize_planned_disposition,
+    settle_effect,
+    validate_evidence_bundle,
+)
+
+
+FIXTURES = ROOT / "fixtures" / "incidents.json"
+
+
+def fixture_data() -> dict:
+    return json.loads(FIXTURES.read_text(encoding="utf-8"))
+
+
+def observation_from_fixture(raw: dict) -> Observation:
+    values = dict(raw)
+    values["continuity"] = InflightContinuity(values.get("continuity", "present_stable"))
+    values["queue"] = QueueDisposition(values.get("queue", "active"))
+    if isinstance(values.get("observed_at"), dict):
+        values["observed_at"] = ClockStamp(**values["observed_at"])
+    if isinstance(values.get("termination_proof"), dict):
+        proof = dict(values["termination_proof"])
+        proof["queue"] = QueueDisposition(proof["queue"])
+        proof["action_reprobe_at"] = ClockStamp(**proof["action_reprobe_at"])
+        values["termination_proof"] = TerminationProof(**proof)
+    return Observation(**values)
+
+
+def repair_observation(
+    episode: str = "ep-ledger",
+    *,
+    continuity: InflightContinuity = InflightContinuity.PRESENT_STABLE,
+    source_id: str = "source-ledger",
+    source_generation: int = 1,
+    durable_anchor: str = "anchor-10",
+    observed_at: ClockStamp | None = None,
+    delivery_progress: bool = False,
+    queue: QueueDisposition = QueueDisposition.ACTIVE,
+) -> Observation:
+    return Observation(
+        episode_key=episode,
+        source_id=source_id,
+        source_generation=source_generation,
+        durable_anchor=durable_anchor,
+        observed_at=observed_at,
+        continuity=continuity,
+        queue=queue,
+        source_progress=True,
+        delivery_progress=delivery_progress,
+        control_contradiction=True,
+    )
+
+
+def delivery_proof(
+    episode: str,
+    *,
+    now: ClockStamp,
+    source_frontier: int,
+    committed_frontier: int,
+    source_id: str = "source-ledger",
+    source_generation: int = 1,
+    durable_anchor: str | None = None,
+    queue: QueueDisposition = QueueDisposition.ACTIVE,
+) -> DeliveryProof:
+    return DeliveryProof(
+        episode_key=episode,
+        source_id=source_id,
+        source_generation=source_generation,
+        durable_anchor=durable_anchor or f"anchor-{committed_frontier}",
+        source_frontier=source_frontier,
+        committed_frontier=committed_frontier,
+        queue=queue,
+        observed_at=now,
+    )
+
+
+def execute_fault_fixture(case: dict) -> dict:
+    operation = case["operation"]
+    inputs = case["input"]
+    if operation in {"recover_reserved", "recover_pending", "pending_continuity"}:
+        episode = inputs["episode"]
+        reserved_at = ClockStamp(10_000, "fixture-boot", 100)
+        observation = repair_observation(
+            episode,
+            observed_at=reserved_at,
+        )
+        reserved = reserve_attempt(
+            None,
+            observation,
+            attempt_id="fixture-attempt",
+            delivery_proof=delivery_proof(
+                episode,
+                now=reserved_at,
+                source_frontier=inputs.get("source", 100),
+                committed_frontier=inputs.get("delivered", 10),
+            ),
+            now=reserved_at,
+        ).record
+        if operation == "recover_reserved":
+            transition = recover_after_crash(
+                reserved,
+                repair_observation(episode),
+                attempt_id=reserved.attempt_id,
+            )
+        else:
+            pending = mark_effect_pending(
+                reserved,
+                attempt_id=reserved.attempt_id,
+                now=ClockStamp(10_001, "fixture-boot", 101),
+            ).record
+            if operation == "recover_pending":
+                transition = recover_after_crash(
+                    pending, attempt_id=pending.attempt_id
+                )
+            else:
+                now = ClockStamp(10_002, "fixture-boot", 102)
+                continuity = InflightContinuity(inputs["continuity"])
+                transition = settle_effect(
+                    pending,
+                    repair_observation(
+                        episode,
+                        continuity=continuity,
+                        observed_at=now,
+                    ),
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=delivery_proof(
+                        episode,
+                        now=now,
+                        source_frontier=101,
+                        committed_frontier=10,
+                    ),
+                    now=now,
+                )
+        return {
+            "changed": transition.changed,
+            "state": transition.record.state.value,
+            "attempts_spent": transition.record.attempts_spent,
+            "must_reprobe": transition.must_reprobe,
+        }
+    if operation == "circuit_rearm":
+        episode = inputs["episode"]
+        record = None
+        for index in range(2):
+            reserve_now = ClockStamp(
+                1_000_000 + index * 700_000,
+                "fixture-boot",
+                10_000 + index * 700_000,
+            )
+            reserve_anchor = "anchor-10"
+            reserved = reserve_attempt(
+                record,
+                repair_observation(
+                    episode,
+                    observed_at=reserve_now,
+                    durable_anchor=reserve_anchor,
+                ),
+                attempt_id=f"fixture-attempt-{index}",
+                delivery_proof=delivery_proof(
+                    episode,
+                    now=reserve_now,
+                    source_frontier=100 + index * 100,
+                    committed_frontier=10,
+                    durable_anchor=reserve_anchor,
+                ),
+                now=reserve_now,
+            ).record
+            pending = mark_effect_pending(
+                reserved,
+                attempt_id=reserved.attempt_id,
+                now=ClockStamp(
+                    reserve_now.wall_ms + 1,
+                    reserve_now.boot_id,
+                    reserve_now.monotonic_ms + 1,
+                ),
+            ).record
+            settle_now = ClockStamp(
+                reserve_now.wall_ms + 10,
+                reserve_now.boot_id,
+                reserve_now.monotonic_ms + 10,
+            )
+            record = settle_effect(
+                pending,
+                repair_observation(
+                    episode,
+                    observed_at=settle_now,
+                    durable_anchor=reserve_anchor,
+                ),
+                attempt_id=pending.attempt_id,
+                delivery_proof=delivery_proof(
+                    episode,
+                    now=settle_now,
+                    source_frontier=200 + index * 100,
+                    committed_frontier=10,
+                    durable_anchor=reserve_anchor,
+                ),
+                now=settle_now,
+            ).record
+        delivered_after = inputs["delivered_after"]
+        rearm_now = ClockStamp(3_000_000, "fixture-boot", 2_010_000)
+        anchor = f"anchor-{delivered_after}"
+        transition = reserve_attempt(
+            record,
+            repair_observation(
+                episode,
+                observed_at=rearm_now,
+                durable_anchor=anchor,
+                delivery_progress=delivered_after > record.baseline_delivered,
+            ),
+            attempt_id="fixture-attempt-rearm",
+            delivery_proof=delivery_proof(
+                episode,
+                now=rearm_now,
+                source_frontier=999,
+                committed_frontier=delivered_after,
+                durable_anchor=anchor,
+            ),
+            now=rearm_now,
+        )
+        return {
+            "changed": transition.changed,
+            "reason": transition.reason,
+            "lifetime_no_effect_count": transition.record.lifetime_no_effect_count,
+        }
+    if operation == "clock_transition":
+        return {
+            "allowed": clock_allows_transition(
+                ClockStamp(**inputs["previous"]),
+                ClockStamp(**inputs["current"]),
+                trusted_now=ClockStamp(**inputs["trusted_now"]),
+                max_future_skew_ms=inputs["max_future_skew_ms"],
+            )
+        }
+    if operation == "load_ledger":
+        loaded = load_ledger_json(
+            inputs["raw"], trusted_now=ClockStamp(20_000, "fixture-boot", 200)
+        )
+        return {"fail_closed": loaded.fail_closed, "reason": loaded.reason}
+    if operation == "plan_single_range":
+        body = "x" * inputs["body_bytes"]
+        source_range = SourceRange(
+            "fixture-range",
+            0,
+            len(body),
+            RangeKind(inputs["kind"]),
+            body,
+        )
+        plan = plan_bounded_batch(
+            [source_range],
+            start_cursor=0,
+            max_pending_items=inputs["max_items"],
+            max_pending_bytes=inputs["max_bytes"],
+        )
+        result = {
+            "processed_end": plan.processed_end,
+            "blocked_reason": plan.blocked_reason,
+            "dispositions": len(plan.dispositions),
+        }
+        if plan.dispositions:
+            committed = commit_dispositions(plan, {0: ["9001"]})
+            result["committed_frontier"] = advance_committed_frontier(0, committed)
+        return result
+    raise AssertionError(f"unknown executable fixture operation: {operation}")
+
+
+class AuthorityFixtureTests(unittest.TestCase):
+    def test_incident_authority_matrix(self) -> None:
+        for case in fixture_data()["authority_cases"]:
+            with self.subTest(case=case["name"]):
+                result = assess(observation_from_fixture(case["observation"]))
+                self.assertEqual(
+                    None if result.candidate is None else result.candidate.value,
+                    case["expected_candidate"],
+                )
+                self.assertEqual(result.action.value, case["expected_action"])
+                self.assertEqual(result.may_spend_automatic_action, case["expected_spend"])
+
+    def test_producer_dead_requires_episode_bound_proof_and_safe_queue(self) -> None:
+        now = ClockStamp(1_000, "boot-proof", 10)
+        for has_proof in (False, True):
+            for queue in QueueDisposition:
+                proof = (
+                    TerminationProof(
+                        episode_key="ep-proof-matrix",
+                        source_id="source-proof",
+                        source_generation=7,
+                        durable_anchor="anchor-proof",
+                        queue=queue,
+                        termination_id="termination-proof",
+                        finalizer_committed=True,
+                        watcher_stopped=True,
+                        action_reprobe_at=now,
+                    )
+                    if has_proof
+                    else None
+                )
+                result = assess(
+                    Observation(
+                        episode_key="ep-proof-matrix",
+                        source_id="source-proof",
+                        source_generation=7,
+                        durable_anchor="anchor-proof",
+                        observed_at=now,
+                        termination_proof=proof,
+                        queue=queue,
+                    )
+                )
+                expected_dead = has_proof and queue in {
+                    QueueDisposition.IDLE,
+                    QueueDisposition.TERMINAL,
+                }
+                self.assertEqual(result.candidate is Verdict.PRODUCER_DEAD, expected_dead)
+
+    def test_failed_repairs_never_mutate_quiet_into_death(self) -> None:
+        for count in (0, 1, 2, 100):
+            result = assess(
+                Observation(
+                    episode_key="ep-failed-repairs",
+                    queue=QueueDisposition.ACTIVE,
+                    failed_repairs=count,
+                )
+            )
+            self.assertIsNone(result.candidate)
+            self.assertEqual(result.action, AllowedAction.NONE)
+
+    def test_boolean_termination_claim_is_not_episode_bound_proof(self) -> None:
+        result = assess(
+            Observation(
+                episode_key="ep-unbound-termination",
+                affirmative_termination=True,
+                queue=QueueDisposition.TERMINAL,
+            )
+        )
+        self.assertIsNone(result.candidate)
+        self.assertEqual(result.action, AllowedAction.NONE)
+
+    def test_termination_proof_requires_exact_identity_and_action_reprobe(self) -> None:
+        now = ClockStamp(5_000, "boot-proof", 50)
+        proof = TerminationProof(
+            episode_key="ep-exact",
+            source_id="source-exact",
+            source_generation=9,
+            durable_anchor="anchor-exact",
+            queue=QueueDisposition.TERMINAL,
+            termination_id="termination-exact",
+            finalizer_committed=True,
+            watcher_stopped=True,
+            action_reprobe_at=now,
+        )
+
+        def observe(candidate: TerminationProof) -> Observation:
+            return Observation(
+                episode_key="ep-exact",
+                source_id="source-exact",
+                source_generation=9,
+                durable_anchor="anchor-exact",
+                observed_at=now,
+                queue=QueueDisposition.TERMINAL,
+                termination_proof=candidate,
+            )
+
+        self.assertEqual(assess(observe(proof)).candidate, Verdict.PRODUCER_DEAD)
+        for mutant in (
+            replace(proof, episode_key="ep-other"),
+            replace(proof, source_id="source-other"),
+            replace(proof, source_generation=10),
+            replace(proof, durable_anchor="anchor-other"),
+            replace(proof, action_reprobe_at=ClockStamp(4_999, "boot-proof", 49)),
+            replace(proof, finalizer_committed=False),
+            replace(proof, watcher_stopped=False),
+        ):
+            with self.subTest(mutant=mutant):
+                self.assertIsNone(assess(observe(mutant)).candidate)
+
+    def test_untyped_observation_enums_never_authorize_an_action(self) -> None:
+        base = Observation(
+            episode_key="ep-untyped",
+            source_progress=True,
+            control_contradiction=True,
+        )
+        for mutant in (
+            replace(base, continuity="present_stable"),
+            replace(base, queue="active"),
+        ):
+            with self.subTest(mutant=mutant):
+                result = assess(mutant)
+                self.assertIsNone(result.candidate)
+                self.assertEqual(result.action, AllowedAction.NONE)
+
+
+class LedgerFaultTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.t0 = ClockStamp(1_000_000, "boot-a", 10_000)
+
+    def _reserve_and_mark(
+        self,
+        record=None,
+        *,
+        episode: str = "ep-ledger",
+        source: int = 100,
+        delivered: int = 10,
+        wall: int = 1_000_000,
+        mono: int = 10_000,
+        attempt: str = "attempt-1",
+    ):
+        reserved_at = ClockStamp(wall, "boot-a", mono)
+        anchor = f"anchor-{delivered}"
+        reserved = reserve_attempt(
+            record,
+            repair_observation(
+                episode,
+                durable_anchor=anchor,
+                observed_at=reserved_at,
+                delivery_progress=(
+                    record is not None and delivered > record.baseline_delivered
+                ),
+            ),
+            attempt_id=attempt,
+            delivery_proof=delivery_proof(
+                episode,
+                now=reserved_at,
+                source_frontier=source,
+                committed_frontier=delivered,
+                durable_anchor=anchor,
+            ),
+            now=reserved_at,
+        )
+        self.assertTrue(reserved.changed, reserved.reason)
+        self.assertEqual(reserved.spent_delta, 0)
+        pending = mark_effect_pending(
+            reserved.record,
+            attempt_id=attempt,
+            now=ClockStamp(wall + 1, "boot-a", mono + 1),
+        )
+        self.assertTrue(pending.changed, pending.reason)
+        self.assertEqual(pending.spent_delta, 1)
+        return reserved.record, pending.record
+
+    def _settle_pending(
+        self,
+        pending,
+        *,
+        source: int,
+        delivered: int,
+        wall: int,
+        mono: int,
+        continuity: InflightContinuity = InflightContinuity.PRESENT_STABLE,
+    ):
+        now = ClockStamp(wall, "boot-a", mono)
+        anchor = f"anchor-{delivered}"
+        progressed = delivered > pending.baseline_delivered
+        return settle_effect(
+            pending,
+            repair_observation(
+                pending.episode_key,
+                continuity=continuity,
+                durable_anchor=anchor,
+                observed_at=now,
+                delivery_progress=progressed,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=source,
+                committed_frontier=delivered,
+                durable_anchor=anchor,
+            ),
+            now=now,
+        )
+
+    def test_reserved_crash_cancels_without_action_spend(self) -> None:
+        reserved, _ = self._reserve_and_mark()
+        recovered = recover_after_crash(
+            reserved, repair_observation(), attempt_id=reserved.attempt_id
+        )
+        self.assertEqual(recovered.record.state, LedgerState.SETTLED)
+        self.assertEqual(recovered.record.outcome, LedgerOutcome.INCONCLUSIVE)
+        self.assertEqual(recovered.record.attempts_spent, 0)
+        self.assertFalse(recovered.must_reprobe)
+
+    def test_reserved_crash_waits_for_exact_stable_reprobe(self) -> None:
+        reserved, _ = self._reserve_and_mark()
+        for observation in (
+            None,
+            repair_observation(continuity=InflightContinuity.MISSING),
+            repair_observation("ep-successor"),
+        ):
+            recovered = recover_after_crash(
+                reserved, observation, attempt_id=reserved.attempt_id
+            )
+            self.assertFalse(recovered.changed)
+            self.assertTrue(recovered.must_reprobe)
+            self.assertEqual(recovered.record.state, LedgerState.RESERVED)
+
+    def test_effect_pending_crash_never_replays_without_reprobe(self) -> None:
+        _, pending = self._reserve_and_mark()
+        recovered = recover_after_crash(pending, attempt_id=pending.attempt_id)
+        self.assertFalse(recovered.changed)
+        self.assertTrue(recovered.must_reprobe)
+        self.assertEqual(recovered.record.attempts_spent, 1)
+
+    def test_effect_pending_cannot_be_overwritten_by_a_new_reservation(self) -> None:
+        _, pending = self._reserve_and_mark()
+        for episode in (pending.episode_key, "ep-successor-before-settle"):
+            now = ClockStamp(1_000_010, "boot-a", 10_010)
+            second = reserve_attempt(
+                pending,
+                repair_observation(
+                    episode,
+                    durable_anchor="anchor-10",
+                    observed_at=now,
+                ),
+                attempt_id="attempt-2",
+                delivery_proof=delivery_proof(
+                    episode,
+                    now=now,
+                    source_frontier=101,
+                    committed_frontier=10,
+                ),
+                now=now,
+            )
+            with self.subTest(episode=episode):
+                self.assertFalse(second.changed)
+                self.assertTrue(second.must_reprobe)
+                self.assertEqual(second.record, pending)
+                self.assertEqual(second.record.attempts_spent, 1)
+
+    def test_attempt_cas_pins_mark_recover_and_settle(self) -> None:
+        reserved, pending = self._reserve_and_mark()
+        wrong_mark = mark_effect_pending(
+            reserved,
+            attempt_id="wrong-attempt",
+            now=ClockStamp(1_000_001, "boot-a", 10_001),
+        )
+        self.assertFalse(wrong_mark.changed)
+        self.assertTrue(wrong_mark.must_reprobe)
+        wrong_recover = recover_after_crash(
+            pending, attempt_id="wrong-attempt"
+        )
+        self.assertFalse(wrong_recover.changed)
+        self.assertTrue(wrong_recover.must_reprobe)
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        wrong_settle = settle_effect(
+            pending,
+            repair_observation(observed_at=now),
+            attempt_id="wrong-attempt",
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=200,
+                committed_frontier=10,
+            ),
+            now=now,
+        )
+        self.assertFalse(wrong_settle.changed)
+        self.assertTrue(wrong_settle.must_reprobe)
+
+    def test_successor_settlement_requires_complete_action_time_identity(self) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        incomplete = settle_effect(
+            pending,
+            Observation(episode_key="ep-successor", observed_at=None),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertFalse(incomplete.changed)
+        self.assertTrue(incomplete.must_reprobe)
+        self.assertEqual(incomplete.reason, "successor_identity_inconclusive")
+
+        complete = settle_effect(
+            pending,
+            repair_observation(
+                "ep-successor",
+                continuity=InflightContinuity.REPLACED,
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertTrue(complete.changed)
+        self.assertEqual(complete.record.outcome, LedgerOutcome.SUPERSEDED)
+
+    def test_delivery_proof_requires_generation_and_anchor_advance(self) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        observation = repair_observation(
+            durable_anchor=pending.durable_anchor,
+            observed_at=now,
+            delivery_progress=True,
+        )
+        unchanged_anchor = settle_effect(
+            pending,
+            observation,
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=200,
+                committed_frontier=11,
+                durable_anchor=pending.durable_anchor,
+            ),
+            now=now,
+        )
+        self.assertFalse(unchanged_anchor.changed)
+        self.assertEqual(unchanged_anchor.reason, "delivery_anchor_did_not_advance")
+
+        wrong_generation = settle_effect(
+            pending,
+            replace(observation, durable_anchor="anchor-11", source_generation=2),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=200,
+                committed_frontier=11,
+                durable_anchor="anchor-11",
+                source_generation=2,
+            ),
+            now=now,
+        )
+        self.assertFalse(wrong_generation.changed)
+        self.assertEqual(
+            wrong_generation.reason, "delivery_proof_record_identity_mismatch"
+        )
+
+    def test_delivery_proof_requires_action_time_observation_and_possible_frontier(self) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        stale = settle_effect(
+            pending,
+            repair_observation(observed_at=ClockStamp(1_000_099, "boot-a", 10_099)),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=200,
+                committed_frontier=10,
+            ),
+            now=now,
+        )
+        self.assertFalse(stale.changed)
+        self.assertEqual(stale.reason, "delivery_observation_not_action_time")
+
+        impossible = settle_effect(
+            pending,
+            repair_observation(
+                durable_anchor="anchor-201",
+                observed_at=now,
+                delivery_progress=True,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=200,
+                committed_frontier=201,
+                durable_anchor="anchor-201",
+            ),
+            now=now,
+        )
+        self.assertFalse(impossible.changed)
+        self.assertEqual(impossible.reason, "delivery_proof_malformed")
+
+    def test_unproved_integer_frontier_cannot_rearm_open_circuit(self) -> None:
+        record = None
+        for index in range(2):
+            wall = 1_000_000 + index * 700_000
+            _, pending = self._reserve_and_mark(
+                record,
+                source=100 + index * 100,
+                wall=wall,
+                mono=10_000 + index * 700_000,
+                attempt=f"attempt-proof-{index}",
+            )
+            record = self._settle_pending(
+                pending,
+                source=200 + index * 100,
+                delivered=10,
+                wall=wall + 10,
+                mono=10_010 + index * 700_000,
+            ).record
+        self.assertTrue(record.circuit_open)
+
+        unproved = reserve_attempt(
+            record,
+            repair_observation(
+                durable_anchor="anchor-11",
+                observed_at=ClockStamp(3_000_000, "boot-a", 2_010_000),
+                delivery_progress=True,
+            ),
+            attempt_id="attempt-unproved-frontier",
+            delivery_proof=None,
+            now=ClockStamp(3_000_000, "boot-a", 2_010_000),
+        )
+        self.assertFalse(unproved.changed)
+        self.assertEqual(unproved.reason, "delivery_proof_required")
+
+    def test_settle_rejects_frontier_growth_without_valid_identity_and_queue(self) -> None:
+        _, pending = self._reserve_and_mark()
+        invalid = settle_effect(
+            pending,
+            Observation(
+                episode_key=pending.episode_key,
+                source_id=pending.source_id,
+                source_generation=pending.source_generation,
+                durable_anchor="anchor-11",
+                observed_at=ClockStamp(1_000_100, "boot-a", 10_100),
+                identity_complete=False,
+                clock_valid=False,
+                queue=QueueDisposition.UNKNOWN,
+                delivery_progress=False,
+                control_contradiction=True,
+                source_progress=True,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=ClockStamp(1_000_100, "boot-a", 10_100),
+                source_frontier=200,
+                committed_frontier=11,
+                durable_anchor="anchor-11",
+                queue=QueueDisposition.UNKNOWN,
+            ),
+            now=ClockStamp(1_000_100, "boot-a", 10_100),
+        )
+        self.assertFalse(invalid.changed)
+        self.assertTrue(invalid.must_reprobe)
+
+    def test_4104_missing_or_reappeared_reserves_nothing(self) -> None:
+        for continuity in (
+            InflightContinuity.MISSING,
+            InflightContinuity.REAPPEARED_SAME,
+        ):
+            transition = reserve_attempt(
+                None,
+                repair_observation(
+                    continuity=continuity,
+                    observed_at=self.t0,
+                ),
+                attempt_id="forbidden",
+                delivery_proof=delivery_proof(
+                    "ep-ledger",
+                    now=self.t0,
+                    source_frontier=100,
+                    committed_frontier=10,
+                ),
+                now=self.t0,
+            )
+            self.assertFalse(transition.changed)
+            self.assertEqual(transition.spent_delta, 0)
+            self.assertIsNone(transition.record)
+
+    def test_4104_missing_pending_freezes_without_settlement_or_respend(self) -> None:
+        _, pending = self._reserve_and_mark()
+        frozen = self._settle_pending(
+            pending,
+            source=200,
+            delivered=10,
+            wall=1_000_100,
+            mono=10_100,
+            continuity=InflightContinuity.MISSING,
+        )
+        self.assertFalse(frozen.changed)
+        self.assertTrue(frozen.must_reprobe)
+        self.assertEqual(frozen.record, pending)
+        self.assertEqual(frozen.spent_delta, 0)
+
+    def test_unknown_continuity_cannot_settle_or_rearm(self) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_010, "boot-a", 10_010)
+        observation = replace(
+            repair_observation(
+                pending.episode_key,
+                durable_anchor="anchor-11",
+                observed_at=now,
+                delivery_progress=True,
+            ),
+            continuity="future_continuity",
+        )
+        transition = settle_effect(
+            pending,
+            observation,
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=101,
+                committed_frontier=11,
+                durable_anchor="anchor-11",
+            ),
+            now=now,
+        )
+        self.assertFalse(transition.changed)
+        self.assertTrue(transition.must_reprobe)
+        self.assertEqual(transition.reason, "continuity_not_typed")
+        self.assertEqual(transition.record.state, LedgerState.EFFECT_PENDING)
+        self.assertEqual(transition.record.baseline_delivered, 10)
+
+    def test_4104_e22_missing_reappearing_sequence_preserves_episode(self) -> None:
+        episode = "ep-4104-e22"
+        _, pending = self._reserve_and_mark(episode=episode, attempt="attempt-e22")
+        original = pending
+        for offset, continuity in enumerate(
+            (
+                InflightContinuity.MISSING,
+                InflightContinuity.REAPPEARED_SAME,
+            )
+        ):
+            frozen = self._settle_pending(
+                pending,
+                source=150 + offset,
+                delivered=10,
+                wall=1_000_100 + offset,
+                mono=10_100 + offset,
+                continuity=continuity,
+            )
+            self.assertFalse(frozen.changed)
+            self.assertTrue(frozen.must_reprobe)
+            self.assertEqual(frozen.record, original)
+            self.assertEqual(frozen.record.attempts_spent, 1)
+            self.assertEqual(frozen.record.failure_streak, 0)
+            pending = frozen.record
+
+        completed = self._settle_pending(
+            pending,
+            source=200,
+            delivered=11,
+            wall=1_000_102,
+            mono=10_102,
+        )
+        self.assertTrue(completed.changed)
+        self.assertEqual(completed.record.state, LedgerState.SETTLED)
+        self.assertEqual(
+            completed.record.outcome, LedgerOutcome.VERIFIED_DELIVERY_PROGRESS
+        )
+        self.assertEqual(completed.record.attempts_spent, 1)
+        self.assertEqual(completed.record.failure_streak, 0)
+
+    def test_source_only_progress_never_rearms_same_episode_circuit(self) -> None:
+        record = None
+        for index in range(2):
+            wall = 1_000_000 + index * 700_000
+            _, pending = self._reserve_and_mark(
+                record,
+                source=100 + index * 100,
+                delivered=10,
+                wall=wall,
+                mono=10_000 + index * 700_000,
+                attempt=f"attempt-{index}",
+            )
+            settled = self._settle_pending(
+                pending,
+                source=200 + index * 100,
+                delivered=10,
+                wall=wall + 10,
+                mono=10_010 + index * 700_000,
+            )
+            self.assertEqual(settled.record.outcome, LedgerOutcome.NO_PROGRESS)
+            record = settled.record
+        self.assertTrue(record.circuit_open)
+
+        blocked = reserve_attempt(
+            record,
+            repair_observation(
+                observed_at=ClockStamp(3_000_000, "boot-a", 2_010_000)
+            ),
+            attempt_id="attempt-source-only-third",
+            delivery_proof=delivery_proof(
+                record.episode_key,
+                now=ClockStamp(3_000_000, "boot-a", 2_010_000),
+                source_frontier=10_000,
+                committed_frontier=10,
+            ),
+            now=ClockStamp(3_000_000, "boot-a", 2_010_000),
+        )
+        self.assertFalse(blocked.changed)
+        self.assertEqual(blocked.reason, "same_episode_circuit_open")
+
+    def test_delivery_progress_rearms_open_same_episode(self) -> None:
+        record = None
+        for index in range(2):
+            wall = 1_000_000 + index * 700_000
+            _, pending = self._reserve_and_mark(
+                record,
+                source=100 + index * 100,
+                wall=wall,
+                mono=10_000 + index * 700_000,
+                attempt=f"attempt-open-{index}",
+            )
+            record = self._settle_pending(
+                pending,
+                source=200 + index * 100,
+                delivered=10,
+                wall=wall + 10,
+                mono=10_010 + index * 700_000,
+            ).record
+        self.assertTrue(record.circuit_open)
+
+        rearmed = reserve_attempt(
+            record,
+            repair_observation(
+                durable_anchor="anchor-11",
+                observed_at=ClockStamp(3_000_000, "boot-a", 2_010_000),
+                delivery_progress=True,
+            ),
+            attempt_id="attempt-after-delivery",
+            delivery_proof=delivery_proof(
+                record.episode_key,
+                now=ClockStamp(3_000_000, "boot-a", 2_010_000),
+                source_frontier=999,
+                committed_frontier=11,
+                durable_anchor="anchor-11",
+            ),
+            now=ClockStamp(3_000_000, "boot-a", 2_010_000),
+        )
+        self.assertTrue(rearmed.changed, rearmed.reason)
+        self.assertEqual(rearmed.record.lifetime_no_effect_count, 0)
+        self.assertEqual(rearmed.record.failure_streak, 0)
+        self.assertEqual(rearmed.record.baseline_delivered, 11)
+
+    def test_new_episode_has_independent_budget(self) -> None:
+        _, pending = self._reserve_and_mark()
+        old = self._settle_pending(
+            pending,
+            source=200,
+            delivered=10,
+            wall=1_000_100,
+            mono=10_100,
+        ).record
+        successor_now = ClockStamp(1_700_000, "boot-a", 710_000)
+        new = reserve_attempt(
+            old,
+            repair_observation(
+                "ep-successor",
+                durable_anchor="anchor-0",
+                observed_at=successor_now,
+            ),
+            attempt_id="successor-attempt",
+            delivery_proof=delivery_proof(
+                "ep-successor",
+                now=successor_now,
+                source_frontier=0,
+                committed_frontier=0,
+                durable_anchor="anchor-0",
+            ),
+            now=successor_now,
+        )
+        self.assertTrue(new.changed)
+        self.assertEqual(new.record.episode_key, "ep-successor")
+        self.assertEqual(new.record.lifetime_no_effect_count, 0)
+        self.assertEqual(new.record.attempts_spent, 0)
+
+    def test_clock_rollback_future_and_monotonic_regression_fail_closed(self) -> None:
+        previous = ClockStamp(10_000, "boot-a", 500)
+        self.assertFalse(clock_allows_transition(previous, ClockStamp(9_999, "boot-b", 1)))
+        self.assertFalse(clock_allows_transition(previous, ClockStamp(9_999, "boot-a", 501)))
+        self.assertFalse(clock_allows_transition(previous, ClockStamp(10_001, "boot-a", 499)))
+        self.assertTrue(clock_allows_transition(previous, ClockStamp(10_001, "boot-a", 501)))
+
+    def test_clock_rejects_u64_overflow(self) -> None:
+        maximum = (1 << 64) - 1
+        previous = ClockStamp(maximum, "boot-a", maximum)
+        self.assertFalse(
+            clock_allows_transition(
+                previous,
+                ClockStamp(maximum + 1, "boot-b", maximum + 1),
+            )
+        )
+
+    def test_clock_rejects_across_boot_future_beyond_injected_skew(self) -> None:
+        trusted_now = ClockStamp(10_000, "boot-current", 500)
+        self.assertFalse(
+            clock_allows_transition(
+                ClockStamp(9_000, "boot-old", 999_999),
+                ClockStamp(1_000_000, "boot-new", 1),
+                trusted_now=trusted_now,
+                max_future_skew_ms=100,
+            )
+        )
+
+    def test_clock_rejects_same_boot_future_monotonic_against_injected_now(self) -> None:
+        trusted_now = ClockStamp(10_000, "boot-a", 100)
+        future = ClockStamp(10_000, "boot-a", 300_101)
+        self.assertFalse(
+            clock_allows_transition(future, future, trusted_now=trusted_now)
+        )
+
+    def test_u64_attempt_and_failure_counters_fail_closed(self) -> None:
+        reserved, pending = self._reserve_and_mark()
+        exhausted = mark_effect_pending(
+            replace(reserved, attempts_spent=MAX_U64),
+            attempt_id=reserved.attempt_id,
+            now=ClockStamp(1_000_001, "boot-a", 10_001),
+        )
+        self.assertFalse(exhausted.changed)
+        self.assertEqual(exhausted.reason, "attempt_counter_overflow")
+
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        overflow = settle_effect(
+            replace(
+                pending,
+                failure_streak=MAX_U64,
+                lifetime_no_effect_count=MAX_U64,
+                attempts_spent=MAX_U64,
+            ),
+            repair_observation(observed_at=now),
+            attempt_id=pending.attempt_id,
+            delivery_proof=delivery_proof(
+                pending.episode_key,
+                now=now,
+                source_frontier=200,
+                committed_frontier=10,
+            ),
+            now=now,
+        )
+        self.assertFalse(overflow.changed)
+        self.assertEqual(overflow.reason, "backoff_clock_overflow")
+
+    def test_corrupt_future_and_legacy_ledger_fail_closed(self) -> None:
+        for raw, reason in (
+            ("{", "corrupt_json"),
+            ('{"schema_version": 2}', "future_or_unknown_schema"),
+            ('{"schema_version": 0}', "legacy_inconclusive"),
+            ('{"schema_version": 1}', "malformed_record"),
+        ):
+            loaded = load_ledger_json(raw, trusted_now=self.t0)
+            self.assertTrue(loaded.fail_closed)
+            self.assertIsNone(loaded.record)
+            self.assertEqual(loaded.reason, reason)
+
+    def test_valid_ledger_record_loads(self) -> None:
+        raw = json.dumps(
+            {
+                "schema_version": 1,
+                "attempt_id": "attempt-valid",
+                "episode_key": "episode-valid",
+                "source_id": "source-valid",
+                "source_generation": 1,
+                "durable_anchor": "anchor-valid",
+                "baseline_source": 10,
+                "baseline_delivered": 5,
+                "state": "settled",
+                "outcome": "inconclusive",
+                "failure_streak": 0,
+                "lifetime_no_effect_count": 0,
+                "attempts_spent": 0,
+                "retry_not_before_ms": None,
+                "clock_stamp": {
+                    "wall_ms": 1000,
+                    "boot_id": "boot-valid",
+                    "monotonic_ms": 10,
+                },
+            }
+        )
+        loaded = load_ledger_json(raw, trusted_now=self.t0)
+        self.assertFalse(loaded.fail_closed)
+        self.assertEqual(loaded.record.episode_key, "episode-valid")
+
+    def test_semantically_impossible_pending_ledger_fails_closed(self) -> None:
+        raw = json.dumps(
+            {
+                "schema_version": 1,
+                "attempt_id": "attempt-impossible",
+                "episode_key": "episode-impossible",
+                "source_id": "source-impossible",
+                "source_generation": 1,
+                "durable_anchor": "anchor-impossible",
+                "baseline_source": 10,
+                "baseline_delivered": 5,
+                "state": "effect_pending",
+                "outcome": "verified_delivery_progress",
+                "failure_streak": 0,
+                "lifetime_no_effect_count": 0,
+                "attempts_spent": 0,
+                "retry_not_before_ms": None,
+                "clock_stamp": {
+                    "wall_ms": 1000,
+                    "boot_id": "boot-valid",
+                    "monotonic_ms": 10,
+                },
+            }
+        )
+        loaded = load_ledger_json(raw, trusted_now=self.t0)
+        self.assertTrue(loaded.fail_closed)
+        self.assertIsNone(loaded.record)
+        self.assertEqual(loaded.reason, "semantic_invariant_violation")
+
+    def test_impossible_ledger_outcome_and_counter_combinations_fail_closed(self) -> None:
+        base = {
+            "schema_version": 1,
+            "attempt_id": "attempt-invariant",
+            "episode_key": "episode-invariant",
+            "source_id": "source-invariant",
+            "source_generation": 1,
+            "durable_anchor": "anchor-invariant",
+            "baseline_source": 10,
+            "baseline_delivered": 5,
+            "state": "settled",
+            "outcome": "inconclusive",
+            "failure_streak": 0,
+            "lifetime_no_effect_count": 0,
+            "attempts_spent": 0,
+            "retry_not_before_ms": None,
+            "clock_stamp": {
+                "wall_ms": 1000,
+                "boot_id": "boot-valid",
+                "monotonic_ms": 10,
+            },
+        }
+        mutations = {
+            "pending_without_unsettled_spend": {
+                "state": "effect_pending",
+                "attempts_spent": 1,
+                "failure_streak": 1,
+                "lifetime_no_effect_count": 1,
+            },
+            "verified_with_failure_counts": {
+                "outcome": "verified_delivery_progress",
+                "attempts_spent": 1,
+                "failure_streak": 1,
+                "lifetime_no_effect_count": 1,
+            },
+            "superseded_without_unsettled_spend": {
+                "outcome": "superseded",
+                "attempts_spent": 1,
+                "failure_streak": 1,
+                "lifetime_no_effect_count": 1,
+            },
+            "cancelled_reservation_with_retry": {
+                "retry_not_before_ms": 2000,
+            },
+            "failed_without_spend_or_retry": {
+                "outcome": "failed",
+            },
+            "no_progress_retry_before_settlement": {
+                "outcome": "no_progress",
+                "attempts_spent": 1,
+                "failure_streak": 1,
+                "lifetime_no_effect_count": 1,
+                "retry_not_before_ms": 999,
+            },
+        }
+        for name, mutation in mutations.items():
+            record = {**base, **mutation}
+            with self.subTest(name=name):
+                loaded = load_ledger_json(json.dumps(record), trusted_now=self.t0)
+                self.assertTrue(loaded.fail_closed)
+                self.assertIsNone(loaded.record)
+                self.assertEqual(loaded.reason, "semantic_invariant_violation")
+
+    def test_future_ledger_clock_fails_closed_against_injected_now(self) -> None:
+        raw = json.dumps(
+            {
+                "schema_version": 1,
+                "attempt_id": "attempt-future",
+                "episode_key": "episode-future",
+                "source_id": "source-future",
+                "source_generation": 1,
+                "durable_anchor": "anchor-future",
+                "baseline_source": 10,
+                "baseline_delivered": 5,
+                "state": "settled",
+                "outcome": "inconclusive",
+                "failure_streak": 0,
+                "lifetime_no_effect_count": 0,
+                "attempts_spent": 0,
+                "retry_not_before_ms": None,
+                "clock_stamp": {
+                    "wall_ms": self.t0.wall_ms + 300_001,
+                    "boot_id": "boot-future",
+                    "monotonic_ms": 1,
+                },
+            }
+        )
+        loaded = load_ledger_json(raw, trusted_now=self.t0)
+        self.assertTrue(loaded.fail_closed)
+        self.assertEqual(loaded.reason, "clock_fail_closed")
+
+    def test_every_fault_fixture_executes_and_matches_expected_transition(self) -> None:
+        cases = fixture_data()["fault_cases"]
+        self.assertGreaterEqual(len(cases), 10)
+        for case in cases:
+            with self.subTest(case=case.get("name")):
+                self.assertIsInstance(case.get("input"), dict)
+                self.assertIsInstance(case.get("expected"), dict)
+                actual = execute_fault_fixture(case)
+                for key, expected in case["expected"].items():
+                    self.assertIn(key, actual)
+                    self.assertEqual(actual[key], expected)
+
+
+class BackpressureTests(unittest.TestCase):
+    def test_batch_and_frontier_reject_untyped_bounds_and_dispositions(self) -> None:
+        entry = SourceRange("a", 0, 6, RangeKind.ASSISTANT_TEXT, "answer")
+        with self.assertRaisesRegex(ValueError, "u64 bounds"):
+            plan_bounded_batch(
+                [entry],
+                start_cursor=False,
+                max_pending_items=1,
+                max_pending_bytes=10,
+            )
+
+        plan = plan_bounded_batch(
+            [entry], start_cursor=0, max_pending_items=1, max_pending_bytes=10
+        )
+        committed = commit_dispositions(plan, {0: ["8001"]})
+        with self.assertRaisesRegex(ValueError, "unknown disposition"):
+            advance_committed_frontier(
+                0, [replace(committed[0], kind="future_disposition")]
+            )
+        with self.assertRaisesRegex(ValueError, "policy reason"):
+            advance_committed_frontier(
+                0, [replace(committed[0], policy_reason="arbitrary")]
+            )
+        with self.assertRaisesRegex(ValueError, "Discord evidence"):
+            advance_committed_frontier(
+                0, [replace(committed[0], discord_message_ids=())]
+            )
+        with self.assertRaisesRegex(ValueError, "exactly one Discord id"):
+            commit_dispositions(plan, {0: ["8001", "8002"]})
+
+    def test_commit_and_frontier_reject_arbitrary_discord_id_values(self) -> None:
+        entry = SourceRange("a", 0, 6, RangeKind.ASSISTANT_TEXT, "answer")
+        plan = plan_bounded_batch(
+            [entry], start_cursor=0, max_pending_items=1, max_pending_bytes=10
+        )
+        for invalid_ids in (
+            [None],
+            [True],
+            [{}],
+            [42],
+            ["not-a-snowflake"],
+            ["9" * 5000],
+            None,
+            "8001",
+        ):
+            with self.subTest(invalid_ids=invalid_ids):
+                with self.assertRaisesRegex(ValueError, "Discord"):
+                    commit_dispositions(plan, {0: invalid_ids})
+
+        committed = commit_dispositions(plan, {0: ["8001"]})
+        for invalid_id in (None, True, {}, 42, "not-a-snowflake"):
+            with self.subTest(frontier_id=invalid_id):
+                with self.assertRaisesRegex(ValueError, "Discord evidence"):
+                    advance_committed_frontier(
+                        0,
+                        [replace(committed[0], discord_message_ids=(invalid_id,))],
+                    )
+
+    def test_planner_rejects_actual_duplicate_marker_without_metadata(self) -> None:
+        marker = "[ADK-E2E:run:case:1:BEGIN]"
+        entry = SourceRange(
+            "a",
+            0,
+            len((marker + marker).encode("utf-8")),
+            RangeKind.ASSISTANT_TEXT,
+            marker + marker,
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate E2E marker"):
+            plan_bounded_batch(
+                [entry],
+                start_cursor=0,
+                max_pending_items=1,
+                max_pending_bytes=100,
+            )
+
+    def test_tool_bulk_is_summarized_with_bounded_memory_and_cursor_forward(self) -> None:
+        assistant = SourceRange("a", 0, 6, RangeKind.ASSISTANT_TEXT, "answer")
+        tool_one_body = "x" * 400
+        marker = "[ADK-E2E:run:bulk:1:END]"
+        tool_two_body = marker + "y" * (400 - len(marker))
+        tool_one = SourceRange("t1", 6, 406, RangeKind.TOOL_BULK, tool_one_body)
+        tool_two = SourceRange(
+            "t2",
+            406,
+            806,
+            RangeKind.TOOL_BULK,
+            tool_two_body,
+            marker,
+        )
+        plan = plan_bounded_batch(
+            [assistant, tool_one, tool_two],
+            start_cursor=0,
+            max_pending_items=3,
+            max_pending_bytes=390,
+        )
+        self.assertIsNone(plan.blocked_reason)
+        self.assertLessEqual(plan.admitted_items, 3)
+        self.assertLessEqual(plan.admitted_bytes, 390)
+        self.assertEqual(
+            [entry.kind for entry in plan.dispositions],
+            [DispositionKind.DELIVERED, DispositionKind.SUMMARIZED],
+        )
+        self.assertIn(marker, plan.dispositions[1].expected_body)
+        self.assertEqual(len(plan.dispositions[1].source_range_sha256s), 2)
+        self.assertEqual(plan.processed_end, 806)
+
+        committed = commit_dispositions(plan, {0: ["2001"], 1: ["2002"]})
+        self.assertEqual(advance_committed_frontier(0, committed), 806)
+
+    def test_uncommitted_summary_does_not_advance_frontier(self) -> None:
+        entry = SourceRange("t", 0, 500, RangeKind.TOOL_BULK, "x" * 500)
+        plan = plan_bounded_batch(
+            [entry], start_cursor=0, max_pending_items=1, max_pending_bytes=300
+        )
+        self.assertEqual(plan.dispositions[0].kind, DispositionKind.SUMMARIZED)
+        self.assertEqual(advance_committed_frontier(0, plan.dispositions), 0)
+
+    def test_oversized_assistant_blocks_without_cursor_advance(self) -> None:
+        entry = SourceRange("a", 10, 110, RangeKind.ASSISTANT_TEXT, "x" * 100)
+        plan = plan_bounded_batch(
+            [entry], start_cursor=10, max_pending_items=4, max_pending_bytes=50
+        )
+        self.assertEqual(plan.blocked_reason, "high_value_range_requires_utf8_safe_split")
+        self.assertEqual(plan.processed_end, 10)
+        self.assertEqual(plan.dispositions, ())
+
+    def test_control_omission_requires_durable_disposition_before_advance(self) -> None:
+        entry = SourceRange("c", 0, 4, RangeKind.CONTROL, "ctrl")
+        plan = plan_bounded_batch(
+            [entry], start_cursor=0, max_pending_items=1, max_pending_bytes=10
+        )
+        self.assertEqual(plan.dispositions[0].kind, DispositionKind.OMITTED_POLICY)
+        self.assertEqual(advance_committed_frontier(0, plan.dispositions), 0)
+        committed = commit_dispositions(plan, {})
+        self.assertEqual(advance_committed_frontier(0, committed), 4)
+
+    def test_oversized_tool_group_admits_bounded_prefix_and_explicit_suffix(self) -> None:
+        ranges = []
+        cursor = 0
+        for sequence in range(1, 9):
+            marker = f"[ADK-E2E:run:bulk-prefix:{sequence}:END]"
+            entry = SourceRange(
+                f"t{sequence}",
+                cursor,
+                cursor + len(marker),
+                RangeKind.TOOL_BULK,
+                marker,
+                marker,
+            )
+            ranges.append(entry)
+            cursor = entry.end
+        plan = plan_bounded_batch(
+            ranges,
+            start_cursor=0,
+            max_pending_items=1,
+            max_pending_bytes=240,
+        )
+        self.assertEqual(len(plan.dispositions), 1)
+        self.assertEqual(plan.dispositions[0].kind, DispositionKind.SUMMARIZED)
+        self.assertGreater(plan.processed_end, 0)
+        self.assertLess(plan.processed_end, cursor)
+        self.assertEqual(plan.blocked_reason, "bounded_tool_bulk_suffix")
+
+        remaining = [entry for entry in ranges if entry.start >= plan.processed_end]
+        next_plan = plan_bounded_batch(
+            remaining,
+            start_cursor=plan.processed_end,
+            max_pending_items=1,
+            max_pending_bytes=240,
+        )
+        self.assertGreater(next_plan.processed_end, plan.processed_end)
+
+    def test_frontier_rejects_duplicate_or_overlapping_committed_spans(self) -> None:
+        first = SourceRange("one", 0, 3, RangeKind.ASSISTANT_TEXT, "one")
+        plan = plan_bounded_batch(
+            [first], start_cursor=0, max_pending_items=1, max_pending_bytes=10
+        )
+        committed = commit_dispositions(plan, {0: ["7001"]})
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            advance_committed_frontier(0, [committed[0], committed[0]])
+
+
+class EvidenceOracleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        data = fixture_data()
+        self.good = data["oracle_good_bundle"]
+        self.pins = data["oracle_pinned_inputs"]
+
+    def validate(self, bundle: dict) -> list[str]:
+        return validate_evidence_bundle(
+            bundle,
+            pinned_manifest=self.pins["pinned_manifest"],
+            actual_source_id=self.pins["actual_source_id"],
+            actual_source_bytes=self.pins["actual_source_utf8"].encode("utf-8"),
+            discord_channel_id=self.pins["discord_channel_id"],
+            discord_after_message_id=self.pins["discord_after_message_id"],
+        )
+
+    def test_good_bundle_reconciles_source_dispositions_discord_and_frontier(self) -> None:
+        self.assertEqual(self.validate(self.good), [])
+
+    def test_missing_discord_message_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["discord_observations"] = [
+            item for item in broken["discord_observations"] if item["message_id"] != "1002"
+        ]
+        self.assertIn("discord_message_not_observed", self.validate(broken))
+
+    def test_duplicate_discord_message_id_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][1]["discord_message_ids"] = ["1001"]
+        self.assertIn("discord_message_reused", self.validate(broken))
+
+    def test_noncanonical_numeric_alias_cannot_evade_duplicate_id_rejection(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][1]["discord_message_ids"] = ["01001"]
+        broken["discord_observations"][1]["message_id"] = "01001"
+        errors = self.validate(broken)
+        self.assertIn("discord_message_id_invalid", errors)
+        self.assertNotEqual(errors, [])
+
+    def test_unhashable_and_non_string_disposition_message_ids_fail_closed(self) -> None:
+        for invalid_id in (
+            {},
+            [],
+            None,
+            True,
+            4254,
+            "not-a-snowflake",
+            "9" * 5000,
+        ):
+            broken = copy.deepcopy(self.good)
+            broken["dispositions"][0]["discord_message_ids"] = [invalid_id]
+            with self.subTest(invalid_id=invalid_id):
+                self.assertIn("discord_message_id_invalid", self.validate(broken))
+
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][0]["discord_message_ids"] = None
+        self.assertIn("disposition_message_ids_invalid", self.validate(broken))
+
+    def test_body_hash_mismatch_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["discord_observations"][0]["normalized_body"] += "mutant"
+        self.assertIn("discord_body_hash_mismatch", self.validate(broken))
+
+    def test_wrong_bot_author_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["discord_observations"][0]["author_id"] = "999"
+        self.assertIn("discord_message_author_mismatch", self.validate(broken))
+
+    def test_source_disposition_hash_mismatch_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][0]["source_sha256"] = "0" * 64
+        self.assertIn("disposition_source_hash_mismatch", self.validate(broken))
+
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][0]["source_range_sha256s"] = ["0" * 64]
+        self.assertIn("disposition_source_hashes_mismatch", self.validate(broken))
+
+    def test_policy_version_mismatch_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][1]["policy_reason"] = "other-policy:tool_bulk_overflow"
+        self.assertIn("disposition_policy_mismatch", self.validate(broken))
+
+    def test_unreferenced_duplicate_marker_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["discord_observations"].append(
+            {
+                "message_id": "1004",
+                "author_id": "424254",
+                "observed_at": "2026-07-13T10:00:03Z",
+                "edited_at": None,
+                "revision_index": 0,
+                "message_role": "relay_body",
+                "normalized_body": "duplicate [ADK-E2E:run4254:high-volume:1:BEGIN]",
+            }
+        )
+        errors = self.validate(broken)
+        self.assertIn(
+            "marker_count:[ADK-E2E:run4254:high-volume:1:BEGIN]:2", errors
+        )
+
+    def test_actual_source_duplicate_marker_ignores_nullable_metadata(self) -> None:
+        marker = "[ADK-E2E:run4254:high-volume:1:BEGIN]"
+        actual_source = (marker + marker).encode("utf-8")
+
+        def length_prefixed_hash(raw: bytes) -> str:
+            digest = hashlib.sha256()
+            digest.update(len(raw).to_bytes(8, "big"))
+            digest.update(raw)
+            return digest.hexdigest()
+
+        source_hash = length_prefixed_hash(actual_source)
+        broken = copy.deepcopy(self.good)
+        broken["manifest"]["source_end"] = len(actual_source)
+        pins = copy.deepcopy(broken["manifest"])
+        broken["source_ranges"] = [
+            {
+                "range_id": "duplicate-marker-range",
+                "start": 0,
+                "end": len(actual_source),
+                "kind": "assistant_text",
+                "sha256": source_hash,
+                "marker": None,
+            }
+        ]
+        broken["dispositions"] = [
+            {
+                "range_ids": ["duplicate-marker-range"],
+                "kind": "delivered",
+                "policy_reason": "assistant_text_must_deliver",
+                "source_sha256": source_hash,
+                "source_range_sha256s": [source_hash],
+                "discord_message_ids": ["1001"],
+                "expected_body_sha256": source_hash,
+                "committed": True,
+            }
+        ]
+        body = actual_source.decode("utf-8")
+        broken["discord_observations"] = [
+            {
+                "message_id": "1001",
+                "channel_id": broken["manifest"]["channel_id"],
+                "author_id": broken["manifest"]["bot_author_id"],
+                "observed_at": "2026-07-13T10:00:01Z",
+                "edited_at": None,
+                "revision_index": 0,
+                "message_role": "relay_body",
+                "raw_body": body,
+                "normalized_body": body,
+            }
+        ]
+        broken["delivery_observation"]["committed_frontier"] = len(actual_source)
+        errors = validate_evidence_bundle(
+            broken,
+            pinned_manifest=pins,
+            actual_source_id=self.pins["actual_source_id"],
+            actual_source_bytes=actual_source,
+            discord_channel_id=self.pins["discord_channel_id"],
+            discord_after_message_id=self.pins["discord_after_message_id"],
+        )
+        self.assertIn("source_marker_duplicate", errors)
+        self.assertIn("source_marker_metadata_missing", errors)
+
+    def test_multi_range_planner_serialization_is_accepted_by_oracle(self) -> None:
+        actual_source = self.pins["actual_source_utf8"]
+        marker = self.good["source_ranges"][1]["marker"]
+        tool_ranges = [
+            SourceRange(
+                "r2",
+                47,
+                109,
+                RangeKind.TOOL_BULK,
+                actual_source[47:109],
+                marker,
+            ),
+            SourceRange(
+                "r3",
+                109,
+                123,
+                RangeKind.TOOL_BULK,
+                actual_source[109:123],
+            ),
+        ]
+        plan = plan_bounded_batch(
+            tool_ranges,
+            start_cursor=47,
+            max_pending_items=1,
+            max_pending_bytes=400,
+        )
+        self.assertEqual(plan.dispositions[0].range_ids, ("r2", "r3"))
+        committed = commit_dispositions(plan, {0: ["1002"]})
+        serialized = serialize_planned_disposition(committed[0])
+        self.assertEqual(len(serialized["source_range_sha256s"]), 2)
+
+        bundle = copy.deepcopy(self.good)
+        bundle["source_ranges"][2]["kind"] = "tool_bulk"
+        bundle["dispositions"] = [bundle["dispositions"][0], serialized]
+        body = committed[0].expected_body
+        bundle["discord_observations"][1]["raw_body"] = body
+        bundle["discord_observations"][1]["normalized_body"] = body
+        self.assertEqual(self.validate(bundle), [])
+
+    def test_source_gap_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["source_ranges"][1]["start"] += 1
+        self.assertIn("source_range_gap_or_order", self.validate(broken))
+
+    def test_unwitnessed_source_marker_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["source_ranges"][0]["marker_in_source"] = False
+        self.assertIn("source_marker_not_witnessed", self.validate(broken))
+
+    def test_discord_revision_gap_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["discord_observations"].append(
+            {
+                "message_id": "1001",
+                "author_id": "424254",
+                "observed_at": "2026-07-13T10:00:04Z",
+                "edited_at": "2026-07-13T10:00:04Z",
+                "revision_index": 2,
+                "message_role": "relay_body",
+                "normalized_body": "edited",
+            }
+        )
+        self.assertIn("discord_revision_gap", self.validate(broken))
+
+    def test_frontier_ahead_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["delivery_observation"]["committed_frontier"] += 1
+        self.assertIn("durable_frontier_mismatch", self.validate(broken))
+
+    def test_pending_disposition_leaves_failed_suffix(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][1]["committed"] = False
+        errors = self.validate(broken)
+        self.assertIn("durable_frontier_mismatch", errors)
+        self.assertIn("pending_source_suffix", errors)
+
+    def test_unrelated_session_regression_is_rejected(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["unrelated_sessions"][0]["relay_gap"] = True
+        self.assertIn("unrelated_session_regression", self.validate(broken))
+
+    def test_self_declared_source_hashes_are_not_authoritative(self) -> None:
+        broken = copy.deepcopy(self.good)
+        for source_range, disposition in zip(
+            broken["source_ranges"], broken["dispositions"]
+        ):
+            source_range["sha256"] = "0" * 64
+            disposition["source_sha256"] = "0" * 64
+        broken["actual_source_artifact"] = {
+            "source_id": broken["manifest"]["actual_source_id"],
+            "raw_utf8": "tampered bytes that do not match the claims",
+        }
+        self.assertIn("source_range_hash_mismatch", self.validate(broken))
+
+    def test_self_consistent_wrong_marker_is_rejected_from_actual_source(self) -> None:
+        broken = copy.deepcopy(self.good)
+        wrong = "[ADK-E2E:run4254:high-volume:99:BEGIN]"
+        broken["source_ranges"][0]["marker"] = wrong
+        broken["discord_observations"][0]["normalized_body"] = wrong + "answer-one"
+        broken["dispositions"][0]["expected_body_sha256"] = normalized_body_sha256(
+            [broken["discord_observations"][0]["normalized_body"]]
+        )
+        self.assertIn("source_marker_bytes_mismatch", self.validate(broken))
+
+    def test_unknown_disposition_kind_fails_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][2]["kind"] = "future_kind"
+        broken["dispositions"][2]["policy_reason"] = "arbitrary"
+        self.assertIn("disposition_kind_unknown", self.validate(broken))
+
+    def test_arbitrary_omission_reason_fails_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][2]["policy_reason"] = "relay-target-v1:anything"
+        self.assertIn("disposition_policy_mismatch", self.validate(broken))
+
+    def test_missing_durable_anchor_fails_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        del broken["delivery_observation"]["durable_anchor"]
+        self.assertIn("durable_anchor_missing", self.validate(broken))
+
+    def test_empty_or_single_provider_unrelated_evidence_fails_closed(self) -> None:
+        empty = copy.deepcopy(self.good)
+        empty["unrelated_sessions"] = []
+        self.assertIn("unrelated_provider_evidence_missing", self.validate(empty))
+        single = copy.deepcopy(self.good)
+        single["unrelated_sessions"] = single["unrelated_sessions"][:1]
+        self.assertIn(
+            "unrelated_provider_evidence_missing", self.validate(single)
+        )
+
+    def test_empty_source_coordinate_span_fails_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["source_ranges"][1]["end"] = 47
+        broken["source_ranges"][2]["start"] = 47
+        self.assertIn("source_range_empty_or_invalid", self.validate(broken))
+
+    def test_manifest_must_match_external_pin(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["manifest"]["base_sha"] = "0" * 40
+        self.assertIn("manifest_not_externally_pinned", self.validate(broken))
+
+    def test_actual_source_extent_is_external_and_required(self) -> None:
+        errors = validate_evidence_bundle(
+            self.good,
+            pinned_manifest=self.pins["pinned_manifest"],
+            actual_source_id=self.pins["actual_source_id"],
+            actual_source_bytes=b"self-declared bundle cannot replace actual source",
+            discord_channel_id=self.pins["discord_channel_id"],
+            discord_after_message_id=self.pins["discord_after_message_id"],
+        )
+        self.assertIn("actual_source_extent_mismatch", errors)
+
+    def test_discord_channel_and_cutoff_are_externally_scoped(self) -> None:
+        wrong_channel = copy.deepcopy(self.good)
+        wrong_channel["discord_observations"][0]["channel_id"] = "other-channel"
+        self.assertIn("discord_message_channel_mismatch", self.validate(wrong_channel))
+        before_cutoff = copy.deepcopy(self.good)
+        before_cutoff["discord_observations"][0]["message_id"] = "998"
+        before_cutoff["dispositions"][0]["discord_message_ids"] = ["998"]
+        self.assertIn("discord_message_outside_cutoff", self.validate(before_cutoff))
+
+    def test_duplicate_committed_span_fails_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"].append(copy.deepcopy(broken["dispositions"][0]))
+        self.assertIn(
+            "duplicate_or_overlapping_committed_span", self.validate(broken)
+        )
+
+    def test_reordered_disposition_ranges_fail_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["dispositions"][1]["range_ids"] = ["r2", "r1"]
+        self.assertIn(
+            "disposition_ranges_noncontiguous_or_reordered", self.validate(broken)
+        )
+
+    def test_unknown_source_kind_fails_closed(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["source_ranges"][1]["kind"] = "future_kind"
+        self.assertIn("source_range_kind_unknown", self.validate(broken))
+
+    def test_durable_anchor_must_match_external_pin(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["delivery_observation"]["durable_anchor"] = "self-declared-anchor"
+        self.assertIn("durable_anchor_not_externally_pinned", self.validate(broken))
+
+    def test_non_string_marker_fails_closed_without_oracle_exception(self) -> None:
+        broken = copy.deepcopy(self.good)
+        broken["source_ranges"][0]["marker"] = 4254
+        errors = self.validate(broken)
+        self.assertIn("source_marker_invalid", errors)
+        self.assertIn("source_marker_bytes_mismatch", errors)
+
+    def test_unsupported_disposition_kind_range_pair_has_no_null_reason_escape(self) -> None:
+        broken = copy.deepcopy(self.good)
+        control = broken["dispositions"][2]
+        control["kind"] = "delivered"
+        control["policy_reason"] = None
+        self.assertIn("disposition_policy_mismatch", self.validate(broken))
+
+    def test_manifest_frontier_and_completion_types_are_strict(self) -> None:
+        invalid_frontier = copy.deepcopy(self.good)
+        invalid_frontier["manifest"]["durable_frontier_before"] = "0"
+        self.assertIn(
+            "manifest_durable_frontier_invalid", self.validate(invalid_frontier)
+        )
+
+        invalid_completion = copy.deepcopy(self.good)
+        invalid_completion["manifest"]["discord_complete"] = "yes"
+        self.assertIn("discord_fetch_incomplete", self.validate(invalid_completion))
+
+    def test_even_externally_pinned_manifest_schema_fails_closed(self) -> None:
+        for field, value, expected in (
+            ("provider", ["claude"], "manifest_provider_unknown"),
+            (
+                "normalization_version",
+                "future-normalization",
+                "normalization_version_unknown",
+            ),
+            ("started_at", 4254, "manifest_text_identity_invalid"),
+        ):
+            bundle = copy.deepcopy(self.good)
+            pins = copy.deepcopy(self.pins["pinned_manifest"])
+            bundle["manifest"][field] = value
+            pins[field] = value
+            with self.subTest(field=field):
+                errors = validate_evidence_bundle(
+                    bundle,
+                    pinned_manifest=pins,
+                    actual_source_id=self.pins["actual_source_id"],
+                    actual_source_bytes=self.pins["actual_source_utf8"].encode(
+                        "utf-8"
+                    ),
+                    discord_channel_id=self.pins["discord_channel_id"],
+                    discord_after_message_id=self.pins["discord_after_message_id"],
+                )
+                self.assertIn(expected, errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/relay_w1a/tests/test_model.py
+++ b/scripts/relay_w1a/tests/test_model.py
@@ -735,6 +735,177 @@ class LedgerFaultTests(unittest.TestCase):
         self.assertTrue(actual_successor.changed)
         self.assertEqual(actual_successor.record.outcome, LedgerOutcome.SUPERSEDED)
 
+    def test_replaced_same_source_requires_strictly_newer_generation(self) -> None:
+        _, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+
+        for generation in (pending.source_generation - 1, pending.source_generation):
+            with self.subTest(generation=generation):
+                stale = settle_effect(
+                    pending,
+                    repair_observation(
+                        pending.episode_key,
+                        continuity=InflightContinuity.REPLACED,
+                        source_id=pending.source_id,
+                        source_generation=generation,
+                        durable_anchor="anchor-stale-replacement",
+                        observed_at=now,
+                    ),
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=None,
+                    now=now,
+                )
+                self.assertFalse(stale.changed)
+                self.assertTrue(stale.must_reprobe)
+                self.assertEqual(stale.record, pending)
+                self.assertEqual(stale.reason, "replacement_generation_not_advanced")
+
+        new_source_same_generation = settle_effect(
+            pending,
+            repair_observation(
+                pending.episode_key,
+                continuity=InflightContinuity.REPLACED,
+                source_id="source-successor",
+                source_generation=pending.source_generation,
+                durable_anchor="anchor-new-source",
+                observed_at=now,
+            ),
+            attempt_id=pending.attempt_id,
+            delivery_proof=None,
+            now=now,
+        )
+        self.assertTrue(new_source_same_generation.changed)
+        self.assertEqual(
+            new_source_same_generation.record.outcome, LedgerOutcome.SUPERSEDED
+        )
+
+    def test_ledger_entrypoints_reject_truthy_string_boolean_flags(self) -> None:
+        reserved, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        boolean_fields = (
+            "identity_complete",
+            "clock_valid",
+            "affirmative_termination",
+            "source_progress",
+            "delivery_progress",
+            "control_contradiction",
+            "terminal_delivery_committed",
+            "typed_idle",
+        )
+
+        for field in boolean_fields:
+            malformed = replace(
+                repair_observation(
+                    reserved.episode_key,
+                    durable_anchor=reserved.durable_anchor,
+                    observed_at=now,
+                ),
+                **{field: "false"},
+            )
+            with self.subTest(entrypoint="reserve", field=field):
+                transition = reserve_attempt(
+                    None,
+                    malformed,
+                    attempt_id=f"malformed-reserve-{field}",
+                    delivery_proof=delivery_proof(
+                        reserved.episode_key,
+                        now=now,
+                        source_frontier=reserved.baseline_source,
+                        committed_frontier=reserved.baseline_delivered,
+                        durable_anchor=reserved.durable_anchor,
+                    ),
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertEqual(transition.reason, "observation_bool_not_typed")
+
+            with self.subTest(entrypoint="recover", field=field):
+                transition = recover_after_crash(
+                    reserved, malformed, attempt_id=reserved.attempt_id
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, reserved)
+                self.assertEqual(transition.reason, "observation_bool_not_typed")
+
+            with self.subTest(entrypoint="settle", field=field):
+                transition = settle_effect(
+                    pending,
+                    malformed,
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=delivery_proof(
+                        pending.episode_key,
+                        now=now,
+                        source_frontier=pending.baseline_source,
+                        committed_frontier=pending.baseline_delivered,
+                        durable_anchor=pending.durable_anchor,
+                    ),
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, pending)
+                self.assertEqual(transition.reason, "observation_bool_not_typed")
+
+            successor = replace(
+                malformed,
+                episode_key="ep-successor",
+                continuity=InflightContinuity.REPLACED,
+            )
+            with self.subTest(entrypoint="successor", field=field):
+                transition = settle_effect(
+                    pending,
+                    successor,
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=None,
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, pending)
+                self.assertEqual(transition.reason, "observation_bool_not_typed")
+
+        valid_observation = repair_observation(
+            pending.episode_key,
+            durable_anchor="anchor-11",
+            observed_at=now,
+            delivery_progress=True,
+        )
+        valid_proof = delivery_proof(
+            pending.episode_key,
+            now=now,
+            source_frontier=pending.baseline_source + 1,
+            committed_frontier=pending.baseline_delivered + 1,
+            durable_anchor="anchor-11",
+        )
+        for field in ("identity_complete", "clock_valid"):
+            malformed_proof = replace(valid_proof, **{field: "false"})
+            with self.subTest(owner="delivery_proof", entrypoint="reserve", field=field):
+                transition = reserve_attempt(
+                    None,
+                    valid_observation,
+                    attempt_id=f"malformed-proof-reserve-{field}",
+                    delivery_proof=malformed_proof,
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertIsNone(transition.record)
+                self.assertEqual(transition.reason, "delivery_proof_bool_not_typed")
+
+            with self.subTest(owner="delivery_proof", entrypoint="settle", field=field):
+                transition = settle_effect(
+                    pending,
+                    valid_observation,
+                    attempt_id=pending.attempt_id,
+                    delivery_proof=malformed_proof,
+                    now=now,
+                )
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.record, pending)
+                self.assertEqual(transition.reason, "delivery_proof_bool_not_typed")
+
     def test_delivery_proof_requires_generation_and_anchor_advance(self) -> None:
         _, pending = self._reserve_and_mark()
         now = ClockStamp(1_000_100, "boot-a", 10_100)
@@ -1197,6 +1368,41 @@ class LedgerFaultTests(unittest.TestCase):
         self.assertEqual(transition.record, unknown)
         self.assertEqual(transition.reason, "ledger_state_not_typed")
 
+    def test_every_ledger_transition_rejects_unknown_in_memory_state(self) -> None:
+        reserved, pending = self._reserve_and_mark()
+        now = ClockStamp(1_000_100, "boot-a", 10_100)
+        cases = (
+            mark_effect_pending(
+                replace(reserved, state="future-ledger-state"),
+                attempt_id=reserved.attempt_id,
+                now=now,
+            ),
+            recover_after_crash(
+                replace(reserved, state="future-ledger-state"),
+                repair_observation(observed_at=now),
+                attempt_id=reserved.attempt_id,
+            ),
+            settle_effect(
+                replace(pending, state="future-ledger-state"),
+                repair_observation(observed_at=now),
+                attempt_id=pending.attempt_id,
+                delivery_proof=delivery_proof(
+                    pending.episode_key,
+                    now=now,
+                    source_frontier=pending.baseline_source,
+                    committed_frontier=pending.baseline_delivered,
+                    durable_anchor=pending.durable_anchor,
+                ),
+                now=now,
+            ),
+        )
+        for transition in cases:
+            with self.subTest(reason=transition.reason):
+                self.assertFalse(transition.changed)
+                self.assertTrue(transition.must_reprobe)
+                self.assertEqual(transition.reason, "ledger_state_not_typed")
+                self.assertEqual(transition.record.state, "future-ledger-state")
+
     def test_corrupt_future_and_legacy_ledger_fail_closed(self) -> None:
         for raw, reason in (
             ("{", "corrupt_json"),
@@ -1428,7 +1634,7 @@ class BackpressureTests(unittest.TestCase):
                         [replace(committed[0], discord_message_ids=(invalid_id,))],
                     )
 
-    def test_commit_and_frontier_require_globally_unique_discord_message_ids(
+    def test_commit_and_frontier_require_call_local_unique_discord_message_ids(
         self,
     ) -> None:
         first = SourceRange("a", 0, 3, RangeKind.ASSISTANT_TEXT, "one")
@@ -1439,7 +1645,7 @@ class BackpressureTests(unittest.TestCase):
             max_pending_items=2,
             max_pending_bytes=10,
         )
-        with self.assertRaisesRegex(ValueError, "globally unique"):
+        with self.assertRaisesRegex(ValueError, "within this call"):
             commit_dispositions(plan, {0: ["8001"], 1: ["8001"]})
 
         committed = commit_dispositions(plan, {0: ["8001"], 1: ["8002"]})
@@ -1447,8 +1653,29 @@ class BackpressureTests(unittest.TestCase):
             committed[0],
             replace(committed[1], discord_message_ids=("8001",)),
         )
-        with self.assertRaisesRegex(ValueError, "globally unique"):
+        with self.assertRaisesRegex(ValueError, "within this call"):
             advance_committed_frontier(0, duplicate_at_frontier)
+
+        first_call = commit_dispositions(
+            plan_bounded_batch(
+                [first],
+                start_cursor=0,
+                max_pending_items=1,
+                max_pending_bytes=10,
+            ),
+            {0: ["8001"]},
+        )
+        second_call = commit_dispositions(
+            plan_bounded_batch(
+                [second],
+                start_cursor=3,
+                max_pending_items=1,
+                max_pending_bytes=10,
+            ),
+            {0: ["8001"]},
+        )
+        self.assertEqual(advance_committed_frontier(0, first_call), 3)
+        self.assertEqual(advance_committed_frontier(3, second_call), 6)
 
     def test_planner_rejects_actual_duplicate_marker_without_metadata(self) -> None:
         marker = "[ADK-E2E:run:case:1:BEGIN]"
@@ -1778,20 +2005,42 @@ class EvidenceOracleTests(unittest.TestCase):
     def test_digest_marker_summary_uses_same_canonical_body_hash_in_oracle(
         self,
     ) -> None:
-        ranges = []
-        cursor = 0
-        for sequence in range(1, 5):
-            marker = f"[ADK-E2E:digest-run:digest-case:{sequence}:END]"
-            entry = SourceRange(
-                f"tool-{sequence}",
-                cursor,
-                cursor + len(marker.encode("utf-8")),
+        marker_bodies = (
+            "[ADK-E2E:digest-run:digest-case:1:END]",
+            "[ADK-E2E:digest-run:digest-case:2:END]",
+            "[ADK-E2E:digest-run:digest-case:3:END]",
+            "[ADK-E2E:digest-run:digest-case:4:END]",
+        )
+        known_range_hashes = (
+            "2e1deeb9a23bec7319c8800d1166f63be13a4345e55821445cfef533912b553c",
+            "c6be45012e36b7574e253b751fbc502841cc682310e82f5c16f66a5248db4504",
+            "41c06d50529d089890853f4d2f5889bc17e010b9fdba2da1d4b16f3b14aa32d6",
+            "31f4744e42be27747eebc78a28428990b78c6cb56593b2cfb7d2ac314b175f47",
+        )
+        known_source_hash = (
+            "ff9c1a1c9bd087f22bc8d08bce0de8b0c8b90ec0b48e5accfbde8a05f5343af9"
+        )
+        known_summary_body = (
+            "[AgentDesk summary policy=relay-target-v1 range=0:152 records=4 "
+            "raw_bytes=152 sha256="
+            "ff9c1a1c9bd087f22bc8d08bce0de8b0c8b90ec0b48e5accfbde8a05f5343af9 "
+            "marker_count=4 marker_sha256="
+            "83be784e890bcc521902c432be51b925b0d09de2c5b17ff3e320ed73d5cc72c6]"
+        )
+        known_summary_body_hash = (
+            "f5397ff500e88323635498fbe5c9bbf1dce90a3684846aae6a401281b43e380a"
+        )
+        ranges = [
+            SourceRange(
+                f"tool-{index}",
+                (index - 1) * 38,
+                index * 38,
                 RangeKind.TOOL_BULK,
                 marker,
                 marker,
             )
-            ranges.append(entry)
-            cursor = entry.end
+            for index, marker in enumerate(marker_bodies, start=1)
+        ]
 
         plan = plan_bounded_batch(
             ranges,
@@ -1801,10 +2050,16 @@ class EvidenceOracleTests(unittest.TestCase):
         )
         self.assertIsNone(plan.blocked_reason)
         self.assertEqual(len(plan.dispositions), 1)
-        self.assertIn("marker_count=4", plan.dispositions[0].expected_body)
-        self.assertIn("marker_sha256=", plan.dispositions[0].expected_body)
+        self.assertEqual(plan.dispositions[0].expected_body, known_summary_body)
+        self.assertEqual(plan.dispositions[0].source_sha256, known_source_hash)
+        self.assertEqual(
+            plan.dispositions[0].source_range_sha256s, known_range_hashes
+        )
         committed = commit_dispositions(plan, {0: ["9001"]})
         serialized = serialize_planned_disposition(committed[0])
+        self.assertEqual(
+            serialized["expected_body_sha256"], known_summary_body_hash
+        )
 
         source_bytes = "".join(entry.body for entry in ranges).encode("utf-8")
         manifest = {
@@ -1838,13 +2093,24 @@ class EvidenceOracleTests(unittest.TestCase):
                     "start": entry.start,
                     "end": entry.end,
                     "kind": entry.kind.value,
-                    "sha256": committed[0].source_range_sha256s[index],
+                    "sha256": known_range_hashes[index],
                     "marker": entry.marker,
                     "marker_in_source": True,
                 }
                 for index, entry in enumerate(ranges)
             ],
-            "dispositions": [serialized],
+            "dispositions": [
+                {
+                    "range_ids": ["tool-1", "tool-2", "tool-3", "tool-4"],
+                    "kind": "summarized",
+                    "policy_reason": "relay-target-v1:tool_bulk_overflow",
+                    "source_sha256": known_source_hash,
+                    "source_range_sha256s": list(known_range_hashes),
+                    "discord_message_ids": ["9001"],
+                    "expected_body_sha256": known_summary_body_hash,
+                    "committed": True,
+                }
+            ],
             "discord_observations": [
                 {
                     "message_id": "9001",
@@ -1854,8 +2120,8 @@ class EvidenceOracleTests(unittest.TestCase):
                     "edited_at": None,
                     "revision_index": 0,
                     "message_role": "relay_body",
-                    "raw_body": committed[0].expected_body,
-                    "normalized_body": committed[0].expected_body,
+                    "raw_body": known_summary_body,
+                    "normalized_body": known_summary_body,
                 }
             ],
             "delivery_observation": {


### PR DESCRIPTION
Part of #4254 — standalone W1-A executable contract only. This PR does not wire runtime recovery authority and does not close the issue.

## Scope

- adds a pure Python executable specification for affirmative-only producer/death authority, exact-attempt repair ledger and crash reconciliation, bounded source-range disposition, and source-to-Discord evidence reconciliation;
- adds machine-readable incident/fault fixtures and behavior-first regression coverage;
- runs the 79-test contract from the existing `Script checks` CI job;
- imports no AgentDesk runtime module and performs no Discord, tmux, process, network, or runtime-state mutation.

## Invariants

- silence/age/repair failure never proves producer death; exact affirmative termination + safe queue disposition is required;
- `Reserved -> EffectPending -> Settled` is attempt-CAS guarded and crash/future-clock/unknown-enum paths fail closed;
- same-episode rearm requires current-generation committed delivery progress;
- every cursor advance has an explicit delivered/summarized/policy-omitted disposition over a contiguous prefix;
- evidence validation recomputes source/body/range/marker/frontier facts from external pins and actual source bytes.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/relay_w1a/tests -p 'test_*.py' -v` — 79/79 GREEN;
- removing canonical Discord-ID rejection makes the leading-zero alias regression RED;
- removing typed continuity rejection makes unknown-continuity settlement/rearm regression RED;
- `shellcheck -S warning scripts/ci-script-checks.sh`, `bash -n`, inventory, agent-maintenance, maintainability, and `git diff --check` GREEN;
- the full local script-check sweep reached an unrelated existing host-environment failure because the relay-watchdog deployment test resolves `/usr/bin/python3` 3.9 instead of Homebrew Python; the new W1-A CI command itself ran 79/79 GREEN. GitHub CI provides Python 3.11.

## Remaining #4254 work

Production W1/W2/W3 integration stays blocked on the issue DAG and serialized runtime authority gates documented in the approved design. The issue remains open.
