### PR TITLE
chore(cli): Discord 전송 3계열 공통 실행 경로로 DRY 통합 (#4225 슬라이스)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -62,7 +62,7 @@
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |
 | `cli::dcserver_pg_bootstrap` | `src/cli/dcserver_pg_bootstrap.rs` | 1068 | 544 | 524 |  |
 | `cli::direct` | `src/cli/direct.rs` | 1758 | 1758 | 0 | giant-file |
-| `cli::discord` | `src/cli/discord.rs` | 300 | 188 | 112 |  |
+| `cli::discord` | `src/cli/discord.rs` | 472 | 249 | 223 |  |
 | `cli::discord_thread_create` | `src/cli/discord_thread_create.rs` | 1468 | 415 | 1053 |  |
 | `cli::discord_thread_create_lock` | `src/cli/discord_thread_create_lock.rs` | 669 | 611 | 58 |  |
 | `cli::doctor` | `src/cli/doctor.rs` | 9 | 9 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -62,7 +62,7 @@
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |
 | `cli::dcserver_pg_bootstrap` | `src/cli/dcserver_pg_bootstrap.rs` | 1068 | 544 | 524 |  |
 | `cli::direct` | `src/cli/direct.rs` | 1758 | 1758 | 0 | giant-file |
-| `cli::discord` | `src/cli/discord.rs` | 123 | 123 | 0 |  |
+| `cli::discord` | `src/cli/discord.rs` | 300 | 188 | 112 |  |
 | `cli::discord_thread_create` | `src/cli/discord_thread_create.rs` | 1468 | 415 | 1053 |  |
 | `cli::discord_thread_create_lock` | `src/cli/discord_thread_create_lock.rs` | 669 | 611 | 58 |  |
 | `cli::doctor` | `src/cli/doctor.rs` | 9 | 9 | 0 |  |

--- a/src/cli/discord.rs
+++ b/src/cli/discord.rs
@@ -12,21 +12,78 @@ enum LegacyDiscordDestination {
     User(u64),
 }
 
+trait LegacyDiscordSender {
+    async fn send_file(
+        &self,
+        token: &str,
+        channel_id: u64,
+        path: &str,
+    ) -> Result<(), Box<dyn std::error::Error>>;
+
+    async fn send_channel_message(
+        &self,
+        token: &str,
+        channel_id: u64,
+        message: &str,
+    ) -> Result<(), Box<dyn std::error::Error>>;
+
+    async fn send_user_message(
+        &self,
+        token: &str,
+        user_id: u64,
+        message: &str,
+    ) -> Result<(), Box<dyn std::error::Error>>;
+}
+
+struct ServiceLegacyDiscordSender;
+
+impl LegacyDiscordSender for ServiceLegacyDiscordSender {
+    async fn send_file(
+        &self,
+        token: &str,
+        channel_id: u64,
+        path: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        services::discord::send_file_to_channel(token, channel_id, path).await
+    }
+
+    async fn send_channel_message(
+        &self,
+        token: &str,
+        channel_id: u64,
+        message: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        services::discord::send_message_to_channel(token, channel_id, message).await
+    }
+
+    async fn send_user_message(
+        &self,
+        token: &str,
+        user_id: u64,
+        message: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        services::discord::send_message_to_user(token, user_id, message).await
+    }
+}
+
 impl LegacyDiscordPayload<'_> {
-    async fn send(
+    async fn send<S: LegacyDiscordSender + ?Sized>(
         self,
+        sender: &S,
         token: &str,
         destination: LegacyDiscordDestination,
     ) -> Result<(), Box<dyn std::error::Error>> {
         match (self, destination) {
             (Self::File(path), LegacyDiscordDestination::Channel(channel_id)) => {
-                services::discord::send_file_to_channel(token, channel_id, path).await
+                sender.send_file(token, channel_id, path).await
             }
             (Self::Message(message), LegacyDiscordDestination::Channel(channel_id)) => {
-                services::discord::send_message_to_channel(token, channel_id, message).await
+                sender
+                    .send_channel_message(token, channel_id, message)
+                    .await
             }
             (Self::Message(message), LegacyDiscordDestination::User(user_id)) => {
-                services::discord::send_message_to_user(token, user_id, message).await
+                sender.send_user_message(token, user_id, message).await
             }
             (Self::File(_), LegacyDiscordDestination::User(_)) => {
                 unreachable!("legacy Discord file sends only support channels")
@@ -144,7 +201,11 @@ fn execute_legacy_discord_send(request: LegacyDiscordSend<'_>) {
     runtime.block_on(async move {
         let mut last_error = None;
         for token in tokens {
-            match request.payload.send(&token, request.destination).await {
+            match request
+                .payload
+                .send(&ServiceLegacyDiscordSender, &token, request.destination)
+                .await
+            {
                 Ok(()) => {
                     println!("{}", request.destination.success_message(request.payload));
                     return;
@@ -188,12 +249,80 @@ pub fn handle_discord_senddm(message: &str, user_id: u64, hash_key: Option<&str>
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
 
     use super::{
-        LegacyDiscordDestination, LegacyDiscordPayload, LegacyDiscordTokenSelection,
-        resolve_legacy_discord_tokens_with,
+        LegacyDiscordDestination, LegacyDiscordPayload, LegacyDiscordSender,
+        LegacyDiscordTokenSelection, resolve_legacy_discord_tokens_with,
     };
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum RecordedSend {
+        File {
+            token: String,
+            channel_id: u64,
+            path: String,
+        },
+        ChannelMessage {
+            token: String,
+            channel_id: u64,
+            message: String,
+        },
+        UserMessage {
+            token: String,
+            user_id: u64,
+            message: String,
+        },
+    }
+
+    #[derive(Default)]
+    struct RecordingSender {
+        sends: RefCell<Vec<RecordedSend>>,
+    }
+
+    impl LegacyDiscordSender for RecordingSender {
+        async fn send_file(
+            &self,
+            token: &str,
+            channel_id: u64,
+            path: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            self.sends.borrow_mut().push(RecordedSend::File {
+                token: token.to_string(),
+                channel_id,
+                path: path.to_string(),
+            });
+            Ok(())
+        }
+
+        async fn send_channel_message(
+            &self,
+            token: &str,
+            channel_id: u64,
+            message: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            self.sends.borrow_mut().push(RecordedSend::ChannelMessage {
+                token: token.to_string(),
+                channel_id,
+                message: message.to_string(),
+            });
+            Ok(())
+        }
+
+        async fn send_user_message(
+            &self,
+            token: &str,
+            user_id: u64,
+            message: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            self.sends.borrow_mut().push(RecordedSend::UserMessage {
+                token: token.to_string(),
+                user_id,
+                message: message.to_string(),
+            });
+            Ok(())
+        }
+    }
 
     #[test]
     fn hashed_token_selection_is_shared_by_all_legacy_send_shapes() {
@@ -296,5 +425,48 @@ mod tests {
         assert!(channel.supports(LegacyDiscordPayload::Message("hello")));
         assert!(user.supports(LegacyDiscordPayload::Message("hello")));
         assert!(!user.supports(LegacyDiscordPayload::File("report.txt")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn payload_dispatches_to_the_matching_low_level_sender() {
+        let sender = RecordingSender::default();
+
+        LegacyDiscordPayload::File("/tmp/report.txt")
+            .send(&sender, "file-token", LegacyDiscordDestination::Channel(42))
+            .await
+            .expect("file dispatch should succeed");
+        LegacyDiscordPayload::Message("channel body")
+            .send(
+                &sender,
+                "channel-token",
+                LegacyDiscordDestination::Channel(43),
+            )
+            .await
+            .expect("channel message dispatch should succeed");
+        LegacyDiscordPayload::Message("dm body")
+            .send(&sender, "dm-token", LegacyDiscordDestination::User(44))
+            .await
+            .expect("user message dispatch should succeed");
+
+        assert_eq!(
+            *sender.sends.borrow(),
+            vec![
+                RecordedSend::File {
+                    token: "file-token".to_string(),
+                    channel_id: 42,
+                    path: "/tmp/report.txt".to_string(),
+                },
+                RecordedSend::ChannelMessage {
+                    token: "channel-token".to_string(),
+                    channel_id: 43,
+                    message: "channel body".to_string(),
+                },
+                RecordedSend::UserMessage {
+                    token: "dm-token".to_string(),
+                    user_id: 44,
+                    message: "dm body".to_string(),
+                },
+            ]
+        );
     }
 }

--- a/src/cli/discord.rs
+++ b/src/cli/discord.rs
@@ -1,123 +1,300 @@
 use crate::services;
 
-pub fn handle_discord_sendfile(path: &str, channel_id: u64, hash_key: &str) {
-    use crate::services::discord::resolve_discord_token_by_hash;
-    let token = match resolve_discord_token_by_hash(hash_key) {
-        Some(t) => t,
-        None => {
-            eprintln!(
-                "Error: no Discord bot token found for hash key: {}",
-                hash_key
-            );
+#[derive(Clone, Copy)]
+enum LegacyDiscordPayload<'a> {
+    File(&'a str),
+    Message(&'a str),
+}
+
+#[derive(Clone, Copy)]
+enum LegacyDiscordDestination {
+    Channel(u64),
+    User(u64),
+}
+
+impl LegacyDiscordPayload<'_> {
+    async fn send(
+        self,
+        token: &str,
+        destination: LegacyDiscordDestination,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match (self, destination) {
+            (Self::File(path), LegacyDiscordDestination::Channel(channel_id)) => {
+                services::discord::send_file_to_channel(token, channel_id, path).await
+            }
+            (Self::Message(message), LegacyDiscordDestination::Channel(channel_id)) => {
+                services::discord::send_message_to_channel(token, channel_id, message).await
+            }
+            (Self::Message(message), LegacyDiscordDestination::User(user_id)) => {
+                services::discord::send_message_to_user(token, user_id, message).await
+            }
+            (Self::File(_), LegacyDiscordDestination::User(_)) => {
+                unreachable!("legacy Discord file sends only support channels")
+            }
+        }
+    }
+}
+
+impl LegacyDiscordDestination {
+    fn success_message(self, payload: LegacyDiscordPayload<'_>) -> String {
+        match (payload, self) {
+            (LegacyDiscordPayload::File(path), Self::Channel(_)) => format!("File sent: {path}"),
+            (LegacyDiscordPayload::Message(_), Self::Channel(channel_id)) => {
+                format!("Message sent to channel {channel_id}")
+            }
+            (LegacyDiscordPayload::Message(_), Self::User(user_id)) => {
+                format!("Message sent to user {user_id}")
+            }
+            (LegacyDiscordPayload::File(_), Self::User(_)) => {
+                unreachable!("legacy Discord file sends only support channels")
+            }
+        }
+    }
+
+    fn failure_message(self, payload: LegacyDiscordPayload<'_>, error: &str) -> String {
+        match (payload, self) {
+            (LegacyDiscordPayload::File(_), Self::Channel(_)) => {
+                format!("Failed to send file: {error}")
+            }
+            (LegacyDiscordPayload::Message(_), Self::Channel(_)) => {
+                format!("Failed to send message: {error}")
+            }
+            (LegacyDiscordPayload::Message(_), Self::User(_)) => {
+                format!("Failed to send DM: {error}")
+            }
+            (LegacyDiscordPayload::File(_), Self::User(_)) => {
+                unreachable!("legacy Discord file sends only support channels")
+            }
+        }
+    }
+
+    fn supports(self, payload: LegacyDiscordPayload<'_>) -> bool {
+        !matches!(
+            (payload, self),
+            (LegacyDiscordPayload::File(_), Self::User(_))
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LegacyDiscordTokenSelection<'a> {
+    RequiredHash(&'a str),
+    OptionalHash(Option<&'a str>),
+}
+
+struct LegacyDiscordSend<'a> {
+    payload: LegacyDiscordPayload<'a>,
+    destination: LegacyDiscordDestination,
+    token_selection: LegacyDiscordTokenSelection<'a>,
+}
+
+fn resolve_legacy_discord_tokens(
+    selection: LegacyDiscordTokenSelection<'_>,
+) -> Result<Vec<String>, String> {
+    resolve_legacy_discord_tokens_with(
+        selection,
+        crate::services::discord::resolve_discord_token_by_hash,
+        || {
+            crate::services::discord::load_discord_bot_launch_configs()
+                .into_iter()
+                .map(|config| config.token)
+                .collect()
+        },
+    )
+}
+
+fn resolve_legacy_discord_tokens_with<R, L>(
+    selection: LegacyDiscordTokenSelection<'_>,
+    resolve_hash: R,
+    load_configured: L,
+) -> Result<Vec<String>, String>
+where
+    R: FnOnce(&str) -> Option<String>,
+    L: FnOnce() -> Vec<String>,
+{
+    let tokens = match selection {
+        LegacyDiscordTokenSelection::RequiredHash(key)
+        | LegacyDiscordTokenSelection::OptionalHash(Some(key)) => resolve_hash(key)
+            .map(|token| vec![token])
+            .ok_or_else(|| format!("Error: no Discord bot token found for hash key: {key}"))?,
+        LegacyDiscordTokenSelection::OptionalHash(None) => load_configured(),
+    };
+
+    if tokens.is_empty() {
+        Err(
+            "Error: no configured Discord bot tokens found in agentdesk.yaml or credential files"
+                .to_string(),
+        )
+    } else {
+        Ok(tokens)
+    }
+}
+
+fn execute_legacy_discord_send(request: LegacyDiscordSend<'_>) {
+    debug_assert!(request.destination.supports(request.payload));
+    let tokens = match resolve_legacy_discord_tokens(request.token_selection) {
+        Ok(tokens) => tokens,
+        Err(error) => {
+            eprintln!("{error}");
             std::process::exit(1);
         }
     };
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
-    rt.block_on(async {
-        match services::discord::send_file_to_channel(&token, channel_id, path).await {
-            Ok(_) => println!("File sent: {}", path),
-            Err(e) => {
-                eprintln!("Failed to send file: {}", e);
-                std::process::exit(1);
+
+    let runtime = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+    runtime.block_on(async move {
+        let mut last_error = None;
+        for token in tokens {
+            match request.payload.send(&token, request.destination).await {
+                Ok(()) => {
+                    println!("{}", request.destination.success_message(request.payload));
+                    return;
+                }
+                Err(error) => last_error = Some(error.to_string()),
             }
         }
+
+        let error = last_error.unwrap_or_else(|| "unknown error".to_string());
+        eprintln!(
+            "{}",
+            request.destination.failure_message(request.payload, &error)
+        );
+        std::process::exit(1);
+    });
+}
+
+pub fn handle_discord_sendfile(path: &str, channel_id: u64, hash_key: &str) {
+    execute_legacy_discord_send(LegacyDiscordSend {
+        payload: LegacyDiscordPayload::File(path),
+        destination: LegacyDiscordDestination::Channel(channel_id),
+        token_selection: LegacyDiscordTokenSelection::RequiredHash(hash_key),
     });
 }
 
 pub fn handle_discord_sendmessage(message: &str, channel_id: u64, hash_key: Option<&str>) {
-    use crate::services::discord::{
-        load_discord_bot_launch_configs, resolve_discord_token_by_hash,
-    };
-
-    let tokens: Vec<String> = match hash_key {
-        Some(key) => match resolve_discord_token_by_hash(key) {
-            Some(token) => vec![token],
-            None => {
-                eprintln!("Error: no Discord bot token found for hash key: {}", key);
-                std::process::exit(1);
-            }
-        },
-        None => load_discord_bot_launch_configs()
-            .into_iter()
-            .map(|cfg| cfg.token)
-            .collect(),
-    };
-
-    if tokens.is_empty() {
-        eprintln!(
-            "Error: no configured Discord bot tokens found in agentdesk.yaml or credential files"
-        );
-        std::process::exit(1);
-    }
-
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
-    rt.block_on(async {
-        let mut last_error: Option<String> = None;
-        for token in tokens {
-            match services::discord::send_message_to_channel(&token, channel_id, message).await {
-                Ok(_) => {
-                    println!("Message sent to channel {}", channel_id);
-                    return;
-                }
-                Err(err) => {
-                    last_error = Some(err.to_string());
-                }
-            }
-        }
-
-        eprintln!(
-            "Failed to send message: {}",
-            last_error.unwrap_or_else(|| "unknown error".to_string())
-        );
-        std::process::exit(1);
+    execute_legacy_discord_send(LegacyDiscordSend {
+        payload: LegacyDiscordPayload::Message(message),
+        destination: LegacyDiscordDestination::Channel(channel_id),
+        token_selection: LegacyDiscordTokenSelection::OptionalHash(hash_key),
     });
 }
 
 pub fn handle_discord_senddm(message: &str, user_id: u64, hash_key: Option<&str>) {
-    use crate::services::discord::{
-        load_discord_bot_launch_configs, resolve_discord_token_by_hash,
+    execute_legacy_discord_send(LegacyDiscordSend {
+        payload: LegacyDiscordPayload::Message(message),
+        destination: LegacyDiscordDestination::User(user_id),
+        token_selection: LegacyDiscordTokenSelection::OptionalHash(hash_key),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::{
+        LegacyDiscordDestination, LegacyDiscordPayload, LegacyDiscordTokenSelection,
+        resolve_legacy_discord_tokens_with,
     };
 
-    let tokens: Vec<String> = match hash_key {
-        Some(key) => match resolve_discord_token_by_hash(key) {
-            Some(token) => vec![token],
-            None => {
-                eprintln!("Error: no Discord bot token found for hash key: {}", key);
-                std::process::exit(1);
-            }
-        },
-        None => load_discord_bot_launch_configs()
-            .into_iter()
-            .map(|cfg| cfg.token)
-            .collect(),
-    };
+    #[test]
+    fn hashed_token_selection_is_shared_by_all_legacy_send_shapes() {
+        for selection in [
+            LegacyDiscordTokenSelection::RequiredHash("file-key"),
+            LegacyDiscordTokenSelection::OptionalHash(Some("message-key")),
+            LegacyDiscordTokenSelection::OptionalHash(Some("dm-key")),
+        ] {
+            let configured_loaded = Cell::new(false);
+            let expected_key = match selection {
+                LegacyDiscordTokenSelection::RequiredHash(key)
+                | LegacyDiscordTokenSelection::OptionalHash(Some(key)) => key,
+                LegacyDiscordTokenSelection::OptionalHash(None) => unreachable!(),
+            };
+            let tokens = resolve_legacy_discord_tokens_with(
+                selection,
+                |key| Some(format!("token-for-{key}")),
+                || {
+                    configured_loaded.set(true);
+                    vec!["configured-token".to_string()]
+                },
+            )
+            .expect("hash should resolve");
 
-    if tokens.is_empty() {
-        eprintln!(
-            "Error: no configured Discord bot tokens found in agentdesk.yaml or credential files"
-        );
-        std::process::exit(1);
+            assert_eq!(tokens, vec![format!("token-for-{expected_key}")]);
+            assert!(!configured_loaded.get());
+        }
     }
 
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
-    rt.block_on(async {
-        let mut last_error: Option<String> = None;
-        for token in tokens {
-            match services::discord::send_message_to_user(&token, user_id, message).await {
-                Ok(_) => {
-                    println!("Message sent to user {}", user_id);
-                    return;
-                }
-                Err(err) => {
-                    last_error = Some(err.to_string());
-                }
-            }
-        }
+    #[test]
+    fn hash_resolution_failure_keeps_the_legacy_error_text() {
+        let error = resolve_legacy_discord_tokens_with(
+            LegacyDiscordTokenSelection::OptionalHash(Some("missing-key")),
+            |_| None,
+            Vec::new,
+        )
+        .unwrap_err();
 
-        eprintln!(
-            "Failed to send DM: {}",
-            last_error.unwrap_or_else(|| "unknown error".to_string())
+        assert_eq!(
+            error,
+            "Error: no Discord bot token found for hash key: missing-key"
         );
-        std::process::exit(1);
-    });
+    }
+
+    #[test]
+    fn configured_token_fallback_keeps_order_and_empty_error() {
+        let tokens = resolve_legacy_discord_tokens_with(
+            LegacyDiscordTokenSelection::OptionalHash(None),
+            |_| panic!("hash resolver must not run"),
+            || vec!["first".to_string(), "second".to_string()],
+        )
+        .expect("configured tokens should resolve");
+        assert_eq!(tokens, vec!["first".to_string(), "second".to_string()]);
+
+        let error = resolve_legacy_discord_tokens_with(
+            LegacyDiscordTokenSelection::OptionalHash(None),
+            |_| panic!("hash resolver must not run"),
+            Vec::new,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "Error: no configured Discord bot tokens found in agentdesk.yaml or credential files"
+        );
+    }
+
+    #[test]
+    fn payload_messages_preserve_each_legacy_cli_contract() {
+        let file = LegacyDiscordPayload::File("/tmp/report.txt");
+        let channel = LegacyDiscordDestination::Channel(42);
+        assert_eq!(channel.success_message(file), "File sent: /tmp/report.txt");
+        assert_eq!(
+            channel.failure_message(file, "denied"),
+            "Failed to send file: denied"
+        );
+
+        let message = LegacyDiscordPayload::Message("hello");
+        assert_eq!(
+            channel.success_message(message),
+            "Message sent to channel 42"
+        );
+        assert_eq!(
+            channel.failure_message(message, "denied"),
+            "Failed to send message: denied"
+        );
+
+        let user = LegacyDiscordDestination::User(43);
+        assert_eq!(user.success_message(message), "Message sent to user 43");
+        assert_eq!(
+            user.failure_message(message, "denied"),
+            "Failed to send DM: denied"
+        );
+    }
+
+    #[test]
+    fn destination_contract_accepts_only_the_three_legacy_send_shapes() {
+        let channel = LegacyDiscordDestination::Channel(42);
+        let user = LegacyDiscordDestination::User(43);
+        assert!(channel.supports(LegacyDiscordPayload::File("report.txt")));
+        assert!(channel.supports(LegacyDiscordPayload::Message("hello")));
+        assert!(user.supports(LegacyDiscordPayload::Message("hello")));
+        assert!(!user.supports(LegacyDiscordPayload::File("report.txt")));
+    }
 }


### PR DESCRIPTION
## #4225 슬라이스 — 레거시 Discord 전송 3계열 DRY 통합

`discord-sendfile`/`discord-sendmessage`/`discord-senddm`의 중복 로직(토큰 선택·순차 시도·runtime 생성·성공/실패 출력·exit)을 단일 실행 경로 `execute_legacy_discord_send`로 통합. 외부 CLI 인터페이스(커맨드명·플래그·출력·exit) 불변. routed `send`/`send-to-agent`·queue↔query는 계약 상이로 의도적 제외(follow-up).

### 변경 (`src/cli/discord.rs` 단일)
- `LegacyDiscordPayload`/`LegacyDiscordDestination` 모델 + 공통 `execute_legacy_discord_send`.
- `resolve_legacy_discord_tokens(_with)`: --key hash 선택 / 미지정 시 설정 봇 토큰 기존 순서 순차.
- **sender seam**(`LegacyDiscordSender` trait + 프로덕션 `ServiceLegacyDiscordSender` 1:1 위임) + dispatch 뮤테이션 가드 테스트(payload별 저수준 함수 배선 assert, 스왑 시 FAIL).

### 리뷰/게이트
- base dual: leg A Opus CLEAN + leg B gpt-5.6-terra(동작 전부 SOUND, dispatch 뮤테이션 가드 부재만 지적) → seam+가드테스트 보강 → seam 델타 Opus 카운터 CLEAN.
- 게이트 GREEN: fmt/check/test(23 pass, 뮤테이션 가드 포함)/audit/freshness rc0.
- #3016 핫파일 무접촉. DRY 강제 원칙 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)