### PR TITLE
refactor(4228): adopt AppError in hook and message routes

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -282,7 +282,7 @@
 | `server::routes::github_dashboard` | `src/server/routes/github_dashboard.rs` | 188 | 188 | 0 |  |
 | `server::routes::health_api` | `src/server/routes/health_api.rs` | 2701 | 1775 | 926 | giant-file |
 | `server::routes::home_metrics` | `src/server/routes/home_metrics.rs` | 352 | 352 | 0 |  |
-| `server::routes::hooks` | `src/server/routes/hooks.rs` | 129 | 129 | 0 |  |
+| `server::routes::hooks` | `src/server/routes/hooks.rs` | 136 | 136 | 0 |  |
 | `server::routes::idle_recap` | `src/server/routes/idle_recap.rs` | 405 | 405 | 0 |  |
 | `server::routes::kanban` | `src/server/routes/kanban.rs` | 2788 | 2725 | 63 | giant-file |
 | `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 266 | 266 | 0 |  |
@@ -290,7 +290,7 @@
 | `server::routes::meetings` | `src/server/routes/meetings.rs` | 1290 | 1290 | 0 | giant-file |
 | `server::routes::memory_api` | `src/server/routes/memory_api.rs` | 901 | 465 | 436 |  |
 | `server::routes::message_outbox` | `src/server/routes/message_outbox.rs` | 477 | 284 | 193 |  |
-| `server::routes::messages` | `src/server/routes/messages.rs` | 185 | 185 | 0 |  |
+| `server::routes::messages` | `src/server/routes/messages.rs` | 195 | 195 | 0 |  |
 | `server::routes::monitoring` | `src/server/routes/monitoring.rs` | 96 | 96 | 0 |  |
 | `server::routes::offices` | `src/server/routes/offices.rs` | 485 | 485 | 0 |  |
 | `server::routes::onboarding` | `src/server/routes/onboarding.rs` | 58 | 58 | 0 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -120,9 +120,9 @@
 | `GET` | `/api/health/detail` | `health_api::health_detail_handler` | `src/server/routes/health_api.rs:847` | `src/server/routes/domains/ops.rs:22` |
 | `GET` | `/api/help` | `docs::api_help` | `src/server/routes/docs.rs:38` | `src/server/routes/domains/ops.rs:352` |
 | `GET` | `/api/home/kpi-trends` | `home_metrics::home_kpi_trends` | `src/server/routes/home_metrics.rs:54` | `src/server/routes/domains/admin.rs:79` |
-| `POST` | `/api/hook/reset-status` | `hooks::reset_status` | `src/server/routes/hooks.rs:25` | `src/server/routes/domains/integrations.rs:49` |
-| `DELETE` | `/api/hook/session/{sessionKey}` | `hooks::disconnect_session` | `src/server/routes/hooks.rs:59` | `src/server/routes/domains/integrations.rs:51` |
-| `POST` | `/api/hook/skill-usage` | `hooks::skill_usage` | `src/server/routes/hooks.rs:42` | `src/server/routes/domains/integrations.rs:50` |
+| `POST` | `/api/hook/reset-status` | `hooks::reset_status` | `src/server/routes/hooks.rs:36` | `src/server/routes/domains/integrations.rs:49` |
+| `DELETE` | `/api/hook/session/{sessionKey}` | `hooks::disconnect_session` | `src/server/routes/hooks.rs:72` | `src/server/routes/domains/integrations.rs:51` |
+| `POST` | `/api/hook/skill-usage` | `hooks::skill_usage` | `src/server/routes/hooks.rs:55` | `src/server/routes/domains/integrations.rs:50` |
 | `POST` | `/api/inflight/rebind` | `health_api::rebind_inflight_handler` | `src/server/routes/health_api.rs:1660` | `src/server/routes/domains/ops.rs:51` |
 | `GET` | `/api/internal/card-thread` | `dispatches::get_card_thread` | `src/server/routes/dispatches/thread_reuse.rs:68` | `src/server/routes/domains/ops.rs:127` |
 | `POST` | `/api/internal/escalation/emit` | `escalation::emit_escalation` | `src/server/routes/escalation.rs:1373` | `src/server/routes/domains/admin.rs:72` |
@@ -162,8 +162,8 @@
 | `GET` | `/api/message-outbox/failed` | `message_outbox::list_failed` | `src/server/routes/message_outbox.rs:200` | `src/server/routes/domains/ops.rs:28` |
 | `POST` | `/api/message-outbox/failed/redrive` | `message_outbox::redrive_failed` | `src/server/routes/message_outbox.rs:235` | `src/server/routes/domains/ops.rs:33` |
 | `POST` | `/api/message-outbox/monitor-alerts` | `message_outbox::enqueue_monitor_alert` | `src/server/routes/message_outbox.rs:143` | `src/server/routes/domains/ops.rs:29` |
-| `GET` | `/api/messages` | `messages::list_messages` | `src/server/routes/messages.rs:41` | `src/server/routes/domains/ops.rs:221` |
-| `POST` | `/api/messages` | `messages::create_message` | `src/server/routes/messages.rs:61` | `src/server/routes/domains/ops.rs:221` |
+| `GET` | `/api/messages` | `messages::list_messages` | `src/server/routes/messages.rs:51` | `src/server/routes/domains/ops.rs:221` |
+| `POST` | `/api/messages` | `messages::create_message` | `src/server/routes/messages.rs:71` | `src/server/routes/domains/ops.rs:221` |
 | `GET` | `/api/offices` | `offices::list_offices` | `src/server/routes/offices.rs:58` | `src/server/routes/domains/admin.rs:16` |
 | `POST` | `/api/offices` | `offices::create_office` | `src/server/routes/offices.rs:124` | `src/server/routes/domains/admin.rs:16` |
 | `PATCH` | `/api/offices/reorder` | `offices::reorder_offices` | `src/server/routes/offices.rs:73` | `src/server/routes/domains/admin.rs:20` |

--- a/src/server/routes/hooks.rs
+++ b/src/server/routes/hooks.rs
@@ -8,6 +8,17 @@ use serde_json::json;
 use sqlx::PgPool;
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
+
+fn app_error(status: StatusCode, message: impl Into<String>) -> AppError {
+    let message = message.into();
+    match status {
+        StatusCode::NOT_FOUND => AppError::not_found(message),
+        StatusCode::INTERNAL_SERVER_ERROR => AppError::internal(message),
+        StatusCode::SERVICE_UNAVAILABLE => AppError::new(status, ErrorCode::Config, message),
+        _ => AppError::new(status, ErrorCode::Internal, message),
+    }
+}
 
 // ── Body types ───────────────────────────────────────────────
 
@@ -22,19 +33,21 @@ pub struct SkillUsageBody {
 // ── Handlers ─────────────────────────────────────────────────
 
 /// POST /api/hook/reset-status
-pub async fn reset_status(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
+pub async fn reset_status(
+    State(state): State<AppState>,
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
     match reset_status_pg(pool).await {
-        Ok(updated) => (
+        Ok(updated) => Ok((
             StatusCode::OK,
             Json(json!({"ok": true, "updated": updated})),
-        ),
-        Err(error) => (
+        )),
+        Err(error) => Err(app_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+            format!("{error}"),
+        )),
     }
 }
 
@@ -42,16 +55,16 @@ pub async fn reset_status(State(state): State<AppState>) -> (StatusCode, Json<se
 pub async fn skill_usage(
     State(state): State<AppState>,
     Json(body): Json<SkillUsageBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
     match skill_usage_pg(pool, &body).await {
-        Ok(id) => (StatusCode::OK, Json(json!({"ok": true, "id": id}))),
-        Err(error) => (
+        Ok(id) => Ok((StatusCode::OK, Json(json!({"ok": true, "id": id})))),
+        Err(error) => Err(app_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+            format!("{error}"),
+        )),
     }
 }
 
@@ -59,30 +72,27 @@ pub async fn skill_usage(
 pub async fn disconnect_session(
     State(state): State<AppState>,
     Path(session_key): Path<String>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
     match disconnect_session_pg(pool, &session_key).await {
-        Ok(false) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "session not found"})),
-        ),
-        Ok(true) => (
+        Ok(false) => Err(app_error(StatusCode::NOT_FOUND, "session not found")),
+        Ok(true) => Ok((
             StatusCode::OK,
             Json(json!({"ok": true, "session_key": session_key})),
-        ),
-        Err(error) => (
+        )),
+        Err(error) => Err(app_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+            format!("{error}"),
+        )),
     }
 }
 
-fn pg_unavailable() -> (StatusCode, Json<serde_json::Value>) {
-    (
+fn pg_unavailable() -> AppError {
+    app_error(
         StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({"error": "postgres pool unavailable"})),
+        "postgres pool unavailable",
     )
 }
 

--- a/src/server/routes/hooks.rs
+++ b/src/server/routes/hooks.rs
@@ -90,10 +90,7 @@ pub async fn disconnect_session(
 }
 
 fn pg_unavailable() -> AppError {
-    app_error(
-        StatusCode::SERVICE_UNAVAILABLE,
-        "postgres pool unavailable",
-    )
+    app_error(StatusCode::SERVICE_UNAVAILABLE, "postgres pool unavailable")
 }
 
 async fn reset_status_pg(pool: &PgPool) -> Result<u64, sqlx::Error> {

--- a/src/server/routes/messages.rs
+++ b/src/server/routes/messages.rs
@@ -8,6 +8,16 @@ use serde_json::json;
 use sqlx::{PgPool, QueryBuilder, Row};
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
+
+fn app_error(status: StatusCode, message: impl Into<String>) -> AppError {
+    let message = message.into();
+    match status {
+        StatusCode::INTERNAL_SERVER_ERROR => AppError::internal(message),
+        StatusCode::SERVICE_UNAVAILABLE => AppError::new(status, ErrorCode::Config, message),
+        _ => AppError::new(status, ErrorCode::Internal, message),
+    }
+}
 
 // ── Query / Body types ─────────────────────────────────────────
 
@@ -41,19 +51,22 @@ pub struct CreateMessageBody {
 pub async fn list_messages(
     State(state): State<AppState>,
     Query(params): Query<ListMessagesQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return (
+        return Err(app_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+            "postgres pool unavailable",
+        ));
     };
     match list_messages_pg(pool, &params).await {
-        Ok(messages) => (StatusCode::OK, Json(json!({"messages": messages}))),
-        Err(error) => (
+        Ok(messages) => Ok((
+            StatusCode::OK,
+            Json(json!({"messages": messages})),
+        )),
+        Err(error) => Err(app_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+            format!("{error}"),
+        )),
     }
 }
 
@@ -61,7 +74,7 @@ pub async fn list_messages(
 pub async fn create_message(
     State(state): State<AppState>,
     Json(body): Json<CreateMessageBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let sender_type = body
         .sender_type
         .clone()
@@ -72,17 +85,17 @@ pub async fn create_message(
         .unwrap_or_else(|| "chat".to_string());
 
     let Some(pool) = state.pg_pool_ref() else {
-        return (
+        return Err(app_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+            "postgres pool unavailable",
+        ));
     };
     match create_message_pg(pool, &body, &sender_type, &message_type).await {
-        Ok(message) => (StatusCode::CREATED, Json(message)),
-        Err(error) => (
+        Ok(message) => Ok((StatusCode::CREATED, Json(message))),
+        Err(error) => Err(app_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+            format!("{error}"),
+        )),
     }
 }
 

--- a/src/server/routes/messages.rs
+++ b/src/server/routes/messages.rs
@@ -59,10 +59,7 @@ pub async fn list_messages(
         ));
     };
     match list_messages_pg(pool, &params).await {
-        Ok(messages) => Ok((
-            StatusCode::OK,
-            Json(json!({"messages": messages})),
-        )),
+        Ok(messages) => Ok((StatusCode::OK, Json(json!({"messages": messages})))),
         Err(error) => Err(app_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("{error}"),


### PR DESCRIPTION
## Summary
- convert `hooks.rs` handlers `reset_status`, `skill_usage`, and `disconnect_session`, plus the shared `pg_unavailable` helper, to `AppResult`
- convert `messages.rs` handlers `list_messages` and `create_message` to `AppResult`
- preserve every prior status code and top-level `error` string; the standard `code` and `context` fields are additive

## Contract invariants
- all failure branches in both files originally contained only top-level `error`, so they map directly to `AppError`
- no failure branch had flat-body companion fields such as `ok`, `id`, or `count`; therefore no flat-body failure branch needed to remain as `Ok((status, Json(...)))`
- all success payloads and status codes remain unchanged

## Caller audit
- exhaustive `rg -n \"<fn_name>\" src/` was run for `reset_status`, `skill_usage`, `disconnect_session`, `pg_unavailable`, `list_messages`, and `create_message`
- the affected public handlers are referenced only by Axum route registration in `routes/domains/integrations.rs` and `routes/domains/ops.rs`; `Result` is handled through `IntoResponse`
- no direct tuple-destructuring CLI caller and no same/subdirectory test caller was found
- similarly named service/database functions from the unfiltered search are unrelated symbols and require no changes

## Test plan
- [x] `git diff --check`
- [x] exhaustive caller grep and raw-signature/error-body grep
- [ ] compile and repository gates are intentionally deferred to the orchestrator (`cargo check --workspace --all-targets` aggregation)

Refs #4228

🤖 Generated with [Claude Code](https://claude.com/claude-code)