### PR TITLE
ux(discord): 명령 응답 문구/언어 통일 — 상태별 단일 한국어 문구 + owner 에러 폴딩 (#4216)

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -87,7 +87,7 @@
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1659 |
-| `src/services/discord/commands/text_commands.rs` | 1496 |
+| `src/services/discord/commands/text_commands.rs` | 1493 |
 | `src/services/discord/formatting.rs` | 2566 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
 | `src/services/discord/mod.rs` | 4167 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -87,7 +87,7 @@
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1659 |
-| `src/services/discord/commands/text_commands.rs` | 1493 |
+| `src/services/discord/commands/text_commands.rs` | 1482 |
 | `src/services/discord/formatting.rs` | 2566 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
 | `src/services/discord/mod.rs` | 4167 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -87,7 +87,7 @@
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1659 |
-| `src/services/discord/commands/text_commands.rs` | 1480 |
+| `src/services/discord/commands/text_commands.rs` | 1496 |
 | `src/services/discord/formatting.rs` | 2566 |
 | `src/services/discord/meeting_orchestrator.rs` | 3222 |
 | `src/services/discord/mod.rs` | 4167 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -437,7 +437,7 @@
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 291 | 291 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::catch_up::too_old_notice` | `src/services/discord/catch_up/too_old_notice.rs` | 195 | 106 | 89 |  |
-| `services::discord::commands` | `src/services/discord/commands/mod.rs` | 185 | 151 | 34 |  |
+| `services::discord::commands` | `src/services/discord/commands/mod.rs` | 247 | 188 | 59 |  |
 | `services::discord::commands::command_policy` | `src/services/discord/commands/command_policy.rs` | 221 | 209 | 12 |  |
 | `services::discord::commands::config` | `src/services/discord/commands/config.rs` | 1224 | 956 | 268 |  |
 | `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 839 | 781 | 58 |  |
@@ -466,7 +466,7 @@
 | `services::discord::commands::sidecar` | `src/services/discord/commands/sidecar.rs` | 41 | 41 | 0 |  |
 | `services::discord::commands::skill` | `src/services/discord/commands/skill.rs` | 381 | 381 | 0 |  |
 | `services::discord::commands::steer` | `src/services/discord/commands/steer.rs` | 147 | 147 | 0 |  |
-| `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1493 | 1493 | 0 | giant-file |
+| `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1482 | 1482 | 0 | giant-file |
 | `services::discord::commands::tui_passthrough` | `src/services/discord/commands/tui_passthrough.rs` | 412 | 357 | 55 |  |
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1056 | 998 | 58 |  |
 | `services::discord::delivery_lease_key` | `src/services/discord/delivery_lease_key.rs` | 156 | 156 | 0 |  |
@@ -659,7 +659,7 @@
 | `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 832 | 474 | 358 |  |
 | `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 122 | 122 | 0 |  |
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |
-| `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 93 | 93 | 0 |  |
+| `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 250 | 211 | 39 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1561 | 1337 | 224 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3070 | 2834 | 236 | giant-file |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -466,7 +466,7 @@
 | `services::discord::commands::sidecar` | `src/services/discord/commands/sidecar.rs` | 41 | 41 | 0 |  |
 | `services::discord::commands::skill` | `src/services/discord/commands/skill.rs` | 381 | 381 | 0 |  |
 | `services::discord::commands::steer` | `src/services/discord/commands/steer.rs` | 147 | 147 | 0 |  |
-| `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1496 | 1496 | 0 | giant-file |
+| `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1493 | 1493 | 0 | giant-file |
 | `services::discord::commands::tui_passthrough` | `src/services/discord/commands/tui_passthrough.rs` | 412 | 357 | 55 |  |
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1056 | 998 | 58 |  |
 | `services::discord::delivery_lease_key` | `src/services/discord/delivery_lease_key.rs` | 156 | 156 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -437,10 +437,10 @@
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 291 | 291 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::catch_up::too_old_notice` | `src/services/discord/catch_up/too_old_notice.rs` | 195 | 106 | 89 |  |
-| `services::discord::commands` | `src/services/discord/commands/mod.rs` | 121 | 121 | 0 |  |
+| `services::discord::commands` | `src/services/discord/commands/mod.rs` | 185 | 151 | 34 |  |
 | `services::discord::commands::command_policy` | `src/services/discord/commands/command_policy.rs` | 221 | 209 | 12 |  |
 | `services::discord::commands::config` | `src/services/discord/commands/config.rs` | 1224 | 956 | 268 |  |
-| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 834 | 776 | 58 |  |
+| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 839 | 781 | 58 |  |
 | `services::discord::commands::diagnostics` | `src/services/discord/commands/diagnostics/mod.rs` | 389 | 389 | 0 |  |
 | `services::discord::commands::diagnostics::reports` | `src/services/discord/commands/diagnostics/reports.rs` | 681 | 655 | 26 |  |
 | `services::discord::commands::fast_mode` | `src/services/discord/commands/fast_mode.rs` | 82 | 82 | 0 |  |
@@ -460,13 +460,13 @@
 | `services::discord::commands::model_ui` | `src/services/discord/commands/model_ui.rs` | 264 | 264 | 0 |  |
 | `services::discord::commands::node` | `src/services/discord/commands/node.rs` | 481 | 452 | 29 |  |
 | `services::discord::commands::receipt` | `src/services/discord/commands/receipt.rs` | 266 | 266 | 0 |  |
-| `services::discord::commands::recovery_ops` | `src/services/discord/commands/recovery_ops.rs` | 502 | 363 | 139 |  |
+| `services::discord::commands::recovery_ops` | `src/services/discord/commands/recovery_ops.rs` | 511 | 372 | 139 |  |
 | `services::discord::commands::restart` | `src/services/discord/commands/restart.rs` | 242 | 242 | 0 |  |
 | `services::discord::commands::session` | `src/services/discord/commands/session.rs` | 230 | 230 | 0 |  |
 | `services::discord::commands::sidecar` | `src/services/discord/commands/sidecar.rs` | 41 | 41 | 0 |  |
 | `services::discord::commands::skill` | `src/services/discord/commands/skill.rs` | 381 | 381 | 0 |  |
 | `services::discord::commands::steer` | `src/services/discord/commands/steer.rs` | 147 | 147 | 0 |  |
-| `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1480 | 1480 | 0 | giant-file |
+| `services::discord::commands::text_commands` | `src/services/discord/commands/text_commands.rs` | 1496 | 1496 | 0 | giant-file |
 | `services::discord::commands::tui_passthrough` | `src/services/discord/commands/tui_passthrough.rs` | 412 | 357 | 55 |  |
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1056 | 998 | 58 |  |
 | `services::discord::delivery_lease_key` | `src/services/discord/delivery_lease_key.rs` | 156 | 156 | 0 |  |

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -503,11 +503,11 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
     match result.token {
         Some(token) => {
             if result.already_stopping {
-                ctx.say("Already stopping...").await?;
+                ctx.say(super::ALREADY_STOPPING_RESPONSE).await?;
                 return Ok(());
             }
 
-            ctx.say("Stopping...").await?;
+            ctx.say(super::STOPPING_RESPONSE).await?;
 
             // #1218: stop_active_turn keeps the abort-key-then-SIGKILL order
             // identical across every stop entrypoint.
@@ -521,7 +521,7 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
             tracing::info!("  [{ts}] ■ Cancel signal sent");
         }
         None => {
-            ctx.say("No active request to stop.").await?;
+            ctx.say(super::NO_ACTIVE_TURN_RESPONSE).await?;
         }
     }
     Ok(())
@@ -554,7 +554,7 @@ pub(in crate::services::discord) async fn cmd_clear(ctx: Context<'_>) -> Result<
     )
     .await;
 
-    ctx.say("Session cleared.").await?;
+    ctx.say(super::SESSION_CLEARED_RESPONSE).await?;
     tracing::info!("  [{ts}] ▶ [{user_name}] Session cleared");
     Ok(())
 }
@@ -571,7 +571,7 @@ mod soft_clear_notify_tests {
         assert_eq!(
             soft_clear_lifecycle_notify_row("/clear", SoftClearNotifyMode::Suppress),
             None,
-            "`/clear` and `!clear` already reply `Session cleared.` and must not enqueue a duplicate `lifecycle.soft_clear` notify row"
+            "`/clear` and `!clear` already reply with the shared clear response and must not enqueue a duplicate `lifecycle.soft_clear` notify row"
         );
         assert_eq!(
             soft_clear_lifecycle_notify_row("!clear", SoftClearNotifyMode::Suppress),
@@ -744,17 +744,22 @@ pub(in crate::services::discord) async fn cmd_shell(
                 parts.push(format!("```\n{}\n```", stdout.trim_end()));
             }
             if !stderr.is_empty() {
-                parts.push(format!("stderr:\n```\n{}\n```", stderr.trim_end()));
+                parts.push(super::owner_error_response(
+                    "셸 명령이 오류 출력을 반환했어요.",
+                    stderr.trim_end(),
+                ));
             }
             if parts.is_empty() {
-                parts.push(format!("(exit code: {})", exit_code));
+                parts.push(format!("(종료 코드: {})", exit_code));
             } else if exit_code != 0 {
-                parts.push(format!("(exit code: {})", exit_code));
+                parts.push(format!("(종료 코드: {})", exit_code));
             }
             parts.join("\n")
         }
-        Ok(Err(e)) => format!("Failed to execute: {}", e),
-        Err(e) => format!("Task error: {}", e),
+        Ok(Err(e)) => super::owner_error_response("셸 명령을 실행하지 못했어요.", &e.to_string()),
+        Err(e) => {
+            super::owner_error_response("셸 명령을 처리하는 중 오류가 발생했어요.", &e.to_string())
+        }
     };
 
     send_long_message_ctx(ctx, &response).await?;

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -21,6 +21,35 @@ mod text_commands;
 mod tui_passthrough;
 mod voice;
 
+pub(super) const STOPPING_RESPONSE: &str = "중지하고 있어요...";
+pub(super) const ALREADY_STOPPING_RESPONSE: &str = "이미 중지 중이에요.";
+pub(super) const NO_ACTIVE_TURN_RESPONSE: &str = "중지할 활성 턴이 없어요.";
+pub(super) const SESSION_CLEARED_RESPONSE: &str = "세션을 초기화했어요.";
+
+pub(super) fn session_started_response(path: &str) -> String {
+    format!("`{path}`에서 세션을 시작했어요.")
+}
+
+pub(super) fn session_restored_response(path: &str) -> String {
+    format!("`{path}`에서 세션을 복원했어요.")
+}
+
+pub(super) fn owner_error_response(summary: &str, detail: &str) -> String {
+    const DETAIL_PREVIEW_CHARS: usize = 1_400;
+
+    let detail = detail.trim();
+    let truncated = detail.chars().count() > DETAIL_PREVIEW_CHARS;
+    let preview: String = detail.chars().take(DETAIL_PREVIEW_CHARS).collect();
+    let preview = super::formatting::escape_for_code_fence(&preview).replace("||", "|\u{200b}|");
+    let suffix = if truncated {
+        "\n…(이하 생략)"
+    } else {
+        ""
+    };
+
+    format!("⚠️ {summary}\n||**상세**\n```text\n{preview}{suffix}\n```||")
+}
+
 #[allow(unused_imports)]
 pub(in crate::services::discord) use command_policy::{CommandRisk, PolicyDecision};
 pub(in crate::services::discord) use command_policy::{
@@ -77,6 +106,41 @@ pub(in crate::services::discord) use voice::{
     register_songbird, voice_occupancy,
 };
 pub(super) use voice::{cmd_vc_join, cmd_vc_leave, cmd_voice};
+
+#[cfg(test)]
+mod response_wording_tests {
+    use super::{
+        ALREADY_STOPPING_RESPONSE, NO_ACTIVE_TURN_RESPONSE, SESSION_CLEARED_RESPONSE,
+        STOPPING_RESPONSE, owner_error_response, session_restored_response,
+        session_started_response,
+    };
+
+    #[test]
+    fn shared_command_states_use_korean_responses() {
+        assert_eq!(STOPPING_RESPONSE, "중지하고 있어요...");
+        assert_eq!(ALREADY_STOPPING_RESPONSE, "이미 중지 중이에요.");
+        assert_eq!(NO_ACTIVE_TURN_RESPONSE, "중지할 활성 턴이 없어요.");
+        assert_eq!(SESSION_CLEARED_RESPONSE, "세션을 초기화했어요.");
+        assert_eq!(
+            session_started_response("/tmp/work"),
+            "`/tmp/work`에서 세션을 시작했어요."
+        );
+        assert_eq!(
+            session_restored_response("/tmp/work"),
+            "`/tmp/work`에서 세션을 복원했어요."
+        );
+    }
+
+    #[test]
+    fn owner_error_detail_is_folded_and_markdown_safe() {
+        let response = owner_error_response("명령을 실행하지 못했어요.", "bad ``` fence || leak");
+
+        assert!(response.starts_with("⚠️ 명령을 실행하지 못했어요.\n||**상세**"));
+        assert!(response.ends_with("```||"));
+        assert!(!response.contains("bad ``` fence"));
+        assert!(!response.contains("|| leak"));
+    }
+}
 
 /// Apply the issue #1005 owner guard to a slash command.
 ///

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -34,7 +34,7 @@ pub(super) fn session_restored_response(path: &str) -> String {
     format!("`{path}`에서 세션을 복원했어요.")
 }
 
-pub(super) fn owner_error_response(summary: &str, detail: &str) -> String {
+pub(in crate::services::discord) fn owner_error_response(summary: &str, detail: &str) -> String {
     const DETAIL_PREVIEW_CHARS: usize = 1_400;
 
     let detail = detail.trim();
@@ -48,6 +48,43 @@ pub(super) fn owner_error_response(summary: &str, detail: &str) -> String {
     };
 
     format!("⚠️ {summary}\n||**상세**\n```text\n{preview}{suffix}\n```||")
+}
+
+pub(in crate::services::discord) fn shell_command_output_response(
+    stdout: &str,
+    stderr: &str,
+    exit_code: i32,
+) -> String {
+    let mut parts = Vec::new();
+    if !stdout.is_empty() {
+        parts.push(format!("```\n{}\n```", stdout.trim_end()));
+    }
+    if !stderr.is_empty() {
+        parts.push(shell_command_stderr_response(stderr));
+    }
+    if parts.is_empty() || exit_code != 0 {
+        parts.push(format!("(종료 코드: {exit_code})"));
+    }
+    parts.join("\n")
+}
+
+pub(in crate::services::discord) fn shell_command_stderr_response(stderr: &str) -> String {
+    owner_error_response("셸 명령이 오류 출력을 반환했어요.", stderr)
+}
+
+pub(in crate::services::discord) fn shell_command_execution_error_response(detail: &str) -> String {
+    owner_error_response("셸 명령을 실행하지 못했어요.", detail)
+}
+
+pub(in crate::services::discord) fn shell_command_task_error_response(detail: &str) -> String {
+    owner_error_response("셸 명령을 처리하는 중 오류가 발생했어요.", detail)
+}
+
+pub(super) fn shell_command_timeout_response(detail: &str) -> String {
+    owner_error_response(
+        "셸 명령이 제한 시간을 초과해 중지됐어요.\n명령을 나누거나 경로 범위를 좁힌 뒤, `--exclude-dir`/`-name` 필터를 추가해 다시 시도해 주세요.",
+        detail,
+    )
 }
 
 #[allow(unused_imports)]
@@ -112,7 +149,8 @@ mod response_wording_tests {
     use super::{
         ALREADY_STOPPING_RESPONSE, NO_ACTIVE_TURN_RESPONSE, SESSION_CLEARED_RESPONSE,
         STOPPING_RESPONSE, owner_error_response, session_restored_response,
-        session_started_response,
+        session_started_response, shell_command_execution_error_response,
+        shell_command_output_response, shell_command_task_error_response,
     };
 
     #[test]
@@ -139,6 +177,30 @@ mod response_wording_tests {
         assert!(response.ends_with("```||"));
         assert!(!response.contains("bad ``` fence"));
         assert!(!response.contains("|| leak"));
+    }
+
+    #[test]
+    fn bare_shell_command_error_uses_shared_folded_korean_rendering() {
+        let stderr = "bad ``` fence || leak";
+        let bare_command_response = shell_command_output_response("", stderr, 1);
+        let explicit_shell_response = shell_command_output_response("", stderr, 1);
+
+        assert_eq!(bare_command_response, explicit_shell_response);
+        assert!(
+            bare_command_response
+                .starts_with("⚠️ 셸 명령이 오류 출력을 반환했어요.\n||**상세**\n```text\n")
+        );
+        assert!(bare_command_response.ends_with("```||\n(종료 코드: 1)"));
+        assert!(!bare_command_response.contains("bad ``` fence"));
+        assert!(!bare_command_response.contains("|| leak"));
+
+        let execution_error = shell_command_execution_error_response(stderr);
+        assert!(execution_error.starts_with("⚠️ 셸 명령을 실행하지 못했어요."));
+        assert!(execution_error.ends_with("```||"));
+
+        let task_error = shell_command_task_error_response(stderr);
+        assert!(task_error.starts_with("⚠️ 셸 명령을 처리하는 중 오류가 발생했어요."));
+        assert!(task_error.ends_with("```||"));
     }
 }
 

--- a/src/services/discord/commands/recovery_ops.rs
+++ b/src/services/discord/commands/recovery_ops.rs
@@ -289,19 +289,28 @@ async fn run_recovery(
                 parts.push(format!("```\n{}\n```", stdout.trim_end()));
             }
             if !stderr.is_empty() {
-                parts.push(format!("stderr:\n```\n{}\n```", stderr.trim_end()));
+                parts.push(super::owner_error_response(
+                    "복구 명령이 오류 출력을 반환했어요.",
+                    stderr.trim_end(),
+                ));
             }
             if let Some(cause) = outcome.timed_out {
-                parts.push(format!("killed by shell guard ({})", cause.as_str()));
+                parts.push(super::owner_error_response(
+                    "복구 명령이 제한 시간을 초과해 중지됐어요.",
+                    cause.as_str(),
+                ));
             } else if parts.is_empty() {
-                parts.push(format!("(exit code: {})", outcome.exit_code));
+                parts.push(format!("(종료 코드: {})", outcome.exit_code));
             } else if outcome.exit_code != 0 {
-                parts.push(format!("(exit code: {})", outcome.exit_code));
+                parts.push(format!("(종료 코드: {})", outcome.exit_code));
             }
             parts.join("\n")
         }
-        Ok(Err(e)) => format!("Failed to execute: {}", e),
-        Err(e) => format!("Task error: {}", e),
+        Ok(Err(e)) => super::owner_error_response("복구 명령을 실행하지 못했어요.", &e),
+        Err(e) => super::owner_error_response(
+            "복구 명령을 처리하는 중 오류가 발생했어요.",
+            &e.to_string(),
+        ),
     };
 
     send_long_message_ctx(ctx, &response).await?;

--- a/src/services/discord/commands/session.rs
+++ b/src/services/discord/commands/session.rs
@@ -156,13 +156,13 @@ pub(in crate::services::discord) async fn cmd_start(
         if has_existing_session {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!("  [{ts}] ▶ Session restored: {effective_path}");
-            response_lines.push(format!("Session restored at `{}`.", effective_path));
+            response_lines.push(super::session_restored_response(&effective_path));
         } else {
             session.history.clear();
 
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!("  [{ts}] ▶ Session started: {effective_path}");
-            response_lines.push(format!("Session started at `{}`.", effective_path));
+            response_lines.push(super::session_started_response(&effective_path));
         }
 
         // Notify about worktree if created

--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -148,7 +148,7 @@ async fn run_skill_slash_command(
     // Handle built-in commands directly instead of sending to AI
     match skill.as_str() {
         "clear" => {
-            ctx.say("Use the `/clear` slash command instead.").await?;
+            ctx.say("`/clear` 슬래시 명령을 사용해 주세요.").await?;
             return Ok(());
         }
         "stop" => {
@@ -166,10 +166,10 @@ async fn run_skill_slash_command(
             match result.token {
                 Some(token) => {
                     if result.already_stopping {
-                        ctx.say("Already stopping...").await?;
+                        ctx.say(super::ALREADY_STOPPING_RESPONSE).await?;
                         return Ok(());
                     }
-                    ctx.say("Stopping...").await?;
+                    ctx.say(super::STOPPING_RESPONSE).await?;
                     super::super::turn_bridge::stop_active_turn(
                         &ctx.data().provider,
                         &token,
@@ -180,7 +180,7 @@ async fn run_skill_slash_command(
                     tracing::info!("  [{ts}] ■ Cancel signal sent");
                 }
                 None => {
-                    ctx.say("No active request to stop.").await?;
+                    ctx.say(super::NO_ACTIVE_TURN_RESPONSE).await?;
                 }
             }
             return Ok(());

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::super::router::{IntakeDeps, IntakeOrigin, dispatch_skill_intake};
 use super::super::*;
-use super::build_provider_skill_prompt;
+use super::{build_provider_skill_prompt, owner_error_response as err};
 use crate::services::provider::CancelToken;
 
 enum TextStopLookup {
@@ -1153,10 +1153,7 @@ Any other message is sent to {p}.
                     parts.join("\n")
                 }
                 Ok(Err(e)) => super::owner_error_response("셸 명령을 실행하지 못했어요.", &e),
-                Err(e) => super::owner_error_response(
-                    "셸 명령을 처리하는 중 오류가 발생했어요.",
-                    &e.to_string(),
-                ),
+                Err(e) => err("셸 명령을 처리하는 중 오류가 발생했어요.", &e.to_string()),
             };
 
             send_long_message_raw(&ctx.http, channel_id, &response, &data.shared).await?;

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::super::router::{IntakeDeps, IntakeOrigin, dispatch_skill_intake};
 use super::super::*;
-use super::{build_provider_skill_prompt, owner_error_response as err};
+use super::build_provider_skill_prompt;
 use crate::services::provider::CancelToken;
 
 enum TextStopLookup {
@@ -1127,33 +1127,22 @@ Any other message is sent to {p}.
                     let stdout = String::from_utf8_lossy(&outcome.stdout);
                     let stderr = String::from_utf8_lossy(&outcome.stderr);
                     let exit_code = outcome.exit_code;
-                    let mut parts = Vec::new();
-                    if !stdout.is_empty() {
-                        parts.push(format!("```\n{}\n```", stdout.trim_end()));
-                    }
-                    if !stderr.is_empty() {
-                        parts.push(super::owner_error_response(
-                            "셸 명령이 오류 출력을 반환했어요.",
-                            stderr.trim_end(),
-                        ));
-                    }
                     if let Some(cause) = outcome.timed_out {
-                        parts.push(format!(
-                            "⚠️ 셸 명령이 제한 시간을 초과해 중지됐어요.\n명령을 나누거나 경로 범위를 좁힌 뒤, `--exclude-dir`/`-name` 필터를 추가해 다시 시도해 주세요.\n{}",
-                            super::owner_error_response(
-                                "중지 원인 상세를 확인해 주세요.",
-                                cause.as_str(),
-                            )
-                        ));
-                    } else if parts.is_empty() {
-                        parts.push(format!("(종료 코드: {})", exit_code));
-                    } else if exit_code != 0 {
-                        parts.push(format!("(종료 코드: {})", exit_code));
+                        let mut parts = Vec::new();
+                        if !stdout.is_empty() {
+                            parts.push(format!("```\n{}\n```", stdout.trim_end()));
+                        }
+                        if !stderr.is_empty() {
+                            parts.push(super::shell_command_stderr_response(&stderr));
+                        }
+                        parts.push(super::shell_command_timeout_response(cause.as_str()));
+                        parts.join("\n")
+                    } else {
+                        super::shell_command_output_response(&stdout, &stderr, exit_code)
                     }
-                    parts.join("\n")
                 }
-                Ok(Err(e)) => super::owner_error_response("셸 명령을 실행하지 못했어요.", &e),
-                Err(e) => err("셸 명령을 처리하는 중 오류가 발생했어요.", &e.to_string()),
+                Ok(Err(e)) => super::shell_command_execution_error_response(&e),
+                Err(e) => super::shell_command_task_error_response(&e.to_string()),
             };
 
             send_long_message_raw(&ctx.http, channel_id, &response, &data.shared).await?;

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -112,13 +112,13 @@ fn format_escalation_settings_summary(settings: &crate::config::EscalationSettin
     let owner = settings
         .owner_user_id
         .map(|id| id.to_string())
-        .unwrap_or_else(|| "(none)".to_string());
+        .unwrap_or_else(|| "(없음)".to_string());
     let pm_channel = settings
         .pm_channel_id
         .clone()
-        .unwrap_or_else(|| "(none)".to_string());
+        .unwrap_or_else(|| "(없음)".to_string());
     format!(
-        "mode: `{}`\nowner_user_id: `{}`\npm_channel_id: `{}`\nschedule: `{}` / `{}`",
+        "모드: `{}`\n소유자 ID: `{}`\nPM 채널 ID: `{}`\n일정: `{}` / `{}`",
         mode, owner, pm_channel, settings.schedule.pm_hours, settings.schedule.timezone
     )
 }
@@ -255,10 +255,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!("  [{ts}] ▶ Session started: {}", effective_path);
             let _ = msg
-                .reply(
-                    &ctx.http,
-                    format!("Session started at `{}`.", effective_path),
-                )
+                .reply(&ctx.http, super::session_started_response(&effective_path))
                 .await;
             return Ok(true);
         }
@@ -426,10 +423,10 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                     );
                 }
                 TextStopLookup::AlreadyStopping => {
-                    let _ = msg.reply(&ctx.http, "Already stopping...").await;
+                    let _ = msg.reply(&ctx.http, super::ALREADY_STOPPING_RESPONSE).await;
                 }
                 TextStopLookup::NoActiveTurn => {
-                    let _ = msg.reply(&ctx.http, "No active turn to stop.").await;
+                    let _ = msg.reply(&ctx.http, super::NO_ACTIVE_TURN_RESPONSE).await;
                 }
             }
             return Ok(true);
@@ -445,7 +442,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                 super::SoftClearNotifyMode::Suppress,
             )
             .await;
-            let _ = msg.reply(&ctx.http, "Session cleared.").await;
+            let _ = msg.reply(&ctx.http, super::SESSION_CLEARED_RESPONSE).await;
             return Ok(true);
         }
 
@@ -541,7 +538,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
 
             if !check_owner(msg.author.id, &data.shared).await {
                 let _ = msg
-                    .reply(&ctx.http, "Only the owner can change escalation settings.")
+                    .reply(&ctx.http, "소유자만 에스컬레이션 설정을 변경할 수 있어요.")
                     .await;
                 return Ok(true);
             }
@@ -552,7 +549,10 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                     let _ = msg
                         .reply(
                             &ctx.http,
-                            format!("Failed to load escalation settings: {err}"),
+                            super::owner_error_response(
+                                "에스컬레이션 설정을 불러오지 못했어요.",
+                                &err,
+                            ),
                         )
                         .await;
                     return Ok(true);
@@ -564,7 +564,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                     .reply(
                         &ctx.http,
                         format!(
-                            "**Escalation Settings**\n{}",
+                            "**에스컬레이션 설정**\n{}",
                             format_escalation_settings_summary(&settings)
                         ),
                     )
@@ -576,7 +576,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
             let subcommand = parts.next().unwrap_or("").trim().to_ascii_lowercase();
             let value = parts.next().unwrap_or("").trim();
 
-            let usage = "Usage: `!escalation status|pm|user|scheduled|schedule <HH:MM-HH:MM>|timezone <IANA>|owner <user_id>|pm-channel <channel_id>`";
+            let usage = "사용법: `!escalation status|pm|user|scheduled|schedule <HH:MM-HH:MM>|timezone <IANA>|owner <user_id>|pm-channel <channel_id>`";
             let update_error = match subcommand.as_str() {
                 "pm" => {
                     settings.mode = crate::config::EscalationMode::Pm;
@@ -592,7 +592,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                 }
                 "schedule" => {
                     if value.is_empty() {
-                        Some("schedule value is required")
+                        Some("일정 값을 입력해 주세요.")
                     } else {
                         settings.mode = crate::config::EscalationMode::Scheduled;
                         settings.schedule.pm_hours = value.to_string();
@@ -601,7 +601,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                 }
                 "timezone" => {
                     if value.is_empty() {
-                        Some("timezone value is required")
+                        Some("시간대 값을 입력해 주세요.")
                     } else {
                         settings.schedule.timezone = value.to_string();
                         None
@@ -612,7 +612,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                         settings.owner_user_id = Some(user_id);
                         None
                     }
-                    None => Some("owner must be a numeric Discord user id or mention"),
+                    None => Some("소유자는 Discord 사용자 숫자 ID 또는 멘션으로 입력해 주세요."),
                 },
                 "clear-owner" => {
                     settings.owner_user_id = None;
@@ -620,7 +620,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                 }
                 "pm-channel" => {
                     if value.is_empty() {
-                        Some("pm-channel value is required")
+                        Some("PM 채널 값을 입력해 주세요.")
                     } else {
                         settings.pm_channel_id = Some(value.to_string());
                         None
@@ -644,7 +644,7 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                         .reply(
                             &ctx.http,
                             format!(
-                                "**Escalation Settings Updated**\n{}",
+                                "**에스컬레이션 설정을 변경했어요**\n{}",
                                 format_escalation_settings_summary(&response.current)
                             ),
                         )
@@ -654,7 +654,10 @@ pub(in crate::services::discord) async fn handle_text_command_with_uploads(
                     let _ = msg
                         .reply(
                             &ctx.http,
-                            format!("Failed to save escalation settings: {err}"),
+                            super::owner_error_response(
+                                "에스컬레이션 설정을 저장하지 못했어요.",
+                                &err,
+                            ),
                         )
                         .await;
                 }
@@ -1062,10 +1065,7 @@ Any other message is sent to {p}.
 
             if cmd_str.is_empty() {
                 let _ = msg
-                    .reply(
-                        &ctx.http,
-                        "Usage: `!shell <command>`\nExample: `!shell ls -la`",
-                    )
+                    .reply(&ctx.http, "사용법: `!shell <command>`\n예: `!shell ls -la`")
                     .await;
                 return Ok(true);
             }
@@ -1132,24 +1132,31 @@ Any other message is sent to {p}.
                         parts.push(format!("```\n{}\n```", stdout.trim_end()));
                     }
                     if !stderr.is_empty() {
-                        parts.push(format!("stderr:\n```\n{}\n```", stderr.trim_end()));
+                        parts.push(super::owner_error_response(
+                            "셸 명령이 오류 출력을 반환했어요.",
+                            stderr.trim_end(),
+                        ));
                     }
                     if let Some(cause) = outcome.timed_out {
                         parts.push(format!(
-                            "killed by shell guard ({}). Issue #1128: split the command, \
-                             scope the path, or add `--exclude-dir`/`-name` filters before \
-                             retrying.",
-                            cause.as_str()
+                            "⚠️ 셸 명령이 제한 시간을 초과해 중지됐어요.\n명령을 나누거나 경로 범위를 좁힌 뒤, `--exclude-dir`/`-name` 필터를 추가해 다시 시도해 주세요.\n{}",
+                            super::owner_error_response(
+                                "중지 원인 상세를 확인해 주세요.",
+                                cause.as_str(),
+                            )
                         ));
                     } else if parts.is_empty() {
-                        parts.push(format!("(exit code: {})", exit_code));
+                        parts.push(format!("(종료 코드: {})", exit_code));
                     } else if exit_code != 0 {
-                        parts.push(format!("(exit code: {})", exit_code));
+                        parts.push(format!("(종료 코드: {})", exit_code));
                     }
                     parts.join("\n")
                 }
-                Ok(Err(e)) => format!("Failed to execute: {}", e),
-                Err(e) => format!("Task error: {}", e),
+                Ok(Err(e)) => super::owner_error_response("셸 명령을 실행하지 못했어요.", &e),
+                Err(e) => super::owner_error_response(
+                    "셸 명령을 처리하는 중 오류가 발생했어요.",
+                    &e.to_string(),
+                ),
             };
 
             send_long_message_raw(&ctx.http, channel_id, &response, &data.shared).await?;
@@ -1250,19 +1257,28 @@ Any other message is sent to {p}.
                         parts.push(format!("```\n{}\n```", stdout.trim_end()));
                     }
                     if !stderr.is_empty() {
-                        parts.push(format!("stderr:\n```\n{}\n```", stderr.trim_end()));
+                        parts.push(super::owner_error_response(
+                            "복구 명령이 오류 출력을 반환했어요.",
+                            stderr.trim_end(),
+                        ));
                     }
                     if let Some(cause) = outcome.timed_out {
-                        parts.push(format!("killed by shell guard ({})", cause.as_str()));
+                        parts.push(super::owner_error_response(
+                            "복구 명령이 제한 시간을 초과해 중지됐어요.",
+                            cause.as_str(),
+                        ));
                     } else if parts.is_empty() {
-                        parts.push(format!("(exit code: {})", outcome.exit_code));
+                        parts.push(format!("(종료 코드: {})", outcome.exit_code));
                     } else if outcome.exit_code != 0 {
-                        parts.push(format!("(exit code: {})", outcome.exit_code));
+                        parts.push(format!("(종료 코드: {})", outcome.exit_code));
                     }
                     parts.join("\n")
                 }
-                Ok(Err(e)) => format!("Failed to execute: {}", e),
-                Err(e) => format!("Task error: {}", e),
+                Ok(Err(e)) => super::owner_error_response("복구 명령을 실행하지 못했어요.", &e),
+                Err(e) => super::owner_error_response(
+                    "복구 명령을 처리하는 중 오류가 발생했어요.",
+                    &e.to_string(),
+                ),
             };
             send_long_message_raw(&ctx.http, channel_id, &response, &data.shared).await?;
             return Ok(true);
@@ -1360,13 +1376,13 @@ Any other message is sent to {p}.
                                 channel_id,
                                 &stop_reason,
                             );
-                            let _ = msg.reply(&ctx.http, "Stopping...").await;
+                            let _ = msg.reply(&ctx.http, super::STOPPING_RESPONSE).await;
                         }
                         TextStopLookup::AlreadyStopping => {
-                            let _ = msg.reply(&ctx.http, "Already stopping...").await;
+                            let _ = msg.reply(&ctx.http, super::ALREADY_STOPPING_RESPONSE).await;
                         }
                         TextStopLookup::NoActiveTurn => {
-                            let _ = msg.reply(&ctx.http, "No active request to stop.").await;
+                            let _ = msg.reply(&ctx.http, super::NO_ACTIVE_TURN_RESPONSE).await;
                         }
                     }
                     return Ok(true);

--- a/src/services/discord/router/message_handler/control.rs
+++ b/src/services/discord/router/message_handler/control.rs
@@ -10,7 +10,7 @@ pub(in crate::services::discord::router) async fn handle_shell_command_raw(
     if cmd_str.is_empty() {
         rate_limit_wait(shared, channel_id).await;
         let _ = channel_id
-            .say(&ctx.http, "Usage: `!<command>`\nExample: `!ls -la`")
+            .say(&ctx.http, "사용법: `!<command>`\n예: `!ls -la`")
             .await;
         return Ok(());
     }
@@ -49,22 +49,16 @@ pub(in crate::services::discord::router) async fn handle_shell_command_raw(
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let exit_code = output.status.code().unwrap_or(-1);
-            let mut parts = Vec::new();
-            if !stdout.is_empty() {
-                parts.push(format!("```\n{}\n```", stdout.trim_end()));
-            }
-            if !stderr.is_empty() {
-                parts.push(format!("stderr:\n```\n{}\n```", stderr.trim_end()));
-            }
-            if parts.is_empty() {
-                parts.push(format!("(exit code: {})", exit_code));
-            } else if exit_code != 0 {
-                parts.push(format!("(exit code: {})", exit_code));
-            }
-            parts.join("\n")
+            crate::services::discord::commands::shell_command_output_response(
+                &stdout, &stderr, exit_code,
+            )
         }
-        Ok(Err(e)) => format!("Failed to execute: {}", e),
-        Err(e) => format!("Task error: {}", e),
+        Ok(Err(e)) => crate::services::discord::commands::shell_command_execution_error_response(
+            &e.to_string(),
+        ),
+        Err(e) => {
+            crate::services::discord::commands::shell_command_task_error_response(&e.to_string())
+        }
     };
 
     send_long_message_raw(&ctx.http, channel_id, &response, shared).await?;


### PR DESCRIPTION
## 이슈
#4216. 같은 상태에 3가지 문구, 영/한 혼용, owner 명령 raw 에러 노출.

## 변경
1. stop/clear/start/restore·active-turn 부재 등 중복 응답을 commands 모듈에 중앙화(단일 한국어 문구 재사용).
2. escalation/shell/recovery 응답을 한국어-facing으로 전환(실행/제어흐름 보존).
3. owner 명령 raw 에러 덤프 → 요약 + bounded·escaped spoiler 상세로 교체. 문구 테스트 추가.

## 게이트 (오케스트레이터 독립 재검증)
fmt/check/test, freshness, **audit_maintainability --check rc=0** (text_commands.rs 1493=baseline, net-zero fold). #3016 핫파일 무편집.

🤖 구현: codex gpt-5.6-sol high / 리뷰: Opus dual (독립)