### PR TITLE
ux(discord): 라이브 상태 패널 헤더 순서·줄바꿈 재배치 (#4601)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -728,7 +728,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2949 | 861 | 2088 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2952 | 861 | 2091 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 844 | 485 | 359 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -579,13 +579,13 @@
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |
 | `services::discord::placeholder_live_events::context_panel` | `src/services/discord/placeholder_live_events/context_panel.rs` | 72 | 72 | 0 |  |
-| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 210 | 101 | 109 |  |
+| `services::discord::placeholder_live_events::freshness` | `src/services/discord/placeholder_live_events/freshness.rs` | 210 | 100 | 110 |  |
 | `services::discord::placeholder_live_events::recent_events` | `src/services/discord/placeholder_live_events/recent_events.rs` | 322 | 322 | 0 |  |
 | `services::discord::placeholder_live_events::session_banner_claim` | `src/services/discord/placeholder_live_events/session_banner_claim.rs` | 91 | 91 | 0 |  |
 | `services::discord::placeholder_live_events::session_panel` | `src/services/discord/placeholder_live_events/session_panel.rs` | 262 | 262 | 0 |  |
 | `services::discord::placeholder_live_events::slot_rehydration` | `src/services/discord/placeholder_live_events/slot_rehydration.rs` | 525 | 447 | 78 |  |
 | `services::discord::placeholder_live_events::status_events` | `src/services/discord/placeholder_live_events/status_events.rs` | 791 | 791 | 0 |  |
-| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 789 | 789 | 0 |  |
+| `services::discord::placeholder_live_events::status_panel` | `src/services/discord/placeholder_live_events/status_panel.rs` | 782 | 782 | 0 |  |
 | `services::discord::placeholder_live_events::subagent_panel` | `src/services/discord/placeholder_live_events/subagent_panel.rs` | 368 | 318 | 50 |  |
 | `services::discord::placeholder_live_events::subagent_rollout` | `src/services/discord/placeholder_live_events/subagent_rollout.rs` | 531 | 356 | 175 |  |
 | `services::discord::placeholder_live_events::subagent_summary` | `src/services/discord/placeholder_live_events/subagent_summary.rs` | 69 | 69 | 0 |  |
@@ -728,7 +728,7 @@
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 81 | 81 | 0 |  |
 | `services::discord::shared_state` | `src/services/discord/shared_state.rs` | 749 | 678 | 71 |  |
 | `services::discord::sidecar_interaction` | `src/services/discord/sidecar_interaction.rs` | 390 | 390 | 0 |  |
-| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2938 | 861 | 2077 |  |
+| `services::discord::single_message_panel` | `src/services/discord/single_message_panel.rs` | 2949 | 861 | 2088 |  |
 | `services::discord::stall_recovery` | `src/services/discord/stall_recovery.rs` | 113 | 113 | 0 |  |
 | `services::discord::standby_relay` | `src/services/discord/standby_relay.rs` | 1649 | 916 | 733 |  |
 | `services::discord::startup_reclaim` | `src/services/discord/startup_reclaim.rs` | 844 | 485 | 359 |  |

--- a/src/services/discord/placeholder_live_events/freshness.rs
+++ b/src/services/discord/placeholder_live_events/freshness.rs
@@ -5,18 +5,16 @@
 //! derived-status activity label and the store-facing time-line builder live here
 //! with their tests.
 //!
-//! The footer header is a fixed two-line block:
-//! - line 1 is the derived-status ACTIVITY label alone (`🟢 진행 중` /
-//!   `🔧 도구 실행 중 (…)` / `✅ 완료`). The spinner
-//!   merge (`single_message_panel::merged_footer_header_line`) swaps the leading
-//!   status emoji for the animated spinner, so the marker set there must stay in
-//!   sync with the emojis this label can start with.
-//! - line 2 is the TIME line (`마지막 업데이트 : MM-DD HH:MM:SS (<t:last:R>) /
-//!   턴 시작 : MM-DD HH:MM:SS (<t:start:R>)`). The fixed KST absolute times keep
-//!   mobile clients readable when they do not refresh Discord's relative token.
-//!   It replaces the pre-#3983 confidence line + `진행 중 — provider` header; the
-//!   freshness class is now absorbed into the line-1 emoji (item B), and the
-//!   provider moved off the footer entirely.
+//! The footer header starts with the derived-status ACTIVITY label (`🟢 진행 중` /
+//! `🔧 도구 실행 중 (…)` / `✅ 완료`). The spinner merge
+//! (`single_message_panel::merged_footer_header_line`) swaps the leading status
+//! emoji for the animated spinner, so the marker set there must stay in sync with
+//! the emojis this label can start with. The request anchor follows the activity
+//! line, then the stable TIME lines render one field per line in turn-start / last-
+//! update order. The fixed KST absolute times keep mobile clients readable when
+//! they do not refresh Discord's relative token. This replaces the pre-#3983
+//! confidence line + `진행 중 — provider` header; the freshness class is absorbed
+//! into the activity emoji, and the provider moved off the footer entirely.
 //!
 //! Both times derive from STABLE store stamps (never "now"), so the footer text
 //! stays byte-identical across heartbeat ticks — the message is not needlessly
@@ -52,17 +50,18 @@ fn render_kst_time(unix: i64) -> String {
         .to_string()
 }
 
-/// #4572: renders the footer's fixed KST and relative time line.
-/// `last_activity_unix` is the store's STABLE per-channel last-live-content
-/// arrival stamp; it falls back to the turn start when no live content has
-/// arrived yet. The injected stamps keep the text identical across heartbeat
-/// ticks (never re-edited) while Discord can still show the localized relative age.
+/// #4572/#4601: renders the footer's fixed KST and relative time fields on
+/// separate lines, with turn start before last update. `last_activity_unix` is
+/// the store's STABLE per-channel last-live-content arrival stamp; it falls back
+/// to the turn start when no live content has arrived yet. The injected stamps
+/// keep the text identical across heartbeat ticks (never re-edited) while
+/// Discord can still show the localized relative age.
 pub(super) fn render_time_line(last_activity_unix: Option<i64>, started_at_unix: i64) -> String {
     let last = last_activity_unix.unwrap_or(started_at_unix);
     format!(
-        "마지막 업데이트 : {} (<t:{last}:R>) / 턴 시작 : {} (<t:{started_at_unix}:R>)",
-        render_kst_time(last),
+        "턴 시작 : {} (<t:{started_at_unix}:R>)\n마지막 업데이트 : {} (<t:{last}:R>)",
         render_kst_time(started_at_unix),
+        render_kst_time(last),
     )
 }
 
@@ -175,10 +174,10 @@ mod tests {
     // ---- render_time_line: anchor selection + heartbeat stability ---------
 
     #[test]
-    fn time_line_anchors_update_to_last_activity_and_start() {
+    fn time_line_renders_start_then_update_on_separate_lines() {
         assert_eq!(
             render_time_line(Some(LAST_ACTIVITY), STARTED_AT),
-            "마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"
+            "턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"
         );
     }
 
@@ -186,8 +185,9 @@ mod tests {
     fn time_line_includes_fixed_kst_and_discord_relative_tokens() {
         let line = render_time_line(Some(LAST_ACTIVITY), STARTED_AT);
 
-        assert!(line.contains("마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"));
         assert!(line.contains("턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"));
+        assert!(line.contains("마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"));
+        assert!(!line.contains(" / "), "time fields must not share one line");
     }
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
         // No live content yet → the update age anchors to the turn start.
         assert_eq!(
             render_time_line(None, STARTED_AT),
-            "마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"
+            "턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>)"
         );
     }
 

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -600,10 +600,10 @@ impl StatusPanelState {
 pub(super) fn render_status_panel(
     snapshot: StatusPanelState,
     provider: &ProviderKind,
-    // #3983 item 2: precomputed `마지막 업데이트 : … / 턴 시작 : …` time line (line 2).
+    // #4601: precomputed `턴 시작 : …\n마지막 업데이트 : …` time lines.
     time_line: String,
-    // #3983 item 3: precomputed `턴 트리거:` deeplink, appended as the LAST footer
-    // line (or `None` for headless/synthetic/id-0 turns with no real user message).
+    // #4601: precomputed `턴 트리거:` deeplink, rendered immediately after the
+    // activity line (or `None` for headless/synthetic/id-0 turns).
     turn_trigger_line: Option<String>,
 ) -> String {
     let header_status = if matches!(provider, ProviderKind::Codex)
@@ -613,22 +613,22 @@ pub(super) fn render_status_panel(
     } else {
         snapshot.status.clone()
     };
-    // #3983: line 1 = derived-status ACTIVITY label, line 2 = relative TIME line
-    // (both built in the colocated `freshness` module — status_panel.rs is at the
-    // namespace cap). The pre-#3983 confidence line + `진행 중 — provider` header is
-    // retired (item 2); the request anchor no longer prepends here (item 3, see the
-    // trailing `턴 트리거:` push below).
-    let mut sections = vec![
-        super::freshness::render_activity_line(&header_status),
-        time_line,
-    ];
+    // #4601: the header opens with the derived-status ACTIVITY label, followed by
+    // the request anchor when present, then the start/update TIME fields. Keep the
+    // entire header in one section so each field occupies the immediately following
+    // physical line and section-wise truncation preserves the header atomically.
+    let mut header_lines = vec![super::freshness::render_activity_line(&header_status)];
+    if let Some(trigger) = turn_trigger_line.filter(|line| !line.trim().is_empty()) {
+        header_lines.push(trigger);
+    }
+    header_lines.push(time_line);
+    let mut sections = vec![header_lines.join("\n")];
 
     // #3983 item4: the session line is NO LONGER rendered in the every-tick
     // footer. It is composed once at the top of the first answer message via
     // `session_banner.rs`, so the
     // repeated per-tick footer echo of `🆕 새 세션 시작 · provider session … · tmux …`
-    // is retired. Track A's 3-line header (activity / time / 턴 트리거) is
-    // unaffected.
+    // is retired. Track A's header is unaffected.
 
     if let Some(task) = snapshot.task.as_ref() {
         sections.push(render_task_panel_line(task));
@@ -687,13 +687,6 @@ pub(super) fn render_status_panel(
         if !lines.is_empty() {
             sections.push(format!("Workflow\n{}", lines.join("\n")));
         }
-    }
-
-    // #3983 item 3: the `턴 트리거:` original-request deeplink is the LAST footer
-    // line (it previously prepended above the header). Absent for headless /
-    // synthetic / id-0 turns that carry no real Discord user message.
-    if let Some(trigger) = turn_trigger_line.filter(|line| !line.trim().is_empty()) {
-        sections.push(trigger);
     }
 
     truncate_status_panel_sections(sections)

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -8891,7 +8891,10 @@ fn status_panel_free_renderer_orders_header_fields_on_separate_lines() {
         ),
         "time fields must occupy separate consecutive lines: {out:?}"
     );
-    assert!(!out.contains(" / "), "combined time line is retired: {out:?}");
+    assert!(
+        !out.contains(" / "),
+        "combined time line is retired: {out:?}"
+    );
     assert!(
         out.chars().count() <= STATUS_PANEL_MAX_CHARS,
         "panel must respect the size cap"

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -376,7 +376,7 @@ fn status_panel_turn_completed_renders_foreground_completion() {
 #[test]
 fn status_panel_absorbs_stale_and_final_into_the_activity_emoji() {
     // #3983 items 2 + B: the separate 신뢰도 line is retired; the freshness class is
-    // absorbed into the line-1 activity emoji, and line 2 carries the time line.
+    // absorbed into the activity emoji, and the following fields carry stable times.
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(38120);
 
@@ -8859,33 +8859,39 @@ fn completion_footer_free_renderer_omits_anchor_and_target_when_absent() {
 }
 
 #[test]
-fn status_panel_free_renderer_leads_with_activity_and_time_lines() {
-    // #3983: the panel opens with the activity label (line 1) then the time line
-    // (line 2); the 턴 트리거 deeplink trails as the last section.
+fn status_panel_free_renderer_orders_header_fields_on_separate_lines() {
+    // #4601: activity remains first; trigger, start, and update follow in order,
+    // with the two time fields split across physical lines.
     let out = super::status_panel::render_status_panel(
         StatusPanelState::default(),
         &ProviderKind::Claude,
-        "마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)".to_string(),
+        "턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)".to_string(),
         Some("턴 트리거: https://discord.com/channels/1/2/3".to_string()),
     );
-    let mut sections = out.split("\n\n");
     assert_eq!(
-        sections.next(),
-        Some("🟢 진행 중"),
-        "line 1 = activity: {out:?}"
+        out.lines().take(4).collect::<Vec<_>>(),
+        vec![
+            "🟢 진행 중",
+            "턴 트리거: https://discord.com/channels/1/2/3",
+            "턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)",
+            "마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)",
+        ],
+        "header must render as four consecutive lines: {out:?}"
     );
-    assert_eq!(
-        sections.next(),
-        Some(
-            "마지막 업데이트 : 11-15 07:13:20 (<t:1700000000:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)"
-        ),
-        "line 2 = time line: {out:?}"
+    let trigger = out.find("턴 트리거:").expect("trigger line");
+    let started = out.find("턴 시작 :").expect("turn-start line");
+    let updated = out.find("마지막 업데이트 :").expect("last-update line");
+    assert!(
+        trigger < started && started < updated,
+        "header order must be trigger -> start -> update: {out:?}"
     );
     assert!(
-        out.trim_end()
-            .ends_with("턴 트리거: https://discord.com/channels/1/2/3"),
-        "턴 트리거 must be the last footer line: {out:?}"
+        out.contains(
+            "턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)"
+        ),
+        "time fields must occupy separate consecutive lines: {out:?}"
     );
+    assert!(!out.contains(" / "), "combined time line is retired: {out:?}");
     assert!(
         out.chars().count() <= STATUS_PANEL_MAX_CHARS,
         "panel must respect the size cap"

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -1293,7 +1293,7 @@ mod tests {
 
     #[test]
     fn footer_rollover_reservation_is_bound_by_panel_budget_s3() {
-        const STREAMING_PLACEHOLDER_MARGIN_BYTES: usize = 10;
+        const STREAMING_PLACEHOLDER_MARGIN_CHARS: usize = 10;
 
         let huge_panel = format!(
             "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nTools\n{}",
@@ -1301,21 +1301,24 @@ mod tests {
         );
         let status_block = super::compose_footer_status_block("⠸", &huge_panel);
         let merged_header = footer_header(&status_block);
-        let max_footer_len =
-            2 + merged_header.len() + 1 + super::SINGLE_MESSAGE_PANEL_LIVE_BODY_BUDGET_BYTES;
+        let max_footer_chars = 2
+            + merged_header.chars().count()
+            + 1
+            + super::SINGLE_MESSAGE_PANEL_LIVE_BODY_BUDGET_BYTES;
         let footer = format!("\n\n{status_block}");
+        let footer_chars = footer.chars().count();
         let expected_body_budget = DISCORD_MSG_LIMIT
-            .saturating_sub(footer.len() + STREAMING_PLACEHOLDER_MARGIN_BYTES)
+            .saturating_sub(footer_chars + STREAMING_PLACEHOLDER_MARGIN_CHARS)
             .max(1);
         let minimum_body_budget = DISCORD_MSG_LIMIT
-            .saturating_sub(max_footer_len + STREAMING_PLACEHOLDER_MARGIN_BYTES)
+            .saturating_sub(max_footer_chars + STREAMING_PLACEHOLDER_MARGIN_CHARS)
             .max(1);
         let current_portion = "x".repeat(expected_body_budget + 1);
         let plan =
             super::super::formatting::plan_streaming_rollover(&current_portion, &status_block)
                 .expect("body should roll over after reserving the bounded footer");
 
-        assert!(footer.len() <= max_footer_len);
+        assert!(footer_chars <= max_footer_chars);
         assert_eq!(plan.split_at, expected_body_budget);
         assert!(plan.split_at >= minimum_body_budget);
         assert!(plan.display_snapshot.ends_with(&footer));

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -660,7 +660,7 @@ fn text_has_single_message_footer_surface(text: &str) -> bool {
                 || line == "Tasks"
                 || line == "Subagents"
                 || line.starts_with("└ ")
-                // #3983: the footer's line-2 time line identifies the new panel surface.
+                // #4601: the footer's split last-update line identifies the panel surface.
                 || line.starts_with("마지막 업데이트 ")
                 // Legacy pre-#3983 merged header shape.
                 || (line.contains(" — ") && line.contains("(<t:"))
@@ -1401,7 +1401,18 @@ mod tests {
     }
 
     #[test]
-    fn footer_only_surface_recognizes_fixed_kst_time_line() {
+    fn footer_only_surface_recognizes_split_fixed_kst_time_lines() {
+        let panel = "🟢 진행 중\n턴 트리거: https://discord.com/channels/1/2/3\n턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)";
+        let rendered = super::compose_footer_status_block("⠸", panel);
+
+        assert!(super::streaming_footer_only_surface_was_exposed(
+            &rendered,
+            &ProviderKind::Claude
+        ));
+    }
+
+    #[test]
+    fn footer_only_surface_recognizes_legacy_combined_time_line() {
         let panel = "🟢 진행 중\n\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)";
         let rendered = super::compose_footer_status_block("⠸", panel);
 

--- a/src/services/discord/tmux_placeholder_suppression/mod.rs
+++ b/src/services/discord/tmux_placeholder_suppression/mod.rs
@@ -355,7 +355,7 @@ mod placeholder_suppression_tests {
     fn footer_status_block() -> String {
         let long_tail = "└ cargo test --lib tmux ".repeat(120);
         let panel = format!(
-            "🟢 진행 중\n\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>) / 턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n\nTools\n└ cargo test --lib tmux\nSubagents\n└ review inspect\n{long_tail}"
+            "🟢 진행 중\n턴 트리거: https://discord.com/channels/1/2/3\n턴 시작 : 11-15 07:13:20 (<t:1700000000:R>)\n마지막 업데이트 : 11-15 07:18:20 (<t:1700000300:R>)\n\nTools\n└ cargo test --lib tmux\nSubagents\n└ review inspect\n{long_tail}"
         );
         let status_block = discord::single_message_panel::compose_footer_status_block("⠋", &panel);
         assert!(status_block.starts_with("⠋ 진행 중"));


### PR DESCRIPTION
## #4601 — 라이브 상태 패널 헤더 재배치

패널 상단을 `턴트리거 → 턴 시작 → 마지막 업데이트` 순서로, 각 항목을 별도 줄로 분리(기존 `마지막 업데이트 / 턴 시작` 한 줄 결합 + footer의 턴트리거 → 상태 이모지 다음 헤더로 이동).

### 변경
- `placeholder_live_events/{freshness,status_panel,tests}.rs`: 시간 필드 2줄 분리 + 헤더 순서 조립.
- `single_message_panel.rs`: footer surface 인식이 신 분리형 + 배포 중 구 결합형 둘 다 인식(재시작 복구 호환). rollover 예산 테스트 산식 byte→char 정정(production은 원래 char 기반, Discord 2000=char 제한).
- `tmux_placeholder_suppression/mod.rs`: fixture를 새 헤더 형태로 갱신.
- 기존 KST 절대시각 + `<t:..:R>` relative + 딥링크 생성 불변.

### 리뷰/게이트
- dual CLEAN: leg A Opus + leg B gpt-5.6-sol fresh (head 98e3fc140). byte→char 테스트수정이 예산 회귀 은폐 아님을 양 leg가 확인(production char 기반, 회귀 없음).
- 게이트 GREEN: fmt/check/test(293 pass)/audit/freshness rc0.
- #3016 핫파일 무접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)