### PR TITLE
fix(test): isolate live release runtime root (#4514)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -501,7 +501,7 @@
 | `services::discord::health::runtime_resolve` | `src/services/discord/health/runtime_resolve.rs` | 390 | 322 | 68 |  |
 | `services::discord::health::session_enrichment` | `src/services/discord/health/session_enrichment.rs` | 264 | 242 | 22 |  |
 | `services::discord::health::snapshot` | `src/services/discord/health/snapshot.rs` | 1240 | 972 | 268 |  |
-| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2383 | 989 | 1394 |  |
+| `services::discord::health::stall_liveness` | `src/services/discord/health/stall_liveness.rs` | 2385 | 989 | 1396 |  |
 | `services::discord::health::stall_verdict` | `src/services/discord/health/stall_verdict.rs` | 1338 | 425 | 913 |  |
 | `services::discord::health::watcher_respawn` | `src/services/discord/health/watcher_respawn.rs` | 1384 | 627 | 757 |  |
 | `services::discord::http` | `src/services/discord/http.rs` | 360 | 266 | 94 |  |
@@ -786,7 +786,7 @@
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 634 | 580 | 54 |  |
 | `services::discord::tmux_watcher::turn_identity` | `src/services/discord/tmux_watcher/turn_identity.rs` | 511 | 511 | 0 |  |
 | `services::discord::tmux_watcher::turn_stream_collector` | `src/services/discord/tmux_watcher/turn_stream_collector.rs` | 1158 | 1158 | 0 | giant-file |
-| `services::discord::tmux_watcher::two_message_panel` | `src/services/discord/tmux_watcher/two_message_panel.rs` | 694 | 382 | 312 |  |
+| `services::discord::tmux_watcher::two_message_panel` | `src/services/discord/tmux_watcher/two_message_panel.rs` | 695 | 382 | 313 |  |
 | `services::discord::tmux_watcher::utf8_chunk_decoder` | `src/services/discord/tmux_watcher/utf8_chunk_decoder.rs` | 88 | 88 | 0 |  |
 | `services::discord::tui_direct_abort_marker` | `src/services/discord/tui_direct_abort_marker/mod.rs` | 3123 | 838 | 2285 |  |
 | `services::discord::tui_direct_abort_marker::deferred_claim` | `src/services/discord/tui_direct_abort_marker/deferred_claim.rs` | 680 | 273 | 407 |  |
@@ -869,7 +869,7 @@
 | `services::discord::turn_bridge::tmux_runtime::process_backend_cancel` | `src/services/discord/turn_bridge/tmux_runtime/process_backend_cancel.rs` | 156 | 156 | 0 |  |
 | `services::discord::turn_bridge::tmux_runtime::process_table` | `src/services/discord/turn_bridge/tmux_runtime/process_table.rs` | 370 | 370 | 0 |  |
 | `services::discord::turn_bridge::turn_analytics` | `src/services/discord/turn_bridge/turn_analytics.rs` | 419 | 348 | 71 |  |
-| `services::discord::turn_bridge::two_message_panel` | `src/services/discord/turn_bridge/two_message_panel.rs` | 800 | 270 | 530 |  |
+| `services::discord::turn_bridge::two_message_panel` | `src/services/discord/turn_bridge/two_message_panel.rs` | 801 | 270 | 531 |  |
 | `services::discord::turn_bridge::voice_completion` | `src/services/discord/turn_bridge/voice_completion.rs` | 385 | 385 | 0 |  |
 | `services::discord::turn_bridge::watcher_handoff` | `src/services/discord/turn_bridge/watcher_handoff.rs` | 935 | 532 | 403 |  |
 | `services::discord::turn_bridge::watcher_orphan_cleanup` | `src/services/discord/turn_bridge/watcher_orphan_cleanup.rs` | 475 | 233 | 242 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -695,7 +695,7 @@
 | `services::discord::runtime_bootstrap::spawns` | `src/services/discord/runtime_bootstrap/spawns.rs` | 268 | 268 | 0 |  |
 | `services::discord::runtime_bootstrap::startup_doctor` | `src/services/discord/runtime_bootstrap/startup_doctor.rs` | 156 | 156 | 0 |  |
 | `services::discord::runtime_bootstrap::voice` | `src/services/discord/runtime_bootstrap/voice.rs` | 271 | 198 | 73 |  |
-| `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 497 | 469 | 28 |  |
+| `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 510 | 465 | 45 |  |
 | `services::discord::semantic_boundaries` | `src/services/discord/semantic_boundaries.rs` | 286 | 286 | 0 |  |
 | `services::discord::session_banner` | `src/services/discord/session_banner.rs` | 495 | 152 | 343 |  |
 | `services::discord::session_identity` | `src/services/discord/session_identity.rs` | 214 | 141 | 73 |  |

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -1001,9 +1001,11 @@ mod tests {
     use super::*;
 
     /// The liveness evidence path reaches `latest_runtime_activity_unix_nanos`,
-    /// which trips the #3293 runtime-store guard when `AGENTDESK_ROOT_DIR` points
-    /// at a live release root (the normal dev-machine env). Point it at a throw-
-    /// away temp root so these tests run anywhere, not just under CI's temp root.
+    /// which resolves the runtime-store root. Under a live release
+    /// `AGENTDESK_ROOT_DIR` (the normal dev-machine env) the #3293 guard now
+    /// falls back to a shared throwaway tempdir instead of the live root (#4514).
+    /// Point it at a per-test throwaway root so these tests stay isolated and run
+    /// anywhere, not just under CI's temp root.
     ///
     /// `AGENTDESK_ROOT_DIR` is process-global, so we hold the shared test env lock
     /// (same as the sibling `recovery.rs` tests) for the whole test — otherwise a

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -19,8 +19,9 @@ fn test_agentdesk_root() -> Option<PathBuf> {
         let trimmed = override_root.trim();
         if !trimmed.is_empty() {
             let root = PathBuf::from(trimmed);
-            assert_not_live_release_runtime_root(&root);
-            return Some(root);
+            if !is_live_release_runtime_root(&root) {
+                return Some(root);
+            }
         }
     }
     static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
@@ -32,14 +33,8 @@ fn test_agentdesk_root() -> Option<PathBuf> {
 }
 
 #[cfg(test)]
-fn assert_not_live_release_runtime_root(root: &Path) {
-    if let Some(home) = dirs::home_dir() {
-        let live = home.join(".adk").join("release");
-        assert!(
-            root != live,
-            "#3293: test must set AGENTDESK_ROOT_DIR via tempdir before resolving AgentDesk runtime store root"
-        );
-    }
+fn is_live_release_runtime_root(root: &Path) -> bool {
+    dirs::home_dir().is_some_and(|home| root == home.join(".adk").join("release"))
 }
 
 pub(super) fn runtime_root() -> Option<PathBuf> {
@@ -464,6 +459,24 @@ pub(crate) fn best_effort_atomic_write_logged(
             error = %error,
             "best-effort atomic write failed"
         );
+    }
+}
+
+#[cfg(test)]
+mod runtime_root_tests {
+    use super::*;
+
+    #[test]
+    fn live_release_override_falls_back_to_isolated_tempdir() {
+        let home = dirs::home_dir().expect("test requires a home directory");
+        let live_release_root = home.join(".adk").join("release");
+        let _env =
+            crate::config::TestEnvVarGuard::set_path("AGENTDESK_ROOT_DIR", &live_release_root);
+
+        let resolved = test_agentdesk_root().expect("test runtime root");
+
+        assert_ne!(resolved, live_release_root);
+        assert!(resolved.exists(), "fallback tempdir must remain alive");
     }
 }
 

--- a/src/services/discord/tmux_watcher/two_message_panel.rs
+++ b/src/services/discord/tmux_watcher/two_message_panel.rs
@@ -657,10 +657,11 @@ mod tests {
         );
     }
 
-    /// #3293: `InflightTurnState::new` resolves the AgentDesk runtime store, which
-    /// panics unless the runtime root is a tempdir (never the live `~/.adk/release`).
-    /// Point `AGENTDESK_ROOT_DIR` at a throwaway dir under the shared env lock so
-    /// constructing a test inflight is deterministic; restore on drop.
+    /// #3293: `InflightTurnState::new` resolves the AgentDesk runtime store; the
+    /// guard keeps this off the live `~/.adk/release`, falling back to a shared
+    /// throwaway tempdir (#4514). Point `AGENTDESK_ROOT_DIR` at a per-test
+    /// throwaway dir under the shared env lock so constructing a test inflight is
+    /// deterministic; restore on drop.
     struct RuntimeRootGuard {
         previous: Option<std::ffi::OsString>,
         _root: tempfile::TempDir,

--- a/src/services/discord/turn_bridge/two_message_panel.rs
+++ b/src/services/discord/turn_bridge/two_message_panel.rs
@@ -276,9 +276,10 @@ mod tests {
     use std::sync::Mutex;
 
     /// #3293: `InflightTurnState::new` resolves the AgentDesk runtime store to
-    /// stamp the born generation, which panics unless the runtime root is a
-    /// tempdir (never the live `~/.adk/release`). Point `AGENTDESK_ROOT_DIR` at a
-    /// throwaway dir under the shared env lock so constructing a test inflight is
+    /// stamp the born generation; the guard keeps this off the live
+    /// `~/.adk/release`, falling back to a shared throwaway tempdir (#4514).
+    /// Point `AGENTDESK_ROOT_DIR` at a per-test throwaway dir under the shared
+    /// env lock so constructing a test inflight is
     /// deterministic regardless of the ambient environment; restore on drop.
     struct RuntimeRootGuard {
         previous: Option<std::ffi::OsString>,

--- a/src/services/discord/turn_view_reconciler/tests.rs
+++ b/src/services/discord/turn_view_reconciler/tests.rs
@@ -99,8 +99,9 @@ fn snapshot_reactions(
 /// Isolate each reconciler test from the process-global `AGENTDESK_ROOT_DIR`.
 /// S4-a2 gave the reconciler a persisted target store (`persist_target` /
 /// `load_persisted_target`), so every `note_state` transition now resolves the
-/// runtime-store root and panics under the #3293 guard unless a test root is
-/// installed. Acquire the crate-wide env lock (the same
+/// runtime-store root; under the #3293 guard a live/unset `AGENTDESK_ROOT_DIR`
+/// falls back to a shared throwaway tempdir (#4514), so per-test isolation still
+/// requires installing a test root. Acquire the crate-wide env lock (the same
 /// `config::shared_test_env_lock()` every other env-mutating test serializes
 /// on) for the FULL test scope, point the env at a private temp dir, and
 /// restore the prior value on drop. The `MutexGuard` is held across the test's


### PR DESCRIPTION
## 이슈
#4514 — `test_agentdesk_root()`가 앰비언트 `AGENTDESK_ROOT_DIR`=live release(~/.adk/release)에서 `assert_not_live_release_runtime_root`(#3293)로 간헐 panic (flaky).

## 수정 (중앙 수정만)
`runtime_store.rs`: panic하던 assert 헬퍼를 boolean `is_live_release_runtime_root`로 전환. live-release override면 return하지 않고 **기존 OnceLock 격리 tempdir 폴백으로 흘림**. 테스트 전용 경로, 비테스트 런타임 거동 불변. 이슈 제안의 레포 전반 명시적 root 주입 리팩터는 스코프 제외.

## 검증
- `env -u AGENTDESK_ROOT_DIR cargo test --lib prompt_builder` 59 passed, runtime_store 2 passed
- **AGENTDESK_ROOT_DIR=~/.adk/release export 상태에서 panic 없이 폴백** (1 passed) — 간헐 panic 제거 증명
- fmt/check/freshness/audit rc=0