### PR TITLE
refactor(4228): adopt AppError in pr-summary routes (batch 1)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -295,7 +295,7 @@
 | `server::routes::offices` | `src/server/routes/offices.rs` | 485 | 485 | 0 |  |
 | `server::routes::onboarding` | `src/server/routes/onboarding.rs` | 58 | 58 | 0 |  |
 | `server::routes::pipeline` | `src/server/routes/pipeline.rs` | 365 | 365 | 0 |  |
-| `server::routes::pr_summary` | `src/server/routes/pr_summary.rs` | 185 | 149 | 36 |  |
+| `server::routes::pr_summary` | `src/server/routes/pr_summary.rs` | 241 | 142 | 99 |  |
 | `server::routes::prompt_manifest_retention` | `src/server/routes/prompt_manifest_retention.rs` | 57 | 57 | 0 |  |
 | `server::routes::provider_cli_api` | `src/server/routes/provider_cli_api.rs` | 386 | 386 | 0 |  |
 | `server::routes::queue_api` | `src/server/routes/queue_api.rs` | 447 | 398 | 49 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -111,8 +111,8 @@
 | `PATCH` | `/api/github-issues/{owner}/{repo}/{number}/close` | `github_dashboard::close_issue` | `src/server/routes/github_dashboard.rs:103` | `src/server/routes/domains/integrations.rs:37` |
 | `GET` | `/api/github-repos` | `github_dashboard::list_repos` | `src/server/routes/github_dashboard.rs:26` | `src/server/routes/domains/integrations.rs:35` |
 | `POST` | `/api/github/issues/create` | `github::create_issue` | `src/server/routes/github.rs:299` | `src/server/routes/domains/integrations.rs:24` |
-| `GET` | `/api/github/pr-summary` | `pr_summary::get_pr_summary` | `src/server/routes/pr_summary.rs:71` | `src/server/routes/domains/integrations.rs:30` |
-| `POST` | `/api/github/pr-summary/invalidate` | `pr_summary::invalidate_pr_summary` | `src/server/routes/pr_summary.rs:127` | `src/server/routes/domains/integrations.rs:31` |
+| `GET` | `/api/github/pr-summary` | `pr_summary::get_pr_summary` | `src/server/routes/pr_summary.rs:88` | `src/server/routes/domains/integrations.rs:30` |
+| `POST` | `/api/github/pr-summary/invalidate` | `pr_summary::invalidate_pr_summary` | `src/server/routes/pr_summary.rs:131` | `src/server/routes/domains/integrations.rs:31` |
 | `GET` | `/api/github/repos` | `github::list_repos` | `src/server/routes/github.rs:771` | `src/server/routes/domains/integrations.rs:25` |
 | `POST` | `/api/github/repos` | `github::register_repo` | `src/server/routes/github.rs:809` | `src/server/routes/domains/integrations.rs:25` |
 | `POST` | `/api/github/repos/{owner}/{repo}/sync` | `github::sync_repo` | `src/server/routes/github.rs:861` | `src/server/routes/domains/integrations.rs:29` |

--- a/src/server/routes/pr_summary.rs
+++ b/src/server/routes/pr_summary.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 use crate::services::pr_summary::{self, FetchOptions, PrSummaryCache};
 
 #[derive(Debug, Deserialize)]
@@ -66,24 +67,29 @@ fn validate_repo(repo: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
+/// Validate the shared `repo` / `pr` inputs, surfacing failures as the
+/// standard [`AppError`] (#4228). The HTTP status (400) and the human-readable
+/// `error` message are preserved from the previous ad-hoc `json!` bodies; the
+/// former top-level `field` hint is carried on the standard `context` object.
+fn ensure_valid_query(repo: &str, pr: i64) -> AppResult<()> {
+    if let Err(msg) = validate_repo(repo) {
+        return Err(AppError::bad_request(msg).with_context("field", "repo"));
+    }
+    if pr <= 0 {
+        return Err(
+            AppError::bad_request("pr must be a positive integer").with_context("field", "pr")
+        );
+    }
+    Ok(())
+}
+
 /// `GET /api/github/pr-summary` — fetch a PR summary from cache (or
 /// fallback to `gh pr view`).
 pub async fn get_pr_summary(
     State(_state): State<AppState>,
     Query(query): Query<PrSummaryQuery>,
-) -> (StatusCode, Json<Value>) {
-    if let Err(msg) = validate_repo(&query.repo) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": msg, "field": "repo" })),
-        );
-    }
-    if query.pr <= 0 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "pr must be a positive integer", "field": "pr" })),
-        );
-    }
+) -> AppResult<(StatusCode, Json<Value>)> {
+    ensure_valid_query(&query.repo, query.pr)?;
 
     let cache: &PrSummaryCache = pr_summary::shared();
     let opts = FetchOptions {
@@ -93,32 +99,30 @@ pub async fn get_pr_summary(
 
     let repo = query.repo.clone();
     let pr = query.pr;
-    // `gh` is a blocking child process — keep it off the runtime thread.
-    let outcome = tokio::task::spawn_blocking(move || cache.fetch(&repo, pr, &opts))
+    // `gh` is a blocking child process — keep it off the runtime thread. A join
+    // failure keeps its previous 500 + `{ "error": … }` contract via
+    // `AppError::internal`.
+    let summary = tokio::task::spawn_blocking(move || cache.fetch(&repo, pr, &opts))
         .await
-        .map_err(|join_err| format!("pr_summary fetch task join: {join_err}"));
+        .map_err(|join_err| AppError::internal(format!("pr_summary fetch task join: {join_err}")))?
+        // A gh CLI / cache miss failure keeps its 502; the former top-level
+        // `source` hint moves onto the standard `context` object.
+        .map_err(|err| {
+            AppError::new(StatusCode::BAD_GATEWAY, ErrorCode::Dispatch, err)
+                .with_context("source", "gh")
+        })?;
 
-    match outcome {
-        Ok(Ok(summary)) => (
-            StatusCode::OK,
-            Json(json!({
-                "repo": summary.repo,
-                "pr": summary.pr_number,
-                "cache_hit": summary.cache_hit,
-                "age_seconds": summary.age_seconds,
-                "head_sha": summary.head_sha,
-                "view": summary.view,
-            })),
-        ),
-        Ok(Err(err)) => (
-            StatusCode::BAD_GATEWAY,
-            Json(json!({ "error": err, "source": "gh" })),
-        ),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": err })),
-        ),
-    }
+    Ok((
+        StatusCode::OK,
+        Json(json!({
+            "repo": summary.repo,
+            "pr": summary.pr_number,
+            "cache_hit": summary.cache_hit,
+            "age_seconds": summary.age_seconds,
+            "head_sha": summary.head_sha,
+            "view": summary.view,
+        })),
+    ))
 }
 
 /// `POST /api/github/pr-summary/invalidate` — drop a single cached PR. Used
@@ -127,24 +131,13 @@ pub async fn get_pr_summary(
 pub async fn invalidate_pr_summary(
     State(_state): State<AppState>,
     Json(body): Json<PrInvalidateBody>,
-) -> (StatusCode, Json<Value>) {
-    if let Err(msg) = validate_repo(&body.repo) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": msg, "field": "repo" })),
-        );
-    }
-    if body.pr <= 0 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "pr must be a positive integer", "field": "pr" })),
-        );
-    }
+) -> AppResult<(StatusCode, Json<Value>)> {
+    ensure_valid_query(&body.repo, body.pr)?;
     pr_summary::shared().invalidate(&body.repo, body.pr);
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({ "status": "ok", "repo": body.repo, "pr": body.pr })),
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -181,5 +174,53 @@ mod tests {
                 "should reject suspicious repo string: {s:?}"
             );
         }
+    }
+
+    // #4228: the ad-hoc `json!` error bodies became `AppError`s. These lock the
+    // externally observable contract — HTTP status and the `error` message —
+    // and record that the former top-level `field` hint now rides on `context`.
+
+    #[test]
+    fn ensure_valid_query_accepts_good_input() {
+        // Asserts a well-formed repo + positive PR yields no error, so the
+        // happy path still falls through to the cache fetch unchanged.
+        ensure_valid_query("itismyfield/AgentDesk", 42).unwrap();
+    }
+
+    #[test]
+    fn ensure_valid_query_bad_repo_preserves_400_and_message() {
+        // Asserts an invalid repo keeps HTTP 400 and the exact `validate_repo`
+        // message under `error`, and that the `field=repo` hint is preserved
+        // (relocated from the old top-level key to `context`).
+        let err = ensure_valid_query("owner", 1).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "repo must be in 'owner/name' form");
+        assert_eq!(err.to_json_value()["error"], "repo must be in 'owner/name' form");
+        assert_eq!(err.context().get("field").and_then(Value::as_str), Some("repo"));
+    }
+
+    #[test]
+    fn ensure_valid_query_nonpositive_pr_preserves_400_and_message() {
+        // Asserts a non-positive PR keeps HTTP 400 and the exact "pr must be a
+        // positive integer" message under `error`, with the `field=pr` hint
+        // preserved on `context`.
+        let err = ensure_valid_query("owner/repo", 0).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.message(), "pr must be a positive integer");
+        assert_eq!(err.to_json_value()["error"], "pr must be a positive integer");
+        assert_eq!(err.context().get("field").and_then(Value::as_str), Some("pr"));
+    }
+
+    #[test]
+    fn gh_fetch_failure_maps_to_502_with_source_context() {
+        // Asserts the gh CLI / cache-miss failure path keeps HTTP 502 (BAD_GATEWAY)
+        // and surfaces the upstream string under `error`, with the former
+        // top-level `source=gh` hint preserved on `context`. Mirrors the inline
+        // `.map_err` in `get_pr_summary`.
+        let err = AppError::new(StatusCode::BAD_GATEWAY, ErrorCode::Dispatch, "gh exploded")
+            .with_context("source", "gh");
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.to_json_value()["error"], "gh exploded");
+        assert_eq!(err.context().get("source").and_then(Value::as_str), Some("gh"));
     }
 }

--- a/src/server/routes/pr_summary.rs
+++ b/src/server/routes/pr_summary.rs
@@ -195,8 +195,14 @@ mod tests {
         let err = ensure_valid_query("owner", 1).unwrap_err();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
         assert_eq!(err.message(), "repo must be in 'owner/name' form");
-        assert_eq!(err.to_json_value()["error"], "repo must be in 'owner/name' form");
-        assert_eq!(err.context().get("field").and_then(Value::as_str), Some("repo"));
+        assert_eq!(
+            err.to_json_value()["error"],
+            "repo must be in 'owner/name' form"
+        );
+        assert_eq!(
+            err.context().get("field").and_then(Value::as_str),
+            Some("repo")
+        );
     }
 
     #[test]
@@ -207,8 +213,14 @@ mod tests {
         let err = ensure_valid_query("owner/repo", 0).unwrap_err();
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
         assert_eq!(err.message(), "pr must be a positive integer");
-        assert_eq!(err.to_json_value()["error"], "pr must be a positive integer");
-        assert_eq!(err.context().get("field").and_then(Value::as_str), Some("pr"));
+        assert_eq!(
+            err.to_json_value()["error"],
+            "pr must be a positive integer"
+        );
+        assert_eq!(
+            err.context().get("field").and_then(Value::as_str),
+            Some("pr")
+        );
     }
 
     #[test]
@@ -221,6 +233,9 @@ mod tests {
             .with_context("source", "gh");
         assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
         assert_eq!(err.to_json_value()["error"], "gh exploded");
-        assert_eq!(err.context().get("source").and_then(Value::as_str), Some("gh"));
+        assert_eq!(
+            err.context().get("source").and_then(Value::as_str),
+            Some("gh")
+        );
     }
 }


### PR DESCRIPTION
## 개요

#4228 (server 라우트 AppError 채택 확산)의 **첫 배치**. GitHub PR-summary 도메인 (`src/server/routes/pr_summary.rs`) 하나만 좁게 전환하여 라우트-도메인 전환 패턴을 확립한다.

## 전환 대상

| 라우트 | 핸들러 | 반환형 변경 |
|---|---|---|
| `GET /api/github/pr-summary` | `get_pr_summary` | `(StatusCode, Json<Value>)` → `AppResult<(StatusCode, Json<Value>)>` |
| `POST /api/github/pr-summary/invalidate` | `invalidate_pr_summary` | 동일 |

ad-hoc `json!({"error": ...})` 바디 6곳 제거 → 표준 `AppError` + `?` 전파 (`IntoResponse for AppError`).

## 적용한 AppError 패턴

- 핸들러 반환형을 `AppResult<_>`로 바꾸고 에러를 `?`로 전파 (이슈가 지정한 `Result<_, AppError>` 패턴 · routines 도메인 기존 채택과 동일).
- 공유 검증을 `ensure_valid_query() -> AppResult<()>`로 추출해 두 핸들러가 재사용.
- 매핑: 검증 실패 → `AppError::bad_request` (400/Validation), gh 실패 → `AppError::new(BAD_GATEWAY, Dispatch, ..)` (502), join 실패 → `AppError::internal` (500). 신규 에러 타입 설계 없음, 기존 `ErrorCode`만 재사용.

## 응답 계약 불변 근거

- **HTTP status 동일**: 400 / 502 / 500 그대로.
- **`error` 메시지 문자열 동일**: `validate_repo` 메시지, `"pr must be a positive integer"`, gh 에러 문자열, join 에러 문자열 모두 보존.
- **top-level `field`/`source` 힌트**: 표준 AppError `context` 오브젝트로 이동. repo 전수 grep 결과 이 두 키를 읽는 소비자 없음 (CLI 파서는 `error`만 파싱 — 이슈 본문 근거). 따라서 회귀 없음.
- 추가된 `code`/`context` 필드는 additive (표준 AppError 바디 = `{error, code, context}`).

## 테스트 (실행 안 함 — 병렬 슬롯 CODE-ONLY)

- `ensure_valid_query_accepts_good_input`: 정상 입력이 에러 없이 통과 (happy path 불변).
- `ensure_valid_query_bad_repo_preserves_400_and_message`: 잘못된 repo → status 400 + `error` 메시지 정확 + `context.field == "repo"`.
- `ensure_valid_query_nonpositive_pr_preserves_400_and_message`: pr<=0 → status 400 + 메시지 정확 + `context.field == "pr"`.
- `gh_fetch_failure_maps_to_502_with_source_context`: gh 실패 → status 502 + `error` 문자열 + `context.source == "gh"`.

## 스코프 밖

나머지 663+ ad-hoc 에러 라우트는 후속 배치. 신규 라우트 ad-hoc json! 금지 규약과 CLI 폴백 파서 단순화도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)