### PR TITLE
refactor(4228): adopt AppError in review verdict routes

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -45,7 +45,7 @@
 | --- | ---: |
 | `src/cli/client.rs` | 2464 |
 | `src/cli/dcserver.rs` | 1650 |
-| `src/cli/direct.rs` | 1758 |
+| `src/cli/direct.rs` | 1767 |
 | `src/cli/doctor/orchestrator.rs` | 4381 |
 | `src/cli/init.rs` | 1444 |
 | `src/cli/migrate/apply.rs` | 3237 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -302,9 +302,9 @@
 | `server::routes::receipt` | `src/server/routes/receipt.rs` | 815 | 502 | 313 |  |
 | `server::routes::resume` | `src/server/routes/resume.rs` | 1260 | 1260 | 0 | giant-file |
 | `server::routes::review_verdict` | `src/server/routes/review_verdict/mod.rs` | 14 | 14 | 0 |  |
-| `server::routes::review_verdict::decision_route` | `src/server/routes/review_verdict/decision_route.rs` | 26 | 26 | 0 |  |
+| `server::routes::review_verdict::decision_route` | `src/server/routes/review_verdict/decision_route.rs` | 56 | 56 | 0 |  |
 | `server::routes::review_verdict::tuning_aggregate` | `src/server/routes/review_verdict/tuning_aggregate.rs` | 14 | 14 | 0 |  |
-| `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 688 | 624 | 64 |  |
+| `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 702 | 638 | 64 |  |
 | `server::routes::reviews` | `src/server/routes/reviews.rs` | 760 | 671 | 89 |  |
 | `server::routes::routines` | `src/server/routes/routines.rs` | 252 | 154 | 98 |  |
 | `server::routes::routines::audit` | `src/server/routes/routines/audit.rs` | 190 | 115 | 75 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -61,7 +61,7 @@
 | `cli::client::runtime_config` | `src/cli/client/runtime_config.rs` | 55 | 23 | 32 |  |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |
 | `cli::dcserver_pg_bootstrap` | `src/cli/dcserver_pg_bootstrap.rs` | 1068 | 544 | 524 |  |
-| `cli::direct` | `src/cli/direct.rs` | 1758 | 1758 | 0 | giant-file |
+| `cli::direct` | `src/cli/direct.rs` | 1767 | 1767 | 0 | giant-file |
 | `cli::discord` | `src/cli/discord.rs` | 472 | 249 | 223 |  |
 | `cli::discord_thread_create` | `src/cli/discord_thread_create.rs` | 1468 | 415 | 1053 |  |
 | `cli::discord_thread_create_lock` | `src/cli/discord_thread_create_lock.rs` | 669 | 611 | 58 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -226,10 +226,10 @@
 | `GET` | `/api/queue/status` | `auto_queue::status` | `src/server/routes/auto_queue.rs:42` | `src/server/routes/domains/ops.rs:295` |
 | `GET` | `/api/rate-limits` | `analytics::rate_limits` | `src/server/routes/analytics.rs:504` | `src/server/routes/domains/admin.rs:78` |
 | `GET` | `/api/receipt` | `receipt::get_receipt` | `src/server/routes/receipt.rs:334` | `src/server/routes/domains/analytics.rs:18` |
-| `POST` | `/api/reviews/decision` | `review_verdict::submit_review_decision` | `src/server/routes/review_verdict/decision_route.rs:21` | `src/server/routes/domains/reviews.rs:23` |
+| `POST` | `/api/reviews/decision` | `review_verdict::submit_review_decision` | `src/server/routes/review_verdict/decision_route.rs:45` | `src/server/routes/domains/reviews.rs:23` |
 | `POST` | `/api/reviews/recovery` | `reviews::recover_review_target` | `src/server/routes/reviews.rs:609` | `src/server/routes/domains/reviews.rs:21` |
 | `POST` | `/api/reviews/tuning/aggregate` | `review_verdict::aggregate_review_tuning` | `src/server/routes/review_verdict/tuning_aggregate.rs:10` | `src/server/routes/domains/reviews.rs:27` |
-| `POST` | `/api/reviews/verdict` | `review_verdict::submit_verdict` | `src/server/routes/review_verdict/verdict_route.rs:257` | `src/server/routes/domains/reviews.rs:22` |
+| `POST` | `/api/reviews/verdict` | `review_verdict::submit_verdict` | `src/server/routes/review_verdict/verdict_route.rs:273` | `src/server/routes/domains/reviews.rs:22` |
 | `GET` | `/api/round-table-meetings` | `meetings::list_meetings` | `src/server/routes/meetings.rs:519` | `src/server/routes/domains/integrations.rs:55` |
 | `POST` | `/api/round-table-meetings` | `meetings::upsert_meeting` | `src/server/routes/meetings.rs:1012` | `src/server/routes/domains/integrations.rs:55` |
 | `GET` | `/api/round-table-meetings/channels` | `meetings::list_meeting_channels` | `src/server/routes/meetings.rs:537` | `src/server/routes/domains/integrations.rs:59` |

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -378,12 +378,16 @@ pub(crate) async fn cmd_review_verdict(
             commit: commit.map(str::to_string),
             provider: provider.map(str::to_string),
         };
-        let (status, body) = crate::server::routes::review_verdict::submit_verdict(
+        let (status, body) = match crate::server::routes::review_verdict::submit_verdict(
             State(state),
             HeaderMap::new(),
             Json(body),
         )
-        .await;
+        .await
+        {
+            Ok((status, body)) => (status, body),
+            Err(error) => (error.status(), Json(error.to_json_value())),
+        };
         route_json(status, body)
     })
     .await
@@ -453,11 +457,16 @@ pub(crate) async fn cmd_review_decision(
                     dispatch_id,
                     out_of_scope: None,
                 };
-                let (status, body) = crate::server::routes::review_verdict::submit_review_decision(
-                    State(state),
-                    Json(body),
-                )
-                .await;
+                let (status, body) =
+                    match crate::server::routes::review_verdict::submit_review_decision(
+                        State(state),
+                        Json(body),
+                    )
+                    .await
+                    {
+                        Ok((status, body)) => (status, body),
+                        Err(error) => (error.status(), Json(error.to_json_value())),
+                    };
                 route_json(status, body)
             }
             ReviewDecisionMode::Pm { requested, applied } => {

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -10,19 +10,26 @@ use crate::services::review_decision::ReviewDecisionBody;
 
 // ── Review Decision (agent's response to counter-model review) ──────────────
 
-fn review_decision_error(status: StatusCode, response: Json<Value>) -> AppError {
+fn review_decision_result(
+    status: StatusCode,
+    response: Json<Value>,
+) -> AppResult<(StatusCode, Json<Value>)> {
     let Value::Object(body) = response.0 else {
-        return AppError::new(status, ErrorCode::Dispatch, "review decision failed");
+        return Err(AppError::new(
+            status,
+            ErrorCode::Dispatch,
+            "review decision failed",
+        ));
     };
+    if body.keys().any(|key| key != "error") {
+        return Ok((status, Json(Value::Object(body))));
+    }
     let message = body
         .get("error")
         .and_then(Value::as_str)
         .unwrap_or("review decision failed")
         .to_string();
-    body.into_iter().filter(|(key, _)| key != "error").fold(
-        AppError::new(status, ErrorCode::Dispatch, message),
-        |error, (key, value)| error.with_context(key, value),
-    )
+    Err(AppError::new(status, ErrorCode::Dispatch, message))
 }
 
 /// POST /api/reviews/decision
@@ -44,6 +51,6 @@ pub async fn submit_review_decision(
     if status.is_success() {
         Ok((status, response))
     } else {
-        Err(review_decision_error(status, response))
+        review_decision_result(status, response)
     }
 }

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -1,12 +1,29 @@
 use axum::{Json, extract::State, http::StatusCode};
+use serde_json::Value;
 
 use super::super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 // #3037: `ReviewDecisionBody` relocated to the services layer so service-side
 // loopback callers no longer reach back into `crate::server`. axum `Json<T>`
 // extraction is location-independent; the handler references the services path.
 use crate::services::review_decision::ReviewDecisionBody;
 
 // ── Review Decision (agent's response to counter-model review) ──────────────
+
+fn review_decision_error(status: StatusCode, response: Json<Value>) -> AppError {
+    let Value::Object(body) = response.0 else {
+        return AppError::new(status, ErrorCode::Dispatch, "review decision failed");
+    };
+    let message = body
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("review decision failed")
+        .to_string();
+    body.into_iter().filter(|(key, _)| key != "error").fold(
+        AppError::new(status, ErrorCode::Dispatch, message),
+        |error, (key, value)| error.with_context(key, value),
+    )
+}
 
 /// POST /api/reviews/decision
 ///
@@ -21,6 +38,12 @@ use crate::services::review_decision::ReviewDecisionBody;
 pub async fn submit_review_decision(
     State(state): State<AppState>,
     Json(body): Json<ReviewDecisionBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    crate::services::review_decision::submit_review_decision(&state, body).await
+) -> AppResult<(StatusCode, Json<Value>)> {
+    let (status, response) =
+        crate::services::review_decision::submit_review_decision(&state, body).await;
+    if status.is_success() {
+        Ok((status, response))
+    } else {
+        Err(review_decision_error(status, response))
+    }
 }

--- a/src/server/routes/review_verdict/verdict_route.rs
+++ b/src/server/routes/review_verdict/verdict_route.rs
@@ -6,6 +6,7 @@ use axum::{
 use serde_json::json;
 
 use super::super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 use crate::services::provider::ProviderKind;
 // #3037: `SubmitVerdictBody` / `VerdictItem` relocated to the services layer so
 // service-side loopback callers no longer reach back into `crate::server`. axum
@@ -16,6 +17,21 @@ use crate::services::review_decision::SubmitVerdictBody;
 #[cfg(test)]
 const PREFLIGHT_SUPPRESS_FOLLOWUP_OUTBOX_HEADER: &str =
     "x-agentdesk-preflight-suppress-followup-outbox";
+
+fn verdict_error(status: StatusCode, body: serde_json::Value) -> AppError {
+    let serde_json::Value::Object(body) = body else {
+        return AppError::new(status, ErrorCode::Dispatch, "review verdict failed");
+    };
+    let message = body
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("review verdict failed")
+        .to_string();
+    body.into_iter().filter(|(key, _)| key != "error").fold(
+        AppError::new(status, ErrorCode::Dispatch, message),
+        |error, (key, value)| error.with_context(key, value),
+    )
+}
 
 fn request_suppresses_followup_outbox(headers: &HeaderMap) -> bool {
     #[cfg(test)]
@@ -258,16 +274,14 @@ pub async fn submit_verdict(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<SubmitVerdictBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     // #116: accept removed — it's a review-decision action, not a counter-model verdict.
     let valid_verdicts = ["pass", "improve", "reject", "rework", "approved"];
     if !valid_verdicts.contains(&body.overall.as_str()) {
-        return (
+        return Err(verdict_error(
             StatusCode::BAD_REQUEST,
-            Json(
-                json!({"error": format!("overall must be one of: {}", valid_verdicts.join(", "))}),
-            ),
-        );
+            json!({"error": format!("overall must be one of: {}", valid_verdicts.join(", "))}),
+        ));
     }
 
     let dispatch = match crate::dispatch::load_dispatch_row_with_backends(
@@ -276,16 +290,16 @@ pub async fn submit_verdict(
     ) {
         Ok(Some(dispatch)) => dispatch,
         Ok(None) => {
-            return (
+            return Err(verdict_error(
                 StatusCode::NOT_FOUND,
-                Json(json!({"error": "dispatch not found"})),
-            );
+                json!({"error": "dispatch not found"}),
+            ));
         }
         Err(error) => {
-            return (
+            return Err(verdict_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("load dispatch: {error}")})),
-            );
+                json!({"error": format!("load dispatch: {error}")}),
+            ));
         }
     };
 
@@ -299,18 +313,18 @@ pub async fn submit_verdict(
         {
             Some("review") => {} // allowed
             Some(dtype) => {
-                return (
+                return Err(verdict_error(
                     StatusCode::BAD_REQUEST,
-                    Json(json!({
+                    json!({
                         "error": format!("review-verdict only accepts 'review' dispatches, got '{}'", dtype)
-                    })),
-                );
+                    }),
+                ));
             }
             None => {
-                return (
+                return Err(verdict_error(
                     StatusCode::NOT_FOUND,
-                    Json(json!({"error": "dispatch not found"})),
-                );
+                    json!({"error": "dispatch not found"}),
+                ));
             }
         }
 
@@ -334,12 +348,12 @@ pub async fn submit_verdict(
             // Require provider field and normalize via ProviderKind.
             match &body.provider {
                 None => {
-                    return (
+                    return Err(verdict_error(
                         StatusCode::BAD_REQUEST,
-                        Json(json!({
+                        json!({
                             "error": "provider field is required for counter-model review verdicts"
-                        })),
-                    );
+                        }),
+                    ));
                 }
                 Some(raw_submitter) => {
                     let submitter = ProviderKind::from_str(raw_submitter);
@@ -349,39 +363,39 @@ pub async fn submit_verdict(
                     match submitter {
                         None => {
                             // Unknown/unsupported provider string
-                            return (
+                            return Err(verdict_error(
                                 StatusCode::BAD_REQUEST,
-                                Json(json!({
+                                json!({
                                     "error": format!(
                                         "unknown provider '{}' — expected a supported provider like 'claude', 'codex', 'gemini', 'opencode', or 'qwen'",
                                         raw_submitter
                                     )
-                                })),
-                            );
+                                }),
+                            ));
                         }
                         Some(ref s) if Some(s) == from_kind.as_ref() => {
                             // Same provider as implementer → self-review blocked
-                            return (
+                            return Err(verdict_error(
                                 StatusCode::BAD_REQUEST,
-                                Json(json!({
+                                json!({
                                     "error": format!(
                                         "self-review rejected: submitting provider '{}' matches implementing provider",
                                         s.as_str()
                                     )
-                                })),
-                            );
+                                }),
+                            ));
                         }
                         Some(ref s) if target_kind.is_some() && Some(s) != target_kind.as_ref() => {
                             // Known provider but doesn't match expected reviewer
-                            return (
+                            return Err(verdict_error(
                                 StatusCode::BAD_REQUEST,
-                                Json(json!({
+                                json!({
                                     "error": format!(
                                         "provider mismatch: expected '{}' but got '{}'",
                                         target_p, s.as_str()
                                     )
-                                })),
-                            );
+                                }),
+                            ));
                         }
                         _ => {} // Normalized cross-provider match → allowed
                     }
@@ -400,12 +414,12 @@ pub async fn submit_verdict(
         if let Some(submitted) = body.commit.as_deref()
             && !is_valid_commit_sha(submitted)
         {
-            return (
+            return Err(verdict_error(
                 StatusCode::BAD_REQUEST,
-                Json(json!({
+                json!({
                     "error": "commit must be a lowercase git SHA matching ^[0-9a-f]{7,64}$"
-                })),
-            );
+                }),
+            ));
         }
 
         let stored_reviewed_commit: Option<String> = dispatch_context
@@ -416,15 +430,15 @@ pub async fn submit_verdict(
         match (&body.commit, &stored_reviewed_commit) {
             (Some(submitted), Some(stored)) => {
                 if submitted != stored {
-                    return (
+                    return Err(verdict_error(
                         StatusCode::BAD_REQUEST,
-                        Json(json!({
+                        json!({
                             "error": format!(
                                 "commit mismatch: submitted {} but dispatch was created for {}",
                                 submitted, stored
                             )
-                        })),
-                    );
+                        }),
+                    ));
                 }
                 Some(stored.clone())
             }
@@ -475,10 +489,10 @@ pub async fn submit_verdict(
     ) {
         Ok(n) => n,
         Err(e) => {
-            return (
+            return Err(verdict_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("update dispatch: {e}")})),
-            );
+                json!({"error": format!("update dispatch: {e}")}),
+            ));
         }
     };
 
@@ -501,7 +515,7 @@ pub async fn submit_verdict(
             Some("failed") => "dispatch already failed",
             _ => "dispatch not found",
         };
-        return (StatusCode::CONFLICT, Json(json!({"error": msg})));
+        return Err(verdict_error(StatusCode::CONFLICT, json!({"error": msg})));
     }
 
     // Find associated card
@@ -531,13 +545,13 @@ pub async fn submit_verdict(
                 Some(&["completed"]),
                 false,
             );
-            return (
+            return Err(verdict_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
+                json!({
                     "ok": false,
                     "error": format!("failed to write release marker: {e}"),
-                })),
-            );
+                }),
+            ));
         }
     }
 
@@ -611,7 +625,7 @@ pub async fn submit_verdict(
         emit_card_updated(&state, cid).await;
     }
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "ok": true,
@@ -619,7 +633,7 @@ pub async fn submit_verdict(
             "overall": body.overall,
             "card_id": card_id,
         })),
-    )
+    ))
 }
 
 #[cfg(test)]

--- a/src/server/routes/review_verdict/verdict_route.rs
+++ b/src/server/routes/review_verdict/verdict_route.rs
@@ -545,12 +545,12 @@ pub async fn submit_verdict(
                 Some(&["completed"]),
                 false,
             );
-            return Err(verdict_error(
+            return Ok((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                json!({
+                Json(json!({
                     "ok": false,
                     "error": format!("failed to write release marker: {e}"),
-                }),
+                })),
             ));
         }
     }


### PR DESCRIPTION
## Summary
- Convert `src/server/routes/review_verdict/decision_route.rs::submit_review_decision` to `AppResult<(StatusCode, Json<Value>)>`.
- Convert `src/server/routes/review_verdict/verdict_route.rs::submit_verdict` to `AppResult<(StatusCode, Json<Value>)>`.
- Preserve existing HTTP status codes, exact `error` strings, successful response bodies, and non-error response fields by mapping legacy JSON failures through `AppError` context, following the merged batch2 `departments.rs` pattern.

`src/server/routes/pr_summary.rs` already contains the merged batch1 conversion on `main`, so it requires no new diff in batch3.

Refs #4228

## Test plan
- [x] Reviewed the merged batch2 `departments.rs` AppError/AppResult convention.
- [x] Ran `rustfmt` on the two modified Rust routes.
- [x] Ran `git diff --check`.
- [ ] Compile and repository gates intentionally deferred to orchestrator shared-target aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)