### PR TITLE
fix(4667): restore external-session auto-compact after #4652 gate

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -869,7 +869,7 @@
 | `services::discord::turn_bridge::stale_resume` | `src/services/discord/turn_bridge/stale_resume.rs` | 301 | 144 | 157 |  |
 | `services::discord::turn_bridge::status_panel` | `src/services/discord/turn_bridge/status_panel.rs` | 678 | 678 | 0 |  |
 | `services::discord::turn_bridge::stream_loop` | `src/services/discord/turn_bridge/stream_loop.rs` | 944 | 944 | 0 |  |
-| `services::discord::turn_bridge::stream_loop::content_arms` | `src/services/discord/turn_bridge/stream_loop/content_arms.rs` | 635 | 584 | 52 |  |
+| `services::discord::turn_bridge::stream_loop::content_arms` | `src/services/discord/turn_bridge/stream_loop/content_arms.rs` | 635 | 583 | 52 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::provider_error_presentation` | `src/services/discord/turn_bridge/stream_loop/content_arms/provider_error_presentation.rs` | 95 | 42 | 53 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::tui_error_classification` | `src/services/discord/turn_bridge/stream_loop/content_arms/tui_error_classification.rs` | 199 | 24 | 175 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::types` | `src/services/discord/turn_bridge/stream_loop/content_arms/types.rs` | 100 | 100 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -481,7 +481,7 @@
 | `services::discord::commands::tui_passthrough` | `src/services/discord/commands/tui_passthrough.rs` | 412 | 357 | 55 |  |
 | `services::discord::commands::voice` | `src/services/discord/commands/voice.rs` | 1029 | 971 | 58 |  |
 | `services::discord::commands::voice::alert` | `src/services/discord/commands/voice/alert.rs` | 50 | 50 | 0 |  |
-| `services::discord::compact_turn_authority` | `src/services/discord/compact_turn_authority.rs` | 77 | 77 | 0 |  |
+| `services::discord::compact_turn_authority` | `src/services/discord/compact_turn_authority.rs` | 151 | 95 | 56 |  |
 | `services::discord::delivery_lease_key` | `src/services/discord/delivery_lease_key.rs` | 156 | 156 | 0 |  |
 | `services::discord::destructive_cancel_capture` | `src/services/discord/destructive_cancel_capture.rs` | 63 | 34 | 29 |  |
 | `services::discord::destructive_cancel_gate` | `src/services/discord/destructive_cancel_gate.rs` | 705 | 350 | 355 |  |
@@ -869,7 +869,7 @@
 | `services::discord::turn_bridge::stale_resume` | `src/services/discord/turn_bridge/stale_resume.rs` | 301 | 144 | 157 |  |
 | `services::discord::turn_bridge::status_panel` | `src/services/discord/turn_bridge/status_panel.rs` | 678 | 678 | 0 |  |
 | `services::discord::turn_bridge::stream_loop` | `src/services/discord/turn_bridge/stream_loop.rs` | 944 | 944 | 0 |  |
-| `services::discord::turn_bridge::stream_loop::content_arms` | `src/services/discord/turn_bridge/stream_loop/content_arms.rs` | 626 | 579 | 47 |  |
+| `services::discord::turn_bridge::stream_loop::content_arms` | `src/services/discord/turn_bridge/stream_loop/content_arms.rs` | 635 | 584 | 52 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::provider_error_presentation` | `src/services/discord/turn_bridge/stream_loop/content_arms/provider_error_presentation.rs` | 95 | 42 | 53 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::tui_error_classification` | `src/services/discord/turn_bridge/stream_loop/content_arms/tui_error_classification.rs` | 199 | 24 | 175 |  |
 | `services::discord::turn_bridge::stream_loop::content_arms::types` | `src/services/discord/turn_bridge/stream_loop/content_arms/types.rs` | 100 | 100 | 0 |  |

--- a/src/services/discord/compact_turn_authority.rs
+++ b/src/services/discord/compact_turn_authority.rs
@@ -12,6 +12,17 @@ pub(in crate::services) struct ManagedCompactTurnIdentity {
     turn_start_offset: Option<u64>,
 }
 
+/// #4667: turn sources eligible for auto-compact identity capture/injection.
+/// `Managed` is the AgentDesk-launched path; `ExternalInput`/`ExternalAdopted`
+/// are interactive Discord-bound sessions (tty / adopted) that #4652 wrongly
+/// gated out. `MonitorTriggered` stays excluded (synthetic auto-turn).
+pub(in crate::services) fn compact_eligible_turn_source(source: TurnSource) -> bool {
+    matches!(
+        source,
+        TurnSource::Managed | TurnSource::ExternalInput | TurnSource::ExternalAdopted
+    )
+}
+
 impl ManagedCompactTurnIdentity {
     pub(in crate::services::discord) fn capture(state: &InflightTurnState) -> Option<Self> {
         let tmux_session_name = state
@@ -19,7 +30,13 @@ impl ManagedCompactTurnIdentity {
             .as_deref()
             .map(str::trim)
             .filter(|name| !name.is_empty())?;
-        (state.turn_source == TurnSource::Managed).then(|| Self {
+        // #4667: auto-compact must reach interactive Discord sessions too.
+        // #4652 restricted capture to `Managed` turns, which silently gated
+        // out `ExternalInput`/`ExternalAdopted` (interactive tty / adopted)
+        // sessions and killed their auto-compact. Relax to those three
+        // sources; identity-field matching below still pins injection to the
+        // exact live turn.
+        compact_eligible_turn_source(state.turn_source).then(|| Self {
             channel_id: state.channel_id,
             user_msg_id: state.user_msg_id,
             started_at: state.started_at.clone(),
@@ -68,10 +85,67 @@ fn managed_turn_matches_state(
     expected: &ManagedCompactTurnIdentity,
     state: &InflightTurnState,
 ) -> bool {
-    state.turn_source == TurnSource::Managed
+    compact_eligible_turn_source(state.turn_source)
         && state.channel_id == expected.channel_id
         && state.user_msg_id == expected.user_msg_id
         && state.started_at == expected.started_at
         && state.tmux_session_name.as_deref() == Some(expected.tmux_session_name.as_str())
         && state.turn_start_offset == expected.turn_start_offset
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::inflight::InflightTurnState;
+    use crate::services::provider::ProviderKind;
+
+    fn state_with_source(source: TurnSource) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Claude,
+            4667,
+            Some("adk-cc".to_string()),
+            7,
+            9001,
+            9002,
+            "hi".to_string(),
+            Some("session-4667".to_string()),
+            Some("AgentDesk-claude-adk-cc".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            None,
+            42,
+        );
+        state.turn_source = source;
+        state
+    }
+
+    /// #4667 mutation-proof: interactive external turns must be compact-eligible.
+    /// Restoring the #4652 `Managed`-only gate makes the `ExternalInput`/
+    /// `ExternalAdopted` iterations of this test FAIL — `capture()` returns
+    /// `None` and `managed_turn_matches_state()` returns `false` for them.
+    #[test]
+    fn external_interactive_turns_are_compact_eligible() {
+        for source in [
+            TurnSource::Managed,
+            TurnSource::ExternalInput,
+            TurnSource::ExternalAdopted,
+        ] {
+            let state = state_with_source(source);
+            let identity = ManagedCompactTurnIdentity::capture(&state)
+                .unwrap_or_else(|| panic!("capture() must return Some for {source:?}"));
+            assert!(
+                managed_turn_matches_state(&identity, &state),
+                "live turn match must hold for {source:?}"
+            );
+        }
+    }
+
+    /// `MonitorTriggered` (synthetic auto-turn) stays outside compact scope.
+    #[test]
+    fn monitor_triggered_turn_stays_gated() {
+        let state = state_with_source(TurnSource::MonitorTriggered);
+        assert!(
+            ManagedCompactTurnIdentity::capture(&state).is_none(),
+            "MonitorTriggered turns must not capture a compact identity"
+        );
+    }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -201,7 +201,7 @@ use adk_session::{
     lookup_pending_dispatch_for_thread, parse_dispatch_id, post_adk_session_status,
 };
 pub(in crate::services) use compact_turn_authority::{
-    ManagedCompactTurnIdentity, live_managed_turn_matches,
+    ManagedCompactTurnIdentity, compact_eligible_turn_source, live_managed_turn_matches,
 };
 use formatting::{
     BUILTIN_SKILLS, extract_skill_description, format_for_discord, format_tool_input,

--- a/src/services/discord/turn_bridge/stream_loop/content_arms.rs
+++ b/src/services/discord/turn_bridge/stream_loop/content_arms.rs
@@ -20,8 +20,12 @@ fn active_usage_snapshot_is_eligible_for_compact(
     turn_source: crate::services::discord::inflight::TurnSource,
     tmux_session_name: Option<&str>,
 ) -> bool {
+    // #4667: #4652 gated this active-usage compact arm on `Managed`, killing
+    // auto-compact for interactive `ExternalInput`/`ExternalAdopted` sessions.
+    // Share `compact_eligible_turn_source` with `ManagedCompactTurnIdentity::
+    // capture` so the arm gate and identity capture stay in lockstep.
     *provider == ProviderKind::Claude
-        && turn_source == crate::services::discord::inflight::TurnSource::Managed
+        && crate::services::discord::compact_eligible_turn_source(turn_source)
         && tmux_session_name.is_some_and(|name| !name.trim().is_empty())
 }
 
@@ -583,30 +587,35 @@ mod tests {
     use crate::services::discord::inflight::TurnSource;
     use crate::services::provider::ProviderKind;
 
-    /// Mutation guard: live usage telemetry may arm compacting only for an
-    /// AgentDesk-managed Claude turn tied to a physical tmux pane. Removing the
-    /// `Managed` predicate makes the ExternalInput assertion fail.
+    /// #4667 mutation guard: live usage telemetry arms compacting for
+    /// `Managed` AND interactive `ExternalInput`/`ExternalAdopted` Claude
+    /// turns tied to a physical tmux pane. Restoring the #4652 `Managed`-only
+    /// predicate makes the `ExternalInput`/`ExternalAdopted` asserts FAIL.
+    /// `MonitorTriggered` (synthetic auto-turn) stays gated out.
     #[test]
-    fn active_usage_compact_gate_allows_managed_and_rejects_external_turns() {
-        assert!(active_usage_snapshot_is_eligible_for_compact(
-            &ProviderKind::Claude,
-            TurnSource::Managed,
-            Some("tmux-4631"),
-        ));
+    fn active_usage_compact_gate_allows_managed_and_external_interactive_turns() {
         for turn_source in [
+            TurnSource::Managed,
             TurnSource::ExternalInput,
-            TurnSource::MonitorTriggered,
             TurnSource::ExternalAdopted,
         ] {
             assert!(
-                !active_usage_snapshot_is_eligible_for_compact(
+                active_usage_snapshot_is_eligible_for_compact(
                     &ProviderKind::Claude,
                     turn_source,
                     Some("tmux-4631"),
                 ),
-                "{turn_source:?} must not create compact trigger state"
+                "{turn_source:?} must arm compact trigger state"
             );
         }
+        assert!(
+            !active_usage_snapshot_is_eligible_for_compact(
+                &ProviderKind::Claude,
+                TurnSource::MonitorTriggered,
+                Some("tmux-4631"),
+            ),
+            "MonitorTriggered must not create compact trigger state"
+        );
         assert!(!active_usage_snapshot_is_eligible_for_compact(
             &ProviderKind::Claude,
             TurnSource::Managed,


### PR DESCRIPTION
## 문제
#4652(20118b16d)가 auto-compact 주입을 `turn_source == Managed` 턴에만 허용하도록 게이팅하여, interactive Discord 세션(`ExternalInput`/`ExternalAdopted`)의 auto-compact가 완전히 죽음. context_compact_percent=50 설정에도 58%(580K)에서 미발사. P1 — 모든 interactive 세션에서 배포마다 재현.

## 근본원인 (2곳)
#4652는 **두 곳**에 Managed-only 게이트를 추가함. 이슈 본문은 첫 번째 파일만 명시했으나, 그것만 완화하면 두 번째 게이트가 external compact를 계속 차단하여 수정이 무효가 됨:
1. `compact_turn_authority.rs` — `capture()` / `managed_turn_matches_state()`가 `Managed`에만 identity 캡처/매칭.
2. `content_arms.rs` — `active_usage_snapshot_is_eligible_for_compact()`. 실제 라이브 발사 경로(`ActiveUsageSnapshot` → `observe_active_usage`)의 게이트로 역시 `Managed` 요구.

## 수정 (option A: 그냥 주입)
- 공유 predicate `compact_eligible_turn_source` (Managed | ExternalInput | ExternalAdopted) 단일 진실값으로 세 콜사이트를 lockstep 유지.
- identity 필드 매칭(channel_id/user_msg_id/started_at/tmux_session_name/turn_start_offset)은 유지 — 현재 live 턴에 정확히 주입.
- `MonitorTriggered`(synthetic auto-turn)는 계속 제외. 유저-턴 방해방지 안전장치는 사용자 지시대로 생략.

## 검증
- fmt/check/test(compact 85 pass)/docs freshness/maintainability audit 모두 green.
- **뮤테이션 증명**: `Managed`-only 복원 시 `external_interactive_turns_are_compact_eligible`, `active_usage_compact_gate_allows_managed_and_external_interactive_turns` 두 테스트 FAILED (capture None / gate false). 복원 시 ok.

refs #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)