### PR TITLE
ux(discord): 성공 subagent 완료도 카드 배달 (성공/실패 비대칭 해소) (#4629)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -574,7 +574,7 @@
 | `services::discord::outbound::turn_output_controller::fresh_send` | `src/services/discord/outbound/turn_output_controller/fresh_send.rs` | 227 | 227 | 0 |  |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
 | `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 978 | 587 | 391 |  |
-| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 678 | 678 | 0 |  |
+| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 675 | 675 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -574,7 +574,7 @@
 | `services::discord::outbound::turn_output_controller::fresh_send` | `src/services/discord/outbound/turn_output_controller/fresh_send.rs` | 227 | 227 | 0 |  |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
 | `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 978 | 587 | 391 |  |
-| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 675 | 675 | 0 |  |
+| `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 681 | 681 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
 | `services::discord::placeholder_live_events::completion_footer` | `src/services/discord/placeholder_live_events/completion_footer.rs` | 490 | 490 | 0 |  |

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -652,10 +652,16 @@ impl PlaceholderLiveEvents {
 
 // Despite its historical name, this helper now recognizes only successful
 // background-Bash completions already represented by a matching footer slot.
-// Successful subagent/agent completions still require a card alongside footer ✓
-// per #4629 (user direction 2026-07-18); `event_key` and
-// `terminal_delivery_fingerprint` dedup prevent repeat observations from posting
-// duplicate cards. Background Bash retains footer-only suppression per #4097.
+// Successful subagent/agent completions now take the card path (CardRequired),
+// SYMMETRIC with failure completions, per #4629 (user direction 2026-07-18):
+// previously only successes were footer-only-suppressed here, so success cards
+// went missing while failures posted. This does NOT keep a footer ✓ *alongside*
+// the card — once the card is confirmed, `claim_terminal_slot_for_card` evicts
+// the matching terminal footer marker (#4055) exactly as it does for failures.
+// The card, not the transient footer ✓, is the durable completion signal.
+// `event_key`/`terminal_delivery_fingerprint` dedup prevent repeat observations
+// from posting duplicate cards. Background Bash retains footer-only suppression
+// per #4097.
 fn task_notification_success_completion_visible_in_snapshot(
     snapshot: &StatusPanelState,
     events: &[StatusEvent],

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -650,6 +650,12 @@ impl PlaceholderLiveEvents {
     }
 }
 
+// Despite its historical name, this helper now recognizes only successful
+// background-Bash completions already represented by a matching footer slot.
+// Successful subagent/agent completions still require a card alongside footer ✓
+// per #4629 (user direction 2026-07-18); `event_key` and
+// `terminal_delivery_fingerprint` dedup prevent repeat observations from posting
+// duplicate cards. Background Bash retains footer-only suppression per #4097.
 fn task_notification_success_completion_visible_in_snapshot(
     snapshot: &StatusPanelState,
     events: &[StatusEvent],
@@ -661,16 +667,7 @@ fn task_notification_success_completion_visible_in_snapshot(
         } => snapshot.tasks.iter().any(|slot| {
             slot.background && slot.tool_use_id.as_deref() == Some(tool_use_id.as_str())
         }),
-        StatusEvent::SubagentEnd {
-            success: true,
-            tool_use_id: Some(tool_use_id),
-            ack_only: false,
-            ..
-        } => snapshot
-            .subagents
-            .iter()
-            .any(|slot| slot.tool_use_id.as_deref() == Some(tool_use_id.as_str())),
-        // Completion footers render Tasks/Subagents only. Suppressing Workflow
+        // Completion footers do not render Workflows. Suppressing Workflow
         // completion cards here would drop the only completion signal.
         StatusEvent::WorkflowEnd { .. } => false,
         _ => false,

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6525,7 +6525,7 @@ fn confirmed_task_notification_card_evicts_only_exact_terminal_footer_slot() {
 }
 
 #[test]
-fn task_completion_card_suppression_requires_idful_matching_subagent_slot() {
+fn success_subagent_completion_requires_card_alongside_footer() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_654_002);
     events.push_status_events(
@@ -6550,9 +6550,9 @@ fn task_completion_card_suppression_requires_idful_matching_subagent_slot() {
         <tool-use-id>toolu_subagent_match</tool-use-id><status>completed</status>\
         <summary>Agent \"Scout issue #3654\" completed</summary></task-notification>";
     assert!(
-        events
+        !events
             .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
-        "matching idful subagent completion should suppress the duplicate card"
+        "successful subagent completion should post a card alongside footer ✓"
     );
 
     let idless = "<task-notification><task-id>sub2</task-id><status>completed</status>\

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -6525,7 +6525,7 @@ fn confirmed_task_notification_card_evicts_only_exact_terminal_footer_slot() {
 }
 
 #[test]
-fn success_subagent_completion_requires_card_alongside_footer() {
+fn success_subagent_completion_takes_card_path_symmetric_with_failure() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(3_654_002);
     events.push_status_events(
@@ -6552,7 +6552,7 @@ fn success_subagent_completion_requires_card_alongside_footer() {
     assert!(
         !events
             .task_notification_completion_visible_in_footer_for_mode(channel_id, completed, true,),
-        "successful subagent completion should post a card alongside footer ✓"
+        "successful subagent completion takes the card path (CardRequired), symmetric with failures"
     );
 
     let idless = "<task-notification><task-id>sub2</task-id><status>completed</status>\


### PR DESCRIPTION
Closes #4629.

## 변경
성공 subagent/agent 완료가 카드 경로(`CardRequired`)를 타도록 `task_notification_success_completion_visible_in_snapshot`(placeholder_live_events/mod.rs)에서 `SubagentEnd { success: true, .. }` footer-only 억제 arm을 제거. 이전엔 **성공 완료만** footer-only로 억제돼 실패는 카드가 오고 성공은 안 오는 비대칭이 있었음.

- 성공 완료 = 실패 완료와 **대칭**: 카드 POST + 카드 확정 후 footer 마커 evict(`claim_terminal_slot_for_card`, #4055). 카드가 durable 완료 신호.
- `BackgroundTaskEnd` arm 유지 → background-bash 완료는 #4097대로 footer-only 억제 유지.
- dedup(`event_key`/`terminal_delivery_fingerprint`)이 재관측/idless 중복 카드 방지.

## 테스트
`task_completion_card_suppression_requires_idful_matching_subagent_slot` → `success_subagent_completion_takes_card_path_symmetric_with_failure`로 리네임, 매칭 성공완료가 CardRequired임을 단언(제거 arm 복원 시 assert 실패 = 뮤테이션 가드). background suppression 테스트 불변.

## 리뷰
dual adversarial CLEAN (Opus counter + fresh gpt-5.6-sol). 초안에서 "card alongside footer ✓" 오버클레임을 dual이 잡아 "실패와 대칭" 정직 서술로 정정 후 재-dual-CLEAN.
