### PR TITLE
fix(discord): preserve busy requeue marker view

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -674,7 +674,7 @@
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |
 | `services::discord::router::message_handler::goal_lifecycle` | `src/services/discord/router/message_handler/goal_lifecycle.rs` | 313 | 222 | 91 |  |
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1744 | 1391 | 353 | giant-file |
-| `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3085 | 2705 | 380 | giant-file |
+| `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3104 | 2705 | 399 | giant-file |
 | `services::discord::router::message_handler::intake_turn::claim_bootstrap` | `src/services/discord/router/message_handler/intake_turn/claim_bootstrap.rs` | 59 | 59 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 699 | 604 | 95 |  |
 | `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 91 | 91 | 0 |  |

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2262,7 +2262,6 @@ pub(super) async fn handle_text_message(
             "claude_tui_followup_busy_pre_submit",
             diagnostic_json,
         );
-        tv_clear_current(shared, http, channel_id, user_msg_id, "intake_busy_queue").await;
         super::super::super::saturating_decrement_global_active(shared);
         shared.turn_start_times.remove(&channel_id);
         post_adk_session_status(
@@ -2700,15 +2699,12 @@ pub(super) async fn handle_text_message(
 #[cfg(test)]
 mod tui_busy_pre_submit_queue_reaction_tests {
     #[test]
-    fn busy_pre_submit_enqueue_applies_the_shared_pending_reaction() {
+    fn busy_pre_submit_enqueue_keeps_the_authoritative_queue_view() {
         let module_src = include_str!("intake_turn.rs");
         let busy_branch_pos = module_src
             .find("claude_tui follow-up queued because hosted TUI is busy before prompt submission")
             .expect("hosted-TUI busy pre-submit queue branch exists");
         let busy_branch = &module_src[..busy_branch_pos];
-        let reaction_call_pos = busy_branch
-            .rfind("note_busy_tui_pre_submit_queue_pending(")
-            .expect("accepted busy pre-submit enqueue must apply a queue-pending reaction");
         let enqueue_pos = busy_branch
             .rfind("enqueue_busy_tui_followup_for_retry(")
             .expect("busy pre-submit branch enqueues the follow-up");
@@ -2716,10 +2712,32 @@ mod tui_busy_pre_submit_queue_reaction_tests {
             .find("if enqueue_outcome.enqueued {")
             .map(|offset| enqueue_pos + offset)
             .expect("busy pre-submit reaction must be gated on accepted enqueue");
+        let accepted_helper = "note_busy_tui_pre_submit_queue_pending(";
+        let refusal_guard = "} else {\n            apply_tui_busy_enqueue_refusal(";
+        let accepted_clear =
+            "tv_clear_current(shared, http, channel_id, user_msg_id, \"intake_busy_queue\")";
+        let refusal_guard_pos = busy_branch[accepted_guard_pos..]
+            .find(refusal_guard)
+            .map(|offset| accepted_guard_pos + offset)
+            .expect("busy pre-submit enqueue refusal branch exists");
+        let reaction_call_pos = busy_branch[accepted_guard_pos..refusal_guard_pos]
+            .find(accepted_helper)
+            .map(|offset| accepted_guard_pos + offset)
+            .expect("accepted busy pre-submit enqueue must apply a queue-pending reaction");
+        let accepted_branch = &busy_branch[accepted_guard_pos..refusal_guard_pos];
+        let refusal_branch = &busy_branch[refusal_guard_pos..];
 
         assert!(
-            enqueue_pos < accepted_guard_pos && accepted_guard_pos < reaction_call_pos,
+            accepted_guard_pos < reaction_call_pos,
             "an accepted hosted-TUI busy pre-submit enqueue must reach the shared queue-pending reaction helper"
+        );
+        assert!(
+            !accepted_branch.contains(accepted_clear),
+            "accepted busy requeue must preserve the reconciler-owned queued marker"
+        );
+        assert!(
+            refusal_branch.contains(accepted_clear),
+            "refused busy enqueue must still clear the optimistic pending view"
         );
     }
 }

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2211,6 +2211,7 @@ pub(super) async fn handle_text_message(
                 enqueue_outcome.refusal_reason,
             )
             .await;
+            tv_clear_current(shared, http, channel_id, user_msg_id, "intake_busy_queue").await;
         }
         let queue_kickoff_scheduled =
             queue_kickoff_scheduled_by_release || enqueue_outcome.enqueued;

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
@@ -296,6 +296,73 @@ async fn stale_start_attempt_repairs_mailbox_from_live_queue_truth() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn busy_tui_requeue_preserves_standalone_marker_after_matching_rollback() {
+    let _root = scoped_runtime_root();
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let http = Arc::new(serenity::Http::new("Bot test-token"));
+    let provider = ProviderKind::Claude;
+    let channel_id = ChannelId::new(455_400_000_000_125);
+    let message_id = MessageId::new(455_400_000_000_126);
+
+    assert!(
+        crate::services::discord::mailbox_try_start_turn(
+            &shared,
+            channel_id,
+            Arc::new(CancelToken::new()),
+            UserId::new(455_400_000_000_127),
+            MessageId::new(455_400_000_000_127),
+        )
+        .await
+    );
+    let start_attempt = crate::services::discord::turn_view_reconciler::note_intake_turn_started_current_with_attempt(
+        &shared,
+        &http,
+        channel_id,
+        message_id,
+        "test_seed_busy_tui_pending",
+    )
+    .await
+    .attempt()
+    .expect("busy TUI intake start records a pending attempt");
+    let enqueue = enqueue_race_loss_requeued_intervention(
+        &shared,
+        &provider,
+        channel_id,
+        message_id,
+        user_intervention(message_id.get()),
+    )
+    .await;
+    assert!(enqueue.enqueued, "busy TUI follow-up genuinely requeues M");
+
+    mailbox_reaction::note_busy_tui_pre_submit_queue_pending(
+        &shared,
+        &http,
+        channel_id,
+        message_id,
+        false,
+        Some(start_attempt),
+    )
+    .await;
+
+    let ops = shared.turn_view_reconciler.ops();
+    let mut visible = Vec::new();
+    for op in ops.iter().filter(|op| op.target.message_id == message_id) {
+        if op.add {
+            if !visible.contains(&op.emoji) {
+                visible.push(op.emoji);
+            }
+        } else {
+            visible.retain(|emoji| *emoji != op.emoji);
+        }
+    }
+    assert_eq!(
+        visible,
+        vec!['📬'],
+        "accepted busy-TUI requeue ends at the reconciler's marker-only queued view"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn recently_finalized_message_requeued_in_live_mailbox_repairs_mailbox_marker() {
     let _root = scoped_runtime_root();
     let shared = crate::services::discord::make_shared_data_for_tests();


### PR DESCRIPTION
## Summary
- Preserve the reconciler-owned queued marker after an accepted hosted-TUI busy requeue.
- Retain optimistic pending-view cleanup when the busy enqueue is refused.
- Add source-wiring and mailbox-authority regression coverage for the standalone queued marker.

## Test plan
- [x] `git diff --check`
- [x] Agent-maintenance inventory regeneration and freshness check (completed before commit)
- [x] Maintainability audit (completed before commit)
- [ ] Local Cargo build/test suite not run in this finalization step; awaiting the orchestrator batch gate because the host is resource constrained.