### PR TITLE
test(provider): provider conformance 테스트 + 잔여 match 4곳 registry 흡수 (#4518)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1046,6 +1046,8 @@ src/
 │   │   ├── mod.rs
 │   │   ├── shell.rs
 │   │   └── tmux.rs
+│   ├── provider/
+│   │   └── provider_conformance_invariant_tests.rs
 │   ├── provider_cli/
 │   │   ├── canary.rs
 │   │   ├── context.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1855,7 +1855,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2948; -21 from #4113 backend_routing/availability extraction), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2198), `src/services/codex.rs` (3131),
-  `src/services/opencode.rs` (2760), `src/services/provider.rs` (1807) —
+  `src/services/opencode.rs` (2760), `src/services/provider.rs` (1801) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1855,7 +1855,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (2948; -21 from #4113 backend_routing/availability extraction), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2198), `src/services/codex.rs` (3131),
-  `src/services/opencode.rs` (2760), `src/services/provider.rs` (1647) —
+  `src/services/opencode.rs` (2760), `src/services/provider.rs` (1807) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider. #3263 added the Codex max-of-cache

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -101,7 +101,7 @@
 | `src/services/onboarding/mod.rs` | 2937 |
 | `src/services/opencode.rs` | 2760 |
 | `src/services/platform/binary_resolver.rs` | 1381 |
-| `src/services/provider.rs` | 1807 |
+| `src/services/provider.rs` | 1801 |
 | `src/services/qwen.rs` | 2198 |
 | `src/services/routines/agent_executor.rs` | 2021 |
 | `src/services/routines/discord_log.rs` | 1593 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -101,7 +101,7 @@
 | `src/services/onboarding/mod.rs` | 2937 |
 | `src/services/opencode.rs` | 2760 |
 | `src/services/platform/binary_resolver.rs` | 1381 |
-| `src/services/provider.rs` | 1647 |
+| `src/services/provider.rs` | 1807 |
 | `src/services/qwen.rs` | 2198 |
 | `src/services/routines/agent_executor.rs` | 2021 |
 | `src/services/routines/discord_log.rs` | 1593 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -980,7 +980,7 @@
 | `services::platform::tmux::availability` | `src/services/platform/tmux/availability.rs` | 269 | 136 | 133 |  |
 | `services::pr_summary` | `src/services/pr_summary.rs` | 542 | 321 | 221 |  |
 | `services::process` | `src/services/process.rs` | 1229 | 759 | 470 |  |
-| `services::provider` | `src/services/provider.rs` | 2261 | 1647 | 614 | giant-file |
+| `services::provider` | `src/services/provider.rs` | 2421 | 1807 | 614 | giant-file |
 | `services::provider_auth` | `src/services/provider_auth.rs` | 628 | 400 | 228 |  |
 | `services::provider_cli` | `src/services/provider_cli/mod.rs` | 21 | 21 | 0 |  |
 | `services::provider_cli::canary` | `src/services/provider_cli/canary.rs` | 86 | 86 | 0 |  |
@@ -996,7 +996,7 @@
 | `services::provider_cli::snapshot` | `src/services/provider_cli/snapshot.rs` | 74 | 74 | 0 |  |
 | `services::provider_cli::upgrade` | `src/services/provider_cli/upgrade.rs` | 637 | 637 | 0 |  |
 | `services::provider_error_transcript` | `src/services/provider_error_transcript.rs` | 87 | 48 | 39 |  |
-| `services::provider_exec` | `src/services/provider_exec.rs` | 309 | 309 | 0 |  |
+| `services::provider_exec` | `src/services/provider_exec.rs` | 335 | 335 | 0 |  |
 | `services::provider_hosting` | `src/services/provider_hosting.rs` | 1073 | 493 | 580 |  |
 | `services::provider_output_guard` | `src/services/provider_output_guard.rs` | 195 | 195 | 0 |  |
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 73 | 73 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -980,7 +980,7 @@
 | `services::platform::tmux::availability` | `src/services/platform/tmux/availability.rs` | 269 | 136 | 133 |  |
 | `services::pr_summary` | `src/services/pr_summary.rs` | 542 | 321 | 221 |  |
 | `services::process` | `src/services/process.rs` | 1229 | 759 | 470 |  |
-| `services::provider` | `src/services/provider.rs` | 2421 | 1807 | 614 | giant-file |
+| `services::provider` | `src/services/provider.rs` | 2415 | 1801 | 614 | giant-file |
 | `services::provider_auth` | `src/services/provider_auth.rs` | 628 | 400 | 228 |  |
 | `services::provider_cli` | `src/services/provider_cli/mod.rs` | 21 | 21 | 0 |  |
 | `services::provider_cli::canary` | `src/services/provider_cli/canary.rs` | 86 | 86 | 0 |  |
@@ -996,7 +996,7 @@
 | `services::provider_cli::snapshot` | `src/services/provider_cli/snapshot.rs` | 74 | 74 | 0 |  |
 | `services::provider_cli::upgrade` | `src/services/provider_cli/upgrade.rs` | 637 | 637 | 0 |  |
 | `services::provider_error_transcript` | `src/services/provider_error_transcript.rs` | 87 | 48 | 39 |  |
-| `services::provider_exec` | `src/services/provider_exec.rs` | 335 | 335 | 0 |  |
+| `services::provider_exec` | `src/services/provider_exec.rs` | 316 | 316 | 0 |  |
 | `services::provider_hosting` | `src/services/provider_hosting.rs` | 1073 | 493 | 580 |  |
 | `services::provider_output_guard` | `src/services/provider_output_guard.rs` | 195 | 195 | 0 |  |
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 73 | 73 | 0 |  |

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -43,6 +43,114 @@ pub struct ProviderCapabilities {
     pub supports_tool_stream: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProviderExecutionAdapter {
+    Claude,
+    Codex,
+    Gemini,
+    OpenCode,
+    Qwen,
+}
+
+impl ProviderExecutionAdapter {
+    pub const fn provider_id(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Gemini => "gemini",
+            Self::OpenCode => "opencode",
+            Self::Qwen => "qwen",
+        }
+    }
+
+    pub const fn supported_capabilities(self) -> ProviderCapabilities {
+        match self {
+            Self::Claude => ProviderCapabilities {
+                binary_name: "claude",
+                supports_structured_output: true,
+                supports_resume: true,
+                supports_tool_stream: true,
+            },
+            Self::Codex => ProviderCapabilities {
+                binary_name: "codex",
+                supports_structured_output: true,
+                supports_resume: true,
+                supports_tool_stream: true,
+            },
+            Self::Gemini => ProviderCapabilities {
+                binary_name: "gemini",
+                supports_structured_output: true,
+                supports_resume: true,
+                supports_tool_stream: true,
+            },
+            Self::OpenCode => ProviderCapabilities {
+                binary_name: "opencode",
+                supports_structured_output: true,
+                supports_resume: false,
+                supports_tool_stream: true,
+            },
+            Self::Qwen => ProviderCapabilities {
+                binary_name: "qwen",
+                supports_structured_output: true,
+                supports_resume: true,
+                supports_tool_stream: true,
+            },
+        }
+    }
+
+    pub const fn cancelled_error_sample(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude request cancelled",
+            Self::Codex => "Codex request cancelled",
+            Self::Gemini => "Gemini request cancelled",
+            Self::OpenCode => "OpenCode request cancelled",
+            Self::Qwen => "Qwen request cancelled",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProviderCompactionAdapter {
+    ClaudeEnvironment,
+    CodexCli,
+    GeminiDisabled,
+    OpenCodeDisabled,
+    QwenDisabled,
+}
+
+impl ProviderCompactionAdapter {
+    pub const fn provider_id(self) -> &'static str {
+        match self {
+            Self::ClaudeEnvironment => "claude",
+            Self::CodexCli => "codex",
+            Self::GeminiDisabled => "gemini",
+            Self::OpenCodeDisabled => "opencode",
+            Self::QwenDisabled => "qwen",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProviderReadinessAdapter {
+    Claude,
+    Codex,
+    Gemini,
+    OpenCode,
+    Qwen,
+}
+
+impl ProviderReadinessAdapter {
+    pub const fn provider_id(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Gemini => "gemini",
+            Self::OpenCode => "opencode",
+            Self::Qwen => "qwen",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProviderRuntimeProbe {
     pub provider: ProviderKind,
@@ -71,6 +179,9 @@ pub struct ProviderRegistryEntry {
     pub default_channel_provider: bool,
     pub counterpart_provider_ids: &'static [&'static str],
     pub capabilities: ProviderCapabilities,
+    pub execution_adapter: ProviderExecutionAdapter,
+    pub compaction_adapter: ProviderCompactionAdapter,
+    pub readiness_adapter: ProviderReadinessAdapter,
     pub default_behavior: ProviderDefaultBehavior,
     pub default_context_window: u64,
     pub managed_tmux_backend: bool,
@@ -140,6 +251,9 @@ const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
             supports_resume: true,
             supports_tool_stream: true,
         },
+        execution_adapter: ProviderExecutionAdapter::Claude,
+        compaction_adapter: ProviderCompactionAdapter::ClaudeEnvironment,
+        readiness_adapter: ProviderReadinessAdapter::Claude,
         default_behavior: ProviderDefaultBehavior {
             resume_without_reset: true,
             runtime_model: None,
@@ -169,6 +283,9 @@ const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
             supports_resume: true,
             supports_tool_stream: true,
         },
+        execution_adapter: ProviderExecutionAdapter::Codex,
+        compaction_adapter: ProviderCompactionAdapter::CodexCli,
+        readiness_adapter: ProviderReadinessAdapter::Codex,
         default_behavior: ProviderDefaultBehavior {
             resume_without_reset: true,
             runtime_model: None,
@@ -200,6 +317,9 @@ const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
             supports_resume: true,
             supports_tool_stream: true,
         },
+        execution_adapter: ProviderExecutionAdapter::Gemini,
+        compaction_adapter: ProviderCompactionAdapter::GeminiDisabled,
+        readiness_adapter: ProviderReadinessAdapter::Gemini,
         default_behavior: ProviderDefaultBehavior {
             resume_without_reset: true,
             runtime_model: None,
@@ -229,6 +349,9 @@ const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
             supports_resume: false,
             supports_tool_stream: true,
         },
+        execution_adapter: ProviderExecutionAdapter::OpenCode,
+        compaction_adapter: ProviderCompactionAdapter::OpenCodeDisabled,
+        readiness_adapter: ProviderReadinessAdapter::OpenCode,
         default_behavior: ProviderDefaultBehavior {
             resume_without_reset: false,
             runtime_model: None,
@@ -258,6 +381,9 @@ const PROVIDER_REGISTRY: &[ProviderRegistryEntry] = &[
             supports_resume: true,
             supports_tool_stream: true,
         },
+        execution_adapter: ProviderExecutionAdapter::Qwen,
+        compaction_adapter: ProviderCompactionAdapter::QwenDisabled,
+        readiness_adapter: ProviderReadinessAdapter::Qwen,
         default_behavior: ProviderDefaultBehavior {
             resume_without_reset: true,
             runtime_model: None,
@@ -353,6 +479,18 @@ impl ProviderKind {
 
     pub fn capabilities(&self) -> Option<ProviderCapabilities> {
         self.registry_entry().map(|entry| entry.capabilities)
+    }
+
+    pub fn execution_adapter(&self) -> Option<ProviderExecutionAdapter> {
+        self.registry_entry().map(|entry| entry.execution_adapter)
+    }
+
+    pub fn compaction_adapter(&self) -> Option<ProviderCompactionAdapter> {
+        self.registry_entry().map(|entry| entry.compaction_adapter)
+    }
+
+    pub fn readiness_adapter(&self) -> Option<ProviderReadinessAdapter> {
+        self.registry_entry().map(|entry| entry.readiness_adapter)
     }
 
     /// Provider-specific behavior when AgentDesk clears its explicit model
@@ -465,13 +603,18 @@ impl ProviderKind {
     /// - Codex: uses CLI args instead (see compact_cli_config)
     #[allow(dead_code)]
     pub fn compact_env_vars(&self, percent: u64) -> Vec<(String, String)> {
-        match self {
-            Self::Claude => vec![(
+        let Some(adapter) = self.compaction_adapter() else {
+            return Vec::new();
+        };
+        match adapter {
+            ProviderCompactionAdapter::ClaudeEnvironment => vec![(
                 "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE".to_string(),
                 percent.to_string(),
             )],
-            // Codex uses -c CLI arg, not env vars
-            _ => vec![],
+            ProviderCompactionAdapter::CodexCli
+            | ProviderCompactionAdapter::GeminiDisabled
+            | ProviderCompactionAdapter::OpenCodeDisabled
+            | ProviderCompactionAdapter::QwenDisabled => Vec::new(),
         }
     }
 
@@ -514,15 +657,21 @@ impl ProviderKind {
     /// Returns Codex-specific CLI config overrides for auto-compact.
     /// Codex uses model_auto_compact_token_limit (absolute token count).
     pub fn compact_cli_config(&self, percent: u64, context_window: u64) -> Vec<(String, String)> {
-        match self {
-            Self::Codex => {
+        let Some(adapter) = self.compaction_adapter() else {
+            return Vec::new();
+        };
+        match adapter {
+            ProviderCompactionAdapter::CodexCli => {
                 let token_limit = context_window * percent / 100;
                 vec![(
                     "model_auto_compact_token_limit".to_string(),
                     token_limit.to_string(),
                 )]
             }
-            _ => vec![],
+            ProviderCompactionAdapter::ClaudeEnvironment
+            | ProviderCompactionAdapter::GeminiDisabled
+            | ProviderCompactionAdapter::OpenCodeDisabled
+            | ProviderCompactionAdapter::QwenDisabled => Vec::new(),
         }
     }
 
@@ -1271,27 +1420,38 @@ pub(crate) fn tmux_capture_indicates_ready_for_input(
     capture: &str,
     provider: &ProviderKind,
 ) -> bool {
-    match provider {
-        ProviderKind::Claude => {
+    let Some(adapter) = provider.readiness_adapter() else {
+        return false;
+    };
+    match adapter {
+        ProviderReadinessAdapter::Claude => {
             crate::services::tmux_common::tmux_capture_indicates_claude_tui_ready_for_input(capture)
         }
-        ProviderKind::Codex => {
+        ProviderReadinessAdapter::Codex => {
             crate::services::codex_tui::input::pane_looks_ready_for_codex_prompt(capture)
                 || crate::services::tmux_common::tmux_capture_indicates_generic_ready_banner(
                     capture,
                 )
                 || tmux_capture_contains_wrapper_ready_marker(capture, provider)
         }
-        ProviderKind::Qwen => {
+        ProviderReadinessAdapter::Qwen => {
             crate::services::tmux_common::tmux_capture_indicates_generic_ready_banner(capture)
                 || tmux_capture_contains_wrapper_ready_marker(capture, provider)
         }
-        ProviderKind::Gemini | ProviderKind::OpenCode | ProviderKind::Unsupported(_) => {
+        ProviderReadinessAdapter::Gemini => {
+            crate::services::tmux_common::tmux_capture_indicates_generic_ready_banner(capture)
+                || tmux_capture_contains_wrapper_ready_marker(capture, provider)
+        }
+        ProviderReadinessAdapter::OpenCode => {
             crate::services::tmux_common::tmux_capture_indicates_generic_ready_banner(capture)
                 || tmux_capture_contains_wrapper_ready_marker(capture, provider)
         }
     }
 }
+
+#[cfg(test)]
+#[path = "provider/provider_conformance_invariant_tests.rs"]
+mod provider_conformance_invariant_tests;
 
 fn tmux_capture_contains_wrapper_ready_marker(capture: &str, provider: &ProviderKind) -> bool {
     capture

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -97,16 +97,6 @@ impl ProviderExecutionAdapter {
             },
         }
     }
-
-    pub const fn cancelled_error_sample(self) -> &'static str {
-        match self {
-            Self::Claude => "Claude request cancelled",
-            Self::Codex => "Codex request cancelled",
-            Self::Gemini => "Gemini request cancelled",
-            Self::OpenCode => "OpenCode request cancelled",
-            Self::Qwen => "Qwen request cancelled",
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1420,6 +1410,10 @@ pub(crate) fn tmux_capture_indicates_ready_for_input(
     capture: &str,
     provider: &ProviderKind,
 ) -> bool {
+    if let ProviderKind::Unsupported(_) = provider {
+        return crate::services::tmux_common::tmux_capture_indicates_generic_ready_banner(capture)
+            || tmux_capture_contains_wrapper_ready_marker(capture, provider);
+    }
     let Some(adapter) = provider.readiness_adapter() else {
         return false;
     };

--- a/src/services/provider/provider_conformance_invariant_tests.rs
+++ b/src/services/provider/provider_conformance_invariant_tests.rs
@@ -1,11 +1,6 @@
 use std::collections::HashSet;
-use std::time::Duration;
 
 use super::{ProviderCompactionAdapter, ProviderKind, provider_registry};
-use crate::services::provider_exec::{
-    ProviderExecutionErrorClass, classify_provider_execution_error, simple_timeout_error,
-    structured_timeout_error,
-};
 
 const READY_CAPTURE: &str = "Ready for input (type message + Enter)\n> ";
 const BUSY_CAPTURE: &str = "working\nstill waiting for tool output";
@@ -86,28 +81,6 @@ fn provider_exec_registry_conformance_invariant() {
             "{} readiness adapter accepted a generic busy capture",
             entry.id
         );
-
-        assert_eq!(
-            classify_provider_execution_error(execution_adapter.cancelled_error_sample()),
-            ProviderExecutionErrorClass::Cancelled,
-            "{} cancellation error is not classified as cancelled",
-            entry.id
-        );
-        assert_eq!(
-            classify_provider_execution_error(&simple_timeout_error(
-                entry.display_name,
-                Duration::from_secs(7),
-            )),
-            ProviderExecutionErrorClass::Timeout,
-            "{} simple timeout error is not classified as timeout",
-            entry.id
-        );
-        assert_eq!(
-            classify_provider_execution_error(&structured_timeout_error(entry.display_name, 7)),
-            ProviderExecutionErrorClass::Timeout,
-            "{} structured timeout error is not classified as timeout",
-            entry.id
-        );
     }
 
     assert!(
@@ -115,6 +88,26 @@ fn provider_exec_registry_conformance_invariant() {
         "provider registry must not be empty"
     );
     assert_scoped_dispatches_have_no_wildcard_arms();
+}
+
+#[test]
+fn unsupported_provider_preserves_generic_readiness_fallback() {
+    let provider = ProviderKind::Unsupported("future-provider".to_string());
+    let wrapper_marker =
+        r#"{"type":"ready_for_input","provider":"future-provider","ts":"2026-07-14T00:00:00Z"}"#;
+
+    assert!(super::tmux_capture_indicates_ready_for_input(
+        READY_CAPTURE,
+        &provider
+    ));
+    assert!(super::tmux_capture_indicates_ready_for_input(
+        wrapper_marker,
+        &provider
+    ));
+    assert!(!super::tmux_capture_indicates_ready_for_input(
+        BUSY_CAPTURE,
+        &provider
+    ));
 }
 
 fn assert_scoped_dispatches_have_no_wildcard_arms() {

--- a/src/services/provider/provider_conformance_invariant_tests.rs
+++ b/src/services/provider/provider_conformance_invariant_tests.rs
@@ -1,0 +1,176 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
+use super::{ProviderCompactionAdapter, ProviderKind, provider_registry};
+use crate::services::provider_exec::{
+    ProviderExecutionErrorClass, classify_provider_execution_error, simple_timeout_error,
+    structured_timeout_error,
+};
+
+const READY_CAPTURE: &str = "Ready for input (type message + Enter)\n> ";
+const BUSY_CAPTURE: &str = "working\nstill waiting for tool output";
+
+#[test]
+fn provider_exec_registry_conformance_invariant() {
+    let mut provider_ids = HashSet::new();
+
+    for entry in provider_registry() {
+        assert!(
+            provider_ids.insert(entry.id),
+            "duplicate provider registry id: {}",
+            entry.id
+        );
+
+        let provider = ProviderKind::from_str(entry.id).unwrap_or_else(|| {
+            panic!("registry provider {} has no ProviderKind mapping", entry.id)
+        });
+        let execution_adapter = provider
+            .execution_adapter()
+            .unwrap_or_else(|| panic!("registry provider {} has no execution adapter", entry.id));
+
+        assert_eq!(
+            execution_adapter.provider_id(),
+            entry.id,
+            "{} execution adapter is wired to another provider",
+            entry.id
+        );
+        assert_eq!(
+            execution_adapter.supported_capabilities(),
+            entry.capabilities,
+            "{} declared capabilities do not match its execution adapter",
+            entry.id
+        );
+
+        let compaction_adapter = provider
+            .compaction_adapter()
+            .unwrap_or_else(|| panic!("registry provider {} has no compaction adapter", entry.id));
+        assert_eq!(
+            compaction_adapter.provider_id(),
+            entry.id,
+            "{} compaction adapter is not provider-specific",
+            entry.id
+        );
+        match compaction_adapter {
+            ProviderCompactionAdapter::ClaudeEnvironment => {
+                assert!(!provider.compact_env_vars(80).is_empty());
+                assert!(provider.compact_cli_config(80, 100_000).is_empty());
+            }
+            ProviderCompactionAdapter::CodexCli => {
+                assert!(provider.compact_env_vars(80).is_empty());
+                assert!(!provider.compact_cli_config(80, 100_000).is_empty());
+            }
+            ProviderCompactionAdapter::GeminiDisabled
+            | ProviderCompactionAdapter::OpenCodeDisabled
+            | ProviderCompactionAdapter::QwenDisabled => {
+                assert!(provider.compact_env_vars(80).is_empty());
+                assert!(provider.compact_cli_config(80, 100_000).is_empty());
+            }
+        }
+
+        let readiness_adapter = provider
+            .readiness_adapter()
+            .unwrap_or_else(|| panic!("registry provider {} has no readiness adapter", entry.id));
+        assert_eq!(
+            readiness_adapter.provider_id(),
+            entry.id,
+            "{} readiness must use a concrete provider adapter",
+            entry.id
+        );
+        assert!(
+            super::tmux_capture_indicates_ready_for_input(READY_CAPTURE, &provider),
+            "{} readiness adapter rejected its ready banner",
+            entry.id
+        );
+        assert!(
+            !super::tmux_capture_indicates_ready_for_input(BUSY_CAPTURE, &provider),
+            "{} readiness adapter accepted a generic busy capture",
+            entry.id
+        );
+
+        assert_eq!(
+            classify_provider_execution_error(execution_adapter.cancelled_error_sample()),
+            ProviderExecutionErrorClass::Cancelled,
+            "{} cancellation error is not classified as cancelled",
+            entry.id
+        );
+        assert_eq!(
+            classify_provider_execution_error(&simple_timeout_error(
+                entry.display_name,
+                Duration::from_secs(7),
+            )),
+            ProviderExecutionErrorClass::Timeout,
+            "{} simple timeout error is not classified as timeout",
+            entry.id
+        );
+        assert_eq!(
+            classify_provider_execution_error(&structured_timeout_error(entry.display_name, 7)),
+            ProviderExecutionErrorClass::Timeout,
+            "{} structured timeout error is not classified as timeout",
+            entry.id
+        );
+    }
+
+    assert!(
+        !provider_ids.is_empty(),
+        "provider registry must not be empty"
+    );
+    assert_scoped_dispatches_have_no_wildcard_arms();
+}
+
+fn assert_scoped_dispatches_have_no_wildcard_arms() {
+    let provider_source = include_str!("../provider.rs");
+    let provider_exec_source = include_str!("../provider_exec.rs");
+
+    for function_name in [
+        "compact_env_vars",
+        "compact_cli_config",
+        "tmux_capture_indicates_ready_for_input",
+    ] {
+        assert_function_has_no_wildcard_arm(provider_source, function_name);
+    }
+    for function_name in [
+        "execute_simple_blocking_inner",
+        "execute_structured_with_context",
+    ] {
+        assert_function_has_no_wildcard_arm(provider_exec_source, function_name);
+    }
+}
+
+fn assert_function_has_no_wildcard_arm(source: &str, function_name: &str) {
+    let body = function_source(source, function_name);
+    let wildcard_line = body.lines().find(|line| {
+        line.split_once("=>")
+            .is_some_and(|(pattern, _)| pattern.trim() == "_")
+    });
+    assert!(
+        wildcard_line.is_none(),
+        "{function_name} contains a wildcard match arm; every registered provider needs an explicit adapter: {}",
+        wildcard_line.unwrap_or_default().trim()
+    );
+}
+
+fn function_source<'a>(source: &'a str, function_name: &str) -> &'a str {
+    let signature = format!("fn {function_name}(");
+    let function_start = source
+        .find(&signature)
+        .unwrap_or_else(|| panic!("missing scoped function {function_name}"));
+    let body_start = source[function_start..]
+        .find('{')
+        .map(|offset| function_start + offset)
+        .unwrap_or_else(|| panic!("missing body for scoped function {function_name}"));
+
+    let mut depth = 0_u32;
+    for (offset, character) in source[body_start..].char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[function_start..=body_start + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unterminated body for scoped function {function_name}");
+}

--- a/src/services/provider_exec.rs
+++ b/src/services/provider_exec.rs
@@ -271,25 +271,6 @@ pub async fn execute_structured_with_context(
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ProviderExecutionErrorClass {
-    Cancelled,
-    Timeout,
-    Other,
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn classify_provider_execution_error(error: &str) -> ProviderExecutionErrorClass {
-    let normalized = error.to_ascii_lowercase();
-    if normalized.contains("cancelled") || normalized.contains("canceled") {
-        ProviderExecutionErrorClass::Cancelled
-    } else if normalized.contains("timeout") || normalized.contains("timed out") {
-        ProviderExecutionErrorClass::Timeout
-    } else {
-        ProviderExecutionErrorClass::Other
-    }
-}
-
 pub(crate) fn simple_timeout_error(stage_label: &str, timeout: Duration) -> String {
     format!("{stage_label} timed out after {}s", timeout.as_secs())
 }

--- a/src/services/provider_exec.rs
+++ b/src/services/provider_exec.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use crate::services::agent_protocol::StreamMessage;
 use crate::services::platform::with_provider_execution_context;
 use crate::services::process::kill_pid_tree;
-use crate::services::provider::{CancelToken, ProviderKind};
+use crate::services::provider::{CancelToken, ProviderExecutionAdapter, ProviderKind};
 use crate::services::provider_cli::ProviderExecutionContext;
 use crate::services::{claude, codex, gemini, opencode, qwen};
 
@@ -66,10 +66,7 @@ pub async fn execute_simple_with_timeout_and_context(
                 kill_pid_tree(pid);
             }
             let _ = tokio::time::timeout(Duration::from_secs(3), &mut handle).await;
-            Err(format!(
-                "{stage_label} timed out after {}s",
-                timeout.as_secs()
-            ))
+            Err(simple_timeout_error(&stage_label, timeout))
         }
     }
 }
@@ -93,23 +90,25 @@ fn execute_simple_blocking_inner(
     prompt: String,
     cancel_token: Option<Arc<CancelToken>>,
 ) -> Result<String, String> {
-    match provider {
-        ProviderKind::Claude => {
+    let Some(adapter) = provider.execution_adapter() else {
+        return Err(format!("Provider '{}' is not installed", provider.as_str()));
+    };
+    match adapter {
+        ProviderExecutionAdapter::Claude => {
             claude::execute_command_simple_cancellable(&prompt, cancel_token.as_deref())
         }
-        ProviderKind::Codex => {
+        ProviderExecutionAdapter::Codex => {
             codex::execute_command_simple_cancellable(&prompt, cancel_token.as_deref())
         }
-        ProviderKind::Gemini => {
+        ProviderExecutionAdapter::Gemini => {
             gemini::execute_command_simple_cancellable(&prompt, cancel_token.as_deref())
         }
-        ProviderKind::OpenCode => {
+        ProviderExecutionAdapter::OpenCode => {
             opencode::execute_command_simple_cancellable(&prompt, cancel_token.as_deref())
         }
-        ProviderKind::Qwen => {
+        ProviderExecutionAdapter::Qwen => {
             qwen::execute_command_simple_cancellable(&prompt, cancel_token.as_deref())
         }
-        ProviderKind::Unsupported(name) => Err(format!("Provider '{}' is not installed", name)),
     }
 }
 
@@ -148,6 +147,9 @@ pub async fn execute_structured_with_context(
     stage_label: &'static str,
     context: Option<ProviderExecutionContext>,
 ) -> Result<String, String> {
+    let Some(adapter) = provider.execution_adapter() else {
+        return Err(format!("Provider '{}' is not installed", provider.as_str()));
+    };
     let cancel_token = Arc::new(CancelToken::new());
     let cancel_for_timeout = Arc::clone(&cancel_token);
     let mut handle = tokio::task::spawn_blocking(move || {
@@ -156,8 +158,8 @@ pub async fn execute_structured_with_context(
             let system_prompt_ref = system_prompt.as_deref();
             let allowed_tools_ref = (!allowed_tools.is_empty()).then_some(allowed_tools.as_slice());
             let model_ref = model.as_deref();
-            let result = match provider {
-                ProviderKind::Claude => claude::execute_command_streaming(
+            let result = match adapter {
+                ProviderExecutionAdapter::Claude => claude::execute_command_streaming(
                     &prompt,
                     None,
                     &working_dir,
@@ -175,7 +177,7 @@ pub async fn execute_structured_with_context(
                     None,
                     None,
                 ),
-                ProviderKind::Codex => codex::execute_command_streaming(
+                ProviderExecutionAdapter::Codex => codex::execute_command_streaming(
                     &prompt,
                     None,
                     &working_dir,
@@ -193,7 +195,7 @@ pub async fn execute_structured_with_context(
                     None,
                     false,
                 ),
-                ProviderKind::Gemini => gemini::execute_command_streaming(
+                ProviderExecutionAdapter::Gemini => gemini::execute_command_streaming(
                     &prompt,
                     None,
                     &working_dir,
@@ -208,7 +210,7 @@ pub async fn execute_structured_with_context(
                     model_ref,
                     None,
                 ),
-                ProviderKind::OpenCode => opencode::execute_command_streaming(
+                ProviderExecutionAdapter::OpenCode => opencode::execute_command_streaming(
                     &prompt,
                     None,
                     &working_dir,
@@ -223,7 +225,7 @@ pub async fn execute_structured_with_context(
                     model_ref,
                     None,
                 ),
-                ProviderKind::Qwen => qwen::execute_command_streaming(
+                ProviderExecutionAdapter::Qwen => qwen::execute_command_streaming(
                     &prompt,
                     None,
                     &working_dir,
@@ -238,9 +240,6 @@ pub async fn execute_structured_with_context(
                     model_ref,
                     None,
                 ),
-                ProviderKind::Unsupported(name) => {
-                    Err(format!("Provider '{}' is not installed", name))
-                }
             };
             drop(sender);
             collect_stream_result(result, receiver)
@@ -267,9 +266,36 @@ pub async fn execute_structured_with_context(
             if tokio::time::timeout(Duration::from_secs(3), &mut handle).await.is_err() {
                 handle.abort();
             }
-            Err(format!("{stage_label} timeout after {timeout_secs}s"))
+            Err(structured_timeout_error(stage_label, timeout_secs))
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderExecutionErrorClass {
+    Cancelled,
+    Timeout,
+    Other,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn classify_provider_execution_error(error: &str) -> ProviderExecutionErrorClass {
+    let normalized = error.to_ascii_lowercase();
+    if normalized.contains("cancelled") || normalized.contains("canceled") {
+        ProviderExecutionErrorClass::Cancelled
+    } else if normalized.contains("timeout") || normalized.contains("timed out") {
+        ProviderExecutionErrorClass::Timeout
+    } else {
+        ProviderExecutionErrorClass::Other
+    }
+}
+
+pub(crate) fn simple_timeout_error(stage_label: &str, timeout: Duration) -> String {
+    format!("{stage_label} timed out after {}s", timeout.as_secs())
+}
+
+pub(crate) fn structured_timeout_error(stage_label: &str, timeout_secs: u64) -> String {
+    format!("{stage_label} timeout after {timeout_secs}s")
 }
 
 fn collect_stream_result(


### PR DESCRIPTION
## 요약
provider registry(#411)는 있으나 exhaustive match가 여러 파일에 반복되고 wildcard `_ =>` arm이 신규 provider를 조용히 부분지원으로 남김(#2550/#2551/#2547 버그 클래스). conformance 테스트 + 잔여 4곳 흡수 + wildcard→명시 arm으로 재발 방지.

## 변경
- `provider_conformance_invariant_tests.rs` (176줄) — registry iterate하며 각 provider 실행 adapter/capability 일치/readiness 구체성/에러분류 단정.
- `provider.rs` (+184) — compact_env_vars/compact_cli_config/readiness의 `_ =>` arm을 명시 provider arm으로.
- `provider_exec.rs` (+70) — simple/structured 실행 분기 registry 흡수.

## 게이트 (직접 검증)
cargo check/audit(0)/conformance test/provider_exec test/freshness 전부 rc=0. **뮤테이션 증명**: 명시 arm을 `_ => Vec::new()`로 되돌리면 conformance test FAILED(rc=101), 복원 시 ok.

머지 후 #4518 명시 close.