### PR TITLE
fix(relay-watchdog): coverage desync 알람을 delivery-gap과 corroborate (#4504)

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -86,6 +86,10 @@ COVERAGE_COVERED = "covered"
 COVERAGE_UNCOVERED = "uncovered"
 COVERAGE_UNKNOWN = "unknown"
 COVERAGE_CONFIRM_TICKS = 2
+# #4504: a bare attached_but_desynced (no corroborating delivery gap) must
+# persist far longer than the 2-tick default before it can alarm on its own,
+# because under bursty load it self-clears with delivery fully intact.
+COVERAGE_DESYNC_CONFIRM_TICKS = 20  # ~10 min at a 30s poll
 # A foreground turn must show an outbound/relay write inside this window before
 # a transient watcher-state desync can be treated as covered.  Ten minutes
 # matches the watchdog's calibrated delivery grace while still letting a
@@ -2675,6 +2679,22 @@ def tick_coverage(
             f"confirm={verdict.consecutive_uncovered}/{COVERAGE_CONFIRM_TICKS}"
         )
         return
+    # #4504: attached_but_desynced is a watcher-state desync, not proof of
+    # delivery loss. Require a corroborating real delivery gap OR much longer
+    # persistence before this alarms on its own. detached / watcher_state_404
+    # keep the 2-tick behavior (different reason strings).
+    if verdict.reason == "attached_but_desynced":
+        delivery_gap_active = bool(chs.get("gap_since") or chs.get("alerting"))
+        if (
+            not delivery_gap_active
+            and verdict.consecutive_uncovered < COVERAGE_DESYNC_CONFIRM_TICKS
+        ):
+            rt.log(
+                f"[{cid}] coverage desync uncorroborated "
+                f"ticks={verdict.consecutive_uncovered}/"
+                f"{COVERAGE_DESYNC_CONFIRM_TICKS} — not alarming"
+            )
+            return
     if rt.in_deploy_window(now):
         rt.log(
             f"[{cid}] coverage violation reason={verdict.reason} suppressed — "

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -87,9 +87,12 @@ COVERAGE_UNCOVERED = "uncovered"
 COVERAGE_UNKNOWN = "unknown"
 COVERAGE_CONFIRM_TICKS = 2
 # #4504: a bare attached_but_desynced (no corroborating delivery gap) must
-# persist far longer than the 2-tick default before it can alarm on its own,
-# because under bursty load it self-clears with delivery fully intact.
-COVERAGE_DESYNC_CONFIRM_TICKS = 20  # ~10 min at a 30s poll
+# persist this long before it can alarm on its own. Wall-clock, NOT tick count,
+# so it is independent of poll_secs (default 120s). ~10 min: comfortably beyond
+# the load-transient false positives (seconds) this suppresses, and the
+# transcript-vs-Discord gap alarm independently catches real delivery loss at
+# gap_alert_secs (~15 min) regardless of this backstop.
+COVERAGE_DESYNC_CONFIRM_SECS = 600
 # A foreground turn must show an outbound/relay write inside this window before
 # a transient watcher-state desync can be treated as covered.  Ten minutes
 # matches the watchdog's calibrated delivery grace while still letting a
@@ -2661,6 +2664,7 @@ def tick_coverage(
         rt.log(f"[{cid}] coverage unknown reason={verdict.reason} — no alert")
         return
     if verdict.state == COVERAGE_COVERED:
+        chs.pop("coverage_desync_since", None)
         if chs.pop("coverage_alerting", None):
             if verdict.reason == "tmux_not_expected":
                 rt.log(
@@ -2672,6 +2676,18 @@ def tick_coverage(
         # Keep last_coverage_alert across recovery as an anti-flap cooldown,
         # matching the independent PG monitor's persistence semantics.
         return
+
+    desync_since: float | None = None
+    if verdict.reason == "attached_but_desynced":
+        raw_desync_since = chs.get("coverage_desync_since")
+        if (
+            _is_finite_nonnegative_number(raw_desync_since)
+            and float(raw_desync_since) <= now
+        ):
+            desync_since = float(raw_desync_since)
+        else:
+            desync_since = now
+            chs["coverage_desync_since"] = desync_since
 
     if not verdict.confirmed:
         rt.log(
@@ -2685,14 +2701,17 @@ def tick_coverage(
     # keep the 2-tick behavior (different reason strings).
     if verdict.reason == "attached_but_desynced":
         delivery_gap_active = bool(chs.get("gap_since") or chs.get("alerting"))
+        desync_for = (
+            max(0.0, now - desync_since) if desync_since is not None else 0.0
+        )
         if (
             not delivery_gap_active
-            and verdict.consecutive_uncovered < COVERAGE_DESYNC_CONFIRM_TICKS
+            and desync_for < COVERAGE_DESYNC_CONFIRM_SECS
         ):
             rt.log(
                 f"[{cid}] coverage desync uncorroborated "
-                f"ticks={verdict.consecutive_uncovered}/"
-                f"{COVERAGE_DESYNC_CONFIRM_TICKS} — not alarming"
+                f"duration={int(desync_for)}s/"
+                f"{COVERAGE_DESYNC_CONFIRM_SECS}s — not alarming"
             )
             return
     if rt.in_deploy_window(now):

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -26,7 +26,7 @@ import scripts.relay_watchdog as relay_watchdog
 from scripts.relay_watchdog import (
     COVERAGE_ACTIVITY_FRESH_SECS,
     COVERAGE_CONFIRM_TICKS,
-    COVERAGE_DESYNC_CONFIRM_TICKS,
+    COVERAGE_DESYNC_CONFIRM_SECS,
     COVERAGE_COVERED,
     COVERAGE_UNCOVERED,
     COVERAGE_UNKNOWN,
@@ -2694,12 +2694,18 @@ class TickChannelTests(unittest.TestCase):
     def test_active_foreground_desync_does_not_advance_coverage_confirmation(self):
         rt = self.make_rt()
         self.arm_coverage(rt, self.active_foreground_probe())
-        state = {"999": {"coverage_uncovered_ticks": 1}}
+        state = {
+            "999": {
+                "coverage_uncovered_ticks": 1,
+                "coverage_desync_since": self.now - 60,
+            }
+        }
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
         self.assertEqual(rt.alerts, [])
         self.assertNotIn("coverage_uncovered_ticks", state["999"])
+        self.assertNotIn("coverage_desync_since", state["999"])
         self.assertNotIn("last_coverage_alert", state["999"])
 
     def test_back_to_back_foreground_churn_never_accumulates_confirmation(self):
@@ -2733,7 +2739,8 @@ class TickChannelTests(unittest.TestCase):
         )
         state = {
             "999": {
-                "coverage_uncovered_ticks": COVERAGE_DESYNC_CONFIRM_TICKS - 1
+                "coverage_uncovered_ticks": 1,
+                "coverage_desync_since": self.now - COVERAGE_DESYNC_CONFIRM_SECS,
             }
         }
 
@@ -2767,31 +2774,38 @@ class TickChannelTests(unittest.TestCase):
             state["999"]["coverage_uncovered_ticks"], COVERAGE_CONFIRM_TICKS
         )
 
-    def test_uncorroborated_load_desync_does_not_alarm_before_longer_backstop(self):
+    def test_uncorroborated_load_desync_alarms_only_after_duration_backstop(self):
         self.write_transcript([(self.now - 30, "delivered block")])
-        rt = self.make_rt()
+        rt = self.make_rt(poll_secs=60)
         rt.haystack = norm("delivered block")
         self.arm_coverage(rt, self.active_foreground_probe(queue_depth=1))
-        state = {"999": {"coverage_uncovered_ticks": 1}}
+        state: dict = {}
 
-        for tick_index in range(4):
+        for tick_index in range(COVERAGE_DESYNC_CONFIRM_SECS // rt.cfg.poll_secs):
             tick_channel(
                 rt,
                 TICK_CHANNEL,
                 state,
                 self.now + tick_index * rt.cfg.poll_secs,
             )
+            self.assertFalse(
+                any("커버리지 불변식 위반" in body for body, _ in rt.alerts)
+            )
 
-        self.assertFalse(
+        self.assertEqual(state["999"]["coverage_desync_since"], self.now)
+        tick_channel(
+            rt,
+            TICK_CHANNEL,
+            state,
+            self.now + COVERAGE_DESYNC_CONFIRM_SECS,
+        )
+
+        self.assertTrue(
             any("커버리지 불변식 위반" in body for body, _ in rt.alerts)
         )
-        self.assertNotIn("last_coverage_alert", state["999"])
+        self.assertIn("last_coverage_alert", state["999"])
         self.assertFalse(state["999"].get("gap_since"))
         self.assertFalse(state["999"].get("alerting"))
-        self.assertLess(
-            state["999"]["coverage_uncovered_ticks"],
-            COVERAGE_DESYNC_CONFIRM_TICKS,
-        )
 
     def test_delivery_gap_corroborates_desync_coverage_alarm(self):
         rt = self.gap_rt()

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -26,6 +26,7 @@ import scripts.relay_watchdog as relay_watchdog
 from scripts.relay_watchdog import (
     COVERAGE_ACTIVITY_FRESH_SECS,
     COVERAGE_CONFIRM_TICKS,
+    COVERAGE_DESYNC_CONFIRM_TICKS,
     COVERAGE_COVERED,
     COVERAGE_UNCOVERED,
     COVERAGE_UNKNOWN,
@@ -2720,7 +2721,7 @@ class TickChannelTests(unittest.TestCase):
         self.assertEqual(rt.alerts, [])
         self.assertNotIn("last_coverage_alert", state["999"])
 
-    def test_stale_foreground_desync_still_confirms_coverage_alert(self):
+    def test_stale_foreground_desync_alarms_at_longer_backstop(self):
         rt = self.make_rt()
         stale_ms = int(self.now * 1000) - COVERAGE_ACTIVITY_FRESH_SECS * 1000
         self.arm_coverage(
@@ -2730,7 +2731,11 @@ class TickChannelTests(unittest.TestCase):
                 last_relay_ts_ms=None,
             ),
         )
-        state = {"999": {"coverage_uncovered_ticks": 1}}
+        state = {
+            "999": {
+                "coverage_uncovered_ticks": COVERAGE_DESYNC_CONFIRM_TICKS - 1
+            }
+        }
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
@@ -2738,7 +2743,7 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
         self.assertIn("attached_but_desynced", rt.alerts[0][0])
 
-    def test_partial_foreground_schema_cannot_suppress_coverage_alert(self):
+    def test_partial_foreground_schema_confirms_without_early_desync_alert(self):
         rt = self.make_rt()
         self.arm_coverage(
             rt,
@@ -2756,12 +2761,54 @@ class TickChannelTests(unittest.TestCase):
 
         tick_channel(rt, TICK_CHANNEL, state, self.now)
 
-        self.assertEqual(len(rt.alerts), 1)
-        self.assertIn("커버리지 불변식 위반", rt.alerts[0][0])
-        self.assertIn("attached_but_desynced", rt.alerts[0][0])
+        self.assertEqual(rt.alerts, [])
+        self.assertNotIn("last_coverage_alert", state["999"])
         self.assertEqual(
             state["999"]["coverage_uncovered_ticks"], COVERAGE_CONFIRM_TICKS
         )
+
+    def test_uncorroborated_load_desync_does_not_alarm_before_longer_backstop(self):
+        self.write_transcript([(self.now - 30, "delivered block")])
+        rt = self.make_rt()
+        rt.haystack = norm("delivered block")
+        self.arm_coverage(rt, self.active_foreground_probe(queue_depth=1))
+        state = {"999": {"coverage_uncovered_ticks": 1}}
+
+        for tick_index in range(4):
+            tick_channel(
+                rt,
+                TICK_CHANNEL,
+                state,
+                self.now + tick_index * rt.cfg.poll_secs,
+            )
+
+        self.assertFalse(
+            any("커버리지 불변식 위반" in body for body, _ in rt.alerts)
+        )
+        self.assertNotIn("last_coverage_alert", state["999"])
+        self.assertFalse(state["999"].get("gap_since"))
+        self.assertFalse(state["999"].get("alerting"))
+        self.assertLess(
+            state["999"]["coverage_uncovered_ticks"],
+            COVERAGE_DESYNC_CONFIRM_TICKS,
+        )
+
+    def test_delivery_gap_corroborates_desync_coverage_alarm(self):
+        rt = self.gap_rt()
+        self.arm_coverage(rt, self.active_foreground_probe(queue_depth=1))
+        state = {
+            "999": {
+                "coverage_uncovered_ticks": 1,
+                "gap_since": self.now - rt.cfg.poll_secs,
+            }
+        }
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+
+        self.assertTrue(
+            any("커버리지 불변식 위반" in body for body, _ in rt.alerts)
+        )
+        self.assertIn("last_coverage_alert", state["999"])
 
     def test_active_foreground_evidence_cannot_suppress_detached_alert(self):
         rt = self.make_rt()


### PR DESCRIPTION
Fixes #4504. out-of-band 릴레이 워치독(#4381)이 `attached_but_desynced`를 2-tick만에 알람 → 부하 구간에 delivery 무손실인데도 cry-wolf(배치당 5회).

## 판정모델 재설계 (증상패치 아님)
- `COVERAGE_DESYNC_CONFIRM_TICKS=20`(~10분@30s poll) 신규.
- `tick_coverage()`에서 `reason==attached_but_desynced`는 **실제 persisted delivery-gap(`chs.gap_since` 또는 `chs.alerting`)이 있거나 consecutive_uncovered>=20** 일 때만 알람. 그 외(부하성 순수 state 드리프트)는 로그만 남기고 억제.
- `detached`/`watcher_state_404`(다른 reason)는 2-tick 그대로. `evaluate_coverage` 순수 유지. delivery-gap 알람·stall-watchdog 불변.

## 안전(진짜 손실 미억제)
- 백스톱A: 실제 손실이면 gap evaluator가 `gap_since`/`alerting` 설정→다음 tick 알람.
- 백스톱B: gap evaluator에 안 잡혀도 20-tick OR-branch 발화.
- 최악은 **지연**(tick_coverage가 gap eval보다 먼저 돌아 prior-tick gap_since 참조)일 뿐 영구 억제 없음.

## 테스트 (뮤테이션 양방향)
tests/test_relay_watchdog.py: (1)desync+gap없음→무알람 (2)desync+실제gap→알람 유지. 뮤테이션: gate 제거→test1 실패(오알람), over-broad→test2 실패(진짜 억제), 복원→ok. CI(unittest tests.test_relay_watchdog) 230 OK.

## 게이트
py_compile · unittest 230 OK · audit --check rc=0 · freshness passed. relay_watchdog.py+20/test+59, python only, 핫루트 미접촉.