### PR TITLE
fix(discord): surface queue reaction delivery failures

### DIFF
--- a/docs/agent-maintenance/discord-outbound-migration.md
+++ b/docs/agent-maintenance/discord-outbound-migration.md
@@ -206,7 +206,7 @@ These callsites already use the unified delivery engine. Rows marked
 | `src/services/discord/task_notification_delivery/gateway.rs` via `gateway/outbound_messages.rs` | durable task-notification cards | **migrated_v3**. Create uses the row's stable nonce with enforcement; edit returns a classified confirmed-missing result only for structured Discord `404/10008`. The PG card authority, not the process deduper, decides create/edit/replacement ownership. |
 | `src/services/discord/formatting/long_send_rollback.rs` via `http.rs` | durable task-response replies | **nonce-hardened required-reference compatibility path**. Sink and watcher share the exact `response_turn_key`; each physical reply chunk derives a distinct stable nonce and sets `enforce_nonce=true`. A retry after Discord POST success but response `sent`-CAS failure reconciles the returned message id instead of duplicating the reply. |
 | `src/services/discord/gateway.rs:400` (`TurnGateway::{send_message, edit_message}`) | turn-bridge messages/edits | **migrated_v3 transitively via gateway**. Used for handoff, rollover freeze, snapshot, stable update, and terminal edit. |
-| `src/services/discord/router/intake_gate.rs` (`send_reaction_control_reply`) | reaction-control lifecycle replies | **migrated_v3**. Short fixed replies for queued-card POST fallback and duplicate stop now use referenced v3 lifecycle notices. Correlation = `intake-reaction-control:<channel_id>:<message_id>`, semantic = `intake-reaction-control:<channel_id>:<message_id>:<reason_key>`. |
+| `src/services/discord/outbound/reaction_control.rs` (`send_reaction_control_reply_http`) | reaction-control lifecycle replies | **migrated_v3 and nonce-hardened**. Queued-card POST and queue-reaction failure fallbacks use referenced v3 lifecycle notices. Correlation = `intake-reaction-control:<channel_id>:<message_id>`, semantic = `intake-reaction-control:<channel_id>:<message_id>:<reason_key>`; the same identity derives an enforced stable Discord create nonce for bounded replay suppression across process-local deduper restarts. |
 | `src/services/discord/monitoring_status.rs:115` (`deliver_monitoring_status`) | monitoring status | **migrated_v3**. Status banner send + edit with `preserve_inline_content`; edits use `without_idempotency()`. |
 | `src/services/discord/meeting_orchestrator.rs:754, 796` (`meeting_outbound_message` / edit path) | meeting status / cancel / parse-error | **migrated_v3**. Stable meeting dedup metadata plus `OutboundOperation::Edit`. |
 | `src/services/routines/discord_log.rs:486, 531` (`deliver_or_update_discord_summary`) | routine Discord summary | **migrated_v3**. Uses direct v3 send/edit and disables semantic dedupe for repeated summary writes. |
@@ -401,9 +401,14 @@ button hits the manual outbound API, which is covered under §3.A
   `response_reply_nonce_reconciles_after_sent_cas_failure_and_lease_takeover_pg`
   pin per-chunk reply nonces, required references, and the POST-success / failed
   `sent`-CAS / expired-lease takeover boundary without a second physical reply.
-- `src/services/discord/outbound/reaction_control.rs`:
-  `reaction_control_reply_ids_are_stable_per_message_and_reason` verifies the
-  reaction-control lifecycle replies keep stable correlation and semantic ids.
+- `src/services/discord/outbound/reaction_control.rs`,
+  `src/services/discord/outbound/serenity_reference.rs`, and
+  `src/services/discord/outbound/delivery.rs`:
+  `reaction_control_reply_ids_are_stable_for_queued_card_failure`,
+  `lifecycle_notice_nonce_is_stable_and_semantic_event_scoped`, and
+  `v3_referenced_send_preserves_reference_and_dedupes` verify stable lifecycle
+  identity, reason-scoped enforced nonce reuse, and reference preservation across
+  a fresh process-local deduper retry.
 - `src/services/discord/turn_bridge/mod.rs`:
   `final_completion_delivery_stays_blocked_until_terminal_message_commits`
   verifies final completion delivery remains blocked until the terminal Discord

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -840,7 +840,7 @@
 | `services::discord::turn_bridge::context_window` | `src/services/discord/turn_bridge/context_window.rs` | 169 | 100 | 69 |  |
 | `services::discord::turn_bridge::early_tui_completion` | `src/services/discord/turn_bridge/early_tui_completion.rs` | 62 | 62 | 0 |  |
 | `services::discord::turn_bridge::finalize_epilogue` | `src/services/discord/turn_bridge/finalize_epilogue.rs` | 306 | 156 | 150 |  |
-| `services::discord::turn_bridge::followup_requeue` | `src/services/discord/turn_bridge/followup_requeue.rs` | 260 | 127 | 133 |  |
+| `services::discord::turn_bridge::followup_requeue` | `src/services/discord/turn_bridge/followup_requeue.rs` | 312 | 135 | 177 |  |
 | `services::discord::turn_bridge::guards` | `src/services/discord/turn_bridge/guards.rs` | 78 | 78 | 0 |  |
 | `services::discord::turn_bridge::headless_delivery` | `src/services/discord/turn_bridge/headless_delivery.rs` | 523 | 447 | 76 |  |
 | `services::discord::turn_bridge::memory_lifecycle` | `src/services/discord/turn_bridge/memory_lifecycle.rs` | 411 | 303 | 108 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -555,7 +555,7 @@
 | `services::discord::outbound` | `src/services/discord/outbound/mod.rs` | 53 | 53 | 0 |  |
 | `services::discord::outbound::confirmation` | `src/services/discord/outbound/confirmation.rs` | 65 | 65 | 0 |  |
 | `services::discord::outbound::decision` | `src/services/discord/outbound/decision.rs` | 248 | 248 | 0 |  |
-| `services::discord::outbound::delivery` | `src/services/discord/outbound/delivery.rs` | 1387 | 737 | 650 |  |
+| `services::discord::outbound::delivery` | `src/services/discord/outbound/delivery.rs` | 1433 | 737 | 696 |  |
 | `services::discord::outbound::delivery_frontier_probe` | `src/services/discord/outbound/delivery_frontier_probe.rs` | 75 | 75 | 0 |  |
 | `services::discord::outbound::delivery_record` | `src/services/discord/outbound/delivery_record.rs` | 2962 | 1326 | 1636 | giant-file |
 | `services::discord::outbound::manual_delivery` | `src/services/discord/outbound/manual_delivery.rs` | 1203 | 594 | 609 |  |
@@ -567,7 +567,7 @@
 | `services::discord::outbound::send_gate` | `src/services/discord/outbound/send_gate.rs` | 555 | 349 | 206 |  |
 | `services::discord::outbound::send_target` | `src/services/discord/outbound/send_target.rs` | 263 | 153 | 110 |  |
 | `services::discord::outbound::send_to_agent` | `src/services/discord/outbound/send_to_agent.rs` | 164 | 100 | 64 |  |
-| `services::discord::outbound::serenity_reference` | `src/services/discord/outbound/serenity_reference.rs` | 149 | 149 | 0 |  |
+| `services::discord::outbound::serenity_reference` | `src/services/discord/outbound/serenity_reference.rs` | 239 | 200 | 39 |  |
 | `services::discord::outbound::source_registry` | `src/services/discord/outbound/source_registry.rs` | 247 | 159 | 88 |  |
 | `services::discord::outbound::transport` | `src/services/discord/outbound/transport.rs` | 431 | 431 | 0 |  |
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3519 | 1228 | 2291 | giant-file |
@@ -603,7 +603,7 @@
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2310 | 751 | 1559 |  |
-| `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 759 | 223 | 536 |  |
+| `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 763 | 223 | 540 |  |
 | `services::discord::queue_overflow_dlq` | `src/services/discord/queue_overflow_dlq.rs` | 210 | 127 | 83 |  |
 | `services::discord::queue_reactions` | `src/services/discord/queue_reactions.rs` | 37 | 25 | 12 |  |
 | `services::discord::queued_placeholders_store` | `src/services/discord/queued_placeholders_store.rs` | 251 | 251 | 0 |  |
@@ -666,9 +666,9 @@
 | `services::discord::router::intake_gate::busy_duplicate_notice` | `src/services/discord/router/intake_gate/busy_duplicate_notice.rs` | 55 | 27 | 28 |  |
 | `services::discord::router::intake_gate::component_events` | `src/services/discord/router/intake_gate/component_events.rs` | 41 | 41 | 0 |  |
 | `services::discord::router::intake_gate::gate` | `src/services/discord/router/intake_gate/gate.rs` | 155 | 102 | 53 |  |
-| `services::discord::router::intake_gate::queue_effects` | `src/services/discord/router/intake_gate/queue_effects.rs` | 1308 | 861 | 447 |  |
+| `services::discord::router::intake_gate::queue_effects` | `src/services/discord/router/intake_gate/queue_effects.rs` | 1345 | 870 | 475 |  |
 | `services::discord::router::intake_gate::stale_turn` | `src/services/discord/router/intake_gate/stale_turn.rs` | 633 | 283 | 350 |  |
-| `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 1123 | 550 | 573 |  |
+| `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 1170 | 550 | 620 |  |
 | `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 208 | 208 | 0 |  |
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -561,7 +561,7 @@
 | `services::discord::outbound::manual_delivery` | `src/services/discord/outbound/manual_delivery.rs` | 1203 | 594 | 609 |  |
 | `services::discord::outbound::message` | `src/services/discord/outbound/message.rs` | 471 | 447 | 24 |  |
 | `services::discord::outbound::policy` | `src/services/discord/outbound/policy.rs` | 124 | 124 | 0 |  |
-| `services::discord::outbound::reaction_control` | `src/services/discord/outbound/reaction_control.rs` | 136 | 104 | 32 |  |
+| `services::discord::outbound::reaction_control` | `src/services/discord/outbound/reaction_control.rs` | 190 | 125 | 65 |  |
 | `services::discord::outbound::result` | `src/services/discord/outbound/result.rs` | 161 | 161 | 0 |  |
 | `services::discord::outbound::send_api` | `src/services/discord/outbound/send_api.rs` | 595 | 299 | 296 |  |
 | `services::discord::outbound::send_gate` | `src/services/discord/outbound/send_gate.rs` | 555 | 349 | 206 |  |
@@ -603,7 +603,7 @@
 | `services::discord::prompt_builder::section_dedupe` | `src/services/discord/prompt_builder/section_dedupe.rs` | 159 | 105 | 54 |  |
 | `services::discord::queue_dispatch` | `src/services/discord/queue_dispatch.rs` | 50 | 50 | 0 |  |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 2310 | 751 | 1559 |  |
-| `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 643 | 223 | 420 |  |
+| `services::discord::queue_marker` | `src/services/discord/queue_marker.rs` | 759 | 223 | 536 |  |
 | `services::discord::queue_overflow_dlq` | `src/services/discord/queue_overflow_dlq.rs` | 210 | 127 | 83 |  |
 | `services::discord::queue_reactions` | `src/services/discord/queue_reactions.rs` | 37 | 25 | 12 |  |
 | `services::discord::queued_placeholders_store` | `src/services/discord/queued_placeholders_store.rs` | 251 | 251 | 0 |  |
@@ -666,9 +666,9 @@
 | `services::discord::router::intake_gate::busy_duplicate_notice` | `src/services/discord/router/intake_gate/busy_duplicate_notice.rs` | 55 | 27 | 28 |  |
 | `services::discord::router::intake_gate::component_events` | `src/services/discord/router/intake_gate/component_events.rs` | 41 | 41 | 0 |  |
 | `services::discord::router::intake_gate::gate` | `src/services/discord/router/intake_gate/gate.rs` | 155 | 102 | 53 |  |
-| `services::discord::router::intake_gate::queue_effects` | `src/services/discord/router/intake_gate/queue_effects.rs` | 1318 | 871 | 447 |  |
+| `services::discord::router::intake_gate::queue_effects` | `src/services/discord/router/intake_gate/queue_effects.rs` | 1308 | 861 | 447 |  |
 | `services::discord::router::intake_gate::stale_turn` | `src/services/discord/router/intake_gate/stale_turn.rs` | 633 | 283 | 350 |  |
-| `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 1104 | 544 | 560 |  |
+| `services::discord::router::intake_queue_transaction` | `src/services/discord/router/intake_queue_transaction.rs` | 1123 | 550 | 573 |  |
 | `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 208 | 208 | 0 |  |
 | `services::discord::router::message_handler::attachments` | `src/services/discord/router/message_handler/attachments.rs` | 142 | 114 | 28 |  |
 | `services::discord::router::message_handler::control` | `src/services/discord/router/message_handler/control.rs` | 87 | 87 | 0 |  |
@@ -676,7 +676,7 @@
 | `services::discord::router::message_handler::headless_turn` | `src/services/discord/router/message_handler/headless_turn.rs` | 1744 | 1391 | 353 | giant-file |
 | `services::discord::router::message_handler::intake_turn` | `src/services/discord/router/message_handler/intake_turn.rs` | 3124 | 2744 | 380 | giant-file |
 | `services::discord::router::message_handler::intake_turn::race_loss` | `src/services/discord/router/message_handler/intake_turn/race_loss.rs` | 699 | 604 | 95 |  |
-| `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 91 | 91 | 0 |  |
+| `services::discord::router::message_handler::intake_turn::race_loss::mailbox_reaction` | `src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs` | 88 | 88 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::turn_watchdog` | `src/services/discord/router/message_handler/intake_turn/turn_watchdog.rs` | 256 | 256 | 0 |  |
 | `services::discord::router::message_handler::intake_turn::voice_intake` | `src/services/discord/router/message_handler/intake_turn/voice_intake.rs` | 155 | 155 | 0 |  |
 | `services::discord::router::message_handler::latency_spans` | `src/services/discord/router/message_handler/latency_spans.rs` | 230 | 158 | 72 |  |
@@ -687,7 +687,7 @@
 | `services::discord::router::message_handler::voice_announcement_route` | `src/services/discord/router/message_handler/voice_announcement_route.rs` | 444 | 106 | 338 |  |
 | `services::discord::router::message_handler::voice_announcement_scope` | `src/services/discord/router/message_handler/voice_announcement_scope.rs` | 125 | 73 | 52 |  |
 | `services::discord::router::message_handler::watchdog` | `src/services/discord/router/message_handler/watchdog.rs` | 1256 | 961 | 295 |  |
-| `services::discord::router::queue_status_presentation` | `src/services/discord/router/queue_status_presentation.rs` | 92 | 7 | 85 |  |
+| `services::discord::router::queue_status_presentation` | `src/services/discord/router/queue_status_presentation.rs` | 91 | 7 | 84 |  |
 | `services::discord::router::response_format` | `src/services/discord/router/response_format.rs` | 519 | 371 | 148 |  |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 130 | 130 | 0 |  |
 | `services::discord::router::turn_start` | `src/services/discord/router/turn_start.rs` | 526 | 526 | 0 |  |

--- a/justfile
+++ b/justfile
@@ -28,6 +28,12 @@ test-non-pg:
     cargo test --lib tui_task_card::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib server::routes::message_outbox::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib discord_thread_create -- --test-threads=1
+    # #4599: queue reaction fallback and persisted-v1 promotion contracts.
+    cargo test --lib reaction_control::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres

--- a/justfile
+++ b/justfile
@@ -31,6 +31,8 @@ test-non-pg:
     # #4599: queue reaction fallback and persisted-v1 promotion contracts.
     cargo test --lib reaction_control::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib intake_queue_transaction::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib pending_reaction_failure_adapter_tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib intake_dispatch_invariant_queued_entrypoints_promote_markers -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres

--- a/justfile
+++ b/justfile
@@ -36,6 +36,8 @@ test-non-pg:
     cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres
+    cargo test --lib serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact
+    cargo test --lib delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact
     cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres

--- a/justfile
+++ b/justfile
@@ -36,8 +36,8 @@ test-non-pg:
     cargo test --lib mailbox_reaction_tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_marker::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres
-    cargo test --lib serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact
-    cargo test --lib delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact
+    cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact
+    cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact
     cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres

--- a/src/services/discord/outbound/delivery.rs
+++ b/src/services/discord/outbound/delivery.rs
@@ -749,6 +749,7 @@ mod tests {
     struct MockClient {
         posts: Arc<Mutex<Vec<(String, String)>>>,
         referenced_posts: Arc<Mutex<Vec<(String, String, String, String)>>>,
+        referenced_nonce_posts: Arc<Mutex<Vec<(String, String, String, String, String, bool)>>>,
         dm_resolutions: Arc<Mutex<Vec<String>>>,
         length_failures_remaining: Arc<Mutex<usize>>,
         send_failures_remaining: Arc<Mutex<usize>>,
@@ -779,6 +780,10 @@ mod tests {
 
         fn referenced_posts(&self) -> Vec<(String, String, String, String)> {
             self.referenced_posts.lock().unwrap().clone()
+        }
+
+        fn referenced_nonce_posts(&self) -> Vec<(String, String, String, String, String, bool)> {
+            self.referenced_nonce_posts.lock().unwrap().clone()
         }
 
         fn dm_resolutions(&self) -> Vec<String> {
@@ -841,6 +846,29 @@ mod tests {
             ));
             Ok(format!(
                 "msg-ref-{target_channel}-{reference_channel}-{reference_message}-{}",
+                content.chars().count()
+            ))
+        }
+
+        async fn post_message_with_reference_and_nonce(
+            &self,
+            target_channel: &str,
+            content: &str,
+            reference_channel: &str,
+            reference_message: &str,
+            nonce: &str,
+            enforce_nonce: bool,
+        ) -> Result<String, DispatchMessagePostError> {
+            self.referenced_nonce_posts.lock().unwrap().push((
+                target_channel.to_string(),
+                content.to_string(),
+                reference_channel.to_string(),
+                reference_message.to_string(),
+                nonce.to_string(),
+                enforce_nonce,
+            ));
+            Ok(format!(
+                "msg-ref-nonce-{target_channel}-{reference_channel}-{reference_message}-{}",
                 content.chars().count()
             ))
         }
@@ -1047,6 +1075,7 @@ mod tests {
                 ChannelId::new(123),
                 poise::serenity_prelude::MessageId::new(456),
             ))
+            .with_create_nonce("stable-lifecycle-nonce", true)
         };
 
         let first = deliver_outbound(&client, &dedup, make(), None).await;
@@ -1059,21 +1088,38 @@ mod tests {
             } => {
                 assert_eq!(
                     existing_messages[0].raw_message_id,
-                    "msg-ref-123-123-456-19"
+                    "msg-ref-nonce-123-123-456-19"
                 );
             }
             other => panic!("expected duplicate, got {other:?}"),
         }
         assert!(client.posts().is_empty());
+        assert!(client.referenced_posts().is_empty());
         assert_eq!(
-            client.referenced_posts(),
+            client.referenced_nonce_posts(),
             vec![(
                 "123".to_string(),
                 "Already stopping...".to_string(),
                 "123".to_string(),
                 "456".to_string(),
+                "stable-lifecycle-nonce".to_string(),
+                true,
             )]
         );
+
+        let after_restart = deliver_outbound(&client, &OutboundDeduper::new(), make(), None).await;
+        assert!(matches!(after_restart, DeliveryResult::Sent { .. }));
+        let attempts = client.referenced_nonce_posts();
+        assert_eq!(
+            attempts.len(),
+            2,
+            "a fresh process-local deduper retries transport"
+        );
+        assert_eq!(
+            attempts[0].4, attempts[1].4,
+            "restart retry must reuse the nonce"
+        );
+        assert!(attempts.iter().all(|attempt| attempt.5));
     }
 
     #[tokio::test]

--- a/src/services/discord/outbound/reaction_control.rs
+++ b/src/services/discord/outbound/reaction_control.rs
@@ -25,6 +25,27 @@ impl ReactionControlReplyReason {
     }
 }
 
+pub(in crate::services::discord) async fn ensure_queue_reaction_or_fallback_http(
+    http: &Arc<serenity::http::Http>,
+    channel_id: serenity::ChannelId,
+    shared: &Arc<SharedData>,
+    message_id: serenity::MessageId,
+    delivered: bool,
+) -> bool {
+    if !delivered {
+        send_reaction_control_reply_http(
+            http,
+            channel_id,
+            shared,
+            message_id,
+            ReactionControlReplyReason::QueueReactionFailed,
+            "📬 큐에 추가됨 — 리액션 표시는 실패했지만 메시지는 큐잉되었습니다.",
+        )
+        .await;
+    }
+    delivered
+}
+
 pub(in crate::services::discord) async fn send_reaction_control_reply(
     ctx: &serenity::Context,
     shared: &Arc<SharedData>,
@@ -104,7 +125,12 @@ fn reaction_control_reply_delivery_ids(
 
 #[cfg(test)]
 mod tests {
-    use super::{ReactionControlReplyReason, reaction_control_reply_delivery_ids};
+    use std::sync::Arc;
+
+    use super::{
+        ReactionControlReplyReason, ensure_queue_reaction_or_fallback_http,
+        reaction_control_reply_delivery_ids, take_test_reply_deliveries,
+    };
     use poise::serenity_prelude::{ChannelId, MessageId};
 
     #[test]
@@ -131,6 +157,34 @@ mod tests {
         assert_eq!(
             reaction.1,
             "intake-reaction-control:123:456:queue_reaction_failed"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn queue_reaction_delivery_uses_fallback_only_on_failure() {
+        assert!(take_test_reply_deliveries().is_empty());
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let http = Arc::new(poise::serenity_prelude::Http::new("Bot test-token"));
+        let channel_id = ChannelId::new(455_400_000_000_301);
+        let message_id = MessageId::new(455_400_000_000_302);
+
+        assert!(
+            ensure_queue_reaction_or_fallback_http(&http, channel_id, &shared, message_id, true,)
+                .await
+        );
+        assert!(
+            take_test_reply_deliveries().is_empty(),
+            "successful queue reactions must remain reaction-only"
+        );
+
+        assert!(
+            !ensure_queue_reaction_or_fallback_http(&http, channel_id, &shared, message_id, false,)
+                .await
+        );
+        assert_eq!(
+            take_test_reply_deliveries(),
+            vec![ReactionControlReplyReason::QueueReactionFailed],
+            "a failed queue reaction must emit exactly one referenced fallback"
         );
     }
 }

--- a/src/services/discord/outbound/serenity_reference.rs
+++ b/src/services/discord/outbound/serenity_reference.rs
@@ -11,6 +11,7 @@ use super::delivery::{deliver_outbound, first_raw_message_id};
 use super::message::{DiscordOutboundMessage, OutboundReferenceContext, OutboundTarget};
 use super::policy::DiscordOutboundPolicy;
 use super::result::DeliveryResult;
+use super::transport::{outbound_fingerprint, post_serenity_message_with_nonce};
 use super::{DiscordOutboundClient, shared_outbound_deduper};
 use crate::services::discord::{SharedData, rate_limit_wait};
 
@@ -29,6 +30,12 @@ pub(in crate::services::discord) async fn send_referenced_lifecycle_notice(
     semantic_event_id: String,
 ) -> Result<Option<MessageId>, String> {
     let client = SerenityReferenceOutboundClient { http, shared };
+    let nonce = referenced_lifecycle_notice_nonce(
+        channel_id,
+        reference_message_id,
+        &correlation_id,
+        &semantic_event_id,
+    );
     let msg = DiscordOutboundMessage::new(
         correlation_id,
         semantic_event_id,
@@ -39,8 +46,24 @@ pub(in crate::services::discord) async fn send_referenced_lifecycle_notice(
     .with_reference(OutboundReferenceContext::reply_to(
         channel_id,
         reference_message_id,
-    ));
+    ))
+    .with_create_nonce(nonce, true);
     delivery_message_id(deliver_outbound(&client, shared_outbound_deduper(), msg, None).await)
+}
+
+fn referenced_lifecycle_notice_nonce(
+    channel_id: ChannelId,
+    reference_message_id: MessageId,
+    correlation_id: &str,
+    semantic_event_id: &str,
+) -> String {
+    outbound_fingerprint(&[
+        "referenced-lifecycle-notice",
+        &channel_id.get().to_string(),
+        &reference_message_id.get().to_string(),
+        correlation_id,
+        semantic_event_id,
+    ])
 }
 
 fn delivery_message_id(result: DeliveryResult) -> Result<Option<MessageId>, String> {
@@ -117,6 +140,33 @@ impl DiscordOutboundClient for SerenityReferenceOutboundClient {
             .map(|message| message.id.get().to_string())
             .map_err(dispatch_post_error)
     }
+
+    async fn post_message_with_reference_and_nonce(
+        &self,
+        target_channel: &str,
+        content: &str,
+        reference_channel: &str,
+        reference_message: &str,
+        nonce: &str,
+        enforce_nonce: bool,
+    ) -> Result<String, DispatchMessagePostError> {
+        let channel_id = parse_channel_id(target_channel)?;
+        let reference_channel_id = parse_channel_id(reference_channel)?;
+        let reference_message_id = parse_message_id(reference_message).map_err(|error| {
+            DispatchMessagePostError::new(DispatchMessagePostErrorKind::Other, error)
+        })?;
+        post_serenity_message_with_nonce(
+            &self.http,
+            &self.shared,
+            channel_id,
+            content,
+            Some((reference_channel_id, reference_message_id)),
+            nonce,
+            enforce_nonce,
+        )
+        .await
+        .map_err(dispatch_post_error)
+    }
 }
 
 fn parse_channel_id(raw: &str) -> Result<ChannelId, DispatchMessagePostError> {
@@ -146,4 +196,44 @@ fn dispatch_post_error(error: serenity::Error) -> DispatchMessagePostError {
         DispatchMessagePostErrorKind::Other
     };
     DispatchMessagePostError::new(kind, detail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::referenced_lifecycle_notice_nonce;
+    use poise::serenity_prelude::{ChannelId, MessageId};
+
+    #[test]
+    fn lifecycle_notice_nonce_is_stable_and_semantic_event_scoped() {
+        let channel_id = ChannelId::new(123);
+        let message_id = MessageId::new(456);
+        let first = referenced_lifecycle_notice_nonce(
+            channel_id,
+            message_id,
+            "intake-reaction-control:123:456",
+            "intake-reaction-control:123:456:queue_reaction_failed",
+        );
+        let retry = referenced_lifecycle_notice_nonce(
+            channel_id,
+            message_id,
+            "intake-reaction-control:123:456",
+            "intake-reaction-control:123:456:queue_reaction_failed",
+        );
+        let distinct_reason = referenced_lifecycle_notice_nonce(
+            channel_id,
+            message_id,
+            "intake-reaction-control:123:456",
+            "intake-reaction-control:123:456:queued_card_post_failed",
+        );
+
+        assert_eq!(
+            first, retry,
+            "retries across process-local dedupers need one nonce"
+        );
+        assert_ne!(
+            first, distinct_reason,
+            "different lifecycle reasons must not coalesce"
+        );
+        assert_eq!(first.len(), 16);
+    }
 }

--- a/src/services/discord/queue_marker.rs
+++ b/src/services/discord/queue_marker.rs
@@ -594,21 +594,25 @@ mod tests {
     #[tokio::test]
     async fn persisted_v1_kickoff_promotion_clears_orphan_queue_marker() {
         let _root = scoped_runtime_root();
-        let shared = crate::services::discord::make_shared_data_for_tests();
+        let mut shared = crate::services::discord::make_shared_data_for_tests();
+        const QUEUED_GENERATION: u64 = 63;
+        const RESTARTED_GENERATION: u64 = 64;
+        Arc::get_mut(&mut shared)
+            .expect("unshared test state")
+            .restart
+            .current_generation = RESTARTED_GENERATION;
         let http = Arc::new(serenity::Http::new("Bot test-token"));
         let channel_id = ChannelId::new(100_000_000_000_197);
         let head = MessageId::new(100_000_000_000_198);
-        write_persisted_v1_queue(&shared, channel_id, head, shared.restart.current_generation);
+        let queued_generation = QUEUED_GENERATION;
+        write_persisted_v1_queue(&shared, channel_id, head, queued_generation);
 
         start_and_drain_kickoff_markers(
             &shared,
             &http,
             channel_id,
             head,
-            &[SourceMessageQueuedGeneration::new(
-                head,
-                shared.restart.current_generation,
-            )],
+            &[SourceMessageQueuedGeneration::new(head, queued_generation)],
         )
         .await;
 

--- a/src/services/discord/queue_marker.rs
+++ b/src/services/discord/queue_marker.rs
@@ -249,6 +249,34 @@ mod tests {
         }
     }
 
+    fn write_persisted_v1_queue(
+        shared: &SharedData,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        generation: u64,
+    ) {
+        let path = persisted_path(channel_id, message_id);
+        std::fs::create_dir_all(path.parent().expect("persisted target parent"))
+            .expect("create persisted target parent");
+        std::fs::write(
+            path,
+            serde_json::json!({
+                "version": 1,
+                "provider": shared.provider.as_str(),
+                "kind": "intake_user_message",
+                "channel_id": channel_id.get(),
+                "message_id": message_id.get(),
+                "owner_generation": generation,
+                "owner_turn_id": format!("discord:{}:{}", channel_id.get(), message_id.get()),
+                "applied": "queued",
+                "identity_label": "intake",
+                "token_hash": shared.token_hash.clone(),
+            })
+            .to_string(),
+        )
+        .expect("write persisted v1 queue state");
+    }
+
     struct ScopedRuntimeRoot {
         _lock: std::sync::MutexGuard<'static, ()>,
         _temp: tempfile::TempDir,
@@ -511,6 +539,94 @@ mod tests {
         )
         .expect("parse pending state");
         assert_eq!(persisted["applied"], "pending");
+    }
+
+    #[tokio::test]
+    async fn persisted_v1_dispatch_promotion_clears_orphan_queue_marker() {
+        let _root = scoped_runtime_root();
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+        let channel_id = ChannelId::new(100_000_000_000_195);
+        let head = MessageId::new(100_000_000_000_196);
+        const GENERATION: u64 = 63;
+        write_persisted_v1_queue(&shared, channel_id, head, GENERATION);
+
+        drain_dispatched_queue_markers(
+            &shared,
+            &http,
+            channel_id,
+            head,
+            &[SourceMessageQueuedGeneration::new(head, GENERATION)],
+        )
+        .await;
+
+        let ops = shared.turn_view_reconciler.ops();
+        assert_eq!(
+            ops.iter()
+                .filter(|op| op.target.message_id == head && !op.add && op.emoji == '📬')
+                .count(),
+            1,
+            "v1 dispatch promotion must remove the legacy queue marker exactly once"
+        );
+        assert_eq!(
+            ops.iter()
+                .filter(|op| op.target.message_id == head && op.add && op.emoji == '⏳')
+                .count(),
+            1,
+            "v1 dispatch promotion must install pending state after cleanup"
+        );
+        assert!(
+            ops.iter()
+                .position(|op| op.target.message_id == head && !op.add && op.emoji == '📬')
+                < ops
+                    .iter()
+                    .position(|op| op.target.message_id == head && op.add && op.emoji == '⏳'),
+            "legacy cleanup must precede pending promotion"
+        );
+        let persisted: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(persisted_path(channel_id, head)).expect("pending state"),
+        )
+        .expect("parse pending state");
+        assert_eq!(persisted["applied"], "pending");
+        assert_eq!(persisted["version"], 1);
+    }
+
+    #[tokio::test]
+    async fn persisted_v1_kickoff_promotion_clears_orphan_queue_marker() {
+        let _root = scoped_runtime_root();
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+        let channel_id = ChannelId::new(100_000_000_000_197);
+        let head = MessageId::new(100_000_000_000_198);
+        write_persisted_v1_queue(&shared, channel_id, head, shared.restart.current_generation);
+
+        start_and_drain_kickoff_markers(
+            &shared,
+            &http,
+            channel_id,
+            head,
+            &[SourceMessageQueuedGeneration::new(
+                head,
+                shared.restart.current_generation,
+            )],
+        )
+        .await;
+
+        let ops = shared.turn_view_reconciler.ops();
+        assert_eq!(
+            ops.iter()
+                .filter(|op| op.target.message_id == head && !op.add && op.emoji == '📬')
+                .count(),
+            1,
+            "v1 idle kickoff must remove the legacy queue marker exactly once"
+        );
+        assert_eq!(
+            ops.iter()
+                .filter(|op| op.target.message_id == head && op.add && op.emoji == '⏳')
+                .count(),
+            1,
+            "v1 idle kickoff must install pending state after cleanup"
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/router/intake_dispatch/tests.rs
+++ b/src/services/discord/router/intake_dispatch/tests.rs
@@ -77,18 +77,33 @@ fn intake_dispatch_invariant_worker_post_claim_is_the_only_router_bypass() {
 }
 
 #[test]
-fn intake_dispatch_invariant_queued_entrypoints_admit_before_teardown() {
-    for (name, source) in [
-        ("gateway", include_str!("../../gateway.rs")),
-        ("discord_mod", include_str!("../../mod.rs")),
+fn intake_dispatch_invariant_queued_entrypoints_promote_markers_after_admission_before_finish() {
+    for (name, source, promotion) in [
+        (
+            "gateway",
+            include_str!("../../gateway.rs"),
+            "drain_dispatched_queue_markers(",
+        ),
+        (
+            "discord_mod",
+            include_str!("../../mod.rs"),
+            "start_and_drain_kickoff_markers(",
+        ),
     ] {
         let admit = source
             .find("admit_queued_intake(")
             .unwrap_or_else(|| panic!("{name} queue path lost central admission"));
+        let promote = source
+            .find(promotion)
+            .unwrap_or_else(|| panic!("{name} queue path lost marker promotion"));
         let finish = source
             .find("finish_admitted_queued_intake(")
             .unwrap_or_else(|| panic!("{name} queue path lost admitted local finish"));
-        assert!(admit < finish, "{name} executes before admission");
+        assert!(
+            admit < promote && promote < finish,
+            "{name} must promote persisted queue markers only after admission and before finish"
+        );
+        assert_eq!(source.matches(promotion).count(), 1);
         assert_eq!(source.matches("finish_admitted_queued_intake(").count(), 1);
     }
 }

--- a/src/services/discord/router/intake_gate/queue_effects.rs
+++ b/src/services/discord/router/intake_gate/queue_effects.rs
@@ -3,7 +3,7 @@ use super::super::intake_queue_transaction::{
 };
 use super::*;
 use crate::services::discord::outbound::reaction_control::{
-    ReactionControlReplyReason, send_reaction_control_reply,
+    ReactionControlReplyReason, ensure_queue_reaction_or_fallback_http, send_reaction_control_reply,
 };
 
 /// Pick the queue-pending reaction emoji based on the enqueue outcome.
@@ -55,15 +55,6 @@ async fn add_queue_pending_reaction_self_healing(
         )
         .await;
     if !delivered {
-        send_reaction_control_reply(
-            ctx,
-            &data.shared,
-            channel_id,
-            user_msg_id,
-            ReactionControlReplyReason::QueueReactionFailed,
-            "📬 큐에 추가됨 — 리액션 표시는 실패했지만 메시지는 큐잉되었습니다.",
-        )
-        .await;
         return false;
     }
     let still_queued = {
@@ -158,13 +149,12 @@ impl IntakeQueueCommitEffects for IntakeGateQueueEffects<'_> {
         channel_id: serenity::ChannelId,
         message_id: serenity::MessageId,
     ) {
-        send_reaction_control_reply(
-            self.ctx,
-            &self.data.shared,
+        ensure_queue_reaction_or_fallback_http(
+            &self.ctx.http,
             channel_id,
+            &self.data.shared,
             message_id,
-            ReactionControlReplyReason::QueueReactionFailed,
-            "📬 큐에 추가됨 — 리액션 표시는 실패했지만 메시지는 큐잉되었습니다.",
+            false,
         )
         .await;
     }

--- a/src/services/discord/router/intake_gate/queue_effects.rs
+++ b/src/services/discord/router/intake_gate/queue_effects.rs
@@ -89,6 +89,15 @@ pub(super) struct IntakeGateQueueEffects<'a> {
     pub(super) data: &'a Data,
 }
 
+async fn notify_pending_reaction_failure_http(
+    http: &Arc<serenity::http::Http>,
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+    message_id: serenity::MessageId,
+) {
+    ensure_queue_reaction_or_fallback_http(http, channel_id, shared, message_id, false).await;
+}
+
 /// #3903/#4024 — pure verdict for whether a post-enqueue deferred idle-queue
 /// drain must run after an intervention actually landed in the mailbox queue.
 ///
@@ -149,12 +158,11 @@ impl IntakeQueueCommitEffects for IntakeGateQueueEffects<'_> {
         channel_id: serenity::ChannelId,
         message_id: serenity::MessageId,
     ) {
-        ensure_queue_reaction_or_fallback_http(
+        notify_pending_reaction_failure_http(
             &self.ctx.http,
-            channel_id,
             &self.data.shared,
+            channel_id,
             message_id,
-            false,
         )
         .await;
     }
@@ -257,6 +265,35 @@ async fn repair_queued_source_pending_reaction_from_mailbox(
         }
     }
     Some(PendingReactionRepair { emoji, delivered })
+}
+
+#[cfg(test)]
+mod pending_reaction_failure_adapter_tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn production_adapter_emits_exactly_one_queue_fallback() {
+        assert!(
+            crate::services::discord::outbound::reaction_control::take_test_reply_deliveries()
+                .is_empty()
+        );
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+
+        notify_pending_reaction_failure_http(
+            &http,
+            &shared,
+            serenity::ChannelId::new(455_400_000_000_231),
+            serenity::MessageId::new(455_400_000_000_232),
+        )
+        .await;
+
+        assert_eq!(
+            crate::services::discord::outbound::reaction_control::take_test_reply_deliveries(),
+            vec![ReactionControlReplyReason::QueueReactionFailed],
+            "the production queue-effects adapter must emit exactly one referenced fallback"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/services/discord/router/intake_queue_transaction.rs
+++ b/src/services/discord/router/intake_queue_transaction.rs
@@ -395,6 +395,9 @@ where
                     } else {
                         outcome.pending_reaction =
                             PendingReactionDecision::Skip(PendingReactionSkipReason::Failed);
+                        effects
+                            .notify_pending_reaction_failure(channel_id, message_id)
+                            .await;
                     }
                 }
                 IntakeQueuePendingReactionPolicy::Static(emoji) => {
@@ -409,6 +412,9 @@ where
                     } else {
                         outcome.pending_reaction =
                             PendingReactionDecision::Skip(PendingReactionSkipReason::Failed);
+                        effects
+                            .notify_pending_reaction_failure(channel_id, message_id)
+                            .await;
                     }
                 }
             }
@@ -765,6 +771,10 @@ mod tests {
                 IntakeQueueCommittedStep::CheckpointAdvanced,
             ]
         );
+        assert!(
+            effects.fallback_notices.is_empty(),
+            "a delivered accepted reaction must not emit fallback UI"
+        );
     }
 
     #[tokio::test]
@@ -795,6 +805,11 @@ mod tests {
                 IntakeQueueCommittedStep::CheckpointAdvanced,
             ],
             "a failed reaction must never be reported as PendingReactionApplied"
+        );
+        assert_eq!(
+            effects.fallback_notices,
+            vec![(serenity::ChannelId::new(42), serenity::MessageId::new(100))],
+            "a failed accepted reaction must emit exactly one referenced fallback notice"
         );
     }
 
@@ -872,6 +887,10 @@ mod tests {
         assert_eq!(
             outcome.committed_steps,
             vec![IntakeQueueCommittedStep::PendingReactionApplied]
+        );
+        assert!(
+            effects.fallback_notices.is_empty(),
+            "a delivered duplicate repair must not emit fallback UI"
         );
     }
 

--- a/src/services/discord/router/intake_queue_transaction.rs
+++ b/src/services/discord/router/intake_queue_transaction.rs
@@ -848,6 +848,49 @@ mod tests {
             effects.checkpoints,
             vec![(serenity::ChannelId::new(42), serenity::MessageId::new(100))]
         );
+        assert!(
+            effects.fallback_notices.is_empty(),
+            "a delivered static reaction must not emit fallback UI"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepted_static_reaction_failure_emits_exactly_one_fallback() {
+        let mut effects = FakeEffects {
+            enqueue_outcome: MailboxEnqueueOutcome {
+                enqueued: true,
+                merged: false,
+                refusal_reason: None,
+                persistence_error: None,
+            },
+            reaction_delivery: false,
+            ..FakeEffects::default()
+        };
+        let mut options = IntakeQueueCommitOptions::default();
+        options.pending_reaction = IntakeQueuePendingReactionPolicy::Static(
+            super::super::super::queue_reactions::QUEUE_RECONCILE_PENDING_REACTION,
+        );
+
+        let outcome = commit_soft_intervention_transaction(&mut effects, request(options)).await;
+
+        assert!(outcome.accepted());
+        assert_eq!(
+            outcome.pending_reaction,
+            PendingReactionDecision::Skip(PendingReactionSkipReason::Failed)
+        );
+        assert_eq!(
+            effects.reactions,
+            vec![(
+                serenity::ChannelId::new(42),
+                serenity::MessageId::new(100),
+                '🔄'
+            )]
+        );
+        assert_eq!(
+            effects.fallback_notices,
+            vec![(serenity::ChannelId::new(42), serenity::MessageId::new(100))],
+            "a failed static accepted reaction must emit exactly one fallback"
+        );
     }
 
     #[tokio::test]
@@ -982,6 +1025,10 @@ mod tests {
 
         assert!(outcome.failed());
         assert!(effects.reactions.is_empty());
+        assert!(
+            effects.fallback_notices.is_empty(),
+            "an intervention that was not durably queued must not claim queue admission"
+        );
         assert!(effects.checkpoints.is_empty());
         assert_eq!(
             outcome.committed_steps,

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction.rs
@@ -77,15 +77,12 @@ pub(super) async fn note_queue_pending(
         source,
     )
     .await;
-    if !delivered {
-        crate::services::discord::outbound::reaction_control::send_reaction_control_reply_http(
-            http,
-            channel_id,
-            shared,
-            user_msg_id,
-            crate::services::discord::outbound::reaction_control::ReactionControlReplyReason::QueueReactionFailed,
-            "📬 큐에 추가됨 — 리액션 표시는 실패했지만 메시지는 큐잉되었습니다.",
-        )
-        .await;
-    }
+    crate::services::discord::outbound::reaction_control::ensure_queue_reaction_or_fallback_http(
+        http,
+        channel_id,
+        shared,
+        user_msg_id,
+        delivered,
+    )
+    .await;
 }

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
@@ -49,17 +49,21 @@ fn user_intervention(id: u64) -> Intervention {
     }
 }
 
-fn mailbox_add_count(shared: &SharedData, message_id: MessageId) -> usize {
+fn reaction_add_count(shared: &SharedData, message_id: MessageId, emoji: char) -> usize {
     shared
         .turn_view_reconciler
         .ops()
         .iter()
-        .filter(|op| op.target.message_id == message_id && op.add && op.emoji == '📬')
+        .filter(|op| op.target.message_id == message_id && op.add && op.emoji == emoji)
         .count()
 }
 
+fn mailbox_add_count(shared: &SharedData, message_id: MessageId) -> usize {
+    reaction_add_count(shared, message_id, '📬')
+}
+
 #[tokio::test(flavor = "current_thread")]
-async fn failed_queue_reaction_sends_exactly_one_referenced_fallback() {
+async fn busy_tui_wrapper_failure_uses_standalone_policy_and_exactly_one_fallback() {
     let _root = scoped_runtime_root();
     let mut shared = crate::services::discord::make_shared_data_for_tests();
     Arc::get_mut(&mut shared)
@@ -76,21 +80,42 @@ async fn failed_queue_reaction_sends_exactly_one_referenced_fallback() {
             .is_empty()
     );
 
-    mailbox_reaction::note_queue_pending(
-        &shared,
-        &http,
-        channel_id,
-        message_id,
-        crate::services::discord::queue_reactions::QUEUE_STANDALONE_PENDING_REACTION,
-        None,
-        "race_loss_message_queued",
+    mailbox_reaction::note_busy_tui_pre_submit_queue_pending(
+        &shared, &http, channel_id, message_id, false, None,
     )
     .await;
 
+    assert_eq!(mailbox_add_count(&shared, message_id), 1);
     assert_eq!(
         crate::services::discord::outbound::reaction_control::take_test_reply_deliveries(),
         vec![crate::services::discord::outbound::reaction_control::ReactionControlReplyReason::QueueReactionFailed],
-        "failed race-loss reaction must emit exactly one referenced fallback"
+        "failed busy-TUI queue reaction must emit exactly one referenced fallback"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn busy_tui_wrapper_merged_success_uses_plus_without_fallback() {
+    let _root = scoped_runtime_root();
+    let shared = crate::services::discord::make_shared_data_for_tests();
+    let http = Arc::new(serenity::Http::new("Bot test-token"));
+    let channel_id = ChannelId::new(455_400_000_000_082);
+    let message_id = MessageId::new(455_400_000_000_083);
+    assert!(
+        crate::services::discord::outbound::reaction_control::take_test_reply_deliveries()
+            .is_empty()
+    );
+
+    mailbox_reaction::note_busy_tui_pre_submit_queue_pending(
+        &shared, &http, channel_id, message_id, true, None,
+    )
+    .await;
+
+    assert_eq!(reaction_add_count(&shared, message_id, '➕'), 1);
+    assert_eq!(mailbox_add_count(&shared, message_id), 0);
+    assert!(
+        crate::services::discord::outbound::reaction_control::take_test_reply_deliveries()
+            .is_empty(),
+        "a delivered busy-TUI merged reaction must remain reaction-only"
     );
 }
 

--- a/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
+++ b/src/services/discord/router/message_handler/intake_turn/race_loss/mailbox_reaction_tests.rs
@@ -164,6 +164,11 @@ async fn standalone_without_start_attempt_adds_mailbox_once() {
         1,
         "race-loss standalone enqueue must imperatively add 📬 without a start attempt"
     );
+    assert!(
+        crate::services::discord::outbound::reaction_control::take_test_reply_deliveries()
+            .is_empty(),
+        "a delivered race-loss reaction must not emit fallback UI"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/src/services/discord/router/queue_status_presentation.rs
+++ b/src/services/discord/router/queue_status_presentation.rs
@@ -45,8 +45,7 @@ mod tests {
         ));
         assert!(race_loss_reaction.contains(&compact(
             r#"
-                if !delivered {
-                    crate::services::discord::outbound::reaction_control::send_reaction_control_reply_http(
+                crate::services::discord::outbound::reaction_control::ensure_queue_reaction_or_fallback_http(
             "#,
         )));
 

--- a/src/services/discord/turn_bridge/followup_requeue.rs
+++ b/src/services/discord/turn_bridge/followup_requeue.rs
@@ -84,7 +84,7 @@ pub(super) async fn requeue_claude_tui_followup_pre_submit_timeout(
             } else {
                 super::super::queue_reactions::QUEUE_STANDALONE_PENDING_REACTION
             };
-            super::super::queue_marker::note_added_queued_generation(
+            let delivered = super::super::queue_marker::note_added_queued_generation(
                 shared_owned,
                 &http,
                 channel_id,
@@ -92,6 +92,14 @@ pub(super) async fn requeue_claude_tui_followup_pre_submit_timeout(
                 queue_marker,
                 queued_generation,
                 "claude_tui_followup_requeue_inflight",
+            )
+            .await;
+            super::super::outbound::reaction_control::ensure_queue_reaction_or_fallback_http(
+                &http,
+                channel_id,
+                shared_owned,
+                message_id,
+                delivered,
             )
             .await;
             let still_queued = super::super::mailbox_snapshot(shared_owned, channel_id)
@@ -204,6 +212,50 @@ mod tests {
         assert!(
             !retry_present_or_accepted(&outcome),
             "a failed queue write must preserve inflight rather than report requeue success"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_submit_retry_reaction_failure_emits_exactly_one_referenced_fallback() {
+        let _root = scoped_runtime_root();
+        let mut shared = crate::services::discord::make_shared_data_for_tests();
+        Arc::get_mut(&mut shared)
+            .expect("fresh shared data")
+            .turn_view_reconciler =
+            crate::services::discord::turn_view_reconciler::TurnViewReconciler::with_test_deliveries(
+                vec![crate::services::discord::turn_view_reconciler::TurnViewDelivery::Failed],
+            );
+        shared
+            .http
+            .cached_bot_token
+            .set("Bot test-token".to_string())
+            .expect("test bot token");
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(100_000_004_248_003);
+        let message_id = MessageId::new(100_000_004_248_004);
+        let inflight = inflight(channel_id, message_id);
+        assert!(
+            crate::services::discord::outbound::reaction_control::take_test_reply_deliveries()
+                .is_empty()
+        );
+
+        assert!(
+            requeue_claude_tui_followup_pre_submit_timeout(
+                &shared,
+                &provider,
+                channel_id,
+                &inflight,
+                None,
+                None,
+                "turn-4248-reaction-failure",
+            )
+            .await
+        );
+
+        assert_eq!(
+            crate::services::discord::outbound::reaction_control::take_test_reply_deliveries(),
+            vec![crate::services::discord::outbound::reaction_control::ReactionControlReplyReason::QueueReactionFailed],
+            "failed follow-up requeue reaction must emit exactly one referenced fallback"
         );
     }
 


### PR DESCRIPTION
## Summary
- centralize referenced fallback delivery when accepted, duplicate-repair, or race-loss queue reactions fail
- preserve reaction-only UI on successful delivery and assert zero duplicate fallback notices
- cover persisted schema-v1 queue-marker cleanup through real dispatch and kickoff promotion entrypoints
- wire the new focused contracts into the required `just check` non-Postgres lane

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --lib`
- [x] focused queue reaction and v1 promotion tests are wired into the required `just check` CI lane
- [x] `python3 scripts/generate_inventory_docs.py --check`
- [x] `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- [x] `python3 scripts/audit_maintainability.py --check`
- [ ] mutation proof for accepted fallback and persisted-v1 cleanup guards (runner contention delayed the isolated local proof; CI exercises the restored exact head)

Closes #4599

🤖 Generated with [Claude Code](https://claude.com/claude-code)