### PR TITLE
refactor(4228): adopt AppError in departments routes (batch2)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -243,7 +243,7 @@
 | `server::routes::claude_accounts_api` | `src/server/routes/claude_accounts_api.rs` | 182 | 182 | 0 |  |
 | `server::routes::cluster` | `src/server/routes/cluster.rs` | 451 | 451 | 0 |  |
 | `server::routes::cron_api` | `src/server/routes/cron_api.rs` | 180 | 180 | 0 |  |
-| `server::routes::departments` | `src/server/routes/departments.rs` | 300 | 300 | 0 |  |
+| `server::routes::departments` | `src/server/routes/departments.rs` | 342 | 266 | 76 |  |
 | `server::routes::discord` | `src/server/routes/discord.rs` | 416 | 359 | 57 |  |
 | `server::routes::dispatched_sessions` | `src/server/routes/dispatched_sessions.rs` | 138 | 138 | 0 |  |
 | `server::routes::dispatches` | `src/server/routes/dispatches/mod.rs` | 29 | 29 | 0 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -68,11 +68,11 @@
 | `POST` | `/api/cluster/test-phase-runs/start` | `cluster::start_test_phase_run` | `src/server/routes/cluster.rs:297` | `src/server/routes/domains/ops.rs:86` |
 | `POST` | `/api/cluster/test-phase-runs/upsert` | `cluster::upsert_test_phase_run` | `src/server/routes/cluster.rs:281` | `src/server/routes/domains/ops.rs:82` |
 | `GET` | `/api/cron-jobs` | `cron_api::list_cron_jobs` | `src/server/routes/cron_api.rs:166` | `src/server/routes/domains/ops.rs:228` |
-| `GET` | `/api/departments` | `departments::list_departments` | `src/server/routes/departments.rs:53` | `src/server/routes/domains/admin.rs:34` |
-| `POST` | `/api/departments` | `departments::create_department` | `src/server/routes/departments.rs:71` | `src/server/routes/domains/admin.rs:34` |
-| `PATCH` | `/api/departments/reorder` | `departments::reorder_departments` | `src/server/routes/departments.rs:210` | `src/server/routes/domains/admin.rs:38` |
-| `DELETE` | `/api/departments/{id}` | `departments::delete_department` | `src/server/routes/departments.rs:184` | `src/server/routes/domains/admin.rs:42` |
-| `PATCH` | `/api/departments/{id}` | `departments::update_department` | `src/server/routes/departments.rs:110` | `src/server/routes/domains/admin.rs:42` |
+| `GET` | `/api/departments` | `departments::list_departments` | `src/server/routes/departments.rs:69` | `src/server/routes/domains/admin.rs:34` |
+| `POST` | `/api/departments` | `departments::create_department` | `src/server/routes/departments.rs:81` | `src/server/routes/domains/admin.rs:34` |
+| `PATCH` | `/api/departments/reorder` | `departments::reorder_departments` | `src/server/routes/departments.rs:186` | `src/server/routes/domains/admin.rs:38` |
+| `DELETE` | `/api/departments/{id}` | `departments::delete_department` | `src/server/routes/departments.rs:166` | `src/server/routes/domains/admin.rs:42` |
+| `PATCH` | `/api/departments/{id}` | `departments::update_department` | `src/server/routes/departments.rs:112` | `src/server/routes/domains/admin.rs:42` |
 | `GET` | `/api/discord/bindings` | `discord::list_bindings` | `src/server/routes/discord.rs:18` | `src/server/routes/domains/integrations.rs:42` |
 | `POST` | `/api/discord/bot-tokens/reload` | `health_api::reload_discord_bot_tokens_handler` | `src/server/routes/health_api.rs:1595` | `src/server/routes/domains/ops.rs:42` |
 | `GET` | `/api/discord/channels/{id}` | `discord::channel_info` | `src/server/routes/discord.rs:315` | `src/server/routes/domains/integrations.rs:47` |

--- a/src/server/routes/departments.rs
+++ b/src/server/routes/departments.rs
@@ -204,8 +204,10 @@ pub async fn reorder_departments(
             Ok(result) => updated += result.rows_affected() as usize,
             Err(error) => {
                 let _ = tx.rollback().await;
-                return Err(AppError::internal(format!("update id={}: {error}", item.id))
-                    .with_code(ErrorCode::Database));
+                return Err(
+                    AppError::internal(format!("update id={}: {error}", item.id))
+                        .with_code(ErrorCode::Database),
+                );
             }
         }
     }
@@ -214,7 +216,10 @@ pub async fn reorder_departments(
         AppError::internal(format!("commit: {error}")).with_code(ErrorCode::Database)
     })?;
 
-    Ok((StatusCode::OK, Json(json!({"ok": true, "updated": updated}))))
+    Ok((
+        StatusCode::OK,
+        Json(json!({"ok": true, "updated": updated})),
+    ))
 }
 
 async fn list_departments_pg(
@@ -319,8 +324,8 @@ mod tests {
         // Asserts the reorder transaction failures keep HTTP 500 and their
         // exact prefixed messages ("begin tx: …", "update id=…: …", "commit:
         // …"), matching the inline `map_err` bodies in `reorder_departments`.
-        let begin = AppError::internal(format!("begin tx: {}", "boom"))
-            .with_code(ErrorCode::Database);
+        let begin =
+            AppError::internal(format!("begin tx: {}", "boom")).with_code(ErrorCode::Database);
         assert_eq!(begin.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(begin.to_json_value()["error"], "begin tx: boom");
 
@@ -329,8 +334,8 @@ mod tests {
         assert_eq!(update.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(update.to_json_value()["error"], "update id=d1: boom");
 
-        let commit = AppError::internal(format!("commit: {}", "boom"))
-            .with_code(ErrorCode::Database);
+        let commit =
+            AppError::internal(format!("commit: {}", "boom")).with_code(ErrorCode::Database);
         assert_eq!(commit.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(commit.to_json_value()["error"], "commit: boom");
     }

--- a/src/server/routes/departments.rs
+++ b/src/server/routes/departments.rs
@@ -4,10 +4,11 @@ use axum::{
     http::StatusCode,
 };
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
 use sqlx::{PgPool, QueryBuilder, Row};
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 
 // ── Query / Body types ────────────────────────────────────────
 
@@ -40,11 +41,26 @@ pub struct ReorderItem {
     pub sort_order: i32,
 }
 
-fn pg_unavailable() -> (StatusCode, Json<serde_json::Value>) {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({"error": "postgres pool not configured"})),
-    )
+/// Resolve the shared Postgres pool or surface the standard [`AppError`]
+/// (#4228). Preserves the prior `pg_unavailable` contract exactly — HTTP 503
+/// (SERVICE_UNAVAILABLE) with `error: "postgres pool not configured"`. The
+/// standard AppError envelope additionally carries `code`/`context`, matching
+/// the batch-1 `pr_summary` precedent (both are additive; consumers read only
+/// the `error` string — see `dashboard/src/api/httpClient.ts`).
+fn ensure_pg(state: &AppState) -> AppResult<&PgPool> {
+    state.pg_pool_ref().ok_or_else(|| {
+        AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ErrorCode::Config,
+            "postgres pool not configured",
+        )
+    })
+}
+
+/// Map a `sqlx` failure onto the standard 500, preserving the exact
+/// `format!("{error}")` message the ad-hoc `json!({"error": …})` bodies emitted.
+fn db_error(error: sqlx::Error) -> AppError {
+    AppError::internal(format!("{error}")).with_code(ErrorCode::Database)
 }
 
 // ── Handlers ──────────────────────────────────────────────────
@@ -53,57 +69,43 @@ fn pg_unavailable() -> (StatusCode, Json<serde_json::Value>) {
 pub async fn list_departments(
     State(state): State<AppState>,
     Query(params): Query<ListDepartmentsQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    if let Some(pool) = state.pg_pool_ref() {
-        return match list_departments_pg(pool, params.office_id.as_deref()).await {
-            Ok(departments) => (StatusCode::OK, Json(json!({"departments": departments}))),
-            Err(error) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            ),
-        };
-    }
-
-    pg_unavailable()
+) -> AppResult<(StatusCode, Json<Value>)> {
+    let pool = ensure_pg(&state)?;
+    let departments = list_departments_pg(pool, params.office_id.as_deref())
+        .await
+        .map_err(db_error)?;
+    Ok((StatusCode::OK, Json(json!({"departments": departments}))))
 }
 
 /// POST /api/departments
 pub async fn create_department(
     State(state): State<AppState>,
     Json(body): Json<CreateDepartmentBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<Value>)> {
     let id = uuid::Uuid::new_v4().to_string();
+    let pool = ensure_pg(&state)?;
 
-    if let Some(pool) = state.pg_pool_ref() {
-        if let Err(error) = sqlx::query(
-            "INSERT INTO departments (id, name, office_id, sort_order, created_at)
-             VALUES ($1, $2, $3, 0, NOW())",
-        )
-        .bind(&id)
-        .bind(body.name.as_str())
-        .bind(body.office_id.as_deref())
-        .execute(pool)
-        .await
-        {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            );
-        }
+    sqlx::query(
+        "INSERT INTO departments (id, name, office_id, sort_order, created_at)
+         VALUES ($1, $2, $3, 0, NOW())",
+    )
+    .bind(&id)
+    .bind(body.name.as_str())
+    .bind(body.office_id.as_deref())
+    .execute(pool)
+    .await
+    .map_err(db_error)?;
 
-        return (
-            StatusCode::CREATED,
-            Json(json!({
-                "department": {
-                    "id": id,
-                    "name": body.name,
-                    "office_id": body.office_id,
-                }
-            })),
-        );
-    }
-
-    pg_unavailable()
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({
+            "department": {
+                "id": id,
+                "name": body.name,
+                "office_id": body.office_id,
+            }
+        })),
+    ))
 }
 
 /// PATCH /api/departments/:id
@@ -111,150 +113,108 @@ pub async fn update_department(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(body): Json<UpdateDepartmentBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    if let Some(pool) = state.pg_pool_ref() {
-        let mut has_updates = false;
-        let mut query = QueryBuilder::<sqlx::Postgres>::new("UPDATE departments SET ");
-        {
-            let mut separated = query.separated(", ");
-            if let Some(ref name) = body.name {
-                separated.push("name = ").push_bind_unseparated(name);
-                has_updates = true;
-            }
-            if let Some(ref office_id) = body.office_id {
-                separated
-                    .push("office_id = ")
-                    .push_bind_unseparated(office_id);
-                has_updates = true;
-            }
+) -> AppResult<(StatusCode, Json<Value>)> {
+    let pool = ensure_pg(&state)?;
+
+    let mut has_updates = false;
+    let mut query = QueryBuilder::<sqlx::Postgres>::new("UPDATE departments SET ");
+    {
+        let mut separated = query.separated(", ");
+        if let Some(ref name) = body.name {
+            separated.push("name = ").push_bind_unseparated(name);
+            has_updates = true;
         }
-
-        if !has_updates {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": "no fields to update"})),
-            );
+        if let Some(ref office_id) = body.office_id {
+            separated
+                .push("office_id = ")
+                .push_bind_unseparated(office_id);
+            has_updates = true;
         }
-
-        query.push(" WHERE id = ");
-        query.push_bind(&id);
-
-        match query.build().execute(pool).await {
-            Ok(result) if result.rows_affected() == 0 => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(json!({"error": "department not found"})),
-                );
-            }
-            Ok(_) => {}
-            Err(error) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("{error}")})),
-                );
-            }
-        }
-
-        return match sqlx::query("SELECT id, name, office_id FROM departments WHERE id = $1")
-            .bind(&id)
-            .fetch_one(pool)
-            .await
-        {
-            Ok(row) => (
-                StatusCode::OK,
-                Json(json!({
-                    "department": {
-                        "id": row.get::<String, _>("id"),
-                        "name": row.get::<Option<String>, _>("name"),
-                        "office_id": row.get::<Option<String>, _>("office_id"),
-                    }
-                })),
-            ),
-            Err(error) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            ),
-        };
     }
 
-    pg_unavailable()
+    if !has_updates {
+        return Err(AppError::bad_request("no fields to update"));
+    }
+
+    query.push(" WHERE id = ");
+    query.push_bind(&id);
+
+    let result = query.build().execute(pool).await.map_err(db_error)?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::not_found("department not found"));
+    }
+
+    let row = sqlx::query("SELECT id, name, office_id FROM departments WHERE id = $1")
+        .bind(&id)
+        .fetch_one(pool)
+        .await
+        .map_err(db_error)?;
+
+    Ok((
+        StatusCode::OK,
+        Json(json!({
+            "department": {
+                "id": row.get::<String, _>("id"),
+                "name": row.get::<Option<String>, _>("name"),
+                "office_id": row.get::<Option<String>, _>("office_id"),
+            }
+        })),
+    ))
 }
 
 /// DELETE /api/departments/:id
 pub async fn delete_department(
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    if let Some(pool) = state.pg_pool_ref() {
-        return match sqlx::query("DELETE FROM departments WHERE id = $1")
-            .bind(&id)
-            .execute(pool)
-            .await
-        {
-            Ok(result) if result.rows_affected() == 0 => (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "department not found"})),
-            ),
-            Ok(_) => (StatusCode::OK, Json(json!({"ok": true}))),
-            Err(error) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            ),
-        };
+) -> AppResult<(StatusCode, Json<Value>)> {
+    let pool = ensure_pg(&state)?;
+
+    let result = sqlx::query("DELETE FROM departments WHERE id = $1")
+        .bind(&id)
+        .execute(pool)
+        .await
+        .map_err(db_error)?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::not_found("department not found"));
     }
 
-    pg_unavailable()
+    Ok((StatusCode::OK, Json(json!({"ok": true}))))
 }
 
 /// PATCH /api/departments/reorder
 pub async fn reorder_departments(
     State(state): State<AppState>,
     Json(body): Json<ReorderBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    if let Some(pool) = state.pg_pool_ref() {
-        let mut tx = match pool.begin().await {
-            Ok(tx) => tx,
+) -> AppResult<(StatusCode, Json<Value>)> {
+    let pool = ensure_pg(&state)?;
+
+    let mut tx = pool.begin().await.map_err(|error| {
+        AppError::internal(format!("begin tx: {error}")).with_code(ErrorCode::Database)
+    })?;
+
+    let mut updated = 0usize;
+    for item in &body.order {
+        match sqlx::query("UPDATE departments SET sort_order = $1 WHERE id = $2")
+            .bind(item.sort_order)
+            .bind(&item.id)
+            .execute(&mut *tx)
+            .await
+        {
+            Ok(result) => updated += result.rows_affected() as usize,
             Err(error) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("begin tx: {error}")})),
-                );
-            }
-        };
-
-        let mut updated = 0usize;
-        for item in &body.order {
-            match sqlx::query("UPDATE departments SET sort_order = $1 WHERE id = $2")
-                .bind(item.sort_order)
-                .bind(&item.id)
-                .execute(&mut *tx)
-                .await
-            {
-                Ok(result) => updated += result.rows_affected() as usize,
-                Err(error) => {
-                    let _ = tx.rollback().await;
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": format!("update id={}: {error}", item.id)})),
-                    );
-                }
+                let _ = tx.rollback().await;
+                return Err(AppError::internal(format!("update id={}: {error}", item.id))
+                    .with_code(ErrorCode::Database));
             }
         }
-
-        if let Err(error) = tx.commit().await {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("commit: {error}")})),
-            );
-        }
-
-        return (
-            StatusCode::OK,
-            Json(json!({"ok": true, "updated": updated})),
-        );
     }
 
-    pg_unavailable()
+    tx.commit().await.map_err(|error| {
+        AppError::internal(format!("commit: {error}")).with_code(ErrorCode::Database)
+    })?;
+
+    Ok((StatusCode::OK, Json(json!({"ok": true, "updated": updated}))))
 }
 
 async fn list_departments_pg(
@@ -297,4 +257,81 @@ fn department_row_to_json_pg(row: &sqlx::postgres::PgRow) -> serde_json::Value {
         "agent_count": row.get::<i64, _>("agent_count"),
         "prompt": serde_json::Value::Null,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #4228: the ad-hoc `json!({"error": …})` bodies became `AppError`s. These
+    // tests lock the externally observable contract — HTTP status and the
+    // `error` message string — for every error branch in this module, and
+    // document that the standard AppError envelope adds `code`/`context`
+    // (additive; the frontend `request` helper reads only `error`).
+
+    #[test]
+    fn ensure_pg_missing_pool_preserves_503_and_message() {
+        // Asserts the 503 body emitted when the pool is absent keeps its exact
+        // status + message. Mirrors the error `ensure_pg` returns on `None`.
+        let err = AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ErrorCode::Config,
+            "postgres pool not configured",
+        );
+        assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.message(), "postgres pool not configured");
+        assert_eq!(err.to_json_value()["error"], "postgres pool not configured");
+    }
+
+    #[test]
+    fn db_error_preserves_500_and_verbatim_message() {
+        // Asserts `db_error` keeps HTTP 500 and reproduces `format!("{error}")`
+        // verbatim under `error`, so callers observe the same DB failure text
+        // as before. `code` is the additive `database` tag.
+        let expected = format!("{}", sqlx::Error::RowNotFound);
+        let err = db_error(sqlx::Error::RowNotFound);
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.message(), expected);
+        assert_eq!(err.to_json_value()["error"], expected);
+        assert_eq!(err.to_json_value()["code"], "database");
+    }
+
+    #[test]
+    fn no_fields_to_update_preserves_400_and_message() {
+        // Asserts the "no fields to update" guard keeps HTTP 400 and its exact
+        // message. Mirrors the `bad_request` returned by `update_department`.
+        let err = AppError::bad_request("no fields to update");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.to_json_value()["error"], "no fields to update");
+    }
+
+    #[test]
+    fn department_not_found_preserves_404_and_message() {
+        // Asserts the missing-row branch (shared by update + delete) keeps HTTP
+        // 404 and the exact "department not found" message.
+        let err = AppError::not_found("department not found");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.to_json_value()["error"], "department not found");
+    }
+
+    #[test]
+    fn reorder_tx_errors_preserve_500_and_prefixed_messages() {
+        // Asserts the reorder transaction failures keep HTTP 500 and their
+        // exact prefixed messages ("begin tx: …", "update id=…: …", "commit:
+        // …"), matching the inline `map_err` bodies in `reorder_departments`.
+        let begin = AppError::internal(format!("begin tx: {}", "boom"))
+            .with_code(ErrorCode::Database);
+        assert_eq!(begin.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(begin.to_json_value()["error"], "begin tx: boom");
+
+        let update = AppError::internal(format!("update id={}: {}", "d1", "boom"))
+            .with_code(ErrorCode::Database);
+        assert_eq!(update.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(update.to_json_value()["error"], "update id=d1: boom");
+
+        let commit = AppError::internal(format!("commit: {}", "boom"))
+            .with_code(ErrorCode::Database);
+        assert_eq!(commit.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(commit.to_json_value()["error"], "commit: boom");
+    }
 }


### PR DESCRIPTION
## 요약

#4228 server 라우트 AppError 채택 **두 번째 배치**. batch1(#4664)이 `pr_summary.rs`에 확립한 패턴을 disjoint 도메인 파일 `src/server/routes/departments.rs` 하나에 좁게 적용.

## 변경

- 핸들러 5개(`list`/`create`/`update`/`delete`/`reorder`) 반환형을 `AppResult<(StatusCode, Json<Value>)>`로 전환, `?` 전파 채택.
- `pg_unavailable()` 인라인 503 바디 → `ensure_pg()` 헬퍼 (`AppError` 503).
- sqlx 실패 → `db_error()` 헬퍼가 `AppError::internal`로 매핑, `format!("{error}")` 메시지 그대로 보존.
- 기존 `ErrorCode` 재사용(Config/Database/Validation/NotFound) — **새 에러 타입 없음**.

## 계약 불변 근거

- 모든 분기에서 **HTTP status와 `error` 메시지 문자열 불변**. AppError 봉투는 `code`/`context`만 추가(additive).
- 소비자 grep: 라우트는 `src/server/routes/domains/admin.rs`에 등록. 유일한 클라이언트는 프론트 `dashboard/src/api/sessionOfficeAgents.ts`(→ `dashboard/src/api/httpClient.ts:196`)로, 에러 응답에서 `err.error`만 메시지로 읽고 `err.code`는 optional 진단 필드(기존 departments 응답엔 부재 → `undefined`였음). 따라서 `code` 추가는 하위호환.
- batch1 `pr_summary.rs` 선례와 동일한 계약 처리.

## 테스트 (본 병렬 슬롯에서 미실행 — CODE-ONLY)

각 에러 분기의 status+메시지를 잠그는 계약 불변 테스트 5개:
- `ensure_pg_missing_pool_preserves_503_and_message` — 503 + "postgres pool not configured"
- `db_error_preserves_500_and_verbatim_message` — 500 + `format!("{error}")` 원문 + `code=database`
- `no_fields_to_update_preserves_400_and_message` — 400 + "no fields to update"
- `department_not_found_preserves_404_and_message` — 404 + "department not found"
- `reorder_tx_errors_preserve_500_and_prefixed_messages` — "begin tx:"/"update id=…:"/"commit:" 접두 메시지 보존

## 준수

- #3016 핫파일 비접촉. giant 비인상(300줄 유지 범위). 신규 에러 타입 금지 준수.

refs #4228 (batch2 — 다도메인 점진 전환이라 이슈 미종결 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
