### PR TITLE
enhance(voice): DAVE E2EE close-code(4017/4016) 분류 + ops 알림 — 무증상 실패 계측 (#4237)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -433,6 +433,14 @@
 
 ### Audited touches
 
+- #4237 DAVE/E2EE voice-close observability: the existing worker-local
+  `DriverDisconnect` handler now classifies Discord voice close codes 4016/4017,
+  records a structured counter event, and routes a deduplicated operator alert
+  through the existing notify bot. Multinode class: **worker-local likely** —
+  the metric, alert dedup, Songbird connection, and rejoin supervisor remain
+  pinned to the node/provider that owns the guild voice connection; no shared
+  authority, PG lease, or leader-only side effect changes.
+
 - #4247 S0 reaction status-only containment removes the guild and DM reaction
   gateway subscriptions plus the only destructive `ReactionRemove` intake
   route. This narrows connection-level event intake on every node; it does not

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -886,7 +886,7 @@
 | `services::discord::voice_barge_in::tts_pipeline` | `src/services/discord/voice_barge_in/tts_pipeline.rs` | 86 | 86 | 0 |  |
 | `services::discord::voice_config_cache` | `src/services/discord/voice_config_cache.rs` | 79 | 79 | 0 |  |
 | `services::discord::voice_id_sequences` | `src/services/discord/voice_id_sequences.rs` | 69 | 69 | 0 |  |
-| `services::discord::voice_lifecycle` | `src/services/discord/voice_lifecycle.rs` | 988 | 688 | 300 |  |
+| `services::discord::voice_lifecycle` | `src/services/discord/voice_lifecycle.rs` | 1135 | 804 | 331 |  |
 | `services::discord::voice_routing` | `src/services/discord/voice_routing.rs` | 163 | 138 | 25 |  |
 | `services::discord::voice_sensitivity` | `src/services/discord/voice_sensitivity.rs` | 113 | 113 | 0 |  |
 | `services::discord::watchers::codex_tui_restore` | `src/services/discord/watchers/codex_tui_restore.rs` | 178 | 146 | 32 |  |

--- a/src/services/discord/voice_lifecycle.rs
+++ b/src/services/discord/voice_lifecycle.rs
@@ -19,9 +19,95 @@ use dashmap::{DashMap, DashSet};
 use poise::serenity_prelude as serenity;
 use serenity::{ChannelId, GuildId};
 use songbird::events::context_data::{DisconnectKind, DisconnectReason};
+use songbird::model::CloseCode as VoiceCloseCode;
 use songbird::{Event, EventContext, EventHandler};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+/// App-level outcome for Discord voice close codes that indicate DAVE/E2EE
+/// negotiation failed. The alert metadata lives beside the classifier so the
+/// close-code -> operator-visible outcome mapping cannot drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) struct VoiceSecurityDisconnect {
+    pub close_code: u16,
+    pub outcome: &'static str,
+    pub alert_kind: &'static str,
+    pub alert_reason: &'static str,
+}
+
+/// Classify Discord voice gateway close codes that require a distinct
+/// DAVE/E2EE operator alert. 4016 is the legacy encryption-mode negotiation
+/// failure; 4017 is Discord's forced-DAVE failure.
+pub(in crate::services::discord) fn classify_voice_security_close_code(
+    close_code: VoiceCloseCode,
+) -> Option<VoiceSecurityDisconnect> {
+    match close_code {
+        VoiceCloseCode::UnknownEncryptionMode => Some(VoiceSecurityDisconnect {
+            close_code: 4016,
+            outcome: "unknown_encryption_mode",
+            alert_kind: "voice-e2ee-4016",
+            alert_reason: "지원되는 음성 암호화 모드를 협상하지 못했습니다.",
+        }),
+        VoiceCloseCode::DaveProtocolRequired => Some(VoiceSecurityDisconnect {
+            close_code: 4017,
+            outcome: "dave_protocol_required",
+            alert_kind: "voice-dave-4017",
+            alert_reason: "Discord가 요구하는 DAVE 종단간 암호화를 협상하지 못했습니다.",
+        }),
+        _ => None,
+    }
+}
+
+fn classify_voice_security_disconnect(
+    reason: Option<DisconnectReason>,
+) -> Option<VoiceSecurityDisconnect> {
+    match reason {
+        Some(DisconnectReason::WsClosed(Some(close_code))) => {
+            classify_voice_security_close_code(close_code)
+        }
+        _ => None,
+    }
+}
+
+fn record_voice_security_disconnect(
+    provider: &str,
+    guild_id: GuildId,
+    channel_id: ChannelId,
+    classified: VoiceSecurityDisconnect,
+) -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TOTAL: AtomicU64 = AtomicU64::new(0);
+    let metric_total = TOTAL.fetch_add(1, Ordering::Relaxed).saturating_add(1);
+    crate::services::observability::events::record_simple(
+        "voice_security_disconnect",
+        Some(channel_id.get()),
+        Some(provider),
+        serde_json::json!({
+            "guild_id": guild_id.get(),
+            "close_code": classified.close_code,
+            "outcome": classified.outcome,
+            "metric": "voice_security_disconnect_total",
+            "metric_total": metric_total,
+        }),
+    );
+    metric_total
+}
+
+fn voice_security_alert_content(
+    provider: &str,
+    guild_id: GuildId,
+    channel_id: ChannelId,
+    classified: VoiceSecurityDisconnect,
+) -> String {
+    format!(
+        "🚨 음성 보안 프로토콜 협상 실패로 연결이 종료되었습니다 (provider `{provider}`, guild `{}`, channel `{}`, close code `{}`). {} DAVE/E2EE 지원 상태를 확인해 주세요.",
+        guild_id.get(),
+        channel_id.get(),
+        classified.close_code,
+        classified.alert_reason,
+    )
+}
 
 /// A request to re-establish a dropped voice connection, routed from a
 /// `VoiceLifecycleHandler` (which fires inside songbird's driver task) to the
@@ -292,7 +378,37 @@ impl EventHandler for VoiceLifecycleHandler {
                 );
             }
             EventContext::DriverDisconnect(data) => {
-                if data.reason.is_none() {
+                if let Some(classified) = classify_voice_security_disconnect(data.reason) {
+                    let metric_total = record_voice_security_disconnect(
+                        &self.provider,
+                        self.guild_id,
+                        self.channel_id,
+                        classified,
+                    );
+                    tracing::warn!(
+                        guild_id = self.guild_id.get(),
+                        channel_id = self.channel_id.get(),
+                        provider = %self.provider,
+                        kind = ?data.kind,
+                        reason = ?data.reason,
+                        close_code = classified.close_code,
+                        outcome = classified.outcome,
+                        metric = "voice_security_disconnect_total",
+                        metric_total,
+                        "voice driver disconnected: DAVE/E2EE negotiation failure"
+                    );
+                    super::commands::notify_voice_alert(
+                        self.control_channel_id,
+                        voice_security_alert_content(
+                            &self.provider,
+                            self.guild_id,
+                            self.channel_id,
+                            classified,
+                        ),
+                        classified.alert_kind,
+                    )
+                    .await;
+                } else if data.reason.is_none() {
                     tracing::info!(
                         guild_id = self.guild_id.get(),
                         channel_id = self.channel_id.get(),
@@ -689,6 +805,37 @@ async fn sleep_through_backoff(
 #[cfg(test)]
 mod lifecycle_tests {
     use super::*;
+
+    #[test]
+    fn close_code_4017_maps_to_dave_failure_and_ops_alert() {
+        let classified = classify_voice_security_close_code(VoiceCloseCode::DaveProtocolRequired)
+            .expect("4017 must be classified as a DAVE/E2EE failure");
+
+        assert_eq!(classified.close_code, 4017);
+        assert_eq!(classified.outcome, "dave_protocol_required");
+        assert_eq!(classified.alert_kind, "voice-dave-4017");
+        let alert = voice_security_alert_content(
+            "claude",
+            GuildId::new(42),
+            ChannelId::new(84),
+            classified,
+        );
+        assert!(alert.contains("음성 보안 프로토콜 협상 실패"));
+        assert!(alert.contains("close code `4017`"));
+        assert!(alert.contains("DAVE/E2EE"));
+
+        let related = classify_voice_security_close_code(VoiceCloseCode::UnknownEncryptionMode)
+            .expect("4016 must share the E2EE classification path");
+        assert_eq!(related.close_code, 4016);
+        assert_eq!(related.outcome, "unknown_encryption_mode");
+        assert_eq!(related.alert_kind, "voice-e2ee-4016");
+
+        assert_eq!(
+            classify_voice_security_close_code(VoiceCloseCode::VoiceServerCrash),
+            None,
+            "non-security close codes must stay on the generic disconnect path"
+        );
+    }
 
     #[test]
     fn reconnect_backoff_table_and_cap() {


### PR DESCRIPTION
## 이슈
#4237. DAVE 4017 close code(강제 E2EE 실패) 앱 레벨 미처리 — 무증상, 계측·알림 없음.

## 변경
1. 기존 Songbird DriverDisconnect 핸들러(#4235) 재사용, close code 4017(DaveProtocolRequired)·4016(UnknownEncryptionMode)를 보안 실패로 분류.
2. 구조화 경고 + observability 이벤트(voice_security_disconnect_total 메트릭) + 기존 notify_voice_alert 경로로 dedup된 한국어 운영 알림('음성 보안 프로토콜 협상 실패').
3. 기존 재연결 스케줄링 동작 보존. 4017/4016/비보안 코드 매핑 단위테스트.

## 게이트 (오케스트레이터 독립 재검증)
fmt/check/test(11 pass), freshness, **audit_maintainability rc=0**. #3016 핫파일 루트 무편집. multinode audited-touch 노트 추가.

🤖 구현: codex gpt-5.6-sol high / 리뷰: Opus dual