### PR TITLE
fix(cli): config set <JSON> clap arg-id collision panic (#4565)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 25 | 25 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1523 | 971 | 552 |  |
+| `cli::args` | `src/cli/args.rs` | 1570 | 972 | 598 |  |
 | `cli::client` | `src/cli/client.rs` | 2722 | 2464 | 258 | giant-file |
 | `cli::client::runtime_config` | `src/cli/client/runtime_config.rs` | 55 | 23 | 32 |  |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -884,6 +884,7 @@ pub(crate) enum ConfigAction {
     /// Set runtime config (JSON string)
     Set {
         /// JSON value to set
+        #[arg(id = "config_json")]
         json: String,
     },
     /// Audit config source-of-truth drift across yaml/DB/legacy files
@@ -1342,6 +1343,34 @@ mod tests {
             Commands::SendToAgent { expect_reply, .. } => assert!(!expect_reply),
             _ => panic!("unexpected command"),
         }
+    }
+
+    #[test]
+    fn config_set_parses_json_value() {
+        let cli = Cli::try_parse_from(["agentdesk", "config", "set", r#"{"a":1}"#])
+            .expect("config set <JSON> parses");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Config {
+                action: ConfigAction::Set { json },
+            }) if json == r#"{"a":1}"#
+        ));
+        assert!(!cli.json);
+    }
+
+    #[test]
+    fn config_set_parses_json_value_with_global_json() {
+        let cli = Cli::try_parse_from(["agentdesk", "config", "set", r#"{"a":1}"#, "--json"])
+            .expect("config set <JSON> --json parses");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Config {
+                action: ConfigAction::Set { json },
+            }) if json == r#"{"a":1}"#
+        ));
+        assert!(cli.json);
     }
 
     #[test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -884,7 +884,7 @@ pub(crate) enum ConfigAction {
     /// Set runtime config (JSON string)
     Set {
         /// JSON value to set
-        #[arg(id = "config_json")]
+        #[arg(id = "config_json", value_name = "JSON")]
         json: String,
     },
     /// Audit config source-of-truth drift across yaml/DB/legacy files
@@ -1357,6 +1357,24 @@ mod tests {
             }) if json == r#"{"a":1}"#
         ));
         assert!(!cli.json);
+    }
+
+    #[test]
+    fn config_set_help_preserves_json_value_name() {
+        let mut command = Cli::command();
+        let config = command
+            .find_subcommand_mut("config")
+            .expect("config subcommand exists");
+        let set = config
+            .find_subcommand_mut("set")
+            .expect("config set subcommand exists");
+        let mut rendered = Vec::new();
+        set.write_long_help(&mut rendered)
+            .expect("config set help renders");
+        let rendered = String::from_utf8(rendered).expect("help is UTF-8");
+
+        assert!(rendered.contains("<JSON>"));
+        assert!(!rendered.contains("<CONFIG_JSON>"));
     }
 
     #[test]


### PR DESCRIPTION
## 문제
`agentdesk config set <JSON>`이 전역 `--json` 플래그와 clap arg-id `json` 충돌로 패닉 (#4565).

## 수정
- `ConfigAction::Set` positional에 `#[arg(id = "config_json", value_name = "JSON")]` 부여 — 내부 id 충돌 해소, help 표기(`<JSON>`)는 보존.
- 전역 인자 id(json/filters/agent/limit/detailed)와 겹치는 다른 positional 전수 확인 — 추가 충돌 없음.

## 테스트
- `config_set_parses_json_value`: `config set '{"a":1}'` 파싱 성공 + payload 보존 + 전역 json=false. id 가드 제거 시 clap 다운캐스트 패닉으로 실패(뮤테이션 증명).
- `config_set_parses_json_value_with_global_json`: `--json` 동시 사용 성공 + cli.json=true.
- help 렌더에 `<JSON>` 포함 / `<CONFIG_JSON>` 미포함 assert.

## 게이트
fmt/check/test(cli::args)/inventory/freshness/maintainability 전부 rc=0 (오케스트레이터 취합 실행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)