### PR TITLE
fix(relay): 합성턴을 command-bot 소유 placeholder에 앵커 — 턴 병합/경계 소실 해소 (#4342, #4242)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -667,7 +667,7 @@
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 313 | 222 | 91 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1632 | 1387 | 245 | giant-file |
-| `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3188 | 2837 | 351 | giant-file |
+| `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3191 | 2837 | 354 | giant-file |
 | `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 696 | 601 | 95 |  |
 | `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 36 | 36 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 256 | 256 | 0 |  |
@@ -683,7 +683,7 @@
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 130 | 130 | 0 |  |
 | `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 526 | 526 | 0 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 907 | 299 | 608 |  |
-| `services::discord::runtime_bootstrap::framework_setup` | `src/services/discord/runtime_bootstrap/framework_setup.rs` | 350 | 326 | 24 |  |
+| `services::discord::runtime_bootstrap::framework_setup` | `src/services/discord/runtime_bootstrap/framework_setup.rs` | 347 | 323 | 24 |  |
 | `services::discord::runtime_bootstrap::gateway_lease` | `src/services/discord/runtime_bootstrap/gateway_lease.rs` | 587 | 587 | 0 |  |
 | `services::discord::runtime_bootstrap::gateway_runtime` | `src/services/discord/runtime_bootstrap/gateway_runtime.rs` | 148 | 148 | 0 |  |
 | `services::discord::runtime_bootstrap::intake` | `src/services/discord/runtime_bootstrap/intake.rs` | 83 | 83 | 0 |  |
@@ -722,7 +722,7 @@
 | `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2927 | 861 | 2066 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
-| `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |
+| `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 786 | 453 | 333 |  |
 | `services::discord::status_panel_orphan_store` | `src/services/discord/status_panel_orphan_store.rs` | 700 | 700 | 0 |  |
 | `services::discord::steering` | `src/services/discord/steering.rs` | 452 | 336 | 116 |  |
 | `services::discord::streaming_finalizer` | `src/services/discord/streaming_finalizer.rs` | 250 | 186 | 64 |  |
@@ -797,7 +797,7 @@
 | `services::discord::tui_direct_abort_marker::sweep` | `src/services/discord/tui_direct_abort_marker/sweep.rs` | 177 | 177 | 0 |  |
 | `services::discord::tui_direct_abort_marker::tombstone` | `src/services/discord/tui_direct_abort_marker/tombstone.rs` | 70 | 70 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 3815 | 1495 | 2320 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 917 | 917 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 919 | 919 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 454 | 218 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |
@@ -814,7 +814,7 @@
 | `services::discord::tui_prompt_relay::synthetic_orphan_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs` | 326 | 127 | 199 |  |
 | `services::discord::tui_prompt_relay::synthetic_start` | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 2416 | 1079 | 1337 | giant-file |
 | `services::discord::tui_prompt_relay::synthetic_start::stale_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs` | 433 | 433 | 0 |  |
-| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 206 | 206 | 0 |  |
+| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 293 | 293 | 0 |  |
 | `services::discord::tui_prompt_relay::task_notification_prompt` | `src/services/discord/tui_prompt_relay/task_notification_prompt.rs` | 230 | 230 | 0 |  |
 | `services::discord::tui_task_card` | `src/services/discord/tui_task_card.rs` | 1461 | 818 | 643 |  |
 | `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 997 | 997 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 25 | 25 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1523 | 971 | 552 |  |
+| `cli::args` | `src/cli/args.rs` | 1570 | 972 | 598 |  |
 | `cli::client` | `src/cli/client.rs` | 2722 | 2464 | 258 | giant-file |
 | `cli::client::runtime_config` | `src/cli/client/runtime_config.rs` | 55 | 23 | 32 |  |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |
@@ -434,7 +434,7 @@
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 981 | 855 | 126 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 1079 | 652 | 427 |  |
-| `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
+| `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1079 | 978 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
 | `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 3169 | 1792 | 1377 | giant-file |
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 291 | 291 | 0 |  |
@@ -545,7 +545,7 @@
 | `services::discord::model_catalog` | `src/services/discord/model_catalog.rs` | 946 | 946 | 0 |  |
 | `services::discord::model_picker_interaction` | `src/services/discord/model_picker_interaction.rs` | 370 | 370 | 0 |  |
 | `services::discord::monitoring_status` | `src/services/discord/monitoring_status.rs` | 386 | 386 | 0 |  |
-| `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 416 | 416 | 0 |  |
+| `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 412 | 412 | 0 |  |
 | `services::discord::org_writer` | `src/services/discord/org_writer.rs` | 169 | 169 | 0 |  |
 | `services::discord::outbound` | `src/services/discord/outbound/mod.rs` | 53 | 53 | 0 |  |
 | `services::discord::outbound::confirmation` | `src/services/discord/outbound/confirmation.rs` | 65 | 65 | 0 |  |
@@ -573,7 +573,7 @@
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |
 | `services::discord::placeholder_live_events::context_panel` | `src/services/discord/placeholder_live_events/context_panel.rs` | 72 | 72 | 0 |  |
-| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 187 | 86 | 101 |  |
+| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 210 | 101 | 109 |  |
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 322 | 322 | 0 |  |
 | `services::discord::placeholder_live_events::session_banner_claim` | `src/services/discord/placeholder_live_events/session_banner_claim.rs` | 91 | 91 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
@@ -587,7 +587,7 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 615 | 615 | 0 |  |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 687 | 687 | 0 |  |
 | `services::discord::prompt_builder::channel_recent_context` | `src/services/discord/prompt_builder/channel_recent_context.rs` | 419 | 200 | 219 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 498 | 299 | 199 |  |
@@ -647,7 +647,7 @@
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 102 | 102 | 0 |  |
 | `services::discord::restart_mode` | `src/services/discord/restart_mode.rs` | 32 | 32 | 0 |  |
 | `services::discord::restart_report` | `src/services/discord/restart_report.rs` | 438 | 438 | 0 |  |
-| `services::discord::role_map` | `src/services/discord/role_map.rs` | 665 | 665 | 0 |  |
+| `services::discord::role_map` | `src/services/discord/role_map.rs` | 661 | 661 | 0 |  |
 | `services::discord::router` | `src/services/discord/router/mod.rs` | 32 | 32 | 0 |  |
 | `services::discord::router::authorization` | `src/services/discord/router/authorization.rs` | 48 | 48 | 0 |  |
 | `services::discord::router::dispatch_trigger` | `src/services/discord/router/dispatch_trigger.rs` | 203 | 143 | 60 |  |
@@ -666,14 +666,14 @@
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 313 | 222 | 91 |  |
-| `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1632 | 1387 | 245 | giant-file |
+| `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1710 | 1387 | 323 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3191 | 2837 | 354 | giant-file |
 | `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 696 | 601 | 95 |  |
 | `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 36 | 36 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 256 | 256 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::latency_spans` | `src/services/discord/router/message_handler/latency_spans.rs` | 230 | 158 | 72 |  |
-| `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 758 | 601 | 157 |  |
+| `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 760 | 601 | 159 |  |
 | `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 996 | 970 | 26 |  |
 | `services::discord::router::message_handler::turn_lifecycle` | `src/services/discord/router/message_handler/turn_lifecycle.rs` | 183 | 183 | 0 |  |
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
@@ -710,8 +710,8 @@
 | `services::discord::session_runtime::channel_routing` | `src/services/discord/session_runtime/channel_routing.rs` | 253 | 240 | 13 |  |
 | `services::discord::session_runtime::restore_cwd` | `src/services/discord/session_runtime/restore_cwd.rs` | 353 | 353 | 0 |  |
 | `services::discord::session_runtime::worktree` | `src/services/discord/session_runtime/worktree.rs` | 601 | 601 | 0 |  |
-| `services::discord::settings` | `src/services/discord/settings.rs` | 345 | 345 | 0 |  |
-| `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 539 | 506 | 33 |  |
+| `services::discord::settings` | `src/services/discord/settings.rs` | 346 | 346 | 0 |  |
+| `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 749 | 612 | 137 |  |
 | `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 205 | 153 | 52 |  |
 | `services::discord::settings::read` | `src/services/discord/settings/read.rs` | 449 | 449 | 0 |  |
 | `services::discord::settings::validation` | `src/services/discord/settings/validation.rs` | 520 | 258 | 262 |  |
@@ -719,7 +719,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2927 | 861 | 2066 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2938 | 861 | 2077 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 844 | 485 | 359 |  |
@@ -748,7 +748,7 @@
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 190 | 190 | 0 |  |
 | `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1332 | 764 | 568 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 347 | 200 | 147 |  |
-| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1377 | 348 | 1029 |  |
+| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1378 | 348 | 1030 |  |
 | `services::discord::tmux_placeholder_suppression::evidence` | `src/services/discord/tmux_placeholder_suppression/evidence.rs` | 259 | 259 | 0 |  |
 | `services::discord::tmux_placeholder_suppression::ops` | `src/services/discord/tmux_placeholder_suppression/ops.rs` | 584 | 584 | 0 |  |
 | `services::discord::tmux_reaper` | `src/services/discord/tmux_reaper.rs` | 1222 | 886 | 336 |  |
@@ -827,7 +827,7 @@
 | `services::discord::turn_bridge::completion_guard::completion_postgres` | `src/services/discord/turn_bridge/completion_guard/completion_postgres.rs` | 644 | 548 | 96 |  |
 | `services::discord::turn_bridge::completion_postlude` | `src/services/discord/turn_bridge/completion_postlude.rs` | 935 | 935 | 0 |  |
 | `services::discord::turn_bridge::context_window` | `src/services/discord/turn_bridge/context_window.rs` | 169 | 100 | 69 |  |
-| `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 71 | 71 | 0 |  |
+| `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 62 | 62 | 0 |  |
 | `services::discord::turn_bridge::finalize_epilogue` | `src/services/discord/turn_bridge/finalize_epilogue.rs` | 306 | 156 | 150 |  |
 | `services::discord::turn_bridge::followup_requeue` | `src/services/discord/turn_bridge/followup_requeue.rs` | 62 | 62 | 0 |  |
 | `services::discord::turn_bridge::guards` | `src/services/discord/turn_bridge/guards.rs` | 76 | 76 | 0 |  |
@@ -835,7 +835,7 @@
 | `services::discord::turn_bridge::memory_lifecycle` | `src/services/discord/turn_bridge/memory_lifecycle.rs` | 411 | 303 | 108 |  |
 | `services::discord::turn_bridge::output_lifecycle` | `src/services/discord/turn_bridge/output_lifecycle.rs` | 75 | 28 | 47 |  |
 | `services::discord::turn_bridge::panel_lifecycle` | `src/services/discord/turn_bridge/panel_lifecycle.rs` | 236 | 236 | 0 |  |
-| `services::discord::turn_bridge::post_loop_finalize` | `src/services/discord/turn_bridge/post_loop_finalize.rs` | 726 | 726 | 0 |  |
+| `services::discord::turn_bridge::post_loop_finalize` | `src/services/discord/turn_bridge/post_loop_finalize.rs` | 677 | 677 | 0 |  |
 | `services::discord::turn_bridge::recall_feedback` | `src/services/discord/turn_bridge/recall_feedback.rs` | 482 | 372 | 110 |  |
 | `services::discord::turn_bridge::recovery_text` | `src/services/discord/turn_bridge/recovery_text.rs` | 841 | 595 | 246 |  |
 | `services::discord::turn_bridge::response_delivery` | `src/services/discord/turn_bridge/response_delivery.rs` | 222 | 93 | 129 |  |
@@ -873,7 +873,7 @@
 | `services::discord::turn_bridge::turn_analytics` | `src/services/discord/turn_bridge/turn_analytics.rs` | 419 | 348 | 71 |  |
 | `services::discord::turn_bridge::two_message_panel` | `src/services/discord/turn_bridge/two_message_panel.rs` | 801 | 270 | 531 |  |
 | `services::discord::turn_bridge::voice_completion` | `src/services/discord/turn_bridge/voice_completion.rs` | 385 | 385 | 0 |  |
-| `services::discord::turn_bridge::watcher_handoff` | `src/services/discord/turn_bridge/watcher_handoff.rs` | 935 | 532 | 403 |  |
+| `services::discord::turn_bridge::watcher_handoff` | `src/services/discord/turn_bridge/watcher_handoff.rs` | 200 | 138 | 62 |  |
 | `services::discord::turn_bridge::watcher_orphan_cleanup` | `src/services/discord/turn_bridge/watcher_orphan_cleanup.rs` | 475 | 233 | 242 |  |
 | `services::discord::turn_completion_events` | `src/services/discord/turn_completion_events.rs` | 85 | 85 | 0 |  |
 | `services::discord::turn_end_wip_warning` | `src/services/discord/turn_end_wip_warning.rs` | 382 | 193 | 189 |  |
@@ -1053,8 +1053,8 @@
 | `services::session_backend::terminal_usage` | `src/services/session_backend/terminal_usage.rs` | 212 | 106 | 106 |  |
 | `services::session_forwarding` | `src/services/session_forwarding.rs` | 493 | 315 | 178 |  |
 | `services::session_selector_validity` | `src/services/session_selector_validity.rs` | 395 | 149 | 246 |  |
-| `services::settings` | `src/services/settings.rs` | 1566 | 1059 | 507 | giant-file |
-| `services::settings::runtime_config_put` | `src/services/settings/runtime_config_put.rs` | 27 | 27 | 0 |  |
+| `services::settings` | `src/services/settings.rs` | 1735 | 1102 | 633 | giant-file |
+| `services::settings::runtime_config_put` | `src/services/settings/runtime_config_put.rs` | 44 | 44 | 0 |  |
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 25 | 25 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1570 | 972 | 598 |  |
+| `cli::args` | `src/cli/args.rs` | 1523 | 971 | 552 |  |
 | `cli::client` | `src/cli/client.rs` | 2722 | 2464 | 258 | giant-file |
 | `cli::client::runtime_config` | `src/cli/client/runtime_config.rs` | 55 | 23 | 32 |  |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |
@@ -434,7 +434,7 @@
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
 | `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 981 | 855 | 126 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 1079 | 652 | 427 |  |
-| `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1079 | 978 | 101 |  |
+| `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1083 | 982 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |
 | `services::discord::catch_up` | `src/services/discord/catch_up.rs` | 3169 | 1792 | 1377 | giant-file |
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 291 | 291 | 0 |  |
@@ -545,7 +545,7 @@
 | `services::discord::model_catalog` | `src/services/discord/model_catalog.rs` | 946 | 946 | 0 |  |
 | `services::discord::model_picker_interaction` | `src/services/discord/model_picker_interaction.rs` | 370 | 370 | 0 |  |
 | `services::discord::monitoring_status` | `src/services/discord/monitoring_status.rs` | 386 | 386 | 0 |  |
-| `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 412 | 412 | 0 |  |
+| `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 416 | 416 | 0 |  |
 | `services::discord::org_writer` | `src/services/discord/org_writer.rs` | 169 | 169 | 0 |  |
 | `services::discord::outbound` | `src/services/discord/outbound/mod.rs` | 53 | 53 | 0 |  |
 | `services::discord::outbound::confirmation` | `src/services/discord/outbound/confirmation.rs` | 65 | 65 | 0 |  |
@@ -573,7 +573,7 @@
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |
 | `services::discord::placeholder_live_events::context_panel` | `src/services/discord/placeholder_live_events/context_panel.rs` | 72 | 72 | 0 |  |
-| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 210 | 101 | 109 |  |
+| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 187 | 86 | 101 |  |
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 322 | 322 | 0 |  |
 | `services::discord::placeholder_live_events::session_banner_claim` | `src/services/discord/placeholder_live_events/session_banner_claim.rs` | 91 | 91 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
@@ -587,7 +587,7 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1315 | 1020 | 295 | giant-file |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 687 | 687 | 0 |  |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 615 | 615 | 0 |  |
 | `services::discord::prompt_builder::channel_recent_context` | `src/services/discord/prompt_builder/channel_recent_context.rs` | 419 | 200 | 219 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |
 | `services::discord::prompt_builder::layer_rendering` | `src/services/discord/prompt_builder/layer_rendering.rs` | 498 | 299 | 199 |  |
@@ -647,7 +647,7 @@
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 102 | 102 | 0 |  |
 | `services::discord::restart_mode` | `src/services/discord/restart_mode.rs` | 32 | 32 | 0 |  |
 | `services::discord::restart_report` | `src/services/discord/restart_report.rs` | 438 | 438 | 0 |  |
-| `services::discord::role_map` | `src/services/discord/role_map.rs` | 661 | 661 | 0 |  |
+| `services::discord::role_map` | `src/services/discord/role_map.rs` | 665 | 665 | 0 |  |
 | `services::discord::router` | `src/services/discord/router/mod.rs` | 32 | 32 | 0 |  |
 | `services::discord::router::authorization` | `src/services/discord/router/authorization.rs` | 48 | 48 | 0 |  |
 | `services::discord::router::dispatch_trigger` | `src/services/discord/router/dispatch_trigger.rs` | 203 | 143 | 60 |  |
@@ -666,14 +666,14 @@
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 313 | 222 | 91 |  |
-| `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1710 | 1387 | 323 | giant-file |
-| `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3166 | 2837 | 329 | giant-file |
+| `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1632 | 1387 | 245 | giant-file |
+| `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3188 | 2837 | 351 | giant-file |
 | `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 696 | 601 | 95 |  |
 | `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 36 | 36 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 256 | 256 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::latency_spans` | `src/services/discord/router/message_handler/latency_spans.rs` | 230 | 158 | 72 |  |
-| `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 760 | 601 | 159 |  |
+| `services::discord::router::message_handler::provider_isolation` | `src/services/discord/router/message_handler/provider_isolation.rs` | 758 | 601 | 157 |  |
 | `services::discord::router::message_handler::tui_followup` | `src/services/discord/router/message_handler/tui_followup.rs` | 996 | 970 | 26 |  |
 | `services::discord::router::message_handler::turn_lifecycle` | `src/services/discord/router/message_handler/turn_lifecycle.rs` | 183 | 183 | 0 |  |
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
@@ -710,8 +710,8 @@
 | `services::discord::session_runtime::channel_routing` | `src/services/discord/session_runtime/channel_routing.rs` | 253 | 240 | 13 |  |
 | `services::discord::session_runtime::restore_cwd` | `src/services/discord/session_runtime/restore_cwd.rs` | 353 | 353 | 0 |  |
 | `services::discord::session_runtime::worktree` | `src/services/discord/session_runtime/worktree.rs` | 601 | 601 | 0 |  |
-| `services::discord::settings` | `src/services/discord/settings.rs` | 346 | 346 | 0 |  |
-| `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 749 | 612 | 137 |  |
+| `services::discord::settings` | `src/services/discord/settings.rs` | 345 | 345 | 0 |  |
+| `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 539 | 506 | 33 |  |
 | `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 205 | 153 | 52 |  |
 | `services::discord::settings::read` | `src/services/discord/settings/read.rs` | 449 | 449 | 0 |  |
 | `services::discord::settings::validation` | `src/services/discord/settings/validation.rs` | 520 | 258 | 262 |  |
@@ -719,7 +719,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2938 | 861 | 2077 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2927 | 861 | 2066 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 541 | 324 | 217 |  |
@@ -748,7 +748,7 @@
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 190 | 190 | 0 |  |
 | `services::discord::tmux_output_stream` | `src/services/discord/tmux_output_stream.rs` | 1332 | 764 | 568 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 347 | 200 | 147 |  |
-| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1378 | 348 | 1030 |  |
+| `services::discord::tmux_placeholder_suppression` | `src/services/discord/tmux_placeholder_suppression/mod.rs` | 1377 | 348 | 1029 |  |
 | `services::discord::tmux_placeholder_suppression::evidence` | `src/services/discord/tmux_placeholder_suppression/evidence.rs` | 259 | 259 | 0 |  |
 | `services::discord::tmux_placeholder_suppression::ops` | `src/services/discord/tmux_placeholder_suppression/ops.rs` | 584 | 584 | 0 |  |
 | `services::discord::tmux_reaper` | `src/services/discord/tmux_reaper.rs` | 1222 | 886 | 336 |  |
@@ -797,7 +797,7 @@
 | `services::discord::tui_direct_abort_marker::sweep` | `src/services/discord/tui_direct_abort_marker/sweep.rs` | 177 | 177 | 0 |  |
 | `services::discord::tui_direct_abort_marker::tombstone` | `src/services/discord/tui_direct_abort_marker/tombstone.rs` | 70 | 70 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 3815 | 1495 | 2320 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 907 | 907 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 917 | 917 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 454 | 218 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |
@@ -814,7 +814,7 @@
 | `services::discord::tui_prompt_relay::synthetic_orphan_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs` | 326 | 127 | 199 |  |
 | `services::discord::tui_prompt_relay::synthetic_start` | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 2416 | 1079 | 1337 | giant-file |
 | `services::discord::tui_prompt_relay::synthetic_start::stale_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs` | 433 | 433 | 0 |  |
-| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 137 | 137 | 0 |  |
+| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 206 | 206 | 0 |  |
 | `services::discord::tui_prompt_relay::task_notification_prompt` | `src/services/discord/tui_prompt_relay/task_notification_prompt.rs` | 230 | 230 | 0 |  |
 | `services::discord::tui_task_card` | `src/services/discord/tui_task_card.rs` | 1461 | 818 | 643 |  |
 | `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 997 | 997 | 0 |  |
@@ -827,7 +827,7 @@
 | `services::discord::turn_bridge::completion_guard::completion_postgres` | `src/services/discord/turn_bridge/completion_guard/completion_postgres.rs` | 644 | 548 | 96 |  |
 | `services::discord::turn_bridge::completion_postlude` | `src/services/discord/turn_bridge/completion_postlude.rs` | 935 | 935 | 0 |  |
 | `services::discord::turn_bridge::context_window` | `src/services/discord/turn_bridge/context_window.rs` | 169 | 100 | 69 |  |
-| `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 62 | 62 | 0 |  |
+| `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 71 | 71 | 0 |  |
 | `services::discord::turn_bridge::finalize_epilogue` | `src/services/discord/turn_bridge/finalize_epilogue.rs` | 306 | 156 | 150 |  |
 | `services::discord::turn_bridge::followup_requeue` | `src/services/discord/turn_bridge/followup_requeue.rs` | 62 | 62 | 0 |  |
 | `services::discord::turn_bridge::guards` | `src/services/discord/turn_bridge/guards.rs` | 76 | 76 | 0 |  |
@@ -835,7 +835,7 @@
 | `services::discord::turn_bridge::memory_lifecycle` | `src/services/discord/turn_bridge/memory_lifecycle.rs` | 411 | 303 | 108 |  |
 | `services::discord::turn_bridge::output_lifecycle` | `src/services/discord/turn_bridge/output_lifecycle.rs` | 75 | 28 | 47 |  |
 | `services::discord::turn_bridge::panel_lifecycle` | `src/services/discord/turn_bridge/panel_lifecycle.rs` | 236 | 236 | 0 |  |
-| `services::discord::turn_bridge::post_loop_finalize` | `src/services/discord/turn_bridge/post_loop_finalize.rs` | 677 | 677 | 0 |  |
+| `services::discord::turn_bridge::post_loop_finalize` | `src/services/discord/turn_bridge/post_loop_finalize.rs` | 726 | 726 | 0 |  |
 | `services::discord::turn_bridge::recall_feedback` | `src/services/discord/turn_bridge/recall_feedback.rs` | 482 | 372 | 110 |  |
 | `services::discord::turn_bridge::recovery_text` | `src/services/discord/turn_bridge/recovery_text.rs` | 841 | 595 | 246 |  |
 | `services::discord::turn_bridge::response_delivery` | `src/services/discord/turn_bridge/response_delivery.rs` | 222 | 93 | 129 |  |
@@ -873,7 +873,7 @@
 | `services::discord::turn_bridge::turn_analytics` | `src/services/discord/turn_bridge/turn_analytics.rs` | 419 | 348 | 71 |  |
 | `services::discord::turn_bridge::two_message_panel` | `src/services/discord/turn_bridge/two_message_panel.rs` | 801 | 270 | 531 |  |
 | `services::discord::turn_bridge::voice_completion` | `src/services/discord/turn_bridge/voice_completion.rs` | 385 | 385 | 0 |  |
-| `services::discord::turn_bridge::watcher_handoff` | `src/services/discord/turn_bridge/watcher_handoff.rs` | 200 | 138 | 62 |  |
+| `services::discord::turn_bridge::watcher_handoff` | `src/services/discord/turn_bridge/watcher_handoff.rs` | 935 | 532 | 403 |  |
 | `services::discord::turn_bridge::watcher_orphan_cleanup` | `src/services/discord/turn_bridge/watcher_orphan_cleanup.rs` | 475 | 233 | 242 |  |
 | `services::discord::turn_completion_events` | `src/services/discord/turn_completion_events.rs` | 85 | 85 | 0 |  |
 | `services::discord::turn_end_wip_warning` | `src/services/discord/turn_end_wip_warning.rs` | 382 | 193 | 189 |  |
@@ -1053,8 +1053,8 @@
 | `services::session_backend::terminal_usage` | `src/services/session_backend/terminal_usage.rs` | 212 | 106 | 106 |  |
 | `services::session_forwarding` | `src/services/session_forwarding.rs` | 493 | 315 | 178 |  |
 | `services::session_selector_validity` | `src/services/session_selector_validity.rs` | 395 | 149 | 246 |  |
-| `services::settings` | `src/services/settings.rs` | 1735 | 1102 | 633 | giant-file |
-| `services::settings::runtime_config_put` | `src/services/settings/runtime_config_put.rs` | 44 | 44 | 0 |  |
+| `services::settings` | `src/services/settings.rs` | 1566 | 1059 | 507 | giant-file |
+| `services::settings::runtime_config_put` | `src/services/settings/runtime_config_put.rs` | 27 | 27 | 0 |  |
 | `services::shell_guard` | `src/services/shell_guard.rs` | 419 | 419 | 0 |  |
 | `services::slo` | `src/services/slo/mod.rs` | 535 | 508 | 27 |  |
 | `services::termination_audit` | `src/services/termination_audit.rs` | 192 | 192 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -797,7 +797,7 @@
 | `services::discord::tui_direct_abort_marker::sweep` | `src/services/discord/tui_direct_abort_marker/sweep.rs` | 177 | 177 | 0 |  |
 | `services::discord::tui_direct_abort_marker::tombstone` | `src/services/discord/tui_direct_abort_marker/tombstone.rs` | 70 | 70 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 3815 | 1495 | 2320 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 919 | 919 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 903 | 903 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 454 | 218 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |
@@ -814,7 +814,7 @@
 | `services::discord::tui_prompt_relay::synthetic_orphan_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs` | 326 | 127 | 199 |  |
 | `services::discord::tui_prompt_relay::synthetic_start` | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 2416 | 1079 | 1337 | giant-file |
 | `services::discord::tui_prompt_relay::synthetic_start::stale_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs` | 433 | 433 | 0 |  |
-| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 293 | 293 | 0 |  |
+| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 328 | 328 | 0 |  |
 | `services::discord::tui_prompt_relay::task_notification_prompt` | `src/services/discord/tui_prompt_relay/task_notification_prompt.rs` | 230 | 230 | 0 |  |
 | `services::discord::tui_task_card` | `src/services/discord/tui_task_card.rs` | 1461 | 818 | 643 |  |
 | `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 997 | 997 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -566,7 +566,7 @@
 | `services::discord::outbound::source_registry` | `src/services/discord/outbound/source_registry.rs` | 247 | 159 | 88 |  |
 | `services::discord::outbound::transport` | `src/services/discord/outbound/transport.rs` | 431 | 431 | 0 |  |
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3467 | 1180 | 2287 | giant-file |
-| `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 686 | 424 | 262 |  |
+| `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
 | `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 941 | 573 | 368 |  |
 | `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 678 | 678 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
@@ -722,7 +722,7 @@
 | `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2927 | 861 | 2066 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
-| `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 786 | 453 | 333 |  |
+| `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 844 | 485 | 359 |  |
 | `services::discord::status_panel_orphan_store` | `src/services/discord/status_panel_orphan_store.rs` | 700 | 700 | 0 |  |
 | `services::discord::steering` | `src/services/discord/steering.rs` | 452 | 336 | 116 |  |
 | `services::discord::streaming_finalizer` | `src/services/discord/streaming_finalizer.rs` | 250 | 186 | 64 |  |
@@ -814,7 +814,7 @@
 | `services::discord::tui_prompt_relay::synthetic_orphan_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_orphan_reclaim.rs` | 326 | 127 | 199 |  |
 | `services::discord::tui_prompt_relay::synthetic_start` | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 2416 | 1079 | 1337 | giant-file |
 | `services::discord::tui_prompt_relay::synthetic_start::stale_reclaim` | `src/services/discord/tui_prompt_relay/synthetic_start/stale_reclaim.rs` | 433 | 433 | 0 |  |
-| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 328 | 328 | 0 |  |
+| `services::discord::tui_prompt_relay::synthetic_start_wiring` | `src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs` | 358 | 358 | 0 |  |
 | `services::discord::tui_prompt_relay::task_notification_prompt` | `src/services/discord/tui_prompt_relay/task_notification_prompt.rs` | 230 | 230 | 0 |  |
 | `services::discord::tui_task_card` | `src/services/discord/tui_task_card.rs` | 1461 | 818 | 643 |  |
 | `services::discord::turn_bridge` | `src/services/discord/turn_bridge/mod.rs` | 997 | 997 | 0 |  |
@@ -966,7 +966,7 @@
 | `services::message_outbox_recovery_support` | `src/services/message_outbox_recovery_support.rs` | 138 | 138 | 0 |  |
 | `services::monitoring_store` | `src/services/monitoring_store.rs` | 141 | 141 | 0 |  |
 | `services::observability` | `src/services/observability/mod.rs` | 630 | 579 | 51 |  |
-| `services::observability::emit` | `src/services/observability/emit.rs` | 1225 | 772 | 453 |  |
+| `services::observability::emit` | `src/services/observability/emit.rs` | 1226 | 773 | 453 |  |
 | `services::observability::events` | `src/services/observability/events.rs` | 310 | 310 | 0 |  |
 | `services::observability::helpers` | `src/services/observability/helpers.rs` | 127 | 127 | 0 |  |
 | `services::observability::metrics` | `src/services/observability/metrics.rs` | 358 | 358 | 0 |  |

--- a/src/services/discord/placeholder_cleanup.rs
+++ b/src/services/discord/placeholder_cleanup.rs
@@ -391,13 +391,7 @@ pub(in crate::services::discord) fn terminal_cleanup_protects_delete(
     channel_id: ChannelId,
     message_id: MessageId,
 ) -> Option<TerminalCleanupDeleteProtection> {
-    if committed_terminal_anchor_protects_delete(
-        registry,
-        provider,
-        channel_id,
-        message_id,
-        None,
-    ) {
+    if committed_terminal_anchor_protects_delete(registry, provider, channel_id, message_id, None) {
         return Some(TerminalCleanupDeleteProtection::CommittedTerminal);
     }
     registry

--- a/src/services/discord/placeholder_cleanup.rs
+++ b/src/services/discord/placeholder_cleanup.rs
@@ -370,6 +370,41 @@ pub(in crate::services::discord) fn committed_terminal_anchor_protects_delete(
     registry.is_committed_terminal_anchor(provider, channel_id, message_id)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum TerminalCleanupDeleteProtection {
+    CommittedTerminal,
+    RetryPending,
+}
+
+impl TerminalCleanupDeleteProtection {
+    pub(in crate::services::discord) fn relay_delete_outcome(self) -> &'static str {
+        match self {
+            Self::CommittedTerminal => "skipped_committed_terminal",
+            Self::RetryPending => "skipped_terminal_retry_pending",
+        }
+    }
+}
+
+pub(in crate::services::discord) fn terminal_cleanup_protects_delete(
+    registry: &PlaceholderCleanupRegistry,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    message_id: MessageId,
+) -> Option<TerminalCleanupDeleteProtection> {
+    if committed_terminal_anchor_protects_delete(
+        registry,
+        provider,
+        channel_id,
+        message_id,
+        None,
+    ) {
+        return Some(TerminalCleanupDeleteProtection::CommittedTerminal);
+    }
+    registry
+        .terminal_cleanup_retry_pending(provider, channel_id, message_id)
+        .then_some(TerminalCleanupDeleteProtection::RetryPending)
+}
+
 /// #3607 panel-sweep terminal-anchor guard wrapper. Returns true (and emits the
 /// `skipped_committed_terminal` delete event + a log) when the orphan
 /// status-panel sweeper is about to delete a committed terminal anchor — so the
@@ -559,6 +594,54 @@ mod terminal_anchor_guard_tests {
             anchor(),
             None,
         ));
+    }
+
+    #[test]
+    fn terminal_cleanup_delete_protection_distinguishes_commit_and_retry() {
+        let committed = PlaceholderCleanupRegistry::default();
+        record(
+            &committed,
+            anchor(),
+            PlaceholderCleanupOperation::EditTerminal,
+            PlaceholderCleanupOutcome::Succeeded,
+        );
+        let committed_protection =
+            terminal_cleanup_protects_delete(&committed, &PROVIDER, channel(), anchor());
+        assert_eq!(
+            committed_protection,
+            Some(TerminalCleanupDeleteProtection::CommittedTerminal),
+        );
+        assert_eq!(
+            committed_protection.map(TerminalCleanupDeleteProtection::relay_delete_outcome),
+            Some("skipped_committed_terminal"),
+        );
+
+        let retry_pending = PlaceholderCleanupRegistry::default();
+        record(
+            &retry_pending,
+            anchor(),
+            PlaceholderCleanupOperation::EditTerminal,
+            PlaceholderCleanupOutcome::failed("transient terminal edit failure"),
+        );
+        let retry_protection =
+            terminal_cleanup_protects_delete(&retry_pending, &PROVIDER, channel(), anchor());
+        assert_eq!(
+            retry_protection,
+            Some(TerminalCleanupDeleteProtection::RetryPending),
+        );
+        assert_eq!(
+            retry_protection.map(TerminalCleanupDeleteProtection::relay_delete_outcome),
+            Some("skipped_terminal_retry_pending"),
+        );
+        assert_eq!(
+            terminal_cleanup_protects_delete(
+                &PlaceholderCleanupRegistry::default(),
+                &PROVIDER,
+                channel(),
+                anchor(),
+            ),
+            None,
+        );
     }
 
     #[test]

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2831,6 +2831,31 @@ pub(super) async fn handle_text_message(
 }
 
 #[cfg(test)]
+mod user_turn_placeholder_identity_tests {
+    #[test]
+    fn discord_user_turn_keeps_user_and_streaming_placeholder_ids_separate() {
+        let module_src = include_str!("intake_turn.rs");
+        let bridge_context_pos = module_src
+            .find("TurnBridgeContext {")
+            .expect("Discord intake builds a turn-bridge context");
+        let bridge_context = &module_src[bridge_context_pos..];
+
+        assert!(
+            bridge_context.contains("user_msg_id: Some(user_msg_id),"),
+            "Discord-origin user turns must retain the real user message as their request identity"
+        );
+        assert!(
+            bridge_context.contains("current_msg_id: Some(placeholder_msg_id),"),
+            "Discord-origin user turns must keep the posted intake placeholder as their streaming edit target"
+        );
+        assert!(
+            bridge_context.contains("is_external_input_tui_direct: false"),
+            "Discord-origin user turns must remain outside the synthetic TUI-direct path"
+        );
+    }
+}
+
+#[cfg(test)]
 mod recovery_context_take_order_tests {
     fn recovery_context_take_call() -> String {
         format!(

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2831,7 +2831,15 @@ pub(super) async fn handle_text_message(
 }
 
 #[cfg(test)]
-mod user_turn_placeholder_identity_tests {
+mod recovery_context_take_order_tests {
+    fn recovery_context_take_call() -> String {
+        format!(
+            "{}{}",
+            "let session_retry_context = ",
+            "take_session_retry_context(shared, channel_id, Some(&turn_id));"
+        )
+    }
+
     #[test]
     fn discord_user_turn_keeps_user_and_streaming_placeholder_ids_separate() {
         let module_src = include_str!("intake_turn.rs");
@@ -2852,17 +2860,6 @@ mod user_turn_placeholder_identity_tests {
             bridge_context.contains("is_external_input_tui_direct: false"),
             "Discord-origin user turns must remain outside the synthetic TUI-direct path"
         );
-    }
-}
-
-#[cfg(test)]
-mod recovery_context_take_order_tests {
-    fn recovery_context_take_call() -> String {
-        format!(
-            "{}{}",
-            "let session_retry_context = ",
-            "take_session_retry_context(shared, channel_id, Some(&turn_id));"
-        )
     }
 
     #[test]

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2847,17 +2847,20 @@ mod recovery_context_take_order_tests {
             .find("TurnBridgeContext {")
             .expect("Discord intake builds a turn-bridge context");
         let bridge_context = &module_src[bridge_context_pos..];
+        let user_message_field = format!("{}{}", "user_msg_id: Some(", "user_msg_id),");
+        let placeholder_field = format!("{}{}", "current_msg_id: Some(", "placeholder_msg_id),");
+        let synthetic_flag = format!("{}{}", "is_external_input_tui_", "direct: false");
 
         assert!(
-            bridge_context.contains("user_msg_id: Some(user_msg_id),"),
+            bridge_context.contains(&user_message_field),
             "Discord-origin user turns must retain the real user message as their request identity"
         );
         assert!(
-            bridge_context.contains("current_msg_id: Some(placeholder_msg_id),"),
+            bridge_context.contains(&placeholder_field),
             "Discord-origin user turns must keep the posted intake placeholder as their streaming edit target"
         );
         assert!(
-            bridge_context.contains("is_external_input_tui_direct: false"),
+            bridge_context.contains(&synthetic_flag),
             "Discord-origin user turns must remain outside the synthetic TUI-direct path"
         );
     }

--- a/src/services/discord/runtime_bootstrap/framework_setup.rs
+++ b/src/services/discord/runtime_bootstrap/framework_setup.rs
@@ -136,13 +136,10 @@ pub(super) async fn run_bot_framework_setup(
         provider_for_setup.clone(),
     );
 
-    // #3412 startup reclaim sweep: a restart drops the in-memory single-message
-    // panel registry, orphaning any panel the previous generation was still
-    // animating (frozen Tasks/footer spinner). This one-shot per-channel sweep
-    // finds those prior-generation messages (inflight anchor ids + a bounded
-    // recent-message read) and applies a single finalize edit that strips the
-    // animated footer and appends `⏹ (재시작으로 중단됨)`. Current-generation live
-    // panels carry a post-boot timestamp and are never touched.
+    // #3412/#4342 startup reclaim: independent bounded passes finalize prior-
+    // generation frozen panels after the boot settle window and later delete
+    // current-bot `...` placeholders left unlinked by a POST-before-persist
+    // crash. Both passes reload durable protections and fail closed on identity.
     super::startup_reclaim::spawn_startup_reclaim_sweep(
         ctx.http.clone(),
         shared_clone.clone(),

--- a/src/services/discord/startup_reclaim.rs
+++ b/src/services/discord/startup_reclaim.rs
@@ -280,6 +280,7 @@ async fn reclaim_frozen_panels(
 
 async fn reclaim_orphan_placeholders(
     http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: u64,
     bot_user_id: u64,
@@ -307,8 +308,38 @@ async fn reclaim_orphan_placeholders(
         ) {
             continue;
         }
+        let operation_kind =
+            super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal.as_str();
+        if let Some(protection) = super::placeholder_cleanup::terminal_cleanup_protects_delete(
+            &shared.ui.placeholder_cleanup,
+            provider,
+            channel,
+            msg.id,
+        ) {
+            crate::services::observability::emit_relay_delete(
+                provider.as_str(),
+                channel_id,
+                msg.id.get(),
+                None,
+                None,
+                "startup_reclaim_orphan_synthetic_placeholder",
+                operation_kind,
+                protection.relay_delete_outcome(),
+                None,
+            );
+            continue;
+        }
         attempted += 1;
-        match channel.delete_message(http, msg.id).await {
+        let result = channel.delete_message(http, msg.id).await;
+        crate::services::observability::emit_relay_delete_result(
+            provider.as_str(),
+            channel_id,
+            msg.id.get(),
+            "startup_reclaim_orphan_synthetic_placeholder",
+            operation_kind,
+            &result,
+        );
+        match result {
             Ok(()) => {
                 deleted += 1;
                 tracing::info!(
@@ -382,6 +413,7 @@ async fn run_startup_reclaim_sweep(
             ReclaimPass::OrphanPlaceholders => {
                 report.orphan_placeholders_deleted += reclaim_orphan_placeholders(
                     http,
+                    shared,
                     provider,
                     channel_id,
                     bot_user_id,
@@ -706,6 +738,32 @@ mod tests {
                 author, 7, content, message_id, changed, now, &protected,
             ));
         }
+    }
+
+    #[test]
+    fn orphan_placeholder_delete_is_terminal_cleanup_guarded() {
+        let module_src = include_str!("startup_reclaim.rs");
+        let guard_needle = ["terminal_cleanup_", "protects_delete("].concat();
+        let attempt_needle = ["attempted ", "+= 1;"].concat();
+        let delete_needle = [".delete_", "message(http, msg.id)"].concat();
+        let result_needle = ["emit_relay_delete_", "result("].concat();
+        let guard = module_src
+            .find(&guard_needle)
+            .expect("orphan reclaim must consult terminal cleanup protection");
+        let attempt = module_src
+            .find(&attempt_needle)
+            .expect("orphan reclaim must count destructive attempts");
+        let delete = module_src
+            .find(&delete_needle)
+            .expect("orphan reclaim must retain its bounded delete");
+        let result = module_src
+            .find(&result_needle)
+            .expect("orphan reclaim delete result must be durably observed");
+
+        assert!(
+            guard < attempt && attempt < delete && delete < result,
+            "committed and retry-pending terminal placeholders must be skipped before a delete attempt"
+        );
     }
 
     #[test]

--- a/src/services/discord/startup_reclaim.rs
+++ b/src/services/discord/startup_reclaim.rs
@@ -47,8 +47,7 @@ const RECLAIM_FETCH_LIMIT: u8 = 50;
 const ORPHAN_PLACEHOLDER_MIN_AGE_SECS: i64 = 5 * 60;
 const FROZEN_PANEL_RECLAIM_DELAY_SECS: u64 = 30;
 /// Wait one second beyond the strict age boundary before the orphan pass.
-const ORPHAN_PLACEHOLDER_RECLAIM_DELAY_SECS: u64 =
-    ORPHAN_PLACEHOLDER_MIN_AGE_SECS as u64 + 1;
+const ORPHAN_PLACEHOLDER_RECLAIM_DELAY_SECS: u64 = ORPHAN_PLACEHOLDER_MIN_AGE_SECS as u64 + 1;
 /// Bound destructive work per channel independently from the bounded read page.
 const ORPHAN_PLACEHOLDER_DELETE_LIMIT: usize = 10;
 
@@ -163,17 +162,14 @@ fn reclaim_scan_plan_from_rows(
             }
         }
         let updated = parse_updated_at_unix(&state.updated_at).unwrap_or(i64::MAX);
-        if updated < boot_unix_secs
-            && state.channel_id != 0
-            && frozen_seen.insert(state.channel_id)
+        if updated < boot_unix_secs && state.channel_id != 0 && frozen_seen.insert(state.channel_id)
         {
             plan.frozen_panel_channels.push(state.channel_id);
         }
     }
     for pending in pending_starts {
         if pending.provider == provider.as_str() && pending.anchor_message_id != 0 {
-            plan.protected_message_ids
-                .insert(pending.anchor_message_id);
+            plan.protected_message_ids.insert(pending.anchor_message_id);
         }
     }
     plan
@@ -634,13 +630,8 @@ mod tests {
             false,      // not committed → live
             false,      // real turn
         )];
-        let plan = reclaim_scan_plan_from_rows(
-            rows,
-            Vec::new(),
-            Vec::new(),
-            &ProviderKind::Claude,
-            boot,
-        );
+        let plan =
+            reclaim_scan_plan_from_rows(rows, Vec::new(), Vec::new(), &ProviderKind::Claude, boot);
         assert!(
             plan.frozen_panel_channels.contains(&555),
             "pre-boot row's channel is still a reclaim candidate"
@@ -665,13 +656,8 @@ mod tests {
             row_with(101, 8001, Some(8002), boot - 50, true, false), // committed
             row_with(102, 8101, Some(8102), boot - 50, false, true), // rebind-origin
         ];
-        let plan = reclaim_scan_plan_from_rows(
-            rows,
-            Vec::new(),
-            Vec::new(),
-            &ProviderKind::Claude,
-            boot,
-        );
+        let plan =
+            reclaim_scan_plan_from_rows(rows, Vec::new(), Vec::new(), &ProviderKind::Claude, boot);
         for id in [8001, 8002, 8101, 8102] {
             assert!(
                 !plan.live_anchor_ids.contains(&id),
@@ -687,13 +673,8 @@ mod tests {
         // a concurrent sweep of the same channel cannot clobber the live panel.
         let boot = 1_700_000_000i64;
         let rows = vec![row_with(303, 7001, Some(7002), boot + 5, false, false)];
-        let plan = reclaim_scan_plan_from_rows(
-            rows,
-            Vec::new(),
-            Vec::new(),
-            &ProviderKind::Claude,
-            boot,
-        );
+        let plan =
+            reclaim_scan_plan_from_rows(rows, Vec::new(), Vec::new(), &ProviderKind::Claude, boot);
         assert!(
             !plan.frozen_panel_channels.contains(&303),
             "post-boot row is current-gen, not a candidate"
@@ -722,13 +703,7 @@ mod tests {
             (7, "...", 9002, now - ORPHAN_PLACEHOLDER_MIN_AGE_SECS),
         ] {
             assert!(!is_orphan_placeholder_candidate(
-                author,
-                7,
-                content,
-                message_id,
-                changed,
-                now,
-                &protected,
+                author, 7, content, message_id, changed, now, &protected,
             ));
         }
     }

--- a/src/services/discord/startup_reclaim.rs
+++ b/src/services/discord/startup_reclaim.rs
@@ -12,26 +12,21 @@
 //!   * #3402 slot rehydration restores slots onto NEW panels, never editing the
 //!     old frozen message.
 //!
-//! This one-shot sweep runs once per channel at startup. It finds the prior
-//! generation's frozen panel via two combined sources and applies a single
-//! finalize edit that strips the animated footer and appends a static
-//! `⏹ (재시작으로 중단됨)` marker (body preserved verbatim, fences re-balanced):
-//!   1. Persisted inflight state (`discord_inflight/<provider>/<channel>.json`)
-//!      — the exact anchor / status-panel message ids of turns whose
-//!      `updated_at` predates this process boot (precise targets).
-//!   2. A bounded recent-message read of each such channel (serenity http,
-//!      limit ≤ 50, the same path `agentdesk discord read` uses) to catch any
-//!      self-authored message that still carries a frozen spinner and whose
-//!      Discord create/edit time predates boot.
+//! Two independent one-shot passes run at startup. After 30 seconds, the frozen-
+//! panel pass scans prior-generation inflight channels and applies one finalize
+//! edit that strips the animated footer and appends `⏹ (재시작으로 중단됨)`.
+//! After 301 seconds, the orphan-placeholder pass scans configured provider
+//! channels and deletes at most ten current-bot-authored messages per channel
+//! whose content is exactly `...`, age exceeds five minutes, and id is absent
+//! from freshly reloaded inflight and pending-start state. Each pass reads one
+//! recent-message page of at most 50 messages per channel.
 //!
-//! The current generation's live panels are never touched. Two ownership gates
-//! guard this (codex round-1 High-a): a message is finalized only when its
-//! Discord change-time predates `boot_unix_secs` AND its id is absent from the
-//! live-anchor exclusion set — the `current_msg_id`/`status_message_id` of every
-//! not-yet-committed inflight row, which covers anchors re-adopted by alive-tmux
-//! recovery without a Discord re-touch. The body must also parse as a TAIL-
-//! anchored frozen-spinner footer (codex round-1 High-b), and a per-channel guard
-//! blocks rescans.
+//! Current-generation panels and durable placeholder identities are never
+//! touched. Frozen panels must predate `boot_unix_secs`, be absent from the live-
+//! anchor exclusion set, and parse as a tail-anchored frozen-spinner footer.
+//! Exact-placeholder cleanup is separately guarded by bot authorship, age, and
+//! durable-link exclusion. Independent per-pass guards block rescans without
+//! letting the earlier frozen-panel pass suppress the delayed orphan pass.
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -48,20 +43,42 @@ use crate::services::provider::ProviderKind;
 /// catch-up path's `CATCH_UP_FETCH_LIMIT` so the spinner-bearing panel is on
 /// the page even after bursty bot activity. `limit` takes `u8` in serenity.
 const RECLAIM_FETCH_LIMIT: u8 = 50;
+/// Exact synthetic placeholders younger than this remain untouched.
+const ORPHAN_PLACEHOLDER_MIN_AGE_SECS: i64 = 5 * 60;
+const FROZEN_PANEL_RECLAIM_DELAY_SECS: u64 = 30;
+/// Wait one second beyond the strict age boundary before the orphan pass.
+const ORPHAN_PLACEHOLDER_RECLAIM_DELAY_SECS: u64 =
+    ORPHAN_PLACEHOLDER_MIN_AGE_SECS as u64 + 1;
+/// Bound destructive work per channel independently from the bounded read page.
+const ORPHAN_PLACEHOLDER_DELETE_LIMIT: usize = 10;
 
-/// One-shot guard: a `(provider, channel_id)` recorded here has already been
-/// reclaim-scanned this process lifetime and is never rescanned.
-fn reclaimed_channels() -> &'static Mutex<HashSet<(String, u64)>> {
-    static GUARD: OnceLock<Mutex<HashSet<(String, u64)>>> = OnceLock::new();
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum ReclaimPass {
+    FrozenPanels,
+    OrphanPlaceholders,
+}
+
+impl ReclaimPass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::FrozenPanels => "frozen_panels",
+            Self::OrphanPlaceholders => "orphan_placeholders",
+        }
+    }
+}
+
+/// One-shot guard per pass: a `(pass, provider, channel_id)` recorded here has
+/// already been scanned this process lifetime and is never rescanned.
+fn reclaimed_channels() -> &'static Mutex<HashSet<(ReclaimPass, String, u64)>> {
+    static GUARD: OnceLock<Mutex<HashSet<(ReclaimPass, String, u64)>>> = OnceLock::new();
     GUARD.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
-/// Record the one-shot guard for `(provider, channel_id)`. Returns `true` if
-/// this is the first claim (caller may proceed), `false` if already scanned.
-fn claim_channel_once(provider: &ProviderKind, channel_id: u64) -> bool {
+/// Record the one-shot guard for one pass and channel.
+fn claim_channel_once(pass: ReclaimPass, provider: &ProviderKind, channel_id: u64) -> bool {
     reclaimed_channels()
         .lock()
-        .map(|mut set| set.insert((provider.as_str().to_string(), channel_id)))
+        .map(|mut set| set.insert((pass, provider.as_str().to_string(), channel_id)))
         .unwrap_or(false)
 }
 
@@ -78,68 +95,85 @@ struct ReclaimReport {
     channels_scanned: usize,
     messages_finalized: usize,
     markers_replaced: usize,
+    orphan_placeholders_deleted: usize,
 }
 
-/// One inflight scan, distilled into the two things the sweep needs:
-///   * `candidate_channels` — channels whose prior generation may have left a
-///     frozen panel (a row whose `updated_at` predates boot);
-///   * `live_anchor_ids` — Discord message ids that the CURRENT generation may
-///     still be relaying to and must never finalize (codex round-1 High-a).
+/// One durable-state scan, distilled into prior-generation frozen-panel
+/// channels, configured orphan-placeholder channels, and the durable Discord
+/// identities that each pass must preserve.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct ReclaimScanPlan {
-    candidate_channels: Vec<u64>,
+    frozen_panel_channels: Vec<u64>,
+    orphan_placeholder_channels: Vec<u64>,
     live_anchor_ids: HashSet<u64>,
+    protected_message_ids: HashSet<u64>,
 }
 
-/// Build the scan plan from inflight rows. codex round-1 High-a: the alive-tmux
-/// recovery path (`recovery_engine::reregister_active_turn_from_inflight`) can
-/// re-adopt a PRE-boot row as a live turn and re-attach a watcher to its
-/// `current_msg_id`/`status_message_id` WITHOUT bumping `updated_at` or editing
-/// Discord. A timestamp gate alone would then let the sweep finalize that live
-/// anchor. So, independent of any timing heuristic, every row that is NOT
-/// terminal-delivery-committed (and is a real user-authored turn, not a
-/// rebind-origin placeholder) contributes its anchor ids to an explicit
-/// exclusion set. The sweep skips those ids unconditionally — a live anchor is
-/// protected even though its Discord timestamp predates boot.
-///
-/// Recovery_engine is referenced read-only (#3410 parallel area); the alternative
-/// of bumping the recovered row's `updated_at` would require editing that file,
-/// so the ownership exclusion is resolved entirely on the sweep side.
+/// Build the scan plan from durable rows and configured channels. Every
+/// nonzero Discord message identity referenced by inflight or pending-start
+/// state is protected, regardless of lifecycle age; only fully unlinked exact
+/// placeholders are eligible for crash-window cleanup.
 fn build_reclaim_scan_plan(provider: &ProviderKind, boot_unix_secs: i64) -> ReclaimScanPlan {
-    reclaim_scan_plan_from_rows(load_inflight_states_for_sweep(provider), boot_unix_secs)
+    reclaim_scan_plan_from_rows(
+        load_inflight_states_for_sweep(provider),
+        super::tui_direct_pending_start::load_all(),
+        super::settings::list_registered_channel_bindings(),
+        provider,
+        boot_unix_secs,
+    )
 }
 
-/// Pure core of `build_reclaim_scan_plan`, split out so the High-a live-anchor
-/// exclusion and the prior-generation candidate selection can be unit-tested
-/// without writing inflight JSON to disk.
+/// Pure core of `build_reclaim_scan_plan`, split out so channel filtering and
+/// durable message-identity protection can be unit-tested without filesystem
+/// or Discord access.
 fn reclaim_scan_plan_from_rows(
     rows: Vec<(super::inflight::InflightTurnState, u64)>,
+    pending_starts: Vec<super::tui_direct_pending_start::TuiDirectPendingStart>,
+    configured_bindings: Vec<super::settings::RegisteredChannelBinding>,
+    provider: &ProviderKind,
     boot_unix_secs: i64,
 ) -> ReclaimScanPlan {
-    let mut seen = HashSet::new();
+    let mut frozen_seen = HashSet::new();
+    let mut orphan_seen = HashSet::new();
     let mut plan = ReclaimScanPlan::default();
+    for binding in configured_bindings {
+        if &binding.owner_provider == provider
+            && binding.channel_id != 0
+            && orphan_seen.insert(binding.channel_id)
+        {
+            plan.orphan_placeholder_channels.push(binding.channel_id);
+        }
+    }
     for (state, _age) in rows {
-        // Live-anchor exclusion: any not-yet-committed real turn owns its anchor
-        // ids regardless of when it was last touched. rebind-origin rows carry
-        // placeholder ids that do not identify a real Discord message, so they
-        // are excluded from the exclusion set (they cannot be a live anchor).
+        for id in [
+            state.user_msg_id,
+            state.current_msg_id,
+            state.status_message_id.unwrap_or(0),
+            state.injected_prompt_message_id.unwrap_or(0),
+        ] {
+            if id != 0 {
+                plan.protected_message_ids.insert(id);
+            }
+        }
         if !state.terminal_delivery_completed() && !state.rebind_origin {
-            for id in [state.current_msg_id]
-                .into_iter()
-                .chain(state.status_message_id)
-            {
+            for id in [state.current_msg_id, state.status_message_id.unwrap_or(0)] {
                 if id != 0 {
                     plan.live_anchor_ids.insert(id);
                 }
             }
         }
         let updated = parse_updated_at_unix(&state.updated_at).unwrap_or(i64::MAX);
-        if updated >= boot_unix_secs {
-            // Touched at or after boot → current generation. Leave it alone.
-            continue;
+        if updated < boot_unix_secs
+            && state.channel_id != 0
+            && frozen_seen.insert(state.channel_id)
+        {
+            plan.frozen_panel_channels.push(state.channel_id);
         }
-        if seen.insert(state.channel_id) && state.channel_id != 0 {
-            plan.candidate_channels.push(state.channel_id);
+    }
+    for pending in pending_starts {
+        if pending.provider == provider.as_str() && pending.anchor_message_id != 0 {
+            plan.protected_message_ids
+                .insert(pending.anchor_message_id);
         }
     }
     plan
@@ -162,10 +196,45 @@ fn change_unix_from_parts(edited_unix: Option<i64>, created_unix: i64) -> i64 {
     edited_unix.unwrap_or(created_unix)
 }
 
-/// Reclaim every self-authored frozen panel on one channel. Reads ONE recent
-/// page, finalizes each message whose body still parses as a frozen footer and
-/// whose Discord change-time predates `boot_unix_secs`.
-async fn reclaim_channel(
+fn is_orphan_placeholder_candidate(
+    author_id: u64,
+    bot_user_id: u64,
+    content: &str,
+    message_id: u64,
+    message_change_unix: i64,
+    now_unix_secs: i64,
+    protected_message_ids: &HashSet<u64>,
+) -> bool {
+    author_id == bot_user_id
+        && content == "..."
+        && message_change_unix < now_unix_secs - ORPHAN_PLACEHOLDER_MIN_AGE_SECS
+        && !protected_message_ids.contains(&message_id)
+}
+
+async fn read_reclaim_messages(
+    http: &Arc<serenity::Http>,
+    provider: &ProviderKind,
+    channel_id: u64,
+) -> Option<Vec<serenity::Message>> {
+    match serenity::ChannelId::new(channel_id)
+        .messages(
+            http,
+            serenity::builder::GetMessages::new().limit(RECLAIM_FETCH_LIMIT),
+        )
+        .await
+    {
+        Ok(messages) => Some(messages),
+        Err(error) => {
+            tracing::debug!(
+                "startup-reclaim: read failed for {}/{channel_id}: {error}",
+                provider.as_str()
+            );
+            None
+        }
+    }
+}
+
+async fn reclaim_frozen_panels(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -174,47 +243,23 @@ async fn reclaim_channel(
     boot_unix_secs: i64,
     live_anchor_ids: &HashSet<u64>,
 ) -> (usize, usize) {
-    let channel = serenity::ChannelId::new(channel_id);
-    let fetched = channel
-        .messages(
-            http,
-            serenity::builder::GetMessages::new().limit(RECLAIM_FETCH_LIMIT),
-        )
-        .await;
-    let messages = match fetched {
-        Ok(messages) => messages,
-        Err(error) => {
-            tracing::debug!(
-                "startup-reclaim: read failed for {}/{channel_id}: {error}",
-                provider.as_str()
-            );
-            return (0, 0);
-        }
+    let Some(messages) = read_reclaim_messages(http, provider, channel_id).await else {
+        return (0, 0);
     };
-
+    let channel = serenity::ChannelId::new(channel_id);
     let mut finalized = 0usize;
     let mut markers = 0usize;
     for msg in &messages {
-        // codex round-1 Medium: `bot_user_id` is now a hard precondition (the
-        // caller skips the channel if it could not resolve), so author matching
-        // is fail-closed — only our own messages are ever edited.
-        if msg.author.id.get() != bot_user_id {
-            continue; // Not our own message.
-        }
-        // codex round-1 High-a: never finalize an anchor the current generation
-        // may still be relaying to, even if its Discord timestamp predates boot
-        // (alive-tmux recovery re-adopts pre-boot anchors without re-touching
-        // Discord). This explicit ownership check supersedes the timing gate.
-        if live_anchor_ids.contains(&msg.id.get()) {
+        if msg.author.id.get() != bot_user_id
+            || live_anchor_ids.contains(&msg.id.get())
+            || message_change_unix(msg) >= boot_unix_secs
+        {
             continue;
         }
-        if message_change_unix(msg) >= boot_unix_secs {
-            continue; // Current generation may still own this message.
-        }
         let Some(finalized_text) = reclaim_finalize_text(&msg.content, provider) else {
-            continue; // No frozen footer to reclaim (already done or live).
+            continue;
         };
-        let edited = edit_outbound_message(
+        if edit_outbound_message(
             http.clone(),
             shared.clone(),
             channel,
@@ -222,8 +267,8 @@ async fn reclaim_channel(
             &finalized_text,
         )
         .await
-        .is_ok();
-        if edited {
+        .is_ok()
+        {
             finalized += 1;
             markers += 1;
             tracing::info!(
@@ -237,89 +282,177 @@ async fn reclaim_channel(
     (finalized, markers)
 }
 
-/// Run the one-shot startup reclaim sweep for `provider`. Candidate channels
-/// come from prior-generation inflight rows; each is scanned at most once.
+async fn reclaim_orphan_placeholders(
+    http: &Arc<serenity::Http>,
+    provider: &ProviderKind,
+    channel_id: u64,
+    bot_user_id: u64,
+    now_unix_secs: i64,
+    protected_message_ids: &HashSet<u64>,
+) -> usize {
+    let Some(messages) = read_reclaim_messages(http, provider, channel_id).await else {
+        return 0;
+    };
+    let channel = serenity::ChannelId::new(channel_id);
+    let mut attempted = 0usize;
+    let mut deleted = 0usize;
+    for msg in &messages {
+        if attempted >= ORPHAN_PLACEHOLDER_DELETE_LIMIT {
+            break;
+        }
+        if !is_orphan_placeholder_candidate(
+            msg.author.id.get(),
+            bot_user_id,
+            &msg.content,
+            msg.id.get(),
+            message_change_unix(msg),
+            now_unix_secs,
+            protected_message_ids,
+        ) {
+            continue;
+        }
+        attempted += 1;
+        match channel.delete_message(http, msg.id).await {
+            Ok(()) => {
+                deleted += 1;
+                tracing::info!(
+                    "startup-reclaim: deleted unlinked synthetic placeholder channel_id={channel_id} message_id={} ({})",
+                    msg.id.get(),
+                    provider.as_str()
+                );
+            }
+            Err(error) => tracing::warn!(
+                "startup-reclaim: failed to delete unlinked synthetic placeholder channel_id={channel_id} message_id={} ({}): {error}",
+                msg.id.get(),
+                provider.as_str()
+            ),
+        }
+    }
+    deleted
+}
+
+/// Run one startup reclaim pass for `provider`. Durable state is reloaded at
+/// the beginning of every pass so delayed orphan cleanup protects current rows.
 async fn run_startup_reclaim_sweep(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     boot_unix_secs: i64,
+    pass: ReclaimPass,
 ) -> ReclaimReport {
     let plan = build_reclaim_scan_plan(provider, boot_unix_secs);
-    if plan.candidate_channels.is_empty() {
+    let candidate_channels = match pass {
+        ReclaimPass::FrozenPanels => &plan.frozen_panel_channels,
+        ReclaimPass::OrphanPlaceholders => &plan.orphan_placeholder_channels,
+    };
+    if candidate_channels.is_empty() {
         return ReclaimReport::default();
     }
-    // codex round-1 Medium: FAIL-CLOSED on bot-id resolution. Without our own
-    // user id the author filter cannot distinguish our messages from any other
-    // bot's, so a fail-open (bot_user_id = None) would edit ANY matching message.
-    // Resolve once, before consuming any per-channel guard; on failure WARN and
-    // abort the whole sweep WITHOUT claiming any channel, so the one-shot guards
-    // stay unconsumed and a later sweep opportunity (e.g. re-fed channel) is
-    // preserved. Editing zero messages is the safe outcome.
+    // Fail closed: without the current bot id neither pass can prove authorship.
+    // Resolve before consuming guards so a later pass still gets its opportunity.
     let bot_user_id = match http.get_current_user().await {
         Ok(user) => user.id.get(),
         Err(error) => {
             tracing::warn!(
-                "startup-reclaim ({}): skipping sweep — could not resolve bot user id (fail-closed): {error}",
-                provider.as_str()
+                "startup-reclaim ({}, {}): skipping sweep — could not resolve bot user id (fail-closed): {error}",
+                provider.as_str(),
+                pass.as_str()
             );
             return ReclaimReport::default();
         }
     };
     let mut report = ReclaimReport::default();
-    for channel_id in plan.candidate_channels {
-        if !claim_channel_once(provider, channel_id) {
-            continue; // Already scanned this process lifetime.
+    let now_unix_secs = chrono::Utc::now().timestamp();
+    for &channel_id in candidate_channels {
+        if !claim_channel_once(pass, provider, channel_id) {
+            continue;
         }
         report.channels_scanned += 1;
-        let (finalized, markers) = reclaim_channel(
-            http,
-            shared,
-            provider,
-            channel_id,
-            bot_user_id,
-            boot_unix_secs,
-            &plan.live_anchor_ids,
-        )
-        .await;
-        report.messages_finalized += finalized;
-        report.markers_replaced += markers;
+        match pass {
+            ReclaimPass::FrozenPanels => {
+                let (finalized, markers) = reclaim_frozen_panels(
+                    http,
+                    shared,
+                    provider,
+                    channel_id,
+                    bot_user_id,
+                    boot_unix_secs,
+                    &plan.live_anchor_ids,
+                )
+                .await;
+                report.messages_finalized += finalized;
+                report.markers_replaced += markers;
+            }
+            ReclaimPass::OrphanPlaceholders => {
+                report.orphan_placeholders_deleted += reclaim_orphan_placeholders(
+                    http,
+                    provider,
+                    channel_id,
+                    bot_user_id,
+                    now_unix_secs,
+                    &plan.protected_message_ids,
+                )
+                .await;
+            }
+        }
     }
     report
 }
 
-/// Spawn the one-shot startup reclaim task for `provider`. Runs once after a
-/// short settle delay so live-turn recovery and #3402 slot rehydration have a
-/// chance to re-register current-generation panels first (those carry a
-/// post-boot timestamp and are skipped regardless, but the delay keeps the
-/// reclaim read off the boot-storm critical path). Never loops — the
-/// per-channel guard makes it idempotent if a channel is somehow re-fed.
+async fn run_delayed_reclaim_pass(
+    http: Arc<serenity::Http>,
+    shared: Arc<SharedData>,
+    provider: ProviderKind,
+    boot_unix_secs: i64,
+    delay_secs: u64,
+    pass: ReclaimPass,
+) {
+    tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
+    let report = run_startup_reclaim_sweep(&http, &shared, &provider, boot_unix_secs, pass).await;
+    if report.messages_finalized > 0 || report.orphan_placeholders_deleted > 0 {
+        tracing::info!(
+            "startup-reclaim ({}, {}): channels_scanned={} messages_finalized={} markers_replaced={} orphan_placeholders_deleted={}",
+            provider.as_str(),
+            pass.as_str(),
+            report.channels_scanned,
+            report.messages_finalized,
+            report.markers_replaced,
+            report.orphan_placeholders_deleted
+        );
+    } else {
+        tracing::debug!(
+            "startup-reclaim ({}, {}): channels_scanned={} messages_finalized=0 orphan_placeholders_deleted=0",
+            provider.as_str(),
+            pass.as_str(),
+            report.channels_scanned
+        );
+    }
+}
+
+/// Spawn independent one-shot passes: frozen panels after the boot settle
+/// window, then exact unlinked placeholders after their minimum-age boundary.
 pub(super) fn spawn_startup_reclaim_sweep(
     http: Arc<serenity::Http>,
     shared: Arc<SharedData>,
     provider: ProviderKind,
     boot_unix_secs: i64,
 ) {
-    tokio::spawn(async move {
-        // Settle window: let recovery/rehydration re-register live panels first.
-        tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
-        let report = run_startup_reclaim_sweep(&http, &shared, &provider, boot_unix_secs).await;
-        if report.messages_finalized > 0 {
-            tracing::info!(
-                "startup-reclaim ({}): channels_scanned={} messages_finalized={} markers_replaced={}",
-                provider.as_str(),
-                report.channels_scanned,
-                report.messages_finalized,
-                report.markers_replaced
-            );
-        } else {
-            tracing::debug!(
-                "startup-reclaim ({}): channels_scanned={} messages_finalized=0",
-                provider.as_str(),
-                report.channels_scanned
-            );
-        }
-    });
+    tokio::spawn(run_delayed_reclaim_pass(
+        http.clone(),
+        shared.clone(),
+        provider.clone(),
+        boot_unix_secs,
+        FROZEN_PANEL_RECLAIM_DELAY_SECS,
+        ReclaimPass::FrozenPanels,
+    ));
+    tokio::spawn(run_delayed_reclaim_pass(
+        http,
+        shared,
+        provider,
+        boot_unix_secs,
+        ORPHAN_PLACEHOLDER_RECLAIM_DELAY_SECS,
+        ReclaimPass::OrphanPlaceholders,
+    ));
 }
 
 #[cfg(test)]
@@ -409,17 +542,29 @@ mod tests {
     }
 
     #[test]
-    fn one_shot_guard_blocks_rescan() {
-        // ③ the per-channel guard claims once then refuses.
+    fn one_shot_guard_is_independent_per_pass() {
         reset_reclaim_guard_for_test();
         let provider = ProviderKind::Claude;
-        assert!(claim_channel_once(&provider, 4242), "first claim succeeds");
-        assert!(
-            !claim_channel_once(&provider, 4242),
-            "second claim on same channel must be refused"
-        );
-        // A different channel is independent.
-        assert!(claim_channel_once(&provider, 9999));
+        assert!(claim_channel_once(
+            ReclaimPass::FrozenPanels,
+            &provider,
+            4242
+        ));
+        assert!(!claim_channel_once(
+            ReclaimPass::FrozenPanels,
+            &provider,
+            4242
+        ));
+        assert!(claim_channel_once(
+            ReclaimPass::OrphanPlaceholders,
+            &provider,
+            4242
+        ));
+        assert!(claim_channel_once(
+            ReclaimPass::FrozenPanels,
+            &provider,
+            9999
+        ));
         reset_reclaim_guard_for_test();
     }
 
@@ -489,9 +634,15 @@ mod tests {
             false,      // not committed → live
             false,      // real turn
         )];
-        let plan = reclaim_scan_plan_from_rows(rows, boot);
+        let plan = reclaim_scan_plan_from_rows(
+            rows,
+            Vec::new(),
+            Vec::new(),
+            &ProviderKind::Claude,
+            boot,
+        );
         assert!(
-            plan.candidate_channels.contains(&555),
+            plan.frozen_panel_channels.contains(&555),
             "pre-boot row's channel is still a reclaim candidate"
         );
         assert!(
@@ -514,7 +665,13 @@ mod tests {
             row_with(101, 8001, Some(8002), boot - 50, true, false), // committed
             row_with(102, 8101, Some(8102), boot - 50, false, true), // rebind-origin
         ];
-        let plan = reclaim_scan_plan_from_rows(rows, boot);
+        let plan = reclaim_scan_plan_from_rows(
+            rows,
+            Vec::new(),
+            Vec::new(),
+            &ProviderKind::Claude,
+            boot,
+        );
         for id in [8001, 8002, 8101, 8102] {
             assert!(
                 !plan.live_anchor_ids.contains(&id),
@@ -530,12 +687,125 @@ mod tests {
         // a concurrent sweep of the same channel cannot clobber the live panel.
         let boot = 1_700_000_000i64;
         let rows = vec![row_with(303, 7001, Some(7002), boot + 5, false, false)];
-        let plan = reclaim_scan_plan_from_rows(rows, boot);
+        let plan = reclaim_scan_plan_from_rows(
+            rows,
+            Vec::new(),
+            Vec::new(),
+            &ProviderKind::Claude,
+            boot,
+        );
         assert!(
-            !plan.candidate_channels.contains(&303),
+            !plan.frozen_panel_channels.contains(&303),
             "post-boot row is current-gen, not a candidate"
         );
         assert!(plan.live_anchor_ids.contains(&7001));
         assert!(plan.live_anchor_ids.contains(&7002));
+    }
+
+    #[test]
+    fn orphan_placeholder_candidate_is_exact_old_owned_and_unlinked() {
+        let now = 1_700_000_000i64;
+        let protected = HashSet::from([9001]);
+        assert!(is_orphan_placeholder_candidate(
+            7,
+            7,
+            "...",
+            9002,
+            now - ORPHAN_PLACEHOLDER_MIN_AGE_SECS - 1,
+            now,
+            &protected,
+        ));
+        for (author, content, message_id, changed) in [
+            (8, "...", 9002, now - ORPHAN_PLACEHOLDER_MIN_AGE_SECS - 1),
+            (7, " ... ", 9002, now - ORPHAN_PLACEHOLDER_MIN_AGE_SECS - 1),
+            (7, "...", 9001, now - ORPHAN_PLACEHOLDER_MIN_AGE_SECS - 1),
+            (7, "...", 9002, now - ORPHAN_PLACEHOLDER_MIN_AGE_SECS),
+        ] {
+            assert!(!is_orphan_placeholder_candidate(
+                author,
+                7,
+                content,
+                message_id,
+                changed,
+                now,
+                &protected,
+            ));
+        }
+    }
+
+    #[test]
+    fn configured_candidates_are_provider_scoped_and_deduplicated() {
+        let bindings = vec![
+            super::super::settings::RegisteredChannelBinding {
+                channel_id: 42,
+                owner_provider: ProviderKind::Claude,
+                fallback_name: None,
+            },
+            super::super::settings::RegisteredChannelBinding {
+                channel_id: 42,
+                owner_provider: ProviderKind::Claude,
+                fallback_name: None,
+            },
+            super::super::settings::RegisteredChannelBinding {
+                channel_id: 43,
+                owner_provider: ProviderKind::Codex,
+                fallback_name: None,
+            },
+        ];
+        let plan = reclaim_scan_plan_from_rows(
+            Vec::new(),
+            Vec::new(),
+            bindings,
+            &ProviderKind::Claude,
+            1_700_000_000,
+        );
+        assert_eq!(plan.orphan_placeholder_channels, vec![42]);
+        assert!(plan.frozen_panel_channels.is_empty());
+    }
+
+    #[test]
+    fn every_inflight_discord_identity_is_protected_from_placeholder_cleanup() {
+        let boot = 1_700_000_000i64;
+        let mut row = row_with(303, 7001, Some(7002), boot - 5, true, false);
+        row.0.user_msg_id = 7003;
+        row.0.injected_prompt_message_id = Some(7004);
+        let plan = reclaim_scan_plan_from_rows(
+            vec![row],
+            Vec::new(),
+            Vec::new(),
+            &ProviderKind::Claude,
+            boot,
+        );
+        for id in [7001, 7002, 7003, 7004] {
+            assert!(plan.protected_message_ids.contains(&id));
+        }
+    }
+
+    #[test]
+    fn matching_pending_start_anchor_is_protected_from_placeholder_cleanup() {
+        let pending = super::super::tui_direct_pending_start::TuiDirectPendingStart {
+            provider: "claude".to_string(),
+            channel_id: 303,
+            tmux_session_name: "tmux-test".to_string(),
+            prompt_text: "continue".to_string(),
+            anchor_message_id: 8001,
+            lease_relay_owner: "bridge_adapter".to_string(),
+            lease_runtime_kind: Some("claude_tui".to_string()),
+            lease_turn_id: None,
+            lease_session_key: None,
+            generation: 0,
+            created_at_ms: 0,
+            observed_at_ms: 0,
+            state: super::super::tui_direct_pending_start::PendingStartState::Waiting,
+            attempt_count: 0,
+        };
+        let plan = reclaim_scan_plan_from_rows(
+            Vec::new(),
+            vec![pending],
+            Vec::new(),
+            &ProviderKind::Claude,
+            1_700_000_000,
+        );
+        assert!(plan.protected_message_ids.contains(&8001));
     }
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -577,7 +577,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 }
             }
         };
-        let anchor_message_id =
+        let synthetic_anchor =
             synthetic_start_wiring::resolve_tui_direct_synthetic_lifecycle_anchor(
                 shared,
                 command_http.clone(),
@@ -587,6 +587,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 &relay_prompt_decision,
             )
             .await;
+        let anchor_message_id = synthetic_anchor.message_id;
         // #3176: pin this turn's anchor id — it becomes the synthetic inflight's
         // `user_msg_id` below, so the idle-tail drain-wait can recognise our own row.
         current_turn_anchor_id = Some(anchor_message_id.get());
@@ -670,6 +671,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             channel_id,
             &prompt,
             anchor_message_id,
+            synthetic_anchor.owned_placeholder,
             &relay_prompt_decision,
             &mut lease,
         )

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -578,34 +578,18 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             }
         };
         let synthetic_anchor =
-            synthetic_start_wiring::resolve_tui_direct_synthetic_lifecycle_anchor(
+            synthetic_start_wiring::establish_tui_direct_synthetic_lifecycle_anchor(
                 shared,
                 command_http.clone(),
                 channel_id,
                 &prompt,
                 notification_anchor_message_id,
                 &relay_prompt_decision,
+                lease.generation,
+                &mut current_turn_anchor_id,
             )
             .await;
         let anchor_message_id = synthetic_anchor.message_id;
-        // #3176: pin this turn's anchor id — it becomes the synthetic inflight's
-        // `user_msg_id` below, so the idle-tail drain-wait can recognise our own row.
-        current_turn_anchor_id = Some(anchor_message_id.get());
-        // Add before the anchor becomes findable so fast completion cannot re-leave ⏳.
-        started(
-            shared,
-            channel_id,
-            anchor_message_id,
-            lease.generation,
-            "tui_anchor_start",
-        )
-        .await;
-        crate::services::tui_prompt_dedupe::record_prompt_anchor(
-            &prompt.provider,
-            &prompt.tmux_session_name,
-            channel_id.get(),
-            anchor_message_id.get(),
-        );
         // #3174: turn-identity guard on the ⏳ lifecycle. A lease-gated completion
         // firing inside the sub-second notify+⏳-add window left a deferred marker;
         // now that THIS turn's anchor exists, drain it (⏳ → ✅ swap). P1: drain ONLY

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -586,10 +586,10 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 notification_anchor_message_id,
                 &relay_prompt_decision,
                 lease.generation,
-                &mut current_turn_anchor_id,
             )
             .await;
         let anchor_message_id = synthetic_anchor.message_id;
+        current_turn_anchor_id = Some(anchor_message_id.get());
         // #3174: turn-identity guard on the ⏳ lifecycle. A lease-gated completion
         // firing inside the sub-second notify+⏳-add window left a deferred marker;
         // now that THIS turn's anchor exists, drain it (⏳ → ✅ swap). P1: drain ONLY

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -557,7 +557,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 &prompt.prompt,
             )
         };
-        let anchor_message_id = if let Some(message_id) = task_card_anchor {
+        let notification_anchor_message_id = if let Some(message_id) = task_card_anchor {
             message_id
         } else {
             match channel_id.say(&*notify_http, content).await {
@@ -577,6 +577,16 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 }
             }
         };
+        let anchor_message_id =
+            synthetic_start_wiring::resolve_tui_direct_synthetic_lifecycle_anchor(
+                shared,
+                command_http.clone(),
+                channel_id,
+                &prompt,
+                notification_anchor_message_id,
+                &relay_prompt_decision,
+            )
+            .await;
         // #3176: pin this turn's anchor id — it becomes the synthetic inflight's
         // `user_msg_id` below, so the idle-tail drain-wait can recognise our own row.
         current_turn_anchor_id = Some(anchor_message_id.get());

--- a/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
@@ -53,10 +53,9 @@ pub(super) async fn delete_failed_synthetic_owned_placeholder(
     anchor_message_id: MessageId,
     anchor_is_owned_placeholder: bool,
 ) {
-    let Some(anchor_message_id) = failed_synthetic_placeholder_cleanup_target(
-        anchor_message_id,
-        anchor_is_owned_placeholder,
-    ) else {
+    let Some(anchor_message_id) =
+        failed_synthetic_placeholder_cleanup_target(anchor_message_id, anchor_is_owned_placeholder)
+    else {
         return;
     };
     let Some(http) = shared.serenity_http_or_token_fallback() else {

--- a/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
@@ -17,14 +17,66 @@
 
 use super::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct SyntheticLifecycleAnchor {
+    pub(super) message_id: MessageId,
+    pub(super) owned_placeholder: bool,
+}
+
 pub(super) fn synthetic_lifecycle_anchor_from_placeholder_result(
     notification_anchor_message_id: MessageId,
     placeholder_result: &Result<MessageId, String>,
-) -> MessageId {
-    placeholder_result
-        .as_ref()
-        .copied()
-        .unwrap_or(notification_anchor_message_id)
+) -> SyntheticLifecycleAnchor {
+    match placeholder_result {
+        Ok(message_id) => SyntheticLifecycleAnchor {
+            message_id: *message_id,
+            owned_placeholder: true,
+        },
+        Err(_) => SyntheticLifecycleAnchor {
+            message_id: notification_anchor_message_id,
+            owned_placeholder: false,
+        },
+    }
+}
+
+pub(super) fn failed_synthetic_placeholder_cleanup_target(
+    anchor_message_id: MessageId,
+    anchor_is_owned_placeholder: bool,
+) -> Option<MessageId> {
+    anchor_is_owned_placeholder.then_some(anchor_message_id)
+}
+
+pub(super) async fn delete_failed_synthetic_owned_placeholder(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    anchor_message_id: MessageId,
+    anchor_is_owned_placeholder: bool,
+) {
+    let Some(anchor_message_id) = failed_synthetic_placeholder_cleanup_target(
+        anchor_message_id,
+        anchor_is_owned_placeholder,
+    ) else {
+        return;
+    };
+    let Some(http) = shared.serenity_http_or_token_fallback() else {
+        tracing::warn!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            anchor_message_id = anchor_message_id.get(),
+            "failed to delete rejected synthetic placeholder; provider serenity HTTP unavailable"
+        );
+        return;
+    };
+    if let Err(error) = channel_id.delete_message(&http, anchor_message_id).await {
+        tracing::warn!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            anchor_message_id = anchor_message_id.get(),
+            error = %error,
+            "failed to delete rejected synthetic placeholder"
+        );
+    }
 }
 
 /// Post the command-bot-owned streaming placeholder before synthetic lifecycle
@@ -37,12 +89,16 @@ pub(super) async fn resolve_tui_direct_synthetic_lifecycle_anchor(
     prompt: &ObservedTuiPrompt,
     notification_anchor_message_id: MessageId,
     relay_prompt_decision: &RelayObservedPromptInjectionDecision,
-) -> MessageId {
+) -> SyntheticLifecycleAnchor {
     if !relay_prompt_decision.starts_external_turn_lifecycle() {
-        return notification_anchor_message_id;
+        return SyntheticLifecycleAnchor {
+            message_id: notification_anchor_message_id,
+            owned_placeholder: false,
+        };
     }
 
     let Some(http) = command_http else {
+        let error = "command-bot HTTP unavailable";
         tracing::warn!(
             provider = %prompt.provider,
             channel_id = channel_id.get(),
@@ -50,7 +106,18 @@ pub(super) async fn resolve_tui_direct_synthetic_lifecycle_anchor(
             notification_anchor_message_id = notification_anchor_message_id.get(),
             "command-bot HTTP unavailable; using the existing notification anchor for the synthetic lifecycle"
         );
-        return notification_anchor_message_id;
+        crate::services::observability::emit_intake_placeholder_post_failed(
+            &prompt.provider,
+            channel_id.get(),
+            None,
+            "synthetic_anchor_before_lifecycle",
+            "notification_anchor_fallback",
+            error,
+        );
+        return SyntheticLifecycleAnchor {
+            message_id: notification_anchor_message_id,
+            owned_placeholder: false,
+        };
     };
 
     let placeholder_result = super::super::gateway::send_intake_placeholder(
@@ -61,7 +128,7 @@ pub(super) async fn resolve_tui_direct_synthetic_lifecycle_anchor(
         false,
     )
     .await;
-    let anchor_message_id = synthetic_lifecycle_anchor_from_placeholder_result(
+    let anchor = synthetic_lifecycle_anchor_from_placeholder_result(
         notification_anchor_message_id,
         &placeholder_result,
     );
@@ -74,16 +141,26 @@ pub(super) async fn resolve_tui_direct_synthetic_lifecycle_anchor(
             placeholder_message_id = placeholder_message_id.get(),
             "posted command-bot-owned placeholder for the synthetic lifecycle anchor"
         ),
-        Err(error) => tracing::warn!(
-            provider = %prompt.provider,
-            channel_id = channel_id.get(),
-            tmux_session_name = %prompt.tmux_session_name,
-            notification_anchor_message_id = notification_anchor_message_id.get(),
-            error = %error,
-            "failed to post command-bot-owned synthetic placeholder; using the existing notification anchor"
-        ),
+        Err(error) => {
+            tracing::warn!(
+                provider = %prompt.provider,
+                channel_id = channel_id.get(),
+                tmux_session_name = %prompt.tmux_session_name,
+                notification_anchor_message_id = notification_anchor_message_id.get(),
+                error = %error,
+                "failed to post command-bot-owned synthetic placeholder; using the existing notification anchor"
+            );
+            crate::services::observability::emit_intake_placeholder_post_failed(
+                &prompt.provider,
+                channel_id.get(),
+                None,
+                "synthetic_anchor_before_lifecycle",
+                "notification_anchor_fallback",
+                &error,
+            );
+        }
     }
-    anchor_message_id
+    anchor
 }
 
 /// Run the shared synthetic-start wiring for a TUI-direct turn. It:
@@ -109,6 +186,7 @@ pub(super) async fn wire_tui_direct_synthetic_turn_start(
     channel_id: ChannelId,
     prompt: &ObservedTuiPrompt,
     anchor_message_id: MessageId,
+    anchor_is_owned_placeholder: bool,
     relay_prompt_decision: &RelayObservedPromptInjectionDecision,
     lease: &mut ExternalInputRelayLease,
 ) -> bool {
@@ -177,6 +255,16 @@ pub(super) async fn wire_tui_direct_synthetic_turn_start(
                 &*lease,
             )
             .await;
+            if !claim.claimed {
+                delete_failed_synthetic_owned_placeholder(
+                    shared,
+                    &provider,
+                    channel_id,
+                    anchor_message_id,
+                    anchor_is_owned_placeholder,
+                )
+                .await;
+            }
             if claim_should_adopt_relay_owner(claim.claimed, lease.relay_owner, claim.relay_owner) {
                 lease.relay_owner = claim.relay_owner;
                 // Re-record overwrites the lease with a FRESH generation; adopt it

--- a/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
@@ -17,6 +17,75 @@
 
 use super::*;
 
+pub(super) fn synthetic_lifecycle_anchor_from_placeholder_result(
+    notification_anchor_message_id: MessageId,
+    placeholder_result: &Result<MessageId, String>,
+) -> MessageId {
+    placeholder_result
+        .as_ref()
+        .copied()
+        .unwrap_or(notification_anchor_message_id)
+}
+
+/// Post the command-bot-owned streaming placeholder before synthetic lifecycle
+/// state becomes visible. Delivery failures fail open to the existing
+/// notification/task-card anchor so observation still starts a relay turn.
+pub(super) async fn resolve_tui_direct_synthetic_lifecycle_anchor(
+    shared: &Arc<SharedData>,
+    command_http: Option<Arc<serenity::Http>>,
+    channel_id: ChannelId,
+    prompt: &ObservedTuiPrompt,
+    notification_anchor_message_id: MessageId,
+    relay_prompt_decision: &RelayObservedPromptInjectionDecision,
+) -> MessageId {
+    if !relay_prompt_decision.starts_external_turn_lifecycle() {
+        return notification_anchor_message_id;
+    }
+
+    let Some(http) = command_http else {
+        tracing::warn!(
+            provider = %prompt.provider,
+            channel_id = channel_id.get(),
+            tmux_session_name = %prompt.tmux_session_name,
+            notification_anchor_message_id = notification_anchor_message_id.get(),
+            "command-bot HTTP unavailable; using the existing notification anchor for the synthetic lifecycle"
+        );
+        return notification_anchor_message_id;
+    };
+
+    let placeholder_result = super::super::gateway::send_intake_placeholder(
+        http,
+        shared.clone(),
+        channel_id,
+        Some((channel_id, notification_anchor_message_id)),
+        false,
+    )
+    .await;
+    let anchor_message_id = synthetic_lifecycle_anchor_from_placeholder_result(
+        notification_anchor_message_id,
+        &placeholder_result,
+    );
+    match placeholder_result {
+        Ok(placeholder_message_id) => tracing::info!(
+            provider = %prompt.provider,
+            channel_id = channel_id.get(),
+            tmux_session_name = %prompt.tmux_session_name,
+            notification_anchor_message_id = notification_anchor_message_id.get(),
+            placeholder_message_id = placeholder_message_id.get(),
+            "posted command-bot-owned placeholder for the synthetic lifecycle anchor"
+        ),
+        Err(error) => tracing::warn!(
+            provider = %prompt.provider,
+            channel_id = channel_id.get(),
+            tmux_session_name = %prompt.tmux_session_name,
+            notification_anchor_message_id = notification_anchor_message_id.get(),
+            error = %error,
+            "failed to post command-bot-owned synthetic placeholder; using the existing notification anchor"
+        ),
+    }
+    anchor_message_id
+}
+
 /// Run the shared synthetic-start wiring for a TUI-direct turn. It:
 ///   0. refuses prompt classes that the shared injected-prompt decision says do
 ///      not start an external turn,

--- a/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
@@ -58,6 +58,27 @@ pub(super) async fn delete_failed_synthetic_owned_placeholder(
     else {
         return;
     };
+    let operation_kind =
+        super::super::placeholder_cleanup::PlaceholderCleanupOperation::DeleteNonterminal.as_str();
+    if let Some(protection) = super::super::placeholder_cleanup::terminal_cleanup_protects_delete(
+        &shared.ui.placeholder_cleanup,
+        provider,
+        channel_id,
+        anchor_message_id,
+    ) {
+        crate::services::observability::emit_relay_delete(
+            provider.as_str(),
+            channel_id.get(),
+            anchor_message_id.get(),
+            None,
+            None,
+            "tui_direct_rejected_synthetic_placeholder_cleanup",
+            operation_kind,
+            protection.relay_delete_outcome(),
+            None,
+        );
+        return;
+    }
     let Some(http) = shared.serenity_http_or_token_fallback() else {
         tracing::warn!(
             provider = %provider.as_str(),
@@ -67,7 +88,16 @@ pub(super) async fn delete_failed_synthetic_owned_placeholder(
         );
         return;
     };
-    if let Err(error) = channel_id.delete_message(&http, anchor_message_id).await {
+    let result = channel_id.delete_message(&http, anchor_message_id).await;
+    crate::services::observability::emit_relay_delete_result(
+        provider.as_str(),
+        channel_id.get(),
+        anchor_message_id.get(),
+        "tui_direct_rejected_synthetic_placeholder_cleanup",
+        operation_kind,
+        &result,
+    );
+    if let Err(error) = result {
         tracing::warn!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),

--- a/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
@@ -162,6 +162,43 @@ pub(super) async fn resolve_tui_direct_synthetic_lifecycle_anchor(
     anchor
 }
 
+pub(super) async fn establish_tui_direct_synthetic_lifecycle_anchor(
+    shared: &Arc<SharedData>,
+    command_http: Option<Arc<serenity::Http>>,
+    channel_id: ChannelId,
+    prompt: &ObservedTuiPrompt,
+    notification_anchor_message_id: MessageId,
+    relay_prompt_decision: &RelayObservedPromptInjectionDecision,
+    lease_generation: u64,
+    current_turn_anchor_id: &mut Option<u64>,
+) -> SyntheticLifecycleAnchor {
+    let anchor = resolve_tui_direct_synthetic_lifecycle_anchor(
+        shared,
+        command_http,
+        channel_id,
+        prompt,
+        notification_anchor_message_id,
+        relay_prompt_decision,
+    )
+    .await;
+    *current_turn_anchor_id = Some(anchor.message_id.get());
+    started(
+        shared,
+        channel_id,
+        anchor.message_id,
+        lease_generation,
+        "tui_anchor_start",
+    )
+    .await;
+    crate::services::tui_prompt_dedupe::record_prompt_anchor(
+        &prompt.provider,
+        &prompt.tmux_session_name,
+        channel_id.get(),
+        anchor.message_id.get(),
+    );
+    anchor
+}
+
 /// Run the shared synthetic-start wiring for a TUI-direct turn. It:
 ///   0. refuses prompt classes that the shared injected-prompt decision says do
 ///      not start an external turn,

--- a/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start_wiring.rs
@@ -170,7 +170,6 @@ pub(super) async fn establish_tui_direct_synthetic_lifecycle_anchor(
     notification_anchor_message_id: MessageId,
     relay_prompt_decision: &RelayObservedPromptInjectionDecision,
     lease_generation: u64,
-    current_turn_anchor_id: &mut Option<u64>,
 ) -> SyntheticLifecycleAnchor {
     let anchor = resolve_tui_direct_synthetic_lifecycle_anchor(
         shared,
@@ -181,7 +180,6 @@ pub(super) async fn establish_tui_direct_synthetic_lifecycle_anchor(
         relay_prompt_decision,
     )
     .await;
-    *current_turn_anchor_id = Some(anchor.message_id.get());
     started(
         shared,
         channel_id,

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -3383,6 +3383,35 @@ fn external_turn_test_lease(
     }
 }
 
+#[test]
+fn synthetic_lifecycle_anchor_uses_posted_placeholder() {
+    let notification_anchor = MessageId::new(940_000_000_004_180);
+    let placeholder_anchor = MessageId::new(940_000_000_004_181);
+
+    assert_eq!(
+        synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
+            notification_anchor,
+            &Ok(placeholder_anchor),
+        ),
+        placeholder_anchor,
+        "successful synthetic placeholder delivery must replace the notification anchor"
+    );
+}
+
+#[test]
+fn synthetic_lifecycle_anchor_falls_back_after_placeholder_failure() {
+    let notification_anchor = MessageId::new(940_000_000_004_280);
+
+    assert_eq!(
+        synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
+            notification_anchor,
+            &Err("delivery failed".to_string()),
+        ),
+        notification_anchor,
+        "failed synthetic placeholder delivery must preserve the notification anchor"
+    );
+}
+
 #[tokio::test]
 async fn compact_continuation_injection_skips_synthetic_and_leaves_mailbox_free() {
     let temp = tempfile::tempdir().expect("temp runtime root");
@@ -3464,7 +3493,8 @@ async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
     let provider = ProviderKind::Claude;
     let channel_id = ChannelId::new(940_000_000_004_083);
     let tmux = "AgentDesk-claude-4082-genuine-typed";
-    let anchor_id = MessageId::new(940_000_000_004_183);
+    let notification_anchor_id = MessageId::new(940_000_000_004_183);
+    let placeholder_anchor_id = MessageId::new(940_000_000_004_283);
     let prompt = ObservedTuiPrompt {
         provider: provider.as_str().to_string(),
         tmux_session_name: tmux.to_string(),
@@ -3493,6 +3523,10 @@ async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
         },
     );
 
+    let anchor_id = synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
+        notification_anchor_id,
+        &Ok(placeholder_anchor_id),
+    );
     let mut lease = external_turn_test_lease(channel_id, tmux);
     let deferred = synthetic_start_wiring::wire_tui_direct_synthetic_turn_start(
         &shared,
@@ -3509,14 +3543,25 @@ async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
         "no prior turn exists, so the claim should be inline"
     );
 
+    assert_eq!(
+        anchor_id, placeholder_anchor_id,
+        "the synthetic claim must receive the posted placeholder identity"
+    );
+    assert_ne!(
+        anchor_id, notification_anchor_id,
+        "the notification/task-card identity must not remain the streaming anchor after placeholder success"
+    );
     let snapshot = super::super::mailbox_snapshot(shared.as_ref(), channel_id).await;
-    assert_eq!(snapshot.active_user_message_id, Some(anchor_id));
+    assert_eq!(
+        snapshot.active_user_message_id,
+        Some(placeholder_anchor_id)
+    );
     assert!(snapshot.cancel_token.is_some());
     let state = super::super::inflight::load_inflight_state(&provider, channel_id.get())
         .expect("typed TUI prompt must create synthetic inflight");
     assert_eq!(state.turn_source, TurnSource::ExternalInput);
     assert_eq!(state.tmux_session_name.as_deref(), Some(tmux));
-    assert_eq!(state.user_msg_id, anchor_id.get());
+    assert_eq!(state.user_msg_id, placeholder_anchor_id.get());
     assert!(
         !state.relay_ownership_only,
         "human typed input must remain a full synthetic external turn"

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -3388,13 +3388,17 @@ fn synthetic_lifecycle_anchor_uses_posted_placeholder() {
     let notification_anchor = MessageId::new(940_000_000_004_180);
     let placeholder_anchor = MessageId::new(940_000_000_004_181);
 
+    let anchor = synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
+        notification_anchor,
+        &Ok(placeholder_anchor),
+    );
     assert_eq!(
-        synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
-            notification_anchor,
-            &Ok(placeholder_anchor),
-        ),
-        placeholder_anchor,
+        anchor.message_id, placeholder_anchor,
         "successful synthetic placeholder delivery must replace the notification anchor"
+    );
+    assert!(
+        anchor.owned_placeholder,
+        "a posted placeholder must remain cleanup-owned until the synthetic claim succeeds"
     );
 }
 
@@ -3402,13 +3406,33 @@ fn synthetic_lifecycle_anchor_uses_posted_placeholder() {
 fn synthetic_lifecycle_anchor_falls_back_after_placeholder_failure() {
     let notification_anchor = MessageId::new(940_000_000_004_280);
 
-    assert_eq!(
-        synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
-            notification_anchor,
-            &Err("delivery failed".to_string()),
-        ),
+    let anchor = synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
         notification_anchor,
+        &Err("delivery failed".to_string()),
+    );
+    assert_eq!(
+        anchor.message_id, notification_anchor,
         "failed synthetic placeholder delivery must preserve the notification anchor"
+    );
+    assert!(
+        !anchor.owned_placeholder,
+        "the fallback notification anchor must never be selected for placeholder cleanup"
+    );
+}
+
+#[test]
+fn failed_synthetic_claim_cleans_only_owned_placeholder() {
+    let anchor = MessageId::new(940_000_000_004_380);
+
+    assert_eq!(
+        synthetic_start_wiring::failed_synthetic_placeholder_cleanup_target(anchor, true),
+        Some(anchor),
+        "a freshly posted synthetic placeholder must be selected for cleanup after claim failure"
+    );
+    assert_eq!(
+        synthetic_start_wiring::failed_synthetic_placeholder_cleanup_target(anchor, false),
+        None,
+        "a fallback notification/task-card anchor must never be deleted after claim failure"
     );
 }
 
@@ -3447,6 +3471,7 @@ async fn compact_continuation_injection_skips_synthetic_and_leaves_mailbox_free(
         channel_id,
         &prompt,
         anchor_id,
+        false,
         &decision,
         &mut lease,
     )
@@ -3523,10 +3548,12 @@ async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
         },
     );
 
-    let anchor_id = synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
-        notification_anchor_id,
-        &Ok(placeholder_anchor_id),
-    );
+    let synthetic_anchor =
+        synthetic_start_wiring::synthetic_lifecycle_anchor_from_placeholder_result(
+            notification_anchor_id,
+            &Ok(placeholder_anchor_id),
+        );
+    let anchor_id = synthetic_anchor.message_id;
     let mut lease = external_turn_test_lease(channel_id, tmux);
     let deferred = synthetic_start_wiring::wire_tui_direct_synthetic_turn_start(
         &shared,
@@ -3534,6 +3561,7 @@ async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
         channel_id,
         &prompt,
         anchor_id,
+        synthetic_anchor.owned_placeholder,
         &decision,
         &mut lease,
     )

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -3552,10 +3552,7 @@ async fn genuine_tui_direct_typed_prompt_still_creates_synthetic_inflight() {
         "the notification/task-card identity must not remain the streaming anchor after placeholder success"
     );
     let snapshot = super::super::mailbox_snapshot(shared.as_ref(), channel_id).await;
-    assert_eq!(
-        snapshot.active_user_message_id,
-        Some(placeholder_anchor_id)
-    );
+    assert_eq!(snapshot.active_user_message_id, Some(placeholder_anchor_id));
     assert!(snapshot.cancel_token.is_some());
     let state = super::super::inflight::load_inflight_state(&provider, channel_id.get())
         .expect("typed TUI prompt must create synthetic inflight");

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -3436,6 +3436,28 @@ fn failed_synthetic_claim_cleans_only_owned_placeholder() {
     );
 }
 
+#[test]
+fn failed_synthetic_placeholder_delete_is_terminal_cleanup_guarded() {
+    let helper_src = include_str!("synthetic_start_wiring.rs");
+    let guard_needle = ["terminal_cleanup_", "protects_delete("].concat();
+    let delete_needle = [".delete_", "message(&http, anchor_message_id)"].concat();
+    let result_needle = ["emit_relay_delete_", "result("].concat();
+    let guard = helper_src
+        .find(&guard_needle)
+        .expect("rejected synthetic cleanup must consult terminal cleanup protection");
+    let delete = helper_src
+        .find(&delete_needle)
+        .expect("rejected synthetic cleanup must retain its owned-placeholder delete");
+    let result = helper_src
+        .find(&result_needle)
+        .expect("rejected synthetic cleanup delete result must be durably observed");
+
+    assert!(
+        guard < delete && delete < result,
+        "committed and retry-pending terminal placeholders must be skipped before delete"
+    );
+}
+
 #[tokio::test]
 async fn compact_continuation_injection_skips_synthetic_and_leaves_mailbox_free() {
     let temp = tempfile::tempdir().expect("temp runtime root");

--- a/src/services/observability/emit.rs
+++ b/src/services/observability/emit.rs
@@ -617,7 +617,8 @@ pub fn emit_relay_delivery(
 /// reuses the `PlaceholderCleanupOperation` vocab (`delete_terminal` /
 /// `delete_nonterminal` / `edit_terminal` / `edit_preserve`) or a site-specific
 /// descriptive verb, and `outcome` is one of `committed` | `already_gone` |
-/// `failed` | `skipped_committed_terminal`. The outcome doubles as the event
+/// `failed` | `skipped_committed_terminal` | `skipped_terminal_retry_pending`.
+/// The outcome doubles as the event
 /// `status` (correlation column) so a query can split committed deletes from
 /// guard-skips without parsing the payload.
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## 요약 (#4342 — #4242 흡수)
합성(TUI-direct/주입/루프) 턴이 task-card/notification 메시지를 anchor로 써서 prose가 직전 메시지에 편집-병합되고 턴 경계가 소실되던 문제(오늘 라이브 감사에서 사이클당 4~5건 재확인).
- active synthetic claim 직후 canonical `send_intake_placeholder`로 command-bot 소유 placeholder 선게시(기존 카드에 reply reference), 반환 ID를 anchor_message_id로.
- ID는 기존 체인(started→record_prompt_anchor→inline/deferred claim→inflight user_msg_id→completion/recovery)으로 자동 관통 — 신규 FSM/복제 필드 없음.
- placeholder 게시 실패 시 기존 notification anchor로 fail-open (회귀 방지).
- SystemContinuation/local-only slash는 lifecycle 밖 유지. #3016 핫파일 무접촉. intake_turn.rs prod net-zero(ratchet 준수).

## 테스트 (뮤테이션 증명)
anchor 선택 성공/실패-fallback/합성 inflight 전파/user-turn 분리 불변 4종.

## 게이트
fmt/check/test/inventory/freshness/maintainability rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)