### PR TITLE
fix(deploy): #4262 post-deploy smoke WARN-rate를 재시작 후 로그로 스코핑 (#4511)

### DIFF
--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -84,6 +84,9 @@ echo "=== Inflight blind-save ratchet guard (#4259) ==="
 "$PYTHON" scripts/check_inflight_blind_save_ratchet.py
 "$PYTHON" -m unittest tests.test_inflight_blind_save_ratchet
 
+# #4511 post-deploy smoke WARN post-restart scoping
+bash tests/test_deploy_smoke_warn_scope_4511.sh
+
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 "$PYTHON" -m unittest tests.test_discord_thread_create_ci_wiring

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1501,6 +1501,17 @@ else
     sleep 2
 fi
 
+# Watermark the shared append-only stdout log only after the old dcserver has
+# exited. The post-deploy WARN-rate smoke must not count lines from the prior
+# process lifetime (#4511).
+POST_DEPLOY_SMOKE_LOG_PATH="$ADK_REL/logs/dcserver.stdout.log"
+POST_DEPLOY_SMOKE_LOG_OFFSET=""
+if [ ! -e "$POST_DEPLOY_SMOKE_LOG_PATH" ]; then
+    POST_DEPLOY_SMOKE_LOG_OFFSET=0
+elif POST_DEPLOY_SMOKE_LOG_OFFSET=$(wc -c < "$POST_DEPLOY_SMOKE_LOG_PATH" 2>/dev/null); then
+    POST_DEPLOY_SMOKE_LOG_OFFSET="${POST_DEPLOY_SMOKE_LOG_OFFSET//[[:space:]]/}"
+fi
+
 # Promote the already signed staged binary atomically. In-place codesign can
 # corrupt the OS signing cache if it fails mid-write.
 #
@@ -1994,7 +2005,7 @@ _post_deploy_smoke_check_wedges() {
 }
 
 _post_deploy_smoke_check_fail_closed_warn_rate() {
-    local log_path="$ADK_REL/logs/dcserver.stdout.log"
+    local log_path="$POST_DEPLOY_SMOKE_LOG_PATH"
     local sample_path="$POST_DEPLOY_SMOKE_TMP_DIR/recent-dcserver.log"
     local sampled_lines warn_lines fail_closed_warns
     case "$POST_DEPLOY_SMOKE_LOG_LINES" in
@@ -2017,8 +2028,15 @@ _post_deploy_smoke_check_fail_closed_warn_rate() {
         _post_deploy_smoke_fail "fail-closed WARN sample: unreadable log ${log_path}" || true
         return 1
     fi
-    if ! tail -n "$POST_DEPLOY_SMOKE_LOG_LINES" "$log_path" > "$sample_path"; then
-        _post_deploy_smoke_fail "fail-closed WARN sample: could not read recent log lines" || true
+    case "$POST_DEPLOY_SMOKE_LOG_OFFSET" in
+        ''|*[!0-9]*)
+            _post_deploy_smoke_fail "fail-closed WARN sample: restart log watermark unavailable" || true
+            return 1
+            ;;
+    esac
+    if ! tail -c "+$((POST_DEPLOY_SMOKE_LOG_OFFSET + 1))" "$log_path" \
+      | tail -n "$POST_DEPLOY_SMOKE_LOG_LINES" > "$sample_path"; then
+        _post_deploy_smoke_fail "fail-closed WARN sample: could not read post-restart log lines" || true
         return 1
     fi
     sampled_lines=$(wc -l < "$sample_path" | tr -d ' ') || return 1
@@ -2037,7 +2055,7 @@ _post_deploy_smoke_check_fail_closed_warn_rate() {
     # default 5 / 500 lines (1%). It intentionally does not block on one WARN.
     if [ "$fail_closed_warns" -ge "$POST_DEPLOY_SMOKE_WARN_LIMIT" ]; then
         _post_deploy_smoke_fail \
-            "fail-closed WARN spike: ${fail_closed_warns} in last ${sampled_lines} log lines (threshold ${POST_DEPLOY_SMOKE_WARN_LIMIT})" \
+            "fail-closed WARN spike: ${fail_closed_warns} in last ${sampled_lines} post-restart log lines (threshold ${POST_DEPLOY_SMOKE_WARN_LIMIT})" \
             || true
         return 1
     fi

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1510,12 +1510,38 @@ _post_deploy_smoke_log_identity_and_size() {
     fi
 }
 
+_post_deploy_smoke_log_head_fingerprint() {
+    local log_path="$1"
+    local byte_count="$2"
+    case "$byte_count" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    if command -v shasum >/dev/null 2>&1; then
+        head -c "$byte_count" "$log_path" \
+            | shasum -a 256 \
+            | awk 'NF { print "sha256:" $1; found = 1 } END { if (!found) exit 1 }'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        head -c "$byte_count" "$log_path" \
+            | sha256sum \
+            | awk 'NF { print "sha256:" $1; found = 1 } END { if (!found) exit 1 }'
+    elif command -v cksum >/dev/null 2>&1; then
+        head -c "$byte_count" "$log_path" \
+            | cksum \
+            | awk 'NF >= 2 { print "cksum:" $1 ":" $2; found = 1 } END { if (!found) exit 1 }'
+    else
+        return 1
+    fi
+}
+
 # Watermark the stdout log only after the old dcserver has exited. The sampler
-# uses the byte offset while the inode is unchanged and the file has not shrunk;
-# after rotation or truncation it samples the entire current file (#4511).
+# uses the byte offset while inode, size, and the bounded head fingerprint still
+# prove append-only growth. Rotation, shrink, or a rewritten head selects the
+# entire current file (#4511).
 POST_DEPLOY_SMOKE_LOG_PATH="$ADK_REL/logs/dcserver.stdout.log"
+POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP=4096
 POST_DEPLOY_SMOKE_LOG_OFFSET=""
 POST_DEPLOY_SMOKE_LOG_INODE=""
+POST_DEPLOY_SMOKE_LOG_FINGERPRINT=""
 if [ ! -e "$POST_DEPLOY_SMOKE_LOG_PATH" ]; then
     POST_DEPLOY_SMOKE_LOG_OFFSET=0
     POST_DEPLOY_SMOKE_LOG_INODE=0
@@ -1525,7 +1551,28 @@ elif POST_DEPLOY_SMOKE_LOG_STAT=$(
     read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
         <<< "$POST_DEPLOY_SMOKE_LOG_STAT"
 fi
+case "$POST_DEPLOY_SMOKE_LOG_OFFSET" in
+    ''|*[!0-9]*) ;;
+    *)
+        POST_DEPLOY_SMOKE_LOG_FINGERPRINT_BYTES="$POST_DEPLOY_SMOKE_LOG_OFFSET"
+        if [ "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_BYTES" -gt "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP" ]; then
+            POST_DEPLOY_SMOKE_LOG_FINGERPRINT_BYTES="$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP"
+        fi
+        POST_DEPLOY_SMOKE_LOG_FINGERPRINT_PATH="$POST_DEPLOY_SMOKE_LOG_PATH"
+        if [ ! -e "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_PATH" ]; then
+            POST_DEPLOY_SMOKE_LOG_FINGERPRINT_PATH=/dev/null
+        fi
+        if ! POST_DEPLOY_SMOKE_LOG_FINGERPRINT=$(
+            _post_deploy_smoke_log_head_fingerprint \
+                "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_PATH" \
+                "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_BYTES"
+        ); then
+            POST_DEPLOY_SMOKE_LOG_FINGERPRINT=""
+        fi
+        ;;
+esac
 unset POST_DEPLOY_SMOKE_LOG_STAT
+unset POST_DEPLOY_SMOKE_LOG_FINGERPRINT_BYTES POST_DEPLOY_SMOKE_LOG_FINGERPRINT_PATH
 
 # Promote the already signed staged binary atomically. In-place codesign can
 # corrupt the OS signing cache if it fails mid-write.
@@ -2022,7 +2069,8 @@ _post_deploy_smoke_check_wedges() {
 _post_deploy_smoke_check_fail_closed_warn_rate() {
     local log_path="$POST_DEPLOY_SMOKE_LOG_PATH"
     local sample_path="$POST_DEPLOY_SMOKE_TMP_DIR/recent-dcserver.log"
-    local current_log_stat current_inode current_size sample_start_byte
+    local current_log_stat current_inode current_size current_head_fingerprint
+    local fingerprint_bytes sample_start_byte
     local sampled_lines warn_lines fail_closed_warns
     case "$POST_DEPLOY_SMOKE_LOG_LINES" in
         ''|*[!0-9]*)
@@ -2056,6 +2104,10 @@ _post_deploy_smoke_check_fail_closed_warn_rate() {
             return 1
             ;;
     esac
+    if [ -z "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT" ]; then
+        _post_deploy_smoke_fail "fail-closed WARN sample: restart log fingerprint unavailable" || true
+        return 1
+    fi
     if ! current_log_stat=$(
         _post_deploy_smoke_log_identity_and_size "$log_path" 2>/dev/null
     ); then
@@ -2069,8 +2121,19 @@ _post_deploy_smoke_check_fail_closed_warn_rate() {
             return 1
             ;;
     esac
+    fingerprint_bytes="$POST_DEPLOY_SMOKE_LOG_OFFSET"
+    if [ "$fingerprint_bytes" -gt "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP" ]; then
+        fingerprint_bytes="$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP"
+    fi
+    if ! current_head_fingerprint=$(
+        _post_deploy_smoke_log_head_fingerprint "$log_path" "$fingerprint_bytes"
+    ); then
+        _post_deploy_smoke_fail "fail-closed WARN sample: could not fingerprint current log ${log_path}" || true
+        return 1
+    fi
     if [ "$current_inode" != "$POST_DEPLOY_SMOKE_LOG_INODE" ] \
-      || [ "$current_size" -lt "$POST_DEPLOY_SMOKE_LOG_OFFSET" ]; then
+      || [ "$current_size" -lt "$POST_DEPLOY_SMOKE_LOG_OFFSET" ] \
+      || [ "$current_head_fingerprint" != "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT" ]; then
         sample_start_byte=1
     else
         sample_start_byte=$((POST_DEPLOY_SMOKE_LOG_OFFSET + 1))

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1501,16 +1501,31 @@ else
     sleep 2
 fi
 
-# Watermark the shared append-only stdout log only after the old dcserver has
-# exited. The post-deploy WARN-rate smoke must not count lines from the prior
-# process lifetime (#4511).
+_post_deploy_smoke_log_identity_and_size() {
+    local log_path="$1"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        stat -f '%i %z' "$log_path"
+    else
+        stat -c '%i %s' "$log_path"
+    fi
+}
+
+# Watermark the stdout log only after the old dcserver has exited. The sampler
+# uses the byte offset while the inode is unchanged and the file has not shrunk;
+# after rotation or truncation it samples the entire current file (#4511).
 POST_DEPLOY_SMOKE_LOG_PATH="$ADK_REL/logs/dcserver.stdout.log"
 POST_DEPLOY_SMOKE_LOG_OFFSET=""
+POST_DEPLOY_SMOKE_LOG_INODE=""
 if [ ! -e "$POST_DEPLOY_SMOKE_LOG_PATH" ]; then
     POST_DEPLOY_SMOKE_LOG_OFFSET=0
-elif POST_DEPLOY_SMOKE_LOG_OFFSET=$(wc -c < "$POST_DEPLOY_SMOKE_LOG_PATH" 2>/dev/null); then
-    POST_DEPLOY_SMOKE_LOG_OFFSET="${POST_DEPLOY_SMOKE_LOG_OFFSET//[[:space:]]/}"
+    POST_DEPLOY_SMOKE_LOG_INODE=0
+elif POST_DEPLOY_SMOKE_LOG_STAT=$(
+    _post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH" 2>/dev/null
+); then
+    read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+        <<< "$POST_DEPLOY_SMOKE_LOG_STAT"
 fi
+unset POST_DEPLOY_SMOKE_LOG_STAT
 
 # Promote the already signed staged binary atomically. In-place codesign can
 # corrupt the OS signing cache if it fails mid-write.
@@ -2007,6 +2022,7 @@ _post_deploy_smoke_check_wedges() {
 _post_deploy_smoke_check_fail_closed_warn_rate() {
     local log_path="$POST_DEPLOY_SMOKE_LOG_PATH"
     local sample_path="$POST_DEPLOY_SMOKE_TMP_DIR/recent-dcserver.log"
+    local current_log_stat current_inode current_size sample_start_byte
     local sampled_lines warn_lines fail_closed_warns
     case "$POST_DEPLOY_SMOKE_LOG_LINES" in
         ''|*[!0-9]*)
@@ -2034,7 +2050,32 @@ _post_deploy_smoke_check_fail_closed_warn_rate() {
             return 1
             ;;
     esac
-    if ! tail -c "+$((POST_DEPLOY_SMOKE_LOG_OFFSET + 1))" "$log_path" \
+    case "$POST_DEPLOY_SMOKE_LOG_INODE" in
+        ''|*[!0-9]*)
+            _post_deploy_smoke_fail "fail-closed WARN sample: restart log identity unavailable" || true
+            return 1
+            ;;
+    esac
+    if ! current_log_stat=$(
+        _post_deploy_smoke_log_identity_and_size "$log_path" 2>/dev/null
+    ); then
+        _post_deploy_smoke_fail "fail-closed WARN sample: could not stat current log ${log_path}" || true
+        return 1
+    fi
+    read -r current_inode current_size <<< "$current_log_stat"
+    case "$current_inode:$current_size" in
+        *[!0-9:]*|:*|*:)
+            _post_deploy_smoke_fail "fail-closed WARN sample: invalid current log identity or size" || true
+            return 1
+            ;;
+    esac
+    if [ "$current_inode" != "$POST_DEPLOY_SMOKE_LOG_INODE" ] \
+      || [ "$current_size" -lt "$POST_DEPLOY_SMOKE_LOG_OFFSET" ]; then
+        sample_start_byte=1
+    else
+        sample_start_byte=$((POST_DEPLOY_SMOKE_LOG_OFFSET + 1))
+    fi
+    if ! tail -c "+${sample_start_byte}" "$log_path" \
       | tail -n "$POST_DEPLOY_SMOKE_LOG_LINES" > "$sample_path"; then
         _post_deploy_smoke_fail "fail-closed WARN sample: could not read post-restart log lines" || true
         return 1

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1516,6 +1516,21 @@ _post_deploy_smoke_log_head_fingerprint() {
     case "$byte_count" in
         ''|*[!0-9]*) return 1 ;;
     esac
+    if [ "$byte_count" -eq 0 ]; then
+        if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 < /dev/null \
+                | awk 'NF { print "sha256:" $1; found = 1 } END { if (!found) exit 1 }'
+        elif command -v sha256sum >/dev/null 2>&1; then
+            sha256sum < /dev/null \
+                | awk 'NF { print "sha256:" $1; found = 1 } END { if (!found) exit 1 }'
+        elif command -v cksum >/dev/null 2>&1; then
+            cksum < /dev/null \
+                | awk 'NF >= 2 { print "cksum:" $1 ":" $2; found = 1 } END { if (!found) exit 1 }'
+        else
+            return 1
+        fi
+        return
+    fi
     if command -v shasum >/dev/null 2>&1; then
         head -c "$byte_count" "$log_path" \
             | shasum -a 256 \

--- a/tests/test_deploy_smoke_warn_scope_4511.sh
+++ b/tests/test_deploy_smoke_warn_scope_4511.sh
@@ -21,14 +21,32 @@ extract_function() {
 
 # Exercise the production functions without executing the deploy script.
 eval "$(extract_function _post_deploy_smoke_log_identity_and_size)"
+eval "$(extract_function _post_deploy_smoke_log_head_fingerprint)"
 eval "$(extract_function _post_deploy_smoke_note)"
 eval "$(extract_function _post_deploy_smoke_fail)"
 eval "$(extract_function _post_deploy_smoke_check_fail_closed_warn_rate)"
+
+capture_log_watermark() {
+    local fingerprint_bytes
+    read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+        <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+    fingerprint_bytes="$POST_DEPLOY_SMOKE_LOG_OFFSET"
+    if [ "$fingerprint_bytes" -gt "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP" ]; then
+        fingerprint_bytes="$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP"
+    fi
+    POST_DEPLOY_SMOKE_LOG_FINGERPRINT=$(
+        _post_deploy_smoke_log_head_fingerprint \
+            "$POST_DEPLOY_SMOKE_LOG_PATH" "$fingerprint_bytes"
+    )
+    export POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET
+    export POST_DEPLOY_SMOKE_LOG_FINGERPRINT
+}
 
 ADK_REL="$TMP_ROOT/release"
 POST_DEPLOY_SMOKE_TMP_DIR="$TMP_ROOT/smoke"
 POST_DEPLOY_SMOKE_EVIDENCE="$TMP_ROOT/evidence.log"
 POST_DEPLOY_SMOKE_LOG_PATH="$ADK_REL/logs/dcserver.stdout.log"
+POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP=4096
 POST_DEPLOY_SMOKE_LOG_LINES=500
 POST_DEPLOY_SMOKE_WARN_LIMIT=5
 POST_DEPLOY_SMOKE_FAILURES=()
@@ -42,9 +60,7 @@ mkdir -p "$ADK_REL/logs" "$POST_DEPLOY_SMOKE_TMP_DIR"
 for index in 1 2 3 4 5; do
     printf '2026-07-14T08:03:4%sZ WARN fail-closed stale-before-restart\n' "$index"
 done > "$POST_DEPLOY_SMOKE_LOG_PATH"
-read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
-    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
-export POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET
+capture_log_watermark
 
 printf '%s\n' \
     '2026-07-14T09:16:54Z INFO dcserver started' \
@@ -78,8 +94,7 @@ POST_DEPLOY_SMOKE_FAILURES=()
 for ((index = 1; index <= 40; index++)); do
     printf 'stale-before-truncation-%02d padding-padding-padding-padding-padding\n' "$index"
 done > "$POST_DEPLOY_SMOKE_LOG_PATH"
-read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
-    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+capture_log_watermark
 : > "$POST_DEPLOY_SMOKE_LOG_PATH"
 for index in 1 2 3 4 5; do
     printf '2026-07-14T09:18:0%sZ WARN fail-closed new-after-truncation\n' "$index"
@@ -103,9 +118,34 @@ echo "truncate-then-WARN: $(grep 'sample=5 warn_lines=5 fail_closed_warns=5 thre
 
 POST_DEPLOY_SMOKE_FAILURES=()
 : > "$POST_DEPLOY_SMOKE_EVIDENCE"
-printf 'stale-before-rotation\n' > "$POST_DEPLOY_SMOKE_LOG_PATH"
-read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+printf '%-120s' 'stale-before-truncate-regrow' > "$POST_DEPLOY_SMOKE_LOG_PATH"
+capture_log_watermark
+: > "$POST_DEPLOY_SMOKE_LOG_PATH"
+for index in 1 2 3 4 5; do
+    printf '2026-07-14T09:18:1%sZ WARN fail-closed new-after-truncate-regrow padding-padding\n' "$index"
+done >> "$POST_DEPLOY_SMOKE_LOG_PATH"
+read -r current_inode current_size \
     <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+if [ "$POST_DEPLOY_SMOKE_LOG_OFFSET" -ne 120 ] \
+  || [ "$current_inode" != "$POST_DEPLOY_SMOKE_LOG_INODE" ] \
+  || [ "$current_size" -lt "$POST_DEPLOY_SMOKE_LOG_OFFSET" ]; then
+    echo "FAIL: truncate-regrow fixture did not retain inode and regrow past watermark" >&2
+    exit 1
+fi
+if _post_deploy_smoke_check_fail_closed_warn_rate; then
+    echo "FAIL: WARN spike after same-inode truncate-regrow did not trip the threshold" >&2
+    exit 1
+fi
+if ! grep -q 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: fingerprint reset did not count the full truncate-regrow WARN spike" >&2
+    exit 1
+fi
+echo "truncate-regrow-then-WARN: $(grep 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE")"
+
+POST_DEPLOY_SMOKE_FAILURES=()
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+printf 'stale-before-rotation\n' > "$POST_DEPLOY_SMOKE_LOG_PATH"
+capture_log_watermark
 mv "$POST_DEPLOY_SMOKE_LOG_PATH" "$POST_DEPLOY_SMOKE_LOG_PATH.1"
 for index in 1 2 3 4 5; do
     printf '2026-07-14T09:19:0%sZ WARN fail-closed new-after-rotation padding-padding\n' "$index"

--- a/tests/test_deploy_smoke_warn_scope_4511.sh
+++ b/tests/test_deploy_smoke_warn_scope_4511.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression test for #4511: post-deploy WARN sampling starts at the dcserver
+# restart watermark, excluding stale lines while retaining the spike threshold.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_SH="$REPO_ROOT/scripts/deploy-release.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-smoke-warn-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+extract_function() {
+    local function_name="$1"
+    awk -v start="^${function_name}[(][)] [{]$" '
+        $0 ~ start { printing = 1 }
+        printing { print }
+        printing && /^}$/ { exit }
+    ' "$DEPLOY_SH"
+}
+
+# Exercise the production functions without executing the deploy script.
+eval "$(extract_function _post_deploy_smoke_note)"
+eval "$(extract_function _post_deploy_smoke_fail)"
+eval "$(extract_function _post_deploy_smoke_check_fail_closed_warn_rate)"
+
+ADK_REL="$TMP_ROOT/release"
+POST_DEPLOY_SMOKE_TMP_DIR="$TMP_ROOT/smoke"
+POST_DEPLOY_SMOKE_EVIDENCE="$TMP_ROOT/evidence.log"
+POST_DEPLOY_SMOKE_LOG_PATH="$ADK_REL/logs/dcserver.stdout.log"
+POST_DEPLOY_SMOKE_LOG_LINES=500
+POST_DEPLOY_SMOKE_WARN_LIMIT=5
+POST_DEPLOY_SMOKE_FAILURES=()
+# The production functions loaded through eval consume these test globals;
+# explicit exports/references make that dynamic use visible to ShellCheck.
+export POST_DEPLOY_SMOKE_LOG_LINES POST_DEPLOY_SMOKE_WARN_LIMIT
+: "${POST_DEPLOY_SMOKE_FAILURES[*]-}"
+mkdir -p "$ADK_REL/logs" "$POST_DEPLOY_SMOKE_TMP_DIR"
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+
+for index in 1 2 3 4 5; do
+    printf '2026-07-14T08:03:4%sZ WARN fail-closed stale-before-restart\n' "$index"
+done > "$POST_DEPLOY_SMOKE_LOG_PATH"
+POST_DEPLOY_SMOKE_LOG_OFFSET=$(wc -c < "$POST_DEPLOY_SMOKE_LOG_PATH" | tr -d '[:space:]')
+export POST_DEPLOY_SMOKE_LOG_OFFSET
+
+printf '%s\n' \
+    '2026-07-14T09:16:54Z INFO dcserver started' \
+    '2026-07-14T09:16:55Z INFO startup recovery running' \
+    >> "$POST_DEPLOY_SMOKE_LOG_PATH"
+
+if ! _post_deploy_smoke_check_fail_closed_warn_rate; then
+    echo "FAIL: stale pre-restart WARNs tripped the post-restart sampler" >&2
+    exit 1
+fi
+if ! grep -q 'sample=2 warn_lines=0 fail_closed_warns=0 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: sampler did not exclude stale pre-restart WARNs" >&2
+    exit 1
+fi
+
+for index in 1 2 3 4 5; do
+    printf '2026-07-14T09:17:0%sZ WARN fail-closed new-after-restart\n' "$index"
+done >> "$POST_DEPLOY_SMOKE_LOG_PATH"
+
+if _post_deploy_smoke_check_fail_closed_warn_rate; then
+    echo "FAIL: genuine post-restart WARN spike did not trip the threshold" >&2
+    exit 1
+fi
+if ! grep -q 'sample=7 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: post-restart WARN spike was not counted at the existing threshold" >&2
+    exit 1
+fi
+
+echo "deploy smoke WARN post-restart scope tests passed"

--- a/tests/test_deploy_smoke_warn_scope_4511.sh
+++ b/tests/test_deploy_smoke_warn_scope_4511.sh
@@ -27,16 +27,23 @@ eval "$(extract_function _post_deploy_smoke_fail)"
 eval "$(extract_function _post_deploy_smoke_check_fail_closed_warn_rate)"
 
 capture_log_watermark() {
-    local fingerprint_bytes
-    read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
-        <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+    local fingerprint_bytes fingerprint_path
+    if [ ! -e "$POST_DEPLOY_SMOKE_LOG_PATH" ]; then
+        POST_DEPLOY_SMOKE_LOG_INODE=0
+        POST_DEPLOY_SMOKE_LOG_OFFSET=0
+        fingerprint_path=/dev/null
+    else
+        read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+            <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+        fingerprint_path="$POST_DEPLOY_SMOKE_LOG_PATH"
+    fi
     fingerprint_bytes="$POST_DEPLOY_SMOKE_LOG_OFFSET"
     if [ "$fingerprint_bytes" -gt "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP" ]; then
         fingerprint_bytes="$POST_DEPLOY_SMOKE_LOG_FINGERPRINT_CAP"
     fi
     POST_DEPLOY_SMOKE_LOG_FINGERPRINT=$(
         _post_deploy_smoke_log_head_fingerprint \
-            "$POST_DEPLOY_SMOKE_LOG_PATH" "$fingerprint_bytes"
+            "$fingerprint_path" "$fingerprint_bytes"
     )
     export POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET
     export POST_DEPLOY_SMOKE_LOG_FINGERPRINT
@@ -57,6 +64,37 @@ export POST_DEPLOY_SMOKE_LOG_LINES POST_DEPLOY_SMOKE_WARN_LIMIT
 mkdir -p "$ADK_REL/logs" "$POST_DEPLOY_SMOKE_TMP_DIR"
 : > "$POST_DEPLOY_SMOKE_EVIDENCE"
 
+capture_log_watermark
+if [ "$POST_DEPLOY_SMOKE_LOG_INODE" -ne 0 ] \
+  || [ "$POST_DEPLOY_SMOKE_LOG_OFFSET" -ne 0 ] \
+  || [ -z "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT" ]; then
+    echo "FAIL: absent log did not produce a complete offset-zero watermark" >&2
+    exit 1
+fi
+if [ "$(_post_deploy_smoke_log_head_fingerprint "$POST_DEPLOY_SMOKE_LOG_PATH" 0)" \
+  != "$POST_DEPLOY_SMOKE_LOG_FINGERPRINT" ]; then
+    echo "FAIL: offset-zero fingerprint did not bypass the absent log path" >&2
+    exit 1
+fi
+for index in 1 2 3 4 5; do
+    printf '2026-07-14T09:15:0%sZ WARN fail-closed new-after-absent-log\n' "$index"
+done > "$POST_DEPLOY_SMOKE_LOG_PATH"
+if _post_deploy_smoke_check_fail_closed_warn_rate; then
+    echo "FAIL: WARN spike after an absent-log watermark did not trip the threshold" >&2
+    exit 1
+fi
+if ! grep -q 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: offset-zero sampler did not read the full new log" >&2
+    exit 1
+fi
+if grep -q 'restart log fingerprint unavailable\|could not fingerprint current log' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: offset-zero watermark raised a spurious fingerprint failure" >&2
+    exit 1
+fi
+echo "absent-log-then-WARN: $(grep 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE")"
+
+POST_DEPLOY_SMOKE_FAILURES=()
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
 for index in 1 2 3 4 5; do
     printf '2026-07-14T08:03:4%sZ WARN fail-closed stale-before-restart\n' "$index"
 done > "$POST_DEPLOY_SMOKE_LOG_PATH"

--- a/tests/test_deploy_smoke_warn_scope_4511.sh
+++ b/tests/test_deploy_smoke_warn_scope_4511.sh
@@ -20,6 +20,7 @@ extract_function() {
 }
 
 # Exercise the production functions without executing the deploy script.
+eval "$(extract_function _post_deploy_smoke_log_identity_and_size)"
 eval "$(extract_function _post_deploy_smoke_note)"
 eval "$(extract_function _post_deploy_smoke_fail)"
 eval "$(extract_function _post_deploy_smoke_check_fail_closed_warn_rate)"
@@ -41,8 +42,9 @@ mkdir -p "$ADK_REL/logs" "$POST_DEPLOY_SMOKE_TMP_DIR"
 for index in 1 2 3 4 5; do
     printf '2026-07-14T08:03:4%sZ WARN fail-closed stale-before-restart\n' "$index"
 done > "$POST_DEPLOY_SMOKE_LOG_PATH"
-POST_DEPLOY_SMOKE_LOG_OFFSET=$(wc -c < "$POST_DEPLOY_SMOKE_LOG_PATH" | tr -d '[:space:]')
-export POST_DEPLOY_SMOKE_LOG_OFFSET
+read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+export POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET
 
 printf '%s\n' \
     '2026-07-14T09:16:54Z INFO dcserver started' \
@@ -70,5 +72,59 @@ if ! grep -q 'sample=7 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPL
     echo "FAIL: post-restart WARN spike was not counted at the existing threshold" >&2
     exit 1
 fi
+
+POST_DEPLOY_SMOKE_FAILURES=()
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+for ((index = 1; index <= 40; index++)); do
+    printf 'stale-before-truncation-%02d padding-padding-padding-padding-padding\n' "$index"
+done > "$POST_DEPLOY_SMOKE_LOG_PATH"
+read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+: > "$POST_DEPLOY_SMOKE_LOG_PATH"
+for index in 1 2 3 4 5; do
+    printf '2026-07-14T09:18:0%sZ WARN fail-closed new-after-truncation\n' "$index"
+done >> "$POST_DEPLOY_SMOKE_LOG_PATH"
+read -r current_inode current_size \
+    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+if [ "$current_inode" != "$POST_DEPLOY_SMOKE_LOG_INODE" ] \
+  || [ "$current_size" -ge "$POST_DEPLOY_SMOKE_LOG_OFFSET" ]; then
+    echo "FAIL: truncation fixture did not retain inode and shrink below watermark" >&2
+    exit 1
+fi
+if _post_deploy_smoke_check_fail_closed_warn_rate; then
+    echo "FAIL: WARN spike after in-place truncation did not trip the threshold" >&2
+    exit 1
+fi
+if ! grep -q 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: sampler did not read the full truncated post-restart log" >&2
+    exit 1
+fi
+echo "truncate-then-WARN: $(grep 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE")"
+
+POST_DEPLOY_SMOKE_FAILURES=()
+: > "$POST_DEPLOY_SMOKE_EVIDENCE"
+printf 'stale-before-rotation\n' > "$POST_DEPLOY_SMOKE_LOG_PATH"
+read -r POST_DEPLOY_SMOKE_LOG_INODE POST_DEPLOY_SMOKE_LOG_OFFSET \
+    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+mv "$POST_DEPLOY_SMOKE_LOG_PATH" "$POST_DEPLOY_SMOKE_LOG_PATH.1"
+for index in 1 2 3 4 5; do
+    printf '2026-07-14T09:19:0%sZ WARN fail-closed new-after-rotation padding-padding\n' "$index"
+done > "$POST_DEPLOY_SMOKE_LOG_PATH"
+read -r current_inode current_size \
+    <<< "$(_post_deploy_smoke_log_identity_and_size "$POST_DEPLOY_SMOKE_LOG_PATH")"
+if [ "$current_inode" = "$POST_DEPLOY_SMOKE_LOG_INODE" ] \
+  || [ "$current_size" -lt "$POST_DEPLOY_SMOKE_LOG_OFFSET" ]; then
+    echo "FAIL: rotation fixture did not replace inode with a larger file" >&2
+    exit 1
+fi
+if _post_deploy_smoke_check_fail_closed_warn_rate; then
+    echo "FAIL: WARN spike after log rotation did not trip the threshold" >&2
+    exit 1
+fi
+if ! grep -q 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE"; then
+    echo "FAIL: sampler did not read the full rotated post-restart log" >&2
+    exit 1
+fi
+echo "rotate-then-WARN: $(grep 'sample=5 warn_lines=5 fail_closed_warns=5 threshold=5' "$POST_DEPLOY_SMOKE_EVIDENCE")"
 
 echo "deploy smoke WARN post-restart scope tests passed"


### PR DESCRIPTION
## 이슈 #4511
#4262 post-deploy smoke의 fail-closed WARN-rate 체크가 재시작 이전 stale 로그 라인(마지막 500줄)을 카운트해 오탐 (관측: 재시작 직후 08:03 stale WARN 5건으로 FAIL).

## 수정
- 재시작 직후(구 dcserver 종료 후) 공유 append-only stdout 로그의 **byte offset watermark** 캡처.
- WARN 샘플러는 그 offset 이후 바이트만(`tail -c +offset`) 읽어 마지막 N줄 → **post-restart 라인만** 카운트. watermark 불가 시 fail-closed.
- 메시지도 'post-restart log lines'로.
- `tests/test_deploy_smoke_warn_scope_4511.sh` (74줄): stale 제외 + **진짜 post-restart 스파이크는 여전히 trip** 양방향 증명. ci-script-checks.sh 배선.

## 게이트
deploy syntax rc=0 / test rc=0(stale제외+스파이크trip) / ci-script rc=0(신규 test 실행) / audit rc=0 / freshness passed. fail-open 전체 동작 유지(smoke 실패해도 배포 healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)