### PR TITLE
ux(relay): turn-end WIP 경고를 완료 풋터로 병합 + 한국어화 + 다중 완료경로 dedup (#4217)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -474,7 +474,7 @@
 | `services::discord::destructive_cancel_gate` | `src/services/discord/destructive_cancel_gate.rs` | 705 | 350 | 355 |  |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 509 | 509 | 0 |  |
 | `services::discord::dispatch_policy` | `src/services/discord/dispatch_policy.rs` | 351 | 218 | 133 |  |
-| `services::discord::footer_view_reconciler` | `src/services/discord/footer_view_reconciler/mod.rs` | 678 | 490 | 188 |  |
+| `services::discord::footer_view_reconciler` | `src/services/discord/footer_view_reconciler/mod.rs` | 658 | 470 | 188 |  |
 | `services::discord::footer_view_reconciler::registry` | `src/services/discord/footer_view_reconciler/registry.rs` | 624 | 624 | 0 |  |
 | `services::discord::formatting` | `src/services/discord/formatting.rs` | 3898 | 2566 | 1332 | giant-file |
 | `services::discord::formatting::long_send_rollback` | `src/services/discord/formatting/long_send_rollback.rs` | 481 | 481 | 0 |  |
@@ -835,7 +835,7 @@
 | `services::discord::turn_bridge::single_message_footer` | `src/services/discord/turn_bridge/single_message_footer.rs` | 835 | 521 | 314 |  |
 | `services::discord::turn_bridge::skill_usage` | `src/services/discord/turn_bridge/skill_usage.rs` | 80 | 80 | 0 |  |
 | `services::discord::turn_bridge::stale_resume` | `src/services/discord/turn_bridge/stale_resume.rs` | 301 | 144 | 157 |  |
-| `services::discord::turn_bridge::status_panel` | `src/services/discord/turn_bridge/status_panel.rs` | 684 | 684 | 0 |  |
+| `services::discord::turn_bridge::status_panel` | `src/services/discord/turn_bridge/status_panel.rs` | 678 | 678 | 0 |  |
 | `services::discord::turn_bridge::stream_loop` | `src/services/discord/turn_bridge/stream_loop.rs` | 979 | 979 | 0 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms` | `src/services/discord/turn_bridge/stream_loop/content_arms.rs` | 635 | 635 | 0 |  |
 | `services::discord::turn_bridge::stream_loop::tool_arms` | `src/services/discord/turn_bridge/stream_loop/tool_arms.rs` | 684 | 684 | 0 |  |
@@ -862,7 +862,7 @@
 | `services::discord::turn_bridge::watcher_handoff` | `src/services/discord/turn_bridge/watcher_handoff.rs` | 935 | 532 | 403 |  |
 | `services::discord::turn_bridge::watcher_orphan_cleanup` | `src/services/discord/turn_bridge/watcher_orphan_cleanup.rs` | 475 | 233 | 242 |  |
 | `services::discord::turn_completion_events` | `src/services/discord/turn_completion_events.rs` | 85 | 85 | 0 |  |
-| `services::discord::turn_end_wip_warning` | `src/services/discord/turn_end_wip_warning.rs` | 344 | 145 | 199 |  |
+| `services::discord::turn_end_wip_warning` | `src/services/discord/turn_end_wip_warning.rs` | 382 | 193 | 189 |  |
 | `services::discord::turn_finalizer` | `src/services/discord/turn_finalizer.rs` | 5040 | 1048 | 3992 | giant-file |
 | `services::discord::turn_finalizer::cleanup` | `src/services/discord/turn_finalizer/cleanup.rs` | 1608 | 613 | 995 |  |
 | `services::discord::turn_finalizer::completion_signal` | `src/services/discord/turn_finalizer/completion_signal.rs` | 310 | 54 | 256 |  |

--- a/src/services/discord/footer_view_reconciler/mod.rs
+++ b/src/services/discord/footer_view_reconciler/mod.rs
@@ -57,7 +57,10 @@ impl<'a> FooterViewWriter<'a> {
     }
 
     #[cfg(test)]
-    fn test(shared: &'a SharedData, sink: &'a FooterViewTestSink) -> Self {
+    pub(in crate::services::discord) fn test(
+        shared: &'a SharedData,
+        sink: &'a FooterViewTestSink,
+    ) -> Self {
         Self::Test { shared, sink }
     }
 
@@ -109,42 +112,6 @@ impl<'a> FooterViewWriter<'a> {
             }
         }
     }
-
-    async fn warn_turn_end_wip(
-        self,
-        channel_id: ChannelId,
-        provider: &ProviderKind,
-        expected_user_msg_id: Option<u64>,
-        source: &'static str,
-    ) {
-        let inflight = super::turn_end_wip_warning::load_matching_inflight_state(
-            provider,
-            channel_id,
-            expected_user_msg_id,
-        );
-        match self {
-            Self::Bridge { shared } => {
-                let _ = super::turn_end_wip_warning::warn_turn_end_wip_with_shared_http(
-                    shared,
-                    channel_id,
-                    inflight.as_ref(),
-                    source,
-                )
-                .await;
-            }
-            Self::Watcher { http, .. } => {
-                let _ = super::turn_end_wip_warning::warn_turn_end_wip_with_http(
-                    http,
-                    channel_id,
-                    inflight.as_ref(),
-                    source,
-                )
-                .await;
-            }
-            #[cfg(test)]
-            Self::Test { .. } => {}
-        }
-    }
 }
 
 #[cfg(test)]
@@ -174,7 +141,7 @@ impl FooterViewTestSink {
             });
     }
 
-    fn edits(&self) -> Vec<FooterViewRecordedEdit> {
+    pub(in crate::services::discord) fn edits(&self) -> Vec<FooterViewRecordedEdit> {
         self.edits
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -208,6 +175,7 @@ fn prepare_turn_completed_footer(
     indicator: &str,
     background: bool,
     background_agent_pending: bool,
+    wip_warning: Option<&super::turn_end_wip_warning::TurnEndWipWarningReservation>,
 ) -> CompletedFooterPlan {
     shared.ui.placeholder_live_events.push_status_event(
         channel_id,
@@ -220,6 +188,11 @@ fn prepare_turn_completed_footer(
         .ui
         .placeholder_live_events
         .render_completion_footer(channel_id, provider, indicator);
+    let completion_block = super::turn_end_wip_warning::merge_turn_end_wip_warning(
+        rendered.block.unwrap_or_default(),
+        wip_warning,
+    );
+    let completion_block = (!completion_block.trim().is_empty()).then_some(completion_block);
     let Some(msg_id) = terminal_msg_id else {
         return CompletedFooterPlan {
             supersede_edit: None,
@@ -233,20 +206,20 @@ fn prepare_turn_completed_footer(
         provider,
         chrono::Utc::now().timestamp(),
         terminal_text,
-        rendered.block.as_deref(),
+        completion_block.as_deref(),
         rendered.has_unfinished_entries,
     );
     let terminal_edit = smp::finalize_streaming_footer_with_completion(
         terminal_text,
         provider,
-        rendered.block.as_deref(),
+        completion_block.as_deref(),
     )
     .map(|text| CompletionFooterTerminalEdit {
         message_id: msg_id,
         owner,
         text,
         remove_after_edit: !rendered.has_unfinished_entries,
-        completion_block: rendered.block,
+        completion_block,
         delivered_terminal_ids: rendered.delivered_terminal_ids,
     });
     CompletedFooterPlan {
@@ -268,6 +241,12 @@ pub(in crate::services::discord) async fn note_turn_completed_footer(
     background_agent_pending: bool,
     source: &'static str,
 ) -> bool {
+    let inflight = super::turn_end_wip_warning::load_matching_inflight_state(
+        provider,
+        channel_id,
+        Some(owner.user_msg_id),
+    );
+    let wip_warning = super::turn_end_wip_warning::reserve_turn_end_wip_warning(inflight.as_ref());
     let plan = prepare_turn_completed_footer(
         writer.shared(),
         channel_id,
@@ -278,6 +257,7 @@ pub(in crate::services::discord) async fn note_turn_completed_footer(
         indicator,
         background,
         background_agent_pending,
+        wip_warning.as_ref(),
     );
     if let Some(edit) = plan.supersede_edit
         && let Err(error) = writer
@@ -295,9 +275,6 @@ pub(in crate::services::discord) async fn note_turn_completed_footer(
     let Some(terminal_edit) = plan.terminal_edit else {
         return true;
     };
-    writer
-        .warn_turn_end_wip(channel_id, provider, Some(owner.user_msg_id), source)
-        .await;
     let edited = match writer
         .edit_channel_message(
             channel_id,
@@ -319,6 +296,9 @@ pub(in crate::services::discord) async fn note_turn_completed_footer(
             false
         }
     };
+    if edited && let Some(warning) = wip_warning {
+        warning.commit();
+    }
     let recorded = registry::completion_footer_record_committed_text_result_for_owner(
         channel_id,
         terminal_edit.message_id,

--- a/src/services/discord/turn_bridge/status_panel.rs
+++ b/src/services/discord/turn_bridge/status_panel.rs
@@ -38,9 +38,19 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
         provider,
         started_at_unix,
     );
+    let inflight = crate::services::discord::turn_end_wip_warning::load_matching_inflight_state(
+        provider,
+        channel_id,
+        Some(expected_user_msg_id),
+    );
+    let (panel_text, wip_warning) =
+        completion_panel_with_wip_warning(panel_text, last_status_panel_text, inflight.as_ref());
 
     match status_panel_completion_action(status_panel_msg_id, last_status_panel_text, &panel_text) {
         StatusPanelCompletionAction::AlreadyCommitted => {
+            if let Some(warning) = wip_warning {
+                warning.commit();
+            }
             purge_pending_bind_for_completed_status_panel(
                 shared,
                 provider,
@@ -50,20 +60,6 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
             true
         }
         StatusPanelCompletionAction::SendFallback => {
-            let inflight =
-                crate::services::discord::turn_end_wip_warning::load_matching_inflight_state(
-                    provider,
-                    channel_id,
-                    Some(expected_user_msg_id),
-                );
-            let _ = warn_turn_end_wip_before_status_panel_commit(
-                shared,
-                gateway,
-                channel_id,
-                inflight.as_ref(),
-                source,
-            )
-            .await;
             complete_status_panel_v2_fallback_with_gateway(
                 shared,
                 gateway,
@@ -72,25 +68,12 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
                 expected_user_msg_id,
                 last_status_panel_text,
                 panel_text,
+                wip_warning,
                 source,
             )
             .await
         }
         StatusPanelCompletionAction::Edit(status_msg_id) => {
-            let inflight =
-                crate::services::discord::turn_end_wip_warning::load_matching_inflight_state(
-                    provider,
-                    channel_id,
-                    Some(expected_user_msg_id),
-                );
-            let _ = warn_turn_end_wip_before_status_panel_commit(
-                shared,
-                gateway,
-                channel_id,
-                inflight.as_ref(),
-                source,
-            )
-            .await;
             let edit_result = if gateway.can_chain_locally() {
                 TurnGateway::edit_message(gateway, channel_id, status_msg_id, &panel_text).await
             } else if let Some(http) = shared.serenity_http_or_token_fallback() {
@@ -103,6 +86,9 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
             };
             match edit_result {
                 Ok(()) => {
+                    if let Some(warning) = wip_warning {
+                        warning.commit();
+                    }
                     *last_status_panel_text = panel_text;
                     purge_pending_bind_for_completed_status_panel(
                         shared,
@@ -122,6 +108,7 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
                             expected_user_msg_id,
                             last_status_panel_text,
                             panel_text,
+                            wip_warning,
                             source,
                         )
                         .await;
@@ -140,23 +127,25 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
     }
 }
 
-async fn warn_turn_end_wip_before_status_panel_commit<G: TurnGateway + ?Sized>(
-    shared: &SharedData,
-    gateway: &G,
-    channel_id: ChannelId,
+fn completion_panel_with_wip_warning(
+    panel_text: String,
+    previous_panel_text: &str,
     inflight: Option<&super::super::InflightTurnState>,
-    source: &'static str,
-) -> crate::services::discord::turn_end_wip_warning::TurnEndWipWarningOutcome {
-    if gateway.can_chain_locally() {
-        return crate::services::discord::turn_end_wip_warning::warn_turn_end_wip_with_gateway(
-            gateway, channel_id, inflight, source,
-        )
-        .await;
-    }
-    crate::services::discord::turn_end_wip_warning::warn_turn_end_wip_with_shared_http(
-        shared, channel_id, inflight, source,
-    )
-    .await
+) -> (
+    String,
+    Option<crate::services::discord::turn_end_wip_warning::TurnEndWipWarningReservation>,
+) {
+    use crate::services::discord::turn_end_wip_warning as wip;
+
+    let reservation = wip::reserve_turn_end_wip_warning(inflight);
+    let panel_text = if reservation.is_some() {
+        wip::merge_turn_end_wip_warning(panel_text, reservation.as_ref())
+    } else if wip::turn_end_wip_warning_was_delivered(inflight) {
+        wip::preserve_merged_turn_end_wip_warning(panel_text, previous_panel_text)
+    } else {
+        panel_text
+    };
+    (panel_text, reservation)
 }
 
 enum StatusPanelWipInflight<'a> {
@@ -223,10 +212,16 @@ async fn complete_status_panel_v2_fallback_with_gateway<G: TurnGateway + ?Sized>
     expected_user_msg_id: u64,
     last_status_panel_text: &mut String,
     panel_text: String,
+    wip_warning: Option<
+        crate::services::discord::turn_end_wip_warning::TurnEndWipWarningReservation,
+    >,
     source: &'static str,
 ) -> bool {
     match send_status_panel_v2_completion_fallback(shared, gateway, channel_id, &panel_text).await {
         Ok(message_id) => {
+            if let Some(warning) = wip_warning {
+                warning.commit();
+            }
             persist_status_panel_completion_fallback_message_id(
                 provider,
                 channel_id,
@@ -278,9 +273,23 @@ pub(in crate::services::discord) async fn complete_status_panel_v2_with_http(
         provider,
         started_at_unix,
     );
+    let inflight = status_panel_wip_inflight_for_completion(
+        inflight_snapshot,
+        provider,
+        channel_id,
+        expected_user_msg_id,
+    );
+    let (panel_text, wip_warning) = completion_panel_with_wip_warning(
+        panel_text,
+        last_status_panel_text,
+        inflight.as_ref().map(StatusPanelWipInflight::as_inflight),
+    );
 
     match status_panel_completion_action(status_panel_msg_id, last_status_panel_text, &panel_text) {
         StatusPanelCompletionAction::AlreadyCommitted => {
+            if let Some(warning) = wip_warning {
+                warning.commit();
+            }
             purge_pending_bind_for_completed_status_panel(
                 shared.as_ref(),
                 provider,
@@ -290,19 +299,6 @@ pub(in crate::services::discord) async fn complete_status_panel_v2_with_http(
             true
         }
         StatusPanelCompletionAction::SendFallback => {
-            let inflight = status_panel_wip_inflight_for_completion(
-                inflight_snapshot,
-                provider,
-                channel_id,
-                expected_user_msg_id,
-            );
-            let _ = crate::services::discord::turn_end_wip_warning::warn_turn_end_wip_with_http(
-                http,
-                channel_id,
-                inflight.as_ref().map(StatusPanelWipInflight::as_inflight),
-                source,
-            )
-            .await;
             rate_limit_wait(shared, channel_id).await;
             complete_status_panel_v2_fallback_with_http(
                 http,
@@ -311,29 +307,20 @@ pub(in crate::services::discord) async fn complete_status_panel_v2_with_http(
                 expected_user_msg_id,
                 last_status_panel_text,
                 panel_text,
+                wip_warning,
                 source,
             )
             .await
         }
         StatusPanelCompletionAction::Edit(status_msg_id) => {
-            let inflight = status_panel_wip_inflight_for_completion(
-                inflight_snapshot,
-                provider,
-                channel_id,
-                expected_user_msg_id,
-            );
-            let _ = crate::services::discord::turn_end_wip_warning::warn_turn_end_wip_with_http(
-                http,
-                channel_id,
-                inflight.as_ref().map(StatusPanelWipInflight::as_inflight),
-                source,
-            )
-            .await;
             rate_limit_wait(shared, channel_id).await;
             match super::http::edit_channel_message(http, channel_id, status_msg_id, &panel_text)
                 .await
             {
                 Ok(_) => {
+                    if let Some(warning) = wip_warning {
+                        warning.commit();
+                    }
                     *last_status_panel_text = panel_text;
                     purge_pending_bind_for_completed_status_panel(
                         shared.as_ref(),
@@ -353,6 +340,7 @@ pub(in crate::services::discord) async fn complete_status_panel_v2_with_http(
                             expected_user_msg_id,
                             last_status_panel_text,
                             panel_text,
+                            wip_warning,
                             source,
                         )
                         .await;
@@ -378,10 +366,16 @@ async fn complete_status_panel_v2_fallback_with_http(
     expected_user_msg_id: Option<u64>,
     last_status_panel_text: &mut String,
     panel_text: String,
+    wip_warning: Option<
+        crate::services::discord::turn_end_wip_warning::TurnEndWipWarningReservation,
+    >,
     source: &'static str,
 ) -> bool {
     match send_status_panel_v2_completion_fallback_http(http, channel_id, &panel_text).await {
         Ok(message_id) => {
+            if let Some(warning) = wip_warning {
+                warning.commit();
+            }
             persist_status_panel_completion_fallback_message_id(
                 provider,
                 channel_id,

--- a/src/services/discord/turn_bridge/status_panel_tests.rs
+++ b/src/services/discord/turn_bridge/status_panel_tests.rs
@@ -38,13 +38,6 @@ impl StatusPanelFallbackGateway {
             ..Self::default()
         }
     }
-
-    fn without_local_chain() -> Self {
-        Self {
-            can_chain_locally: false,
-            ..Self::default()
-        }
-    }
 }
 
 impl Default for StatusPanelFallbackGateway {
@@ -142,42 +135,6 @@ impl TurnGateway for StatusPanelFallbackGateway {
     fn bot_owner_provider(&self) -> Option<ProviderKind> {
         Some(ProviderKind::Claude)
     }
-}
-
-#[tokio::test]
-async fn status_panel_wip_warning_does_not_use_synthetic_gateway_when_http_path_required() {
-    let Some(worktree) = init_git_repo_for_wip_warning() else {
-        return;
-    };
-    fs::write(worktree.path().join("untracked.txt"), "untracked\n").expect("write untracked file");
-
-    let shared = make_status_panel_v2_shared_for_tests();
-    let gateway = StatusPanelFallbackGateway::without_local_chain();
-    let state =
-        wip_warning_inflight_state(&ProviderKind::Claude, 3_792_010, 3_792_011, worktree.path());
-
-    let outcome = super::warn_turn_end_wip_before_status_panel_commit(
-        shared.as_ref(),
-        &gateway,
-        ChannelId::new(3_792_010),
-        Some(&state),
-        "test_wip_warning_http_path",
-    )
-    .await;
-
-    assert_eq!(
-        outcome,
-        crate::services::discord::turn_end_wip_warning::TurnEndWipWarningOutcome::SendFailed,
-        "no local-chain gateway plus no HTTP handle should fail instead of being swallowed"
-    );
-    assert!(
-        gateway
-            .sent_messages
-            .lock()
-            .expect("sent messages lock")
-            .is_empty(),
-        "headless/synthetic gateway sends must not absorb WIP warnings"
-    );
 }
 
 #[test]
@@ -801,7 +758,7 @@ async fn status_panel_completion_fallback_posts_when_message_id_is_synthetic() {
 }
 
 #[tokio::test]
-async fn status_panel_completion_sends_wip_warning_before_completion_surface() {
+async fn status_panel_completion_merges_korean_wip_warning_into_completion_surface() {
     let Some(worktree) = init_git_repo_for_wip_warning() else {
         return;
     };
@@ -844,11 +801,15 @@ async fn status_panel_completion_sends_wip_warning_before_completion_surface() {
         .lock()
         .expect("sent messages lock")
         .clone();
-    assert_eq!(sent_messages.len(), 2);
-    assert!(sent_messages[0].contains("WIP uncommitted files detected"));
-    assert!(sent_messages[0].contains(&format!("Workspace: `{}`", worktree.path().display())));
-    assert!(sent_messages[0].contains("Counts: 0 staged, 0 unstaged, 1 untracked."));
-    assert!(sent_messages[1].contains("완료"));
+    assert_eq!(sent_messages.len(), 1);
+    assert!(sent_messages[0].contains("완료"));
+    assert!(sent_messages[0].contains("커밋되지 않은 변경사항"));
+    assert!(sent_messages[0].contains(&format!("작업공간: `{}`", worktree.path().display())));
+    assert!(
+        sent_messages[0]
+            .contains("파일 수: 스테이징됨 0개 · 스테이징 안 됨 0개 · 추적되지 않음 1개")
+    );
+    assert!(!sent_messages[0].contains("WARNING:"));
 
     let committed_retry = complete_status_panel_v2(
         shared.as_ref(),
@@ -872,8 +833,97 @@ async fn status_panel_completion_sends_wip_warning_before_completion_surface() {
             .lock()
             .expect("sent messages lock")
             .len(),
-        2,
+        1,
         "already-committed completion retries must not duplicate WIP warnings"
+    );
+}
+
+#[tokio::test]
+async fn multiple_completion_paths_render_wip_warning_exactly_once() {
+    let Some(worktree) = init_git_repo_for_wip_warning() else {
+        return;
+    };
+    fs::write(worktree.path().join("untracked.txt"), "untracked\n").expect("write untracked file");
+
+    let (_env_lock, _runtime_root) = isolate_agentdesk_runtime_root();
+    let shared = make_status_panel_v2_shared_for_tests();
+    let gateway = StatusPanelFallbackGateway::default();
+    let footer_sink =
+        crate::services::discord::footer_view_reconciler::FooterViewTestSink::default();
+    let provider = ProviderKind::Claude;
+    let channel_id = ChannelId::new(3_792_030);
+    let user_msg_id = 3_792_031;
+    save_inflight_state(&wip_warning_inflight_state(
+        &provider,
+        channel_id.get(),
+        user_msg_id,
+        worktree.path(),
+    ))
+    .expect("save inflight state");
+
+    assert!(
+        crate::services::discord::footer_view_reconciler::note_turn_completed_footer(
+            crate::services::discord::footer_view_reconciler::FooterViewWriter::test(
+                shared.as_ref(),
+                &footer_sink,
+            ),
+            channel_id,
+            Some(MessageId::new(3_792_032)),
+            crate::services::discord::footer_view_reconciler::CompletionFooterOwner::new(
+                user_msg_id,
+                1_700_000_000,
+            ),
+            &provider,
+            "Final answer",
+            "⠸",
+            false,
+            false,
+            "test_footer_completion_path",
+        )
+        .await
+    );
+
+    let mut last_status_panel_text = String::new();
+    assert!(
+        complete_status_panel_v2(
+            shared.as_ref(),
+            &gateway,
+            channel_id,
+            None,
+            &provider,
+            1_700_000_000,
+            &mut last_status_panel_text,
+            false,
+            false,
+            "test_status_panel_completion_path",
+            user_msg_id,
+        )
+        .await
+    );
+
+    let footer_edits = footer_sink.edits();
+    let status_messages = gateway
+        .sent_messages
+        .lock()
+        .expect("sent messages lock")
+        .clone();
+    assert_eq!(footer_edits.len(), 1);
+    assert_eq!(status_messages.len(), 1);
+    assert!(footer_edits[0].text.contains("Final answer"));
+    let warning_count = footer_edits
+        .iter()
+        .map(|edit| edit.text.matches("커밋되지 않은 변경사항").count())
+        .sum::<usize>()
+        + status_messages
+            .iter()
+            .map(|message| message.matches("커밋되지 않은 변경사항").count())
+            .sum::<usize>();
+    assert_eq!(
+        warning_count, 1,
+        "footer reconciler and status-panel completion must share one inflight-key dedup"
+    );
+    crate::services::discord::footer_view_reconciler::completion_footer_forget_registered_target(
+        channel_id,
     );
 }
 

--- a/src/services/discord/turn_end_wip_warning.rs
+++ b/src/services/discord/turn_end_wip_warning.rs
@@ -1,26 +1,78 @@
-//! Turn-end WIP warning facade (#3792).
+//! Turn-end WIP warning completion-surface merge (#3792, #4217).
 //!
 //! This module bridges the generic git detector in `utils::wip_detect` to the
-//! Discord completion helpers. It is intentionally best-effort: failing to read
-//! git state or failing to send the Discord warning must never fail the turn.
+//! Discord completion helpers. A per-inflight reservation ensures that the
+//! bridge, watcher, and footer reconciler cannot render duplicate warnings.
 
-use std::future::Future;
+use std::collections::{HashSet, VecDeque};
 use std::path::Path;
+use std::sync::{LazyLock, Mutex};
 
-use poise::serenity_prelude as serenity;
-use serenity::ChannelId;
+use poise::serenity_prelude::ChannelId;
 
-use super::SharedData;
-use super::gateway::TurnGateway;
 use super::inflight::InflightTurnState;
 use crate::services::provider::ProviderKind;
 use crate::utils::wip_detect::{WipWarning, check_wip_uncommitted_files};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::services::discord) enum TurnEndWipWarningOutcome {
-    Suppressed,
-    Sent,
-    SendFailed,
+const WIP_WARNING_MARKER: &str = "⚠️ **턴을 완료하기 전에 커밋되지 않은 변경사항을 확인하세요.**";
+const MAX_RECORDED_DELIVERIES: usize = 2_048;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TurnEndWipKey {
+    provider: String,
+    channel_id: u64,
+    user_msg_id: u64,
+}
+
+#[derive(Default)]
+struct TurnEndWipDedup {
+    claimed: HashSet<TurnEndWipKey>,
+    delivered: HashSet<TurnEndWipKey>,
+    delivery_order: VecDeque<TurnEndWipKey>,
+}
+
+static TURN_END_WIP_DEDUP: LazyLock<Mutex<TurnEndWipDedup>> =
+    LazyLock::new(|| Mutex::new(TurnEndWipDedup::default()));
+
+pub(in crate::services::discord) struct TurnEndWipWarningReservation {
+    key: TurnEndWipKey,
+    text: String,
+    committed: bool,
+}
+
+impl TurnEndWipWarningReservation {
+    pub(in crate::services::discord) fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub(in crate::services::discord) fn commit(mut self) {
+        let mut dedup = TURN_END_WIP_DEDUP
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        dedup.claimed.remove(&self.key);
+        if dedup.delivered.insert(self.key.clone()) {
+            dedup.delivery_order.push_back(self.key.clone());
+        }
+        while dedup.delivery_order.len() > MAX_RECORDED_DELIVERIES {
+            if let Some(expired) = dedup.delivery_order.pop_front() {
+                dedup.delivered.remove(&expired);
+            }
+        }
+        self.committed = true;
+    }
+}
+
+impl Drop for TurnEndWipWarningReservation {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        TURN_END_WIP_DEDUP
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .claimed
+            .remove(&self.key);
+    }
 }
 
 pub(in crate::services::discord) fn load_matching_inflight_state(
@@ -57,10 +109,10 @@ pub(in crate::services::discord) fn turn_end_wip_warning_text(
 
 fn format_turn_end_wip_warning(warning: &WipWarning) -> String {
     format!(
-        "WARNING: WIP uncommitted files detected before turn completion.\n\
-         Workspace: `{}`\n\
-         Counts: {} staged, {} unstaged, {} untracked.\n\
-         Commit or explicitly discard these changes before ending the turn.",
+        "{WIP_WARNING_MARKER}\n\
+         작업공간: `{}`\n\
+         파일 수: 스테이징됨 {}개 · 스테이징 안 됨 {}개 · 추적되지 않음 {}개\n\
+         턴을 끝내기 전에 변경사항을 커밋하거나 명시적으로 폐기하세요.",
         warning.workspace.display(),
         warning.staged.len(),
         warning.unstaged.len(),
@@ -68,87 +120,81 @@ fn format_turn_end_wip_warning(warning: &WipWarning) -> String {
     )
 }
 
-pub(in crate::services::discord) async fn send_turn_end_wip_warning_with<F, Fut>(
+pub(in crate::services::discord) fn reserve_turn_end_wip_warning(
     inflight: Option<&InflightTurnState>,
-    source: &'static str,
-    mut send_warning: F,
-) -> TurnEndWipWarningOutcome
-where
-    F: FnMut(String) -> Fut,
-    Fut: Future<Output = Result<(), String>>,
-{
-    let Some(text) = turn_end_wip_warning_text(inflight) else {
-        return TurnEndWipWarningOutcome::Suppressed;
+) -> Option<TurnEndWipWarningReservation> {
+    let inflight = inflight?;
+    if inflight.user_msg_id == 0 {
+        return None;
+    }
+    let text = turn_end_wip_warning_text(Some(inflight))?;
+    let key = TurnEndWipKey {
+        provider: inflight.provider.clone(),
+        channel_id: inflight.channel_id,
+        user_msg_id: inflight.user_msg_id,
     };
-    match send_warning(text).await {
-        Ok(()) => TurnEndWipWarningOutcome::Sent,
-        Err(error) => {
-            tracing::warn!(
-                "[turn_end_wip_warning] failed to send WIP warning from {}: {}",
-                source,
-                error
-            );
-            TurnEndWipWarningOutcome::SendFailed
-        }
+    let mut dedup = TURN_END_WIP_DEDUP
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if dedup.claimed.contains(&key) || dedup.delivered.contains(&key) {
+        return None;
+    }
+    dedup.claimed.insert(key.clone());
+    Some(TurnEndWipWarningReservation {
+        key,
+        text,
+        committed: false,
+    })
+}
+
+pub(in crate::services::discord) fn turn_end_wip_warning_was_delivered(
+    inflight: Option<&InflightTurnState>,
+) -> bool {
+    let Some(inflight) = inflight.filter(|state| state.user_msg_id != 0) else {
+        return false;
+    };
+    let key = TurnEndWipKey {
+        provider: inflight.provider.clone(),
+        channel_id: inflight.channel_id,
+        user_msg_id: inflight.user_msg_id,
+    };
+    TURN_END_WIP_DEDUP
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .delivered
+        .contains(&key)
+}
+
+pub(in crate::services::discord) fn merge_turn_end_wip_warning(
+    completion_surface: String,
+    reservation: Option<&TurnEndWipWarningReservation>,
+) -> String {
+    let Some(warning) = reservation.map(TurnEndWipWarningReservation::text) else {
+        return completion_surface;
+    };
+    let completion_surface = completion_surface.trim_end();
+    if completion_surface.is_empty() {
+        warning.to_string()
+    } else {
+        format!("{completion_surface}\n\n{warning}")
     }
 }
 
-pub(in crate::services::discord) async fn warn_turn_end_wip_with_gateway<
-    G: TurnGateway + ?Sized,
->(
-    gateway: &G,
-    channel_id: ChannelId,
-    inflight: Option<&InflightTurnState>,
-    source: &'static str,
-) -> TurnEndWipWarningOutcome {
-    send_turn_end_wip_warning_with(inflight, source, |text| async move {
-        TurnGateway::send_message(gateway, channel_id, &text)
-            .await
-            .map(|_| ())
-    })
-    .await
-}
-
-pub(in crate::services::discord) async fn warn_turn_end_wip_with_http(
-    http: &serenity::Http,
-    channel_id: ChannelId,
-    inflight: Option<&InflightTurnState>,
-    source: &'static str,
-) -> TurnEndWipWarningOutcome {
-    send_turn_end_wip_warning_with(inflight, source, |text| async move {
-        super::http::send_channel_message(http, channel_id, &text)
-            .await
-            .map(|_| ())
-            .map_err(|error| error.to_string())
-    })
-    .await
-}
-
-pub(in crate::services::discord) async fn warn_turn_end_wip_with_shared_http(
-    shared: &SharedData,
-    channel_id: ChannelId,
-    inflight: Option<&InflightTurnState>,
-    source: &'static str,
-) -> TurnEndWipWarningOutcome {
-    let Some(http) = shared.serenity_http_or_token_fallback() else {
-        if turn_end_wip_warning_text(inflight).is_some() {
-            tracing::warn!(
-                "[turn_end_wip_warning] failed to send WIP warning from {}: no Discord HTTP available",
-                source
-            );
-            return TurnEndWipWarningOutcome::SendFailed;
-        }
-        return TurnEndWipWarningOutcome::Suppressed;
+pub(in crate::services::discord) fn preserve_merged_turn_end_wip_warning(
+    completion_surface: String,
+    previous_surface: &str,
+) -> String {
+    let Some((_, warning)) = previous_surface.split_once(WIP_WARNING_MARKER) else {
+        return completion_surface;
     };
-    warn_turn_end_wip_with_http(&http, channel_id, inflight, source).await
+    let completion_surface = completion_surface.trim_end();
+    format!("{completion_surface}\n\n{WIP_WARNING_MARKER}{warning}")
 }
 
 #[cfg(test)]
 mod tests {
     use std::fs;
     use std::path::Path;
-    use std::sync::{Arc, Mutex};
-
     use tempfile::TempDir;
 
     use super::*;
@@ -258,9 +304,10 @@ mod tests {
         let state = inflight_for_worktree(temp.path());
         let text = turn_end_wip_warning_text(Some(&state)).expect("dirty warning text");
 
-        assert!(text.contains("WIP uncommitted files detected"));
-        assert!(text.contains(&format!("Workspace: `{}`", temp.path().display())));
-        assert!(text.contains("Counts: 1 staged, 1 unstaged, 1 untracked."));
+        assert!(text.contains("커밋되지 않은 변경사항"));
+        assert!(text.contains(&format!("작업공간: `{}`", temp.path().display())));
+        assert!(text.contains("파일 수: 스테이징됨 1개 · 스테이징 안 됨 1개 · 추적되지 않음 1개"));
+        assert!(!text.contains("WARNING:"));
     }
 
     #[test]
@@ -300,8 +347,8 @@ mod tests {
         assert_eq!(turn_end_wip_warning_text(None), None);
     }
 
-    #[tokio::test]
-    async fn send_failure_is_non_fatal() {
+    #[test]
+    fn dropped_reservation_can_be_claimed_by_another_completion_path() {
         let Some(temp) = init_git_repo() else {
             return;
         };
@@ -310,35 +357,26 @@ mod tests {
         fs::write(temp.path().join("untracked.txt"), "untracked\n").expect("write untracked");
         let state = inflight_for_worktree(temp.path());
 
-        let outcome = send_turn_end_wip_warning_with(Some(&state), "unit_test", |_text| async {
-            Err("discord unavailable".to_string())
-        })
-        .await;
-
-        assert_eq!(outcome, TurnEndWipWarningOutcome::SendFailed);
+        let first = reserve_turn_end_wip_warning(Some(&state)).expect("first reservation");
+        assert!(reserve_turn_end_wip_warning(Some(&state)).is_none());
+        drop(first);
+        assert!(reserve_turn_end_wip_warning(Some(&state)).is_some());
     }
 
-    #[tokio::test]
-    async fn clean_warning_does_not_call_sender() {
-        let Some(temp) = committed_repo() else {
+    #[test]
+    fn committed_reservation_suppresses_other_completion_paths() {
+        let Some(temp) = init_git_repo() else {
             return;
         };
         let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
         let _root = RuntimeRootGuard::new();
-        let state = inflight_for_worktree(temp.path());
-        let called = Arc::new(Mutex::new(false));
-        let called_for_send = called.clone();
+        fs::write(temp.path().join("untracked.txt"), "untracked\n").expect("write untracked");
+        let mut state = inflight_for_worktree(temp.path());
+        state.user_msg_id = 33_792_001;
 
-        let outcome = send_turn_end_wip_warning_with(Some(&state), "unit_test", move |_text| {
-            let called_for_send = called_for_send.clone();
-            async move {
-                *called_for_send.lock().expect("called lock") = true;
-                Ok(())
-            }
-        })
-        .await;
-
-        assert_eq!(outcome, TurnEndWipWarningOutcome::Suppressed);
-        assert!(!*called.lock().expect("called lock"));
+        reserve_turn_end_wip_warning(Some(&state))
+            .expect("first completion path reservation")
+            .commit();
+        assert!(reserve_turn_end_wip_warning(Some(&state)).is_none());
     }
 }


### PR DESCRIPTION
## 이슈
#4217. turn-end WIP 경고가 영어 전용·본문/완료패널 사이 삽입·다중 완료경로 중복 게시 가능.

## 변경
1. 독립 WIP-경고 전송 제거, 완료 풋터/상태패널 텍스트에 병합.
2. 영어 전용 → 한국어(워크스페이스·파일수·조치 안내).
3. gateway/HTTP/footer-reconciler 완료경로가 공유하는 bounded inflight-key 예약/전달 dedup → '정확히 한 번' 렌더 보장. 2경로 회귀테스트 포함.

## 게이트 (오케스트레이터 독립 재검증)
fmt/check/test, freshness, **audit_maintainability --check rc=0**. status_panel.rs는 turn_bridge submodule(핫파일 루트 아님), #3016 핫파일 루트 무편집.

🤖 구현: codex gpt-5.6-sol high / 리뷰: Opus dual (독립)