### PR TITLE
chore(cli): guide flat queue users to query

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -56,7 +56,7 @@
 | `app_state` | `src/app_state.rs` | 47 | 47 | 0 |  |
 | `bootstrap` | `src/bootstrap.rs` | 93 | 93 | 0 |  |
 | `cli` | `src/cli/mod.rs` | 25 | 25 | 0 |  |
-| `cli::args` | `src/cli/args.rs` | 1570 | 972 | 598 |  |
+| `cli::args` | `src/cli/args.rs` | 1592 | 975 | 617 |  |
 | `cli::client` | `src/cli/client.rs` | 2722 | 2464 | 258 | giant-file |
 | `cli::client::runtime_config` | `src/cli/client/runtime_config.rs` | 55 | 23 | 32 |  |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ test-non-pg:
     cargo test --lib queue_status_presentation::tests -- --skip _pg --skip pg_ --skip postgres
     cargo test --lib services::discord::outbound::serenity_reference::tests::lifecycle_notice_nonce_is_stable_and_semantic_event_scoped -- --exact
     cargo test --lib services::discord::outbound::delivery::tests::v3_referenced_send_preserves_reference_and_dedupes -- --exact
+    cargo test --lib cli::args::tests::legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract
     cargo test --all-targets transition -- --skip _pg --skip pg_ --skip postgres --test-threads=1
     cargo test --all-targets auto_queue -- --skip _pg --skip pg_ --skip postgres
     cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -423,6 +423,9 @@ pub(crate) enum Commands {
         issue_number: String,
     },
     /// Show auto-queue status with thread links
+    #[command(
+        after_help = "Deprecated compatibility command. For the queue-only inspector, use `agentdesk query queue`; use `agentdesk query` for the combined queue, dispatch, and phase-gate snapshot. This command preserves its legacy text and JSON output shapes."
+    )]
     Queue,
     /// Unified queue + dispatch + phase-gate inspection (issue #2651).
     ///
@@ -1136,6 +1139,25 @@ mod tests {
                 key: None,
             }) if message == "hello user"
         ));
+    }
+
+    #[test]
+    fn legacy_queue_help_directs_users_to_query_without_changing_compatibility_contract() {
+        let Err(error) = Cli::try_parse_from(["agentdesk", "queue", "--help"]) else {
+            panic!("queue --help must render help instead of running the command");
+        };
+        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+        assert_eq!(error.exit_code(), 0);
+
+        let help = error
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(help.contains("Deprecated compatibility command."));
+        assert!(help.contains("`agentdesk query queue`"));
+        assert!(help.contains("`agentdesk query`"));
+        assert!(help.contains("legacy text and JSON output shapes"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- mark the legacy flat `agentdesk queue` inspector as a compatibility command
- direct queue-only use to `agentdesk query queue` and complete snapshots to `agentdesk query`
- retain legacy text and JSON output contracts for existing automation

## Test plan
- [ ] Not run by design: this is a parallel implementation slot; cargo/fmt/check/test/clippy and Python gates were explicitly prohibited by the dispatch.
- [x] Added parser help assertions for Clap success, both replacement commands, and the retained output-compatibility statement.
- [x] `git diff --check`

## Follow-up
This is the first independently mergeable slice for #4225's duplicate queue command surface. It does not close #4225: command-tree grouping, diagnostic consolidation, and broader duplicate-command convergence remain.

Generated with Claude Code
