### PR TITLE
fix(prompt): unbound 채널 memory backend 결정성 — global 백엔드 상속 + state-independent SAK/role 주입 (#4310)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -673,7 +673,7 @@
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
 | `services::discord::router::message_handler::voice_announcement_scope` | `src/services/discord/router/message_handler/voice_announcement_scope.rs` | 125 | 73 | 52 |  |
 | `services::discord::router::message_handler::watchdog` | `src/services/discord/router/message_handler/watchdog.rs` | 1255 | 960 | 295 |  |
-| `services::discord::router::response_format` | `src/services/discord/router/response_format.rs` | 430 | 351 | 79 |  |
+| `services::discord::router::response_format` | `src/services/discord/router/response_format.rs` | 470 | 358 | 112 |  |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 130 | 130 | 0 |  |
 | `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 526 | 526 | 0 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 907 | 299 | 608 |  |
@@ -706,7 +706,7 @@
 | `services::discord::session_runtime::worktree` | `src/services/discord/session_runtime/worktree.rs` | 601 | 601 | 0 |  |
 | `services::discord::settings` | `src/services/discord/settings.rs` | 345 | 345 | 0 |  |
 | `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 539 | 506 | 33 |  |
-| `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 152 | 152 | 0 |  |
+| `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 205 | 153 | 52 |  |
 | `services::discord::settings::read` | `src/services/discord/settings/read.rs` | 449 | 449 | 0 |  |
 | `services::discord::settings::validation` | `src/services/discord/settings/validation.rs` | 520 | 258 | 262 |  |
 | `services::discord::settings::write` | `src/services/discord/settings/write.rs` | 386 | 386 | 0 |  |

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -57,6 +57,49 @@ fn test_role_binding(role_id: &str) -> RoleBinding {
 }
 
 #[test]
+fn issue_4310_role_and_sak_layers_survive_memento_health_changes() {
+    let temp = tempfile::tempdir().expect("prompt dir");
+    let _runtime_guard = crate::config::set_agentdesk_root_for_test(temp.path());
+    let prompt_path = temp.path().join("role.md");
+    std::fs::write(&prompt_path, "ISSUE 4310 ROLE PROMPT").expect("write role prompt");
+    let mut binding = test_role_binding("issue-4310-role");
+    binding.prompt_file = prompt_path.display().to_string();
+    let sak = "[Shared Agent Knowledge]\nISSUE 4310 SAK";
+
+    for settings in [
+        ResolvedMemorySettings {
+            backend: MemoryBackendKind::Memento,
+            ..ResolvedMemorySettings::default()
+        },
+        ResolvedMemorySettings {
+            backend: MemoryBackendKind::File,
+            memento_fallback: true,
+            ..ResolvedMemorySettings::default()
+        },
+    ] {
+        let prompt = build_system_prompt(
+            "ctx",
+            &[],
+            "/tmp",
+            ChannelId::new(1),
+            "tok",
+            Some(&binding),
+            false,
+            DispatchProfile::Full,
+            None,
+            None,
+            Some(sak),
+            None,
+            Some(&settings),
+            true,
+        );
+
+        assert!(prompt.contains("ISSUE 4310 ROLE PROMPT"));
+        assert!(prompt.contains("ISSUE 4310 SAK"));
+    }
+}
+
+#[test]
 fn issue_4313_prompt_policy_contract() {
     let built = build_prompt_with_optional_manifest_for(None, Some("implementation"));
     let prompt = built.system_prompt;

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -843,7 +843,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     if let Some(reply_context) = reply_context {
         context_chunks.push(reply_context);
     }
-    if let Some(knowledge) = memory_injection_plan.shared_knowledge_for_context {
+    if let Some(ref knowledge) = memory_injection_plan.shared_knowledge_for_context {
         context_chunks.push(knowledge.to_string());
     }
     if let Some(external_recall) = memory_injection_plan.external_recall_for_context {
@@ -867,7 +867,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         true,
     );
 
-    let sak_for_system = memory_injection_plan.shared_knowledge_for_system_prompt;
+    let sak_for_system = memory_injection_plan.sak_for_system_prompt();
     let longterm_catalog_for_prompt = memory_injection_plan.longterm_catalog_for_system_prompt;
     let memento_mcp_available = crate::services::mcp_config::provider_has_memento_mcp(&provider);
     let channel_participants = shared.channel_roster(channel_id, request_owner, request_owner_name);

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1763,7 +1763,7 @@ pub(super) async fn handle_text_message(
     if let Some(ref reply_ctx) = reply_context {
         context_chunks.push(reply_ctx.clone());
     }
-    if let Some(knowledge) = memory_injection_plan.shared_knowledge_for_context {
+    if let Some(ref knowledge) = memory_injection_plan.shared_knowledge_for_context {
         context_chunks.push(knowledge.to_string());
     }
     if let Some(external_recall) = memory_injection_plan.external_recall_for_context {
@@ -1794,7 +1794,7 @@ pub(super) async fn handle_text_message(
 
     // Claude keeps SAK in the system prompt for prefix-cache stability.
     // Non-Claude providers receive SAK in the user context instead.
-    let sak_for_system = memory_injection_plan.shared_knowledge_for_system_prompt;
+    let sak_for_system = memory_injection_plan.sak_for_system_prompt();
     let longterm_catalog_for_prompt = memory_injection_plan.longterm_catalog_for_system_prompt;
     let current_task_context = active_dispatch_info.as_ref().map(|info| {
         super::super::super::prompt_builder::CurrentTaskContext {

--- a/src/services/discord/router/response_format.rs
+++ b/src/services/discord/router/response_format.rs
@@ -3,10 +3,16 @@ use crate::services::memory::{RecallMode, RecallResponse};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct MemoryInjectionPlan<'a> {
-    pub(super) shared_knowledge_for_context: Option<&'a str>,
-    pub(super) shared_knowledge_for_system_prompt: Option<&'a str>,
+    pub(super) shared_knowledge_for_context: Option<String>,
+    pub(super) shared_knowledge_for_system_prompt: Option<String>,
     pub(super) external_recall_for_context: Option<&'a str>,
     pub(super) longterm_catalog_for_system_prompt: Option<&'a str>,
+}
+
+impl MemoryInjectionPlan<'_> {
+    pub(super) fn sak_for_system_prompt(&self) -> Option<&str> {
+        self.shared_knowledge_for_system_prompt.as_deref()
+    }
 }
 
 /// #1083: Memento recall gate decision.
@@ -32,17 +38,18 @@ pub(super) fn build_memory_injection_plan<'a>(
     dispatch_profile: DispatchProfile,
     memory_recall: &'a RecallResponse,
 ) -> MemoryInjectionPlan<'a> {
+    let shared_knowledge = crate::services::discord::shared_memory::load_shared_knowledge();
     let should_inject_shared_knowledge =
         dispatch_profile == DispatchProfile::Full && !has_session_id;
     let shared_knowledge_for_context =
         if should_inject_shared_knowledge && !matches!(provider, ProviderKind::Claude) {
-            memory_recall.shared_knowledge.as_deref()
+            shared_knowledge.as_deref().map(str::to_owned)
         } else {
             None
         };
     let shared_knowledge_for_system_prompt =
         if dispatch_profile == DispatchProfile::Full && matches!(provider, ProviderKind::Claude) {
-            memory_recall.shared_knowledge.as_deref()
+            shared_knowledge.as_deref().map(str::to_owned)
         } else {
             None
         };
@@ -426,5 +433,38 @@ mod tests {
             merge_reply_contexts(None, format_voluntary_feedback_reminder("")),
             None,
         );
+    }
+
+    #[test]
+    fn issue_4310_sak_layer_is_independent_of_memento_recall_state() {
+        let runtime_root = tempfile::tempdir().expect("runtime root");
+        let _root_guard = crate::config::set_agentdesk_root_for_test(runtime_root.path());
+        let sak_path = crate::runtime_layout::shared_agent_knowledge_path(runtime_root.path());
+        std::fs::create_dir_all(sak_path.parent().expect("SAK parent")).expect("create SAK parent");
+        std::fs::write(&sak_path, "state-independent rules").expect("write SAK");
+        crate::services::discord::shared_memory::invalidate_shared_knowledge_cache_for_tests();
+        let expected = "[Shared Agent Knowledge]\nstate-independent rules";
+        let healthy_recall = RecallResponse {
+            external_recall: Some("memento context".to_string()),
+            memento_context_loaded: true,
+            ..RecallResponse::default()
+        };
+        let degraded_recall = RecallResponse {
+            warnings: vec!["memento unavailable; local fallback used".to_string()],
+            ..RecallResponse::default()
+        };
+
+        for recall in [&healthy_recall, &degraded_recall] {
+            let plan = build_memory_injection_plan(
+                &ProviderKind::Claude,
+                false,
+                DispatchProfile::Full,
+                recall,
+            );
+            assert_eq!(
+                plan.shared_knowledge_for_system_prompt.as_deref(),
+                Some(expected)
+            );
+        }
     }
 }

--- a/src/services/discord/settings/memory.rs
+++ b/src/services/discord/settings/memory.rs
@@ -148,5 +148,58 @@ pub(crate) fn memory_settings_for_binding(
 ) -> ResolvedMemorySettings {
     role_binding
         .map(|binding| binding.memory.clone())
-        .unwrap_or_default()
+        .unwrap_or_else(|| resolve_memory_settings(None, None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn issue_4310_unbound_channel_resolves_global_memory_backend() {
+        let runtime_root = tempfile::tempdir().expect("runtime root");
+        let _root_guard = crate::config::set_agentdesk_root_for_test(runtime_root.path());
+        let _access_key_guard = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "ISSUE_4310_MEMENTO_KEY",
+            Path::new("configured"),
+        );
+        let config_path = runtime_layout::memory_backend_path(runtime_root.path());
+        fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+
+        fs::write(
+            &config_path,
+            serde_json::to_vec(&serde_json::json!({
+                "version": 2,
+                "backend": "memento",
+                "mcp": {
+                    "endpoint": "http://127.0.0.1:4310",
+                    "access_key_env": "ISSUE_4310_MEMENTO_KEY"
+                }
+            }))
+            .expect("serialize memento config"),
+        )
+        .expect("write memento config");
+
+        assert_eq!(
+            memory_settings_for_binding(None).backend,
+            MemoryBackendKind::Memento,
+            "unbound channels must inherit an active global memento backend"
+        );
+
+        fs::write(
+            &config_path,
+            serde_json::to_vec(&serde_json::json!({
+                "version": 2,
+                "backend": "file"
+            }))
+            .expect("serialize file config"),
+        )
+        .expect("write file config");
+
+        assert_eq!(
+            memory_settings_for_binding(None).backend,
+            MemoryBackendKind::File,
+            "unbound channels must inherit an explicitly configured global file backend"
+        );
+    }
 }


### PR DESCRIPTION
## 이슈
Closes-ref #4310. 시스템 프롬프트 주입이 런타임 상태에 종속 — memento 헬스 degraded 시 SAK 미주입, unbound 스레드가 role prompt 상실.

## 변경
1. Unbound 채널이 무조건 File fallback하지 않고 global/default memory 백엔드를 상속 (명시적 File 배포·활성 Memento 배포 보존).
2. SAK를 state-independent 프롬프트 입력으로 로드 — active-Memento / degraded-Memento(File fallback) 양쪽에서 role+SAK 레이어 유지.
3. File fallback은 기존 '명시적 Memento unavailable' 경로로만 제한 (기존 fallback WARN 로그 유지).

## 테스트
- global 백엔드 상속, healthy/degraded recall SAK 합성, role+SAK 프롬프트 유지 회귀 테스트 3종 (issue_4310).
- #3016 핫파일 루트 무편집.

## 게이트 (구현자 자체통과, 오케스트레이터 재검증 예정)
cargo fmt/check/test --lib issue_4310, agent-maintenance freshness passed.

🤖 구현: codex gpt-5.6-sol high / 리뷰: Opus dual (독립)