### PR TITLE
fix(multinode): forward turn cancel to owner worker

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -122,6 +122,9 @@ jobs:
               - 'src/services/auto_queue.rs'
               - 'src/services/auto_queue/**'
               - 'src/services/dispatches/**'
+              - 'src/services/queue.rs'
+              - 'src/services/session_forwarding.rs'
+              - 'src/server/routes/queue_api.rs'
               # #4460: recovery owns production-shaped PostgreSQL/outbox
               # tests; changes to the owner or its sidecars must run them.
               - 'src/services/discord/health/recovery.rs'

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -757,6 +757,15 @@
   effective authority. Classification: PG-lease-backed worker-local execution;
   no new gateway owner, no extra leader election surface.
 
+- #4611 owner-targeted cancel forwarding: REST cancel and Discord `/stop` resolve
+  the canonical active `sessions.instance_id` owner and fail closed instead of
+  mutating leader-local state when ownership is remote or changes during cancel.
+  Rolling upgrade order is workers first, then leaders: a routable owner must
+  advertise `capabilities.agentdesk_api.cancel_forwarding_v1=true`; leaders do
+  not forward cancel to older workers that lack the capability. Keep old and new
+  nodes registered during rollout only after every potential owner advertises
+  the fence. No durable cancel outbox or new lease is introduced.
+
 - #4350 session-owner intake affinity: leader-only routing resolves the existing
   PG `sessions.instance_id` owner before `/node` or preferred labels, and every
   Discord/skill/queued producer shares one admission path. Stale or conflicting

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -92,7 +92,7 @@
 | `src/services/discord/mod.rs` | 4169 |
 | `src/services/discord/router/message_handler/headless_turn.rs` | 1391 |
 | `src/services/discord_config_audit.rs` | 1288 |
-| `src/services/dispatched_sessions.rs` | 1815 |
+| `src/services/dispatched_sessions.rs` | 1821 |
 | `src/services/dispatches/discord_delivery/orchestration.rs` | 1500 |
 | `src/services/dispatches/outbox_route.rs` | 1177 |
 | `src/services/gemini.rs` | 1358 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -421,7 +421,7 @@
 | `services::cluster::session_discovery` | `src/services/cluster/session_discovery.rs` | 1280 | 693 | 587 |  |
 | `services::cluster::session_matcher` | `src/services/cluster/session_matcher.rs` | 952 | 529 | 423 |  |
 | `services::cluster::session_registry` | `src/services/cluster/session_registry.rs` | 566 | 330 | 236 |  |
-| `services::cluster::session_routing` | `src/services/cluster/session_routing.rs` | 416 | 220 | 196 |  |
+| `services::cluster::session_routing` | `src/services/cluster/session_routing.rs` | 421 | 221 | 200 |  |
 | `services::cluster::stream_relay` | `src/services/cluster/stream_relay.rs` | 1638 | 985 | 653 |  |
 | `services::cluster::stream_relay::identity` | `src/services/cluster/stream_relay/identity.rs` | 37 | 37 | 0 |  |
 | `services::cluster::watcher_supervisor` | `src/services/cluster/watcher_supervisor.rs` | 845 | 373 | 472 |  |
@@ -450,7 +450,7 @@
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 248 | 189 | 59 |  |
 | `services::discord::commands::command_policy` | `src/services/discord/commands/command_policy.rs` | 227 | 209 | 18 |  |
 | `services::discord::commands::config` | `src/services/discord/commands/config.rs` | 1224 | 956 | 268 |  |
-| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 939 | 872 | 67 |  |
+| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 952 | 885 | 67 |  |
 | `services::discord::commands::diagnostics` | `src/services/discord/commands/diagnostics/mod.rs` | 389 | 389 | 0 |  |
 | `services::discord::commands::diagnostics::reports` | `src/services/discord/commands/diagnostics/reports.rs` | 765 | 667 | 98 |  |
 | `services::discord::commands::fast_mode` | `src/services/discord/commands/fast_mode.rs` | 82 | 82 | 0 |  |
@@ -1039,7 +1039,7 @@
 | `services::provider_hosting` | `src/services/provider_hosting.rs` | 1073 | 493 | 580 |  |
 | `services::provider_output_guard` | `src/services/provider_output_guard.rs` | 195 | 195 | 0 |  |
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 73 | 73 | 0 |  |
-| `services::queue` | `src/services/queue.rs` | 1050 | 906 | 144 |  |
+| `services::queue` | `src/services/queue.rs` | 966 | 822 | 144 |  |
 | `services::qwen` | `src/services/qwen.rs` | 2219 | 2198 | 21 | giant-file |
 | `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 944 | 944 | 0 |  |
 | `services::remote_stub` | `src/services/remote_stub.rs` | 126 | 58 | 68 |  |
@@ -1075,7 +1075,7 @@
 | `services::session_backend` | `src/services/session_backend.rs` | 1087 | 676 | 411 |  |
 | `services::session_backend::stream_line` | `src/services/session_backend/stream_line.rs` | 761 | 585 | 176 |  |
 | `services::session_backend::terminal_usage` | `src/services/session_backend/terminal_usage.rs` | 212 | 106 | 106 |  |
-| `services::session_forwarding` | `src/services/session_forwarding.rs` | 925 | 519 | 406 |  |
+| `services::session_forwarding` | `src/services/session_forwarding.rs` | 1418 | 784 | 634 |  |
 | `services::session_selector_validity` | `src/services/session_selector_validity.rs` | 395 | 149 | 246 |  |
 | `services::settings` | `src/services/settings.rs` | 1745 | 1112 | 633 | giant-file |
 | `services::settings::runtime_config_put` | `src/services/settings/runtime_config_put.rs` | 44 | 44 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -298,7 +298,7 @@
 | `server::routes::pr_summary` | `src/server/routes/pr_summary.rs` | 185 | 149 | 36 |  |
 | `server::routes::prompt_manifest_retention` | `src/server/routes/prompt_manifest_retention.rs` | 57 | 57 | 0 |  |
 | `server::routes::provider_cli_api` | `src/server/routes/provider_cli_api.rs` | 386 | 386 | 0 |  |
-| `server::routes::queue_api` | `src/server/routes/queue_api.rs` | 439 | 390 | 49 |  |
+| `server::routes::queue_api` | `src/server/routes/queue_api.rs` | 447 | 398 | 49 |  |
 | `server::routes::receipt` | `src/server/routes/receipt.rs` | 815 | 502 | 313 |  |
 | `server::routes::resume` | `src/server/routes/resume.rs` | 1260 | 1260 | 0 | giant-file |
 | `server::routes::review_verdict` | `src/server/routes/review_verdict/mod.rs` | 14 | 14 | 0 |  |
@@ -450,7 +450,7 @@
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 248 | 189 | 59 |  |
 | `services::discord::commands::command_policy` | `src/services/discord/commands/command_policy.rs` | 227 | 209 | 18 |  |
 | `services::discord::commands::config` | `src/services/discord/commands/config.rs` | 1224 | 956 | 268 |  |
-| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 909 | 842 | 67 |  |
+| `services::discord::commands::control` | `src/services/discord/commands/control.rs` | 939 | 872 | 67 |  |
 | `services::discord::commands::diagnostics` | `src/services/discord/commands/diagnostics/mod.rs` | 389 | 389 | 0 |  |
 | `services::discord::commands::diagnostics::reports` | `src/services/discord/commands/diagnostics/reports.rs` | 765 | 667 | 98 |  |
 | `services::discord::commands::fast_mode` | `src/services/discord/commands/fast_mode.rs` | 82 | 82 | 0 |  |
@@ -936,7 +936,7 @@
 | `services::disk_monitor` | `src/services/disk_monitor.rs` | 234 | 234 | 0 |  |
 | `services::dispatch_gate` | `src/services/dispatch_gate.rs` | 1440 | 828 | 612 |  |
 | `services::dispatch_watchdog` | `src/services/dispatch_watchdog.rs` | 259 | 203 | 56 |  |
-| `services::dispatched_sessions` | `src/services/dispatched_sessions.rs` | 2267 | 1815 | 452 | giant-file |
+| `services::dispatched_sessions` | `src/services/dispatched_sessions.rs` | 2273 | 1821 | 452 | giant-file |
 | `services::dispatches` | `src/services/dispatches/mod.rs` | 169 | 169 | 0 |  |
 | `services::dispatches::discord_delivery` | `src/services/dispatches/discord_delivery/mod.rs` | 26 | 26 | 0 |  |
 | `services::dispatches::discord_delivery::guard` | `src/services/dispatches/discord_delivery/guard.rs` | 1606 | 645 | 961 |  |
@@ -1039,7 +1039,7 @@
 | `services::provider_hosting` | `src/services/provider_hosting.rs` | 1073 | 493 | 580 |  |
 | `services::provider_output_guard` | `src/services/provider_output_guard.rs` | 195 | 195 | 0 |  |
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 73 | 73 | 0 |  |
-| `services::queue` | `src/services/queue.rs` | 1019 | 875 | 144 |  |
+| `services::queue` | `src/services/queue.rs` | 1050 | 906 | 144 |  |
 | `services::qwen` | `src/services/qwen.rs` | 2219 | 2198 | 21 | giant-file |
 | `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 944 | 944 | 0 |  |
 | `services::remote_stub` | `src/services/remote_stub.rs` | 126 | 58 | 68 |  |
@@ -1075,7 +1075,7 @@
 | `services::session_backend` | `src/services/session_backend.rs` | 1087 | 676 | 411 |  |
 | `services::session_backend::stream_line` | `src/services/session_backend/stream_line.rs` | 761 | 585 | 176 |  |
 | `services::session_backend::terminal_usage` | `src/services/session_backend/terminal_usage.rs` | 212 | 106 | 106 |  |
-| `services::session_forwarding` | `src/services/session_forwarding.rs` | 493 | 315 | 178 |  |
+| `services::session_forwarding` | `src/services/session_forwarding.rs` | 925 | 519 | 406 |  |
 | `services::session_selector_validity` | `src/services/session_selector_validity.rs` | 395 | 149 | 246 |  |
 | `services::settings` | `src/services/settings.rs` | 1745 | 1112 | 633 | giant-file |
 | `services::settings::runtime_config_put` | `src/services/settings/runtime_config_put.rs` | 44 | 44 | 0 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -48,7 +48,7 @@
 | `DELETE` | `/api/channels/{channel_id}/monitoring/{key}` | `monitoring::remove_monitoring` | `src/server/routes/monitoring.rs:52` | `src/server/routes/domains/ops.rs:334` |
 | `GET` | `/api/channels/{id}/queue` | `queue_api::list_channel_queue` | `src/server/routes/queue_api.rs:20` | `src/server/routes/domains/ops.rs:321` |
 | `POST` | `/api/channels/{id}/relay-recovery` | `health_api::relay_recovery_handler` | `src/server/routes/health_api.rs:1473` | `src/server/routes/domains/ops.rs:326` |
-| `GET` | `/api/channels/{id}/watcher-state` | `queue_api::get_watcher_state` | `src/server/routes/queue_api.rs:240` | `src/server/routes/domains/ops.rs:322` |
+| `GET` | `/api/channels/{id}/watcher-state` | `queue_api::get_watcher_state` | `src/server/routes/queue_api.rs:248` | `src/server/routes/domains/ops.rs:322` |
 | `GET` | `/api/claude-accounts` | `claude_accounts_api::get_claude_accounts` | `src/server/routes/claude_accounts_api.rs:16` | `src/server/routes/domains/integrations.rs:16` |
 | `POST` | `/api/claude-accounts/switch` | `claude_accounts_api::switch_claude_account` | `src/server/routes/claude_accounts_api.rs:47` | `src/server/routes/domains/integrations.rs:20` |
 | `GET` | `/api/cluster/issue-specs` | `cluster::list_issue_specs` | `src/server/routes/cluster.rs:378` | `src/server/routes/domains/ops.rs:102` |
@@ -285,7 +285,7 @@
 | `GET` | `/api/streaks` | `analytics::streaks` | `src/server/routes/analytics.rs:409` | `src/server/routes/domains/analytics.rs:15` |
 | `GET` | `/api/token-analytics` | `receipt::get_token_analytics` | `src/server/routes/receipt.rs:413` | `src/server/routes/domains/analytics.rs:19` |
 | `POST` | `/api/turns/{channel_id}/cancel` | `queue_api::cancel_turn` | `src/server/routes/queue_api.rs:197` | `src/server/routes/domains/ops.rs:347` |
-| `POST` | `/api/turns/{channel_id}/extend-timeout` | `queue_api::extend_turn_timeout` | `src/server/routes/queue_api.rs:295` | `src/server/routes/domains/ops.rs:348` |
+| `POST` | `/api/turns/{channel_id}/extend-timeout` | `queue_api::extend_turn_timeout` | `src/server/routes/queue_api.rs:303` | `src/server/routes/domains/ops.rs:348` |
 | `GET` | `/api/v1/achievements` | `achievements` | `src/server/routes/v1.rs:328` | `src/server/routes/v1.rs:124` |
 | `GET` | `/api/v1/activity` | `activity` | `src/server/routes/v1.rs:288` | `src/server/routes/v1.rs:123` |
 | `GET` | `/api/v1/agents` | `list_agents` | `src/server/routes/v1.rs:183` | `src/server/routes/v1.rs:118` |

--- a/src/server/routes/queue_api.rs
+++ b/src/server/routes/queue_api.rs
@@ -6,7 +6,7 @@ use axum::{
     Json,
     body::Bytes,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -196,14 +196,22 @@ fn resolve_cancel_force(query_force: bool, body: &Bytes) -> bool {
 /// #3029); the body wins when both are present.
 pub async fn cancel_turn(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(channel_id): Path<String>,
     Query(query): Query<CancelTurnQuery>,
     body: Bytes,
 ) -> (StatusCode, Json<serde_json::Value>) {
     let force = resolve_cancel_force(query.force, &body);
+    let forward_context = crate::services::session_forwarding::ForwardCallerContext::from(&state);
     match state
         .queue_service()
-        .cancel_turn(state.health_registry.as_ref(), &channel_id, force)
+        .cancel_turn(
+            state.health_registry.as_ref(),
+            &channel_id,
+            force,
+            &headers,
+            &forward_context,
+        )
         .await
     {
         Ok(response) => (StatusCode::OK, Json(response)),

--- a/src/services/cluster/session_routing.rs
+++ b/src/services/cluster/session_routing.rs
@@ -31,6 +31,7 @@ pub(crate) fn cluster_capabilities_with_worker_api(config: &ClusterConfig) -> Va
             .unwrap_or_default();
         metadata.insert("base_url".to_string(), Value::String(api_base_url));
         metadata.insert("session_forwarding".to_string(), Value::Bool(true));
+        metadata.insert("cancel_forwarding_v1".to_string(), Value::Bool(true));
         capabilities.insert("agentdesk_api".to_string(), Value::Object(metadata));
     }
     Value::Object(capabilities)
@@ -269,6 +270,10 @@ mod tests {
         );
         assert_eq!(
             capabilities["agentdesk_api"]["session_forwarding"].as_bool(),
+            Some(true)
+        );
+        assert_eq!(
+            capabilities["agentdesk_api"]["cancel_forwarding_v1"].as_bool(),
             Some(true)
         );
 

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -507,6 +507,36 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
     tracing::info!("  [{ts}] ◀ [{user_name}] /stop");
 
     let channel_id = ctx.channel_id();
+    let forward_context =
+        crate::services::session_forwarding::ForwardCallerContext::from_live_globals(
+            ctx.data().shared.pg_pool.clone(),
+        );
+    match crate::services::session_forwarding::forward_remote_cancel_if_needed(
+        &forward_context,
+        &axum::http::HeaderMap::new(),
+        &channel_id.get().to_string(),
+        false,
+    )
+    .await
+    {
+        Ok(Some(_)) => {
+            ctx.say(super::STOPPING_RESPONSE).await?;
+            tracing::info!("  [{ts}] ■ Remote cancel acknowledged");
+            return Ok(());
+        }
+        Ok(None) => {}
+        Err(error) if error.status() == axum::http::StatusCode::NOT_FOUND => {
+            ctx.say(super::NO_ACTIVE_TURN_RESPONSE).await?;
+            return Ok(());
+        }
+        Err(error) => {
+            tracing::error!(channel_id = channel_id.get(), error = %error, "/stop remote cancel failed closed");
+            ctx.say("중지 요청을 owner에 전달하지 못했어요. 잠시 후 다시 시도해 주세요.")
+                .await?;
+            return Ok(());
+        }
+    }
+
     let result = mailbox_cancel_active_turn(&ctx.data().shared, channel_id).await;
 
     match result.token {

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -537,6 +537,19 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
         }
     }
 
+    if let Err(error) = crate::services::session_forwarding::revalidate_local_cancel_owner(
+        &forward_context,
+        &channel_id.get().to_string(),
+        None,
+    )
+    .await
+    {
+        tracing::error!(channel_id = channel_id.get(), error = %error, "/stop owner moved before local mutation");
+        ctx.say("중지 요청 중 owner가 변경됐어요. 잠시 후 다시 시도해 주세요.")
+            .await?;
+        return Ok(());
+    }
+
     let result = mailbox_cancel_active_turn(&ctx.data().shared, channel_id).await;
 
     match result.token {

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -676,8 +676,10 @@ async fn force_kill_session_impl_with_reason_and_forwarding(
         };
 
     if !crate::services::session_forwarding::is_forwarded_request(headers) {
+        let forward_context =
+            crate::services::session_forwarding::ForwardCallerContext::from(state);
         match crate::services::session_forwarding::resolve_forward_target(
-            state,
+            &forward_context,
             owner_instance_id.as_deref(),
             pool,
         )
@@ -686,7 +688,7 @@ async fn force_kill_session_impl_with_reason_and_forwarding(
             crate::services::session_forwarding::ForwardResolution::Local => {}
             crate::services::session_forwarding::ForwardResolution::Forward(target) => {
                 return crate::services::session_forwarding::forward_force_kill(
-                    state,
+                    &forward_context,
                     &target,
                     session_key,
                     retry,
@@ -936,8 +938,10 @@ pub async fn tmux_output(
     };
 
     if !crate::services::session_forwarding::is_forwarded_request(&headers) {
+        let forward_context =
+            crate::services::session_forwarding::ForwardCallerContext::from(&state);
         match crate::services::session_forwarding::resolve_forward_target(
-            &state,
+            &forward_context,
             owner_instance_id.as_deref(),
             pool,
         )
@@ -946,7 +950,7 @@ pub async fn tmux_output(
             crate::services::session_forwarding::ForwardResolution::Local => {}
             crate::services::session_forwarding::ForwardResolution::Forward(target) => {
                 return crate::services::session_forwarding::forward_tmux_output(
-                    &state,
+                    &forward_context,
                     &target,
                     id,
                     effective_lines,
@@ -1486,8 +1490,10 @@ async fn kill_tmux_session_impl(
         };
 
     if !crate::services::session_forwarding::is_forwarded_request(headers) {
+        let forward_context =
+            crate::services::session_forwarding::ForwardCallerContext::from(state);
         match crate::services::session_forwarding::resolve_forward_target(
-            state,
+            &forward_context,
             owner_instance_id.as_deref(),
             pool,
         )
@@ -1496,7 +1502,7 @@ async fn kill_tmux_session_impl(
             crate::services::session_forwarding::ForwardResolution::Local => {}
             crate::services::session_forwarding::ForwardResolution::Forward(target) => {
                 return crate::services::session_forwarding::forward_kill_tmux(
-                    state,
+                    &forward_context,
                     &target,
                     session_key,
                     reason,

--- a/src/services/queue.rs
+++ b/src/services/queue.rs
@@ -138,16 +138,6 @@ pub struct QueueService {
 }
 
 #[derive(Debug)]
-struct CancelTurnSessionInfo {
-    session_key: String,
-    dispatch_id: Option<String>,
-    provider_name: Option<String>,
-    agent_id: Option<String>,
-    requested_provider: Option<String>,
-    match_rank: i64,
-}
-
-#[derive(Debug)]
 struct CancelTurnChannelTarget {
     agent_id: String,
     requested_provider: Option<String>,
@@ -482,14 +472,20 @@ impl QueueService {
             return Ok(response);
         }
 
+        let pool = self.pg_pool.as_ref().ok_or_else(|| {
+            ServiceError::internal("postgres pool unavailable for cancel_turn session lookup")
+                .with_code(ErrorCode::Database)
+                .with_operation("cancel_turn.query_active_session.no_pool")
+                .with_context("channel_id", channel_id)
+        })?;
+        let session_info =
+            crate::services::session_forwarding::load_cancel_turn_session(pool, channel_id).await?;
+
         if crate::services::session_forwarding::is_forwarded_request(headers) {
-            let pool = self.pg_pool.as_ref().ok_or_else(|| {
-                ServiceError::internal("postgres pool unavailable for forwarded cancel guard")
-                    .with_code(ErrorCode::Database)
-            })?;
-            let owner =
-                crate::services::session_forwarding::load_cancel_owner(pool, channel_id).await?;
-            if owner.as_deref() != forward_context.cluster_instance_id.as_deref() {
+            let owner = session_info
+                .as_ref()
+                .and_then(|session| session.owner_instance_id.as_deref());
+            if owner != forward_context.cluster_instance_id.as_deref() {
                 return Err(ServiceError::conflict(
                     "forwarded cancel owner changed before local mutation",
                 )
@@ -499,7 +495,6 @@ impl QueueService {
         }
 
         let channel_target = self.resolve_cancel_turn_channel_target(channel_id).await?;
-        let session_info = self.load_cancel_turn_session(channel_id).await?;
 
         let (session_key, dispatch_id, provider_name, agent_id, requested_provider, match_rank) =
             if let Some(session_info) = session_info {
@@ -758,102 +753,6 @@ impl QueueService {
             ServiceError::internal(format!("load postgres cancel channel target: {error}"))
                 .with_code(ErrorCode::Database)
                 .with_operation("cancel_turn.query_channel_target_pg")
-                .with_context("channel_id", channel_id)
-        })
-    }
-
-    async fn load_cancel_turn_session(
-        &self,
-        channel_id: &str,
-    ) -> ServiceResult<Option<CancelTurnSessionInfo>> {
-        let Some(pool) = self.pg_pool.as_ref() else {
-            return Err(ServiceError::internal(
-                "postgres pool unavailable for cancel_turn session lookup",
-            )
-            .with_code(ErrorCode::Database)
-            .with_operation("cancel_turn.query_active_session.no_pool")
-            .with_context("channel_id", channel_id));
-        };
-        sqlx::query_as::<
-            _,
-            (
-                String,
-                Option<String>,
-                Option<String>,
-                Option<String>,
-                Option<String>,
-                i64,
-            ),
-        >(
-            "WITH channel_agent AS (
-               SELECT id AS agent_id,
-                      CASE
-                        WHEN discord_channel_cc = $1 OR discord_channel_id = $1 THEN 'claude'
-                        WHEN discord_channel_cdx = $1 OR discord_channel_alt = $1 THEN 'codex'
-                        ELSE NULL
-                      END AS requested_provider
-               FROM agents
-               WHERE discord_channel_id = $1
-                  OR discord_channel_alt = $1
-                  OR discord_channel_cc = $1
-                  OR discord_channel_cdx = $1
-               LIMIT 1
-             )
-             SELECT s.session_key,
-                    s.active_dispatch_id,
-                    s.provider,
-                    s.agent_id,
-                    ca.requested_provider,
-                    CASE
-                      WHEN COALESCE(s.thread_channel_id, '') = $1 THEN 0
-                      WHEN s.session_key LIKE '%' || $1 || '%' THEN 1
-                      WHEN ca.requested_provider IS NOT NULL
-                           AND COALESCE(s.provider, '') = ca.requested_provider THEN 2
-                      ELSE 3
-                    END::BIGINT AS match_rank
-             FROM sessions s
-             LEFT JOIN channel_agent ca ON s.agent_id = ca.agent_id
-             WHERE s.status IN ('turn_active', 'working')
-               AND (
-                 COALESCE(s.thread_channel_id, '') = $1
-                 OR s.session_key LIKE '%' || $1 || '%'
-                 OR (
-                   ca.agent_id IS NOT NULL
-                   AND (
-                     ca.requested_provider IS NULL
-                     OR COALESCE(s.provider, '') = ca.requested_provider
-                   )
-                 )
-               )
-             ORDER BY match_rank ASC, s.last_heartbeat DESC
-             LIMIT 1",
-        )
-        .bind(channel_id)
-        .fetch_optional(pool)
-        .await
-        .map(|row| {
-            row.map(
-                |(
-                    session_key,
-                    dispatch_id,
-                    provider_name,
-                    agent_id,
-                    requested_provider,
-                    match_rank,
-                )| CancelTurnSessionInfo {
-                    session_key,
-                    dispatch_id,
-                    provider_name,
-                    agent_id,
-                    requested_provider,
-                    match_rank,
-                },
-            )
-        })
-        .map_err(|error| {
-            ServiceError::internal(format!("load postgres active turn: {error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("cancel_turn.query_active_session_pg")
                 .with_context("channel_id", channel_id)
         })
     }

--- a/src/services/queue.rs
+++ b/src/services/queue.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use axum::http::HeaderMap;
 use serde_json::{Value, json};
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
@@ -466,7 +467,37 @@ impl QueueService {
         health_registry: Option<&Arc<HealthRegistry>>,
         channel_id: &str,
         force: bool,
+        headers: &HeaderMap,
+        forward_context: &crate::services::session_forwarding::ForwardCallerContext,
     ) -> ServiceResult<Value> {
+        if let Some(response) =
+            crate::services::session_forwarding::forward_remote_cancel_if_needed(
+                forward_context,
+                headers,
+                channel_id,
+                force,
+            )
+            .await?
+        {
+            return Ok(response);
+        }
+
+        if crate::services::session_forwarding::is_forwarded_request(headers) {
+            let pool = self.pg_pool.as_ref().ok_or_else(|| {
+                ServiceError::internal("postgres pool unavailable for forwarded cancel guard")
+                    .with_code(ErrorCode::Database)
+            })?;
+            let owner =
+                crate::services::session_forwarding::load_cancel_owner(pool, channel_id).await?;
+            if owner.as_deref() != forward_context.cluster_instance_id.as_deref() {
+                return Err(ServiceError::conflict(
+                    "forwarded cancel owner changed before local mutation",
+                )
+                .with_context("channel_id", channel_id)
+                .with_context("owner_instance_id", owner));
+            }
+        }
+
         let channel_target = self.resolve_cancel_turn_channel_target(channel_id).await?;
         let session_info = self.load_cancel_turn_session(channel_id).await?;
 

--- a/src/services/queue.rs
+++ b/src/services/queue.rs
@@ -518,8 +518,15 @@ impl QueueService {
             } else {
                 return Err(
                     ServiceError::not_found("no active turn found for this channel")
-                        .with_code(ErrorCode::Queue)
-                        .with_context("channel_id", channel_id),
+                        .with_context("channel_id", channel_id)
+                        .with_context(
+                            "expected_owner_instance_id",
+                            crate::services::session_forwarding::forwarded_session_owner(headers),
+                        )
+                        .with_context(
+                            "receiver_instance_id",
+                            forward_context.cluster_instance_id.as_deref(),
+                        ),
                 );
             };
 
@@ -530,10 +537,20 @@ impl QueueService {
         {
             return Err(
                 ServiceError::not_found("no active turn found for this channel")
-                    .with_code(ErrorCode::Queue)
-                    .with_context("channel_id", channel_id),
+                    .with_context("channel_id", channel_id)
+                    .with_context(
+                        "owner_instance_id",
+                        forward_context.cluster_instance_id.as_deref(),
+                    ),
             );
         }
+
+        crate::services::session_forwarding::revalidate_local_cancel_owner(
+            forward_context,
+            channel_id,
+            session_key.as_deref(),
+        )
+        .await?;
 
         let tmux_name = session_key
             .as_deref()

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -9,6 +9,7 @@ use serde_json::{Value, json};
 use sqlx::PgPool;
 
 use crate::app_state::AppState;
+use crate::services::service_error::{ErrorCode, ServiceError, ServiceResult};
 
 const FORWARDED_BY_HEADER: &str = "x-agentdesk-forwarded-by";
 const SESSION_OWNER_HEADER: &str = "x-agentdesk-session-owner";
@@ -27,6 +28,41 @@ pub(crate) enum ForwardResolution {
     Local,
     Forward(ForwardTarget),
     Unavailable { status: StatusCode, body: Value },
+}
+
+/// Narrow state needed by session-control callers outside HTTP route handlers.
+#[derive(Clone)]
+pub(crate) struct ForwardCallerContext {
+    pub(crate) pg_pool: Option<PgPool>,
+    pub(crate) config: std::sync::Arc<crate::config::Config>,
+    pub(crate) cluster_instance_id: Option<String>,
+}
+
+impl From<&AppState> for ForwardCallerContext {
+    fn from(state: &AppState) -> Self {
+        Self {
+            pg_pool: state.pg_pool.clone(),
+            config: state.config.clone(),
+            cluster_instance_id: state.cluster_instance_id.clone(),
+        }
+    }
+}
+
+impl ForwardCallerContext {
+    pub(crate) fn from_live_globals(pg_pool: Option<PgPool>) -> Self {
+        Self {
+            pg_pool,
+            config: crate::config_live_reload::current()
+                .unwrap_or_else(|| std::sync::Arc::new(crate::config::Config::default())),
+            cluster_instance_id: Some(
+                crate::services::cluster::node_registry::resolve_self_instance_id_without_config(),
+            ),
+        }
+    }
+
+    pub(crate) fn pg_pool_ref(&self) -> Option<&PgPool> {
+        self.pg_pool.as_ref()
+    }
 }
 
 pub(crate) fn is_forwarded_request(headers: &HeaderMap) -> bool {
@@ -131,7 +167,7 @@ fn valid_instance_id(value: &str) -> bool {
 }
 
 pub(crate) async fn resolve_forward_target(
-    state: &AppState,
+    state: &ForwardCallerContext,
     owner_instance_id: Option<&str>,
     pool: &PgPool,
 ) -> ForwardResolution {
@@ -174,7 +210,7 @@ pub(crate) async fn resolve_forward_target(
 }
 
 pub(crate) async fn forward_tmux_output(
-    state: &AppState,
+    state: &ForwardCallerContext,
     target: &ForwardTarget,
     session_id: i64,
     lines: i32,
@@ -188,7 +224,7 @@ pub(crate) async fn forward_tmux_output(
 }
 
 pub(crate) async fn forward_force_kill(
-    state: &AppState,
+    state: &ForwardCallerContext,
     target: &ForwardTarget,
     session_key: &str,
     retry: bool,
@@ -210,7 +246,7 @@ pub(crate) async fn forward_force_kill(
 }
 
 pub(crate) async fn forward_kill_tmux(
-    state: &AppState,
+    state: &ForwardCallerContext,
     target: &ForwardTarget,
     session_key: &str,
     reason: &str,
@@ -231,8 +267,176 @@ pub(crate) async fn forward_kill_tmux(
     forward_json_response(request, "kill-tmux", target).await
 }
 
+pub(crate) async fn forward_cancel_turn(
+    state: &ForwardCallerContext,
+    target: &ForwardTarget,
+    channel_id: &str,
+    force: bool,
+) -> (StatusCode, Json<Value>) {
+    let url = format!(
+        "{}/api/turns/{}/cancel",
+        target.base_url,
+        encode_path_segment(channel_id)
+    );
+    let request = apply_node_headers(
+        state,
+        target,
+        client().post(url).json(&json!({ "force": force })),
+    );
+    forward_json_response(request, "cancel-turn", target).await
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CancelRetryDecision {
+    Success,
+    RetryOwner,
+    Fail,
+}
+
+pub(crate) fn classify_cancel_forward_status(status: StatusCode) -> CancelRetryDecision {
+    match status {
+        StatusCode::OK | StatusCode::NOT_FOUND => CancelRetryDecision::Success,
+        StatusCode::CONFLICT => CancelRetryDecision::RetryOwner,
+        _ => CancelRetryDecision::Fail,
+    }
+}
+
+pub(crate) async fn forward_cancel_with_owner_retry(
+    state: &ForwardCallerContext,
+    channel_id: &str,
+    force: bool,
+    first_target: ForwardTarget,
+) -> ServiceResult<Option<Value>> {
+    let (status, Json(body)) = forward_cancel_turn(state, &first_target, channel_id, force).await;
+    match classify_cancel_forward_status(status) {
+        CancelRetryDecision::Success => {
+            return Ok(Some(cancel_success_body(status, body, channel_id)));
+        }
+        CancelRetryDecision::Fail => return Err(cancel_forward_error(status, body, channel_id)),
+        CancelRetryDecision::RetryOwner => {}
+    }
+
+    let pool = state.pg_pool_ref().ok_or_else(|| {
+        ServiceError::internal("postgres pool unavailable for cancel owner retry")
+            .with_code(ErrorCode::Database)
+    })?;
+    let owner = load_cancel_owner(pool, channel_id).await?;
+    let resolution = resolve_forward_target(state, owner.as_deref(), pool).await;
+    let retry_target = match resolution {
+        ForwardResolution::Forward(target) if target != first_target => target,
+        ForwardResolution::Local => return Ok(None),
+        ForwardResolution::Forward(_) => {
+            return Err(ServiceError::conflict(
+                "cancel owner rejected the request without changing",
+            )
+            .with_context("channel_id", channel_id));
+        }
+        ForwardResolution::Unavailable { status, body } => {
+            return Err(cancel_forward_error(status, body, channel_id));
+        }
+    };
+
+    let (status, Json(body)) = forward_cancel_turn(state, &retry_target, channel_id, force).await;
+    match classify_cancel_forward_status(status) {
+        CancelRetryDecision::Success => Ok(Some(cancel_success_body(status, body, channel_id))),
+        CancelRetryDecision::RetryOwner | CancelRetryDecision::Fail => {
+            Err(cancel_forward_error(status, body, channel_id))
+        }
+    }
+}
+
+pub(crate) async fn forward_remote_cancel_if_needed(
+    state: &ForwardCallerContext,
+    headers: &HeaderMap,
+    channel_id: &str,
+    force: bool,
+) -> ServiceResult<Option<Value>> {
+    let pool = state.pg_pool_ref().ok_or_else(|| {
+        ServiceError::internal("postgres pool unavailable for cancel owner lookup")
+            .with_code(ErrorCode::Database)
+    })?;
+    let owner = load_cancel_owner(pool, channel_id).await?;
+    let resolution = resolve_forward_target(state, owner.as_deref(), pool).await;
+
+    if is_forwarded_request(headers) {
+        return match resolution {
+            ForwardResolution::Local => Ok(None),
+            _ => Err(ServiceError::conflict(
+                "forwarded cancel reached a non-owner instance",
+            )
+            .with_context("channel_id", channel_id)
+            .with_context("owner_instance_id", owner)),
+        };
+    }
+
+    match resolution {
+        ForwardResolution::Local => Ok(None),
+        ForwardResolution::Forward(target) => {
+            forward_cancel_with_owner_retry(state, channel_id, force, target).await
+        }
+        ForwardResolution::Unavailable { status, body } => Err(cancel_forward_error(
+            status,
+            body,
+            channel_id,
+        )),
+    }
+}
+
+pub(crate) async fn load_cancel_owner(
+    pool: &PgPool,
+    channel_id: &str,
+) -> ServiceResult<Option<String>> {
+    sqlx::query_scalar::<_, Option<String>>(
+        "SELECT instance_id
+         FROM sessions
+         WHERE status IN ('turn_active', 'working')
+           AND (COALESCE(thread_channel_id, '') = $1 OR COALESCE(channel_id, '') = $1)
+         ORDER BY last_heartbeat DESC
+         LIMIT 1",
+    )
+    .bind(channel_id)
+    .fetch_optional(pool)
+    .await
+    .map(|value| value.flatten())
+    .map_err(|error| {
+        ServiceError::internal(format!("load cancel owner: {error}"))
+            .with_code(ErrorCode::Database)
+            .with_operation("cancel_turn.query_owner_pg")
+            .with_context("channel_id", channel_id)
+    })
+}
+
+fn cancel_success_body(status: StatusCode, body: Value, channel_id: &str) -> Value {
+    if status == StatusCode::NOT_FOUND {
+        json!({
+            "ok": true,
+            "channel_id": channel_id,
+            "already_absent": true,
+            "remote_response": body,
+        })
+    } else {
+        body
+    }
+}
+
+fn cancel_forward_error(status: StatusCode, body: Value, channel_id: &str) -> ServiceError {
+    ServiceError::new(
+        status,
+        if status == StatusCode::CONFLICT {
+            ErrorCode::Conflict
+        } else {
+            ErrorCode::Queue
+        },
+        body.get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("remote cancel forwarding failed"),
+    )
+    .with_context("channel_id", channel_id)
+    .with_context("remote_response", body)
+}
+
 fn apply_node_headers(
-    state: &AppState,
+    state: &ForwardCallerContext,
     target: &ForwardTarget,
     mut request: RequestBuilder,
 ) -> RequestBuilder {
@@ -316,8 +520,9 @@ fn encode_path_segment(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ForwardResolution, ForwardTarget, client, encode_path_segment, forward_json_response,
-        is_forwarded_request, resolve_forward_target_from_nodes,
+        CancelRetryDecision, ForwardResolution, ForwardTarget, classify_cancel_forward_status,
+        client, encode_path_segment, forward_json_response, is_forwarded_request,
+        load_cancel_owner, resolve_forward_target_from_nodes,
     };
     use axum::Json;
     use axum::http::{HeaderMap, HeaderValue};
@@ -489,5 +694,232 @@ mod tests {
             encode_path_segment("host:AgentDesk-codex/a b"),
             "host%3AAgentDesk-codex%2Fa%20b"
         );
+    }
+
+    #[test]
+    fn cancel_retry_status_accepts_ack_and_idempotent_not_found() {
+        assert_eq!(
+            classify_cancel_forward_status(axum::http::StatusCode::OK),
+            CancelRetryDecision::Success
+        );
+        assert_eq!(
+            classify_cancel_forward_status(axum::http::StatusCode::NOT_FOUND),
+            CancelRetryDecision::Success
+        );
+    }
+
+    #[test]
+    fn cancel_retry_status_reloads_owner_only_for_conflict() {
+        assert_eq!(
+            classify_cancel_forward_status(axum::http::StatusCode::CONFLICT),
+            CancelRetryDecision::RetryOwner
+        );
+        for status in [
+            axum::http::StatusCode::BAD_GATEWAY,
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::http::StatusCode::UNAUTHORIZED,
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            assert_eq!(
+                classify_cancel_forward_status(status),
+                CancelRetryDecision::Fail
+            );
+        }
+    }
+
+    // PostgreSQL cases below pin sessions.instance_id as cancel authority.
+    async fn insert_cancel_owner_fixture(
+        pool: &sqlx::PgPool,
+        session_key: &str,
+        channel_id: Option<&str>,
+        thread_channel_id: Option<&str>,
+        instance_id: Option<&str>,
+        status: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO sessions
+             (session_key, status, channel_id, thread_channel_id, instance_id, last_heartbeat)
+             VALUES ($1, $2, $3, $4, $5, NOW())",
+        )
+        .bind(session_key)
+        .bind(status)
+        .bind(channel_id)
+        .bind(thread_channel_id)
+        .bind(instance_id)
+        .execute(pool)
+        .await
+        .expect("insert cancel owner fixture");
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_reads_sessions_instance_id_for_thread_channel() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-thread",
+            None,
+            Some("101"),
+            Some("worker-a"),
+            "turn_active",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "101").await.expect("load owner"),
+            Some("worker-a".to_string())
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_reads_sessions_instance_id_for_runtime_channel() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-runtime",
+            Some("102"),
+            None,
+            Some("worker-b"),
+            "working",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "102").await.expect("load owner"),
+            Some("worker-b".to_string())
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_ignores_disconnected_sessions() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-disconnected",
+            Some("103"),
+            None,
+            Some("worker-c"),
+            "disconnected",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "103").await.expect("load owner"),
+            None
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_preserves_null_instance_as_local_authority() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-null",
+            Some("104"),
+            None,
+            None,
+            "turn_active",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "104").await.expect("load owner"),
+            None
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_prefers_latest_active_heartbeat() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-old",
+            Some("105"),
+            None,
+            Some("worker-old"),
+            "turn_active",
+        )
+        .await;
+        sqlx::query("UPDATE sessions SET last_heartbeat = NOW() - INTERVAL '1 minute' WHERE session_key = $1")
+            .bind("cancel-owner-old")
+            .execute(&pool)
+            .await
+            .expect("age owner fixture");
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-new",
+            Some("105"),
+            None,
+            Some("worker-new"),
+            "turn_active",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "105").await.expect("load owner"),
+            Some("worker-new".to_string())
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_matches_exact_channel_not_session_key_text() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "contains-106",
+            Some("999"),
+            None,
+            Some("worker-wrong"),
+            "turn_active",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "106").await.expect("load owner"),
+            None
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_does_not_fall_back_to_agent_binding() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "cancel-owner-unrelated",
+            Some("107"),
+            None,
+            Some("worker-unrelated"),
+            "turn_active",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "108").await.expect("load owner"),
+            None
+        );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_owner_returns_none_when_no_session_exists() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        assert_eq!(
+            load_cancel_owner(&pool, "109").await.expect("load owner"),
+            None
+        );
+        pg_db.drop().await;
     }
 }

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -430,8 +430,11 @@ pub(crate) async fn load_cancel_turn_session(
                 ca.requested_provider,
                 s.instance_id,
                 CASE
-                  WHEN COALESCE(s.thread_channel_id, '') = $1 THEN 0
-                  WHEN s.session_key LIKE '%' || $1 || '%' THEN 1
+                  WHEN COALESCE(s.thread_channel_id, '') = $1
+                    OR COALESCE(s.channel_id, '') = $1 THEN 0
+                  WHEN s.session_key LIKE '%' || $1 || '%'
+                    AND s.thread_channel_id IS NULL
+                    AND s.channel_id IS NULL THEN 1
                   WHEN ca.requested_provider IS NOT NULL
                        AND COALESCE(s.provider, '') = ca.requested_provider THEN 2
                   ELSE 3
@@ -441,7 +444,12 @@ pub(crate) async fn load_cancel_turn_session(
          WHERE s.status = 'turn_active'
            AND (
              COALESCE(s.thread_channel_id, '') = $1
-             OR s.session_key LIKE '%' || $1 || '%'
+             OR COALESCE(s.channel_id, '') = $1
+             OR (
+               s.session_key LIKE '%' || $1 || '%'
+               AND s.thread_channel_id IS NULL
+               AND s.channel_id IS NULL
+             )
              OR (
                ca.agent_id IS NOT NULL
                AND (

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -30,6 +30,17 @@ pub(crate) enum ForwardResolution {
     Unavailable { status: StatusCode, body: Value },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CancelTurnSessionInfo {
+    pub(crate) session_key: String,
+    pub(crate) dispatch_id: Option<String>,
+    pub(crate) provider_name: Option<String>,
+    pub(crate) agent_id: Option<String>,
+    pub(crate) requested_provider: Option<String>,
+    pub(crate) owner_instance_id: Option<String>,
+    pub(crate) match_rank: i64,
+}
+
 /// Narrow state needed by session-control callers outside HTTP route handlers.
 #[derive(Clone)]
 pub(crate) struct ForwardCallerContext {
@@ -382,28 +393,105 @@ pub(crate) async fn forward_remote_cancel_if_needed(
     }
 }
 
-pub(crate) async fn load_cancel_owner(
+pub(crate) async fn load_cancel_turn_session(
     pool: &PgPool,
     channel_id: &str,
-) -> ServiceResult<Option<String>> {
-    sqlx::query_scalar::<_, Option<String>>(
-        "SELECT instance_id
-         FROM sessions
-         WHERE status IN ('turn_active', 'working')
-           AND (COALESCE(thread_channel_id, '') = $1 OR COALESCE(channel_id, '') = $1)
-         ORDER BY last_heartbeat DESC
+) -> ServiceResult<Option<CancelTurnSessionInfo>> {
+    sqlx::query_as::<
+        _,
+        (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i64,
+        ),
+    >(
+        "WITH channel_agent AS (
+           SELECT id AS agent_id,
+                  CASE
+                    WHEN discord_channel_cc = $1 OR discord_channel_id = $1 THEN 'claude'
+                    WHEN discord_channel_cdx = $1 OR discord_channel_alt = $1 THEN 'codex'
+                    ELSE NULL
+                  END AS requested_provider
+           FROM agents
+           WHERE discord_channel_id = $1
+              OR discord_channel_alt = $1
+              OR discord_channel_cc = $1
+              OR discord_channel_cdx = $1
+           LIMIT 1
+         )
+         SELECT s.session_key,
+                s.active_dispatch_id,
+                s.provider,
+                s.agent_id,
+                ca.requested_provider,
+                s.instance_id,
+                CASE
+                  WHEN COALESCE(s.thread_channel_id, '') = $1 THEN 0
+                  WHEN s.session_key LIKE '%' || $1 || '%' THEN 1
+                  WHEN ca.requested_provider IS NOT NULL
+                       AND COALESCE(s.provider, '') = ca.requested_provider THEN 2
+                  ELSE 3
+                END::BIGINT AS match_rank
+         FROM sessions s
+         LEFT JOIN channel_agent ca ON s.agent_id = ca.agent_id
+         WHERE s.status = 'turn_active'
+           AND (
+             COALESCE(s.thread_channel_id, '') = $1
+             OR s.session_key LIKE '%' || $1 || '%'
+             OR (
+               ca.agent_id IS NOT NULL
+               AND (
+                 ca.requested_provider IS NULL
+                 OR COALESCE(s.provider, '') = ca.requested_provider
+               )
+             )
+           )
+         ORDER BY match_rank ASC, s.last_heartbeat DESC
          LIMIT 1",
     )
     .bind(channel_id)
     .fetch_optional(pool)
     .await
-    .map(|value| value.flatten())
+    .map(|row| {
+        row.map(
+            |(
+                session_key,
+                dispatch_id,
+                provider_name,
+                agent_id,
+                requested_provider,
+                owner_instance_id,
+                match_rank,
+            )| CancelTurnSessionInfo {
+                session_key,
+                dispatch_id,
+                provider_name,
+                agent_id,
+                requested_provider,
+                owner_instance_id,
+                match_rank,
+            },
+        )
+    })
     .map_err(|error| {
-        ServiceError::internal(format!("load cancel owner: {error}"))
+        ServiceError::internal(format!("load postgres active turn: {error}"))
             .with_code(ErrorCode::Database)
-            .with_operation("cancel_turn.query_owner_pg")
+            .with_operation("cancel_turn.query_active_session_pg")
             .with_context("channel_id", channel_id)
     })
+}
+
+pub(crate) async fn load_cancel_owner(
+    pool: &PgPool,
+    channel_id: &str,
+) -> ServiceResult<Option<String>> {
+    Ok(load_cancel_turn_session(pool, channel_id)
+        .await?
+        .and_then(|session| session.owner_instance_id))
 }
 
 fn cancel_success_body(status: StatusCode, body: Value, channel_id: &str) -> Value {
@@ -522,7 +610,7 @@ mod tests {
     use super::{
         CancelRetryDecision, ForwardResolution, ForwardTarget, classify_cancel_forward_status,
         client, encode_path_segment, forward_json_response, is_forwarded_request,
-        load_cancel_owner, resolve_forward_target_from_nodes,
+        load_cancel_owner, load_cancel_turn_session, resolve_forward_target_from_nodes,
     };
     use axum::Json;
     use axum::http::{HeaderMap, HeaderValue};
@@ -909,6 +997,78 @@ mod tests {
             load_cancel_owner(&pool, "108").await.expect("load owner"),
             None
         );
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_selection_session_key_fallback_preserves_remote_owner() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "host:AgentDesk-claude-110",
+            None,
+            None,
+            Some("worker-key"),
+            "turn_active",
+        )
+        .await;
+
+        let selected = load_cancel_turn_session(&pool, "110")
+            .await
+            .expect("load selected session")
+            .expect("session-key fallback selection");
+        assert_eq!(selected.session_key, "host:AgentDesk-claude-110");
+        assert_eq!(selected.owner_instance_id.as_deref(), Some("worker-key"));
+        assert_eq!(selected.match_rank, 1);
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM sessions WHERE session_key = 'host:AgentDesk-claude-110'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load unchanged status");
+        assert_eq!(status, "turn_active");
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_selection_agent_provider_fallback_preserves_remote_owner() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        sqlx::query(
+            "INSERT INTO agents (id, name, provider, discord_channel_cc)
+             VALUES ('cancel-agent-111', 'Cancel Agent', 'claude', '111')",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert cancel agent fixture");
+        sqlx::query(
+            "INSERT INTO sessions
+             (session_key, agent_id, provider, status, instance_id, last_heartbeat)
+             VALUES ('owner-provider-fallback', 'cancel-agent-111', 'claude', 'turn_active', 'worker-provider', NOW())",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert provider fallback session");
+
+        let selected = load_cancel_turn_session(&pool, "111")
+            .await
+            .expect("load selected session")
+            .expect("agent/provider fallback selection");
+        assert_eq!(selected.session_key, "owner-provider-fallback");
+        assert_eq!(
+            selected.owner_instance_id.as_deref(),
+            Some("worker-provider")
+        );
+        assert_eq!(selected.requested_provider.as_deref(), Some("claude"));
+        assert_eq!(selected.match_rank, 2);
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM sessions WHERE session_key = 'owner-provider-fallback'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("load unchanged status");
+        assert_eq!(status, "turn_active");
         pg_db.drop().await;
     }
 

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -456,11 +456,11 @@ pub(crate) async fn forward_remote_cancel_if_needed(
     if is_forwarded_request(headers) {
         return match resolution {
             ForwardResolution::Local => Ok(None),
-            _ => Err(ServiceError::conflict(
-                "forwarded cancel reached a non-owner instance",
-            )
-            .with_context("channel_id", channel_id)
-            .with_context("owner_instance_id", owner)),
+            _ => Err(
+                ServiceError::conflict("forwarded cancel reached a non-owner instance")
+                    .with_context("channel_id", channel_id)
+                    .with_context("owner_instance_id", owner),
+            ),
         };
     }
 
@@ -469,11 +469,9 @@ pub(crate) async fn forward_remote_cancel_if_needed(
         ForwardResolution::Forward(target) => {
             forward_cancel_with_owner_retry(state, channel_id, force, target).await
         }
-        ForwardResolution::Unavailable { status, body } => Err(cancel_forward_error(
-            status,
-            body,
-            channel_id,
-        )),
+        ForwardResolution::Unavailable { status, body } => {
+            Err(cancel_forward_error(status, body, channel_id))
+        }
     }
 }
 
@@ -482,8 +480,10 @@ pub(crate) async fn load_cancel_turn_session(
     channel_id: &str,
 ) -> ServiceResult<Option<CancelTurnSessionInfo>> {
     if channel_id.is_empty() || !channel_id.bytes().all(|byte| byte.is_ascii_digit()) {
-        return Err(ServiceError::bad_request("channel_id must contain only decimal digits")
-            .with_context("channel_id", channel_id));
+        return Err(
+            ServiceError::bad_request("channel_id must contain only decimal digits")
+                .with_context("channel_id", channel_id),
+        );
     }
 
     let rows = sqlx::query_as::<
@@ -571,7 +571,9 @@ pub(crate) async fn load_cancel_turn_session(
         {
             1
         } else if requested_provider.as_deref().is_some_and(|requested| {
-            provider_name.as_deref().is_some_and(|provider| provider == requested)
+            provider_name
+                .as_deref()
+                .is_some_and(|provider| provider == requested)
         }) {
             2
         } else {
@@ -586,20 +588,21 @@ pub(crate) async fn load_cancel_turn_session(
             owner_instance_id,
             match_rank,
         };
-        let replace = selected.as_ref().is_none_or(|(rank, heartbeat, current)| {
-            match match_rank.cmp(rank) {
-                std::cmp::Ordering::Less => true,
-                std::cmp::Ordering::Greater => false,
-                std::cmp::Ordering::Equal => match (last_heartbeat, *heartbeat) {
-                    (Some(candidate), Some(existing)) if candidate != existing => {
-                        candidate > existing
-                    }
-                    (Some(_), None) => true,
-                    (None, Some(_)) => false,
-                    _ => info.session_key < current.session_key,
-                },
-            }
-        });
+        let replace =
+            selected
+                .as_ref()
+                .is_none_or(|(rank, heartbeat, current)| match match_rank.cmp(rank) {
+                    std::cmp::Ordering::Less => true,
+                    std::cmp::Ordering::Greater => false,
+                    std::cmp::Ordering::Equal => match (last_heartbeat, *heartbeat) {
+                        (Some(candidate), Some(existing)) if candidate != existing => {
+                            candidate > existing
+                        }
+                        (Some(_), None) => true,
+                        (None, Some(_)) => false,
+                        _ => info.session_key < current.session_key,
+                    },
+                });
         if replace {
             selected = Some((match_rank, last_heartbeat, info));
         }
@@ -608,6 +611,10 @@ pub(crate) async fn load_cancel_turn_session(
 }
 
 fn legacy_session_key_matches_channel(session_key: &str, channel_id: &str) -> bool {
+    if channel_id.is_empty() || !channel_id.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+
     session_key
         .as_bytes()
         .windows(channel_id.len())
@@ -615,7 +622,10 @@ fn legacy_session_key_matches_channel(session_key: &str, channel_id: &str) -> bo
         .any(|(offset, window)| {
             window == channel_id.as_bytes()
                 && offset > 0
-                && matches!(session_key.as_bytes()[offset - 1], b'-' | b'_' | b':' | b'/')
+                && matches!(
+                    session_key.as_bytes()[offset - 1],
+                    b'-' | b'_' | b':' | b'/'
+                )
                 && session_key
                     .as_bytes()
                     .get(offset + channel_id.len())
@@ -645,16 +655,18 @@ pub(crate) async fn revalidate_local_cancel_owner(
     let owner = selected
         .as_ref()
         .and_then(|session| session.owner_instance_id.as_deref());
-    let selected_key = selected.as_ref().map(|session| session.session_key.as_str());
+    let selected_key = selected
+        .as_ref()
+        .map(|session| session.session_key.as_str());
     if (owner.is_some() && owner != state.cluster_instance_id.as_deref())
         || expected_session_key.is_some_and(|expected| selected_key != Some(expected))
     {
-        return Err(ServiceError::conflict(
-            "cancel owner changed before local mutation",
-        )
-        .with_context("channel_id", channel_id)
-        .with_context("owner_instance_id", owner)
-        .with_context("selected_session_key", selected_key));
+        return Err(
+            ServiceError::conflict("cancel owner changed before local mutation")
+                .with_context("channel_id", channel_id)
+                .with_context("owner_instance_id", owner)
+                .with_context("selected_session_key", selected_key),
+        );
     }
     Ok(())
 }
@@ -1015,8 +1027,7 @@ mod tests {
             base_url: format!("http://{addr}"),
         };
 
-        let (status, Json(body)) =
-            super::forward_cancel_turn(&state, &target, "42", false).await;
+        let (status, Json(body)) = super::forward_cancel_turn(&state, &target, "42", false).await;
         server.await.expect("test server task");
         assert_eq!(status, axum::http::StatusCode::OK);
         assert_eq!(body["ok"].as_bool(), Some(true));

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -80,6 +80,12 @@ pub(crate) fn is_forwarded_request(headers: &HeaderMap) -> bool {
     headers.contains_key(FORWARDED_BY_HEADER)
 }
 
+pub(crate) fn forwarded_session_owner(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(SESSION_OWNER_HEADER)
+        .and_then(|value| value.to_str().ok())
+}
+
 fn client() -> &'static reqwest::Client {
     SESSION_FORWARD_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
@@ -175,6 +181,62 @@ fn valid_instance_id(value: &str) -> bool {
         && value.bytes().all(
             |byte| matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.'),
         )
+}
+
+fn owner_supports_cancel_forwarding(owner_instance_id: &str, worker_nodes: &[Value]) -> bool {
+    worker_nodes.iter().any(|node| {
+        node.get("instance_id").and_then(Value::as_str) == Some(owner_instance_id)
+            && node
+                .get("capabilities")
+                .and_then(|capabilities| capabilities.get("agentdesk_api"))
+                .and_then(|api| api.get("cancel_forwarding_v1"))
+                .and_then(Value::as_bool)
+                == Some(true)
+    })
+}
+
+pub(crate) async fn resolve_cancel_forward_target(
+    state: &ForwardCallerContext,
+    owner_instance_id: Option<&str>,
+    pool: &PgPool,
+) -> ForwardResolution {
+    let resolution = resolve_forward_target(state, owner_instance_id, pool).await;
+    let ForwardResolution::Forward(_) = &resolution else {
+        return resolution;
+    };
+    let Some(owner) = owner_instance_id else {
+        return resolution;
+    };
+    let worker_nodes = match crate::services::cluster::node_registry::list_worker_nodes(
+        pool,
+        state.config.cluster.lease_ttl_secs,
+    )
+    .await
+    {
+        Ok(nodes) => nodes,
+        Err(error) => {
+            return ForwardResolution::Unavailable {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                body: json!({
+                    "error": format!("failed to load worker nodes for cancel capability: {error}"),
+                    "code": "worker_nodes_unavailable",
+                    "owner_instance_id": owner,
+                }),
+            };
+        }
+    };
+    if owner_supports_cancel_forwarding(owner, &worker_nodes) {
+        resolution
+    } else {
+        ForwardResolution::Unavailable {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            body: json!({
+                "error": "session owner does not advertise cancel forwarding support",
+                "code": "cancel_forwarding_capability_missing",
+                "owner_instance_id": owner,
+            }),
+        }
+    }
 }
 
 pub(crate) async fn resolve_forward_target(
@@ -304,9 +366,31 @@ pub(crate) enum CancelRetryDecision {
     Fail,
 }
 
-pub(crate) fn classify_cancel_forward_status(status: StatusCode) -> CancelRetryDecision {
+pub(crate) fn classify_cancel_forward_response(
+    status: StatusCode,
+    body: &Value,
+    target: &ForwardTarget,
+    channel_id: &str,
+) -> CancelRetryDecision {
     match status {
-        StatusCode::OK | StatusCode::NOT_FOUND => CancelRetryDecision::Success,
+        StatusCode::OK => CancelRetryDecision::Success,
+        StatusCode::NOT_FOUND
+            if body.get("error").and_then(Value::as_str)
+                == Some("no active turn found for this channel")
+                && body.get("code").and_then(Value::as_str) == Some("not_found")
+                && body.pointer("/context/channel_id").and_then(Value::as_str)
+                    == Some(channel_id)
+                && body
+                    .pointer("/context/expected_owner_instance_id")
+                    .and_then(Value::as_str)
+                    == Some(target.owner_instance_id.as_str())
+                && body
+                    .pointer("/context/receiver_instance_id")
+                    .and_then(Value::as_str)
+                    == Some(target.owner_instance_id.as_str()) =>
+        {
+            CancelRetryDecision::Success
+        }
         StatusCode::CONFLICT => CancelRetryDecision::RetryOwner,
         _ => CancelRetryDecision::Fail,
     }
@@ -319,7 +403,7 @@ pub(crate) async fn forward_cancel_with_owner_retry(
     first_target: ForwardTarget,
 ) -> ServiceResult<Option<Value>> {
     let (status, Json(body)) = forward_cancel_turn(state, &first_target, channel_id, force).await;
-    match classify_cancel_forward_status(status) {
+    match classify_cancel_forward_response(status, &body, &first_target, channel_id) {
         CancelRetryDecision::Success => {
             return Ok(Some(cancel_success_body(status, body, channel_id)));
         }
@@ -332,7 +416,7 @@ pub(crate) async fn forward_cancel_with_owner_retry(
             .with_code(ErrorCode::Database)
     })?;
     let owner = load_cancel_owner(pool, channel_id).await?;
-    let resolution = resolve_forward_target(state, owner.as_deref(), pool).await;
+    let resolution = resolve_cancel_forward_target(state, owner.as_deref(), pool).await;
     let retry_target = match resolution {
         ForwardResolution::Forward(target) if target != first_target => target,
         ForwardResolution::Local => return Ok(None),
@@ -348,7 +432,7 @@ pub(crate) async fn forward_cancel_with_owner_retry(
     };
 
     let (status, Json(body)) = forward_cancel_turn(state, &retry_target, channel_id, force).await;
-    match classify_cancel_forward_status(status) {
+    match classify_cancel_forward_response(status, &body, &retry_target, channel_id) {
         CancelRetryDecision::Success => Ok(Some(cancel_success_body(status, body, channel_id))),
         CancelRetryDecision::RetryOwner | CancelRetryDecision::Fail => {
             Err(cancel_forward_error(status, body, channel_id))
@@ -367,7 +451,7 @@ pub(crate) async fn forward_remote_cancel_if_needed(
             .with_code(ErrorCode::Database)
     })?;
     let owner = load_cancel_owner(pool, channel_id).await?;
-    let resolution = resolve_forward_target(state, owner.as_deref(), pool).await;
+    let resolution = resolve_cancel_forward_target(state, owner.as_deref(), pool).await;
 
     if is_forwarded_request(headers) {
         return match resolution {
@@ -397,7 +481,12 @@ pub(crate) async fn load_cancel_turn_session(
     pool: &PgPool,
     channel_id: &str,
 ) -> ServiceResult<Option<CancelTurnSessionInfo>> {
-    sqlx::query_as::<
+    if channel_id.is_empty() || !channel_id.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(ServiceError::bad_request("channel_id must contain only decimal digits")
+            .with_context("channel_id", channel_id));
+    }
+
+    let rows = sqlx::query_as::<
         _,
         (
             String,
@@ -406,7 +495,9 @@ pub(crate) async fn load_cancel_turn_session(
             Option<String>,
             Option<String>,
             Option<String>,
-            i64,
+            Option<String>,
+            Option<String>,
+            Option<chrono::DateTime<chrono::Utc>>,
         ),
     >(
         "WITH channel_agent AS (
@@ -429,68 +520,107 @@ pub(crate) async fn load_cancel_turn_session(
                 s.agent_id,
                 ca.requested_provider,
                 s.instance_id,
-                CASE
-                  WHEN COALESCE(s.thread_channel_id, '') = $1
-                    OR COALESCE(s.channel_id, '') = $1 THEN 0
-                  WHEN s.session_key LIKE '%' || $1 || '%'
-                    AND s.thread_channel_id IS NULL
-                    AND s.channel_id IS NULL THEN 1
-                  WHEN ca.requested_provider IS NOT NULL
-                       AND COALESCE(s.provider, '') = ca.requested_provider THEN 2
-                  ELSE 3
-                END::BIGINT AS match_rank
+                s.thread_channel_id,
+                s.channel_id,
+                s.last_heartbeat
          FROM sessions s
          LEFT JOIN channel_agent ca ON s.agent_id = ca.agent_id
          WHERE s.status = 'turn_active'
            AND (
              COALESCE(s.thread_channel_id, '') = $1
              OR COALESCE(s.channel_id, '') = $1
-             OR (
-               s.session_key LIKE '%' || $1 || '%'
-               AND s.thread_channel_id IS NULL
-               AND s.channel_id IS NULL
-             )
-             OR (
-               ca.agent_id IS NOT NULL
-               AND (
-                 ca.requested_provider IS NULL
-                 OR COALESCE(s.provider, '') = ca.requested_provider
-               )
-             )
+             OR (s.thread_channel_id IS NULL AND s.channel_id IS NULL)
+             OR ca.agent_id IS NOT NULL
            )
-         ORDER BY match_rank ASC, s.last_heartbeat DESC
-         LIMIT 1",
+         ORDER BY s.last_heartbeat DESC NULLS LAST, s.session_key ASC",
     )
     .bind(channel_id)
-    .fetch_optional(pool)
+    .fetch_all(pool)
     .await
-    .map(|row| {
-        row.map(
-            |(
-                session_key,
-                dispatch_id,
-                provider_name,
-                agent_id,
-                requested_provider,
-                owner_instance_id,
-                match_rank,
-            )| CancelTurnSessionInfo {
-                session_key,
-                dispatch_id,
-                provider_name,
-                agent_id,
-                requested_provider,
-                owner_instance_id,
-                match_rank,
-            },
-        )
-    })
     .map_err(|error| {
         ServiceError::internal(format!("load postgres active turn: {error}"))
             .with_code(ErrorCode::Database)
             .with_operation("cancel_turn.query_active_session_pg")
             .with_context("channel_id", channel_id)
-    })
+    })?;
+
+    let mut selected: Option<(
+        i64,
+        Option<chrono::DateTime<chrono::Utc>>,
+        CancelTurnSessionInfo,
+    )> = None;
+    for (
+        session_key,
+        dispatch_id,
+        provider_name,
+        agent_id,
+        requested_provider,
+        owner_instance_id,
+        thread_channel_id,
+        runtime_channel_id,
+        last_heartbeat,
+    ) in rows
+    {
+        let match_rank = if thread_channel_id.as_deref() == Some(channel_id)
+            || runtime_channel_id.as_deref() == Some(channel_id)
+        {
+            0
+        } else if legacy_session_key_matches_channel(&session_key, channel_id)
+            && thread_channel_id.is_none()
+            && runtime_channel_id.is_none()
+        {
+            1
+        } else if requested_provider.as_deref().is_some_and(|requested| {
+            provider_name.as_deref().is_some_and(|provider| provider == requested)
+        }) {
+            2
+        } else {
+            continue;
+        };
+        let info = CancelTurnSessionInfo {
+            session_key,
+            dispatch_id,
+            provider_name,
+            agent_id,
+            requested_provider,
+            owner_instance_id,
+            match_rank,
+        };
+        let replace = selected.as_ref().is_none_or(|(rank, heartbeat, current)| {
+            match match_rank.cmp(rank) {
+                std::cmp::Ordering::Less => true,
+                std::cmp::Ordering::Greater => false,
+                std::cmp::Ordering::Equal => match (last_heartbeat, *heartbeat) {
+                    (Some(candidate), Some(existing)) if candidate != existing => {
+                        candidate > existing
+                    }
+                    (Some(_), None) => true,
+                    (None, Some(_)) => false,
+                    _ => info.session_key < current.session_key,
+                },
+            }
+        });
+        if replace {
+            selected = Some((match_rank, last_heartbeat, info));
+        }
+    }
+    Ok(selected.map(|(_, _, info)| info))
+}
+
+fn legacy_session_key_matches_channel(session_key: &str, channel_id: &str) -> bool {
+    session_key
+        .as_bytes()
+        .windows(channel_id.len())
+        .enumerate()
+        .any(|(offset, window)| {
+            window == channel_id.as_bytes()
+                && offset > 0
+                && matches!(session_key.as_bytes()[offset - 1], b'-' | b'_' | b':' | b'/')
+                && session_key
+                    .as_bytes()
+                    .get(offset + channel_id.len())
+                    .is_none_or(|byte| !byte.is_ascii_digit())
+        })
 }
 
 pub(crate) async fn load_cancel_owner(
@@ -500,6 +630,33 @@ pub(crate) async fn load_cancel_owner(
     Ok(load_cancel_turn_session(pool, channel_id)
         .await?
         .and_then(|session| session.owner_instance_id))
+}
+
+pub(crate) async fn revalidate_local_cancel_owner(
+    state: &ForwardCallerContext,
+    channel_id: &str,
+    expected_session_key: Option<&str>,
+) -> ServiceResult<()> {
+    let pool = state.pg_pool_ref().ok_or_else(|| {
+        ServiceError::internal("postgres pool unavailable for cancel owner revalidation")
+            .with_code(ErrorCode::Database)
+    })?;
+    let selected = load_cancel_turn_session(pool, channel_id).await?;
+    let owner = selected
+        .as_ref()
+        .and_then(|session| session.owner_instance_id.as_deref());
+    let selected_key = selected.as_ref().map(|session| session.session_key.as_str());
+    if (owner.is_some() && owner != state.cluster_instance_id.as_deref())
+        || expected_session_key.is_some_and(|expected| selected_key != Some(expected))
+    {
+        return Err(ServiceError::conflict(
+            "cancel owner changed before local mutation",
+        )
+        .with_context("channel_id", channel_id)
+        .with_context("owner_instance_id", owner)
+        .with_context("selected_session_key", selected_key));
+    }
+    Ok(())
 }
 
 fn cancel_success_body(status: StatusCode, body: Value, channel_id: &str) -> Value {
@@ -616,9 +773,10 @@ fn encode_path_segment(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        CancelRetryDecision, ForwardResolution, ForwardTarget, classify_cancel_forward_status,
+        CancelRetryDecision, ForwardResolution, ForwardTarget, classify_cancel_forward_response,
         client, encode_path_segment, forward_json_response, is_forwarded_request,
-        load_cancel_owner, load_cancel_turn_session, resolve_forward_target_from_nodes,
+        legacy_session_key_matches_channel, load_cancel_owner, load_cancel_turn_session,
+        resolve_forward_target_from_nodes,
     };
     use axum::Json;
     use axum::http::{HeaderMap, HeaderValue};
@@ -646,7 +804,8 @@ mod tests {
         let nodes = vec![json!({
             "instance_id": "worker-a",
             "status": "online",
-            "api_base_url": "http://worker-a.local:8791"
+            "api_base_url": "http://worker-a.local:8791",
+            "capabilities": {"agentdesk_api": {"cancel_forwarding_v1": true}}
         })];
 
         let resolution =
@@ -659,11 +818,30 @@ mod tests {
     }
 
     #[test]
+    fn cancel_capability_fence_rejects_legacy_owner_metadata() {
+        assert!(!super::owner_supports_cancel_forwarding(
+            "worker-a",
+            &[json!({
+                "instance_id": "worker-a",
+                "capabilities": {"agentdesk_api": {"session_forwarding": true}}
+            })]
+        ));
+        assert!(super::owner_supports_cancel_forwarding(
+            "worker-a",
+            &[json!({
+                "instance_id": "worker-a",
+                "capabilities": {"agentdesk_api": {"cancel_forwarding_v1": true}}
+            })]
+        ));
+    }
+
+    #[test]
     fn resolve_forward_target_reports_stale_owner_explicitly() {
         let nodes = vec![json!({
             "instance_id": "worker-a",
             "status": "offline",
-            "api_base_url": "http://worker-a.local:8791"
+            "api_base_url": "http://worker-a.local:8791",
+            "capabilities": {"agentdesk_api": {"cancel_forwarding_v1": true}}
         })];
 
         let resolution =
@@ -680,7 +858,8 @@ mod tests {
         let nodes = vec![json!({
             "instance_id": "worker-a",
             "status": "online",
-            "api_base_url": "file:///tmp/agentdesk.sock"
+            "api_base_url": "file:///tmp/agentdesk.sock",
+            "capabilities": {"agentdesk_api": {"cancel_forwarding_v1": true}}
         })];
 
         let resolution =
@@ -696,7 +875,8 @@ mod tests {
         let nodes = vec![json!({
             "instance_id": "worker-a\r\nx-injected: true",
             "status": "online",
-            "api_base_url": "http://worker-a.local:8791"
+            "api_base_url": "http://worker-a.local:8791",
+            "capabilities": {"agentdesk_api": {"cancel_forwarding_v1": true}}
         })];
 
         let resolution = resolve_forward_target_from_nodes(
@@ -718,7 +898,8 @@ mod tests {
         let nodes = vec![json!({
             "instance_id": "worker-a",
             "status": "online",
-            "api_base_url": "http://worker-a.local:8791"
+            "api_base_url": "http://worker-a.local:8791",
+            "capabilities": {"agentdesk_api": {"cancel_forwarding_v1": true}}
         })];
 
         let resolution = resolve_forward_target_from_nodes(
@@ -792,22 +973,111 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn forward_cancel_sends_auth_and_owner_headers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("test listener addr");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept test request");
+            let mut buffer = [0_u8; 2048];
+            let read = socket.read(&mut buffer).await.expect("read request");
+            let request = String::from_utf8_lossy(&buffer[..read]).to_ascii_lowercase();
+            assert!(request.contains("authorization: bearer secret-token"));
+            assert!(request.contains("x-agentdesk-forwarded-by: leader"));
+            assert!(request.contains("x-agentdesk-session-owner: worker-a"));
+            let body = r#"{"ok":true}"#;
+            let response = format!(
+                concat!(
+                    "HTTP/1.1 200 OK\r\n",
+                    "content-type: application/json\r\n",
+                    "content-length: {}\r\n",
+                    "connection: close\r\n\r\n{}"
+                ),
+                body.len(),
+                body
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+        let mut config = crate::config::Config::default();
+        config.server.auth_token = Some("secret-token".to_string());
+        let state = super::ForwardCallerContext {
+            pg_pool: None,
+            config: std::sync::Arc::new(config),
+            cluster_instance_id: Some("leader".to_string()),
+        };
+        let target = ForwardTarget {
+            owner_instance_id: "worker-a".to_string(),
+            base_url: format!("http://{addr}"),
+        };
+
+        let (status, Json(body)) =
+            super::forward_cancel_turn(&state, &target, "42", false).await;
+        server.await.expect("test server task");
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(body["ok"].as_bool(), Some(true));
+    }
+
     #[test]
-    fn cancel_retry_status_accepts_ack_and_idempotent_not_found() {
+    fn cancel_retry_accepts_ack_and_authenticated_structured_not_found() {
+        let target = ForwardTarget {
+            owner_instance_id: "worker-a".to_string(),
+            base_url: "http://worker-a.local:8791".to_string(),
+        };
         assert_eq!(
-            classify_cancel_forward_status(axum::http::StatusCode::OK),
+            classify_cancel_forward_response(
+                axum::http::StatusCode::OK,
+                &json!({"ok": true}),
+                &target,
+                "42",
+            ),
             CancelRetryDecision::Success
         );
         assert_eq!(
-            classify_cancel_forward_status(axum::http::StatusCode::NOT_FOUND),
+            classify_cancel_forward_response(
+                axum::http::StatusCode::NOT_FOUND,
+                &json!({
+                    "error": "no active turn found for this channel",
+                    "code": "not_found",
+                    "context": {
+                        "channel_id": "42",
+                        "expected_owner_instance_id": "worker-a",
+                        "receiver_instance_id": "worker-a"
+                    },
+                }),
+                &target,
+                "42",
+            ),
             CancelRetryDecision::Success
+        );
+        assert_eq!(
+            classify_cancel_forward_response(
+                axum::http::StatusCode::NOT_FOUND,
+                &json!({"error": "proxy route missing"}),
+                &target,
+                "42",
+            ),
+            CancelRetryDecision::Fail
         );
     }
 
     #[test]
-    fn cancel_retry_status_reloads_owner_only_for_conflict() {
+    fn cancel_retry_reloads_owner_only_for_conflict() {
+        let target = ForwardTarget {
+            owner_instance_id: "worker-a".to_string(),
+            base_url: "http://worker-a.local:8791".to_string(),
+        };
         assert_eq!(
-            classify_cancel_forward_status(axum::http::StatusCode::CONFLICT),
+            classify_cancel_forward_response(
+                axum::http::StatusCode::CONFLICT,
+                &json!({}),
+                &target,
+                "42",
+            ),
             CancelRetryDecision::RetryOwner
         );
         for status in [
@@ -817,10 +1087,27 @@ mod tests {
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
         ] {
             assert_eq!(
-                classify_cancel_forward_status(status),
+                classify_cancel_forward_response(status, &json!({}), &target, "42"),
                 CancelRetryDecision::Fail
             );
         }
+    }
+
+    #[test]
+    fn legacy_session_key_match_is_numeric_delimiter_aware() {
+        assert!(legacy_session_key_matches_channel(
+            "host:AgentDesk-claude-110",
+            "110"
+        ));
+        assert!(!legacy_session_key_matches_channel(
+            "host:AgentDesk-claude-1100",
+            "110"
+        ));
+        assert!(!legacy_session_key_matches_channel("contains110", "110"));
+        assert!(!legacy_session_key_matches_channel(
+            "host:AgentDesk-claude-%_",
+            "%_"
+        ));
     }
 
     // PostgreSQL cases below pin sessions.instance_id as cancel authority.
@@ -848,7 +1135,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_reads_sessions_instance_id_for_thread_channel() {
+    async fn cancel_owner_reads_sessions_instance_id_for_thread_channel_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -869,7 +1156,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_reads_sessions_instance_id_for_runtime_channel() {
+    async fn cancel_owner_reads_sessions_instance_id_for_runtime_channel_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -890,7 +1177,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_ignores_disconnected_sessions() {
+    async fn cancel_owner_ignores_disconnected_sessions_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -911,7 +1198,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_preserves_null_instance_as_local_authority() {
+    async fn cancel_owner_preserves_null_instance_as_local_authority_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -932,7 +1219,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_prefers_latest_active_heartbeat() {
+    async fn cancel_owner_prefers_latest_active_heartbeat_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -967,7 +1254,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_matches_exact_channel_not_session_key_text() {
+    async fn cancel_owner_matches_exact_channel_not_session_key_text_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -988,7 +1275,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_does_not_fall_back_to_agent_binding() {
+    async fn cancel_owner_does_not_fall_back_to_agent_binding_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -1009,7 +1296,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_selection_session_key_fallback_preserves_remote_owner() {
+    async fn cancel_selection_session_key_fallback_preserves_remote_owner_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         insert_cancel_owner_fixture(
@@ -1040,7 +1327,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_selection_agent_provider_fallback_preserves_remote_owner() {
+    async fn cancel_selection_rejects_overlapping_and_pattern_channel_ids_pg() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        insert_cancel_owner_fixture(
+            &pool,
+            "host:AgentDesk-claude-1100",
+            None,
+            None,
+            Some("worker-overlap"),
+            "turn_active",
+        )
+        .await;
+
+        assert_eq!(
+            load_cancel_owner(&pool, "110").await.expect("load owner"),
+            None
+        );
+        for invalid in ["%", "_", "10%", "10_2"] {
+            let error = load_cancel_owner(&pool, invalid)
+                .await
+                .expect_err("pattern-like channel id must be rejected");
+            assert_eq!(error.status(), axum::http::StatusCode::BAD_REQUEST);
+        }
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_selection_agent_provider_fallback_preserves_remote_owner_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         sqlx::query(
@@ -1081,7 +1395,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_owner_returns_none_when_no_session_exists() {
+    async fn cancel_owner_returns_none_when_no_session_exists_pg() {
         let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
         assert_eq!(

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -782,7 +782,7 @@ mod tests {
             Some("102"),
             None,
             Some("worker-b"),
-            "working",
+            "turn_active",
         )
         .await;
 


### PR DESCRIPTION
## Summary
- forward Discord `/stop` and REST turn cancellation to the authoritative session owner worker
- fail closed unless the owner acknowledges cancellation; treat only owner 404 as idempotent already-stopped success
- re-resolve ownership once on handoff conflict and prevent stale forwarded workers from mutating local state
- add PostgreSQL owner-routing/retry coverage and wire touched paths into the required PG CI filter

## Scope
- `sessions.instance_id` remains the ownership authority
- durable retry across leader restart is intentionally out of scope for this PR
- no #3016 hotfiles, migrations, or `justfile` changes

## Verification
- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo test --lib session_forwarding -- --test-threads=1` — 19 passed
- inventory generation/freshness gate
- maintainability audit

Closes #4611

🤖 Generated with [Claude Code](https://claude.com/claude-code)