### PR TITLE
chore(security): expand ClaudeBinary compile-fail guard coverage

### DIFF
--- a/docs/ci/rust-quality-gates.md
+++ b/docs/ci/rust-quality-gates.md
@@ -6,8 +6,9 @@ repository is already clippy-clean.
 ## Entrypoints
 
 - `just check`: local/CI aggregate for `just fmt-check`, staged clippy,
-  `cargo check --workspace --all-features --all-targets`, and the existing
-  non-Postgres test subset.
+  `cargo check --workspace --all-features --all-targets`, the existing
+  non-Postgres test subset, and the targeted `ClaudeBinary` compile-fail
+  doctest guard.
 - `just test-postgres`: existing PostgreSQL test lane for CI jobs with a
   Postgres service.
 - `just lint-strict`: target end state, `cargo clippy --workspace --all-targets

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -204,7 +204,7 @@
 | `kanban::transition_cleanup` | `src/kanban/transition_cleanup.rs` | 341 | 341 | 0 |  |
 | `kanban::transition_core` | `src/kanban/transition_core.rs` | 674 | 674 | 0 |  |
 | `launch` | `src/launch.rs` | 67 | 67 | 0 |  |
-| `lib` | `src/lib.rs` | 187 | 187 | 0 |  |
+| `lib` | `src/lib.rs` | 259 | 259 | 0 |  |
 | `logging` | `src/logging.rs` | 554 | 382 | 172 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 35 | 35 | 0 |  |
 | `pipeline` | `src/pipeline.rs` | 1517 | 1383 | 134 | giant-file |

--- a/justfile
+++ b/justfile
@@ -37,6 +37,9 @@ test-non-pg:
     python3 scripts/ci-timeout.py 900 env -u AGENTDESK_ROOT_DIR cargo test --lib health -- --skip _pg --skip pg_ --skip postgres
     env -u AGENTDESK_ROOT_DIR cargo test --lib relay_recovery -- --skip _pg --skip pg_ --skip postgres
     cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
+    # `ClaudeBinary` capability invariants are compile-fail doctests in src/lib.rs.
+    # Filter the real rustdoc harness to this public capability contract.
+    cargo test --doc ClaudeBinary
 
 test-postgres:
     cargo test -- _pg pg_ postgres --nocapture --test-threads=1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,81 @@ mod services;
 /// }
 /// ```
 ///
+/// The capability remains sealed through aliases, references, helpers, closures,
+/// and renamed imports as well:
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command as ProcessCommand;
+///
+/// type BinaryAlias = ClaudeBinary;
+///
+/// fn bypass_alias(binary: ClaudeBinary) {
+///     let alias: BinaryAlias = binary;
+///     let _raw_command = ProcessCommand::new(alias);
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command as ProcessCommand;
+///
+/// fn bypass_reference(binary: ClaudeBinary) {
+///     let reference = &binary;
+///     let _raw_command = ProcessCommand::new(reference);
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command as ProcessCommand;
+///
+/// fn helper(binary: ClaudeBinary) {
+///     let _raw_command = ProcessCommand::new(binary);
+/// }
+///
+/// fn bypass_helper(binary: ClaudeBinary) {
+///     helper(binary);
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command as ProcessCommand;
+///
+/// fn bypass_closure(binary: ClaudeBinary) {
+///     let spawn = |candidate: ClaudeBinary| ProcessCommand::new(candidate);
+///     let _raw_command = spawn(binary);
+/// }
+/// ```
+///
+/// A renamed `Command` import does not provide an escape hatch:
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command as ProcessCommand;
+///
+/// fn bypass_renamed_command(binary: ClaudeBinary) {
+///     let _raw_command = ProcessCommand::new(binary);
+/// }
+/// ```
+
 /// `ClaudeBinary` intentionally does not implement `AsRef<OsStr>`, `Deref`,
 /// `Display`, or a public path getter. It can therefore be consumed only through
 /// guarded Claude launch APIs rather than passed directly to `Command::new`.
+///
+/// This capability is created at trusted Claude launch boundaries and consumed
+/// by the guarded launch builder; raw process construction is intentionally not
+/// part of its public API.
+///
+/// ```compile_fail
+/// use agentdesk::ClaudeBinary;
+/// use std::process::Command as ProcessCommand;
+///
+/// fn bypass_public_capability(binary: ClaudeBinary) {
+///     let _raw_command = ProcessCommand::new(binary);
+/// }
+/// ```
 pub use services::claude_command::ClaudeBinary;
 
 // Supervisor test hooks are intentionally retained for dispatch/runtime tests.


### PR DESCRIPTION
## Summary
- Extend the public `ClaudeBinary` compile-fail contract with mutation-resistant examples for aliases, references, helper functions, closures, and renamed `Command` imports.
- Keep the resolver-layer sealing follow-up in #4627 untouched; retain the existing substring guard as defense-in-depth.
- Regenerate the module inventory for the documentation-only line-count change.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `python3 scripts/audit_maintainability.py --check`
- [ ] `cargo test --doc ClaudeBinary` (blocked by concurrent repository-wide Cargo builds; prior full doc-test attempt timed out after 10 minutes)
- [ ] Focused Rust test execution (blocked by concurrent repository-wide Cargo builds; timed out after 10 minutes)

This PR intentionally does not modify #3016 hotfiles or #4627 resolver code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)