### PR TITLE
ops(process): 주간 회귀 churn 감사 스크립트 (#4265)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ routines/monitoring/*
 !routines/monitoring/daily-log-digest.js
 !routines/monitoring/daily_log_digest.py
 !routines/monitoring/log_digest_issue_drafts.py
+!routines/monitoring/weekly_churn_audit.py

--- a/docs/routines/weekly-churn-audit.md
+++ b/docs/routines/weekly-churn-audit.md
@@ -1,0 +1,58 @@
+# Weekly regression-churn audit
+
+Issue #4265 adds the offline `routines/monitoring/weekly_churn_audit.py` cron entry point. It reads
+the local repository's `git log --since='7 days'`, recognizes only conventional `fix:` and
+`fix(scope):` subjects, and counts each fix commit once per changed file and once per containing
+module directory. A file with at least the configured threshold (default `3`) is reported as a
+`재설계 후보`.
+
+References such as `#4262`, `(#4511)`, and references in the commit body are parsed in text order.
+Adjacent references form `#A→#B` edges; edges that meet across squash commits are joined, and the
+longest chain in each connected lineage is reported with its generation count. The audit uses only
+commit text from every commit in the window and the local git object database for this analysis;
+the file/module churn tallies remain restricted to conventional fix commits.
+
+## Weekly cron entry point
+
+The default invocation is a dry run and prints the report to stdout:
+
+```bash
+ROOT="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
+python3 "$ROOT/routines/monitoring/weekly_churn_audit.py" \
+  --repo-root "$ROOT" \
+  --runtime-root "$ROOT"
+```
+
+For example, an operator-managed KST cron can run it at 09:20 every Monday:
+
+```cron
+20 9 * * 1 python3 "$HOME/.adk/release/routines/monitoring/weekly_churn_audit.py" --repo-root "$HOME/.adk/release" --runtime-root "$HOME/.adk/release"
+```
+
+Optional configuration:
+
+- `AGENTDESK_CHURN_AUDIT_THRESHOLD`: positive candidate threshold, default `3`.
+- `AGENTDESK_CHURN_AUDIT_SINCE`: local git window, default `7 days`.
+- `AGENTDESK_CHURN_AUDIT_REPO`: repository used only by confirmed GitHub dedup/creation, default
+  `itismyfield/AgentDesk`.
+- `AGENTDESK_CHURN_AUDIT_API`: local AgentDesk send endpoint, default
+  `http://127.0.0.1:8791/api/discord/send`.
+- `AGENTDESK_CHURN_AUDIT_CHANNEL_ID`: weekly operations channel or thread ID.
+
+## Default-off side effects
+
+Both side-effect paths require a literal, human-set confirmation:
+
+- `AGENTDESK_CHURN_AUDIT_POST_CHANNEL=confirmed` posts the stdout report to
+  `AGENTDESK_CHURN_AUDIT_CHANNEL_ID`. The default is `off`. A successful report fingerprint is
+  stored under `runtime/weekly-churn-audit/post-state.json`, so rerunning an identical weekly report
+  does not post it twice.
+- `AGENTDESK_CHURN_AUDIT_CREATE_ISSUE=confirmed` enables the GitHub open-issue scan and pending
+  draft emission. The default is `off`, so an ordinary run makes no `gh` or network call and writes
+  no draft. If dedup is unavailable or truncated, draft emission fails closed.
+
+Pending drafts use the stable writer shared with the daily log digest and live under
+`runtime/pending-issue-drafts/weekly-churn-audit/`. Confirmation alone does not create an issue:
+the operator must review a draft and add its adjacent `.approved` marker. Only a subsequent run
+with both that marker and `AGENTDESK_CHURN_AUDIT_CREATE_ISSUE=confirmed` can invoke issue creation.
+This is the same two-step human approval boundary used by the sibling daily digest.

--- a/docs/routines/weekly-churn-audit.md
+++ b/docs/routines/weekly-churn-audit.md
@@ -1,16 +1,19 @@
 # Weekly regression-churn audit
 
 Issue #4265 adds the offline `routines/monitoring/weekly_churn_audit.py` cron entry point. It reads
-the local repository's `git log --since='7 days'`, recognizes only conventional `fix:` and
-`fix(scope):` subjects, and counts each fix commit once per changed file and once per containing
-module directory. A file with at least the configured threshold (default `3`) is reported as a
-`재설계 후보`.
+the local repository's `git log --since='7 days'`, recognizes conventional `fix:` and
+`fix(scope):` subjects (including the optional breaking-change `!` marker), and counts each fix
+commit once per changed file and once per containing module directory. A file with at least the
+configured threshold (default `3`) is reported as a `재설계 후보`.
 
-References such as `#4262`, `(#4511)`, and references in the commit body are parsed in text order.
-Adjacent references form `#A→#B` edges; edges that meet across squash commits are joined, and the
-longest chain in each connected lineage is reported with its generation count. The audit uses only
-commit text from every commit in the window and the local git object database for this analysis;
-the file/module churn tallies remain restricted to conventional fix commits.
+Genuine issue references such as a leading `#4262` and references in the commit body are parsed in
+text order. Terminal squash-merge PR suffixes such as `(#4511) (#4523)` are removed from the
+subject before parsing, so they never become regression generations. Adjacent remaining references
+form `#A→#B` edges; edges that meet across commits are joined, and the longest chain in each
+connected lineage is reported with its generation count. Lineage path exploration is bounded and
+logs a warning if a dense component must be truncated. The audit uses only commit text from every
+commit in the window and the local git object database for this analysis; the file/module churn
+tallies remain restricted to conventional fix commits.
 
 ## Weekly cron entry point
 
@@ -31,7 +34,8 @@ For example, an operator-managed KST cron can run it at 09:20 every Monday:
 
 Optional configuration:
 
-- `AGENTDESK_CHURN_AUDIT_THRESHOLD`: positive candidate threshold, default `3`.
+- `AGENTDESK_CHURN_AUDIT_THRESHOLD`: positive candidate threshold, default `3`. Invalid values log
+  a warning and fall back to the default.
 - `AGENTDESK_CHURN_AUDIT_SINCE`: local git window, default `7 days`.
 - `AGENTDESK_CHURN_AUDIT_REPO`: repository used only by confirmed GitHub dedup/creation, default
   `itismyfield/AgentDesk`.
@@ -55,4 +59,6 @@ Pending drafts use the stable writer shared with the daily log digest and live u
 `runtime/pending-issue-drafts/weekly-churn-audit/`. Confirmation alone does not create an issue:
 the operator must review a draft and add its adjacent `.approved` marker. Only a subsequent run
 with both that marker and `AGENTDESK_CHURN_AUDIT_CREATE_ISSUE=confirmed` can invoke issue creation.
-This is the same two-step human approval boundary used by the sibling daily digest.
+Created drafts include a stable per-file `churn-audit:candidate` marker; later runs use that exact
+marker to suppress duplicates while the issue remains open. This is the same two-step human
+approval boundary used by the sibling daily digest.

--- a/routines/monitoring/weekly_churn_audit.py
+++ b/routines/monitoring/weekly_churn_audit.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Audit one week of repeated fix churn and flag redesign candidates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable, Mapping, Sequence
+
+from daily_log_digest import (
+    REPOSITORY,
+    create_github_issue,
+    load_open_issues,
+    runtime_root,
+)
+from log_digest_issue_drafts import (
+    CONFIRMED_APPROVAL,
+    IssueDraft,
+    OpenIssue,
+    PostDecision,
+    issue_matches_signature,
+    maybe_post_approved_drafts,
+    write_pending_drafts,
+)
+
+
+DEFAULT_THRESHOLD = 3
+DEFAULT_SINCE = "7 days"
+DEFAULT_API_URL = "http://127.0.0.1:8791/api/discord/send"
+_FIX_SUBJECT_RE = re.compile(r"^fix(?:\([^)\r\n]+\))?:")
+_ISSUE_REFERENCE_RE = re.compile(r"(?<![\w#])#([1-9]\d*)\b")
+
+
+@dataclass(frozen=True)
+class GitCommit:
+    sha: str
+    subject: str
+    body: str
+    files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ChurnCandidate:
+    file: str
+    count: int
+    commits: tuple[GitCommit, ...]
+
+
+@dataclass(frozen=True)
+class IssueLineage:
+    issues: tuple[int, ...]
+
+    @property
+    def generations(self) -> int:
+        return len(self.issues)
+
+
+@dataclass(frozen=True)
+class ChurnAudit:
+    since: str
+    threshold: int
+    fix_commits: tuple[GitCommit, ...]
+    file_counts: Mapping[str, int]
+    module_counts: Mapping[str, int]
+    candidates: tuple[ChurnCandidate, ...]
+    lineages: tuple[IssueLineage, ...]
+
+
+def is_fix_commit_subject(subject: str) -> bool:
+    """Recognize only conventional ``fix:`` and ``fix(scope):`` subjects."""
+
+    return _FIX_SUBJECT_RE.match(subject) is not None
+
+
+def issue_references(subject: str, body: str = "") -> tuple[int, ...]:
+    """Return issue references in commit-text order, removing repeats."""
+
+    ordered: list[int] = []
+    seen: set[int] = set()
+    for match in _ISSUE_REFERENCE_RE.finditer(f"{subject}\n{body}"):
+        number = int(match.group(1))
+        if number not in seen:
+            seen.add(number)
+            ordered.append(number)
+    return tuple(ordered)
+
+
+def module_for_file(file: str) -> str:
+    """Map a file to its containing repo-relative module directory."""
+
+    path = PurePosixPath(file)
+    if path.name == "mod.rs":
+        return str(path.parent)
+    if str(path.parent) != ".":
+        return str(path.parent)
+    return path.stem
+
+
+def _git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _require_git(result: subprocess.CompletedProcess[str], operation: str) -> str:
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"git exited {result.returncode}"
+        raise RuntimeError(f"could not {operation}: {detail}")
+    return result.stdout
+
+
+def collect_git_commits(repo_root: Path, since: str = DEFAULT_SINCE) -> list[GitCommit]:
+    """Collect commit text and changed paths from the requested local git window."""
+
+    log = _require_git(
+        _git(repo_root, ["log", f"--since={since}", "--format=%H"]),
+        "read weekly git log",
+    )
+    commits: list[GitCommit] = []
+    for sha in (line.strip() for line in log.splitlines() if line.strip()):
+        text = _require_git(
+            _git(repo_root, ["show", "-s", "--format=%s%x00%b", sha]),
+            f"read commit text for {sha}",
+        )
+        subject, separator, body = text.rstrip("\n").partition("\x00")
+        if not separator:
+            raise RuntimeError(f"could not parse commit text for {sha}")
+        if not is_fix_commit_subject(subject):
+            commits.append(GitCommit(sha=sha, subject=subject, body=body.strip(), files=()))
+            continue
+        changed = _require_git(
+            _git(
+                repo_root,
+                ["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", sha],
+            ),
+            f"read changed files for {sha}",
+        )
+        files = tuple(sorted({line for line in changed.splitlines() if line}))
+        commits.append(GitCommit(sha=sha, subject=subject, body=body.strip(), files=files))
+    return commits
+
+
+def _longest_lineage(
+    component: set[int], edges: Mapping[int, set[int]]
+) -> tuple[int, ...]:
+    best: tuple[int, ...] = ()
+
+    def visit(node: int, path: tuple[int, ...]) -> None:
+        nonlocal best
+        extended = (*path, node)
+        if len(extended) > len(best) or (len(extended) == len(best) and extended < best):
+            best = extended
+        for child in sorted(edges.get(node, set())):
+            if child not in extended:
+                visit(child, extended)
+
+    for start in sorted(component):
+        visit(start, ())
+    return best
+
+
+def compute_issue_lineages(commits: Sequence[GitCommit]) -> tuple[IssueLineage, ...]:
+    """Merge commit-text #A→#B edges and report the longest chain per component."""
+
+    nodes: set[int] = set()
+    edges: dict[int, set[int]] = {}
+    neighbours: dict[int, set[int]] = {}
+    for commit in commits:
+        references = issue_references(commit.subject, commit.body)
+        nodes.update(references)
+        for parent, child in zip(references, references[1:]):
+            edges.setdefault(parent, set()).add(child)
+            neighbours.setdefault(parent, set()).add(child)
+            neighbours.setdefault(child, set()).add(parent)
+
+    lineages: list[IssueLineage] = []
+    unseen = set(nodes)
+    while unseen:
+        first = min(unseen)
+        component: set[int] = set()
+        pending = [first]
+        while pending:
+            node = pending.pop()
+            if node in component:
+                continue
+            component.add(node)
+            pending.extend(neighbours.get(node, set()) - component)
+        unseen -= component
+        lineages.append(IssueLineage(_longest_lineage(component, edges)))
+    return tuple(sorted(lineages, key=lambda item: (-item.generations, item.issues)))
+
+
+def analyze_churn(
+    commits: Sequence[GitCommit],
+    *,
+    since: str = DEFAULT_SINCE,
+    threshold: int = DEFAULT_THRESHOLD,
+) -> ChurnAudit:
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+
+    fix_commits = tuple(commit for commit in commits if is_fix_commit_subject(commit.subject))
+    file_counts: Counter[str] = Counter()
+    module_counts: Counter[str] = Counter()
+    commits_by_file: dict[str, list[GitCommit]] = {}
+    for commit in fix_commits:
+        unique_files = set(commit.files)
+        file_counts.update(unique_files)
+        module_counts.update({module_for_file(file) for file in unique_files})
+        for file in unique_files:
+            commits_by_file.setdefault(file, []).append(commit)
+
+    candidates = tuple(
+        ChurnCandidate(file=file, count=count, commits=tuple(commits_by_file[file]))
+        for file, count in sorted(file_counts.items(), key=lambda item: (-item[1], item[0]))
+        if count >= threshold
+    )
+    return ChurnAudit(
+        since=since,
+        threshold=threshold,
+        fix_commits=fix_commits,
+        file_counts=dict(file_counts),
+        module_counts=dict(module_counts),
+        candidates=candidates,
+        lineages=compute_issue_lineages(commits),
+    )
+
+
+def _candidate_signature(candidate: ChurnCandidate) -> str:
+    return f"repeated fix churn redesign candidate {candidate.file}"
+
+
+def build_candidate_draft(candidate: ChurnCandidate, since: str, threshold: int) -> IssueDraft:
+    evidence = [
+        f"- `{commit.sha[:12]}` {commit.subject}" for commit in candidate.commits
+    ]
+    body = "\n".join(
+        [
+            "# 주간 회귀 churn 재설계 후보",
+            "",
+            "This is a pending draft generated for human review. It has not been posted to GitHub.",
+            "",
+            f"- File: `{candidate.file}`",
+            f"- Window: `git log --since={since!r}`",
+            f"- Fix commits: `{candidate.count}`",
+            f"- Candidate threshold: `>={threshold}`",
+            "",
+            "## Fix lineage evidence",
+            "",
+            *evidence,
+            "",
+            "## Human review",
+            "",
+            "Confirm the recurring failure model, intended ownership, and redesign boundary before approval.",
+        ]
+    )
+    return IssueDraft(
+        severity="CHURN",
+        signature=_candidate_signature(candidate),
+        count=candidate.count,
+        title=f"ops(process): redesign candidate for {candidate.file}",
+        body=body,
+    )
+
+
+def candidate_drafts(
+    candidates: Sequence[ChurnCandidate],
+    open_issues: Sequence[OpenIssue],
+    *,
+    since: str,
+    threshold: int,
+    dedup_available: bool = True,
+) -> tuple[list[IssueDraft], list[tuple[ChurnCandidate, OpenIssue]]]:
+    """Build drafts only when the complete open-issue dedup authority is available."""
+
+    drafts: list[IssueDraft] = []
+    matches: list[tuple[ChurnCandidate, OpenIssue]] = []
+    for candidate in candidates:
+        matching = next(
+            (
+                issue
+                for issue in open_issues
+                if issue_matches_signature(_candidate_signature(candidate), issue)
+            ),
+            None,
+        )
+        if matching is not None:
+            matches.append((candidate, matching))
+        elif dedup_available:
+            drafts.append(build_candidate_draft(candidate, since, threshold))
+    return drafts, matches
+
+
+def format_report(audit: ChurnAudit, notes: Sequence[str] = ()) -> str:
+    lines = [
+        f"📈 AgentDesk 주간 회귀 churn 감사 — git log --since={audit.since!r}",
+        f"Fix commits: {len(audit.fix_commits)} | 재설계 후보 threshold: >={audit.threshold}",
+        "",
+        f"재설계 후보 ({len(audit.candidates)}):",
+    ]
+    if audit.candidates:
+        lines.extend(f"- {item.count}× `{item.file}`" for item in audit.candidates)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", f"파일별 fix-commit tally ({len(audit.file_counts)}):"])
+    if audit.file_counts:
+        lines.extend(
+            f"- {count}× `{file}`"
+            for file, count in sorted(
+                audit.file_counts.items(), key=lambda item: (-item[1], item[0])
+            )
+        )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", f"모듈별 fix-commit tally ({len(audit.module_counts)}):"])
+    if audit.module_counts:
+        lines.extend(
+            f"- {count}× `{module}`"
+            for module, count in sorted(
+                audit.module_counts.items(), key=lambda item: (-item[1], item[0])
+            )
+        )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", f"Issue-reference lineages ({len(audit.lineages)}):"])
+    if audit.lineages:
+        lines.extend(
+            f"- generations={lineage.generations}: "
+            + "→".join(f"#{issue}" for issue in lineage.issues)
+            for lineage in audit.lineages
+        )
+    else:
+        lines.append("- none")
+    lines.extend(["", *(f"⚠ {note}" for note in notes)])
+    return "\n".join(lines).rstrip()
+
+
+def _post_report(api_url: str, channel_id: str, report: str) -> None:
+    payload = json.dumps(
+        {
+            "target": f"channel:{channel_id}",
+            "content": report,
+            "source": "weekly-churn-audit",
+            "bot": "notify",
+        }
+    ).encode()
+    request = urllib.request.Request(
+        api_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        response_payload = json.loads(response.read().decode())
+    if not isinstance(response_payload, dict) or response_payload.get("ok") is not True:
+        raise RuntimeError(f"AgentDesk channel post rejected: {response_payload!r}")
+
+
+def maybe_post_weekly_channel(
+    report: str,
+    approval_mode: str,
+    channel_id: str | None,
+    state_path: Path,
+    post_report: Callable[[str], None],
+) -> tuple[bool, str]:
+    """Post once per report fingerprint, and only behind literal confirmation."""
+
+    if approval_mode != CONFIRMED_APPROVAL:
+        return False, "weekly ops channel post disabled"
+    if not channel_id:
+        return False, "channel post confirmed but AGENTDESK_CHURN_AUDIT_CHANNEL_ID is unset"
+
+    fingerprint = hashlib.sha256(report.encode()).hexdigest()
+    try:
+        prior = json.loads(state_path.read_text(encoding="utf-8")) if state_path.is_file() else {}
+    except (OSError, json.JSONDecodeError):
+        prior = {}
+    if isinstance(prior, dict) and prior.get("fingerprint") == fingerprint:
+        return False, "identical weekly report already posted"
+
+    post_report(report)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = state_path.with_suffix(".tmp")
+    temporary.write_text(json.dumps({"fingerprint": fingerprint}) + "\n", encoding="utf-8")
+    temporary.replace(state_path)
+    return True, "weekly ops channel report posted"
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    script_repo_root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=script_repo_root)
+    parser.add_argument("--runtime-root", type=Path, default=runtime_root())
+    parser.add_argument(
+        "--repo", default=os.environ.get("AGENTDESK_CHURN_AUDIT_REPO", REPOSITORY)
+    )
+    parser.add_argument(
+        "--since", default=os.environ.get("AGENTDESK_CHURN_AUDIT_SINCE", DEFAULT_SINCE)
+    )
+    parser.add_argument(
+        "--threshold",
+        type=positive_int,
+        default=positive_int(
+            os.environ.get("AGENTDESK_CHURN_AUDIT_THRESHOLD", str(DEFAULT_THRESHOLD))
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    audit = analyze_churn(
+        collect_git_commits(args.repo_root, args.since),
+        since=args.since,
+        threshold=args.threshold,
+    )
+    notes: list[str] = []
+
+    issue_mode = os.environ.get("AGENTDESK_CHURN_AUDIT_CREATE_ISSUE", "off")
+    if issue_mode == CONFIRMED_APPROVAL:
+        open_issues, dedup_warning = load_open_issues(args.repo)
+        if dedup_warning:
+            notes.append(dedup_warning)
+        proposed, matches = candidate_drafts(
+            audit.candidates,
+            open_issues,
+            since=args.since,
+            threshold=args.threshold,
+            dedup_available=dedup_warning is None,
+        )
+        pending_dir = (
+            args.runtime_root / "runtime" / "pending-issue-drafts" / "weekly-churn-audit"
+        )
+        drafts = write_pending_drafts(proposed, pending_dir)
+        if matches:
+            notes.append(
+                "open-issue dedup matched: "
+                + ", ".join(f"{item.file}→#{issue.number}" for item, issue in matches)
+            )
+        post: PostDecision = maybe_post_approved_drafts(
+            drafts,
+            issue_mode,
+            lambda draft: create_github_issue(args.repo, draft),
+        )
+        notes.append(
+            "pending drafts: "
+            + (", ".join(str(draft.path) for draft in drafts) if drafts else "none")
+        )
+        if not post.attempted:
+            notes.append(post.reason)
+        elif post.created_urls:
+            notes.append("human-confirmed issues created: " + ", ".join(post.created_urls))
+    elif issue_mode == "off":
+        notes.append(
+            "issue drafts dry-run only; set AGENTDESK_CHURN_AUDIT_CREATE_ISSUE=confirmed "
+            "to dedup and emit human-review drafts"
+        )
+    else:
+        notes.append(
+            "invalid AGENTDESK_CHURN_AUDIT_CREATE_ISSUE value ignored; "
+            "use literal 'confirmed' or 'off'"
+        )
+
+    report = format_report(audit, notes)
+    channel_mode = os.environ.get("AGENTDESK_CHURN_AUDIT_POST_CHANNEL", "off")
+    try:
+        posted, channel_note = maybe_post_weekly_channel(
+            report,
+            channel_mode,
+            os.environ.get("AGENTDESK_CHURN_AUDIT_CHANNEL_ID"),
+            args.runtime_root / "runtime" / "weekly-churn-audit" / "post-state.json",
+            lambda content: _post_report(
+                os.environ.get("AGENTDESK_CHURN_AUDIT_API", DEFAULT_API_URL),
+                os.environ.get("AGENTDESK_CHURN_AUDIT_CHANNEL_ID", ""),
+                content,
+            ),
+        )
+    except (OSError, RuntimeError, ValueError, urllib.error.URLError) as error:
+        posted, channel_note = False, f"weekly ops channel post failed: {error}"
+    if channel_mode not in {"off", CONFIRMED_APPROVAL}:
+        channel_note = (
+            "invalid AGENTDESK_CHURN_AUDIT_POST_CHANNEL value ignored; "
+            "use literal 'confirmed' or 'off'"
+        )
+    if posted or channel_mode != "off":
+        report = f"{report}\n⚠ {channel_note}"
+
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/routines/monitoring/weekly_churn_audit.py
+++ b/routines/monitoring/weekly_churn_audit.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 from collections import Counter
@@ -27,7 +28,6 @@ from log_digest_issue_drafts import (
     IssueDraft,
     OpenIssue,
     PostDecision,
-    issue_matches_signature,
     maybe_post_approved_drafts,
     write_pending_drafts,
 )
@@ -36,8 +36,10 @@ from log_digest_issue_drafts import (
 DEFAULT_THRESHOLD = 3
 DEFAULT_SINCE = "7 days"
 DEFAULT_API_URL = "http://127.0.0.1:8791/api/discord/send"
-_FIX_SUBJECT_RE = re.compile(r"^fix(?:\([^)\r\n]+\))?:")
+LINEAGE_PATH_STATE_LIMIT = 10_000
+_FIX_SUBJECT_RE = re.compile(r"^fix(?:\([^)\r\n]+\))?!?:")
 _ISSUE_REFERENCE_RE = re.compile(r"(?<![\w#])#([1-9]\d*)\b")
+_SQUASH_PR_SUFFIX_RE = re.compile(r"(?:\s+\(#[1-9]\d*\))+\s*$")
 
 
 @dataclass(frozen=True)
@@ -76,17 +78,18 @@ class ChurnAudit:
 
 
 def is_fix_commit_subject(subject: str) -> bool:
-    """Recognize only conventional ``fix:`` and ``fix(scope):`` subjects."""
+    """Recognize conventional fix subjects, including breaking-change markers."""
 
     return _FIX_SUBJECT_RE.match(subject) is not None
 
 
 def issue_references(subject: str, body: str = "") -> tuple[int, ...]:
-    """Return issue references in commit-text order, removing repeats."""
+    """Return genuine issue references in text order, excluding squash PR suffixes."""
 
     ordered: list[int] = []
     seen: set[int] = set()
-    for match in _ISSUE_REFERENCE_RE.finditer(f"{subject}\n{body}"):
+    issue_text = f"{_SQUASH_PR_SUFFIX_RE.sub('', subject)}\n{body}"
+    for match in _ISSUE_REFERENCE_RE.finditer(issue_text):
         number = int(match.group(1))
         if number not in seen:
             seen.add(number)
@@ -105,12 +108,18 @@ def module_for_file(file: str) -> str:
     return path.stem
 
 
+def log(message: str) -> None:
+    print(f"weekly-churn-audit: {message}", file=sys.stderr)
+
+
 def _git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", "-C", str(repo_root), *args],
         check=False,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
 
 
@@ -156,18 +165,28 @@ def _longest_lineage(
     component: set[int], edges: Mapping[int, set[int]]
 ) -> tuple[int, ...]:
     best: tuple[int, ...] = ()
-
-    def visit(node: int, path: tuple[int, ...]) -> None:
-        nonlocal best
+    starts = sorted(component)
+    pending = [(node, ()) for node in reversed(starts[:LINEAGE_PATH_STATE_LIMIT])]
+    scheduled = len(pending)
+    truncated = len(starts) > LINEAGE_PATH_STATE_LIMIT
+    while pending:
+        node, path = pending.pop()
         extended = (*path, node)
         if len(extended) > len(best) or (len(extended) == len(best) and extended < best):
             best = extended
-        for child in sorted(edges.get(node, set())):
-            if child not in extended:
-                visit(child, extended)
-
-    for start in sorted(component):
-        visit(start, ())
+        for child in reversed(sorted(edges.get(node, set()))):
+            if child in extended:
+                continue
+            if scheduled >= LINEAGE_PATH_STATE_LIMIT:
+                truncated = True
+                break
+            pending.append((child, extended))
+            scheduled += 1
+    if truncated:
+        log(
+            "issue-lineage search truncated at "
+            f"{LINEAGE_PATH_STATE_LIMIT} path states for a {len(component)}-issue component"
+        )
     return best
 
 
@@ -238,8 +257,8 @@ def analyze_churn(
     )
 
 
-def _candidate_signature(candidate: ChurnCandidate) -> str:
-    return f"repeated fix churn redesign candidate {candidate.file}"
+def _candidate_marker(candidate: ChurnCandidate) -> str:
+    return f"<!-- churn-audit:candidate={candidate.file} -->"
 
 
 def build_candidate_draft(candidate: ChurnCandidate, since: str, threshold: int) -> IssueDraft:
@@ -248,6 +267,7 @@ def build_candidate_draft(candidate: ChurnCandidate, since: str, threshold: int)
     ]
     body = "\n".join(
         [
+            _candidate_marker(candidate),
             "# 주간 회귀 churn 재설계 후보",
             "",
             "This is a pending draft generated for human review. It has not been posted to GitHub.",
@@ -268,7 +288,7 @@ def build_candidate_draft(candidate: ChurnCandidate, since: str, threshold: int)
     )
     return IssueDraft(
         severity="CHURN",
-        signature=_candidate_signature(candidate),
+        signature=_candidate_marker(candidate),
         count=candidate.count,
         title=f"ops(process): redesign candidate for {candidate.file}",
         body=body,
@@ -292,7 +312,7 @@ def candidate_drafts(
             (
                 issue
                 for issue in open_issues
-                if issue_matches_signature(_candidate_signature(candidate), issue)
+                if _candidate_marker(candidate) in issue.body
             ),
             None,
         )
@@ -408,8 +428,23 @@ def positive_int(value: str) -> int:
     return parsed
 
 
+def threshold_from_env(value: str | None) -> tuple[int, str | None]:
+    configured = value if value is not None else str(DEFAULT_THRESHOLD)
+    try:
+        return positive_int(configured), None
+    except (ValueError, argparse.ArgumentTypeError):
+        return (
+            DEFAULT_THRESHOLD,
+            "invalid AGENTDESK_CHURN_AUDIT_THRESHOLD "
+            f"value {configured!r}; using default {DEFAULT_THRESHOLD}",
+        )
+
+
 def parse_args() -> argparse.Namespace:
     script_repo_root = Path(__file__).resolve().parents[2]
+    env_threshold, threshold_warning = threshold_from_env(
+        os.environ.get("AGENTDESK_CHURN_AUDIT_THRESHOLD")
+    )
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=script_repo_root)
     parser.add_argument("--runtime-root", type=Path, default=runtime_root())
@@ -422,11 +457,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--threshold",
         type=positive_int,
-        default=positive_int(
-            os.environ.get("AGENTDESK_CHURN_AUDIT_THRESHOLD", str(DEFAULT_THRESHOLD))
-        ),
+        default=None,
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.threshold is None:
+        args.threshold = env_threshold
+        if threshold_warning:
+            log(threshold_warning)
+    return args
 
 
 def main() -> int:

--- a/routines/monitoring/weekly_churn_audit.py
+++ b/routines/monitoring/weekly_churn_audit.py
@@ -39,6 +39,9 @@ DEFAULT_API_URL = "http://127.0.0.1:8791/api/discord/send"
 LINEAGE_PATH_STATE_LIMIT = 10_000
 _FIX_SUBJECT_RE = re.compile(r"^fix(?:\([^)\r\n]+\))?!?:")
 _ISSUE_REFERENCE_RE = re.compile(r"(?<![\w#])#([1-9]\d*)\b")
+# Trailing (#N) groups are GitHub squash-merge PR numbers and are intentionally
+# excluded from lineage; including them would reintroduce the original
+# PR-number-as-generation bug.
 _SQUASH_PR_SUFFIX_RE = re.compile(r"(?:\s+\(#[1-9]\d*\))+\s*$")
 
 
@@ -133,12 +136,12 @@ def _require_git(result: subprocess.CompletedProcess[str], operation: str) -> st
 def collect_git_commits(repo_root: Path, since: str = DEFAULT_SINCE) -> list[GitCommit]:
     """Collect commit text and changed paths from the requested local git window."""
 
-    log = _require_git(
+    log_output = _require_git(
         _git(repo_root, ["log", f"--since={since}", "--format=%H"]),
         "read weekly git log",
     )
     commits: list[GitCommit] = []
-    for sha in (line.strip() for line in log.splitlines() if line.strip()):
+    for sha in (line.strip() for line in log_output.splitlines() if line.strip()):
         text = _require_git(
             _git(repo_root, ["show", "-s", "--format=%s%x00%b", sha]),
             f"read commit text for {sha}",

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -72,6 +72,9 @@ echo "=== Daily log-digest routine tests (#4263) ==="
 node --test policies/__tests__/daily-log-digest.test.js
 "$PYTHON" -m unittest tests.test_daily_log_digest
 
+echo "=== Weekly regression-churn audit tests (#4265) ==="
+"$PYTHON" -m unittest tests.test_weekly_churn_audit
+
 echo "=== await_holding_lock ratchet guard ==="
 "$PYTHON" scripts/check_await_holding_lock_ratchet.py
 "$PYTHON" -m unittest tests.test_await_holding_lock_ratchet

--- a/tests/test_weekly_churn_audit.py
+++ b/tests/test_weekly_churn_audit.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -18,7 +19,7 @@ ROUTINE_DIR = ROOT / "routines" / "monitoring"
 sys.path.insert(0, str(ROUTINE_DIR))
 
 import weekly_churn_audit  # noqa: E402
-from log_digest_issue_drafts import OpenIssue  # noqa: E402
+from log_digest_issue_drafts import OpenIssue, stable_draft_filename  # noqa: E402
 from weekly_churn_audit import (  # noqa: E402
     GitCommit,
     analyze_churn,
@@ -45,6 +46,8 @@ class WeeklyChurnAuditTests(unittest.TestCase):
         for subject in (
             "fix: stop duplicate relay",
             "fix(discord): stop duplicate relay",
+            "fix!: stop breaking duplicate relay",
+            "fix(discord)!: stop breaking duplicate relay",
         ):
             with self.subTest(subject=subject):
                 self.assertTrue(is_fix_commit_subject(subject))
@@ -77,19 +80,18 @@ class WeeklyChurnAuditTests(unittest.TestCase):
         self.assertEqual([candidate.file for candidate in audit.candidates], [repeated])
         self.assertEqual(audit.module_counts["src/services/discord"], 3)
 
-    def test_squash_subject_parses_all_issue_references_in_order(self) -> None:
-        subject = (
-            "fix(deploy): #4262 post-deploy scope (#4511) (#4523)"
-        )
+    def test_squash_pr_suffixes_do_not_create_issue_generations(self) -> None:
+        subject = "fix(deploy): #4262 post-deploy scope (#4511) (#4523)"
 
         self.assertTrue(is_fix_commit_subject(subject))
-        self.assertEqual(issue_references(subject), (4262, 4511, 4523))
+        self.assertEqual(issue_references(subject), (4262,))
+        self.assertEqual(compute_issue_lineages([commit(subject)])[0].issues, (4262,))
 
     def test_issue_lineage_generation_count_spans_commit_text_edges(self) -> None:
         commits = [
-            commit("fix: first regression (#100) (#200)"),
-            commit("fix: follow-up (#200)", body="Regression-of cross-reference: #300"),
-            commit("fix: independent (#900)"),
+            commit("fix: #100 first regression", body="Regression-of cross-reference: #200"),
+            commit("fix: #200 follow-up", body="Regression-of cross-reference: #300"),
+            commit("fix: independent #900"),
         ]
 
         lineages = compute_issue_lineages(commits)
@@ -106,26 +108,155 @@ class WeeklyChurnAuditTests(unittest.TestCase):
             ],
             threshold=3,
         ).candidates[0]
-        matching = OpenIssue(
-            number=4265,
-            title=(
-                "ops(process): repeated fix churn redesign candidate "
-                "src/services/discord/example.rs"
-            ),
-        )
+        created = weekly_churn_audit.build_candidate_draft(candidate, "7 days", 3)
+        matching = OpenIssue(number=4265, title=created.title, body=created.body)
 
-        with patch.object(
-            weekly_churn_audit,
-            "issue_matches_signature",
-            wraps=weekly_churn_audit.issue_matches_signature,
-        ) as matcher:
-            drafts, matches = candidate_drafts(
-                [candidate], [matching], since="7 days", threshold=3
-            )
+        drafts, matches = candidate_drafts(
+            [candidate], [matching], since="7 days", threshold=3
+        )
 
         self.assertEqual(drafts, [])
         self.assertEqual(matches, [(candidate, matching)])
-        matcher.assert_called_once()
+
+    def test_created_issue_marker_prevents_duplicate_on_second_run(self) -> None:
+        audit_commits = [
+            commit(f"fix: repeat {index}", ("justfile",), sha=str(index) * 40)
+            for index in range(1, 4)
+        ]
+        candidate = analyze_churn(audit_commits, threshold=3).candidates[0]
+        draft = weekly_churn_audit.build_candidate_draft(candidate, "7 days", 3)
+        open_issues: list[OpenIssue] = []
+
+        def load_open(_repo: str) -> tuple[list[OpenIssue], None]:
+            return list(open_issues), None
+
+        def create_issue(_repo: str, approved) -> str:
+            open_issues.append(
+                OpenIssue(number=4265, title=approved.title, body=approved.body)
+            )
+            return "https://example.test/issues/4265"
+
+        with tempfile.TemporaryDirectory() as temp:
+            pending = (
+                Path(temp)
+                / "runtime"
+                / "pending-issue-drafts"
+                / "weekly-churn-audit"
+            )
+            pending.mkdir(parents=True)
+            draft_name = stable_draft_filename(draft)
+            Path(f"{pending / draft_name}.approved").touch()
+            argv = [
+                "weekly_churn_audit.py",
+                "--repo-root",
+                str(ROOT),
+                "--runtime-root",
+                temp,
+            ]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.dict(
+                    os.environ,
+                    {"AGENTDESK_CHURN_AUDIT_CREATE_ISSUE": "confirmed"},
+                    clear=True,
+                ),
+                patch.object(
+                    weekly_churn_audit,
+                    "collect_git_commits",
+                    return_value=audit_commits,
+                ),
+                patch.object(
+                    weekly_churn_audit, "load_open_issues", side_effect=load_open
+                ),
+                patch.object(
+                    weekly_churn_audit, "create_github_issue", side_effect=create_issue
+                ) as create,
+                redirect_stdout(StringIO()),
+            ):
+                self.assertEqual(weekly_churn_audit.main(), 0)
+                self.assertEqual(weekly_churn_audit.main(), 0)
+
+        create.assert_called_once()
+
+    def test_git_replaces_non_utf8_commit_text(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo = Path(temp)
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.name", "Audit Test"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.email", "audit@example.test"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo),
+                    "config",
+                    "i18n.commitEncoding",
+                    "ISO-8859-1",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo),
+                    "config",
+                    "i18n.logOutputEncoding",
+                    "ISO-8859-1",
+                ],
+                check=True,
+            )
+            (repo / "sample.txt").write_text("sample\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "sample.txt"], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "commit", "-q", "-F", "-"],
+                input=b"fix: latin-1 \xff message\n",
+                check=True,
+            )
+
+            commits = weekly_churn_audit.collect_git_commits(repo, "7 days")
+
+        self.assertEqual(len(commits), 1)
+        self.assertIn("\ufffd", commits[0].subject)
+        self.assertEqual(commits[0].files, ("sample.txt",))
+
+    def test_invalid_env_thresholds_fall_back_and_log(self) -> None:
+        for value in ("abc", "0", "-1"):
+            with (
+                self.subTest(value=value),
+                patch.object(sys, "argv", ["weekly_churn_audit.py"]),
+                patch.dict(
+                    os.environ,
+                    {"AGENTDESK_CHURN_AUDIT_THRESHOLD": value},
+                    clear=True,
+                ),
+                patch.object(weekly_churn_audit, "log") as audit_log,
+            ):
+                args = weekly_churn_audit.parse_args()
+
+            self.assertEqual(args.threshold, weekly_churn_audit.DEFAULT_THRESHOLD)
+            audit_log.assert_called_once()
+            self.assertIn(value, audit_log.call_args.args[0])
+
+    def test_dense_cyclic_lineage_search_is_bounded_and_logged(self) -> None:
+        component = set(range(1, 8))
+        edges = {node: component - {node} for node in component}
+        with (
+            patch.object(weekly_churn_audit, "LINEAGE_PATH_STATE_LIMIT", 25),
+            patch.object(weekly_churn_audit, "log") as audit_log,
+        ):
+            lineage = weekly_churn_audit._longest_lineage(component, edges)
+
+        self.assertTrue(lineage)
+        self.assertLessEqual(len(lineage), len(component))
+        audit_log.assert_called_once()
+        self.assertIn("truncated at 25 path states", audit_log.call_args.args[0])
 
     def test_channel_post_gate_is_default_off_and_confirmed_is_idempotent(self) -> None:
         calls: list[str] = []

--- a/tests/test_weekly_churn_audit.py
+++ b/tests/test_weekly_churn_audit.py
@@ -86,6 +86,11 @@ class WeeklyChurnAuditTests(unittest.TestCase):
         self.assertTrue(is_fix_commit_subject(subject))
         self.assertEqual(issue_references(subject), (4262,))
         self.assertEqual(compute_issue_lineages([commit(subject)])[0].issues, (4262,))
+        self.assertEqual(issue_references("fix(deploy): #100 (#101) (#102)"), (100,))
+        self.assertEqual(
+            issue_references("fix: #100 see #99", "Regression-of: #98"),
+            (100, 99, 98),
+        )
 
     def test_issue_lineage_generation_count_spans_commit_text_edges(self) -> None:
         commits = [

--- a/tests/test_weekly_churn_audit.py
+++ b/tests/test_weekly_churn_audit.py
@@ -204,6 +204,52 @@ class WeeklyChurnAuditTests(unittest.TestCase):
         self.assertIn("재설계 후보 (1)", output.getvalue())
         self.assertIn("issue drafts dry-run only", output.getvalue())
 
+    def test_confirmed_issue_gate_still_requires_per_draft_approval(self) -> None:
+        audit_commits = [
+            commit(f"fix: repeat {index}", sha=str(index) * 40)
+            for index in range(1, 4)
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            argv = [
+                "weekly_churn_audit.py",
+                "--repo-root",
+                str(ROOT),
+                "--runtime-root",
+                temp,
+            ]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.dict(
+                    os.environ,
+                    {"AGENTDESK_CHURN_AUDIT_CREATE_ISSUE": "confirmed"},
+                    clear=True,
+                ),
+                patch.object(
+                    weekly_churn_audit,
+                    "collect_git_commits",
+                    return_value=audit_commits,
+                ),
+                patch.object(
+                    weekly_churn_audit, "load_open_issues", return_value=([], None)
+                ) as load_open,
+                patch.object(
+                    weekly_churn_audit,
+                    "create_github_issue",
+                    return_value="https://example.test/issues/1",
+                ) as create_issue,
+                redirect_stdout(StringIO()),
+            ):
+                self.assertEqual(weekly_churn_audit.main(), 0)
+                draft = next(
+                    (Path(temp) / "runtime" / "pending-issue-drafts").rglob("*.md")
+                )
+                create_issue.assert_not_called()
+                Path(f"{draft}.approved").touch()
+                self.assertEqual(weekly_churn_audit.main(), 0)
+
+        self.assertEqual(load_open.call_count, 2)
+        create_issue.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_weekly_churn_audit.py
+++ b/tests/test_weekly_churn_audit.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Focused tests for the weekly regression-churn audit (#4265)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTINE_DIR = ROOT / "routines" / "monitoring"
+sys.path.insert(0, str(ROUTINE_DIR))
+
+import weekly_churn_audit  # noqa: E402
+from log_digest_issue_drafts import OpenIssue  # noqa: E402
+from weekly_churn_audit import (  # noqa: E402
+    GitCommit,
+    analyze_churn,
+    candidate_drafts,
+    compute_issue_lineages,
+    is_fix_commit_subject,
+    issue_references,
+    maybe_post_weekly_channel,
+)
+
+
+def commit(
+    subject: str,
+    files: tuple[str, ...] = ("src/services/discord/example.rs",),
+    *,
+    sha: str = "a" * 40,
+    body: str = "",
+) -> GitCommit:
+    return GitCommit(sha=sha, subject=subject, body=body, files=files)
+
+
+class WeeklyChurnAuditTests(unittest.TestCase):
+    def test_fix_commit_classifier_is_precise(self) -> None:
+        for subject in (
+            "fix: stop duplicate relay",
+            "fix(discord): stop duplicate relay",
+        ):
+            with self.subTest(subject=subject):
+                self.assertTrue(is_fix_commit_subject(subject))
+
+        for subject in (
+            "chore: stop duplicate relay",
+            "feat(discord): stop duplicate relay",
+            "refactor: stop duplicate relay",
+            "docs: explain duplicate relay",
+            "test: reproduce duplicate relay",
+            "prefix: fix: embedded text is not a fix subject",
+        ):
+            with self.subTest(subject=subject):
+                self.assertFalse(is_fix_commit_subject(subject))
+
+    def test_threshold_includes_n_but_not_n_minus_one(self) -> None:
+        repeated = "src/services/discord/repeated.rs"
+        below = "src/services/discord/below.rs"
+        commits = [
+            commit("fix: first", (repeated, below), sha="1" * 40),
+            commit("fix(scope): second", (repeated, below), sha="2" * 40),
+            commit("fix: third", (repeated,), sha="3" * 40),
+            commit("feat: not counted", (below,), sha="4" * 40),
+        ]
+
+        audit = analyze_churn(commits, threshold=3)
+
+        self.assertEqual(audit.file_counts[repeated], 3)
+        self.assertEqual(audit.file_counts[below], 2)
+        self.assertEqual([candidate.file for candidate in audit.candidates], [repeated])
+        self.assertEqual(audit.module_counts["src/services/discord"], 3)
+
+    def test_squash_subject_parses_all_issue_references_in_order(self) -> None:
+        subject = (
+            "fix(deploy): #4262 post-deploy scope (#4511) (#4523)"
+        )
+
+        self.assertTrue(is_fix_commit_subject(subject))
+        self.assertEqual(issue_references(subject), (4262, 4511, 4523))
+
+    def test_issue_lineage_generation_count_spans_commit_text_edges(self) -> None:
+        commits = [
+            commit("fix: first regression (#100) (#200)"),
+            commit("fix: follow-up (#200)", body="Regression-of cross-reference: #300"),
+            commit("fix: independent (#900)"),
+        ]
+
+        lineages = compute_issue_lineages(commits)
+
+        self.assertEqual(lineages[0].issues, (100, 200, 300))
+        self.assertEqual(lineages[0].generations, 3)
+        self.assertIn((900,), [lineage.issues for lineage in lineages])
+
+    def test_open_issue_dedup_suppresses_matching_candidate_draft(self) -> None:
+        candidate = analyze_churn(
+            [
+                commit(f"fix: regression {index}", sha=str(index) * 40)
+                for index in range(1, 4)
+            ],
+            threshold=3,
+        ).candidates[0]
+        matching = OpenIssue(
+            number=4265,
+            title=(
+                "ops(process): repeated fix churn redesign candidate "
+                "src/services/discord/example.rs"
+            ),
+        )
+
+        with patch.object(
+            weekly_churn_audit,
+            "issue_matches_signature",
+            wraps=weekly_churn_audit.issue_matches_signature,
+        ) as matcher:
+            drafts, matches = candidate_drafts(
+                [candidate], [matching], since="7 days", threshold=3
+            )
+
+        self.assertEqual(drafts, [])
+        self.assertEqual(matches, [(candidate, matching)])
+        matcher.assert_called_once()
+
+    def test_channel_post_gate_is_default_off_and_confirmed_is_idempotent(self) -> None:
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as temp:
+            state = Path(temp) / "post-state.json"
+            disabled = maybe_post_weekly_channel(
+                "report",
+                "off",
+                "123",
+                state,
+                calls.append,
+            )
+            first = maybe_post_weekly_channel(
+                "report",
+                "confirmed",
+                "123",
+                state,
+                calls.append,
+            )
+            repeated = maybe_post_weekly_channel(
+                "report",
+                "confirmed",
+                "123",
+                state,
+                calls.append,
+            )
+
+        self.assertEqual(disabled, (False, "weekly ops channel post disabled"))
+        self.assertEqual(first, (True, "weekly ops channel report posted"))
+        self.assertEqual(repeated, (False, "identical weekly report already posted"))
+        self.assertEqual(calls, ["report"])
+
+    def test_main_default_off_has_no_issue_or_channel_side_effect(self) -> None:
+        audit_commits = [
+            commit(f"fix: repeat {index}", sha=str(index) * 40)
+            for index in range(1, 4)
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            output = StringIO()
+            with (
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "weekly_churn_audit.py",
+                        "--repo-root",
+                        str(ROOT),
+                        "--runtime-root",
+                        temp,
+                    ],
+                ),
+                patch.dict(os.environ, {}, clear=True),
+                patch.object(
+                    weekly_churn_audit,
+                    "collect_git_commits",
+                    return_value=audit_commits,
+                ),
+                patch.object(weekly_churn_audit, "load_open_issues") as load_open,
+                patch.object(weekly_churn_audit, "write_pending_drafts") as write_drafts,
+                patch.object(
+                    weekly_churn_audit, "maybe_post_approved_drafts"
+                ) as create_issues,
+                patch.object(weekly_churn_audit, "_post_report") as post_channel,
+                redirect_stdout(output),
+            ):
+                rc = weekly_churn_audit.main()
+
+            runtime_files = list(Path(temp).rglob("*"))
+
+        self.assertEqual(rc, 0)
+        load_open.assert_not_called()
+        write_drafts.assert_not_called()
+        create_issues.assert_not_called()
+        post_channel.assert_not_called()
+        self.assertEqual(runtime_files, [])
+        self.assertIn("재설계 후보 (1)", output.getvalue())
+        self.assertIn("issue drafts dry-run only", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약
같은 파일/모듈이 7일 내 fix 커밋 N회(기본 3) 이상이면 '판정 모델 재설계 후보'로 등재하는 주간 감사 스크립트. stall-watchdog 4세대 7커밋 재작업 사례(#4140→#4178→#4181) 같은 churn을 자동 표면화.

## 변경
- `routines/monitoring/weekly_churn_audit.py` (515줄, <1000) — git log fix-커밋 집계 + 이슈 계보(#A→#B→#C) 세대 카운트 + 후보 리포트 + issue-draft(default-off gate). #4263 log_digest 헬퍼 + #4269 admission 스키마 패턴 재사용.
- `tests/test_weekly_churn_audit.py` (255줄) — fix분류/N경계/squash파싱/계보세대/dedup/default-off gate 커버.
- `scripts/ci-script-checks.sh` — 테스트 CI 배선.
- offline(gh/network 없음) 분석, side-effect default-OFF(dry-run stdout).

## 게이트 (직접 검증)
syntax/unittest/ci-script-checks/audit(0)/freshness 전부 rc=0. 뮤테이션 증명 포함.

Closes #4265 아님 — 머지 후 명시 close.