### PR TITLE
fix(4564): persistent-dedupe catch-up too-old notice (slice4)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -447,7 +447,7 @@
 | `services::discord::catch_up::classification` | `src/services/discord/catch_up/classification.rs` | 321 | 321 | 0 |  |
 | `services::discord::catch_up::phase2` | `src/services/discord/catch_up/phase2.rs` | 97 | 97 | 0 |  |
 | `services::discord::catch_up::settled_ledger_consult` | `src/services/discord/catch_up/settled_ledger_consult.rs` | 25 | 25 | 0 |  |
-| `services::discord::catch_up::too_old_notice` | `src/services/discord/catch_up/too_old_notice.rs` | 195 | 106 | 89 |  |
+| `services::discord::catch_up::too_old_notice` | `src/services/discord/catch_up/too_old_notice.rs` | 294 | 115 | 179 |  |
 | `services::discord::commands` | `src/services/discord/commands/mod.rs` | 248 | 189 | 59 |  |
 | `services::discord::commands::command_policy` | `src/services/discord/commands/command_policy.rs` | 227 | 209 | 18 |  |
 | `services::discord::commands::config` | `src/services/discord/commands/config.rs` | 1224 | 956 | 268 |  |

--- a/src/services/discord/catch_up/too_old_notice.rs
+++ b/src/services/discord/catch_up/too_old_notice.rs
@@ -243,10 +243,14 @@ mod tests {
         };
 
         // First notice for the batch (control plane boot #1).
-        super::super::CatchUpDiscordApi::enqueue_too_old_notice(&api, Some(pool.clone()), batch.clone())
-            .expect("first boot must spawn the PG producer")
-            .await
-            .expect("first boot producer task");
+        super::super::CatchUpDiscordApi::enqueue_too_old_notice(
+            &api,
+            Some(pool.clone()),
+            batch.clone(),
+        )
+        .expect("first boot must spawn the PG producer")
+        .await
+        .expect("first boot producer task");
 
         // Age the staged row past the 5-minute TTL window to emulate a restart
         // whose gap exceeds the rolling dedupe horizon. Shift the whole row back

--- a/src/services/discord/catch_up/too_old_notice.rs
+++ b/src/services/discord/catch_up/too_old_notice.rs
@@ -95,7 +95,16 @@ pub(super) fn spawn_outbox(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let message = outbox_message(&request);
-        if let Err(error) = crate::services::message_outbox::enqueue_outbox_pg(&pool, message).await
+        // Persistent dedupe (NULL expiry) instead of the rolling 5-minute TTL:
+        // the batch identity ("catch_up_too_old:{channel}:{batch_id}") is stable,
+        // so a restart more than 5 minutes after the first notice must not re-notify
+        // the same too-old batch. The returned row id is a best-effort audit handle
+        // and is intentionally discarded here.
+        if let Err(error) =
+            crate::services::message_outbox::enqueue_outbox_pg_returning_id_with_persistent_dedupe(
+                &pool, message,
+            )
+            .await
         {
             tracing::warn!(
                 "[dlq] failed to enqueue catch-up too-old notice (best-effort): {error}"
@@ -189,6 +198,92 @@ mod tests {
             ],
             "same batch must dedupe while a distinct human batch inserts with the exact producer contract"
         );
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    /// Mutation-proof for slice4 (#4564): the same too-old batch must be noticed
+    /// exactly once even when the second attempt lands more than the 5-minute
+    /// dedupe TTL after the first — i.e. a control-plane restart with a wide gap.
+    ///
+    /// The batch identity `session_key = "catch_up_too_old:{channel}:{batch_id}"`
+    /// is stable, so `spawn_outbox` now stages via
+    /// `enqueue_outbox_pg_returning_id_with_persistent_dedupe` (NULL expiry,
+    /// `ON CONFLICT(dedupe_key) WHERE status != 'failed'`). The dedupe key has no
+    /// time component, so the restart converges on the original row.
+    ///
+    /// We simulate the >5-minute gap by shifting the first row back in time by
+    /// 10 minutes (both `created_at` and any `dedupe_expires_at`). This is exactly
+    /// where the reverted rolling-TTL path would break: with `enqueue_outbox_pg`
+    /// (300s TTL), the aged row falls outside the `created_at >= NOW() - 300s`
+    /// duplicate window *and* its `dedupe_expires_at` has passed, so the expired
+    /// key is released and a SECOND row is inserted — a duplicate notice. Under
+    /// that mutation this test FAILS on the `assert_eq!(count, 1, ...)` below.
+    #[tokio::test(flavor = "current_thread")]
+    async fn persistent_dedupe_suppresses_too_old_notice_across_restart_gap_pg() {
+        let Some(pg_db) = crate::dispatch::test_support::DispatchPostgresTestDb::try_create(
+            "agentdesk_catch_up_too_old_persistent_dedupe",
+            "catch-up too-old persistent dedupe across restart gap",
+        )
+        .await
+        else {
+            return;
+        };
+        let pool = pg_db.connect_and_migrate().await;
+        let http = std::sync::Arc::new(poise::serenity_prelude::Http::new("test-token"));
+        let api = super::super::SerenityCatchUpDiscordApi { http: &http };
+        let target = "channel:4453005".to_string();
+        let batch = CatchUpTooOldOutboxRequest {
+            target: target.clone(),
+            content: "재시작 공백 배치를 다시 보내주세요".to_string(),
+            bot: "notify",
+            source: "catch_up_too_old",
+            reason_code: "catch_up.too_old",
+            session_key: "catch_up_too_old:4453005:4453900".to_string(),
+        };
+
+        // First notice for the batch (control plane boot #1).
+        super::super::CatchUpDiscordApi::enqueue_too_old_notice(&api, Some(pool.clone()), batch.clone())
+            .expect("first boot must spawn the PG producer")
+            .await
+            .expect("first boot producer task");
+
+        // Age the staged row past the 5-minute TTL window to emulate a restart
+        // whose gap exceeds the rolling dedupe horizon. Shift the whole row back
+        // in time so a reverted TTL path would treat it as fully expired.
+        sqlx::query(
+            "UPDATE message_outbox
+                SET created_at = created_at - INTERVAL '10 minutes',
+                    dedupe_expires_at = dedupe_expires_at - INTERVAL '10 minutes'
+              WHERE target = $1",
+        )
+        .bind(&target)
+        .execute(&pool)
+        .await
+        .expect("age the staged too-old notice row");
+
+        // Second notice for the *same* batch (control plane boot #2, >5min later).
+        super::super::CatchUpDiscordApi::enqueue_too_old_notice(&api, Some(pool.clone()), batch)
+            .expect("second boot must spawn the PG producer")
+            .await
+            .expect("second boot producer task");
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM message_outbox
+              WHERE target = $1
+                AND session_key = 'catch_up_too_old:4453005:4453900'",
+        )
+        .bind(&target)
+        .fetch_one(&pool)
+        .await
+        .expect("count staged too-old notices for the batch");
+
+        assert_eq!(
+            count, 1,
+            "persistent dedupe must notice the same too-old batch exactly once across a >5min \
+             restart gap; a rolling-TTL revert would insert a duplicate row here"
+        );
+
         pool.close().await;
         pg_db.drop().await;
     }


### PR DESCRIPTION
## What
Issue #4564 slice4 — outbox persistent-dedupe follow-up for the catch-up **too-old** notice.

`too_old_notice::spawn_outbox` staged its best-effort notice through `enqueue_outbox_pg` (→ `enqueue_outbox_pg_returning_id_with_ttl(LIFECYCLE_NOTIFY_DEDUPE_TTL_SECS=300)`, a **rolling 5-minute TTL**). A control-plane restart more than 5 minutes after the first notice falls outside that window and **re-notifies the same too-old batch**.

## Change
- `spawn_outbox` now stages via **`enqueue_outbox_pg_returning_id_with_persistent_dedupe`** (NULL `dedupe_expires_at`, `ON CONFLICT(dedupe_key) WHERE dedupe_key IS NOT NULL AND status != 'failed'`). The dedupe key has no time component, so a restart of any gap converges on the original row.
- The batch identity `session_key = "catch_up_too_old:{channel}:{batch_id}"` is already stable, and `dedupe_key_for_message` builds the key from `(target, reason_code="catch_up.too_old", session_key)` (content ignored when `reason_code` is set) — so the persistent key is stable across restarts.
- Return type changed `bool` → `i64`; the row id is a best-effort audit handle and is discarded at the fire-and-forget spawn site (the `if let Err` logging path is unchanged).
- `message_outbox.rs` is reused only, not modified.

## Test (mutation-proof)
`persistent_dedupe_suppresses_too_old_notice_across_restart_gap_pg`:
1. Enqueue a too-old batch (boot #1).
2. Shift the staged row back 10 minutes (`created_at` and `dedupe_expires_at`) to emulate a >5min restart gap past the TTL horizon.
3. Re-enqueue the **same** batch (boot #2) and assert **exactly one** row.

Reverting `spawn_outbox` to the rolling-TTL `enqueue_outbox_pg`: the aged row falls outside the `created_at >= NOW() - 300s` duplicate window and its `dedupe_expires_at` has passed (key released), so a **second** row is inserted — failing `assert_eq!(count, 1, ...)`.

The existing `default_adapter_preserves_outbox_contract_and_pg_dedupe_pg` still holds: within one run no time passes, so same-batch dedupes and a distinct batch inserts under both paths.

## Scope / safety
- #3016 hotfiles untouched (`too_old_notice.rs` is a catch_up submodule, not a hotfile).
- No giant-file growth; no migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)