### PR TITLE
fix(relay): keep killed task notifications status-only

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1138,7 +1138,7 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (2105 lines; -41 from #4591 R4: remove
+  - `src/services/tui_prompt_dedupe.rs` (2134 lines; +29 from #4567: classify start-anchored structured task notifications as status-only observations before generic external-input ownership, preserving task-card/status delivery while leaving the next human prompt immediately admissible; -41 from #4591 R4: remove
     raw/envelope time-pair state so local slash-control representations may
     duplicate rather than swallowing a later human command; local stable entry
     IDs are now recorded only after the relay confirms its Discord session note,

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -106,6 +106,6 @@
 | `src/services/routines/discord_log.rs` | 1594 |
 | `src/services/routines/store.rs` | 3559 |
 | `src/services/settings.rs` | 1112 |
-| `src/services/tui_prompt_dedupe.rs` | 2105 |
+| `src/services/tui_prompt_dedupe.rs` | 2134 |
 | `src/services/turn_orchestrator.rs` | 3288 |
 | `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -807,7 +807,7 @@
 | `services::discord::tui_direct_abort_marker::sweep` | `src/services/discord/tui_direct_abort_marker/sweep.rs` | 177 | 177 | 0 |  |
 | `services::discord::tui_direct_abort_marker::tombstone` | `src/services/discord/tui_direct_abort_marker/tombstone.rs` | 70 | 70 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 3815 | 1495 | 2320 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 836 | 836 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 854 | 854 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 454 | 218 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |
@@ -817,7 +817,7 @@
 | `services::discord::tui_prompt_relay::codex_idle_rollout` | `src/services/discord/tui_prompt_relay/codex_idle_rollout.rs` | 613 | 613 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_offset_resolution` | `src/services/discord/tui_prompt_relay/idle_offset_resolution.rs` | 100 | 100 | 0 |  |
 | `services::discord::tui_prompt_relay::idle_transcript_scan` | `src/services/discord/tui_prompt_relay/idle_transcript_scan.rs` | 495 | 347 | 148 |  |
-| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 431 | 431 | 0 |  |
+| `services::discord::tui_prompt_relay::injected_prompt_policy` | `src/services/discord/tui_prompt_relay/injected_prompt_policy.rs` | 434 | 434 | 0 |  |
 | `services::discord::tui_prompt_relay::launch_script` | `src/services/discord/tui_prompt_relay/launch_script.rs` | 129 | 107 | 22 |  |
 | `services::discord::tui_prompt_relay::observed_prompt_decision` | `src/services/discord/tui_prompt_relay/observed_prompt_decision.rs` | 61 | 61 | 0 |  |
 | `services::discord::tui_prompt_relay::rehydration` | `src/services/discord/tui_prompt_relay/rehydration.rs` | 997 | 796 | 201 |  |
@@ -1080,8 +1080,8 @@
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 898 | 787 | 111 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |
-| `services::tui_prompt_control` | `src/services/tui_prompt_control.rs` | 232 | 194 | 38 |  |
-| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4702 | 2105 | 2597 | giant-file |
+| `services::tui_prompt_control` | `src/services/tui_prompt_control.rs` | 246 | 208 | 38 |  |
+| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4759 | 2134 | 2625 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2033 | 648 | 1385 |  |
 | `services::tui_turn_state::completion_scan` | `src/services/tui_turn_state/completion_scan.rs` | 360 | 360 | 0 |  |

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -392,6 +392,24 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     let injected_class = relay_prompt_decision.injected_class;
     let task_notification =
         task_notification_prompt::observe(shared, &prompt, channel_id, injected_class);
+    if matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
+        // #4567: structured task lifecycle records retain their status-card
+        // authority, but have no positive user-input provenance. Resolve the
+        // card without recording a generic external lease; in particular, do
+        // not let a killed notification mint an anchor, mailbox token, or
+        // synthetic inflight that can fence the next real prompt.
+        let status_only_lease = ExternalInputRelayLease::unassigned(Some(channel_id.get()));
+        let _ = task_notification_prompt::resolve_gate(
+            shared,
+            &prompt,
+            channel_id,
+            injected_class,
+            &status_only_lease,
+            task_notification,
+        )
+        .await;
+        return;
+    }
     // Only external slash controls enter this broad two-second kind gate. Local
     // controls bypass it entirely: raw and envelope transcript records may each
     // render a note rather than risking suppression of a later human command.

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -378,17 +378,6 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         }
         return;
     }
-    // #3811: TUI-direct is an id-0 synthetic turn — clear any stale interactive 요청 anchor.
-    let live_events = &shared.ui.placeholder_live_events;
-    live_events.set_turn_request_anchor(channel_id, None);
-    let recap_provider = ProviderKind::from_str_or_unsupported(&prompt.provider);
-    // #3178 (codex P1 lease-overwrite): run the slash-command-control dedupe BEFORE
-    // recording ANY external-input lease. The #3153 double-post (raw echo + expanded
-    // `<command-*>` wrapper, ~tens-of-ms apart) must not let the SECOND half record a
-    // lease: the table is one-per-(provider,session), so it would overwrite the first
-    // turn's lease and its guard would clear that generation, stranding the first
-    // bridge tail. Drop the duplicate here, before any lease/anchor/inflight exists;
-    // a genuine second /loop / /compact falls outside the 2s window → fresh turn.
     let injected_class = relay_prompt_decision.injected_class;
     let task_notification =
         task_notification_prompt::observe(shared, &prompt, channel_id, injected_class);
@@ -410,6 +399,17 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         .await;
         return;
     }
+    // #3811: TUI-direct is an id-0 synthetic turn — clear any stale interactive 요청 anchor.
+    let live_events = &shared.ui.placeholder_live_events;
+    live_events.set_turn_request_anchor(channel_id, None);
+    let recap_provider = ProviderKind::from_str_or_unsupported(&prompt.provider);
+    // #3178 (codex P1 lease-overwrite): run the slash-command-control dedupe BEFORE
+    // recording ANY external-input lease. The #3153 double-post (raw echo + expanded
+    // `<command-*>` wrapper, ~tens-of-ms apart) must not let the SECOND half record a
+    // lease: the table is one-per-(provider,session), so it would overwrite the first
+    // turn's lease and its guard would clear that generation, stranding the first
+    // bridge tail. Drop the duplicate here, before any lease/anchor/inflight exists;
+    // a genuine second /loop / /compact falls outside the 2s window → fresh turn.
     // Only external slash controls enter this broad two-second kind gate. Local
     // controls bypass it entirely: raw and envelope transcript records may each
     // render a note rather than risking suppression of a later human command.

--- a/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
+++ b/src/services/discord/tui_prompt_relay/injected_prompt_policy.rs
@@ -24,8 +24,9 @@ const LOCAL_COMMAND_STDOUT_CLOSE: &str = "</local-command-stdout>";
 const COMPACTED_LOCAL_COMMAND_STDOUT_PREFIX: &str = "<local-command-stdout>Compacted";
 
 /// Classification of TUI-injected prompt text. Each class drives different
-/// lifecycle handling: human/task turns get active-turn ownership, continuation
-/// banners stay passive, and slash-control echoes use command-kind rendering.
+/// lifecycle handling: human turns get active-turn ownership, task/subagent
+/// events and continuation banners stay passive, and slash-control echoes use
+/// command-kind rendering.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum InjectedPromptClass {
     HumanTuiDirect,
@@ -48,6 +49,7 @@ impl InjectedPromptClass {
         matches!(
             self,
             InjectedPromptClass::SystemContinuation
+                | InjectedPromptClass::TaskNotificationEvent
                 | InjectedPromptClass::SubagentNotificationEvent
         )
     }
@@ -58,6 +60,7 @@ impl InjectedPromptClass {
         !matches!(
             self,
             InjectedPromptClass::SystemContinuation
+                | InjectedPromptClass::TaskNotificationEvent
                 | InjectedPromptClass::SubagentNotificationEvent
         )
     }

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -797,9 +797,23 @@ fn classify_injected_prompt_human_direct_input() {
     assert!(classify_injected_prompt("hi").is_human_active_turn());
 }
 
-// #3099: a `<task-notification>` auto-turn is a real provider turn (it earns
-// a `⏳`) but is not human-driven; its completion cleanup is anchored on the
-// injected message id, so it is classified distinctly from human input.
+// #4567: a `<task-notification>` is a status/card event, not positive
+// human-input provenance; it must not claim an external user-turn lifecycle.
+#[test]
+fn task_notification_lifecycle_is_not_an_external_turn() {
+    let decision = relay_observed_prompt_injected_prompt_decision(
+        "<task-notification><status>killed</status></task-notification>",
+    );
+    assert_eq!(
+        decision.injected_class,
+        InjectedPromptClass::TaskNotificationEvent
+    );
+    assert!(
+        !decision.starts_external_turn_lifecycle(),
+        "killed task status must not claim synthetic ownership"
+    );
+}
+
 #[test]
 fn classify_injected_prompt_task_notification_event() {
     let bare = "<task-notification><status>completed</status><task_id>codex-background-event</task_id></task-notification>";
@@ -1844,18 +1858,20 @@ fn system_continuation_suppresses_external_turn_lifecycle() {
     assert!(!subagent.still_delivers_assistant_output());
     assert!(!subagent.is_human_active_turn());
 
-    // Human + task-notification turns keep their user-turn lifecycle AND deliver
-    // output.
-    for active in [
-        InjectedPromptClass::HumanTuiDirect,
-        InjectedPromptClass::TaskNotificationEvent,
-    ] {
-        assert!(
-            !active.suppresses_user_turn_lifecycle(),
-            "{active:?} must keep its user-turn lifecycle"
-        );
-        assert!(active.still_delivers_assistant_output());
-    }
+    let human = InjectedPromptClass::HumanTuiDirect;
+    assert!(!human.suppresses_user_turn_lifecycle());
+    assert!(human.still_delivers_assistant_output());
+
+    let task = InjectedPromptClass::TaskNotificationEvent;
+    assert!(
+        task.suppresses_user_turn_lifecycle(),
+        "task lifecycle records must never claim a user-turn lifecycle"
+    );
+    assert!(
+        !task.still_delivers_assistant_output(),
+        "task lifecycle records must not spawn an output bridge tail"
+    );
+    assert!(!task.is_human_active_turn());
 }
 
 // #3100 codex re-review (P2): a human message that merely *quotes* the

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -814,6 +814,43 @@ fn task_notification_lifecycle_is_not_an_external_turn() {
     );
 }
 
+#[tokio::test]
+async fn task_notification_status_only_preserves_existing_turn_request_anchor() {
+    let shared = super::super::make_shared_data_for_tests();
+    let channel_id = ChannelId::new(940_000_000_004_567);
+    let existing_anchor = 940_000_000_004_568;
+    let tmux = "AgentDesk-claude-4567-status-only-anchor";
+    shared
+        .tmux_watchers
+        .restore_owner_channel_for_tmux_session(tmux, channel_id);
+    shared
+        .ui
+        .placeholder_live_events
+        .set_turn_request_anchor(channel_id, Some(existing_anchor));
+    let prompt = ObservedTuiPrompt {
+        provider: ProviderKind::Claude.as_str().to_string(),
+        tmux_session_name: tmux.to_string(),
+        prompt: "<task-notification><status>killed</status></task-notification>".to_string(),
+        source_event_id: None,
+        observed_at: chrono::Utc::now(),
+        external_input_lease_generation:
+            crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        ssh_direct_observation_generation:
+            crate::services::tui_prompt_dedupe::SSH_DIRECT_OBSERVATION_GENERATION_UNRECORDED,
+    };
+
+    relay_observed_prompt(&shared, prompt).await;
+
+    assert_eq!(
+        shared
+            .ui
+            .placeholder_live_events
+            .request_user_msg_id_for_test(channel_id),
+        Some(existing_anchor),
+        "status-only task notifications must not clear or replace the existing Discord turn request anchor",
+    );
+}
+
 #[test]
 fn classify_injected_prompt_task_notification_event() {
     let bare = "<task-notification><status>completed</status><task_id>codex-background-event</task_id></task-notification>";

--- a/src/services/tui_prompt_control.rs
+++ b/src/services/tui_prompt_control.rs
@@ -115,6 +115,20 @@ pub(crate) fn strip_leading_injection_wrapper(text: &str) -> &str {
     after_wrapper_line
 }
 
+/// Returns true only for a structured task lifecycle record at the beginning of
+/// an observed prompt. This seam is deliberately provider-neutral so the
+/// pre-publish dedupe layer can classify status records before it records any
+/// generic external-input lease. Human text quoting the tag mid-prompt is not a
+/// lifecycle record.
+pub(crate) fn is_start_anchored_task_notification_prompt(prompt: &str) -> bool {
+    let normalized = strip_terminal_controls(prompt);
+    let normalized = strip_leading_injection_wrapper(normalized.trim_start()).trim_start();
+    let Some(rest) = normalized.strip_prefix("<task-notification") else {
+        return false;
+    };
+    rest.starts_with('>') || rest.chars().next().is_some_and(char::is_whitespace)
+}
+
 fn strip_trailing_injection_code_fence(text: &str) -> &str {
     let trimmed = text.trim_end();
     let Some(before_fence) = trimmed.strip_suffix("```") else {

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 
 use crate::services::agent_protocol::RuntimeHandoffKind;
-use crate::services::tui_prompt_control::classify_local_only_slash_control;
+use crate::services::tui_prompt_control::{
+    classify_local_only_slash_control, is_start_anchored_task_notification_prompt,
+};
 use chrono::{DateTime, Utc};
 
 mod synthetic_prompt;
@@ -1158,6 +1160,30 @@ fn observe_prompt_candidates_by_tmux_inner(
     if provider.is_empty() || tmux_session_name.is_empty() || candidates.is_empty() {
         return PromptObservation::Ignored;
     }
+    // #4567: structured task lifecycle records are status events, not positive
+    // user-input provenance. Publish them for the task-card/status observer, but
+    // deliberately bypass entry-id, pending, recent, lease, and SSH markers.
+    if candidates
+        .iter()
+        .any(|prompt| is_start_anchored_task_notification_prompt(prompt))
+    {
+        let prompt = candidates
+            .iter()
+            .find(|prompt| is_start_anchored_task_notification_prompt(prompt))
+            .expect("task notification candidate")
+            .to_string();
+        let event = ObservedTuiPrompt {
+            provider,
+            tmux_session_name: tmux_session_name.to_string(),
+            prompt,
+            source_event_id: entry_id.map(str::to_string),
+            observed_at,
+            external_input_lease_generation: EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+            ssh_direct_observation_generation: SSH_DIRECT_OBSERVATION_GENERATION_UNRECORDED,
+        };
+        let _ = OBSERVED_PROMPTS.send(event);
+        return PromptObservation::PublishedTaskNotification;
+    }
     // #3540 (root cause): suppress by STABLE entry identity BEFORE any pending /
     // recent / lease bookkeeping or synthetic-turn mint. If this JSONL entry
     // `uuid` was already relayed for this `(provider, tmux)` pair it is a
@@ -1788,6 +1814,9 @@ fn starts_with_xmlish_tag(text: &str, tag: &str) -> bool {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PromptObservation {
     PublishedSshDirect,
+    /// A structured `<task-notification>` was published for status/card
+    /// rendering without creating external-input ownership or a response tail.
+    PublishedTaskNotification,
     SuppressedDiscordDuplicate,
     SuppressedRecentDuplicate,
     /// #3540: the observed prompt's stable JSONL entry `uuid` was ALREADY relayed
@@ -3627,6 +3656,34 @@ No response requested.\n\
             PromptObservation::PublishedSshDirect,
             "the local-delivery acknowledgement path cannot alter generic entry-id semantics"
         );
+    }
+
+    #[test]
+    fn task_notification_is_status_only_and_next_prompt_keeps_lease_free() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let task = "<task-notification><status>killed</status><task-id>stop-1</task-id></task-notification>";
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-stop-task", task),
+            PromptObservation::PublishedTaskNotification
+        );
+        assert!(
+            !external_input_relay_lease_present("claude", "tmux-stop-task", 42),
+            "killed task status must not create an external-input lease"
+        );
+        assert!(!is_ssh_direct_observation_pending(
+            "claude",
+            "tmux-stop-task"
+        ));
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-stop-task", "the next real prompt"),
+            PromptObservation::PublishedSshDirect
+        );
+        assert!(external_input_relay_lease_present(
+            "claude",
+            "tmux-stop-task",
+            42
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classify start-anchored `<task-notification>` records before generic prompt ownership and publish them as status-only observations.
- Keep task-card/status authority while preventing external-input leases, SSH-direct markers, synthetic inflight ownership, mailbox claims, cancel-token rebinding, and response tails from status events.
- Preserve immediate admission for the first genuine TUI-direct prompt after stop and refresh generated maintenance inventories.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --lib`
- [x] Prompt dedupe regression suite: 80 passed
- [x] Prompt relay regression suite: 135 passed
- [x] `python3 scripts/generate_inventory_docs.py --check`
- [x] `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate`
- [x] `python3 scripts/audit_maintainability.py --check`
- [x] `git diff --check`
- [x] Legacy interrupt-marker and stale-anchor coverage remains in the relevant suites

Closes #4567

🤖 Generated with [Claude Code](https://claude.com/claude-code)