### PR TITLE
ux(discord): 큐 상태 리액션에서 ⏳ 제거 — 큐 마커 단독 표시 (#4606)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1488,11 +1488,11 @@
     `turn_finalizer/finalize.rs` is now 246 prod LoC, `turn_finalizer/finalize_context.rs` 113 prod LoC,
     `turn_finalizer/reconcile.rs` 221 prod LoC, and
     `turn_finalizer/cleanup.rs` 565 prod LoC. No PG lease/schema change.
-  - `src/services/discord/turn_view_reconciler.rs` (2257 prod lines; +45 from #4248/#4329 review hardening: queued-state schema v2 invalidates v1 queue records while keeping v1 pending-anchor recovery compatible, and multi-reaction transitions compensate already-applied operations on partial failure; #4248 moves
+  - `src/services/discord/turn_view_reconciler.rs` (2356 prod lines; +55 from #4606 migrating queued-state persistence to schema v3, converging legacy v2 marker+hourglass records, and making queued user-message views marker-only while `Queued*` → `Pending` adds a fresh `⏳` through the target-set diff; +45 from #4248/#4329 review hardening: queued-state schema v2 invalidates v1 queue records while keeping v1 pending-anchor recovery compatible, and multi-reaction transitions compensate already-applied operations on partial failure; #4248 moves
     the derived reaction mapping into `turn_view_reconciler/reaction_set.rs` and
-    makes queued user-message views include an immediate `⏳` alongside their
-    queue-kind marker; promotion removes only the queue-kind marker and terminal
-    completion converges to `✅` through the same persisted adder identity; +104 from
+    originally made queued user-message views include an immediate `⏳` alongside
+    their queue-kind marker; #4606 supersedes that queue presentation while
+    terminal completion still converges to `✅` through the same persisted adder identity; +104 from
     #4049 S4-a2 round-9 adding an attempt-scoped clear API/current-generation
     shim so race-loss stale attempt-1 clears cannot wipe a same-generation
     attempt-2 Pending marker; #4049 S4-a2 extends the S4-a1 reaction reconciler

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -31,7 +31,7 @@
 | `src/services/discord/tui_direct_pending_start.rs` | 1495 | discord-relay | 2026-08-31 | #3540 |
 | `src/services/discord/tui_prompt_relay/synthetic_start.rs` | 1079 | discord-relay | 2026-10-31 | #4019 |
 | `src/services/discord/turn_finalizer.rs` | 1048 | discord-finalizer | 2026-08-31 | #3016 |
-| `src/services/discord/turn_view_reconciler.rs` | 2301 | discord-relay | 2026-08-31 | #4049 |
+| `src/services/discord/turn_view_reconciler.rs` | 2358 | discord-relay | 2026-08-31 | #4049 |
 | `src/services/discord/voice_barge_in.rs` | 2887 | voice-runtime | 2026-08-31 | #3405 |
 | `src/services/discord/watchers/lifecycle.rs` | 2077 | discord-relay | 2026-10-31 | #3840 |
 | `src/services/tmux_common.rs` | 1311 | discord-relay | 2026-10-31 | #3924 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -597,9 +597,9 @@
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2310 | 751 | 1559 |  |
-| `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 646 | 223 | 423 |  |
+| `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 643 | 223 | 420 |  |
 | `services::discord::queue_overflow_dlq` | `src/services/discord/queue_overflow_dlq.rs` | 210 | 127 | 83 |  |
-| `services::discord::queue_reactions` | `src/services/discord/queue_reactions.rs` | 35 | 25 | 10 |  |
+| `services::discord::queue_reactions` | `src/services/discord/queue_reactions.rs` | 37 | 25 | 12 |  |
 | `services::discord::queued_placeholders_store` | `src/services/discord/queued_placeholders_store.rs` | 251 | 251 | 0 |  |
 | `services::discord::reaction_cleanup` | `src/services/discord/reaction_cleanup.rs` | 49 | 24 | 25 |  |
 | `services::discord::reaction_lifecycle` | `src/services/discord/reaction_lifecycle.rs` | 363 | 321 | 42 |  |
@@ -669,7 +669,7 @@
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 313 | 222 | 91 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1734 | 1381 | 353 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3081 | 2727 | 354 | giant-file |
-| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 699 | 604 | 95 |  |
+| `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 698 | 603 | 95 |  |
 | `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 65 | 65 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 256 | 256 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
@@ -831,7 +831,7 @@
 | `services::discord::turn_bridge::context_window` | `src/services/discord/turn_bridge/context_window.rs` | 169 | 100 | 69 |  |
 | `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 62 | 62 | 0 |  |
 | `services::discord::turn_bridge::finalize_epilogue` | `src/services/discord/turn_bridge/finalize_epilogue.rs` | 306 | 156 | 150 |  |
-| `services::discord::turn_bridge::followup_requeue` | `src/services/discord/turn_bridge/followup_requeue.rs` | 237 | 122 | 115 |  |
+| `services::discord::turn_bridge::followup_requeue` | `src/services/discord/turn_bridge/followup_requeue.rs` | 238 | 122 | 116 |  |
 | `services::discord::turn_bridge::guards` | `src/services/discord/turn_bridge/guards.rs` | 76 | 76 | 0 |  |
 | `services::discord::turn_bridge::headless_delivery` | `src/services/discord/turn_bridge/headless_delivery.rs` | 518 | 442 | 76 |  |
 | `services::discord::turn_bridge::memory_lifecycle` | `src/services/discord/turn_bridge/memory_lifecycle.rs` | 411 | 303 | 108 |  |
@@ -889,7 +889,7 @@
 | `services::discord::turn_finalizer::finalize_context` | `src/services/discord/turn_finalizer/finalize_context.rs` | 179 | 148 | 31 |  |
 | `services::discord::turn_finalizer::reconcile` | `src/services/discord/turn_finalizer/reconcile.rs` | 221 | 221 | 0 |  |
 | `services::discord::turn_finalizer::watcher_backstop` | `src/services/discord/turn_finalizer/watcher_backstop.rs` | 273 | 210 | 63 |  |
-| `services::discord::turn_view_reconciler` | `src/services/discord/turn_view_reconciler.rs` | 2301 | 2301 | 0 | giant-file |
+| `services::discord::turn_view_reconciler` | `src/services/discord/turn_view_reconciler.rs` | 2358 | 2358 | 0 | giant-file |
 | `services::discord::turn_view_reconciler::orphan_sweep` | `src/services/discord/turn_view_reconciler/orphan_sweep.rs` | 611 | 321 | 290 |  |
 | `services::discord::turn_view_reconciler::queue_repair` | `src/services/discord/turn_view_reconciler/queue_repair.rs` | 31 | 31 | 0 |  |
 | `services::discord::turn_view_reconciler::reaction_set` | `src/services/discord/turn_view_reconciler/reaction_set.rs` | 23 | 23 | 0 |  |

--- a/src/services/discord/queue_marker.rs
+++ b/src/services/discord/queue_marker.rs
@@ -483,9 +483,8 @@ mod tests {
         )
         .await;
         let ops_after_queue = shared.turn_view_reconciler.ops();
-        assert_eq!(ops_after_queue.len(), 2);
+        assert_eq!(ops_after_queue.len(), 1);
         assert!(ops_after_queue[0].add && ops_after_queue[0].emoji == '📬');
-        assert!(ops_after_queue[1].add && ops_after_queue[1].emoji == '⏳');
         assert!(persisted_path(channel_id, head).exists());
 
         drain_dispatched_queue_markers(
@@ -498,16 +497,14 @@ mod tests {
         .await;
 
         let ops = shared.turn_view_reconciler.ops();
-        assert_eq!(ops.len(), ops_after_queue.len() + 1);
-        assert!(
-            !ops.last().expect("promotion op").add
-                && ops.last().expect("promotion op").emoji == '📬'
-        );
+        assert_eq!(ops.len(), ops_after_queue.len() + 2);
+        assert!(!ops[1].add && ops[1].emoji == '📬');
+        assert!(ops[2].add && ops[2].emoji == '⏳');
         assert!(persisted_path(channel_id, head).exists());
         assert_eq!(
             ops.iter().filter(|op| op.add && op.emoji == '⏳').count(),
             1,
-            "live dispatch promotion must remove only the queue marker and retain acceptance hourglass"
+            "live dispatch promotion must add the pending hourglass after removing the queue marker"
         );
         let persisted: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(persisted_path(channel_id, head)).expect("pending state"),

--- a/src/services/discord/queue_reactions.rs
+++ b/src/services/discord/queue_reactions.rs
@@ -26,10 +26,12 @@ pub(in crate::services::discord) fn drain_reactions_for_queue_exit(
 #[cfg(test)]
 mod tests {
     #[test]
-    fn drain_sets_include_reconcile_marker() {
+    fn drain_sets_include_only_queue_markers() {
         assert!(super::QUEUE_PENDING_REACTION_EMOJIS.contains(&'🔄'));
         assert!(super::QUEUE_STANDALONE_DRAIN_REACTION_EMOJIS.contains(&'🔄'));
         assert!(super::drain_reactions_for_queue_exit(true).contains(&'🔄'));
         assert!(super::drain_reactions_for_queue_exit(false).contains(&'🔄'));
+        assert!(!super::drain_reactions_for_queue_exit(true).contains(&'⏳'));
+        assert!(!super::drain_reactions_for_queue_exit(false).contains(&'⏳'));
     }
 }

--- a/src/services/discord/router/message_handler/intake_turn/race_loss.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss.rs
@@ -147,8 +147,8 @@ pub(super) async fn handle_race_loss_enqueue(
     // for the dispatch path to pick up. Skip the placeholder POST + the
     // mapping insert entirely — POSTing a fresh card here would orphan
     // it. `📬` reaction is also skipped (the prior live enqueue already
-    // owns the card and emoji). Only the matching start attempt may clear
-    // its own `⏳`; a delayed attempt must not erase a newer attempt's state.
+    // owns the card and emoji). Only the matching start attempt may clear its
+    // own pending `⏳`; a delayed attempt must not erase a newer attempt's state.
     if !enqueue_outcome.enqueued {
         mailbox_reaction::clear_rejected_attempt_pending(
             shared,
@@ -231,11 +231,10 @@ pub(super) async fn handle_race_loss_enqueue(
                 // later kickoff (or the deferred idle drain scheduled
                 // above) will dispatch it — `dispatch_queued_turn` ->
                 // `handle_text_message` will POST its own fresh card
-                // through the missing-mapping fallback. The user
-                // briefly sees `⏳` only and no `📬`, but the message
-                // WILL be processed correctly. Roll back the `⏳`
-                // sentinel so the user knows we did not silently
-                // accept the message.
+                // through the missing-mapping fallback. The user briefly
+                // sees no queue marker, but the message WILL be processed
+                // correctly. Roll back the pending `⏳` to the marker-only
+                // queued state so the user knows the message remains queued.
                 if let Some(turn_start_attempt) = turn_start_attempt {
                     crate::services::discord::turn_view_reconciler::note_intake_start_rolled_back_to_queued(
                         shared,
@@ -339,8 +338,8 @@ pub(super) async fn handle_race_loss_enqueue(
             // In all cases our POSTed placeholder is an orphan that no
             // future dispatch or queue-exit cleanup will ever reference
             // — drop the lock before the HTTP DELETE await, delete the
-            // orphan, remove the `⏳` reaction, and skip the mapping
-            // insert.
+            // orphan, clear the matching pending attempt, and skip the
+            // mapping insert.
             drop(persist_guard);
             let _ = channel_id.delete_message(http, placeholder_msg_id).await;
             crate::services::discord::turn_view_reconciler::note_intake_turn_cleared_current_if_attempt_matches(

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
@@ -266,11 +266,29 @@ async fn stale_start_attempt_repairs_mailbox_from_live_queue_truth() {
     let ops = shared.turn_view_reconciler.ops();
     assert_eq!(
         ops.iter()
+            .filter(|op| op.target.message_id == message_id && !op.add && op.emoji == '⏳')
+            .count(),
+        1,
+        "queue repair must remove the pending hourglass before adding the marker-only queued state"
+    );
+    assert_eq!(
+        ops.iter()
             .filter(|op| op.target.message_id == message_id && op.add && op.emoji == '⏳')
             .count(),
         1,
-        "queue repair must preserve the one acceptance hourglass without re-adding it"
+        "same-state redispatch must not add a second pending hourglass"
     );
+    let mut visible = Vec::new();
+    for op in ops.iter().filter(|op| op.target.message_id == message_id) {
+        if op.add {
+            if !visible.contains(&op.emoji) {
+                visible.push(op.emoji);
+            }
+        } else {
+            visible.retain(|emoji| *emoji != op.emoji);
+        }
+    }
+    assert_eq!(visible, vec!['📬']);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/src/services/discord/turn_bridge/followup_requeue.rs
+++ b/src/services/discord/turn_bridge/followup_requeue.rs
@@ -212,8 +212,9 @@ mod tests {
 
         let ops = shared.turn_view_reconciler.ops();
         assert!(
-            ops.iter()
-                .any(|op| { op.target.message_id == message_id && op.add && op.emoji == '⏳' })
+            !ops.iter()
+                .any(|op| { op.target.message_id == message_id && op.add && op.emoji == '⏳' }),
+            "queued retry must publish only its queue-kind marker"
         );
         assert!(ops.iter().any(|op| {
             op.target.message_id == message_id

--- a/src/services/discord/turn_view_reconciler.rs
+++ b/src/services/discord/turn_view_reconciler.rs
@@ -27,7 +27,8 @@ pub(in crate::services::discord) use orphan_sweep::sweep_orphan_tui_anchor_react
 const TURN_VIEW_REACTIONS: [char; 7] = ['📬', '➕', '🔄', '⏳', '✅', '⚠', '🛑'];
 const QUEUE_EXIT_FEEDBACK_REACTIONS: [char; 3] = ['🚫', '⌛', '⏏'];
 const PERSISTED_STATE_VERSION: u32 = 1;
-const QUEUED_HOURGLASS_STATE_VERSION: u32 = 2;
+const LEGACY_QUEUED_HOURGLASS_STATE_VERSION: u32 = 2;
+const QUEUED_MARKER_ONLY_STATE_VERSION: u32 = 3;
 const RECENTLY_FINALIZED_TARGET_MAX: usize = 1024;
 const RECENTLY_FINALIZED_TARGET_TTL: time::Duration = time::Duration::from_secs(10 * 60);
 
@@ -263,7 +264,7 @@ struct AppliedTarget {
     applied: TurnViewState,
     identity: ResolvedIdentity,
     start_attempt: Option<TurnStartAttempt>,
-    legacy_queue_marker: Option<char>,
+    legacy_queue_reactions: Vec<char>,
 }
 
 #[derive(Clone, Copy)]
@@ -410,7 +411,7 @@ impl TurnViewReconciler {
             start_attempt: (applied == TurnViewState::Pending)
                 .then_some(start_attempt)
                 .flatten(),
-            legacy_queue_marker: None,
+            legacy_queue_reactions: Vec::new(),
         }
     }
 
@@ -429,7 +430,7 @@ impl TurnViewReconciler {
             applied: TurnViewState::Pending,
             identity: current.identity.clone(),
             start_attempt: Some(start_attempt),
-            legacy_queue_marker: current.legacy_queue_marker,
+            legacy_queue_reactions: current.legacy_queue_reactions.clone(),
         };
         self.targets.insert(target, updated.clone());
         self.persist_target(target, &updated, shared, source);
@@ -857,10 +858,16 @@ impl TurnViewReconciler {
         if let Some(current) = current.as_ref() {
             if desired == TurnViewState::None
                 && clear_start_attempt.is_none()
-                && let Some(emoji) = current.legacy_queue_marker
+                && !current.legacy_queue_reactions.is_empty()
             {
                 let delivery = self
-                    .apply_reaction(shared, target, emoji, false, &current.identity, source)
+                    .remove_legacy_queue_reactions(
+                        shared,
+                        target,
+                        &current.legacy_queue_reactions,
+                        &current.identity,
+                        source,
+                    )
                     .await;
                 if delivery.delivered() || matches!(delivery, TurnViewDelivery::FailedPermanent) {
                     self.discard_target_locked(target, source, &target_lock);
@@ -1021,7 +1028,10 @@ impl TurnViewReconciler {
                 applied,
                 desired,
                 current.is_none(),
-                current.as_ref().and_then(|entry| entry.legacy_queue_marker),
+                current
+                    .as_ref()
+                    .map(|entry| entry.legacy_queue_reactions.as_slice())
+                    .unwrap_or_default(),
                 &resolved_identity,
                 source,
             )
@@ -1110,9 +1120,15 @@ impl TurnViewReconciler {
         };
 
         if current.applied != expected_state {
-            if current.owner == owner && current.legacy_queue_marker == Some(emoji) {
+            if current.owner == owner && current.legacy_queue_reactions.contains(&emoji) {
                 let delivery = self
-                    .apply_reaction(shared, target, emoji, false, &current.identity, source)
+                    .remove_legacy_queue_reactions(
+                        shared,
+                        target,
+                        &current.legacy_queue_reactions,
+                        &current.identity,
+                        source,
+                    )
                     .await;
                 if delivery.delivered() || matches!(delivery, TurnViewDelivery::FailedPermanent) {
                     self.discard_target_locked(target, source, &target_lock);
@@ -1416,7 +1432,9 @@ impl TurnViewReconciler {
         };
         if !matches!(
             record.version,
-            PERSISTED_STATE_VERSION | QUEUED_HOURGLASS_STATE_VERSION
+            PERSISTED_STATE_VERSION
+                | LEGACY_QUEUED_HOURGLASS_STATE_VERSION
+                | QUEUED_MARKER_ONLY_STATE_VERSION
         ) || record.provider != shared.provider.as_str()
             || TurnViewTargetKind::from_str(&record.kind) != Some(target.kind)
             || record.channel_id != target.channel_id.get()
@@ -1450,13 +1468,20 @@ impl TurnViewReconciler {
             return None;
         }
         let identity = self.resolve_persisted_identity(&record, shared, source)?;
-        let legacy_queue_marker = (record.version == PERSISTED_STATE_VERSION
-            && recorded_applied.is_queue_marker())
-        .then(|| reaction_set::for_state(recorded_applied)[0]);
-        let applied = if legacy_queue_marker.is_some() {
-            TurnViewState::None
-        } else {
+        let legacy_queue_reactions = match record.version {
+            PERSISTED_STATE_VERSION if recorded_applied.is_queue_marker() => {
+                vec![reaction_set::for_state(recorded_applied)[0]]
+            }
+            LEGACY_QUEUED_HOURGLASS_STATE_VERSION if recorded_applied.is_queue_marker() => vec![
+                reaction_set::for_state(recorded_applied)[0],
+                reaction_set::for_state(TurnViewState::Pending)[0],
+            ],
+            _ => Vec::new(),
+        };
+        let applied = if legacy_queue_reactions.is_empty() {
             recorded_applied
+        } else {
+            TurnViewState::None
         };
         let mut target = Self::applied_target(
             TurnViewOwner::new(record.owner_generation, record.owner_turn_id),
@@ -1464,7 +1489,7 @@ impl TurnViewReconciler {
             identity,
             record.start_attempt_id.map(TurnStartAttempt),
         );
-        target.legacy_queue_marker = legacy_queue_marker;
+        target.legacy_queue_reactions = legacy_queue_reactions;
         Some(target)
     }
 
@@ -1475,7 +1500,7 @@ impl TurnViewReconciler {
         shared: &SharedData,
         source: &'static str,
     ) {
-        if applied.applied == TurnViewState::None && applied.legacy_queue_marker.is_none() {
+        if applied.applied == TurnViewState::None && applied.legacy_queue_reactions.is_empty() {
             self.delete_persisted_target(target, source);
             return;
         }
@@ -1483,12 +1508,15 @@ impl TurnViewReconciler {
             return;
         };
         let applied_state = applied
-            .legacy_queue_marker
-            .and_then(TurnViewState::from_queue_marker_emoji)
+            .legacy_queue_reactions
+            .iter()
+            .find_map(|emoji| TurnViewState::from_queue_marker_emoji(*emoji))
             .unwrap_or(applied.applied);
         let record = PersistedTargetState {
-            version: if applied.applied.is_queue_marker() || applied.legacy_queue_marker.is_some() {
-                QUEUED_HOURGLASS_STATE_VERSION
+            version: if applied.applied.is_queue_marker()
+                || !applied.legacy_queue_reactions.is_empty()
+            {
+                QUEUED_MARKER_ONLY_STATE_VERSION
             } else {
                 PERSISTED_STATE_VERSION
             },
@@ -1539,7 +1567,7 @@ impl TurnViewReconciler {
         applied: TurnViewState,
         desired: TurnViewState,
         cold: bool,
-        legacy_queue_marker: Option<char>,
+        legacy_queue_reactions: &[char],
         identity: &ResolvedIdentity,
         source: &'static str,
     ) -> TurnViewDelivery {
@@ -1563,9 +1591,15 @@ impl TurnViewReconciler {
             return delivery;
         }
 
-        if let Some(emoji) = legacy_queue_marker {
+        if !legacy_queue_reactions.is_empty() {
             let delivery = self
-                .apply_reaction(shared, target, emoji, false, identity, source)
+                .remove_legacy_queue_reactions(
+                    shared,
+                    target,
+                    legacy_queue_reactions,
+                    identity,
+                    source,
+                )
                 .await;
             if !delivery.delivered() {
                 return delivery;
@@ -1573,6 +1607,29 @@ impl TurnViewReconciler {
         }
         self.apply_diff(shared, target, applied, desired, identity, source)
             .await
+    }
+
+    async fn remove_legacy_queue_reactions(
+        &self,
+        shared: &SharedData,
+        target: TurnViewTarget,
+        reactions: &[char],
+        identity: &ResolvedIdentity,
+        source: &'static str,
+    ) -> TurnViewDelivery {
+        let mut removed = Vec::new();
+        for emoji in reactions {
+            let delivery = self
+                .apply_reaction(shared, target, *emoji, false, identity, source)
+                .await;
+            if !delivery.delivered() {
+                self.compensate_reaction_ops(shared, target, identity, source, &removed)
+                    .await;
+                return delivery;
+            }
+            removed.push((*emoji, false));
+        }
+        TurnViewDelivery::Delivered
     }
 
     async fn apply_diff(

--- a/src/services/discord/turn_view_reconciler/reaction_set.rs
+++ b/src/services/discord/turn_view_reconciler/reaction_set.rs
@@ -1,9 +1,9 @@
 use super::TurnViewState;
 
 const NONE: &[char] = &[];
-const QUEUED: &[char] = &['📬', '⏳'];
-const QUEUED_MERGED: &[char] = &['➕', '⏳'];
-const QUEUED_RECONCILE: &[char] = &['🔄', '⏳'];
+const QUEUED: &[char] = &['📬'];
+const QUEUED_MERGED: &[char] = &['➕'];
+const QUEUED_RECONCILE: &[char] = &['🔄'];
 const PENDING: &[char] = &['⏳'];
 const COMPLETED: &[char] = &['✅'];
 const FAILED: &[char] = &['⚠'];

--- a/src/services/discord/turn_view_reconciler/tests.rs
+++ b/src/services/discord/turn_view_reconciler/tests.rs
@@ -199,7 +199,7 @@ async fn sequence_start_complete_leaves_only_completed_reaction() {
 }
 
 #[tokio::test]
-async fn queued_then_started_swaps_queue_marker_to_hourglass_without_residue() {
+async fn queued_then_started_swaps_queue_marker_for_new_hourglass_without_residue() {
     let _root = scoped_runtime_root();
     let reconciler = note_sequence(&[TurnViewState::Queued, TurnViewState::Pending]).await;
 
@@ -208,17 +208,10 @@ async fn queued_then_started_swaps_queue_marker_to_hourglass_without_residue() {
         vec![expected('⏳', "intake-a")]
     );
     let ops = reconciler.ops();
-    assert!(ops.iter().any(|op| op.add && op.emoji == '📬'));
-    assert!(ops.iter().any(|op| !op.add && op.emoji == '📬'));
-    assert!(ops.iter().any(|op| op.add && op.emoji == '⏳'));
-    assert!(
-        !ops.iter().any(|op| !op.add && op.emoji == '⏳'),
-        "processing start keeps the queue-acceptance hourglass in place"
-    );
-    assert!(
-        !snapshot_reactions(&reconciler, target())
-            .iter()
-            .any(|(emoji, _)| *emoji == '📬')
+    assert_eq!(
+        ops.iter().map(|op| (op.emoji, op.add)).collect::<Vec<_>>(),
+        vec![('📬', true), ('📬', false), ('⏳', true)],
+        "queued promotion must remove the queue marker and add a fresh pending hourglass"
     );
 }
 
@@ -246,6 +239,41 @@ async fn queued_started_completed_uses_one_identity_and_leaves_checkmark() {
 }
 
 #[tokio::test]
+async fn queued_states_are_marker_only() {
+    let _root = scoped_runtime_root();
+
+    for (index, state, emoji) in [
+        (0, TurnViewState::Queued, '📬'),
+        (1, TurnViewState::QueuedMerged, '➕'),
+        (2, TurnViewState::QueuedReconcile, '🔄'),
+    ] {
+        let reconciler = TurnViewReconciler::default();
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let target = target_with(100_000_000_000_121 + index, 100_000_000_000_125 + index);
+        clear_persisted(target);
+        reconciler
+            .note_state(
+                &shared,
+                target,
+                owner(34, "marker-only"),
+                TurnViewIdentity::Test("intake-a"),
+                state,
+                "test_marker_only_queue_state",
+            )
+            .await;
+
+        assert_eq!(
+            snapshot_reactions(&reconciler, target),
+            vec![expected(emoji, "intake-a")]
+        );
+        assert!(
+            !reconciler.ops().iter().any(|op| op.add && op.emoji == '⏳'),
+            "queued state {state:?} must not add an hourglass"
+        );
+    }
+}
+
+#[tokio::test]
 async fn requeue_renotification_of_queued_target_is_coalesced_noop() {
     let _root = scoped_runtime_root();
     let reconciler = note_sequence(&[TurnViewState::Queued, TurnViewState::Queued]).await;
@@ -254,7 +282,7 @@ async fn requeue_renotification_of_queued_target_is_coalesced_noop() {
     assert_eq!(ops.iter().filter(|op| op.emoji == '📬').count(), 1);
     assert_eq!(
         snapshot_reactions(&reconciler, target()),
-        vec![expected('📬', "intake-a"), expected('⏳', "intake-a")]
+        vec![expected('📬', "intake-a")]
     );
 }
 
@@ -310,7 +338,7 @@ async fn regression_4109_pre_migration_untracked_queue_markers_still_remove_reac
 }
 
 #[tokio::test]
-async fn regression_4248_start_rollback_to_queued_keeps_hourglass_and_cancel_cleans() {
+async fn regression_4248_start_rollback_to_queued_removes_hourglass_and_cancel_cleans() {
     let _root = scoped_runtime_root();
     let reconciler = TurnViewReconciler::default();
     let shared = crate::services::discord::make_shared_data_for_tests();
@@ -346,11 +374,12 @@ async fn regression_4248_start_rollback_to_queued_keeps_hourglass_and_cancel_cle
         .await;
 
     let ops = reconciler.ops();
-    assert_eq!(ops.len(), 2);
-    assert!(ops[1].emoji == '📬' && ops[1].add);
+    assert_eq!(ops.len(), 3);
+    assert!(!ops[1].add && ops[1].emoji == '⏳');
+    assert!(ops[2].add && ops[2].emoji == '📬');
     assert_eq!(
         snapshot_reactions(&reconciler, target),
-        vec![expected('⏳', "intake-a"), expected('📬', "intake-a")]
+        vec![expected('📬', "intake-a")]
     );
     assert_eq!(
         reconciler
@@ -625,7 +654,7 @@ async fn regression_4049_stale_clear_after_newer_rollback_keeps_queued_marker() 
 
     assert_eq!(
         snapshot_reactions(&reconciler, target),
-        vec![expected('⏳', "intake-a"), expected('📬', "intake-a")]
+        vec![expected('📬', "intake-a")]
     );
     let current = reconciler
         .targets
@@ -656,7 +685,7 @@ async fn regression_4049_stale_clear_after_newer_rollback_keeps_queued_marker() 
     );
     assert_eq!(
         snapshot_reactions(&reconciler, target),
-        vec![expected('⏳', "intake-a"), expected('📬', "intake-a")],
+        vec![expected('📬', "intake-a")],
         "stale attempt1 clear must not remove the newer queued state"
     );
     let current = reconciler
@@ -693,22 +722,29 @@ async fn persisted_v1_queued_state_is_invalidated_for_reapplication() {
 
     assert_eq!(
         snapshot_reactions(&reconciler, target),
-        vec![expected('📬', "intake-a"), expected('⏳', "intake-a")],
-        "v1 queued records predate the hourglass contract and must not short-circuit reapplication"
+        vec![expected('📬', "intake-a")],
+        "v1 queued records must be re-applied under the marker-only contract"
     );
-    let text = std::fs::read_to_string(persisted_path(target)).expect("rewritten v2 state");
-    let rewritten: PersistedTargetState = serde_json::from_str(&text).expect("parse v2 state");
-    assert_eq!(rewritten.version, QUEUED_HOURGLASS_STATE_VERSION);
+    let text = std::fs::read_to_string(persisted_path(target)).expect("rewritten v3 state");
+    let rewritten: PersistedTargetState = serde_json::from_str(&text).expect("parse v3 state");
+    assert_eq!(rewritten.version, QUEUED_MARKER_ONLY_STATE_VERSION);
 }
 
 #[tokio::test]
-async fn persisted_v1_queued_promotion_clears_legacy_marker_before_pending() {
+async fn persisted_v2_queued_promotion_clears_legacy_set_before_pending() {
     let _root = scoped_runtime_root();
     let shared = crate::services::discord::make_shared_data_for_tests();
     let target = target_with(100_000_000_000_165, 100_000_000_000_166);
     clear_persisted(target);
     let provider = shared.provider.as_str().to_string();
-    let record = persisted_queue_record(&shared, target, &provider, "queued", "intake-a");
+    let mut record = persisted_record_with_version(
+        &shared,
+        target,
+        &provider,
+        "queued",
+        LEGACY_QUEUED_HOURGLASS_STATE_VERSION,
+    );
+    record.identity_label = "intake-a".to_string();
     write_persisted(&record, target);
 
     let reconciler = TurnViewReconciler::default();
@@ -719,21 +755,23 @@ async fn persisted_v1_queued_promotion_clears_legacy_marker_before_pending() {
             owner(92, "persisted"),
             TurnViewIdentity::Test("intake-a"),
             TurnViewState::Pending,
-            "test_v1_queue_promotion",
+            "test_v2_queue_promotion",
         )
         .await;
 
     assert_eq!(
         snapshot_reactions(&reconciler, target),
         vec![expected('⏳', "intake-a")],
-        "v1 queue promotion must explicitly remove the legacy queue marker before adding pending"
+        "v2 queue promotion must remove legacy queue reactions before adding pending"
     );
-    let ops = reconciler.ops();
-    assert!(
-        !ops[0].add && ops[0].emoji == '📬',
-        "legacy queue marker clear must precede the fresh pending add"
+    assert_eq!(
+        reconciler
+            .ops()
+            .iter()
+            .map(|op| (op.emoji, op.add))
+            .collect::<Vec<_>>(),
+        vec![('📬', false), ('⏳', false), ('⏳', true)]
     );
-    assert!(ops[1].add && ops[1].emoji == '⏳');
 }
 
 #[tokio::test]
@@ -1019,7 +1057,7 @@ async fn queued_cancel_ignores_nonmatching_generation() {
     assert_eq!(reconciler.ops().len(), ops_after_queue);
     assert_eq!(
         snapshot_reactions(&reconciler, target),
-        vec![expected('📬', "intake-a"), expected('⏳', "intake-a")]
+        vec![expected('📬', "intake-a")]
     );
     assert!(persisted_exists(target));
     assert_eq!(
@@ -1529,33 +1567,32 @@ async fn regression_4041_duplicate_transitions_are_coalesced() {
 }
 
 #[tokio::test]
-async fn partial_queue_apply_failure_compensates_prior_hourglass() {
+async fn failed_queue_marker_apply_leaves_no_persisted_state() {
     let _root = scoped_runtime_root();
     let shared = crate::services::discord::make_shared_data_for_tests();
     let target = target_with(100_000_000_000_591, 100_000_000_000_592);
     clear_persisted(target);
-    let reconciler = TurnViewReconciler::with_test_deliveries(vec![
-        TurnViewDelivery::Failed,
-        TurnViewDelivery::Delivered,
-        TurnViewDelivery::Delivered,
-    ]);
+    let reconciler = TurnViewReconciler::with_test_deliveries(vec![TurnViewDelivery::Failed]);
 
     let delivery = reconciler
         .note_state_delivery(
             &shared,
             target,
-            owner(29, "partial-queue"),
+            owner(29, "failed-queue-marker"),
             TurnViewIdentity::Test("intake-a"),
             TurnViewState::Queued,
-            "test_partial_queue_apply",
+            "test_failed_queue_marker_apply",
         )
         .await;
 
     assert_eq!(delivery, TurnViewDelivery::Failed);
     assert_eq!(
-        snapshot_reactions(&reconciler, target),
-        vec![expected('📬', "intake-a")],
-        "partial failure must leave no orphan hourglass and restore pre-transition state"
+        reconciler
+            .ops()
+            .iter()
+            .map(|op| (op.emoji, op.add))
+            .collect::<Vec<_>>(),
+        vec![('📬', true)]
     );
     assert!(!persisted_exists(target));
 }


### PR DESCRIPTION
## 변경 요약
- `Queued`/`QueuedMerged`/`QueuedReconcile` 리액션 세트를 각각 📬/➕/🔄 단독으로 변경
- `Queued* → Pending` 전환에서 큐 마커 제거 후 새 ⏳ 추가를 target-set diff 테스트로 고정
- 기존 v2 큐 상태(큐 마커+⏳)를 v3 marker-only 스키마로 수렴해 재시작 뒤 잔존 ⏳까지 정리
- queue drain, race-loss mailbox repair, pre-submit requeue 테스트의 marker-only 계약을 동기화

## 검증
- `cargo fmt --check`
- `CARGO_BUILD_JOBS=4 cargo check --lib`
- `CARGO_BUILD_JOBS=4 cargo test --lib turn_view_reconciler` (46 passed)
- `CARGO_BUILD_JOBS=4 cargo test --lib queue` (399 passed, 2 ignored)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`

Closes #4606