### PR TITLE
ops(ratchet): decompose_issue 필수화 + admission 이력 + N초과 WARN (#4269)

### DIFF
--- a/scripts/audit_maintainability/checks/giant_file_ratchet.py
+++ b/scripts/audit_maintainability/checks/giant_file_ratchet.py
@@ -16,6 +16,7 @@ Production LoC (test code excluded) is shared with ``giant_files`` via
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -23,6 +24,7 @@ from .. import common
 from ..common import Finding
 from . import CheckSpec
 from .giant_files import giant_production_loc
+from ratchet_admission import audit_repository_admissions
 
 CONFIG_REL_PATH = "scripts/audit_maintainability_giant_baseline.toml"
 
@@ -69,6 +71,25 @@ def _run(allowlist: set[str]) -> Iterable[Finding]:
 
     current = giant_production_loc()
     findings: list[Finding] = []
+    admission_audit = audit_repository_admissions(
+        repo_root=common.REPO_ROOT,
+        ratchet="giant_file_ratchet",
+        config_rel_path=CONFIG_REL_PATH,
+        table_name="giant_file_ratchet",
+    )
+    for warning in admission_audit.warnings:
+        print(warning, file=sys.stderr)
+    for message in admission_audit.errors:
+        findings.append(
+            Finding(
+                rule="giant_file_ratchet",
+                severity="error",
+                file=CONFIG_REL_PATH,
+                line=None,
+                message=message,
+                extra={"history": "scripts/ratchet_admission_history.toml"},
+            )
+        )
     for rel, frozen in baseline.items():
         if common.is_allowlisted(allowlist, rel):
             continue

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -9,7 +9,9 @@
 # Workflow:
 #   * As a file shrinks, LOWER its number here to lock in the win.
 #   * Growing a giant requires RAISING its number — a deliberate, reviewable
-#     admission in the diff that the giant got bigger. Prefer splitting instead.
+#     admission in the diff that the giant got bigger. Every raise must append a
+#     matching [[admission]] with decompose_issue to
+#     scripts/ratchet_admission_history.toml. Prefer splitting instead.
 #
 # Scope (this batch): the M2.x turn-lifecycle decomposition surface
 # (src/services/discord/** and src/services/turn_*), where re-inflation was

--- a/scripts/check_hotfile_ratchet.py
+++ b/scripts/check_hotfile_ratchet.py
@@ -55,6 +55,8 @@ if sys.version_info < MIN_PYTHON:
 
 import tomllib
 
+from ratchet_admission import audit_repository_admissions
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = REPO_ROOT / "scripts" / "hotfile_ratchet.toml"
 
@@ -106,6 +108,18 @@ def main() -> int:
         return 1
 
     failed = False
+    admission_audit = audit_repository_admissions(
+        repo_root=REPO_ROOT,
+        ratchet="hotfile_ratchet",
+        config_rel_path="scripts/hotfile_ratchet.toml",
+        table_name="hotfile_ratchet",
+    )
+    for warning in admission_audit.warnings:
+        print(warning, file=sys.stderr)
+    for error in admission_audit.errors:
+        print(f"FAIL: {error}", file=sys.stderr)
+        failed = True
+
     for rel, ceiling in sorted(ceilings.items()):
         path = REPO_ROOT / rel
         if not path.is_file():

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -71,6 +71,7 @@ echo "=== await_holding_lock ratchet guard ==="
 
 echo "=== Hotfile LOC ratchet guard (#3565) ==="
 "$PYTHON" scripts/check_hotfile_ratchet.py
+"$PYTHON" -m unittest scripts.test_ratchet_admission
 
 echo "=== Discord log field-key drift guard (#4218) ==="
 "$PYTHON" scripts/check_log_key_drift.py

--- a/scripts/hotfile_ratchet.toml
+++ b/scripts/hotfile_ratchet.toml
@@ -17,7 +17,9 @@
 # Workflow:
 #   * As a file shrinks, LOWER its number here to lock in the win.
 #   * Growing a hot file requires RAISING its number — a deliberate, reviewable
-#     admission in the diff that the file got bigger. Prefer splitting instead.
+#     admission in the diff that the file got bigger. Every raise must append a
+#     matching [[admission]] with decompose_issue to
+#     scripts/ratchet_admission_history.toml. Prefer splitting instead.
 #
 # Counts are raw `wc -l` (equivalently Python `str.splitlines()`) on the
 # LF-terminated source; the two agree exactly for this repo's LF-only files.

--- a/scripts/ratchet_admission.py
+++ b/scripts/ratchet_admission.py
@@ -1,0 +1,346 @@
+"""Shared cap-admission validation for the giant and hot-file ratchets (#4269).
+
+The checked-in cap manifests describe the current ceilings.  A cap increase is
+an admission only when the current manifest value is greater than the value at
+the branch's merge-base with ``origin/main``.  Every such increase must append
+one event to ``ratchet_admission_history.toml``.
+
+The history is deliberately small and append-only.  Each ``[[admission]]`` has
+this schema::
+
+    ratchet = "hotfile_ratchet"  # or "giant_file_ratchet"
+    file = "repo/relative/path.rs"
+    old_cap = 100
+    new_cap = 120
+    decompose_issue = 4269        # positive integer, no leading '#'
+    count = 2                     # previous event count for this file + 1
+
+``count`` is global per file (across both metrics), so churn audit #4265 can
+read a single monotonic sequence.  The checker only warns after repeated
+admissions; it never creates issues or invokes ``gh``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+HISTORY_REL_PATH = "scripts/ratchet_admission_history.toml"
+ADMISSION_WARN_THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class AdmissionEvent:
+    ratchet: object
+    file: object
+    old_cap: object
+    new_cap: object
+    decompose_issue: object
+    count: object
+
+
+@dataclass(frozen=True)
+class AdmissionAudit:
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def parse_cap_table(text: str, table_name: str) -> dict[str, int]:
+    """Parse one path -> positive integer cap table from TOML text."""
+
+    parsed = tomllib.loads(text)
+    table = parsed.get(table_name, {})
+    if not isinstance(table, dict):
+        raise ValueError(f"[{table_name}] must be a TOML table")
+
+    caps: dict[str, int] = {}
+    for file, cap in table.items():
+        if not isinstance(file, str) or not file:
+            raise ValueError(f"[{table_name}] contains an invalid file key")
+        if isinstance(cap, bool) or not isinstance(cap, int) or cap <= 0:
+            raise ValueError(
+                f"[{table_name}] cap for {file!r} must be a positive integer"
+            )
+        caps[file] = cap
+    return caps
+
+
+def parse_history(text: str) -> list[AdmissionEvent]:
+    """Parse admission events, retaining malformed fields for clear validation."""
+
+    parsed = tomllib.loads(text)
+    if parsed.get("schema_version") != 1:
+        raise ValueError("ratchet admission history schema_version must be 1")
+    raw_events = parsed.get("admission", [])
+    if not isinstance(raw_events, list):
+        raise ValueError(
+            "ratchet admission history [[admission]] entries must be an array"
+        )
+    events: list[AdmissionEvent] = []
+    for raw in raw_events:
+        if not isinstance(raw, dict):
+            raise ValueError("ratchet admission history contains a non-table admission")
+        events.append(
+            AdmissionEvent(
+                ratchet=raw.get("ratchet"),
+                file=raw.get("file"),
+                old_cap=raw.get("old_cap"),
+                new_cap=raw.get("new_cap"),
+                decompose_issue=raw.get("decompose_issue"),
+                count=raw.get("count"),
+            )
+        )
+    return events
+
+
+def validate_history(events: list[AdmissionEvent]) -> list[str]:
+    """Validate the simple append-only event schema and per-file counts."""
+
+    errors: list[str] = []
+    last_count: dict[str, int] = {}
+    allowed_ratchets = {"giant_file_ratchet", "hotfile_ratchet"}
+    for index, event in enumerate(events, start=1):
+        label = f"admission event {index}"
+        if not isinstance(event.ratchet, str) or event.ratchet not in allowed_ratchets:
+            errors.append(
+                f"{label}: ratchet must be one of {sorted(allowed_ratchets)}, "
+                f"got {event.ratchet!r}"
+            )
+        if not isinstance(event.file, str) or not event.file:
+            errors.append(f"{label}: file must be a non-empty repo-relative path")
+            continue
+        for field_name, value in (
+            ("old_cap", event.old_cap),
+            ("new_cap", event.new_cap),
+            ("count", event.count),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                errors.append(
+                    f"{label} ({event.file}): {field_name} must be a positive integer"
+                )
+        if (
+            isinstance(event.old_cap, int)
+            and not isinstance(event.old_cap, bool)
+            and isinstance(event.new_cap, int)
+            and not isinstance(event.new_cap, bool)
+            and event.new_cap <= event.old_cap
+        ):
+            errors.append(
+                f"{label} ({event.file}): new_cap {event.new_cap} must exceed "
+                f"old_cap {event.old_cap}"
+            )
+        if (
+            event.decompose_issue is None
+            or isinstance(event.decompose_issue, bool)
+            or not isinstance(event.decompose_issue, int)
+            or event.decompose_issue <= 0
+        ):
+            errors.append(
+                f"{label} ({event.file}): decompose_issue is mandatory and must "
+                "be a positive issue number"
+            )
+        expected_count = last_count.get(event.file, 0) + 1
+        if event.count != expected_count:
+            errors.append(
+                f"{label} ({event.file}): count must be {expected_count}, "
+                f"got {event.count!r}"
+            )
+        if isinstance(event.count, int) and not isinstance(event.count, bool):
+            last_count[event.file] = event.count
+    return errors
+
+
+def validate_admission_delta(
+    *,
+    ratchet: str,
+    current_caps: dict[str, int],
+    prior_caps: dict[str, int],
+    current_events: list[AdmissionEvent],
+    prior_events: list[AdmissionEvent],
+    prior_history_exists: bool = True,
+) -> list[str]:
+    """Require one valid newly appended history event for every raised cap."""
+
+    errors = validate_history(current_events)
+    if prior_history_exists and current_events[: len(prior_events)] != prior_events:
+        errors.append(
+            f"{HISTORY_REL_PATH} is append-only; existing admission events "
+            "must not be edited, reordered, or removed"
+        )
+        return errors
+
+    # The first schema commit may migrate reviewable annotated admissions such
+    # as #3983 without those historical events corresponding to a current cap
+    # raise.  Once the history exists at the base, every appended event must
+    # correspond exactly to a raise in the same change.
+    new_events = current_events[len(prior_events) :] if prior_history_exists else []
+    raised = {
+        file: (prior_caps[file], cap)
+        for file, cap in current_caps.items()
+        if file in prior_caps and cap > prior_caps[file]
+    }
+
+    for file, (old_cap, new_cap) in sorted(raised.items()):
+        matches = [
+            event
+            for event in new_events
+            if event.ratchet == ratchet
+            and event.file == file
+            and event.old_cap == old_cap
+            and event.new_cap == new_cap
+        ]
+        if not matches:
+            errors.append(
+                f"{ratchet} cap raised for {file}: {old_cap} -> {new_cap}; "
+                f"append a matching [[admission]] to {HISTORY_REL_PATH} with "
+                "a mandatory decompose_issue issue number"
+            )
+        elif len(matches) > 1:
+            errors.append(
+                f"{ratchet} cap raised for {file}: {old_cap} -> {new_cap}; "
+                "history contains duplicate matching admission events"
+            )
+
+    if prior_history_exists:
+        expected = [
+            (ratchet, file, old_cap, new_cap)
+            for file, (old_cap, new_cap) in raised.items()
+        ]
+        for event in new_events:
+            key = (event.ratchet, event.file, event.old_cap, event.new_cap)
+            if event.ratchet == ratchet and key not in expected:
+                errors.append(
+                    f"unmatched {ratchet} admission history event for "
+                    f"{event.file!r}: {event.old_cap!r} -> {event.new_cap!r}; "
+                    "only append an event in the change that raises that cap"
+                )
+    return errors
+
+
+def _run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _merge_base(repo_root: Path) -> tuple[str | None, str | None]:
+    configured = os.environ.get("RATCHET_ADMISSION_BASE_REF")
+    candidates = [configured] if configured else []
+    github_base = os.environ.get("GITHUB_BASE_REF")
+    if github_base:
+        candidates.append(f"origin/{github_base}")
+    candidates.extend(["origin/main", "main"])
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        result = _run_git(repo_root, ["merge-base", "HEAD", candidate])
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip(), None
+    return None, (
+        "cannot resolve a ratchet admission base (tried "
+        + ", ".join(candidate for candidate in candidates if candidate)
+        + "); set RATCHET_ADMISSION_BASE_REF to a fetched base ref"
+    )
+
+
+def _git_text(repo_root: Path, commit: str, rel_path: str) -> tuple[str | None, bool]:
+    result = _run_git(repo_root, ["show", f"{commit}:{rel_path}"])
+    if result.returncode == 0:
+        return result.stdout, True
+    # A missing file is expected for the first history-schema commit.  Distinguish
+    # it from a broader git failure by asking whether the path exists at all.
+    exists = _run_git(repo_root, ["cat-file", "-e", f"{commit}:{rel_path}"])
+    if exists.returncode != 0:
+        return None, False
+    raise ValueError(
+        f"git could not read {rel_path} at {commit}: "
+        f"{result.stderr.strip() or 'unknown error'}"
+    )
+
+
+def admission_warning_messages(
+    events: list[AdmissionEvent], ratchet: str
+) -> list[str]:
+    latest: dict[str, AdmissionEvent] = {}
+    for event in events:
+        if isinstance(event.file, str):
+            latest[event.file] = event
+    warnings: list[str] = []
+    for file, event in sorted(latest.items()):
+        if (
+            event.ratchet == ratchet
+            and isinstance(event.count, int)
+            and event.count > ADMISSION_WARN_THRESHOLD
+        ):
+            warnings.append(
+                f"WARN: RATCHET ADMISSION COUNT EXCEEDED: {file} has been "
+                f"admitted {event.count} times (threshold "
+                f"{ADMISSION_WARN_THRESHOLD}); prioritize decomposition."
+            )
+    return warnings
+
+
+def audit_repository_admissions(
+    *,
+    repo_root: Path,
+    ratchet: str,
+    config_rel_path: str,
+    table_name: str,
+) -> AdmissionAudit:
+    """Audit current cap raises against the base manifest and event history."""
+
+    try:
+        current_text = (repo_root / config_rel_path).read_text(encoding="utf-8")
+        current_caps = parse_cap_table(current_text, table_name)
+        history_path = repo_root / HISTORY_REL_PATH
+        current_events = parse_history(history_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
+        return AdmissionAudit((f"ratchet admission metadata invalid: {exc}",), ())
+
+    schema_errors = validate_history(current_events)
+    warnings = admission_warning_messages(current_events, ratchet)
+
+    # Unit fixtures and source exports do not carry git metadata.  The schema is
+    # still validated there; branch-delta enforcement runs in every CI checkout.
+    if not (repo_root / ".git").exists():
+        return AdmissionAudit(tuple(schema_errors), tuple(warnings))
+
+    base, base_error = _merge_base(repo_root)
+    if base is None:
+        return AdmissionAudit(
+            tuple(schema_errors + [base_error or "missing base"]), tuple(warnings)
+        )
+
+    try:
+        prior_config_text, prior_config_exists = _git_text(
+            repo_root, base, config_rel_path
+        )
+        if not prior_config_exists or prior_config_text is None:
+            return AdmissionAudit(tuple(schema_errors), tuple(warnings))
+        prior_caps = parse_cap_table(prior_config_text, table_name)
+        prior_history_text, prior_history_exists = _git_text(
+            repo_root, base, HISTORY_REL_PATH
+        )
+        prior_events = (
+            parse_history(prior_history_text)
+            if prior_history_text is not None
+            else []
+        )
+        errors = validate_admission_delta(
+            ratchet=ratchet,
+            current_caps=current_caps,
+            prior_caps=prior_caps,
+            current_events=current_events,
+            prior_events=prior_events,
+            prior_history_exists=prior_history_exists,
+        )
+    except (tomllib.TOMLDecodeError, ValueError) as exc:
+        errors = schema_errors + [f"ratchet admission base metadata invalid: {exc}"]
+    return AdmissionAudit(tuple(errors), tuple(warnings))

--- a/scripts/ratchet_admission_history.toml
+++ b/scripts/ratchet_admission_history.toml
@@ -1,0 +1,31 @@
+# Ratchet cap admission history (#4269). Schema version 1.
+#
+# Append-only schema for every future giant-file or hot-file cap increase:
+#   ratchet = "giant_file_ratchet" or "hotfile_ratchet"
+#   file = repo-relative path
+#   old_cap/new_cap = exact cap change in the same diff
+#   decompose_issue = positive integer issue number (mandatory; no leading '#')
+#   count = previous admission count for this file across both ratchets + 1
+#
+# The checker warns (but does not fail or create an issue) when count exceeds
+# ADMISSION_WARN_THRESHOLD in scripts/ratchet_admission.py. Historical comments
+# before #4269 remain in their manifests; the two #3983 item4 admissions below
+# are migrated explicitly as the reviewable-admission compatibility examples.
+
+schema_version = 1
+
+[[admission]]
+ratchet = "giant_file_ratchet"
+file = "src/services/discord/tmux_watcher.rs"
+old_cap = 7120
+new_cap = 7122
+decompose_issue = 3983
+count = 1
+
+[[admission]]
+ratchet = "hotfile_ratchet"
+file = "src/services/discord/turn_bridge/mod.rs"
+old_cap = 6645
+new_cap = 6646
+decompose_issue = 3983
+count = 1

--- a/scripts/test_ratchet_admission.py
+++ b/scripts/test_ratchet_admission.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Focused tests for the ratchet cap-admission guard (#4269)."""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts.ratchet_admission import (
+    ADMISSION_WARN_THRESHOLD,
+    AdmissionEvent,
+    admission_warning_messages,
+    validate_admission_delta,
+)
+
+
+class RatchetAdmissionGuardTest(unittest.TestCase):
+    def _event(self, decompose_issue: object) -> AdmissionEvent:
+        return AdmissionEvent(
+            ratchet="hotfile_ratchet",
+            file="src/services/discord/example.rs",
+            old_cap=100,
+            new_cap=120,
+            decompose_issue=decompose_issue,
+            count=1,
+        )
+
+    def test_admission_requires_decompose_issue_and_accepts_it_when_present(self) -> None:
+        common = {
+            "ratchet": "hotfile_ratchet",
+            "current_caps": {"src/services/discord/example.rs": 120},
+            "prior_caps": {"src/services/discord/example.rs": 100},
+            "prior_events": [],
+        }
+
+        rejected = validate_admission_delta(
+            **common,
+            current_events=[self._event(None)],
+        )
+        self.assertTrue(
+            any("decompose_issue is mandatory" in error for error in rejected),
+            "cap admission without decompose_issue must be rejected",
+        )
+
+        accepted = validate_admission_delta(
+            **common,
+            current_events=[self._event(4269)],
+        )
+        self.assertEqual(accepted, [], "linked cap admission must be accepted")
+
+    def test_more_than_named_threshold_emits_decomposition_warning(self) -> None:
+        events = [
+            AdmissionEvent(
+                ratchet="hotfile_ratchet",
+                file="src/services/discord/example.rs",
+                old_cap=100 + count,
+                new_cap=101 + count,
+                decompose_issue=4200 + count,
+                count=count,
+            )
+            for count in range(1, ADMISSION_WARN_THRESHOLD + 2)
+        ]
+
+        warnings = admission_warning_messages(events, "hotfile_ratchet")
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("prioritize decomposition", warnings[0])
+        self.assertIn("src/services/discord/example.rs", warnings[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes nothing automatically (see #4269).

## 변경
- `scripts/ratchet_admission.py` (신규, 346줄): 공유 admission validator. merge-base cap 테이블과 비교해 **상향된 cap은 정확히 1개의 append된 admission 이벤트(양의 정수 `decompose_issue`)가 없으면 거부**(rc!=0). append-only 이력 + 파일별 monotonic count 강제.
- `scripts/ratchet_admission_history.toml` (신규): schema-v1 append-only ledger. 기존 `#3983 item4` admission을 cap 변경 없이 `decompose_issue=3983`로 마이그레이션.
- `check_hotfile_ratchet.py` / `audit_maintainability/checks/giant_file_ratchet.py`: admission audit를 raw-LoC 검사 전에 실행. 메타 위반=hard-gate, N초과=경고-only(비차단).
- `ci-script-checks.sh`: `python3 -m unittest scripts.test_ratchet_admission` 배선.
- N초과 임계 `ADMISSION_WARN_THRESHOLD=3`. checker는 gh 호출/이슈 생성 안 함(탐지+경고만).

## 불변식
CI-red를 cap 상향으로 푸는 우회로 차단. admission엔 반드시 분해 이슈 링크.

## 테스트 (뮤테이션 증명)
가드 제거 시 `test_admission_requires_decompose_issue` assert 실패(rc=1), 복원 시 통과(rc=0). ci-script-checks.sh가 CI에서 실행.

## 게이트
audit --check rc=0 · ci-script-checks rc=0 · unittest rc=0 · freshness passed. 핫루트 미접촉, 신규 파일 <1000줄.