### PR TITLE
chore(security): raw-spawn 가드를 substring→ClaudeBinary 타입 by-construction 승격 (#4619)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1970,7 +1970,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   migrated launchd validation, Discord notification plumbing, and agent
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
-- `src/services/platform/binary_resolver.rs` (1408) — provider CLI resolver
+- `src/services/platform/binary_resolver.rs` (1412) — provider CLI resolver
   surface. #3823 adds macOS Codex.app fallback discovery and all-candidate
   Codex semver probing so AgentDesk prefers the newest compatible Codex binary
   instead of silently launching a stale npm shim. #4619 threads the opaque

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1970,10 +1970,13 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   migrated launchd validation, Discord notification plumbing, and agent
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
-- `src/services/platform/binary_resolver.rs` (1395) — provider CLI resolver
+- `src/services/platform/binary_resolver.rs` (1408) — provider CLI resolver
   surface. #3823 adds macOS Codex.app fallback discovery and all-candidate
   Codex semver probing so AgentDesk prefers the newest compatible Codex binary
-  instead of silently launching a stale npm shim.
+  instead of silently launching a stale npm shim. #4619 threads the opaque
+  `ClaudeBinary` capability newtype through the resolver so the resolved Claude
+  path can only be consumed via `ClaudeCommandBuilder` (raw `Command::new`
+  by-construction blocked).
 - `src/services/discord/mod.rs` (now 4152 prod LoC after #4049 S4-a2 moved
   queue-marker routing into `queue_marker.rs` and retired direct reaction
   mutation call sites; 4157 prod LoC after #4048 S3 extracted

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -81,7 +81,7 @@
 | `src/services/auto_queue.rs` | 1545 |
 | `src/services/auto_queue/activate_command.rs` | 1506 |
 | `src/services/auto_queue/cancel_run.rs` | 1031 |
-| `src/services/claude.rs` | 2967 |
+| `src/services/claude.rs` | 2953 |
 | `src/services/claude_tui/input.rs` | 2187 |
 | `src/services/codex.rs` | 3131 |
 | `src/services/codex_tmux_wrapper.rs` | 1403 |
@@ -99,8 +99,8 @@
 | `src/services/memory/memento.rs` | 1893 |
 | `src/services/onboarding/mod.rs` | 2937 |
 | `src/services/opencode.rs` | 2760 |
-| `src/services/platform/binary_resolver.rs` | 1395 |
-| `src/services/provider.rs` | 1820 |
+| `src/services/platform/binary_resolver.rs` | 1408 |
+| `src/services/provider.rs` | 1822 |
 | `src/services/qwen.rs` | 2198 |
 | `src/services/routines/agent_executor.rs` | 2131 |
 | `src/services/routines/discord_log.rs` | 1594 |

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -99,7 +99,7 @@
 | `src/services/memory/memento.rs` | 1893 |
 | `src/services/onboarding/mod.rs` | 2937 |
 | `src/services/opencode.rs` | 2760 |
-| `src/services/platform/binary_resolver.rs` | 1408 |
+| `src/services/platform/binary_resolver.rs` | 1412 |
 | `src/services/provider.rs` | 1822 |
 | `src/services/qwen.rs` | 2198 |
 | `src/services/routines/agent_executor.rs` | 2131 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -378,7 +378,7 @@
 | `services::automation_candidate_materializer` | `src/services/automation_candidate_materializer.rs` | 844 | 844 | 0 |  |
 | `services::claude` | `src/services/claude.rs` | 4308 | 2953 | 1355 | giant-file |
 | `services::claude::backend_routing` | `src/services/claude/backend_routing.rs` | 122 | 122 | 0 |  |
-| `services::claude_command` | `src/services/claude_command.rs` | 949 | 458 | 491 |  |
+| `services::claude_command` | `src/services/claude_command.rs` | 956 | 465 | 491 |  |
 | `services::claude_compact_context` | `src/services/claude_compact_context.rs` | 1044 | 694 | 350 |  |
 | `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 722 | 369 | 353 |  |
 | `services::claude_e` | `src/services/claude_e/mod.rs` | 18 | 18 | 0 |  |
@@ -1003,7 +1003,7 @@
 | `services::pipeline_override` | `src/services/pipeline_override.rs` | 1001 | 333 | 668 |  |
 | `services::pipeline_routes` | `src/services/pipeline_routes.rs` | 863 | 672 | 191 |  |
 | `services::platform` | `src/services/platform/mod.rs` | 26 | 26 | 0 |  |
-| `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1561 | 1408 | 153 | giant-file |
+| `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1565 | 1412 | 153 | giant-file |
 | `services::platform::dump_tool` | `src/services/platform/dump_tool.rs` | 97 | 97 | 0 |  |
 | `services::platform::shell` | `src/services/platform/shell.rs` | 49 | 49 | 0 |  |
 | `services::platform::tmux` | `src/services/platform/tmux.rs` | 1263 | 951 | 312 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -204,7 +204,7 @@
 | `kanban::transition_cleanup` | `src/kanban/transition_cleanup.rs` | 341 | 341 | 0 |  |
 | `kanban::transition_core` | `src/kanban/transition_core.rs` | 674 | 674 | 0 |  |
 | `launch` | `src/launch.rs` | 67 | 67 | 0 |  |
-| `lib` | `src/lib.rs` | 170 | 170 | 0 |  |
+| `lib` | `src/lib.rs` | 187 | 187 | 0 |  |
 | `logging` | `src/logging.rs` | 554 | 382 | 172 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 35 | 35 | 0 |  |
 | `pipeline` | `src/pipeline.rs` | 1517 | 1383 | 134 | giant-file |
@@ -376,15 +376,15 @@
 | `services::auto_queue::view_admin_routes` | `src/services/auto_queue/view_admin_routes.rs` | 730 | 730 | 0 |  |
 | `services::automation_candidate_contract` | `src/services/automation_candidate_contract.rs` | 127 | 87 | 40 |  |
 | `services::automation_candidate_materializer` | `src/services/automation_candidate_materializer.rs` | 844 | 844 | 0 |  |
-| `services::claude` | `src/services/claude.rs` | 4320 | 2967 | 1353 | giant-file |
+| `services::claude` | `src/services/claude.rs` | 4308 | 2953 | 1355 | giant-file |
 | `services::claude::backend_routing` | `src/services/claude/backend_routing.rs` | 122 | 122 | 0 |  |
-| `services::claude_command` | `src/services/claude_command.rs` | 833 | 350 | 483 |  |
+| `services::claude_command` | `src/services/claude_command.rs` | 949 | 458 | 491 |  |
 | `services::claude_compact_context` | `src/services/claude_compact_context.rs` | 1044 | 694 | 350 |  |
 | `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 722 | 369 | 353 |  |
 | `services::claude_e` | `src/services/claude_e/mod.rs` | 18 | 18 | 0 |  |
 | `services::claude_e::cancellation` | `src/services/claude_e/cancellation.rs` | 3 | 3 | 0 |  |
 | `services::claude_e::jsonl_parser` | `src/services/claude_e/jsonl_parser.rs` | 4 | 4 | 0 |  |
-| `services::claude_e::process` | `src/services/claude_e/process.rs` | 451 | 393 | 58 |  |
+| `services::claude_e::process` | `src/services/claude_e/process.rs` | 445 | 387 | 58 |  |
 | `services::claude_e::spawn_queue` | `src/services/claude_e/spawn_queue.rs` | 3 | 3 | 0 |  |
 | `services::claude_gateway_proxy` | `src/services/claude_gateway_proxy.rs` | 372 | 179 | 193 |  |
 | `services::claude_tui` | `src/services/claude_tui/mod.rs` | 18 | 18 | 0 |  |
@@ -401,7 +401,7 @@
 | `services::claude_tui::hosting::warm_followup` | `src/services/claude_tui/hosting/warm_followup.rs` | 769 | 712 | 57 |  |
 | `services::claude_tui::input` | `src/services/claude_tui/input.rs` | 3989 | 2187 | 1802 | giant-file |
 | `services::claude_tui::memento_feedback` | `src/services/claude_tui/memento_feedback.rs` | 1566 | 863 | 703 |  |
-| `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 828 | 439 | 389 |  |
+| `services::claude_tui::session` | `src/services/claude_tui/session.rs` | 832 | 443 | 389 |  |
 | `services::claude_tui::startup_dialog` | `src/services/claude_tui/startup_dialog.rs` | 276 | 121 | 155 |  |
 | `services::claude_tui::transcript_tail` | `src/services/claude_tui/transcript_tail.rs` | 651 | 328 | 323 |  |
 | `services::claude_tui::tui_relay` | `src/services/claude_tui/tui_relay.rs` | 1323 | 618 | 705 |  |
@@ -1003,14 +1003,14 @@
 | `services::pipeline_override` | `src/services/pipeline_override.rs` | 1001 | 333 | 668 |  |
 | `services::pipeline_routes` | `src/services/pipeline_routes.rs` | 863 | 672 | 191 |  |
 | `services::platform` | `src/services/platform/mod.rs` | 26 | 26 | 0 |  |
-| `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1548 | 1395 | 153 | giant-file |
+| `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1561 | 1408 | 153 | giant-file |
 | `services::platform::dump_tool` | `src/services/platform/dump_tool.rs` | 97 | 97 | 0 |  |
 | `services::platform::shell` | `src/services/platform/shell.rs` | 49 | 49 | 0 |  |
 | `services::platform::tmux` | `src/services/platform/tmux.rs` | 1263 | 951 | 312 |  |
 | `services::platform::tmux::availability` | `src/services/platform/tmux/availability.rs` | 269 | 136 | 133 |  |
 | `services::pr_summary` | `src/services/pr_summary.rs` | 542 | 321 | 221 |  |
 | `services::process` | `src/services/process.rs` | 1229 | 759 | 470 |  |
-| `services::provider` | `src/services/provider.rs` | 2434 | 1820 | 614 | giant-file |
+| `services::provider` | `src/services/provider.rs` | 2436 | 1822 | 614 | giant-file |
 | `services::provider::cancel_token_claude_interrupt` | `src/services/provider/cancel_token_claude_interrupt.rs` | 317 | 142 | 175 |  |
 | `services::provider_auth` | `src/services/provider_auth.rs` | 628 | 400 | 228 |  |
 | `services::provider_cli` | `src/services/provider_cli/mod.rs` | 21 | 21 | 0 |  |
@@ -1023,7 +1023,7 @@
 | `services::provider_cli::registry` | `src/services/provider_cli/registry.rs` | 248 | 248 | 0 |  |
 | `services::provider_cli::retention` | `src/services/provider_cli/retention.rs` | 91 | 91 | 0 |  |
 | `services::provider_cli::session_guard` | `src/services/provider_cli/session_guard.rs` | 199 | 199 | 0 |  |
-| `services::provider_cli::smoke` | `src/services/provider_cli/smoke.rs` | 216 | 172 | 44 |  |
+| `services::provider_cli::smoke` | `src/services/provider_cli/smoke.rs` | 227 | 183 | 44 |  |
 | `services::provider_cli::snapshot` | `src/services/provider_cli/snapshot.rs` | 74 | 74 | 0 |  |
 | `services::provider_cli::upgrade` | `src/services/provider_cli/upgrade.rs` | 637 | 637 | 0 |  |
 | `services::provider_error_transcript` | `src/services/provider_error_transcript.rs` | 87 | 48 | 39 |  |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,23 @@ mod server;
 // service submodules. The remaining dirty submodules each carry a scoped allow
 // (with a residual count) to be retired subtree-by-subtree.
 mod services;
+
+/// Opaque capability for a resolved Claude executable.
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command;
+///
+/// fn bypass_the_claude_builder(binary: ClaudeBinary) {
+///     let _raw_command = Command::new(binary);
+/// }
+/// ```
+///
+/// `ClaudeBinary` intentionally does not implement `AsRef<OsStr>`, `Deref`,
+/// `Display`, or a public path getter. It can therefore be consumed only through
+/// guarded Claude launch APIs rather than passed directly to `Command::new`.
+pub use services::claude_command::ClaudeBinary;
+
 // Supervisor test hooks are intentionally retained for dispatch/runtime tests.
 pub(crate) mod supervisor;
 mod ui;

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -591,10 +591,8 @@ mod simple_launch_env_tests {
         launch_env: ClaudeLaunchEnv,
     ) -> std::collections::HashMap<String, Option<String>> {
         let resolution = claude_resolution();
-        let binary = crate::services::claude_command::ClaudeBinary::from_tmux_wrapper_argv(
-            "claude",
-        )
-        .unwrap();
+        let binary =
+            crate::services::claude_command::ClaudeBinary::from_tmux_wrapper_argv("claude");
         // Route through the chokepoint exactly as the production simple `-p`
         // spawn site does: the builder applies the gateway env by construction,
         // then `configure_execute_command_simple` adds the non-gateway config.

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -143,13 +143,13 @@ mod claude_tui_followup_requeue_flag_tests {
     }
 }
 
-/// Resolve the path to the claude binary.
-pub fn resolve_claude_path() -> Option<String> {
-    crate::services::platform::resolve_provider_binary("claude").resolved_path
-}
+type ClaudeResolution = (
+    crate::services::claude_command::ClaudeBinary,
+    crate::services::platform::BinaryResolution,
+);
 
-pub(crate) fn resolve_claude_binary() -> crate::services::platform::BinaryResolution {
-    crate::services::platform::resolve_provider_binary("claude")
+fn resolve_claude_binary() -> Result<ClaudeResolution, String> {
+    crate::services::claude_command::ClaudeBinary::resolve()
 }
 
 pub(crate) fn append_claude_mcp_config_arg(args: &mut Vec<String>, dispatch_type: Option<&str>) {
@@ -363,11 +363,7 @@ fn execute_command_simple_with_model_and_cancel(
         );
     session_selection.log_start("claude.execute_command_simple");
 
-    let resolution = resolve_claude_binary();
-    let claude_bin = resolution
-        .resolved_path
-        .clone()
-        .ok_or("Claude CLI not found")?;
+    let (claude_bin, resolution) = resolve_claude_binary()?;
 
     let mut args = vec![
         "-p".to_string(),
@@ -595,11 +591,15 @@ mod simple_launch_env_tests {
         launch_env: ClaudeLaunchEnv,
     ) -> std::collections::HashMap<String, Option<String>> {
         let resolution = claude_resolution();
+        let binary = crate::services::claude_command::ClaudeBinary::from_tmux_wrapper_argv(
+            "claude",
+        )
+        .unwrap();
         // Route through the chokepoint exactly as the production simple `-p`
         // spawn site does: the builder applies the gateway env by construction,
         // then `configure_execute_command_simple` adds the non-gateway config.
         let mut builder =
-            ClaudeCommandBuilder::build_for_test("claude", Some(&resolution), launch_env);
+            ClaudeCommandBuilder::for_binary_with_env(&binary, &resolution, launch_env);
         configure_execute_command_simple(builder.command_mut(), &[]);
         builder
             .into_command()
@@ -910,14 +910,13 @@ IMPORTANT: Format your responses using Markdown for better readability:
         return execute_streaming_remote(profile, &args, prompt, working_dir, sender, cancel_token);
     }
 
-    let resolution = resolve_claude_binary();
-    let claude_bin = resolution.resolved_path.clone().ok_or_else(|| {
+    let (claude_bin, resolution) = resolve_claude_binary().map_err(|error| {
         debug_log("ERROR: Claude CLI not found");
-        "Claude CLI not found. Is Claude CLI installed?".to_string()
+        error
     })?;
 
     debug_log("--- Spawning claude process ---");
-    debug_log(&format!("Command: {}", claude_bin));
+    debug_log("Command: resolved Claude binary");
     debug_log(&format!("Args count: {}", args.len()));
     for (i, arg) in args.iter().enumerate() {
         if arg.len() > 100 {
@@ -2042,15 +2041,11 @@ fn prepare_and_create_claude_tui_session(
     let launch_result = (|| -> Result<std::process::Output, String> {
         let exe =
             std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
-        let resolution = resolve_claude_binary();
-        let claude_bin = resolution
-            .resolved_path
-            .clone()
-            .ok_or_else(|| "Claude CLI not found".to_string())?;
+        let (claude_bin, _resolution) = resolve_claude_binary()?;
         let launch_config = crate::services::claude_tui::session::ClaudeTuiLaunchConfig {
             tmux_session_name: tmux_session_name.to_string(),
             working_dir: working_dir_path.to_path_buf(),
-            claude_bin: std::path::PathBuf::from(claude_bin),
+            claude_bin,
             agentdesk_exe: exe,
             hook_endpoint,
             session_id: resolved_session_id.to_string(),
@@ -2812,11 +2807,7 @@ fn execute_streaming_local_tmux(
     // Get paths
     let exe =
         std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
-    let resolution = resolve_claude_binary();
-    let claude_bin = resolution
-        .resolved_path
-        .clone()
-        .ok_or_else(|| "Claude CLI not found".to_string())?;
+    let (claude_bin, resolution) = resolve_claude_binary()?;
 
     // Build wrapper command via script file to avoid tmux "command too long" errors.
     // The system prompt in --append-system-prompt can be thousands of chars, exceeding
@@ -2842,6 +2833,8 @@ fn execute_streaming_local_tmux(
         &launch_env,
     );
 
+    let mut escaped_claude_bin = String::new();
+    claude_bin.append_shell_escaped_to(&mut escaped_claude_bin);
     let script_content = format!(
         "#!/bin/bash\n\
         {env}\
@@ -2857,7 +2850,7 @@ fn execute_streaming_local_tmux(
         input_fifo = shell_escape(&input_fifo_path),
         prompt = shell_escape(&prompt_path),
         wd = shell_escape(working_dir),
-        claude_bin = shell_escape(&claude_bin),
+        claude_bin = escaped_claude_bin,
         claude_args = escaped_args.join(" "),
     );
 
@@ -3101,12 +3094,9 @@ pub(crate) fn execute_streaming_local_process(
 
     // Build wrapper args — no shell_escape here because ProcessBackend uses
     // Command::new().args() (direct argv), not a shell script.
-    let resolution = resolve_claude_binary();
-    let claude_bin = resolution
-        .resolved_path
-        .clone()
-        .ok_or_else(|| "Claude CLI not found".to_string())?;
-    let mut wrapper_args: Vec<String> = vec!["--".to_string(), claude_bin.to_string()];
+    let (claude_bin, resolution) = resolve_claude_binary()?;
+    let mut wrapper_args = Vec::new();
+    claude_bin.append_process_backend_wrapper_args(&mut wrapper_args);
     wrapper_args.extend(args.iter().map(|a| a.to_string()));
 
     let exe =

--- a/src/services/claude_command.rs
+++ b/src/services/claude_command.rs
@@ -26,7 +26,6 @@
 //! other module references them directly, so the single authority cannot erode.
 
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
 use std::process::Command;
 
 use crate::services::claude_gateway_proxy::ClaudeGatewayProxyEnv;
@@ -64,15 +63,10 @@ impl ClaudeBinary {
         Ok((binary, resolution))
     }
 
-    pub(crate) fn from_tmux_wrapper_argv(program: &str) -> Result<Self, String> {
-        let candidate = Path::new(program);
-        let file_name = candidate.file_name().and_then(OsStr::to_str);
-        if file_name != Some("claude") {
-            return Err("tmux-wrapper requires a Claude executable as its command".to_string());
+    pub(crate) fn from_tmux_wrapper_argv(program: &str) -> Self {
+        Self {
+            program: OsString::from(program),
         }
-        Ok(Self {
-            program: candidate.as_os_str().to_os_string(),
-        })
     }
 
     fn from_cli_boundary(program: impl AsRef<OsStr>) -> Self {
@@ -402,14 +396,11 @@ impl ClaudeCommandBuilder {
     /// untyped CLI argv ingress; once it is wrapped, the path cannot escape this
     /// module. Applies the exec-path PATH plus the supplied (already-resolved)
     /// launch env by construction.
-    pub(crate) fn for_tmux_wrapper_argv(
-        program: &str,
-        launch_env: ClaudeLaunchEnv,
-    ) -> Result<Self, String> {
-        let binary = ClaudeBinary::from_tmux_wrapper_argv(program)?;
+    pub(crate) fn for_tmux_wrapper_argv(program: &str, launch_env: ClaudeLaunchEnv) -> Self {
+        let binary = ClaudeBinary::from_tmux_wrapper_argv(program);
         let mut builder = Self::build(binary.program(), None, launch_env);
         binary.augment_exec_path(builder.command_mut());
-        Ok(builder)
+        builder
     }
 
     /// Test-only constructor that injects a pre-resolved launch env, letting a
@@ -480,7 +471,7 @@ mod chokepoint_gateway_mutation_tests {
     }
 
     fn claude_binary() -> ClaudeBinary {
-        ClaudeBinary::from_tmux_wrapper_argv("claude").unwrap()
+        ClaudeBinary::from_tmux_wrapper_argv("claude")
     }
 
     // Mutation target: `ClaudeCommandBuilder::build` applies the gateway env via
@@ -548,8 +539,7 @@ mod chokepoint_gateway_mutation_tests {
         let builder = ClaudeCommandBuilder::for_tmux_wrapper_argv(
             "/opt/claude/bin/claude",
             ClaudeLaunchEnv::inject_for_test("http://127.0.0.1:10100"),
-        )
-        .unwrap();
+        );
         let envs = command_env_map(&builder.into_command());
         assert_eq!(
             envs.get(BASE_URL_ENV),
@@ -558,19 +548,6 @@ mod chokepoint_gateway_mutation_tests {
         assert_eq!(envs.get(DISCOVERY_ENV), Some(&Some("1".to_string())));
         // exec-path PATH is derived from the binary path (augment_exec_path).
         assert!(envs.get("PATH").is_some());
-    }
-
-    #[test]
-    fn tmux_wrapper_argv_rejects_non_claude_programs() {
-        let error = ClaudeCommandBuilder::for_tmux_wrapper_argv(
-            "/opt/codex/bin/codex",
-            ClaudeLaunchEnv::scrub_for_test(),
-        )
-        .unwrap_err();
-        assert_eq!(
-            error,
-            "tmux-wrapper requires a Claude executable as its command"
-        );
     }
 
     fn inject(url: &str) -> ClaudeGatewayProxyEnv {

--- a/src/services/claude_command.rs
+++ b/src/services/claude_command.rs
@@ -25,11 +25,86 @@
 //! source-scanning guard test (`chokepoint_guard_tests`) fails the build if any
 //! other module references them directly, so the single authority cannot erode.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
 use std::process::Command;
 
 use crate::services::claude_gateway_proxy::ClaudeGatewayProxyEnv;
 use crate::services::platform::BinaryResolution;
+
+/// Opaque capability for the resolved Claude executable.
+///
+/// Its only constructor and path consumers are crate-private. In particular,
+/// this type deliberately does not implement `AsRef<OsStr>`, `AsRef<Path>`,
+/// `Deref`, `Display`, or expose any path getter, so code outside this module
+/// cannot feed it to `Command::new` (directly, through a re-binding, or through
+/// a helper).
+#[derive(Clone, PartialEq, Eq)]
+pub struct ClaudeBinary {
+    program: OsString,
+}
+
+impl std::fmt::Debug for ClaudeBinary {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ClaudeBinary(..)")
+    }
+}
+
+impl ClaudeBinary {
+    pub(crate) fn from_resolution(resolution: &BinaryResolution) -> Option<Self> {
+        resolution.resolved_path.as_ref().map(|path| Self {
+            program: OsString::from(path),
+        })
+    }
+
+    pub(crate) fn resolve() -> Result<(Self, BinaryResolution), String> {
+        let resolution = crate::services::platform::resolve_provider_binary("claude");
+        let binary = Self::from_resolution(&resolution)
+            .ok_or_else(|| "Claude CLI not found. Is Claude CLI installed?".to_string())?;
+        Ok((binary, resolution))
+    }
+
+    pub(crate) fn from_tmux_wrapper_argv(program: &str) -> Result<Self, String> {
+        let candidate = Path::new(program);
+        let file_name = candidate.file_name().and_then(OsStr::to_str);
+        if file_name != Some("claude") {
+            return Err("tmux-wrapper requires a Claude executable as its command".to_string());
+        }
+        Ok(Self {
+            program: candidate.as_os_str().to_os_string(),
+        })
+    }
+
+    fn from_cli_boundary(program: impl AsRef<OsStr>) -> Self {
+        Self {
+            program: program.as_ref().to_os_string(),
+        }
+    }
+
+    fn program(&self) -> &OsStr {
+        &self.program
+    }
+
+    pub(crate) fn append_process_backend_wrapper_args(&self, args: &mut Vec<String>) {
+        args.push("--".to_string());
+        args.push(self.program.to_string_lossy().into_owned());
+    }
+
+    pub(crate) fn append_claude_e_bin_arg(&self, args: &mut Vec<String>) {
+        args.push("--claude-bin".to_string());
+        args.push(self.program.to_string_lossy().into_owned());
+    }
+
+    pub(crate) fn append_shell_escaped_to(&self, output: &mut String) {
+        output.push_str(&crate::services::process::shell_escape(
+            self.program.to_string_lossy().as_ref(),
+        ));
+    }
+
+    pub(crate) fn augment_exec_path(&self, command: &mut Command) {
+        crate::services::platform::augment_exec_path(command, Path::new(&self.program));
+    }
+}
 
 /// Why a Claude process is being spawned. Selects the gateway env policy so the
 /// launch-vs-probe decision is made in exactly one place.
@@ -245,11 +320,11 @@ impl ClaudeCommandBuilder {
     /// Build a command that launches the Claude binary directly. Applies the
     /// binary-resolution PATH and the gateway env for `intent` by construction.
     pub(crate) fn for_binary(
-        program: impl AsRef<OsStr>,
+        binary: &ClaudeBinary,
         resolution: &BinaryResolution,
         intent: ClaudeLaunchIntent,
     ) -> Self {
-        Self::build(program, Some(resolution), ClaudeLaunchEnv::resolve(intent))
+        Self::build(binary.program(), Some(resolution), ClaudeLaunchEnv::resolve(intent))
     }
 
     /// Binary-launch variant of [`for_binary`] that threads in an
@@ -261,11 +336,11 @@ impl ClaudeCommandBuilder {
     /// probe the proxy twice and disagree. Applies the binary-resolution PATH
     /// plus the supplied launch env through the shared `build` guard arm.
     pub(crate) fn for_binary_with_env(
-        program: impl AsRef<OsStr>,
+        binary: &ClaudeBinary,
         resolution: &BinaryResolution,
         launch_env: ClaudeLaunchEnv,
     ) -> Self {
-        Self::build(program, Some(resolution), launch_env)
+        Self::build(binary.program(), Some(resolution), launch_env)
     }
 
     /// Build a command that launches a wrapper program which transitively
@@ -294,19 +369,47 @@ impl ClaudeCommandBuilder {
         Self::build(program, None, launch_env)
     }
 
-    /// Build a command that launches the Claude binary directly when only its
-    /// path (not a full [`BinaryResolution`]) is known — the tmux-wrapper case,
-    /// where the Claude command line arrives as argv. Applies the exec-path PATH
-    /// derived from the binary path plus the supplied (already-resolved) launch
-    /// env, both by construction. The launch env is threaded in (rather than
-    /// re-resolved) so the wrapper can honour its managed-vs-public decision from
-    /// [`ClaudeLaunchEnv::for_tmux_wrapper`]; the gateway env is still applied
-    /// through the shared `build` guard arm.
-    pub(crate) fn for_binary_path(program: impl AsRef<OsStr>, launch_env: ClaudeLaunchEnv) -> Self {
-        let program = program.as_ref();
-        let mut builder = Self::build(program, None, launch_env);
-        crate::services::platform::augment_exec_path(builder.command_mut(), program);
+    /// Build the native Claude `--version` probe from a resolved capability.
+    /// The generic platform resolver owns candidate discovery; production Claude
+    /// launches enter this builder only after the candidate is wrapped.
+    pub(crate) fn for_resolved_version_probe(
+        binary: &ClaudeBinary,
+        resolution: &BinaryResolution,
+    ) -> Self {
+        Self::build(
+            binary.program(),
+            Some(resolution),
+            ClaudeLaunchEnv::resolve(ClaudeLaunchIntent::VersionProbe),
+        )
+    }
+
+    /// Build the native Claude version-smoke probe. This uses the CLI boundary
+    /// string only after the provider discriminator selected `claude`.
+    pub(crate) fn for_version_smoke(program: &str, canonical_path: &str) -> Self {
+        let binary = ClaudeBinary::from_cli_boundary(program);
+        let canonical = ClaudeBinary::from_cli_boundary(canonical_path);
+        let mut builder = Self::build(
+            binary.program(),
+            None,
+            ClaudeLaunchEnv::resolve(ClaudeLaunchIntent::VersionProbe),
+        );
+        canonical.augment_exec_path(builder.command_mut());
         builder
+    }
+
+    /// Build a command that launches the Claude binary delivered by the
+    /// `agentdesk tmux-wrapper` boundary. The wrapper boundary is the sole
+    /// untyped CLI argv ingress; once it is wrapped, the path cannot escape this
+    /// module. Applies the exec-path PATH plus the supplied (already-resolved)
+    /// launch env by construction.
+    pub(crate) fn for_tmux_wrapper_argv(
+        program: &str,
+        launch_env: ClaudeLaunchEnv,
+    ) -> Result<Self, String> {
+        let binary = ClaudeBinary::from_tmux_wrapper_argv(program)?;
+        let mut builder = Self::build(binary.program(), None, launch_env);
+        binary.augment_exec_path(builder.command_mut());
+        Ok(builder)
     }
 
     /// Test-only constructor that injects a pre-resolved launch env, letting a
@@ -319,6 +422,15 @@ impl ClaudeCommandBuilder {
         launch_env: ClaudeLaunchEnv,
     ) -> Self {
         Self::build(program, resolution, launch_env)
+    }
+
+    #[cfg(test)]
+    fn build_for_binary_test(
+        binary: &ClaudeBinary,
+        resolution: Option<&BinaryResolution>,
+        launch_env: ClaudeLaunchEnv,
+    ) -> Self {
+        Self::build(binary.program(), resolution, launch_env)
     }
 
     /// Mutable access to the wrapped command for site-specific configuration
@@ -367,6 +479,10 @@ mod chokepoint_gateway_mutation_tests {
         }
     }
 
+    fn claude_binary() -> ClaudeBinary {
+        ClaudeBinary::from_tmux_wrapper_argv("claude").unwrap()
+    }
+
     // Mutation target: `ClaudeCommandBuilder::build` applies the gateway env via
     // `launch_env.apply_to_command`. Every Claude spawn site funnels through
     // `build` (via `for_binary` / `for_wrapper`), so deleting that single line
@@ -376,8 +492,9 @@ mod chokepoint_gateway_mutation_tests {
     #[test]
     fn for_binary_injects_gateway_env_by_construction() {
         let resolution = claude_resolution();
-        let builder = ClaudeCommandBuilder::build_for_test(
-            "claude",
+        let binary = claude_binary();
+        let builder = ClaudeCommandBuilder::build_for_binary_test(
+            &binary,
             Some(&resolution),
             ClaudeLaunchEnv::inject_for_test("http://127.0.0.1:10100"),
         );
@@ -394,8 +511,9 @@ mod chokepoint_gateway_mutation_tests {
     #[test]
     fn for_binary_scrubs_inherited_gateway_env_by_construction() {
         let resolution = claude_resolution();
-        let builder = ClaudeCommandBuilder::build_for_test(
-            "claude",
+        let binary = claude_binary();
+        let builder = ClaudeCommandBuilder::build_for_binary_test(
+            &binary,
             Some(&resolution),
             ClaudeLaunchEnv::scrub_for_test(),
         );
@@ -424,13 +542,14 @@ mod chokepoint_gateway_mutation_tests {
     }
 
     #[test]
-    fn for_binary_path_applies_launch_env_by_construction() {
+    fn tmux_wrapper_argv_applies_launch_env_by_construction() {
         // The tmux-wrapper constructor: gateway env applied through the shared
         // `build` guard arm (removing it fails this), PATH added on top.
-        let builder = ClaudeCommandBuilder::for_binary_path(
+        let builder = ClaudeCommandBuilder::for_tmux_wrapper_argv(
             "/opt/claude/bin/claude",
             ClaudeLaunchEnv::inject_for_test("http://127.0.0.1:10100"),
-        );
+        )
+        .unwrap();
         let envs = command_env_map(&builder.into_command());
         assert_eq!(
             envs.get(BASE_URL_ENV),
@@ -439,6 +558,19 @@ mod chokepoint_gateway_mutation_tests {
         assert_eq!(envs.get(DISCOVERY_ENV), Some(&Some("1".to_string())));
         // exec-path PATH is derived from the binary path (augment_exec_path).
         assert!(envs.get("PATH").is_some());
+    }
+
+    #[test]
+    fn tmux_wrapper_argv_rejects_non_claude_programs() {
+        let error = ClaudeCommandBuilder::for_tmux_wrapper_argv(
+            "/opt/codex/bin/codex",
+            ClaudeLaunchEnv::scrub_for_test(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "tmux-wrapper requires a Claude executable as its command"
+        );
     }
 
     fn inject(url: &str) -> ClaudeGatewayProxyEnv {
@@ -575,11 +707,13 @@ mod chokepoint_guard_tests {
         ".gateway_proxy_env().append",
     ];
 
-    /// Raw `Command::new(<claude binary var>)` idioms. These are exactly the
-    /// bypass class #4559 R-B flagged (tmux_wrapper spawning Claude directly):
-    /// a Claude/claude-e binary spawned as a `Command` without going through
-    /// `ClaudeCommandBuilder`. Every such spawn now routes through the builder,
-    /// so any reappearance of these idioms is a regression that fails the build.
+    /// Defense-in-depth text guard for raw `Command::new(<claude binary var>)`
+    /// idioms. The primary defense is [`ClaudeBinary`]: its private path field
+    /// and deliberately absent `AsRef<OsStr>`/`Deref` implementations make a
+    /// resolved Claude binary unusable with `Command::new`, including through
+    /// aliases, re-bindings, helpers, and closures. This scan remains as a cheap
+    /// regression tripwire for raw string argv received at the public wrapper
+    /// boundary.
     const FORBIDDEN_RAW_SPAWN: &[&str] = &[
         "Command::new(claude_bin",
         "Command::new(&claude_bin",
@@ -720,9 +854,9 @@ mod chokepoint_guard_tests {
         );
     }
 
-    /// Guards the specific bypass class R-B found: a raw `Command::new(claude…)`
-    /// that launches Claude/claude-e without the chokepoint. Removing the
-    /// tmux_wrapper builder wiring (reintroducing the raw spawn) fails here.
+    /// Defense-in-depth regression tripwire for the specific raw-spawn spelling
+    /// R-B found. `ClaudeBinary` is the primary by-construction guard; this scan
+    /// stays intentionally narrow to catch an untyped wrapper-argv regression.
     #[test]
     fn claude_binaries_are_not_raw_spawned_outside_the_chokepoint() {
         let sources = crate_source_entries();

--- a/src/services/claude_command.rs
+++ b/src/services/claude_command.rs
@@ -32,13 +32,17 @@ use std::process::Command;
 use crate::services::claude_gateway_proxy::ClaudeGatewayProxyEnv;
 use crate::services::platform::BinaryResolution;
 
-/// Opaque capability for the resolved Claude executable.
+/// Opaque capability for the builder's resolved Claude executable path.
 ///
-/// Its only constructor and path consumers are crate-private. In particular,
-/// this type deliberately does not implement `AsRef<OsStr>`, `AsRef<Path>`,
-/// `Deref`, `Display`, or expose any path getter, so code outside this module
-/// cannot feed it to `Command::new` (directly, through a re-binding, or through
-/// a helper).
+/// This type deliberately does not implement `AsRef<OsStr>`, `AsRef<Path>`,
+/// `Deref`, `Display`, or expose any path getter, so `Command::new(ClaudeBinary)`
+/// is a compile error. That seals the builder's typed path, including aliases,
+/// re-bindings, helpers, and closures that receive this capability.
+///
+/// This is not complete resolver-layer sealing: the public
+/// `resolve_provider_binary("claude").resolved_path` still exposes a raw path
+/// that a new spawn site could misuse. Full by-construction sealing is tracked in
+/// #4627; `FORBIDDEN_RAW_SPAWN` remains defense-in-depth in the meantime.
 #[derive(Clone, PartialEq, Eq)]
 pub struct ClaudeBinary {
     program: OsString,
@@ -80,6 +84,9 @@ impl ClaudeBinary {
         &self.program
     }
 
+    // The established wrapper/script contracts below require string argv egress.
+    // These controlled conversions are not general path getters or raw-spawn
+    // escape hatches.
     pub(crate) fn append_process_backend_wrapper_args(&self, args: &mut Vec<String>) {
         args.push("--".to_string());
         args.push(self.program.to_string_lossy().into_owned());

--- a/src/services/claude_command.rs
+++ b/src/services/claude_command.rs
@@ -26,6 +26,7 @@
 //! other module references them directly, so the single authority cannot erode.
 
 use std::ffi::{OsStr, OsString};
+use std::path::Path;
 use std::process::Command;
 
 use crate::services::claude_gateway_proxy::ClaudeGatewayProxyEnv;

--- a/src/services/claude_command.rs
+++ b/src/services/claude_command.rs
@@ -319,7 +319,11 @@ impl ClaudeCommandBuilder {
         resolution: &BinaryResolution,
         intent: ClaudeLaunchIntent,
     ) -> Self {
-        Self::build(binary.program(), Some(resolution), ClaudeLaunchEnv::resolve(intent))
+        Self::build(
+            binary.program(),
+            Some(resolution),
+            ClaudeLaunchEnv::resolve(intent),
+        )
     }
 
     /// Binary-launch variant of [`for_binary`] that threads in an

--- a/src/services/claude_e/process.rs
+++ b/src/services/claude_e/process.rs
@@ -15,7 +15,9 @@ use std::sync::mpsc::Sender;
 use serde_json::Value;
 
 use crate::services::agent_protocol::{RuntimeHandoff, StreamMessage, is_valid_session_id};
-use crate::services::claude_command::{ClaudeCommandBuilder, ClaudeLaunchEnv, ClaudeLaunchIntent};
+use crate::services::claude_command::{
+    ClaudeBinary, ClaudeCommandBuilder, ClaudeLaunchEnv, ClaudeLaunchIntent,
+};
 use crate::services::claude_compact_context::{
     apply_auto_compact_window_to_command, launch_auto_compact_window,
 };
@@ -58,19 +60,14 @@ pub fn execute_streaming(
     let claude_e_bin = which::which("claude-e").map_err(|_| {
         "claude-e CLI not found. Install with `npm install -g claude-e`.".to_string()
     })?;
-    let claude_resolution = crate::services::claude::resolve_claude_binary();
-    let claude_bin = claude_resolution
-        .resolved_path
-        .clone()
-        .ok_or_else(|| "Claude CLI not found. Is Claude CLI installed?".to_string())?;
+    let (claude_bin, _claude_resolution) = ClaudeBinary::resolve()?;
 
     let mut args: Vec<String> = vec![
         "--output-format".to_string(),
         "stream-json".to_string(),
-        "--claude-bin".to_string(),
-        claude_bin.clone(),
-        "--no-session-footer".to_string(),
     ];
+    claude_bin.append_claude_e_bin_arg(&mut args);
+    args.push("--no-session-footer".to_string());
     crate::services::claude::append_claude_mcp_config_arg(&mut args, dispatch_type);
     crate::services::claude::append_claude_fast_mode_arg(&mut args, fast_mode_enabled);
     if let Some(model) = model_override {
@@ -90,7 +87,7 @@ pub fn execute_streaming(
 
     tracing::info!(
         binary = %claude_e_bin.display(),
-        claude_bin = %claude_bin,
+        claude_binary = "resolved",
         working_dir = working_dir,
         session_id = session_id,
         model = model_override,

--- a/src/services/claude_e/process.rs
+++ b/src/services/claude_e/process.rs
@@ -62,10 +62,7 @@ pub fn execute_streaming(
     })?;
     let (claude_bin, _claude_resolution) = ClaudeBinary::resolve()?;
 
-    let mut args: Vec<String> = vec![
-        "--output-format".to_string(),
-        "stream-json".to_string(),
-    ];
+    let mut args: Vec<String> = vec!["--output-format".to_string(), "stream-json".to_string()];
     claude_bin.append_claude_e_bin_arg(&mut args);
     args.push("--no-session-footer".to_string());
     crate::services::claude::append_claude_mcp_config_arg(&mut args, dispatch_type);

--- a/src/services/claude_tui/session.rs
+++ b/src/services/claude_tui/session.rs
@@ -453,7 +453,7 @@ mod tests {
         ClaudeTuiLaunchConfig {
             tmux_session_name: "AgentDesk-claude-test".to_string(),
             working_dir: PathBuf::from("/tmp/project dir"),
-            claude_bin: ClaudeBinary::from_tmux_wrapper_argv("/usr/local/bin/claude").unwrap(),
+            claude_bin: ClaudeBinary::from_tmux_wrapper_argv("/usr/local/bin/claude"),
             agentdesk_exe: PathBuf::from("/usr/local/bin/agentdesk"),
             hook_endpoint: "http://127.0.0.1:49152".to_string(),
             session_id: "01234567-89ab-cdef-0123-456789abcdef".to_string(),

--- a/src/services/claude_tui/session.rs
+++ b/src/services/claude_tui/session.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::services::claude_command::ClaudeLaunchEnv;
+use crate::services::claude_command::{ClaudeBinary, ClaudeLaunchEnv};
 use crate::services::claude_tui::hook_bundle::{HookBundleConfig, write_claude_hook_settings};
 use crate::services::process::shell_escape;
 
@@ -272,7 +272,7 @@ fn persist_claude_continuation_session_files(
 pub struct ClaudeTuiLaunchConfig {
     pub tmux_session_name: String,
     pub working_dir: PathBuf,
-    pub claude_bin: PathBuf,
+    pub(crate) claude_bin: ClaudeBinary,
     pub agentdesk_exe: PathBuf,
     pub hook_endpoint: String,
     pub session_id: String,
@@ -422,6 +422,10 @@ fn write_launch_script(
         &mut gateway_exports,
         None,
     );
+    let mut escaped_claude_bin = String::new();
+    config
+        .claude_bin
+        .append_shell_escaped_to(&mut escaped_claude_bin);
     let script = format!(
         "#!/bin/bash\n\
          cd {cwd}\n\
@@ -429,7 +433,7 @@ fn write_launch_script(
          {gateway_exports}\
          exec {claude_bin} {args}\n",
         cwd = shell_escape(&config.working_dir.display().to_string()),
-        claude_bin = shell_escape(&config.claude_bin.display().to_string()),
+        claude_bin = escaped_claude_bin,
         gateway_exports = gateway_exports,
         args = args,
     );
@@ -449,7 +453,7 @@ mod tests {
         ClaudeTuiLaunchConfig {
             tmux_session_name: "AgentDesk-claude-test".to_string(),
             working_dir: PathBuf::from("/tmp/project dir"),
-            claude_bin: PathBuf::from("/usr/local/bin/claude"),
+            claude_bin: ClaudeBinary::from_tmux_wrapper_argv("/usr/local/bin/claude").unwrap(),
             agentdesk_exe: PathBuf::from("/usr/local/bin/agentdesk"),
             hook_endpoint: "http://127.0.0.1:49152".to_string(),
             session_id: "01234567-89ab-cdef-0123-456789abcdef".to_string(),

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -804,14 +804,13 @@ pub fn probe_resolved_binary_version(
     resolution: &BinaryResolution,
 ) -> (Option<String>, Option<String>) {
     let mut command = if resolution.requested_binary == "claude" {
-        let Some(binary) = crate::services::claude_command::ClaudeBinary::from_resolution(
-            resolution,
-        ) else {
+        let Some(binary) =
+            crate::services::claude_command::ClaudeBinary::from_resolution(resolution)
+        else {
             return (None, Some("version_probe_spawn_failed".to_string()));
         };
         crate::services::claude_command::ClaudeCommandBuilder::for_resolved_version_probe(
-            &binary,
-            resolution,
+            &binary, resolution,
         )
         .into_command()
     } else {

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -803,8 +803,22 @@ pub fn probe_resolved_binary_version(
     binary_path: impl AsRef<OsStr>,
     resolution: &BinaryResolution,
 ) -> (Option<String>, Option<String>) {
-    let mut command = Command::new(binary_path);
-    configure_version_probe_command(&mut command, resolution);
+    let mut command = if resolution.requested_binary == "claude" {
+        let Some(binary) = crate::services::claude_command::ClaudeBinary::from_resolution(
+            resolution,
+        ) else {
+            return (None, Some("version_probe_spawn_failed".to_string()));
+        };
+        crate::services::claude_command::ClaudeCommandBuilder::for_resolved_version_probe(
+            &binary,
+            resolution,
+        )
+        .into_command()
+    } else {
+        let mut command = Command::new(binary_path);
+        configure_version_probe_command(&mut command, resolution);
+        command
+    };
     command.arg("--version");
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -27,6 +27,8 @@ thread_local! {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BinaryResolution {
     pub requested_binary: String,
+    // #4627: raw Claude paths remain publicly exposed here; full
+    // by-construction sealing is tracked separately from #4619.
     pub resolved_path: Option<String>,
     pub canonical_path: Option<String>,
     pub source: Option<String>,
@@ -179,6 +181,8 @@ pub fn resolve_binary_with_login_shell(name: &str) -> Option<String> {
         .map(|path| path.to_string_lossy().to_string())
 }
 
+// #4627: this public resolver can return `resolved_path` for Claude, so it is
+// not a complete type-level raw-spawn barrier yet.
 pub fn resolve_provider_binary(provider: &str) -> BinaryResolution {
     match resolve_provider_binary_set(provider) {
         ProviderResolutionSet::Candidates(candidates) => match candidates.len() {

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -498,9 +498,11 @@ impl ProviderKind {
     }
 
     #[allow(dead_code)]
-    pub fn resolve_runtime_path(&self) -> Option<String> {
+    pub(crate) fn resolve_runtime_path(&self) -> Option<String> {
         match self {
-            Self::Claude => crate::services::claude::resolve_claude_path(),
+            Self::Claude => {
+                crate::services::platform::resolve_provider_binary("claude").resolved_path
+            }
             Self::Codex => crate::services::codex::resolve_codex_path(),
             Self::Gemini => crate::services::gemini::resolve_gemini_path(),
             Self::OpenCode => crate::services::opencode::resolve_opencode_path(),

--- a/src/services/provider_cli/smoke.rs
+++ b/src/services/provider_cli/smoke.rs
@@ -15,13 +15,24 @@ struct CheckRunner<'a> {
 
 impl<'a> CheckRunner<'a> {
     fn run_version(&self) -> SmokeCheckStatus {
-        let mut command = Command::new(self.binary);
+        let mut command = if self.provider == "claude" {
+            crate::services::claude_command::ClaudeCommandBuilder::for_version_smoke(
+                self.binary,
+                self.canonical_path,
+            )
+            .into_command()
+        } else {
+            let mut command = Command::new(self.binary);
+            crate::services::platform::augment_exec_path(&mut command, self.canonical_path);
+            command
+        };
         command
             .arg("--version")
             .stdout(Stdio::null())
             .stderr(Stdio::null());
-        crate::services::platform::augment_exec_path(&mut command, self.canonical_path);
-        configure_version_probe_command(&mut command, self.provider);
+        if self.provider != "claude" {
+            configure_version_probe_command(&mut command, self.provider);
+        }
 
         match run_command_status_with_timeout(command, SMOKE_TIMEOUT) {
             Ok(true) => SmokeCheckStatus::Ok,

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -133,8 +133,7 @@ pub fn run(
     // reads the managed marker to classify, then the builder *consumes* it
     // one-hop (`env_remove`) so the marker never propagates to the Claude child
     // or its descendants — see `claude_child_command_builder`.
-    let mut builder =
-        claude_child_command_builder(claude_bin, ClaudeLaunchEnv::for_tmux_wrapper());
+    let mut builder = claude_child_command_builder(claude_bin, ClaudeLaunchEnv::for_tmux_wrapper());
     {
         let claude_command = builder.command_mut();
         crate::services::process::configure_child_process_group(claude_command);

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -133,7 +133,16 @@ pub fn run(
     // reads the managed marker to classify, then the builder *consumes* it
     // one-hop (`env_remove`) so the marker never propagates to the Claude child
     // or its descendants — see `claude_child_command_builder`.
-    let mut builder = claude_child_command_builder(claude_bin, ClaudeLaunchEnv::for_tmux_wrapper());
+    let mut builder = match claude_child_command_builder(
+        claude_bin,
+        ClaudeLaunchEnv::for_tmux_wrapper(),
+    ) {
+        Ok(builder) => builder,
+        Err(error) => {
+            redacted_eprintln!("\x1b[31mInvalid Claude command: {}\x1b[0m", error);
+            std::process::exit(1);
+        }
+    };
     {
         let claude_command = builder.command_mut();
         crate::services::process::configure_child_process_group(claude_command);
@@ -543,12 +552,12 @@ pub fn run(
 fn claude_child_command_builder(
     claude_bin: &str,
     launch_env: ClaudeLaunchEnv,
-) -> ClaudeCommandBuilder {
-    let mut builder = ClaudeCommandBuilder::for_binary_path(claude_bin, launch_env);
+) -> Result<ClaudeCommandBuilder, String> {
+    let mut builder = ClaudeCommandBuilder::for_tmux_wrapper_argv(claude_bin, launch_env)?;
     builder
         .command_mut()
         .env_remove(TMUX_WRAPPER_GATEWAY_RESOLVED_ENV);
-    builder
+    Ok(builder)
 }
 
 /// #3207 (part 1): is this `result` event a deliberate turn-abort (from a
@@ -880,7 +889,8 @@ mod marker_one_hop_tests {
         let builder = claude_child_command_builder(
             "/opt/claude/bin/claude",
             ClaudeLaunchEnv::inject_for_test("http://managed.proxy/"),
-        );
+        )
+        .unwrap();
         let envs = command_env_map(&builder.into_command());
         // Managed gateway decision is still applied to the child…
         assert_eq!(

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -133,16 +133,8 @@ pub fn run(
     // reads the managed marker to classify, then the builder *consumes* it
     // one-hop (`env_remove`) so the marker never propagates to the Claude child
     // or its descendants — see `claude_child_command_builder`.
-    let mut builder = match claude_child_command_builder(
-        claude_bin,
-        ClaudeLaunchEnv::for_tmux_wrapper(),
-    ) {
-        Ok(builder) => builder,
-        Err(error) => {
-            redacted_eprintln!("\x1b[31mInvalid Claude command: {}\x1b[0m", error);
-            std::process::exit(1);
-        }
-    };
+    let mut builder =
+        claude_child_command_builder(claude_bin, ClaudeLaunchEnv::for_tmux_wrapper());
     {
         let claude_command = builder.command_mut();
         crate::services::process::configure_child_process_group(claude_command);
@@ -552,12 +544,12 @@ pub fn run(
 fn claude_child_command_builder(
     claude_bin: &str,
     launch_env: ClaudeLaunchEnv,
-) -> Result<ClaudeCommandBuilder, String> {
-    let mut builder = ClaudeCommandBuilder::for_tmux_wrapper_argv(claude_bin, launch_env)?;
+) -> ClaudeCommandBuilder {
+    let mut builder = ClaudeCommandBuilder::for_tmux_wrapper_argv(claude_bin, launch_env);
     builder
         .command_mut()
         .env_remove(TMUX_WRAPPER_GATEWAY_RESOLVED_ENV);
-    Ok(builder)
+    builder
 }
 
 /// #3207 (part 1): is this `result` event a deliberate turn-abort (from a
@@ -889,8 +881,7 @@ mod marker_one_hop_tests {
         let builder = claude_child_command_builder(
             "/opt/claude/bin/claude",
             ClaudeLaunchEnv::inject_for_test("http://managed.proxy/"),
-        )
-        .unwrap();
+        );
         let envs = command_env_map(&builder.into_command());
         // Managed gateway decision is still applied to the child…
         assert_eq!(


### PR DESCRIPTION
## #4619 — raw-spawn 가드 by-construction 승격 (#4559 follow-up)

#4559에서 Claude 스폰 8사이트를 `ClaudeCommandBuilder`로 수렴시켰으나 가드가 substring 스캔이라 변수재바인딩/참조/alias/helper 우회 가능했다. 이번엔 불투명 capability newtype `ClaudeBinary`(비공개 경로, AsRef/Deref/Display/getter 부재)로 `Command::new(ClaudeBinary)`를 **타입에러**로 만들고 8사이트를 newtype 소비 경로로 유지.

### 변경
- `claude_command.rs`: `ClaudeBinary` capability newtype + builder typed 실행 생성자. substring `FORBIDDEN_RAW_SPAWN`은 2차 방어로 유지.
- 8 spawn 사이트(claude.rs/claude_e/process.rs/claude_tui/session.rs/provider.rs/provider_cli/smoke.rs/tmux_wrapper.rs/binary_resolver.rs) 인자·env·동작 불변 수렴.
- `lib.rs`: `compile_fail` doctest로 `Command::new(binary)` 타입불가 증명.
- public `agentdesk tmux-wrapper -- <custom-binary>` argv 수용 보존.

### 정직성 (dual 리뷰 반영)
- `ClaudeBinary`는 **builder의 typed 경로만** 봉인. `resolve_provider_binary("claude").resolved_path`(public)는 원시 경로를 여전히 노출 → 완전 by-construction 아님. resolver 봉인은 **#4627** follow-up에서 추적.

### 리뷰/게이트
- dual: leg A Fable(acct2) CLEAN(스폰 8사이트 동작보존·by-construction·wrapper 보존) + leg B gpt-5.6-sol(by-construction 과장 P2 지적) → 정직성 fix(overclaim 정정+#4627) → Opus 재리뷰 CLEAN(코드 주석-only 무변경).
- 게이트 GREEN: fmt/check/test(18 pass)/audit/freshness/gen-check rc0. binary_resolver freeze 1412 sync.
- #3016 핫파일 무접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)