### PR TITLE
fix(discord): idle recap '맥락 압축' 버튼을 native /compact 주입 경로로 (#4557)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -511,7 +511,7 @@
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 301 | 287 | 14 |  |
-| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 545 | 494 | 51 |  |
+| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 709 | 636 | 73 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 5817 | 608 | 5209 |  |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 550 | 189 | 361 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -511,7 +511,7 @@
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 301 | 287 | 14 |  |
-| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 943 | 724 | 219 |  |
+| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 1246 | 778 | 468 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 5817 | 608 | 5209 |  |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 550 | 189 | 361 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -511,7 +511,7 @@
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 301 | 287 | 14 |  |
-| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 1246 | 778 | 468 |  |
+| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 1376 | 842 | 534 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 5817 | 608 | 5209 |  |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 550 | 189 | 361 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -511,7 +511,7 @@
 | `services::discord::idle_recap::context_display` | `src/services/discord/idle_recap/context_display.rs` | 154 | 154 | 0 |  |
 | `services::discord::idle_recap::relay_integrity` | `src/services/discord/idle_recap/relay_integrity.rs` | 213 | 160 | 53 |  |
 | `services::discord::idle_recap::scrollback` | `src/services/discord/idle_recap/scrollback.rs` | 301 | 287 | 14 |  |
-| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 709 | 636 | 73 |  |
+| `services::discord::idle_recap_interaction` | `src/services/discord/idle_recap_interaction.rs` | 943 | 724 | 219 |  |
 | `services::discord::idle_relay_drift` | `src/services/discord/idle_relay_drift.rs` | 764 | 529 | 235 |  |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 5817 | 608 | 5209 |  |
 | `services::discord::inflight::anchor_repost` | `src/services/discord/inflight/anchor_repost.rs` | 550 | 189 | 361 |  |

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -38,6 +38,8 @@ enum RecapCompactOutcome {
     Started(NativeCompactRequest),
     AlreadyClaimed,
     ClaimFailed(String),
+    PostClaimOwnerChanged,
+    PostClaimFenceFailed(String),
     InvalidTarget,
     RoutingUnavailable {
         owner_instance_id: Option<String>,
@@ -54,7 +56,10 @@ impl RecapCompactOutcome {
     fn preserves_recap_card(&self) -> bool {
         matches!(
             self,
-            Self::ClaimFailed(_) | Self::InvalidTarget | Self::RoutingUnavailable { .. }
+            Self::AlreadyClaimed
+                | Self::ClaimFailed(_)
+                | Self::InvalidTarget
+                | Self::RoutingUnavailable { .. }
         )
     }
 }
@@ -369,15 +374,22 @@ async fn handle_idle_recap_compact_interaction(
     }
 
     let target_for_claim = target.clone();
+    let target_for_pre_inject_fence = target.clone();
     let target_session_key_for_log = target.session_key.clone();
     let channel_id = component.channel_id.get();
     let pool_for_claim = pool.clone();
+    let pool_for_pre_inject_fence = pool.clone();
     let outcome = run_native_compact_once(
         target,
         &crate::services::platform::hostname_short(),
         &crate::services::cluster::node_registry::resolve_self_instance_id_without_config(),
         move || async move {
             claim_recap_compact_pointer(&pool_for_claim, &target_for_claim, message_id, channel_id)
+                .await
+                .map_err(|error| error.to_string())
+        },
+        move || async move {
+            recap_compact_owner_unchanged(&pool_for_pre_inject_fence, &target_for_pre_inject_fence)
                 .await
                 .map_err(|error| error.to_string())
         },
@@ -403,6 +415,23 @@ async fn handle_idle_recap_compact_interaction(
                 "idle_recap compact: atomic claim failed"
             );
             "맥락 압축 요청 실패: 세션 선점 오류. /compact를 직접 실행하세요."
+        }
+        RecapCompactOutcome::PostClaimOwnerChanged => {
+            tracing::warn!(
+                message_id,
+                session_key = %target_session_key_for_log,
+                "idle_recap compact: owner changed after atomic claim"
+            );
+            "맥락 압축 요청 실패: 세션이 다른 노드로 이동했습니다. 원래 세션 노드에서 /compact를 실행하세요."
+        }
+        RecapCompactOutcome::PostClaimFenceFailed(error) => {
+            tracing::warn!(
+                error = %error,
+                message_id,
+                session_key = %target_session_key_for_log,
+                "idle_recap compact: post-claim owner fence failed"
+            );
+            "맥락 압축 요청 실패: 세션 소유권을 재확인할 수 없습니다. /compact를 직접 실행하세요."
         }
         RecapCompactOutcome::InvalidTarget => {
             "맥락 압축 요청 실패: recap 세션 대상을 확인할 수 없습니다."
@@ -445,17 +474,29 @@ async fn handle_idle_recap_compact_interaction(
     Ok(())
 }
 
-async fn run_native_compact_once<Claim, ClaimFut, IsLive, IsLiveFut, Inject, InjectFut>(
+async fn run_native_compact_once<
+    Claim,
+    ClaimFut,
+    PreInjectFence,
+    PreInjectFenceFut,
+    IsLive,
+    IsLiveFut,
+    Inject,
+    InjectFut,
+>(
     target: RecapClearTarget,
     local_hostname: &str,
     local_instance_id: &str,
     claim: Claim,
+    pre_inject_fence: PreInjectFence,
     is_live: IsLive,
     inject: Inject,
 ) -> RecapCompactOutcome
 where
     Claim: FnOnce() -> ClaimFut,
     ClaimFut: std::future::Future<Output = Result<bool, String>>,
+    PreInjectFence: FnOnce() -> PreInjectFenceFut,
+    PreInjectFenceFut: std::future::Future<Output = Result<bool, String>>,
     IsLive: FnOnce(&str) -> IsLiveFut,
     IsLiveFut: std::future::Future<Output = bool>,
     Inject: FnOnce(NativeCompactRequest) -> InjectFut,
@@ -497,6 +538,11 @@ where
     };
     if !is_live(&request.tmux_session_name).await {
         return RecapCompactOutcome::TargetNotLive(request);
+    }
+    match pre_inject_fence().await {
+        Ok(true) => {}
+        Ok(false) => return RecapCompactOutcome::PostClaimOwnerChanged,
+        Err(error) => return RecapCompactOutcome::PostClaimFenceFailed(error),
     }
 
     match inject(request.clone()).await {
@@ -560,6 +606,24 @@ async fn claim_recap_compact_pointer(
     .execute(pool)
     .await
     .map(|result| result.rows_affected() == 1)
+}
+
+async fn recap_compact_owner_unchanged(
+    pool: &PgPool,
+    target: &RecapClearTarget,
+) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+             SELECT 1
+             FROM sessions
+             WHERE session_key = $1
+               AND instance_id IS NOT DISTINCT FROM $2
+         )",
+    )
+    .bind(&target.session_key)
+    .bind(target.owner_instance_id.as_deref())
+    .fetch_one(pool)
+    .await
 }
 
 async fn handle_idle_recap_suggest_interaction(
@@ -810,6 +874,7 @@ mod tests {
             "mac-mini",
             "mac-mini-release",
             || async { Ok(true) },
+            || async { Ok(true) },
             |target| std::future::ready(target == "old-bound-session"),
             move |request| {
                 observed.lock().unwrap().push(request.clone());
@@ -834,6 +899,7 @@ mod tests {
             recap_target("claude/token/mac-mini:old-bound-session"),
             "mac-mini",
             "mac-mini-release",
+            || async { Ok(true) },
             || async { Ok(true) },
             |target| std::future::ready(target == "new-current-session"),
             move |_| {
@@ -882,6 +948,7 @@ mod tests {
                     claims_in_flight.fetch_sub(1, Ordering::SeqCst);
                     Ok(won)
                 },
+                || async { Ok(true) },
                 |_| async { true },
                 move |_| async move {
                     injections.fetch_add(1, Ordering::SeqCst);
@@ -931,6 +998,7 @@ mod tests {
                     Ok(true)
                 }
             },
+            || async { Ok(true) },
             {
                 let live_checks = live_checks.clone();
                 move |_| {
@@ -979,6 +1047,7 @@ mod tests {
                     observed_claims.fetch_add(1, Ordering::SeqCst);
                     async { Ok(true) }
                 },
+                || async { Ok(true) },
                 |_| async { true },
                 |_| async { Ok(()) },
             )
@@ -1007,6 +1076,7 @@ mod tests {
                 observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 async { Ok(true) }
             },
+            || async { Ok(true) },
             |_| async { true },
             |_| async { Err("submit failed".to_string()) },
         )
@@ -1018,6 +1088,7 @@ mod tests {
             "mac-mini",
             "mac-mini-release",
             || async { Ok(false) },
+            || async { Ok(true) },
             |_| async { true },
             move |_| {
                 observed_retries.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -1048,6 +1119,7 @@ mod tests {
             "mac-mini",
             "mac-mini-release",
             || async { Err("database unavailable".to_string()) },
+            || async { Ok(true) },
             |_| async { true },
             move |_| {
                 observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -1061,6 +1133,41 @@ mod tests {
             RecapCompactOutcome::ClaimFailed("database unavailable".to_string())
         );
         assert_eq!(injection_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn owner_handoff_after_claim_is_fenced_immediately_before_injection() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let live_checks = std::sync::Arc::new(AtomicUsize::new(0));
+        let injections = std::sync::Arc::new(AtomicUsize::new(0));
+        let outcome = run_native_compact_once(
+            recap_target("mac-mini:claimed-session"),
+            "mac-mini",
+            "mac-mini-release",
+            || async { Ok(true) },
+            || async { Ok(false) },
+            {
+                let live_checks = live_checks.clone();
+                move |_| async move {
+                    live_checks.fetch_add(1, Ordering::SeqCst);
+                    true
+                }
+            },
+            {
+                let injections = injections.clone();
+                move |_| async move {
+                    injections.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(outcome, RecapCompactOutcome::PostClaimOwnerChanged);
+        assert!(!outcome.preserves_recap_card());
+        assert_eq!(live_checks.load(Ordering::SeqCst), 1);
+        assert_eq!(injections.load(Ordering::SeqCst), 0);
     }
 
     async fn seed_recap_compact_session_pg(
@@ -1165,10 +1272,36 @@ mod tests {
             .await
             .expect("handoff recap compact owner");
 
-        assert!(
-            !claim_recap_compact_pointer(&pool, &target, message_id, channel_id)
-                .await
-                .expect("owner-fenced recap compact claim")
+        let injections = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let outcome = run_native_compact_once(
+            target.clone(),
+            "mac-mini",
+            "mac-mini-release",
+            {
+                let pool = pool.clone();
+                let target = target.clone();
+                move || async move {
+                    claim_recap_compact_pointer(&pool, &target, message_id, channel_id)
+                        .await
+                        .map_err(|error| error.to_string())
+                }
+            },
+            || async { Ok(true) },
+            |_| async { true },
+            {
+                let injections = injections.clone();
+                move |_| async move {
+                    injections.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+        assert_eq!(outcome, RecapCompactOutcome::AlreadyClaimed);
+        assert!(outcome.preserves_recap_card());
+        assert_eq!(
+            injections.load(std::sync::atomic::Ordering::SeqCst),
+            0
         );
         let pointer = sqlx::query_as::<_, (Option<i64>, Option<i64>, Option<String>)>(
             "SELECT idle_recap_message_id, idle_recap_channel_id, instance_id

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -1299,10 +1299,7 @@ mod tests {
         .await;
         assert_eq!(outcome, RecapCompactOutcome::AlreadyClaimed);
         assert!(outcome.preserves_recap_card());
-        assert_eq!(
-            injections.load(std::sync::atomic::Ordering::SeqCst),
-            0
-        );
+        assert_eq!(injections.load(std::sync::atomic::Ordering::SeqCst), 0);
         let pointer = sqlx::query_as::<_, (Option<i64>, Option<i64>, Option<String>)>(
             "SELECT idle_recap_message_id, idle_recap_channel_id, instance_id
              FROM sessions

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -361,20 +361,13 @@ async fn handle_idle_recap_compact_interaction(
     let outcome = run_native_compact_once(
         target,
         move || async move {
-            claim_recap_compact_pointer(
-                &pool_for_claim,
-                &target_for_claim,
-                message_id,
-                channel_id,
-            )
-            .await
-            .map_err(|error| error.to_string())
+            claim_recap_compact_pointer(&pool_for_claim, &target_for_claim, message_id, channel_id)
+                .await
+                .map_err(|error| error.to_string())
         },
         |tmux_session_name| {
             std::future::ready(
-                crate::services::tmux_diagnostics::tmux_session_has_live_pane(
-                    tmux_session_name,
-                ),
+                crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name),
             )
         },
         |request| async move { inject_native_compact(request).await },

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -16,11 +16,33 @@ use crate::services::discord::idle_recap::{
 };
 use crate::services::provider::ProviderKind;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct RecapClearTarget {
     session_key: String,
+    provider: String,
+    turn_generation: i64,
     channel_matches: bool,
     provider_matches: bool,
     recap_current: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct NativeCompactRequest {
+    tmux_session_name: String,
+    prompt: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RecapCompactOutcome {
+    Started(NativeCompactRequest),
+    AlreadyClaimed,
+    ClaimFailed(String),
+    InvalidTarget,
+    TargetNotLive(NativeCompactRequest),
+    InjectionFailed {
+        request: NativeCompactRequest,
+        error: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -294,21 +316,33 @@ async fn handle_idle_recap_compact_interaction(
         send_ephemeral(ctx, component, "맥락 압축 요청 실패: DB 연결 없음.").await;
         return Ok(());
     };
-    let Some(target) = lookup_current_recap_target(
+    let target = match lookup_current_recap_target(
         &pool,
         message_id,
         component.channel_id.get(),
         data.provider.as_str(),
     )
-    .await?
-    else {
-        send_ephemeral(
-            ctx,
-            component,
-            "맥락 압축 대상이 더 이상 유효하지 않습니다.",
-        )
-        .await;
-        return Ok(());
+    .await
+    {
+        Ok(Some(target)) => target,
+        Ok(None) => {
+            send_ephemeral(
+                ctx,
+                component,
+                "맥락 압축 대상이 더 이상 유효하지 않거나 이미 처리되었습니다.",
+            )
+            .await;
+            return Ok(());
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                message_id,
+                "idle_recap compact: target lookup failed"
+            );
+            send_ephemeral(ctx, component, "맥락 압축 요청 실패: 세션 확인 오류.").await;
+            return Ok(());
+        }
     };
 
     if let Err(error) = component.defer_ephemeral(ctx).await {
@@ -320,61 +354,125 @@ async fn handle_idle_recap_compact_interaction(
         return Ok(());
     }
 
-    let channel_name = {
-        let core = data.shared.core.lock().await;
-        core.sessions
-            .get(&component.channel_id)
-            .and_then(|session| session.channel_name.clone())
-    };
-    let effective_provider = crate::services::discord::commands::effective_provider_for_channel(
-        &data.shared,
-        component.channel_id,
-        &data.provider,
-        channel_name.as_deref(),
+    let target_for_claim = target.clone();
+    let target_session_key_for_log = target.session_key.clone();
+    let channel_id = component.channel_id.get();
+    let pool_for_claim = pool.clone();
+    let outcome = run_native_compact_once(
+        target,
+        move || async move {
+            claim_recap_compact_pointer(
+                &pool_for_claim,
+                &target_for_claim,
+                message_id,
+                channel_id,
+            )
+            .await
+            .map_err(|error| error.to_string())
+        },
+        |tmux_session_name| {
+            std::future::ready(
+                crate::services::tmux_diagnostics::tmux_session_has_live_pane(
+                    tmux_session_name,
+                ),
+            )
+        },
+        |request| async move { inject_native_compact(request).await },
     )
     .await;
-    let tmux_session_name = if !matches!(&effective_provider, ProviderKind::Claude) {
-        edit_deferred_ephemeral(
-            ctx,
-            component,
-            message_id,
-            "맥락 압축 요청은 Claude 세션에서만 사용할 수 있습니다.",
-        )
-        .await;
-        return Ok(());
-    } else if let Some(channel_name) = channel_name.filter(|name| !name.trim().is_empty()) {
-        effective_provider.build_tmux_session_name(&channel_name)
-    } else {
-        edit_deferred_ephemeral(
-            ctx,
-            component,
-            message_id,
-            "맥락 압축 요청 실패: 실행 중인 Claude 세션을 찾을 수 없습니다.",
-        )
-        .await;
-        return Ok(());
+
+    let response = match &outcome {
+        RecapCompactOutcome::Started(_) => "Claude 맥락 압축을 시작했습니다.",
+        RecapCompactOutcome::AlreadyClaimed => {
+            "맥락 압축 요청이 이미 처리되었거나 대상이 더 이상 유효하지 않습니다."
+        }
+        RecapCompactOutcome::ClaimFailed(error) => {
+            tracing::warn!(
+                error = %error,
+                message_id,
+                session_key = %target_session_key_for_log,
+                "idle_recap compact: atomic claim failed"
+            );
+            "맥락 압축 요청 실패: 세션 선점 오류. /compact를 직접 실행하세요."
+        }
+        RecapCompactOutcome::InvalidTarget => {
+            "맥락 압축 요청 실패: recap 세션 대상을 확인할 수 없습니다."
+        }
+        RecapCompactOutcome::TargetNotLive(request) => {
+            tracing::warn!(
+                message_id,
+                tmux_session_name = %request.tmux_session_name,
+                "idle_recap compact: claimed target has no live pane"
+            );
+            "맥락 압축 요청 실패: 원래 Claude 세션이 종료되었습니다."
+        }
+        RecapCompactOutcome::InjectionFailed { request, error } => {
+            tracing::warn!(
+                error = %error,
+                message_id,
+                tmux_session_name = %request.tmux_session_name,
+                "idle_recap compact: terminal native /compact injection failure"
+            );
+            "맥락 압축 요청을 전송하지 못했습니다. 중복 방지를 위해 요청을 종료했습니다. /compact를 직접 실행하세요."
+        }
     };
-    if !crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name) {
-        edit_deferred_ephemeral(
-            ctx,
-            component,
-            message_id,
-            "맥락 압축 요청 실패: 실행 중인 Claude 세션을 찾을 수 없습니다.",
-        )
-        .await;
-        return Ok(());
+    edit_deferred_ephemeral(ctx, component, message_id, response).await;
+
+    if !matches!(outcome, RecapCompactOutcome::ClaimFailed(_)) {
+        delete_previous_card(&ctx.http, channel_id, message_id).await;
+    }
+    Ok(())
+}
+
+async fn run_native_compact_once<Claim, ClaimFut, IsLive, IsLiveFut, Inject, InjectFut>(
+    target: RecapClearTarget,
+    claim: Claim,
+    is_live: IsLive,
+    inject: Inject,
+) -> RecapCompactOutcome
+where
+    Claim: FnOnce() -> ClaimFut,
+    ClaimFut: std::future::Future<Output = Result<bool, String>>,
+    IsLive: FnOnce(&str) -> IsLiveFut,
+    IsLiveFut: std::future::Future<Output = bool>,
+    Inject: FnOnce(NativeCompactRequest) -> InjectFut,
+    InjectFut: std::future::Future<Output = Result<(), String>>,
+{
+    match claim().await {
+        Ok(true) => {}
+        Ok(false) => return RecapCompactOutcome::AlreadyClaimed,
+        Err(error) => return RecapCompactOutcome::ClaimFailed(error),
     }
 
-    let tmux_session_name_for_inject = tmux_session_name.clone();
-    let injection_result = tokio::task::spawn_blocking(move || {
+    let Some(tmux_session_name) =
+        crate::services::discord::idle_recap::tmux_session_name_from_key(&target.session_key)
+    else {
+        return RecapCompactOutcome::InvalidTarget;
+    };
+    let request = NativeCompactRequest {
+        tmux_session_name,
+        prompt: "/compact",
+    };
+    if !is_live(&request.tmux_session_name).await {
+        return RecapCompactOutcome::TargetNotLive(request);
+    }
+
+    match inject(request.clone()).await {
+        Ok(()) => RecapCompactOutcome::Started(request),
+        Err(error) => RecapCompactOutcome::InjectionFailed { request, error },
+    }
+}
+
+async fn inject_native_compact(request: NativeCompactRequest) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
         #[cfg(unix)]
         {
             crate::services::claude::with_claude_tui_session_turn_lock(
-                &tmux_session_name_for_inject,
+                &request.tmux_session_name,
                 || {
                     crate::services::claude_tui::input::send_followup_prompt(
-                        &tmux_session_name_for_inject,
-                        "/compact",
+                        &request.tmux_session_name,
+                        request.prompt,
                         None,
                     )
                 },
@@ -383,55 +481,41 @@ async fn handle_idle_recap_compact_interaction(
         #[cfg(not(unix))]
         {
             crate::services::claude_tui::input::send_followup_prompt(
-                &tmux_session_name_for_inject,
-                "/compact",
+                &request.tmux_session_name,
+                request.prompt,
                 None,
             )
         }
     })
-    .await;
-    let injection_succeeded = matches!(&injection_result, Ok(Ok(())));
-    let response = match injection_result {
-        Ok(Ok(())) => "Claude 맥락 압축을 시작했습니다.",
-        Ok(Err(error)) => {
-            tracing::warn!(
-                error = %error,
-                message_id,
-                tmux_session_name = %tmux_session_name,
-                "idle_recap compact: native /compact injection failed"
-            );
-            "맥락 압축 요청을 전송하지 못했습니다. 잠시 후 다시 시도하세요."
-        }
-        Err(error) => {
-            tracing::warn!(
-                error = %error,
-                message_id,
-                tmux_session_name = %tmux_session_name,
-                "idle_recap compact: native /compact injection task failed"
-            );
-            "맥락 압축 요청을 전송하지 못했습니다. 잠시 후 다시 시도하세요."
-        }
-    };
-    edit_deferred_ephemeral(ctx, component, message_id, response).await;
-    if !injection_succeeded {
-        return Ok(());
-    }
+    .await
+    .map_err(|error| error.to_string())?
+}
 
-    match clear_recap_pointer(&pool, &target.session_key, message_id).await {
-        Ok(true) => delete_previous_card(&ctx.http, component.channel_id.get(), message_id).await,
-        Ok(false) => tracing::warn!(
-            message_id,
-            session_key = %target.session_key,
-            "idle_recap compact: native /compact succeeded but recap pointer was no longer current"
-        ),
-        Err(error) => tracing::warn!(
-            error = %error,
-            message_id,
-            session_key = %target.session_key,
-            "idle_recap compact: native /compact succeeded but recap cleanup failed"
-        ),
-    }
-    Ok(())
+async fn claim_recap_compact_pointer(
+    pool: &PgPool,
+    target: &RecapClearTarget,
+    message_id: u64,
+    channel_id: u64,
+) -> Result<bool, sqlx::Error> {
+    sqlx::query(
+        "UPDATE sessions
+         SET idle_recap_message_id = NULL,
+             idle_recap_channel_id = NULL
+         WHERE session_key = $1
+           AND provider = $2
+           AND idle_recap_turn_generation = $3
+           AND idle_recap_message_id = $4
+           AND idle_recap_channel_id = $5
+           AND COALESCE(idle_recap_posted_at >= COALESCE(last_heartbeat, created_at), false)",
+    )
+    .bind(&target.session_key)
+    .bind(&target.provider)
+    .bind(target.turn_generation)
+    .bind(message_id as i64)
+    .bind(channel_id as i64)
+    .execute(pool)
+    .await
+    .map(|result| result.rows_affected() == 1)
 }
 
 async fn handle_idle_recap_suggest_interaction(
@@ -593,8 +677,10 @@ async fn lookup_recap_clear_target(
     channel_id: u64,
     provider: &str,
 ) -> Result<Option<RecapClearTarget>, sqlx::Error> {
-    let row = sqlx::query_as::<_, (String, bool, bool, bool)>(
+    let row = sqlx::query_as::<_, (String, String, i64, bool, bool, bool)>(
         "SELECT session_key,
+                provider,
+                idle_recap_turn_generation,
                 idle_recap_channel_id = $2 AS channel_matches,
                 provider = $3 AS provider_matches,
                 COALESCE(idle_recap_posted_at >= COALESCE(last_heartbeat, created_at), false) AS recap_current
@@ -608,8 +694,17 @@ async fn lookup_recap_clear_target(
     .fetch_optional(pool)
     .await?;
     Ok(row.map(
-        |(session_key, channel_matches, provider_matches, recap_current)| RecapClearTarget {
+        |(
             session_key,
+            provider,
+            turn_generation,
+            channel_matches,
+            provider_matches,
+            recap_current,
+        )| RecapClearTarget {
+            session_key,
+            provider,
+            turn_generation,
             channel_matches,
             provider_matches,
             recap_current,
@@ -647,12 +742,158 @@ mod tests {
         assert!(!is_idle_recap_custom_id("steer:cancel:1"));
     }
 
-    #[test]
-    fn recap_prompt_route_sends_compact_to_native_claude_slash_handler() {
+    fn recap_target(session_key: &str) -> RecapClearTarget {
+        RecapClearTarget {
+            session_key: session_key.to_string(),
+            provider: "claude".to_string(),
+            turn_generation: 7,
+            channel_matches: true,
+            provider_matches: true,
+            recap_current: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn compact_uses_claimed_recap_target_and_native_prompt() {
+        let injected = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let observed = injected.clone();
+        let outcome = run_native_compact_once(
+            recap_target("claude/token/mac-mini:old-bound-session"),
+            || async { Ok(true) },
+            |target| std::future::ready(target == "old-bound-session"),
+            move |request| {
+                observed.lock().unwrap().push(request.clone());
+                async { Ok(()) }
+            },
+        )
+        .await;
+
+        let expected = NativeCompactRequest {
+            tmux_session_name: "old-bound-session".to_string(),
+            prompt: "/compact",
+        };
+        assert_eq!(outcome, RecapCompactOutcome::Started(expected.clone()));
+        assert_eq!(*injected.lock().unwrap(), vec![expected]);
+    }
+
+    #[tokio::test]
+    async fn rebinding_cannot_redirect_compact_to_current_channel_session() {
+        let injection_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed = injection_calls.clone();
+        let outcome = run_native_compact_once(
+            recap_target("claude/token/mac-mini:old-bound-session"),
+            || async { Ok(true) },
+            |target| std::future::ready(target == "new-current-session"),
+            move |_| {
+                observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async { Ok(()) }
+            },
+        )
+        .await;
+
         assert_eq!(
-            recap_prompt_route("idle_recap:compact:42"),
-            Some(RecapPromptRoute::NativeSlashCompact)
+            outcome,
+            RecapCompactOutcome::TargetNotLive(NativeCompactRequest {
+                tmux_session_name: "old-bound-session".to_string(),
+                prompt: "/compact",
+            })
         );
+        assert_eq!(injection_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn concurrent_compact_claims_allow_exactly_one_injection() {
+        let claimed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let injections = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let run = || {
+            let claimed = claimed.clone();
+            let injections = injections.clone();
+            run_native_compact_once(
+                recap_target("mac-mini:claimed-session"),
+                move || async move {
+                    Ok(claimed
+                        .compare_exchange(
+                            false,
+                            true,
+                            std::sync::atomic::Ordering::SeqCst,
+                            std::sync::atomic::Ordering::SeqCst,
+                        )
+                        .is_ok())
+                },
+                |_| async { true },
+                move |_| async move {
+                    injections.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+        };
+
+        let (first, second) = tokio::join!(run(), run());
+        assert!(matches!(first, RecapCompactOutcome::Started(_)));
+        assert_eq!(second, RecapCompactOutcome::AlreadyClaimed);
+        assert_eq!(injections.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn injection_failure_is_terminal_after_claim() {
+        let claim_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed = claim_calls.clone();
+        let first = run_native_compact_once(
+            recap_target("mac-mini:claimed-session"),
+            move || {
+                observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async { Ok(true) }
+            },
+            |_| async { true },
+            |_| async { Err("submit failed".to_string()) },
+        )
+        .await;
+        let retried_injections = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed_retries = retried_injections.clone();
+        let retry = run_native_compact_once(
+            recap_target("mac-mini:claimed-session"),
+            || async { Ok(false) },
+            |_| async { true },
+            move |_| {
+                observed_retries.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async { Ok(()) }
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            first,
+            RecapCompactOutcome::InjectionFailed { ref request, ref error }
+                if request.prompt == "/compact" && error == "submit failed"
+        ));
+        assert_eq!(retry, RecapCompactOutcome::AlreadyClaimed);
+        assert_eq!(claim_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            retried_injections.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_database_error_fails_closed_without_injection() {
+        let injection_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed = injection_calls.clone();
+        let outcome = run_native_compact_once(
+            recap_target("mac-mini:claimed-session"),
+            || async { Err("database unavailable".to_string()) },
+            |_| async { true },
+            move |_| {
+                observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async { Ok(()) }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            RecapCompactOutcome::ClaimFailed("database unavailable".to_string())
+        );
+        assert_eq!(injection_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -562,7 +562,7 @@ async fn edit_deferred_ephemeral(
     }
 }
 
-fn truncate_interaction_body(body: &str) {
+fn truncate_interaction_body(body: &str) -> String {
     const LIMIT: usize = 1800;
     let mut out = String::new();
     let mut chars = body.chars();

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -23,6 +23,22 @@ struct RecapClearTarget {
     recap_current: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RecapPromptRoute {
+    NativeSlashCompact,
+    InternalFollowup,
+}
+
+fn recap_prompt_route(custom_id: &str) -> Option<RecapPromptRoute> {
+    if custom_id.starts_with(IDLE_RECAP_COMPACT_BUTTON_PREFIX) {
+        Some(RecapPromptRoute::NativeSlashCompact)
+    } else if custom_id.starts_with(IDLE_RECAP_SUGGEST_BUTTON_PREFIX) {
+        Some(RecapPromptRoute::InternalFollowup)
+    } else {
+        None
+    }
+}
+
 /// True if `custom_id` belongs to the idle-recap clear button.
 pub(super) fn is_idle_recap_clear_custom_id(custom_id: &str) -> bool {
     custom_id.starts_with(IDLE_RECAP_CLEAR_BUTTON_PREFIX)
@@ -47,11 +63,14 @@ pub(super) async fn handle_idle_recap_interaction(
     if custom_id.starts_with(IDLE_RECAP_RELAY_DIAG_BUTTON_PREFIX) {
         return handle_idle_recap_relay_diag_interaction(ctx, component, data).await;
     }
-    if custom_id.starts_with(IDLE_RECAP_COMPACT_BUTTON_PREFIX) {
-        return handle_idle_recap_compact_interaction(ctx, component, data).await;
-    }
-    if custom_id.starts_with(IDLE_RECAP_SUGGEST_BUTTON_PREFIX) {
-        return handle_idle_recap_suggest_interaction(ctx, component, data).await;
+    match recap_prompt_route(custom_id) {
+        Some(RecapPromptRoute::NativeSlashCompact) => {
+            return handle_idle_recap_compact_interaction(ctx, component, data).await;
+        }
+        Some(RecapPromptRoute::InternalFollowup) => {
+            return handle_idle_recap_suggest_interaction(ctx, component, data).await;
+        }
+        None => {}
     }
     let _ = component
         .create_response(ctx, serenity::CreateInteractionResponse::Acknowledge)
@@ -292,24 +311,126 @@ async fn handle_idle_recap_compact_interaction(
         return Ok(());
     };
 
-    let prompt = "/compact";
-    let enqueued = crate::services::discord::enqueue_internal_followup(
-        &data.shared,
-        &data.provider,
-        component.channel_id,
-        serenity::MessageId::new(message_id),
-        prompt,
-        "idle recap context compact",
-    )
-    .await;
-    if !enqueued {
-        send_ephemeral(ctx, component, "맥락 압축 요청을 큐에 넣지 못했습니다.").await;
+    if let Err(error) = component.defer_ephemeral(ctx).await {
+        tracing::warn!(
+            error = %error,
+            message_id,
+            "idle_recap compact: failed to defer interaction response"
+        );
         return Ok(());
     }
 
-    send_ephemeral(ctx, component, &prompt_sent_ephemeral(prompt)).await;
-    let _ = clear_recap_pointer(&pool, &target.session_key, message_id).await;
-    delete_previous_card(&ctx.http, component.channel_id.get(), message_id).await;
+    let channel_name = {
+        let core = data.shared.core.lock().await;
+        core.sessions
+            .get(&component.channel_id)
+            .and_then(|session| session.channel_name.clone())
+    };
+    let effective_provider = crate::services::discord::commands::effective_provider_for_channel(
+        &data.shared,
+        component.channel_id,
+        &data.provider,
+        channel_name.as_deref(),
+    )
+    .await;
+    let tmux_session_name = if !matches!(&effective_provider, ProviderKind::Claude) {
+        edit_deferred_ephemeral(
+            ctx,
+            component,
+            message_id,
+            "맥락 압축 요청은 Claude 세션에서만 사용할 수 있습니다.",
+        )
+        .await;
+        return Ok(());
+    } else if let Some(channel_name) = channel_name.filter(|name| !name.trim().is_empty()) {
+        effective_provider.build_tmux_session_name(&channel_name)
+    } else {
+        edit_deferred_ephemeral(
+            ctx,
+            component,
+            message_id,
+            "맥락 압축 요청 실패: 실행 중인 Claude 세션을 찾을 수 없습니다.",
+        )
+        .await;
+        return Ok(());
+    };
+    if !crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name) {
+        edit_deferred_ephemeral(
+            ctx,
+            component,
+            message_id,
+            "맥락 압축 요청 실패: 실행 중인 Claude 세션을 찾을 수 없습니다.",
+        )
+        .await;
+        return Ok(());
+    }
+
+    let tmux_session_name_for_inject = tmux_session_name.clone();
+    let injection_result = tokio::task::spawn_blocking(move || {
+        #[cfg(unix)]
+        {
+            crate::services::claude::with_claude_tui_session_turn_lock(
+                &tmux_session_name_for_inject,
+                || {
+                    crate::services::claude_tui::input::send_followup_prompt(
+                        &tmux_session_name_for_inject,
+                        "/compact",
+                        None,
+                    )
+                },
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            crate::services::claude_tui::input::send_followup_prompt(
+                &tmux_session_name_for_inject,
+                "/compact",
+                None,
+            )
+        }
+    })
+    .await;
+    let injection_succeeded = matches!(&injection_result, Ok(Ok(())));
+    let response = match injection_result {
+        Ok(Ok(())) => "Claude 맥락 압축을 시작했습니다.",
+        Ok(Err(error)) => {
+            tracing::warn!(
+                error = %error,
+                message_id,
+                tmux_session_name = %tmux_session_name,
+                "idle_recap compact: native /compact injection failed"
+            );
+            "맥락 압축 요청을 전송하지 못했습니다. 잠시 후 다시 시도하세요."
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                message_id,
+                tmux_session_name = %tmux_session_name,
+                "idle_recap compact: native /compact injection task failed"
+            );
+            "맥락 압축 요청을 전송하지 못했습니다. 잠시 후 다시 시도하세요."
+        }
+    };
+    edit_deferred_ephemeral(ctx, component, message_id, response).await;
+    if !injection_succeeded {
+        return Ok(());
+    }
+
+    match clear_recap_pointer(&pool, &target.session_key, message_id).await {
+        Ok(true) => delete_previous_card(&ctx.http, component.channel_id.get(), message_id).await,
+        Ok(false) => tracing::warn!(
+            message_id,
+            session_key = %target.session_key,
+            "idle_recap compact: native /compact succeeded but recap pointer was no longer current"
+        ),
+        Err(error) => tracing::warn!(
+            error = %error,
+            message_id,
+            session_key = %target.session_key,
+            "idle_recap compact: native /compact succeeded but recap cleanup failed"
+        ),
+    }
     Ok(())
 }
 
@@ -420,7 +541,28 @@ async fn send_ephemeral(
         .await;
 }
 
-fn truncate_interaction_body(body: &str) -> String {
+async fn edit_deferred_ephemeral(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    message_id: u64,
+    content: &str,
+) {
+    if let Err(error) = component
+        .edit_response(
+            ctx,
+            serenity::EditInteractionResponse::new().content(content),
+        )
+        .await
+    {
+        tracing::warn!(
+            error = %error,
+            message_id,
+            "idle_recap compact: failed to edit deferred interaction response"
+        );
+    }
+}
+
+fn truncate_interaction_body(body: &str) {
     const LIMIT: usize = 1800;
     let mut out = String::new();
     let mut chars = body.chars();
@@ -503,6 +645,28 @@ mod tests {
         assert!(is_idle_recap_custom_id("idle_recap:compact:1"));
         assert!(is_idle_recap_custom_id("idle_recap:suggest:1"));
         assert!(!is_idle_recap_custom_id("steer:cancel:1"));
+    }
+
+    #[test]
+    fn recap_prompt_route_sends_compact_to_native_claude_slash_handler() {
+        assert_eq!(
+            recap_prompt_route("idle_recap:compact:42"),
+            Some(RecapPromptRoute::NativeSlashCompact)
+        );
+    }
+
+    #[test]
+    fn recap_prompt_route_sends_suggest_to_internal_followup_handler() {
+        assert_eq!(
+            recap_prompt_route("idle_recap:suggest:42"),
+            Some(RecapPromptRoute::InternalFollowup)
+        );
+    }
+
+    #[test]
+    fn recap_prompt_route_rejects_unrelated_custom_ids() {
+        assert_eq!(recap_prompt_route("idle_recap:clear:42"), None);
+        assert_eq!(recap_prompt_route("steer:cancel:42"), None);
     }
 
     #[test]

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -1122,7 +1122,13 @@ mod tests {
         };
         let (first, second) = tokio::join!(claim(), claim());
 
-        assert_eq!([first, second].into_iter().filter(|claimed| *claimed).count(), 1);
+        assert_eq!(
+            [first, second]
+                .into_iter()
+                .filter(|claimed| *claimed)
+                .count(),
+            1
+        );
         let pointer = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
             "SELECT idle_recap_message_id, idle_recap_channel_id
              FROM sessions

--- a/src/services/discord/idle_recap_interaction.rs
+++ b/src/services/discord/idle_recap_interaction.rs
@@ -20,6 +20,7 @@ use crate::services::provider::ProviderKind;
 struct RecapClearTarget {
     session_key: String,
     provider: String,
+    owner_instance_id: Option<String>,
     turn_generation: i64,
     channel_matches: bool,
     provider_matches: bool,
@@ -38,11 +39,24 @@ enum RecapCompactOutcome {
     AlreadyClaimed,
     ClaimFailed(String),
     InvalidTarget,
+    RoutingUnavailable {
+        owner_instance_id: Option<String>,
+        reason: String,
+    },
     TargetNotLive(NativeCompactRequest),
     InjectionFailed {
         request: NativeCompactRequest,
         error: String,
     },
+}
+
+impl RecapCompactOutcome {
+    fn preserves_recap_card(&self) -> bool {
+        matches!(
+            self,
+            Self::ClaimFailed(_) | Self::InvalidTarget | Self::RoutingUnavailable { .. }
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -360,6 +374,8 @@ async fn handle_idle_recap_compact_interaction(
     let pool_for_claim = pool.clone();
     let outcome = run_native_compact_once(
         target,
+        &crate::services::platform::hostname_short(),
+        &crate::services::cluster::node_registry::resolve_self_instance_id_without_config(),
         move || async move {
             claim_recap_compact_pointer(&pool_for_claim, &target_for_claim, message_id, channel_id)
                 .await
@@ -391,6 +407,18 @@ async fn handle_idle_recap_compact_interaction(
         RecapCompactOutcome::InvalidTarget => {
             "맥락 압축 요청 실패: recap 세션 대상을 확인할 수 없습니다."
         }
+        RecapCompactOutcome::RoutingUnavailable {
+            owner_instance_id,
+            reason,
+        } => {
+            tracing::warn!(
+                message_id,
+                owner_instance_id = owner_instance_id.as_deref().unwrap_or("unknown"),
+                reason,
+                "idle_recap compact: recap owner is not local"
+            );
+            "맥락 압축 요청을 현재 노드에서 처리할 수 없습니다. 원래 세션 노드에서 다시 시도하세요."
+        }
         RecapCompactOutcome::TargetNotLive(request) => {
             tracing::warn!(
                 message_id,
@@ -411,7 +439,7 @@ async fn handle_idle_recap_compact_interaction(
     };
     edit_deferred_ephemeral(ctx, component, message_id, response).await;
 
-    if !matches!(outcome, RecapCompactOutcome::ClaimFailed(_)) {
+    if !outcome.preserves_recap_card() {
         delete_previous_card(&ctx.http, channel_id, message_id).await;
     }
     Ok(())
@@ -419,6 +447,8 @@ async fn handle_idle_recap_compact_interaction(
 
 async fn run_native_compact_once<Claim, ClaimFut, IsLive, IsLiveFut, Inject, InjectFut>(
     target: RecapClearTarget,
+    local_hostname: &str,
+    local_instance_id: &str,
     claim: Claim,
     is_live: IsLive,
     inject: Inject,
@@ -431,19 +461,38 @@ where
     Inject: FnOnce(NativeCompactRequest) -> InjectFut,
     InjectFut: std::future::Future<Output = Result<(), String>>,
 {
+    let Some(identity) =
+        crate::services::discord::session_identity::SessionIdentity::parse(&target.session_key)
+    else {
+        return RecapCompactOutcome::InvalidTarget;
+    };
+    let routing = crate::services::cluster::session_routing::session_owner_routing_status(
+        target.owner_instance_id.as_deref(),
+        Some(local_instance_id),
+        &[],
+    );
+    if identity.host != local_hostname || routing["is_local"].as_bool() != Some(true) {
+        let reason = if identity.host != local_hostname {
+            "session_key_host_mismatch"
+        } else {
+            routing["reason"]
+                .as_str()
+                .unwrap_or("session_owner_not_local")
+        };
+        return RecapCompactOutcome::RoutingUnavailable {
+            owner_instance_id: target.owner_instance_id.clone(),
+            reason: reason.to_string(),
+        };
+    }
+
     match claim().await {
         Ok(true) => {}
         Ok(false) => return RecapCompactOutcome::AlreadyClaimed,
         Err(error) => return RecapCompactOutcome::ClaimFailed(error),
     }
 
-    let Some(tmux_session_name) =
-        crate::services::discord::idle_recap::tmux_session_name_from_key(&target.session_key)
-    else {
-        return RecapCompactOutcome::InvalidTarget;
-    };
     let request = NativeCompactRequest {
-        tmux_session_name,
+        tmux_session_name: identity.tmux_name,
         prompt: "/compact",
     };
     if !is_live(&request.tmux_session_name).await {
@@ -499,6 +548,7 @@ async fn claim_recap_compact_pointer(
            AND idle_recap_turn_generation = $3
            AND idle_recap_message_id = $4
            AND idle_recap_channel_id = $5
+           AND instance_id IS NOT DISTINCT FROM $6
            AND COALESCE(idle_recap_posted_at >= COALESCE(last_heartbeat, created_at), false)",
     )
     .bind(&target.session_key)
@@ -506,6 +556,7 @@ async fn claim_recap_compact_pointer(
     .bind(target.turn_generation)
     .bind(message_id as i64)
     .bind(channel_id as i64)
+    .bind(target.owner_instance_id.as_deref())
     .execute(pool)
     .await
     .map(|result| result.rows_affected() == 1)
@@ -670,9 +721,10 @@ async fn lookup_recap_clear_target(
     channel_id: u64,
     provider: &str,
 ) -> Result<Option<RecapClearTarget>, sqlx::Error> {
-    let row = sqlx::query_as::<_, (String, String, i64, bool, bool, bool)>(
+    let row = sqlx::query_as::<_, (String, String, Option<String>, i64, bool, bool, bool)>(
         "SELECT session_key,
                 provider,
+                instance_id,
                 idle_recap_turn_generation,
                 idle_recap_channel_id = $2 AS channel_matches,
                 provider = $3 AS provider_matches,
@@ -690,6 +742,7 @@ async fn lookup_recap_clear_target(
         |(
             session_key,
             provider,
+            owner_instance_id,
             turn_generation,
             channel_matches,
             provider_matches,
@@ -697,6 +750,7 @@ async fn lookup_recap_clear_target(
         )| RecapClearTarget {
             session_key,
             provider,
+            owner_instance_id,
             turn_generation,
             channel_matches,
             provider_matches,
@@ -739,6 +793,7 @@ mod tests {
         RecapClearTarget {
             session_key: session_key.to_string(),
             provider: "claude".to_string(),
+            owner_instance_id: Some("mac-mini-release".to_string()),
             turn_generation: 7,
             channel_matches: true,
             provider_matches: true,
@@ -752,6 +807,8 @@ mod tests {
         let observed = injected.clone();
         let outcome = run_native_compact_once(
             recap_target("claude/token/mac-mini:old-bound-session"),
+            "mac-mini",
+            "mac-mini-release",
             || async { Ok(true) },
             |target| std::future::ready(target == "old-bound-session"),
             move |request| {
@@ -775,6 +832,8 @@ mod tests {
         let observed = injection_calls.clone();
         let outcome = run_native_compact_once(
             recap_target("claude/token/mac-mini:old-bound-session"),
+            "mac-mini",
+            "mac-mini-release",
             || async { Ok(true) },
             |target| std::future::ready(target == "new-current-session"),
             move |_| {
@@ -796,35 +855,144 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_compact_claims_allow_exactly_one_injection() {
-        let claimed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let injections = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let claim_barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let claimed = std::sync::Arc::new(AtomicBool::new(false));
+        let claims_in_flight = std::sync::Arc::new(AtomicUsize::new(0));
+        let max_claims_in_flight = std::sync::Arc::new(AtomicUsize::new(0));
+        let injections = std::sync::Arc::new(AtomicUsize::new(0));
         let run = || {
+            let claim_barrier = claim_barrier.clone();
             let claimed = claimed.clone();
+            let claims_in_flight = claims_in_flight.clone();
+            let max_claims_in_flight = max_claims_in_flight.clone();
             let injections = injections.clone();
             run_native_compact_once(
                 recap_target("mac-mini:claimed-session"),
+                "mac-mini",
+                "mac-mini-release",
                 move || async move {
-                    Ok(claimed
-                        .compare_exchange(
-                            false,
-                            true,
-                            std::sync::atomic::Ordering::SeqCst,
-                            std::sync::atomic::Ordering::SeqCst,
-                        )
-                        .is_ok())
+                    let in_flight = claims_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_claims_in_flight.fetch_max(in_flight, Ordering::SeqCst);
+                    claim_barrier.wait().await;
+                    let won = claimed
+                        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                        .is_ok();
+                    claims_in_flight.fetch_sub(1, Ordering::SeqCst);
+                    Ok(won)
                 },
                 |_| async { true },
                 move |_| async move {
-                    injections.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    injections.fetch_add(1, Ordering::SeqCst);
                     Ok(())
                 },
             )
         };
 
         let (first, second) = tokio::join!(run(), run());
-        assert!(matches!(first, RecapCompactOutcome::Started(_)));
-        assert_eq!(second, RecapCompactOutcome::AlreadyClaimed);
-        assert_eq!(injections.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let outcomes = [first, second];
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, RecapCompactOutcome::Started(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, RecapCompactOutcome::AlreadyClaimed))
+                .count(),
+            1
+        );
+        assert_eq!(max_claims_in_flight.load(Ordering::SeqCst), 2);
+        assert_eq!(injections.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn foreign_session_identity_preserves_pointer_without_claim_or_injection() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let claim_calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let pointer_consumed = std::sync::Arc::new(AtomicBool::new(false));
+        let live_checks = std::sync::Arc::new(AtomicUsize::new(0));
+        let injections = std::sync::Arc::new(AtomicUsize::new(0));
+        let outcome = run_native_compact_once(
+            recap_target("claude/token/mac-book:foo"),
+            "mac-mini",
+            "mac-mini-release",
+            {
+                let claim_calls = claim_calls.clone();
+                let pointer_consumed = pointer_consumed.clone();
+                move || async move {
+                    claim_calls.fetch_add(1, Ordering::SeqCst);
+                    pointer_consumed.store(true, Ordering::SeqCst);
+                    Ok(true)
+                }
+            },
+            {
+                let live_checks = live_checks.clone();
+                move |_| {
+                    live_checks.fetch_add(1, Ordering::SeqCst);
+                    async { true }
+                }
+            },
+            {
+                let injections = injections.clone();
+                move |_| async move {
+                    injections.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            RecapCompactOutcome::RoutingUnavailable {
+                owner_instance_id: Some("mac-mini-release".to_string()),
+                reason: "session_key_host_mismatch".to_string(),
+            }
+        );
+        assert!(outcome.preserves_recap_card());
+        assert_eq!(claim_calls.load(Ordering::SeqCst), 0);
+        assert!(!pointer_consumed.load(Ordering::SeqCst));
+        assert_eq!(live_checks.load(Ordering::SeqCst), 0);
+        assert_eq!(injections.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn foreign_or_missing_owner_never_claims_local_host_target() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        for owner_instance_id in [Some("mac-book-release".to_string()), None] {
+            let mut target = recap_target("claude/token/mac-mini:foo");
+            target.owner_instance_id = owner_instance_id.clone();
+            let claim_calls = std::sync::Arc::new(AtomicUsize::new(0));
+            let observed_claims = claim_calls.clone();
+            let outcome = run_native_compact_once(
+                target,
+                "mac-mini",
+                "mac-mini-release",
+                move || {
+                    observed_claims.fetch_add(1, Ordering::SeqCst);
+                    async { Ok(true) }
+                },
+                |_| async { true },
+                |_| async { Ok(()) },
+            )
+            .await;
+
+            assert!(matches!(
+                outcome,
+                RecapCompactOutcome::RoutingUnavailable {
+                    owner_instance_id: ref observed_owner,
+                    ..
+                } if observed_owner == &owner_instance_id
+            ));
+            assert_eq!(claim_calls.load(Ordering::SeqCst), 0);
+        }
     }
 
     #[tokio::test]
@@ -833,6 +1001,8 @@ mod tests {
         let observed = claim_calls.clone();
         let first = run_native_compact_once(
             recap_target("mac-mini:claimed-session"),
+            "mac-mini",
+            "mac-mini-release",
             move || {
                 observed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 async { Ok(true) }
@@ -845,6 +1015,8 @@ mod tests {
         let observed_retries = retried_injections.clone();
         let retry = run_native_compact_once(
             recap_target("mac-mini:claimed-session"),
+            "mac-mini",
+            "mac-mini-release",
             || async { Ok(false) },
             |_| async { true },
             move |_| {
@@ -873,6 +1045,8 @@ mod tests {
         let observed = injection_calls.clone();
         let outcome = run_native_compact_once(
             recap_target("mac-mini:claimed-session"),
+            "mac-mini",
+            "mac-mini-release",
             || async { Err("database unavailable".to_string()) },
             |_| async { true },
             move |_| {
@@ -887,6 +1061,129 @@ mod tests {
             RecapCompactOutcome::ClaimFailed("database unavailable".to_string())
         );
         assert_eq!(injection_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    async fn seed_recap_compact_session_pg(
+        pool: &PgPool,
+        target: &RecapClearTarget,
+        message_id: u64,
+        channel_id: u64,
+    ) {
+        sqlx::query(
+            "INSERT INTO sessions (
+                session_key,
+                provider,
+                instance_id,
+                idle_recap_turn_generation,
+                idle_recap_message_id,
+                idle_recap_channel_id,
+                idle_recap_posted_at,
+                last_heartbeat
+             ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())",
+        )
+        .bind(&target.session_key)
+        .bind(&target.provider)
+        .bind(target.owner_instance_id.as_deref())
+        .bind(target.turn_generation)
+        .bind(message_id as i64)
+        .bind(channel_id as i64)
+        .execute(pool)
+        .await
+        .expect("seed recap compact session");
+    }
+
+    #[tokio::test]
+    async fn concurrent_recap_compact_claim_pg_consumes_exactly_once() {
+        let Some(pg_db) = crate::dispatch::test_support::DispatchPostgresTestDb::try_create(
+            "adk_recap_claim",
+            "idle recap compact concurrent claim test",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = pg_db.connect_and_migrate_with_max_connections(2).await;
+        let target = recap_target("claude/token/mac-mini:pg-claimed-session");
+        let message_id = 42;
+        let channel_id = 84;
+        seed_recap_compact_session_pg(&pool, &target, message_id, channel_id).await;
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let claim = || {
+            let pool = pool.clone();
+            let target = target.clone();
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                claim_recap_compact_pointer(&pool, &target, message_id, channel_id)
+                    .await
+                    .expect("claim recap compact pointer")
+            }
+        };
+        let (first, second) = tokio::join!(claim(), claim());
+
+        assert_eq!([first, second].into_iter().filter(|claimed| *claimed).count(), 1);
+        let pointer = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+            "SELECT idle_recap_message_id, idle_recap_channel_id
+             FROM sessions
+             WHERE session_key = $1",
+        )
+        .bind(&target.session_key)
+        .fetch_one(&pool)
+        .await
+        .expect("load claimed recap compact pointer");
+        assert_eq!(pointer, (None, None));
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn recap_compact_claim_pg_rejects_owner_handoff_without_consuming_pointer() {
+        let Some(pg_db) = crate::dispatch::test_support::DispatchPostgresTestDb::try_create(
+            "adk_recap_owner",
+            "idle recap compact owner handoff fence test",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = pg_db.connect_and_migrate().await;
+        let target = recap_target("claude/token/mac-mini:pg-owner-session");
+        let message_id = 43;
+        let channel_id = 85;
+        seed_recap_compact_session_pg(&pool, &target, message_id, channel_id).await;
+        sqlx::query("UPDATE sessions SET instance_id = 'mac-book-release' WHERE session_key = $1")
+            .bind(&target.session_key)
+            .execute(&pool)
+            .await
+            .expect("handoff recap compact owner");
+
+        assert!(
+            !claim_recap_compact_pointer(&pool, &target, message_id, channel_id)
+                .await
+                .expect("owner-fenced recap compact claim")
+        );
+        let pointer = sqlx::query_as::<_, (Option<i64>, Option<i64>, Option<String>)>(
+            "SELECT idle_recap_message_id, idle_recap_channel_id, instance_id
+             FROM sessions
+             WHERE session_key = $1",
+        )
+        .bind(&target.session_key)
+        .fetch_one(&pool)
+        .await
+        .expect("load owner-fenced recap compact pointer");
+        assert_eq!(
+            pointer,
+            (
+                Some(message_id as i64),
+                Some(channel_id as i64),
+                Some("mac-book-release".to_string())
+            )
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
     }
 
     #[test]


### PR DESCRIPTION
## 요약 (#4557)
'맥락 압축' 버튼이 enqueue_internal_followup으로 /compact를 일반 텍스트 큐잉 → 슬래시 미실행·실제 미압축. 수정:
- `RecapPromptRoute` 순수 분류: compact → native slash(spawn_blocking + with_claude_tui_session_turn_lock + send_followup_prompt), suggest → 기존 경로 불변.
- effective provider(Claude)·live pane preflight, defer_ephemeral → edit_response 수명주기.
- 주입 성공시에만 recap pointer/카드 정리, 실패·JoinError는 보존(재시도 가능).

## 테스트 (뮤테이션 증명)
route 분류 3종(compact/suggest/unknown) — 분기 제거·오연결 시 각 assert 실패.

## 게이트
fmt/check/test/inventory/freshness/maintainability rc=0. (r1 컴파일 에러 3건 → 구현자 수정 후 재게이트 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)