### PR TITLE
fix(4594): abandoned placeholder detach incarnation guard

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -567,7 +567,7 @@
 | `services::discord::outbound::transport` | `src/services/discord/outbound/transport.rs` | 431 | 431 | 0 |  |
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3467 | 1180 | 2287 | giant-file |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
-| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1316 | 713 | 603 |  |
+| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1590 | 828 | 762 |  |
 | `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 678 | 678 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
@@ -587,7 +587,7 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1294 | 999 | 295 |  |
-| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 1036 | 445 | 591 |  |
+| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 1275 | 471 | 804 |  |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 687 | 687 | 0 |  |
 | `services::discord::prompt_builder::channel_recent_context` | `src/services/discord/prompt_builder/channel_recent_context.rs` | 419 | 200 | 219 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -567,7 +567,7 @@
 | `services::discord::outbound::transport` | `src/services/discord/outbound/transport.rs` | 431 | 431 | 0 |  |
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3467 | 1180 | 2287 | giant-file |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
-| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1309 | 706 | 603 |  |
+| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1316 | 713 | 603 |  |
 | `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 678 | 678 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
@@ -587,7 +587,7 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1294 | 999 | 295 |  |
-| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 749 | 437 | 312 |  |
+| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 1036 | 445 | 591 |  |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 687 | 687 | 0 |  |
 | `services::discord::prompt_builder::channel_recent_context` | `src/services/discord/prompt_builder/channel_recent_context.rs` | 419 | 200 | 219 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -567,7 +567,7 @@
 | `services::discord::outbound::transport` | `src/services/discord/outbound/transport.rs` | 431 | 431 | 0 |  |
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3467 | 1180 | 2287 | giant-file |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
-| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 978 | 587 | 391 |  |
+| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1309 | 706 | 603 |  |
 | `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 678 | 678 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
@@ -586,8 +586,8 @@
 | `services::discord::placeholder_live_events::task_panel` | `src/services/discord/placeholder_live_events/task_panel.rs` | 399 | 399 | 0 |  |
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
-| `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1290 | 995 | 295 |  |
-| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 737 | 425 | 312 |  |
+| `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1294 | 999 | 295 |  |
+| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 749 | 437 | 312 |  |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 687 | 687 | 0 |  |
 | `services::discord::prompt_builder::channel_recent_context` | `src/services/discord/prompt_builder/channel_recent_context.rs` | 419 | 200 | 219 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -673,6 +673,13 @@ impl PlaceholderController {
             .remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
     }
 
+    #[cfg(test)]
+    pub(super) fn entry_detached_for_test(&self, key: &PlaceholderKey) -> Option<bool> {
+        self.entries
+            .get(key)
+            .map(|entry| entry.detached.load(Ordering::Acquire))
+    }
+
     /// Drop a key from the controller without emitting any Discord PATCH.
     /// Used by rollover paths whose external overwrite already committed.
     pub(super) fn detach(&self, key: &PlaceholderKey) {

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -123,8 +123,10 @@ impl PlaceholderEntrySlot {
     }
 
     async fn wait_for_active_edits(&self) {
+        let mut backoff = Duration::from_millis(1);
         while self.active_edits.load(Ordering::Acquire) != 0 {
-            tokio::task::yield_now().await;
+            tokio::time::sleep(backoff).await;
+            backoff = backoff.saturating_mul(2).min(Duration::from_millis(50));
         }
     }
 }
@@ -674,6 +676,219 @@ impl PlaceholderController {
             self.entries
                 .remove_if(&key, |_, current| Arc::ptr_eq(current, &entry));
         }
+    }
+}
+
+#[cfg(test)]
+mod detach_incarnation_tests {
+    use super::*;
+    use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
+    use poise::serenity_prelude::{ChannelId, MessageId};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct BlockingGateway {
+        calls: AtomicUsize,
+        entered: tokio::sync::Semaphore,
+        release: tokio::sync::Semaphore,
+    }
+
+    impl BlockingGateway {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                entered: tokio::sync::Semaphore::new(0),
+                release: tokio::sync::Semaphore::new(0),
+            }
+        }
+    }
+
+    impl TurnGateway for BlockingGateway {
+        fn send_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<MessageId, String>> {
+            Box::pin(async { Ok(MessageId::new(1)) })
+        }
+
+        fn edit_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.entered.add_permits(1);
+                self.release
+                    .acquire()
+                    .await
+                    .expect("release semaphore remains open")
+                    .forget();
+                Ok(())
+            })
+        }
+
+        fn replace_message_with_outcome<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<
+            'a,
+            Result<crate::services::discord::formatting::ReplaceLongMessageOutcome, String>,
+        > {
+            Box::pin(async {
+                Ok(crate::services::discord::formatting::ReplaceLongMessageOutcome::EditedOriginal)
+            })
+        }
+
+        fn schedule_retry_with_history<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _user_message_id: MessageId,
+            _user_text: &'a str,
+        ) -> GatewayFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn dispatch_queued_turn<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _intervention: &'a crate::services::discord::Intervention,
+            _request_owner_name: &'a str,
+            _has_more_queued_turns: bool,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn validate_live_routing<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn requester_mention(&self) -> Option<String> {
+            None
+        }
+
+        fn can_chain_locally(&self) -> bool {
+            false
+        }
+
+        fn bot_owner_provider(&self) -> Option<ProviderKind> {
+            Some(ProviderKind::Codex)
+        }
+    }
+
+    fn key() -> PlaceholderKey {
+        PlaceholderKey {
+            provider: ProviderKind::Codex,
+            channel_id: ChannelId::new(11),
+            message_id: MessageId::new(12),
+        }
+    }
+
+    fn input() -> PlaceholderActiveInput {
+        PlaceholderActiveInput {
+            reason: MonitorHandoffReason::ExplicitCall,
+            started_at_unix: 1_700_000_000,
+            tool_summary: Some("Monitor".to_string()),
+            command_summary: Some("session=detach-race".to_string()),
+            reason_detail: None,
+            context_line: None,
+            request_line: None,
+            progress_line: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn detach_during_active_patch_rejects_late_commit_and_lookup() {
+        let gateway = Arc::new(BlockingGateway::new());
+        let controller = Arc::new(PlaceholderController::default());
+        let old_slot = controller.entry(&key());
+        let ensure = {
+            let gateway = gateway.clone();
+            let controller = controller.clone();
+            tokio::spawn(async move {
+                controller
+                    .ensure_active(gateway.as_ref(), key(), input())
+                    .await
+            })
+        };
+        gateway
+            .entered
+            .acquire()
+            .await
+            .expect("gateway entry semaphore remains open")
+            .forget();
+
+        let detach = {
+            let controller = controller.clone();
+            tokio::spawn(async move {
+                controller.begin_detach(&key()).await;
+            })
+        };
+        while !old_slot.detached.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+        gateway.release.add_permits(1);
+
+        assert_eq!(
+            ensure.await.expect("ensure task joins"),
+            PlaceholderControllerOutcome::Rejected
+        );
+        detach.await.expect("detach task joins");
+        assert_ne!(old_slot.inner.lock().await.state, PlaceholderLifecycle::Active);
+        assert_eq!(
+            controller
+                .ensure_active(gateway.as_ref(), key(), input())
+                .await,
+            PlaceholderControllerOutcome::Rejected
+        );
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 1);
+        controller.finish_detach(&key());
+    }
+
+    #[tokio::test]
+    async fn detach_first_rejects_active_without_patch() {
+        let gateway = BlockingGateway::new();
+        let controller = PlaceholderController::default();
+        let _slot = controller.entry(&key());
+
+        controller.begin_detach(&key()).await;
+        let outcome = controller
+            .ensure_active(&gateway, key(), input())
+            .await;
+
+        assert_eq!(outcome, PlaceholderControllerOutcome::Rejected);
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 0);
+        controller.finish_detach(&key());
+    }
+
+    #[tokio::test]
+    async fn uncontended_active_to_terminal_path_is_preserved() {
+        let gateway = BlockingGateway::new();
+        gateway.release.add_permits(2);
+        let controller = PlaceholderController::default();
+
+        let active = controller.ensure_active(&gateway, key(), input()).await;
+        let terminal = controller
+            .transition(&gateway, key(), PlaceholderLifecycle::Completed)
+            .await;
+        let repeated = controller
+            .transition(&gateway, key(), PlaceholderLifecycle::Aborted)
+            .await;
+
+        assert_eq!(active, PlaceholderControllerOutcome::Edited);
+        assert_eq!(terminal, PlaceholderControllerOutcome::Edited);
+        assert_eq!(repeated, PlaceholderControllerOutcome::AlreadyTerminal);
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            controller.entry(&key()).inner.lock().await.state,
+            PlaceholderLifecycle::Completed
+        );
     }
 }
 

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -605,8 +605,12 @@ impl PlaceholderController {
             snapshot.progress_line.as_deref(),
         );
 
+        let Some(edit_lease) = entry.begin_edit() else {
+            return PlaceholderControllerOutcome::AlreadyTerminal;
+        };
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
+        drop(edit_lease);
 
         match edit_result {
             Ok(_) => {

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -669,7 +669,8 @@ impl PlaceholderController {
         if !entry.detached.load(Ordering::Acquire) {
             return;
         }
-        self.entries.remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
+        self.entries
+            .remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
     }
 
     /// Drop a key from the controller without emitting any Discord PATCH.
@@ -862,7 +863,10 @@ mod detach_incarnation_tests {
             PlaceholderControllerOutcome::Rejected
         );
         detach.await.expect("detach task joins");
-        assert_ne!(old_slot.inner.lock().await.state, PlaceholderLifecycle::Active);
+        assert_ne!(
+            old_slot.inner.lock().await.state,
+            PlaceholderLifecycle::Active
+        );
         assert_eq!(
             controller
                 .ensure_active(gateway.as_ref(), key(), input())
@@ -879,9 +883,7 @@ mod detach_incarnation_tests {
         let controller = PlaceholderController::default();
 
         controller.begin_detach(&key()).await;
-        let outcome = controller
-            .ensure_active(&gateway, key(), input())
-            .await;
+        let outcome = controller.ensure_active(&gateway, key(), input()).await;
 
         assert_eq!(outcome, PlaceholderControllerOutcome::Rejected);
         assert_eq!(gateway.calls.load(Ordering::SeqCst), 0);

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -21,6 +21,7 @@
 
 use poise::serenity_prelude::{ChannelId, MessageId};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
@@ -89,6 +90,41 @@ impl Default for PlaceholderEntry {
             active_snapshot: None,
             last_live_events_block: None,
             last_live_events_edit_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct PlaceholderEntrySlot {
+    detached: AtomicBool,
+    active_edits: AtomicUsize,
+    inner: Mutex<PlaceholderEntry>,
+}
+
+impl PlaceholderEntrySlot {
+    fn begin_active_edit(&self) -> bool {
+        if self.detached.load(Ordering::Acquire) {
+            return false;
+        }
+        self.active_edits.fetch_add(1, Ordering::AcqRel);
+        if self.detached.load(Ordering::Acquire) {
+            self.active_edits.fetch_sub(1, Ordering::AcqRel);
+            return false;
+        }
+        true
+    }
+
+    fn finish_active_edit(&self) {
+        self.active_edits.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn detach(&self) {
+        self.detached.store(true, Ordering::Release);
+    }
+
+    async fn wait_for_active_edits(&self) {
+        while self.active_edits.load(Ordering::Acquire) != 0 {
+            tokio::task::yield_now().await;
         }
     }
 }
@@ -225,7 +261,7 @@ async fn edit_message_with_retry<G: TurnGateway + ?Sized>(
 
 #[derive(Debug, Default)]
 pub(super) struct PlaceholderController {
-    entries: dashmap::DashMap<PlaceholderKey, Arc<Mutex<PlaceholderEntry>>>,
+    entries: dashmap::DashMap<PlaceholderKey, Arc<PlaceholderEntrySlot>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -245,7 +281,7 @@ pub(super) enum PlaceholderControllerOutcome {
 }
 
 impl PlaceholderController {
-    fn entry(&self, key: &PlaceholderKey) -> Arc<Mutex<PlaceholderEntry>> {
+    fn entry(&self, key: &PlaceholderKey) -> Arc<PlaceholderEntrySlot> {
         if let Some(existing) = self.entries.get(key) {
             return existing.clone();
         }
@@ -254,7 +290,7 @@ impl PlaceholderController {
         }
         self.entries
             .entry(key.clone())
-            .or_insert_with(|| Arc::new(Mutex::new(PlaceholderEntry::default())))
+            .or_insert_with(|| Arc::new(PlaceholderEntrySlot::default()))
             .clone()
     }
 
@@ -266,16 +302,20 @@ impl PlaceholderController {
     fn evict_terminal_entries(&self) {
         let mut to_remove: Vec<PlaceholderKey> = Vec::new();
         for kv in self.entries.iter() {
-            if let Ok(guard) = kv.value().try_lock() {
-                if matches!(
+            if kv.value().detached.load(Ordering::Acquire) {
+                to_remove.push(kv.key().clone());
+                continue;
+            }
+            if let Ok(guard) = kv.value().inner.try_lock()
+                && matches!(
                     guard.state,
                     PlaceholderLifecycle::NotCreated
                         | PlaceholderLifecycle::Completed
                         | PlaceholderLifecycle::TimedOut
                         | PlaceholderLifecycle::Aborted
-                ) {
-                    to_remove.push(kv.key().clone());
-                }
+                )
+            {
+                to_remove.push(kv.key().clone());
             }
         }
         for key in to_remove {
@@ -315,17 +355,19 @@ impl PlaceholderController {
         live_events_block: Option<String>,
     ) -> PlaceholderControllerOutcome {
         let entry = self.entry(&key);
-        let mut guarded = entry.lock().await;
+        let mut guarded = entry.inner.lock().await;
 
         // Forbid re-activating after a terminal transition — placeholder_sweeper
         // owns stale-Active recovery and we never want to drag a closed card
         // back into the Active state.
-        if matches!(
-            guarded.state,
-            PlaceholderLifecycle::Completed
-                | PlaceholderLifecycle::TimedOut
-                | PlaceholderLifecycle::Aborted
-        ) {
+        if entry.detached.load(Ordering::Acquire)
+            || matches!(
+                guarded.state,
+                PlaceholderLifecycle::Completed
+                    | PlaceholderLifecycle::TimedOut
+                    | PlaceholderLifecycle::Aborted
+            )
+        {
             return PlaceholderControllerOutcome::Rejected;
         }
 
@@ -363,8 +405,16 @@ impl PlaceholderController {
             return PlaceholderControllerOutcome::Coalesced;
         }
 
+        if !entry.begin_active_edit() {
+            return PlaceholderControllerOutcome::Rejected;
+        }
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
+        entry.finish_active_edit();
+
+        if entry.detached.load(Ordering::Acquire) {
+            return PlaceholderControllerOutcome::Rejected;
+        }
 
         match edit_result {
             Ok(_) => {
@@ -410,15 +460,17 @@ impl PlaceholderController {
         input: PlaceholderActiveInput,
     ) -> PlaceholderControllerOutcome {
         let entry = self.entry(&key);
-        let mut guarded = entry.lock().await;
+        let mut guarded = entry.inner.lock().await;
 
-        if matches!(
-            guarded.state,
-            PlaceholderLifecycle::Active
-                | PlaceholderLifecycle::Completed
-                | PlaceholderLifecycle::TimedOut
-                | PlaceholderLifecycle::Aborted
-        ) {
+        if entry.detached.load(Ordering::Acquire)
+            || matches!(
+                guarded.state,
+                PlaceholderLifecycle::Active
+                    | PlaceholderLifecycle::Completed
+                    | PlaceholderLifecycle::TimedOut
+                    | PlaceholderLifecycle::Aborted
+            )
+        {
             return PlaceholderControllerOutcome::Rejected;
         }
 
@@ -440,8 +492,15 @@ impl PlaceholderController {
             return PlaceholderControllerOutcome::Coalesced;
         }
 
+        if entry.detached.load(Ordering::Acquire) {
+            return PlaceholderControllerOutcome::Rejected;
+        }
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
+
+        if entry.detached.load(Ordering::Acquire) {
+            return PlaceholderControllerOutcome::Rejected;
+        }
 
         match edit_result {
             Ok(_) => {
@@ -484,8 +543,11 @@ impl PlaceholderController {
             target
         );
         let entry = self.entry(&key);
-        let mut guarded = entry.lock().await;
+        let mut guarded = entry.inner.lock().await;
 
+        if entry.detached.load(Ordering::Acquire) {
+            return PlaceholderControllerOutcome::AlreadyTerminal;
+        }
         if matches!(
             guarded.state,
             PlaceholderLifecycle::Completed
@@ -554,33 +616,64 @@ impl PlaceholderController {
         let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) else {
             return false;
         };
-        let mut guarded = entry.lock().await;
+        let mut guarded = entry.inner.lock().await;
+        if entry.detached.load(Ordering::Acquire) {
+            return false;
+        }
         guarded.last_rendered = None;
         guarded.last_live_events_block = None;
         guarded.last_live_events_edit_at = None;
         true
     }
 
-    /// Drop a key from the controller without emitting any Discord PATCH.
-    /// Used by the rollover retarget path on `turn_bridge`: when the old
-    /// `current_msg_id` is overwritten with a frozen response chunk, the
-    /// controller's old entry is no longer referenced and must not survive as
-    /// a non-evictable `Active` row in the cap-bounded map (codex round-4
-    /// #1308 P2).
-    pub(super) fn detach(&self, key: &PlaceholderKey) {
-        self.entries.remove(key);
+    /// Tombstone a key without emitting any Discord PATCH. The tombstone stays
+    /// addressable until the caller has performed the external overwrite or
+    /// delete and then invokes [`Self::finish_detach`].
+    pub(super) async fn begin_detach(&self, key: &PlaceholderKey) {
+        let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) else {
+            return;
+        };
+        entry.detach();
+        entry.wait_for_active_edits().await;
     }
 
-    /// #1332: drop every entry whose `(channel_id, message_id)` matches the
-    /// argument, regardless of provider. Used by the queue-exit feedback path
-    /// where the provider scope was discarded with the queued-placeholder
-    /// mapping; without provider-agnostic detach a cancelled queued
-    /// intervention would leave a stale `Queued` row in the cap-bounded
-    /// `entries` map (`Queued` is excluded from the regular eviction sweep
-    /// because in-flight queued placeholders must survive until dispatch).
+    /// Remove the exact tombstoned incarnation installed for `key`.
+    pub(super) fn finish_detach(&self, key: &PlaceholderKey) {
+        let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) else {
+            return;
+        };
+        if !entry.detached.load(Ordering::Acquire) {
+            return;
+        }
+        self.entries.remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
+    }
+
+    /// Drop a key from the controller without emitting any Discord PATCH.
+    /// Used by rollover paths whose external overwrite already committed.
+    pub(super) fn detach(&self, key: &PlaceholderKey) {
+        if let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) {
+            entry.detach();
+            self.entries
+                .remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
+        }
+    }
+
+    /// Tombstone every incarnation whose `(channel_id, message_id)` matches,
+    /// regardless of provider, then remove those exact slots.
     pub(super) fn detach_by_message(&self, channel_id: ChannelId, message_id: MessageId) {
-        self.entries
-            .retain(|key, _| !(key.channel_id == channel_id && key.message_id == message_id));
+        let matches: Vec<(PlaceholderKey, Arc<PlaceholderEntrySlot>)> = self
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry.key().channel_id == channel_id && entry.key().message_id == message_id
+            })
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
+        for (key, entry) in matches {
+            entry.detach();
+            self.entries
+                .remove_if(&key, |_, current| Arc::ptr_eq(current, &entry));
+        }
     }
 }
 

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -112,13 +112,6 @@ impl Drop for PlaceholderEditLease<'_> {
 }
 
 impl PlaceholderEntrySlot {
-    fn detached() -> Self {
-        Self {
-            detached: AtomicBool::new(true),
-            ..Self::default()
-        }
-    }
-
     fn begin_edit(&self) -> Option<PlaceholderEditLease<'_>> {
         if self.detached.load(Ordering::SeqCst) {
             return None;
@@ -152,6 +145,15 @@ impl PlaceholderEntrySlot {
 /// background-tool activity; eviction prefers terminal entries over Active
 /// ones so we never drop a live card mid-flight.
 const PLACEHOLDER_ENTRIES_MAX: usize = 4096;
+
+/// Cap on the number of `(provider, channel)` scopes tracked in the bounded
+/// per-channel settled record (#4594 incarnation guard). The record holds one
+/// `u64` high-water per scope, so this bounds it at O(channels). When the cap
+/// is exceeded we evict the coldest scope — the one with the lowest high-water,
+/// i.e. the oldest settlement by monotonic-snowflake time — which can only be
+/// referenced by callers older than `SETTLED_SCOPES_MAX` distinct channels of
+/// settle activity, far beyond any in-flight stale turn.
+const SETTLED_SCOPES_MAX: usize = 4096;
 const PLACEHOLDER_LIVE_EVENTS_MIN_EDIT_INTERVAL: Duration = Duration::from_secs(3);
 
 /// PR #5 — bounded retry budget for placeholder edits. Discord routinely
@@ -279,6 +281,26 @@ async fn edit_message_with_retry<G: TurnGateway + ?Sized>(
 #[derive(Debug, Default)]
 pub(super) struct PlaceholderController {
     entries: dashmap::DashMap<PlaceholderKey, Arc<PlaceholderEntrySlot>>,
+    /// #4594 incarnation guard. Bounded per-`(provider, channel)` record of the
+    /// highest Discord message id that has been *terminally disposed* (detached
+    /// by the sweeper's confirmed delivered/gone probe arm, or committed to a
+    /// terminal state by `transition`). Any `ensure_active` / `ensure_queued` /
+    /// `transition` for a message id at-or-below its scope's high-water is
+    /// rejected — even after the `entries` slot was torn down and `entry()`
+    /// would recreate a fresh, non-detached one. This closes the evict+recreate
+    /// reactivation window that a tombstone-in-`entries` could not: the record
+    /// lives independently of `entries` eviction.
+    ///
+    /// Soundness of the `<=` (high-water) test rests on the verified per-channel
+    /// concurrency model: at most one active placeholder turn exists per
+    /// `(provider, channel)` (the mailbox serialises turns; losers are shown a
+    /// *higher-id* Queued card), and only that lowest-id active card is ever
+    /// settled here — queued cards are cleared via `detach_by_message` + Discord
+    /// delete, never `transition`. Settlement is therefore monotonic per scope,
+    /// so no live or future card ever has an id `<=` the high-water, and a
+    /// legitimate new turn (always a strictly higher snowflake) is never
+    /// rejected.
+    settled: dashmap::DashMap<(ProviderKind, ChannelId), u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -311,32 +333,72 @@ impl PlaceholderController {
             .clone()
     }
 
-    /// Sweep entries eligible for removal so the map cannot grow without
-    /// bound on a long-running process:
-    /// - detached tombstones (`detached=true`) — #4594's abandoned-placeholder
-    ///   detach path leaves these resident on purpose so a late `ensure_active`
-    ///   from a stale turn is rejected instead of re-inserting a fresh,
-    ///   non-detached slot for an already-delivered/gone message id. Once no
-    ///   caller is mid-edit on one (`begin_edit`'s double-checked `detached`
-    ///   gate guarantees no *new* edit lease can start after detach, so this
-    ///   only guards against a caller that started before detach and hasn't
-    ///   finished its own post-edit detach re-check yet), it carries no live
-    ///   Discord card and is safe to reclaim under capacity pressure.
-    /// - non-detached entries whose state is terminal
-    ///   (Completed/TimedOut/Aborted) or `NotCreated` (initial edit failed;
-    ///   nobody committed).
-    /// `Active` entries are left in place — they own a live Discord card.
-    /// Uses `try_lock` to avoid blocking on / disrupting entries the caller
-    /// is mid-edit on.
+    /// True when `key`'s message id has been terminally disposed for its
+    /// `(provider, channel)` scope — i.e. it is at or below the scope's settled
+    /// high-water. See the `settled` field doc for why the `<=` test never
+    /// over-rejects a live or future card.
+    fn is_settled(&self, key: &PlaceholderKey) -> bool {
+        self.settled
+            .get(&(key.provider.clone(), key.channel_id))
+            .is_some_and(|hw| key.message_id.get() <= *hw)
+    }
+
+    /// Record `key`'s message id as terminally disposed for its
+    /// `(provider, channel)` scope (monotonic high-water). Called from
+    /// `begin_detach` and `transition`'s terminal commit so a later
+    /// evict+recreate of the `entries` slot cannot reactivate an already
+    /// delivered/gone/completed card. Bounds the record at `SETTLED_SCOPES_MAX`
+    /// scopes by evicting the coldest (lowest high-water) one on overflow.
+    fn record_settled(&self, key: &PlaceholderKey) {
+        let scope = (key.provider.clone(), key.channel_id);
+        let msg = key.message_id.get();
+        // Scope the shard guard so it is dropped before any other DashMap lock.
+        {
+            let mut hw = self.settled.entry(scope.clone()).or_insert(0);
+            if msg > *hw {
+                *hw = msg;
+            }
+        }
+        if self.settled.len() > SETTLED_SCOPES_MAX {
+            // Find the coldest scope (lowest high-water) other than the one we
+            // just recorded. `iter()` releases each shard read-lock as the
+            // per-item guard drops, and the loop fully completes before the
+            // `remove` takes a write lock, so no guards overlap.
+            let mut victim: Option<((ProviderKind, ChannelId), u64)> = None;
+            for kv in self.settled.iter() {
+                if kv.key() == &scope {
+                    continue;
+                }
+                let v = *kv.value();
+                if victim.as_ref().map(|(_, lv)| v < *lv).unwrap_or(true) {
+                    victim = Some((kv.key().clone(), v));
+                }
+            }
+            if let Some((victim_scope, _)) = victim {
+                self.settled.remove(&victim_scope);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn settled_high_water_for_test(&self, key: &PlaceholderKey) -> Option<u64> {
+        self.settled
+            .get(&(key.provider.clone(), key.channel_id))
+            .map(|hw| *hw)
+    }
+
+    /// Sweep entries eligible for removal so the map cannot grow without bound
+    /// on a long-running process: non-detached entries whose state is terminal
+    /// (Completed/TimedOut/Aborted) or `NotCreated` (initial edit failed; nobody
+    /// committed). Terminal disposition no longer parks a permanent tombstone
+    /// here — `begin_detach` records the settled message id in the bounded
+    /// per-channel `settled` record and drops the slot outright — so there is no
+    /// detached-tombstone arm to sweep. `Active` entries are left in place; they
+    /// own a live Discord card. Uses `try_lock` to avoid blocking on / disrupting
+    /// entries the caller is mid-edit on.
     fn evict_terminal_entries(&self) {
         let mut to_remove: Vec<(PlaceholderKey, Arc<PlaceholderEntrySlot>)> = Vec::new();
         for kv in self.entries.iter() {
-            if kv.value().detached.load(Ordering::Acquire) {
-                if kv.value().inner.try_lock().is_ok() {
-                    to_remove.push((kv.key().clone(), kv.value().clone()));
-                }
-                continue;
-            }
             if let Ok(guard) = kv.value().inner.try_lock()
                 && matches!(
                     guard.state,
@@ -386,6 +448,12 @@ impl PlaceholderController {
         input: PlaceholderActiveInput,
         live_events_block: Option<String>,
     ) -> PlaceholderControllerOutcome {
+        // #4594 incarnation guard: a message id already terminally disposed for
+        // this scope must never be dragged back to Active, even after its slot
+        // was evicted and `entry()` would recreate a fresh, non-detached one.
+        if self.is_settled(&key) {
+            return PlaceholderControllerOutcome::Rejected;
+        }
         let entry = self.entry(&key);
         let mut guarded = entry.inner.lock().await;
 
@@ -491,6 +559,11 @@ impl PlaceholderController {
         key: PlaceholderKey,
         input: PlaceholderActiveInput,
     ) -> PlaceholderControllerOutcome {
+        // #4594 incarnation guard: reject a queued render for an already
+        // terminally-disposed message id (see `ensure_active_inner`).
+        if self.is_settled(&key) {
+            return PlaceholderControllerOutcome::Rejected;
+        }
         let entry = self.entry(&key);
         let mut guarded = entry.inner.lock().await;
 
@@ -575,6 +648,11 @@ impl PlaceholderController {
             "transition() expects a terminal target, got {:?}",
             target
         );
+        // #4594 incarnation guard: a message id already settled for this scope
+        // is terminal regardless of whether its slot still exists.
+        if self.is_settled(&key) {
+            return PlaceholderControllerOutcome::AlreadyTerminal;
+        }
         let entry = self.entry(&key);
         let mut guarded = entry.inner.lock().await;
 
@@ -595,8 +673,11 @@ impl PlaceholderController {
         let snapshot = match guarded.active_snapshot.clone() {
             Some(snapshot) => snapshot,
             None => {
-                // Mark terminal anyway so future Active calls remain rejected.
+                // Mark terminal anyway so future Active calls remain rejected —
+                // and record the settled id so an evict+recreate of this slot
+                // cannot resurrect it into a fresh Active either.
                 guarded.state = target;
+                self.record_settled(&key);
                 return PlaceholderControllerOutcome::Rejected;
             }
         };
@@ -625,18 +706,21 @@ impl PlaceholderController {
         };
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
-        drop(edit_lease);
 
-        // Same post-edit detach fence as `ensure_active_inner`/`ensure_queued`:
-        // a concurrent `begin_detach` may have tombstoned this entry while we
-        // held `inner` locked across the awaited PATCH (it only needs the
-        // atomic `detached` flag, not the `inner` lock, then blocks in
-        // `wait_for_edits` until our `edit_lease` above is dropped). Without
-        // this re-check a stale terminal commit could land on an entry a
-        // confirmed-delete probe arm already tombstoned, overwriting Discord
-        // with this call's (possibly stale) terminal card after the
-        // authoritative outcome was already established.
+        // #4594 Finding-3 / TOCTOU fix: re-check `detached` and commit the
+        // terminal state while STILL holding `edit_lease`. A concurrent
+        // `begin_detach` sets the atomic `detached` flag (it does not take
+        // `inner`) and then blocks in `wait_for_edits` until this lease drops.
+        // Holding the lease across the re-check + commit makes them indivisible
+        // w.r.t. a detach *completing*: either we observe `detached` here and
+        // bail (`AlreadyTerminal`, no commit), or we commit before the detach is
+        // observable — in which case `begin_detach` records the settled id only
+        // after our terminal card has landed. Dropping the lease before the
+        // re-check (as the old code did) left a window where the detached store
+        // could land between the load and the `guarded.state = target` write on
+        // a multi-threaded runtime, resurrecting a slot the probe arm tombstoned.
         if entry.detached.load(Ordering::Acquire) {
+            drop(edit_lease);
             return PlaceholderControllerOutcome::AlreadyTerminal;
         }
 
@@ -644,9 +728,14 @@ impl PlaceholderController {
             Ok(_) => {
                 guarded.state = target;
                 guarded.last_rendered = Some(rendered);
+                // Record the terminal disposition so an evict+recreate of this
+                // slot cannot reactivate the now-closed card.
+                self.record_settled(&key);
+                drop(edit_lease);
                 PlaceholderControllerOutcome::Edited
             }
             Err(err) => {
+                drop(edit_lease);
                 tracing::warn!(
                     key = ?key,
                     error = %err,
@@ -676,29 +765,27 @@ impl PlaceholderController {
         true
     }
 
-    /// Tombstone a key without emitting any Discord PATCH. The tombstone stays
-    /// addressable until the caller has performed the external overwrite or
-    /// delete and then invokes [`Self::finish_detach`].
+    /// Terminally dispose `key` without emitting any Discord PATCH (#4594's
+    /// abandoned-placeholder detach). Records the settled message id in the
+    /// bounded per-channel `settled` record — which is what rejects a late
+    /// `ensure_active` / `ensure_queued` for this now delivered/gone id, and
+    /// survives independently of `entries` eviction — then drains any in-flight
+    /// edit under the existing slot (so a caller mid-PATCH observes the detach
+    /// via its own `Arc` clone and rejects its stale commit) and drops the slot.
+    ///
+    /// Unlike the previous permanent-tombstone design this neither bypasses the
+    /// `entries` cap nor leaves a resident slot, so a detach-heavy / restart
+    /// cleanup workload cannot grow the map without bound (#4594 P2). If no slot
+    /// exists (e.g. a restart's first sweep of a persisted-abandoned row), the
+    /// settled record alone suffices — a future incarnation is still rejected.
     pub(super) async fn begin_detach(&self, key: &PlaceholderKey) {
-        let entry = self
-            .entries
-            .entry(key.clone())
-            .or_insert_with(|| Arc::new(PlaceholderEntrySlot::detached()))
-            .clone();
-        entry.detach();
-        entry.wait_for_edits().await;
-    }
-
-    /// Remove the exact tombstoned incarnation installed for `key`.
-    pub(super) fn finish_detach(&self, key: &PlaceholderKey) {
-        let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) else {
-            return;
-        };
-        if !entry.detached.load(Ordering::Acquire) {
-            return;
+        self.record_settled(key);
+        if let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) {
+            entry.detach();
+            entry.wait_for_edits().await;
+            self.entries
+                .remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
         }
-        self.entries
-            .remove_if(key, |_, current| Arc::ptr_eq(current, &entry));
     }
 
     #[cfg(test)]
@@ -909,7 +996,11 @@ mod detach_incarnation_tests {
             PlaceholderControllerOutcome::Rejected
         );
         assert_eq!(gateway.calls.load(Ordering::SeqCst), 1);
-        controller.finish_detach(&key());
+        // begin_detach records the settled id and drops the slot outright, so
+        // the stale re-activation above was rejected by the incarnation guard,
+        // not a resident tombstone.
+        assert_eq!(controller.entry_detached_for_test(&key()), None);
+        assert_eq!(controller.settled_high_water_for_test(&key()), Some(12));
     }
 
     #[tokio::test]
@@ -922,7 +1013,6 @@ mod detach_incarnation_tests {
 
         assert_eq!(outcome, PlaceholderControllerOutcome::Rejected);
         assert_eq!(gateway.calls.load(Ordering::SeqCst), 0);
-        controller.finish_detach(&key());
     }
 
     #[tokio::test]
@@ -949,11 +1039,13 @@ mod detach_incarnation_tests {
         );
     }
 
-    /// #4594 Finding 3: `transition()`'s terminal path must re-check
-    /// `detached` after the PATCH lands instead of unconditionally
-    /// committing `guarded.state = target` — otherwise a stale terminal
-    /// edit could resurrect a slot the probe arm already tombstoned while
-    /// the PATCH was in flight.
+    /// #4594 Finding 3 / TOCTOU (d): `transition()`'s terminal path must
+    /// re-check `detached` and commit `guarded.state = target` while STILL
+    /// holding the edit lease — otherwise a stale terminal edit could resurrect
+    /// a slot a concurrent `begin_detach` disposed while the PATCH was in
+    /// flight. Here the detach flag is set before the PATCH completes, so the
+    /// under-lease re-check observes it and returns `AlreadyTerminal` without
+    /// committing `Completed`.
     #[tokio::test]
     async fn transition_after_concurrent_detach_does_not_resurrect_terminal_state() {
         let gateway = Arc::new(BlockingGateway::new());
@@ -1015,47 +1107,73 @@ mod detach_incarnation_tests {
         detach.await.expect("detach task joins");
         assert_eq!(slot.inner.lock().await.state, PlaceholderLifecycle::Active);
         assert_eq!(gateway.calls.load(Ordering::SeqCst), 2);
-        controller.finish_detach(&key());
+        // The transition committed no terminal state; the detach recorded the
+        // settled id and dropped the slot.
+        assert_eq!(controller.entry_detached_for_test(&key()), None);
+        assert_eq!(controller.settled_high_water_for_test(&key()), Some(12));
     }
 
-    /// #4594 Finding 2: `evict_terminal_entries()` must reclaim a detached
-    /// tombstone once nobody holds its `inner` lock (otherwise every
-    /// probe-arm confirmed-delete leaks a permanent slot toward
-    /// `PLACEHOLDER_ENTRIES_MAX`), but must never race a caller still mid
-    /// PATCH under that same tombstone (the post-edit detach fence needs
-    /// `inner` to still exist to report its outcome), and must never touch
-    /// a live, non-detached entry.
+    /// #4594 P1 incarnation guard (settled-id record): once a message id is
+    /// terminally disposed via `begin_detach`, a *later* `ensure_active` for
+    /// that exact key must be rejected even though `begin_detach` tore the slot
+    /// out of the map entirely and `entry()` would recreate a fresh,
+    /// non-detached one. This is the evict+recreate reactivation window #4594
+    /// closes — the settled record survives the slot teardown.
     #[tokio::test]
-    async fn evict_terminal_entries_reclaims_idle_detached_tombstones_but_not_locked_ones() {
+    async fn settled_message_id_rejects_stale_activation_after_detach_and_recreate() {
+        let gateway = BlockingGateway::new();
+        gateway.release.add_permits(1);
         let controller = PlaceholderController::default();
 
+        // A real production disposition: commit an Active card, then detach it
+        // the way the sweeper's confirmed-delete probe arm does.
+        assert_eq!(
+            controller.ensure_active(&gateway, key(), input()).await,
+            PlaceholderControllerOutcome::Edited
+        );
+        controller.begin_detach(&key()).await;
+
+        // begin_detach removed the slot (no permanent tombstone) but recorded
+        // the settled high-water for the (provider, channel) scope.
+        assert_eq!(controller.entry_detached_for_test(&key()), None);
+        assert_eq!(controller.settled_high_water_for_test(&key()), Some(12));
+
+        // A stale late activation for the same key — which `entry()` would
+        // gladly back with a brand-new non-detached slot — must be rejected
+        // before any Discord PATCH by the incarnation guard.
+        assert_eq!(
+            controller.ensure_active(&gateway, key(), input()).await,
+            PlaceholderControllerOutcome::Rejected
+        );
+        // The queued render path is guarded identically.
+        assert_eq!(
+            controller.ensure_queued(&gateway, key(), input()).await,
+            PlaceholderControllerOutcome::Rejected
+        );
+        // Exactly one PATCH ever (the initial Active); the stale reactivations
+        // issued none.
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// The simplified `evict_terminal_entries` (no detached-tombstone arm)
+    /// still reclaims terminal / never-committed slots under capacity pressure
+    /// but must never evict a live `Active` entry.
+    #[tokio::test]
+    async fn evict_terminal_entries_reclaims_terminal_slots_but_not_live() {
+        let gateway = BlockingGateway::new();
+        gateway.release.add_permits(1);
+        let controller = PlaceholderController::default();
+
+        // A `NotCreated` slot (initial edit never committed) is eligible.
         let idle_key = PlaceholderKey {
             provider: ProviderKind::Codex,
             channel_id: ChannelId::new(21),
             message_id: MessageId::new(22),
         };
-        let locked_key = PlaceholderKey {
-            provider: ProviderKind::Codex,
-            channel_id: ChannelId::new(23),
-            message_id: MessageId::new(24),
-        };
+        let _ = controller.entry(&idle_key);
+
+        // A live `Active` entry must survive.
         let live_key = key();
-
-        // A #4594 tombstone with nobody mid-edit: safe to reclaim under
-        // capacity pressure.
-        controller.begin_detach(&idle_key).await;
-        assert_eq!(controller.entry_detached_for_test(&idle_key), Some(true));
-
-        // A #4594 tombstone whose caller still holds `inner` locked (e.g. a
-        // post-edit detach-fence check that has not returned yet): eviction's
-        // `try_lock` must fail so it does not race that caller.
-        let locked_entry = controller.entry(&locked_key);
-        locked_entry.detach();
-        let held_guard = locked_entry.inner.lock().await;
-
-        // An ordinary live `Active` entry must never be evicted.
-        let gateway = BlockingGateway::new();
-        gateway.release.add_permits(1);
         assert_eq!(
             controller
                 .ensure_active(&gateway, live_key.clone(), input())
@@ -1068,21 +1186,13 @@ mod detach_incarnation_tests {
         assert_eq!(
             controller.entry_detached_for_test(&idle_key),
             None,
-            "idle detached tombstone must be reclaimed once no caller holds its lock"
-        );
-        assert_eq!(
-            controller.entry_detached_for_test(&locked_key),
-            Some(true),
-            "a detached entry whose lock is still held must survive eviction"
+            "a NotCreated slot must be reclaimed under capacity pressure"
         );
         assert_eq!(
             controller.entry_detached_for_test(&live_key),
             Some(false),
             "a live Active entry must survive eviction"
         );
-
-        drop(held_guard);
-        controller.finish_detach(&locked_key);
     }
 }
 

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -97,34 +97,49 @@ impl Default for PlaceholderEntry {
 #[derive(Debug, Default)]
 struct PlaceholderEntrySlot {
     detached: AtomicBool,
-    active_edits: AtomicUsize,
+    in_flight_edits: AtomicUsize,
     inner: Mutex<PlaceholderEntry>,
 }
 
+struct PlaceholderEditLease<'a> {
+    in_flight_edits: &'a AtomicUsize,
+}
+
+impl Drop for PlaceholderEditLease<'_> {
+    fn drop(&mut self) {
+        self.in_flight_edits.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 impl PlaceholderEntrySlot {
-    fn begin_active_edit(&self) -> bool {
-        if self.detached.load(Ordering::Acquire) {
-            return false;
+    fn detached() -> Self {
+        Self {
+            detached: AtomicBool::new(true),
+            ..Self::default()
         }
-        self.active_edits.fetch_add(1, Ordering::AcqRel);
-        if self.detached.load(Ordering::Acquire) {
-            self.active_edits.fetch_sub(1, Ordering::AcqRel);
-            return false;
-        }
-        true
     }
 
-    fn finish_active_edit(&self) {
-        self.active_edits.fetch_sub(1, Ordering::AcqRel);
+    fn begin_edit(&self) -> Option<PlaceholderEditLease<'_>> {
+        if self.detached.load(Ordering::SeqCst) {
+            return None;
+        }
+        self.in_flight_edits.fetch_add(1, Ordering::SeqCst);
+        if self.detached.load(Ordering::SeqCst) {
+            self.in_flight_edits.fetch_sub(1, Ordering::SeqCst);
+            return None;
+        }
+        Some(PlaceholderEditLease {
+            in_flight_edits: &self.in_flight_edits,
+        })
     }
 
     fn detach(&self) {
-        self.detached.store(true, Ordering::Release);
+        self.detached.store(true, Ordering::SeqCst);
     }
 
-    async fn wait_for_active_edits(&self) {
+    async fn wait_for_edits(&self) {
         let mut backoff = Duration::from_millis(1);
-        while self.active_edits.load(Ordering::Acquire) != 0 {
+        while self.in_flight_edits.load(Ordering::SeqCst) != 0 {
             tokio::time::sleep(backoff).await;
             backoff = backoff.saturating_mul(2).min(Duration::from_millis(50));
         }
@@ -302,10 +317,9 @@ impl PlaceholderController {
     /// left in place — they own a live Discord card. Uses `try_lock` to avoid
     /// blocking on entries the caller is mid-edit on.
     fn evict_terminal_entries(&self) {
-        let mut to_remove: Vec<PlaceholderKey> = Vec::new();
+        let mut to_remove: Vec<(PlaceholderKey, Arc<PlaceholderEntrySlot>)> = Vec::new();
         for kv in self.entries.iter() {
             if kv.value().detached.load(Ordering::Acquire) {
-                to_remove.push(kv.key().clone());
                 continue;
             }
             if let Ok(guard) = kv.value().inner.try_lock()
@@ -317,11 +331,12 @@ impl PlaceholderController {
                         | PlaceholderLifecycle::Aborted
                 )
             {
-                to_remove.push(kv.key().clone());
+                to_remove.push((kv.key().clone(), kv.value().clone()));
             }
         }
-        for key in to_remove {
-            self.entries.remove(&key);
+        for (key, entry) in to_remove {
+            self.entries
+                .remove_if(&key, |_, current| Arc::ptr_eq(current, &entry));
         }
     }
 
@@ -407,12 +422,12 @@ impl PlaceholderController {
             return PlaceholderControllerOutcome::Coalesced;
         }
 
-        if !entry.begin_active_edit() {
+        let Some(edit_lease) = entry.begin_edit() else {
             return PlaceholderControllerOutcome::Rejected;
-        }
+        };
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
-        entry.finish_active_edit();
+        drop(edit_lease);
 
         if entry.detached.load(Ordering::Acquire) {
             return PlaceholderControllerOutcome::Rejected;
@@ -494,11 +509,12 @@ impl PlaceholderController {
             return PlaceholderControllerOutcome::Coalesced;
         }
 
-        if entry.detached.load(Ordering::Acquire) {
+        let Some(edit_lease) = entry.begin_edit() else {
             return PlaceholderControllerOutcome::Rejected;
-        }
+        };
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
+        drop(edit_lease);
 
         if entry.detached.load(Ordering::Acquire) {
             return PlaceholderControllerOutcome::Rejected;
@@ -632,11 +648,13 @@ impl PlaceholderController {
     /// addressable until the caller has performed the external overwrite or
     /// delete and then invokes [`Self::finish_detach`].
     pub(super) async fn begin_detach(&self, key: &PlaceholderKey) {
-        let Some(entry) = self.entries.get(key).map(|entry| entry.clone()) else {
-            return;
-        };
+        let entry = self
+            .entries
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(PlaceholderEntrySlot::detached()))
+            .clone();
         entry.detach();
-        entry.wait_for_active_edits().await;
+        entry.wait_for_edits().await;
     }
 
     /// Remove the exact tombstoned incarnation installed for `key`.
@@ -855,7 +873,6 @@ mod detach_incarnation_tests {
     async fn detach_first_rejects_active_without_patch() {
         let gateway = BlockingGateway::new();
         let controller = PlaceholderController::default();
-        let _slot = controller.entry(&key());
 
         controller.begin_detach(&key()).await;
         let outcome = controller

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -311,15 +311,30 @@ impl PlaceholderController {
             .clone()
     }
 
-    /// Sweep entries whose state is terminal (Completed/TimedOut/Aborted) or
-    /// `NotCreated` (initial edit failed; nobody committed) so the map cannot
-    /// grow without bound on a long-running process. `Active` entries are
-    /// left in place — they own a live Discord card. Uses `try_lock` to avoid
-    /// blocking on entries the caller is mid-edit on.
+    /// Sweep entries eligible for removal so the map cannot grow without
+    /// bound on a long-running process:
+    /// - detached tombstones (`detached=true`) — #4594's abandoned-placeholder
+    ///   detach path leaves these resident on purpose so a late `ensure_active`
+    ///   from a stale turn is rejected instead of re-inserting a fresh,
+    ///   non-detached slot for an already-delivered/gone message id. Once no
+    ///   caller is mid-edit on one (`begin_edit`'s double-checked `detached`
+    ///   gate guarantees no *new* edit lease can start after detach, so this
+    ///   only guards against a caller that started before detach and hasn't
+    ///   finished its own post-edit detach re-check yet), it carries no live
+    ///   Discord card and is safe to reclaim under capacity pressure.
+    /// - non-detached entries whose state is terminal
+    ///   (Completed/TimedOut/Aborted) or `NotCreated` (initial edit failed;
+    ///   nobody committed).
+    /// `Active` entries are left in place — they own a live Discord card.
+    /// Uses `try_lock` to avoid blocking on / disrupting entries the caller
+    /// is mid-edit on.
     fn evict_terminal_entries(&self) {
         let mut to_remove: Vec<(PlaceholderKey, Arc<PlaceholderEntrySlot>)> = Vec::new();
         for kv in self.entries.iter() {
             if kv.value().detached.load(Ordering::Acquire) {
+                if kv.value().inner.try_lock().is_ok() {
+                    to_remove.push((kv.key().clone(), kv.value().clone()));
+                }
                 continue;
             }
             if let Ok(guard) = kv.value().inner.try_lock()
@@ -611,6 +626,19 @@ impl PlaceholderController {
         let edit_result =
             edit_message_with_retry(gateway, key.channel_id, key.message_id, &rendered).await;
         drop(edit_lease);
+
+        // Same post-edit detach fence as `ensure_active_inner`/`ensure_queued`:
+        // a concurrent `begin_detach` may have tombstoned this entry while we
+        // held `inner` locked across the awaited PATCH (it only needs the
+        // atomic `detached` flag, not the `inner` lock, then blocks in
+        // `wait_for_edits` until our `edit_lease` above is dropped). Without
+        // this re-check a stale terminal commit could land on an entry a
+        // confirmed-delete probe arm already tombstoned, overwriting Discord
+        // with this call's (possibly stale) terminal card after the
+        // authoritative outcome was already established.
+        if entry.detached.load(Ordering::Acquire) {
+            return PlaceholderControllerOutcome::AlreadyTerminal;
+        }
 
         match edit_result {
             Ok(_) => {
@@ -919,6 +947,142 @@ mod detach_incarnation_tests {
             controller.entry(&key()).inner.lock().await.state,
             PlaceholderLifecycle::Completed
         );
+    }
+
+    /// #4594 Finding 3: `transition()`'s terminal path must re-check
+    /// `detached` after the PATCH lands instead of unconditionally
+    /// committing `guarded.state = target` — otherwise a stale terminal
+    /// edit could resurrect a slot the probe arm already tombstoned while
+    /// the PATCH was in flight.
+    #[tokio::test]
+    async fn transition_after_concurrent_detach_does_not_resurrect_terminal_state() {
+        let gateway = Arc::new(BlockingGateway::new());
+        let controller = Arc::new(PlaceholderController::default());
+        let slot = controller.entry(&key());
+
+        // Phase 1: land a committed `Active` snapshot synchronously (pre-fund
+        // the release semaphore so this call's single edit does not block).
+        gateway.release.add_permits(1);
+        assert_eq!(
+            controller
+                .ensure_active(gateway.as_ref(), key(), input())
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+        // Drain the leftover `entered` permit from phase 1 so phase 2's wait
+        // below only unblocks once the *terminal* edit has actually entered.
+        gateway
+            .entered
+            .acquire()
+            .await
+            .expect("gateway entry semaphore remains open")
+            .forget();
+
+        // Phase 2: start the terminal transition; it blocks mid-PATCH.
+        let terminal = {
+            let gateway = gateway.clone();
+            let controller = controller.clone();
+            tokio::spawn(async move {
+                controller
+                    .transition(gateway.as_ref(), key(), PlaceholderLifecycle::Completed)
+                    .await
+            })
+        };
+        gateway
+            .entered
+            .acquire()
+            .await
+            .expect("gateway entry semaphore remains open")
+            .forget();
+
+        // A concurrent detach tombstones the entry while the terminal PATCH
+        // is still in flight.
+        let detach = {
+            let controller = controller.clone();
+            tokio::spawn(async move {
+                controller.begin_detach(&key()).await;
+            })
+        };
+        while !slot.detached.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+        gateway.release.add_permits(1);
+
+        assert_eq!(
+            terminal.await.expect("transition task joins"),
+            PlaceholderControllerOutcome::AlreadyTerminal
+        );
+        detach.await.expect("detach task joins");
+        assert_eq!(slot.inner.lock().await.state, PlaceholderLifecycle::Active);
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 2);
+        controller.finish_detach(&key());
+    }
+
+    /// #4594 Finding 2: `evict_terminal_entries()` must reclaim a detached
+    /// tombstone once nobody holds its `inner` lock (otherwise every
+    /// probe-arm confirmed-delete leaks a permanent slot toward
+    /// `PLACEHOLDER_ENTRIES_MAX`), but must never race a caller still mid
+    /// PATCH under that same tombstone (the post-edit detach fence needs
+    /// `inner` to still exist to report its outcome), and must never touch
+    /// a live, non-detached entry.
+    #[tokio::test]
+    async fn evict_terminal_entries_reclaims_idle_detached_tombstones_but_not_locked_ones() {
+        let controller = PlaceholderController::default();
+
+        let idle_key = PlaceholderKey {
+            provider: ProviderKind::Codex,
+            channel_id: ChannelId::new(21),
+            message_id: MessageId::new(22),
+        };
+        let locked_key = PlaceholderKey {
+            provider: ProviderKind::Codex,
+            channel_id: ChannelId::new(23),
+            message_id: MessageId::new(24),
+        };
+        let live_key = key();
+
+        // A #4594 tombstone with nobody mid-edit: safe to reclaim under
+        // capacity pressure.
+        controller.begin_detach(&idle_key).await;
+        assert_eq!(controller.entry_detached_for_test(&idle_key), Some(true));
+
+        // A #4594 tombstone whose caller still holds `inner` locked (e.g. a
+        // post-edit detach-fence check that has not returned yet): eviction's
+        // `try_lock` must fail so it does not race that caller.
+        let locked_entry = controller.entry(&locked_key);
+        locked_entry.detach();
+        let held_guard = locked_entry.inner.lock().await;
+
+        // An ordinary live `Active` entry must never be evicted.
+        let gateway = BlockingGateway::new();
+        gateway.release.add_permits(1);
+        assert_eq!(
+            controller
+                .ensure_active(&gateway, live_key.clone(), input())
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+
+        controller.evict_terminal_entries();
+
+        assert_eq!(
+            controller.entry_detached_for_test(&idle_key),
+            None,
+            "idle detached tombstone must be reclaimed once no caller holds its lock"
+        );
+        assert_eq!(
+            controller.entry_detached_for_test(&locked_key),
+            Some(true),
+            "a detached entry whose lock is still held must survive eviction"
+        );
+        assert_eq!(
+            controller.entry_detached_for_test(&live_key),
+            Some(false),
+            "a live Active entry must survive eviction"
+        );
+
+        drop(held_guard);
+        controller.finish_detach(&locked_key);
     }
 }
 

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -612,6 +612,12 @@ async fn run_placeholder_sweep_pass(
                 {
                     continue;
                 }
+                let key = super::placeholder_controller::PlaceholderKey {
+                    provider: provider.clone(),
+                    channel_id: serenity::ChannelId::new(state.channel_id),
+                    message_id: serenity::MessageId::new(state.current_msg_id),
+                };
+                shared.ui.placeholder_controller.begin_detach(&key).await;
                 let text = build_abandoned_placeholder(&state);
                 let edited = edit_placeholder_safe(
                     http,
@@ -647,6 +653,8 @@ async fn run_placeholder_sweep_pass(
                     .await
                 {
                     report.abandoned += 1;
+                } else {
+                    shared.ui.placeholder_controller.finish_detach(&key);
                 }
             }
         }

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -636,25 +636,20 @@ async fn run_placeholder_sweep_pass(
                 // `inflight_state_still_same_turn` covers (2) and (3); edit
                 // success covers (1), and the production cleanup plan covers (4).
                 //
-                // Controller-entry pair-detach is NOT done here: it happens
-                // atomically INSIDE `finalize_owner_dead_cleanup_if_same_turn`
-                // (via `finalize_abandoned_placeholder_detach_if_deleted`),
-                // gated on confirmed inflight-state deletion. Detaching
-                // speculatively before that confirmation — or unconditionally
-                // on the failure/revival branch — would strand a revived
-                // turn's placeholder without its `active_snapshot`, so a
-                // later normal completion could not PATCH the Discord card
-                // (#4594 regression; see dual-review Finding 1).
-                if edited
-                    && finalize_owner_dead_cleanup_if_same_turn(
-                        shared,
-                        provider,
-                        &state,
-                        age_secs,
-                        sweep_started_before,
-                        true,
-                    )
-                    .await
+                // Controller-entry detach is confined to
+                // `finalize_abandoned_after_abort_edit` (which gates it on a
+                // confirmed inflight-state delete). Never detach speculatively
+                // here — that would strand a revived turn's card (#4594 Finding
+                // 1); see the helper's doc.
+                if abandon_guard::finalize_abandoned_after_abort_edit(
+                    shared,
+                    provider,
+                    &state,
+                    age_secs,
+                    sweep_started_before,
+                    edited,
+                )
+                .await
                 {
                     report.abandoned += 1;
                 }

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -637,10 +637,9 @@ async fn run_placeholder_sweep_pass(
                 // success covers (1), and the production cleanup plan covers (4).
                 //
                 // Controller-entry detach is confined to
-                // `finalize_abandoned_after_abort_edit` (which gates it on a
-                // confirmed inflight-state delete). Never detach speculatively
-                // here — that would strand a revived turn's card (#4594 Finding
-                // 1); see the helper's doc.
+                // `finalize_abandoned_after_abort_edit`, gated on a confirmed
+                // inflight-state delete. Never detach speculatively here — it
+                // would strand a revived turn's card (#4594 Finding 1).
                 if abandon_guard::finalize_abandoned_after_abort_edit(
                     shared,
                     provider,

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -39,8 +39,7 @@ use crate::services::provider::ProviderKind;
 mod abandon_guard;
 use abandon_guard::{
     AbandonedTmuxCleanupDecision, abandoned_tmux_cleanup_decision_for,
-    begin_abandoned_placeholder_detach, finalize_owner_dead_cleanup_if_same_turn,
-    finish_abandoned_placeholder_detach,
+    finalize_owner_dead_cleanup_if_same_turn,
 };
 
 /// Age (seconds since `updated_at`) at which a placeholder is treated as
@@ -613,7 +612,6 @@ async fn run_placeholder_sweep_pass(
                 {
                     continue;
                 }
-                begin_abandoned_placeholder_detach(shared, &state).await;
                 let text = build_abandoned_placeholder(&state);
                 let edited = edit_placeholder_safe(
                     http,
@@ -637,6 +635,16 @@ async fn run_placeholder_sweep_pass(
                 //      returns PreserveRetry, which keeps both mailbox and row.
                 // `inflight_state_still_same_turn` covers (2) and (3); edit
                 // success covers (1), and the production cleanup plan covers (4).
+                //
+                // Controller-entry pair-detach is NOT done here: it happens
+                // atomically INSIDE `finalize_owner_dead_cleanup_if_same_turn`
+                // (via `finalize_abandoned_placeholder_detach_if_deleted`),
+                // gated on confirmed inflight-state deletion. Detaching
+                // speculatively before that confirmation — or unconditionally
+                // on the failure/revival branch — would strand a revived
+                // turn's placeholder without its `active_snapshot`, so a
+                // later normal completion could not PATCH the Discord card
+                // (#4594 regression; see dual-review Finding 1).
                 if edited
                     && finalize_owner_dead_cleanup_if_same_turn(
                         shared,
@@ -649,8 +657,6 @@ async fn run_placeholder_sweep_pass(
                     .await
                 {
                     report.abandoned += 1;
-                } else {
-                    finish_abandoned_placeholder_detach(shared, &state);
                 }
             }
         }

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -39,7 +39,8 @@ use crate::services::provider::ProviderKind;
 mod abandon_guard;
 use abandon_guard::{
     AbandonedTmuxCleanupDecision, abandoned_tmux_cleanup_decision_for,
-    finalize_owner_dead_cleanup_if_same_turn,
+    begin_abandoned_placeholder_detach, finalize_owner_dead_cleanup_if_same_turn,
+    finish_abandoned_placeholder_detach,
 };
 
 /// Age (seconds since `updated_at`) at which a placeholder is treated as
@@ -612,12 +613,7 @@ async fn run_placeholder_sweep_pass(
                 {
                     continue;
                 }
-                let key = super::placeholder_controller::PlaceholderKey {
-                    provider: provider.clone(),
-                    channel_id: serenity::ChannelId::new(state.channel_id),
-                    message_id: serenity::MessageId::new(state.current_msg_id),
-                };
-                shared.ui.placeholder_controller.begin_detach(&key).await;
+                begin_abandoned_placeholder_detach(shared, &state).await;
                 let text = build_abandoned_placeholder(&state);
                 let edited = edit_placeholder_safe(
                     http,
@@ -654,7 +650,7 @@ async fn run_placeholder_sweep_pass(
                 {
                     report.abandoned += 1;
                 } else {
-                    shared.ui.placeholder_controller.finish_detach(&key);
+                    finish_abandoned_placeholder_detach(shared, &state);
                 }
             }
         }

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -325,7 +325,7 @@ fn abandoned_placeholder_key(
 
 fn detach_abandoned_placeholder_controller(shared: &Arc<SharedData>, state: &InflightTurnState) {
     if let Some(key) = abandoned_placeholder_key(state) {
-        shared.ui.placeholder_controller.detach(&key);
+        shared.ui.placeholder_controller.finish_detach(&key);
     }
 }
 

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -449,12 +449,25 @@ mod tests {
         AbandonedCleanupEvidence, AbandonedTmuxCleanupDecision, RevivedVisibleRepair,
         RuntimeActivityEvidence, abandoned_cleanup_evidence_for_probe, abandoned_cleanup_plan,
         abandoned_mailbox_finish_actions, abandoned_tmux_cleanup_decision,
-        abandoned_tmux_cleanup_decision_for, decision_for_user_identity, revived_visible_repair,
-        run_blocking_cleanup_probe, runtime_activity_evidence_from, should_detach_after_cleanup,
+        abandoned_tmux_cleanup_decision_for, decision_for_user_identity,
+        finalize_probe_cleanup_if_same_turn, revived_visible_repair, run_blocking_cleanup_probe,
+        runtime_activity_evidence_from, should_detach_after_cleanup,
     };
-    use crate::services::discord::inflight::InflightTurnState;
+    use super::super::PlaceholderProbe;
+    use crate::services::discord::formatting::MonitorHandoffReason;
+    use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
+    use crate::services::discord::inflight::{
+        InflightTurnState, load_inflight_state, save_inflight_state,
+    };
+    use crate::services::discord::make_shared_data_for_tests;
+    use crate::services::discord::placeholder_controller::{
+        PlaceholderActiveInput, PlaceholderControllerOutcome, PlaceholderKey,
+    };
     use crate::services::platform::tmux::PaneLiveness;
     use crate::services::provider::ProviderKind;
+    use poise::serenity_prelude::{ChannelId, MessageId};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn sweep_state() -> InflightTurnState {
         InflightTurnState::new(
@@ -471,6 +484,140 @@ mod tests {
             None,
             0,
         )
+    }
+
+    fn inflight_state(channel_id: u64, message_id: u64) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            None,
+            7,
+            9101,
+            message_id,
+            "prompt".to_string(),
+            Some("session".to_string()),
+            Some("AgentDesk-codex".to_string()),
+            Some("/tmp/recovery.jsonl".to_string()),
+            None,
+            0,
+        )
+    }
+
+    fn key(channel_id: u64, message_id: u64) -> PlaceholderKey {
+        PlaceholderKey {
+            provider: ProviderKind::Codex,
+            channel_id: ChannelId::new(channel_id),
+            message_id: MessageId::new(message_id),
+        }
+    }
+
+    fn input() -> PlaceholderActiveInput {
+        PlaceholderActiveInput {
+            reason: MonitorHandoffReason::ExplicitCall,
+            started_at_unix: 1_700_000_000,
+            tool_summary: Some("Monitor".to_string()),
+            command_summary: Some("session=abandon-guard-race".to_string()),
+            reason_detail: None,
+            context_line: None,
+            request_line: None,
+            progress_line: None,
+        }
+    }
+
+    struct BlockingGateway {
+        calls: AtomicUsize,
+        entered: tokio::sync::Semaphore,
+        release: tokio::sync::Semaphore,
+    }
+
+    impl BlockingGateway {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                entered: tokio::sync::Semaphore::new(0),
+                release: tokio::sync::Semaphore::new(0),
+            }
+        }
+    }
+
+    impl TurnGateway for BlockingGateway {
+        fn send_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<MessageId, String>> {
+            Box::pin(async { Ok(MessageId::new(1)) })
+        }
+
+        fn edit_message<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.entered.add_permits(1);
+                self.release
+                    .acquire()
+                    .await
+                    .expect("release semaphore remains open")
+                    .forget();
+                Ok(())
+            })
+        }
+
+        fn replace_message_with_outcome<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _message_id: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<
+            'a,
+            Result<crate::services::discord::formatting::ReplaceLongMessageOutcome, String>,
+        > {
+            Box::pin(async {
+                Ok(crate::services::discord::formatting::ReplaceLongMessageOutcome::EditedOriginal)
+            })
+        }
+
+        fn schedule_retry_with_history<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _user_message_id: MessageId,
+            _user_text: &'a str,
+        ) -> GatewayFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn dispatch_queued_turn<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+            _intervention: &'a crate::services::discord::Intervention,
+            _request_owner_name: &'a str,
+            _has_more_queued_turns: bool,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn validate_live_routing<'a>(
+            &'a self,
+            _channel_id: ChannelId,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn requester_mention(&self) -> Option<String> {
+            None
+        }
+
+        fn can_chain_locally(&self) -> bool {
+            false
+        }
+
+        fn bot_owner_provider(&self) -> Option<ProviderKind> {
+            Some(ProviderKind::Codex)
+        }
     }
 
     #[test]
@@ -778,9 +925,7 @@ mod tests {
             let controller = shared.ui.placeholder_controller.clone();
             let key = key.clone();
             let input = input.clone();
-            tokio::spawn(
-                async move { controller.ensure_active(gateway.as_ref(), key, input).await },
-            )
+            tokio::spawn(async move { controller.ensure_active(gateway.as_ref(), key, input).await })
         };
         gateway
             .entered
@@ -803,12 +948,7 @@ mod tests {
                 .await
             })
         };
-        while shared
-            .ui
-            .placeholder_controller
-            .entry_detached_for_test(&key)
-            != Some(true)
-        {
+        while shared.ui.placeholder_controller.entry_detached_for_test(&key) != Some(true) {
             tokio::task::yield_now().await;
         }
         gateway.release.add_permits(1);
@@ -818,13 +958,7 @@ mod tests {
             PlaceholderControllerOutcome::Rejected
         );
         assert!(finalize.await.expect("finalize task joins"));
-        assert_eq!(
-            shared
-                .ui
-                .placeholder_controller
-                .entry_detached_for_test(&key),
-            None
-        );
+        assert_eq!(shared.ui.placeholder_controller.entry_detached_for_test(&key), None);
         assert!(load_inflight_state(&ProviderKind::Codex, 11).is_none());
     }
 

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -30,7 +30,7 @@ impl AbandonedTmuxCleanupDecision {
     }
 }
 
-pub(super) fn abandoned_tmux_cleanup_decision(
+fn abandoned_tmux_cleanup_decision(
     has_usable_session_name: bool,
     pane: PaneLiveness,
     activity: RuntimeActivityEvidence,
@@ -355,8 +355,20 @@ async fn invalidate_abandoned_placeholder_render_cache(
         .await
 }
 
+#[cfg(test)]
 fn should_detach_after_cleanup(same_turn: bool, state_deleted: bool) -> bool {
     same_turn && state_deleted
+}
+
+async fn finalize_abandoned_placeholder_detach_if_deleted(
+    shared: &Arc<SharedData>,
+    state: &InflightTurnState,
+    state_deleted: bool,
+) {
+    if state_deleted {
+        begin_abandoned_placeholder_detach(shared, state).await;
+        finish_abandoned_placeholder_detach(shared, state);
+    }
 }
 
 async fn finalize_cleanup_if_same_turn(
@@ -374,9 +386,7 @@ async fn finalize_cleanup_if_same_turn(
         finalize_abandoned_mailbox(shared, provider, state, sweep_started_before, evidence).await;
     let same_turn = super::inflight_state_still_same_turn(provider, state, age_secs);
     let deleted = same_turn && cleanup.delete_state_if_allowed(provider, state);
-    if should_detach_after_cleanup(same_turn, deleted) {
-        finish_abandoned_placeholder_detach(shared, state);
-    }
+    finalize_abandoned_placeholder_detach_if_deleted(shared, state, deleted).await;
     deleted
 }
 
@@ -429,9 +439,7 @@ pub(super) async fn finalize_owner_dead_cleanup_if_same_turn(
         return false;
     }
     let deleted = same_turn && cleanup.delete_state_if_allowed(provider, state);
-    if should_detach_after_cleanup(same_turn, deleted) {
-        finish_abandoned_placeholder_detach(shared, state);
-    }
+    finalize_abandoned_placeholder_detach_if_deleted(shared, state, deleted).await;
     deleted
 }
 
@@ -745,5 +753,121 @@ mod tests {
     async fn blocking_probe_join_failure_preserves_retry() {
         let decision = run_blocking_cleanup_probe(|| panic!("synthetic probe panic")).await;
         assert_eq!(decision, AbandonedTmuxCleanupDecision::PreserveRetry);
+    }
+
+    #[tokio::test]
+    async fn probe_arm_cleanup_detaches_controller_entry_and_rejects_late_commit() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().expect("runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            temp.path(),
+        );
+        let shared = make_shared_data_for_tests();
+        let gateway = Arc::new(BlockingGateway::new());
+        let key = key(11, 12);
+        let input = input();
+        let state = inflight_state(11, 12);
+        save_inflight_state(&state).expect("seed inflight row");
+        let snapshot = load_inflight_state(&ProviderKind::Codex, 11).expect("load snapshot");
+
+        let ensure = {
+            let gateway = gateway.clone();
+            let controller = shared.ui.placeholder_controller.clone();
+            let key = key.clone();
+            let input = input.clone();
+            tokio::spawn(async move { controller.ensure_active(gateway.as_ref(), key, input).await })
+        };
+        gateway
+            .entered
+            .acquire()
+            .await
+            .expect("gateway entry semaphore remains open")
+            .forget();
+
+        let finalize = {
+            let shared = shared.clone();
+            tokio::spawn(async move {
+                finalize_probe_cleanup_if_same_turn(
+                    &shared,
+                    &ProviderKind::Codex,
+                    &snapshot,
+                    0,
+                    std::time::Instant::now(),
+                    PlaceholderProbe::AlreadyDelivered,
+                )
+                .await
+            })
+        };
+        while shared.ui.placeholder_controller.entry_detached_for_test(&key) != Some(true) {
+            tokio::task::yield_now().await;
+        }
+        gateway.release.add_permits(1);
+
+        assert_eq!(
+            ensure.await.expect("ensure task joins"),
+            PlaceholderControllerOutcome::Rejected
+        );
+        assert!(finalize.await.expect("finalize task joins"));
+        assert_eq!(shared.ui.placeholder_controller.entry_detached_for_test(&key), None);
+        assert!(load_inflight_state(&ProviderKind::Codex, 11).is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_arm_cleanup_preserves_live_entry_when_same_turn_gate_fails() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().expect("runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            temp.path(),
+        );
+        let shared = make_shared_data_for_tests();
+        let gateway = Arc::new(BlockingGateway::new());
+        gateway.release.add_permits(1);
+        let key = key(21, 22);
+        let input = input();
+        let state = inflight_state(21, 22);
+        save_inflight_state(&state).expect("seed inflight row");
+        let snapshot = load_inflight_state(&ProviderKind::Codex, 21).expect("load snapshot");
+
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key.clone(), input.clone())
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+        let mut newer = snapshot.clone();
+        newer.current_msg_id = 23;
+        save_inflight_state(&newer).expect("overwrite inflight row");
+
+        let deleted = finalize_probe_cleanup_if_same_turn(
+            &shared,
+            &ProviderKind::Codex,
+            &snapshot,
+            0,
+            std::time::Instant::now(),
+            PlaceholderProbe::AlreadyDelivered,
+        )
+        .await;
+
+        assert!(!deleted);
+        assert_eq!(
+            shared.ui.placeholder_controller.entry_detached_for_test(&key),
+            Some(false)
+        );
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key, input)
+                .await,
+            PlaceholderControllerOutcome::Coalesced
+        );
     }
 }

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -356,19 +356,45 @@ async fn finalize_abandoned_placeholder_detach_if_deleted(
     state: &InflightTurnState,
     state_deleted: bool,
 ) {
-    // #4594: leave the tombstone (`detached=true`) permanently resident in the
-    // controller map for this key instead of calling `finish_detach` right
-    // back here. `finish_detach` removes the map entry entirely, which lets a
-    // late-arriving `ensure_active`/`ensure_queued` from the same
-    // now-delivered/gone message id re-insert a fresh, non-detached slot and
-    // reactivate a card the probe arm already confirmed is gone — the exact
-    // stale-reactivation window this function exists to close. The
-    // now-permanent tombstone is still bounded: `evict_terminal_entries`
-    // reclaims idle detached entries under capacity pressure (see
-    // `placeholder_controller.rs`), so the map cannot grow without bound.
+    // #4594: the controller detach is gated on a *confirmed* inflight-state
+    // delete. `begin_detach` records this message id in the controller's bounded
+    // per-channel settled record (and drops the slot), so a late-arriving
+    // `ensure_active`/`ensure_queued` for the same now-delivered/gone id is
+    // rejected even after the slot is evicted and recreated — the exact
+    // stale-reactivation window #4594 closes. Detaching before the delete is
+    // confirmed (`state_deleted == false`, e.g. a revived turn or a failed
+    // guarded clear) would strand a still-live turn's card without its
+    // `active_snapshot`, so the gate below is load-bearing and must stay.
     if state_deleted {
         begin_abandoned_placeholder_detach(shared, state).await;
     }
+}
+
+/// Production tail of the sweeper's `StillPlaceholder` abandon arm, invoked once
+/// the abort edit has been attempted. Centralises the abandon finalization here
+/// — beside the confirmed-delete-gated controller detach — so the sweep loop
+/// cannot grow a *speculative* pre-confirmation detach next to it: the only
+/// detach lives inside [`finalize_owner_dead_cleanup_if_same_turn`], gated on a
+/// committed state delete. Returns whether the row was actually abandoned (the
+/// sweep report increments its counter on `true`).
+pub(super) async fn finalize_abandoned_after_abort_edit(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    state: &InflightTurnState,
+    age_secs: u64,
+    sweep_started_before: std::time::Instant,
+    edited: bool,
+) -> bool {
+    edited
+        && finalize_owner_dead_cleanup_if_same_turn(
+            shared,
+            provider,
+            state,
+            age_secs,
+            sweep_started_before,
+            true,
+        )
+        .await
 }
 
 async fn finalize_cleanup_if_same_turn(
@@ -451,9 +477,9 @@ mod tests {
         RuntimeActivityEvidence, abandoned_cleanup_evidence_for_probe, abandoned_cleanup_plan,
         abandoned_mailbox_finish_actions, abandoned_tmux_cleanup_decision,
         abandoned_tmux_cleanup_decision_for, decision_for_user_identity,
-        finalize_owner_dead_cleanup_if_same_turn, finalize_probe_cleanup_if_same_turn,
-        revived_visible_repair, run_blocking_cleanup_probe, runtime_activity_evidence_from,
-        should_detach_after_cleanup,
+        finalize_abandoned_after_abort_edit, finalize_abandoned_placeholder_detach_if_deleted,
+        finalize_probe_cleanup_if_same_turn, revived_visible_repair, run_blocking_cleanup_probe,
+        runtime_activity_evidence_from, should_detach_after_cleanup,
     };
     use crate::services::discord::formatting::MonitorHandoffReason;
     use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
@@ -462,7 +488,7 @@ mod tests {
     };
     use crate::services::discord::make_shared_data_for_tests;
     use crate::services::discord::placeholder_controller::{
-        PlaceholderActiveInput, PlaceholderControllerOutcome, PlaceholderKey,
+        PlaceholderActiveInput, PlaceholderControllerOutcome, PlaceholderKey, PlaceholderLifecycle,
     };
     use crate::services::platform::tmux::PaneLiveness;
     use crate::services::provider::ProviderKind;
@@ -966,23 +992,29 @@ mod tests {
             PlaceholderControllerOutcome::Rejected
         );
         assert!(finalize.await.expect("finalize task joins"));
-        // #4594 regression: the tombstone must stay resident (not be
-        // removed) so a stale late-arriving activation for this exact key
-        // keeps being rejected. Removing it here (as the old `finish_detach`
-        // call used to do) would let the next `ensure_active` below
-        // re-insert a fresh, non-detached slot and re-activate a message the
-        // probe arm already confirmed delivered/gone.
+        // #4594: begin_detach dropped the slot outright (no permanent
+        // tombstone) but recorded the settled high-water for this scope, which
+        // is what keeps rejecting a stale late-arriving activation for this
+        // exact key even after the slot is gone.
         assert_eq!(
             shared
                 .ui
                 .placeholder_controller
                 .entry_detached_for_test(&key),
-            Some(true)
+            None
+        );
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .settled_high_water_for_test(&key),
+            Some(12)
         );
         assert!(load_inflight_state(&ProviderKind::Codex, 11).is_none());
 
         // A late-arriving activation from the same (now stale) turn must
-        // still be rejected — this is the revival window #4594 closes.
+        // still be rejected — even though `entry()` would recreate a fresh,
+        // non-detached slot. This is the evict+recreate window #4594 closes.
         assert_eq!(
             shared
                 .ui
@@ -1065,18 +1097,16 @@ mod tests {
         );
         let shared = make_shared_data_for_tests();
         let gateway = Arc::new(BlockingGateway::new());
-        // Two PATCHes are expected: the seeding `ensure_active` below, and the
-        // post-revival `ensure_active` at the end of this test. The latter is
-        // forced to issue a real PATCH (not coalesce) because the revival
-        // branch invalidates the render cache (`last_rendered = None`) so a
-        // possibly-clobbered visible card gets repainted.
+        // Two PATCHes are expected: the seeding `ensure_active`, and the
+        // post-revival terminal `transition` that renders from the PRESERVED
+        // `active_snapshot`.
         gateway.release.add_permits(2);
         let key = key(31, 32);
         let input = input();
         let mut state = inflight_state(31, 32);
-        // Forces `abandoned_tmux_cleanup_decision_for` to `PreserveRetry`
-        // without touching a real tmux process, exercising the StillPlaceholder
-        // safety-net arm's owner-revival branch deterministically.
+        // Forces the finalize re-probe (`abandoned_tmux_cleanup_decision_for`)
+        // to `PreserveRetry` without touching a real tmux process, exercising
+        // the StillPlaceholder arm's owner-revival branch deterministically.
         state.tmux_session_name = None;
         save_inflight_state(&state).expect("seed inflight row");
         let snapshot = load_inflight_state(&ProviderKind::Codex, 31).expect("load snapshot");
@@ -1090,13 +1120,15 @@ mod tests {
             PlaceholderControllerOutcome::Edited
         );
 
-        // StillPlaceholder safety-net arm: owner-death cleanup with the
-        // visible-repair flag enabled must hit the revival branch
-        // (`decision == PreserveRetry && same_turn`) and must NOT strand the
-        // live entry by detaching it (regression guard for dual-review
-        // finding #1: the safety-net arm used to detach unconditionally
-        // before the abort edit was even confirmed).
-        let deleted = finalize_owner_dead_cleanup_if_same_turn(
+        // Drive the REAL production tail of the sweeper's StillPlaceholder
+        // abandon arm — `finalize_abandoned_after_abort_edit`, the exact fn the
+        // arm calls at the `if … { report.abandoned += 1 }` site — with the
+        // abort edit reported as done. The revival branch
+        // (`decision == PreserveRetry && same_turn`) must NOT detach: a
+        // speculative `begin_abandoned_placeholder_detach` re-added anywhere in
+        // this seam records the settled id and is caught by the terminal
+        // `transition` below (regression guard for dual-review finding #1).
+        let deleted = finalize_abandoned_after_abort_edit(
             &shared,
             &ProviderKind::Codex,
             &snapshot,
@@ -1114,25 +1146,130 @@ mod tests {
                 .entry_detached_for_test(&key),
             Some(false)
         );
-        // The inflight row itself must survive too — the revival branch must
-        // not authorize a state delete.
+        // No settled disposition was recorded — the revived card is still live.
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .settled_high_water_for_test(&key),
+            None
+        );
+        // The inflight row itself must survive — the revival branch must not
+        // authorize a state delete.
         assert!(load_inflight_state(&ProviderKind::Codex, 31).is_some());
 
-        // The live entry, including its `active_snapshot`, must remain fully
-        // usable for the revived turn's subsequent placeholder edits instead
-        // of being rejected as if the key had been torn down. The outcome is
-        // `Edited` rather than `Coalesced`: the revival branch invalidated
-        // the render cache, so this call cannot coalesce and must actually
-        // issue (and succeed at) a real PATCH — proving the entry is still
-        // live and editable, not detached.
+        // The revived turn's PRESERVED `active_snapshot` must still drive a
+        // terminal render. `transition` renders from `active_snapshot` and
+        // takes NO fresh input, so it can only PATCH (`Edited`) if the snapshot
+        // survived revival AND the card was never settled. A snapshot-clear
+        // mutation turns this into `Rejected` (the no-snapshot branch); a
+        // speculative-detach mutation turns it into `AlreadyTerminal` (settled)
+        // — either way this assert fails. (A fresh `ensure_active` here would
+        // instead REPOPULATE the snapshot and mask the clear.)
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .transition(gateway.as_ref(), key, PlaceholderLifecycle::Completed)
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// #4594 test-3: pierce `finalize_abandoned_placeholder_detach_if_deleted`'s
+    /// `if state_deleted` gate directly. The two preservation tests return
+    /// early before reaching this gate (one on the first same-turn check, one on
+    /// the revival branch), so nothing pinned it — flipping it to a constant
+    /// went undetected. Here we drive both sides with a real live entry:
+    /// `state_deleted = false` (same turn, but the guarded state-delete did not
+    /// commit) must NOT detach, and `state_deleted = true` must. Flipping the
+    /// gate to `if true` fails the first side; flipping it to `if false` fails
+    /// the second.
+    #[tokio::test]
+    async fn abandoned_detach_gate_only_detaches_on_committed_state_delete() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().expect("runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            temp.path(),
+        );
+        let shared = make_shared_data_for_tests();
+        let gateway = Arc::new(BlockingGateway::new());
+        gateway.release.add_permits(1);
+        let key = key(41, 42);
+        let input = input();
+        let state = inflight_state(41, 42);
+
+        // A real, live Active card for this key.
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key.clone(), input.clone())
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+
+        // deleted == false (same turn, but the state-delete did not commit):
+        // the gate must NOT detach — a revived/failed-delete turn keeps its
+        // live card.
+        finalize_abandoned_placeholder_detach_if_deleted(&shared, &state, false).await;
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .entry_detached_for_test(&key),
+            Some(false),
+            "gate must not detach when the state-delete did not commit"
+        );
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .settled_high_water_for_test(&key),
+            None
+        );
+        // The card is still fully live: an identical re-render coalesces rather
+        // than being rejected.
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key.clone(), input.clone())
+                .await,
+            PlaceholderControllerOutcome::Coalesced
+        );
+
+        // deleted == true: the gate MUST detach — records the settled id and
+        // drops the slot, so a later activation for this key is rejected.
+        finalize_abandoned_placeholder_detach_if_deleted(&shared, &state, true).await;
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .entry_detached_for_test(&key),
+            None,
+            "gate must detach (drop the slot) once the state-delete is committed"
+        );
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .settled_high_water_for_test(&key),
+            Some(42)
+        );
         assert_eq!(
             shared
                 .ui
                 .placeholder_controller
                 .ensure_active(gateway.as_ref(), key, input)
                 .await,
-            PlaceholderControllerOutcome::Edited
+            PlaceholderControllerOutcome::Rejected
         );
-        assert_eq!(gateway.calls.load(Ordering::SeqCst), 2);
+        // Only the seeding PATCH ever fired.
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -445,6 +445,7 @@ pub(super) async fn finalize_owner_dead_cleanup_if_same_turn(
 
 #[cfg(test)]
 mod tests {
+    use super::super::PlaceholderProbe;
     use super::{
         AbandonedCleanupEvidence, AbandonedTmuxCleanupDecision, RevivedVisibleRepair,
         RuntimeActivityEvidence, abandoned_cleanup_evidence_for_probe, abandoned_cleanup_plan,
@@ -453,7 +454,6 @@ mod tests {
         finalize_probe_cleanup_if_same_turn, revived_visible_repair, run_blocking_cleanup_probe,
         runtime_activity_evidence_from, should_detach_after_cleanup,
     };
-    use super::super::PlaceholderProbe;
     use crate::services::discord::formatting::MonitorHandoffReason;
     use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
     use crate::services::discord::inflight::{
@@ -925,7 +925,9 @@ mod tests {
             let controller = shared.ui.placeholder_controller.clone();
             let key = key.clone();
             let input = input.clone();
-            tokio::spawn(async move { controller.ensure_active(gateway.as_ref(), key, input).await })
+            tokio::spawn(
+                async move { controller.ensure_active(gateway.as_ref(), key, input).await },
+            )
         };
         gateway
             .entered
@@ -948,7 +950,12 @@ mod tests {
                 .await
             })
         };
-        while shared.ui.placeholder_controller.entry_detached_for_test(&key) != Some(true) {
+        while shared
+            .ui
+            .placeholder_controller
+            .entry_detached_for_test(&key)
+            != Some(true)
+        {
             tokio::task::yield_now().await;
         }
         gateway.release.add_permits(1);
@@ -958,7 +965,13 @@ mod tests {
             PlaceholderControllerOutcome::Rejected
         );
         assert!(finalize.await.expect("finalize task joins"));
-        assert_eq!(shared.ui.placeholder_controller.entry_detached_for_test(&key), None);
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .entry_detached_for_test(&key),
+            None
+        );
         assert!(load_inflight_state(&ProviderKind::Codex, 11).is_none());
     }
 

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -323,7 +323,19 @@ fn abandoned_placeholder_key(
     })
 }
 
-fn detach_abandoned_placeholder_controller(shared: &Arc<SharedData>, state: &InflightTurnState) {
+pub(super) async fn begin_abandoned_placeholder_detach(
+    shared: &Arc<SharedData>,
+    state: &InflightTurnState,
+) {
+    if let Some(key) = abandoned_placeholder_key(state) {
+        shared.ui.placeholder_controller.begin_detach(&key).await;
+    }
+}
+
+pub(super) fn finish_abandoned_placeholder_detach(
+    shared: &Arc<SharedData>,
+    state: &InflightTurnState,
+) {
     if let Some(key) = abandoned_placeholder_key(state) {
         shared.ui.placeholder_controller.finish_detach(&key);
     }
@@ -363,7 +375,7 @@ async fn finalize_cleanup_if_same_turn(
     let same_turn = super::inflight_state_still_same_turn(provider, state, age_secs);
     let deleted = same_turn && cleanup.delete_state_if_allowed(provider, state);
     if should_detach_after_cleanup(same_turn, deleted) {
-        detach_abandoned_placeholder_controller(shared, state);
+        finish_abandoned_placeholder_detach(shared, state);
     }
     deleted
 }
@@ -418,7 +430,7 @@ pub(super) async fn finalize_owner_dead_cleanup_if_same_turn(
     }
     let deleted = same_turn && cleanup.delete_state_if_allowed(provider, state);
     if should_detach_after_cleanup(same_turn, deleted) {
-        detach_abandoned_placeholder_controller(shared, state);
+        finish_abandoned_placeholder_detach(shared, state);
     }
     deleted
 }

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -332,15 +332,6 @@ pub(super) async fn begin_abandoned_placeholder_detach(
     }
 }
 
-pub(super) fn finish_abandoned_placeholder_detach(
-    shared: &Arc<SharedData>,
-    state: &InflightTurnState,
-) {
-    if let Some(key) = abandoned_placeholder_key(state) {
-        shared.ui.placeholder_controller.finish_detach(&key);
-    }
-}
-
 async fn invalidate_abandoned_placeholder_render_cache(
     shared: &Arc<SharedData>,
     state: &InflightTurnState,
@@ -365,9 +356,18 @@ async fn finalize_abandoned_placeholder_detach_if_deleted(
     state: &InflightTurnState,
     state_deleted: bool,
 ) {
+    // #4594: leave the tombstone (`detached=true`) permanently resident in the
+    // controller map for this key instead of calling `finish_detach` right
+    // back here. `finish_detach` removes the map entry entirely, which lets a
+    // late-arriving `ensure_active`/`ensure_queued` from the same
+    // now-delivered/gone message id re-insert a fresh, non-detached slot and
+    // reactivate a card the probe arm already confirmed is gone — the exact
+    // stale-reactivation window this function exists to close. The
+    // now-permanent tombstone is still bounded: `evict_terminal_entries`
+    // reclaims idle detached entries under capacity pressure (see
+    // `placeholder_controller.rs`), so the map cannot grow without bound.
     if state_deleted {
         begin_abandoned_placeholder_detach(shared, state).await;
-        finish_abandoned_placeholder_detach(shared, state);
     }
 }
 
@@ -451,8 +451,9 @@ mod tests {
         RuntimeActivityEvidence, abandoned_cleanup_evidence_for_probe, abandoned_cleanup_plan,
         abandoned_mailbox_finish_actions, abandoned_tmux_cleanup_decision,
         abandoned_tmux_cleanup_decision_for, decision_for_user_identity,
-        finalize_probe_cleanup_if_same_turn, revived_visible_repair, run_blocking_cleanup_probe,
-        runtime_activity_evidence_from, should_detach_after_cleanup,
+        finalize_owner_dead_cleanup_if_same_turn, finalize_probe_cleanup_if_same_turn,
+        revived_visible_repair, run_blocking_cleanup_probe, runtime_activity_evidence_from,
+        should_detach_after_cleanup,
     };
     use crate::services::discord::formatting::MonitorHandoffReason;
     use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
@@ -965,14 +966,32 @@ mod tests {
             PlaceholderControllerOutcome::Rejected
         );
         assert!(finalize.await.expect("finalize task joins"));
+        // #4594 regression: the tombstone must stay resident (not be
+        // removed) so a stale late-arriving activation for this exact key
+        // keeps being rejected. Removing it here (as the old `finish_detach`
+        // call used to do) would let the next `ensure_active` below
+        // re-insert a fresh, non-detached slot and re-activate a message the
+        // probe arm already confirmed delivered/gone.
         assert_eq!(
             shared
                 .ui
                 .placeholder_controller
                 .entry_detached_for_test(&key),
-            None
+            Some(true)
         );
         assert!(load_inflight_state(&ProviderKind::Codex, 11).is_none());
+
+        // A late-arriving activation from the same (now stale) turn must
+        // still be rejected — this is the revival window #4594 closes.
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key, input)
+                .await,
+            PlaceholderControllerOutcome::Rejected
+        );
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -1032,5 +1051,88 @@ mod tests {
                 .await,
             PlaceholderControllerOutcome::Coalesced
         );
+    }
+
+    #[tokio::test]
+    async fn owner_dead_cleanup_revival_preserves_live_entry_and_active_snapshot() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempfile::TempDir::new().expect("runtime root");
+        let _env = crate::config::TestEnvVarGuard::set_path_after_shared_test_env_lock(
+            "AGENTDESK_ROOT_DIR",
+            temp.path(),
+        );
+        let shared = make_shared_data_for_tests();
+        let gateway = Arc::new(BlockingGateway::new());
+        // Two PATCHes are expected: the seeding `ensure_active` below, and the
+        // post-revival `ensure_active` at the end of this test. The latter is
+        // forced to issue a real PATCH (not coalesce) because the revival
+        // branch invalidates the render cache (`last_rendered = None`) so a
+        // possibly-clobbered visible card gets repainted.
+        gateway.release.add_permits(2);
+        let key = key(31, 32);
+        let input = input();
+        let mut state = inflight_state(31, 32);
+        // Forces `abandoned_tmux_cleanup_decision_for` to `PreserveRetry`
+        // without touching a real tmux process, exercising the StillPlaceholder
+        // safety-net arm's owner-revival branch deterministically.
+        state.tmux_session_name = None;
+        save_inflight_state(&state).expect("seed inflight row");
+        let snapshot = load_inflight_state(&ProviderKind::Codex, 31).expect("load snapshot");
+
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key.clone(), input.clone())
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+
+        // StillPlaceholder safety-net arm: owner-death cleanup with the
+        // visible-repair flag enabled must hit the revival branch
+        // (`decision == PreserveRetry && same_turn`) and must NOT strand the
+        // live entry by detaching it (regression guard for dual-review
+        // finding #1: the safety-net arm used to detach unconditionally
+        // before the abort edit was even confirmed).
+        let deleted = finalize_owner_dead_cleanup_if_same_turn(
+            &shared,
+            &ProviderKind::Codex,
+            &snapshot,
+            0,
+            std::time::Instant::now(),
+            true,
+        )
+        .await;
+
+        assert!(!deleted);
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .entry_detached_for_test(&key),
+            Some(false)
+        );
+        // The inflight row itself must survive too — the revival branch must
+        // not authorize a state delete.
+        assert!(load_inflight_state(&ProviderKind::Codex, 31).is_some());
+
+        // The live entry, including its `active_snapshot`, must remain fully
+        // usable for the revived turn's subsequent placeholder edits instead
+        // of being rejected as if the key had been torn down. The outcome is
+        // `Edited` rather than `Coalesced`: the revival branch invalidated
+        // the render cache, so this call cannot coalesce and must actually
+        // issue (and succeed at) a real PATCH — proving the entry is still
+        // live and editable, not detached.
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .ensure_active(gateway.as_ref(), key, input)
+                .await,
+            PlaceholderControllerOutcome::Edited
+        );
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -778,7 +778,9 @@ mod tests {
             let controller = shared.ui.placeholder_controller.clone();
             let key = key.clone();
             let input = input.clone();
-            tokio::spawn(async move { controller.ensure_active(gateway.as_ref(), key, input).await })
+            tokio::spawn(
+                async move { controller.ensure_active(gateway.as_ref(), key, input).await },
+            )
         };
         gateway
             .entered
@@ -801,7 +803,12 @@ mod tests {
                 .await
             })
         };
-        while shared.ui.placeholder_controller.entry_detached_for_test(&key) != Some(true) {
+        while shared
+            .ui
+            .placeholder_controller
+            .entry_detached_for_test(&key)
+            != Some(true)
+        {
             tokio::task::yield_now().await;
         }
         gateway.release.add_permits(1);
@@ -811,7 +818,13 @@ mod tests {
             PlaceholderControllerOutcome::Rejected
         );
         assert!(finalize.await.expect("finalize task joins"));
-        assert_eq!(shared.ui.placeholder_controller.entry_detached_for_test(&key), None);
+        assert_eq!(
+            shared
+                .ui
+                .placeholder_controller
+                .entry_detached_for_test(&key),
+            None
+        );
         assert!(load_inflight_state(&ProviderKind::Codex, 11).is_none());
     }
 
@@ -858,7 +871,10 @@ mod tests {
 
         assert!(!deleted);
         assert_eq!(
-            shared.ui.placeholder_controller.entry_detached_for_test(&key),
+            shared
+                .ui
+                .placeholder_controller
+                .entry_detached_for_test(&key),
             Some(false)
         );
         assert_eq!(


### PR DESCRIPTION
issue #4594 — abandoned placeholder detach incarnation.

## 변경
- `placeholder_controller.rs` (+417): abandoned placeholder detach lifecycle
- `placeholder_sweeper.rs` (+6): `begin_abandoned_placeholder_detach` / `finish_abandoned_placeholder_detach` 배선
- `placeholder_sweeper/abandon_guard.rs` (+20): detach guard 헬퍼

## 게이트 (로컬, 공유 CARGO_TARGET_DIR)
- `cargo fmt --check`: rc=0
- `cargo check --lib`: rc=0
- `cargo test --lib placeholder`: rc=0
- `audit_maintainability.py --check`: rc=0
- inventory/freshness: passed

## 리뷰
dual (Fable + sol fresh) 예정 — session-control/kill 권위 tier.