### PR TITLE
docs(policy): 신규/수정 코드 주석 영어 정책 (#4232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 ## 코드 수정 전 필독
 
 - **어디를 건드릴지 결정표**: [`docs/agent-maintenance/change-surfaces.md`](docs/agent-maintenance/change-surfaces.md) — 변경 표면별 필수 동반 수정·검증을 정의. 프로덕션 라인수는 [`docs/generated/module-inventory.md`](docs/generated/module-inventory.md)가 진실값.
+- **코드 주석 언어 정책**: [`docs/agent-maintenance/comment-language-policy.md`](docs/agent-maintenance/comment-language-policy.md) — 신규·수정 코드 주석 및 문서 주석의 작성 언어와 적용 범위.
 - **agent-maintenance 인덱스**: [`docs/agent-maintenance/index.md`](docs/agent-maintenance/index.md)
 - **아키텍처 개요**: [`ARCHITECTURE.md`](ARCHITECTURE.md)
 - **릴레이 불변식(디스코드 릴레이 상태 계약)**: [`docs/relay-state-contract.md`](docs/relay-state-contract.md)

--- a/docs/agent-maintenance/comment-language-policy.md
+++ b/docs/agent-maintenance/comment-language-policy.md
@@ -10,8 +10,10 @@ specific line or block for another reason.
 
 ## Rationale
 
-Korean and English comments are mixed across 70% of non-test files, creating
-inconsistency and making cross-model review harder.
+A substantial minority of non-test source files mix Korean and English comments
+(~11% of non-test `.rs` files contain Korean in comments; ~25% contain Korean
+anywhere including string literals), creating inconsistency and making
+cross-model review harder.
 
 ## Scope
 

--- a/docs/agent-maintenance/comment-language-policy.md
+++ b/docs/agent-maintenance/comment-language-policy.md
@@ -1,0 +1,21 @@
+# Code Comment Language Policy
+
+All new or modified code comments and doc-comments must be written in English.
+
+## Existing Comments
+
+Do not bulk-translate existing comments; doing so pollutes `git blame`. Translate
+an existing comment only when you are already substantively editing that
+specific line or block for another reason.
+
+## Rationale
+
+Korean and English comments are mixed across 70% of non-test files, creating
+inconsistency and making cross-model review harder.
+
+## Scope
+
+This is a human and agent authoring policy, not a CI-enforced gate. It does not
+retroactively enforce changes to existing comments. Test files and user-facing
+strings or messages are out of scope; this policy covers only code comments and
+doc-comments.

--- a/docs/agent-maintenance/index.md
+++ b/docs/agent-maintenance/index.md
@@ -23,6 +23,8 @@
 - [`change-surfaces.md`](change-surfaces.md) — change-allowed surfaces, with
   canonical modules, giant-file flags, and `do_not_edit_without_migration_plan`
   list. Use this before adding logic to any new file.
+- [`comment-language-policy.md`](comment-language-policy.md) — authoring policy
+  for the language and review scope of code comments and doc-comments.
 - [`dispatch-mod-extraction-plan.md`](dispatch-mod-extraction-plan.md) —
   subdomain map and ordered extraction issues for shrinking
   `src/dispatch/mod.rs` into a facade (#1785).


### PR DESCRIPTION
Addresses #4232. 유지관리자 결정: **영어 통일, 신규/수정 코드만** (bulk 재작성 금지 — blame 오염).

## 변경 (docs-only)
- `docs/agent-maintenance/comment-language-policy.md` (신규 21줄): 신규/수정 코드 주석·doc-comment는 영어. 기존 주석 bulk 번역 금지(이미 그 라인을 다른 이유로 수정할 때만). CI 강제 게이트 아님(휴먼/에이전트 authoring 정책). 테스트 파일·사용자 대면 문자열 제외.
- `CLAUDE.md`: '코드 수정 전 필독' 포인터 1줄 추가(내용 복제 금지, 드리프트 방지).
- `docs/agent-maintenance/index.md`: 유지관리 문서 목록 등록.

## 게이트
freshness passed · audit --check rc=0 · ci-script-checks rc=0. 소스/lint/테스트/핫루트 미변경.