### PR TITLE
fix(dashboard): runtime validation for kanban status/timestamp + office terminal parity (#4520)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 - [ ] **시안에 없는 기존 기능을 임의로 삭제하지 않았다.** Reference 시안(redesign reference)에서 빠진 위젯·필터·탭이라도 기존 dashboard에 있던 기능은 사용자 명시 제거 요청 없이 삭제하지 않는다. 시안의 톤·간격·타이포에 맞춰 확장하거나 별도 sub-issue로 분리한다. (관련 결정: #1254 audit, 2026-04-15 결정 기록)
 - [ ] 에이전트 아바타는 sprite 컴포넌트(`AgentAvatar`)로 표시한다. inline `${emoji} ${name}` 문자열 패턴은 sprite 또는 name-only로 대체한다 (#1251 / #1254).
 - [ ] 추가 또는 변경한 위젯이 mobile/desktop 모두에서 깨지지 않는다.
+- [ ] 새 dashboard API 엔드포인트는 zod 응답 스키마를 정의하고 `request`의 parser 인자로 전달한다 (#4520).
 
 ## Closes
 <!-- e.g. Closes #1234 -->

--- a/dashboard/src/api/client.test.ts
+++ b/dashboard/src/api/client.test.ts
@@ -152,7 +152,7 @@ describe("kanban dispatch mutation responses", () => {
     ).rejects.toThrow(/transition[\s\S]*error/);
   });
 
-  it("returns the full retry contract instead of dropping dispatch fields", async () => {
+  it("returns the full retry contract without changing server timestamps", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse({
         card,
@@ -166,10 +166,62 @@ describe("kanban dispatch mutation responses", () => {
     const result = await retryKanbanCard("card-1", { request_now: true });
 
     expect(result.card.id).toBe("card-1");
-    expect(result.card.created_at).toBe(Date.parse(card.created_at));
+    expect(result.card.created_at).toBe(card.created_at);
+    expect(typeof result.card.created_at).toBe("string");
     expect(result.new_dispatch_id).toBe("dispatch-new");
     expect(result.cancelled_dispatch_id).toBeNull();
     expect(result.next_action).toBe("none_required");
+  });
+
+  it.each(["failed", "cancelled"])(
+    "accepts the %s server status and preserves PostgreSQL timestamps",
+    async (status) => {
+      const postgresTimestamp = "2026-07-17 00:00:00+00";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockJsonResponse({
+            card: {
+              ...card,
+              status,
+              created_at: postgresTimestamp,
+              updated_at: postgresTimestamp,
+            },
+            new_dispatch_id: null,
+            cancelled_dispatch_id: "dispatch-old",
+            next_action: "none_required",
+          }),
+        ),
+      );
+
+      const result = await retryKanbanCard("card-1");
+
+      expect(result.card.status).toBe(status);
+      expect(result.card.created_at).toBe(postgresTimestamp);
+      expect(typeof result.card.created_at).toBe("string");
+    },
+  );
+
+  it.each([
+    { label: "custom", priority: "critical_path" },
+    { label: "empty", priority: "" },
+    { label: "whitespace-only", priority: "   " },
+  ])("accepts and preserves $label server priority strings", async ({ priority }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          card: { ...card, priority },
+          new_dispatch_id: null,
+          cancelled_dispatch_id: null,
+          next_action: "none_required",
+        }),
+      ),
+    );
+
+    const result = await retryKanbanCard("card-1");
+
+    expect(result.card.priority).toBe(priority);
   });
 
   it("rejects retry responses with malformed Kanban cards", async () => {
@@ -177,7 +229,7 @@ describe("kanban dispatch mutation responses", () => {
       "fetch",
       vi.fn().mockResolvedValue(
         mockJsonResponse({
-          card: { ...card, status: "unexpected" },
+          card: { ...card, status: "Unexpected status" },
           new_dispatch_id: "dispatch-new",
           cancelled_dispatch_id: null,
           next_action: "none_required",

--- a/dashboard/src/api/client.test.ts
+++ b/dashboard/src/api/client.test.ts
@@ -176,7 +176,7 @@ describe("kanban dispatch mutation responses", () => {
   it.each(["failed", "cancelled"])(
     "accepts the %s server status and preserves PostgreSQL timestamps",
     async (status) => {
-      const postgresTimestamp = "2026-07-17 00:00:00+00";
+      const postgresTimestamp = "2026-07-17 00:00:00.123456+00";
       vi.stubGlobal(
         "fetch",
         vi.fn().mockResolvedValue(

--- a/dashboard/src/api/client.test.ts
+++ b/dashboard/src/api/client.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import {
   assignKanbanIssue,
   getDispatchDeliveryEvents,
   getSkillRanking,
   onApiError,
+  readCachedGet,
   redispatchKanbanCard,
   request,
   retryKanbanCard,
@@ -13,8 +15,29 @@ import {
 const card = {
   id: "card-1",
   title: "Contract card",
+  description: null,
   status: "requested",
+  github_repo: "itismyfield/AgentDesk",
+  owner_agent_id: null,
+  requester_agent_id: null,
+  assignee_agent_id: "agent-1",
+  parent_card_id: null,
+  latest_dispatch_id: null,
+  sort_order: 0,
   priority: "medium",
+  depth: 0,
+  blocked_reason: null,
+  review_notes: null,
+  github_issue_number: 1733,
+  github_issue_url: "https://github.com/itismyfield/AgentDesk/issues/1733",
+  metadata_json: null,
+  pipeline_stage_id: null,
+  review_status: null,
+  created_at: "2026-07-17T00:00:00Z",
+  updated_at: "2026-07-17T00:00:00Z",
+  started_at: null,
+  requested_at: null,
+  completed_at: null,
 };
 
 function mockJsonResponse(body: unknown): Response {
@@ -36,6 +59,34 @@ function mockErrorResponse(status: number, body: unknown): Response {
 afterEach(() => {
   onApiError(null);
   vi.unstubAllGlobals();
+});
+
+describe("runtime response parsing", () => {
+  it("returns and caches the parser output instead of the raw GET payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockJsonResponse({ value: "42" })),
+    );
+    const endpoint = "/api/parser-output";
+    const schema = z.object({ value: z.coerce.number() });
+
+    const result = await request(endpoint, undefined, schema);
+
+    expect(result).toEqual({ value: 42 });
+    expect(readCachedGet(endpoint)?.data).toEqual({ value: 42 });
+  });
+
+  it("rejects invalid GET payloads before they reach the response cache", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockJsonResponse({ value: "invalid" })),
+    );
+    const endpoint = "/api/parser-rejection";
+    const schema = z.object({ value: z.number() });
+
+    await expect(request(endpoint, undefined, schema)).rejects.toThrow();
+    expect(readCachedGet(endpoint)).toBeNull();
+  });
 });
 
 describe("global API error reporting", () => {
@@ -98,7 +149,7 @@ describe("kanban dispatch mutation responses", () => {
         title: "Contract card",
         assignee_agent_id: "agent-1",
       }),
-    ).rejects.toThrow("missing required field 'error'");
+    ).rejects.toThrow(/transition[\s\S]*error/);
   });
 
   it("returns the full retry contract instead of dropping dispatch fields", async () => {
@@ -115,9 +166,26 @@ describe("kanban dispatch mutation responses", () => {
     const result = await retryKanbanCard("card-1", { request_now: true });
 
     expect(result.card.id).toBe("card-1");
+    expect(result.card.created_at).toBe(Date.parse(card.created_at));
     expect(result.new_dispatch_id).toBe("dispatch-new");
     expect(result.cancelled_dispatch_id).toBeNull();
     expect(result.next_action).toBe("none_required");
+  });
+
+  it("rejects retry responses with malformed Kanban cards", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          card: { ...card, status: "unexpected" },
+          new_dispatch_id: "dispatch-new",
+          cancelled_dispatch_id: null,
+          next_action: "none_required",
+        }),
+      ),
+    );
+
+    await expect(retryKanbanCard("card-1")).rejects.toThrow(/card[\s\S]*status/);
   });
 
   it("rejects redispatch responses that omit required contract fields", async () => {
@@ -133,7 +201,7 @@ describe("kanban dispatch mutation responses", () => {
     );
 
     await expect(redispatchKanbanCard("card-1")).rejects.toThrow(
-      "missing required field 'next_action'",
+      /next_action/,
     );
   });
 });

--- a/dashboard/src/api/httpClient.ts
+++ b/dashboard/src/api/httpClient.ts
@@ -8,6 +8,10 @@ export const SLOW_MUTATION_TIMEOUT_MS = 60_000;
 const MAX_RETRIES = 2;
 const INITIAL_BACKOFF_MS = 500;
 
+export interface Parser<T> {
+  parse(value: unknown): T;
+}
+
 // ── GET deduplication ──
 const inflightGets = new Map<string, Promise<unknown>>();
 export interface CachedGetEntry<T = unknown> {
@@ -144,7 +148,11 @@ export function readCachedSnapshot<T>(url: string): CachedApiSnapshot<T> | null 
   };
 }
 
-export async function request<T>(url: string, opts?: RequestOptions): Promise<T> {
+export async function request<T>(
+  url: string,
+  opts?: RequestOptions,
+  parser?: Parser<T>,
+): Promise<T> {
   const method = opts?.method?.toUpperCase() ?? "GET";
   const isGet = method === "GET";
   const shouldDedupe = isGet && !opts?.signal;
@@ -206,9 +214,10 @@ export async function request<T>(url: string, opts?: RequestOptions): Promise<T>
           }
           throw error;
         }
-        const payload = await res.json();
+        const rawPayload: unknown = await res.json();
+        const payload = parser ? parser.parse(rawPayload) : (rawPayload as T);
         if (isGet) {
-          // #2050 P3 finding 12/17 — bounded cache + fresh=1 normalization.
+          // Only validated payloads reach this cache when a parser is supplied.
           storeCachedGet(url, payload);
         }
         return payload;

--- a/dashboard/src/api/kanban.ts
+++ b/dashboard/src/api/kanban.ts
@@ -45,10 +45,7 @@ export async function deleteKanbanCard(id: string): Promise<void> {
 }
 
 const nonEmptyStringSchema = z.string().trim().min(1);
-const timestampSchema = z.string().refine(
-  (value) => Number.isFinite(Date.parse(value)),
-  { message: "Invalid timestamp" },
-);
+const timestampSchema = z.string();
 const nullableTimestampSchema = timestampSchema.nullable();
 const kanbanCardStatusSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
 

--- a/dashboard/src/api/kanban.ts
+++ b/dashboard/src/api/kanban.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { KanbanCard, KanbanRepoSource } from "../types";
 import { request, SLOW_MUTATION_TIMEOUT_MS } from "./httpClient";
 
@@ -42,78 +44,70 @@ export async function deleteKanbanCard(id: string): Promise<void> {
   await request(`/api/kanban-cards/${id}`, { method: "DELETE" });
 }
 
-export interface KanbanDispatchMutationResponse {
-  card: KanbanCard;
-  new_dispatch_id: string | null;
-  cancelled_dispatch_id: string | null;
-  next_action: string;
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function hasOwn(value: Record<string, unknown>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(value, key);
-}
-
-function requireFields(
-  endpoint: string,
-  value: Record<string, unknown>,
-  keys: string[],
-): void {
-  for (const key of keys) {
-    if (!hasOwn(value, key)) {
-      throw new Error(
-        `${endpoint} response contract invalid: missing required field '${key}'`,
-      );
+const nonEmptyStringSchema = z.string().trim().min(1);
+const timestampSchema = z
+  .union([z.string(), z.number()])
+  .transform((value, context) => {
+    const timestamp = typeof value === "number" ? value : Date.parse(value);
+    if (!Number.isFinite(timestamp)) {
+      context.addIssue({ code: "custom", message: "Invalid timestamp" });
+      return z.NEVER;
     }
-  }
-}
+    return timestamp;
+  });
+const nullableTimestampSchema = timestampSchema.nullable();
+const kanbanCardStatusSchema = z.enum([
+  "backlog",
+  "ready",
+  "requested",
+  "blocked",
+  "in_progress",
+  "review",
+  "done",
+  "qa_pending",
+  "qa_in_progress",
+  "qa_failed",
+]);
+const kanbanCardPrioritySchema = z.enum(["low", "medium", "high", "urgent"]);
 
-function parseKanbanDispatchMutationResponse(
-  endpoint: string,
-  raw: unknown,
-): KanbanDispatchMutationResponse {
-  if (!isObjectRecord(raw)) {
-    throw new Error(`${endpoint} response contract invalid: expected object`);
-  }
-  requireFields(endpoint, raw, [
-    "card",
-    "new_dispatch_id",
-    "cancelled_dispatch_id",
-    "next_action",
-  ]);
-  if (!isObjectRecord(raw.card)) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'card' must be an object`,
-    );
-  }
-  if (raw.new_dispatch_id !== null && typeof raw.new_dispatch_id !== "string") {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'new_dispatch_id' must be string or null`,
-    );
-  }
-  if (
-    raw.cancelled_dispatch_id !== null &&
-    typeof raw.cancelled_dispatch_id !== "string"
-  ) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'cancelled_dispatch_id' must be string or null`,
-    );
-  }
-  if (typeof raw.next_action !== "string" || raw.next_action.trim() === "") {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'next_action' must be a non-empty string`,
-    );
-  }
-  return {
-    card: raw.card as unknown as KanbanCard,
-    new_dispatch_id: raw.new_dispatch_id,
-    cancelled_dispatch_id: raw.cancelled_dispatch_id,
-    next_action: raw.next_action,
-  };
-}
+const kanbanCardSchema = z.looseObject({
+  id: nonEmptyStringSchema,
+  title: z.string(),
+  description: z.string().nullable(),
+  status: kanbanCardStatusSchema,
+  github_repo: z.string().nullable(),
+  owner_agent_id: z.string().nullable(),
+  requester_agent_id: z.string().nullable(),
+  assignee_agent_id: z.string().nullable(),
+  parent_card_id: z.string().nullable(),
+  latest_dispatch_id: z.string().nullable(),
+  sort_order: z.number(),
+  priority: kanbanCardPrioritySchema,
+  depth: z.number(),
+  blocked_reason: z.string().nullable(),
+  review_notes: z.string().nullable(),
+  github_issue_number: z.number().nullable(),
+  github_issue_url: z.string().nullable(),
+  metadata_json: z.string().nullable(),
+  pipeline_stage_id: z.string().nullable(),
+  review_status: z.string().nullable(),
+  created_at: timestampSchema,
+  updated_at: timestampSchema,
+  started_at: nullableTimestampSchema,
+  requested_at: nullableTimestampSchema,
+  completed_at: nullableTimestampSchema,
+}) satisfies z.ZodType<KanbanCard>;
+
+const kanbanDispatchMutationResponseSchema = z.object({
+  card: kanbanCardSchema,
+  new_dispatch_id: z.string().nullable(),
+  cancelled_dispatch_id: z.string().nullable(),
+  next_action: nonEmptyStringSchema,
+});
+
+export type KanbanDispatchMutationResponse = z.infer<
+  typeof kanbanDispatchMutationResponseSchema
+>;
 
 export async function retryKanbanCard(
   id: string,
@@ -122,12 +116,15 @@ export async function retryKanbanCard(
   const endpoint = `/api/kanban-cards/${id}/retry`;
   // #2050 P3 finding 15 — retry hits GitHub + Discord; 15s would race
   // ahead of a still-processing server. Bump to 60s.
-  const res = await request<unknown>(endpoint, {
-    method: "POST",
-    body: JSON.stringify(payload ?? {}),
-    timeoutMs: SLOW_MUTATION_TIMEOUT_MS,
-  });
-  return parseKanbanDispatchMutationResponse(endpoint, res);
+  return request(
+    endpoint,
+    {
+      method: "POST",
+      body: JSON.stringify(payload ?? {}),
+      timeoutMs: SLOW_MUTATION_TIMEOUT_MS,
+    },
+    kanbanDispatchMutationResponseSchema,
+  );
 }
 
 export async function redispatchKanbanCard(
@@ -136,12 +133,15 @@ export async function redispatchKanbanCard(
 ): Promise<KanbanDispatchMutationResponse> {
   const endpoint = `/api/kanban-cards/${id}/redispatch`;
   // #2050 P3 finding 15 — same external-I/O envelope as retry.
-  const res = await request<unknown>(endpoint, {
-    method: "POST",
-    body: JSON.stringify(payload ?? {}),
-    timeoutMs: SLOW_MUTATION_TIMEOUT_MS,
-  });
-  return parseKanbanDispatchMutationResponse(endpoint, res);
+  return request(
+    endpoint,
+    {
+      method: "POST",
+      body: JSON.stringify(payload ?? {}),
+      timeoutMs: SLOW_MUTATION_TIMEOUT_MS,
+    },
+    kanbanDispatchMutationResponseSchema,
+  );
 }
 
 export async function patchKanbanDeferDod(
@@ -163,119 +163,47 @@ export async function patchKanbanDeferDod(
   return res.card;
 }
 
-export interface AssignmentResult {
-  ok: boolean;
-  agent_id: string;
-}
+const assignmentResultSchema = z.object({
+  ok: z.boolean(),
+  agent_id: nonEmptyStringSchema,
+});
 
-export interface AssignmentTransitionResult {
-  attempted: boolean;
-  ok: boolean;
-  from?: string;
-  to?: string;
-  target?: string;
-  target_status: string;
-  next_action: string;
-  steps?: string[];
-  completed_steps?: Array<{ from?: string; to?: string; changed?: boolean }>;
-  failed_step?: string;
-  error: string | null;
-}
+const assignmentTransitionResultSchema = z.object({
+  attempted: z.boolean(),
+  ok: z.boolean(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  target: z.string().optional(),
+  target_status: nonEmptyStringSchema,
+  next_action: nonEmptyStringSchema,
+  steps: z.array(z.string()).optional(),
+  completed_steps: z
+    .array(
+      z.object({
+        from: z.string().optional(),
+        to: z.string().optional(),
+        changed: z.boolean().optional(),
+      }),
+    )
+    .optional(),
+  failed_step: z.string().optional(),
+  error: z.string().nullable(),
+});
 
-export interface AssignKanbanIssueResponse {
-  card: KanbanCard;
-  deduplicated?: boolean;
-  assignment: AssignmentResult;
-  transition: AssignmentTransitionResult;
-}
+const assignKanbanIssueResponseSchema = z.object({
+  card: kanbanCardSchema,
+  deduplicated: z.boolean().optional(),
+  assignment: assignmentResultSchema,
+  transition: assignmentTransitionResultSchema,
+});
 
-function parseAssignKanbanIssueResponse(
-  endpoint: string,
-  raw: unknown,
-): AssignKanbanIssueResponse {
-  if (!isObjectRecord(raw)) {
-    throw new Error(`${endpoint} response contract invalid: expected object`);
-  }
-  requireFields(endpoint, raw, ["card", "assignment", "transition"]);
-
-  const assignment = raw.assignment;
-  const transition = raw.transition;
-  if (!isObjectRecord(raw.card)) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'card' must be an object`,
-    );
-  }
-  if (!isObjectRecord(assignment)) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'assignment' must be an object`,
-    );
-  }
-  if (!isObjectRecord(transition)) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'transition' must be an object`,
-    );
-  }
-
-  requireFields(endpoint, assignment, ["ok", "agent_id"]);
-  requireFields(endpoint, transition, [
-    "attempted",
-    "ok",
-    "target_status",
-    "error",
-    "next_action",
-  ]);
-
-  if (typeof assignment.ok !== "boolean") {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'assignment.ok' must be boolean`,
-    );
-  }
-  if (
-    typeof assignment.agent_id !== "string" ||
-    assignment.agent_id.trim() === ""
-  ) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'assignment.agent_id' must be a non-empty string`,
-    );
-  }
-  if (
-    typeof transition.attempted !== "boolean" ||
-    typeof transition.ok !== "boolean"
-  ) {
-    throw new Error(
-      `${endpoint} response contract invalid: transition booleans must be boolean`,
-    );
-  }
-  if (
-    typeof transition.target_status !== "string" ||
-    transition.target_status.trim() === ""
-  ) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'transition.target_status' must be a non-empty string`,
-    );
-  }
-  if (transition.error !== null && typeof transition.error !== "string") {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'transition.error' must be string or null`,
-    );
-  }
-  if (
-    typeof transition.next_action !== "string" ||
-    transition.next_action.trim() === ""
-  ) {
-    throw new Error(
-      `${endpoint} response contract invalid: field 'transition.next_action' must be a non-empty string`,
-    );
-  }
-
-  return {
-    card: raw.card as unknown as KanbanCard,
-    deduplicated:
-      typeof raw.deduplicated === "boolean" ? raw.deduplicated : undefined,
-    assignment: assignment as unknown as AssignmentResult,
-    transition: transition as unknown as AssignmentTransitionResult,
-  };
-}
+export type AssignmentResult = z.infer<typeof assignmentResultSchema>;
+export type AssignmentTransitionResult = z.infer<
+  typeof assignmentTransitionResultSchema
+>;
+export type AssignKanbanIssueResponse = z.infer<
+  typeof assignKanbanIssueResponseSchema
+>;
 
 export async function assignKanbanIssue(payload: {
   github_repo: string;
@@ -286,11 +214,14 @@ export async function assignKanbanIssue(payload: {
   assignee_agent_id: string;
 }): Promise<AssignKanbanIssueResponse> {
   const endpoint = "/api/kanban-cards/assign-issue";
-  const res = await request<unknown>(endpoint, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
-  return parseAssignKanbanIssueResponse(endpoint, res);
+  return request(
+    endpoint,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+    assignKanbanIssueResponseSchema,
+  );
 }
 
 export async function getStalledCards(): Promise<KanbanCard[]> {

--- a/dashboard/src/api/kanban.ts
+++ b/dashboard/src/api/kanban.ts
@@ -45,30 +45,12 @@ export async function deleteKanbanCard(id: string): Promise<void> {
 }
 
 const nonEmptyStringSchema = z.string().trim().min(1);
-const timestampSchema = z
-  .union([z.string(), z.number()])
-  .transform((value, context) => {
-    const timestamp = typeof value === "number" ? value : Date.parse(value);
-    if (!Number.isFinite(timestamp)) {
-      context.addIssue({ code: "custom", message: "Invalid timestamp" });
-      return z.NEVER;
-    }
-    return timestamp;
-  });
+const timestampSchema = z.string().refine(
+  (value) => Number.isFinite(Date.parse(value)),
+  { message: "Invalid timestamp" },
+);
 const nullableTimestampSchema = timestampSchema.nullable();
-const kanbanCardStatusSchema = z.enum([
-  "backlog",
-  "ready",
-  "requested",
-  "blocked",
-  "in_progress",
-  "review",
-  "done",
-  "qa_pending",
-  "qa_in_progress",
-  "qa_failed",
-]);
-const kanbanCardPrioritySchema = z.enum(["low", "medium", "high", "urgent"]);
+const kanbanCardStatusSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
 
 const kanbanCardSchema = z.looseObject({
   id: nonEmptyStringSchema,
@@ -82,7 +64,7 @@ const kanbanCardSchema = z.looseObject({
   parent_card_id: z.string().nullable(),
   latest_dispatch_id: z.string().nullable(),
   sort_order: z.number(),
-  priority: kanbanCardPrioritySchema,
+  priority: z.string(),
   depth: z.number(),
   blocked_reason: z.string().nullable(),
   review_notes: z.string().nullable(),

--- a/dashboard/src/app/HomeOverviewPage.tsx
+++ b/dashboard/src/app/HomeOverviewPage.tsx
@@ -17,6 +17,7 @@ import { HomeSortableWidget } from "./HomeOverviewWidgets";
 import { buildHomeWidgetSpecs } from "./HomeWidgetSpecs";
 import { StatusBadge } from "../components/common/StatusBadge";
 import { FreshnessIndicator } from "../components/common/FreshnessIndicator";
+import { coerceTimestampMs } from "../components/agent-manager/kanban-utils";
 
 export default function HomeOverviewPage({
   isMobileViewport,
@@ -104,8 +105,16 @@ export default function HomeOverviewPage({
   const recentDoneCards = useMemo(() => {
     const cutoff = Date.now() - KANBAN_DONE_RECENT_WINDOW_MS;
     return kanbanCards
-      .filter((card) => card.status === "done" && (card.completed_at ?? 0) >= cutoff)
-      .sort((a, b) => (b.completed_at ?? 0) - (a.completed_at ?? 0));
+      .filter(
+        (card) =>
+          card.status === "done" &&
+          (coerceTimestampMs(card.completed_at) ?? 0) >= cutoff,
+      )
+      .sort(
+        (a, b) =>
+          (coerceTimestampMs(b.completed_at) ?? 0) -
+          (coerceTimestampMs(a.completed_at) ?? 0),
+      );
   }, [kanbanCards]);
   const recentDoneCount = recentDoneCards.length;
   const blockedCards = kanbanCards.filter((card) => card.status === "blocked").length;

--- a/dashboard/src/components/agent-manager/BacklogTab.tsx
+++ b/dashboard/src/components/agent-manager/BacklogTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "../common/SurfacePrimitives";
 import AgentAvatar from "../AgentAvatar";
 import {
+  coerceTimestampMs,
   formatAgeLabel,
   getCardStateEnteredAt,
   labelForStatus,
@@ -119,7 +120,9 @@ function compareCards(
   }
 
   if (result === 0) {
-    result = right.updated_at - left.updated_at;
+    result =
+      (coerceTimestampMs(right.updated_at) ?? 0) -
+      (coerceTimestampMs(left.updated_at) ?? 0);
   }
   return direction === "asc" ? result : -result;
 }

--- a/dashboard/src/components/agent-manager/KanbanBoardSurface.tsx
+++ b/dashboard/src/components/agent-manager/KanbanBoardSurface.tsx
@@ -126,7 +126,7 @@ export default function KanbanBoardSurface({ ctx }: KanbanBoardSurfaceProps) {
                                 className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
                                 style={{ background: `${statusDef?.accent ?? "#22c55e"}22`, color: statusDef?.accent ?? "#22c55e" }}
                               >
-                                {card.status === "done" ? tr("완료", "Done") : tr("취소", "Cancelled")}
+                                {tr("완료", "Done")}
                               </span>
                               {card.github_issue_number && (
                                 <span className="shrink-0 text-xs" style={{ color: "var(--th-text-muted)" }}>#{card.github_issue_number}</span>

--- a/dashboard/src/components/agent-manager/kanban-filter-state.ts
+++ b/dashboard/src/components/agent-manager/kanban-filter-state.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import type { Agent, KanbanCard } from "../../types";
 import {
+  coerceTimestampMs,
   getBoardColumnStatus,
   isManualInterventionCard,
   isReviewCard,
@@ -144,8 +145,11 @@ export function filterKanbanCards({
   });
 }
 
-function isStaleInProgress(startedAt: number | null | undefined, nowMs: number, staleInProgressMs: number): boolean {
-  if (!startedAt) return false;
-  const startedAtMs = startedAt < 1e12 ? startedAt * 1000 : startedAt;
-  return nowMs - startedAtMs > staleInProgressMs;
+function isStaleInProgress(
+  startedAt: string | number | null | undefined,
+  nowMs: number,
+  staleInProgressMs: number,
+): boolean {
+  const startedAtMs = coerceTimestampMs(startedAt);
+  return startedAtMs != null && nowMs - startedAtMs > staleInProgressMs;
 }

--- a/dashboard/src/components/agent-manager/kanban-utils.ts
+++ b/dashboard/src/components/agent-manager/kanban-utils.ts
@@ -128,9 +128,11 @@ export function isReviewCard(card: KanbanCard): boolean {
   return !!(card.latest_dispatch_type && REVIEW_DISPATCH_TYPES.has(card.latest_dispatch_type));
 }
 
-export function getBoardColumnStatus(status: KanbanCardStatus): KanbanBoardColumnStatus {
+export function getBoardColumnStatus(
+  status: KanbanCardStatus,
+): KanbanCardStatus | KanbanBoardColumnStatus {
   if (status === "ready" || status === "requested") return "requested";
-  if (status === "blocked" || status === "qa_failed") return "failed";
+  if (status === "blocked" || status === "failed" || status === "qa_failed") return "failed";
   return status;
 }
 
@@ -219,6 +221,8 @@ export function priorityLabel(priority: KanbanCardPriority, tr: (ko: string, en:
       return tr("높음", "High");
     case "urgent":
       return tr("긴급", "Urgent");
+    default:
+      return priority;
   }
 }
 

--- a/dashboard/src/components/agent-manager/kanban-utils.ts
+++ b/dashboard/src/components/agent-manager/kanban-utils.ts
@@ -53,7 +53,7 @@ export const BOARD_COLUMN_DEFS: Array<KanbanColumnDef<KanbanBoardColumnStatus>> 
   { status: "done", labelKo: "완료 일감", labelEn: "Completed Work", accent: KANBAN_STATUS_TONES.done.accent },
 ];
 
-export const TERMINAL_STATUSES = new Set<KanbanCardStatus>(["done"]);
+export const TERMINAL_STATUSES = new Set<KanbanCardStatus>(["done", "cancelled"]);
 export const QA_STATUSES = new Set<KanbanCardStatus>(["qa_pending", "qa_in_progress", "qa_failed"]);
 export const PRIORITY_OPTIONS: KanbanCardPriority[] = ["low", "medium", "high", "urgent"];
 export const REVIEW_DISPATCH_TYPES = new Set(["review", "review-decision"]);
@@ -133,6 +133,7 @@ export function getBoardColumnStatus(
 ): KanbanCardStatus | KanbanBoardColumnStatus {
   if (status === "ready" || status === "requested") return "requested";
   if (status === "blocked" || status === "failed" || status === "qa_failed") return "failed";
+  if (status === "cancelled") return "done";
   return status;
 }
 

--- a/dashboard/src/components/agent-manager/useKanbanBoardModel.test.tsx
+++ b/dashboard/src/components/agent-manager/useKanbanBoardModel.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../../api";
+import type { KanbanCard } from "../../types";
+import { useKanbanBoardModel } from "./useKanbanBoardModel";
+
+function makeCard(overrides: Partial<KanbanCard> = {}): KanbanCard {
+  return {
+    id: "card-1",
+    title: "Test card",
+    description: null,
+    status: "in_progress",
+    github_repo: "itismyfield/AgentDesk",
+    owner_agent_id: null,
+    requester_agent_id: null,
+    assignee_agent_id: "agent-1",
+    parent_card_id: null,
+    latest_dispatch_id: null,
+    sort_order: 0,
+    priority: "medium",
+    depth: 0,
+    blocked_reason: null,
+    review_notes: null,
+    github_issue_number: 4520,
+    github_issue_url: null,
+    metadata_json: null,
+    pipeline_stage_id: null,
+    review_status: null,
+    created_at: "2026-07-17T00:00:00Z",
+    updated_at: "2026-07-17T00:00:00Z",
+    started_at: null,
+    requested_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function ModelProbe({
+  params,
+  onModel,
+}: {
+  params: Record<string, unknown>;
+  onModel: (model: ReturnType<typeof useKanbanBoardModel>) => void;
+}) {
+  onModel(useKanbanBoardModel(params));
+  return null;
+}
+
+function createParams(cards: KanbanCard[], overrides: Record<string, unknown> = {}) {
+  return {
+    agentFilter: "all",
+    agentMap: new Map(),
+    agents: [],
+    agentPipelineStages: [],
+    cardTypeFilter: "all",
+    cards,
+    cardsById: new Map(cards.map((card) => [card.id, card])),
+    deptFilter: "all",
+    getAgentLabel: (agentId: string | null | undefined) => agentId ?? "Unassigned",
+    issues: [],
+    mobileColumnStatus: "backlog",
+    nowMs: Date.parse("2026-07-18T00:00:00Z"),
+    repoSources: [],
+    search: "",
+    selectedAgentId: null,
+    selectedCardId: null,
+    selectedRepo: "itismyfield/AgentDesk",
+    setAgentPipelineStages: vi.fn(),
+    setRecentDonePage: vi.fn(),
+    setSelectedAgentId: vi.fn(),
+    setSelectedCardId: vi.fn(),
+    showClosed: true,
+    signalStatusFilter: "all",
+    staleInProgressMs: 60 * 60 * 1000,
+    tr: (_ko: string, en: string) => en,
+    ...overrides,
+  };
+}
+
+describe("useKanbanBoardModel status grouping", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+      root = null;
+    }
+    container?.remove();
+    container = null;
+    vi.restoreAllMocks();
+  });
+
+  it("places cancelled cards in Done and excludes them from the open count", async () => {
+    const cancelledCard = makeCard({ id: "cancelled-card", status: "cancelled" });
+    const modelRef: { current: ReturnType<typeof useKanbanBoardModel> | null } = { current: null };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        <ModelProbe
+          params={createParams([cancelledCard])}
+          onModel={(nextModel) => {
+            modelRef.current = nextModel;
+          }}
+        />,
+      );
+    });
+
+    if (!modelRef.current) throw new Error("Expected board model to render");
+    expect(modelRef.current.cardsByStatus.get("done")).toEqual([cancelledCard]);
+    expect(modelRef.current.openCount).toBe(0);
+  });
+
+  it("preserves configured custom stages and falls back unknown statuses to Backlog", async () => {
+    vi.spyOn(api, "getPipelineStagesForAgent").mockResolvedValue([]);
+    const customStageCard = makeCard({ id: "custom-stage-card", status: "release_gate" });
+    const unknownStatusCard = makeCard({ id: "unknown-status-card", status: "legacy_hold" });
+    const modelRef: { current: ReturnType<typeof useKanbanBoardModel> | null } = { current: null };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        <ModelProbe
+          params={createParams([customStageCard, unknownStatusCard], {
+            selectedAgentId: "agent-1",
+            agentPipelineStages: [{ stage_name: "release_gate", trigger_after: "review_pass" }],
+          })}
+          onModel={(nextModel) => {
+            modelRef.current = nextModel;
+          }}
+        />,
+      );
+    });
+
+    if (!modelRef.current) throw new Error("Expected board model to render");
+    expect(modelRef.current.cardsByStatus.get("release_gate")).toEqual([customStageCard]);
+    expect(modelRef.current.cardsByStatus.get("backlog")).toEqual([unknownStatusCard]);
+  });
+});

--- a/dashboard/src/components/agent-manager/useKanbanBoardModel.ts
+++ b/dashboard/src/components/agent-manager/useKanbanBoardModel.ts
@@ -179,7 +179,9 @@ export function useKanbanBoardModel(params: UseKanbanBoardModelParams) {
       grouped.set(column.status, []);
     }
     for (const card of filteredCards) {
-      grouped.get(getBoardColumnStatus(card.status))?.push(card);
+      const mappedStatus = getBoardColumnStatus(card.status);
+      const targetStatus = grouped.has(mappedStatus) ? mappedStatus : "backlog";
+      grouped.get(targetStatus)?.push(card);
     }
 
     const isAncestor = (possibleAncestorId: string, card: KanbanCard): boolean => {

--- a/dashboard/src/components/agent-manager/useKanbanBoardModel.ts
+++ b/dashboard/src/components/agent-manager/useKanbanBoardModel.ts
@@ -4,6 +4,7 @@ import type { KanbanCard, KanbanCardStatus } from "../../types";
 import {
   BOARD_COLUMN_DEFS,
   TERMINAL_STATUSES,
+  coerceTimestampMs,
   getBoardColumnStatus,
   isManualInterventionCard,
   isReviewCard,
@@ -146,7 +147,11 @@ export function useKanbanBoardModel(params: UseKanbanBoardModelParams) {
         if (cardTypeFilter === "review" && !isReviewCard(c)) return false;
         return true;
       })
-      .sort((a: KanbanCard, b: KanbanCard) => (b.completed_at ?? 0) - (a.completed_at ?? 0));
+      .sort(
+        (a: KanbanCard, b: KanbanCard) =>
+          (coerceTimestampMs(b.completed_at) ?? 0) -
+          (coerceTimestampMs(a.completed_at) ?? 0),
+      );
   }, [repoCards, cardTypeFilter]);
 
   useEffect(() => { setRecentDonePage(0); }, [selectedRepo]);
@@ -208,7 +213,12 @@ export function useKanbanBoardModel(params: UseKanbanBoardModelParams) {
         const aRoot = getRootCard(a);
         const bRoot = getRootCard(b);
         if (aRoot.sort_order !== bRoot.sort_order) return aRoot.sort_order - bRoot.sort_order;
-        if (aRoot.updated_at !== bRoot.updated_at) return bRoot.updated_at - aRoot.updated_at;
+        if (aRoot.updated_at !== bRoot.updated_at) {
+          return (
+            (coerceTimestampMs(bRoot.updated_at) ?? 0) -
+            (coerceTimestampMs(aRoot.updated_at) ?? 0)
+          );
+        }
 
         if (a.parent_card_id !== b.parent_card_id) {
           if (!a.parent_card_id) return -1;
@@ -217,7 +227,10 @@ export function useKanbanBoardModel(params: UseKanbanBoardModelParams) {
           if (a.parent_card_id > b.parent_card_id) return 1;
         }
         if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
-        return b.updated_at - a.updated_at;
+        return (
+          (coerceTimestampMs(b.updated_at) ?? 0) -
+          (coerceTimestampMs(a.updated_at) ?? 0)
+        );
       });
     }
     return grouped;

--- a/dashboard/src/components/office-view/OfficeAgentDrawer.tsx
+++ b/dashboard/src/components/office-view/OfficeAgentDrawer.tsx
@@ -33,6 +33,7 @@ import {
   formatDiscordSummary,
 } from "../agent-manager/discord-routing";
 import { getAgentLevel, getAgentTitle } from "../agent-manager/agentProgress";
+import { coerceTimestampMs } from "../agent-manager/kanban-utils";
 import type { OfficeManualIntervention } from "./officeAgentState";
 import {
   buildCardIssueUrl,
@@ -41,7 +42,6 @@ import {
   formatDateTime,
   formatElapsed,
   hydrateSession,
-  normalizeTimestampMs,
   sessionSortValue,
   t,
   type OfficeSkillRow,
@@ -181,7 +181,7 @@ export default function OfficeAgentDrawer({
   const level = getAgentLevel(agent.stats_xp);
   const levelTitle = getAgentTitle(agent.stats_xp, isKo);
   const currentTaskStartedAt = useMemo(
-    () => normalizeTimestampMs(currentCard?.started_at ?? currentCard?.requested_at ?? null),
+    () => coerceTimestampMs(currentCard?.started_at ?? currentCard?.requested_at ?? null),
     [currentCard],
   );
   const currentTaskIssueUrl = currentCard ? buildCardIssueUrl(currentCard) : null;

--- a/dashboard/src/components/office-view/OfficeAgentDrawerModel.ts
+++ b/dashboard/src/components/office-view/OfficeAgentDrawerModel.ts
@@ -8,6 +8,7 @@ import type {
   KanbanCard,
   UiLanguage,
 } from "../../types";
+import { coerceTimestampMs } from "../agent-manager/kanban-utils";
 
 export interface OfficeSkillRow {
   skillName: string;
@@ -50,19 +51,6 @@ export function formatElapsed(value: number | null, isKo: boolean): string | nul
   return t(isKo, `${days}일째`, `${days}d running`);
 }
 
-export function normalizeTimestampMs(value: number | string | null | undefined): number | null {
-  if (value == null || value === "") return null;
-  if (typeof value === "number") {
-    return value < 1e12 ? value * 1000 : value;
-  }
-  const numeric = Number(value);
-  if (Number.isFinite(numeric)) {
-    return numeric < 1e12 ? numeric * 1000 : numeric;
-  }
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
 function extractSkillNameFromEventContent(content: string): string | null {
   try {
     const parsed = JSON.parse(content) as Record<string, unknown>;
@@ -83,7 +71,7 @@ function deriveFallbackSkillRows(transcripts: SessionTranscript[]): OfficeSkillR
   const aggregates = new Map<string, OfficeSkillRow>();
 
   for (const transcript of transcripts) {
-    const usedAt = normalizeTimestampMs(transcript.created_at);
+    const usedAt = coerceTimestampMs(transcript.created_at);
     if (!usedAt || usedAt < cutoff) continue;
 
     const used = new Set<string>();

--- a/dashboard/src/components/office-view/officeAgentState.test.ts
+++ b/dashboard/src/components/office-view/officeAgentState.test.ts
@@ -150,4 +150,21 @@ describe("deriveOfficeAgentState", () => {
 
     expect(state.manualInterventionByAgent.has(agent.id)).toBe(false);
   });
+
+  it("does not select a cancelled card as the agent primary card", () => {
+    const agent = makeAgent();
+
+    const state = deriveOfficeAgentState([agent], [
+      makeCard({
+        id: "card-cancelled",
+        status: "cancelled",
+        blocked_reason: "maintainer approval required before deploy",
+        review_status: "dilemma_pending",
+      }),
+    ]);
+
+    // Mutation guard: removing "cancelled" from TERMINAL_CARD_STATUSES makes both assertions fail.
+    expect(state.primaryCardByAgent.has(agent.id)).toBe(false);
+    expect(state.manualInterventionByAgent.has(agent.id)).toBe(false);
+  });
 });

--- a/dashboard/src/components/office-view/officeAgentState.ts
+++ b/dashboard/src/components/office-view/officeAgentState.ts
@@ -1,5 +1,6 @@
 import type { Agent, KanbanCard, KanbanCardStatus } from "../../types";
 import {
+  coerceTimestampMs,
   hasManualInterventionReason,
   isManualInterventionCard,
 } from "../agent-manager/kanban-utils";
@@ -62,19 +63,6 @@ const ACTIVE_ISSUE_PRIORITY: Record<string, number> = {
   done: 9,
 };
 
-function normalizeTimestampMs(value: number | string | null | undefined): number | null {
-  if (value == null || value === "") return null;
-  if (typeof value === "number") {
-    return value < 1e12 ? value * 1000 : value;
-  }
-  const numeric = Number(value);
-  if (Number.isFinite(numeric)) {
-    return numeric < 1e12 ? numeric * 1000 : numeric;
-  }
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
 function compareCards(left: KanbanCard, right: KanbanCard, priority: Record<string, number>): number {
   const leftPriority = priority[left.status] ?? 99;
   const rightPriority = priority[right.status] ?? 99;
@@ -82,8 +70,8 @@ function compareCards(left: KanbanCard, right: KanbanCard, priority: Record<stri
     return leftPriority - rightPriority;
   }
   return (
-    (normalizeTimestampMs(right.updated_at) ?? 0) -
-    (normalizeTimestampMs(left.updated_at) ?? 0)
+    (coerceTimestampMs(right.updated_at) ?? 0) -
+    (coerceTimestampMs(left.updated_at) ?? 0)
   );
 }
 
@@ -155,8 +143,8 @@ export function deriveOfficeAgentState(
           status: card.status,
           number: card.github_issue_number ?? null,
           url: buildIssueUrl(card),
-          startedAt: normalizeTimestampMs(card.started_at),
-          updatedAt: normalizeTimestampMs(card.updated_at) ?? 0,
+          startedAt: coerceTimestampMs(card.started_at),
+          updatedAt: coerceTimestampMs(card.updated_at) ?? 0,
         }),
       );
     }
@@ -172,7 +160,7 @@ export function deriveOfficeAgentState(
           reason: hasManualInterventionReason(card) ? card.blocked_reason?.trim() ?? null : null,
           issueNumber: card.github_issue_number ?? null,
           issueUrl: buildIssueUrl(card),
-          updatedAt: normalizeTimestampMs(card.updated_at) ?? 0,
+          updatedAt: coerceTimestampMs(card.updated_at) ?? 0,
         }),
       );
     }

--- a/dashboard/src/components/office-view/officeAgentState.ts
+++ b/dashboard/src/components/office-view/officeAgentState.ts
@@ -35,7 +35,7 @@ export interface OfficeAgentState {
   seatStatusByAgent: Map<string, OfficeSeatStatus>;
 }
 
-const TERMINAL_CARD_STATUSES = new Set<KanbanCardStatus>(["done"]);
+const TERMINAL_CARD_STATUSES = new Set<KanbanCardStatus>(["done", "cancelled"]);
 
 const PRIMARY_CARD_PRIORITY: Record<string, number> = {
   review: 0,

--- a/dashboard/src/components/office-view/officeAgentState.ts
+++ b/dashboard/src/components/office-view/officeAgentState.ts
@@ -36,7 +36,7 @@ export interface OfficeAgentState {
 
 const TERMINAL_CARD_STATUSES = new Set<KanbanCardStatus>(["done"]);
 
-const PRIMARY_CARD_PRIORITY: Record<KanbanCardStatus, number> = {
+const PRIMARY_CARD_PRIORITY: Record<string, number> = {
   review: 0,
   in_progress: 1,
   requested: 2,
@@ -49,7 +49,7 @@ const PRIMARY_CARD_PRIORITY: Record<KanbanCardStatus, number> = {
   done: 9,
 };
 
-const ACTIVE_ISSUE_PRIORITY: Record<KanbanCardStatus, number> = {
+const ACTIVE_ISSUE_PRIORITY: Record<string, number> = {
   review: 0,
   in_progress: 1,
   requested: 2,
@@ -75,13 +75,16 @@ function normalizeTimestampMs(value: number | string | null | undefined): number
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function compareCards(left: KanbanCard, right: KanbanCard, priority: Record<KanbanCardStatus, number>): number {
+function compareCards(left: KanbanCard, right: KanbanCard, priority: Record<string, number>): number {
   const leftPriority = priority[left.status] ?? 99;
   const rightPriority = priority[right.status] ?? 99;
   if (leftPriority !== rightPriority) {
     return leftPriority - rightPriority;
   }
-  return right.updated_at - left.updated_at;
+  return (
+    (normalizeTimestampMs(right.updated_at) ?? 0) -
+    (normalizeTimestampMs(left.updated_at) ?? 0)
+  );
 }
 
 function selectPreferredCard(current: KanbanCard | undefined, next: KanbanCard): KanbanCard {
@@ -153,7 +156,7 @@ export function deriveOfficeAgentState(
           number: card.github_issue_number ?? null,
           url: buildIssueUrl(card),
           startedAt: normalizeTimestampMs(card.started_at),
-          updatedAt: card.updated_at,
+          updatedAt: normalizeTimestampMs(card.updated_at) ?? 0,
         }),
       );
     }
@@ -169,7 +172,7 @@ export function deriveOfficeAgentState(
           reason: hasManualInterventionReason(card) ? card.blocked_reason?.trim() ?? null : null,
           issueNumber: card.github_issue_number ?? null,
           issueUrl: buildIssueUrl(card),
-          updatedAt: card.updated_at,
+          updatedAt: normalizeTimestampMs(card.updated_at) ?? 0,
         }),
       );
     }

--- a/dashboard/src/types/kanban.ts
+++ b/dashboard/src/types/kanban.ts
@@ -126,19 +126,9 @@ export interface DispatchDeliveryEvent {
   updated_at: string;
 }
 
-export type KanbanCardStatus =
-  | "backlog"
-  | "ready"
-  | "requested"
-  | "blocked"
-  | "in_progress"
-  | "review"
-  | "done"
-  | "qa_pending"
-  | "qa_in_progress"
-  | "qa_failed";
+export type KanbanCardStatus = string;
 
-export type KanbanCardPriority = "low" | "medium" | "high" | "urgent";
+export type KanbanCardPriority = string;
 
 export interface KanbanReviewChecklistItem {
   id: string;
@@ -194,12 +184,12 @@ export interface KanbanCard {
   metadata_json: string | null;
   pipeline_stage_id: string | null;
   review_status: string | null;
-  created_at: number;
-  updated_at: number;
-  started_at: number | null;
-  requested_at: number | null;
-  review_entered_at?: string | number | null;
-  completed_at: number | null;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  requested_at: string | null;
+  review_entered_at?: string | null;
+  completed_at: string | null;
   latest_dispatch_status?: TaskDispatchStatus | null;
   latest_dispatch_title?: string | null;
   latest_dispatch_type?: string | null;


### PR DESCRIPTION
## 요약
대시보드 칸반 런타임 검증 강화 + office view terminal 계약 정합.

## 핵심
- kanban status slug 정규식 검증(`/^[a-z][a-z0-9_]*$/`), unknown status → Backlog fallback, cancelled → Done 컬럼 매핑(terminal 처리).
- timestampSchema를 `z.string()`으로 완화(Postgres `timestamptz::text` 마이크로초 포맷 hard-reject 제거), 표시계층은 `coerceTimestampMs`로 NaN-safe.
- office view `TERMINAL_CARD_STATUSES`에 cancelled 추가 — 보드/오피스뷰 terminal 계약 일치(취소 카드가 primaryCard/manualIntervention에 활성으로 안 잡힘).
- KanbanBoardSurface 도달불가 dead branch 제거, timestamp 파서 DRY 통일(normalizeTimestampMs → coerceTimestampMs).

## 검증
- tsc --noEmit exit 0, vitest 304 pass(48 files) — 뮤테이션 회귀 테스트 포함.
- 적대 Opus 카운터리뷰 CLEAN(contained TS 단독 리뷰): 3라운드 수렴, 뮤테이션 non-vacuous(실제 deriveOfficeAgentState 경로) 확인.

Closes #4520