### PR TITLE
memento-hygiene: Sunday cross-workspace deep pass + drop dead local-memory migration

### DIFF
--- a/scripts/launchd-migrated/memento-deep-cleanup.sql
+++ b/scripts/launchd-migrated/memento-deep-cleanup.sql
@@ -1,0 +1,38 @@
+-- memento-hygiene 심화 패스 (일요일 03:00 KST): cross-workspace 결정론적 정리.
+-- 하드가드는 WHERE 에 강제 내장 — 무인 실행 안전장치. 캡 1500.
+-- 절대 삭제 안 함: is_anchor / importance>=0.6 / age<14d / family / cookingheart·storycraft.
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE TEMP TABLE _mh_del ON COMMIT DROP AS
+SELECT id, type
+  FROM agent_memory.fragments
+ WHERE valid_to IS NULL
+   AND is_anchor = false
+   AND importance < 0.6
+   AND created_at < now() - interval '14 days'
+   AND (workspace IS NULL OR workspace NOT ILIKE '%family%')
+   AND lower(coalesce(topic,'')) NOT LIKE '%cookingheart%'
+   AND lower(coalesce(topic,'')) NOT LIKE '%storycraft%'
+   AND (
+        (type = 'episode' AND access_count = 0)
+     OR (type = 'error'   AND resolution_status = 'resolved' AND created_at < now() - interval '7 days')
+     OR (type = 'fact'    AND topic = 'session_reflect' AND importance <= 0.5)
+   )
+ ORDER BY importance ASC, created_at ASC
+ LIMIT 1500;
+
+\echo DEEP_CANDIDATES
+SELECT count(*) FROM _mh_del;
+\echo DEEP_BYTYPE
+SELECT type || '=' || count(*) FROM _mh_del GROUP BY type ORDER BY type;
+
+\echo DEEP_DELETED
+WITH del AS (
+  DELETE FROM agent_memory.fragments f USING _mh_del d
+   WHERE f.id = d.id
+  RETURNING f.id
+)
+SELECT count(*) FROM del;
+
+COMMIT;

--- a/scripts/launchd-migrated/memento-hygiene.sh
+++ b/scripts/launchd-migrated/memento-hygiene.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# Migrated from launchd: com.itismyfield.memento-hygiene
+# Owner routine agent: project-agentmanager (workspace agentfactory)
+# Schedule: 0 3 * * * (KST, 03:00 daily). Sunday(=7) additionally runs the
+# deterministic cross-workspace deep pass (memento-deep-cleanup.sql).
+#
+# Design (2026-07-15):
+#  - Daily light pass: in-scope MCP hygiene + store-health monitor (LLM job).
+#  - Sunday deep pass: deterministic SQL cross-workspace cleanup with hard
+#    guards + cap 1500, run by THIS wrapper (NOT the LLM). LLM only reports it.
+#  - DB access is node-agnostic: local psql on the memento host, ssh otherwise.
 set -euo pipefail
 
 PROMPT_FILE="$(mktemp)"
@@ -9,84 +19,67 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_portable-resolver.sh"
 agentdesk_source_portable_resolver
 
-cat >"$PROMPT_FILE" <<'PROMPT'
-Memento 위생 관리 작업을 수행한다. 아래 3단계를 순서대로 실행.
+# --- Sunday deep pass: deterministic cross-workspace cleanup (safe, bounded) ---
+run_deep_cleanup() {
+  local sqlf="$SCRIPT_DIR/memento-deep-cleanup.sql"
+  if [ -f "$HOME/memento-mcp/.env" ]; then
+    # memento DB is local on this node (mac-mini)
+    ( set -a; . "$HOME/memento-mcp/.env"; set +a; psql "$DATABASE_URL" -qtA -f "$sqlf" )
+  else
+    # remote node: pipe the SQL to psql on the memento host over ssh
+    ssh mac-mini 'set -a; . ~/memento-mcp/.env; set +a; psql "$DATABASE_URL" -qtA' < "$sqlf"
+  fi
+}
 
-## 1단계: Claude/Codex 로컬 메모리 이관 검토
+DEEP_REPORT="스킵 (일요일 아님 — 심화 cross-workspace 패스는 일요일만 수행)"
+if [ "$(TZ='Asia/Seoul' date +%u)" = "7" ]; then
+  if DEEP_OUT=$(run_deep_cleanup 2>&1); then
+    DEEP_REPORT="$DEEP_OUT"
+  else
+    DEEP_REPORT="심화 패스 실행 오류(삭제 미수행 가능):
+$DEEP_OUT"
+  fi
+fi
 
-~/.claude/projects/ 하위 모든 프로젝트의 memory/ 디렉토리와 MEMORY.md를 스캔한다.
-~/.codex/memories/ 도 스캔한다.
+cat >"$PROMPT_FILE" <<PROMPT
+Memento 위생 관리(in-scope 경량 + 저장소 모니터)를 수행한다. 아래 순서로 실행.
 
-파일이 있으면:
-- 각 파일 내용을 읽고, Memento에 이미 존재하는 정보인지 recall로 확인
-- 중복이 아닌 유효한 정보는 remember로 Memento에 저장 (적절한 type/topic/importance 부여)
-- 이관 완료 후 해당 파일 삭제
-- 파일이 없으면 "로컬 메모리 비어있음" 보고
+## 절대 규칙 (하드 가드레일 — 위반 시 즉시 중단)
+- DB 직접 접근 절대 금지: psql / SSH / SQL 등 어떤 DB 직접 조작도 하지 않는다. 오직 Memento MCP 도구(recall / forget / amend / memory_consolidate / memory_stats / context)만 사용한다.
+- cross-workspace 삭제 절대 금지: 현재 에이전트 스코프 밖(다른 에이전트 소유) 또는 RLS로 forget이 차단되는 파편은 절대 삭제하지 않는다. (cross-workspace 심화 정리는 이 루틴의 래퍼 스크립트가 결정론적 SQL로 이미 처리했다 — 아래 '심화 패스 결과' 참조. LLM은 관여하지 않는다.)
+- 미수행 작업 보고 금지: 실제 실행하여 success 응답을 받은 작업만 보고한다. 삭제 건수는 forget이 success를 반환한 건만 집계한다. 실행하지 않은 작업을 지어내지 않는다.
 
-## 2단계: Memento consolidation
+## 1단계: Memento consolidation
+memory_consolidate를 호출한다 (TTL 전환·중요도 감쇠·만료 삭제·중복 병합). 권한(master key) 없어 실패하면 에러를 그대로 보고한다.
 
-memory_consolidate를 호출한다. TTL 전환, 중요도 감쇠, 만료 삭제, 중복 병합이 자동 수행된다.
+## 2단계: in-scope 저가치 스윕 (자기 스코프만, forget)
+recall로 자기 스코프 파편을 조회하고 아래 기준에 해당하면 forget(필요 시 force=true).
+- error: age>7d, 또는 resolutionStatus=resolved, 또는 assertionStatus=rejected, 또는 importance<0.3, 또는 resolved_by 링크 존재(graph_explore 확인)
+- episode: topic=session_reflect & importance<0.6 & age>1d; 또는 resolution_status=resolved & age>2d
+- decision: topic=session_reflect & content에 숫자(이슈/포트/버전)·파일경로·도구명이 하나도 없는 추상 문장 & importance<=0.7 & age>1d
+- fact: topic=session_reflect & importance<=0.5; 또는 content에 현황/status/상태 포함 & age>3d
+보존(삭제 금지): isAnchor=true, importance>=0.8, 현재 스코프 밖 파편.
+삭제 전 "원인→해결" 패턴이 명확한 error는 procedure 파편으로 remember한 뒤 삭제.
 
-## 3단계: 미해결 에러 자동 정리
+## 3단계: 저장소 건강 모니터 (읽기 전용)
+- memory_stats 호출 → 총 파편수, type별 분포(특히 episode 비중), avg_importance 확인.
+- context(structured=true) 호출 → 자기 스코프 anchorCount 확인.
+- 경보 판단:
+  · episode 비중이 과도(예: 전체의 절반 이상)하거나 총 파편수가 급증 → "deprecation-audit 심화 권장" 경보
+  · anchorCount가 주입 한도(약 10)를 크게 초과 → "앵커 인플레 — de-anchor 필요" 경보
 
-recall로 type=error 파편을 전부 조회한다 (resolutionStatus 무관, pageSize=50).
+## 심화 패스 결과 (래퍼가 수행, 일요일만 — cross-workspace 결정론적 SQL)
+아래는 이번 실행의 심화 패스 원시 출력이다. DEEP_CANDIDATES/DEEP_BYTYPE/DEEP_DELETED 값을 그대로 해석해 보고에 반영한다(네가 삭제한 게 아니라 래퍼가 SQL로 삭제한 것이다):
+---
+${DEEP_REPORT}
+---
 
-**삭제 규칙 (forget)** — 하나라도 해당하면 삭제:
-1. 생성 7일 이상 경과한 error 파편 (timeRange.to = 7일 전)
-2. resolutionStatus가 "resolved"인 파편
-3. assertionStatus가 "rejected"인 파편
-4. importance가 0.3 미만인 파편
-5. resolved_by 링크가 있는 파편 (graph_explore로 확인)
-
-**보존 규칙** — 아래 조건은 삭제하지 않음:
-- isAnchor=true인 파편
-- importance 0.8 이상이면서 생성 3일 이내인 파편
-
-삭제 전 각 파편의 content에서 핵심 교훈이 있으면 procedure 파편으로 remember한 뒤 삭제.
-교훈 추출 기준: "원인→해결" 패턴이 명확한 경우만.
-
-정리 건수와 보존 건수를 보고.
-
-## 4단계: 저가치 파편 정리
-
-recall로 아래 카테고리별 파편을 조회하고 삭제 규칙에 따라 forget(force=true) 처리.
-
-### 4-1. 에피소드 쓰레기
-- topic="session_reflect", type=episode 중 importance < 0.6이고 age > 1일인 파편 삭제
-  (세션 통계, 도구 사용 횟수만 기록된 내용 없는 파편)
-- type=episode, resolution_status="resolved"이고 age > 2일인 이슈 회고 에피소드 삭제
-  (완료된 이슈의 "성공 종료" 기록은 이슈/커밋에 이미 남아있으므로 불필요)
-
-### 4-2. 모호한 결정 정리
-- topic="session_reflect", type=decision 중 content가 구체적 설정값·파일경로·이슈번호 없이
-  추상적 문장만 있는 파편 삭제 (예: "~를 채택했다", "~로 결정했다"만 있고 what/where/how 없음)
-- 판단 기준: content에 숫자(이슈번호·포트·버전), 파일경로, 구체적 도구명이 하나도 없으면 삭제 후보
-- importance 0.7 이하이고 age > 1일인 것만 대상
-
-### 4-3. 메타 쓰레기 사실 정리
-- topic="session_reflect", type=fact 중 importance ≤ 0.5인 파편 삭제
-  (예: "파편 N개를 forget으로 제거했다", "git log --grep 명령어를 활용했다" 같은 메타 기록)
-
-### 4-4. 오래된 스냅샷 사실 정리
-- type=fact 중 "현황", "status", "상태" 키워드가 content에 포함되고 age > 3일인 파편 삭제
-  (시점 스냅샷은 3일 지나면 stale)
-
-**보존 규칙** — 아래는 절대 삭제하지 않음:
-- isAnchor=true
-- workspace가 현재 에이전트 스코프 밖인 파편 (다른 에이전트 소유)
-- importance 0.8 이상
-
-4단계 정리 건수를 카테고리별로 보고.
-
-## 결과 보고
-
-Discord 메시지로 아래 포맷의 한국어 요약을 반환:
-- 로컬 메모리 이관: N건 이관 / M건 중복 스킵 / 비어있음
-- Consolidation: 결과 요약
-- 에러 정리: N건 정리 / M건 미해결 유지
-- 파편 위생: 에피소드 N건 / 결정 N건 / 사실 N건 삭제
-
-내용이 없으면 NO_REPLY를 반환.
+## 결과 보고 (한국어, Discord)
+- Consolidation: 요약(또는 권한오류)
+- in-scope 위생: error N / episode N / decision N / fact N 삭제
+- 저장소 건강: 총 파편 X · episode 비중 Y% · anchorCount Z (+경보 여부)
+- 심화 패스(일요일): 삭제 N건(type별) / 또는 "스킵"
+정리·경보 내용이 하나도 없으면 NO_REPLY를 반환.
 PROMPT
 
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \


### PR DESCRIPTION
## 개요
`memento-hygiene` 루틴(소유: project-agentmanager)을 재설계. 운영자 루틴 스크립트 변경(제품 Rust/relay 로직 아님).

## 변경
- **죽은 1단계 제거**: `~/.claude/projects/*/memory/`·`~/.codex/memories/` 로컬메모리 이관 단계 삭제 (memento 단일화 방침으로 스캔 대상 없음)
- **일요일 심화 패스 추가**: `date +%u == 7`일 때만 cross-workspace 결정론적 정리 (`memento-deep-cleanup.sql`)
  - 하드가드 WHERE 강제: `is_anchor=false` · `importance<0.6` · `age>14d` · family/cookingheart/storycraft 제외
  - 캡 1500, 대상: 미조회 episode / resolved 오래된 error / session_reflect 메타팩트
  - **래퍼(bash+SQL)가 실행, LLM은 보고만** — 무인 LLM 자유삭제 위험 제거
- **저장소 건강 모니터**: `memory_stats` + `anchorCount` → episode 비중/앵커 인플레 경보
- **in-scope 스윕 통합**: error/episode/decision/fact
- DB 접근 노드무관: memento 호스트는 로컬 psql, 타 노드는 ssh 파이프

## 스케줄
routine 스케줄은 API로 이미 `0 3 * * *`(03:00 daily KST)로 변경됨.

## 검증
- `bash -n` OK, 심화 SQL ROLLBACK 파이프 테스트(실삭제 0), 요일 게이트 확인, 양 노드 배포·md5 일치.

## 머지 긴급도
release 배포는 `rsync --delete`로 repo의 launchd-migrated를 release 트리에 밀어넣으므로, **다음 deploy 전에 머지되지 않으면 현재 라이브 편집이 stale 버전으로 되돌아가고 새 .sql이 삭제됨.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
