### PR TITLE
refactor(4228): adopt AppError in idle recap and kanban repos

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -283,9 +283,9 @@
 | `server::routes::health_api` | `src/server/routes/health_api.rs` | 2701 | 1775 | 926 | giant-file |
 | `server::routes::home_metrics` | `src/server/routes/home_metrics.rs` | 352 | 352 | 0 |  |
 | `server::routes::hooks` | `src/server/routes/hooks.rs` | 136 | 136 | 0 |  |
-| `server::routes::idle_recap` | `src/server/routes/idle_recap.rs` | 405 | 405 | 0 |  |
+| `server::routes::idle_recap` | `src/server/routes/idle_recap.rs` | 406 | 406 | 0 |  |
 | `server::routes::kanban` | `src/server/routes/kanban.rs` | 2788 | 2725 | 63 | giant-file |
-| `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 266 | 266 | 0 |  |
+| `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 234 | 234 | 0 |  |
 | `server::routes::maintenance` | `src/server/routes/maintenance.rs` | 17 | 17 | 0 |  |
 | `server::routes::meetings` | `src/server/routes/meetings.rs` | 1290 | 1290 | 0 | giant-file |
 | `server::routes::memory_api` | `src/server/routes/memory_api.rs` | 901 | 465 | 436 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -148,10 +148,10 @@
 | `GET` | `/api/kanban-cards/{id}/review-state` | `kanban::get_card_review_state` | `src/server/routes/kanban.rs:1053` | `src/server/routes/domains/kanban.rs:43` |
 | `GET` | `/api/kanban-cards/{id}/reviews` | `kanban::list_card_reviews` | `src/server/routes/kanban.rs:1075` | `src/server/routes/domains/kanban.rs:42` |
 | `POST` | `/api/kanban-cards/{id}/transition` | `kanban::force_transition` | `src/server/routes/kanban.rs:2423` | `src/server/routes/domains/kanban.rs:31` |
-| `GET` | `/api/kanban-repos` | `kanban_repos::list_repos` | `src/server/routes/kanban_repos.rs:29` | `src/server/routes/domains/kanban.rs:52` |
-| `POST` | `/api/kanban-repos` | `kanban_repos::create_repo` | `src/server/routes/kanban_repos.rs:78` | `src/server/routes/domains/kanban.rs:52` |
-| `DELETE` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::delete_repo` | `src/server/routes/kanban_repos.rs:234` | `src/server/routes/domains/kanban.rs:56` |
-| `PATCH` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::update_repo` | `src/server/routes/kanban_repos.rs:153` | `src/server/routes/domains/kanban.rs:56` |
+| `GET` | `/api/kanban-repos` | `kanban_repos::list_repos` | `src/server/routes/kanban_repos.rs:30` | `src/server/routes/domains/kanban.rs:52` |
+| `POST` | `/api/kanban-repos` | `kanban_repos::create_repo` | `src/server/routes/kanban_repos.rs:76` | `src/server/routes/domains/kanban.rs:52` |
+| `DELETE` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::delete_repo` | `src/server/routes/kanban_repos.rs:207` | `src/server/routes/domains/kanban.rs:56` |
+| `PATCH` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::update_repo` | `src/server/routes/kanban_repos.rs:139` | `src/server/routes/domains/kanban.rs:56` |
 | `PATCH` | `/api/kanban-reviews/{id}/decisions` | `reviews::update_decisions` | `src/server/routes/reviews.rs:573` | `src/server/routes/domains/reviews.rs:13` |
 | `POST` | `/api/kanban-reviews/{id}/trigger-rework` | `reviews::trigger_rework` | `src/server/routes/reviews.rs:627` | `src/server/routes/domains/reviews.rs:17` |
 | `GET` | `/api/machine-status` | `analytics::machine_status` | `src/server/routes/analytics.rs:496` | `src/server/routes/domains/admin.rs:77` |
@@ -265,7 +265,7 @@
 | `GET` | `/api/sessions` | `agents_crud::list_sessions` | `src/server/routes/agents_crud.rs:1259` | `src/server/routes/domains/agents.rs:49` |
 | `GET` | `/api/sessions/{id}/tmux-output` | `dispatched_sessions::tmux_output` | `src/server/routes/dispatched_sessions.rs:93` | `src/server/routes/domains/ops.rs:213` |
 | `POST` | `/api/sessions/{session_key}/force-kill` | `dispatched_sessions::force_kill_session` | `src/server/routes/dispatched_sessions.rs:109` | `src/server/routes/domains/ops.rs:199` |
-| `POST` | `/api/sessions/{session_key}/idle-recap` | `idle_recap::post_idle_recap` | `src/server/routes/idle_recap.rs:69` | `src/server/routes/domains/ops.rs:207` |
+| `POST` | `/api/sessions/{session_key}/idle-recap` | `idle_recap::post_idle_recap` | `src/server/routes/idle_recap.rs:70` | `src/server/routes/domains/ops.rs:207` |
 | `POST` | `/api/sessions/{session_key}/kill-tmux` | `dispatched_sessions::kill_tmux_session` | `src/server/routes/dispatched_sessions.rs:125` | `src/server/routes/domains/ops.rs:203` |
 | `GET` | `/api/settings` | `settings::get_settings` | `src/server/routes/settings.rs:28` | `src/server/routes/domains/admin.rs:48` |
 | `PUT` | `/api/settings` | `settings::put_settings` | `src/server/routes/settings.rs:38` | `src/server/routes/domains/admin.rs:48` |

--- a/src/server/routes/idle_recap.rs
+++ b/src/server/routes/idle_recap.rs
@@ -61,6 +61,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 
 use super::AppState;
+use crate::error::AppResult;
 use crate::services::discord::idle_recap;
 use crate::services::discord::idle_recap::RecapSnapshot;
 use crate::services::provider::ProviderKind;
@@ -69,7 +70,7 @@ use crate::services::provider::ProviderKind;
 pub async fn post_idle_recap(
     State(state): State<AppState>,
     Path(session_key): Path<String>,
-) -> (StatusCode, Json<Value>) {
+) -> AppResult<(StatusCode, Json<Value>)> {
     let Some(pool) = state.pg_pool.as_ref().cloned() else {
         return error(StatusCode::INTERNAL_SERVER_ERROR, "pg pool unavailable");
     };
@@ -139,7 +140,7 @@ pub async fn post_idle_recap(
         }
     });
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "ok": true,
@@ -147,7 +148,7 @@ pub async fn post_idle_recap(
             "posted": false,
             "channel_id": channel_id.to_string(),
         })),
-    )
+    ))
 }
 
 async fn run_idle_recap_post_job(
@@ -393,13 +394,13 @@ async fn run_idle_recap_post_job(
     }
 }
 
-fn skip(reason: &str) -> (StatusCode, Json<Value>) {
-    (
+fn skip(reason: &str) -> AppResult<(StatusCode, Json<Value>)> {
+    Ok((
         StatusCode::OK,
         Json(json!({"ok": true, "posted": false, "skipped": true, "reason": reason})),
-    )
+    ))
 }
 
-fn error(status: StatusCode, message: &str) -> (StatusCode, Json<Value>) {
-    (status, Json(json!({"ok": false, "error": message})))
+fn error(status: StatusCode, message: &str) -> AppResult<(StatusCode, Json<Value>)> {
+    Ok((status, Json(json!({"ok": false, "error": message}))))
 }

--- a/src/server/routes/kanban_repos.rs
+++ b/src/server/routes/kanban_repos.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 use sqlx::Row;
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 
 // ── Body types ─────────────────────────────────────────────────
 
@@ -26,9 +27,11 @@ pub struct UpdateRepoBody {
 // ── Handlers ───────────────────────────────────────────────────
 
 /// GET /api/kanban-repos
-pub async fn list_repos(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
+pub async fn list_repos(
+    State(state): State<AppState>,
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
     let rows = match sqlx::query(
         "SELECT id, display_name, sync_enabled, last_synced_at::text AS last_synced_at,
@@ -40,12 +43,7 @@ pub async fn list_repos(State(state): State<AppState>) -> (StatusCode, Json<serd
     .await
     {
         Ok(rows) => rows,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            );
-        }
+        Err(error) => return Err(AppError::internal(format!("{error}"))),
     };
 
     let repos: Vec<serde_json::Value> = rows
@@ -71,23 +69,20 @@ pub async fn list_repos(State(state): State<AppState>) -> (StatusCode, Json<serd
         })
         .collect();
 
-    (StatusCode::OK, Json(json!({"repos": repos})))
+    Ok((StatusCode::OK, Json(json!({"repos": repos}))))
 }
 
 /// POST /api/kanban-repos
 pub async fn create_repo(
     State(state): State<AppState>,
     Json(body): Json<CreateRepoBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     if body.repo.is_empty() || !body.repo.contains('/') {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "repo must be in 'owner/name' format"})),
-        );
+        return Err(AppError::bad_request("repo must be in 'owner/name' format"));
     }
 
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
 
     let display_name = body
@@ -98,10 +93,7 @@ pub async fn create_repo(
         .to_string();
 
     if let Err(error) = crate::db::postgres::register_repo(pool, &body.repo).await {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": error})),
-        );
+        return Err(AppError::internal(error).with_code(ErrorCode::Database));
     }
 
     if let Err(error) = sqlx::query(
@@ -117,10 +109,7 @@ pub async fn create_repo(
     .execute(pool)
     .await
     {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        );
+        return Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database));
     }
 
     match sqlx::query(
@@ -132,7 +121,7 @@ pub async fn create_repo(
     .fetch_one(pool)
     .await
     {
-        Ok(row) => (
+        Ok(row) => Ok((
             StatusCode::CREATED,
             Json(json!({"repo": {
                 "id": row.try_get::<String, _>("id").unwrap_or_default(),
@@ -141,11 +130,8 @@ pub async fn create_repo(
                 "last_synced_at": row.try_get::<Option<String>, _>("last_synced_at").ok().flatten(),
                 "default_agent_id": row.try_get::<Option<String>, _>("default_agent_id").ok().flatten(),
             }})),
-        ),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+        )),
+        Err(error) => Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database)),
     }
 }
 
@@ -154,11 +140,11 @@ pub async fn update_repo(
     State(state): State<AppState>,
     Path((owner, repo)): Path<(String, String)>,
     Json(body): Json<UpdateRepoBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let id = format!("{owner}/{repo}");
 
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
     if let Some(ref agent_id) = body.default_agent_id {
         match sqlx::query("UPDATE github_repos SET default_agent_id = $1 WHERE id = $2")
@@ -168,17 +154,11 @@ pub async fn update_repo(
             .await
         {
             Ok(result) if result.rows_affected() == 0 => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(json!({"error": "repo not found"})),
-                );
+                return Err(AppError::not_found("repo not found"));
             }
             Ok(_) => {}
             Err(error) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("{error}")})),
-                );
+                return Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database));
             }
         }
     } else {
@@ -190,17 +170,13 @@ pub async fn update_repo(
             {
                 Ok(count) => count > 0,
                 Err(error) => {
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": format!("{error}")})),
+                    return Err(
+                        AppError::internal(format!("{error}")).with_code(ErrorCode::Database)
                     );
                 }
             };
         if !exists {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "repo not found"})),
-            );
+            return Err(AppError::not_found("repo not found"));
         }
     }
 
@@ -213,7 +189,7 @@ pub async fn update_repo(
     .fetch_one(pool)
     .await
     {
-        Ok(row) => (
+        Ok(row) => Ok((
             StatusCode::OK,
             Json(json!({"repo": {
                 "id": row.try_get::<String, _>("id").unwrap_or_default(),
@@ -222,11 +198,8 @@ pub async fn update_repo(
                 "last_synced_at": row.try_get::<Option<String>, _>("last_synced_at").ok().flatten(),
                 "default_agent_id": row.try_get::<Option<String>, _>("default_agent_id").ok().flatten(),
             }})),
-        ),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+        )),
+        Err(error) => Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database)),
     }
 }
 
@@ -234,11 +207,11 @@ pub async fn update_repo(
 pub async fn delete_repo(
     State(state): State<AppState>,
     Path((owner, repo)): Path<(String, String)>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let id = format!("{owner}/{repo}");
 
     let Some(pool) = state.pg_pool_ref() else {
-        return pg_unavailable();
+        return Err(pg_unavailable());
     };
 
     match sqlx::query("DELETE FROM github_repos WHERE id = $1")
@@ -246,21 +219,16 @@ pub async fn delete_repo(
         .execute(pool)
         .await
     {
-        Ok(result) if result.rows_affected() == 0 => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "repo not found"})),
-        ),
-        Ok(_) => (StatusCode::OK, Json(json!({"ok": true}))),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+        Ok(result) if result.rows_affected() == 0 => Err(AppError::not_found("repo not found")),
+        Ok(_) => Ok((StatusCode::OK, Json(json!({"ok": true})))),
+        Err(error) => Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database)),
     }
 }
 
-fn pg_unavailable() -> (StatusCode, Json<serde_json::Value>) {
-    (
+fn pg_unavailable() -> AppError {
+    AppError::new(
         StatusCode::SERVICE_UNAVAILABLE,
-        Json(json!({"error": "postgres pool unavailable"})),
+        ErrorCode::Config,
+        "postgres pool unavailable",
     )
 }


### PR DESCRIPTION
## Summary
- Convert `idle_recap::post_idle_recap` and its response helpers to `AppResult`.
- Convert all four `kanban_repos` route handlers and the PostgreSQL-unavailable helper to `AppResult`/`AppError`.
- Preserve response contracts: all converted failures originally had only top-level `error`; success and flat-body branches remain `Ok((status, Json(...)))`.

## Caller audit
- Exhaustive `rg -n` across `src/` found only Axum route registrations for the converted handlers; `IntoResponse` handles `AppResult` directly.
- No tuple-destructuring CLI or test callers required changes.

## Flat-body preservation
- `idle_recap` error responses retain the original top-level `ok: false` beside `error`, so they remain flat-body `Ok` responses rather than `AppError`.
- `idle_recap` skip and success bodies retain their original flat response shape.

## Test plan
- [ ] Orchestrator: `cargo check --workspace --all-targets`
- [ ] Orchestrator: formatting and repository gates

refs #4228