### PR TITLE
fix(4640): 재시작 후 idle-at-prompt readiness timeout이 살아있는 resumed 세션을 죽이는 회귀 수정

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -859,11 +859,11 @@
 | `services::discord::turn_bridge::stream_loop` | `src/services/discord/turn_bridge/stream_loop.rs` | 975 | 975 | 0 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms` | `src/services/discord/turn_bridge/stream_loop/content_arms.rs` | 629 | 629 | 0 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::provider_error_presentation` | `src/services/discord/turn_bridge/stream_loop/content_arms/provider_error_presentation.rs` | 95 | 42 | 53 |  |
-| `services::discord::turn_bridge::stream_loop::content_arms::tui_error_classification` | `src/services/discord/turn_bridge/stream_loop/content_arms/tui_error_classification.rs` | 153 | 24 | 129 |  |
+| `services::discord::turn_bridge::stream_loop::content_arms::tui_error_classification` | `src/services/discord/turn_bridge/stream_loop/content_arms/tui_error_classification.rs` | 199 | 24 | 175 |  |
 | `services::discord::turn_bridge::stream_loop::tool_arms` | `src/services/discord/turn_bridge/stream_loop/tool_arms.rs` | 684 | 684 | 0 |  |
 | `services::discord::turn_bridge::stream_receiver` | `src/services/discord/turn_bridge/stream_receiver.rs` | 109 | 64 | 45 |  |
 | `services::discord::turn_bridge::stream_tick` | `src/services/discord/turn_bridge/stream_tick.rs` | 908 | 787 | 121 |  |
-| `services::discord::turn_bridge::streaming_edit_text` | `src/services/discord/turn_bridge/streaming_edit_text.rs` | 714 | 298 | 416 |  |
+| `services::discord::turn_bridge::streaming_edit_text` | `src/services/discord/turn_bridge/streaming_edit_text.rs` | 733 | 317 | 416 |  |
 | `services::discord::turn_bridge::task_notification_lifecycle` | `src/services/discord/turn_bridge/task_notification_lifecycle.rs` | 221 | 104 | 117 |  |
 | `services::discord::turn_bridge::terminal_controller_cutover` | `src/services/discord/turn_bridge/terminal_controller_cutover.rs` | 1839 | 961 | 878 |  |
 | `services::discord::turn_bridge::terminal_delivery` | `src/services/discord/turn_bridge/terminal_delivery.rs` | 2002 | 738 | 1264 |  |

--- a/src/services/discord/turn_bridge/stream_loop/content_arms/tui_error_classification.rs
+++ b/src/services/discord/turn_bridge/stream_loop/content_arms/tui_error_classification.rs
@@ -143,11 +143,57 @@ mod tests {
             include_str!("../../terminal_outcome_delivery.rs"),
             r#"
                 claude_tui_followup_pre_submit_requeue_candidate,
+                claude_tui_busy_requeue_pending,
                 tui_error_classification,
                 #[cfg(unix)]
                 bridge_tui_gate_outcome_early,
             "#,
             "terminal outcome -> DeliveryEpilogueContext",
         );
+    }
+
+    /// #4640 regression: a follow-up readiness timeout where the pane is idle at
+    /// a ready prompt (prompt_marker_detected=true, hence
+    /// previous_tui_turn_still_running=false) proves the resumed provider session
+    /// is alive — only the follow-up input failed to confirm in time. It must be
+    /// classified as a session-preserving readiness timeout so the empty-response
+    /// no-handshake fallback does NOT kill the live tmux session for a fresh
+    /// retry. Before #4640, only previous_tui_turn_still_running=true (marker
+    /// absent) was preserved, so this restart follow-up case leaked to
+    /// fresh-session and dropped the resumed session.
+    #[test]
+    fn readiness_timeout_idle_at_prompt_marker_preserves_live_session() {
+        let provider = ProviderKind::Claude;
+        let resolution = resolve_tui_error(
+            &provider,
+            concat!(
+                "timeout waiting for claude tui follow-up prompt input readiness after 45s; ",
+                "reason=prompt_marker_unconfirmed; previous_tui_turn_still_running=false; ",
+                "prompt_marker_detected=true; prompt_draft_detected=false; ",
+                "capture_available=true",
+            ),
+            "",
+        );
+        assert!(
+            bridge_claude_tui_followup_busy_readiness_timeout(
+                &provider,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                resolution.tui_error_classification,
+            ),
+            "an idle-at-prompt readiness timeout (marker detected) proves the resumed \
+             session is alive and must be preserved from the fresh-session fallback"
+        );
+        // The follow-up input never confirmed, so it is still requeued like any
+        // other readiness timeout — preservation only blocks the destructive
+        // fresh-session retry, it does not swallow the pending follow-up.
+        let ProviderErrorPresentation::Failure(full_response) = resolution.presentation else {
+            panic!("readiness timeout must remain an ordinary provider failure");
+        };
+        assert!(bridge_claude_tui_followup_requeue_prompt_error(
+            &provider,
+            Some(RuntimeHandoffKind::ClaudeTui),
+            &full_response,
+            resolution.tui_error_classification,
+        ));
     }
 }

--- a/src/services/discord/turn_bridge/streaming_edit_text.rs
+++ b/src/services/discord/turn_bridge/streaming_edit_text.rs
@@ -86,8 +86,27 @@ pub(in crate::services::discord) fn classify_raw_tui_error(
     let claude_followup_requeue_prompt_error = matches!(provider, ProviderKind::Claude)
         && pre_submission_prompt_error
         && error_text.contains("follow-up prompt input readiness");
+    // A follow-up readiness timeout only reaches this classifier when the tmux
+    // pane is still alive (the capture that produced the timeout proves the pane
+    // exists). The producer derives its two witnesses from that same pane
+    // snapshot:
+    //   previous_tui_turn_still_running = tmux_pane_alive && !prompt_marker_detected
+    //   prompt_marker_detected          = tmux_pane_alive && REPL idle at a prompt
+    // They are mutually exclusive and each implies tmux_pane_alive, so their
+    // union is exactly "pane-alive readiness timeout". A live pane means the
+    // resumed provider session is intact — the follow-up input simply failed to
+    // confirm in time — so the empty-response no-handshake fallback must NOT kill
+    // it for a fresh retry (that would drop the resumed session and start over,
+    // violating the restart live-turn-preservation contract). #4605 covered only
+    // the first witness (pane busy, no marker); the second (pane idle at a ready
+    // prompt — a *more* certain "session alive" signal, and the exact restart
+    // follow-up case) leaked through to fresh-session (#4640). A genuinely failed
+    // resume surfaces a stale session_id error in the output file, which
+    // output_file_has_stale_resume_error_after_offset detects and retries ahead
+    // of this preserve path, so widening here cannot mask a real resume failure.
     let claude_followup_busy_readiness_timeout = claude_followup_requeue_prompt_error
-        && error_text.contains("previous_tui_turn_still_running=true");
+        && (error_text.contains("previous_tui_turn_still_running=true")
+            || error_text.contains("prompt_marker_detected=true"));
     let transport_error_should_skip_quiescence = match provider {
         ProviderKind::Claude => {
             pre_submission_prompt_error


### PR DESCRIPTION
## 증상
서버 재시작 후 provider 세션 resume에 **성공**했는데도 곧바로 새 세션을 만들어 기존 resumed 세션을 폐기한다. 사용자 운영 원칙(planned restart는 tmux+live turn 보존, fresh는 최후 fallback) 위반.

## 재현 로그 (adk-cc, 2026-07-18 12:01~12:02)
1. `resumed=true tmux_alive=true` — resume 성공
2. `timeout waiting for claude tui follow-up prompt input readiness after 45s; previous_tui_turn_still_running=false; prompt_marker_detected=true; capture_available=true`
3. `empty_response_recovery: ⚠ Empty response with no Init handshake — auto-retrying with fresh session` → `✂ tmux kill` → `resumed=false` 새 세션

## 근본 원인
`classify_raw_tui_error`(streaming_edit_text.rs)가 세션 보존을 `previous_tui_turn_still_running=true` 하나로만 판정. producer(input.rs:1696) 정의:
- `previous_tui_turn_still_running = tmux_pane_alive && !prompt_marker_detected`
- `prompt_marker_detected = tmux_pane_alive && REPL idle at prompt`

두 필드는 상호배타적이고 **둘 다 tmux_pane_alive를 함의**. pane 살아있는 readiness timeout = resume 세션 정상인데, marker 안 뜬 절반(busy)만 보존하고 marker 뜬 절반(idle-at-prompt = 정확히 재시작 follow-up)이 fresh-session으로 샘. #4605가 busy witness만 덮은 구멍.

## 수정
- **streaming_edit_text.rs**: 보존 조건을 두 witness OR로 확장 → pane-alive readiness timeout 전체 커버. pane dead면 여전히 정당하게 fresh. 진짜 resume 실패(stale session_id)는 `output_file_has_stale_resume_error_after_offset`가 이 preserve 경로보다 먼저 처리하므로 확장이 실제 실패를 가리지 않음.
- **tui_error_classification.rs**: 회귀 테스트 `readiness_timeout_idle_at_prompt_marker_preserves_live_session` 추가 + #4605(89dc78b76)가 남긴 broken mutation-guard assert 수정(terminal_outcome_delivery.rs에 `claude_tui_busy_requeue_pending` 필드 추가하면서 expected 업데이트 누락 → main 테스트 red 상태였음).

## 검증
`cargo test -p agentdesk --lib tui_error_classification` → 2 passed, 0 failed. fmt clean.

## 후속(별도)
error_text substring 파싱은 producer 포맷 변경에 취약. 구조화된 bool classification 직접 전달로 대체하는 근본 정리는 별도 이슈로 추적 예정.

Fixes #4640

🤖 Generated with [Claude Code](https://claude.com/claude-code)