### PR TITLE
ux(discord): status footer time line에 KST 절대시각 + <t:R> 병기 (#4572)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -573,7 +573,7 @@
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |
 | `services::discord::placeholder_live_events::context_panel` | `src/services/discord/placeholder_live_events/context_panel.rs` | 72 | 72 | 0 |  |
-| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 187 | 86 | 101 |  |
+| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 210 | 101 | 109 |  |
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 322 | 322 | 0 |  |
 | `services::discord::placeholder_live_events::session_banner_claim` | `src/services/discord/placeholder_live_events/session_banner_claim.rs` | 91 | 91 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
@@ -719,7 +719,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2927 | 861 | 2066 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2938 | 861 | 2077 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |
@@ -748,7 +748,7 @@
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 190 | 190 | 0 |  |
 | `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1332 | 764 | 568 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 347 | 200 | 147 |  |
-| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1377 | 348 | 1029 |  |
+| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1378 | 348 | 1030 |  |
 | `services::discord::tmux_placeholder_suppression::evidence` | `src/services/discord/tmux_placeholder_suppression/evidence.rs` | 259 | 259 | 0 |  |
 | `services::discord::tmux_placeholder_suppression::ops` | `src/services/discord/tmux_placeholder_suppression/ops.rs` | 584 | 584 | 0 |  |
 | `services::discord::tmux_reaper` | `src/services/discord/tmux_reaper.rs` | 1222 | 886 | 336 |  |

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -11,15 +11,17 @@
 //!   merge (`single_message_panel::merged_footer_header_line`) swaps the leading
 //!   status emoji for the animated spinner, so the marker set there must stay in
 //!   sync with the emojis this label can start with.
-//! - line 2 is the relative TIME line (`마지막 업데이트 : <t:last:R> / 턴 시작 :
-//!   <t:start:R>`). It replaces the pre-#3983 confidence line + `진행 중 —
-//!   provider` header; the freshness class is now absorbed into the line-1 emoji
-//!   (item B), and the provider moved off the footer entirely.
+//! - line 2 is the TIME line (`마지막 업데이트 : MM-DD HH:MM:SS (<t:last:R>) /
+//!   턴 시작 : MM-DD HH:MM:SS (<t:start:R>)`). The fixed KST absolute times keep
+//!   mobile clients readable when they do not refresh Discord's relative token.
+//!   It replaces the pre-#3983 confidence line + `진행 중 — provider` header; the
+//!   freshness class is now absorbed into the line-1 emoji (item B), and the
+//!   provider moved off the footer entirely.
 //!
-//! Both relative ages render with Discord's native `<t:UNIX:R>` token anchored to
-//! STABLE store stamps (never "now"), so the footer text stays byte-identical
-//! across heartbeat ticks — the message is not needlessly re-edited (the #3477
-//! stability invariant) while Discord renders the live localized age client-side.
+//! Both times derive from STABLE store stamps (never "now"), so the footer text
+//! stays byte-identical across heartbeat ticks — the message is not needlessly
+//! re-edited (the #3477 stability invariant) while Discord renders the live
+//! localized age client-side.
 
 use poise::serenity_prelude::ChannelId;
 
@@ -41,14 +43,27 @@ impl super::PlaceholderLiveEvents {
     }
 }
 
-/// #3983: renders the footer's relative time line. `last_activity_unix` is the
-/// store's STABLE per-channel last-live-content arrival stamp; it falls back to the
-/// turn start when no live content has arrived yet. Uses Discord's `<t:UNIX:R>`
-/// token so the text is identical across heartbeat ticks (never re-edited) while
-/// the client shows the live localized age.
+/// #4572: renders a stable Unix stamp as a fixed KST time for the footer.
+fn render_kst_time(unix: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(unix, 0)
+        .expect("status-panel timestamps must be valid Unix seconds")
+        .with_timezone(&chrono_tz::Asia::Seoul)
+        .format("%m-%d %H:%M:%S")
+        .to_string()
+}
+
+/// #4572: renders the footer's fixed KST and relative time line.
+/// `last_activity_unix` is the store's STABLE per-channel last-live-content
+/// arrival stamp; it falls back to the turn start when no live content has
+/// arrived yet. The injected stamps keep the text identical across heartbeat
+/// ticks (never re-edited) while Discord can still show the localized relative age.
 pub(super) fn render_time_line(last_activity_unix: Option<i64>, started_at_unix: i64) -> String {
     let last = last_activity_unix.unwrap_or(started_at_unix);
-    format!("마지막 업데이트 : <t:{last}:R> / 턴 시작 : <t:{started_at_unix}:R>")
+    format!(
+        "마지막 업데이트 : {} (<t:{last}:R>) / 턴 시작 : {} (<t:{started_at_unix}:R>)",
+        render_kst_time(last),
+        render_kst_time(started_at_unix),
+    )
 }
 
 /// #3983: the panel's first (activity) line — the derived-status label alone (no
@@ -163,8 +178,16 @@ mod tests {
     fn time_line_anchors_update_to_last_activity_and_start() {
         assert_eq!(
             render_time_line(Some(LAST_ACTIVITY), STARTED_AT),
-            "마지막 업데이트 : <t:1700000300:R> / 턴 시작 : <t:1700000000:R>"
+            "마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"
         );
+    }
+
+    #[test]
+    fn time_line_includes_fixed_kst_and_discord_relative_tokens() {
+        let line = render_time_line(Some(LAST_ACTIVITY), STARTED_AT);
+
+        assert!(line.contains("마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"));
+        assert!(line.contains("턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"));
     }
 
     #[test]
@@ -172,7 +195,7 @@ mod tests {
         // No live content yet → the update age anchors to the turn start.
         assert_eq!(
             render_time_line(None, STARTED_AT),
-            "마지막 업데이트 : <t:1700000000:R> / 턴 시작 : <t:1700000000:R>"
+            "마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"
         );
     }
 

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -391,8 +391,10 @@ fn status_panel_absorbs_stale_and_final_into_the_activity_emoji() {
         "running activity: {live:?}"
     );
     assert!(
-        live.contains("마지막 업데이트 : <t:") && live.contains("턴 시작 : <t:"),
-        "time line must render: {live:?}"
+        live.contains("마지막 업데이트 : ")
+            && live.contains("턴 시작 : ")
+            && live.contains(" (<t:"),
+        "time line must include fixed KST and relative timestamps: {live:?}"
     );
     assert!(
         !live.contains("신뢰도"),
@@ -8863,7 +8865,7 @@ fn status_panel_free_renderer_leads_with_activity_and_time_lines() {
     let out = super::status_panel::render_status_panel(
         StatusPanelState::default(),
         &ProviderKind::Claude,
-        "마지막 업데이트 : <t:1700000000:R> / 턴 시작 : <t:1700000000:R>".to_string(),
+        "마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)".to_string(),
         Some("턴 트리거: https://discord.com/channels/1/2/3".to_string()),
     );
     let mut sections = out.split("\n\n");
@@ -8874,7 +8876,9 @@ fn status_panel_free_renderer_leads_with_activity_and_time_lines() {
     );
     assert_eq!(
         sections.next(),
-        Some("마지막 업데이트 : <t:1700000000:R> / 턴 시작 : <t:1700000000:R>"),
+        Some(
+            "마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"
+        ),
         "line 2 = time line: {out:?}"
     );
     assert!(

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -1401,6 +1401,17 @@ mod tests {
     }
 
     #[test]
+    fn footer_only_surface_recognizes_fixed_kst_time_line() {
+        let panel = "🟢 진행 중\n\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)";
+        let rendered = super::compose_footer_status_block("⠸", panel);
+
+        assert!(super::streaming_footer_only_surface_was_exposed(
+            &rendered,
+            &ProviderKind::Claude
+        ));
+    }
+
+    #[test]
     fn terminal_footer_replacement_keeps_completion_context_block() {
         let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
         let rendered = format!(

--- a/src/services/discord/tmux_placeholder_suppression/mod.rs
+++ b/src/services/discord/tmux_placeholder_suppression/mod.rs
@@ -355,10 +355,11 @@ mod placeholder_suppression_tests {
     fn footer_status_block() -> String {
         let long_tail = "└ cargo test --lib tmux ".repeat(120);
         let panel = format!(
-            "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nTools\n└ cargo test --lib tmux\nSubagents\n└ review inspect\n{long_tail}"
+            "🟢 진행 중\n\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n\nTools\n└ cargo test --lib tmux\nSubagents\n└ review inspect\n{long_tail}"
         );
         let status_block = discord::single_message_panel::compose_footer_status_block("⠋", &panel);
-        assert!(status_block.starts_with("⠋ 진행 중 — Claude (<t:1700000000:R>)"));
+        assert!(status_block.starts_with("⠋ 진행 중"));
+        assert!(status_block.contains("마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"));
         assert!(status_block.contains("Tools"));
         assert!(status_block.contains("Subagents"));
         assert!(status_block.contains('…'));


### PR DESCRIPTION
## 요약 (#4572 — 유실 원지시 복원)
footer time line을 `MM-DD HH:MM:SS (<t:UNIX:R>)` 형식(KST 고정 + Discord 상대토큰 병기)으로 — 모바일 상대시각 미갱신 대응.
- 렌더는 stable Unix stamp만 사용, render-time now 미참조 (heartbeat 간 footer byte-stable 불변식 #3477 보존).
- single-message footer 감지/cleanup·placeholder suppression fixture를 새 형식으로 갱신.
- chrono-tz(기존 dep)·Asia::Seoul(기존 관례) 사용.

## 테스트 (뮤테이션 증명 포함)
time_line_anchors/includes/fallback/independent 4종 + status_panel 2종 + footer_only surface 1종 — KST 변환·병기·fallback·byte-stable 각각 제거 시 해당 assert 실패.

## 게이트
fmt/check/test/inventory/freshness/maintainability rc=0 (취합 실행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)