### PR TITLE
fix(claude-tui): kind-aware MCP auth warning gate — warm follow-up 오탐 해소 (#4528)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1906,7 +1906,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   non-bugfix behavior beyond the readiness/cancel contract. #4411 promotes the
   existing action planner to production, consumes composer-ready signals once,
   and requires two live draft snapshots before a warm submit may be replayed.
-- `src/services/claude_tui/input.rs` (1957) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1961) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1906,7 +1906,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   non-bugfix behavior beyond the readiness/cancel contract. #4411 promotes the
   existing action planner to production, consumes composer-ready signals once,
   and requires two live draft snapshots before a warm submit may be replayed.
-- `src/services/claude_tui/input.rs` (1932) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1949) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1906,7 +1906,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   non-bugfix behavior beyond the readiness/cancel contract. #4411 promotes the
   existing action planner to production, consumes composer-ready signals once,
   and requires two live draft snapshots before a warm submit may be replayed.
-- `src/services/claude_tui/input.rs` (1949) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1957) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -83,7 +83,7 @@
 | `src/services/auto_queue/activate_command.rs` | 1506 |
 | `src/services/auto_queue/cancel_run.rs` | 1031 |
 | `src/services/claude.rs` | 2969 |
-| `src/services/claude_tui/input.rs` | 1932 |
+| `src/services/claude_tui/input.rs` | 1949 |
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1659 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1259 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1273 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1288 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1310 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1099 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1163 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered
@@ -83,7 +83,7 @@
 | `src/services/auto_queue/activate_command.rs` | 1506 |
 | `src/services/auto_queue/cancel_run.rs` | 1031 |
 | `src/services/claude.rs` | 2969 |
-| `src/services/claude_tui/input.rs` | 1949 |
+| `src/services/claude_tui/input.rs` | 1957 |
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1659 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1273 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1288 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1310 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1311 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1200 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1221 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1163 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1200 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered
@@ -83,7 +83,7 @@
 | `src/services/auto_queue/activate_command.rs` | 1506 |
 | `src/services/auto_queue/cancel_run.rs` | 1031 |
 | `src/services/claude.rs` | 2969 |
-| `src/services/claude_tui/input.rs` | 1957 |
+| `src/services/claude_tui/input.rs` | 1961 |
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
 | `src/services/codex_tui/input.rs` | 1659 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1221 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1248 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -35,7 +35,7 @@
 | `src/services/discord/turn_view_reconciler.rs` | 2214 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
-| `src/services/tmux_common.rs` | 1248 | discord-relay | 2026-10-31 | #3924 |
+| `src/services/tmux_common.rs` | 1259 | discord-relay | 2026-10-31 | #3924 |
 | `src/voice/announce_meta.rs` | 1001 | voice-runtime | 2026-08-31 | #3405 |
 
 ## Grandfathered

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -396,7 +396,7 @@
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
-| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3490 | 1957 | 1533 | giant-file |
+| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3504 | 1961 | 1543 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 1566 | 863 | 703 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 838 | 439 | 399 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2036 | 1163 | 873 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2096 | 1200 | 896 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -396,7 +396,7 @@
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
-| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3504 | 1961 | 1543 | giant-file |
+| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3550 | 1961 | 1589 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 1566 | 863 | 703 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 838 | 439 | 399 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2096 | 1200 | 896 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2141 | 1221 | 920 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2275 | 1273 | 1002 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2293 | 1288 | 1005 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2217 | 1248 | 969 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2243 | 1259 | 984 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2293 | 1288 | 1005 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2331 | 1310 | 1021 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -396,7 +396,7 @@
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
-| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3445 | 1949 | 1496 | giant-file |
+| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3490 | 1957 | 1533 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 1566 | 863 | 703 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 838 | 439 | 399 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 1951 | 1099 | 852 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2036 | 1163 | 873 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2141 | 1221 | 920 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2217 | 1248 | 969 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2243 | 1259 | 984 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2275 | 1273 | 1002 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -1058,7 +1058,7 @@
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |
-| `services::tmux_common` | `src/services/tmux_common.rs` | 2331 | 1310 | 1021 | giant-file |
+| `services::tmux_common` | `src/services/tmux_common.rs` | 2356 | 1311 | 1045 | giant-file |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 803 | 743 | 60 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -396,7 +396,7 @@
 | `services::claude_tui::hosting` | `src/services/claude_tui/hosting/mod.rs` | 13 | 13 | 0 |  |
 | `services::claude_tui::hosting::followup_support` | `src/services/claude_tui/hosting/followup_support.rs` | 524 | 409 | 115 |  |
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 750 | 693 | 57 |  |
-| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3358 | 1932 | 1426 | giant-file |
+| `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3445 | 1949 | 1496 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 1566 | 863 | 703 |  |
 | `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 838 | 439 | 399 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |

--- a/src/services/claude_tui/hosting/warm_followup.rs
+++ b/src/services/claude_tui/hosting/warm_followup.rs
@@ -321,7 +321,7 @@ fn run_claude_tui_warm_followup_submit_and_stream(
         // envelope is authoritative but the prompt glyph is not visible.
         match crate::services::claude_tui::input::wait_for_prompt_ready_or_idle_transcript(
             tmux_session_name,
-            crate::services::claude_tui::input::PromptReadinessKind::Followup,
+            crate::services::claude_tui::input::PromptReadinessKind::ProvenWarmFollowup,
             cancel_token.as_deref(),
             &transcript_path,
         ) {

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -61,6 +61,7 @@ const STARTUP_DIALOG_DISMISS_SETTLE: Duration = Duration::from_millis(500);
 pub enum PromptReadinessKind {
     FreshTurn,
     Followup,
+    ProvenWarmFollowup,
 }
 
 /// Resolve the Follow-up readiness budget from the live config snapshot,
@@ -134,22 +135,30 @@ impl PromptReadinessKind {
     fn timeout(self) -> Duration {
         match self {
             Self::FreshTurn => FRESH_PROMPT_READY_TIMEOUT,
-            Self::Followup => followup_prompt_ready_timeout(),
+            Self::Followup | Self::ProvenWarmFollowup => followup_prompt_ready_timeout(),
         }
     }
 
     fn event_budget(self) -> Duration {
         match self {
             Self::FreshTurn => FRESH_PROMPT_READY_EVENT_BUDGET,
-            Self::Followup => FOLLOWUP_PROMPT_READY_EVENT_BUDGET,
+            Self::Followup | Self::ProvenWarmFollowup => FOLLOWUP_PROMPT_READY_EVENT_BUDGET,
         }
     }
 
     fn label(self) -> &'static str {
         match self {
             Self::FreshTurn => "fresh",
-            Self::Followup => "follow-up",
+            Self::Followup | Self::ProvenWarmFollowup => "follow-up",
         }
+    }
+
+    fn is_followup(self) -> bool {
+        matches!(self, Self::Followup | Self::ProvenWarmFollowup)
+    }
+
+    fn allows_stale_mcp_auth_warning(self) -> bool {
+        matches!(self, Self::ProvenWarmFollowup)
     }
 }
 
@@ -361,20 +370,26 @@ pub fn prompt_readiness_snapshot(session_name: &str) -> PromptReadinessSnapshot 
         session_name,
         PROMPT_READY_CAPTURE_SCROLLBACK,
     );
-    let prompt_marker_detected = pane.as_deref().is_some_and(pane_looks_ready_for_prompt);
+    prompt_readiness_snapshot_from_capture(
+        pane.as_deref(),
+        crate::services::tmux_diagnostics::tmux_session_has_live_pane(session_name),
+    )
+}
+
+fn prompt_readiness_snapshot_from_capture(
+    pane: Option<&str>,
+    tmux_pane_alive: bool,
+) -> PromptReadinessSnapshot {
+    let prompt_marker_detected = pane.is_some_and(pane_looks_ready_for_prompt);
     let prompt_draft_detected = pane
-        .as_deref()
         .is_some_and(crate::services::tmux_common::tmux_capture_indicates_claude_tui_prompt_draft);
     let pane_tail = pane
-        .as_deref()
         .map(prompt_ready_debug_tail)
         .unwrap_or_else(|| "<capture unavailable>".to_string());
     PromptReadinessSnapshot {
         prompt_marker_detected,
         prompt_draft_detected,
-        tmux_pane_alive: crate::services::tmux_diagnostics::tmux_session_has_live_pane(
-            session_name,
-        ),
+        tmux_pane_alive,
         capture_available: pane.is_some(),
         pane_tail,
     }
@@ -939,7 +954,7 @@ pub fn send_followup_prompt_or_idle_transcript(
     let actions = plan_prompt_submit(prompt)?;
     wait_for_prompt_ready_or_idle_transcript(
         session_name,
-        PromptReadinessKind::Followup,
+        PromptReadinessKind::ProvenWarmFollowup,
         cancel_token,
         transcript_path,
     )?;
@@ -971,17 +986,14 @@ fn wait_for_prompt_ready_inner(
     let timeout = readiness.timeout();
     let start = Instant::now();
 
-    // #3889: a fresh cold-boot can land on the MCP-authentication-required
+    // #3889/#4528: a cold pane can land on the MCP-authentication-required
     // welcome screen, which paints composer chrome (so it reads READY) yet
     // silently drops every prompt submission until the operator runs `/mcp`.
-    // Detect it up front and fail fast with an actionable, non-timeout reason
-    // instead of blind-waiting the full readiness timeout and then rebooting
-    // into the same blocked screen. Scoped to FreshTurn (the cold-boot case):
-    // Claude Code v2.1.209 can leave the same warning visible in a usable warm
-    // session, so Followup readiness must rely on the real composer/busy state.
-    // The check only re-captures when the banner is actually present, so a
-    // healthy fresh boot pays just one extra capture.
-    if matches!(readiness, PromptReadinessKind::FreshTurn) {
+    // Detect it up front and fail fast with an actionable, non-timeout reason.
+    // Only the hosted existing-session path supplies ProvenWarmFollowup after a
+    // recorded turn; a plain Followup intent is not proof that this warning is
+    // stale. The check only re-captures when the banner is actually present.
+    if !readiness.allows_stale_mcp_auth_warning() {
         let snapshot = prompt_readiness_snapshot(session_name);
         if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)? {
             log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
@@ -1027,9 +1039,9 @@ fn wait_for_prompt_ready_inner(
         );
     }
 
-    // #3889/#4528: an idle transcript must not bypass the FreshTurn cold-boot
-    // auth block. A warm Followup may retain the same warning in a usable Claude
-    // Code session, but the confirming pane capture must still reject busy chrome.
+    // #3889/#4528: an idle transcript must not bypass an auth block without
+    // recorded-turn warm provenance. Even proven warm reuse must still reject
+    // live busy chrome in the confirming pane capture.
     if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path)
         && pane_allows_prompt_readiness(session_name, readiness)
     {
@@ -1109,8 +1121,8 @@ fn wait_for_prompt_ready_inner(
             );
             return Ok(());
         }
-        // #3889/#4528: the auth warning gates only FreshTurn. Warm Followup
-        // readiness still honors the live draft and transcript state below.
+        // #3889/#4528: only proven warm reuse may treat this banner as stale.
+        // Every path still honors the live draft and busy state below.
         if snapshot_allows_prompt_readiness(readiness, &snapshot)
             && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
         {
@@ -1327,9 +1339,9 @@ fn wait_for_prompt_ready_polling(
     let mut active_turn_extension_logged = false;
     loop {
         check_prompt_cancel(cancel_token)?;
-        // #3889/#4528: preserve the FreshTurn cold-boot auth gate without
-        // treating a persistent warning as a warm Followup block. Short-circuit
-        // ordering keeps the pane capture off the non-idle poll cadence.
+        // #3889/#4528: preserve the auth gate unless the caller supplied
+        // recorded-turn warm provenance. Short-circuit ordering keeps the pane
+        // capture off the non-idle poll cadence.
         if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path)
             && pane_allows_prompt_readiness(session_name, readiness)
         {
@@ -1343,10 +1355,9 @@ fn wait_for_prompt_ready_polling(
         }
         let snapshot = prompt_readiness_snapshot(session_name);
         check_prompt_cancel(cancel_token)?;
-        // #3889/#4528: fail fast only for the FreshTurn cold-boot screen. Claude
-        // Code v2.1.209 may retain this warning after a successful warm turn, so
-        // Followup readiness proceeds to the real composer/busy classification.
-        if matches!(readiness, PromptReadinessKind::FreshTurn) {
+        // #3889/#4528: plain Followup callers may point at a genuine cold pane,
+        // so only recorded-turn warm provenance can bypass the stable auth block.
+        if !readiness.allows_stale_mcp_auth_warning() {
             if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)?
             {
                 log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
@@ -1399,8 +1410,8 @@ fn wait_for_prompt_ready_polling(
                 }
             }
         }
-        // #3889/#4528: keep the FreshTurn auth belt-and-suspenders gate while
-        // allowing a warm Followup warning to follow the real idle/busy state.
+        // #3889/#4528: apply the same provenance-aware auth policy to the
+        // transcript-idle fallback; draft and busy state still veto every kind.
         if snapshot_allows_prompt_readiness(readiness, &snapshot)
             && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
         {
@@ -1553,16 +1564,11 @@ fn prompt_marker_confirms_prompt_ready(
         && snapshot_allows_prompt_readiness(readiness, snapshot)
 }
 
-/// #3889/#4528: an MCP-auth warning is a terminal readiness block only for a
-/// FreshTurn cold boot. Claude Code v2.1.209 can retain the same warning in a
-/// usable warm session, so Followup ignores that warning but still rejects an
-/// unsent prompt draft and the narrow positive busy signals in the captured
-/// pane. Followup additionally fails closed on a structurally valid spinner +
-/// duration footer even when its verb is newer than the shared busy classifier's
-/// allowlist. Keeping that conservative extension Followup-only avoids changing
-/// FreshTurn and existing shared-classifier semantics. The draft and busy checks
-/// are also load-bearing for transcript-idle fallback paths that do not require
-/// a prompt marker.
+/// #3889/#4528: an MCP-auth warning blocks readiness unless the caller proves
+/// this is hosted reuse after a recorded turn. A plain Followup intent can also
+/// target a genuine cold/auth-blocked pane, so it receives no exemption. Draft
+/// and live busy evidence veto every readiness kind, including proven warm reuse
+/// and transcript-idle fallback paths that do not require a prompt marker.
 fn snapshot_allows_prompt_readiness(
     readiness: PromptReadinessKind,
     snapshot: &PromptReadinessSnapshot,
@@ -1571,17 +1577,13 @@ fn snapshot_allows_prompt_readiness(
         return false;
     }
     if snapshot.capture_available
-        && (crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
+        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
             &snapshot.pane_tail,
-        ) || (matches!(readiness, PromptReadinessKind::Followup)
-            && crate::services::tmux_common::tmux_capture_indicates_claude_tui_structured_spinner(
-                &snapshot.pane_tail,
-            )))
+        )
     {
         return false;
     }
-    matches!(readiness, PromptReadinessKind::Followup)
-        || !snapshot_indicates_mcp_auth_block(snapshot)
+    readiness.allows_stale_mcp_auth_warning() || !snapshot_indicates_mcp_auth_block(snapshot)
 }
 
 /// Whether the snapshot's captured pane shows the MCP-authentication-required
@@ -1596,12 +1598,12 @@ fn snapshot_indicates_mcp_auth_block(snapshot: &PromptReadinessSnapshot) -> bool
         )
 }
 
-/// #3889/#4528: apply the same readiness-kind auth policy to the transcript-idle
-/// path, which has no live snapshot of its own. Callers MUST gate this behind the
-/// transcript-idle check via short-circuit `&&` so the pane is captured only at
-/// the confirm boundary. Followup ignores only the auth warning; an unsent draft
-/// or positive busy signal in the captured pane still blocks readiness. A blind
-/// capture cannot assert a draft, busy frame, or FreshTurn auth block.
+/// #3889/#4528: apply the same provenance-aware auth policy to the transcript-
+/// idle path, which has no live snapshot of its own. Callers MUST gate this
+/// behind the transcript-idle check via short-circuit `&&` so the pane is
+/// captured only at the confirm boundary. Only ProvenWarmFollowup ignores the
+/// auth warning; draft or busy evidence still blocks it. A blind capture cannot
+/// assert a draft, busy frame, or auth block.
 fn pane_allows_prompt_readiness(session_name: &str, readiness: PromptReadinessKind) -> bool {
     snapshot_allows_prompt_readiness(readiness, &prompt_readiness_snapshot(session_name))
 }
@@ -1680,8 +1682,7 @@ fn prompt_ready_timeout_should_clear_followup_draft(
     snapshot: &PromptReadinessSnapshot,
     requeue_enabled: bool,
 ) -> bool {
-    matches!(readiness, PromptReadinessKind::Followup)
-        && requeue_enabled
+    readiness.is_followup() && requeue_enabled
         && snapshot.tmux_pane_alive
         && snapshot.capture_available
         && snapshot.prompt_draft_detected
@@ -2009,6 +2010,10 @@ mod tests {
             FOLLOWUP_PROMPT_READY_TIMEOUT
         );
         assert_eq!(PromptReadinessKind::Followup.timeout().as_secs(), 45);
+        assert_eq!(
+            PromptReadinessKind::ProvenWarmFollowup.timeout().as_secs(),
+            45
+        );
         assert_eq!(PromptReadinessKind::FreshTurn.timeout().as_secs(), 120);
     }
 
@@ -2381,6 +2386,24 @@ mod tests {
     }
 
     #[test]
+    fn readiness_snapshot_derives_marker_draft_and_tail_from_one_capture() {
+        let pane = "\
+earlier output
+────────────────────────────────────────────────────
+❯ pending draft
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+
+        let snapshot = prompt_readiness_snapshot_from_capture(Some(pane), true);
+
+        assert!(snapshot.prompt_marker_detected);
+        assert!(snapshot.prompt_draft_detected);
+        assert!(snapshot.capture_available);
+        assert!(snapshot.tmux_pane_alive);
+        assert_eq!(snapshot.pane_tail, pane);
+    }
+
+    #[test]
     fn prompt_marker_does_not_confirm_readiness_when_draft_is_present() {
         let snapshot = PromptReadinessSnapshot {
             prompt_marker_detected: true,
@@ -2463,11 +2486,11 @@ mod tests {
     }
 
     // #4528: Claude Code v2.1.209 can keep the MCP-auth warning visible after a
-    // successful turn. Followup readiness must accept the real idle composer but
-    // still reject a pane carrying Claude TUI positive busy chrome. FreshTurn
-    // keeps the #3889 cold-boot block for the same warning fixture.
+    // successful turn. Only a caller with recorded-turn warm provenance may
+    // accept the idle composer; plain Followup remains a cold/auth-blocked pane.
+    // Positive busy chrome vetoes every kind.
     #[test]
-    fn mcp_auth_warning_warm_followup_is_ready_but_busy_pane_is_not() {
+    fn mcp_auth_warning_requires_warm_provenance_and_idle_pane() {
         let idle_pane = "\
 ╭─── Claude Code v2.1.209 ───────────────────────────╮
 │            Welcome back 오부장!                    │
@@ -2492,8 +2515,15 @@ mod tests {
 
         assert!(snapshot_indicates_mcp_auth_block(&idle));
         assert!(
-            prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &idle),
-            "a persistent MCP warning must not block a usable warm follow-up composer"
+            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &idle),
+            "Followup intent alone must not bypass a genuine cold auth block"
+        );
+        assert!(
+            prompt_marker_confirms_prompt_ready(
+                PromptReadinessKind::ProvenWarmFollowup,
+                &idle,
+            ),
+            "recorded-turn warm provenance may ignore a persistent warning"
         );
         assert!(
             !prompt_marker_confirms_prompt_ready(PromptReadinessKind::FreshTurn, &idle),
@@ -2523,17 +2553,23 @@ mod tests {
 
         assert!(snapshot_indicates_mcp_auth_block(&busy));
         assert!(crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(busy_pane));
-        assert!(
-            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &busy),
-            "positive generating chrome must remain not-ready despite the ignored warning"
-        );
+        for readiness in [
+            PromptReadinessKind::FreshTurn,
+            PromptReadinessKind::Followup,
+            PromptReadinessKind::ProvenWarmFollowup,
+        ] {
+            assert!(
+                !prompt_marker_confirms_prompt_ready(readiness, &busy),
+                "positive generating chrome must veto readiness for {readiness:?}"
+            );
+        }
     }
 
     #[test]
-    fn mcp_auth_warning_unknown_duration_spinner_keeps_followup_not_ready() {
-        // Claude Code 2.1.209 ships spinner verbs beyond the shared busy
-        // classifier's compatibility allowlist. The stale prompt marker must not
-        // override a structurally valid duration-only spinner footer.
+    fn mcp_auth_warning_unknown_duration_spinner_keeps_warm_followup_not_ready() {
+        // Claude Code 2.1.209 ships spinner phrases beyond the legacy verb
+        // allowlist. The shared structural classifier must veto the stale prompt
+        // marker even when warm provenance permits the auth warning itself.
         let pane = "\
  ⚠ 1 MCP server needs authentication · run /mcp
  ✳ Architecting… (12s)
@@ -2551,18 +2587,15 @@ mod tests {
 
         assert!(snapshot_indicates_mcp_auth_block(&snapshot));
         assert!(
-            !crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(pane),
-            "mutation precondition: the shared allowlist intentionally does not know Architecting"
+            crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(pane),
+            "shared live-turn classification must include unknown structured spinner phrases"
         );
         assert!(
-            crate::services::tmux_common::tmux_capture_indicates_claude_tui_structured_spinner(
-                pane,
+            !prompt_marker_confirms_prompt_ready(
+                PromptReadinessKind::ProvenWarmFollowup,
+                &snapshot,
             ),
-            "spinner glyph + status verb + duration must identify the live footer without esc text"
-        );
-        assert!(
-            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &snapshot),
-            "a duration-only unknown-verb spinner must veto stale Followup readiness"
+            "a duration-only unknown-phrase spinner must veto proven warm readiness"
         );
     }
 
@@ -2874,9 +2907,9 @@ line 13";
         ));
     }
 
-    // #3889/#4528: transcript-idle fallback applies the same kind-aware policy
-    // as marker readiness. FreshTurn rejects the auth welcome pane, while a warm
-    // Followup ignores only that warning and still rejects an unsent draft.
+    // #3889/#4528: transcript-idle fallback applies the same provenance-aware
+    // policy as marker readiness. Plain Followup rejects an auth welcome pane;
+    // only ProvenWarmFollowup may ignore that warning, and drafts still veto it.
     #[test]
     fn idle_transcript_fallback_applies_kind_aware_mcp_auth_gate() {
         let file = tempfile::NamedTempFile::new().unwrap();
@@ -2910,9 +2943,9 @@ line 13";
             "MCP-auth welcome pane must not confirm FreshTurn via idle transcript"
         );
         assert!(
-            !(snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &blocked)
+            !(snapshot_allows_prompt_readiness(PromptReadinessKind::ProvenWarmFollowup, &blocked)
                 && transcript_idle),
-            "an unsent draft must block Followup despite the idle transcript and ignored warning"
+            "an unsent draft must block proven warm reuse despite an idle transcript"
         );
 
         let warm_idle = PromptReadinessSnapshot {
@@ -2920,9 +2953,16 @@ line 13";
             ..blocked.clone()
         };
         assert!(
-            snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &warm_idle)
-                && transcript_idle,
-            "a warm Followup may ignore the persistent warning only when the composer is idle"
+            !(snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &warm_idle)
+                && transcript_idle),
+            "Followup intent alone must not bypass a genuine cold auth block"
+        );
+        assert!(
+            snapshot_allows_prompt_readiness(
+                PromptReadinessKind::ProvenWarmFollowup,
+                &warm_idle,
+            ) && transcript_idle,
+            "recorded-turn warm provenance may ignore a stale warning only when idle"
         );
 
         // No regression: a normal recorded-turn idle pane (no welcome banner)
@@ -2968,6 +3008,10 @@ line 13";
     fn prompt_ready_timeouts_are_split_for_fresh_and_followup_turns() {
         assert_eq!(PromptReadinessKind::FreshTurn.timeout().as_secs(), 120);
         assert_eq!(PromptReadinessKind::Followup.timeout().as_secs(), 45);
+        assert_eq!(
+            PromptReadinessKind::ProvenWarmFollowup.timeout().as_secs(),
+            45
+        );
     }
 
     #[test]
@@ -2977,6 +3021,7 @@ line 13";
         for kind in [
             PromptReadinessKind::FreshTurn,
             PromptReadinessKind::Followup,
+            PromptReadinessKind::ProvenWarmFollowup,
         ] {
             assert!(
                 kind.event_budget() < kind.timeout(),
@@ -3302,6 +3347,11 @@ line 13";
         // budget should be cleared (only when requeue is enabled).
         assert!(prompt_ready_timeout_should_clear_followup_draft(
             PromptReadinessKind::Followup,
+            &draft,
+            true
+        ));
+        assert!(prompt_ready_timeout_should_clear_followup_draft(
+            PromptReadinessKind::ProvenWarmFollowup,
             &draft,
             true
         ));

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -2388,11 +2388,13 @@ mod tests {
     #[test]
     fn readiness_snapshot_derives_marker_draft_and_tail_from_one_capture() {
         let pane = "\
-earlier output
+❯ completed prompt
+⏺ earlier completed output
+✻ Baked for 2s
 ────────────────────────────────────────────────────
 ❯ pending draft
 ────────────────────────────────────────────────────
-  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+  🤖 Opus(H) │ 7% │ MCP: 2";
 
         let snapshot = prompt_readiness_snapshot_from_capture(Some(pane), true);
 

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -976,10 +976,11 @@ fn wait_for_prompt_ready_inner(
     // silently drops every prompt submission until the operator runs `/mcp`.
     // Detect it up front and fail fast with an actionable, non-timeout reason
     // instead of blind-waiting the full readiness timeout and then rebooting
-    // into the same blocked screen. Scoped to FreshTurn (the cold-boot case);
-    // the kind-agnostic polling-loop check below is the safety net for both
-    // kinds. The check only re-captures when the banner is actually present, so
-    // a healthy fresh boot pays just one extra capture.
+    // into the same blocked screen. Scoped to FreshTurn (the cold-boot case):
+    // Claude Code v2.1.209 can leave the same warning visible in a usable warm
+    // session, so Followup readiness must rely on the real composer/busy state.
+    // The check only re-captures when the banner is actually present, so a
+    // healthy fresh boot pays just one extra capture.
     if matches!(readiness, PromptReadinessKind::FreshTurn) {
         let snapshot = prompt_readiness_snapshot(session_name);
         if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)? {
@@ -1008,7 +1009,7 @@ fn wait_for_prompt_ready_inner(
     if claude_registry_stop_already_buffered(session_name) {
         check_prompt_cancel(cancel_token)?;
         let snapshot = prompt_readiness_snapshot(session_name);
-        if prompt_marker_confirms_prompt_ready(&snapshot) {
+        if prompt_marker_confirms_prompt_ready(readiness, &snapshot) {
             tracing::debug!(
                 tmux_session_name = session_name,
                 readiness = readiness.label(),
@@ -1026,11 +1027,11 @@ fn wait_for_prompt_ready_inner(
         );
     }
 
-    // #3889: even an idle transcript must not confirm ready while the live pane
-    // is stranded on the MCP-auth welcome screen (short-circuit keeps the pane
-    // capture off the non-idle hot path).
+    // #3889/#4528: an idle transcript must not bypass the FreshTurn cold-boot
+    // auth block. A warm Followup may retain the same warning in a usable Claude
+    // Code session, but the confirming pane capture must still reject busy chrome.
     if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path)
-        && pane_not_mcp_auth_blocked(session_name)
+        && pane_allows_prompt_readiness(session_name, readiness)
     {
         tracing::info!(
             tmux_session_name = session_name,
@@ -1065,8 +1066,12 @@ fn wait_for_prompt_ready_inner(
     // guaranteed to wake this specific permit, even if the wait has not yet
     // been polled. See issue #2445.
     let notify = crate::services::claude_tui::hook_server::prompt_ready_notify();
-    let (fast_path, post_event_snapshot) =
-        run_prompt_ready_fast_path(notify, session_name.to_string(), readiness.event_budget());
+    let (fast_path, post_event_snapshot) = run_prompt_ready_fast_path(
+        notify,
+        session_name.to_string(),
+        readiness,
+        readiness.event_budget(),
+    );
 
     match fast_path {
         HookFastPathOutcome::PreSnapshotReady => {
@@ -1088,7 +1093,7 @@ fn wait_for_prompt_ready_inner(
 
     check_prompt_cancel(cancel_token)?;
     if let Some(snapshot) = post_event_snapshot {
-        if prompt_marker_confirms_prompt_ready(&snapshot) {
+        if prompt_marker_confirms_prompt_ready(readiness, &snapshot) {
             check_prompt_cancel(cancel_token)?;
             // The live broadcast woke this waiter. Drain the parallel registry
             // copy as consumed too, otherwise the same Stop can be replayed into
@@ -1104,9 +1109,9 @@ fn wait_for_prompt_ready_inner(
             );
             return Ok(());
         }
-        // #3889: gate the idle-transcript fallback on the MCP-auth check too —
-        // we already hold the post-event snapshot, so this is free.
-        if !snapshot_indicates_mcp_auth_block(&snapshot)
+        // #3889/#4528: the auth warning gates only FreshTurn. Warm Followup
+        // readiness still honors the live draft and transcript state below.
+        if snapshot_allows_prompt_readiness(readiness, &snapshot)
             && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
         {
             check_prompt_cancel(cancel_token)?;
@@ -1185,6 +1190,7 @@ fn wait_for_prompt_ready_event(notify: Arc<Notify>, budget: Duration) -> HookFas
 fn run_prompt_ready_fast_path(
     notify: Arc<Notify>,
     session_name: String,
+    readiness: PromptReadinessKind,
     budget: Duration,
 ) -> (HookFastPathOutcome, Option<PromptReadinessSnapshot>) {
     let fut = async move {
@@ -1198,7 +1204,7 @@ fn run_prompt_ready_fast_path(
         notified.as_mut().enable();
 
         let pre_snapshot = prompt_readiness_snapshot(&session_name);
-        if prompt_marker_confirms_prompt_ready(&pre_snapshot) {
+        if prompt_marker_confirms_prompt_ready(readiness, &pre_snapshot) {
             return (HookFastPathOutcome::PreSnapshotReady, None);
         }
         if !pre_snapshot.tmux_pane_alive {
@@ -1321,12 +1327,11 @@ fn wait_for_prompt_ready_polling(
     let mut active_turn_extension_logged = false;
     loop {
         check_prompt_cancel(cancel_token)?;
-        // #3889: idle transcript alone must not confirm ready while the pane is
-        // stranded on the MCP-auth welcome screen (short-circuit keeps the pane
-        // capture off the non-idle poll cadence). When it IS blocked this falls
-        // through to the snapshot + auth fail-fast just below.
+        // #3889/#4528: preserve the FreshTurn cold-boot auth gate without
+        // treating a persistent warning as a warm Followup block. Short-circuit
+        // ordering keeps the pane capture off the non-idle poll cadence.
         if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path)
-            && pane_not_mcp_auth_blocked(session_name)
+            && pane_allows_prompt_readiness(session_name, readiness)
         {
             tracing::info!(
                 tmux_session_name = session_name,
@@ -1338,17 +1343,18 @@ fn wait_for_prompt_ready_polling(
         }
         let snapshot = prompt_readiness_snapshot(session_name);
         check_prompt_cancel(cancel_token)?;
-        // #3889: bail out of the wait the moment the pane is confirmed stranded
-        // on the MCP-authentication-required cold-boot welcome screen. This must
-        // precede the ready check because that screen's composer chrome would
-        // otherwise read as ready (`prompt_marker_confirms_prompt_ready` already
-        // refuses it, but failing fast here surfaces the actionable reason and
-        // avoids burning the rest of the timeout).
-        if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)? {
-            log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
-            return Err(mcp_auth_required_error_message(session_name));
+        // #3889/#4528: fail fast only for the FreshTurn cold-boot screen. Claude
+        // Code v2.1.209 may retain this warning after a successful warm turn, so
+        // Followup readiness proceeds to the real composer/busy classification.
+        if matches!(readiness, PromptReadinessKind::FreshTurn) {
+            if let Some(confirmed) =
+                confirm_mcp_auth_block(session_name, cancel_token, &snapshot)?
+            {
+                log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
+                return Err(mcp_auth_required_error_message(session_name));
+            }
         }
-        if prompt_marker_confirms_prompt_ready(&snapshot) {
+        if prompt_marker_confirms_prompt_ready(readiness, &snapshot) {
             return Ok(());
         }
         // Startup dialogs (resume-from-summary picker, workspace trust) park
@@ -1394,10 +1400,9 @@ fn wait_for_prompt_ready_polling(
                 }
             }
         }
-        // #3889: gate the idle-transcript fallback on the MCP-auth check (the
-        // snapshot is already in hand). The auth fail-fast above normally returns
-        // first, so this is belt-and-suspenders for any future reordering.
-        if !snapshot_indicates_mcp_auth_block(&snapshot)
+        // #3889/#4528: keep the FreshTurn auth belt-and-suspenders gate while
+        // allowing a warm Followup warning to follow the real idle/busy state.
+        if snapshot_allows_prompt_readiness(readiness, &snapshot)
             && transcript_idle_confirms_prompt_ready(&snapshot, transcript_path)
         {
             tracing::info!(
@@ -1540,14 +1545,34 @@ fn pane_looks_ready_for_prompt(pane: &str) -> bool {
     crate::services::tmux_common::tmux_capture_indicates_claude_tui_ready_for_input(pane)
 }
 
-fn prompt_marker_confirms_prompt_ready(snapshot: &PromptReadinessSnapshot) -> bool {
+fn prompt_marker_confirms_prompt_ready(
+    readiness: PromptReadinessKind,
+    snapshot: &PromptReadinessSnapshot,
+) -> bool {
     snapshot.prompt_marker_detected
         && !snapshot.prompt_draft_detected
-        // #3889: the MCP-authentication-required cold-boot welcome screen paints
-        // composer chrome that otherwise reads as ready, but Claude Code drops
-        // submissions into it. Never confirm ready while that banner is up — in
-        // any path (fast-path pre/post snapshot, buffered-Stop, or polling).
-        && !snapshot_indicates_mcp_auth_block(snapshot)
+        && snapshot_allows_prompt_readiness(readiness, snapshot)
+}
+
+/// #3889/#4528: an MCP-auth warning is a terminal readiness block only for a
+/// FreshTurn cold boot. Claude Code v2.1.209 can retain the same warning in a
+/// usable warm session, so Followup ignores that warning but still rejects the
+/// narrow positive busy signals in the captured pane. The explicit busy check is
+/// also load-bearing for transcript-idle fallback paths that do not require a
+/// prompt marker.
+fn snapshot_allows_prompt_readiness(
+    readiness: PromptReadinessKind,
+    snapshot: &PromptReadinessSnapshot,
+) -> bool {
+    if snapshot.capture_available
+        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
+            &snapshot.pane_tail,
+        )
+    {
+        return false;
+    }
+    matches!(readiness, PromptReadinessKind::Followup)
+        || !snapshot_indicates_mcp_auth_block(snapshot)
 }
 
 /// Whether the snapshot's captured pane shows the MCP-authentication-required
@@ -1562,19 +1587,20 @@ fn snapshot_indicates_mcp_auth_block(snapshot: &PromptReadinessSnapshot) -> bool
         )
 }
 
-/// #3889 (Codex review #3931 [2]): a ready-return path that relies on transcript
-/// idleness — NOT a live pane marker — must still refuse to confirm ready when
-/// the pane is stranded on the MCP-authentication-required cold-boot welcome
-/// screen. Otherwise a stale idle transcript from a prior run (reachable via the
-/// #3880 A2 recorded-turn fast path) lets the prompt submit into a dead screen,
-/// bypassing the marker-path gate entirely.
-///
-/// Captures the pane to verify. Callers MUST gate this behind the transcript-idle
-/// check via short-circuit `&&` so the steady-state polling cadence pays no extra
-/// capture — the snapshot is taken only at the confirm boundary. A blind capture
-/// cannot assert a block, so it reports "not blocked".
-fn pane_not_mcp_auth_blocked(session_name: &str) -> bool {
-    !snapshot_indicates_mcp_auth_block(&prompt_readiness_snapshot(session_name))
+/// #3889/#4528: apply the same readiness-kind auth policy to the transcript-idle
+/// path, which has no live snapshot of its own. Callers MUST gate this behind the
+/// transcript-idle check via short-circuit `&&` so the pane is captured only at
+/// the confirm boundary. Followup ignores only the auth warning; the captured
+/// pane's positive busy signals still block readiness. A blind capture cannot
+/// assert either a busy frame or a FreshTurn auth block.
+fn pane_allows_prompt_readiness(
+    session_name: &str,
+    readiness: PromptReadinessKind,
+) -> bool {
+    snapshot_allows_prompt_readiness(
+        readiness,
+        &prompt_readiness_snapshot(session_name),
+    )
 }
 
 /// Actionable, NON-timeout error for a cold-boot stranded on the
@@ -2361,7 +2387,10 @@ mod tests {
             pane_tail: "\u{276f} stale draft".to_string(),
         };
 
-        assert!(!prompt_marker_confirms_prompt_ready(&snapshot));
+        assert!(!prompt_marker_confirms_prompt_ready(
+            PromptReadinessKind::Followup,
+            &snapshot,
+        ));
     }
 
     // #3889: the MCP-authentication-required cold-boot welcome screen paints
@@ -2397,7 +2426,7 @@ mod tests {
         };
         assert!(snapshot_indicates_mcp_auth_block(&blocked));
         assert!(
-            !prompt_marker_confirms_prompt_ready(&blocked),
+            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::FreshTurn, &blocked),
             "MCP-auth cold-boot welcome screen must not be classified ready-to-submit"
         );
 
@@ -2416,7 +2445,7 @@ mod tests {
         };
         assert!(!snapshot_indicates_mcp_auth_block(&ready));
         assert!(
-            prompt_marker_confirms_prompt_ready(&ready),
+            prompt_marker_confirms_prompt_ready(PromptReadinessKind::FreshTurn, &ready),
             "a normal empty composer must still confirm ready"
         );
 
@@ -2428,6 +2457,75 @@ mod tests {
             ..blocked.clone()
         };
         assert!(!snapshot_indicates_mcp_auth_block(&blind));
+    }
+
+    // #4528: Claude Code v2.1.209 can keep the MCP-auth warning visible after a
+    // successful turn. Followup readiness must accept the real idle composer but
+    // still reject a pane carrying Claude TUI positive busy chrome. FreshTurn
+    // keeps the #3889 cold-boot block for the same warning fixture.
+    #[test]
+    fn mcp_auth_warning_warm_followup_is_ready_but_busy_pane_is_not() {
+        let idle_pane = "\
+╭─── Claude Code v2.1.209 ───────────────────────────╮
+│            Welcome back 오부장!                    │
+╰────────────────────────────────────────────────────
+
+ ⚠ 1 MCP server needs authentication · run /mcp
+
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+        let idle = PromptReadinessSnapshot {
+            prompt_marker_detected: pane_looks_ready_for_prompt(idle_pane),
+            prompt_draft_detected:
+                crate::services::tmux_common::tmux_capture_indicates_claude_tui_prompt_draft(
+                    idle_pane,
+                ),
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: idle_pane.to_string(),
+        };
+
+        assert!(snapshot_indicates_mcp_auth_block(&idle));
+        assert!(
+            prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &idle),
+            "a persistent MCP warning must not block a usable warm follow-up composer"
+        );
+        assert!(
+            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::FreshTurn, &idle),
+            "the same warning must keep the #3889 cold-boot FreshTurn guard"
+        );
+
+        let busy_pane = "\
+ ⚠ 1 MCP server needs authentication · run /mcp
+ ⏺ Running 1 shell command…
+ · Actioning… (4m 7s · esc to interrupt)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+        let busy = PromptReadinessSnapshot {
+            // Exercise the readiness boundary directly with the stale marker
+            // bit observed in the #4528 trace; the pane body must still veto it.
+            prompt_marker_detected: true,
+            prompt_draft_detected:
+                crate::services::tmux_common::tmux_capture_indicates_claude_tui_prompt_draft(
+                    busy_pane,
+                ),
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: busy_pane.to_string(),
+        };
+
+        assert!(snapshot_indicates_mcp_auth_block(&busy));
+        assert!(
+            crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(busy_pane)
+        );
+        assert!(
+            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &busy),
+            "positive generating chrome must remain not-ready despite the ignored warning"
+        );
     }
 
     // #3889: the MCP-auth fail-fast error must be a DISTINCT, non-timeout error
@@ -2738,13 +2836,11 @@ line 13";
         ));
     }
 
-    // Codex review #3931 [2] (under-block): the transcript-idle fallback paths
-    // must also honour the MCP-auth gate. A recorded-turn (idle) transcript +
-    // an MCP-auth welcome pane must NOT confirm ready, even though the
-    // transcript-idle predicate ALONE accepts the composer-chrome pane — a
-    // normal recorded-turn idle pane (no welcome banner) still does.
+    // #3889/#4528: transcript-idle fallback applies the same kind-aware policy
+    // as marker readiness. FreshTurn rejects the auth welcome pane, while a warm
+    // Followup may accept it when no positive busy signal is present.
     #[test]
-    fn idle_transcript_fallback_is_gated_on_mcp_auth_block() {
+    fn idle_transcript_fallback_applies_kind_aware_mcp_auth_gate() {
         let file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
             file.path(),
@@ -2767,16 +2863,19 @@ line 13";
         };
         // Precondition: the transcript-idle predicate alone accepts the
         // composer-chrome welcome pane (this is exactly why the gate is needed).
-        assert!(transcript_idle_confirms_prompt_ready(
-            &blocked,
-            Some(file.path())
-        ));
+        let transcript_idle =
+            transcript_idle_confirms_prompt_ready(&blocked, Some(file.path()));
+        assert!(transcript_idle);
         assert!(snapshot_indicates_mcp_auth_block(&blocked));
-        // The gate the fallback paths apply (`!block && idle`) refuses it.
         assert!(
-            !(!snapshot_indicates_mcp_auth_block(&blocked)
-                && transcript_idle_confirms_prompt_ready(&blocked, Some(file.path()))),
-            "MCP-auth welcome pane must not confirm ready via the idle-transcript fallback"
+            !(snapshot_allows_prompt_readiness(PromptReadinessKind::FreshTurn, &blocked)
+                && transcript_idle),
+            "MCP-auth welcome pane must not confirm FreshTurn via idle transcript"
+        );
+        assert!(
+            snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &blocked)
+                && transcript_idle,
+            "a warm Followup may ignore the persistent warning when the pane is idle"
         );
 
         // No regression: a normal recorded-turn idle pane (no welcome banner)
@@ -2790,7 +2889,7 @@ line 13";
         };
         assert!(!snapshot_indicates_mcp_auth_block(&ready));
         assert!(
-            !snapshot_indicates_mcp_auth_block(&ready)
+            snapshot_allows_prompt_readiness(PromptReadinessKind::FreshTurn, &ready)
                 && transcript_idle_confirms_prompt_ready(&ready, Some(file.path())),
             "a normal recorded-turn idle pane must still confirm ready (no regression)"
         );

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -1555,17 +1555,21 @@ fn prompt_marker_confirms_prompt_ready(
 
 /// #3889/#4528: an MCP-auth warning is a terminal readiness block only for a
 /// FreshTurn cold boot. Claude Code v2.1.209 can retain the same warning in a
-/// usable warm session, so Followup ignores that warning but still rejects the
-/// narrow positive busy signals in the captured pane. Followup additionally
-/// fails closed on a structurally valid spinner + duration footer even when its
-/// verb is newer than the shared busy classifier's allowlist. Keeping that
-/// conservative extension Followup-only avoids changing FreshTurn and existing
-/// shared-classifier semantics. The explicit busy checks are also load-bearing
-/// for transcript-idle fallback paths that do not require a prompt marker.
+/// usable warm session, so Followup ignores that warning but still rejects an
+/// unsent prompt draft and the narrow positive busy signals in the captured
+/// pane. Followup additionally fails closed on a structurally valid spinner +
+/// duration footer even when its verb is newer than the shared busy classifier's
+/// allowlist. Keeping that conservative extension Followup-only avoids changing
+/// FreshTurn and existing shared-classifier semantics. The draft and busy checks
+/// are also load-bearing for transcript-idle fallback paths that do not require
+/// a prompt marker.
 fn snapshot_allows_prompt_readiness(
     readiness: PromptReadinessKind,
     snapshot: &PromptReadinessSnapshot,
 ) -> bool {
+    if snapshot.prompt_draft_detected {
+        return false;
+    }
     if snapshot.capture_available
         && (crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
             &snapshot.pane_tail,
@@ -1595,9 +1599,9 @@ fn snapshot_indicates_mcp_auth_block(snapshot: &PromptReadinessSnapshot) -> bool
 /// #3889/#4528: apply the same readiness-kind auth policy to the transcript-idle
 /// path, which has no live snapshot of its own. Callers MUST gate this behind the
 /// transcript-idle check via short-circuit `&&` so the pane is captured only at
-/// the confirm boundary. Followup ignores only the auth warning; the captured
-/// pane's positive busy signals still block readiness. A blind capture cannot
-/// assert either a busy frame or a FreshTurn auth block.
+/// the confirm boundary. Followup ignores only the auth warning; an unsent draft
+/// or positive busy signal in the captured pane still blocks readiness. A blind
+/// capture cannot assert a draft, busy frame, or FreshTurn auth block.
 fn pane_allows_prompt_readiness(session_name: &str, readiness: PromptReadinessKind) -> bool {
     snapshot_allows_prompt_readiness(readiness, &prompt_readiness_snapshot(session_name))
 }
@@ -2872,7 +2876,7 @@ line 13";
 
     // #3889/#4528: transcript-idle fallback applies the same kind-aware policy
     // as marker readiness. FreshTurn rejects the auth welcome pane, while a warm
-    // Followup may accept it when no positive busy signal is present.
+    // Followup ignores only that warning and still rejects an unsent draft.
     #[test]
     fn idle_transcript_fallback_applies_kind_aware_mcp_auth_gate() {
         let file = tempfile::NamedTempFile::new().unwrap();
@@ -2906,9 +2910,19 @@ line 13";
             "MCP-auth welcome pane must not confirm FreshTurn via idle transcript"
         );
         assert!(
-            snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &blocked)
+            !(snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &blocked)
+                && transcript_idle),
+            "an unsent draft must block Followup despite the idle transcript and ignored warning"
+        );
+
+        let warm_idle = PromptReadinessSnapshot {
+            prompt_draft_detected: false,
+            ..blocked.clone()
+        };
+        assert!(
+            snapshot_allows_prompt_readiness(PromptReadinessKind::Followup, &warm_idle)
                 && transcript_idle,
-            "a warm Followup may ignore the persistent warning when the pane is idle"
+            "a warm Followup may ignore the persistent warning only when the composer is idle"
         );
 
         // No regression: a normal recorded-turn idle pane (no welcome banner)

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -1577,9 +1577,7 @@ fn snapshot_allows_prompt_readiness(
         return false;
     }
     if snapshot.capture_available
-        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
-            &snapshot.pane_tail,
-        )
+        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(&snapshot.pane_tail)
     {
         return false;
     }
@@ -1682,7 +1680,8 @@ fn prompt_ready_timeout_should_clear_followup_draft(
     snapshot: &PromptReadinessSnapshot,
     requeue_enabled: bool,
 ) -> bool {
-    readiness.is_followup() && requeue_enabled
+    readiness.is_followup()
+        && requeue_enabled
         && snapshot.tmux_pane_alive
         && snapshot.capture_available
         && snapshot.prompt_draft_detected
@@ -2521,10 +2520,7 @@ mod tests {
             "Followup intent alone must not bypass a genuine cold auth block"
         );
         assert!(
-            prompt_marker_confirms_prompt_ready(
-                PromptReadinessKind::ProvenWarmFollowup,
-                &idle,
-            ),
+            prompt_marker_confirms_prompt_ready(PromptReadinessKind::ProvenWarmFollowup, &idle,),
             "recorded-turn warm provenance may ignore a persistent warning"
         );
         assert!(
@@ -2960,10 +2956,8 @@ line 13";
             "Followup intent alone must not bypass a genuine cold auth block"
         );
         assert!(
-            snapshot_allows_prompt_readiness(
-                PromptReadinessKind::ProvenWarmFollowup,
-                &warm_idle,
-            ) && transcript_idle,
+            snapshot_allows_prompt_readiness(PromptReadinessKind::ProvenWarmFollowup, &warm_idle,)
+                && transcript_idle,
             "recorded-turn warm provenance may ignore a stale warning only when idle"
         );
 

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -1347,8 +1347,7 @@ fn wait_for_prompt_ready_polling(
         // Code v2.1.209 may retain this warning after a successful warm turn, so
         // Followup readiness proceeds to the real composer/busy classification.
         if matches!(readiness, PromptReadinessKind::FreshTurn) {
-            if let Some(confirmed) =
-                confirm_mcp_auth_block(session_name, cancel_token, &snapshot)?
+            if let Some(confirmed) = confirm_mcp_auth_block(session_name, cancel_token, &snapshot)?
             {
                 log_prompt_ready_mcp_auth_block(session_name, readiness, &confirmed);
                 return Err(mcp_auth_required_error_message(session_name));
@@ -1565,9 +1564,7 @@ fn snapshot_allows_prompt_readiness(
     snapshot: &PromptReadinessSnapshot,
 ) -> bool {
     if snapshot.capture_available
-        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
-            &snapshot.pane_tail,
-        )
+        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(&snapshot.pane_tail)
     {
         return false;
     }
@@ -1593,14 +1590,8 @@ fn snapshot_indicates_mcp_auth_block(snapshot: &PromptReadinessSnapshot) -> bool
 /// the confirm boundary. Followup ignores only the auth warning; the captured
 /// pane's positive busy signals still block readiness. A blind capture cannot
 /// assert either a busy frame or a FreshTurn auth block.
-fn pane_allows_prompt_readiness(
-    session_name: &str,
-    readiness: PromptReadinessKind,
-) -> bool {
-    snapshot_allows_prompt_readiness(
-        readiness,
-        &prompt_readiness_snapshot(session_name),
-    )
+fn pane_allows_prompt_readiness(session_name: &str, readiness: PromptReadinessKind) -> bool {
+    snapshot_allows_prompt_readiness(readiness, &prompt_readiness_snapshot(session_name))
 }
 
 /// Actionable, NON-timeout error for a cold-boot stranded on the
@@ -2519,9 +2510,7 @@ mod tests {
         };
 
         assert!(snapshot_indicates_mcp_auth_block(&busy));
-        assert!(
-            crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(busy_pane)
-        );
+        assert!(crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(busy_pane));
         assert!(
             !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &busy),
             "positive generating chrome must remain not-ready despite the ignored warning"
@@ -2863,8 +2852,7 @@ line 13";
         };
         // Precondition: the transcript-idle predicate alone accepts the
         // composer-chrome welcome pane (this is exactly why the gate is needed).
-        let transcript_idle =
-            transcript_idle_confirms_prompt_ready(&blocked, Some(file.path()));
+        let transcript_idle = transcript_idle_confirms_prompt_ready(&blocked, Some(file.path()));
         assert!(transcript_idle);
         assert!(snapshot_indicates_mcp_auth_block(&blocked));
         assert!(

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -1556,15 +1556,23 @@ fn prompt_marker_confirms_prompt_ready(
 /// #3889/#4528: an MCP-auth warning is a terminal readiness block only for a
 /// FreshTurn cold boot. Claude Code v2.1.209 can retain the same warning in a
 /// usable warm session, so Followup ignores that warning but still rejects the
-/// narrow positive busy signals in the captured pane. The explicit busy check is
-/// also load-bearing for transcript-idle fallback paths that do not require a
-/// prompt marker.
+/// narrow positive busy signals in the captured pane. Followup additionally
+/// fails closed on a structurally valid spinner + duration footer even when its
+/// verb is newer than the shared busy classifier's allowlist. Keeping that
+/// conservative extension Followup-only avoids changing FreshTurn and existing
+/// shared-classifier semantics. The explicit busy checks are also load-bearing
+/// for transcript-idle fallback paths that do not require a prompt marker.
 fn snapshot_allows_prompt_readiness(
     readiness: PromptReadinessKind,
     snapshot: &PromptReadinessSnapshot,
 ) -> bool {
     if snapshot.capture_available
-        && crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(&snapshot.pane_tail)
+        && (crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(
+            &snapshot.pane_tail,
+        ) || (matches!(readiness, PromptReadinessKind::Followup)
+            && crate::services::tmux_common::tmux_capture_indicates_claude_tui_structured_spinner(
+                &snapshot.pane_tail,
+            )))
     {
         return false;
     }
@@ -2514,6 +2522,43 @@ mod tests {
         assert!(
             !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &busy),
             "positive generating chrome must remain not-ready despite the ignored warning"
+        );
+    }
+
+    #[test]
+    fn mcp_auth_warning_unknown_duration_spinner_keeps_followup_not_ready() {
+        // Claude Code 2.1.209 ships spinner verbs beyond the shared busy
+        // classifier's compatibility allowlist. The stale prompt marker must not
+        // override a structurally valid duration-only spinner footer.
+        let pane = "\
+ ⚠ 1 MCP server needs authentication · run /mcp
+ ✳ Architecting… (12s)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+        let snapshot = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: pane.to_string(),
+        };
+
+        assert!(snapshot_indicates_mcp_auth_block(&snapshot));
+        assert!(
+            !crate::services::tmux_common::tmux_capture_indicates_claude_tui_busy(pane),
+            "mutation precondition: the shared allowlist intentionally does not know Architecting"
+        );
+        assert!(
+            crate::services::tmux_common::tmux_capture_indicates_claude_tui_structured_spinner(
+                pane,
+            ),
+            "spinner glyph + status verb + duration must identify the live footer without esc text"
+        );
+        assert!(
+            !prompt_marker_confirms_prompt_ready(PromptReadinessKind::Followup, &snapshot),
+            "a duration-only unknown-verb spinner must veto stale Followup readiness"
         );
     }
 

--- a/src/services/codex_tui/input.rs
+++ b/src/services/codex_tui/input.rs
@@ -399,31 +399,29 @@ pub fn is_prompt_ready_cancelled_error(error: &str) -> bool {
 /// is visible. Returned regardless of timing so callers can log the
 /// state at decision points.
 pub fn prompt_readiness_snapshot(session_name: &str) -> PromptReadinessSnapshot {
+    let pane = crate::services::platform::tmux::capture_pane(
+        session_name,
+        PROMPT_READY_CAPTURE_SCROLLBACK,
+    );
     // Preserve ANSI attributes for Codex compact-mode prompts. Codex renders
     // canned prompt suggestions in dim text, while user drafts are normal
-    // text. Derive every plain-text signal from this same captured frame so a
-    // redraw cannot mix an old draft with a newer ANSI-ready composer.
+    // text. Plain capture loses that distinction and can make an idle compact
+    // prompt look like a still-running turn.
     let pane_with_escapes = crate::services::platform::tmux::capture_pane_with_escapes(
         session_name,
         PROMPT_READY_CAPTURE_SCROLLBACK,
     );
-    prompt_readiness_snapshot_from_ansi_capture(
-        pane_with_escapes.as_deref(),
-        crate::services::tmux_diagnostics::tmux_session_has_live_pane(session_name),
-    )
-}
-
-fn prompt_readiness_snapshot_from_ansi_capture(
-    pane_with_escapes: Option<&str>,
-    tmux_pane_alive: bool,
-) -> PromptReadinessSnapshot {
-    let pane = pane_with_escapes.map(strip_ansi_escape_sequences);
     let composer_marker_detected = pane_with_escapes
-        .is_some_and(pane_looks_ready_for_codex_prompt_with_ansi);
+        .as_deref()
+        .is_some_and(pane_looks_ready_for_codex_prompt_with_ansi)
+        || pane
+            .as_deref()
+            .is_some_and(pane_looks_ready_for_codex_prompt);
     let dim_placeholder_detected = pane_with_escapes
+        .as_deref()
         .is_some_and(pane_has_dim_legacy_codex_prompt_in_pane);
-    let prompt_draft_detected = !dim_placeholder_detected
-        && pane.as_deref().is_some_and(pane_has_codex_prompt_draft);
+    let prompt_draft_detected =
+        !dim_placeholder_detected && pane.as_deref().is_some_and(pane_has_codex_prompt_draft);
     let pane_tail = pane
         .as_deref()
         .map(prompt_ready_debug_tail)
@@ -431,8 +429,10 @@ fn prompt_readiness_snapshot_from_ansi_capture(
     PromptReadinessSnapshot {
         composer_marker_detected,
         prompt_draft_detected,
-        tmux_pane_alive,
-        capture_available: pane_with_escapes.is_some(),
+        tmux_pane_alive: crate::services::tmux_diagnostics::tmux_session_has_live_pane(
+            session_name,
+        ),
+        capture_available: pane.is_some(),
         pane_tail,
     }
 }
@@ -2262,35 +2262,6 @@ The documentation example ends with:
             " · \x1b[0m\x1b[38;2;171;223;167m~/.adk/release/workspaces/baby\n",
         );
         assert!(pane_looks_ready_for_codex_prompt_with_ansi(pane));
-        let snapshot = prompt_readiness_snapshot_from_ansi_capture(Some(pane), true);
-        assert!(snapshot.composer_marker_detected);
-        assert!(!snapshot.prompt_draft_detected);
-        assert_eq!(
-            snapshot.pane_tail,
-            prompt_ready_debug_tail(&strip_ansi_escape_sequences(pane))
-        );
-    }
-
-    #[test]
-    fn readiness_snapshot_derives_marker_draft_and_tail_from_one_ansi_frame() {
-        let pane = concat!(
-            "old output\n",
-            "\x1b[0;1m›\x1b[0m run the pending draft\n",
-            "\n",
-            "\x1b[0m  \x1b[38;2;246;226;183mgpt-5.5 xhigh\x1b[2m\x1b[39m",
-            " · \x1b[0m\x1b[38;2;171;223;167m~/.adk/release/workspaces/baby\n",
-        );
-
-        let snapshot = prompt_readiness_snapshot_from_ansi_capture(Some(pane), true);
-
-        assert!(!snapshot.composer_marker_detected);
-        assert!(snapshot.prompt_draft_detected);
-        assert!(snapshot.capture_available);
-        assert!(snapshot.tmux_pane_alive);
-        assert_eq!(
-            snapshot.pane_tail,
-            prompt_ready_debug_tail(&strip_ansi_escape_sequences(pane))
-        );
     }
 
     #[test]

--- a/src/services/codex_tui/input.rs
+++ b/src/services/codex_tui/input.rs
@@ -399,29 +399,31 @@ pub fn is_prompt_ready_cancelled_error(error: &str) -> bool {
 /// is visible. Returned regardless of timing so callers can log the
 /// state at decision points.
 pub fn prompt_readiness_snapshot(session_name: &str) -> PromptReadinessSnapshot {
-    let pane = crate::services::platform::tmux::capture_pane(
-        session_name,
-        PROMPT_READY_CAPTURE_SCROLLBACK,
-    );
     // Preserve ANSI attributes for Codex compact-mode prompts. Codex renders
     // canned prompt suggestions in dim text, while user drafts are normal
-    // text. Plain capture loses that distinction and can make an idle compact
-    // prompt look like a still-running turn.
+    // text. Derive every plain-text signal from this same captured frame so a
+    // redraw cannot mix an old draft with a newer ANSI-ready composer.
     let pane_with_escapes = crate::services::platform::tmux::capture_pane_with_escapes(
         session_name,
         PROMPT_READY_CAPTURE_SCROLLBACK,
     );
+    prompt_readiness_snapshot_from_ansi_capture(
+        pane_with_escapes.as_deref(),
+        crate::services::tmux_diagnostics::tmux_session_has_live_pane(session_name),
+    )
+}
+
+fn prompt_readiness_snapshot_from_ansi_capture(
+    pane_with_escapes: Option<&str>,
+    tmux_pane_alive: bool,
+) -> PromptReadinessSnapshot {
+    let pane = pane_with_escapes.map(strip_ansi_escape_sequences);
     let composer_marker_detected = pane_with_escapes
-        .as_deref()
-        .is_some_and(pane_looks_ready_for_codex_prompt_with_ansi)
-        || pane
-            .as_deref()
-            .is_some_and(pane_looks_ready_for_codex_prompt);
+        .is_some_and(pane_looks_ready_for_codex_prompt_with_ansi);
     let dim_placeholder_detected = pane_with_escapes
-        .as_deref()
         .is_some_and(pane_has_dim_legacy_codex_prompt_in_pane);
-    let prompt_draft_detected =
-        !dim_placeholder_detected && pane.as_deref().is_some_and(pane_has_codex_prompt_draft);
+    let prompt_draft_detected = !dim_placeholder_detected
+        && pane.as_deref().is_some_and(pane_has_codex_prompt_draft);
     let pane_tail = pane
         .as_deref()
         .map(prompt_ready_debug_tail)
@@ -429,10 +431,8 @@ pub fn prompt_readiness_snapshot(session_name: &str) -> PromptReadinessSnapshot 
     PromptReadinessSnapshot {
         composer_marker_detected,
         prompt_draft_detected,
-        tmux_pane_alive: crate::services::tmux_diagnostics::tmux_session_has_live_pane(
-            session_name,
-        ),
-        capture_available: pane.is_some(),
+        tmux_pane_alive,
+        capture_available: pane_with_escapes.is_some(),
         pane_tail,
     }
 }
@@ -2262,6 +2262,35 @@ The documentation example ends with:
             " · \x1b[0m\x1b[38;2;171;223;167m~/.adk/release/workspaces/baby\n",
         );
         assert!(pane_looks_ready_for_codex_prompt_with_ansi(pane));
+        let snapshot = prompt_readiness_snapshot_from_ansi_capture(Some(pane), true);
+        assert!(snapshot.composer_marker_detected);
+        assert!(!snapshot.prompt_draft_detected);
+        assert_eq!(
+            snapshot.pane_tail,
+            prompt_ready_debug_tail(&strip_ansi_escape_sequences(pane))
+        );
+    }
+
+    #[test]
+    fn readiness_snapshot_derives_marker_draft_and_tail_from_one_ansi_frame() {
+        let pane = concat!(
+            "old output\n",
+            "\x1b[0;1m›\x1b[0m run the pending draft\n",
+            "\n",
+            "\x1b[0m  \x1b[38;2;246;226;183mgpt-5.5 xhigh\x1b[2m\x1b[39m",
+            " · \x1b[0m\x1b[38;2;171;223;167m~/.adk/release/workspaces/baby\n",
+        );
+
+        let snapshot = prompt_readiness_snapshot_from_ansi_capture(Some(pane), true);
+
+        assert!(!snapshot.composer_marker_detected);
+        assert!(snapshot.prompt_draft_detected);
+        assert!(snapshot.capture_available);
+        assert!(snapshot.tmux_pane_alive);
+        assert_eq!(
+            snapshot.pane_tail,
+            prompt_ready_debug_tail(&strip_ansi_escape_sequences(pane))
+        );
     }
 
     #[test]

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -264,9 +264,7 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     }
     let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
     let recent = &non_empty[start..];
-    recent
-        .iter()
-        .any(|line| line_has_claude_tui_interrupt_chrome(line))
+    tmux_recent_lines_show_claude_tui_interrupt_chrome(recent)
         || tmux_capture_indicates_claude_tui_structured_spinner(capture)
         || tmux_recent_lines_show_claude_tui_active_work(recent)
 }
@@ -400,13 +398,28 @@ fn line_has_claude_tui_interrupt_chrome(line: &str) -> bool {
         && !before_interrupt[1..].contains(')')
         && before_interrupt[1..].contains('·');
     let spinner_prefix = line.chars().next().is_some_and(is_claude_tui_spinner_glyph);
-    let wrapped_status_tail = before_interrupt.is_empty()
-        && line[interrupt_start + "esc to interrupt".len()..]
-            .trim()
-            .starts_with(')');
-    has_status_group
-        || (spinner_prefix && lower[..interrupt_start].contains('…'))
-        || wrapped_status_tail
+    has_status_group || (spinner_prefix && lower[..interrupt_start].contains('…'))
+}
+
+fn line_is_claude_tui_wrapped_interrupt_tail(line: &str) -> bool {
+    let line = trim_prompt_line(line);
+    let lower = line.to_ascii_lowercase();
+    lower
+        .strip_prefix("esc to interrupt")
+        .is_some_and(|suffix| suffix.trim().starts_with(')'))
+}
+
+fn tmux_recent_lines_show_claude_tui_interrupt_chrome(lines: &[&str]) -> bool {
+    lines.iter().enumerate().any(|(index, line)| {
+        line_has_claude_tui_interrupt_chrome(line)
+            || (line_is_claude_tui_wrapped_interrupt_tail(line)
+                && index.checked_sub(1).is_some_and(|previous_index| {
+                    let previous = trim_prompt_line(lines[previous_index]);
+                    tmux_line_is_claude_tui_structured_spinner(previous)
+                        && previous.contains('(')
+                        && !previous.contains(')')
+                }))
+    })
 }
 
 fn claude_tui_markdown_fence_marker(line: &str) -> Option<(char, usize)> {
@@ -492,18 +505,18 @@ fn claude_tui_spinner_status_phrase_is_compact(status: &str) -> bool {
 }
 
 fn claude_tui_spinner_status_is_known(status: &str) -> bool {
-    const MULTI_WORD_STATUSES: [&str; 2] = ["Compacting conversation", "Mapping distant galaxies"];
-    if MULTI_WORD_STATUSES
+    const SPECIAL_STATUSES: [&str; 3] = [
+        "Beboppin'",
+        "Compacting conversation",
+        "Mapping distant galaxies",
+    ];
+    if SPECIAL_STATUSES
         .iter()
         .any(|candidate| status.eq_ignore_ascii_case(candidate))
     {
         return true;
     }
-    if status.chars().any(char::is_whitespace) {
-        return false;
-    }
-    let lower = status.to_ascii_lowercase();
-    lower.ends_with("ing") || lower.ends_with("in'") || lower.ends_with("in’")
+    !status.chars().any(char::is_whitespace) && status.to_ascii_lowercase().ends_with("ing")
 }
 
 fn line_has_claude_tui_spinner_status_fragment(line: &str) -> bool {
@@ -630,13 +643,13 @@ fn line_is_mcp_auth_required_warning(line: &str) -> bool {
 }
 
 fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
-    lines.iter().any(|line| {
-        let line = trim_prompt_line(line);
-        let lower = line.to_ascii_lowercase();
-        line.contains("Actioning")
-            || line.contains("Musing")
-            || line_has_claude_tui_interrupt_chrome(line)
-            || lower.contains("current work")
+    tmux_recent_lines_show_claude_tui_interrupt_chrome(lines)
+        || lines.iter().any(|line| {
+            let line = trim_prompt_line(line);
+            let lower = line.to_ascii_lowercase();
+            line.contains("Actioning")
+                || line.contains("Musing")
+                || lower.contains("current work")
             // NOTE: neither the footer context-usage bar (`🤖 Model │ ██░░ │ NN%`)
             // nor the completed-thinking summary line (`✻ Churned for 4m 56s`) is a
             // running signal — both render in IDLE/ready states too. #3051 keyed
@@ -650,7 +663,7 @@ fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
                     || line.contains("Searching for ")
                     || line.contains("Reading ")
                     || line.contains("Editing ")))
-    })
+        })
 }
 
 pub(crate) fn tmux_capture_claude_tui_prompt_draft_backspace_budget(
@@ -2164,6 +2177,19 @@ esc to interrupt)
             wrapped_spinner_pane
         ));
         assert!(tmux_capture_indicates_claude_tui_busy(wrapped_spinner_pane));
+
+        let stale_wrapped_tail = "\
+⏺ completed response
+✻ Baked for 2s
+esc to interrupt)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done";
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(
+            stale_wrapped_tail
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_busy(stale_wrapped_tail));
     }
 
     #[test]
@@ -2180,7 +2206,7 @@ esc to interrupt)
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "· Thinking through the problem…"
         ));
-        for line in ["✳ Done…", "✳ Done… (12s)"] {
+        for line in ["✳ Done…", "✳ Done… (12s)", "· Nothin'…"] {
             assert!(!tmux_line_is_claude_tui_structured_spinner(line));
         }
         assert!(!tmux_capture_indicates_claude_tui_busy(

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -297,9 +297,7 @@ pub(crate) fn tmux_capture_indicates_claude_tui_structured_spinner(capture: &str
     for (index, line) in lines.iter().enumerate() {
         if let Some(marker) = claude_tui_markdown_fence_marker(line) {
             match open_fence {
-                Some((open_char, open_len))
-                    if marker.0 == open_char && marker.1 >= open_len =>
-                {
+                Some((open_char, open_len)) if marker.0 == open_char && marker.1 >= open_len => {
                     open_fence = None;
                 }
                 None => open_fence = Some(marker),
@@ -417,7 +415,10 @@ fn claude_tui_markdown_fence_marker(line: &str) -> Option<(char, usize)> {
     if !matches!(marker, '`' | '~') {
         return None;
     }
-    let length = trimmed.chars().take_while(|character| *character == marker).count();
+    let length = trimmed
+        .chars()
+        .take_while(|character| *character == marker)
+        .count();
     (length >= 3).then_some((marker, length))
 }
 

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -2057,9 +2057,7 @@ earlier assistant prose
 ❯
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
-        assert!(!tmux_line_is_claude_tui_spinner_progress(
-            "✳ Architecting…"
-        ));
+        assert!(!tmux_line_is_claude_tui_spinner_progress("✳ Architecting…"));
         assert!(tmux_line_is_claude_tui_structured_spinner(
             "✳ Architecting…"
         ));

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -396,9 +396,9 @@ fn line_has_claude_tui_interrupt_chrome(line: &str) -> bool {
         return false;
     };
     let before_interrupt = &line[..interrupt_start];
-    let has_status_group = before_interrupt.rfind('(').is_some_and(|open| {
-        !before_interrupt[open + 1..].contains(')') && before_interrupt[open + 1..].contains('·')
-    });
+    let has_status_group = before_interrupt.starts_with('(')
+        && !before_interrupt[1..].contains(')')
+        && before_interrupt[1..].contains('·');
     let spinner_prefix = line.chars().next().is_some_and(is_claude_tui_spinner_glyph);
     has_status_group || (spinner_prefix && lower[..interrupt_start].contains('…'))
 }
@@ -462,9 +462,12 @@ fn tmux_line_is_claude_tui_structured_spinner(line: &str) -> bool {
     if !claude_tui_spinner_status_phrase_is_compact(status) {
         return false;
     }
+    if !claude_tui_spinner_status_is_known(status) {
+        return false;
+    }
     let suffix = suffix.trim_start();
     if suffix.is_empty() {
-        return claude_tui_spinner_status_is_known(status);
+        return true;
     }
     if !suffix.starts_with('(') {
         return false;
@@ -2040,6 +2043,18 @@ some earlier assistant prose still on screen
 
         assert!(!tmux_capture_indicates_claude_tui_busy(capture));
         assert!(tmux_capture_indicates_claude_tui_ready_for_input(capture));
+
+        let parenthesized_prose = "\
+⏺ The footer shows (12s · esc to interrupt) while the turn is running.
+✻ Baked for 2s
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done";
+        assert!(!tmux_capture_indicates_claude_tui_busy(parenthesized_prose));
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(
+            parenthesized_prose
+        ));
     }
 
     // #3107 codex re-review (F2 PARTIAL close): a spinner-progress line keyed on
@@ -2139,9 +2154,11 @@ earlier assistant prose
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "· Thinking through the problem…"
         ));
-        assert!(!tmux_line_is_claude_tui_structured_spinner("✳ Done…"));
+        for line in ["✳ Done…", "✳ Done… (12s)"] {
+            assert!(!tmux_line_is_claude_tui_structured_spinner(line));
+        }
         assert!(!tmux_capture_indicates_claude_tui_busy(
-            "✳ Done…\n────────────────────────────────────────\n❯"
+            "✳ Done… (12s)\n────────────────────────────────────────\n❯"
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "✳ This ordinary prose has far too many words to be compact status chrome…"

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -400,7 +400,13 @@ fn line_has_claude_tui_interrupt_chrome(line: &str) -> bool {
         && !before_interrupt[1..].contains(')')
         && before_interrupt[1..].contains('·');
     let spinner_prefix = line.chars().next().is_some_and(is_claude_tui_spinner_glyph);
-    has_status_group || (spinner_prefix && lower[..interrupt_start].contains('…'))
+    let wrapped_status_tail = before_interrupt.is_empty()
+        && line[interrupt_start + "esc to interrupt".len()..]
+            .trim()
+            .starts_with(')');
+    has_status_group
+        || (spinner_prefix && lower[..interrupt_start].contains('…'))
+        || wrapped_status_tail
 }
 
 fn claude_tui_markdown_fence_marker(line: &str) -> Option<(char, usize)> {
@@ -480,7 +486,8 @@ fn claude_tui_spinner_status_phrase_is_compact(status: &str) -> bool {
         && status.chars().count() <= 48
         && status.split_whitespace().count() <= 5
         && status.chars().all(|character| {
-            character.is_alphanumeric() || matches!(character, ' ' | '-' | '_' | '/' | ':')
+            character.is_alphanumeric()
+                || matches!(character, ' ' | '-' | '_' | '/' | ':' | '\'' | '’')
         })
 }
 
@@ -492,7 +499,13 @@ fn claude_tui_spinner_status_is_known(status: &str) -> bool {
     {
         return true;
     }
-    !status.chars().any(char::is_whitespace) && status.to_ascii_lowercase().ends_with("ing")
+    if status.chars().any(char::is_whitespace) {
+        return false;
+    }
+    status
+        .trim_end_matches(|character| matches!(character, '\'' | '’'))
+        .to_ascii_lowercase()
+        .ends_with("ing")
 }
 
 fn line_has_claude_tui_spinner_status_fragment(line: &str) -> bool {
@@ -2117,6 +2130,8 @@ earlier assistant prose
         assert!(tmux_capture_indicates_claude_tui_busy(capture));
         for line in [
             "· Thinking…",
+            "✳ Beboppin'…",
+            "✳ Beboppin'… (12s)",
             "✦ Mapping distant galaxies…",
             "✦ Mapping distant galaxies… (12s",
             "· Compacting conversation… (30s)",
@@ -2138,6 +2153,18 @@ earlier assistant prose
         assert!(tmux_capture_indicates_claude_tui_busy(
             stale_prompt_busy_pane
         ));
+
+        let wrapped_spinner_pane = "\
+✳ Beboppin'… (12s · ↓ 1.2k tokens ·
+esc to interrupt)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2";
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(
+            wrapped_spinner_pane
+        ));
+        assert!(tmux_capture_indicates_claude_tui_busy(wrapped_spinner_pane));
     }
 
     #[test]

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -86,7 +86,7 @@ fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) ->
     let busy = lines.iter().any(|line| {
         let trimmed = trim_prompt_line(line);
         let lower = trimmed.to_ascii_lowercase();
-        lower.contains("esc to interrupt")
+        line_has_claude_tui_interrupt_chrome(trimmed)
             || lower.contains("processing")
             || lower.contains("thinking")
             || lower.contains("running")
@@ -400,12 +400,22 @@ fn line_has_claude_tui_interrupt_chrome(line: &str) -> bool {
     let Some(interrupt_start) = lower.find("esc to interrupt") else {
         return false;
     };
+    let after_interrupt = &line[interrupt_start + "esc to interrupt".len()..];
+    // Complete footer chrome ends at its closing parenthesis. Any trailing
+    // non-whitespace turns the line into assistant prose quoting the footer.
+    if after_interrupt.trim() != ")" {
+        return false;
+    }
     let before_interrupt = &line[..interrupt_start];
     let has_status_group = before_interrupt.starts_with('(')
         && !before_interrupt[1..].contains(')')
-        && before_interrupt[1..].contains('·');
+        && before_interrupt[1..].contains('·')
+        && after_interrupt.trim() == ")";
     let spinner_prefix = line.chars().next().is_some_and(is_claude_tui_spinner_glyph);
-    has_status_group || (spinner_prefix && lower[..interrupt_start].contains('…'))
+    has_status_group
+        || (spinner_prefix
+            && lower[..interrupt_start].contains('…')
+            && after_interrupt.trim() == ")")
 }
 
 fn line_is_claude_tui_wrapped_interrupt_tail(line: &str) -> bool {
@@ -413,7 +423,7 @@ fn line_is_claude_tui_wrapped_interrupt_tail(line: &str) -> bool {
     let lower = line.to_ascii_lowercase();
     lower
         .strip_prefix("esc to interrupt")
-        .is_some_and(|suffix| suffix.trim().starts_with(')'))
+        .is_some_and(|suffix| suffix.trim() == ")")
 }
 
 fn tmux_recent_lines_show_claude_tui_interrupt_chrome(lines: &[&str]) -> bool {
@@ -530,14 +540,23 @@ fn line_has_claude_tui_spinner_status_fragment(line: &str) -> bool {
     let Some(open) = line.find('(') else {
         return false;
     };
-    let group = line[open + 1..].split(')').next().unwrap_or_default();
+    let after_open = &line[open + 1..];
+    let (group, closed) = if let Some(close) = after_open.find(')') {
+        if !after_open[close + 1..].trim().is_empty() {
+            return false;
+        }
+        (&after_open[..close], true)
+    } else {
+        (after_open, false)
+    };
     let lower = group.to_ascii_lowercase();
-    lower.contains("esc to interrupt")
+    let has_status = lower.contains("esc to interrupt")
         || lower.contains("tokens")
         || group.contains('·')
         || group
             .split(|c: char| !c.is_ascii_alphanumeric())
-            .any(is_claude_tui_duration_token)
+            .any(is_claude_tui_duration_token);
+    has_status && (closed || !group.trim().is_empty())
 }
 
 fn is_claude_tui_duration_token(token: &str) -> bool {
@@ -563,6 +582,9 @@ fn line_has_claude_tui_spinner_status_group(line: &str) -> bool {
     let Some(close_rel) = after_open.find(')') else {
         return false;
     };
+    if !after_open[close_rel + 1..].trim().is_empty() {
+        return false;
+    }
     let group = &after_open[..close_rel];
     let lower = group.to_ascii_lowercase();
     if lower.contains("esc to interrupt") || lower.contains("tokens") || group.contains('·') {
@@ -2087,17 +2109,27 @@ some earlier assistant prose still on screen
         assert!(!tmux_capture_indicates_claude_tui_busy(capture));
         assert!(tmux_capture_indicates_claude_tui_ready_for_input(capture));
 
-        let parenthesized_prose = "\
+        for parenthesized_prose in [
+            "\
 ⏺ The footer shows (12s · esc to interrupt) while the turn is running.
 ✻ Baked for 2s
 ────────────────────────────────────────────────────
 ❯
 ────────────────────────────────────────────────────
-  🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done";
-        assert!(!tmux_capture_indicates_claude_tui_busy(parenthesized_prose));
-        assert!(tmux_capture_indicates_claude_tui_ready_for_input(
-            parenthesized_prose
-        ));
+  🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done",
+            "\
+(12s · esc to interrupt) is the footer example
+✻ Baked for 2s
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done",
+        ] {
+            assert!(!tmux_capture_indicates_claude_tui_busy(parenthesized_prose));
+            assert!(tmux_capture_indicates_claude_tui_ready_for_input(
+                parenthesized_prose
+            ));
+        }
     }
 
     // #3107 codex re-review (F2 PARTIAL close): a spinner-progress line keyed on
@@ -2223,6 +2255,12 @@ esc to interrupt)
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "✳ Architecting… (a fresh idea)"
+        ));
+        assert!(!tmux_line_is_claude_tui_structured_spinner(
+            "✳ Architecting… (12s) is displayed here"
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_busy(
+            "✳ Architecting… (12s) is displayed here\n────────────────────────\n❯"
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "Architecting… (12s)"

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -243,14 +243,15 @@ pub(crate) fn tmux_capture_indicates_claude_tui_actively_streaming(capture: &str
 /// The reliable in-progress markers the Claude TUI actually RENDERS are:
 ///   1. the `esc to interrupt` footer — the strongest, unambiguous signal; it
 ///      only renders while a turn is in flight; and
-///   2. the spinner progress line — a leading spinner glyph (`· ✢ ✻ ✽ ✶ ✳ ✦`)
-///      immediately followed by a work verb (`Actioning…`, `Musing…`,
-///      `Thinking…`, `Processing…`, `Running…`, …). This is the footer the TUI
-///      draws while streaming, NOT free-text in the response body.
+///   2. structured spinner chrome — a leading spinner glyph, a compact status
+///      phrase, and an ellipsis, optionally followed by duration/token/interrupt
+///      chrome. This admits multi-word and earliest truncated frames without a
+///      fixed verb allowlist while excluding ordinary prose and balanced fenced
+///      examples.
 /// Plus the explicit `⏺ Running command / Searching for / Reading / Editing …`
 /// active-work markers via `tmux_recent_lines_show_claude_tui_active_work`.
 ///
-/// Bare `processing`/`thinking`/`running` NOT anchored to the spinner glyph or
+/// Bare `processing`/`thinking`/`running` NOT anchored to spinner structure or
 /// the `esc to interrupt` footer are DROPPED. Anything that is not a
 /// recognizable Claude-TUI in-progress frame biases to FALSE.
 pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
@@ -266,23 +267,18 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     recent.iter().any(|line| {
         let trimmed = trim_prompt_line(line);
         // (1) the `esc to interrupt` footer — strongest in-flight marker.
-        if trimmed.to_ascii_lowercase().contains("esc to interrupt") {
-            return true;
-        }
-        // (2) the spinner progress line: a leading spinner glyph adjacent to a
-        // work verb, as the Claude TUI renders the streaming footer. The
-        // verb-word match is ANCHORED to the spinner glyph so the same word in
-        // assistant body text does NOT trip it.
-        tmux_line_is_claude_tui_spinner_progress(trimmed)
-    }) || tmux_recent_lines_show_claude_tui_active_work(recent)
+        trimmed.to_ascii_lowercase().contains("esc to interrupt")
+    }) || tmux_capture_indicates_claude_tui_structured_spinner(capture)
+        || tmux_recent_lines_show_claude_tui_active_work(recent)
 }
 
-/// A conservative readiness-only busy signal for a Claude TUI spinner footer
-/// whose status verb is newer than the shared busy classifier's allowlist.
-/// The full structure is required: spinner glyph + one `-ing` status verb +
-/// ellipsis + a parenthesized duration. Candidates inside Markdown fenced code
-/// blocks are excluded so an exact spinner example in idle assistant prose does
-/// not block readiness.
+/// A conservative live-turn signal for Claude TUI spinner chrome. The status
+/// line must have a spinner glyph, a compact status phrase, and an ellipsis.
+/// Parenthesized duration/interrupt chrome is a strong positive signal, while a
+/// single-word decorative-glyph frame is accepted before that suffix mounts.
+/// Only candidates inside a fence pair that is balanced in this capture are
+/// excluded. An unmatched fence can be a closing fence whose opener scrolled
+/// away, so it must not hide later live status chrome.
 pub(crate) fn tmux_capture_indicates_claude_tui_structured_spinner(capture: &str) -> bool {
     let lines = capture.lines().collect::<Vec<_>>();
     let recent_start = lines
@@ -293,26 +289,14 @@ pub(crate) fn tmux_capture_indicates_claude_tui_structured_spinner(capture: &str
         .nth(CLAUDE_TUI_ACTIVE_SCAN_LINES.saturating_sub(1))
         .map(|(index, _)| index)
         .unwrap_or(0);
-    let mut open_fence = None;
-    for (index, line) in lines.iter().enumerate() {
-        if let Some(marker) = claude_tui_markdown_fence_marker(line) {
-            match open_fence {
-                Some((open_char, open_len)) if marker.0 == open_char && marker.1 >= open_len => {
-                    open_fence = None;
-                }
-                None => open_fence = Some(marker),
-                _ => {}
-            }
-            continue;
-        }
-        if index >= recent_start
-            && open_fence.is_none()
+    let balanced_fences = claude_tui_balanced_markdown_fence_ranges(&lines);
+    lines.iter().enumerate().any(|(index, line)| {
+        index >= recent_start
+            && !balanced_fences
+                .iter()
+                .any(|(open, close)| index > *open && index < *close)
             && tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line))
-        {
-            return true;
-        }
-    }
-    false
+    })
 }
 
 /// #3521: `true` when the Claude TUI pane shows a BACKGROUND AGENT still pending — the
@@ -422,6 +406,27 @@ fn claude_tui_markdown_fence_marker(line: &str) -> Option<(char, usize)> {
     (length >= 3).then_some((marker, length))
 }
 
+fn claude_tui_balanced_markdown_fence_ranges(lines: &[&str]) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut open_fence = None;
+    for (index, line) in lines.iter().enumerate() {
+        let Some(marker) = claude_tui_markdown_fence_marker(line) else {
+            continue;
+        };
+        match open_fence {
+            Some((open_index, open_char, open_len))
+                if marker.0 == open_char && marker.1 >= open_len =>
+            {
+                ranges.push((open_index, index));
+                open_fence = None;
+            }
+            None => open_fence = Some((index, marker.0, marker.1)),
+            _ => {}
+        }
+    }
+    ranges
+}
+
 fn tmux_line_is_claude_tui_structured_spinner(line: &str) -> bool {
     let line = line.trim_start();
     let mut chars = line.chars();
@@ -441,24 +446,40 @@ fn tmux_line_is_claude_tui_structured_spinner(line: &str) -> bool {
         return false;
     };
     let status = status.trim();
-    !status.is_empty()
-        && !status.chars().any(char::is_whitespace)
-        && status.to_ascii_lowercase().ends_with("ing")
-        && suffix.trim_start().starts_with('(')
-        && line_has_claude_tui_spinner_duration_group(suffix)
+    if !claude_tui_spinner_status_phrase_is_compact(status) {
+        return false;
+    }
+    let suffix = suffix.trim_start();
+    if suffix.is_empty() {
+        return first != '·' && !status.chars().any(char::is_whitespace);
+    }
+    if !suffix.starts_with('(') {
+        return false;
+    }
+    line_has_claude_tui_spinner_status_fragment(suffix)
 }
 
-fn line_has_claude_tui_spinner_duration_group(line: &str) -> bool {
+fn claude_tui_spinner_status_phrase_is_compact(status: &str) -> bool {
+    !status.is_empty()
+        && status.chars().count() <= 48
+        && status.split_whitespace().count() <= 5
+        && status.chars().all(|character| {
+            character.is_alphanumeric() || matches!(character, ' ' | '-' | '_' | '/' | ':')
+        })
+}
+
+fn line_has_claude_tui_spinner_status_fragment(line: &str) -> bool {
     let Some(open) = line.find('(') else {
         return false;
     };
-    let after_open = &line[open + 1..];
-    let Some(close_rel) = after_open.find(')') else {
-        return false;
-    };
-    after_open[..close_rel]
-        .split(|c: char| !c.is_ascii_alphanumeric())
-        .any(is_claude_tui_duration_token)
+    let group = line[open + 1..].split(')').next().unwrap_or_default();
+    let lower = group.to_ascii_lowercase();
+    lower.contains("esc to interrupt")
+        || lower.contains("tokens")
+        || group.contains('·')
+        || group
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .any(is_claude_tui_duration_token)
 }
 
 fn is_claude_tui_duration_token(token: &str) -> bool {
@@ -2028,27 +2049,31 @@ another line of prior output";
     }
 
     #[test]
-    fn structured_spinner_accepts_unknown_duration_verb_without_interrupt_copy() {
+    fn structured_spinner_accepts_unknown_and_early_status_frames() {
         let capture = "\
 earlier assistant prose
-✳ Architecting… (12s)
+✳ Architecting…
 ────────────────────────────────────────────────────
 ❯
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
         assert!(!tmux_line_is_claude_tui_spinner_progress(
-            "✳ Architecting… (12s)"
+            "✳ Architecting…"
         ));
         assert!(tmux_line_is_claude_tui_structured_spinner(
-            "✳ Architecting… (12s)"
+            "✳ Architecting…"
         ));
-        assert!(tmux_capture_indicates_claude_tui_structured_spinner(
-            capture
+        assert!(tmux_capture_indicates_claude_tui_busy(capture));
+        assert!(tmux_line_is_claude_tui_structured_spinner(
+            "✦ Mapping distant galaxies… (12s"
+        ));
+        assert!(tmux_line_is_claude_tui_structured_spinner(
+            "· Compacting conversation… (30s)"
         ));
     }
 
     #[test]
-    fn structured_spinner_rejects_prose_and_non_duration_parentheticals() {
+    fn structured_spinner_rejects_prose_and_non_status_parentheticals() {
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "✳ Architecting the response (12s)"
         ));
@@ -2057,6 +2082,12 @@ earlier assistant prose
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "Architecting… (12s)"
+        ));
+        assert!(!tmux_line_is_claude_tui_structured_spinner(
+            "· Thinking through the problem…"
+        ));
+        assert!(!tmux_line_is_claude_tui_structured_spinner(
+            "✳ This ordinary prose has far too many words to be compact status chrome…"
         ));
         assert!(!tmux_capture_indicates_claude_tui_structured_spinner(
             "\
@@ -2069,6 +2100,22 @@ Here is the exact status-line format:
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on"
         ));
+    }
+
+    #[test]
+    fn unmatched_fence_does_not_hide_later_spinner_chrome() {
+        // The first fence is a closing-only tail after its opener scrolled away;
+        // the second fixture leaves a dangling opener. Neither incomplete capture
+        // context may suppress later live status chrome.
+        for capture in [
+            "```\nprior prose after a scrolled-away opener\n✦ Mapping distant galaxies… (12s)",
+            "```text\n✳ Architecting…",
+        ] {
+            assert!(
+                tmux_capture_indicates_claude_tui_structured_spinner(capture),
+                "an unmatched tail fence must fail safe for later spinner chrome"
+            );
+        }
     }
 
     #[test]

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -264,18 +264,17 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     }
     let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
     let recent = &non_empty[start..];
-    recent.iter().any(|line| {
-        let trimmed = trim_prompt_line(line);
-        // (1) the `esc to interrupt` footer — strongest in-flight marker.
-        trimmed.to_ascii_lowercase().contains("esc to interrupt")
-    }) || tmux_capture_indicates_claude_tui_structured_spinner(capture)
+    recent
+        .iter()
+        .any(|line| line_has_claude_tui_interrupt_chrome(line))
+        || tmux_capture_indicates_claude_tui_structured_spinner(capture)
         || tmux_recent_lines_show_claude_tui_active_work(recent)
 }
 
 /// A conservative live-turn signal for Claude TUI spinner chrome. The status
 /// line must have a spinner glyph, a compact status phrase, and an ellipsis.
-/// Parenthesized duration/interrupt chrome is a strong positive signal, while a
-/// single-word decorative-glyph frame is accepted before that suffix mounts.
+/// Parenthesized duration/interrupt chrome is a strong positive signal, while an
+/// early suffix-free frame must use a known work-status shape or phrase.
 /// Only candidates inside a fence pair that is balanced in this capture are
 /// excluded. An unmatched fence can be a closing fence whose opener scrolled
 /// away, so it must not hide later live status chrome.
@@ -379,7 +378,7 @@ fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
     //   - the literal `esc to interrupt`, OR
     //   - a parenthesized TUI status group containing a duration (`<N>s` /
     //     `<N>m`), a `tokens` count, and/or the `·` separator the TUI uses.
-    if lower.contains("esc to interrupt") {
+    if line_has_claude_tui_interrupt_chrome(line) {
         return true;
     }
     line_has_claude_tui_spinner_status_group(line)
@@ -388,6 +387,20 @@ fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
 fn is_claude_tui_spinner_glyph(glyph: char) -> bool {
     const SPINNER_GLYPHS: [char; 8] = ['·', '✢', '✳', '✶', '✻', '✽', '✦', '∗'];
     SPINNER_GLYPHS.contains(&glyph)
+}
+
+fn line_has_claude_tui_interrupt_chrome(line: &str) -> bool {
+    let line = trim_prompt_line(line);
+    let lower = line.to_ascii_lowercase();
+    let Some(interrupt_start) = lower.find("esc to interrupt") else {
+        return false;
+    };
+    let before_interrupt = &line[..interrupt_start];
+    let has_status_group = before_interrupt.rfind('(').is_some_and(|open| {
+        !before_interrupt[open + 1..].contains(')') && before_interrupt[open + 1..].contains('·')
+    });
+    let spinner_prefix = line.chars().next().is_some_and(is_claude_tui_spinner_glyph);
+    has_status_group || (spinner_prefix && lower[..interrupt_start].contains('…'))
 }
 
 fn claude_tui_markdown_fence_marker(line: &str) -> Option<(char, usize)> {
@@ -451,7 +464,7 @@ fn tmux_line_is_claude_tui_structured_spinner(line: &str) -> bool {
     }
     let suffix = suffix.trim_start();
     if suffix.is_empty() {
-        return first != '·' && !status.chars().any(char::is_whitespace);
+        return claude_tui_spinner_status_is_known(status);
     }
     if !suffix.starts_with('(') {
         return false;
@@ -466,6 +479,17 @@ fn claude_tui_spinner_status_phrase_is_compact(status: &str) -> bool {
         && status.chars().all(|character| {
             character.is_alphanumeric() || matches!(character, ' ' | '-' | '_' | '/' | ':')
         })
+}
+
+fn claude_tui_spinner_status_is_known(status: &str) -> bool {
+    const MULTI_WORD_STATUSES: [&str; 2] = ["Compacting conversation", "Mapping distant galaxies"];
+    if MULTI_WORD_STATUSES
+        .iter()
+        .any(|candidate| status.eq_ignore_ascii_case(candidate))
+    {
+        return true;
+    }
+    !status.chars().any(char::is_whitespace) && status.to_ascii_lowercase().ends_with("ing")
 }
 
 fn line_has_claude_tui_spinner_status_fragment(line: &str) -> bool {
@@ -597,7 +621,7 @@ fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
         let lower = line.to_ascii_lowercase();
         line.contains("Actioning")
             || line.contains("Musing")
-            || lower.contains("esc to interrupt")
+            || line_has_claude_tui_interrupt_chrome(line)
             || lower.contains("current work")
             // NOTE: neither the footer context-usage bar (`🤖 Model │ ██░░ │ NN%`)
             // nor the completed-thinking summary line (`✻ Churned for 4m 56s`) is a
@@ -2004,6 +2028,20 @@ some earlier assistant prose still on screen
         ));
     }
 
+    #[test]
+    fn busy_rejects_assistant_interrupt_prose_above_idle_composer() {
+        let capture = "\
+⏺ Press Esc to interrupt the current Claude Code turn.
+✻ Baked for 2s
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done";
+
+        assert!(!tmux_capture_indicates_claude_tui_busy(capture));
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(capture));
+    }
+
     // #3107 codex re-review (F2 PARTIAL close): a spinner-progress line keyed on
     // ONLY the leading glyph + work verb still false-positived on assistant prose
     // that happens to begin with a spinner glyph and a verb. The real Claude TUI
@@ -2062,11 +2100,28 @@ earlier assistant prose
             "✳ Architecting…"
         ));
         assert!(tmux_capture_indicates_claude_tui_busy(capture));
-        assert!(tmux_line_is_claude_tui_structured_spinner(
-            "✦ Mapping distant galaxies… (12s"
+        for line in [
+            "· Thinking…",
+            "✦ Mapping distant galaxies…",
+            "✦ Mapping distant galaxies… (12s",
+            "· Compacting conversation… (30s)",
+        ] {
+            assert!(
+                tmux_line_is_claude_tui_structured_spinner(line),
+                "live early or duration spinner must be recognized: {line}"
+            );
+        }
+        let stale_prompt_busy_pane = "\
+· Thinking…
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2";
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(
+            stale_prompt_busy_pane
         ));
-        assert!(tmux_line_is_claude_tui_structured_spinner(
-            "· Compacting conversation… (30s)"
+        assert!(tmux_capture_indicates_claude_tui_busy(
+            stale_prompt_busy_pane
         ));
     }
 
@@ -2083,6 +2138,10 @@ earlier assistant prose
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "· Thinking through the problem…"
+        ));
+        assert!(!tmux_line_is_claude_tui_structured_spinner("✳ Done…"));
+        assert!(!tmux_capture_indicates_claude_tui_busy(
+            "✳ Done…\n────────────────────────────────────────\n❯"
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "✳ This ordinary prose has far too many words to be compact status chrome…"

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -289,9 +289,9 @@ pub(crate) fn tmux_capture_indicates_claude_tui_structured_spinner(capture: &str
         .filter(|l| !l.trim().is_empty())
         .collect::<Vec<_>>();
     let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
-    non_empty[start..].iter().any(|line| {
-        tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line))
-    })
+    non_empty[start..]
+        .iter()
+        .any(|line| tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line)))
 }
 
 /// #3521: `true` when the Claude TUI pane shows a BACKGROUND AGENT still pending — the

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -280,18 +280,41 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
 /// A conservative readiness-only busy signal for a Claude TUI spinner footer
 /// whose status verb is newer than the shared busy classifier's allowlist.
 /// The full structure is required: spinner glyph + one `-ing` status verb +
-/// ellipsis + a parenthesized duration. Callers can therefore fail closed on a
-/// live footer such as `✳ Architecting… (12s)` without treating ordinary prose
-/// or an idle composer as busy.
+/// ellipsis + a parenthesized duration. Candidates inside Markdown fenced code
+/// blocks are excluded so an exact spinner example in idle assistant prose does
+/// not block readiness.
 pub(crate) fn tmux_capture_indicates_claude_tui_structured_spinner(capture: &str) -> bool {
-    let non_empty = capture
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .collect::<Vec<_>>();
-    let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
-    non_empty[start..]
+    let lines = capture.lines().collect::<Vec<_>>();
+    let recent_start = lines
         .iter()
-        .any(|line| tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line)))
+        .enumerate()
+        .filter(|(_, line)| !line.trim().is_empty())
+        .rev()
+        .nth(CLAUDE_TUI_ACTIVE_SCAN_LINES.saturating_sub(1))
+        .map(|(index, _)| index)
+        .unwrap_or(0);
+    let mut open_fence = None;
+    for (index, line) in lines.iter().enumerate() {
+        if let Some(marker) = claude_tui_markdown_fence_marker(line) {
+            match open_fence {
+                Some((open_char, open_len))
+                    if marker.0 == open_char && marker.1 >= open_len =>
+                {
+                    open_fence = None;
+                }
+                None => open_fence = Some(marker),
+                _ => {}
+            }
+            continue;
+        }
+        if index >= recent_start
+            && open_fence.is_none()
+            && tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// #3521: `true` when the Claude TUI pane shows a BACKGROUND AGENT still pending — the
@@ -383,6 +406,19 @@ fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
 fn is_claude_tui_spinner_glyph(glyph: char) -> bool {
     const SPINNER_GLYPHS: [char; 8] = ['·', '✢', '✳', '✶', '✻', '✽', '✦', '∗'];
     SPINNER_GLYPHS.contains(&glyph)
+}
+
+fn claude_tui_markdown_fence_marker(line: &str) -> Option<(char, usize)> {
+    let trimmed = trim_prompt_line(line).trim_start_matches(|character: char| {
+        matches!(character, '│' | '┃' | '┆' | '┊' | '▏' | '▕')
+    });
+    let trimmed = trimmed.trim_start();
+    let marker = trimmed.chars().next()?;
+    if !matches!(marker, '`' | '~') {
+        return None;
+    }
+    let length = trimmed.chars().take_while(|character| *character == marker).count();
+    (length >= 3).then_some((marker, length))
 }
 
 fn tmux_line_is_claude_tui_structured_spinner(line: &str) -> bool {
@@ -1992,10 +2028,22 @@ another line of prior output";
 
     #[test]
     fn structured_spinner_accepts_unknown_duration_verb_without_interrupt_copy() {
-        let line = "✳ Architecting… (12s)";
-        assert!(!tmux_line_is_claude_tui_spinner_progress(line));
-        assert!(tmux_line_is_claude_tui_structured_spinner(line));
-        assert!(tmux_capture_indicates_claude_tui_structured_spinner(line));
+        let capture = "\
+earlier assistant prose
+✳ Architecting… (12s)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on";
+        assert!(!tmux_line_is_claude_tui_spinner_progress(
+            "✳ Architecting… (12s)"
+        ));
+        assert!(tmux_line_is_claude_tui_structured_spinner(
+            "✳ Architecting… (12s)"
+        ));
+        assert!(tmux_capture_indicates_claude_tui_structured_spinner(
+            capture
+        ));
     }
 
     #[test]
@@ -2008,6 +2056,17 @@ another line of prior output";
         ));
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "Architecting… (12s)"
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_structured_spinner(
+            "\
+Here is the exact status-line format:
+```text
+✳ Architecting… (12s)
+```
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2 │ ⏵⏵ bypass permissions on"
         ));
     }
 

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -141,6 +141,13 @@ pub(crate) fn tmux_capture_indicates_claude_tui_ready_for_input(capture: &str) -
     if recent.iter().any(|l| l.contains(CLAUDE_TUI_READY_BANNER)) {
         return true;
     }
+    // `recent` is reverse-ordered for bottom-up prompt lookup below. Restore
+    // screen order inside the active-work helper before evaluating wrapped
+    // spinner head → interrupt-tail adjacency. This predicate is only a prompt-
+    // marker producer; every production readiness acceptance also runs the full
+    // forward capture through `snapshot_allows_prompt_readiness`, whose shared
+    // busy classifier vetoes partial spinner frames this lightweight scan cannot
+    // reconstruct by itself.
     if tmux_recent_lines_show_claude_tui_active_work(&recent) {
         return false;
     }
@@ -266,7 +273,7 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     let recent = &non_empty[start..];
     tmux_recent_lines_show_claude_tui_interrupt_chrome(recent)
         || tmux_capture_indicates_claude_tui_structured_spinner(capture)
-        || tmux_recent_lines_show_claude_tui_active_work(recent)
+        || tmux_recent_forward_lines_show_claude_tui_active_work(recent)
 }
 
 /// A conservative live-turn signal for Claude TUI spinner chrome. The status
@@ -642,15 +649,23 @@ fn line_is_mcp_auth_required_warning(line: &str) -> bool {
         && (lower.contains("need") || lower.contains("run /mcp"))
 }
 
-fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
-    let forward = lines.iter().rev().copied().collect::<Vec<_>>();
+fn tmux_recent_lines_show_claude_tui_active_work(lines_reverse_ordered: &[&str]) -> bool {
+    let forward = lines_reverse_ordered
+        .iter()
+        .rev()
+        .copied()
+        .collect::<Vec<_>>();
     tmux_recent_lines_show_claude_tui_interrupt_chrome(&forward)
-        || lines.iter().any(|line| {
-            let line = trim_prompt_line(line);
-            let lower = line.to_ascii_lowercase();
-            line.contains("Actioning")
-                || line.contains("Musing")
-                || lower.contains("current work")
+        || tmux_recent_forward_lines_show_claude_tui_active_work(&forward)
+}
+
+fn tmux_recent_forward_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
+    lines.iter().any(|line| {
+        let line = trim_prompt_line(line);
+        let lower = line.to_ascii_lowercase();
+        line.contains("Actioning")
+            || line.contains("Musing")
+            || lower.contains("current work")
             // NOTE: neither the footer context-usage bar (`🤖 Model │ ██░░ │ NN%`)
             // nor the completed-thinking summary line (`✻ Churned for 4m 56s`) is a
             // running signal — both render in IDLE/ready states too. #3051 keyed
@@ -664,7 +679,7 @@ fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
                     || line.contains("Searching for ")
                     || line.contains("Reading ")
                     || line.contains("Editing ")))
-        })
+    })
 }
 
 pub(crate) fn tmux_capture_claude_tui_prompt_draft_backspace_budget(
@@ -2050,6 +2065,9 @@ another line of prior output";
         let capture = "\
 some earlier assistant prose still on screen
 (13s · ↓ 1.2k tokens · esc to interrupt)";
+        // Claude renders this parenthesized footer as a standalone status line
+        // while a turn is active. It is intentionally sufficient busy evidence;
+        // prose with the same text embedded mid-line is rejected below.
         assert!(tmux_capture_indicates_claude_tui_busy(capture));
         assert!(tmux_capture_indicates_claude_tui_actively_streaming(
             capture

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -502,10 +502,8 @@ fn claude_tui_spinner_status_is_known(status: &str) -> bool {
     if status.chars().any(char::is_whitespace) {
         return false;
     }
-    status
-        .trim_end_matches(|character| matches!(character, '\'' | '’'))
-        .to_ascii_lowercase()
-        .ends_with("ing")
+    let lower = status.to_ascii_lowercase();
+    lower.ends_with("ing") || lower.ends_with("in'") || lower.ends_with("in’")
 }
 
 fn line_has_claude_tui_spinner_status_fragment(line: &str) -> bool {
@@ -2132,6 +2130,7 @@ earlier assistant prose
             "· Thinking…",
             "✳ Beboppin'…",
             "✳ Beboppin'… (12s)",
+            "✳ Dilly-dallying…",
             "✦ Mapping distant galaxies…",
             "✦ Mapping distant galaxies… (12s",
             "· Compacting conversation… (30s)",

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -2160,7 +2160,7 @@ esc to interrupt)
 ❯
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2";
-        assert!(tmux_capture_indicates_claude_tui_ready_for_input(
+        assert!(!tmux_capture_indicates_claude_tui_ready_for_input(
             wrapped_spinner_pane
         ));
         assert!(tmux_capture_indicates_claude_tui_busy(wrapped_spinner_pane));

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -277,6 +277,23 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     }) || tmux_recent_lines_show_claude_tui_active_work(recent)
 }
 
+/// A conservative readiness-only busy signal for a Claude TUI spinner footer
+/// whose status verb is newer than the shared busy classifier's allowlist.
+/// The full structure is required: spinner glyph + one `-ing` status verb +
+/// ellipsis + a parenthesized duration. Callers can therefore fail closed on a
+/// live footer such as `✳ Architecting… (12s)` without treating ordinary prose
+/// or an idle composer as busy.
+pub(crate) fn tmux_capture_indicates_claude_tui_structured_spinner(capture: &str) -> bool {
+    let non_empty = capture
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>();
+    let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
+    non_empty[start..].iter().any(|line| {
+        tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line))
+    })
+}
+
 /// #3521: `true` when the Claude TUI pane shows a BACKGROUND AGENT still pending — the
 /// `✻ Waiting for N background agent(s) to finish` footer, or a fresh `Backgrounded agent`
 /// spawn line. Distinct from `tmux_capture_indicates_claude_tui_busy`: a detached background
@@ -318,13 +335,12 @@ pub(crate) fn sniff_background_agent_pending(tmux_session_name: &str) -> bool {
 /// verb. Anchoring the verb to the spinner glyph is what distinguishes the TUI
 /// chrome from the same verb appearing in assistant body text.
 fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
-    const SPINNER_GLYPHS: [char; 8] = ['·', '✢', '✳', '✶', '✻', '✽', '✦', '∗'];
     let line = line.trim_start();
     let mut chars = line.chars();
     let Some(first) = chars.next() else {
         return false;
     };
-    if !SPINNER_GLYPHS.contains(&first) {
+    if !is_claude_tui_spinner_glyph(first) {
         return false;
     }
     // The remainder after the glyph (and its following space) must lead with a
@@ -364,6 +380,59 @@ fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
     line_has_claude_tui_spinner_status_group(line)
 }
 
+fn is_claude_tui_spinner_glyph(glyph: char) -> bool {
+    const SPINNER_GLYPHS: [char; 8] = ['·', '✢', '✳', '✶', '✻', '✽', '✦', '∗'];
+    SPINNER_GLYPHS.contains(&glyph)
+}
+
+fn tmux_line_is_claude_tui_structured_spinner(line: &str) -> bool {
+    let line = line.trim_start();
+    let mut chars = line.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !is_claude_tui_spinner_glyph(first) {
+        return false;
+    }
+
+    let rest = chars.as_str().trim_start();
+    let (status, suffix) = if let Some(status_end) = rest.find('…') {
+        (&rest[..status_end], &rest[status_end + '…'.len_utf8()..])
+    } else if let Some(status_end) = rest.find("...") {
+        (&rest[..status_end], &rest[status_end + 3..])
+    } else {
+        return false;
+    };
+    let status = status.trim();
+    !status.is_empty()
+        && !status.chars().any(char::is_whitespace)
+        && status.to_ascii_lowercase().ends_with("ing")
+        && suffix.trim_start().starts_with('(')
+        && line_has_claude_tui_spinner_duration_group(suffix)
+}
+
+fn line_has_claude_tui_spinner_duration_group(line: &str) -> bool {
+    let Some(open) = line.find('(') else {
+        return false;
+    };
+    let after_open = &line[open + 1..];
+    let Some(close_rel) = after_open.find(')') else {
+        return false;
+    };
+    after_open[..close_rel]
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(is_claude_tui_duration_token)
+}
+
+fn is_claude_tui_duration_token(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    bytes.len() >= 2
+        && matches!(bytes[bytes.len() - 1], b's' | b'm')
+        && bytes[..bytes.len() - 1]
+            .iter()
+            .all(|byte| byte.is_ascii_digit())
+}
+
 /// `true` when `line` contains the parenthesized status group the Claude TUI
 /// spinner footer renders next to the work verb, e.g.
 /// `(12s · ↑ 1.2k tokens · esc to interrupt)`. The group must carry at least one
@@ -386,12 +455,7 @@ fn line_has_claude_tui_spinner_status_group(line: &str) -> bool {
     // A standalone duration token such as `12s` / `4m` inside the group.
     group
         .split(|c: char| !c.is_ascii_alphanumeric())
-        .any(|tok| {
-            let bytes = tok.as_bytes();
-            bytes.len() >= 2
-                && matches!(bytes[bytes.len() - 1], b's' | b'm')
-                && bytes[..bytes.len() - 1].iter().all(|b| b.is_ascii_digit())
-        })
+        .any(is_claude_tui_duration_token)
 }
 
 pub(crate) fn tmux_capture_indicates_claude_tui_prompt_draft(capture: &str) -> bool {
@@ -1924,6 +1988,27 @@ another line of prior output";
         // (no `esc to interrupt`, no `tokens`) still qualifies.
         let line = "✻ Thinking… (12s)";
         assert!(tmux_line_is_claude_tui_spinner_progress(line));
+    }
+
+    #[test]
+    fn structured_spinner_accepts_unknown_duration_verb_without_interrupt_copy() {
+        let line = "✳ Architecting… (12s)";
+        assert!(!tmux_line_is_claude_tui_spinner_progress(line));
+        assert!(tmux_line_is_claude_tui_structured_spinner(line));
+        assert!(tmux_capture_indicates_claude_tui_structured_spinner(line));
+    }
+
+    #[test]
+    fn structured_spinner_rejects_prose_and_non_duration_parentheticals() {
+        assert!(!tmux_line_is_claude_tui_structured_spinner(
+            "✳ Architecting the response (12s)"
+        ));
+        assert!(!tmux_line_is_claude_tui_structured_spinner(
+            "✳ Architecting… (a fresh idea)"
+        ));
+        assert!(!tmux_line_is_claude_tui_structured_spinner(
+            "Architecting… (12s)"
+        ));
     }
 
     #[test]

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -668,19 +668,27 @@ fn tmux_recent_lines_show_claude_tui_active_work(lines_reverse_ordered: &[&str])
         .rev()
         .copied()
         .collect::<Vec<_>>();
+    // Prompt-marker detection intentionally consumes only decisive in-flight
+    // chrome. A suffix-free early spinner can coexist briefly with an already
+    // painted empty composer, so it remains marker-ready here; the final
+    // readiness boundary independently applies the full structured-spinner busy
+    // veto to the same capture.
     tmux_recent_lines_show_claude_tui_interrupt_chrome(&forward)
-        || tmux_recent_forward_lines_show_claude_tui_active_work(&forward)
+        || tmux_recent_forward_lines_show_claude_tui_active_work_without_spinner(&forward)
 }
 
 fn tmux_recent_forward_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
+    lines
+        .iter()
+        .any(|line| tmux_line_is_claude_tui_structured_spinner(trim_prompt_line(line)))
+        || tmux_recent_forward_lines_show_claude_tui_active_work_without_spinner(lines)
+}
+
+fn tmux_recent_forward_lines_show_claude_tui_active_work_without_spinner(lines: &[&str]) -> bool {
     lines.iter().any(|line| {
         let line = trim_prompt_line(line);
         let lower = line.to_ascii_lowercase();
-        // Spinner verbs are recognized only through the same structural parser as
-        // every other status phrase, so quoted/trailing prose cannot bypass its
-        // exact-suffix gate merely because the verb is Actioning or Musing.
-        tmux_line_is_claude_tui_structured_spinner(line)
-            || lower.contains("current work")
+        lower.contains("current work")
             // NOTE: neither the footer context-usage bar (`🤖 Model │ ██░░ │ NN%`)
             // nor the completed-thinking summary line (`✻ Churned for 4m 56s`) is a
             // running signal — both render in IDLE/ready states too. #3051 keyed

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -409,33 +409,24 @@ fn line_has_claude_tui_interrupt_chrome(line: &str) -> bool {
     let before_interrupt = &line[..interrupt_start];
     let has_status_group = before_interrupt.starts_with('(')
         && !before_interrupt[1..].contains(')')
-        && before_interrupt[1..].contains('·')
-        && after_interrupt.trim() == ")";
+        && before_interrupt[1..].contains('·');
     let spinner_prefix = line.chars().next().is_some_and(is_claude_tui_spinner_glyph);
-    has_status_group
-        || (spinner_prefix
-            && lower[..interrupt_start].contains('…')
-            && after_interrupt.trim() == ")")
+    has_status_group || (spinner_prefix && lower[..interrupt_start].contains('…'))
 }
 
-fn line_is_claude_tui_wrapped_interrupt_tail(line: &str) -> bool {
-    let line = trim_prompt_line(line);
-    let lower = line.to_ascii_lowercase();
-    lower
-        .strip_prefix("esc to interrupt")
-        .is_some_and(|suffix| suffix.trim() == ")")
+fn lines_reconstruct_claude_tui_interrupt_chrome(first: &str, second: &str) -> bool {
+    let mut combined = String::with_capacity(first.len() + second.len());
+    combined.push_str(trim_prompt_line(first));
+    combined.push_str(trim_prompt_line(second));
+    line_has_claude_tui_interrupt_chrome(&combined)
 }
 
 fn tmux_recent_lines_show_claude_tui_interrupt_chrome(lines: &[&str]) -> bool {
     lines.iter().enumerate().any(|(index, line)| {
         line_has_claude_tui_interrupt_chrome(line)
-            || (line_is_claude_tui_wrapped_interrupt_tail(line)
-                && index.checked_sub(1).is_some_and(|previous_index| {
-                    let previous = trim_prompt_line(lines[previous_index]);
-                    tmux_line_is_claude_tui_structured_spinner(previous)
-                        && previous.contains('(')
-                        && !previous.contains(')')
-                }))
+            || index.checked_sub(1).is_some_and(|previous_index| {
+                lines_reconstruct_claude_tui_interrupt_chrome(lines[previous_index], line)
+            })
     })
 }
 
@@ -685,8 +676,10 @@ fn tmux_recent_forward_lines_show_claude_tui_active_work(lines: &[&str]) -> bool
     lines.iter().any(|line| {
         let line = trim_prompt_line(line);
         let lower = line.to_ascii_lowercase();
-        line.contains("Actioning")
-            || line.contains("Musing")
+        // Spinner verbs are recognized only through the same structural parser as
+        // every other status phrase, so quoted/trailing prose cannot bypass its
+        // exact-suffix gate merely because the verb is Actioning or Musing.
+        tmux_line_is_claude_tui_structured_spinner(line)
             || lower.contains("current work")
             // NOTE: neither the footer context-usage bar (`🤖 Model │ ██░░ │ NN%`)
             // nor the completed-thinking summary line (`✻ Churned for 4m 56s`) is a
@@ -695,7 +688,7 @@ fn tmux_recent_forward_lines_show_claude_tui_active_work(lines: &[&str]) -> bool
             // context usage to not-ready; the running vs. idle distinction is
             // instead carried by the footer (`Tools: 0 done` = freshly-started, no
             // tools yet) handled in `..._show_idle_suggestion_chrome`, plus the
-            // explicit `esc to interrupt`/spinner-verb keywords above.
+            // explicit interrupt/status chrome above.
             || (line.starts_with('⏺')
                 && ((line.contains("Running ") && line.contains("command"))
                     || line.contains("Searching for ")
@@ -2220,17 +2213,34 @@ earlier assistant prose
 
     #[test]
     fn wrapped_interrupt_tail_requires_adjacent_open_spinner_head() {
-        let live_wrapped_spinner = "\
+        for live_wrapped_spinner in [
+            "\
 ✳ Beboppin'… (12s · ↓ 1.2k tokens ·
 esc to interrupt)
 ────────────────────────────────────────────────────
 ❯
 ────────────────────────────────────────────────────
-  🤖 Opus(H) │ 7% │ MCP: 2";
-        assert!(!tmux_capture_indicates_claude_tui_ready_for_input(
-            live_wrapped_spinner
-        ));
-        assert!(tmux_capture_indicates_claude_tui_busy(live_wrapped_spinner));
+  🤖 Opus(H) │ 7% │ MCP: 2",
+            "\
+(13s · ↓ 1.2k tokens · esc to interrupt
+)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2",
+            "\
+(13s · ↓ 1.2k tokens · esc to interru
+pt)
+────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────
+  🤖 Opus(H) │ 7% │ MCP: 2",
+        ] {
+            assert!(!tmux_capture_indicates_claude_tui_ready_for_input(
+                live_wrapped_spinner
+            ));
+            assert!(tmux_capture_indicates_claude_tui_busy(live_wrapped_spinner));
+        }
 
         let stale_isolated_wrapped_tail = "\
 ⏺ completed response
@@ -2262,6 +2272,13 @@ esc to interrupt)
         assert!(!tmux_capture_indicates_claude_tui_busy(
             "✳ Architecting… (12s) is displayed here\n────────────────────────\n❯"
         ));
+        for verb in ["Actioning", "Musing"] {
+            let prose = format!(
+                "· {verb}… (12s) is displayed here\n✻ Baked for 2s\n────────────────────────\n❯\n────────────────────────\n  Tools: 1 done"
+            );
+            assert!(!tmux_capture_indicates_claude_tui_busy(&prose));
+            assert!(tmux_capture_indicates_claude_tui_ready_for_input(&prose));
+        }
         assert!(!tmux_line_is_claude_tui_structured_spinner(
             "Architecting… (12s)"
         ));

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -643,7 +643,8 @@ fn line_is_mcp_auth_required_warning(line: &str) -> bool {
 }
 
 fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
-    tmux_recent_lines_show_claude_tui_interrupt_chrome(lines)
+    let forward = lines.iter().rev().copied().collect::<Vec<_>>();
+    tmux_recent_lines_show_claude_tui_interrupt_chrome(&forward)
         || lines.iter().any(|line| {
             let line = trim_prompt_line(line);
             let lower = line.to_ascii_lowercase();
@@ -2153,20 +2154,23 @@ earlier assistant prose
                 "live early or duration spinner must be recognized: {line}"
             );
         }
-        let stale_prompt_busy_pane = "\
+        let live_early_spinner_with_stale_prompt = "\
 · Thinking…
 ────────────────────────────────────────────────────
 ❯
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2";
         assert!(tmux_capture_indicates_claude_tui_ready_for_input(
-            stale_prompt_busy_pane
+            live_early_spinner_with_stale_prompt
         ));
         assert!(tmux_capture_indicates_claude_tui_busy(
-            stale_prompt_busy_pane
+            live_early_spinner_with_stale_prompt
         ));
+    }
 
-        let wrapped_spinner_pane = "\
+    #[test]
+    fn wrapped_interrupt_tail_requires_adjacent_open_spinner_head() {
+        let live_wrapped_spinner = "\
 ✳ Beboppin'… (12s · ↓ 1.2k tokens ·
 esc to interrupt)
 ────────────────────────────────────────────────────
@@ -2174,11 +2178,11 @@ esc to interrupt)
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2";
         assert!(!tmux_capture_indicates_claude_tui_ready_for_input(
-            wrapped_spinner_pane
+            live_wrapped_spinner
         ));
-        assert!(tmux_capture_indicates_claude_tui_busy(wrapped_spinner_pane));
+        assert!(tmux_capture_indicates_claude_tui_busy(live_wrapped_spinner));
 
-        let stale_wrapped_tail = "\
+        let stale_isolated_wrapped_tail = "\
 ⏺ completed response
 ✻ Baked for 2s
 esc to interrupt)
@@ -2187,9 +2191,11 @@ esc to interrupt)
 ────────────────────────────────────────────────────
   🤖 Opus(H) │ 7% │ MCP: 2 │ Tools: 1 done";
         assert!(tmux_capture_indicates_claude_tui_ready_for_input(
-            stale_wrapped_tail
+            stale_isolated_wrapped_tail
         ));
-        assert!(!tmux_capture_indicates_claude_tui_busy(stale_wrapped_tail));
+        assert!(!tmux_capture_indicates_claude_tui_busy(
+            stale_isolated_wrapped_tail
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 요약 (#4528, #3889 회귀)
Claude Code v2.1.209의 persistent MCP auth warning이 readiness 판정을 kind 무관하게 차단해 warm follow-up이 전부 cold-start로 밀리던 오탐 수정.
- `FreshTurn`: #3889 cold-boot 인증 차단 유지 (기존 보호 불변).
- `Followup`: auth warning만으로 차단하지 않고 composer/draft + positive busy 신호(esc to interrupt 등)로 판정.

## 테스트 (뮤테이션 증명 포함)
kind-aware 분기·busy guard·draft guard·cold-boot guard 각각 제거 시 해당 assert 실패하는 4종.

## 게이트
fmt/check/test/inventory/freshness/maintainability rc=0 (input.rs giant freeze 1932→1949 동기 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)