### PR TITLE
feat(routines): daily dcserver 로그 다이제스트 루틴 (#4263)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,13 +53,16 @@ routines/*
 !src/server/routes/routines/
 !src/server/routes/routines/*.rs
 
-# Exception: the automation-candidate pipeline routines are shipped engine code
-# (feat(pipeline-v2) #2064), loaded by name via RoutineScriptLoader's default
-# `./routines` dir and exercised by `npm run test:policies`. They were swept up
-# by mistake in the operator-routine untrack pass (#4076) — keep them tracked.
+# Exception: bundled monitoring routines are shipped engine code, loaded by
+# name via RoutineScriptLoader's default `./routines` dir, and exercised by CI.
+# The automation pipeline was swept up by mistake in the operator-routine
+# untrack pass (#4076); keep it and later bundled monitoring routines tracked.
 !routines/monitoring/
 routines/monitoring/*
 !routines/monitoring/automation-executor.js
 !routines/monitoring/automation-candidate-executor.js
 !routines/monitoring/automation-candidate-detector.js
 !routines/monitoring/automation-candidate-recommender.js
+!routines/monitoring/daily-log-digest.js
+!routines/monitoring/daily_log_digest.py
+!routines/monitoring/log_digest_issue_drafts.py

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -433,6 +433,17 @@
 
 ### Audited touches
 
+- #4263 (daily log-digest routine): adds a **LEADER-ONLY/SINGLETON** scheduled
+  monitoring routine. `server::worker_registry` already runs
+  `routine_runtime_loop` through `register_leader_tokio`, and the existing
+  PostgreSQL routine claim also locks the single attached routine row with
+  `FOR UPDATE SKIP LOCKED` plus `in_flight_run_id`; no second scheduler or
+  node-local timer is introduced. Operators attach exactly one daily row on the
+  cluster leader. The routine checkpoint suppresses a second KST-day dispatch,
+  while pending issue drafts are written on the active leader's runtime root.
+  On leader failover the normal stale-run recovery and routine lease semantics
+  remain authoritative. GitHub issue reads happen in the agent turn; issue
+  creation stays default-off and requires the literal human-confirmed gate.
 - #4262 (post-deploy functional smoke): adds a **WORKER-LOCAL deploy-tooling**
   stage after `DEPLOY_OK` in `scripts/deploy-release.sh`. Each deployed node
   probes its own loopback API on the configured `server.port`, local

--- a/docs/routines/daily-log-digest.md
+++ b/docs/routines/daily-log-digest.md
@@ -38,14 +38,16 @@ release tooling: `AGENTDESK_ROOT_DIR`, then `ADK_REL`, then `$HOME/.adk/release`
 - `logs/dcserver.stdout.log` and its numbered rotations (the internal tracing writer);
 - `logs/dcserver.launchd.stderr.log` (the path emitted by AgentDesk's launchd/systemd setup).
 
-Timestamped lines are limited to the preceding 24 hours. An undated launchd bootstrap line is
-included only when its current file was modified in that window.
+Timestamped lines are limited to the preceding 24 hours. Undated launchd stderr uses a persistent
+device/inode/byte-offset checkpoint under `runtime/daily-log-digest/`, so a range is counted at
+most once; rotation or truncation starts a new range. The first observation establishes the
+watermark, and a stale file outside the window is baselined without counting its old contents.
 
 Optional environment settings, normally placed in the deployment's preserved
 `config/launchd.env`, are:
 
 - `AGENTDESK_LOG_DIGEST_THRESHOLD`: positive daily count threshold, default `50`; a pattern must
-  be strictly greater than the threshold.
+  be strictly greater than the threshold. Invalid values warn and fall back to `50`.
 - `AGENTDESK_LOG_DIGEST_REPO`: GitHub repository for open-issue dedup, default
   `itismyfield/AgentDesk`.
 - `AGENTDESK_LOG_DIGEST_CREATE_ISSUE`: default `off`. Only the literal `confirmed`, set by a human
@@ -66,11 +68,15 @@ post = maybe_post_approved_drafts(drafts, approval_mode, create_issue)
 ```
 
 Normalization removes ANSI decoration and timestamps, canonicalizes ERROR/WARN, and replaces UUIDs,
-hashes, numeric values, dynamic IDs, and request tokens with placeholders. Counts are grouped by
-severity plus normalized signature. Threshold crossings are compared with normalized open-issue
-title/body tokens; direct containment, high signature-token coverage, or high Jaccard overlap
-suppresses the draft. If the open-issue query is unavailable, draft generation fails closed to
-avoid duplicate pending work.
+hashes, known embedded/dynamic IDs, request tokens, and most bare numbers with placeholders. HTTP
+status codes and explicitly labelled ports remain distinct; unlabeled semantic numbers may still
+collapse. Counts are grouped by severity plus normalized signature. Threshold crossings are
+compared against the bounded issue title and first non-empty body line using at least three shared
+tokens and symmetric Jaccard similarity; direct containment is accepted only for signature-like
+candidates. This can miss a duplicate described only deep in a long body, but avoids suppressing a
+new short signature merely mentioned in an unrelated epic. If the open-issue query is unavailable,
+invalid, or reaches the 1,000-result cap, draft generation fails closed to avoid duplicate pending
+work from an incomplete dedup set.
 
 Pending Markdown files use a stable signature hash and live at:
 

--- a/docs/routines/daily-log-digest.md
+++ b/docs/routines/daily-log-digest.md
@@ -1,0 +1,86 @@
+# Daily dcserver log digest routine
+
+Issue #4263 adds `monitoring/daily-log-digest.js` to the existing PostgreSQL-backed routine
+worker. It is an agent-backed monitoring routine because the QuickJS routine sandbox intentionally
+has no filesystem or network bridge. The routine dispatches one fresh agent turn per day; that turn
+runs the deterministic sibling helper, and the existing routine Discord logger posts the final
+summary to the configured routine channel/thread.
+
+## Attach once
+
+Routines use `routines.default_timezone` (Asia/Seoul by default). Attach one row on the cluster
+leader and target the operations channel with `discord_thread_id`:
+
+```bash
+REL_PORT="${AGENTDESK_REL_PORT:-8791}"
+API="http://127.0.0.1:${REL_PORT}"
+
+curl -sf "$API/api/routines" -X POST -H 'Content-Type: application/json' -d '{
+  "script_ref": "monitoring/daily-log-digest.js",
+  "name": "daily-dcserver-log-digest",
+  "agent_id": "project-agentdesk",
+  "execution_strategy": "fresh",
+  "schedule": "10 9 * * *",
+  "discord_thread_id": "YOUR_OPS_CHANNEL_OR_THREAD_ID",
+  "timeout_secs": 900
+}'
+```
+
+The cron schedule is persisted in the normal routines table and claimed through the existing
+routine lease. A checkpoint day key is a second guard against a manual or duplicate same-day run,
+so the routine dispatches at most one digest agent turn per KST day.
+
+## Inputs and configuration
+
+`routines/monitoring/daily_log_digest.py` resolves the runtime root in the same order used by
+release tooling: `AGENTDESK_ROOT_DIR`, then `ADK_REL`, then `$HOME/.adk/release`. It reads:
+
+- `logs/dcserver.stdout.log` and its numbered rotations (the internal tracing writer);
+- `logs/dcserver.launchd.stderr.log` (the path emitted by AgentDesk's launchd/systemd setup).
+
+Timestamped lines are limited to the preceding 24 hours. An undated launchd bootstrap line is
+included only when its current file was modified in that window.
+
+Optional environment settings, normally placed in the deployment's preserved
+`config/launchd.env`, are:
+
+- `AGENTDESK_LOG_DIGEST_THRESHOLD`: positive daily count threshold, default `50`; a pattern must
+  be strictly greater than the threshold.
+- `AGENTDESK_LOG_DIGEST_REPO`: GitHub repository for open-issue dedup, default
+  `itismyfield/AgentDesk`.
+- `AGENTDESK_LOG_DIGEST_CREATE_ISSUE`: default `off`. Only the literal `confirmed`, set by a human
+  after reviewing pending drafts, allows the approval path to inspect per-draft markers.
+
+## Normalization, dedup, and drafts
+
+`log_digest_issue_drafts.py` is the reusable API for this routine and #4265. Its public pipeline is:
+
+```python
+patterns = aggregate_normalized_signatures(lines)
+decisions = decide_issue_drafts(patterns, open_issues, threshold=50)
+drafts = write_pending_drafts(
+    [decision.draft for decision in decisions if decision.draft],
+    pending_dir,
+)
+post = maybe_post_approved_drafts(drafts, approval_mode, create_issue)
+```
+
+Normalization removes ANSI decoration and timestamps, canonicalizes ERROR/WARN, and replaces UUIDs,
+hashes, numeric values, dynamic IDs, and request tokens with placeholders. Counts are grouped by
+severity plus normalized signature. Threshold crossings are compared with normalized open-issue
+title/body tokens; direct containment, high signature-token coverage, or high Jaccard overlap
+suppresses the draft. If the open-issue query is unavailable, draft generation fails closed to
+avoid duplicate pending work.
+
+Pending Markdown files use a stable signature hash and live at:
+
+```text
+${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}/runtime/pending-issue-drafts/daily-log-digest/
+```
+
+The normal/default path never creates an issue. Approval is deliberately two-step: after reviewing
+one pending file, create its adjacent marker (for example
+`error-0123456789abcdef.md.approved`) and set
+`AGENTDESK_LOG_DIGEST_CREATE_ISSUE=confirmed`. Both the literal environment gate and that specific
+draft's `.approved` marker must exist before the injected issue-creation callback can run. A future
+caller using the shared helper inherits both checks.

--- a/policies/__tests__/daily-log-digest.test.js
+++ b/policies/__tests__/daily-log-digest.test.js
@@ -1,0 +1,64 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { loadRoutine } = require("./support/routine-harness");
+
+const ROUTINE_PATH = "routines/monitoring/daily-log-digest.js";
+
+test("daily log digest uses the monitoring agent-action frame", () => {
+  const { routine, tick } = loadRoutine(ROUTINE_PATH);
+  const now = new Date("2026-07-14T00:10:00Z");
+
+  const result = tick({ now, checkpoint: null, observations: [], automationInventory: [] });
+
+  assert.equal(routine.name, "Daily dcserver Log Digest");
+  assert.equal(result.action, "agent");
+  assert.match(result.prompt, /python3 "\$ROOT\/routines\/monitoring\/daily_log_digest\.py"/);
+  assert.match(result.prompt, /Do not call `gh issue create` directly/);
+  assert.match(result.prompt, /AGENTDESK_LOG_DIGEST_CREATE_ISSUE=confirmed/);
+  assert.equal(result.checkpoint.last_dispatched_day, "2026-07-14");
+});
+
+test("daily checkpoint suppresses a second digest on the same day", () => {
+  const { tick } = loadRoutine(ROUTINE_PATH);
+  const first = tick({
+    now: new Date("2026-07-14T00:10:00Z"),
+    checkpoint: null,
+    observations: [],
+    automationInventory: [],
+  });
+  const duplicate = tick({
+    now: new Date("2026-07-14T12:10:00Z"),
+    checkpoint: first.checkpoint,
+    observations: [],
+    automationInventory: [],
+  });
+
+  assert.equal(duplicate.action, "complete");
+  assert.equal(duplicate.result.status, "already_dispatched");
+});
+
+test("daily checkpoint dispatches again on the next day", () => {
+  const { tick } = loadRoutine(ROUTINE_PATH);
+  const result = tick({
+    now: new Date("2026-07-15T00:10:00Z"),
+    checkpoint: { version: 1, last_dispatched_day: "2026-07-14" },
+    observations: [],
+    automationInventory: [],
+  });
+
+  assert.equal(result.action, "agent");
+  assert.equal(result.checkpoint.last_dispatched_day, "2026-07-15");
+});
+
+test("daily checkpoint day key follows the routine's default KST timezone", () => {
+  const { tick } = loadRoutine(ROUTINE_PATH);
+  const result = tick({
+    now: new Date("2026-07-14T16:10:00Z"),
+    checkpoint: { version: 1, last_dispatched_day: "2026-07-14" },
+    observations: [],
+    automationInventory: [],
+  });
+
+  assert.equal(result.action, "agent");
+  assert.equal(result.checkpoint.last_dispatched_day, "2026-07-15");
+});

--- a/routines/monitoring/daily-log-digest.js
+++ b/routines/monitoring/daily-log-digest.js
@@ -1,0 +1,71 @@
+// Daily dcserver Log Digest (#4263)
+//
+// QuickJS routines intentionally have no filesystem/network bridge. Match the
+// existing monitoring frame by dispatching one fresh agent turn; the agent runs
+// the deterministic sibling helper and its final response is posted through the
+// routine Discord logger.
+
+const CHECKPOINT_VERSION = 1;
+
+function dayKey(now) {
+  const value = typeof now === "string" ? now : now.toISOString();
+  const kst = new Date(new Date(value).getTime() + 9 * 60 * 60 * 1000);
+  return kst.toISOString().slice(0, 10);
+}
+
+function loadCheckpoint(raw) {
+  if (!raw || raw.version !== CHECKPOINT_VERSION) {
+    return { version: CHECKPOINT_VERSION, last_dispatched_day: null };
+  }
+  return {
+    version: CHECKPOINT_VERSION,
+    last_dispatched_day: raw.last_dispatched_day || null,
+  };
+}
+
+function buildPrompt(day) {
+  return [
+    "# Daily dcserver log digest",
+    "",
+    `Digest day: ${day}`,
+    "",
+    "Run the repository-bundled deterministic helper:",
+    "```bash",
+    'ROOT="${AGENTDESK_ROOT_DIR:-${ADK_REL:-$HOME/.adk/release}}"',
+    'python3 "$ROOT/routines/monitoring/daily_log_digest.py"',
+    "```",
+    "",
+    "Return the helper stdout verbatim as your final response, with no preface or follow-up.",
+    "Do not call `gh issue create` directly. The helper writes pending drafts and its shared",
+    "gate permits posting only when a human has explicitly set",
+    "`AGENTDESK_LOG_DIGEST_CREATE_ISSUE=confirmed` and marked that specific draft",
+    "with an adjacent `.approved` file; the default is `off`.",
+  ].join("\n");
+}
+
+agentdesk.routines.register({
+  name: "Daily dcserver Log Digest",
+
+  tick(ctx) {
+    const day = dayKey(ctx.now);
+    const checkpoint = loadCheckpoint(ctx.checkpoint);
+    if (checkpoint.last_dispatched_day === day) {
+      return {
+        action: "complete",
+        result: {
+          status: "already_dispatched",
+          summary: `daily log digest already dispatched for ${day}`,
+        },
+        checkpoint,
+      };
+    }
+
+    checkpoint.last_dispatched_day = day;
+    return {
+      action: "agent",
+      prompt: buildPrompt(day),
+      lastResult: `daily log digest dispatched for ${day}`,
+      checkpoint,
+    };
+  },
+});

--- a/routines/monitoring/daily_log_digest.py
+++ b/routines/monitoring/daily_log_digest.py
@@ -27,14 +27,19 @@ from log_digest_issue_drafts import (
 
 
 REPOSITORY = "itismyfield/AgentDesk"
+OPEN_ISSUE_LIMIT = 1000
+UNDATED_CHECKPOINT_VERSION = 1
 _LINE_TIMESTAMP_RE = re.compile(
     r"(?<!\d)(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
 )
 
 
 def runtime_root() -> Path:
-    """Mirror AgentDesk's AGENTDESK_ROOT_DIR then release-root fallback."""
+    """Resolve the runtime root used by the release launcher."""
 
+    # src/config.rs owns AGENTDESK_ROOT_DIR as the canonical runtime override.
+    # ADK_REL remains a compatibility fallback because deploy-release.sh derives
+    # it from that override and the routine launcher may pass only ADK_REL.
     configured = os.environ.get("AGENTDESK_ROOT_DIR") or os.environ.get("ADK_REL")
     if configured:
         return Path(configured).expanduser()
@@ -68,23 +73,88 @@ def _parse_line_timestamp(line: str) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-def recent_log_lines(paths: Iterable[Path], since: datetime, now: datetime) -> tuple[list[str], list[str]]:
-    """Read the 24h window; recent undated launchd lines use file mtime."""
+def _load_undated_offsets(checkpoint_path: Path | None) -> tuple[dict[str, dict[str, int]], list[str]]:
+    if checkpoint_path is None or not checkpoint_path.is_file():
+        return {}, []
+    try:
+        payload = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("unsupported checkpoint shape")
+        files = payload.get("files")
+        if payload.get("version") != UNDATED_CHECKPOINT_VERSION or not isinstance(files, dict):
+            raise ValueError("unsupported checkpoint shape")
+        offsets: dict[str, dict[str, int]] = {}
+        for path, entry in files.items():
+            if not isinstance(path, str) or not isinstance(entry, dict):
+                raise ValueError("invalid checkpoint entry")
+            offsets[path] = {
+                "device": int(entry["device"]),
+                "inode": int(entry["inode"]),
+                "offset": int(entry["offset"]),
+            }
+        return offsets, []
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        return {}, [f"could not load undated-line checkpoint {checkpoint_path}: {error}"]
+
+
+def _save_undated_offsets(
+    checkpoint_path: Path | None, offsets: dict[str, dict[str, int]]
+) -> list[str]:
+    if checkpoint_path is None:
+        return []
+    try:
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = checkpoint_path.with_suffix(checkpoint_path.suffix + ".tmp")
+        temporary.write_text(
+            json.dumps(
+                {"version": UNDATED_CHECKPOINT_VERSION, "files": offsets},
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(checkpoint_path)
+    except OSError as error:
+        return [f"could not save undated-line checkpoint {checkpoint_path}: {error}"]
+    return []
+
+
+def recent_log_lines(
+    paths: Iterable[Path],
+    since: datetime,
+    now: datetime,
+    *,
+    undated_checkpoint: Path | None = None,
+) -> tuple[list[str], list[str]]:
+    """Read the 24h window and consume each undated launchd byte range once."""
 
     lines: list[str] = []
-    warnings: list[str] = []
+    undated_offsets, warnings = _load_undated_offsets(undated_checkpoint)
     found_any = False
     for path in paths:
         if not path.is_file():
             continue
         found_any = True
         try:
+            stat = path.stat()
             include_undated = (
                 path.name == "dcserver.launchd.stderr.log"
-                and datetime.fromtimestamp(path.stat().st_mtime, timezone.utc) >= since
+                and datetime.fromtimestamp(stat.st_mtime, timezone.utc) >= since
             )
-            with path.open(encoding="utf-8", errors="replace") as stream:
-                for raw_line in stream:
+            checkpoint_key = str(path.resolve())
+            previous = undated_offsets.get(checkpoint_key)
+            previous_offset = 0
+            if (
+                previous is not None
+                and previous["device"] == stat.st_dev
+                and previous["inode"] == stat.st_ino
+                and 0 <= previous["offset"] <= stat.st_size
+            ):
+                previous_offset = previous["offset"]
+            with path.open("rb") as stream:
+                while raw_bytes := stream.readline():
+                    line_end = stream.tell()
+                    raw_line = raw_bytes.decode("utf-8", errors="replace")
                     if extract_severity(raw_line) is None:
                         continue
                     line = raw_line.rstrip("\n")
@@ -92,15 +162,22 @@ def recent_log_lines(paths: Iterable[Path], since: datetime, now: datetime) -> t
                     if timestamp is not None:
                         if since <= timestamp <= now + timedelta(minutes=5):
                             lines.append(line)
-                    elif include_undated:
-                        # launchd bootstrap stderr is not guaranteed to carry a
-                        # timestamp. Its bounded current file is included only when
-                        # the file itself changed during the daily window.
+                    elif include_undated and line_end > previous_offset:
+                        # launchd stderr is append-only and often undated. The
+                        # identity+offset watermark makes each byte range eligible
+                        # once; rotation or truncation starts a fresh identity/range.
                         lines.append(line)
+                if path.name == "dcserver.launchd.stderr.log":
+                    undated_offsets[checkpoint_key] = {
+                        "device": stat.st_dev,
+                        "inode": stat.st_ino,
+                        "offset": stream.tell(),
+                    }
         except OSError as error:
             warnings.append(f"could not read {path}: {error}")
     if not found_any:
         warnings.append("no dcserver stdout or launchd stderr log files were found")
+    warnings.extend(_save_undated_offsets(undated_checkpoint, undated_offsets))
     return lines, warnings
 
 
@@ -114,7 +191,7 @@ def load_open_issues(repo: str) -> tuple[list[OpenIssue], str | None]:
         "--state",
         "open",
         "--limit",
-        "1000",
+        str(OPEN_ISSUE_LIMIT),
         "--json",
         "number,title,body,url",
     ]
@@ -138,6 +215,11 @@ def load_open_issues(repo: str) -> tuple[list[OpenIssue], str | None]:
         ]
     except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         return [], f"open-issue dedup response invalid ({error}); drafts suppressed"
+    if len(issues) == OPEN_ISSUE_LIMIT:
+        return (
+            issues,
+            f"open-issue dedup may be truncated at {OPEN_ISSUE_LIMIT} results; drafts suppressed",
+        )
     return issues, None
 
 
@@ -171,17 +253,38 @@ def positive_int(value: str) -> int:
     return parsed
 
 
+def threshold_from_env(value: str | None) -> tuple[int, str | None]:
+    configured = value if value is not None else str(DEFAULT_DAILY_THRESHOLD)
+    try:
+        return positive_int(configured), None
+    except (ValueError, argparse.ArgumentTypeError):
+        return (
+            DEFAULT_DAILY_THRESHOLD,
+            "invalid AGENTDESK_LOG_DIGEST_THRESHOLD "
+            f"value {configured!r}; using default {DEFAULT_DAILY_THRESHOLD}",
+        )
+
+
 def parse_args() -> argparse.Namespace:
+    env_threshold, threshold_warning = threshold_from_env(
+        os.environ.get("AGENTDESK_LOG_DIGEST_THRESHOLD")
+    )
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=runtime_root())
     parser.add_argument("--repo", default=os.environ.get("AGENTDESK_LOG_DIGEST_REPO", REPOSITORY))
     parser.add_argument(
         "--threshold",
         type=positive_int,
-        default=positive_int(os.environ.get("AGENTDESK_LOG_DIGEST_THRESHOLD", str(DEFAULT_DAILY_THRESHOLD))),
+        default=None,
     )
     parser.add_argument("--now", help="RFC3339 test/diagnostic override")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.threshold is None:
+        args.threshold = env_threshold
+        args.threshold_warning = threshold_warning
+    else:
+        args.threshold_warning = None
+    return args
 
 
 def main() -> int:
@@ -193,7 +296,17 @@ def main() -> int:
     since = now - timedelta(days=1)
     window_label = f"{since:%Y-%m-%d %H:%M}–{now:%Y-%m-%d %H:%M} UTC"
 
-    lines, warnings = recent_log_lines(dcserver_log_paths(args.root), since, now)
+    lines, warnings = recent_log_lines(
+        dcserver_log_paths(args.root),
+        since,
+        now,
+        undated_checkpoint=args.root
+        / "runtime"
+        / "daily-log-digest"
+        / "undated-line-offsets.json",
+    )
+    if args.threshold_warning:
+        warnings.append(args.threshold_warning)
     patterns = aggregate_normalized_signatures(lines)
     open_issues, dedup_warning = load_open_issues(args.repo)
     if dedup_warning:

--- a/routines/monitoring/daily_log_digest.py
+++ b/routines/monitoring/daily_log_digest.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Aggregate the last day of dcserver logs and emit one human-review digest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+from log_digest_issue_drafts import (
+    CONFIRMED_APPROVAL,
+    DEFAULT_DAILY_THRESHOLD,
+    IssueDraft,
+    OpenIssue,
+    aggregate_normalized_signatures,
+    decide_issue_drafts,
+    extract_severity,
+    format_daily_summary,
+    maybe_post_approved_drafts,
+    write_pending_drafts,
+)
+
+
+REPOSITORY = "itismyfield/AgentDesk"
+_LINE_TIMESTAMP_RE = re.compile(
+    r"(?<!\d)(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
+)
+
+
+def runtime_root() -> Path:
+    """Mirror AgentDesk's AGENTDESK_ROOT_DIR then release-root fallback."""
+
+    configured = os.environ.get("AGENTDESK_ROOT_DIR") or os.environ.get("ADK_REL")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".adk" / "release"
+
+
+def dcserver_log_paths(root: Path) -> list[Path]:
+    """Return internal stdout rotations plus the actual launchd stderr path."""
+
+    logs = root / "logs"
+    stdout = logs / "dcserver.stdout.log"
+    paths = [stdout]
+    paths.extend(logs / f"dcserver.stdout.log.{index}" for index in range(1, 11))
+    paths.append(logs / "dcserver.launchd.stderr.log")
+    return paths
+
+
+def _parse_line_timestamp(line: str) -> datetime | None:
+    match = _LINE_TIMESTAMP_RE.search(line)
+    if not match:
+        return None
+    value = match.group(1).replace(",", ".")
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def recent_log_lines(paths: Iterable[Path], since: datetime, now: datetime) -> tuple[list[str], list[str]]:
+    """Read the 24h window; recent undated launchd lines use file mtime."""
+
+    lines: list[str] = []
+    warnings: list[str] = []
+    found_any = False
+    for path in paths:
+        if not path.is_file():
+            continue
+        found_any = True
+        try:
+            include_undated = (
+                path.name == "dcserver.launchd.stderr.log"
+                and datetime.fromtimestamp(path.stat().st_mtime, timezone.utc) >= since
+            )
+            with path.open(encoding="utf-8", errors="replace") as stream:
+                for raw_line in stream:
+                    if extract_severity(raw_line) is None:
+                        continue
+                    line = raw_line.rstrip("\n")
+                    timestamp = _parse_line_timestamp(line)
+                    if timestamp is not None:
+                        if since <= timestamp <= now + timedelta(minutes=5):
+                            lines.append(line)
+                    elif include_undated:
+                        # launchd bootstrap stderr is not guaranteed to carry a
+                        # timestamp. Its bounded current file is included only when
+                        # the file itself changed during the daily window.
+                        lines.append(line)
+        except OSError as error:
+            warnings.append(f"could not read {path}: {error}")
+    if not found_any:
+        warnings.append("no dcserver stdout or launchd stderr log files were found")
+    return lines, warnings
+
+
+def load_open_issues(repo: str) -> tuple[list[OpenIssue], str | None]:
+    command = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--limit",
+        "1000",
+        "--json",
+        "number,title,body,url",
+    ]
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return [], f"open-issue dedup unavailable ({error}); drafts suppressed"
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or f"gh exited {completed.returncode}"
+        return [], f"open-issue dedup unavailable ({detail}); drafts suppressed"
+    try:
+        payload = json.loads(completed.stdout)
+        issues = [
+            OpenIssue(
+                number=int(item["number"]),
+                title=str(item.get("title") or ""),
+                body=str(item.get("body") or ""),
+                url=str(item.get("url") or ""),
+            )
+            for item in payload
+        ]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        return [], f"open-issue dedup response invalid ({error}); drafts suppressed"
+    return issues, None
+
+
+def create_github_issue(repo: str, draft: IssueDraft) -> str:
+    if draft.path is None:
+        raise ValueError("approved issue draft must be written before posting")
+    completed = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            draft.title,
+            "--body-file",
+            str(draft.path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return completed.stdout.strip()
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=runtime_root())
+    parser.add_argument("--repo", default=os.environ.get("AGENTDESK_LOG_DIGEST_REPO", REPOSITORY))
+    parser.add_argument(
+        "--threshold",
+        type=positive_int,
+        default=positive_int(os.environ.get("AGENTDESK_LOG_DIGEST_THRESHOLD", str(DEFAULT_DAILY_THRESHOLD))),
+    )
+    parser.add_argument("--now", help="RFC3339 test/diagnostic override")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    now = datetime.fromisoformat(args.now.replace("Z", "+00:00")) if args.now else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(timezone.utc)
+    since = now - timedelta(days=1)
+    window_label = f"{since:%Y-%m-%d %H:%M}–{now:%Y-%m-%d %H:%M} UTC"
+
+    lines, warnings = recent_log_lines(dcserver_log_paths(args.root), since, now)
+    patterns = aggregate_normalized_signatures(lines)
+    open_issues, dedup_warning = load_open_issues(args.repo)
+    if dedup_warning:
+        warnings.append(dedup_warning)
+    decisions = decide_issue_drafts(
+        patterns,
+        open_issues,
+        threshold=args.threshold,
+        window_label=window_label,
+        dedup_available=dedup_warning is None,
+    )
+    pending_dir = args.root / "runtime" / "pending-issue-drafts" / "daily-log-digest"
+    drafts = write_pending_drafts(
+        [decision.draft for decision in decisions if decision.draft is not None],
+        pending_dir,
+    )
+
+    approval_mode = os.environ.get("AGENTDESK_LOG_DIGEST_CREATE_ISSUE", "off")
+    post = maybe_post_approved_drafts(
+        drafts,
+        approval_mode,
+        lambda draft: create_github_issue(args.repo, draft),
+    )
+    if approval_mode not in {"off", CONFIRMED_APPROVAL}:
+        warnings.append(
+            "invalid AGENTDESK_LOG_DIGEST_CREATE_ISSUE value ignored; use literal 'confirmed' or 'off'"
+        )
+    elif approval_mode == CONFIRMED_APPROVAL and not post.attempted:
+        warnings.append(post.reason)
+    if post.created_urls:
+        warnings.append("human-confirmed issues created: " + ", ".join(post.created_urls))
+
+    print(
+        format_daily_summary(
+            patterns,
+            decisions,
+            drafts,
+            threshold=args.threshold,
+            window_label=window_label,
+            warnings=warnings,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/routines/monitoring/daily_log_digest.py
+++ b/routines/monitoring/daily_log_digest.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import BinaryIO, Iterable
 
 from log_digest_issue_drafts import (
     CONFIRMED_APPROVAL,
@@ -28,7 +29,8 @@ from log_digest_issue_drafts import (
 
 REPOSITORY = "itismyfield/AgentDesk"
 OPEN_ISSUE_LIMIT = 1000
-UNDATED_CHECKPOINT_VERSION = 1
+UNDATED_CHECKPOINT_VERSION = 2
+UNDATED_FINGERPRINT_BYTES = 128
 _LINE_TIMESTAMP_RE = re.compile(
     r"(?<!\d)(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
 )
@@ -73,7 +75,9 @@ def _parse_line_timestamp(line: str) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-def _load_undated_offsets(checkpoint_path: Path | None) -> tuple[dict[str, dict[str, int]], list[str]]:
+def _load_undated_offsets(
+    checkpoint_path: Path | None,
+) -> tuple[dict[str, dict[str, int | str]], list[str]]:
     if checkpoint_path is None or not checkpoint_path.is_file():
         return {}, []
     try:
@@ -83,7 +87,7 @@ def _load_undated_offsets(checkpoint_path: Path | None) -> tuple[dict[str, dict[
         files = payload.get("files")
         if payload.get("version") != UNDATED_CHECKPOINT_VERSION or not isinstance(files, dict):
             raise ValueError("unsupported checkpoint shape")
-        offsets: dict[str, dict[str, int]] = {}
+        offsets: dict[str, dict[str, int | str]] = {}
         for path, entry in files.items():
             if not isinstance(path, str) or not isinstance(entry, dict):
                 raise ValueError("invalid checkpoint entry")
@@ -91,6 +95,8 @@ def _load_undated_offsets(checkpoint_path: Path | None) -> tuple[dict[str, dict[
                 "device": int(entry["device"]),
                 "inode": int(entry["inode"]),
                 "offset": int(entry["offset"]),
+                "tail_hash": str(entry["tail_hash"]),
+                "tail_length": int(entry["tail_length"]),
             }
         return offsets, []
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
@@ -98,7 +104,7 @@ def _load_undated_offsets(checkpoint_path: Path | None) -> tuple[dict[str, dict[
 
 
 def _save_undated_offsets(
-    checkpoint_path: Path | None, offsets: dict[str, dict[str, int]]
+    checkpoint_path: Path | None, offsets: dict[str, dict[str, int | str]]
 ) -> list[str]:
     if checkpoint_path is None:
         return []
@@ -119,6 +125,23 @@ def _save_undated_offsets(
     return []
 
 
+def _tail_fingerprint(stream: BinaryIO, offset: int) -> tuple[int, str]:
+    tail_length = min(offset, UNDATED_FINGERPRINT_BYTES)
+    stream.seek(offset - tail_length)
+    digest = hashlib.sha256(stream.read(tail_length)).hexdigest()
+    return tail_length, digest
+
+
+def _watermark_matches(stream: BinaryIO, previous: dict[str, int | str]) -> bool:
+    offset = int(previous["offset"])
+    tail_length = int(previous["tail_length"])
+    if tail_length != min(offset, UNDATED_FINGERPRINT_BYTES):
+        return False
+    stream.seek(offset - tail_length)
+    current = hashlib.sha256(stream.read(tail_length)).hexdigest()
+    return current == previous["tail_hash"]
+
+
 def recent_log_lines(
     paths: Iterable[Path],
     since: datetime,
@@ -126,7 +149,7 @@ def recent_log_lines(
     *,
     undated_checkpoint: Path | None = None,
 ) -> tuple[list[str], list[str]]:
-    """Read the 24h window and consume each undated launchd byte range once."""
+    """Read the 24h window, baselining unseen undated launchd files at EOF."""
 
     lines: list[str] = []
     undated_offsets, warnings = _load_undated_offsets(undated_checkpoint)
@@ -143,15 +166,21 @@ def recent_log_lines(
             )
             checkpoint_key = str(path.resolve())
             previous = undated_offsets.get(checkpoint_key)
-            previous_offset = 0
-            if (
-                previous is not None
-                and previous["device"] == stat.st_dev
-                and previous["inode"] == stat.st_ino
-                and 0 <= previous["offset"] <= stat.st_size
-            ):
-                previous_offset = previous["offset"]
             with path.open("rb") as stream:
+                previous_offset = 0
+                if previous is None and undated_checkpoint is not None:
+                    # The first persisted observation establishes a watermark;
+                    # pre-existing undated history has no reliable 24h timestamp.
+                    previous_offset = stat.st_size
+                elif (
+                    previous is not None
+                    and previous["device"] == stat.st_dev
+                    and previous["inode"] == stat.st_ino
+                    and 0 <= int(previous["offset"]) <= stat.st_size
+                    and _watermark_matches(stream, previous)
+                ):
+                    previous_offset = int(previous["offset"])
+                stream.seek(0)
                 while raw_bytes := stream.readline():
                     line_end = stream.tell()
                     raw_line = raw_bytes.decode("utf-8", errors="replace")
@@ -163,15 +192,19 @@ def recent_log_lines(
                         if since <= timestamp <= now + timedelta(minutes=5):
                             lines.append(line)
                     elif include_undated and line_end > previous_offset:
-                        # launchd stderr is append-only and often undated. The
-                        # identity+offset watermark makes each byte range eligible
-                        # once; rotation or truncation starts a fresh identity/range.
+                        # Identity, offset, and tail fingerprint make appended
+                        # ranges eligible once. Rotation or detected rewrite
+                        # restarts at byte zero; first observation baselines EOF.
                         lines.append(line)
                 if path.name == "dcserver.launchd.stderr.log":
+                    final_offset = stream.tell()
+                    tail_length, tail_hash = _tail_fingerprint(stream, final_offset)
                     undated_offsets[checkpoint_key] = {
                         "device": stat.st_dev,
                         "inode": stat.st_ino,
-                        "offset": stream.tell(),
+                        "offset": final_offset,
+                        "tail_length": tail_length,
+                        "tail_hash": tail_hash,
                     }
         except OSError as error:
             warnings.append(f"could not read {path}: {error}")

--- a/routines/monitoring/daily_log_digest.py
+++ b/routines/monitoring/daily_log_digest.py
@@ -29,8 +29,8 @@ from log_digest_issue_drafts import (
 
 REPOSITORY = "itismyfield/AgentDesk"
 OPEN_ISSUE_LIMIT = 1000
-UNDATED_CHECKPOINT_VERSION = 2
-UNDATED_FINGERPRINT_BYTES = 128
+UNDATED_CHECKPOINT_VERSION = 3
+UNDATED_HEAD_FINGERPRINT_CAP = 65_536
 _LINE_TIMESTAMP_RE = re.compile(
     r"(?<!\d)(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
 )
@@ -95,8 +95,8 @@ def _load_undated_offsets(
                 "device": int(entry["device"]),
                 "inode": int(entry["inode"]),
                 "offset": int(entry["offset"]),
-                "tail_hash": str(entry["tail_hash"]),
-                "tail_length": int(entry["tail_length"]),
+                "head_hash": str(entry["head_hash"]),
+                "head_length": int(entry["head_length"]),
             }
         return offsets, []
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
@@ -125,21 +125,21 @@ def _save_undated_offsets(
     return []
 
 
-def _tail_fingerprint(stream: BinaryIO, offset: int) -> tuple[int, str]:
-    tail_length = min(offset, UNDATED_FINGERPRINT_BYTES)
-    stream.seek(offset - tail_length)
-    digest = hashlib.sha256(stream.read(tail_length)).hexdigest()
-    return tail_length, digest
+def _head_fingerprint(stream: BinaryIO, offset: int) -> tuple[int, str]:
+    head_length = min(offset, UNDATED_HEAD_FINGERPRINT_CAP)
+    stream.seek(0)
+    digest = hashlib.sha256(stream.read(head_length)).hexdigest()
+    return head_length, digest
 
 
 def _watermark_matches(stream: BinaryIO, previous: dict[str, int | str]) -> bool:
     offset = int(previous["offset"])
-    tail_length = int(previous["tail_length"])
-    if tail_length != min(offset, UNDATED_FINGERPRINT_BYTES):
+    head_length = int(previous["head_length"])
+    if head_length != min(offset, UNDATED_HEAD_FINGERPRINT_CAP):
         return False
-    stream.seek(offset - tail_length)
-    current = hashlib.sha256(stream.read(tail_length)).hexdigest()
-    return current == previous["tail_hash"]
+    stream.seek(0)
+    current = hashlib.sha256(stream.read(head_length)).hexdigest()
+    return current == previous["head_hash"]
 
 
 def recent_log_lines(
@@ -192,19 +192,23 @@ def recent_log_lines(
                         if since <= timestamp <= now + timedelta(minutes=5):
                             lines.append(line)
                     elif include_undated and line_end > previous_offset:
-                        # Identity, offset, and tail fingerprint make appended
+                        # Identity, offset, and head fingerprint make appended
                         # ranges eligible once. Rotation or detected rewrite
                         # restarts at byte zero; first observation baselines EOF.
                         lines.append(line)
                 if path.name == "dcserver.launchd.stderr.log":
                     final_offset = stream.tell()
-                    tail_length, tail_hash = _tail_fingerprint(stream, final_offset)
+                    # A rewrite beyond the cap that reproduces the first 64 KiB
+                    # cannot be distinguished from an append. For append-only
+                    # launchd logs, reproducing that prefix (or a SHA collision)
+                    # after truncate/regrow is considered operationally negligible.
+                    head_length, head_hash = _head_fingerprint(stream, final_offset)
                     undated_offsets[checkpoint_key] = {
                         "device": stat.st_dev,
                         "inode": stat.st_ino,
                         "offset": final_offset,
-                        "tail_length": tail_length,
-                        "tail_hash": tail_hash,
+                        "head_length": head_length,
+                        "head_hash": head_hash,
                     }
         except OSError as error:
             warnings.append(f"could not read {path}: {error}")

--- a/routines/monitoring/log_digest_issue_drafts.py
+++ b/routines/monitoring/log_digest_issue_drafts.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Reusable log-signature aggregation and human-gated issue-draft helpers.
+
+The daily log digest and future audits (notably #4265) share this module so
+signature normalization, open-issue deduplication, and the default-off issue
+creation boundary do not drift between routines.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+
+DEFAULT_DAILY_THRESHOLD = 50
+CONFIRMED_APPROVAL = "confirmed"
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_SEVERITY_RE = re.compile(r"\b(ERROR|WARN(?:ING)?)\b", re.IGNORECASE)
+_TIMESTAMP_RE = re.compile(
+    r"(?<!\d)"
+    r"(?:\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+    r"(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
+)
+_UUID_RE = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+_HASH_RE = re.compile(r"\b(?=[0-9a-f]{7,64}\b)(?=[0-9a-f]*[a-f])[0-9a-f]+\b", re.IGNORECASE)
+_DYNAMIC_KEY_VALUE_RE = re.compile(
+    r"\b("
+    r"(?:request|trace|span|session|turn|task|card|dispatch|run|job|message|channel|user|agent)"
+    r"[_-]?id|id|token|nonce|cursor"
+    r")\s*[:=]\s*(?:\"[^\"]+\"|'[^']+'|[^\s,;\]}]+)",
+    re.IGNORECASE,
+)
+_NUMBER_RE = re.compile(r"(?<![A-Za-z0-9])\d+(?:\.\d+)?(?![A-Za-z0-9])")
+_WHITESPACE_RE = re.compile(r"\s+")
+_TOKEN_RE = re.compile(r"[a-z][a-z0-9_-]{1,}")
+_STOP_WORDS = {
+    "and",
+    "are",
+    "error",
+    "errors",
+    "failed",
+    "failure",
+    "for",
+    "from",
+    "hash",
+    "has",
+    "id",
+    "into",
+    "issue",
+    "log",
+    "logs",
+    "the",
+    "this",
+    "warn",
+    "warning",
+    "with",
+    "uuid",
+}
+
+
+@dataclass(frozen=True)
+class SignatureCount:
+    severity: str
+    signature: str
+    count: int
+    sample: str
+
+
+@dataclass(frozen=True)
+class OpenIssue:
+    number: int
+    title: str
+    body: str = ""
+    url: str = ""
+
+
+@dataclass(frozen=True)
+class IssueDraft:
+    severity: str
+    signature: str
+    count: int
+    title: str
+    body: str
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class DraftDecision:
+    pattern: SignatureCount
+    draft: IssueDraft | None
+    matching_issue: OpenIssue | None
+
+
+@dataclass(frozen=True)
+class PostDecision:
+    attempted: bool
+    created_urls: tuple[str, ...]
+    reason: str
+
+
+def extract_severity(line: str) -> str | None:
+    """Return canonical ERROR/WARN severity when the line contains one."""
+
+    match = _SEVERITY_RE.search(_ANSI_RE.sub("", line))
+    if not match:
+        return None
+    return "ERROR" if match.group(1).upper() == "ERROR" else "WARN"
+
+
+def normalize_signature(line: str) -> str:
+    """Collapse volatile log fields while retaining the semantic message.
+
+    Timestamps, UUIDs, hashes, dynamic id/token key-values, and numeric values
+    become stable placeholders. The severity token is removed because callers
+    group severity independently.
+    """
+
+    normalized = _ANSI_RE.sub("", line).strip()
+    normalized = _TIMESTAMP_RE.sub("", normalized)
+    normalized = _SEVERITY_RE.sub("", normalized)
+    normalized = _UUID_RE.sub("<uuid>", normalized)
+    normalized = _HASH_RE.sub("<hash>", normalized)
+    normalized = _DYNAMIC_KEY_VALUE_RE.sub(lambda match: f"{match.group(1).lower()}=<id>", normalized)
+    normalized = _NUMBER_RE.sub("<n>", normalized)
+    normalized = _WHITESPACE_RE.sub(" ", normalized).strip(" -:|\t")
+    return normalized.lower()[:500]
+
+
+def aggregate_normalized_signatures(lines: Iterable[str]) -> list[SignatureCount]:
+    """Count ERROR/WARN lines by ``(severity, normalized signature)``."""
+
+    counts: Counter[tuple[str, str]] = Counter()
+    samples: dict[tuple[str, str], str] = {}
+    for raw_line in lines:
+        severity = extract_severity(raw_line)
+        if severity is None:
+            continue
+        signature = normalize_signature(raw_line)
+        if not signature:
+            continue
+        key = (severity, signature)
+        counts[key] += 1
+        samples.setdefault(key, _WHITESPACE_RE.sub(" ", _ANSI_RE.sub("", raw_line)).strip()[:500])
+
+    return sorted(
+        (
+            SignatureCount(severity=severity, signature=signature, count=count, sample=samples[key])
+            for key, count in counts.items()
+            for severity, signature in [key]
+        ),
+        key=lambda pattern: (-pattern.count, pattern.severity, pattern.signature),
+    )
+
+
+def exceeds_threshold(count: int, threshold: int = DEFAULT_DAILY_THRESHOLD) -> bool:
+    """The issue contract says *exceeds*, so equality does not cross the gate."""
+
+    if threshold < 0:
+        raise ValueError("threshold must be non-negative")
+    return count > threshold
+
+
+def _similarity_tokens_from_normalized(normalized: str) -> set[str]:
+    return {
+        token
+        for token in _TOKEN_RE.findall(normalized)
+        if token not in _STOP_WORDS and not token.startswith("timestamp")
+    }
+
+
+def _normalized_issue_text(issue: OpenIssue) -> str:
+    # Normalize the complete body in bounded chunks. ``normalize_signature``
+    # intentionally caps one log signature at 500 characters, but dedup must
+    # still consider issue-body evidence beyond the opening paragraph.
+    parts = [issue.title]
+    parts.extend(issue.body[offset : offset + 500] for offset in range(0, len(issue.body), 500))
+    return " ".join(normalize_signature(part) for part in parts if part)
+
+
+def issue_matches_signature(signature: str, issue: OpenIssue) -> bool:
+    """Match a signature against normalized open-issue title/body similarity.
+
+    A direct normalized containment match wins. Otherwise at least three
+    meaningful tokens must overlap, with either 65% signature coverage or 50%
+    Jaccard similarity. Requiring both semantic overlap and a minimum token
+    count avoids deduping unrelated generic ERROR/WARN reports.
+    """
+
+    normalized_signature = normalize_signature(signature)
+    normalized_issue = _normalized_issue_text(issue)
+    if len(normalized_signature) >= 16 and normalized_signature in normalized_issue:
+        return True
+
+    signature_tokens = _similarity_tokens_from_normalized(normalized_signature)
+    issue_tokens = _similarity_tokens_from_normalized(normalized_issue)
+    overlap = signature_tokens & issue_tokens
+    if len(overlap) < 3 or not signature_tokens:
+        return False
+    coverage = len(overlap) / len(signature_tokens)
+    union = signature_tokens | issue_tokens
+    jaccard = len(overlap) / len(union) if union else 0.0
+    return coverage >= 0.65 or jaccard >= 0.50
+
+
+def build_issue_draft(pattern: SignatureCount, window_label: str, threshold: int) -> IssueDraft:
+    signature_preview = pattern.signature[:120]
+    title = f"ops(log-digest): {pattern.severity} {signature_preview}"
+    safe_sample = normalize_signature(pattern.sample) or pattern.signature
+    body = "\n".join(
+        [
+            "# Daily log-digest draft",
+            "",
+            "This is a pending draft generated for human review. It has not been posted to GitHub.",
+            "",
+            f"- Window: `{window_label}`",
+            f"- Severity: `{pattern.severity}`",
+            f"- Count: `{pattern.count}`",
+            f"- Draft threshold: `>{threshold}`",
+            f"- Normalized signature: `{pattern.signature}`",
+            "",
+            "## Representative sample",
+            "",
+            "```text",
+            f"{pattern.severity} {safe_sample}",
+            "```",
+            "",
+            "## Human review",
+            "",
+            "Confirm impact, reproduction, ownership, and labels before approving issue creation.",
+        ]
+    )
+    return IssueDraft(
+        severity=pattern.severity,
+        signature=pattern.signature,
+        count=pattern.count,
+        title=title,
+        body=body,
+    )
+
+
+def decide_issue_drafts(
+    patterns: Sequence[SignatureCount],
+    open_issues: Sequence[OpenIssue],
+    *,
+    threshold: int = DEFAULT_DAILY_THRESHOLD,
+    window_label: str = "last 24 hours",
+    dedup_available: bool = True,
+) -> list[DraftDecision]:
+    """Apply threshold and fail-closed open-issue deduplication.
+
+    If the GitHub open-issue scan is unavailable, threshold crossings are
+    reported but no draft is emitted; this prevents duplicate drafts when the
+    dedup authority cannot be consulted.
+    """
+
+    decisions: list[DraftDecision] = []
+    for pattern in patterns:
+        if not exceeds_threshold(pattern.count, threshold):
+            continue
+        matching_issue = next(
+            (issue for issue in open_issues if issue_matches_signature(pattern.signature, issue)),
+            None,
+        )
+        draft = None
+        if dedup_available and matching_issue is None:
+            draft = build_issue_draft(pattern, window_label, threshold)
+        decisions.append(DraftDecision(pattern=pattern, draft=draft, matching_issue=matching_issue))
+    return decisions
+
+
+def stable_draft_filename(draft: IssueDraft) -> str:
+    digest = hashlib.sha256(f"{draft.severity}\0{draft.signature}".encode()).hexdigest()[:16]
+    return f"{draft.severity.lower()}-{digest}.md"
+
+
+def write_pending_drafts(drafts: Iterable[IssueDraft], pending_dir: Path) -> list[IssueDraft]:
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    written: list[IssueDraft] = []
+    for draft in drafts:
+        path = pending_dir / stable_draft_filename(draft)
+        path.write_text(draft.body + "\n", encoding="utf-8")
+        written.append(
+            IssueDraft(
+                severity=draft.severity,
+                signature=draft.signature,
+                count=draft.count,
+                title=draft.title,
+                body=draft.body,
+                path=path,
+            )
+        )
+    return written
+
+
+def maybe_post_approved_drafts(
+    drafts: Sequence[IssueDraft],
+    approval_mode: str,
+    create_issue: Callable[[IssueDraft], str],
+) -> PostDecision:
+    """Post only after the operator supplies the literal ``confirmed`` gate.
+
+    This check is intentionally in the shared helper (not only its CLI caller),
+    so every future consumer inherits the same default-off safety boundary.
+    """
+
+    if approval_mode != CONFIRMED_APPROVAL:
+        return PostDecision(
+            attempted=False,
+            created_urls=(),
+            reason="issue creation disabled; set approval mode to literal 'confirmed' after human review",
+        )
+
+    approved = [
+        draft
+        for draft in drafts
+        if draft.path is not None and Path(f"{draft.path}.approved").is_file()
+    ]
+    if not approved:
+        return PostDecision(
+            attempted=False,
+            created_urls=(),
+            reason="confirmation enabled, but no human-reviewed .approved draft markers exist",
+        )
+
+    created_urls = tuple(create_issue(draft) for draft in approved)
+    return PostDecision(attempted=True, created_urls=created_urls, reason="human-confirmed issue creation")
+
+
+def _compact(text: str, limit: int = 100) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def format_daily_summary(
+    patterns: Sequence[SignatureCount],
+    decisions: Sequence[DraftDecision],
+    drafts: Sequence[IssueDraft],
+    *,
+    threshold: int,
+    window_label: str,
+    warnings: Sequence[str] = (),
+    top_per_severity: int = 3,
+) -> str:
+    """Format the single routine-channel digest for one daily run."""
+
+    lines = [f"📊 dcserver daily log digest — {window_label}"]
+    for severity in ("ERROR", "WARN"):
+        top = [pattern for pattern in patterns if pattern.severity == severity][:top_per_severity]
+        if top:
+            lines.append(f"{severity} top: " + " | ".join(
+                f"{pattern.count}× {_compact(pattern.signature, 90)}" for pattern in top
+            ))
+        else:
+            lines.append(f"{severity} top: none")
+
+    crossed = [decision for decision in decisions]
+    lines.append(f"Threshold >{threshold}: {len(crossed)} crossed")
+    if crossed:
+        lines.append(
+            "Crossed: "
+            + " | ".join(
+                f"{decision.pattern.count}× {decision.pattern.severity} "
+                f"{_compact(decision.pattern.signature, 75)}"
+                for decision in crossed[:10]
+            )
+        )
+        if len(crossed) > 10:
+            lines.append(f"Crossed: +{len(crossed) - 10} more")
+    matched = [decision for decision in crossed if decision.matching_issue is not None]
+    if matched:
+        references = ", ".join(f"#{decision.matching_issue.number}" for decision in matched)
+        lines.append(f"Open-issue dedup: {len(matched)} matched ({references})")
+    if drafts:
+        lines.append("Pending drafts: " + ", ".join(str(draft.path or draft.title) for draft in drafts))
+    else:
+        lines.append("Pending drafts: none")
+    lines.extend(f"⚠ {warning}" for warning in warnings)
+    return "\n".join(lines)

--- a/routines/monitoring/log_digest_issue_drafts.py
+++ b/routines/monitoring/log_digest_issue_drafts.py
@@ -32,6 +32,11 @@ _UUID_RE = re.compile(
     re.IGNORECASE,
 )
 _HASH_RE = re.compile(r"\b(?=[0-9a-f]{7,64}\b)(?=[0-9a-f]*[a-f])[0-9a-f]+\b", re.IGNORECASE)
+_EMBEDDED_ID_RE = re.compile(
+    r"\b((?:req(?:uest)?|trace|span|session|turn|task|card|dispatch|run|job|message|id)[_-])"
+    r"(?=[a-z0-9]{4,}\b)(?=[a-z0-9]*[a-z])(?=[a-z0-9]*\d)[a-z0-9]+\b",
+    re.IGNORECASE,
+)
 _DYNAMIC_KEY_VALUE_RE = re.compile(
     r"\b("
     r"(?:request|trace|span|session|turn|task|card|dispatch|run|job|message|channel|user|agent)"
@@ -119,9 +124,11 @@ def extract_severity(line: str) -> str | None:
 def normalize_signature(line: str) -> str:
     """Collapse volatile log fields while retaining the semantic message.
 
-    Timestamps, UUIDs, hashes, dynamic id/token key-values, and numeric values
-    become stable placeholders. The severity token is removed because callers
-    group severity independently.
+    Timestamps, UUIDs, hashes, and known dynamic identifiers become stable
+    placeholders. Bare numbers are treated as volatile except HTTP/status codes
+    and values explicitly labelled as ports. This deliberately narrow heuristic
+    preserves the common semantic cases without pretending every number's role
+    can be inferred from free-form text; unlabeled semantic numbers may collapse.
     """
 
     normalized = _ANSI_RE.sub("", line).strip()
@@ -129,10 +136,18 @@ def normalize_signature(line: str) -> str:
     normalized = _SEVERITY_RE.sub("", normalized)
     normalized = _UUID_RE.sub("<uuid>", normalized)
     normalized = _HASH_RE.sub("<hash>", normalized)
+    normalized = _EMBEDDED_ID_RE.sub(lambda match: f"{match.group(1)}<id>", normalized)
     normalized = _DYNAMIC_KEY_VALUE_RE.sub(lambda match: f"{match.group(1).lower()}=<id>", normalized)
-    normalized = _NUMBER_RE.sub("<n>", normalized)
+    normalized = _NUMBER_RE.sub(_normalize_bare_number, normalized)
     normalized = _WHITESPACE_RE.sub(" ", normalized).strip(" -:|\t")
     return normalized.lower()[:500]
+
+
+def _normalize_bare_number(match: re.Match[str]) -> str:
+    prefix = match.string[max(0, match.start() - 24) : match.start()]
+    if re.search(r"\b(?:http(?:\s+status)?|status|port)\s*$", prefix, re.IGNORECASE):
+        return match.group(0)
+    return "<n>"
 
 
 def aggregate_normalized_signatures(lines: Iterable[str]) -> list[SignatureCount]:
@@ -177,38 +192,40 @@ def _similarity_tokens_from_normalized(normalized: str) -> set[str]:
     }
 
 
-def _normalized_issue_text(issue: OpenIssue) -> str:
-    # Normalize the complete body in bounded chunks. ``normalize_signature``
-    # intentionally caps one log signature at 500 characters, but dedup must
-    # still consider issue-body evidence beyond the opening paragraph.
-    parts = [issue.title]
-    parts.extend(issue.body[offset : offset + 500] for offset in range(0, len(issue.body), 500))
-    return " ".join(normalize_signature(part) for part in parts if part)
+def _normalized_issue_candidates(issue: OpenIssue) -> list[str]:
+    """Return bounded, issue-defining text rather than an unbounded epic body."""
+
+    first_body_line = next((line.strip() for line in issue.body.splitlines() if line.strip()), "")
+    return [normalize_signature(part) for part in (issue.title, first_body_line) if part]
 
 
 def issue_matches_signature(signature: str, issue: OpenIssue) -> bool:
-    """Match a signature against normalized open-issue title/body similarity.
+    """Match against the issue title or first non-empty body line.
 
-    A direct normalized containment match wins. Otherwise at least three
-    meaningful tokens must overlap, with either 65% signature coverage or 50%
-    Jaccard similarity. Requiring both semantic overlap and a minimum token
-    count avoids deduping unrelated generic ERROR/WARN reports.
+    Each bounded candidate must share at least three meaningful tokens and reach
+    50% symmetric Jaccard similarity. Direct containment is accepted only when
+    the candidate is still signature-like (at most 3x the signature token count,
+    with a floor of 12 tokens). This avoids a three-token signature matching an
+    unrelated long epic that merely mentions those words. A duplicate described
+    only deep in a long issue body may therefore require human reconciliation.
     """
 
     normalized_signature = normalize_signature(signature)
-    normalized_issue = _normalized_issue_text(issue)
-    if len(normalized_signature) >= 16 and normalized_signature in normalized_issue:
-        return True
-
     signature_tokens = _similarity_tokens_from_normalized(normalized_signature)
-    issue_tokens = _similarity_tokens_from_normalized(normalized_issue)
-    overlap = signature_tokens & issue_tokens
-    if len(overlap) < 3 or not signature_tokens:
+    if len(signature_tokens) < 3:
         return False
-    coverage = len(overlap) / len(signature_tokens)
-    union = signature_tokens | issue_tokens
-    jaccard = len(overlap) / len(union) if union else 0.0
-    return coverage >= 0.65 or jaccard >= 0.50
+    for candidate in _normalized_issue_candidates(issue):
+        issue_tokens = _similarity_tokens_from_normalized(candidate)
+        overlap = signature_tokens & issue_tokens
+        if len(overlap) < 3:
+            continue
+        signature_like_limit = max(12, len(signature_tokens) * 3)
+        if normalized_signature in candidate and len(issue_tokens) <= signature_like_limit:
+            return True
+        union = signature_tokens | issue_tokens
+        if union and len(overlap) / len(union) >= 0.50:
+            return True
+    return False
 
 
 def build_issue_draft(pattern: SignatureCount, window_label: str, threshold: int) -> IssueDraft:

--- a/routines/monitoring/log_digest_issue_drafts.py
+++ b/routines/monitoring/log_digest_issue_drafts.py
@@ -45,7 +45,9 @@ _DYNAMIC_KEY_VALUE_RE = re.compile(
     re.IGNORECASE,
 )
 _MEASURED_NUMBER_RE = re.compile(
-    r"(?<![A-Za-z0-9])\d+(?:\.\d+)?\s*(req/s|/s|kib|mib|gib|kb|mb|gb|ms|us|ns|b|s|m|h|%)(?![A-Za-z0-9])",
+    r"(?<![A-Za-z0-9_./-])\d+(?:\.\d+)?\s*"
+    r"(req/s|/s|kib|mib|gib|kb|mb|gb|ms|us|ns|b|s|m|h|%)"
+    r"(?![A-Za-z0-9_./-])",
     re.IGNORECASE,
 )
 _NUMBER_RE = re.compile(r"(?<![A-Za-z0-9])\d+(?:\.\d+)?(?![A-Za-z0-9])")

--- a/routines/monitoring/log_digest_issue_drafts.py
+++ b/routines/monitoring/log_digest_issue_drafts.py
@@ -44,6 +44,10 @@ _DYNAMIC_KEY_VALUE_RE = re.compile(
     r")\s*[:=]\s*(?:\"[^\"]+\"|'[^']+'|[^\s,;\]}]+)",
     re.IGNORECASE,
 )
+_MEASURED_NUMBER_RE = re.compile(
+    r"(?<![A-Za-z0-9])\d+(?:\.\d+)?\s*(req/s|/s|kib|mib|gib|kb|mb|gb|ms|us|ns|b|s|m|h|%)(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
 _NUMBER_RE = re.compile(r"(?<![A-Za-z0-9])\d+(?:\.\d+)?(?![A-Za-z0-9])")
 _WHITESPACE_RE = re.compile(r"\s+")
 _TOKEN_RE = re.compile(r"[a-z][a-z0-9_-]{1,}")
@@ -70,6 +74,18 @@ _STOP_WORDS = {
     "with",
     "uuid",
 }
+
+# Known best-effort limits: labelled ports and HTTP/status numbers intentionally
+# remain distinct, so high-cardinality ephemeral values can fragment; collapsing
+# them would also collapse meaningful service ports and status codes. Open-issue
+# fuzzy matching can over-suppress a short unrelated signature or under-suppress
+# a long reworded duplicate, and signatures longer than the 120-character issue
+# title preview may fail to match their own title on a later run. Retuning the
+# candidate window, Jaccard/containment thresholds, or number preservation merely
+# trades precision for recall (and vice versa), so it is deliberately not done.
+# Drafts are advisory: independently of threshold/dedup, the summary exposes the
+# top three patterns per severity for human review; stable_draft_filename also
+# overwrites one path instead of accumulating redraft churn.
 
 
 @dataclass(frozen=True)
@@ -138,9 +154,19 @@ def normalize_signature(line: str) -> str:
     normalized = _HASH_RE.sub("<hash>", normalized)
     normalized = _EMBEDDED_ID_RE.sub(lambda match: f"{match.group(1)}<id>", normalized)
     normalized = _DYNAMIC_KEY_VALUE_RE.sub(lambda match: f"{match.group(1).lower()}=<id>", normalized)
+    normalized = _MEASURED_NUMBER_RE.sub(_normalize_measured_number, normalized)
     normalized = _NUMBER_RE.sub(_normalize_bare_number, normalized)
     normalized = _WHITESPACE_RE.sub(" ", normalized).strip(" -:|\t")
     return normalized.lower()[:500]
+
+
+def _normalize_measured_number(match: re.Match[str]) -> str:
+    unit = match.group(1).lower()
+    if unit in {"ms", "us", "ns", "s", "m", "h"}:
+        return "<dur>"
+    if unit in {"b", "kb", "mb", "gb", "kib", "mib", "gib"}:
+        return "<size>"
+    return "<rate>"
 
 
 def _normalize_bare_number(match: re.Match[str]) -> str:
@@ -377,6 +403,7 @@ def format_daily_summary(
             ))
         else:
             lines.append(f"{severity} top: none")
+    lines.append("ℹ best-effort signatures; verify top patterns manually")
 
     crossed = [decision for decision in decisions]
     lines.append(f"Threshold >{threshold}: {len(crossed)} crossed")

--- a/routines/monitoring/log_digest_issue_drafts.py
+++ b/routines/monitoring/log_digest_issue_drafts.py
@@ -45,9 +45,9 @@ _DYNAMIC_KEY_VALUE_RE = re.compile(
     re.IGNORECASE,
 )
 _MEASURED_NUMBER_RE = re.compile(
-    r"(?<![A-Za-z0-9_./-])\d+(?:\.\d+)?\s*"
+    r"(?<![A-Za-z0-9_-])(?<![A-Za-z0-9]\.)\d+(?:\.\d+)?\s*"
     r"(req/s|/s|kib|mib|gib|kb|mb|gb|ms|us|ns|b|s|m|h|%)"
-    r"(?![A-Za-z0-9_./-])",
+    r"(?![A-Za-z0-9_-]|\.[A-Za-z0-9])",
     re.IGNORECASE,
 )
 _NUMBER_RE = re.compile(r"(?<![A-Za-z0-9])\d+(?:\.\d+)?(?![A-Za-z0-9])")

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -68,6 +68,10 @@ echo "=== Policy DB capability manifest guard (#3734) ==="
 echo "=== Merge automation policy tests (#4250) ==="
 node --test policies/__tests__/merge-automation.test.js
 
+echo "=== Daily log-digest routine tests (#4263) ==="
+node --test policies/__tests__/daily-log-digest.test.js
+"$PYTHON" -m unittest tests.test_daily_log_digest
+
 echo "=== await_holding_lock ratchet guard ==="
 "$PYTHON" scripts/check_await_holding_lock_ratchet.py
 "$PYTHON" -m unittest tests.test_await_holding_lock_ratchet

--- a/tests/test_daily_log_digest.py
+++ b/tests/test_daily_log_digest.py
@@ -183,6 +183,53 @@ class SignatureNormalizationTests(unittest.TestCase):
         self.assertEqual(fresh, ["ERROR new content after truncation"] * 10)
         self.assertEqual(warnings, [])
 
+    def test_truncate_regrow_with_same_tail_resets_then_plain_append_resumes(self) -> None:
+        now = datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(days=1)
+        tail = "ERROR tail unchanged marker\n" * 8
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            launchd_stderr = root / "dcserver.launchd.stderr.log"
+            checkpoint = root / "runtime" / "undated-offsets.json"
+            launchd_stderr.write_text("ERROR old prelude\n" + tail, encoding="utf-8")
+            os.utime(launchd_stderr, (now.timestamp(), now.timestamp()))
+            baseline, baseline_warnings = recent_log_lines(
+                [launchd_stderr], since, now, undated_checkpoint=checkpoint
+            )
+            old_inode = launchd_stderr.stat().st_ino
+            old_offset = launchd_stderr.stat().st_size
+
+            rewritten = (
+                "ERROR new prelude\n"
+                + tail
+                + "ERROR appended beyond old offset\n"
+            )
+            with launchd_stderr.open("w", encoding="utf-8") as stream:
+                stream.write(rewritten)
+            os.utime(launchd_stderr, (now.timestamp(), now.timestamp()))
+            new_inode = launchd_stderr.stat().st_ino
+            fresh, fresh_warnings = recent_log_lines(
+                [launchd_stderr], since, now, undated_checkpoint=checkpoint
+            )
+
+            with launchd_stderr.open("a", encoding="utf-8") as stream:
+                stream.write("ERROR plain append after rewrite\n")
+            appended, append_warnings = recent_log_lines(
+                [launchd_stderr], since, now, undated_checkpoint=checkpoint
+            )
+
+        self.assertEqual(baseline, [])
+        self.assertEqual(new_inode, old_inode)
+        self.assertGreater(len(rewritten.encode()), old_offset)
+        self.assertEqual(
+            fresh,
+            ["ERROR new prelude"]
+            + ["ERROR tail unchanged marker"] * 8
+            + ["ERROR appended beyond old offset"],
+        )
+        self.assertEqual(appended, ["ERROR plain append after rewrite"])
+        self.assertEqual(baseline_warnings + fresh_warnings + append_warnings, [])
+
     def test_different_ids_hashes_and_timestamps_collapse(self) -> None:
         first = (
             "2026-07-13T01:02:03.123Z WARN sqlx pool timed out while acquiring "
@@ -251,6 +298,31 @@ class SignatureNormalizationTests(unittest.TestCase):
             normalize_signature("ERROR error500handler failed"),
             "error500handler failed",
         )
+
+    def test_measured_numbers_require_standalone_token_boundaries(self) -> None:
+        for first, second in (
+            ("cache_1mb_loader", "cache_2mb_loader"),
+            ("cache-1mb-loader", "cache-2mb-loader"),
+        ):
+            with self.subTest(first=first, second=second):
+                patterns = aggregate_normalized_signatures(
+                    [f"ERROR {first} failed", f"ERROR {second} failed"]
+                )
+                self.assertEqual(len(patterns), 2)
+                self.assertNotEqual(patterns[0].signature, patterns[1].signature)
+
+        for first, second, placeholder in (
+            ("took 123ms", "took 456ms", "<dur>"),
+            ("used 512kb", "used 1mb", "<size>"),
+            ("took 1.5s", "took 8.25s", "<dur>"),
+        ):
+            with self.subTest(first=first, second=second):
+                patterns = aggregate_normalized_signatures(
+                    [f"ERROR {first}", f"ERROR {second}"]
+                )
+                self.assertEqual(len(patterns), 1)
+                self.assertEqual(patterns[0].count, 2)
+                self.assertIn(placeholder, patterns[0].signature)
 
     def test_http_status_codes_remain_distinct(self) -> None:
         self.assertNotEqual(

--- a/tests/test_daily_log_digest.py
+++ b/tests/test_daily_log_digest.py
@@ -22,6 +22,7 @@ ROUTINE_DIR = ROOT / "routines" / "monitoring"
 sys.path.insert(0, str(ROUTINE_DIR))
 
 from log_digest_issue_drafts import (  # noqa: E402
+    _MEASURED_NUMBER_RE,
     IssueDraft,
     OpenIssue,
     SignatureCount,
@@ -303,6 +304,7 @@ class SignatureNormalizationTests(unittest.TestCase):
         for first, second in (
             ("cache_1mb_loader", "cache_2mb_loader"),
             ("cache-1mb-loader", "cache-2mb-loader"),
+            ("cache.1mb.loader", "cache.2mb.loader"),
         ):
             with self.subTest(first=first, second=second):
                 patterns = aggregate_normalized_signatures(
@@ -311,10 +313,26 @@ class SignatureNormalizationTests(unittest.TestCase):
                 self.assertEqual(len(patterns), 2)
                 self.assertNotEqual(patterns[0].signature, patterns[1].signature)
 
+        for first, second, expected_signature in (
+            ("request took 123ms.", "request took 456ms.", "request took <dur>."),
+            ("size 512kb.", "size 1mb.", "size <size>."),
+            ("request took 123ms,", "request took 456ms,", "request took <dur>,"),
+            ("request took (123ms)", "request took (456ms)", "request took (<dur>)"),
+            ("request took 123ms;", "request took 456ms;", "request took <dur>;"),
+            ("request took 123ms:", "request took 456ms:", "request took <dur>"),
+        ):
+            with self.subTest(first=first, second=second):
+                patterns = aggregate_normalized_signatures(
+                    [f"ERROR {first}", f"ERROR {second}"]
+                )
+                self.assertEqual(len(patterns), 1)
+                self.assertEqual(patterns[0].count, 2)
+                self.assertEqual(patterns[0].signature, expected_signature)
+
         for first, second, placeholder in (
             ("took 123ms", "took 456ms", "<dur>"),
-            ("used 512kb", "used 1mb", "<size>"),
-            ("took 1.5s", "took 8.25s", "<dur>"),
+            ("512kb", "1mb", "<size>"),
+            ("took 1.5s", "took 2.5s", "<dur>"),
         ):
             with self.subTest(first=first, second=second):
                 patterns = aggregate_normalized_signatures(
@@ -323,6 +341,8 @@ class SignatureNormalizationTests(unittest.TestCase):
                 self.assertEqual(len(patterns), 1)
                 self.assertEqual(patterns[0].count, 2)
                 self.assertIn(placeholder, patterns[0].signature)
+
+        self.assertIsNone(_MEASURED_NUMBER_RE.search("0.144.1"))
 
     def test_http_status_codes_remain_distinct(self) -> None:
         self.assertNotEqual(

--- a/tests/test_daily_log_digest.py
+++ b/tests/test_daily_log_digest.py
@@ -3,12 +3,18 @@
 
 from __future__ import annotations
 
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
+from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -28,10 +34,27 @@ from log_digest_issue_drafts import (  # noqa: E402
     normalize_signature,
     write_pending_drafts,
 )
-from daily_log_digest import dcserver_log_paths, recent_log_lines  # noqa: E402
+import daily_log_digest  # noqa: E402
+from daily_log_digest import (  # noqa: E402
+    OPEN_ISSUE_LIMIT,
+    dcserver_log_paths,
+    load_open_issues,
+    recent_log_lines,
+    runtime_root,
+)
 
 
 class SignatureNormalizationTests(unittest.TestCase):
+    def test_runtime_root_keeps_canonical_override_before_deploy_fallback(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"AGENTDESK_ROOT_DIR": "/canonical", "ADK_REL": "/deploy-fallback"},
+            clear=False,
+        ):
+            self.assertEqual(runtime_root(), Path("/canonical"))
+        with patch.dict(os.environ, {"ADK_REL": "/deploy-fallback"}, clear=True):
+            self.assertEqual(runtime_root(), Path("/deploy-fallback"))
+
     def test_runtime_log_paths_include_internal_stdout_and_launchd_stderr(self) -> None:
         paths = dcserver_log_paths(Path("/srv/agentdesk"))
         self.assertIn(Path("/srv/agentdesk/logs/dcserver.stdout.log"), paths)
@@ -70,6 +93,44 @@ class SignatureNormalizationTests(unittest.TestCase):
             ],
         )
 
+    def test_undated_launchd_lines_are_consumed_once_by_byte_offset(self) -> None:
+        now = datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(days=1)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            launchd_stderr = root / "dcserver.launchd.stderr.log"
+            checkpoint = root / "runtime" / "undated-offsets.json"
+            launchd_stderr.write_text(
+                "".join(f"ERROR panic stale-{index}\n" for index in range(60)),
+                encoding="utf-8",
+            )
+            old_run = now - timedelta(days=3)
+            os.utime(launchd_stderr, (old_run.timestamp(), old_run.timestamp()))
+
+            baseline, baseline_warnings = recent_log_lines(
+                [launchd_stderr],
+                old_run - timedelta(days=1),
+                old_run,
+                undated_checkpoint=checkpoint,
+            )
+            with launchd_stderr.open("a", encoding="utf-8") as stream:
+                stream.write("WARN fresh append today\n")
+            os.utime(launchd_stderr, (now.timestamp(), now.timestamp()))
+            fresh, fresh_warnings = recent_log_lines(
+                [launchd_stderr], since, now, undated_checkpoint=checkpoint
+            )
+            repeated, repeated_warnings = recent_log_lines(
+                [launchd_stderr],
+                now,
+                now + timedelta(days=1),
+                undated_checkpoint=checkpoint,
+            )
+
+        self.assertEqual(len(baseline), 60)
+        self.assertEqual(fresh, ["WARN fresh append today"])
+        self.assertEqual(repeated, [])
+        self.assertEqual(baseline_warnings + fresh_warnings + repeated_warnings, [])
+
     def test_different_ids_hashes_and_timestamps_collapse(self) -> None:
         first = (
             "2026-07-13T01:02:03.123Z WARN sqlx pool timed out while acquiring "
@@ -96,6 +157,31 @@ class SignatureNormalizationTests(unittest.TestCase):
 
         self.assertEqual(len(patterns), 2)
         self.assertNotEqual(patterns[0].signature, patterns[1].signature)
+
+    def test_short_embedded_request_ids_collapse_and_cross_threshold(self) -> None:
+        ids = ("4f2a", "8c1d", "0b7e", "9d3c")
+        lines = [
+            f"ERROR failed to open /tmp/req-{ids[index % len(ids)]}/data"
+            for index in range(100)
+        ]
+        patterns = aggregate_normalized_signatures(lines)
+
+        self.assertEqual(len(patterns), 1)
+        self.assertEqual(patterns[0].count, 100)
+        self.assertIn("req-<id>", patterns[0].signature)
+        self.assertTrue(exceeds_threshold(patterns[0].count, 50))
+
+    def test_http_status_codes_remain_distinct(self) -> None:
+        self.assertNotEqual(
+            normalize_signature("ERROR HTTP 500 upstream error"),
+            normalize_signature("ERROR HTTP 404 upstream error"),
+        )
+
+    def test_port_numbers_remain_distinct(self) -> None:
+        self.assertNotEqual(
+            normalize_signature("ERROR connection to port 5432 refused"),
+            normalize_signature("ERROR connection to port 6379 refused"),
+        )
 
 
 class DraftDecisionTests(unittest.TestCase):
@@ -134,14 +220,39 @@ class DraftDecisionTests(unittest.TestCase):
         self.assertEqual(decisions[0].matching_issue, issue)
         self.assertIsNone(decisions[0].draft)
 
-    def test_open_issue_dedup_considers_body_beyond_first_500_characters(self) -> None:
+    def test_unrelated_long_issue_body_does_not_suppress_short_signature(self) -> None:
+        pattern = SignatureCount(
+            severity="WARN",
+            signature="worker lease expired",
+            count=60,
+            sample="WARN worker lease expired",
+        )
         issue = OpenIssue(
             number=4250,
-            title="ops: recurring database degradation",
-            body="unrelated preface " * 40 + "postgres pool timed out while acquiring connection",
+            title="epic: routine runtime hardening",
+            body=(
+                "This broad epic discusses workers, scheduling, and resilience.\n"
+                + "unrelated planning context " * 80
+                + "worker ownership and lease cleanup after expired sessions"
+            ),
         )
 
-        self.assertTrue(issue_matches_signature(self.pattern.signature, issue))
+        self.assertFalse(issue_matches_signature(pattern.signature, issue))
+        decisions = decide_issue_drafts([pattern], [issue], threshold=50)
+        self.assertIsNotNone(decisions[0].draft)
+
+    def test_genuine_short_signature_duplicate_is_suppressed(self) -> None:
+        pattern = SignatureCount(
+            severity="WARN",
+            signature="worker lease expired",
+            count=60,
+            sample="WARN worker lease expired",
+        )
+        issue = OpenIssue(number=4251, title="fix(runtime): worker lease expired")
+
+        self.assertTrue(issue_matches_signature(pattern.signature, issue))
+        decisions = decide_issue_drafts([pattern], [issue], threshold=50)
+        self.assertIsNone(decisions[0].draft)
 
     def test_unavailable_dedup_fails_closed_without_draft(self) -> None:
         decisions = decide_issue_drafts(
@@ -165,16 +276,22 @@ class DraftDecisionTests(unittest.TestCase):
             body="draft body",
         )
 
-        decision = maybe_post_approved_drafts(
-            [draft],
-            "off",
-            lambda item: calls.append(item.title) or "https://example.test/1",
-        )
-
-        self.assertFalse(decision.attempted)
-        self.assertEqual(calls, [], "default mode must never invoke gh issue creation")
         with tempfile.TemporaryDirectory() as temp:
             written = write_pending_drafts([draft], Path(temp))[0]
+            Path(f"{written.path}.approved").touch()
+
+            with patch.dict(os.environ, {}, clear=True):
+                unset_mode = os.environ.get("AGENTDESK_LOG_DIGEST_CREATE_ISSUE", "off")
+            for mode in (unset_mode, "off", "invalid"):
+                disabled = maybe_post_approved_drafts(
+                    [written],
+                    mode,
+                    lambda item: calls.append(item.title) or "https://example.test/1",
+                )
+                self.assertFalse(disabled.attempted)
+                self.assertEqual(calls, [], f"mode {mode!r} must suppress an approved draft")
+
+            Path(f"{written.path}.approved").unlink()
             unreviewed = maybe_post_approved_drafts(
                 [written],
                 "confirmed",
@@ -213,6 +330,108 @@ class DraftDecisionTests(unittest.TestCase):
         self.assertIn("Crossed: 51× ERROR postgres pool timed out", summary)
         self.assertIn("Pending drafts:", summary)
         self.assertNotIn("Pending drafts: none", summary)
+
+
+class DailyDigestIntegrationTests(unittest.TestCase):
+    def _write_threshold_crossing(self, root: Path) -> None:
+        logs = root / "logs"
+        logs.mkdir(parents=True)
+        (logs / "dcserver.stdout.log").write_text(
+            "".join(
+                f"2026-07-13T12:00:{index % 60:02d}Z ERROR worker lease expired id={index}\n"
+                for index in range(51)
+            ),
+            encoding="utf-8",
+        )
+
+    def test_main_gh_failure_wires_dedup_unavailable_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self._write_threshold_crossing(root)
+            completed = subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr="simulated gh failure"
+            )
+            output = StringIO()
+            with (
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "daily_log_digest.py",
+                        "--root",
+                        str(root),
+                        "--now",
+                        "2026-07-14T00:00:00Z",
+                    ],
+                ),
+                patch.object(daily_log_digest.subprocess, "run", return_value=completed),
+                patch.dict(os.environ, {"AGENTDESK_LOG_DIGEST_CREATE_ISSUE": "off"}, clear=False),
+                redirect_stdout(output),
+            ):
+                rc = daily_log_digest.main()
+
+            drafts = list(
+                (root / "runtime" / "pending-issue-drafts" / "daily-log-digest").glob("*.md")
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(drafts, [])
+        self.assertIn("dedup unavailable", output.getvalue())
+        self.assertIn("drafts suppressed", output.getvalue())
+
+    def test_invalid_threshold_env_warns_and_falls_back_to_50(self) -> None:
+        for invalid in ("0", "-4", "not-a-number"):
+            with self.subTest(invalid=invalid), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                self._write_threshold_crossing(root)
+                output = StringIO()
+                with (
+                    patch.object(
+                        sys,
+                        "argv",
+                        [
+                            "daily_log_digest.py",
+                            "--root",
+                            str(root),
+                            "--now",
+                            "2026-07-14T00:00:00Z",
+                        ],
+                    ),
+                    patch.object(daily_log_digest, "load_open_issues", return_value=([], None)),
+                    patch.dict(
+                        os.environ,
+                        {
+                            "AGENTDESK_LOG_DIGEST_THRESHOLD": invalid,
+                            "AGENTDESK_LOG_DIGEST_CREATE_ISSUE": "off",
+                        },
+                        clear=False,
+                    ),
+                    redirect_stdout(output),
+                ):
+                    rc = daily_log_digest.main()
+
+                self.assertEqual(rc, 0)
+                self.assertIn("invalid AGENTDESK_LOG_DIGEST_THRESHOLD", output.getvalue())
+                self.assertIn("using default 50", output.getvalue())
+                self.assertIn("Threshold >50: 1 crossed", output.getvalue())
+
+    def test_open_issue_cap_is_fail_closed_with_warning(self) -> None:
+        payload = [
+            {"number": index, "title": f"issue {index}", "body": "", "url": ""}
+            for index in range(1, OPEN_ISSUE_LIMIT + 1)
+        ]
+        completed = SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+        with patch.object(daily_log_digest.subprocess, "run", return_value=completed):
+            issues, warning = load_open_issues("owner/repo")
+
+        self.assertEqual(len(issues), OPEN_ISSUE_LIMIT)
+        self.assertIsNotNone(warning)
+        self.assertIn("may be truncated", warning)
+        pattern = SignatureCount("ERROR", "brand new failure pattern", 51, "ERROR sample")
+        decisions = decide_issue_drafts(
+            [pattern], issues, threshold=50, dedup_available=warning is None
+        )
+        self.assertIsNone(decisions[0].draft)
 
 
 if __name__ == "__main__":

--- a/tests/test_daily_log_digest.py
+++ b/tests/test_daily_log_digest.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Focused tests for the reusable daily log-digest draft pipeline (#4263)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTINE_DIR = ROOT / "routines" / "monitoring"
+sys.path.insert(0, str(ROUTINE_DIR))
+
+from log_digest_issue_drafts import (  # noqa: E402
+    IssueDraft,
+    OpenIssue,
+    SignatureCount,
+    aggregate_normalized_signatures,
+    decide_issue_drafts,
+    exceeds_threshold,
+    format_daily_summary,
+    issue_matches_signature,
+    maybe_post_approved_drafts,
+    normalize_signature,
+    write_pending_drafts,
+)
+from daily_log_digest import dcserver_log_paths, recent_log_lines  # noqa: E402
+
+
+class SignatureNormalizationTests(unittest.TestCase):
+    def test_runtime_log_paths_include_internal_stdout_and_launchd_stderr(self) -> None:
+        paths = dcserver_log_paths(Path("/srv/agentdesk"))
+        self.assertIn(Path("/srv/agentdesk/logs/dcserver.stdout.log"), paths)
+        self.assertIn(Path("/srv/agentdesk/logs/dcserver.stdout.log.1"), paths)
+        self.assertIn(Path("/srv/agentdesk/logs/dcserver.launchd.stderr.log"), paths)
+
+    def test_recent_window_filters_old_and_undated_stdout_lines(self) -> None:
+        now = datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(days=1)
+        with tempfile.TemporaryDirectory() as temp:
+            logs = Path(temp)
+            stdout = logs / "dcserver.stdout.log"
+            launchd_stderr = logs / "dcserver.launchd.stderr.log"
+            stdout.write_text(
+                "2026-07-12T23:59:00Z ERROR stale failure id=1\n"
+                "2026-07-13T12:00:00Z WARN recent timeout id=2\n"
+                "ERROR undated stale stdout line\n",
+                encoding="utf-8",
+            )
+            launchd_stderr.write_text("WARN undated recent launchd bootstrap\n", encoding="utf-8")
+            timestamp = now.timestamp()
+            stdout.touch()
+            launchd_stderr.touch()
+            # touch() uses wall clock; explicitly pin both mtimes to the test window.
+            os.utime(stdout, (timestamp, timestamp))
+            os.utime(launchd_stderr, (timestamp, timestamp))
+
+            lines, warnings = recent_log_lines([stdout, launchd_stderr], since, now)
+
+        self.assertEqual(warnings, [])
+        self.assertEqual(
+            lines,
+            [
+                "2026-07-13T12:00:00Z WARN recent timeout id=2",
+                "WARN undated recent launchd bootstrap",
+            ],
+        )
+
+    def test_different_ids_hashes_and_timestamps_collapse(self) -> None:
+        first = (
+            "2026-07-13T01:02:03.123Z WARN sqlx pool timed out while acquiring "
+            "id=123 request_id=req-a9f3 token=secret-one commit=deadbeef"
+        )
+        second = (
+            "2026-07-14T04:05:06.987Z WARN sqlx pool timed out while acquiring "
+            "id=456 request_id=req-b7d1 token=secret-two commit=cafebabe"
+        )
+
+        self.assertEqual(normalize_signature(first), normalize_signature(second))
+        patterns = aggregate_normalized_signatures([first, second])
+        self.assertEqual(len(patterns), 1)
+        self.assertEqual(patterns[0].severity, "WARN")
+        self.assertEqual(patterns[0].count, 2)
+
+    def test_semantically_distinct_patterns_stay_distinct(self) -> None:
+        patterns = aggregate_normalized_signatures(
+            [
+                "2026-07-14T01:00:00Z ERROR postgres pool timed out id=123",
+                "2026-07-14T01:00:01Z ERROR discord gateway connection refused id=456",
+            ]
+        )
+
+        self.assertEqual(len(patterns), 2)
+        self.assertNotEqual(patterns[0].signature, patterns[1].signature)
+
+
+class DraftDecisionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pattern = SignatureCount(
+            severity="ERROR",
+            signature="postgres pool timed out while acquiring connection id=<id>",
+            count=51,
+            sample="ERROR postgres pool timed out while acquiring connection id=9234",
+        )
+
+    def test_threshold_crosses_only_above_named_limit(self) -> None:
+        self.assertFalse(exceeds_threshold(49, 50))
+        self.assertFalse(exceeds_threshold(50, 50))
+        self.assertTrue(exceeds_threshold(51, 50))
+
+        below = SignatureCount(**{**self.pattern.__dict__, "count": 50})
+        self.assertEqual(decide_issue_drafts([below], [], threshold=50), [])
+        crossed = decide_issue_drafts([self.pattern], [], threshold=50)
+        self.assertEqual(len(crossed), 1)
+        self.assertIsNotNone(crossed[0].draft)
+        self.assertNotIn("9234", crossed[0].draft.body)
+        self.assertIn("id=<id>", crossed[0].draft.body)
+
+    def test_matching_open_issue_suppresses_draft(self) -> None:
+        issue = OpenIssue(
+            number=4249,
+            title="fix(db): postgres pool timed out while acquiring connection",
+            body="Repeated pool acquisition timeouts are visible in dcserver.",
+            url="https://github.com/itismyfield/AgentDesk/issues/4249",
+        )
+
+        self.assertTrue(issue_matches_signature(self.pattern.signature, issue))
+        decisions = decide_issue_drafts([self.pattern], [issue], threshold=50)
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].matching_issue, issue)
+        self.assertIsNone(decisions[0].draft)
+
+    def test_open_issue_dedup_considers_body_beyond_first_500_characters(self) -> None:
+        issue = OpenIssue(
+            number=4250,
+            title="ops: recurring database degradation",
+            body="unrelated preface " * 40 + "postgres pool timed out while acquiring connection",
+        )
+
+        self.assertTrue(issue_matches_signature(self.pattern.signature, issue))
+
+    def test_unavailable_dedup_fails_closed_without_draft(self) -> None:
+        decisions = decide_issue_drafts(
+            [self.pattern],
+            [],
+            threshold=50,
+            dedup_available=False,
+        )
+        self.assertEqual(len(decisions), 1)
+        self.assertIsNone(decisions[0].draft)
+
+    def test_issue_creation_is_default_off_mutation_guard(self) -> None:
+        """Removing the shared approval check makes this mutation-style test fail."""
+
+        calls: list[str] = []
+        draft = IssueDraft(
+            severity=self.pattern.severity,
+            signature=self.pattern.signature,
+            count=self.pattern.count,
+            title="draft title",
+            body="draft body",
+        )
+
+        decision = maybe_post_approved_drafts(
+            [draft],
+            "off",
+            lambda item: calls.append(item.title) or "https://example.test/1",
+        )
+
+        self.assertFalse(decision.attempted)
+        self.assertEqual(calls, [], "default mode must never invoke gh issue creation")
+        with tempfile.TemporaryDirectory() as temp:
+            written = write_pending_drafts([draft], Path(temp))[0]
+            unreviewed = maybe_post_approved_drafts(
+                [written],
+                "confirmed",
+                lambda item: calls.append(item.title) or "https://example.test/1",
+            )
+            self.assertFalse(unreviewed.attempted)
+            self.assertEqual(calls, [], "confirmation alone cannot bypass per-draft review")
+
+            Path(f"{written.path}.approved").touch()
+            confirmed = maybe_post_approved_drafts(
+                [written],
+                "confirmed",
+                lambda item: calls.append(item.title) or "https://example.test/1",
+            )
+            self.assertTrue(confirmed.attempted)
+            self.assertEqual(calls, ["draft title"])
+
+    def test_daily_summary_lists_top_patterns_crossings_and_drafts(self) -> None:
+        decisions = decide_issue_drafts([self.pattern], [], threshold=50)
+        with tempfile.TemporaryDirectory() as temp:
+            drafts = write_pending_drafts(
+                [decision.draft for decision in decisions if decision.draft],
+                Path(temp),
+            )
+            summary = format_daily_summary(
+                [self.pattern],
+                decisions,
+                drafts,
+                threshold=50,
+                window_label="2026-07-13 00:00–2026-07-14 00:00 UTC",
+            )
+
+        self.assertIn("ERROR top: 51× postgres pool timed out", summary)
+        self.assertIn("WARN top: none", summary)
+        self.assertIn("Threshold >50: 1 crossed", summary)
+        self.assertIn("Crossed: 51× ERROR postgres pool timed out", summary)
+        self.assertIn("Pending drafts:", summary)
+        self.assertNotIn("Pending drafts: none", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daily_log_digest.py
+++ b/tests/test_daily_log_digest.py
@@ -93,7 +93,7 @@ class SignatureNormalizationTests(unittest.TestCase):
             ],
         )
 
-    def test_undated_launchd_lines_are_consumed_once_by_byte_offset(self) -> None:
+    def test_first_undated_observation_baselines_then_counts_only_append(self) -> None:
         now = datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
         since = now - timedelta(days=1)
         with tempfile.TemporaryDirectory() as temp:
@@ -126,10 +126,62 @@ class SignatureNormalizationTests(unittest.TestCase):
                 undated_checkpoint=checkpoint,
             )
 
-        self.assertEqual(len(baseline), 60)
+        self.assertEqual(baseline, [])
         self.assertEqual(fresh, ["WARN fresh append today"])
         self.assertEqual(repeated, [])
         self.assertEqual(baseline_warnings + fresh_warnings + repeated_warnings, [])
+
+    def test_corrupt_checkpoint_also_baselines_undated_history(self) -> None:
+        now = datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            launchd_stderr = root / "dcserver.launchd.stderr.log"
+            checkpoint = root / "runtime" / "undated-offsets.json"
+            launchd_stderr.write_text("ERROR old undated history\n" * 60, encoding="utf-8")
+            os.utime(launchd_stderr, (now.timestamp(), now.timestamp()))
+            checkpoint.parent.mkdir(parents=True)
+            checkpoint.write_text("{broken", encoding="utf-8")
+
+            baseline, warnings = recent_log_lines(
+                [launchd_stderr],
+                now - timedelta(days=1),
+                now,
+                undated_checkpoint=checkpoint,
+            )
+
+        self.assertEqual(baseline, [])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("could not load undated-line checkpoint", warnings[0])
+
+    def test_truncate_then_regrow_past_offset_resets_same_inode_watermark(self) -> None:
+        now = datetime(2026, 7, 14, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(days=1)
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            launchd_stderr = root / "dcserver.launchd.stderr.log"
+            checkpoint = root / "runtime" / "undated-offsets.json"
+            launchd_stderr.write_text("ERROR old history\n" * 8, encoding="utf-8")
+            os.utime(launchd_stderr, (now.timestamp(), now.timestamp()))
+            baseline, _ = recent_log_lines(
+                [launchd_stderr], since, now, undated_checkpoint=checkpoint
+            )
+            old_offset = launchd_stderr.stat().st_size
+            old_inode = launchd_stderr.stat().st_ino
+
+            with launchd_stderr.open("w", encoding="utf-8") as stream:
+                stream.write("ERROR new content after truncation\n" * 10)
+            os.utime(launchd_stderr, (now.timestamp(), now.timestamp()))
+            fresh, warnings = recent_log_lines(
+                [launchd_stderr], since, now, undated_checkpoint=checkpoint
+            )
+            new_offset = launchd_stderr.stat().st_size
+            new_inode = launchd_stderr.stat().st_ino
+
+        self.assertEqual(baseline, [])
+        self.assertEqual(new_inode, old_inode)
+        self.assertGreater(new_offset, old_offset)
+        self.assertEqual(fresh, ["ERROR new content after truncation"] * 10)
+        self.assertEqual(warnings, [])
 
     def test_different_ids_hashes_and_timestamps_collapse(self) -> None:
         first = (
@@ -170,6 +222,35 @@ class SignatureNormalizationTests(unittest.TestCase):
         self.assertEqual(patterns[0].count, 100)
         self.assertIn("req-<id>", patterns[0].signature)
         self.assertTrue(exceeds_threshold(patterns[0].count, 50))
+
+    def test_unit_suffixed_numbers_collapse_without_touching_identifiers(self) -> None:
+        duration_patterns = aggregate_normalized_signatures(
+            ["ERROR request took 123ms", "ERROR request took 456ms"]
+        )
+        size_patterns = aggregate_normalized_signatures(
+            ["WARN payload reached 512kb", "WARN payload reached 1mb"]
+        )
+
+        self.assertEqual(len(duration_patterns), 1)
+        self.assertEqual(duration_patterns[0].count, 2)
+        self.assertIn("<dur>", duration_patterns[0].signature)
+        self.assertEqual(len(size_patterns), 1)
+        self.assertEqual(size_patterns[0].count, 2)
+        self.assertIn("<size>", size_patterns[0].signature)
+        for value, placeholder in (
+            ("1.5s", "<dur>"),
+            ("20us", "<dur>"),
+            ("8gib", "<size>"),
+            ("99%", "<rate>"),
+            ("20/s", "<rate>"),
+            ("30req/s", "<rate>"),
+        ):
+            with self.subTest(value=value):
+                self.assertIn(placeholder, normalize_signature(f"ERROR measured {value}"))
+        self.assertEqual(
+            normalize_signature("ERROR error500handler failed"),
+            "error500handler failed",
+        )
 
     def test_http_status_codes_remain_distinct(self) -> None:
         self.assertNotEqual(
@@ -326,6 +407,7 @@ class DraftDecisionTests(unittest.TestCase):
 
         self.assertIn("ERROR top: 51× postgres pool timed out", summary)
         self.assertIn("WARN top: none", summary)
+        self.assertIn("best-effort signatures; verify top patterns manually", summary)
         self.assertIn("Threshold >50: 1 crossed", summary)
         self.assertIn("Crossed: 51× ERROR postgres pool timed out", summary)
         self.assertIn("Pending drafts:", summary)


### PR DESCRIPTION
## 이슈
#4263 — 일일 dcserver 로그 다이제스트 루틴. ERROR/WARN을 정규화 시그니처로 집계 → 임계 초과 + open-issue dedup → 이슈 DRAFT(자동생성 금지) + 일일 요약 채널 게시.

## 접근
- 기존 monitoring 루틴 프레임 재사용 (`routines/monitoring/daily-log-digest.js` QuickJS 정의 → `action:agent` → 번들 Python 헬퍼). 새 스케줄러 미도입.
- 싱글턴: 기존 `routine-runtime` LeaderOnly 워커 + `FOR UPDATE SKIP LOCKED` row claim + KST day-key 중복게시 방지.
- 루트 해석: `AGENTDESK_ROOT_DIR`→`ADK_REL`→`$HOME/.adk/release` (릴리스 툴링과 동일). stdout+launchd stderr 24h 스캔.
- 정규화: ANSI/타임스탬프 제거, UUID/hash/숫자ID/nonce/cursor/token → placeholder. 키=(severity, normalized_signature).
- 임계 `DEFAULT_DAILY_THRESHOLD=50` (`AGENTDESK_LOG_DIGEST_THRESHOLD`), 엄격히 count>threshold.
- dedup: open issue `gh issue list` 대비 title+body 컨테인먼트/토큰유사도. 스캔 불가 시 fail-closed(중복 draft 방지).
- **이슈 자동생성 금지**: draft는 Markdown으로만 write, 실제 `gh issue create`는 기본 OFF 휴먼승인 게이트 뒤 (#4262 규율 동일).

## 재사용 헬퍼 (#4265 공유)
`routines/monitoring/log_digest_issue_drafts.py` (386줄) — 정규화 집계 + 임계/dedup/휴먼승인 draft 경로. 주간 churn audit(#4265)가 재사용.

## 테스트
- `tests/test_daily_log_digest.py` (219줄): 시그니처 정규화(다른 ID 병합/구분 유지), 임계 교차, open-issue dedup(매치→draft 없음), 요약 포맷, 자동생성-금지 뮤테이션.
- `policies/__tests__/daily-log-digest.test.js` (node --test) — CI 배선(`ci-script-checks.sh`에 python 테스트 추가).

## 게이트 (직접 재실행, rc 캡처)
fmt --check rc=0 / ci-script-checks rc=0 / audit_maintainability --check rc=0 / test_daily_log_digest rc=0 / node --test rc=0 / agent-maintenance freshness passed. Rust 미변경.

모듈 크기: 신규 파일 전부 <1000 prod줄. #3016 핫파일 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)