### PR TITLE
ops: draft-gated external toolchain update routine (#4555)

### DIFF
--- a/docs/routines/toolchain-update.md
+++ b/docs/routines/toolchain-update.md
@@ -19,7 +19,7 @@ services, and manual-only tools are reported explicitly rather than silently dro
 | native installer | `claude` | approval required; never scheduled for apply |
 | npm global | `codex`, `ocx`, `claude-e` | `codex`/`ocx` approval tier; all npm mutations, including hygiene `claude-e`, require an exact per-tool approval marker |
 | uv tool | `cswap` (`claude-swap`) | approval required because `--list --json` has drifted |
-| rustup | `cargo/rustc` | hygiene candidate; post-update compiler smoke required |
+| rustup | `cargo/rustc` | hygiene candidate; per-tool approval required; rustup binary self-update disabled; post-update compiler smoke required |
 | Homebrew | `tmux`, `gh`, `node`, `python@3.14`, `uv`, `pipx`, `jq`, `ripgrep`, `ffmpeg`, `whisper-cpp`, `postgresql@17` | `tmux`, `node`, and PostgreSQL require approval; the rest are hygiene candidates |
 | pipx | `edge-tts` | hygiene candidate |
 | native installer | `opencode` | hygiene candidate only when already installed; its self-updater still requires exact per-tool approval |
@@ -64,9 +64,10 @@ python3 "$ROOT/scripts/toolchain_update.py" apply \
 ```
 
 `--apply-hygiene` selects every hygiene row whose draft decision is `update-available`.
-Native/self-updater/npm mutations remain approval-gated even when their tier is hygiene, so
-`claude-e` and `opencode` must be approved first. Report-only rows cannot enter the apply path. The
-launchd plist contains neither `approve` nor `apply` and cannot cross either gate.
+Native/self-updater/rustup/npm mutations remain approval-gated even when their tier is hygiene, so
+`claude-e`, `cargo/rustc`, and `opencode` must be approved first. Rustup toolchain updates pass
+`--no-self-update`, so they cannot silently replace the rustup binary. Report-only rows cannot enter
+the apply path. The launchd plist contains neither `approve` nor `apply` and cannot cross either gate.
 
 ## Smoke and failure handling
 

--- a/docs/routines/toolchain-update.md
+++ b/docs/routines/toolchain-update.md
@@ -1,0 +1,120 @@
+# External toolchain update routine
+
+Issue #4555 adds a weekly, draft-first inventory check for the external tools used by AgentDesk.
+The scheduler never applies an update. Its only entry point is:
+
+```bash
+python3 scripts/toolchain_update.py check
+```
+
+That command performs bounded, read-only current/latest probes and atomically rewrites
+`runtime/toolchain-update/latest.md` plus its machine-readable sibling `latest.json`. Every
+inventory target always receives a row. Missing binaries, registry failures, unreachable remote
+services, and manual-only tools are reported explicitly rather than silently dropped.
+
+## Inventory and authority
+
+| Update method | Targets | Authority |
+|---|---|---|
+| native installer | `claude` | approval required; never scheduled for apply |
+| npm global | `codex`, `ocx`, `claude-e` | `codex`/`ocx` approval tier; all npm mutations, including hygiene `claude-e`, require an exact per-tool approval marker |
+| uv tool | `cswap` (`claude-swap`) | approval required because `--list --json` has drifted |
+| rustup | `cargo/rustc` | hygiene candidate; post-update compiler smoke required |
+| Homebrew | `tmux`, `gh`, `node`, `python@3.14`, `uv`, `pipx`, `jq`, `ripgrep`, `ffmpeg`, `whisper-cpp`, `postgresql@17` | `tmux`, `node`, and PostgreSQL require approval; the rest are hygiene candidates |
+| pipx | `edge-tts` | hygiene candidate |
+| native installer | `opencode` | hygiene candidate only when already installed |
+| remote service | memento MCP at the configured mac-mini endpoint | health/version report only; no local mutation |
+| npx always-latest | brave-search MCP | reports the unpinned spec and latest package version; pin approval is a manual config decision |
+| manual/receipt | `SidecarLauncher`, Playwright + Chromium | report only; no mutation |
+
+The `check --offline` diagnostic skips all registry and HTTP probes, including memento, while still
+emitting every row. Normal weekly checks do query npm, PyPI, Homebrew metadata, rustup, and memento.
+Homebrew metadata probes set `HOMEBREW_NO_AUTO_UPDATE=1`.
+
+## Draft to approval to apply
+
+Review `latest.md`, especially the approval cards, risks, and changelog links. An approval marker
+is bound to the exact SHA-256 draft ID and exact current/latest pair, so editing or replacing the
+JSON invalidates existing approval.
+
+```bash
+ROOT="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
+DRAFT="$ROOT/runtime/toolchain-update/latest.json"
+
+python3 "$ROOT/scripts/toolchain_update.py" approve \
+  --draft "$DRAFT" \
+  --tool codex \
+  --confirm approve-exact-toolchain-draft
+```
+
+Applying is a separate human invocation. It requires the literal safe-window confirmation and then
+independently fails closed unless `agentdesk status --json` reports zero working/active-dispatch
+sessions, the queue is not running, neither `cargo` nor `rustc` is running, and no
+`deploy-release.sh` process exists. Current/latest versions are re-probed immediately before the
+first mutation; any mismatch with the approved draft is treated as a stale draft and blocks apply.
+
+```bash
+python3 "$ROOT/scripts/toolchain_update.py" apply \
+  --draft "$DRAFT" \
+  --tool codex \
+  --confirm-safe-window no-active-turns-or-deploys
+```
+
+`--apply-hygiene` selects every hygiene row whose draft decision is `update-available`. Native/npm
+mutations remain approval-gated even when their tier is hygiene, so `claude-e` must be approved
+first. Report-only rows cannot enter the apply path. The launchd plist contains neither `approve`
+nor `apply` and cannot cross either gate.
+
+## Smoke and failure handling
+
+Each applied tool must first re-probe at or above the draft's target version, then immediately runs
+its profile before the batch can continue:
+
+- `claude --version`, `codex --version`, and other version probes must contain a semantic version;
+  Codex output uses the highest semantic version found.
+- `cswap --list --json` must match the permissive camelCase object/list shape consumed by
+  `src/services/cswap.rs`, including fractional `usageAgeSeconds`.
+- `ocx health` must succeed after the version probe. This catches the proxy-stop behavior observed
+  during prior `ocx update` use; the script does not restart the proxy automatically.
+- `tmux -V` must parse; Node must load `npm ls -g --depth=0 --json` and every recognized installed
+  global CLI (`codex`, `ocx`, `claude-e`).
+- PostgreSQL requires both `psql --version` and a matching server major from `SHOW server_version`.
+  A strict apply therefore requires `AGENTDESK_DATABASE_URL` or `DATABASE_URL`.
+- Rust checks the actual rustup `stable` rustc/cargo pair; Homebrew hygiene tools, `edge-tts`, and
+  `opencode` must load their version command.
+
+The smoke gate can also be run independently:
+
+```bash
+python3 "$ROOT/scripts/toolchain_update.py" smoke --tool codex --tool cswap
+```
+
+On the first failed post-update smoke, the batch stops and exits non-zero. It writes
+`runtime/toolchain-update/alerts/<draft>-<tool>.md` with the failed checks and an exact rollback
+command where package managers support version pins, or a Homebrew pin/native rollback instruction
+otherwise. No dcserver/proxy restart occurs until an operator completes that plan and the smoke
+profile passes.
+
+## launchd template (documented installation only)
+
+`scripts/launchd/com.agentdesk.toolchain-update.plist` runs every Sunday at 09:30 in the host's
+local timezone. It is a source template: replace `__AGENTDESK_ROOT__` with the absolute release
+root before loading. It resolves `python3` through the plist's Homebrew-first explicit `PATH` so
+the repository's Python 3.11+ requirement is honored. The repository does not install or load it
+automatically.
+
+The following are operator commands; implementation and tests do not execute them:
+
+```bash
+ROOT="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
+SOURCE="$ROOT/scripts/launchd/com.agentdesk.toolchain-update.plist"
+DEST="$HOME/Library/LaunchAgents/com.agentdesk.toolchain-update.plist"
+
+sed "s|__AGENTDESK_ROOT__|$ROOT|g" "$SOURCE" > "$DEST"
+plutil -lint "$DEST"
+launchctl bootstrap "gui/$(id -u)" "$DEST"
+```
+
+To remove the schedule, use `launchctl bootout "gui/$(id -u)/com.agentdesk.toolchain-update"` and
+then remove the materialized plist. Removing the schedule does not remove drafts or approval
+markers.

--- a/docs/routines/toolchain-update.md
+++ b/docs/routines/toolchain-update.md
@@ -22,7 +22,7 @@ services, and manual-only tools are reported explicitly rather than silently dro
 | rustup | `cargo/rustc` | hygiene candidate; post-update compiler smoke required |
 | Homebrew | `tmux`, `gh`, `node`, `python@3.14`, `uv`, `pipx`, `jq`, `ripgrep`, `ffmpeg`, `whisper-cpp`, `postgresql@17` | `tmux`, `node`, and PostgreSQL require approval; the rest are hygiene candidates |
 | pipx | `edge-tts` | hygiene candidate |
-| native installer | `opencode` | hygiene candidate only when already installed |
+| native installer | `opencode` | hygiene candidate only when already installed; its self-updater still requires exact per-tool approval |
 | remote service | memento MCP at the configured mac-mini endpoint | health/version report only; no local mutation |
 | npx always-latest | brave-search MCP | reports the unpinned spec and latest package version; pin approval is a manual config decision |
 | manual/receipt | `SidecarLauncher`, Playwright + Chromium | report only; no mutation |
@@ -33,9 +33,10 @@ Homebrew metadata probes set `HOMEBREW_NO_AUTO_UPDATE=1`.
 
 ## Draft to approval to apply
 
-Review `latest.md`, especially the approval cards, risks, and changelog links. An approval marker
-is bound to the exact SHA-256 draft ID and exact current/latest pair, so editing or replacing the
-JSON invalidates existing approval.
+Review `latest.md`, especially the approval cards, risks, and changelog links. Each generated draft
+has a fresh nonce included in its SHA-256 draft ID. An approval marker is bound to that exact draft
+instance and exact current/latest pair, so editing, replacing, or regenerating byte-identical checks
+invalidates existing approval.
 
 ```bash
 ROOT="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
@@ -49,9 +50,11 @@ python3 "$ROOT/scripts/toolchain_update.py" approve \
 
 Applying is a separate human invocation. It requires the literal safe-window confirmation and then
 independently fails closed unless `agentdesk status --json` reports zero working/active-dispatch
-sessions, the queue is not running, neither `cargo` nor `rustc` is running, and no
-`deploy-release.sh` process exists. Current/latest versions are re-probed immediately before the
-first mutation; any mismatch with the approved draft is treated as a stale draft and blocks apply.
+sessions, the queue has no non-terminal live status, neither `cargo` nor `rustc` is running, and no
+`deploy-release.sh` process exists. Current/latest versions are re-probed before mutation; any
+mismatch with the approved draft is treated as a stale draft and blocks apply. The full safe-window
+check runs again immediately before every destructive command to close the preflight-to-mutation
+race.
 
 ```bash
 python3 "$ROOT/scripts/toolchain_update.py" apply \
@@ -60,15 +63,16 @@ python3 "$ROOT/scripts/toolchain_update.py" apply \
   --confirm-safe-window no-active-turns-or-deploys
 ```
 
-`--apply-hygiene` selects every hygiene row whose draft decision is `update-available`. Native/npm
-mutations remain approval-gated even when their tier is hygiene, so `claude-e` must be approved
-first. Report-only rows cannot enter the apply path. The launchd plist contains neither `approve`
-nor `apply` and cannot cross either gate.
+`--apply-hygiene` selects every hygiene row whose draft decision is `update-available`.
+Native/self-updater/npm mutations remain approval-gated even when their tier is hygiene, so
+`claude-e` and `opencode` must be approved first. Report-only rows cannot enter the apply path. The
+launchd plist contains neither `approve` nor `apply` and cannot cross either gate.
 
 ## Smoke and failure handling
 
-Each applied tool must first re-probe at or above the draft's target version, then immediately runs
-its profile before the batch can continue:
+Each applied tool must first re-probe at exactly the draft's approved target version, then
+immediately runs its profile before the batch can continue. A newer-at-runtime native updater
+result is an unapproved version and fails before smoke:
 
 - `claude --version`, `codex --version`, and other version probes must contain a semantic version;
   Codex output uses the highest semantic version found.
@@ -76,8 +80,8 @@ its profile before the batch can continue:
   `src/services/cswap.rs`, including fractional `usageAgeSeconds`.
 - `ocx health` must succeed after the version probe. This catches the proxy-stop behavior observed
   during prior `ocx update` use; the script does not restart the proxy automatically.
-- `tmux -V` must parse; Node must load `npm ls -g --depth=0 --json` and every recognized installed
-  global CLI (`codex`, `ocx`, `claude-e`).
+- `tmux -V` must parse; Node must load `npm ls -g --depth=0 --json`, retain every npm-global CLI in
+  the manifest (`codex`, `ocx`, `claude-e`), and successfully probe every corresponding binary.
 - PostgreSQL requires both `psql --version` and a matching server major from `SHOW server_version`.
   A strict apply therefore requires `AGENTDESK_DATABASE_URL` or `DATABASE_URL`.
 - Rust checks the actual rustup `stable` rustc/cargo pair; Homebrew hygiene tools, `edge-tts`, and
@@ -89,7 +93,9 @@ The smoke gate can also be run independently:
 python3 "$ROOT/scripts/toolchain_update.py" smoke --tool codex --tool cswap
 ```
 
-On the first failed post-update smoke, the batch stops and exits non-zero. It writes
+On the first failed update command, exact-version verification, or post-update smoke, the batch
+stops and exits non-zero. Build-capable Homebrew updates receive a two-hour timeout rather than
+being killed after five minutes. Every post-mutation failure writes
 `runtime/toolchain-update/alerts/<draft>-<tool>.md` with the failed checks and an exact rollback
 command where package managers support version pins, or a Homebrew pin/native rollback instruction
 otherwise. No dcserver/proxy restart occurs until an operator completes that plan and the smoke
@@ -99,8 +105,9 @@ profile passes.
 
 `scripts/launchd/com.agentdesk.toolchain-update.plist` runs every Sunday at 09:30 in the host's
 local timezone. It is a source template: replace `__AGENTDESK_ROOT__` with the absolute release
-root before loading. It resolves `python3` through the plist's Homebrew-first explicit `PATH` so
-the repository's Python 3.11+ requirement is honored. The repository does not install or load it
+root and `__HOME__` with the user's absolute home directory before loading. Its explicit `PATH`
+includes user-local, rustup, opencode, and `~/bin` locations before Homebrew and system directories,
+so scheduled probes can find the same managed tools. The repository does not install or load it
 automatically.
 
 The following are operator commands; implementation and tests do not execute them:
@@ -110,7 +117,7 @@ ROOT="${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}"
 SOURCE="$ROOT/scripts/launchd/com.agentdesk.toolchain-update.plist"
 DEST="$HOME/Library/LaunchAgents/com.agentdesk.toolchain-update.plist"
 
-sed "s|__AGENTDESK_ROOT__|$ROOT|g" "$SOURCE" > "$DEST"
+sed -e "s|__AGENTDESK_ROOT__|$ROOT|g" -e "s|__HOME__|$HOME|g" "$SOURCE" > "$DEST"
 plutil -lint "$DEST"
 launchctl bootstrap "gui/$(id -u)" "$DEST"
 ```

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -75,6 +75,9 @@ node --test policies/__tests__/daily-log-digest.test.js
 echo "=== Weekly regression-churn audit tests (#4265) ==="
 "$PYTHON" -m unittest tests.test_weekly_churn_audit
 
+echo "=== External toolchain draft/approval/smoke tests (#4555) ==="
+"$PYTHON" -m unittest tests.test_toolchain_update
+
 echo "=== await_holding_lock ratchet guard ==="
 "$PYTHON" scripts/check_await_holding_lock_ratchet.py
 "$PYTHON" -m unittest tests.test_await_holding_lock_ratchet

--- a/scripts/launchd/com.agentdesk.toolchain-update.plist
+++ b/scripts/launchd/com.agentdesk.toolchain-update.plist
@@ -37,7 +37,7 @@
     <key>AGENTDESK_ROOT_DIR</key>
     <string>__AGENTDESK_ROOT__</string>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>__HOME__/.local/bin:__HOME__/.cargo/bin:__HOME__/.opencode/bin:__HOME__/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>
 
   <key>StandardOutPath</key>

--- a/scripts/launchd/com.agentdesk.toolchain-update.plist
+++ b/scripts/launchd/com.agentdesk.toolchain-update.plist
@@ -18,7 +18,7 @@
   <key>StartCalendarInterval</key>
   <dict>
     <key>Weekday</key>
-    <integer>1</integer>
+    <integer>0</integer>
     <key>Hour</key>
     <integer>9</integer>
     <key>Minute</key>

--- a/scripts/launchd/com.agentdesk.toolchain-update.plist
+++ b/scripts/launchd/com.agentdesk.toolchain-update.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentdesk.toolchain-update</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>python3</string>
+    <string>__AGENTDESK_ROOT__/scripts/toolchain_update.py</string>
+    <string>check</string>
+    <string>--output-dir</string>
+    <string>__AGENTDESK_ROOT__/runtime/toolchain-update</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>1</integer>
+    <key>Hour</key>
+    <integer>9</integer>
+    <key>Minute</key>
+    <integer>30</integer>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENTDESK_ROOT_DIR</key>
+    <string>__AGENTDESK_ROOT__</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>__AGENTDESK_ROOT__/logs/toolchain-update.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>__AGENTDESK_ROOT__/logs/toolchain-update.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/toolchain_manifest.py
+++ b/scripts/toolchain_manifest.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Declarative external-tool inventory for the AgentDesk update routine."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_MEMENTO_URL = "http://100.123.183.105:57332"
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    key: str
+    display_name: str
+    method: str
+    tier: str
+    current_kind: str
+    current_value: tuple[str, ...] | str
+    latest_kind: str
+    latest_value: tuple[str, ...] | str
+    update_kind: str | None
+    update_value: tuple[str, ...] | str | None
+    smoke_profile: str | None
+    risk: str
+    changelog_url: str
+    report_only: bool = False
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class ValueProbe:
+    ok: bool
+    value: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ToolCheck:
+    key: str
+    display_name: str
+    method: str
+    tier: str
+    current: str
+    latest: str
+    decision: str
+    current_detail: str
+    latest_detail: str
+    risk: str
+    changelog_url: str
+    report_only: bool
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    check: str
+    ok: bool
+    detail: str
+
+
+def tool_inventory() -> tuple[ToolSpec, ...]:
+    """Return the exhaustive inventory from AgentDesk issue #4555."""
+
+    home = Path.home()
+    brew_tools = (
+        ("tmux", "tmux", "approval", "tmux", "tmux/tmux", "tmux capture/paste is load-bearing"),
+        ("gh", "gh", "hygiene", "gh", "cli/cli", "GitHub CLI compatibility"),
+        ("node", "node", "approval", "node", "nodejs/node", "major upgrades can break every global npm CLI"),
+        (
+            "python-3-14",
+            "python@3.14",
+            "hygiene",
+            "python@3.14",
+            "python/cpython",
+            "automation interpreter compatibility",
+        ),
+        ("uv", "uv", "hygiene", "uv", "astral-sh/uv", "Python tool installer compatibility"),
+        ("pipx", "pipx", "hygiene", "pipx", "pypa/pipx", "isolated Python CLI management"),
+        ("jq", "jq", "hygiene", "jq", "jqlang/jq", "JSON command-line parsing"),
+        ("ripgrep", "ripgrep", "hygiene", "ripgrep", "BurntSushi/ripgrep", "repository search tooling"),
+        ("ffmpeg", "ffmpeg", "hygiene", "ffmpeg", "FFmpeg/FFmpeg", "voice media processing"),
+        (
+            "whisper-cpp",
+            "whisper-cpp",
+            "hygiene",
+            "whisper-cpp",
+            "ggml-org/whisper.cpp",
+            "voice transcription runtime",
+        ),
+        (
+            "postgresql-17",
+            "postgresql@17",
+            "approval",
+            "postgresql@17",
+            "postgres/postgres",
+            "client major must remain compatible with the server",
+        ),
+    )
+    specs: list[ToolSpec] = [
+        ToolSpec(
+            "claude",
+            "claude",
+            "native",
+            "approval",
+            "command",
+            ("claude", "--version"),
+            "npm",
+            "@anthropic-ai/claude-code",
+            "command",
+            ("claude", "update"),
+            "claude",
+            "auth/session behavior can desynchronize cswap",
+            "https://docs.anthropic.com/en/release-notes/claude-code",
+        ),
+        ToolSpec(
+            "codex",
+            "codex (@openai/codex)",
+            "npm-g",
+            "approval",
+            "command",
+            ("codex", "--version"),
+            "npm",
+            "@openai/codex",
+            "npm-exact",
+            "@openai/codex",
+            "codex",
+            "version parsing and all Codex agent sessions depend on it",
+            "https://github.com/openai/codex/releases",
+        ),
+        ToolSpec(
+            "ocx",
+            "ocx (@bitkyc08/opencodex)",
+            "npm-g",
+            "approval",
+            "command",
+            ("ocx", "--version"),
+            "npm",
+            "@bitkyc08/opencodex",
+            "npm-exact",
+            "@bitkyc08/opencodex",
+            "ocx",
+            "proxy lifecycle and agent routing depend on it",
+            "https://www.npmjs.com/package/@bitkyc08/opencodex",
+        ),
+        ToolSpec(
+            "claude-e",
+            "claude-e",
+            "npm-g",
+            "hygiene",
+            "command",
+            ("claude-e", "--version"),
+            "npm",
+            "claude-e",
+            "npm-exact",
+            "claude-e",
+            "claude-e",
+            "claude-e wrapper compatibility",
+            "https://www.npmjs.com/package/claude-e",
+        ),
+        ToolSpec(
+            "cswap",
+            "cswap (claude-swap)",
+            "uv-tool",
+            "approval",
+            "command",
+            ("cswap", "--version"),
+            "pypi",
+            "claude-swap",
+            "uv-exact",
+            "claude-swap",
+            "cswap",
+            "cswap 0.17 changed the --list --json shape",
+            "https://pypi.org/project/claude-swap/",
+        ),
+        ToolSpec(
+            "cargo-rustc",
+            "cargo/rustc",
+            "rustup",
+            "hygiene",
+            "command",
+            ("rustup", "run", "stable", "rustc", "--version"),
+            "rustup",
+            ("rustup", "check"),
+            "command",
+            ("rustup", "update", "stable"),
+            "rust",
+            "the repository MSRV and pinned toolchain must still compile",
+            "https://blog.rust-lang.org/releases/",
+        ),
+    ]
+    for key, display, tier, formula, upstream, risk in brew_tools:
+        specs.append(
+            ToolSpec(
+                key,
+                display,
+                "homebrew",
+                tier,
+                "brew-current",
+                formula,
+                "brew-latest",
+                formula,
+                "brew-upgrade",
+                formula,
+                key,
+                risk,
+                f"https://formulae.brew.sh/formula/{formula.replace('@', '%40')}",
+            )
+        )
+    specs.extend(
+        [
+            ToolSpec(
+                "edge-tts",
+                "edge-tts",
+                "pipx",
+                "hygiene",
+                "command",
+                ("edge-tts", "--version"),
+                "pypi",
+                "edge-tts",
+                "pipx-exact",
+                "edge-tts",
+                "edge-tts",
+                "voice synthesis CLI compatibility",
+                "https://pypi.org/project/edge-tts/",
+            ),
+            ToolSpec(
+                "opencode",
+                "opencode",
+                "installer",
+                "hygiene",
+                "command",
+                ("opencode", "--version"),
+                "npm",
+                "opencode-ai",
+                "command",
+                ("opencode", "upgrade"),
+                "opencode",
+                "only update hosts where the optional provider is installed",
+                "https://github.com/anomalyco/opencode/releases",
+            ),
+            ToolSpec(
+                "memento-mcp",
+                "memento MCP",
+                "remote-service",
+                "report-only",
+                "memento-health",
+                os.environ.get("AGENTDESK_TOOLCHAIN_MEMENTO_URL", DEFAULT_MEMENTO_URL),
+                "remote-managed",
+                "mac-mini service owner",
+                None,
+                None,
+                None,
+                "remote mac-mini service; local mutation is forbidden",
+                "http://100.123.183.105:57332/health",
+                report_only=True,
+            ),
+            ToolSpec(
+                "brave-search-mcp",
+                "brave-search MCP",
+                "npx-always-latest",
+                "approval",
+                "literal",
+                "npx -y @modelcontextprotocol/server-brave-search (unpinned)",
+                "npm",
+                "@modelcontextprotocol/server-brave-search",
+                None,
+                None,
+                None,
+                "pinning @x.y.z is the update-management decision",
+                "https://www.npmjs.com/package/@modelcontextprotocol/server-brave-search",
+                report_only=True,
+            ),
+            ToolSpec(
+                "sidecar-launcher",
+                "SidecarLauncher",
+                "manual",
+                "report-only",
+                "manual-command",
+                (str(home / "bin" / "SidecarLauncher"), "devices"),
+                "manual",
+                "manual receipt/upstream check",
+                None,
+                None,
+                None,
+                "manually installed binary; do not mutate it",
+                "https://github.com/Ocasio-J/SidecarLauncher",
+                report_only=True,
+            ),
+            ToolSpec(
+                "playwright-chromium",
+                "playwright + Chromium",
+                "manual",
+                "report-only",
+                "command",
+                ("playwright", "--version"),
+                "manual",
+                "inspect /receipt when installed",
+                None,
+                None,
+                None,
+                "installation is on-demand and receipt-managed",
+                "https://playwright.dev/docs/browsers",
+                report_only=True,
+            ),
+        ]
+    )
+    return tuple(specs)

--- a/scripts/toolchain_manifest.py
+++ b/scripts/toolchain_manifest.py
@@ -190,7 +190,7 @@ def tool_inventory() -> tuple[ToolSpec, ...]:
             "rustup",
             ("rustup", "check"),
             "command",
-            ("rustup", "update", "stable"),
+            ("rustup", "update", "stable", "--no-self-update"),
             "rust",
             "the repository MSRV and pinned toolchain must still compile",
             "https://blog.rust-lang.org/releases/",

--- a/scripts/toolchain_update.py
+++ b/scripts/toolchain_update.py
@@ -29,7 +29,7 @@ from toolchain_manifest import (
 SCHEMA_VERSION = 2
 APPROVAL_CONFIRMATION = "approve-exact-toolchain-draft"
 SAFE_WINDOW_CONFIRMATION = "no-active-turns-or-deploys"
-APPROVAL_REQUIRED_METHODS = frozenset({"installer", "native", "npm-g"})
+APPROVAL_REQUIRED_METHODS = frozenset({"installer", "native", "npm-g", "rustup"})
 DEFAULT_TIMEOUT_SECONDS = 20
 DEFAULT_UPDATE_TIMEOUT_SECONDS = 1800
 BUILD_UPDATE_TIMEOUT_SECONDS = 7200
@@ -225,11 +225,16 @@ def _brew_latest(runner: Runner, formula: str) -> ValueProbe:
         return ValueProbe(False, "unavailable", _compact_detail(result.stderr))
     try:
         payload = json.loads(result.stdout)
-        stable = payload["formulae"][0]["versions"]["stable"]
+        formula_payload = payload["formulae"][0]
+        stable = formula_payload["versions"]["stable"]
+        revision = formula_payload.get("revision", 0)
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 0:
+            raise TypeError("formula revision must be a non-negative integer")
     except (KeyError, IndexError, TypeError, json.JSONDecodeError) as error:
         return ValueProbe(False, "invalid-brew-response", str(error))
     stable_text = str(stable).strip()
-    version = stable_text if _BREW_VERSION_RE.fullmatch(stable_text) else None
+    expected_text = f"{stable_text}_{revision}" if revision else stable_text
+    version = expected_text if _BREW_VERSION_RE.fullmatch(expected_text) else None
     return ValueProbe(version is not None, version or "invalid-brew-response", f"brew formula {formula}")
 
 
@@ -396,7 +401,7 @@ def render_draft(checks: Sequence[ToolCheck], generated_at: str, draft_id: str) 
     else:
         for check in hygiene:
             destructive = (
-                " (per-tool approval also required: native/self-updater/npm mutation)"
+                " (per-tool approval also required: native/self-updater/rustup/npm mutation)"
                 if check.method in APPROVAL_REQUIRED_METHODS
                 else ""
             )
@@ -426,9 +431,10 @@ def render_draft(checks: Sequence[ToolCheck], generated_at: str, draft_id: str) 
             "",
             "## Gate contract",
             "",
-            "Applying requires an explicit safe-window confirmation. Approval-tier tools and all native/self-updater/npm",
-            "mutations require a per-tool approval marker bound to this draft ID. Every applied tool runs its",
-            "smoke profile immediately; failure stops the batch, emits an alert/rollback-or-pin plan, and exits non-zero.",
+            "Applying requires an explicit safe-window confirmation. Approval-tier tools and all native/self-updater/rustup/npm",
+            "mutations require a per-tool approval marker bound to this draft ID. After mutation, exact-version verification",
+            "runs first and may stop the batch before smoke. Otherwise the smoke profile runs immediately; failure stops the",
+            "batch, emits an alert/rollback-or-pin plan, and exits non-zero.",
             "",
         ]
     )

--- a/scripts/toolchain_update.py
+++ b/scripts/toolchain_update.py
@@ -267,12 +267,29 @@ def _version_tuple(value: str) -> tuple[int, int, int] | None:
     return tuple(map(int, match.groups())) if match else None
 
 
-def _loose_version_key(value: str) -> tuple[tuple[int, ...], str] | None:
+def _loose_version_identity(value: str) -> tuple[tuple[int, ...], str] | None:
     match = re.search(r"(?<!\d)(\d+(?:\.\d+){1,2})([0-9A-Za-z._+-]*)(?!\d)", value)
     if not match:
         return None
     numeric = tuple(int(part) for part in match.group(1).split("."))
     return numeric + (0,) * (3 - len(numeric)), match.group(2)
+
+
+def _loose_version_key(value: str) -> tuple[tuple[int, ...], str, int] | None:
+    identity = _loose_version_identity(value)
+    if identity is None:
+        return None
+    numeric, suffix = identity
+    revision_match = re.fullmatch(r"(.*)_([0-9]+)", suffix)
+    if revision_match is None:
+        # Preserve the prior lexical ordering for non-Homebrew or malformed suffixes.
+        return numeric, suffix, 0
+    try:
+        revision = int(revision_match.group(2))
+    except ValueError:
+        # Extremely long numeric-looking suffixes can exceed Python's conversion limit.
+        return numeric, suffix, 0
+    return numeric, revision_match.group(1), revision
 
 
 def decide_check(spec: ToolSpec, current: ValueProbe, latest: ValueProbe) -> str:
@@ -785,8 +802,8 @@ def _rollback_or_pin_hint(spec: ToolSpec, current: str) -> str:
 
 
 def _same_version(left: str, right: str) -> bool:
-    left_key = _loose_version_key(left)
-    right_key = _loose_version_key(right)
+    left_key = _loose_version_identity(left)
+    right_key = _loose_version_identity(right)
     return left_key == right_key if left_key is not None and right_key is not None else left == right
 
 

--- a/scripts/toolchain_update.py
+++ b/scripts/toolchain_update.py
@@ -1,0 +1,997 @@
+#!/usr/bin/env python3
+"""Draft, approve, apply, and smoke-gate AgentDesk's external toolchain.
+
+The scheduled operation is read-only; apply is separately human-gated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from toolchain_manifest import (
+    CommandResult, SmokeResult, ToolCheck, ToolSpec, ValueProbe, tool_inventory
+)
+
+
+SCHEMA_VERSION = 1
+APPROVAL_CONFIRMATION = "approve-exact-toolchain-draft"
+SAFE_WINDOW_CONFIRMATION = "no-active-turns-or-deploys"
+DESTRUCTIVE_METHODS = frozenset({"native", "npm-g"})
+DEFAULT_TIMEOUT_SECONDS = 20
+_SEMVER_RE = re.compile(
+    r"(?<![0-9A-Za-z])v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?(?![0-9A-Za-z])"
+)
+_SAFE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+_BREW_VERSION_RE = re.compile(r"^[0-9][0-9A-Za-z._+-]*$")
+
+
+class ToolchainError(RuntimeError):
+    """Base class for an operator-actionable toolchain error."""
+
+
+class ApprovalError(ToolchainError):
+    """Raised when an exact, required approval marker is absent or stale."""
+
+
+class Runner:
+    """Bounded subprocess and HTTP runner used by probes and smoke checks."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        process_env = os.environ.copy()
+        if env:
+            process_env.update(env)
+        try:
+            completed = subprocess.run(
+                list(argv),
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+                env=process_env,
+            )
+        except FileNotFoundError as error:
+            return CommandResult(127, "", str(error))
+        except subprocess.TimeoutExpired:
+            return CommandResult(124, "", f"timed out after {timeout}s")
+        except OSError as error:
+            return CommandResult(126, "", str(error))
+        return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+    def get_json(
+        self,
+        url: str,
+        *,
+        timeout: int = 5,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        request_headers = {
+            "Accept": "application/json",
+            "User-Agent": "AgentDesk-toolchain-update/1",
+        }
+        if headers:
+            request_headers.update(headers)
+        request = urllib.request.Request(url, headers=request_headers)
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.load(response)
+
+def highest_semver(text: str) -> str | None:
+    """Return the numerically highest semantic version found in free-form text."""
+
+    matches = [
+        ((int(match[0]), int(match[1]), int(match[2])), ".".join(match[:3]))
+        for match in _SEMVER_RE.findall(text)
+    ]
+    return max(matches, default=((), None), key=lambda item: item[0])[1]
+
+
+def _compact_detail(text: str, limit: int = 240) -> str:
+    return " ".join(text.split())[:limit]
+
+
+def _command_probe(
+    runner: Runner,
+    argv: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    allow_unparsed: bool = False,
+) -> ValueProbe:
+    result = runner.run(argv, env=env)
+    if result.returncode != 0:
+        detail = _compact_detail(result.stderr or result.stdout or f"exit {result.returncode}")
+        return ValueProbe(False, "unavailable", detail)
+    combined = f"{result.stdout}\n{result.stderr}".strip()
+    version = highest_semver(combined)
+    if version:
+        return ValueProbe(True, version, _compact_detail(combined))
+    if allow_unparsed and combined:
+        return ValueProbe(True, _compact_detail(combined, 80), _compact_detail(combined))
+    return ValueProbe(False, "unknown", "command succeeded but no semantic version was found")
+
+
+def _memento_probe(runner: Runner, base_url: str) -> ValueProbe:
+    headers: dict[str, str] = {}
+    token = os.environ.get("MEMENTO_ACCESS_KEY", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        payload = runner.get_json(f"{base_url.rstrip('/')}/health", timeout=3, headers=headers)
+    except (OSError, ValueError, urllib.error.URLError) as error:
+        return ValueProbe(False, "unreachable", _compact_detail(str(error)))
+    if not isinstance(payload, dict):
+        return ValueProbe(False, "invalid-health-shape", "health response is not a JSON object")
+    healthy = payload.get("ok", payload.get("healthy", payload.get("status") in {"ok", "healthy"}))
+    version = next(
+        (
+            value
+            for key in ("version", "serviceVersion", "buildVersion")
+            if isinstance((value := payload.get(key)), str) and value.strip()
+        ),
+        None,
+    )
+    if healthy is not True:
+        return ValueProbe(False, version or "unhealthy", _compact_detail(json.dumps(payload)))
+    return ValueProbe(True, version or "healthy/version-unreported", "remote health probe succeeded")
+
+
+def probe_current(spec: ToolSpec, runner: Runner) -> ValueProbe:
+    if spec.current_kind == "literal":
+        return ValueProbe(True, str(spec.current_value), "configured behavior")
+    if spec.current_kind == "memento-health":
+        return _memento_probe(runner, str(spec.current_value))
+    if spec.current_kind == "manual-command":
+        argv = tuple(spec.current_value)
+        result = runner.run(argv)
+        if result.returncode == 0:
+            return ValueProbe(True, "installed/manual-version", _compact_detail(result.stdout))
+        return ValueProbe(False, "manual-check-required", _compact_detail(result.stderr))
+    if spec.current_kind == "brew-current":
+        formula = str(spec.current_value)
+        result = runner.run(
+            ("brew", "list", "--versions", formula),
+            env={"HOMEBREW_NO_AUTO_UPDATE": "1"},
+        )
+        if result.returncode != 0:
+            return ValueProbe(False, "not-installed", _compact_detail(result.stderr))
+        tokens = result.stdout.split()[1:]
+        versions = [token for token in tokens if _BREW_VERSION_RE.fullmatch(token)]
+        version = max(versions, key=_loose_version_key) if versions else None
+        return ValueProbe(
+            version is not None,
+            version or "unknown",
+            _compact_detail(result.stdout) or "formula present but version was not parseable",
+        )
+    if spec.current_kind == "command":
+        return _command_probe(runner, tuple(spec.current_value))
+    raise ToolchainError(f"unsupported current probe kind for {spec.key}: {spec.current_kind}")
+
+
+def _npm_latest(runner: Runner, package: str) -> ValueProbe:
+    result = runner.run(("npm", "view", package, "version", "--json"))
+    if result.returncode != 0:
+        return ValueProbe(False, "unavailable", _compact_detail(result.stderr))
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        return ValueProbe(False, "invalid-registry-response", str(error))
+    value = payload if isinstance(payload, str) else None
+    version = highest_semver(value or "")
+    return ValueProbe(
+        version is not None,
+        version or "invalid-registry-response",
+        f"npm package {package}",
+    )
+
+
+def _pypi_latest(runner: Runner, package: str) -> ValueProbe:
+    try:
+        payload = runner.get_json(f"https://pypi.org/pypi/{package}/json")
+        value = payload["info"]["version"]
+    except (KeyError, TypeError, ValueError, OSError, urllib.error.URLError) as error:
+        return ValueProbe(False, "unavailable", _compact_detail(str(error)))
+    version = highest_semver(str(value))
+    return ValueProbe(version is not None, version or "invalid-registry-response", f"PyPI {package}")
+
+
+def _brew_latest(runner: Runner, formula: str) -> ValueProbe:
+    result = runner.run(
+        ("brew", "info", "--json=v2", formula),
+        env={"HOMEBREW_NO_AUTO_UPDATE": "1"},
+    )
+    if result.returncode != 0:
+        return ValueProbe(False, "unavailable", _compact_detail(result.stderr))
+    try:
+        payload = json.loads(result.stdout)
+        stable = payload["formulae"][0]["versions"]["stable"]
+    except (KeyError, IndexError, TypeError, json.JSONDecodeError) as error:
+        return ValueProbe(False, "invalid-brew-response", str(error))
+    stable_text = str(stable).strip()
+    version = stable_text if _BREW_VERSION_RE.fullmatch(stable_text) else None
+    return ValueProbe(version is not None, version or "invalid-brew-response", f"brew formula {formula}")
+
+
+def probe_latest(spec: ToolSpec, runner: Runner, *, offline: bool) -> ValueProbe:
+    if offline:
+        return ValueProbe(False, "offline/not-queried", "latest-version probe explicitly skipped")
+    if spec.latest_kind == "npm":
+        return _npm_latest(runner, str(spec.latest_value))
+    if spec.latest_kind == "pypi":
+        return _pypi_latest(runner, str(spec.latest_value))
+    if spec.latest_kind == "brew-latest":
+        return _brew_latest(runner, str(spec.latest_value))
+    if spec.latest_kind == "rustup":
+        result = runner.run(tuple(spec.latest_value))
+        if result.returncode != 0:
+            return ValueProbe(False, "unavailable", _compact_detail(result.stderr))
+        stable_line = next(
+            (line for line in result.stdout.splitlines() if "stable" in line.lower()),
+            result.stdout,
+        )
+        version = highest_semver(stable_line)
+        return ValueProbe(version is not None, version or "unknown", _compact_detail(stable_line))
+    if spec.latest_kind in {"manual", "remote-managed"}:
+        return ValueProbe(True, str(spec.latest_value), "no local update query or mutation")
+    raise ToolchainError(f"unsupported latest probe kind for {spec.key}: {spec.latest_kind}")
+
+
+def _version_tuple(value: str) -> tuple[int, int, int] | None:
+    match = _SEMVER_RE.search(value)
+    return tuple(map(int, match.groups())) if match else None
+
+
+def _loose_version_key(value: str) -> tuple[tuple[int, ...], str] | None:
+    match = re.search(r"(?<!\d)(\d+(?:\.\d+){1,2})([0-9A-Za-z._+-]*)(?!\d)", value)
+    if not match:
+        return None
+    numeric = tuple(int(part) for part in match.group(1).split("."))
+    return numeric + (0,) * (3 - len(numeric)), match.group(2)
+
+
+def decide_check(spec: ToolSpec, current: ValueProbe, latest: ValueProbe) -> str:
+    if spec.report_only:
+        if spec.key == "brave-search-mcp" and latest.ok:
+            return "approval-required-pin-decision"
+        return "report-only"
+    if not current.ok:
+        return "not-installed-or-current-probe-failed"
+    if not latest.ok:
+        return "latest-probe-failed"
+    current_version = _loose_version_key(current.value)
+    latest_version = _loose_version_key(latest.value)
+    if current_version is None or latest_version is None:
+        return "manual-version-review"
+    if latest_version > current_version:
+        return "update-available"
+    if latest_version == current_version:
+        return "current"
+    return "installed-newer-than-registry"
+
+
+def collect_checks(runner: Runner, *, offline: bool = False) -> list[ToolCheck]:
+    checks: list[ToolCheck] = []
+    for spec in tool_inventory():
+        current = (
+            ValueProbe(False, "offline/not-queried", "remote health probe explicitly skipped")
+            if offline and spec.current_kind == "memento-health"
+            else probe_current(spec, runner)
+        )
+        latest = probe_latest(spec, runner, offline=offline)
+        checks.append(
+            ToolCheck(
+                key=spec.key,
+                display_name=spec.display_name,
+                method=spec.method,
+                tier=spec.tier,
+                current=current.value,
+                latest=latest.value,
+                decision=decide_check(spec, current, latest),
+                current_detail=current.detail,
+                latest_detail=latest.detail,
+                risk=spec.risk,
+                changelog_url=spec.changelog_url,
+                report_only=spec.report_only,
+            )
+        )
+    return checks
+
+
+def draft_basis(checks: Sequence[ToolCheck]) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "checks": [asdict(check) for check in checks],
+    }
+
+
+def compute_draft_id(basis: Mapping[str, Any]) -> str:
+    canonical = json.dumps(basis, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def render_draft(checks: Sequence[ToolCheck], generated_at: str, draft_id: str) -> str:
+    lines = [
+        "# AgentDesk toolchain update draft",
+        "",
+        "> Evidence-only draft. No update command was executed while producing this report.",
+        "> The scheduled launchd job is check-only and cannot enter the apply path.",
+        "",
+        f"- Generated: `{generated_at}`",
+        f"- Draft ID: `{draft_id}`",
+        f"- Inventory rows: `{len(checks)}`",
+        "",
+        "## Full inventory",
+        "",
+        "| Tool | Method | Tier | Current | Latest | Decision |",
+        "|---|---|---|---|---|---|",
+    ]
+    for check in checks:
+        values = (
+            check.display_name,
+            check.method,
+            check.tier,
+            check.current,
+            check.latest,
+            check.decision,
+        )
+        lines.append("| " + " | ".join(value.replace("|", "\\|") for value in values) + " |")
+
+    approval_cards = [
+        check
+        for check in checks
+        if check.tier == "approval"
+        and check.decision in {"update-available", "approval-required-pin-decision"}
+    ]
+    hygiene = [
+        check
+        for check in checks
+        if check.tier == "hygiene" and check.decision == "update-available"
+    ]
+    lines.extend(["", "## Approval cards", ""])
+    if not approval_cards:
+        lines.append("No approval-tier update or pin decision is currently pending.")
+    for check in approval_cards:
+        lines.extend(
+            [
+                f"### {check.display_name}",
+                "",
+                f"- Version: `{check.current}` → `{check.latest}`",
+                f"- Risk: {check.risk}",
+                f"- Changelog: {check.changelog_url}",
+                "- Action: review this exact draft, then run the documented `approve` command.",
+                "",
+            ]
+        )
+    lines.extend(["## Hygiene candidates", ""])
+    if not hygiene:
+        lines.append("No hygiene-tier update is currently pending.")
+    else:
+        for check in hygiene:
+            destructive = " (per-tool approval also required: native/npm mutation)" if check.method in DESTRUCTIVE_METHODS else ""
+            lines.append(f"- `{check.display_name}`: `{check.current}` → `{check.latest}`{destructive}")
+
+    exceptions = [
+        check
+        for check in checks
+        if check.decision
+        in {
+            "not-installed-or-current-probe-failed",
+            "latest-probe-failed",
+            "manual-version-review",
+            "report-only",
+        }
+    ]
+    lines.extend(["", "## Explicit omissions and probe failures", ""])
+    if not exceptions:
+        lines.append("None.")
+    for check in exceptions:
+        lines.append(
+            f"- `{check.display_name}` — {check.decision}; current: {check.current_detail or check.current}; "
+            f"latest: {check.latest_detail or check.latest}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Gate contract",
+            "",
+            "Applying requires an explicit safe-window confirmation. Approval-tier tools and all native/npm",
+            "mutations require a per-tool approval marker bound to this draft ID. Every applied tool runs its",
+            "smoke profile immediately; failure stops the batch, emits an alert/rollback-or-pin plan, and exits non-zero.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(path)
+
+
+def write_draft(
+    checks: Sequence[ToolCheck],
+    output_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> tuple[Path, Path, str]:
+    generated = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    generated_at = generated.isoformat(timespec="seconds").replace("+00:00", "Z")
+    basis = draft_basis(checks)
+    draft_id = compute_draft_id(basis)
+    payload = {
+        **basis,
+        "draft_id": draft_id,
+        "generated_at": generated_at,
+    }
+    json_path = output_dir / "latest.json"
+    markdown_path = output_dir / "latest.md"
+    _atomic_write(json_path, json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+    _atomic_write(markdown_path, render_draft(checks, generated_at, draft_id))
+    return markdown_path, json_path, draft_id
+
+
+def load_draft(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ToolchainError(f"could not load draft {path}: {error}") from error
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        raise ToolchainError("unsupported or invalid toolchain draft schema")
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        raise ToolchainError("toolchain draft checks must be a list")
+    basis = {"schema_version": SCHEMA_VERSION, "checks": checks}
+    expected = compute_draft_id(basis)
+    if payload.get("draft_id") != expected:
+        raise ToolchainError("toolchain draft contents do not match its draft_id")
+    return payload
+
+
+def _approval_dir(draft_path: Path) -> Path:
+    return draft_path.parent / f"{draft_path.stem}.approvals"
+
+
+def approval_path(draft_path: Path, tool: str) -> Path:
+    return _approval_dir(draft_path) / f"{tool}.json"
+
+
+def approve_tool(draft_path: Path, tool: str, confirmation: str) -> Path:
+    if confirmation != APPROVAL_CONFIRMATION:
+        raise ApprovalError(f"confirmation must be exactly {APPROVAL_CONFIRMATION!r}")
+    payload = load_draft(draft_path)
+    check = next((item for item in payload["checks"] if item.get("key") == tool), None)
+    if check is None:
+        raise ApprovalError(f"tool {tool!r} is not present in the draft")
+    marker = {
+        "schema_version": SCHEMA_VERSION,
+        "draft_id": payload["draft_id"],
+        "tool": tool,
+        "current": check.get("current"),
+        "latest": check.get("latest"),
+        "approved_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    path = approval_path(draft_path, tool)
+    _atomic_write(path, json.dumps(marker, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def _approval_matches(draft_path: Path, draft: Mapping[str, Any], check: Mapping[str, Any]) -> bool:
+    path = approval_path(draft_path, str(check["key"]))
+    try:
+        marker = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        marker.get("schema_version") == SCHEMA_VERSION
+        and marker.get("draft_id") == draft.get("draft_id")
+        and marker.get("tool") == check.get("key")
+        and marker.get("current") == check.get("current")
+        and marker.get("latest") == check.get("latest")
+    )
+
+
+def validate_cswap_shape(text: str) -> tuple[bool, str]:
+    """Validate the permissive camelCase shape consumed by services/cswap.rs."""
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as error:
+        return False, f"invalid JSON: {error}"
+    if not isinstance(payload, dict):
+        return False, "top-level value must be an object"
+    if payload.get("error") is not None:
+        return False, "cswap returned an error payload"
+    if "schemaVersion" in payload and (
+        not isinstance(payload["schemaVersion"], int) or isinstance(payload["schemaVersion"], bool)
+    ):
+        return False, "schemaVersion must be an integer"
+    if (
+        "activeAccountNumber" in payload
+        and payload["activeAccountNumber"] is not None
+        and (
+            not isinstance(payload["activeAccountNumber"], int)
+            or isinstance(payload["activeAccountNumber"], bool)
+        )
+    ):
+        return False, "activeAccountNumber must be an integer or null"
+    accounts = payload.get("accounts", [])
+    if accounts is None:
+        accounts = []
+    if not isinstance(accounts, list):
+        return False, "accounts must be a list"
+    for index, account in enumerate(accounts):
+        if not isinstance(account, dict):
+            return False, f"accounts[{index}] must be an object"
+        if (
+            "number" in account
+            and account["number"] is not None
+            and (not isinstance(account["number"], int) or isinstance(account["number"], bool))
+        ):
+            return False, f"accounts[{index}].number must be an integer or null"
+        if "active" in account and not isinstance(account["active"], bool):
+            return False, f"accounts[{index}].active must be a boolean"
+        age = account.get("usageAgeSeconds")
+        if age is not None and (not isinstance(age, (int, float)) or isinstance(age, bool)):
+            return False, f"accounts[{index}].usageAgeSeconds must be numeric or null"
+    return True, f"schemaVersion={payload.get('schemaVersion', 1)}, accounts={len(accounts)}"
+
+
+def _smoke_version(runner: Runner, name: str, argv: Sequence[str]) -> SmokeResult:
+    result = runner.run(argv)
+    if result.returncode != 0:
+        return SmokeResult(name, False, _compact_detail(result.stderr or result.stdout))
+    combined = f"{result.stdout}\n{result.stderr}".strip()
+    version = highest_semver(combined)
+    return SmokeResult(
+        name,
+        version is not None,
+        f"highest-semver={version}" if version else "no semantic version found",
+    )
+
+
+def _smoke_loose_version(runner: Runner, name: str, argv: Sequence[str]) -> SmokeResult:
+    result = runner.run(argv)
+    if result.returncode != 0:
+        return SmokeResult(name, False, _compact_detail(result.stderr or result.stdout))
+    combined = f"{result.stdout}\n{result.stderr}".strip()
+    version = _loose_version_key(combined)
+    return SmokeResult(
+        name,
+        version is not None,
+        f"version={'.'.join(map(str, version[0]))}{version[1]}" if version else "no parseable version found",
+    )
+
+
+def _smoke_node(runner: Runner) -> list[SmokeResult]:
+    results = [_smoke_version(runner, "node --version", ("node", "--version"))]
+    npm_list = runner.run(("npm", "ls", "-g", "--depth=0", "--json"))
+    if npm_list.returncode != 0:
+        results.append(SmokeResult("node global CLI inventory", False, _compact_detail(npm_list.stderr)))
+        return results
+    try:
+        payload = json.loads(npm_list.stdout)
+        dependencies = payload.get("dependencies", {})
+        if not isinstance(dependencies, dict):
+            raise ValueError("dependencies is not an object")
+    except (json.JSONDecodeError, ValueError, AttributeError) as error:
+        results.append(SmokeResult("node global CLI inventory", False, str(error)))
+        return results
+    results.append(SmokeResult("node global CLI inventory", True, f"packages={len(dependencies)}"))
+    package_binaries = {
+        "@openai/codex": ("codex", "--version"),
+        "@bitkyc08/opencodex": ("ocx", "--version"),
+        "claude-e": ("claude-e", "--version"),
+    }
+    for package, argv in package_binaries.items():
+        if package in dependencies:
+            results.append(_smoke_version(runner, f"global {package} load", argv))
+    return results
+
+
+def _smoke_postgresql(runner: Runner, *, strict: bool) -> list[SmokeResult]:
+    client = _smoke_loose_version(runner, "psql --version", ("psql", "--version"))
+    results = [client]
+    database_url = os.environ.get("AGENTDESK_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not database_url:
+        results.append(
+            SmokeResult(
+                "psql server major comparison",
+                not strict,
+                "DATABASE_URL/AGENTDESK_DATABASE_URL is required for a strict post-update gate",
+            )
+        )
+        return results
+    server = runner.run(
+        ("psql", "-Atqc", "SHOW server_version"),
+        env={"PGDATABASE": database_url},
+    )
+    if server.returncode != 0:
+        results.append(SmokeResult("psql server major comparison", False, _compact_detail(server.stderr)))
+        return results
+    client_version = _loose_version_key(client.detail)
+    server_version = _loose_version_key(server.stdout)
+    matches = (
+        client_version is not None
+        and server_version is not None
+        and client_version[0][0] == server_version[0][0]
+    )
+    results.append(
+        SmokeResult(
+            "psql server major comparison",
+            matches,
+            f"client={client_version[0][0] if client_version else 'unknown'} server={server_version[0][0] if server_version else 'unknown'}",
+        )
+    )
+    return results
+
+
+def run_smoke_profile(profile: str, runner: Runner, *, strict: bool = True) -> list[SmokeResult]:
+    simple = {
+        "claude": ("claude", "--version"),
+        "codex": ("codex", "--version"),
+        "claude-e": ("claude-e", "--version"),
+        "tmux": ("tmux", "-V"),
+        "gh": ("gh", "--version"),
+        "python-3-14": ("python3.14", "--version"),
+        "uv": ("uv", "--version"),
+        "pipx": ("pipx", "--version"),
+        "jq": ("jq", "--version"),
+        "ripgrep": ("rg", "--version"),
+        "ffmpeg": ("ffmpeg", "-version"),
+        "whisper-cpp": ("whisper-cli", "--version"),
+        "edge-tts": ("edge-tts", "--version"),
+        "opencode": ("opencode", "--version"),
+    }
+    if profile in simple:
+        if profile == "tmux":
+            return [_smoke_loose_version(runner, "tmux version", simple[profile])]
+        return [_smoke_version(runner, f"{profile} version", simple[profile])]
+    if profile == "ocx":
+        version = _smoke_version(runner, "ocx version", ("ocx", "--version"))
+        health = runner.run(("ocx", "health"), timeout=30)
+        return [
+            version,
+            SmokeResult("ocx health", health.returncode == 0, _compact_detail(health.stdout or health.stderr)),
+        ]
+    if profile == "cswap":
+        version = _smoke_version(runner, "cswap version", ("cswap", "--version"))
+        listing = runner.run(("cswap", "--list", "--json"), timeout=60)
+        if listing.returncode != 0:
+            shape = SmokeResult("cswap --list --json shape", False, _compact_detail(listing.stderr))
+        else:
+            ok, detail = validate_cswap_shape(listing.stdout)
+            shape = SmokeResult("cswap --list --json shape", ok, detail)
+        return [version, shape]
+    if profile == "rust":
+        return [
+            _smoke_version(
+                runner,
+                "stable rustc version",
+                ("rustup", "run", "stable", "rustc", "--version"),
+            ),
+            _smoke_version(
+                runner,
+                "stable cargo version",
+                ("rustup", "run", "stable", "cargo", "--version"),
+            ),
+        ]
+    if profile == "node":
+        return _smoke_node(runner)
+    if profile == "postgresql-17":
+        return _smoke_postgresql(runner, strict=strict)
+    raise ToolchainError(f"unsupported smoke profile: {profile}")
+
+
+def _update_argv(spec: ToolSpec, latest: str) -> tuple[str, ...]:
+    if spec.update_kind is None or spec.update_value is None:
+        raise ToolchainError(f"{spec.key} is report-only and has no local update command")
+    if spec.update_kind in {"npm-exact", "uv-exact", "pipx-exact"} and not _SAFE_VERSION_RE.fullmatch(latest):
+        raise ToolchainError(f"refusing unsafe or non-semver version for {spec.key}: {latest!r}")
+    if spec.update_kind == "npm-exact":
+        return ("npm", "install", "-g", f"{spec.update_value}@{latest}")
+    if spec.update_kind == "uv-exact":
+        return ("uv", "tool", "install", "--force", f"{spec.update_value}=={latest}")
+    if spec.update_kind == "pipx-exact":
+        return ("pipx", "install", "--force", f"{spec.update_value}=={latest}")
+    if spec.update_kind == "brew-upgrade":
+        return ("brew", "upgrade", str(spec.update_value))
+    if spec.update_kind == "command":
+        return tuple(spec.update_value)
+    raise ToolchainError(f"unsupported update kind for {spec.key}: {spec.update_kind}")
+
+
+def _rollback_or_pin_hint(spec: ToolSpec, current: str) -> str:
+    if not _SAFE_VERSION_RE.fullmatch(current):
+        return "No exact previous semantic version was recorded; stop and pin manually before retrying."
+    if spec.update_kind == "npm-exact":
+        return f"npm install -g {spec.update_value}@{current}"
+    if spec.update_kind == "uv-exact":
+        return f"uv tool install --force {spec.update_value}=={current}"
+    if spec.update_kind == "pipx-exact":
+        return f"pipx install --force {spec.update_value}=={current}"
+    if spec.update_kind == "brew-upgrade":
+        return f"brew pin {spec.update_value}; restore {current} from the approved Homebrew rollback procedure"
+    return f"restore/pin {spec.display_name} to {current} using its native installer"
+
+
+def _same_version(left: str, right: str) -> bool:
+    left_key = _loose_version_key(left)
+    right_key = _loose_version_key(right)
+    return left_key == right_key if left_key is not None and right_key is not None else left == right
+
+
+def _version_reached(observed: str, expected: str) -> bool:
+    observed_key = _loose_version_key(observed)
+    expected_key = _loose_version_key(expected)
+    return (
+        observed_key >= expected_key
+        if observed_key is not None and expected_key is not None
+        else observed == expected
+    )
+
+
+def _write_smoke_alert(
+    draft_path: Path,
+    draft_id: str,
+    spec: ToolSpec,
+    check: Mapping[str, Any],
+    smoke: Sequence[SmokeResult],
+) -> Path:
+    path = draft_path.parent / "alerts" / f"{draft_id[:16]}-{spec.key}.md"
+    failed = [result for result in smoke if not result.ok]
+    content = "\n".join(
+        [
+            f"# Toolchain smoke failure: {spec.display_name}",
+            "",
+            f"- Draft ID: `{draft_id}`",
+            f"- Attempted: `{check.get('current')}` → `{check.get('latest')}`",
+            f"- Failed checks: {', '.join(result.check for result in failed)}",
+            f"- Rollback/pin plan: `{_rollback_or_pin_hint(spec, str(check.get('current', 'unknown')))}`",
+            "",
+            "The apply batch stopped. Do not restart dcserver or the ocx proxy until the pin/rollback is completed and the smoke profile passes.",
+            "",
+        ]
+    )
+    _atomic_write(path, content)
+    return path
+
+
+def assert_safe_window(runner: Runner) -> None:
+    """Fail closed unless AgentDesk and local build activity are idle."""
+
+    status = runner.run(("agentdesk", "status", "--json"), timeout=10)
+    if status.returncode != 0:
+        raise ToolchainError(
+            "safe-window status is unavailable; refusing apply: "
+            + _compact_detail(status.stderr or status.stdout)
+        )
+    try:
+        payload = json.loads(status.stdout)
+        sessions = payload["sessions"]
+        queue = payload["queue"]
+        working = int(sessions["working"])
+        active_dispatches = int(sessions["with_active_dispatch"])
+        queue_running = queue.get("status") == "running"
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ToolchainError(f"safe-window status shape is invalid: {error}") from error
+    if working or active_dispatches or queue_running:
+        raise ToolchainError(
+            "safe window is busy: "
+            f"working_sessions={working}, active_dispatches={active_dispatches}, "
+            f"queue_running={str(queue_running).lower()}"
+        )
+    for process in ("cargo", "rustc"):
+        running = runner.run(("pgrep", "-x", process), timeout=5)
+        if running.returncode == 0:
+            raise ToolchainError(f"safe window is busy: {process} process is running")
+        if running.returncode != 1:
+            raise ToolchainError(
+                f"could not verify safe window for {process}: "
+                + _compact_detail(running.stderr or running.stdout)
+            )
+    processes = runner.run(("ps", "-axo", "command="), timeout=5)
+    if processes.returncode != 0:
+        raise ToolchainError(
+            "could not inspect the process table for deploy-release.sh: "
+            + _compact_detail(processes.stderr or processes.stdout)
+        )
+    if any("deploy-release.sh" in line for line in processes.stdout.splitlines()):
+        raise ToolchainError("safe window is busy: deploy-release.sh is running")
+
+
+def apply_draft(
+    draft_path: Path,
+    *,
+    requested_tools: Sequence[str],
+    apply_hygiene: bool,
+    safe_window_confirmation: str,
+    runner: Runner,
+) -> tuple[list[str], Path | None]:
+    if safe_window_confirmation != SAFE_WINDOW_CONFIRMATION:
+        raise ApprovalError(f"safe-window confirmation must be exactly {SAFE_WINDOW_CONFIRMATION!r}")
+    assert_safe_window(runner)
+    draft = load_draft(draft_path)
+    specs = {spec.key: spec for spec in tool_inventory()}
+    checks = {str(item.get("key")): item for item in draft["checks"] if isinstance(item, dict)}
+    selected = set(requested_tools)
+    unknown = selected - specs.keys()
+    if unknown:
+        raise ToolchainError(f"unknown tool(s): {', '.join(sorted(unknown))}")
+    if apply_hygiene:
+        selected.update(
+            key
+            for key, check in checks.items()
+            if specs[key].tier == "hygiene" and check.get("decision") == "update-available"
+        )
+    if not selected:
+        raise ToolchainError("no tools selected; use --tool and/or --apply-hygiene")
+
+    ordered = [spec for spec in tool_inventory() if spec.key in selected]
+    for spec in ordered:
+        check = checks.get(spec.key)
+        if check is None or check.get("decision") != "update-available":
+            raise ToolchainError(f"{spec.key} is not an update-available row in this draft")
+        if spec.report_only:
+            raise ToolchainError(f"{spec.key} is report-only")
+        needs_approval = spec.tier == "approval" or spec.method in DESTRUCTIVE_METHODS
+        if needs_approval and not _approval_matches(draft_path, draft, check):
+            raise ApprovalError(
+                f"{spec.key} requires a per-tool approval marker matching draft {draft['draft_id']}"
+            )
+        current = probe_current(spec, runner)
+        latest = probe_latest(spec, runner, offline=False)
+        if not current.ok or not _same_version(current.value, str(check["current"])):
+            raise ToolchainError(
+                f"stale draft for {spec.key}: expected current={check['current']}, observed={current.value}"
+            )
+        if not latest.ok or not _same_version(latest.value, str(check["latest"])):
+            raise ToolchainError(
+                f"stale draft for {spec.key}: expected latest={check['latest']}, observed={latest.value}"
+            )
+
+    applied: list[str] = []
+    for spec in ordered:
+        check = checks[spec.key]
+        argv = _update_argv(spec, str(check["latest"]))
+        update = runner.run(argv, timeout=300, env={"HOMEBREW_NO_AUTO_UPDATE": "1"})
+        if update.returncode != 0:
+            raise ToolchainError(
+                f"update command failed for {spec.key}: {_compact_detail(update.stderr or update.stdout)}"
+            )
+        observed = probe_current(spec, runner)
+        smoke = [
+            SmokeResult(
+                "post-update target version",
+                observed.ok and _version_reached(observed.value, str(check["latest"])),
+                f"expected>={check['latest']}, observed={observed.value}",
+            ),
+            *run_smoke_profile(spec.smoke_profile or spec.key, runner, strict=True),
+        ]
+        if any(not result.ok for result in smoke):
+            alert = _write_smoke_alert(draft_path, str(draft["draft_id"]), spec, check, smoke)
+            return applied, alert
+        applied.append(spec.key)
+    return applied, None
+
+
+def _check_command(args: argparse.Namespace, runner: Runner) -> int:
+    checks = collect_checks(runner, offline=args.offline)
+    markdown, json_path, draft_id = write_draft(checks, args.output_dir)
+    print(f"toolchain draft written: {markdown}")
+    print(f"toolchain draft data: {json_path}")
+    print(f"draft_id={draft_id}")
+    print(f"inventory_rows={len(checks)} updates_executed=0")
+    return 0
+
+
+def _approve_command(args: argparse.Namespace) -> int:
+    path = approve_tool(args.draft, args.tool, args.confirm)
+    print(f"approval marker written: {path}")
+    return 0
+
+
+def _apply_command(args: argparse.Namespace, runner: Runner) -> int:
+    applied, alert = apply_draft(
+        args.draft,
+        requested_tools=args.tool,
+        apply_hygiene=args.apply_hygiene,
+        safe_window_confirmation=args.confirm_safe_window,
+        runner=runner,
+    )
+    if alert is not None:
+        print(f"SMOKE FAILED; apply batch stopped; alert={alert}", file=sys.stderr)
+        return 3
+    print(f"applied_and_smoked={','.join(applied)}")
+    return 0
+
+
+def _smoke_command(args: argparse.Namespace, runner: Runner) -> int:
+    specs = {spec.key: spec for spec in tool_inventory()}
+    selected = args.tool or [
+        "claude",
+        "codex",
+        "ocx",
+        "cswap",
+        "tmux",
+        "node",
+        "postgresql-17",
+    ]
+    results: list[SmokeResult] = []
+    for key in selected:
+        spec = specs.get(key)
+        if spec is None or spec.smoke_profile is None:
+            raise ToolchainError(f"tool {key!r} has no smoke profile")
+        results.extend(run_smoke_profile(spec.smoke_profile, runner, strict=not args.allow_server_skip))
+    print(json.dumps([asdict(result) for result in results], indent=2, sort_keys=True))
+    return 0 if all(result.ok for result in results) else 1
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    root = Path(os.environ.get("AGENTDESK_ROOT_DIR", Path.home() / ".adk" / "release"))
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="write a read-only current/latest draft")
+    check.add_argument("--output-dir", type=Path, default=root / "runtime" / "toolchain-update")
+    check.add_argument("--offline", action="store_true", help="skip all latest/network probes")
+
+    approve = subparsers.add_parser("approve", help="approve one tool in an exact draft")
+    approve.add_argument("--draft", type=Path, required=True)
+    approve.add_argument("--tool", required=True)
+    approve.add_argument("--confirm", required=True)
+
+    apply = subparsers.add_parser("apply", help="apply selected approved/hygiene updates")
+    apply.add_argument("--draft", type=Path, required=True)
+    apply.add_argument("--tool", action="append", default=[])
+    apply.add_argument("--apply-hygiene", action="store_true")
+    apply.add_argument("--confirm-safe-window", required=True)
+
+    smoke = subparsers.add_parser("smoke", help="run the post-update smoke gate")
+    smoke.add_argument("--tool", action="append", default=[])
+    smoke.add_argument(
+        "--allow-server-skip",
+        action="store_true",
+        help="allow psql client-only diagnostics outside a post-update gate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None, *, runner: Runner | None = None) -> int:
+    args = parse_args(argv)
+    active_runner = runner or Runner()
+    try:
+        if args.command == "check":
+            return _check_command(args, active_runner)
+        if args.command == "approve":
+            return _approve_command(args)
+        if args.command == "apply":
+            return _apply_command(args, active_runner)
+        if args.command == "smoke":
+            return _smoke_command(args, active_runner)
+    except ToolchainError as error:
+        print(f"toolchain-update: ERROR: {error}", file=sys.stderr)
+        return 2
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/toolchain_update.py
+++ b/scripts/toolchain_update.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import subprocess
 import sys
 import urllib.error
@@ -25,11 +26,14 @@ from toolchain_manifest import (
 )
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 APPROVAL_CONFIRMATION = "approve-exact-toolchain-draft"
 SAFE_WINDOW_CONFIRMATION = "no-active-turns-or-deploys"
-DESTRUCTIVE_METHODS = frozenset({"native", "npm-g"})
+APPROVAL_REQUIRED_METHODS = frozenset({"installer", "native", "npm-g"})
 DEFAULT_TIMEOUT_SECONDS = 20
+DEFAULT_UPDATE_TIMEOUT_SECONDS = 1800
+BUILD_UPDATE_TIMEOUT_SECONDS = 7200
+IDLE_QUEUE_STATUSES = frozenset({"canceled", "cancelled", "completed", "failed", "idle"})
 _SEMVER_RE = re.compile(
     r"(?<![0-9A-Za-z])v?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?(?![0-9A-Za-z])"
 )
@@ -314,10 +318,17 @@ def collect_checks(runner: Runner, *, offline: bool = False) -> list[ToolCheck]:
     return checks
 
 
-def draft_basis(checks: Sequence[ToolCheck]) -> dict[str, Any]:
+def draft_basis(
+    checks: Sequence[ToolCheck | Mapping[str, Any]],
+    *,
+    generated_at: str,
+    draft_nonce: str,
+) -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
-        "checks": [asdict(check) for check in checks],
+        "generated_at": generated_at,
+        "draft_nonce": draft_nonce,
+        "checks": [dict(check) if isinstance(check, Mapping) else asdict(check) for check in checks],
     }
 
 
@@ -384,7 +395,11 @@ def render_draft(checks: Sequence[ToolCheck], generated_at: str, draft_id: str) 
         lines.append("No hygiene-tier update is currently pending.")
     else:
         for check in hygiene:
-            destructive = " (per-tool approval also required: native/npm mutation)" if check.method in DESTRUCTIVE_METHODS else ""
+            destructive = (
+                " (per-tool approval also required: native/self-updater/npm mutation)"
+                if check.method in APPROVAL_REQUIRED_METHODS
+                else ""
+            )
             lines.append(f"- `{check.display_name}`: `{check.current}` → `{check.latest}`{destructive}")
 
     exceptions = [
@@ -411,7 +426,7 @@ def render_draft(checks: Sequence[ToolCheck], generated_at: str, draft_id: str) 
             "",
             "## Gate contract",
             "",
-            "Applying requires an explicit safe-window confirmation. Approval-tier tools and all native/npm",
+            "Applying requires an explicit safe-window confirmation. Approval-tier tools and all native/self-updater/npm",
             "mutations require a per-tool approval marker bound to this draft ID. Every applied tool runs its",
             "smoke profile immediately; failure stops the batch, emits an alert/rollback-or-pin plan, and exits non-zero.",
             "",
@@ -435,12 +450,12 @@ def write_draft(
 ) -> tuple[Path, Path, str]:
     generated = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     generated_at = generated.isoformat(timespec="seconds").replace("+00:00", "Z")
-    basis = draft_basis(checks)
+    draft_nonce = secrets.token_hex(16)
+    basis = draft_basis(checks, generated_at=generated_at, draft_nonce=draft_nonce)
     draft_id = compute_draft_id(basis)
     payload = {
         **basis,
         "draft_id": draft_id,
-        "generated_at": generated_at,
     }
     json_path = output_dir / "latest.json"
     markdown_path = output_dir / "latest.md"
@@ -459,7 +474,13 @@ def load_draft(path: Path) -> dict[str, Any]:
     checks = payload.get("checks")
     if not isinstance(checks, list):
         raise ToolchainError("toolchain draft checks must be a list")
-    basis = {"schema_version": SCHEMA_VERSION, "checks": checks}
+    generated_at = payload.get("generated_at")
+    draft_nonce = payload.get("draft_nonce")
+    if not isinstance(generated_at, str) or not generated_at:
+        raise ToolchainError("toolchain draft generated_at must be a non-empty string")
+    if not isinstance(draft_nonce, str) or not draft_nonce:
+        raise ToolchainError("toolchain draft nonce must be a non-empty string")
+    basis = draft_basis(checks, generated_at=generated_at, draft_nonce=draft_nonce)
     expected = compute_draft_id(basis)
     if payload.get("draft_id") != expected:
         raise ToolchainError("toolchain draft contents do not match its draft_id")
@@ -484,6 +505,8 @@ def approve_tool(draft_path: Path, tool: str, confirmation: str) -> Path:
     marker = {
         "schema_version": SCHEMA_VERSION,
         "draft_id": payload["draft_id"],
+        "generated_at": payload["generated_at"],
+        "draft_nonce": payload["draft_nonce"],
         "tool": tool,
         "current": check.get("current"),
         "latest": check.get("latest"),
@@ -503,6 +526,8 @@ def _approval_matches(draft_path: Path, draft: Mapping[str, Any], check: Mapping
     return (
         marker.get("schema_version") == SCHEMA_VERSION
         and marker.get("draft_id") == draft.get("draft_id")
+        and marker.get("generated_at") == draft.get("generated_at")
+        and marker.get("draft_nonce") == draft.get("draft_nonce")
         and marker.get("tool") == check.get("key")
         and marker.get("current") == check.get("current")
         and marker.get("latest") == check.get("latest")
@@ -510,7 +535,7 @@ def _approval_matches(draft_path: Path, draft: Mapping[str, Any], check: Mapping
 
 
 def validate_cswap_shape(text: str) -> tuple[bool, str]:
-    """Validate the permissive camelCase shape consumed by services/cswap.rs."""
+    """Validate the required camelCase shape consumed by services/cswap.rs."""
 
     try:
         payload = json.loads(text)
@@ -533,9 +558,9 @@ def validate_cswap_shape(text: str) -> tuple[bool, str]:
         )
     ):
         return False, "activeAccountNumber must be an integer or null"
-    accounts = payload.get("accounts", [])
-    if accounts is None:
-        accounts = []
+    if "accounts" not in payload or payload["accounts"] is None:
+        return False, "accounts must be a present, non-null list"
+    accounts = payload["accounts"]
     if not isinstance(accounts, list):
         return False, "accounts must be a list"
     for index, account in enumerate(accounts):
@@ -595,12 +620,33 @@ def _smoke_node(runner: Runner) -> list[SmokeResult]:
     except (json.JSONDecodeError, ValueError, AttributeError) as error:
         results.append(SmokeResult("node global CLI inventory", False, str(error)))
         return results
-    results.append(SmokeResult("node global CLI inventory", True, f"packages={len(dependencies)}"))
+    npm_global_specs = [spec for spec in tool_inventory() if spec.method == "npm-g"]
+    invalid_specs = [
+        spec.key
+        for spec in npm_global_specs
+        if not isinstance(spec.update_value, str) or isinstance(spec.current_value, str)
+    ]
+    if invalid_specs:
+        results.append(
+            SmokeResult(
+                "node manifest npm global inventory",
+                False,
+                f"missing package/binary argv for {','.join(invalid_specs)}",
+            )
+        )
+        return results
     package_binaries = {
-        "@openai/codex": ("codex", "--version"),
-        "@bitkyc08/opencodex": ("ocx", "--version"),
-        "claude-e": ("claude-e", "--version"),
+        str(spec.update_value): tuple(spec.current_value) for spec in npm_global_specs
     }
+    missing = sorted(package_binaries.keys() - dependencies.keys())
+    results.append(
+        SmokeResult(
+            "node global CLI inventory",
+            not missing,
+            f"expected={len(package_binaries)}, packages={len(dependencies)}, "
+            f"missing={','.join(missing) if missing else 'none'}",
+        )
+    )
     for package, argv in package_binaries.items():
         if package in dependencies:
             results.append(_smoke_version(runner, f"global {package} load", argv))
@@ -621,8 +667,7 @@ def _smoke_postgresql(runner: Runner, *, strict: bool) -> list[SmokeResult]:
         )
         return results
     server = runner.run(
-        ("psql", "-Atqc", "SHOW server_version"),
-        env={"PGDATABASE": database_url},
+        ("psql", "-Atqc", "SHOW server_version", database_url),
     )
     if server.returncode != 0:
         results.append(SmokeResult("psql server major comparison", False, _compact_detail(server.stderr)))
@@ -739,32 +784,32 @@ def _same_version(left: str, right: str) -> bool:
     return left_key == right_key if left_key is not None and right_key is not None else left == right
 
 
-def _version_reached(observed: str, expected: str) -> bool:
-    observed_key = _loose_version_key(observed)
-    expected_key = _loose_version_key(expected)
-    return (
-        observed_key >= expected_key
-        if observed_key is not None and expected_key is not None
-        else observed == expected
-    )
+def _update_timeout(spec: ToolSpec) -> int:
+    if spec.method == "homebrew":
+        return BUILD_UPDATE_TIMEOUT_SECONDS
+    return DEFAULT_UPDATE_TIMEOUT_SECONDS
 
 
-def _write_smoke_alert(
+def _write_apply_alert(
     draft_path: Path,
     draft_id: str,
     spec: ToolSpec,
     check: Mapping[str, Any],
-    smoke: Sequence[SmokeResult],
+    failures: Sequence[SmokeResult],
+    *,
+    stage: str,
 ) -> Path:
     path = draft_path.parent / "alerts" / f"{draft_id[:16]}-{spec.key}.md"
-    failed = [result for result in smoke if not result.ok]
+    failed = [result for result in failures if not result.ok]
     content = "\n".join(
         [
-            f"# Toolchain smoke failure: {spec.display_name}",
+            f"# Toolchain apply failure: {spec.display_name}",
             "",
             f"- Draft ID: `{draft_id}`",
             f"- Attempted: `{check.get('current')}` → `{check.get('latest')}`",
+            f"- Failure stage: {stage}",
             f"- Failed checks: {', '.join(result.check for result in failed)}",
+            f"- Failure details: {'; '.join(result.detail for result in failed)}",
             f"- Rollback/pin plan: `{_rollback_or_pin_hint(spec, str(check.get('current', 'unknown')))}`",
             "",
             "The apply batch stopped. Do not restart dcserver or the ocx proxy until the pin/rollback is completed and the smoke profile passes.",
@@ -790,14 +835,17 @@ def assert_safe_window(runner: Runner) -> None:
         queue = payload["queue"]
         working = int(sessions["working"])
         active_dispatches = int(sessions["with_active_dispatch"])
-        queue_running = queue.get("status") == "running"
+        queue_status = queue.get("status")
+        if queue_status is not None and not isinstance(queue_status, str):
+            raise TypeError("queue.status must be a string or null")
+        queue_busy = queue_status is not None and queue_status not in IDLE_QUEUE_STATUSES
     except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         raise ToolchainError(f"safe-window status shape is invalid: {error}") from error
-    if working or active_dispatches or queue_running:
+    if working or active_dispatches or queue_busy:
         raise ToolchainError(
             "safe window is busy: "
             f"working_sessions={working}, active_dispatches={active_dispatches}, "
-            f"queue_running={str(queue_running).lower()}"
+            f"queue_status={queue_status or 'idle'}"
         )
     for process in ("cargo", "rustc"):
         running = runner.run(("pgrep", "-x", process), timeout=5)
@@ -836,6 +884,12 @@ def apply_draft(
     unknown = selected - specs.keys()
     if unknown:
         raise ToolchainError(f"unknown tool(s): {', '.join(sorted(unknown))}")
+    stale_manifest = checks.keys() - specs.keys()
+    if stale_manifest:
+        raise ToolchainError(
+            "draft contains tool(s) absent from the current manifest: "
+            f"{', '.join(sorted(stale_manifest))}; generate a fresh draft"
+        )
     if apply_hygiene:
         selected.update(
             key
@@ -852,7 +906,7 @@ def apply_draft(
             raise ToolchainError(f"{spec.key} is not an update-available row in this draft")
         if spec.report_only:
             raise ToolchainError(f"{spec.key} is report-only")
-        needs_approval = spec.tier == "approval" or spec.method in DESTRUCTIVE_METHODS
+        needs_approval = spec.tier == "approval" or spec.method in APPROVAL_REQUIRED_METHODS
         if needs_approval and not _approval_matches(draft_path, draft, check):
             raise ApprovalError(
                 f"{spec.key} requires a per-tool approval marker matching draft {draft['draft_id']}"
@@ -872,22 +926,81 @@ def apply_draft(
     for spec in ordered:
         check = checks[spec.key]
         argv = _update_argv(spec, str(check["latest"]))
-        update = runner.run(argv, timeout=300, env={"HOMEBREW_NO_AUTO_UPDATE": "1"})
-        if update.returncode != 0:
-            raise ToolchainError(
-                f"update command failed for {spec.key}: {_compact_detail(update.stderr or update.stdout)}"
+        assert_safe_window(runner)
+        update_result = runner.run(
+            argv,
+            timeout=_update_timeout(spec),
+            env={"HOMEBREW_NO_AUTO_UPDATE": "1"},
+        )
+        if update_result.returncode != 0:
+            failure = SmokeResult(
+                "update command",
+                False,
+                _compact_detail(
+                    update_result.stderr
+                    or update_result.stdout
+                    or f"exit {update_result.returncode}"
+                ),
             )
-        observed = probe_current(spec, runner)
-        smoke = [
-            SmokeResult(
-                "post-update target version",
-                observed.ok and _version_reached(observed.value, str(check["latest"])),
-                f"expected>={check['latest']}, observed={observed.value}",
-            ),
-            *run_smoke_profile(spec.smoke_profile or spec.key, runner, strict=True),
-        ]
+            alert = _write_apply_alert(
+                draft_path,
+                str(draft["draft_id"]),
+                spec,
+                check,
+                [failure],
+                stage="update command",
+            )
+            return applied, alert
+        try:
+            observed = probe_current(spec, runner)
+        except Exception as error:
+            failure = SmokeResult("post-update version probe", False, _compact_detail(str(error)))
+            alert = _write_apply_alert(
+                draft_path,
+                str(draft["draft_id"]),
+                spec,
+                check,
+                [failure],
+                stage="post-update version probe",
+            )
+            return applied, alert
+        exact_version = SmokeResult(
+            "post-update exact approved version",
+            observed.ok and _same_version(observed.value, str(check["latest"])),
+            f"expected={check['latest']}, observed={observed.value}",
+        )
+        if not exact_version.ok:
+            alert = _write_apply_alert(
+                draft_path,
+                str(draft["draft_id"]),
+                spec,
+                check,
+                [exact_version],
+                stage="post-update exact-version verification (smoke not run)",
+            )
+            return applied, alert
+        try:
+            smoke = run_smoke_profile(spec.smoke_profile or spec.key, runner, strict=True)
+        except Exception as error:
+            failure = SmokeResult("post-update smoke setup", False, _compact_detail(str(error)))
+            alert = _write_apply_alert(
+                draft_path,
+                str(draft["draft_id"]),
+                spec,
+                check,
+                [failure],
+                stage="post-update smoke setup",
+            )
+            return applied, alert
         if any(not result.ok for result in smoke):
-            alert = _write_smoke_alert(draft_path, str(draft["draft_id"]), spec, check, smoke)
+            alert = _write_apply_alert(
+                draft_path,
+                str(draft["draft_id"]),
+                spec,
+                check,
+                smoke,
+                stage="post-update smoke",
+            )
             return applied, alert
         applied.append(spec.key)
     return applied, None
@@ -918,7 +1031,7 @@ def _apply_command(args: argparse.Namespace, runner: Runner) -> int:
         runner=runner,
     )
     if alert is not None:
-        print(f"SMOKE FAILED; apply batch stopped; alert={alert}", file=sys.stderr)
+        print(f"APPLY FAILED; apply batch stopped; alert={alert}", file=sys.stderr)
         return 3
     print(f"applied_and_smoked={','.join(applied)}")
     return 0

--- a/tests/test_toolchain_update.py
+++ b/tests/test_toolchain_update.py
@@ -701,8 +701,46 @@ class SmokeGateTests(unittest.TestCase):
         )
 
     def test_homebrew_loose_versions_cover_tmux_and_postgresql(self) -> None:
-        self.assertEqual(update._loose_version_key("tmux 3.6a"), ((3, 6, 0), "a"))
-        self.assertEqual(update._loose_version_key("psql 17.9"), ((17, 9, 0), ""))
+        self.assertEqual(update._loose_version_key("tmux 3.6a"), ((3, 6, 0), "a", 0))
+        self.assertEqual(update._loose_version_key("psql 17.9"), ((17, 9, 0), "", 0))
+
+    def test_homebrew_revision_nine_to_ten_is_update_available(self) -> None:
+        spec = next(item for item in tool_inventory() if item.key == "gh")
+        decision = update.decide_check(
+            spec,
+            update.ValueProbe(True, "1.1.0_9", "installed"),
+            update.ValueProbe(True, "1.1.0_10", "registry"),
+        )
+
+        self.assertEqual(decision, "update-available")
+
+    def test_homebrew_revision_ten_to_nine_is_installed_newer(self) -> None:
+        spec = next(item for item in tool_inventory() if item.key == "gh")
+        decision = update.decide_check(
+            spec,
+            update.ValueProbe(True, "1.1.0_10", "installed"),
+            update.ValueProbe(True, "1.1.0_9", "registry"),
+        )
+
+        self.assertEqual(decision, "installed-newer-than-registry")
+
+    def test_homebrew_revision_zero_orders_before_one_without_loosening_equality(self) -> None:
+        spec = next(item for item in tool_inventory() if item.key == "gh")
+        decision = update.decide_check(
+            spec,
+            update.ValueProbe(True, "1.1.0", "installed"),
+            update.ValueProbe(True, "1.1.0_1", "registry"),
+        )
+
+        self.assertEqual(decision, "update-available")
+        self.assertFalse(update._same_version("1.1.0", "1.1.0_0"))
+        self.assertFalse(update._same_version("1.1.0_01", "1.1.0_1"))
+
+    def test_malformed_homebrew_revision_suffix_falls_back_without_crashing(self) -> None:
+        self.assertEqual(
+            update._loose_version_key("1.1.0_not-a-revision"),
+            ((1, 1, 0), "_not-a-revision", 0),
+        )
 
     def test_cswap_shape_accepts_fractional_age_and_rejects_drift(self) -> None:
         valid, detail = update.validate_cswap_shape(

--- a/tests/test_toolchain_update.py
+++ b/tests/test_toolchain_update.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Focused safety and smoke tests for issue #4555's toolchain routine."""
+
+from __future__ import annotations
+
+import json
+import plistlib
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import toolchain_update as update  # noqa: E402
+from toolchain_manifest import tool_inventory  # noqa: E402
+
+
+class FakeRunner(update.Runner):
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.urls: list[str] = []
+        self.overrides: dict[tuple[str, ...], update.CommandResult] = {}
+        self.sequence_overrides: dict[tuple[str, ...], list[update.CommandResult]] = {}
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout: int = update.DEFAULT_TIMEOUT_SECONDS,
+        env: Mapping[str, str] | None = None,
+    ) -> update.CommandResult:
+        del timeout, env
+        command = tuple(argv)
+        self.calls.append(command)
+        if command in self.sequence_overrides and self.sequence_overrides[command]:
+            return self.sequence_overrides[command].pop(0)
+        if command in self.overrides:
+            return self.overrides[command]
+        if command == ("agentdesk", "status", "--json"):
+            return update.CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "sessions": {"working": 0, "with_active_dispatch": 0},
+                        "queue": {"status": "idle"},
+                    }
+                ),
+                "",
+            )
+        if command[:2] == ("pgrep", "-x"):
+            return update.CommandResult(1, "", "")
+        if command == ("ps", "-axo", "command="):
+            return update.CommandResult(0, "launchd\nagentdesk dcserver\n", "")
+        if command[:3] == ("brew", "list", "--versions"):
+            return update.CommandResult(0, f"{command[-1]} 1.0.0\n", "")
+        if command[:3] == ("brew", "info", "--json=v2"):
+            return update.CommandResult(
+                0,
+                json.dumps({"formulae": [{"versions": {"stable": "1.1.0"}}]}),
+                "",
+            )
+        if command[:2] == ("npm", "view"):
+            return update.CommandResult(0, '"1.1.0"\n', "")
+        if command == ("rustup", "check"):
+            return update.CommandResult(0, "stable-aarch64 - Update available : 1.1.0\n", "")
+        if command[:2] in {
+            ("npm", "install"),
+            ("brew", "upgrade"),
+            ("pipx", "install"),
+            ("claude", "update"),
+            ("opencode", "upgrade"),
+            ("rustup", "update"),
+        } or command[:3] == ("uv", "tool", "install"):
+            return update.CommandResult(0, "updated\n", "")
+        if command == ("cswap", "--list", "--json"):
+            return update.CommandResult(
+                0,
+                '{"schemaVersion":1,"accounts":[{"number":1,"active":true,"usageAgeSeconds":5.4}]}',
+                "",
+            )
+        if command == ("ocx", "health"):
+            return update.CommandResult(0, "healthy\n", "")
+        if command == ("npm", "ls", "-g", "--depth=0", "--json"):
+            return update.CommandResult(0, '{"dependencies":{}}', "")
+        if command and command[0].endswith("SidecarLauncher"):
+            return update.CommandResult(0, "iPad\n", "")
+        return update.CommandResult(0, "tool 1.0.0\n", "")
+
+    def get_json(
+        self,
+        url: str,
+        *,
+        timeout: int = 5,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        del timeout, headers
+        self.urls.append(url)
+        if url.endswith("/health"):
+            return {"ok": True, "version": "1.0.0"}
+        return {"info": {"version": "1.1.0"}}
+
+
+def check_for(key: str, *, tier: str, method: str) -> update.ToolCheck:
+    spec = next(item for item in tool_inventory() if item.key == key)
+    return update.ToolCheck(
+        key=key,
+        display_name=spec.display_name,
+        method=method,
+        tier=tier,
+        current="1.0.0",
+        latest="1.1.0",
+        decision="update-available",
+        current_detail="tool 1.0.0",
+        latest_detail="registry 1.1.0",
+        risk=spec.risk,
+        changelog_url=spec.changelog_url,
+        report_only=False,
+    )
+
+
+class InventoryAndDraftTests(unittest.TestCase):
+    def test_inventory_matches_issue_4555_without_silent_omissions(self) -> None:
+        inventory = tool_inventory()
+        self.assertEqual(
+            {spec.key for spec in inventory},
+            {
+                "claude",
+                "codex",
+                "ocx",
+                "claude-e",
+                "cswap",
+                "cargo-rustc",
+                "tmux",
+                "gh",
+                "node",
+                "python-3-14",
+                "uv",
+                "pipx",
+                "jq",
+                "ripgrep",
+                "ffmpeg",
+                "whisper-cpp",
+                "postgresql-17",
+                "edge-tts",
+                "opencode",
+                "memento-mcp",
+                "brave-search-mcp",
+                "sidecar-launcher",
+                "playwright-chromium",
+            },
+        )
+        self.assertEqual(
+            {spec.method for spec in inventory},
+            {
+                "native",
+                "npm-g",
+                "uv-tool",
+                "rustup",
+                "homebrew",
+                "pipx",
+                "installer",
+                "remote-service",
+                "npx-always-latest",
+                "manual",
+            },
+        )
+        self.assertEqual(len(inventory), len({spec.key for spec in inventory}))
+
+    def test_check_writes_every_row_without_any_update_command(self) -> None:
+        runner = FakeRunner()
+        checks = update.collect_checks(runner)
+        with tempfile.TemporaryDirectory() as temp:
+            markdown, json_path, draft_id = update.write_draft(
+                checks,
+                Path(temp),
+                now=datetime(2026, 7, 15, tzinfo=timezone.utc),
+            )
+            report = markdown.read_text(encoding="utf-8")
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(len(checks), len(tool_inventory()))
+        self.assertEqual(payload["draft_id"], draft_id)
+        self.assertEqual(len(payload["checks"]), len(tool_inventory()))
+        for spec in tool_inventory():
+            self.assertIn(spec.display_name, report)
+        mutating_prefixes = {
+            ("npm", "install"),
+            ("brew", "upgrade"),
+            ("rustup", "update"),
+            ("pipx", "install"),
+            ("claude", "update"),
+            ("opencode", "upgrade"),
+        }
+        self.assertFalse(
+            any(call[:2] in mutating_prefixes or call[:3] == ("uv", "tool", "install") for call in runner.calls),
+            runner.calls,
+        )
+        self.assertIn("No update command was executed", report)
+
+    def test_offline_check_skips_all_http_including_remote_memento(self) -> None:
+        runner = FakeRunner()
+        checks = update.collect_checks(runner, offline=True)
+        memento = next(check for check in checks if check.key == "memento-mcp")
+        self.assertEqual(runner.urls, [])
+        self.assertEqual(memento.current, "offline/not-queried")
+
+    def test_launchd_schedule_can_only_enter_check_path(self) -> None:
+        plist_path = ROOT / "scripts" / "launchd" / "com.agentdesk.toolchain-update.plist"
+        with plist_path.open("rb") as stream:
+            plist = plistlib.load(stream)
+        arguments = plist["ProgramArguments"]
+        self.assertEqual(arguments[:2], ["/usr/bin/env", "python3"])
+        self.assertIn("check", arguments)
+        self.assertNotIn("apply", arguments)
+        self.assertNotIn("approve", arguments)
+        self.assertIn("StartCalendarInterval", plist)
+
+
+class ApprovalAndApplyTests(unittest.TestCase):
+    def test_destructive_npm_hygiene_requires_per_tool_approval(self) -> None:
+        runner = FakeRunner()
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("claude-e", tier="hygiene", method="npm-g")], Path(temp)
+            )
+            with self.assertRaises(update.ApprovalError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=[],
+                    apply_hygiene=True,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("npm", "install", "-g", "claude-e@1.1.0"), runner.calls)
+
+    def test_approval_is_bound_to_exact_draft_and_allows_smoked_apply(self) -> None:
+        runner = FakeRunner()
+        runner.sequence_overrides[("codex", "--version")] = [
+            update.CommandResult(0, "codex-cli 1.0.0\n", ""),
+            update.CommandResult(0, "old-candidate 0.9.0\ncodex-cli 1.1.0\n", ""),
+            update.CommandResult(0, "old-candidate 0.9.0\ncodex-cli 1.1.0\n", ""),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("codex", tier="approval", method="npm-g")], Path(temp)
+            )
+            update.approve_tool(draft, "codex", update.APPROVAL_CONFIRMATION)
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=["codex"],
+                apply_hygiene=False,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+        self.assertEqual(applied, ["codex"])
+        self.assertIsNone(alert)
+        self.assertIn(("npm", "install", "-g", "@openai/codex@1.1.0"), runner.calls)
+
+    def test_busy_agentdesk_window_fails_closed_before_mutation(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("agentdesk", "status", "--json")] = update.CommandResult(
+            0,
+            '{"sessions":{"working":1,"with_active_dispatch":0},"queue":{"status":"idle"}}',
+            "",
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            with self.assertRaises(update.ToolchainError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["gh"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+    def test_running_deploy_fails_closed_before_mutation(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("ps", "-axo", "command=")] = update.CommandResult(
+            0, "/bin/bash /release/scripts/deploy-release.sh\n", ""
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            with self.assertRaises(update.ToolchainError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["gh"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+    def test_smoke_failure_stops_batch_and_emits_pin_plan(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("gh", "--version")] = update.CommandResult(1, "", "broken loader")
+        runner.sequence_overrides[("brew", "list", "--versions", "gh")] = [
+            update.CommandResult(0, "gh 1.0.0\n", ""),
+            update.CommandResult(0, "gh 1.1.0\n", ""),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=["gh"],
+                apply_hygiene=False,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+            self.assertEqual(applied, [])
+            self.assertIsNotNone(alert)
+            alert_text = alert.read_text(encoding="utf-8")
+        self.assertIn("brew pin gh", alert_text)
+        self.assertIn("apply batch stopped", alert_text)
+
+    def test_stale_draft_blocks_before_update_command(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("brew", "list", "--versions", "gh")] = update.CommandResult(
+            0, "gh 1.0.1\n", ""
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            with self.assertRaises(update.ToolchainError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["gh"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+
+class SmokeGateTests(unittest.TestCase):
+    def test_highest_semver_selects_newest_codex_candidate(self) -> None:
+        self.assertEqual(
+            update.highest_semver("PATH-A codex 0.139.0\nPATH-B codex 0.142.3"),
+            "0.142.3",
+        )
+
+    def test_homebrew_loose_versions_cover_tmux_and_postgresql(self) -> None:
+        self.assertEqual(update._loose_version_key("tmux 3.6a"), ((3, 6, 0), "a"))
+        self.assertEqual(update._loose_version_key("psql 17.9"), ((17, 9, 0), ""))
+
+    def test_cswap_shape_accepts_fractional_age_and_rejects_drift(self) -> None:
+        valid, detail = update.validate_cswap_shape(
+            '{"schemaVersion":1,"activeAccountNumber":2,"accounts":'
+            '[{"number":2,"active":true,"usageAgeSeconds":5.4}]}'
+        )
+        invalid, invalid_detail = update.validate_cswap_shape(
+            '{"schemaVersion":1,"accounts":{"number":2}}'
+        )
+        self.assertTrue(valid, detail)
+        self.assertFalse(invalid)
+        self.assertIn("accounts must be a list", invalid_detail)
+        bool_schema, bool_detail = update.validate_cswap_shape(
+            '{"schemaVersion":true,"accounts":[]}'
+        )
+        self.assertFalse(bool_schema)
+        self.assertIn("schemaVersion must be an integer", bool_detail)
+
+    def test_postgresql_strict_gate_requires_server_comparison(self) -> None:
+        runner = FakeRunner()
+        with patch.dict(
+            update.os.environ,
+            {"DATABASE_URL": "", "AGENTDESK_DATABASE_URL": ""},
+            clear=False,
+        ):
+            results = update.run_smoke_profile("postgresql-17", runner, strict=True)
+        self.assertFalse(results[-1].ok)
+        self.assertIn("required", results[-1].detail)
+
+    def test_postgresql_strict_gate_compares_two_part_server_major(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("psql", "--version")] = update.CommandResult(
+            0, "psql (PostgreSQL) 17.9\n", ""
+        )
+        runner.overrides[("psql", "-Atqc", "SHOW server_version")] = update.CommandResult(
+            0, "17.8\n", ""
+        )
+        with patch.dict(update.os.environ, {"DATABASE_URL": "postgresql://example"}, clear=False):
+            results = update.run_smoke_profile("postgresql-17", runner, strict=True)
+        self.assertTrue(all(result.ok for result in results), results)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_toolchain_update.py
+++ b/tests/test_toolchain_update.py
@@ -64,7 +64,7 @@ class FakeRunner(update.Runner):
         if command[:3] == ("brew", "info", "--json=v2"):
             return update.CommandResult(
                 0,
-                json.dumps({"formulae": [{"versions": {"stable": "1.1.0"}}]}),
+                json.dumps({"formulae": [{"versions": {"stable": "1.1.0"}, "revision": 0}]}),
                 "",
             )
         if command[:2] == ("npm", "view"):
@@ -221,7 +221,10 @@ class InventoryAndDraftTests(unittest.TestCase):
         self.assertIn("check", arguments)
         self.assertNotIn("apply", arguments)
         self.assertNotIn("approve", arguments)
-        self.assertIn("StartCalendarInterval", plist)
+        self.assertEqual(
+            plist["StartCalendarInterval"],
+            {"Weekday": 0, "Hour": 9, "Minute": 30},
+        )
         path = plist["EnvironmentVariables"]["PATH"].split(":")
         self.assertEqual(path[0], "__HOME__/.local/bin")
         self.assertIn("__HOME__/.cargo/bin", path)
@@ -253,7 +256,7 @@ class ApprovalAndApplyTests(unittest.TestCase):
                 [check_for("opencode", tier="hygiene", method="installer")], Path(temp)
             )
             self.assertIn(
-                "per-tool approval also required: native/self-updater/npm mutation",
+                "per-tool approval also required: native/self-updater/rustup/npm mutation",
                 markdown.read_text(encoding="utf-8"),
             )
             with self.assertRaises(update.ApprovalError):
@@ -265,6 +268,121 @@ class ApprovalAndApplyTests(unittest.TestCase):
                     runner=runner,
                 )
         self.assertNotIn(("opencode", "upgrade"), runner.calls)
+
+    def test_rustup_hygiene_requires_approval_and_disables_self_update(self) -> None:
+        runner = FakeRunner()
+        rustc_version = ("rustup", "run", "stable", "rustc", "--version")
+        runner.sequence_overrides[rustc_version] = [
+            update.CommandResult(0, "rustc 1.0.0\n", ""),
+            update.CommandResult(0, "rustc 1.1.0\n", ""),
+            update.CommandResult(0, "rustc 1.1.0\n", ""),
+        ]
+        update_command = ("rustup", "update", "stable", "--no-self-update")
+        with tempfile.TemporaryDirectory() as temp:
+            markdown, draft, _ = update.write_draft(
+                [check_for("cargo-rustc", tier="hygiene", method="rustup")], Path(temp)
+            )
+            self.assertIn("native/self-updater/rustup/npm", markdown.read_text(encoding="utf-8"))
+            with self.assertRaises(update.ApprovalError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=[],
+                    apply_hygiene=True,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+            self.assertNotIn(update_command, runner.calls)
+
+            update.approve_tool(draft, "cargo-rustc", update.APPROVAL_CONFIRMATION)
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=[],
+                apply_hygiene=True,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+
+        self.assertEqual(applied, ["cargo-rustc"])
+        self.assertIsNone(alert)
+        self.assertIn(update_command, runner.calls)
+        self.assertFalse(any(call == ("rustup", "update", "stable") for call in runner.calls))
+
+    def test_revisioned_homebrew_upgrade_accepts_approved_bottle(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("brew", "info", "--json=v2", "gh")] = update.CommandResult(
+            0,
+            json.dumps({"formulae": [{"versions": {"stable": "1.1.0"}, "revision": 1}]}),
+            "",
+        )
+        runner.sequence_overrides[("brew", "list", "--versions", "gh")] = [
+            update.CommandResult(0, "gh 1.0.0\n", ""),
+            update.CommandResult(0, "gh 1.1.0_1\n", ""),
+        ]
+        check = replace(
+            check_for("gh", tier="hygiene", method="homebrew"),
+            latest="1.1.0_1",
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft([check], Path(temp))
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=["gh"],
+                apply_hygiene=False,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+
+        self.assertEqual(applied, ["gh"])
+        self.assertIsNone(alert)
+        self.assertIn(("gh", "--version"), runner.calls)
+
+    def test_revisioned_homebrew_upgrade_rejects_different_bottle_before_smoke(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("brew", "info", "--json=v2", "gh")] = update.CommandResult(
+            0,
+            json.dumps({"formulae": [{"versions": {"stable": "1.1.0"}, "revision": 1}]}),
+            "",
+        )
+        runner.sequence_overrides[("brew", "list", "--versions", "gh")] = [
+            update.CommandResult(0, "gh 1.0.0\n", ""),
+            update.CommandResult(0, "gh 1.1.0_2\n", ""),
+        ]
+        check = replace(
+            check_for("gh", tier="hygiene", method="homebrew"),
+            latest="1.1.0_1",
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft([check], Path(temp))
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=["gh"],
+                apply_hygiene=False,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+            self.assertEqual(applied, [])
+            self.assertIsNotNone(alert)
+            alert_text = alert.read_text(encoding="utf-8")
+
+        self.assertIn("expected=1.1.0_1, observed=1.1.0_2", alert_text)
+        self.assertIn("smoke not run", alert_text)
+        self.assertNotIn(("gh", "--version"), runner.calls)
+
+    def test_generated_contract_says_exact_version_can_prevent_smoke(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            markdown, _, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            report = markdown.read_text(encoding="utf-8")
+
+        self.assertIn("exact-version verification", report)
+        self.assertIn("may stop the batch before smoke", report)
+        self.assertNotIn("Every applied tool runs its smoke profile", report)
+
+    def test_non_homebrew_default_update_timeout_is_1800_seconds(self) -> None:
+        spec = next(item for item in tool_inventory() if item.key == "cargo-rustc")
+        self.assertEqual(update.DEFAULT_UPDATE_TIMEOUT_SECONDS, 1800)
+        self.assertEqual(update._update_timeout(spec), 1800)
 
     def test_approval_is_bound_to_exact_draft_and_allows_smoked_apply(self) -> None:
         runner = FakeRunner()

--- a/tests/test_toolchain_update.py
+++ b/tests/test_toolchain_update.py
@@ -8,6 +8,7 @@ import plistlib
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -24,6 +25,7 @@ from toolchain_manifest import tool_inventory  # noqa: E402
 class FakeRunner(update.Runner):
     def __init__(self) -> None:
         self.calls: list[tuple[str, ...]] = []
+        self.invocations: list[tuple[tuple[str, ...], int, dict[str, str]]] = []
         self.urls: list[str] = []
         self.overrides: dict[tuple[str, ...], update.CommandResult] = {}
         self.sequence_overrides: dict[tuple[str, ...], list[update.CommandResult]] = {}
@@ -35,9 +37,9 @@ class FakeRunner(update.Runner):
         timeout: int = update.DEFAULT_TIMEOUT_SECONDS,
         env: Mapping[str, str] | None = None,
     ) -> update.CommandResult:
-        del timeout, env
         command = tuple(argv)
         self.calls.append(command)
+        self.invocations.append((command, timeout, dict(env or {})))
         if command in self.sequence_overrides and self.sequence_overrides[command]:
             return self.sequence_overrides[command].pop(0)
         if command in self.overrides:
@@ -220,6 +222,11 @@ class InventoryAndDraftTests(unittest.TestCase):
         self.assertNotIn("apply", arguments)
         self.assertNotIn("approve", arguments)
         self.assertIn("StartCalendarInterval", plist)
+        path = plist["EnvironmentVariables"]["PATH"].split(":")
+        self.assertEqual(path[0], "__HOME__/.local/bin")
+        self.assertIn("__HOME__/.cargo/bin", path)
+        self.assertIn("__HOME__/.opencode/bin", path)
+        self.assertIn("__HOME__/bin", path)
 
 
 class ApprovalAndApplyTests(unittest.TestCase):
@@ -238,6 +245,26 @@ class ApprovalAndApplyTests(unittest.TestCase):
                     runner=runner,
                 )
         self.assertNotIn(("npm", "install", "-g", "claude-e@1.1.0"), runner.calls)
+
+    def test_installer_hygiene_requires_per_tool_approval(self) -> None:
+        runner = FakeRunner()
+        with tempfile.TemporaryDirectory() as temp:
+            markdown, draft, _ = update.write_draft(
+                [check_for("opencode", tier="hygiene", method="installer")], Path(temp)
+            )
+            self.assertIn(
+                "per-tool approval also required: native/self-updater/npm mutation",
+                markdown.read_text(encoding="utf-8"),
+            )
+            with self.assertRaises(update.ApprovalError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=[],
+                    apply_hygiene=True,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("opencode", "upgrade"), runner.calls)
 
     def test_approval_is_bound_to_exact_draft_and_allows_smoked_apply(self) -> None:
         runner = FakeRunner()
@@ -262,6 +289,31 @@ class ApprovalAndApplyTests(unittest.TestCase):
         self.assertIsNone(alert)
         self.assertIn(("npm", "install", "-g", "@openai/codex@1.1.0"), runner.calls)
 
+    def test_newer_than_approved_native_result_fails_before_smoke_with_alert(self) -> None:
+        runner = FakeRunner()
+        runner.sequence_overrides[("claude", "--version")] = [
+            update.CommandResult(0, "claude 1.0.0\n", ""),
+            update.CommandResult(0, "claude 1.2.0\n", ""),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("claude", tier="approval", method="native")], Path(temp)
+            )
+            update.approve_tool(draft, "claude", update.APPROVAL_CONFIRMATION)
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=["claude"],
+                apply_hygiene=False,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+            self.assertEqual(applied, [])
+            self.assertIsNotNone(alert)
+            alert_text = alert.read_text(encoding="utf-8")
+        self.assertIn("expected=1.1.0, observed=1.2.0", alert_text)
+        self.assertIn("smoke not run", alert_text)
+        self.assertEqual(runner.calls.count(("claude", "--version")), 2)
+
     def test_busy_agentdesk_window_fails_closed_before_mutation(self) -> None:
         runner = FakeRunner()
         runner.overrides[("agentdesk", "status", "--json")] = update.CommandResult(
@@ -282,6 +334,76 @@ class ApprovalAndApplyTests(unittest.TestCase):
                     runner=runner,
                 )
         self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+    def test_active_queue_fails_closed_before_mutation(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("agentdesk", "status", "--json")] = update.CommandResult(
+            0,
+            '{"sessions":{"working":0,"with_active_dispatch":0},"queue":{"status":"active"}}',
+            "",
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            with self.assertRaisesRegex(update.ToolchainError, "queue_status=active"):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["gh"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+    def test_completed_queue_history_is_not_treated_as_live(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("agentdesk", "status", "--json")] = update.CommandResult(
+            0,
+            '{"sessions":{"working":0,"with_active_dispatch":0},"queue":{"status":"completed"}}',
+            "",
+        )
+        update.assert_safe_window(runner)
+
+    def test_safe_window_is_rechecked_before_each_mutation(self) -> None:
+        runner = FakeRunner()
+        idle = update.CommandResult(
+            0,
+            '{"sessions":{"working":0,"with_active_dispatch":0},"queue":{"status":"idle"}}',
+            "",
+        )
+        active = update.CommandResult(
+            0,
+            '{"sessions":{"working":0,"with_active_dispatch":0},"queue":{"status":"active"}}',
+            "",
+        )
+        runner.sequence_overrides[("agentdesk", "status", "--json")] = [idle, idle, active]
+        runner.sequence_overrides[("brew", "list", "--versions", "gh")] = [
+            update.CommandResult(0, "gh 1.0.0\n", ""),
+            update.CommandResult(0, "gh 1.1.0\n", ""),
+        ]
+        runner.sequence_overrides[("brew", "list", "--versions", "jq")] = [
+            update.CommandResult(0, "jq 1.0.0\n", ""),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [
+                    check_for("gh", tier="hygiene", method="homebrew"),
+                    check_for("jq", tier="hygiene", method="homebrew"),
+                ],
+                Path(temp),
+            )
+            with self.assertRaisesRegex(update.ToolchainError, "queue_status=active"):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["gh", "jq"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertIn(("brew", "upgrade", "gh"), runner.calls)
+        self.assertNotIn(("brew", "upgrade", "jq"), runner.calls)
+        self.assertEqual(runner.calls.count(("agentdesk", "status", "--json")), 3)
 
     def test_running_deploy_fails_closed_before_mutation(self) -> None:
         runner = FakeRunner()
@@ -326,6 +448,63 @@ class ApprovalAndApplyTests(unittest.TestCase):
         self.assertIn("brew pin gh", alert_text)
         self.assertIn("apply batch stopped", alert_text)
 
+    def test_update_timeout_uses_build_window_and_emits_rollback_alert(self) -> None:
+        runner = FakeRunner()
+        runner.overrides[("brew", "upgrade", "gh")] = update.CommandResult(
+            124, "", "timed out during source build"
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            applied, alert = update.apply_draft(
+                draft,
+                requested_tools=["gh"],
+                apply_hygiene=False,
+                safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                runner=runner,
+            )
+            self.assertEqual(applied, [])
+            self.assertIsNotNone(alert)
+            alert_text = alert.read_text(encoding="utf-8")
+        timeout = next(
+            timeout
+            for command, timeout, _env in runner.invocations
+            if command == ("brew", "upgrade", "gh")
+        )
+        self.assertEqual(timeout, update.BUILD_UPDATE_TIMEOUT_SECONDS)
+        self.assertGreaterEqual(timeout, 3600)
+        self.assertIn("timed out during source build", alert_text)
+        self.assertIn("brew pin gh", alert_text)
+
+    def test_post_mutation_smoke_setup_error_emits_rollback_alert(self) -> None:
+        runner = FakeRunner()
+        runner.sequence_overrides[("brew", "list", "--versions", "gh")] = [
+            update.CommandResult(0, "gh 1.0.0\n", ""),
+            update.CommandResult(0, "gh 1.1.0\n", ""),
+        ]
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft(
+                [check_for("gh", tier="hygiene", method="homebrew")], Path(temp)
+            )
+            with patch.object(
+                update,
+                "run_smoke_profile",
+                side_effect=update.ToolchainError("smoke profile misconfigured"),
+            ):
+                applied, alert = update.apply_draft(
+                    draft,
+                    requested_tools=["gh"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+            self.assertEqual(applied, [])
+            self.assertIsNotNone(alert)
+            alert_text = alert.read_text(encoding="utf-8")
+        self.assertIn("smoke profile misconfigured", alert_text)
+        self.assertIn("brew pin gh", alert_text)
+
     def test_stale_draft_blocks_before_update_command(self) -> None:
         runner = FakeRunner()
         runner.overrides[("brew", "list", "--versions", "gh")] = update.CommandResult(
@@ -344,6 +523,56 @@ class ApprovalAndApplyTests(unittest.TestCase):
                     runner=runner,
                 )
         self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+    def test_stale_manifest_row_has_operator_friendly_error(self) -> None:
+        runner = FakeRunner()
+        stale = replace(check_for("gh", tier="hygiene", method="homebrew"), key="retired-tool")
+        with tempfile.TemporaryDirectory() as temp:
+            _, draft, _ = update.write_draft([stale], Path(temp))
+            with self.assertRaisesRegex(
+                update.ToolchainError,
+                "draft contains tool.*retired-tool.*generate a fresh draft",
+            ):
+                update.apply_draft(
+                    draft,
+                    requested_tools=[],
+                    apply_hygiene=True,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("brew", "upgrade", "gh"), runner.calls)
+
+    def test_later_identical_draft_rejects_old_approval_and_reprobe_catches_move(self) -> None:
+        runner = FakeRunner()
+        check = check_for("codex", tier="approval", method="npm-g")
+        same_time = datetime(2026, 7, 15, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as temp:
+            output_dir = Path(temp)
+            _, draft, draft_a_id = update.write_draft([check], output_dir, now=same_time)
+            update.approve_tool(draft, "codex", update.APPROVAL_CONFIRMATION)
+            _, draft, draft_b_id = update.write_draft([check], output_dir, now=same_time)
+            self.assertNotEqual(draft_a_id, draft_b_id)
+            runner.overrides[("codex", "--version")] = update.CommandResult(
+                0, "codex-cli 1.0.1\n", ""
+            )
+            with self.assertRaises(update.ApprovalError):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["codex"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+            update.approve_tool(draft, "codex", update.APPROVAL_CONFIRMATION)
+            with self.assertRaisesRegex(update.ToolchainError, "stale draft for codex"):
+                update.apply_draft(
+                    draft,
+                    requested_tools=["codex"],
+                    apply_hygiene=False,
+                    safe_window_confirmation=update.SAFE_WINDOW_CONFIRMATION,
+                    runner=runner,
+                )
+        self.assertNotIn(("npm", "install", "-g", "@openai/codex@1.1.0"), runner.calls)
 
 
 class SmokeGateTests(unittest.TestCase):
@@ -373,6 +602,33 @@ class SmokeGateTests(unittest.TestCase):
         )
         self.assertFalse(bool_schema)
         self.assertIn("schemaVersion must be an integer", bool_detail)
+        for invalid_payload in ("{}", '{"accounts":null}'):
+            valid_accounts, accounts_detail = update.validate_cswap_shape(invalid_payload)
+            self.assertFalse(valid_accounts)
+            self.assertIn("present, non-null list", accounts_detail)
+
+    def test_node_smoke_fails_when_expected_global_inventory_is_empty(self) -> None:
+        runner = FakeRunner()
+        results = update.run_smoke_profile("node", runner, strict=True)
+        inventory = next(result for result in results if result.check == "node global CLI inventory")
+        self.assertFalse(inventory.ok)
+        self.assertIn("expected=3", inventory.detail)
+        self.assertIn("@openai/codex", inventory.detail)
+
+    def test_node_smoke_probes_every_manifest_npm_global_cli(self) -> None:
+        runner = FakeRunner()
+        dependencies = {
+            spec.update_value: {}
+            for spec in tool_inventory()
+            if spec.method == "npm-g" and isinstance(spec.update_value, str)
+        }
+        runner.overrides[("npm", "ls", "-g", "--depth=0", "--json")] = update.CommandResult(
+            0, json.dumps({"dependencies": dependencies}), ""
+        )
+        results = update.run_smoke_profile("node", runner, strict=True)
+        self.assertTrue(all(result.ok for result in results), results)
+        for command in (("codex", "--version"), ("ocx", "--version"), ("claude-e", "--version")):
+            self.assertIn(command, runner.calls)
 
     def test_postgresql_strict_gate_requires_server_comparison(self) -> None:
         runner = FakeRunner()
@@ -387,15 +643,24 @@ class SmokeGateTests(unittest.TestCase):
 
     def test_postgresql_strict_gate_compares_two_part_server_major(self) -> None:
         runner = FakeRunner()
+        database_url = "postgresql://example/agentdesk"
         runner.overrides[("psql", "--version")] = update.CommandResult(
             0, "psql (PostgreSQL) 17.9\n", ""
         )
-        runner.overrides[("psql", "-Atqc", "SHOW server_version")] = update.CommandResult(
+        server_command = ("psql", "-Atqc", "SHOW server_version", database_url)
+        runner.overrides[server_command] = update.CommandResult(
             0, "17.8\n", ""
         )
-        with patch.dict(update.os.environ, {"DATABASE_URL": "postgresql://example"}, clear=False):
+        with patch.dict(
+            update.os.environ,
+            {"DATABASE_URL": database_url, "AGENTDESK_DATABASE_URL": ""},
+            clear=False,
+        ):
             results = update.run_smoke_profile("postgresql-17", runner, strict=True)
         self.assertTrue(all(result.ok for result in results), results)
+        self.assertIn(server_command, runner.calls)
+        server_invocation = next(item for item in runner.invocations if item[0] == server_command)
+        self.assertNotIn("PGDATABASE", server_invocation[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 이슈
#4555 — 외부 툴체인(claude/codex/ocx/cswap/tmux/brew 등) 업데이트 자동화 전무. draft→승인→apply→스모크 루틴 추가.

## 산출 (신규 파일 6, +1885)
- `scripts/toolchain_manifest.py` (315) — 업데이트 방식별 인벤토리(native/npm-g/uv/rustup/homebrew) + 티어
- `scripts/toolchain_update.py` (997) — **scheduled=read-only draft 생성**(업데이트 명령 미실행), apply는 exact 승인마커(`approve-exact-toolchain-draft`)로 human-gated, 스모크 게이트(codex --version 최고-semver, cswap --list --json shape 등)
- `scripts/launchd/com.agentdesk.toolchain-update.plist` (48) — 주기 스케줄(로드는 문서화만)
- `docs/routines/toolchain-update.md` (120)
- `tests/test_toolchain_update.py` (402, unittest) — **ci-script-checks.sh:79에 배선**
- `scripts/ci-script-checks.sh` (+3)

## 안전
- 스케줄 경로는 파괴적 명령 미실행(evidence-only draft). DESTRUCTIVE_METHODS={native,npm-g}는 승인마커 필수.

## 검증
- `python3 -m unittest tests.test_toolchain_update` 15 tests OK
- ci-script-checks rc=0, audit rc=0