### PR TITLE
ops(process): 수동개입 재발 카운터 → 임계 초과 시 이슈 초안 (#4264)

### DIFF
--- a/docs/runbooks/manual-intervention-recurrence.md
+++ b/docs/runbooks/manual-intervention-recurrence.md
@@ -1,0 +1,46 @@
+# Manual Intervention Recurrence
+
+Use the recorder whenever an operator performs one of these manual recovery
+actions:
+
+- Clear a `.stuck-manual-*` marker: `--type marker-clear`
+- Re-baseline a giant-file or watchdog baseline: `--type re-baseline`
+- Force-restart dcserver: `--type force-restart`
+
+Record the intervention immediately, with a concrete reason and the related
+issue when one exists:
+
+```bash
+python scripts/intervention_log.py record \
+  --type marker-clear \
+  --note "relay-wedge hand recovery" \
+  --node mac-mini \
+  --issue 4206
+```
+
+The append-only store is `scripts/intervention_history.toml`. Counts are
+monotonic per intervention type, so a force restart does not increment the
+marker-clear recurrence count.
+
+When a type's count exceeds the recurrence threshold, the recorder always
+writes `logs/intervention-recurrence-<type>.draft.md` and prints a loud warning.
+This draft promotes the pattern as a **판정 모델 재설계 후보**, following the
+agentdesk-issue-pipeline §0 “첫 사고 때 판정 모델 재설계” principle.
+
+Issue filing is default-off and remains a separate operator approval step. To
+file the generated draft, repeat the recording command only for the actual new
+intervention with the literal confirmation gate set:
+
+```bash
+AGENTDESK_INTERVENTION_CREATE_ISSUE=confirmed \
+  python scripts/intervention_log.py record \
+  --type marker-clear \
+  --note "relay-wedge hand recovery recurred"
+```
+
+Any unset value or value other than literal `confirmed` retains the local draft
+and never invokes `gh issue create`. Do not set confirmation merely to file an
+older draft, because every `record` invocation appends a real intervention.
+
+This v1 recorder is operator-invoked ops tooling. It does not hook deploy,
+watchdog, or cross-node runtime authority automatically.

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -75,6 +75,7 @@ echo "=== await_holding_lock ratchet guard ==="
 echo "=== Hotfile LOC ratchet guard (#3565) ==="
 "$PYTHON" scripts/check_hotfile_ratchet.py
 "$PYTHON" -m unittest scripts.test_ratchet_admission
+"$PYTHON" -m unittest scripts.test_intervention_log
 
 echo "=== Discord log field-key drift guard (#4218) ==="
 "$PYTHON" scripts/check_log_key_drift.py

--- a/scripts/intervention_history.toml
+++ b/scripts/intervention_history.toml
@@ -1,0 +1,6 @@
+# Manual intervention recurrence history (#4264). Schema version 1.
+#
+# Append one [[intervention]] block with the next per-type count whenever an
+# operator clears a marker, re-baselines a monitor, or force-restarts dcserver.
+
+schema_version = 1

--- a/scripts/intervention_log.py
+++ b/scripts/intervention_log.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import fcntl
 import json
 import os
 import socket
@@ -43,8 +44,13 @@ class RecordResult:
 
 def parse_history(text: str) -> list[InterventionEvent]:
     parsed = tomllib.loads(text)
-    if parsed.get("schema_version") != 1:
-        raise ValueError("intervention history schema_version must be 1")
+    schema_version = parsed.get("schema_version")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != 1
+    ):
+        raise ValueError("intervention history schema_version must be integer 1")
     rows = parsed.get("intervention", [])
     if not isinstance(rows, list):
         raise ValueError("intervention history [[intervention]] entries must be an array")
@@ -72,10 +78,16 @@ def parse_history(text: str) -> list[InterventionEvent]:
             raise ValueError(f"intervention event {index}: issue must be positive")
         count = row.get("count")
         expected = last_count.get(event_type, 0) + 1
-        if isinstance(count, bool) or not isinstance(count, int) or count != expected:
+        if isinstance(count, bool) or not isinstance(count, int) or count <= 0:
             raise ValueError(
-                f"intervention event {index} ({event_type}): count must be "
-                f"{expected}, got {count!r}"
+                f"intervention event {index} ({event_type}): count must be a "
+                f"positive integer, got {count!r}"
+            )
+        if count != expected:
+            print(
+                f"WARNING: intervention event {index} ({event_type}) has "
+                f"out-of-sequence count {count}; using positional count {expected}",
+                file=sys.stderr,
             )
         event = InterventionEvent(
             type=event_type,
@@ -83,10 +95,10 @@ def parse_history(text: str) -> list[InterventionEvent]:
             node=row["node"],
             note=row["note"],
             issue=issue,
-            count=count,
+            count=expected,
         )
         events.append(event)
-        last_count[event_type] = count
+        last_count[event_type] = expected
     return events
 
 
@@ -201,22 +213,26 @@ def record_intervention(
     ):
         raise ValueError("issue must be a positive integer")
 
-    history_text = history_path.read_text(encoding="utf-8")
-    events = parse_history(history_text)
-    now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
-    event = InterventionEvent(
-        type=type,
-        timestamp=timestamp or now.replace("+00:00", "Z"),
-        node=node,
-        note=note,
-        issue=issue,
-        count=next_count(events, type),
-    )
-    separator = "" if history_text.endswith("\n\n") else "\n"
-    block = separator + _event_block(event)
-    parse_history(history_text + block)
-    with history_path.open("a", encoding="utf-8") as history_file:
+    with history_path.open("r+", encoding="utf-8") as history_file:
+        fcntl.flock(history_file.fileno(), fcntl.LOCK_EX)
+        history_text = history_file.read()
+        events = parse_history(history_text)
+        now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+        event = InterventionEvent(
+            type=type,
+            timestamp=timestamp or now.replace("+00:00", "Z"),
+            node=node,
+            note=note,
+            issue=issue,
+            count=next_count(events, type),
+        )
+        separator = "" if history_text.endswith("\n\n") else "\n"
+        block = separator + _event_block(event)
+        parse_history(history_text + block)
+        history_file.seek(0, os.SEEK_END)
         history_file.write(block)
+        history_file.flush()
+        fcntl.flock(history_file.fileno(), fcntl.LOCK_UN)
 
     draft_path: Path | None = None
     invoked = False

--- a/scripts/intervention_log.py
+++ b/scripts/intervention_log.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Record manual-operation interventions and surface repeated patterns (#4264).
+
+Future consolidation may share parsing with the deferred #4263 log-digest helper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import socket
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+VALID_TYPES = ("marker-clear", "re-baseline", "force-restart")
+INTERVENTION_RECURRENCE_THRESHOLD = 3
+HISTORY_REL_PATH = Path("scripts/intervention_history.toml")
+RECENT_EVENT_LIMIT = 5
+
+
+@dataclass(frozen=True)
+class InterventionEvent:
+    type: str
+    timestamp: str
+    node: str
+    note: str
+    issue: int | None
+    count: int
+
+
+@dataclass(frozen=True)
+class RecordResult:
+    event: InterventionEvent
+    draft_path: Path | None
+    issue_create_invoked: bool
+
+
+def parse_history(text: str) -> list[InterventionEvent]:
+    parsed = tomllib.loads(text)
+    if parsed.get("schema_version") != 1:
+        raise ValueError("intervention history schema_version must be 1")
+    rows = parsed.get("intervention", [])
+    if not isinstance(rows, list):
+        raise ValueError("intervention history [[intervention]] entries must be an array")
+
+    events: list[InterventionEvent] = []
+    last_count: dict[str, int] = {}
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, dict):
+            raise ValueError(f"intervention event {index} must be a TOML table")
+        event_type = row.get("type")
+        if event_type not in VALID_TYPES:
+            raise ValueError(
+                f"intervention event {index}: type must be one of {VALID_TYPES}, "
+                f"got {event_type!r}"
+            )
+        for field in ("timestamp", "node", "note"):
+            if not isinstance(row.get(field), str) or not row[field].strip():
+                raise ValueError(
+                    f"intervention event {index}: {field} must be a non-empty string"
+                )
+        issue = row.get("issue")
+        if issue is not None and (
+            isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0
+        ):
+            raise ValueError(f"intervention event {index}: issue must be positive")
+        count = row.get("count")
+        expected = last_count.get(event_type, 0) + 1
+        if isinstance(count, bool) or not isinstance(count, int) or count != expected:
+            raise ValueError(
+                f"intervention event {index} ({event_type}): count must be "
+                f"{expected}, got {count!r}"
+            )
+        event = InterventionEvent(
+            type=event_type,
+            timestamp=row["timestamp"],
+            node=row["node"],
+            note=row["note"],
+            issue=issue,
+            count=count,
+        )
+        events.append(event)
+        last_count[event_type] = count
+    return events
+
+
+def recurrence_count(events: Sequence[InterventionEvent], type: str) -> int:
+    if type not in VALID_TYPES:
+        raise ValueError(f"invalid intervention type: {type!r}")
+    return sum(event.type == type for event in events)
+
+
+def next_count(events: Sequence[InterventionEvent], type: str) -> int:
+    return recurrence_count(events, type) + 1
+
+
+def crosses_threshold(count: int) -> bool:
+    return count > INTERVENTION_RECURRENCE_THRESHOLD
+
+
+def build_draft_body(
+    type: str, count: int, recent_events: Sequence[InterventionEvent]
+) -> str:
+    rows = ["| Timestamp | Node | Type | Count | Issue | Note |",
+            "| --- | --- | --- | ---: | ---: | --- |"]
+    for event in recent_events[-RECENT_EVENT_LIMIT:]:
+        issue = f"#{event.issue}" if event.issue is not None else "—"
+        note = event.note.replace("|", "\\|").replace("\n", " ")
+        rows.append(
+            f"| {event.timestamp} | {event.node} | {event.type} | "
+            f"{event.count} | {issue} | {note} |"
+        )
+    return "\n".join(
+        [
+            f"# ops: repeated manual intervention — {type}",
+            "",
+            f"- Intervention type: `{type}`",
+            f"- Per-type recurrence count: **{count}**",
+            f"- Promotion threshold: more than {INTERVENTION_RECURRENCE_THRESHOLD}",
+            "",
+            "## Recent intervention rows",
+            "",
+            *rows,
+            "",
+            "## Recommendation",
+            "",
+            "**판정 모델 재설계 후보**로 검토한다. agentdesk-issue-pipeline §0의 "
+            '"첫 사고 때 판정 모델 재설계" 원칙에 따라 반복 수동 복구를 자동 판정·복구 '
+            "모델로 대체할 수 있는지 분석한다.",
+            "",
+        ]
+    )
+
+
+def recurrence_warning_messages(
+    type: str, count: int, draft_path: Path, create_confirmed: bool
+) -> tuple[str, ...]:
+    if not crosses_threshold(count):
+        return ()
+    messages = (
+        f"WARNING: MANUAL INTERVENTION RECURRENCE EXCEEDED: {type} count={count} "
+        f"(threshold {INTERVENTION_RECURRENCE_THRESHOLD}); draft={draft_path}",
+    )
+    if not create_confirmed:
+        messages += (
+            "draft retained; set AGENTDESK_INTERVENTION_CREATE_ISSUE=confirmed "
+            "to file.",
+        )
+    return messages
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _event_block(event: InterventionEvent) -> str:
+    lines = [
+        "[[intervention]]",
+        f"type = {_toml_string(event.type)}",
+        f"timestamp = {_toml_string(event.timestamp)}",
+        f"node = {_toml_string(event.node)}",
+        f"note = {_toml_string(event.note)}",
+    ]
+    if event.issue is not None:
+        lines.append(f"issue = {event.issue}")
+    lines.extend((f"count = {event.count}", ""))
+    return "\n".join(lines)
+
+
+def resolve_root(environ: Mapping[str, str]) -> Path:
+    configured = environ.get("AGENTDESK_ROOT_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(__file__).resolve().parents[1]
+
+
+def record_intervention(
+    *,
+    type: str,
+    note: str,
+    node: str,
+    issue: int | None,
+    history_path: Path,
+    logs_dir: Path,
+    environ: Mapping[str, str],
+    runner: Callable[..., object] = subprocess.run,
+    timestamp: str | None = None,
+) -> RecordResult:
+    if type not in VALID_TYPES:
+        raise ValueError(f"invalid intervention type: {type!r}")
+    if not note.strip() or not node.strip():
+        raise ValueError("note and node must be non-empty")
+    if issue is not None and (
+        isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0
+    ):
+        raise ValueError("issue must be a positive integer")
+
+    history_text = history_path.read_text(encoding="utf-8")
+    events = parse_history(history_text)
+    now = dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+    event = InterventionEvent(
+        type=type,
+        timestamp=timestamp or now.replace("+00:00", "Z"),
+        node=node,
+        note=note,
+        issue=issue,
+        count=next_count(events, type),
+    )
+    separator = "" if history_text.endswith("\n\n") else "\n"
+    block = separator + _event_block(event)
+    parse_history(history_text + block)
+    with history_path.open("a", encoding="utf-8") as history_file:
+        history_file.write(block)
+
+    draft_path: Path | None = None
+    invoked = False
+    confirmed = environ.get("AGENTDESK_INTERVENTION_CREATE_ISSUE") == "confirmed"
+    if crosses_threshold(event.count):
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        draft_path = logs_dir / f"intervention-recurrence-{type}.draft.md"
+        relevant = [row for row in (*events, event) if row.type == type]
+        draft_path.write_text(
+            build_draft_body(type, event.count, relevant), encoding="utf-8"
+        )
+        for message in recurrence_warning_messages(
+            type, event.count, draft_path, confirmed
+        ):
+            print(message, file=sys.stderr)
+        if confirmed and draft_path.is_file():
+            invoked = True
+            result = runner(
+                [
+                    "gh", "issue", "create",
+                    "--repo", "itismyfield/AgentDesk",
+                    "--title",
+                    f"ops: repeated manual intervention ({type}, count {event.count})",
+                    "--body-file", str(draft_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if getattr(result, "returncode", 1) != 0:
+                print(
+                    f"WARNING: gh issue create failed; draft retained: {draft_path}",
+                    file=sys.stderr,
+                )
+    return RecordResult(event, draft_path, invoked)
+
+
+def _positive_issue(value: str) -> int:
+    if value.startswith("#"):
+        raise argparse.ArgumentTypeError("issue must not include a leading '#'")
+    try:
+        issue = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("issue must be a positive integer") from exc
+    if issue <= 0:
+        raise argparse.ArgumentTypeError("issue must be a positive integer")
+    return issue
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    record = commands.add_parser("record", help="append one intervention event")
+    record.add_argument("--type", required=True, choices=VALID_TYPES)
+    record.add_argument("--note", required=True)
+    record.add_argument("--node", default=socket.gethostname())
+    record.add_argument("--issue", type=_positive_issue)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    root = resolve_root(os.environ)
+    try:
+        result = record_intervention(
+            type=args.type, note=args.note, node=args.node, issue=args.issue,
+            history_path=root / HISTORY_REL_PATH,
+            logs_dir=root / "logs",
+            environ=os.environ,
+        )
+    except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
+        print(f"ERROR: intervention not recorded: {exc}", file=sys.stderr)
+        return 2
+    print(f"recorded {result.event.type} intervention count={result.event.count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_intervention_log.py
+++ b/scripts/test_intervention_log.py
@@ -4,11 +4,15 @@
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import io
+import threading
 import tempfile
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from scripts.intervention_log import (
     INTERVENTION_RECURRENCE_THRESHOLD,
@@ -22,6 +26,10 @@ from scripts.intervention_log import (
 
 
 class InterventionLogTest(unittest.TestCase):
+    @staticmethod
+    def _schema_history(value: str) -> str:
+        return f"schema_version = {value}\n"
+
     def _seed(self, root: Path, count: int = 0) -> Path:
         path = root / "scripts" / "intervention_history.toml"
         path.parent.mkdir(parents=True)
@@ -78,6 +86,100 @@ class InterventionLogTest(unittest.TestCase):
             self.assertEqual(restart.event.count, 1)
             self.assertEqual(second.event.count, 2)
             self.assertEqual([event.count for event in parse_history(history.read_text())], [1, 1, 2])
+
+    def test_concurrent_records_serialize_read_count_append(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            history = self._seed(root)
+            second_lock_attempted = threading.Event()
+            counter_lock = threading.Lock()
+            lock_attempts = 0
+            first_parse = True
+            original_flock = fcntl.flock
+            original_parse = parse_history
+
+            def observed_flock(file_descriptor: int, operation: int) -> None:
+                nonlocal lock_attempts
+                if operation == fcntl.LOCK_EX:
+                    with counter_lock:
+                        lock_attempts += 1
+                        if lock_attempts == 2:
+                            second_lock_attempted.set()
+                original_flock(file_descriptor, operation)
+
+            def parse_after_both_lock_attempts(text: str):
+                nonlocal first_parse
+                with counter_lock:
+                    wait_for_second = first_parse
+                    first_parse = False
+                if wait_for_second and not second_lock_attempted.wait(timeout=5):
+                    raise AssertionError("second record did not attempt the store lock")
+                return original_parse(text)
+
+            with (
+                mock.patch(
+                    "scripts.intervention_log.fcntl.flock", side_effect=observed_flock
+                ),
+                mock.patch(
+                    "scripts.intervention_log.parse_history",
+                    side_effect=parse_after_both_lock_attempts,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                futures = [
+                    executor.submit(
+                        self._record, root, history, "marker-clear", []
+                    )
+                    for _ in range(2)
+                ]
+                results = [future.result(timeout=10) for future in futures]
+
+            self.assertEqual(sorted(result.event.count for result in results), [1, 2])
+            stored = history.read_text(encoding="utf-8")
+            self.assertEqual(
+                [event.count for event in parse_history(stored)],
+                [1, 2],
+            )
+            self.assertIn("count = 2", stored)
+
+    def test_out_of_sequence_count_is_repaired_and_recording_continues(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            history = self._seed(root, 2)
+            corrupted = history.read_text(encoding="utf-8").replace(
+                "count = 2", "count = 1"
+            )
+            history.write_text(corrupted, encoding="utf-8")
+
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                repaired = parse_history(corrupted)
+                result = self._record(root, history, "marker-clear", [])
+
+            self.assertEqual([event.count for event in repaired], [1, 2])
+            self.assertEqual(result.event.count, 3)
+            self.assertIn("using positional count 2", stderr.getvalue())
+            stored = history.read_text(encoding="utf-8")
+            self.assertIn("count = 3", stored)
+            self.assertEqual(
+                [event.count for event in parse_history(stored)],
+                [1, 2, 3],
+            )
+
+    def test_schema_version_true_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_history(self._schema_history("true"))
+
+    def test_schema_version_float_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_history(self._schema_history("1.0"))
+
+    def test_schema_version_string_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_history(self._schema_history('"1"'))
+
+    def test_schema_version_integer_is_accepted(self) -> None:
+        self.assertEqual(parse_history(self._schema_history("1")), [])
 
     def test_threshold_crossing_builds_redesign_candidate_draft(self) -> None:
         below = INTERVENTION_RECURRENCE_THRESHOLD

--- a/scripts/test_intervention_log.py
+++ b/scripts/test_intervention_log.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Focused tests for the manual-intervention recurrence recorder (#4264)."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.intervention_log import (
+    INTERVENTION_RECURRENCE_THRESHOLD,
+    InterventionEvent,
+    build_draft_body,
+    crosses_threshold,
+    main,
+    parse_history,
+    record_intervention,
+)
+
+
+class InterventionLogTest(unittest.TestCase):
+    def _seed(self, root: Path, count: int = 0) -> Path:
+        path = root / "scripts" / "intervention_history.toml"
+        path.parent.mkdir(parents=True)
+        rows = ["schema_version = 1", ""]
+        for value in range(1, count + 1):
+            rows.extend(
+                [
+                    "[[intervention]]",
+                    'type = "marker-clear"',
+                    f'timestamp = "2026-06-18T09:1{value}:00Z"',
+                    'node = "mac-mini"',
+                    f'note = "seed {value}"',
+                    f"count = {value}",
+                    "",
+                ]
+            )
+        path.write_text("\n".join(rows), encoding="utf-8")
+        return path
+
+    def _record(
+        self,
+        root: Path,
+        history: Path,
+        type: str,
+        calls: list[list[str]],
+        environ: dict[str, str] | None = None,
+    ):
+        def fake_runner(command, **_kwargs):
+            calls.append(command)
+            return SimpleNamespace(returncode=0, stdout="url", stderr="")
+
+        return record_intervention(
+            type=type,
+            note=f"test {type}",
+            node="mac-mini",
+            issue=None,
+            history_path=history,
+            logs_dir=root / "logs",
+            environ=environ or {},
+            runner=fake_runner,
+            timestamp="2026-07-14T00:00:00Z",
+        )
+
+    def test_counts_are_monotonic_and_isolated_per_type(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            history = self._seed(root)
+            calls: list[list[str]] = []
+            first = self._record(root, history, "marker-clear", calls)
+            restart = self._record(root, history, "force-restart", calls)
+            second = self._record(root, history, "marker-clear", calls)
+
+            self.assertEqual(first.event.count, 1)
+            self.assertEqual(restart.event.count, 1)
+            self.assertEqual(second.event.count, 2)
+            self.assertEqual([event.count for event in parse_history(history.read_text())], [1, 1, 2])
+
+    def test_threshold_crossing_builds_redesign_candidate_draft(self) -> None:
+        below = INTERVENTION_RECURRENCE_THRESHOLD
+        crossing = INTERVENTION_RECURRENCE_THRESHOLD + 1
+        self.assertFalse(crosses_threshold(below))
+        self.assertTrue(crosses_threshold(crossing))
+        event = InterventionEvent(
+            "marker-clear", "2026-07-14T00:00:00Z", "mac-mini", "test", None, crossing
+        )
+        draft = build_draft_body("marker-clear", crossing, [event])
+        self.assertIn("marker-clear", draft)
+        self.assertIn(str(crossing), draft)
+        self.assertIn("재설계 후보", draft)
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            history = self._seed(root, below - 1)
+            result = self._record(root, history, "marker-clear", [])
+            self.assertEqual(result.event.count, below)
+            self.assertIsNone(result.draft_path)
+
+    def test_gh_issue_creation_is_default_off_and_literal_confirmed_only(self) -> None:
+        for environ in ({}, {"AGENTDESK_INTERVENTION_CREATE_ISSUE": "off"}):
+            with self.subTest(environ=environ), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                history = self._seed(root, INTERVENTION_RECURRENCE_THRESHOLD)
+                calls: list[list[str]] = []
+                result = self._record(root, history, "marker-clear", calls, environ)
+                self.assertIsNotNone(result.draft_path)
+                self.assertTrue(result.draft_path.is_file())
+                self.assertEqual(calls, [])
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            history = self._seed(root, INTERVENTION_RECURRENCE_THRESHOLD)
+            calls = []
+            result = self._record(
+                root,
+                history,
+                "marker-clear",
+                calls,
+                {"AGENTDESK_INTERVENTION_CREATE_ISSUE": "confirmed"},
+            )
+            self.assertTrue(result.draft_path.is_file())
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][:3], ["gh", "issue", "create"])
+
+    def test_validation_and_history_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            history = self._seed(root)
+            self._record(root, history, "re-baseline", [])
+            reparsed = parse_history(history.read_text(encoding="utf-8"))
+            self.assertEqual(reparsed[0].type, "re-baseline")
+            self.assertIn("schema_version = 1", history.read_text(encoding="utf-8"))
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit):
+            main(["record", "--type", "unknown", "--note", "test"])
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit):
+            main(
+                [
+                    "record",
+                    "--type",
+                    "marker-clear",
+                    "--note",
+                    "test",
+                    "--issue",
+                    "#4206",
+                ]
+            )
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit):
+            main(
+                [
+                    "record",
+                    "--type",
+                    "marker-clear",
+                    "--note",
+                    "test",
+                    "--issue",
+                    "not-an-int",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 이슈 #4264
수동 개입(marker-clear / re-baseline / force-restart)을 재발 신호로 기록 — 묻히는 반복 문제(6/18 wedge 5건→#4206 재발)를 '판정모델 재설계 후보'로 승격.

## 구현 (process/docs-light + 자체완결 Python)
- `scripts/intervention_log.py` (298줄): recorder CLI + 순수 라이브러리. per-type 재발 카운트, 임계(3) 초과 시 로컬 draft + stderr 경고. **이슈 자동생성 금지** — `gh issue create`는 `AGENTDESK_INTERVENTION_CREATE_ISSUE=confirmed`일 때만(기본 OFF, 휴먼승인). injectable gh runner로 테스트가 비호출 단언.
- `scripts/intervention_history.toml`: append-only 카운터 스토어 (ratchet_admission_history 패턴).
- `scripts/test_intervention_log.py` (167줄): per-type 격리 / 임계→draft / **no-auto-create 뮤테이션 가드** / 검증. ci-script-checks.sh 배선.
- `docs/runbooks/manual-intervention-recurrence.md`: 운영자 규칙.
- ratchet_admission + #4262 draft/default-off 패턴 재사용. #4263 헬퍼 미의존(자체완결).

## 게이트 (직접 재검증)
test_intervention_log OK / ci-script-checks rc=0(신규 test 실행) / audit rc=0 / fmt rc=0 / freshness passed. Rust·핫파일 무접촉.

스킬 companion 편집(out-of-repo, 비차단): agentdesk-issue-pipeline/agentdesk-runtime-ops에 recorder 규칙 1줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)