### PR TITLE
fix(pg-tunnel): Unix socket remote target으로 mac-mini ephemeral 포트 고갈 제거 (PR-A)

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -856,10 +856,25 @@ _reset_pg_tunnel_rollback_state() {
     PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
 }
 
+_pg_canonical_listener_absent() {
+    command -v lsof >/dev/null 2>&1 || return 1
+    ! lsof -nP -a -iTCP@127.0.0.1:15432 -sTCP:LISTEN >/dev/null 2>&1
+}
+
+_pg_wait_canonical_listener_absent() {
+    local attempt=0
+    while [ "$attempt" -lt 25 ]; do
+        _pg_canonical_listener_absent && return 0
+        sleep 0.2
+        attempt=$((attempt + 1))
+    done
+    return 1
+}
+
 _rollback_pg_tunnel_migration() {
     local domain="${PG_TUNNEL_LAUNCHD_DOMAIN:-}" bin="${PG_TUNNEL_BIN:-}"
     local plist="${PG_TUNNEL_PLIST_PATH:-}" backup="${PG_TUNNEL_ROLLBACK_DIR:-}"
-    local restore_ok=1
+    local restore_ok=1 readiness_ok=0
     [ "${PG_TUNNEL_ROLLBACK_ARMED:-0}" = 1 ] || return 0
     if [ -z "$domain" ] || [ -z "$bin" ] || [ -z "$plist" ] || [ -z "$backup" ]; then
         echo "✗ PG tunnel rollback state is incomplete; recovery material retained at ${backup:-unknown}" >&2
@@ -907,16 +922,27 @@ _rollback_pg_tunnel_migration() {
     fi
 
     if [ "$restore_ok" = 1 ]; then
-        if _pg_sql_probe 15432; then
-            if rm -rf "$backup" 2>/dev/null; then
-                _reset_pg_tunnel_rollback_state
-                echo "✓ Previous PG tunnel state restored and SQL-ready" >&2
-                return 0
+        if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ] \
+          || [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ]; then
+            if _pg_sql_probe 15432; then
+                readiness_ok=1
+            else
+                echo "✗ Restored PG tunnel did not become SQL-ready on :15432" >&2
             fi
-            echo "✗ Previous PG tunnel is SQL-ready but rollback backup cleanup failed" >&2
+            _cleanup_owned_pg_tunnel_preflight
+        elif _pg_wait_canonical_listener_absent; then
+            readiness_ok=1
         else
-            echo "✗ Restored PG tunnel did not become SQL-ready on :15432" >&2
+            echo "✗ Restored no-tunnel state still has a listener on :15432" >&2
         fi
+    fi
+    if [ "$restore_ok" = 1 ] && [ "$readiness_ok" = 1 ]; then
+        if rm -rf "$backup" 2>/dev/null; then
+            _reset_pg_tunnel_rollback_state
+            echo "✓ Previous PG tunnel state restored and verified" >&2
+            return 0
+        fi
+        echo "✗ Previous PG tunnel state is verified but rollback backup cleanup failed" >&2
     fi
     echo "⚠ PG tunnel rollback incomplete; recovery material retained at $backup" >&2
     return 1
@@ -924,10 +950,12 @@ _rollback_pg_tunnel_migration() {
 
 _cleanup_on_exit() {
     local status=${1:-$?}
-    trap - EXIT INT TERM
+    trap - EXIT
+    trap '' INT TERM
     _cleanup_owned_pg_tunnel_preflight
     if [ "$status" -ne 0 ]; then
         _rollback_pg_tunnel_migration || true
+        _cleanup_owned_pg_tunnel_preflight
     fi
     # #3858: if the binary was promoted (ROLLBACK_ARMED) but the deploy never
     # reached DEPLOY_OK, restore the last-known-good binary and restart BEFORE the
@@ -1669,6 +1697,7 @@ port, output_dir, password_output = ARGV
 uri = URI.parse(ENV.fetch("DATABASE_URL"))
 raise "unsupported database URL scheme" unless %w[postgres postgresql].include?(uri.scheme)
 decode = ->(value) { URI::DEFAULT_PARSER.unescape(value.to_s) }
+host = uri.hostname.to_s
 user = decode.call(uri.user)
 name = decode.call(uri.path.to_s.sub(%r{\A/}, ""))
 password = decode.call(uri.password) if uri.password
@@ -1679,10 +1708,6 @@ option_env = {
   "connect_timeout" => "PGCONNECT_TIMEOUT",
   "fallback_application_name" => "PGAPPNAME",
   "gssencmode" => "PGGSSENCMODE",
-  "keepalives" => "PGKEEPALIVES",
-  "keepalives_count" => "PGKEEPALIVESCOUNT",
-  "keepalives_idle" => "PGKEEPALIVESIDLE",
-  "keepalives_interval" => "PGKEEPALIVESINTERVAL",
   "krbsrvname" => "PGKRBSRVNAME",
   "options" => "PGOPTIONS",
   "require_auth" => "PGREQUIREAUTH",
@@ -1694,11 +1719,14 @@ option_env = {
   "sslrootcert" => "PGSSLROOTCERT",
   "ssl_max_protocol_version" => "PGSSLMAXPROTOCOLVERSION",
   "ssl_min_protocol_version" => "PGSSLMINPROTOCOLVERSION",
-  "target_session_attrs" => "PGTARGETSESSIONATTRS",
-  "tcp_user_timeout" => "PGTCPUSER_TIMEOUT"
+  "target_session_attrs" => "PGTARGETSESSIONATTRS"
 }
 fields = {}
-URI.decode_www_form(uri.query.to_s).each do |key, value|
+uri.query.to_s.split("&", -1).each do |pair|
+  next if pair.empty?
+  encoded_key, encoded_value = pair.split("=", 2)
+  key = decode.call(encoded_key)
+  value = decode.call(encoded_value)
   case key
   when "password"
     password = value
@@ -1713,8 +1741,9 @@ URI.decode_www_form(uri.query.to_s).each do |key, value|
     fields[env_name] = value if env_name
   end
 end
-raise "database user or name missing" if user.empty? || name.empty?
-fields.merge!("PGHOST" => "127.0.0.1", "PGPORT" => Integer(port, 10).to_s,
+raise "database host, user, or name missing" if host.empty? || user.empty? || name.empty?
+fields.merge!("PGHOST" => host, "PGHOSTADDR" => "127.0.0.1",
+              "PGPORT" => Integer(port, 10).to_s,
               "PGUSER" => user, "PGDATABASE" => name)
 raise "NUL is not allowed in PostgreSQL settings" if fields.values.any? { |value| value.include?("\0") }
 fields.each do |env_name, value|
@@ -1724,9 +1753,11 @@ fields.each do |env_name, value|
 end
 if password
   raise "NUL is not allowed in PostgreSQL password" if password.include?("\0")
-  escape = ->(value) { value.to_s.gsub("\\", "\\\\").gsub(":", "\\:") }
+  escape = lambda do |value|
+    value.to_s.gsub("\\") { "\\\\" }.gsub(":") { "\\:" }
+  end
   File.open(password_output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
-    file.write(["127.0.0.1", port, name, user, password].map { |value| escape.call(value) }.join(":") + "\n")
+    file.write([host, port, name, user, password].map { |value| escape.call(value) }.join(":") + "\n")
   end
 end
 RUBY
@@ -1739,10 +1770,12 @@ config_path, port, output_dir, password_output = ARGV
 config = YAML.safe_load(File.read(config_path), aliases: true) || {}
 db = config.fetch("database", {})
 raise "database disabled" unless db["enabled"] == true
+host = db.fetch("host").to_s
 user = db.fetch("user").to_s
 name = db.fetch("dbname").to_s
-raise "database user or name missing" if user.empty? || name.empty?
-fields = { "PGHOST" => "127.0.0.1", "PGPORT" => Integer(port, 10).to_s,
+raise "database host, user, or name missing" if host.empty? || user.empty? || name.empty?
+fields = { "PGHOST" => host, "PGHOSTADDR" => "127.0.0.1",
+           "PGPORT" => Integer(port, 10).to_s,
            "PGUSER" => user, "PGDATABASE" => name }
 raise "NUL is not allowed in PostgreSQL settings" if fields.values.any? { |value| value.include?("\0") }
 fields.each do |env_name, value|
@@ -1753,9 +1786,11 @@ end
 if db.key?("password") && !db["password"].nil?
   password = db["password"].to_s
   raise "NUL is not allowed in PostgreSQL password" if password.include?("\0")
-  escape = ->(value) { value.to_s.gsub("\\", "\\\\").gsub(":", "\\:") }
+  escape = lambda do |value|
+    value.to_s.gsub("\\") { "\\\\" }.gsub(":") { "\\:" }
+  end
   File.open(password_output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
-    file.write(["127.0.0.1", port, name, user, password].map { |value| escape.call(value) }.join(":") + "\n")
+    file.write([host, port, name, user, password].map { |value| escape.call(value) }.join(":") + "\n")
   end
 end
 RUBY
@@ -1776,11 +1811,10 @@ _pg_sql_probe() {
     )
     local -a conninfo_names=(
         PGAPPNAME PGCHANNELBINDING PGCLIENTENCODING PGCONNECT_TIMEOUT
-        PGGSSENCMODE PGHOST PGKEEPALIVES PGKEEPALIVESCOUNT PGKEEPALIVESIDLE
-        PGKEEPALIVESINTERVAL PGKRBSRVNAME PGOPTIONS PGPORT PGREQUIREAUTH
-        PGSSLCERT PGSSLCRL PGSSLCRLDIR PGSSLKEY PGSSLMAXPROTOCOLVERSION
-        PGSSLMINPROTOCOLVERSION PGSSLMODE PGSSLROOTCERT PGTARGETSESSIONATTRS
-        PGTCPUSER_TIMEOUT PGUSER PGDATABASE
+        PGGSSENCMODE PGHOST PGHOSTADDR PGKRBSRVNAME PGOPTIONS PGPORT
+        PGREQUIREAUTH PGSSLCERT PGSSLCRL PGSSLCRLDIR PGSSLKEY
+        PGSSLMAXPROTOCOLVERSION PGSSLMINPROTOCOLVERSION PGSSLMODE
+        PGSSLROOTCERT PGTARGETSESSIONATTRS PGUSER PGDATABASE
     )
     command -v psql >/dev/null 2>&1 || return 1
     for name in "${clear_names[@]}"; do
@@ -1805,6 +1839,8 @@ _pg_sql_probe() {
     done
     if [ -s "$password_file" ]; then
         psql_env+=("PGPASSFILE=$password_file")
+    else
+        psql_env+=("PGPASSFILE=/dev/null")
     fi
     while [ "$attempt" -lt 20 ]; do
         if "${psql_env[@]}" psql --no-psqlrc \
@@ -1872,6 +1908,13 @@ _migrate_pg_tunnel_before_release_stop() {
     PG_TUNNEL_ROLLBACK_JOB_LOADED=0
     PG_TUNNEL_ROLLBACK_MANUAL_KIND="none"
     if launchctl print "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" >/dev/null 2>&1; then
+        if [ ! -f "$PG_TUNNEL_ROLLBACK_DIR/wrapper" ] \
+          || [ ! -f "$PG_TUNNEL_ROLLBACK_DIR/plist" ]; then
+            echo "✗ Loaded PG tunnel job lacks restorable wrapper/plist snapshots"
+            rm -rf "$PG_TUNNEL_ROLLBACK_DIR" 2>/dev/null || true
+            _reset_pg_tunnel_rollback_state
+            return 1
+        fi
         PG_TUNNEL_ROLLBACK_JOB_LOADED=1
     else
         if ! PG_TUNNEL_ROLLBACK_MANUAL_KIND=$(
@@ -1898,6 +1941,14 @@ _migrate_pg_tunnel_before_release_stop() {
     _install_pg_tunnel_plist || return 1
     xattr -d com.apple.quarantine "$PG_TUNNEL_PLIST_PATH" 2>/dev/null || true
     launchctl bootout "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" 2>/dev/null || true
+    if ! "$wrapper_source" --take-over-canonical; then
+        echo "✗ Failed to synchronously take over the canonical PG tunnel"
+        return 1
+    fi
+    if ! _pg_wait_canonical_listener_absent; then
+        echo "✗ Canonical PG tunnel listener survived synchronous takeover"
+        return 1
+    fi
     if ! launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
         echo "✗ PG tunnel bootstrap failed"
         return 1

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1780,7 +1780,7 @@ if password
   end
 end
 RUBY
-        return
+        return $?
     fi
     [ -r "$config_path" ] || return 1
     ruby -ryaml - "$config_path" "$local_port" "$output_dir" "$password_output" \

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -115,6 +115,15 @@ STAGED_BINARY=""
 POLICIES_STAGED=""
 LAUNCHD_MIGRATED_STAGED=""
 RELEASE_ROOT_SCRIPTS_STAGED=""
+PG_TUNNEL_PREFLIGHT_PID=""
+PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
+PG_TUNNEL_ROLLBACK_ARMED=0
+PG_TUNNEL_ROLLBACK_DIR=""
+PG_TUNNEL_ROLLBACK_JOB_LOADED=0
+PG_TUNNEL_ROLLBACK_MANUAL_KIND="none"
+PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
+PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
 DEPLOY_ALL_NODES="${AGENTDESK_DEPLOY_ALL_NODES:-0}"
 DEPLOY_PEERS_OVERRIDE=()
 DEPLOY_PEERS_FILE="${AGENTDESK_DEPLOY_PEERS_FILE:-$ADK_REL/config/deploy-peers.txt}"
@@ -815,8 +824,70 @@ _rollback_release_binary() {
     fi
 }
 
+_cleanup_owned_pg_tunnel_preflight() {
+    local pid="${PG_TUNNEL_PREFLIGHT_PID:-}" attempts=0
+    if [ -n "$pid" ]; then
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+            while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 25 ]; do
+                sleep 0.2
+                attempts=$((attempts + 1))
+            done
+            if kill -0 "$pid" 2>/dev/null; then
+                kill -KILL "$pid" 2>/dev/null || true
+            fi
+        fi
+        # Reap the child on every exit path, including an early SSH failure.
+        wait "$pid" 2>/dev/null || true
+    fi
+    PG_TUNNEL_PREFLIGHT_PID=""
+    [ -z "${PG_TUNNEL_PREFLIGHT_DSN_FILE:-}" ] || rm -f "$PG_TUNNEL_PREFLIGHT_DSN_FILE" 2>/dev/null || true
+    [ -z "${PG_TUNNEL_PREFLIGHT_PASSWORD_FILE:-}" ] || rm -f "$PG_TUNNEL_PREFLIGHT_PASSWORD_FILE" 2>/dev/null || true
+    PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+    PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
+}
+
+_rollback_pg_tunnel_migration() {
+    local domain="${PG_TUNNEL_LAUNCHD_DOMAIN:-}" bin="${PG_TUNNEL_BIN:-}"
+    local plist="${PG_TUNNEL_PLIST_PATH:-}" backup="${PG_TUNNEL_ROLLBACK_DIR:-}"
+    [ "${PG_TUNNEL_ROLLBACK_ARMED:-0}" = 1 ] || return 0
+    [ -n "$domain" ] && [ -n "$bin" ] && [ -n "$plist" ] && [ -n "$backup" ] || return 0
+
+    echo "↩ Restoring previous PG tunnel state..." >&2
+    launchctl bootout "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null || true
+    if [ -e "$backup/wrapper" ]; then
+        install -m 0755 "$backup/wrapper" "$bin" 2>/dev/null || true
+    else
+        rm -f "$bin" 2>/dev/null || true
+    fi
+    if [ -e "$backup/plist" ]; then
+        cp -p "$backup/plist" "$plist.tmp" 2>/dev/null \
+            && mv -f "$plist.tmp" "$plist" 2>/dev/null || true
+    else
+        rm -f "$plist" "$plist.tmp" 2>/dev/null || true
+    fi
+    if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ] && [ -f "$plist" ]; then
+        launchctl bootstrap "$domain" "$plist" 2>/dev/null || true
+    elif [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ] \
+      && [ -x "${PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE:-}" ] \
+      && [ -r "${PG_TUNNEL_ROLLBACK_MANUAL_CONFIG:-}" ]; then
+        "$PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE" --restore-canonical \
+            "$PG_TUNNEL_ROLLBACK_MANUAL_CONFIG" \
+            "$PG_TUNNEL_ROLLBACK_MANUAL_KIND" >/dev/null 2>&1 || true
+    fi
+    PG_TUNNEL_ROLLBACK_ARMED=0
+    rm -rf "$backup" 2>/dev/null || true
+    PG_TUNNEL_ROLLBACK_DIR=""
+    PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
+    PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
+}
+
 _cleanup_on_exit() {
     local status=$?
+    _cleanup_owned_pg_tunnel_preflight
+    if [ "$status" -ne 0 ]; then
+        _rollback_pg_tunnel_migration
+    fi
     # #3858: if the binary was promoted (ROLLBACK_ARMED) but the deploy never
     # reached DEPLOY_OK, restore the last-known-good binary and restart BEFORE the
     # staging cleanup below. This catches ANY non-zero exit after promotion — an
@@ -1406,18 +1477,19 @@ if [ -f "$REL_LAUNCHD_ENV_FILE" ]; then
     _apply_launchd_env_file_to_shell "$REL_LAUNCHD_ENV_FILE"
 fi
 
-echo "▸ Preflight PostgreSQL migration integrity via doctor..."
-DOCTOR_JSON_TMP=$(mktemp "${TMPDIR:-/tmp}/agentdesk-doctor.XXXXXX.json")
-set +e
-"$SOURCE_BINARY" doctor --json >"$DOCTOR_JSON_TMP" 2>/dev/null
-DOCTOR_RC=$?
-set -e
-if [ ! -s "$DOCTOR_JSON_TMP" ]; then
-    echo "✗ Doctor preflight did not return JSON output."
-    rm -f "$DOCTOR_JSON_TMP"
-    exit 1
-fi
-if ! python3 - "$DOCTOR_JSON_TMP" <<'PY'
+_doctor_postgres_preflight() {
+    local label=$1 doctor_json_tmp doctor_rc
+    doctor_json_tmp=$(mktemp "${TMPDIR:-/tmp}/agentdesk-doctor.XXXXXX.json") || return 1
+    set +e
+    "$SOURCE_BINARY" doctor --json >"$doctor_json_tmp" 2>/dev/null
+    doctor_rc=$?
+    set -e
+    if [ ! -s "$doctor_json_tmp" ]; then
+        echo "✗ ${label} did not return JSON output."
+        rm -f "$doctor_json_tmp"
+        return 1
+    fi
+    if ! python3 - "$doctor_json_tmp" <<'PY'
 import json
 import sys
 
@@ -1451,14 +1523,18 @@ else:
     print(f"✗ Doctor postgres preflight failed: status={status}, detail={detail}, actual={actual}")
 raise SystemExit(1)
 PY
-then
-    rm -f "$DOCTOR_JSON_TMP"
-    exit 1
-fi
-if [ "$DOCTOR_RC" -ne 0 ]; then
-    echo "⚠ doctor command returned non-zero ($DOCTOR_RC), but postgres preflight check passed."
-fi
-rm -f "$DOCTOR_JSON_TMP"
+    then
+        rm -f "$doctor_json_tmp"
+        return 1
+    fi
+    if [ "$doctor_rc" -ne 0 ]; then
+        echo "⚠ doctor command returned non-zero ($doctor_rc), but postgres preflight check passed."
+    fi
+    rm -f "$doctor_json_tmp"
+}
+
+echo "▸ Preflight PostgreSQL migration integrity via doctor..."
+_doctor_postgres_preflight "Doctor preflight"
 
 # Copy and sign the binary before stopping release. This keeps a missing
 # certificate or failed codesign from taking down a healthy dcserver.
@@ -1469,6 +1545,223 @@ chmod +x "$STAGED_BINARY"
 xattr -d com.apple.provenance "$STAGED_BINARY" 2>/dev/null || true
 sign_binary_with_fallback "$STAGED_BINARY"
 _clean_release_build_cache_after_staging
+
+# ── Fail-closed PostgreSQL tunnel migration (#4378) ───────────────────────────
+# Prove the new remote Unix-socket route on an alternate local port, then replace
+# and prove the canonical launchd route before dcserver is stopped. A missing
+# machine-local config is a node gate; a present but invalid or unusable config
+# aborts without disrupting dcserver.
+PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"
+PG_TUNNEL_PLIST_PATH="$HOME/Library/LaunchAgents/$PG_TUNNEL_LABEL.plist"
+PG_TUNNEL_BIN="$ADK_REL/bin/pg-tunnel.sh"
+PG_TUNNEL_CONFIG="$ADK_REL/config/pg-tunnel.env"
+PG_TUNNEL_LAUNCHD_DOMAIN="$(_launchd_domain)"
+
+_pg_xml_escape() {
+    local s=$1
+    s=${s//&/\&amp;}
+    s=${s//</\&lt;}
+    s=${s//>/\&gt;}
+    s=${s//\"/\&quot;}
+    s=${s//\'/\&apos;}
+    printf '%s' "$s"
+}
+
+_install_pg_tunnel_plist() {
+    local label_x bin_x config_x root_x
+    label_x=$(_pg_xml_escape "$PG_TUNNEL_LABEL") || return 1
+    bin_x=$(_pg_xml_escape "$PG_TUNNEL_BIN") || return 1
+    config_x=$(_pg_xml_escape "$PG_TUNNEL_CONFIG") || return 1
+    root_x=$(_pg_xml_escape "$ADK_REL") || return 1
+    mkdir -p "$HOME/Library/LaunchAgents" || return 1
+    cat > "$PG_TUNNEL_PLIST_PATH.tmp" <<PLIST_EOF || return 1
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$label_x</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$bin_x</string>
+    <string>$config_x</string>
+    <string>-N</string>
+    <string>-T</string>
+    <string>-o</string><string>BatchMode=yes</string>
+    <string>-o</string><string>ConnectTimeout=10</string>
+    <string>-o</string><string>ServerAliveInterval=15</string>
+    <string>-o</string><string>ServerAliveCountMax=3</string>
+    <string>-o</string><string>ExitOnForwardFailure=yes</string>
+    <string>-L</string><string>127.0.0.1:15432:/tmp/.s.PGSQL.5432</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>StandardOutPath</key><string>$root_x/logs/pg-tunnel.launchd.out.log</string>
+  <key>StandardErrorPath</key><string>$root_x/logs/pg-tunnel.launchd.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AGENTDESK_ROOT_DIR</key><string>$root_x</string>
+  </dict>
+</dict>
+</plist>
+PLIST_EOF
+    mv -f "$PG_TUNNEL_PLIST_PATH.tmp" "$PG_TUNNEL_PLIST_PATH" || return 1
+}
+
+_pg_write_probe_conninfo() {
+    local local_port=$1 output=$2 password_output=$3
+    local config_path="$ADK_REL/config/agentdesk.yaml"
+    command -v ruby >/dev/null 2>&1 || return 1
+    if [ -n "${DATABASE_URL:-}" ]; then
+        DATABASE_URL="$DATABASE_URL" ruby -ruri - "$local_port" "$output" "$password_output" \
+            2>/dev/null <<'RUBY'
+port, output, password_output = ARGV
+uri = URI.parse(ENV.fetch("DATABASE_URL"))
+raise "unsupported database URL scheme" unless %w[postgres postgresql].include?(uri.scheme)
+password = URI::DEFAULT_PARSER.unescape(uri.password) if uri.password
+uri.password = nil if password
+if uri.query
+  query = URI.decode_www_form(uri.query)
+  query.reject! do |key, value|
+    case key
+    when "password"
+      password = value
+      true
+    when "host", "hostaddr", "port"
+      true
+    else
+      false
+    end
+  end
+  uri.query = query.empty? ? nil : URI.encode_www_form(query)
+end
+uri.host = "127.0.0.1"
+uri.port = Integer(port, 10)
+File.open(output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(uri.to_s) }
+if password
+  escaped = password.gsub("\\", "\\\\").gsub(":", "\\:")
+  File.open(password_output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+    file.write("127.0.0.1:#{port}:*:*:#{escaped}\n")
+  end
+end
+RUBY
+        return
+    fi
+    [ -r "$config_path" ] || return 1
+    ruby -ryaml -ruri - "$config_path" "$local_port" "$output" "$password_output" \
+        2>/dev/null <<'RUBY'
+config_path, port, output, password_output = ARGV
+config = YAML.safe_load_file(config_path, aliases: true) || {}
+db = config.fetch("database", {})
+raise "database disabled" unless db["enabled"] == true
+user = db.fetch("user").to_s
+name = db.fetch("dbname").to_s
+raise "database user or name missing" if user.empty? || name.empty?
+uri = URI::Generic.build(
+  scheme: "postgresql", userinfo: URI.encode_www_form_component(user),
+  host: "127.0.0.1", port: Integer(port, 10), path: "/#{URI.encode_www_form_component(name)}"
+)
+File.open(output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(uri.to_s) }
+if db.key?("password") && !db["password"].nil?
+  escaped = db["password"].to_s.gsub("\\", "\\\\").gsub(":", "\\:")
+  File.open(password_output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+    file.write("127.0.0.1:#{port}:*:*:#{escaped}\n")
+  end
+end
+RUBY
+}
+
+_pg_sql_probe() {
+    local local_port=$1 conninfo_file password_file attempt=0
+    local -a psql_env=()
+    command -v psql >/dev/null 2>&1 || return 1
+    conninfo_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pg-probe.XXXXXX") || return 1
+    password_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pgpass.XXXXXX") || return 1
+    PG_TUNNEL_PREFLIGHT_DSN_FILE="$conninfo_file"
+    PG_TUNNEL_PREFLIGHT_PASSWORD_FILE="$password_file"
+    chmod 600 "$conninfo_file" "$password_file" || return 1
+    _pg_write_probe_conninfo "$local_port" "$conninfo_file" "$password_file" || return 1
+    if [ -s "$password_file" ]; then
+        psql_env=(env PGPASSFILE="$password_file")
+    fi
+    while [ "$attempt" -lt 20 ]; do
+        if PGDATABASE="$(<"$conninfo_file")" "${psql_env[@]}" psql --no-psqlrc \
+          -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null 2>&1; then
+            rm -f "$conninfo_file" "$password_file"
+            PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+            PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
+            return 0
+        fi
+        sleep 0.25
+        attempt=$((attempt + 1))
+    done
+    return 1
+}
+
+_migrate_pg_tunnel_before_release_stop() {
+    local probe_port wrapper_source="$REPO/scripts/pg_tunnel.sh"
+    [ -f "$PG_TUNNEL_CONFIG" ] || {
+        echo "▸ PG tunnel config absent: $PG_TUNNEL_CONFIG"
+        echo "  Supervisor NOT armed on this node (machine-local node gate)."
+        return 0
+    }
+    [ -x "$wrapper_source" ] || { echo "✗ PG tunnel wrapper missing: $wrapper_source"; return 1; }
+    "$wrapper_source" --check-config "$PG_TUNNEL_CONFIG" || {
+        echo "✗ PG tunnel config invalid: $PG_TUNNEL_CONFIG"
+        return 1
+    }
+
+    probe_port=$((20000 + ($$ % 20000)))
+    echo "▸ Proving remote PostgreSQL Unix-socket route on alternate port..."
+    "$wrapper_source" --probe-remote "$PG_TUNNEL_CONFIG" "$probe_port" \
+        >/dev/null 2>&1 &
+    PG_TUNNEL_PREFLIGHT_PID=$!
+    if ! _pg_sql_probe "$probe_port"; then
+        echo "✗ Remote PostgreSQL Unix-socket SQL probe failed"
+        _cleanup_owned_pg_tunnel_preflight
+        return 1
+    fi
+    _cleanup_owned_pg_tunnel_preflight
+
+    PG_TUNNEL_ROLLBACK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-pg-rollback.XXXXXX") || return 1
+    PG_TUNNEL_ROLLBACK_ARMED=1
+    PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE="$wrapper_source"
+    [ ! -e "$PG_TUNNEL_BIN" ] || cp -p "$PG_TUNNEL_BIN" "$PG_TUNNEL_ROLLBACK_DIR/wrapper" || return 1
+    [ ! -e "$PG_TUNNEL_PLIST_PATH" ] || cp -p "$PG_TUNNEL_PLIST_PATH" "$PG_TUNNEL_ROLLBACK_DIR/plist" || return 1
+    cp -p "$PG_TUNNEL_CONFIG" "$PG_TUNNEL_ROLLBACK_DIR/config" || return 1
+    PG_TUNNEL_ROLLBACK_MANUAL_CONFIG="$PG_TUNNEL_ROLLBACK_DIR/config"
+    if launchctl print "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" >/dev/null 2>&1; then
+        PG_TUNNEL_ROLLBACK_JOB_LOADED=1
+    else
+        PG_TUNNEL_ROLLBACK_MANUAL_KIND=$(
+            "$wrapper_source" --canonical-kind 2>/dev/null || printf '%s\n' none
+        )
+    fi
+
+    install -m 0755 "$wrapper_source" "$PG_TUNNEL_BIN" || return 1
+    _install_pg_tunnel_plist || return 1
+    xattr -d com.apple.quarantine "$PG_TUNNEL_PLIST_PATH" 2>/dev/null || true
+    launchctl bootout "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" 2>/dev/null || true
+    if ! launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
+        echo "✗ PG tunnel bootstrap failed"
+        return 1
+    fi
+    echo "▸ Proving canonical PostgreSQL tunnel readiness on :15432..."
+    if ! _pg_sql_probe 15432; then
+        echo "✗ Canonical PostgreSQL tunnel SQL readiness failed"
+        return 1
+    fi
+
+    rm -rf "$PG_TUNNEL_ROLLBACK_DIR" || return 1
+    PG_TUNNEL_ROLLBACK_DIR=""
+    PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
+    PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
+    PG_TUNNEL_ROLLBACK_ARMED=0
+    echo "✓ PG tunnel migrated and SQL-ready before release stop"
+}
+
+_migrate_pg_tunnel_before_release_stop
 
 # #4381: a deploy restarts dcserver, so a short relay gap is EXPECTED here.
 # Touch the marker the out-of-band relay watchdog checks; while it is fresh
@@ -2546,101 +2839,6 @@ PLIST_EOF
     fi
 else
     echo "⚠ Relay watchdog staging FAILED (source: $REPO/scripts/relay_watchdog.py)"
-fi
-
-# ── Consumer-owned PostgreSQL SSH tunnel supervisor (#4378) ──────────────────
-# This is deliberately a separate launchd lifetime from dcserver: dcserver may
-# crash-loop while PG is absent (#4379), but the process that restores PG must
-# remain alive.  Like the relay watchdog above, this block is after DEPLOY_OK
-# and entirely fail-open so an ops-side install failure cannot turn a healthy,
-# health-confirmed binary deploy into a rollback or skip peer propagation.
-PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"
-PG_TUNNEL_PLIST_PATH="$HOME/Library/LaunchAgents/$PG_TUNNEL_LABEL.plist"
-PG_TUNNEL_BIN="$ADK_REL/bin/pg-tunnel.sh"
-PG_TUNNEL_CONFIG="$ADK_REL/config/pg-tunnel.env"
-echo "▸ Staging consumer-owned PG tunnel supervisor (#4378)..."
-if install -m 0755 "$REPO/scripts/pg_tunnel.sh" "$PG_TUNNEL_BIN"; then
-    # Machine-local config is the node-identity gate.  It is intentionally not
-    # shipped by the repo: mac-mini and future nodes must never arm a tunnel
-    # pointed back at themselves merely because cluster deploy propagated.
-    if [ -f "$PG_TUNNEL_CONFIG" ]; then
-        _pg_xml_escape() {
-            local s=$1
-            s=${s//&/\&amp;}
-            s=${s//</\&lt;}
-            s=${s//>/\&gt;}
-            s=${s//\"/\&quot;}
-            s=${s//\'/\&apos;}
-            printf '%s' "$s"
-        }
-        _install_pg_tunnel_plist() {
-            local label_x bin_x config_x root_x
-            label_x=$(_pg_xml_escape "$PG_TUNNEL_LABEL") || return 1
-            bin_x=$(_pg_xml_escape "$PG_TUNNEL_BIN") || return 1
-            config_x=$(_pg_xml_escape "$PG_TUNNEL_CONFIG") || return 1
-            root_x=$(_pg_xml_escape "$ADK_REL") || return 1
-            mkdir -p "$HOME/Library/LaunchAgents" || return 1
-            cat > "$PG_TUNNEL_PLIST_PATH.tmp" <<PLIST_EOF || return 1
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>$label_x</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>$bin_x</string>
-    <string>$config_x</string>
-    <string>-N</string>
-    <string>-T</string>
-    <string>-o</string><string>BatchMode=yes</string>
-    <string>-o</string><string>ConnectTimeout=10</string>
-    <string>-o</string><string>ServerAliveInterval=15</string>
-    <string>-o</string><string>ServerAliveCountMax=3</string>
-    <string>-o</string><string>ExitOnForwardFailure=yes</string>
-    <string>-L</string><string>127.0.0.1:15432:/tmp/.s.PGSQL.5432</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>ThrottleInterval</key><integer>10</integer>
-  <key>StandardOutPath</key><string>$root_x/logs/pg-tunnel.launchd.out.log</string>
-  <key>StandardErrorPath</key><string>$root_x/logs/pg-tunnel.launchd.err.log</string>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key><string>/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>AGENTDESK_ROOT_DIR</key><string>$root_x</string>
-  </dict>
-</dict>
-</plist>
-PLIST_EOF
-            # Atomic publish: launchd never observes a partially-written XML.
-            mv -f "$PG_TUNNEL_PLIST_PATH.tmp" "$PG_TUNNEL_PLIST_PATH" || return 1
-        }
-        if ! "$PG_TUNNEL_BIN" --check-config "$PG_TUNNEL_CONFIG"; then
-            echo "⚠ PG tunnel config invalid: $PG_TUNNEL_CONFIG — NOT armed"
-            echo "  Required: PG_TUNNEL_SSH_TARGET=mac-mini (or PG_TUNNEL_HOST alias)."
-        elif _install_pg_tunnel_plist; then
-            xattr -d com.apple.quarantine "$PG_TUNNEL_PLIST_PATH" 2>/dev/null || true
-            echo "⚠ PG tunnel deploy prerequisite: on mac-mini, bootout and remove BOTH"
-            echo "  reverse plists (com.agentdesk.macbook-pg-tunnel and"
-            echo "  com.agentdesk.macbook-memento-tunnel) before this job is activated."
-            # bootout+bootstrap (not kickstart): pick up both wrapper and plist.
-            launchctl bootout "$LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" 2>/dev/null || true
-            if launchctl bootstrap "$LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"; then
-                echo "✓ PG tunnel supervisor armed ($PG_TUNNEL_LABEL)"
-            else
-                echo "⚠ PG tunnel bootstrap FAILED — dcserver PG path is unsupervised"
-            fi
-        else
-            rm -f "$PG_TUNNEL_PLIST_PATH.tmp" 2>/dev/null || true
-            echo "⚠ PG tunnel plist write FAILED ($PG_TUNNEL_PLIST_PATH) — not armed"
-            echo "  Deploy continues (fail-open): fix permissions/disk space and redeploy."
-        fi
-    else
-        echo "▸ PG tunnel config absent: $PG_TUNNEL_CONFIG"
-        echo "  Supervisor NOT armed on this node (machine-local node gate)."
-    fi
-else
-    echo "⚠ PG tunnel staging FAILED (source: $REPO/scripts/pg_tunnel.sh)"
 fi
 
 _write_release_source_manifest

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -116,7 +116,7 @@ POLICIES_STAGED=""
 LAUNCHD_MIGRATED_STAGED=""
 RELEASE_ROOT_SCRIPTS_STAGED=""
 PG_TUNNEL_PREFLIGHT_PID=""
-PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=""
 PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
 PG_TUNNEL_ROLLBACK_ARMED=0
 PG_TUNNEL_ROLLBACK_DIR=""
@@ -841,52 +841,93 @@ _cleanup_owned_pg_tunnel_preflight() {
         wait "$pid" 2>/dev/null || true
     fi
     PG_TUNNEL_PREFLIGHT_PID=""
-    [ -z "${PG_TUNNEL_PREFLIGHT_DSN_FILE:-}" ] || rm -f "$PG_TUNNEL_PREFLIGHT_DSN_FILE" 2>/dev/null || true
+    [ -z "${PG_TUNNEL_PREFLIGHT_CONNINFO_DIR:-}" ] || rm -rf "$PG_TUNNEL_PREFLIGHT_CONNINFO_DIR" 2>/dev/null || true
     [ -z "${PG_TUNNEL_PREFLIGHT_PASSWORD_FILE:-}" ] || rm -f "$PG_TUNNEL_PREFLIGHT_PASSWORD_FILE" 2>/dev/null || true
-    PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+    PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=""
     PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
+}
+
+_reset_pg_tunnel_rollback_state() {
+    PG_TUNNEL_ROLLBACK_ARMED=0
+    PG_TUNNEL_ROLLBACK_DIR=""
+    PG_TUNNEL_ROLLBACK_JOB_LOADED=0
+    PG_TUNNEL_ROLLBACK_MANUAL_KIND="none"
+    PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
+    PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
 }
 
 _rollback_pg_tunnel_migration() {
     local domain="${PG_TUNNEL_LAUNCHD_DOMAIN:-}" bin="${PG_TUNNEL_BIN:-}"
     local plist="${PG_TUNNEL_PLIST_PATH:-}" backup="${PG_TUNNEL_ROLLBACK_DIR:-}"
+    local restore_ok=1
     [ "${PG_TUNNEL_ROLLBACK_ARMED:-0}" = 1 ] || return 0
-    [ -n "$domain" ] && [ -n "$bin" ] && [ -n "$plist" ] && [ -n "$backup" ] || return 0
+    if [ -z "$domain" ] || [ -z "$bin" ] || [ -z "$plist" ] || [ -z "$backup" ]; then
+        echo "✗ PG tunnel rollback state is incomplete; recovery material retained at ${backup:-unknown}" >&2
+        return 1
+    fi
 
     echo "↩ Restoring previous PG tunnel state..." >&2
     launchctl bootout "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null || true
     if [ -e "$backup/wrapper" ]; then
-        install -m 0755 "$backup/wrapper" "$bin" 2>/dev/null || true
-    else
-        rm -f "$bin" 2>/dev/null || true
+        if ! install -m 0755 "$backup/wrapper" "$bin" 2>/dev/null; then
+            echo "✗ Failed to restore PG tunnel wrapper" >&2
+            restore_ok=0
+        fi
+    elif ! rm -f "$bin" 2>/dev/null; then
+        echo "✗ Failed to remove newly installed PG tunnel wrapper" >&2
+        restore_ok=0
     fi
     if [ -e "$backup/plist" ]; then
-        cp -p "$backup/plist" "$plist.tmp" 2>/dev/null \
-            && mv -f "$plist.tmp" "$plist" 2>/dev/null || true
-    else
-        rm -f "$plist" "$plist.tmp" 2>/dev/null || true
+        if ! cp -p "$backup/plist" "$plist.tmp" 2>/dev/null \
+          || ! mv -f "$plist.tmp" "$plist" 2>/dev/null; then
+            echo "✗ Failed to restore PG tunnel launchd plist" >&2
+            restore_ok=0
+        fi
+    elif ! rm -f "$plist" "$plist.tmp" 2>/dev/null; then
+        echo "✗ Failed to remove newly installed PG tunnel launchd plist" >&2
+        restore_ok=0
     fi
-    if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ] && [ -f "$plist" ]; then
-        launchctl bootstrap "$domain" "$plist" 2>/dev/null || true
-    elif [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ] \
-      && [ -x "${PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE:-}" ] \
-      && [ -r "${PG_TUNNEL_ROLLBACK_MANUAL_CONFIG:-}" ]; then
-        "$PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE" --restore-canonical \
-            "$PG_TUNNEL_ROLLBACK_MANUAL_CONFIG" \
-            "$PG_TUNNEL_ROLLBACK_MANUAL_KIND" >/dev/null 2>&1 || true
+
+    if [ "$restore_ok" = 1 ]; then
+        if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ]; then
+            if [ ! -f "$plist" ] || ! launchctl bootstrap "$domain" "$plist" 2>/dev/null; then
+                echo "✗ Failed to restart previous PG tunnel launchd job" >&2
+                restore_ok=0
+            fi
+        elif [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ]; then
+            if [ ! -x "${PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE:-}" ] \
+              || [ ! -r "${PG_TUNNEL_ROLLBACK_MANUAL_CONFIG:-}" ] \
+              || ! "$PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE" --restore-canonical \
+                    "$PG_TUNNEL_ROLLBACK_MANUAL_CONFIG" \
+                    "$PG_TUNNEL_ROLLBACK_MANUAL_KIND" >/dev/null 2>&1; then
+                echo "✗ Failed to restart previous manual PG tunnel" >&2
+                restore_ok=0
+            fi
+        fi
     fi
-    PG_TUNNEL_ROLLBACK_ARMED=0
-    rm -rf "$backup" 2>/dev/null || true
-    PG_TUNNEL_ROLLBACK_DIR=""
-    PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
-    PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
+
+    if [ "$restore_ok" = 1 ]; then
+        if _pg_sql_probe 15432; then
+            if rm -rf "$backup" 2>/dev/null; then
+                _reset_pg_tunnel_rollback_state
+                echo "✓ Previous PG tunnel state restored and SQL-ready" >&2
+                return 0
+            fi
+            echo "✗ Previous PG tunnel is SQL-ready but rollback backup cleanup failed" >&2
+        else
+            echo "✗ Restored PG tunnel did not become SQL-ready on :15432" >&2
+        fi
+    fi
+    echo "⚠ PG tunnel rollback incomplete; recovery material retained at $backup" >&2
+    return 1
 }
 
 _cleanup_on_exit() {
-    local status=$?
+    local status=${1:-$?}
+    trap - EXIT INT TERM
     _cleanup_owned_pg_tunnel_preflight
     if [ "$status" -ne 0 ]; then
-        _rollback_pg_tunnel_migration
+        _rollback_pg_tunnel_migration || true
     fi
     # #3858: if the binary was promoted (ROLLBACK_ARMED) but the deploy never
     # reached DEPLOY_OK, restore the last-known-good binary and restart BEFORE the
@@ -914,7 +955,15 @@ _cleanup_on_exit() {
     _finalize_detached_helper "$status"
 }
 
+_handle_cleanup_signal() {
+    local status=$1
+    _cleanup_on_exit "$status"
+    exit "$status"
+}
+
 trap _cleanup_on_exit EXIT
+trap '_handle_cleanup_signal 130' INT
+trap '_handle_cleanup_signal 143' TERM
 
 _self_hosted_release_session() {
     [ "$DEPLOY_DETACHED_CHILD" != "1" ] || return 1
@@ -1610,86 +1659,159 @@ PLIST_EOF
 }
 
 _pg_write_probe_conninfo() {
-    local local_port=$1 output=$2 password_output=$3
+    local local_port=$1 output_dir=$2 password_output=$3
     local config_path="$ADK_REL/config/agentdesk.yaml"
     command -v ruby >/dev/null 2>&1 || return 1
     if [ -n "${DATABASE_URL:-}" ]; then
-        DATABASE_URL="$DATABASE_URL" ruby -ruri - "$local_port" "$output" "$password_output" \
+        DATABASE_URL="$DATABASE_URL" ruby -ruri - "$local_port" "$output_dir" "$password_output" \
             2>/dev/null <<'RUBY'
-port, output, password_output = ARGV
+port, output_dir, password_output = ARGV
 uri = URI.parse(ENV.fetch("DATABASE_URL"))
 raise "unsupported database URL scheme" unless %w[postgres postgresql].include?(uri.scheme)
-password = URI::DEFAULT_PARSER.unescape(uri.password) if uri.password
-uri.password = nil if password
-if uri.query
-  query = URI.decode_www_form(uri.query)
-  query.reject! do |key, value|
-    case key
-    when "password"
-      password = value
-      true
-    when "host", "hostaddr", "port"
-      true
-    else
-      false
-    end
+decode = ->(value) { URI::DEFAULT_PARSER.unescape(value.to_s) }
+user = decode.call(uri.user)
+name = decode.call(uri.path.to_s.sub(%r{\A/}, ""))
+password = decode.call(uri.password) if uri.password
+option_env = {
+  "application_name" => "PGAPPNAME",
+  "channel_binding" => "PGCHANNELBINDING",
+  "client_encoding" => "PGCLIENTENCODING",
+  "connect_timeout" => "PGCONNECT_TIMEOUT",
+  "fallback_application_name" => "PGAPPNAME",
+  "gssencmode" => "PGGSSENCMODE",
+  "keepalives" => "PGKEEPALIVES",
+  "keepalives_count" => "PGKEEPALIVESCOUNT",
+  "keepalives_idle" => "PGKEEPALIVESIDLE",
+  "keepalives_interval" => "PGKEEPALIVESINTERVAL",
+  "krbsrvname" => "PGKRBSRVNAME",
+  "options" => "PGOPTIONS",
+  "require_auth" => "PGREQUIREAUTH",
+  "sslcert" => "PGSSLCERT",
+  "sslcrl" => "PGSSLCRL",
+  "sslcrldir" => "PGSSLCRLDIR",
+  "sslkey" => "PGSSLKEY",
+  "sslmode" => "PGSSLMODE",
+  "sslrootcert" => "PGSSLROOTCERT",
+  "ssl_max_protocol_version" => "PGSSLMAXPROTOCOLVERSION",
+  "ssl_min_protocol_version" => "PGSSLMINPROTOCOLVERSION",
+  "target_session_attrs" => "PGTARGETSESSIONATTRS",
+  "tcp_user_timeout" => "PGTCPUSER_TIMEOUT"
+}
+fields = {}
+URI.decode_www_form(uri.query.to_s).each do |key, value|
+  case key
+  when "password"
+    password = value
+  when "user"
+    user = value
+  when "dbname"
+    name = value
+  when "host", "hostaddr", "port"
+    next
+  else
+    env_name = option_env[key]
+    fields[env_name] = value if env_name
   end
-  uri.query = query.empty? ? nil : URI.encode_www_form(query)
 end
-uri.host = "127.0.0.1"
-uri.port = Integer(port, 10)
-File.open(output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(uri.to_s) }
+raise "database user or name missing" if user.empty? || name.empty?
+fields.merge!("PGHOST" => "127.0.0.1", "PGPORT" => Integer(port, 10).to_s,
+              "PGUSER" => user, "PGDATABASE" => name)
+raise "NUL is not allowed in PostgreSQL settings" if fields.values.any? { |value| value.include?("\0") }
+fields.each do |env_name, value|
+  File.open(File.join(output_dir, env_name), File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+    file.write(value)
+  end
+end
 if password
-  escaped = password.gsub("\\", "\\\\").gsub(":", "\\:")
+  raise "NUL is not allowed in PostgreSQL password" if password.include?("\0")
+  escape = ->(value) { value.to_s.gsub("\\", "\\\\").gsub(":", "\\:") }
   File.open(password_output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
-    file.write("127.0.0.1:#{port}:*:*:#{escaped}\n")
+    file.write(["127.0.0.1", port, name, user, password].map { |value| escape.call(value) }.join(":") + "\n")
   end
 end
 RUBY
         return
     fi
     [ -r "$config_path" ] || return 1
-    ruby -ryaml -ruri - "$config_path" "$local_port" "$output" "$password_output" \
+    ruby -ryaml - "$config_path" "$local_port" "$output_dir" "$password_output" \
         2>/dev/null <<'RUBY'
-config_path, port, output, password_output = ARGV
-config = YAML.safe_load_file(config_path, aliases: true) || {}
+config_path, port, output_dir, password_output = ARGV
+config = YAML.safe_load(File.read(config_path), aliases: true) || {}
 db = config.fetch("database", {})
 raise "database disabled" unless db["enabled"] == true
 user = db.fetch("user").to_s
 name = db.fetch("dbname").to_s
 raise "database user or name missing" if user.empty? || name.empty?
-uri = URI::Generic.build(
-  scheme: "postgresql", userinfo: URI.encode_www_form_component(user),
-  host: "127.0.0.1", port: Integer(port, 10), path: "/#{URI.encode_www_form_component(name)}"
-)
-File.open(output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) { |file| file.write(uri.to_s) }
+fields = { "PGHOST" => "127.0.0.1", "PGPORT" => Integer(port, 10).to_s,
+           "PGUSER" => user, "PGDATABASE" => name }
+raise "NUL is not allowed in PostgreSQL settings" if fields.values.any? { |value| value.include?("\0") }
+fields.each do |env_name, value|
+  File.open(File.join(output_dir, env_name), File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+    file.write(value)
+  end
+end
 if db.key?("password") && !db["password"].nil?
-  escaped = db["password"].to_s.gsub("\\", "\\\\").gsub(":", "\\:")
+  password = db["password"].to_s
+  raise "NUL is not allowed in PostgreSQL password" if password.include?("\0")
+  escape = ->(value) { value.to_s.gsub("\\", "\\\\").gsub(":", "\\:") }
   File.open(password_output, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
-    file.write("127.0.0.1:#{port}:*:*:#{escaped}\n")
+    file.write(["127.0.0.1", port, name, user, password].map { |value| escape.call(value) }.join(":") + "\n")
   end
 end
 RUBY
 }
 
 _pg_sql_probe() {
-    local local_port=$1 conninfo_file password_file attempt=0
-    local -a psql_env=(env)
+    local local_port=$1 conninfo_dir password_file attempt=0 name value
+    local -a psql_env=(env -u DATABASE_URL)
+    local -a clear_names=(
+        PGAPPNAME PGCHANNELBINDING PGCLIENTENCODING PGCONNECT_TIMEOUT PGDATABASE
+        PGGSSENCMODE PGHOST PGHOSTADDR PGKEEPALIVES PGKEEPALIVESCOUNT
+        PGKEEPALIVESIDLE PGKEEPALIVESINTERVAL PGKRBSRVNAME PGLOADBALANCEHOSTS
+        PGOPTIONS PGPASSFILE PGPASSWORD PGPORT PGREQUIREAUTH PGSERVICE
+        PGSERVICEFILE PGSSLCERT PGSSLCRL PGSSLCRLDIR PGSSLKEY
+        PGSSLMAXPROTOCOLVERSION PGSSLMINPROTOCOLVERSION PGSSLMODE
+        PGSSLNEGOTIATION PGSSLROOTCERT PGTARGETSESSIONATTRS PGTCPUSER_TIMEOUT
+        PGUSER
+    )
+    local -a conninfo_names=(
+        PGAPPNAME PGCHANNELBINDING PGCLIENTENCODING PGCONNECT_TIMEOUT
+        PGGSSENCMODE PGHOST PGKEEPALIVES PGKEEPALIVESCOUNT PGKEEPALIVESIDLE
+        PGKEEPALIVESINTERVAL PGKRBSRVNAME PGOPTIONS PGPORT PGREQUIREAUTH
+        PGSSLCERT PGSSLCRL PGSSLCRLDIR PGSSLKEY PGSSLMAXPROTOCOLVERSION
+        PGSSLMINPROTOCOLVERSION PGSSLMODE PGSSLROOTCERT PGTARGETSESSIONATTRS
+        PGTCPUSER_TIMEOUT PGUSER PGDATABASE
+    )
     command -v psql >/dev/null 2>&1 || return 1
-    conninfo_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pg-probe.XXXXXX") || return 1
-    password_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pgpass.XXXXXX") || return 1
-    PG_TUNNEL_PREFLIGHT_DSN_FILE="$conninfo_file"
+    for name in "${clear_names[@]}"; do
+        psql_env+=(-u "$name")
+    done
+    conninfo_dir=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-pg-probe.XXXXXX") || return 1
+    PG_TUNNEL_PREFLIGHT_CONNINFO_DIR="$conninfo_dir"
+    if ! password_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pgpass.XXXXXX"); then
+        rm -rf "$conninfo_dir" 2>/dev/null || true
+        PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=""
+        return 1
+    fi
     PG_TUNNEL_PREFLIGHT_PASSWORD_FILE="$password_file"
-    chmod 600 "$conninfo_file" "$password_file" || return 1
-    _pg_write_probe_conninfo "$local_port" "$conninfo_file" "$password_file" || return 1
+    chmod 700 "$conninfo_dir" || return 1
+    chmod 600 "$password_file" || return 1
+    _pg_write_probe_conninfo "$local_port" "$conninfo_dir" "$password_file" || return 1
+    for name in "${conninfo_names[@]}"; do
+        if [ -f "$conninfo_dir/$name" ]; then
+            value=$(<"$conninfo_dir/$name")
+            psql_env+=("$name=$value")
+        fi
+    done
     if [ -s "$password_file" ]; then
-        psql_env=(env PGPASSFILE="$password_file")
+        psql_env+=("PGPASSFILE=$password_file")
     fi
     while [ "$attempt" -lt 20 ]; do
-        if PGDATABASE="$(<"$conninfo_file")" "${psql_env[@]}" psql --no-psqlrc \
+        if "${psql_env[@]}" psql --no-psqlrc \
           -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null 2>&1; then
-            rm -f "$conninfo_file" "$password_file"
-            PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+            rm -rf "$conninfo_dir"
+            rm -f "$password_file"
+            PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=""
             PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
             return 0
         fi
@@ -1725,19 +1847,52 @@ _migrate_pg_tunnel_before_release_stop() {
     _cleanup_owned_pg_tunnel_preflight
 
     PG_TUNNEL_ROLLBACK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/agentdesk-pg-rollback.XXXXXX") || return 1
-    PG_TUNNEL_ROLLBACK_ARMED=1
+    if [ -e "$PG_TUNNEL_BIN" ] \
+      && ! cp -p "$PG_TUNNEL_BIN" "$PG_TUNNEL_ROLLBACK_DIR/wrapper"; then
+        echo "✗ Failed to snapshot existing PG tunnel wrapper"
+        rm -rf "$PG_TUNNEL_ROLLBACK_DIR" 2>/dev/null || true
+        _reset_pg_tunnel_rollback_state
+        return 1
+    fi
+    if [ -e "$PG_TUNNEL_PLIST_PATH" ] \
+      && ! cp -p "$PG_TUNNEL_PLIST_PATH" "$PG_TUNNEL_ROLLBACK_DIR/plist"; then
+        echo "✗ Failed to snapshot existing PG tunnel launchd plist"
+        rm -rf "$PG_TUNNEL_ROLLBACK_DIR" 2>/dev/null || true
+        _reset_pg_tunnel_rollback_state
+        return 1
+    fi
+    if ! cp -p "$PG_TUNNEL_CONFIG" "$PG_TUNNEL_ROLLBACK_DIR/config"; then
+        echo "✗ Failed to snapshot PG tunnel machine config"
+        rm -rf "$PG_TUNNEL_ROLLBACK_DIR" 2>/dev/null || true
+        _reset_pg_tunnel_rollback_state
+        return 1
+    fi
     PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE="$wrapper_source"
-    [ ! -e "$PG_TUNNEL_BIN" ] || cp -p "$PG_TUNNEL_BIN" "$PG_TUNNEL_ROLLBACK_DIR/wrapper" || return 1
-    [ ! -e "$PG_TUNNEL_PLIST_PATH" ] || cp -p "$PG_TUNNEL_PLIST_PATH" "$PG_TUNNEL_ROLLBACK_DIR/plist" || return 1
-    cp -p "$PG_TUNNEL_CONFIG" "$PG_TUNNEL_ROLLBACK_DIR/config" || return 1
     PG_TUNNEL_ROLLBACK_MANUAL_CONFIG="$PG_TUNNEL_ROLLBACK_DIR/config"
+    PG_TUNNEL_ROLLBACK_JOB_LOADED=0
+    PG_TUNNEL_ROLLBACK_MANUAL_KIND="none"
     if launchctl print "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL" >/dev/null 2>&1; then
         PG_TUNNEL_ROLLBACK_JOB_LOADED=1
     else
-        PG_TUNNEL_ROLLBACK_MANUAL_KIND=$(
-            "$wrapper_source" --canonical-kind 2>/dev/null || printf '%s\n' none
-        )
+        if ! PG_TUNNEL_ROLLBACK_MANUAL_KIND=$(
+            "$wrapper_source" --canonical-kind 2>/dev/null
+        ); then
+            echo "✗ Failed to snapshot existing manual PG tunnel state"
+            rm -rf "$PG_TUNNEL_ROLLBACK_DIR" 2>/dev/null || true
+            _reset_pg_tunnel_rollback_state
+            return 1
+        fi
+        case "$PG_TUNNEL_ROLLBACK_MANUAL_KIND" in
+            none|tcp|unix) ;;
+            *)
+                echo "✗ Refusing unknown PG tunnel rollback kind"
+                rm -rf "$PG_TUNNEL_ROLLBACK_DIR" 2>/dev/null || true
+                _reset_pg_tunnel_rollback_state
+                return 1
+                ;;
+        esac
     fi
+    PG_TUNNEL_ROLLBACK_ARMED=1
 
     install -m 0755 "$wrapper_source" "$PG_TUNNEL_BIN" || return 1
     _install_pg_tunnel_plist || return 1
@@ -1754,10 +1909,7 @@ _migrate_pg_tunnel_before_release_stop() {
     fi
 
     rm -rf "$PG_TUNNEL_ROLLBACK_DIR" || return 1
-    PG_TUNNEL_ROLLBACK_DIR=""
-    PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
-    PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
-    PG_TUNNEL_ROLLBACK_ARMED=0
+    _reset_pg_tunnel_rollback_state
     echo "✓ PG tunnel migrated and SQL-ready before release stop"
 }
 

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -871,18 +871,31 @@ _pg_wait_canonical_listener_absent() {
     return 1
 }
 
+_pg_report_rollback_recovery() {
+    local backup=${1:-unknown}
+    echo "⚠ PG tunnel rollback incomplete; recovery material retained at $backup" >&2
+    echo "  Manual recovery: clear the canonical :15432 listener, inspect state, then restore" >&2
+    echo "  the saved wrapper/plist and restart the prior launchd or manual tunnel." >&2
+}
+
 _rollback_pg_tunnel_migration() {
     local domain="${PG_TUNNEL_LAUNCHD_DOMAIN:-}" bin="${PG_TUNNEL_BIN:-}"
     local plist="${PG_TUNNEL_PLIST_PATH:-}" backup="${PG_TUNNEL_ROLLBACK_DIR:-}"
     local restore_ok=1 readiness_ok=0
     [ "${PG_TUNNEL_ROLLBACK_ARMED:-0}" = 1 ] || return 0
     if [ -z "$domain" ] || [ -z "$bin" ] || [ -z "$plist" ] || [ -z "$backup" ]; then
-        echo "✗ PG tunnel rollback state is incomplete; recovery material retained at ${backup:-unknown}" >&2
+        echo "✗ PG tunnel rollback state is incomplete" >&2
+        _pg_report_rollback_recovery "${backup:-unknown}"
         return 1
     fi
 
     echo "↩ Restoring previous PG tunnel state..." >&2
     launchctl bootout "$domain/${PG_TUNNEL_LABEL:-com.agentdesk.pg-tunnel}" 2>/dev/null || true
+    if ! _pg_wait_canonical_listener_absent; then
+        echo "✗ New PG tunnel listener survived rollback bootout; refusing restore bind race" >&2
+        _pg_report_rollback_recovery "$backup"
+        return 1
+    fi
     if [ -e "$backup/wrapper" ]; then
         if ! install -m 0755 "$backup/wrapper" "$bin" 2>/dev/null; then
             echo "✗ Failed to restore PG tunnel wrapper" >&2
@@ -922,8 +935,14 @@ _rollback_pg_tunnel_migration() {
     fi
 
     if [ "$restore_ok" = 1 ]; then
-        if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ] \
-          || [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ]; then
+        if [ "${PG_TUNNEL_ROLLBACK_JOB_LOADED:-0}" = 1 ]; then
+            if _pg_sql_probe 15432 12; then
+                readiness_ok=1
+            else
+                echo "✗ Restored PG tunnel did not become SQL-ready on :15432 after launchd throttle window" >&2
+            fi
+            _cleanup_owned_pg_tunnel_preflight
+        elif [ "${PG_TUNNEL_ROLLBACK_MANUAL_KIND:-none}" != none ]; then
             if _pg_sql_probe 15432; then
                 readiness_ok=1
             else
@@ -944,7 +963,7 @@ _rollback_pg_tunnel_migration() {
         fi
         echo "✗ Previous PG tunnel state is verified but rollback backup cleanup failed" >&2
     fi
-    echo "⚠ PG tunnel rollback incomplete; recovery material retained at $backup" >&2
+    _pg_report_rollback_recovery "$backup"
     return 1
 }
 
@@ -1797,7 +1816,8 @@ RUBY
 }
 
 _pg_sql_probe() {
-    local local_port=$1 conninfo_dir password_file attempt=0 name value
+    local local_port=$1 minimum_wait_secs=${2:-5} conninfo_dir password_file
+    local attempt=0 max_attempts name value connect_timeout_seen=0
     local -a psql_env=(env -u DATABASE_URL)
     local -a clear_names=(
         PGAPPNAME PGCHANNELBINDING PGCLIENTENCODING PGCONNECT_TIMEOUT PGDATABASE
@@ -1835,14 +1855,20 @@ _pg_sql_probe() {
         if [ -f "$conninfo_dir/$name" ]; then
             value=$(<"$conninfo_dir/$name")
             psql_env+=("$name=$value")
+            [ "$name" != PGCONNECT_TIMEOUT ] || connect_timeout_seen=1
         fi
     done
+    if [ "$connect_timeout_seen" = 0 ]; then
+        psql_env+=("PGCONNECT_TIMEOUT=5")
+    fi
     if [ -s "$password_file" ]; then
         psql_env+=("PGPASSFILE=$password_file")
     else
         psql_env+=("PGPASSFILE=/dev/null")
     fi
-    while [ "$attempt" -lt 20 ]; do
+    max_attempts=$((minimum_wait_secs * 4))
+    [ "$max_attempts" -ge 20 ] || max_attempts=20
+    while [ "$attempt" -lt "$max_attempts" ]; do
         if "${psql_env[@]}" psql --no-psqlrc \
           -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null 2>&1; then
             rm -rf "$conninfo_dir"
@@ -1936,6 +1962,7 @@ _migrate_pg_tunnel_before_release_stop() {
         esac
     fi
     PG_TUNNEL_ROLLBACK_ARMED=1
+    echo "▸ PG tunnel rollback armed; recovery material: $PG_TUNNEL_ROLLBACK_DIR"
 
     install -m 0755 "$wrapper_source" "$PG_TUNNEL_BIN" || return 1
     _install_pg_tunnel_plist || return 1

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1674,7 +1674,7 @@ RUBY
 
 _pg_sql_probe() {
     local local_port=$1 conninfo_file password_file attempt=0
-    local -a psql_env=()
+    local -a psql_env=(env)
     command -v psql >/dev/null 2>&1 || return 1
     conninfo_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pg-probe.XXXXXX") || return 1
     password_file=$(mktemp "${TMPDIR:-/tmp}/agentdesk-pgpass.XXXXXX") || return 1

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -2597,7 +2597,7 @@ if install -m 0755 "$REPO/scripts/pg_tunnel.sh" "$PG_TUNNEL_BIN"; then
     <string>-o</string><string>ServerAliveInterval=15</string>
     <string>-o</string><string>ServerAliveCountMax=3</string>
     <string>-o</string><string>ExitOnForwardFailure=yes</string>
-    <string>-L</string><string>127.0.0.1:15432:127.0.0.1:5432</string>
+    <string>-L</string><string>127.0.0.1:15432:/tmp/.s.PGSQL.5432</string>
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>

--- a/scripts/pg_tunnel.sh
+++ b/scripts/pg_tunnel.sh
@@ -12,9 +12,14 @@ set -euo pipefail
 #   PG_TUNNEL_SSH_TARGET=mac-mini
 # PG_TUNNEL_HOST is accepted as a backwards-friendly alias.  No config file is
 # shipped in the repository; deploy-release.sh only arms launchd when the local
-# file exists and passes --check-config.
+# file exists and passes --check-config.  The doctor PostgreSQL preflight
+# validates the remote socket before deployment; --check-config only validates
+# local machine configuration and must not be treated as remote reachability.
 
-TAKEOVER_PATTERN='^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:'
+# A migration deploy must take over both the new socket target and the old TCP
+# target on the exact loopback listener. Other bind addresses and ports remain
+# outside this ownership boundary.
+TAKEOVER_PATTERN='^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:(/tmp/[.]s[.]PGSQL[.]5432|127[.]0[.]0[.]1:5432)([[:space:]]|$)'
 EXPECTED_SSH_ARGS=(
     -N
     -T
@@ -23,7 +28,7 @@ EXPECTED_SSH_ARGS=(
     -o ServerAliveInterval=15
     -o ServerAliveCountMax=3
     -o ExitOnForwardFailure=yes
-    -L 127.0.0.1:15432:127.0.0.1:5432
+    -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432
 )
 
 die() {

--- a/scripts/pg_tunnel.sh
+++ b/scripts/pg_tunnel.sh
@@ -172,6 +172,11 @@ case "${1:-}" in
         canonical_forward_kind
         exit 0
         ;;
+    --take-over-canonical)
+        [ "$#" -eq 1 ] || die "usage: $0 --take-over-canonical"
+        take_over_manual_tunnel
+        exit 0
+        ;;
     --restore-canonical)
         [ "$#" -eq 3 ] || die "usage: $0 --restore-canonical CONFIG KIND"
         load_config "$2"

--- a/scripts/pg_tunnel.sh
+++ b/scripts/pg_tunnel.sh
@@ -12,14 +12,25 @@ set -euo pipefail
 #   PG_TUNNEL_SSH_TARGET=mac-mini
 # PG_TUNNEL_HOST is accepted as a backwards-friendly alias.  No config file is
 # shipped in the repository; deploy-release.sh only arms launchd when the local
-# file exists and passes --check-config.  The doctor PostgreSQL preflight
-# validates the remote socket before deployment; --check-config only validates
-# local machine configuration and must not be treated as remote reachability.
+# file exists, passes --check-config, and proves the remote Unix-socket path with
+# a dedicated SQL probe.  --check-config validates local configuration only.
 
 # A migration deploy must take over both the new socket target and the old TCP
 # target on the exact loopback listener. Other bind addresses and ports remain
-# outside this ownership boundary.
+# outside this ownership boundary. The endpoint boundary is load-bearing: a
+# superstring such as port 54321 or socket .5432.bak must never be signaled.
 TAKEOVER_PATTERN='^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:(/tmp/[.]s[.]PGSQL[.]5432|127[.]0[.]0[.]1:5432)([[:space:]]|$)'
+UNIX_FORWARD_PATTERN='^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:/tmp/[.]s[.]PGSQL[.]5432([[:space:]]|$)'
+TCP_FORWARD_PATTERN='^([^[:space:]]*/)?ssh[[:space:]].*-L[[:space:]]+127[.]0[.]0[.]1:15432:127[.]0[.]0[.]1:5432([[:space:]]|$)'
+SSH_BASE_ARGS=(
+    -N
+    -T
+    -o BatchMode=yes
+    -o ConnectTimeout=10
+    -o ServerAliveInterval=15
+    -o ServerAliveCountMax=3
+    -o ExitOnForwardFailure=yes
+)
 EXPECTED_SSH_ARGS=(
     -N
     -T
@@ -104,11 +115,69 @@ validate_ssh_args() {
     done
 }
 
-if [ "${1:-}" = "--check-config" ]; then
-    [ "$#" -eq 2 ] || die "usage: $0 --check-config CONFIG"
-    load_config "$2"
-    exit 0
-fi
+validate_probe_port() {
+    local port=$1
+    case "$port" in
+        ""|*[!0-9]*) die "probe port must be a decimal integer" ;;
+    esac
+    [ "$port" -ge 1024 ] && [ "$port" -le 65535 ] ||
+        die "probe port must be between 1024 and 65535"
+    [ "$port" -ne 15432 ] || die "probe port must not be the canonical port"
+}
+
+canonical_forward_kind() {
+    local pids pid command kind=""
+    pids=$(/usr/bin/pgrep -f "$TAKEOVER_PATTERN" 2>/dev/null || true)
+    # pgrep returns one numeric pid per line; intentional whitespace splitting.
+    # shellcheck disable=SC2086
+    for pid in $pids; do
+        case "$pid" in *[!0-9]*|"") continue ;; esac
+        command=$(/bin/ps -p "$pid" -o command= 2>/dev/null || true)
+        if printf '%s\n' "$command" | /usr/bin/grep -Eq "$UNIX_FORWARD_PATTERN"; then
+            [ -z "$kind" ] || [ "$kind" = "unix" ] || die "ambiguous canonical tunnel state"
+            kind="unix"
+        elif printf '%s\n' "$command" | /usr/bin/grep -Eq "$TCP_FORWARD_PATTERN"; then
+            [ -z "$kind" ] || [ "$kind" = "tcp" ] || die "ambiguous canonical tunnel state"
+            kind="tcp"
+        fi
+    done
+    printf '%s\n' "${kind:-none}"
+}
+
+restore_canonical_forward() {
+    local kind=$1 endpoint
+    case "$kind" in
+        unix) endpoint="127.0.0.1:15432:/tmp/.s.PGSQL.5432" ;;
+        tcp) endpoint="127.0.0.1:15432:127.0.0.1:5432" ;;
+        *) die "restore kind must be 'unix' or 'tcp'" ;;
+    esac
+    exec /usr/bin/ssh -f "${SSH_BASE_ARGS[@]}" -L "$endpoint" "$PG_TUNNEL_SSH_TARGET"
+}
+
+case "${1:-}" in
+    --check-config)
+        [ "$#" -eq 2 ] || die "usage: $0 --check-config CONFIG"
+        load_config "$2"
+        exit 0
+        ;;
+    --probe-remote)
+        [ "$#" -eq 3 ] || die "usage: $0 --probe-remote CONFIG PORT"
+        load_config "$2"
+        validate_probe_port "$3"
+        exec /usr/bin/ssh "${SSH_BASE_ARGS[@]}" \
+            -L "127.0.0.1:$3:/tmp/.s.PGSQL.5432" "$PG_TUNNEL_SSH_TARGET"
+        ;;
+    --canonical-kind)
+        [ "$#" -eq 1 ] || die "usage: $0 --canonical-kind"
+        canonical_forward_kind
+        exit 0
+        ;;
+    --restore-canonical)
+        [ "$#" -eq 3 ] || die "usage: $0 --restore-canonical CONFIG KIND"
+        load_config "$2"
+        restore_canonical_forward "$3"
+        ;;
+esac
 
 [ "$#" -ge 1 ] || die "usage: $0 CONFIG SSH_ARGS..."
 CONFIG_PATH=$1

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -24,16 +24,17 @@ class WrapperSafetyTests(unittest.TestCase):
         pattern = shlex.split(line.split("=", 1)[1])[0]
 
         matching = [
+            "/usr/bin/ssh -f -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432 mac-mini",
             "/usr/bin/ssh -f -N -L 127.0.0.1:15432:127.0.0.1:5432 mac-mini",
-            "ssh -N -o BatchMode=yes -L  127.0.0.1:15432:db:5432 host",
         ]
         rejected = [
-            "/usr/bin/ssh -N -R 15432:127.0.0.1:5432 mac-book",
-            "/usr/bin/ssh -N -L 127.0.0.1:15433:127.0.0.1:5432 mac-mini",
-            "/usr/bin/ssh -N -L 0.0.0.0:15432:127.0.0.1:5432 mac-mini",
-            "/usr/bin/ssh -N -L127.0.0.1:15432:127.0.0.1:5432 mac-mini",
-            "python monitor.py ssh -N -L 127.0.0.1:15432:db:5432 host",
-            "/usr/bin/notssh -N -L 127.0.0.1:15432:db:5432 host",
+            "/usr/bin/ssh -N -R 15432:/tmp/.s.PGSQL.5432 mac-book",
+            "/usr/bin/ssh -N -L 127.0.0.1:15433:/tmp/.s.PGSQL.5432 mac-mini",
+            "/usr/bin/ssh -N -L 0.0.0.0:15432:/tmp/.s.PGSQL.5432 mac-mini",
+            "/usr/bin/ssh -N -L127.0.0.1:15432:/tmp/.s.PGSQL.5432 mac-mini",
+            "/usr/bin/ssh -N -L 127.0.0.1:15432:db:5432 host",
+            "python monitor.py ssh -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432 host",
+            "/usr/bin/notssh -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432 host",
         ]
         for command in matching:
             with self.subTest(command=command):
@@ -94,6 +95,16 @@ class WrapperSafetyTests(unittest.TestCase):
             )
             self.assertNotEqual(p.returncode, 0)
             self.assertIn("non-canonical ssh arguments", p.stderr)
+
+    def test_wrapper_pins_unix_socket_forward_and_rejects_tcp_target(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        self.assertIn("-L 127.0.0.1:15432:/tmp/.s.PGSQL.5432", text)
+        self.assertNotIn("-L 127.0.0.1:15432:127.0.0.1:5432", text)
+
+    def test_check_config_does_not_claim_remote_socket_validation(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        self.assertIn("doctor PostgreSQL preflight", text)
+        self.assertIn("must not be treated as remote reachability", text)
 
 
 class DeploymentWiringTests(unittest.TestCase):
@@ -228,8 +239,27 @@ class DeploymentWiringTests(unittest.TestCase):
             plist_path = home / "Library/LaunchAgents/com.agentdesk.pg-tunnel.plist"
             with plist_path.open("rb") as f:
                 plist = plistlib.load(f)
-            self.assertEqual(plist["ProgramArguments"][0], str(adk / "bin/pg-tunnel.sh"))
-            self.assertEqual(plist["ProgramArguments"][1], str(adk / "config/pg-tunnel.env"))
+            self.assertEqual(
+                plist["ProgramArguments"],
+                [
+                    str(adk / "bin/pg-tunnel.sh"),
+                    str(adk / "config/pg-tunnel.env"),
+                    "-N",
+                    "-T",
+                    "-o",
+                    "BatchMode=yes",
+                    "-o",
+                    "ConnectTimeout=10",
+                    "-o",
+                    "ServerAliveInterval=15",
+                    "-o",
+                    "ServerAliveCountMax=3",
+                    "-o",
+                    "ExitOnForwardFailure=yes",
+                    "-L",
+                    "127.0.0.1:15432:/tmp/.s.PGSQL.5432",
+                ],
+            )
             self.assertTrue(plist["KeepAlive"])
             self.assertEqual(plist["ThrottleInterval"], 10)
 

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -74,6 +74,24 @@ class WrapperSafetyTests(unittest.TestCase):
             '[ "$#" -eq 1 ] || die "usage: $0 --take-over-canonical"', text
         )
 
+    def test_production_takeover_owns_term_kill_and_final_refusal(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        start = text.index("take_over_manual_tunnel() {")
+        end = text.index("validate_ssh_args() {", start)
+        helper = text[start:end]
+        self.assertLess(
+            helper.index('still_matching_manual_tunnel "$pid" || continue'),
+            helper.index('/bin/kill -TERM "$pid"'),
+        )
+        self.assertLess(
+            helper.index('/bin/kill -TERM "$pid"'),
+            helper.index('/bin/kill -KILL "$pid"'),
+        )
+        self.assertLess(
+            helper.index('/bin/kill -KILL "$pid"'),
+            helper.index('die "residual manual tunnel pid=$pid did not exit'),
+        )
+
     def test_machine_config_requires_safe_ssh_target(self):
         with tempfile.TemporaryDirectory() as tmp:
             good = Path(tmp) / "good.env"
@@ -238,6 +256,8 @@ class DeploymentWiringTests(unittest.TestCase):
         fail_restore_bootstrap: bool = False,
         fail_manual_restore: bool = False,
         fail_listener_absence: bool = False,
+        rollback_listener_checks: int = 0,
+        rollback_ready_attempt: int = 1,
         job_loaded: bool = False,
         old_wrapper: str | None = None,
         old_plist: str | None = None,
@@ -254,6 +274,10 @@ printf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"
 if [ "$1" = print ]; then
   if [ "${JOB_LOADED:-0}" = 1 ]; then exit 0; else exit 1; fi
 fi
+if [ "$1" = bootout ]; then
+  bootout_count=$(grep -c '^bootout ' "$LAUNCHCTL_LOG" || true)
+  [ "$bootout_count" -lt 2 ] || : > "$ROLLBACK_BOOTOUT"
+fi
 if [ "$1" = bootstrap ] && [ "${FAIL_RESTORE_BOOTSTRAP:-0}" = 1 ]; then
   bootstrap_count=$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG" || true)
   [ "$bootstrap_count" -lt 2 ] || exit 1
@@ -263,15 +287,23 @@ exit 0
             "xattr": "#!/bin/sh\nexit 0\n",
             "lsof": """#!/bin/sh
 printf 'lsof %s\\n' "$*" >> "$EVENT_LOG"
-[ "${FAIL_LISTENER_ABSENCE:-0}" = 1 ]
+if [ "${FAIL_LISTENER_ABSENCE:-0}" = 1 ]; then exit 0; fi
+if [ -f "$ROLLBACK_BOOTOUT" ] && [ "${ROLLBACK_LISTENER_CHECKS:-0}" -gt 0 ]; then
+  current=0
+  [ ! -f "$ROLLBACK_LISTENER_COUNT" ] || current=$(cat "$ROLLBACK_LISTENER_COUNT")
+  current=$((current + 1))
+  printf '%s\\n' "$current" > "$ROLLBACK_LISTENER_COUNT"
+  [ "$current" -gt "$ROLLBACK_LISTENER_CHECKS" ] || exit 0
+fi
+exit 1
 """,
             "sleep": "#!/bin/sh\nexec /bin/sleep 0.01\n",
             "psql": """#!/bin/sh
 while [ ! -f "$PROBE_READY" ]; do /bin/sleep 0.01; done
-printf 'psql host=%s hostaddr=%s port=%s user=%s db=%s sslmode=%s passfile=%s\\n' \
+printf 'psql host=%s hostaddr=%s port=%s user=%s db=%s sslmode=%s timeout=%s passfile=%s\\n' \
   "${PGHOST:-missing}" "${PGHOSTADDR:-missing}" "${PGPORT:-missing}" \
   "${PGUSER:-missing}" "${PGDATABASE:-missing}" "${PGSSLMODE:-missing}" \
-  "${PGPASSFILE:+set}" >> "$EVENT_LOG"
+  "${PGCONNECT_TIMEOUT:-missing}" "${PGPASSFILE:+set}" >> "$EVENT_LOG"
 [ "${PGHOST:-}" = db.internal ] || exit 81
 [ "${PGHOSTADDR:-}" = 127.0.0.1 ] || exit 87
 [ "${PGUSER:-}" = agentdesk ] || exit 82
@@ -288,7 +320,14 @@ case "${PGPORT:-}" in
       [ "$bootstrap_count" -lt 2 ] || rollback_active=1
     fi
     if [ "$rollback_active" -eq 0 ] && [ "${FAIL_CANONICAL:-0}" = 1 ]; then exit 1; fi
-    if [ "$rollback_active" -eq 1 ] && [ "${FAIL_ROLLBACK_READINESS:-0}" = 1 ]; then exit 1; fi
+    if [ "$rollback_active" -eq 1 ]; then
+      if [ "${FAIL_ROLLBACK_READINESS:-0}" = 1 ]; then exit 1; fi
+      rollback_attempt=0
+      [ ! -f "$ROLLBACK_PSQL_COUNT" ] || rollback_attempt=$(cat "$ROLLBACK_PSQL_COUNT")
+      rollback_attempt=$((rollback_attempt + 1))
+      printf '%s\n' "$rollback_attempt" > "$ROLLBACK_PSQL_COUNT"
+      [ "$rollback_attempt" -ge "${ROLLBACK_READY_ATTEMPT:-1}" ] || exit 1
+    fi
     ;;
   "") exit 86 ;;
   *) [ "${FAIL_PROBE:-0}" != 1 ] ;;
@@ -370,12 +409,17 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             f"FAIL_RESTORE_BOOTSTRAP={int(fail_restore_bootstrap)}\n"
             f"FAIL_MANUAL_RESTORE={int(fail_manual_restore)}\n"
             f"FAIL_LISTENER_ABSENCE={int(fail_listener_absence)}\n"
+            f"ROLLBACK_LISTENER_CHECKS={rollback_listener_checks}\n"
+            f"ROLLBACK_READY_ATTEMPT={rollback_ready_attempt}\n"
             f"JOB_LOADED={int(job_loaded)}\n"
             f"MANUAL_KIND={shlex.quote(manual_kind)}\n"
             f"PROBE_READY={shlex.quote(str(home / 'probe.ready'))}\n"
             f"ROLLBACK_STATE={shlex.quote(str(rollback_state))}\n"
+            f"ROLLBACK_BOOTOUT={shlex.quote(str(home / 'rollback.bootout'))}\n"
+            f"ROLLBACK_LISTENER_COUNT={shlex.quote(str(home / 'rollback-listener.count'))}\n"
+            f"ROLLBACK_PSQL_COUNT={shlex.quote(str(home / 'rollback-psql.count'))}\n"
             "DATABASE_URL=postgresql://agentdesk:s3cr3t@db.internal:5432/agentdesk?sslmode=require\n"
-            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE FAIL_LISTENER_ABSENCE JOB_LOADED MANUAL_KIND PROBE_READY DATABASE_URL\n"
+            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE FAIL_LISTENER_ABSENCE ROLLBACK_LISTENER_CHECKS ROLLBACK_READY_ATTEMPT JOB_LOADED MANUAL_KIND PROBE_READY ROLLBACK_BOOTOUT ROLLBACK_LISTENER_COUNT ROLLBACK_PSQL_COUNT DATABASE_URL\n"
             f"FAKE_BIN={shlex.quote(str(fake_bin))}\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
             "export PATH\n"
@@ -482,11 +526,62 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         self.assertIn("local -a psql_env=(env -u DATABASE_URL)", block)
         self.assertIn('psql_env+=(-u "$name")', block)
         self.assertIn('psql_env+=("$name=$value")', block)
+        self.assertIn('psql_env+=("PGCONNECT_TIMEOUT=5")', block)
         self.assertIn('psql_env+=("PGPASSFILE=$password_file")', block)
         self.assertIn('psql_env+=("PGPASSFILE=/dev/null")', block)
         self.assertIn("YAML.safe_load(File.read(config_path), aliases: true)", block)
         self.assertNotIn("YAML.safe_load_file", block)
         self.assertNotIn('PGDATABASE="$(<', block)
+
+    def _run_production_probe(self, database_url: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            event_log = root / "events.log"
+            psql = fake_bin / "psql"
+            psql.write_text(
+                "#!/bin/sh\n"
+                "printf 'timeout=%s\\n' \"${PGCONNECT_TIMEOUT:-missing}\" >> \"$EVENT_LOG\"\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            psql.chmod(0o755)
+            deploy = DEPLOY.read_text(encoding="utf-8")
+            start = deploy.index("_pg_write_probe_conninfo() {")
+            end = deploy.index("_migrate_pg_tunnel_before_release_stop() {", start)
+            helper = deploy[start:end]
+            script = (
+                "set -euo pipefail\n"
+                f"ADK_REL={shlex.quote(str(root))}\n"
+                f"DATABASE_URL={shlex.quote(database_url)}\n"
+                f"EVENT_LOG={shlex.quote(str(event_log))}\n"
+                f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
+                "PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=\"\"\n"
+                "PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=\"\"\n"
+                "export DATABASE_URL EVENT_LOG PATH\n"
+                + helper
+                + "\n_pg_sql_probe 25432\n"
+            )
+            p = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, timeout=10
+            )
+            events = event_log.read_text(encoding="utf-8") if event_log.exists() else ""
+            return p.returncode, events
+
+    def test_probe_defaults_connect_timeout_when_dsn_omits_it(self):
+        status, events = self._run_production_probe(
+            "postgresql://agentdesk@db.internal/agentdesk"
+        )
+        self.assertEqual(status, 0, events)
+        self.assertEqual(events, "timeout=5\n")
+
+    def test_probe_preserves_explicit_connect_timeout(self):
+        status, events = self._run_production_probe(
+            "postgresql://agentdesk@db.internal/agentdesk?connect_timeout=17"
+        )
+        self.assertEqual(status, 0, events)
+        self.assertEqual(events, "timeout=17\n")
 
     def test_production_ruby_parses_ipv6_escaped_uri_and_pgpass(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -727,6 +822,57 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 "armed=0 backup=\n",
             )
 
+    def test_rollback_waits_for_listener_absence_before_manual_restore(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                rollback_listener_checks=2,
+                old_wrapper="#!/bin/sh\nexit 99\n",
+                manual_kind="tcp",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertNotEqual(p.returncode, 0)
+            rollback_bootout = events.rindex("launchctl bootout")
+            second_listener = events.index("lsof ", events.index("lsof ", rollback_bootout) + 1)
+            restore = events.index("restore tcp", second_listener)
+            self.assertLess(rollback_bootout, second_listener)
+            self.assertLess(second_listener, restore)
+
+    def test_rollback_refuses_restore_while_new_listener_survives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                fail_listener_absence=True,
+                old_wrapper="#!/bin/sh\nexit 99\n",
+                manual_kind="tcp",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("refusing restore bind race", p.stderr)
+            self.assertNotIn("restore tcp", events)
+            self.assertIn("Manual recovery", p.stderr)
+            self._assert_rollback_material_retained(home)
+
     def test_snapshot_failure_does_not_touch_live_tunnel(self):
         with tempfile.TemporaryDirectory() as tmp:
             adk = Path(tmp) / "adk"
@@ -874,7 +1020,7 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 adk, home, fail_canonical=True, fail_listener_absence=True
             )
             self.assertNotEqual(p.returncode, 0)
-            self.assertIn("still has a listener", p.stderr)
+            self.assertIn("listener survived rollback bootout", p.stderr)
             self._assert_rollback_material_retained(home)
 
     def test_rollback_readiness_failure_retains_recovery_material(self):
@@ -898,6 +1044,36 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             self.assertNotEqual(p.returncode, 0)
             self.assertIn("did not become SQL-ready", p.stderr)
             self._assert_rollback_material_retained(home)
+
+    def test_launchd_rollback_readiness_covers_throttle_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                rollback_ready_attempt=45,
+                job_loaded=True,
+                old_wrapper="old-wrapper\n",
+                old_plist="old-plist\n",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertNotEqual(p.returncode, 0)
+            rollback_attempts = int(
+                (home / "rollback-psql.count").read_text(encoding="utf-8")
+            )
+            self.assertEqual(rollback_attempts, 45, events)
+            self.assertEqual(
+                (home / "rollback-state.txt").read_text(encoding="utf-8"),
+                "armed=0 backup=\n",
+            )
 
     @staticmethod
     def _assert_rollback_material_retained(home: Path) -> None:
@@ -926,7 +1102,7 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             self.assertEqual(p.returncode, 0, p.stdout + p.stderr + events)
             self.assertIn(
                 "psql host=db.internal hostaddr=127.0.0.1 port=15432 "
-                "user=agentdesk db=agentdesk sslmode=require passfile=set",
+                "user=agentdesk db=agentdesk sslmode=require timeout=5 passfile=set",
                 events,
                 p.stdout + p.stderr + events,
             )

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -584,6 +584,7 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         self.assertIn('psql_env+=("PGPASSFILE=$password_file")', block)
         self.assertIn('psql_env+=("PGPASSFILE=/dev/null")', block)
         self.assertIn("YAML.safe_load(File.read(config_path), aliases: true)", block)
+        self.assertIn("RUBY\n        return $?\n    fi", block)
         self.assertNotIn("YAML.safe_load_file", block)
         self.assertNotIn('PGDATABASE="$(<', block)
 

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -268,6 +268,22 @@ class DeploymentWiringTests(unittest.TestCase):
         event_log = home / "events.log"
         launchctl_log = home / "launchctl.log"
         for name, body in {
+            "probe": """#!/usr/bin/env python3
+import os
+import signal
+
+
+def stop(_signum, _frame):
+    with open(os.environ["EVENT_LOG"], "a", encoding="utf-8") as handle:
+        handle.write("probe-term\\n")
+    raise SystemExit(0)
+
+
+signal.signal(signal.SIGTERM, stop)
+open(os.environ["PROBE_READY"], "a", encoding="utf-8").close()
+while True:
+    signal.pause()
+""",
             "launchctl": """#!/bin/sh
 printf 'launchctl %s\\n' "$*" >> "$EVENT_LOG"
 printf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"
@@ -285,18 +301,6 @@ fi
 exit 0
 """,
             "xattr": "#!/bin/sh\nexit 0\n",
-            "lsof": """#!/bin/sh
-printf 'lsof %s\\n' "$*" >> "$EVENT_LOG"
-if [ "${FAIL_LISTENER_ABSENCE:-0}" = 1 ]; then exit 0; fi
-if [ -f "$ROLLBACK_BOOTOUT" ] && [ "${ROLLBACK_LISTENER_CHECKS:-0}" -gt 0 ]; then
-  current=0
-  [ ! -f "$ROLLBACK_LISTENER_COUNT" ] || current=$(cat "$ROLLBACK_LISTENER_COUNT")
-  current=$((current + 1))
-  printf '%s\\n' "$current" > "$ROLLBACK_LISTENER_COUNT"
-  [ "$current" -gt "$ROLLBACK_LISTENER_CHECKS" ] || exit 0
-fi
-exit 1
-""",
             "sleep": "#!/bin/sh\nexec /bin/sleep 0.01\n",
             "psql": """#!/bin/sh
 while [ ! -f "$PROBE_READY" ]; do /bin/sleep 0.01; done
@@ -365,7 +369,7 @@ exec /bin/cp "$@"
 printf 'wrapper %s\\n' "$*" >> "$EVENT_LOG"
 case "$1" in
   --check-config) grep -q '^PG_TUNNEL_SSH_TARGET=[A-Za-z0-9_.:@][A-Za-z0-9_.:@-]*$' "$2" ;;
-  --probe-remote) trap 'printf "probe-term\\n" >> "$EVENT_LOG"; exit 0' TERM; : > "$PROBE_READY"; while :; do /bin/sleep 1; done ;;
+  --probe-remote) exec "$FAKE_BIN/probe" ;;
   --canonical-kind) [ "${FAIL_KIND_SNAPSHOT:-0}" != 1 ] || exit 1; printf '%s\\n' "${MANUAL_KIND:-none}" ;;
   --take-over-canonical) printf 'takeover\\n' >> "$EVENT_LOG" ;;
   --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG"; [ "${FAIL_MANUAL_RESTORE:-0}" != 1 ] ;;
@@ -422,12 +426,23 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE FAIL_LISTENER_ABSENCE ROLLBACK_LISTENER_CHECKS ROLLBACK_READY_ATTEMPT JOB_LOADED MANUAL_KIND PROBE_READY ROLLBACK_BOOTOUT ROLLBACK_LISTENER_COUNT ROLLBACK_PSQL_COUNT DATABASE_URL\n"
             f"FAKE_BIN={shlex.quote(str(fake_bin))}\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
-            "export PATH\n"
+            "export FAKE_BIN PATH\n"
             "ruby() { \"$FAKE_BIN/ruby\" \"$@\"; }\n"
             "psql() { \"$FAKE_BIN/psql\" \"$@\"; }\n"
             "launchctl() { \"$FAKE_BIN/launchctl\" \"$@\"; }\n"
             "xattr() { \"$FAKE_BIN/xattr\" \"$@\"; }\n"
-            "lsof() { \"$FAKE_BIN/lsof\" \"$@\"; }\n"
+            "lsof() {\n"
+            "  printf 'lsof %s\\n' \"$*\" >> \"$EVENT_LOG\"\n"
+            "  [ \"${FAIL_LISTENER_ABSENCE:-0}\" != 1 ] || return 0\n"
+            "  if [ -f \"$ROLLBACK_BOOTOUT\" ] && [ \"${ROLLBACK_LISTENER_CHECKS:-0}\" -gt 0 ]; then\n"
+            "    local current=0\n"
+            "    [ ! -f \"$ROLLBACK_LISTENER_COUNT\" ] || current=$(<\"$ROLLBACK_LISTENER_COUNT\")\n"
+            "    current=$((current + 1))\n"
+            "    printf '%s\\n' \"$current\" > \"$ROLLBACK_LISTENER_COUNT\"\n"
+            "    [ \"$current\" -gt \"$ROLLBACK_LISTENER_CHECKS\" ] || return 0\n"
+            "  fi\n"
+            "  return 1\n"
+            "}\n"
             "cp() { \"$FAKE_BIN/cp\" \"$@\"; }\n"
             "command -v psql >/dev/null || exit 97\n"
             "command -v ruby >/dev/null || exit 98\n"
@@ -462,12 +477,23 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 "#!/bin/sh\nexec /bin/sleep 0.01\n", encoding="utf-8"
             )
             (fake_bin / "sleep").chmod(0o755)
-            probe = root / "probe.sh"
+            probe = root / "probe.py"
             probe.write_text(
-                "#!/bin/sh\n"
-                "trap 'kill -TERM \"$PARENT_PID\"; printf \"probe-term\\n\" >> \"$EVENT_LOG\"; exit 0' TERM\n"
-                "printf 'probe-ready\\n' >> \"$EVENT_LOG\"\n"
-                "while :; do /bin/sleep 1; done\n",
+                "#!/usr/bin/env python3\n"
+                "import os\n"
+                "import signal\n"
+                "\n"
+                "def stop(_signum, _frame):\n"
+                "    os.kill(int(os.environ['PARENT_PID']), signal.SIGTERM)\n"
+                "    with open(os.environ['EVENT_LOG'], 'a', encoding='utf-8') as handle:\n"
+                "        handle.write('probe-term\\n')\n"
+                "    raise SystemExit(0)\n"
+                "\n"
+                "signal.signal(signal.SIGTERM, stop)\n"
+                "with open(os.environ['EVENT_LOG'], 'a', encoding='utf-8') as handle:\n"
+                "    handle.write('probe-ready\\n')\n"
+                "while True:\n"
+                "    signal.pause()\n",
                 encoding="utf-8",
             )
             probe.chmod(0o755)

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -67,6 +67,13 @@ class WrapperSafetyTests(unittest.TestCase):
             text.index('exec /usr/bin/ssh "$@" "$PG_TUNNEL_SSH_TARGET"'),
         )
 
+    def test_restricted_takeover_mode_accepts_no_extra_arguments(self):
+        text = WRAPPER.read_text(encoding="utf-8")
+        self.assertIn('    --take-over-canonical)', text)
+        self.assertIn(
+            '[ "$#" -eq 1 ] || die "usage: $0 --take-over-canonical"', text
+        )
+
     def test_machine_config_requires_safe_ssh_target(self):
         with tempfile.TemporaryDirectory() as tmp:
             good = Path(tmp) / "good.env"
@@ -102,6 +109,8 @@ class WrapperSafetyTests(unittest.TestCase):
     def test_wrapper_pins_unix_socket_forward_and_rejects_tcp_target(self):
         text = WRAPPER.read_text(encoding="utf-8")
         self.assertIn("-L 127.0.0.1:15432:/tmp/.s.PGSQL.5432", text)
+        expected = "-L 127.0.0.1:15432:/tmp/.s.PGSQL.5432"
+        self.assertIn(expected, text)
         self.assertNotIn("-L 127.0.0.1:15432:127.0.0.1:5432", text)
 
     def test_remote_probe_rejects_unrestricted_arguments_and_ports(self):
@@ -228,6 +237,7 @@ class DeploymentWiringTests(unittest.TestCase):
         fail_kind_snapshot: bool = False,
         fail_restore_bootstrap: bool = False,
         fail_manual_restore: bool = False,
+        fail_listener_absence: bool = False,
         job_loaded: bool = False,
         old_wrapper: str | None = None,
         old_plist: str | None = None,
@@ -251,13 +261,19 @@ fi
 exit 0
 """,
             "xattr": "#!/bin/sh\nexit 0\n",
+            "lsof": """#!/bin/sh
+printf 'lsof %s\\n' "$*" >> "$EVENT_LOG"
+[ "${FAIL_LISTENER_ABSENCE:-0}" = 1 ]
+""",
             "sleep": "#!/bin/sh\nexec /bin/sleep 0.01\n",
             "psql": """#!/bin/sh
 while [ ! -f "$PROBE_READY" ]; do /bin/sleep 0.01; done
-printf 'psql host=%s port=%s user=%s db=%s sslmode=%s passfile=%s\\n' \
-  "${PGHOST:-missing}" "${PGPORT:-missing}" "${PGUSER:-missing}" \
-  "${PGDATABASE:-missing}" "${PGSSLMODE:-missing}" "${PGPASSFILE:+set}" >> "$EVENT_LOG"
-[ "${PGHOST:-}" = 127.0.0.1 ] || exit 81
+printf 'psql host=%s hostaddr=%s port=%s user=%s db=%s sslmode=%s passfile=%s\\n' \
+  "${PGHOST:-missing}" "${PGHOSTADDR:-missing}" "${PGPORT:-missing}" \
+  "${PGUSER:-missing}" "${PGDATABASE:-missing}" "${PGSSLMODE:-missing}" \
+  "${PGPASSFILE:+set}" >> "$EVENT_LOG"
+[ "${PGHOST:-}" = db.internal ] || exit 81
+[ "${PGHOSTADDR:-}" = 127.0.0.1 ] || exit 87
 [ "${PGUSER:-}" = agentdesk ] || exit 82
 [ "${PGDATABASE:-}" = agentdesk ] || exit 83
 [ "${PGSSLMODE:-}" = require ] || exit 84
@@ -284,12 +300,13 @@ while [ "$#" -gt 3 ]; do shift; done
 port=$1
 output_dir=$2
 password_output=$3
-printf '%s' 127.0.0.1 > "$output_dir/PGHOST"
+printf '%s' db.internal > "$output_dir/PGHOST"
+printf '%s' 127.0.0.1 > "$output_dir/PGHOSTADDR"
 printf '%s' "$port" > "$output_dir/PGPORT"
 printf '%s' agentdesk > "$output_dir/PGUSER"
 printf '%s' agentdesk > "$output_dir/PGDATABASE"
 printf '%s' require > "$output_dir/PGSSLMODE"
-printf '%s\\n' '127.0.0.1:'"$port"':agentdesk:agentdesk:s3cr3t' > "$password_output"
+printf '%s\\n' 'db.internal:'"$port"':agentdesk:agentdesk:s3cr3t' > "$password_output"
 """,
             "cp": """#!/bin/sh
 if [ "${FAIL_BACKUP_COPY:-0}" = 1 ] && [ "$1" = -p ]; then
@@ -311,6 +328,7 @@ case "$1" in
   --check-config) grep -q '^PG_TUNNEL_SSH_TARGET=[A-Za-z0-9_.:@][A-Za-z0-9_.:@-]*$' "$2" ;;
   --probe-remote) trap 'printf "probe-term\\n" >> "$EVENT_LOG"; exit 0' TERM; : > "$PROBE_READY"; while :; do /bin/sleep 1; done ;;
   --canonical-kind) [ "${FAIL_KIND_SNAPSHOT:-0}" != 1 ] || exit 1; printf '%s\\n' "${MANUAL_KIND:-none}" ;;
+  --take-over-canonical) printf 'takeover\\n' >> "$EVENT_LOG" ;;
   --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG"; [ "${FAIL_MANUAL_RESTORE:-0}" != 1 ] ;;
   *) exit 1 ;;
 esac
@@ -351,12 +369,13 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             f"FAIL_KIND_SNAPSHOT={int(fail_kind_snapshot)}\n"
             f"FAIL_RESTORE_BOOTSTRAP={int(fail_restore_bootstrap)}\n"
             f"FAIL_MANUAL_RESTORE={int(fail_manual_restore)}\n"
+            f"FAIL_LISTENER_ABSENCE={int(fail_listener_absence)}\n"
             f"JOB_LOADED={int(job_loaded)}\n"
             f"MANUAL_KIND={shlex.quote(manual_kind)}\n"
             f"PROBE_READY={shlex.quote(str(home / 'probe.ready'))}\n"
             f"ROLLBACK_STATE={shlex.quote(str(rollback_state))}\n"
             "DATABASE_URL=postgresql://agentdesk:s3cr3t@db.internal:5432/agentdesk?sslmode=require\n"
-            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE JOB_LOADED MANUAL_KIND PROBE_READY DATABASE_URL\n"
+            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE FAIL_LISTENER_ABSENCE JOB_LOADED MANUAL_KIND PROBE_READY DATABASE_URL\n"
             f"FAKE_BIN={shlex.quote(str(fake_bin))}\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
             "export PATH\n"
@@ -364,6 +383,7 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             "psql() { \"$FAKE_BIN/psql\" \"$@\"; }\n"
             "launchctl() { \"$FAKE_BIN/launchctl\" \"$@\"; }\n"
             "xattr() { \"$FAKE_BIN/xattr\" \"$@\"; }\n"
+            "lsof() { \"$FAKE_BIN/lsof\" \"$@\"; }\n"
             "cp() { \"$FAKE_BIN/cp\" \"$@\"; }\n"
             "command -v psql >/dev/null || exit 97\n"
             "command -v ruby >/dev/null || exit 98\n"
@@ -401,7 +421,7 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             probe = root / "probe.sh"
             probe.write_text(
                 "#!/bin/sh\n"
-                "trap 'printf \"probe-term\\n\" >> \"$EVENT_LOG\"; exit 0' TERM\n"
+                "trap 'kill -TERM \"$PARENT_PID\"; printf \"probe-term\\n\" >> \"$EVENT_LOG\"; exit 0' TERM\n"
                 "printf 'probe-ready\\n' >> \"$EVENT_LOG\"\n"
                 "while :; do /bin/sleep 1; done\n",
                 encoding="utf-8",
@@ -415,22 +435,19 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 "PG_TUNNEL_PREFLIGHT_PID=\"\"\n"
                 "PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=\"\"\n"
                 "PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=\"\"\n"
-                + self._probe_cleanup_helper()
-                + "\n_cleanup_on_exit() {\n"
-                "    local status=${1:-$?}\n"
-                "    trap - EXIT INT TERM\n"
-                "    _cleanup_owned_pg_tunnel_preflight\n"
-                "    printf 'cleanup=%s\\n' \"$status\" >> \"$EVENT_LOG\"\n"
-                "}\n"
-                "_handle_cleanup_signal() {\n"
-                "    local status=$1\n"
-                "    _cleanup_on_exit \"$status\"\n"
-                "    exit \"$status\"\n"
-                "}\n"
-                "trap _cleanup_on_exit EXIT\n"
-                "trap '_handle_cleanup_signal 130' INT\n"
-                "trap '_handle_cleanup_signal 143' TERM\n"
-                f"{shlex.quote(str(probe))} &\n"
+                "PG_TUNNEL_ROLLBACK_ARMED=0\n"
+                "ROLLBACK_ARMED=0\n"
+                "DEPLOY_OK=0\n"
+                "STAGED_BINARY=\"\"\n"
+                "POLICIES_STAGED=\"\"\n"
+                "LAUNCHD_MIGRATED_STAGED=\"\"\n"
+                "RELEASE_ROOT_SCRIPTS_STAGED=\"\"\n"
+                "DEPLOY_MKDIR_LOCK_DIR=\"\"\n"
+                "_rollback_pg_tunnel_migration() { :; }\n"
+                "_rollback_release_binary() { :; }\n"
+                "_finalize_detached_helper() { printf 'cleanup=%s\\n' \"$1\" >> \"$EVENT_LOG\"; }\n"
+                + self._production_cleanup_handlers()
+                + f"\nPARENT_PID=$$ {shlex.quote(str(probe))} &\n"
                 "PG_TUNNEL_PREFLIGHT_PID=$!\n"
                 "while ! grep -q '^probe-ready$' \"$EVENT_LOG\"; do /bin/sleep 0.01; done\n"
                 f"kill -{signal_name} $$\n"
@@ -442,10 +459,10 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             return p.returncode, event_log.read_text(encoding="utf-8")
 
     @staticmethod
-    def _probe_cleanup_helper() -> str:
+    def _production_cleanup_handlers() -> str:
         deploy = DEPLOY.read_text(encoding="utf-8")
         start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
-        end = deploy.index("_reset_pg_tunnel_rollback_state() {", start)
+        end = deploy.index("_self_hosted_release_session() {", start)
         return deploy[start:end]
 
     def test_int_cleanup_reaps_probe_once_and_returns_130(self):
@@ -466,9 +483,85 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         self.assertIn('psql_env+=(-u "$name")', block)
         self.assertIn('psql_env+=("$name=$value")', block)
         self.assertIn('psql_env+=("PGPASSFILE=$password_file")', block)
+        self.assertIn('psql_env+=("PGPASSFILE=/dev/null")', block)
         self.assertIn("YAML.safe_load(File.read(config_path), aliases: true)", block)
         self.assertNotIn("YAML.safe_load_file", block)
         self.assertNotIn('PGDATABASE="$(<', block)
+
+    def test_production_ruby_parses_ipv6_escaped_uri_and_pgpass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output_dir = root / "conninfo"
+            output_dir.mkdir()
+            password_file = root / "pgpass"
+            deploy = DEPLOY.read_text(encoding="utf-8")
+            start = deploy.index("_pg_write_probe_conninfo() {")
+            end = deploy.index("_pg_sql_probe() {", start)
+            helper = deploy[start:end]
+            uri = (
+                "postgresql://user%3Aname:p%5C%3Aa%2Bss@"
+                "[2001:db8::1]:5432/db%2Bname?"
+                "sslmode=verify-full&application_name=a+b"
+            )
+            script = (
+                "set -euo pipefail\n"
+                f"ADK_REL={shlex.quote(str(root))}\n"
+                f"DATABASE_URL={shlex.quote(uri)}\n"
+                "export DATABASE_URL\n"
+                + helper
+                + f"\n_pg_write_probe_conninfo 25432 {shlex.quote(str(output_dir))} "
+                f"{shlex.quote(str(password_file))}\n"
+            )
+            p = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, timeout=10
+            )
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            expected = {
+                "PGHOST": "2001:db8::1",
+                "PGHOSTADDR": "127.0.0.1",
+                "PGPORT": "25432",
+                "PGUSER": "user:name",
+                "PGDATABASE": "db+name",
+                "PGSSLMODE": "verify-full",
+                "PGAPPNAME": "a+b",
+            }
+            for name, value in expected.items():
+                with self.subTest(name=name):
+                    self.assertEqual(
+                        (output_dir / name).read_text(encoding="utf-8"), value
+                    )
+                    self.assertEqual((output_dir / name).stat().st_mode & 0o777, 0o600)
+            self.assertEqual(
+                password_file.read_text(encoding="utf-8"),
+                r"2001\:db8\:\:1:25432:db+name:user\:name:p\\\:a+ss" + "\n",
+            )
+            self.assertEqual(password_file.stat().st_mode & 0o777, 0o600)
+
+    def test_production_ruby_without_password_leaves_pgpass_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output_dir = root / "conninfo"
+            output_dir.mkdir()
+            password_file = root / "pgpass"
+            password_file.touch(mode=0o600)
+            deploy = DEPLOY.read_text(encoding="utf-8")
+            start = deploy.index("_pg_write_probe_conninfo() {")
+            end = deploy.index("_pg_sql_probe() {", start)
+            helper = deploy[start:end]
+            script = (
+                "set -euo pipefail\n"
+                f"ADK_REL={shlex.quote(str(root))}\n"
+                "DATABASE_URL=postgresql://agentdesk@db.internal/agentdesk\n"
+                "export DATABASE_URL\n"
+                + helper
+                + f"\n_pg_write_probe_conninfo 25432 {shlex.quote(str(output_dir))} "
+                f"{shlex.quote(str(password_file))}\n"
+            )
+            p = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, timeout=10
+            )
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertEqual(password_file.read_bytes(), b"")
 
     def test_generated_plist_is_valid_and_round_trips_metachar_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -558,6 +651,24 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             self.assertNotIn("bootstrap", events)
             self.assertNotIn("release-stop", events)
             self.assertFalse(launchctl_log.exists())
+
+    def test_loaded_job_without_restorable_files_fails_before_bootout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(adk, home, job_loaded=True)
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("lacks restorable wrapper/plist snapshots", p.stdout)
+            events = event_log.read_text(encoding="utf-8")
+            self.assertNotIn("launchctl bootout", events)
+            self.assertNotIn("takeover", events)
+            self.assertNotIn("release-stop", events)
 
     def test_canonical_failure_restores_wrapper_plist_and_job(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -730,6 +841,42 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             self.assertIn("Failed to restart previous manual PG tunnel", p.stderr)
             self._assert_rollback_material_retained(home)
 
+    def test_new_node_rollback_accepts_restored_listener_absence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(adk, home, fail_canonical=True)
+            self.assertNotEqual(p.returncode, 0)
+            self.assertEqual(
+                (home / "rollback-state.txt").read_text(encoding="utf-8"),
+                "armed=0 backup=\n",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertIn("lsof -nP -a -iTCP@127.0.0.1:15432 -sTCP:LISTEN", events)
+
+    def test_new_node_rollback_retains_material_if_listener_survives(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, _ = self._run_block(
+                adk, home, fail_canonical=True, fail_listener_absence=True
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("still has a listener", p.stderr)
+            self._assert_rollback_material_retained(home)
+
     def test_rollback_readiness_failure_retains_recovery_material(self):
         with tempfile.TemporaryDirectory() as tmp:
             adk = Path(tmp) / "adk"
@@ -778,18 +925,20 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             events = event_log.read_text(encoding="utf-8")
             self.assertEqual(p.returncode, 0, p.stdout + p.stderr + events)
             self.assertIn(
-                "psql host=127.0.0.1 port=15432 user=agentdesk "
-                "db=agentdesk sslmode=require passfile=set",
+                "psql host=db.internal hostaddr=127.0.0.1 port=15432 "
+                "user=agentdesk db=agentdesk sslmode=require passfile=set",
                 events,
                 p.stdout + p.stderr + events,
             )
-            probe_sql = events.index("psql host=127.0.0.1 port=")
+            probe_sql = events.index("psql host=db.internal hostaddr=127.0.0.1 port=")
             cleanup = events.index("probe-term", probe_sql)
-            bootstrap = events.index("launchctl bootstrap", cleanup)
+            takeover = events.index("takeover", cleanup)
+            bootstrap = events.index("launchctl bootstrap", takeover)
             canonical_sql = events.index("port=15432", bootstrap)
             stop = events.index("release-stop", canonical_sql)
             self.assertLess(probe_sql, cleanup)
-            self.assertLess(cleanup, bootstrap)
+            self.assertLess(cleanup, takeover)
+            self.assertLess(takeover, bootstrap)
             self.assertLess(bootstrap, canonical_sql)
             self.assertLess(canonical_sql, stop)
 

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -294,9 +294,9 @@ if [ "$1" = bootout ]; then
   bootout_count=$(grep -c '^bootout ' "$LAUNCHCTL_LOG" || true)
   [ "$bootout_count" -lt 2 ] || : > "$ROLLBACK_BOOTOUT"
 fi
-if [ "$1" = bootstrap ] && [ "${FAIL_RESTORE_BOOTSTRAP:-0}" = 1 ]; then
-  bootstrap_count=$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG" || true)
-  [ "$bootstrap_count" -lt 2 ] || exit 1
+if [ "$1" = bootstrap ] && [ -f "$ROLLBACK_BOOTOUT" ]; then
+  [ "${FAIL_RESTORE_BOOTSTRAP:-0}" != 1 ] || exit 1
+  : > "$ROLLBACK_READY"
 fi
 exit 0
 """,
@@ -330,18 +330,16 @@ printf 'psql host=%s hostaddr=%s port=%s user=%s db=%s sslmode=%s timeout=%s pas
 [ -n "${PGPASSFILE:-}" ] && [ -s "$PGPASSFILE" ] || exit 85
 case "${PGPORT:-}" in
   15432)
-    rollback_active=0
-    if grep -q '^restore ' "$EVENT_LOG"; then
-      rollback_active=1
-    elif [ -f "$LAUNCHCTL_LOG" ]; then
-      bootstrap_count=$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG" || true)
-      [ "$bootstrap_count" -lt 2 ] || rollback_active=1
-    fi
-    if [ "$rollback_active" -eq 0 ] && [ "${FAIL_CANONICAL:-0}" = 1 ]; then exit 1; fi
-    if [ "$rollback_active" -eq 1 ]; then
-      if [ "${FAIL_ROLLBACK_READINESS:-0}" = 1 ]; then exit 1; fi
+    if [ ! -f "$ROLLBACK_READY" ]; then
+      printf 'psql-state canonical\n' >> "$EVENT_LOG"
+      [ "${FAIL_CANONICAL:-0}" != 1 ] || exit 1
+    else
+      printf 'psql-state rollback\n' >> "$EVENT_LOG"
+      [ "${FAIL_ROLLBACK_READINESS:-0}" != 1 ] || exit 1
       rollback_attempt=0
-      [ ! -f "$ROLLBACK_PSQL_COUNT" ] || rollback_attempt=$(cat "$ROLLBACK_PSQL_COUNT")
+      if [ -f "$ROLLBACK_PSQL_COUNT" ]; then
+        IFS= read -r rollback_attempt < "$ROLLBACK_PSQL_COUNT"
+      fi
       rollback_attempt=$((rollback_attempt + 1))
       printf '%s\n' "$rollback_attempt" > "$ROLLBACK_PSQL_COUNT"
       [ "$rollback_attempt" -ge "${ROLLBACK_READY_ATTEMPT:-1}" ] || exit 1
@@ -386,7 +384,11 @@ case "$1" in
   --probe-remote) exec "$FAKE_BIN/probe" ;;
   --canonical-kind) [ "${FAIL_KIND_SNAPSHOT:-0}" != 1 ] || exit 1; printf '%s\\n' "${MANUAL_KIND:-none}" ;;
   --take-over-canonical) printf 'takeover\\n' >> "$EVENT_LOG" ;;
-  --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG"; [ "${FAIL_MANUAL_RESTORE:-0}" != 1 ] ;;
+  --restore-canonical)
+    printf 'restore %s\\n' "$3" >> "$EVENT_LOG"
+    [ "${FAIL_MANUAL_RESTORE:-0}" != 1 ] || exit 1
+    : > "$ROLLBACK_READY"
+    ;;
   *) exit 1 ;;
 esac
 """,
@@ -434,10 +436,11 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             f"PROBE_READY={shlex.quote(str(home / 'probe.ready'))}\n"
             f"ROLLBACK_STATE={shlex.quote(str(rollback_state))}\n"
             f"ROLLBACK_BOOTOUT={shlex.quote(str(home / 'rollback.bootout'))}\n"
+            f"ROLLBACK_READY={shlex.quote(str(home / 'rollback.ready'))}\n"
             f"ROLLBACK_LISTENER_COUNT={shlex.quote(str(home / 'rollback-listener.count'))}\n"
             f"ROLLBACK_PSQL_COUNT={shlex.quote(str(home / 'rollback-psql.count'))}\n"
             "DATABASE_URL=postgresql://agentdesk:s3cr3t@db.internal:5432/agentdesk?sslmode=require\n"
-            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE FAIL_LISTENER_ABSENCE ROLLBACK_LISTENER_CHECKS ROLLBACK_READY_ATTEMPT JOB_LOADED MANUAL_KIND PROBE_READY ROLLBACK_BOOTOUT ROLLBACK_LISTENER_COUNT ROLLBACK_PSQL_COUNT DATABASE_URL\n"
+            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE FAIL_LISTENER_ABSENCE ROLLBACK_LISTENER_CHECKS ROLLBACK_READY_ATTEMPT JOB_LOADED MANUAL_KIND PROBE_READY ROLLBACK_BOOTOUT ROLLBACK_READY ROLLBACK_LISTENER_COUNT ROLLBACK_PSQL_COUNT DATABASE_URL\n"
             f"FAKE_BIN={shlex.quote(str(fake_bin))}\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
             "export FAKE_BIN PATH\n"
@@ -471,11 +474,18 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             kind = "dir" if path.is_dir() else "file"
             files.append(f"{path.relative_to(home)} [{kind}]")
         listing = "\n".join(files) if files else "<empty>"
+        safe_logs = []
+        for name in ("events.log", "launchctl.log"):
+            path = home / name
+            if path.is_file():
+                safe_logs.append(f"{name}:\n{path.read_text(encoding='utf-8')}")
+        log_output = "\n".join(safe_logs) if safe_logs else "<none>"
         return (
             f"returncode={p.returncode}\n"
             f"stdout:\n{p.stdout}\n"
             f"stderr:\n{p.stderr}\n"
-            f"home files:\n{listing}"
+            f"home files:\n{listing}\n"
+            f"safe harness logs:\n{log_output}"
         )
 
     @staticmethod

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -301,6 +301,20 @@ fi
 exit 0
 """,
             "xattr": "#!/bin/sh\nexit 0\n",
+            "lsof": """#!/bin/sh
+printf 'lsof %s\n' "$*" >> "$EVENT_LOG"
+if [ "${FAIL_LISTENER_ABSENCE:-0}" = 1 ]; then exit 0; fi
+if [ -f "$ROLLBACK_BOOTOUT" ] && [ "${ROLLBACK_LISTENER_CHECKS:-0}" -gt 0 ]; then
+  current=0
+  if [ -f "$ROLLBACK_LISTENER_COUNT" ]; then
+    IFS= read -r current < "$ROLLBACK_LISTENER_COUNT"
+  fi
+  current=$((current + 1))
+  printf '%s\n' "$current" > "$ROLLBACK_LISTENER_COUNT"
+  [ "$current" -gt "$ROLLBACK_LISTENER_CHECKS" ] || exit 0
+fi
+exit 1
+""",
             "sleep": "#!/bin/sh\nexec /bin/sleep 0.01\n",
             "psql": """#!/bin/sh
 while [ ! -f "$PROBE_READY" ]; do /bin/sleep 0.01; done
@@ -431,18 +445,6 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             "psql() { \"$FAKE_BIN/psql\" \"$@\"; }\n"
             "launchctl() { \"$FAKE_BIN/launchctl\" \"$@\"; }\n"
             "xattr() { \"$FAKE_BIN/xattr\" \"$@\"; }\n"
-            "lsof() {\n"
-            "  printf 'lsof %s\\n' \"$*\" >> \"$EVENT_LOG\"\n"
-            "  [ \"${FAIL_LISTENER_ABSENCE:-0}\" != 1 ] || return 0\n"
-            "  if [ -f \"$ROLLBACK_BOOTOUT\" ] && [ \"${ROLLBACK_LISTENER_CHECKS:-0}\" -gt 0 ]; then\n"
-            "    local current=0\n"
-            "    [ ! -f \"$ROLLBACK_LISTENER_COUNT\" ] || current=$(<\"$ROLLBACK_LISTENER_COUNT\")\n"
-            "    current=$((current + 1))\n"
-            "    printf '%s\\n' \"$current\" > \"$ROLLBACK_LISTENER_COUNT\"\n"
-            "    [ \"$current\" -gt \"$ROLLBACK_LISTENER_CHECKS\" ] || return 0\n"
-            "  fi\n"
-            "  return 1\n"
-            "}\n"
             "cp() { \"$FAKE_BIN/cp\" \"$@\"; }\n"
             "command -v psql >/dev/null || exit 97\n"
             "command -v ruby >/dev/null || exit 98\n"
@@ -459,6 +461,22 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             ["bash", "-c", script], capture_output=True, text=True, timeout=30
         )
         return p, launchctl_log, event_log
+
+    @staticmethod
+    def _block_failure_diagnostics(
+        p: subprocess.CompletedProcess, home: Path
+    ) -> str:
+        files = []
+        for path in sorted(home.rglob("*"), key=lambda item: str(item)):
+            kind = "dir" if path.is_dir() else "file"
+            files.append(f"{path.relative_to(home)} [{kind}]")
+        listing = "\n".join(files) if files else "<empty>"
+        return (
+            f"returncode={p.returncode}\n"
+            f"stdout:\n{p.stdout}\n"
+            f"stderr:\n{p.stderr}\n"
+            f"home files:\n{listing}"
+        )
 
     @staticmethod
     def _cleanup_helpers() -> str:
@@ -841,11 +859,15 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 old_wrapper="#!/bin/sh\nexit 99\n",
                 manual_kind="tcp",
             )
-            self.assertNotEqual(p.returncode, 0)
-            self.assertIn("restore tcp", event_log.read_text(encoding="utf-8"))
+            diagnostics = self._block_failure_diagnostics(p, home)
+            self.assertNotEqual(p.returncode, 0, diagnostics)
+            self.assertIn(
+                "restore tcp", event_log.read_text(encoding="utf-8"), diagnostics
+            )
             self.assertEqual(
                 (home / "rollback-state.txt").read_text(encoding="utf-8"),
                 "armed=0 backup=\n",
+                diagnostics,
             )
 
     def test_rollback_waits_for_listener_absence_before_manual_restore(self):
@@ -1091,14 +1113,17 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
                 old_plist="old-plist\n",
             )
             events = event_log.read_text(encoding="utf-8")
-            self.assertNotEqual(p.returncode, 0)
-            rollback_attempts = int(
-                (home / "rollback-psql.count").read_text(encoding="utf-8")
-            )
-            self.assertEqual(rollback_attempts, 45, events)
+            diagnostics = self._block_failure_diagnostics(p, home)
+            self.assertNotEqual(p.returncode, 0, diagnostics)
+            rollback_count = home / "rollback-psql.count"
+            if not rollback_count.is_file():
+                self.fail(diagnostics)
+            rollback_attempts = int(rollback_count.read_text(encoding="utf-8"))
+            self.assertEqual(rollback_attempts, 45, events + "\n" + diagnostics)
             self.assertEqual(
                 (home / "rollback-state.txt").read_text(encoding="utf-8"),
                 "armed=0 backup=\n",
+                diagnostics,
             )
 
     @staticmethod

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -242,8 +242,9 @@ fi
 exit 0
 """,
             "xattr": "#!/bin/sh\nexit 0\n",
-            "sleep": "#!/bin/sh\nexit 0\n",
+            "sleep": "#!/bin/sh\nexec /bin/sleep 0.01\n",
             "psql": """#!/bin/sh
+while [ ! -f "$PROBE_READY" ]; do /bin/sleep 0.01; done
 printf 'psql %s\\n' "${PGDATABASE:-missing}" >> "$EVENT_LOG"
 case "${PGDATABASE:-}" in
   *:15432/*) [ "${FAIL_CANONICAL:-0}" != 1 ] ;;
@@ -251,6 +252,7 @@ case "${PGDATABASE:-}" in
 esac
 """,
             "ruby": """#!/bin/sh
+printf 'ruby %s\\n' "$*" >> "$EVENT_LOG"
 while [ "$#" -gt 3 ]; do shift; done
 port=$1
 output=$2
@@ -267,8 +269,8 @@ printf 'postgresql://agentdesk@127.0.0.1:%s/agentdesk?sslmode=require' "$port" >
             """#!/bin/sh
 printf 'wrapper %s\\n' "$*" >> "$EVENT_LOG"
 case "$1" in
-  --check-config) grep -q '^PG_TUNNEL_SSH_TARGET=[A-Za-z0-9_.:@-][A-Za-z0-9_.:@-]*$' "$2" ;;
-  --probe-remote) trap 'printf "probe-term\\n" >> "$EVENT_LOG"; exit 0' TERM; while :; do /bin/sleep 1; done ;;
+  --check-config) grep -q '^PG_TUNNEL_SSH_TARGET=[A-Za-z0-9_.:@][A-Za-z0-9_.:@-]*$' "$2" ;;
+  --probe-remote) trap 'printf "probe-term\\n" >> "$EVENT_LOG"; exit 0' TERM; : > "$PROBE_READY"; while :; do /bin/sleep 1; done ;;
   --canonical-kind) printf '%s\\n' "${MANUAL_KIND:-none}" ;;
   --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG" ;;
   *) exit 1 ;;
@@ -306,9 +308,18 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             f"FAIL_CANONICAL={int(fail_canonical)}\n"
             f"JOB_LOADED={int(job_loaded)}\n"
             f"MANUAL_KIND={shlex.quote(manual_kind)}\n"
-            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL JOB_LOADED MANUAL_KIND\n"
+            f"PROBE_READY={shlex.quote(str(home / 'probe.ready'))}\n"
+            "DATABASE_URL=postgresql://agentdesk@db.internal:5432/agentdesk?sslmode=require\n"
+            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL JOB_LOADED MANUAL_KIND PROBE_READY DATABASE_URL\n"
+            f"FAKE_BIN={shlex.quote(str(fake_bin))}\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
             "export PATH\n"
+            "ruby() { \"$FAKE_BIN/ruby\" \"$@\"; }\n"
+            "psql() { \"$FAKE_BIN/psql\" \"$@\"; }\n"
+            "launchctl() { \"$FAKE_BIN/launchctl\" \"$@\"; }\n"
+            "xattr() { \"$FAKE_BIN/xattr\" \"$@\"; }\n"
+            "command -v psql >/dev/null || exit 97\n"
+            "command -v ruby >/dev/null || exit 98\n"
             + prelude
             + "\n"
             + self._cleanup_helpers()
@@ -482,8 +493,9 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             home = Path(tmp) / "home"
             home.mkdir()
             p, _, event_log = self._run_block(adk, home)
-            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
             events = event_log.read_text(encoding="utf-8")
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr + events)
+            self.assertIn("psql postgresql://", events, p.stdout + p.stderr + events)
             probe_sql = events.index("psql postgresql://")
             cleanup = events.index("probe-term", probe_sql)
             bootstrap = events.index("launchctl bootstrap", cleanup)

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -33,6 +33,9 @@ class WrapperSafetyTests(unittest.TestCase):
             "/usr/bin/ssh -N -L 0.0.0.0:15432:/tmp/.s.PGSQL.5432 mac-mini",
             "/usr/bin/ssh -N -L127.0.0.1:15432:/tmp/.s.PGSQL.5432 mac-mini",
             "/usr/bin/ssh -N -L 127.0.0.1:15432:db:5432 host",
+            "/usr/bin/ssh -N -L 127.0.0.1:15432:127.0.0.1:54321 mac-mini",
+            "/usr/bin/ssh -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432.bak mac-mini",
+            "/usr/bin/ssh -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.54321 mac-mini",
             "python monitor.py ssh -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432 host",
             "/usr/bin/notssh -N -L 127.0.0.1:15432:/tmp/.s.PGSQL.5432 host",
         ]
@@ -101,10 +104,37 @@ class WrapperSafetyTests(unittest.TestCase):
         self.assertIn("-L 127.0.0.1:15432:/tmp/.s.PGSQL.5432", text)
         self.assertNotIn("-L 127.0.0.1:15432:127.0.0.1:5432", text)
 
-    def test_check_config_does_not_claim_remote_socket_validation(self):
+    def test_remote_probe_rejects_unrestricted_arguments_and_ports(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "pg-tunnel.env"
+            config.write_text("PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8")
+            for argv in (
+                ["--probe-remote", str(config)],
+                ["--probe-remote", str(config), "15432"],
+                ["--probe-remote", str(config), "1023"],
+                ["--probe-remote", str(config), "65536"],
+                ["--probe-remote", str(config), "not-a-port"],
+                ["--probe-remote", str(config), "25432", "-oProxyCommand=bad"],
+            ):
+                with self.subTest(argv=argv):
+                    p = subprocess.run(
+                        [str(WRAPPER), *argv], capture_output=True, text=True
+                    )
+                    self.assertNotEqual(p.returncode, 0)
+
+    def test_remote_probe_executes_only_exact_unix_socket_forward(self):
         text = WRAPPER.read_text(encoding="utf-8")
-        self.assertIn("doctor PostgreSQL preflight", text)
-        self.assertIn("must not be treated as remote reachability", text)
+        self.assertIn('[ "$#" -eq 3 ] || die "usage: $0 --probe-remote CONFIG PORT"', text)
+        self.assertIn('-L "127.0.0.1:$3:/tmp/.s.PGSQL.5432"', text)
+        self.assertIn('"$PG_TUNNEL_SSH_TARGET"', text)
+
+    def test_probe_cleanup_always_waits_after_term_and_kill(self):
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
+        end = deploy.index("_rollback_pg_tunnel_migration() {", start)
+        cleanup = deploy[start:end]
+        self.assertLess(cleanup.index('kill -TERM "$pid"'), cleanup.index('wait "$pid"'))
+        self.assertLess(cleanup.index('kill -KILL "$pid"'), cleanup.index('wait "$pid"'))
 
 
 class DeploymentWiringTests(unittest.TestCase):
@@ -112,16 +142,10 @@ class DeploymentWiringTests(unittest.TestCase):
 
     @staticmethod
     def _pg_block() -> str:
-        lines = DEPLOY.read_text(encoding="utf-8").splitlines()
-        start = next(
-            i
-            for i, line in enumerate(lines)
-            if 'PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"' in line
-        )
-        end = next(
-            i for i, line in enumerate(lines) if "PG tunnel staging FAILED" in line
-        )
-        return "\n".join(lines[start : end + 2])
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        start = deploy.index("PG_TUNNEL_LABEL=\"com.agentdesk.pg-tunnel\"")
+        end = deploy.index("# #4381: a deploy restarts dcserver", start)
+        return deploy[start:end]
 
     def test_ci_script_checks_runs_this_suite(self):
         ci = (REPO_ROOT / "scripts/ci-script-checks.sh").read_text(encoding="utf-8")
@@ -173,53 +197,137 @@ class DeploymentWiringTests(unittest.TestCase):
 
     def test_machine_local_env_gates_bootout_and_bootstrap(self):
         block = self._pg_block()
-        gate = block.index('if [ -f "$PG_TUNNEL_CONFIG" ]; then')
+        gate = block.index('[ -f "$PG_TUNNEL_CONFIG" ] || {')
         bootout = block.index(
-            'launchctl bootout "$LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL"'
+            'launchctl bootout "$PG_TUNNEL_LAUNCHD_DOMAIN/$PG_TUNNEL_LABEL"'
         )
         bootstrap = block.index(
-            'launchctl bootstrap "$LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"'
+            'launchctl bootstrap "$PG_TUNNEL_LAUNCHD_DOMAIN" "$PG_TUNNEL_PLIST_PATH"'
         )
         self.assertLess(gate, bootout)
         self.assertLess(gate, bootstrap)
         self.assertIn("Supervisor NOT armed on this node", block)
 
-    def test_block_is_after_deploy_ok_and_before_manifest(self):
+    def test_block_is_before_release_stop_and_deploy_success(self):
         deploy = DEPLOY.read_text(encoding="utf-8")
         block_at = deploy.index('PG_TUNNEL_LABEL="com.agentdesk.pg-tunnel"')
-        self.assertLess(deploy.index("DEPLOY_OK=1"), block_at)
-        self.assertLess(block_at, deploy.index("_write_release_source_manifest", block_at))
+        migrate_at = deploy.index("_migrate_pg_tunnel_before_release_stop", block_at)
+        stop_at = deploy.index('echo "▸ Stopping release..."', migrate_at)
+        self.assertLess(migrate_at, stop_at)
+        self.assertLess(stop_at, deploy.index("DEPLOY_OK=1", stop_at))
 
-    def _run_block(self, adk_rel: Path, home: Path) -> tuple[subprocess.CompletedProcess, Path]:
+    def _run_block(
+        self,
+        adk_rel: Path,
+        home: Path,
+        *,
+        fail_probe: bool = False,
+        fail_canonical: bool = False,
+        job_loaded: bool = False,
+        old_wrapper: str | None = None,
+        old_plist: str | None = None,
+        manual_kind: str = "none",
+    ) -> tuple[subprocess.CompletedProcess, Path, Path]:
         fake_bin = home / "fake-bin"
         fake_bin.mkdir(parents=True)
+        event_log = home / "events.log"
         launchctl_log = home / "launchctl.log"
-        launchctl = fake_bin / "launchctl"
-        launchctl.write_text(
-            '#!/bin/sh\nprintf "%s\\n" "$*" >> "$LAUNCHCTL_LOG"\n',
+        for name, body in {
+            "launchctl": """#!/bin/sh
+printf 'launchctl %s\\n' "$*" >> "$EVENT_LOG"
+printf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"
+if [ "$1" = print ]; then
+  if [ "${JOB_LOADED:-0}" = 1 ]; then exit 0; else exit 1; fi
+fi
+exit 0
+""",
+            "xattr": "#!/bin/sh\nexit 0\n",
+            "sleep": "#!/bin/sh\nexit 0\n",
+            "psql": """#!/bin/sh
+printf 'psql %s\\n' "${PGDATABASE:-missing}" >> "$EVENT_LOG"
+case "${PGDATABASE:-}" in
+  *:15432/*) [ "${FAIL_CANONICAL:-0}" != 1 ] ;;
+  *) [ "${FAIL_PROBE:-0}" != 1 ] ;;
+esac
+""",
+            "ruby": """#!/bin/sh
+while [ "$#" -gt 3 ]; do shift; done
+port=$1
+output=$2
+printf 'postgresql://agentdesk@127.0.0.1:%s/agentdesk?sslmode=require' "$port" > "$output"
+""",
+        }.items():
+            path = fake_bin / name
+            path.write_text(body, encoding="utf-8")
+            path.chmod(0o755)
+        repo = home / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        wrapper = repo / "scripts/pg_tunnel.sh"
+        wrapper.write_text(
+            """#!/bin/sh
+printf 'wrapper %s\\n' "$*" >> "$EVENT_LOG"
+case "$1" in
+  --check-config) grep -q '^PG_TUNNEL_SSH_TARGET=[A-Za-z0-9_.:@-][A-Za-z0-9_.:@-]*$' "$2" ;;
+  --probe-remote) trap 'printf "probe-term\\n" >> "$EVENT_LOG"; exit 0' TERM; while :; do /bin/sleep 1; done ;;
+  --canonical-kind) printf '%s\\n' "${MANUAL_KIND:-none}" ;;
+  --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG" ;;
+  *) exit 1 ;;
+esac
+""",
             encoding="utf-8",
         )
-        xattr = fake_bin / "xattr"
-        xattr.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-        launchctl.chmod(0o755)
-        xattr.chmod(0o755)
+        wrapper.chmod(0o755)
+        if old_wrapper is not None:
+            (adk_rel / "bin/pg-tunnel.sh").write_text(old_wrapper, encoding="utf-8")
+        plist_path = home / "Library/LaunchAgents/com.agentdesk.pg-tunnel.plist"
+        if old_plist is not None:
+            plist_path.parent.mkdir(parents=True)
+            plist_path.write_text(old_plist, encoding="utf-8")
+        prelude = """
+PG_TUNNEL_PREFLIGHT_PID=""
+PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
+PG_TUNNEL_ROLLBACK_ARMED=0
+PG_TUNNEL_ROLLBACK_DIR=""
+PG_TUNNEL_ROLLBACK_JOB_LOADED=0
+PG_TUNNEL_ROLLBACK_MANUAL_KIND="none"
+PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
+PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
+_launchd_domain() { printf '%s\\n' gui/999999; }
+"""
         script = (
             "set -euo pipefail\n"
-            f"REPO={shlex.quote(str(REPO_ROOT))}\n"
+            f"REPO={shlex.quote(str(repo))}\n"
             f"ADK_REL={shlex.quote(str(adk_rel))}\n"
             f"HOME={shlex.quote(str(home))}\n"
-            "LAUNCHD_DOMAIN=gui/999999\n"
+            f"EVENT_LOG={shlex.quote(str(event_log))}\n"
             f"LAUNCHCTL_LOG={shlex.quote(str(launchctl_log))}\n"
-            "export LAUNCHCTL_LOG\n"
+            f"FAIL_PROBE={int(fail_probe)}\n"
+            f"FAIL_CANONICAL={int(fail_canonical)}\n"
+            f"JOB_LOADED={int(job_loaded)}\n"
+            f"MANUAL_KIND={shlex.quote(manual_kind)}\n"
+            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL JOB_LOADED MANUAL_KIND\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
             "export PATH\n"
+            + prelude
+            + "\n"
+            + self._cleanup_helpers()
+            + "\ntrap '_status=$?; _cleanup_owned_pg_tunnel_preflight; "
+            "[ \"$_status\" -eq 0 ] || _rollback_pg_tunnel_migration' EXIT\n"
             + self._pg_block()
-            + "\necho HARNESS-END\n"
+            + "\nprintf 'release-stop\\n' >> \"$EVENT_LOG\"\necho HARNESS-END\n"
         )
         p = subprocess.run(
             ["bash", "-c", script], capture_output=True, text=True, timeout=30
         )
-        return p, launchctl_log
+        return p, launchctl_log, event_log
+
+    @staticmethod
+    def _cleanup_helpers() -> str:
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
+        end = deploy.index("_cleanup_on_exit() {", start)
+        return deploy[start:end]
 
     def test_generated_plist_is_valid_and_round_trips_metachar_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -231,7 +339,7 @@ class DeploymentWiringTests(unittest.TestCase):
             )
             home = Path(tmp) / "home & <operator>"
             home.mkdir()
-            p, launchctl_log = self._run_block(adk, home)
+            p, launchctl_log, _ = self._run_block(adk, home)
             self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
             self.assertIn("HARNESS-END", p.stdout)
             self.assertTrue(launchctl_log.is_file())
@@ -270,7 +378,7 @@ class DeploymentWiringTests(unittest.TestCase):
                 (adk / sub).mkdir(parents=True)
             home = Path(tmp) / "home"
             home.mkdir()
-            p, launchctl_log = self._run_block(adk, home)
+            p, launchctl_log, _ = self._run_block(adk, home)
             self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
             self.assertIn("Supervisor NOT armed on this node", p.stdout)
             self.assertFalse(launchctl_log.exists())
@@ -285,10 +393,106 @@ class DeploymentWiringTests(unittest.TestCase):
             )
             home = Path(tmp) / "home"
             home.mkdir()
-            p, launchctl_log = self._run_block(adk, home)
-            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            p, launchctl_log, _ = self._run_block(adk, home)
+            self.assertNotEqual(p.returncode, 0)
             self.assertIn("config invalid", p.stdout)
             self.assertFalse(launchctl_log.exists())
+
+    def test_remote_sql_failure_stops_before_canonical_install(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, launchctl_log, event_log = self._run_block(
+                adk, home, fail_probe=True
+            )
+            self.assertNotEqual(p.returncode, 0)
+            events = event_log.read_text(encoding="utf-8")
+            self.assertIn("probe-term", events)
+            self.assertNotIn("bootstrap", events)
+            self.assertNotIn("release-stop", events)
+            self.assertFalse(launchctl_log.exists())
+
+    def test_canonical_failure_restores_wrapper_plist_and_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                job_loaded=True,
+                old_wrapper="old-wrapper\n",
+                old_plist="old-plist\n",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertEqual(
+                (adk / "bin/pg-tunnel.sh").read_text(encoding="utf-8"),
+                "old-wrapper\n",
+            )
+            self.assertEqual(
+                (
+                    home / "Library/LaunchAgents/com.agentdesk.pg-tunnel.plist"
+                ).read_text(encoding="utf-8"),
+                "old-plist\n",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertGreaterEqual(events.count("launchctl bootstrap"), 2)
+            self.assertNotIn("release-stop", events)
+
+    def test_canonical_failure_restores_manual_tcp_tunnel_with_source_wrapper(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                old_wrapper="#!/bin/sh\nexit 99\n",
+                manual_kind="tcp",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("restore tcp", event_log.read_text(encoding="utf-8"))
+
+    def test_success_order_is_remote_sql_then_canonical_sql_then_stop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(adk, home)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            events = event_log.read_text(encoding="utf-8")
+            probe_sql = events.index("psql postgresql://")
+            cleanup = events.index("probe-term", probe_sql)
+            bootstrap = events.index("launchctl bootstrap", cleanup)
+            canonical_sql = events.index(":15432/", bootstrap)
+            stop = events.index("release-stop", canonical_sql)
+            self.assertLess(probe_sql, cleanup)
+            self.assertLess(cleanup, bootstrap)
+            self.assertLess(bootstrap, canonical_sql)
+            self.assertLess(canonical_sql, stop)
 
 
 if __name__ == "__main__":

--- a/tests/test_pg_tunnel.py
+++ b/tests/test_pg_tunnel.py
@@ -223,6 +223,11 @@ class DeploymentWiringTests(unittest.TestCase):
         *,
         fail_probe: bool = False,
         fail_canonical: bool = False,
+        fail_rollback_readiness: bool = False,
+        fail_backup_copy: bool = False,
+        fail_kind_snapshot: bool = False,
+        fail_restore_bootstrap: bool = False,
+        fail_manual_restore: bool = False,
         job_loaded: bool = False,
         old_wrapper: str | None = None,
         old_plist: str | None = None,
@@ -239,24 +244,58 @@ printf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"
 if [ "$1" = print ]; then
   if [ "${JOB_LOADED:-0}" = 1 ]; then exit 0; else exit 1; fi
 fi
+if [ "$1" = bootstrap ] && [ "${FAIL_RESTORE_BOOTSTRAP:-0}" = 1 ]; then
+  bootstrap_count=$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG" || true)
+  [ "$bootstrap_count" -lt 2 ] || exit 1
+fi
 exit 0
 """,
             "xattr": "#!/bin/sh\nexit 0\n",
             "sleep": "#!/bin/sh\nexec /bin/sleep 0.01\n",
             "psql": """#!/bin/sh
 while [ ! -f "$PROBE_READY" ]; do /bin/sleep 0.01; done
-printf 'psql %s\\n' "${PGDATABASE:-missing}" >> "$EVENT_LOG"
-case "${PGDATABASE:-}" in
-  *:15432/*) [ "${FAIL_CANONICAL:-0}" != 1 ] ;;
+printf 'psql host=%s port=%s user=%s db=%s sslmode=%s passfile=%s\\n' \
+  "${PGHOST:-missing}" "${PGPORT:-missing}" "${PGUSER:-missing}" \
+  "${PGDATABASE:-missing}" "${PGSSLMODE:-missing}" "${PGPASSFILE:+set}" >> "$EVENT_LOG"
+[ "${PGHOST:-}" = 127.0.0.1 ] || exit 81
+[ "${PGUSER:-}" = agentdesk ] || exit 82
+[ "${PGDATABASE:-}" = agentdesk ] || exit 83
+[ "${PGSSLMODE:-}" = require ] || exit 84
+[ -n "${PGPASSFILE:-}" ] && [ -s "$PGPASSFILE" ] || exit 85
+case "${PGPORT:-}" in
+  15432)
+    rollback_active=0
+    if grep -q '^restore ' "$EVENT_LOG"; then
+      rollback_active=1
+    elif [ -f "$LAUNCHCTL_LOG" ]; then
+      bootstrap_count=$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG" || true)
+      [ "$bootstrap_count" -lt 2 ] || rollback_active=1
+    fi
+    if [ "$rollback_active" -eq 0 ] && [ "${FAIL_CANONICAL:-0}" = 1 ]; then exit 1; fi
+    if [ "$rollback_active" -eq 1 ] && [ "${FAIL_ROLLBACK_READINESS:-0}" = 1 ]; then exit 1; fi
+    ;;
+  "") exit 86 ;;
   *) [ "${FAIL_PROBE:-0}" != 1 ] ;;
 esac
 """,
             "ruby": """#!/bin/sh
-printf 'ruby %s\\n' "$*" >> "$EVENT_LOG"
+printf 'ruby invoked\\n' >> "$EVENT_LOG"
 while [ "$#" -gt 3 ]; do shift; done
 port=$1
-output=$2
-printf 'postgresql://agentdesk@127.0.0.1:%s/agentdesk?sslmode=require' "$port" > "$output"
+output_dir=$2
+password_output=$3
+printf '%s' 127.0.0.1 > "$output_dir/PGHOST"
+printf '%s' "$port" > "$output_dir/PGPORT"
+printf '%s' agentdesk > "$output_dir/PGUSER"
+printf '%s' agentdesk > "$output_dir/PGDATABASE"
+printf '%s' require > "$output_dir/PGSSLMODE"
+printf '%s\\n' '127.0.0.1:'"$port"':agentdesk:agentdesk:s3cr3t' > "$password_output"
+""",
+            "cp": """#!/bin/sh
+if [ "${FAIL_BACKUP_COPY:-0}" = 1 ] && [ "$1" = -p ]; then
+  exit 1
+fi
+exec /bin/cp "$@"
 """,
         }.items():
             path = fake_bin / name
@@ -271,8 +310,8 @@ printf 'wrapper %s\\n' "$*" >> "$EVENT_LOG"
 case "$1" in
   --check-config) grep -q '^PG_TUNNEL_SSH_TARGET=[A-Za-z0-9_.:@][A-Za-z0-9_.:@-]*$' "$2" ;;
   --probe-remote) trap 'printf "probe-term\\n" >> "$EVENT_LOG"; exit 0' TERM; : > "$PROBE_READY"; while :; do /bin/sleep 1; done ;;
-  --canonical-kind) printf '%s\\n' "${MANUAL_KIND:-none}" ;;
-  --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG" ;;
+  --canonical-kind) [ "${FAIL_KIND_SNAPSHOT:-0}" != 1 ] || exit 1; printf '%s\\n' "${MANUAL_KIND:-none}" ;;
+  --restore-canonical) printf 'restore %s\\n' "$3" >> "$EVENT_LOG"; [ "${FAIL_MANUAL_RESTORE:-0}" != 1 ] ;;
   *) exit 1 ;;
 esac
 """,
@@ -287,7 +326,7 @@ esac
             plist_path.write_text(old_plist, encoding="utf-8")
         prelude = """
 PG_TUNNEL_PREFLIGHT_PID=""
-PG_TUNNEL_PREFLIGHT_DSN_FILE=""
+PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=""
 PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=""
 PG_TUNNEL_ROLLBACK_ARMED=0
 PG_TUNNEL_ROLLBACK_DIR=""
@@ -297,6 +336,7 @@ PG_TUNNEL_ROLLBACK_MANUAL_CONFIG=""
 PG_TUNNEL_ROLLBACK_WRAPPER_SOURCE=""
 _launchd_domain() { printf '%s\\n' gui/999999; }
 """
+        rollback_state = home / "rollback-state.txt"
         script = (
             "set -euo pipefail\n"
             f"REPO={shlex.quote(str(repo))}\n"
@@ -306,11 +346,17 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             f"LAUNCHCTL_LOG={shlex.quote(str(launchctl_log))}\n"
             f"FAIL_PROBE={int(fail_probe)}\n"
             f"FAIL_CANONICAL={int(fail_canonical)}\n"
+            f"FAIL_ROLLBACK_READINESS={int(fail_rollback_readiness)}\n"
+            f"FAIL_BACKUP_COPY={int(fail_backup_copy)}\n"
+            f"FAIL_KIND_SNAPSHOT={int(fail_kind_snapshot)}\n"
+            f"FAIL_RESTORE_BOOTSTRAP={int(fail_restore_bootstrap)}\n"
+            f"FAIL_MANUAL_RESTORE={int(fail_manual_restore)}\n"
             f"JOB_LOADED={int(job_loaded)}\n"
             f"MANUAL_KIND={shlex.quote(manual_kind)}\n"
             f"PROBE_READY={shlex.quote(str(home / 'probe.ready'))}\n"
-            "DATABASE_URL=postgresql://agentdesk@db.internal:5432/agentdesk?sslmode=require\n"
-            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL JOB_LOADED MANUAL_KIND PROBE_READY DATABASE_URL\n"
+            f"ROLLBACK_STATE={shlex.quote(str(rollback_state))}\n"
+            "DATABASE_URL=postgresql://agentdesk:s3cr3t@db.internal:5432/agentdesk?sslmode=require\n"
+            "export EVENT_LOG LAUNCHCTL_LOG FAIL_PROBE FAIL_CANONICAL FAIL_ROLLBACK_READINESS FAIL_BACKUP_COPY FAIL_KIND_SNAPSHOT FAIL_RESTORE_BOOTSTRAP FAIL_MANUAL_RESTORE JOB_LOADED MANUAL_KIND PROBE_READY DATABASE_URL\n"
             f"FAKE_BIN={shlex.quote(str(fake_bin))}\n"
             f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
             "export PATH\n"
@@ -318,13 +364,15 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             "psql() { \"$FAKE_BIN/psql\" \"$@\"; }\n"
             "launchctl() { \"$FAKE_BIN/launchctl\" \"$@\"; }\n"
             "xattr() { \"$FAKE_BIN/xattr\" \"$@\"; }\n"
+            "cp() { \"$FAKE_BIN/cp\" \"$@\"; }\n"
             "command -v psql >/dev/null || exit 97\n"
             "command -v ruby >/dev/null || exit 98\n"
             + prelude
             + "\n"
             + self._cleanup_helpers()
             + "\ntrap '_status=$?; _cleanup_owned_pg_tunnel_preflight; "
-            "[ \"$_status\" -eq 0 ] || _rollback_pg_tunnel_migration' EXIT\n"
+            "if [ \"$_status\" -ne 0 ]; then _rollback_pg_tunnel_migration || true; fi; "
+            "printf \"armed=%s backup=%s\\n\" \"$PG_TUNNEL_ROLLBACK_ARMED\" \"$PG_TUNNEL_ROLLBACK_DIR\" > \"$ROLLBACK_STATE\"' EXIT\n"
             + self._pg_block()
             + "\nprintf 'release-stop\\n' >> \"$EVENT_LOG\"\necho HARNESS-END\n"
         )
@@ -339,6 +387,88 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
         start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
         end = deploy.index("_cleanup_on_exit() {", start)
         return deploy[start:end]
+
+    def _run_signal_cleanup(self, signal_name: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            event_log = root / "events.log"
+            (fake_bin / "sleep").write_text(
+                "#!/bin/sh\nexec /bin/sleep 0.01\n", encoding="utf-8"
+            )
+            (fake_bin / "sleep").chmod(0o755)
+            probe = root / "probe.sh"
+            probe.write_text(
+                "#!/bin/sh\n"
+                "trap 'printf \"probe-term\\n\" >> \"$EVENT_LOG\"; exit 0' TERM\n"
+                "printf 'probe-ready\\n' >> \"$EVENT_LOG\"\n"
+                "while :; do /bin/sleep 1; done\n",
+                encoding="utf-8",
+            )
+            probe.chmod(0o755)
+            script = (
+                "set -euo pipefail\n"
+                f"EVENT_LOG={shlex.quote(str(event_log))}\n"
+                f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin:/usr/sbin:/sbin\n"
+                "export EVENT_LOG PATH\n"
+                "PG_TUNNEL_PREFLIGHT_PID=\"\"\n"
+                "PG_TUNNEL_PREFLIGHT_CONNINFO_DIR=\"\"\n"
+                "PG_TUNNEL_PREFLIGHT_PASSWORD_FILE=\"\"\n"
+                + self._probe_cleanup_helper()
+                + "\n_cleanup_on_exit() {\n"
+                "    local status=${1:-$?}\n"
+                "    trap - EXIT INT TERM\n"
+                "    _cleanup_owned_pg_tunnel_preflight\n"
+                "    printf 'cleanup=%s\\n' \"$status\" >> \"$EVENT_LOG\"\n"
+                "}\n"
+                "_handle_cleanup_signal() {\n"
+                "    local status=$1\n"
+                "    _cleanup_on_exit \"$status\"\n"
+                "    exit \"$status\"\n"
+                "}\n"
+                "trap _cleanup_on_exit EXIT\n"
+                "trap '_handle_cleanup_signal 130' INT\n"
+                "trap '_handle_cleanup_signal 143' TERM\n"
+                f"{shlex.quote(str(probe))} &\n"
+                "PG_TUNNEL_PREFLIGHT_PID=$!\n"
+                "while ! grep -q '^probe-ready$' \"$EVENT_LOG\"; do /bin/sleep 0.01; done\n"
+                f"kill -{signal_name} $$\n"
+                "exit 99\n"
+            )
+            p = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, timeout=10
+            )
+            return p.returncode, event_log.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _probe_cleanup_helper() -> str:
+        deploy = DEPLOY.read_text(encoding="utf-8")
+        start = deploy.index("_cleanup_owned_pg_tunnel_preflight() {")
+        end = deploy.index("_reset_pg_tunnel_rollback_state() {", start)
+        return deploy[start:end]
+
+    def test_int_cleanup_reaps_probe_once_and_returns_130(self):
+        status, events = self._run_signal_cleanup("INT")
+        self.assertEqual(status, 130, events)
+        self.assertEqual(events.count("probe-term"), 1, events)
+        self.assertEqual(events.count("cleanup=130"), 1, events)
+
+    def test_term_cleanup_reaps_probe_once_and_returns_143(self):
+        status, events = self._run_signal_cleanup("TERM")
+        self.assertEqual(status, 143, events)
+        self.assertEqual(events.count("probe-term"), 1, events)
+        self.assertEqual(events.count("cleanup=143"), 1, events)
+
+    def test_probe_uses_individual_libpq_environment_without_dsn_argv(self):
+        block = self._pg_block()
+        self.assertIn("local -a psql_env=(env -u DATABASE_URL)", block)
+        self.assertIn('psql_env+=(-u "$name")', block)
+        self.assertIn('psql_env+=("$name=$value")', block)
+        self.assertIn('psql_env+=("PGPASSFILE=$password_file")', block)
+        self.assertIn("YAML.safe_load(File.read(config_path), aliases: true)", block)
+        self.assertNotIn("YAML.safe_load_file", block)
+        self.assertNotIn('PGDATABASE="$(<', block)
 
     def test_generated_plist_is_valid_and_round_trips_metachar_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -481,6 +611,158 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             )
             self.assertNotEqual(p.returncode, 0)
             self.assertIn("restore tcp", event_log.read_text(encoding="utf-8"))
+            self.assertEqual(
+                (home / "rollback-state.txt").read_text(encoding="utf-8"),
+                "armed=0 backup=\n",
+            )
+
+    def test_snapshot_failure_does_not_touch_live_tunnel(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_backup_copy=True,
+                job_loaded=True,
+                old_wrapper="old-wrapper\n",
+                old_plist="old-plist\n",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertEqual(
+                (adk / "bin/pg-tunnel.sh").read_text(encoding="utf-8"),
+                "old-wrapper\n",
+            )
+            self.assertEqual(
+                (
+                    home / "Library/LaunchAgents/com.agentdesk.pg-tunnel.plist"
+                ).read_text(encoding="utf-8"),
+                "old-plist\n",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertNotIn("launchctl bootout", events)
+            self.assertNotIn("restore ", events)
+            self.assertNotIn("release-stop", events)
+            self.assertEqual(
+                (home / "rollback-state.txt").read_text(encoding="utf-8"),
+                "armed=0 backup=\n",
+            )
+
+    def test_manual_state_snapshot_failure_does_not_arm_or_install(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, event_log = self._run_block(
+                adk,
+                home,
+                fail_kind_snapshot=True,
+                old_wrapper="old-wrapper\n",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("Failed to snapshot existing manual PG tunnel state", p.stdout)
+            self.assertEqual(
+                (adk / "bin/pg-tunnel.sh").read_text(encoding="utf-8"),
+                "old-wrapper\n",
+            )
+            events = event_log.read_text(encoding="utf-8")
+            self.assertNotIn("launchctl bootout", events)
+            self.assertNotIn("launchctl bootstrap", events)
+            self.assertNotIn("release-stop", events)
+            self.assertEqual(
+                (home / "rollback-state.txt").read_text(encoding="utf-8"),
+                "armed=0 backup=\n",
+            )
+
+    def test_rollback_bootstrap_failure_retains_recovery_material(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, _ = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                fail_restore_bootstrap=True,
+                job_loaded=True,
+                old_wrapper="old-wrapper\n",
+                old_plist="old-plist\n",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("Failed to restart previous PG tunnel launchd job", p.stderr)
+            self._assert_rollback_material_retained(home)
+
+    def test_manual_restore_failure_retains_recovery_material(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, _ = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                fail_manual_restore=True,
+                old_wrapper="old-wrapper\n",
+                manual_kind="tcp",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("Failed to restart previous manual PG tunnel", p.stderr)
+            self._assert_rollback_material_retained(home)
+
+    def test_rollback_readiness_failure_retains_recovery_material(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adk = Path(tmp) / "adk"
+            for sub in ("bin", "config", "logs"):
+                (adk / sub).mkdir(parents=True)
+            (adk / "config/pg-tunnel.env").write_text(
+                "PG_TUNNEL_SSH_TARGET=mac-mini\n", encoding="utf-8"
+            )
+            home = Path(tmp) / "home"
+            home.mkdir()
+            p, _, _ = self._run_block(
+                adk,
+                home,
+                fail_canonical=True,
+                fail_rollback_readiness=True,
+                old_wrapper="old-wrapper\n",
+                manual_kind="tcp",
+            )
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("did not become SQL-ready", p.stderr)
+            self._assert_rollback_material_retained(home)
+
+    @staticmethod
+    def _assert_rollback_material_retained(home: Path) -> None:
+        state = (home / "rollback-state.txt").read_text(encoding="utf-8").strip()
+        armed, backup = state.split(" backup=", 1)
+        if armed != "armed=1":
+            raise AssertionError(state)
+        backup_path = Path(backup)
+        if not backup_path.is_dir():
+            raise AssertionError(f"rollback backup missing: {backup_path}")
+        if not (backup_path / "config").is_file():
+            raise AssertionError(f"rollback config missing: {backup_path}")
 
     def test_success_order_is_remote_sql_then_canonical_sql_then_stop(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -495,11 +777,16 @@ _launchd_domain() { printf '%s\\n' gui/999999; }
             p, _, event_log = self._run_block(adk, home)
             events = event_log.read_text(encoding="utf-8")
             self.assertEqual(p.returncode, 0, p.stdout + p.stderr + events)
-            self.assertIn("psql postgresql://", events, p.stdout + p.stderr + events)
-            probe_sql = events.index("psql postgresql://")
+            self.assertIn(
+                "psql host=127.0.0.1 port=15432 user=agentdesk "
+                "db=agentdesk sslmode=require passfile=set",
+                events,
+                p.stdout + p.stderr + events,
+            )
+            probe_sql = events.index("psql host=127.0.0.1 port=")
             cleanup = events.index("probe-term", probe_sql)
             bootstrap = events.index("launchctl bootstrap", cleanup)
-            canonical_sql = events.index(":15432/", bootstrap)
+            canonical_sql = events.index("port=15432", bootstrap)
             stop = events.index("release-stop", canonical_sql)
             self.assertLess(probe_sql, cleanup)
             self.assertLess(cleanup, bootstrap)


### PR DESCRIPTION
## Summary
- mac-book consumer tunnel의 로컬 endpoint `127.0.0.1:15432`는 유지
- SSH remote target만 `127.0.0.1:5432` → `/tmp/.s.PGSQL.5432`로 변경
- 기존 TCP-form canonical tunnel은 한 번의 migration takeover 대상으로만 허용
- unrelated SSH/local port/bind/target은 takeover 거부
- doctor PostgreSQL preflight가 remote socket reachability를 fail-closed 검증

## Evidence
- mac-mini TIME_WAIT 36k+, `:5432` 관련 20k+; high ephemeral pool 고갈로 새 IPv4 loopback connect reset
- PostgreSQL Unix socket과 IPv6는 정상
- 임시 SSH Unix-socket forward로 local TCP psql `select 1` PASS
- `python3 -m unittest tests.test_pg_tunnel`: 20 PASS
- `bash -n scripts/{pg_tunnel,deploy-release}.sh`: PASS

Refs #4580

PR-A only: mac-mini local runtime/CI direct TCP connection reduction remains in #4580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)