### PR TITLE
refactor(4228): adopt AppError in voice and receipt routes

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -299,7 +299,7 @@
 | `server::routes::prompt_manifest_retention` | `src/server/routes/prompt_manifest_retention.rs` | 57 | 57 | 0 |  |
 | `server::routes::provider_cli_api` | `src/server/routes/provider_cli_api.rs` | 386 | 386 | 0 |  |
 | `server::routes::queue_api` | `src/server/routes/queue_api.rs` | 430 | 381 | 49 |  |
-| `server::routes::receipt` | `src/server/routes/receipt.rs` | 815 | 502 | 313 |  |
+| `server::routes::receipt` | `src/server/routes/receipt.rs` | 813 | 500 | 313 |  |
 | `server::routes::resume` | `src/server/routes/resume.rs` | 1260 | 1260 | 0 | giant-file |
 | `server::routes::review_verdict` | `src/server/routes/review_verdict/mod.rs` | 14 | 14 | 0 |  |
 | `server::routes::review_verdict::decision_route` | `src/server/routes/review_verdict/decision_route.rs` | 56 | 56 | 0 |  |
@@ -321,7 +321,7 @@
 | `server::routes::tests::preflight_harness::types` | `src/server/routes/tests/preflight_harness/types.rs` | 217 | 0 | 217 |  |
 | `server::routes::tests::preflight_harness::validation` | `src/server/routes/tests/preflight_harness/validation.rs` | 260 | 0 | 260 |  |
 | `server::routes::v1` | `src/server/routes/v1.rs` | 1857 | 1857 | 0 | giant-file |
-| `server::routes::voice_config` | `src/server/routes/voice_config.rs` | 463 | 393 | 70 |  |
+| `server::routes::voice_config` | `src/server/routes/voice_config.rs` | 466 | 396 | 70 |  |
 | `server::startup_preflight` | `src/server/startup_preflight.rs` | 72 | 36 | 36 |  |
 | `server::state` | `src/server/state.rs` | 11 | 11 | 0 |  |
 | `server::task_dispatch_claims` | `src/server/task_dispatch_claims.rs` | 1039 | 359 | 680 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -225,7 +225,7 @@
 | `POST` | `/api/queue/slots/{agent_id}/{slot_index}/reset-thread` | `auto_queue::reset_slot_thread` | `src/server/routes/auto_queue.rs:102` | `src/server/routes/domains/ops.rs:311` |
 | `GET` | `/api/queue/status` | `auto_queue::status` | `src/server/routes/auto_queue.rs:42` | `src/server/routes/domains/ops.rs:295` |
 | `GET` | `/api/rate-limits` | `analytics::rate_limits` | `src/server/routes/analytics.rs:504` | `src/server/routes/domains/admin.rs:78` |
-| `GET` | `/api/receipt` | `receipt::get_receipt` | `src/server/routes/receipt.rs:334` | `src/server/routes/domains/analytics.rs:18` |
+| `GET` | `/api/receipt` | `receipt::get_receipt` | `src/server/routes/receipt.rs:335` | `src/server/routes/domains/analytics.rs:18` |
 | `POST` | `/api/reviews/decision` | `review_verdict::submit_review_decision` | `src/server/routes/review_verdict/decision_route.rs:45` | `src/server/routes/domains/reviews.rs:23` |
 | `POST` | `/api/reviews/recovery` | `reviews::recover_review_target` | `src/server/routes/reviews.rs:609` | `src/server/routes/domains/reviews.rs:21` |
 | `POST` | `/api/reviews/tuning/aggregate` | `review_verdict::aggregate_review_tuning` | `src/server/routes/review_verdict/tuning_aggregate.rs:10` | `src/server/routes/domains/reviews.rs:27` |
@@ -283,7 +283,7 @@
 | `GET` | `/api/stats` | `stats::get_stats` | `src/server/routes/stats.rs:500` | `src/server/routes/domains/admin.rs:46` |
 | `GET` | `/api/stats/memento` | `stats::get_memento_stats` | `src/server/routes/stats.rs:520` | `src/server/routes/domains/admin.rs:47` |
 | `GET` | `/api/streaks` | `analytics::streaks` | `src/server/routes/analytics.rs:409` | `src/server/routes/domains/analytics.rs:15` |
-| `GET` | `/api/token-analytics` | `receipt::get_token_analytics` | `src/server/routes/receipt.rs:413` | `src/server/routes/domains/analytics.rs:19` |
+| `GET` | `/api/token-analytics` | `receipt::get_token_analytics` | `src/server/routes/receipt.rs:411` | `src/server/routes/domains/analytics.rs:19` |
 | `POST` | `/api/turns/{channel_id}/cancel` | `queue_api::cancel_turn` | `src/server/routes/queue_api.rs:192` | `src/server/routes/domains/ops.rs:347` |
 | `POST` | `/api/turns/{channel_id}/extend-timeout` | `queue_api::extend_turn_timeout` | `src/server/routes/queue_api.rs:290` | `src/server/routes/domains/ops.rs:348` |
 | `GET` | `/api/v1/achievements` | `achievements` | `src/server/routes/v1.rs:328` | `src/server/routes/v1.rs:124` |
@@ -296,6 +296,6 @@
 | `PATCH` | `/api/v1/settings/{key}` | `patch_setting` | `src/server/routes/v1.rs:374` | `src/server/routes/v1.rs:126` |
 | `GET` | `/api/v1/stream` | `stream` | `src/server/routes/v1.rs:228` | `src/server/routes/v1.rs:122` |
 | `GET` | `/api/v1/tokens` | `tokens` | `src/server/routes/v1.rs:202` | `src/server/routes/v1.rs:119` |
-| `GET` | `/api/voice/config` | `voice_config::get_voice_config` | `src/server/routes/voice_config.rs:109` | `src/server/routes/domains/admin.rs:68` |
-| `PUT` | `/api/voice/config` | `voice_config::put_voice_config` | `src/server/routes/voice_config.rs:117` | `src/server/routes/domains/admin.rs:68` |
+| `GET` | `/api/voice/config` | `voice_config::get_voice_config` | `src/server/routes/voice_config.rs:110` | `src/server/routes/domains/admin.rs:68` |
+| `PUT` | `/api/voice/config` | `voice_config::put_voice_config` | `src/server/routes/voice_config.rs:120` | `src/server/routes/domains/admin.rs:68` |
 | `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:24` | `src/server/mod.rs:439` |

--- a/src/server/routes/receipt.rs
+++ b/src/server/routes/receipt.rs
@@ -16,6 +16,7 @@ use std::time::{Duration as StdDuration, Instant};
 use tokio::sync::Mutex as AsyncMutex;
 
 use super::AppState;
+use crate::error::{AppError, AppResult};
 use crate::receipt;
 
 #[derive(Debug, Deserialize)]
@@ -334,7 +335,7 @@ pub async fn prewarm_token_analytics_cache() {
 pub async fn get_receipt(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<ReceiptQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let period = params.period.as_deref().unwrap_or("month");
     let now = chrono::Utc::now();
     let local_now = now.with_timezone(&Local);
@@ -399,14 +400,11 @@ pub async fn get_receipt(
     {
         Ok(d) => d,
         Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("collection failed: {e}")})),
-            );
+            return Err(AppError::internal(format!("collection failed: {e}")));
         }
     };
 
-    (StatusCode::OK, Json(json!(data)))
+    Ok((StatusCode::OK, Json(json!(data))))
 }
 
 /// GET /api/token-analytics?period=30d&fresh=1

--- a/src/server/routes/voice_config.rs
+++ b/src/server/routes/voice_config.rs
@@ -7,6 +7,7 @@ use sha2::{Digest, Sha256};
 
 use super::AppState;
 use crate::config::{AgentDef, Config};
+use crate::error::AppResult;
 use crate::voice::barge_in::BargeInSensitivity;
 use crate::voice::config::DEFAULT_ACTIVE_AGENT_TTL_SECS;
 
@@ -90,25 +91,27 @@ enum VoiceConfigError {
 }
 
 impl VoiceConfigError {
-    fn into_response(self) -> (StatusCode, Json<Value>) {
+    fn into_response(self) -> AppResult<(StatusCode, Json<Value>)> {
         match self {
-            Self::BadRequest(message) => (
+            Self::BadRequest(message) => Ok((
                 StatusCode::BAD_REQUEST,
                 Json(json!({"error": "bad_request", "message": message})),
-            ),
-            Self::Conflict(body) => (StatusCode::CONFLICT, Json(body)),
-            Self::Internal(message) => (
+            )),
+            Self::Conflict(body) => Ok((StatusCode::CONFLICT, Json(body))),
+            Self::Internal(message) => Ok((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "internal_error", "message": message})),
-            ),
+            )),
         }
     }
 }
 
 /// GET /api/voice/config
-pub async fn get_voice_config(State(_state): State<AppState>) -> (StatusCode, Json<Value>) {
+pub async fn get_voice_config(
+    State(_state): State<AppState>,
+) -> AppResult<(StatusCode, Json<Value>)> {
     match load_voice_config_response() {
-        Ok(response) => (StatusCode::OK, Json(json!(response))),
+        Ok(response) => Ok((StatusCode::OK, Json(json!(response)))),
         Err(error) => error.into_response(),
     }
 }
@@ -117,9 +120,9 @@ pub async fn get_voice_config(State(_state): State<AppState>) -> (StatusCode, Js
 pub async fn put_voice_config(
     State(state): State<AppState>,
     Json(body): Json<PutVoiceConfigBody>,
-) -> (StatusCode, Json<Value>) {
+) -> AppResult<(StatusCode, Json<Value>)> {
     match put_voice_config_inner(&state, body).await {
-        Ok(response) => (StatusCode::OK, Json(json!(response))),
+        Ok(response) => Ok((StatusCode::OK, Json(json!(response)))),
         Err(error) => error.into_response(),
     }
 }


### PR DESCRIPTION
## Summary
- convert `voice_config::{get_voice_config, put_voice_config}` to `AppResult<(StatusCode, Json<_>)>`
- convert `receipt::get_receipt` to `AppResult<(StatusCode, Json<_>)>`
- preserve existing status codes and response body contracts; refs #4228

## Contract invariants
- successful responses retain their original status and JSON shape
- receipt collection failure remains HTTP 500 with the same top-level `error` string; `AppError` only adds the standard `code` and `context`
- voice-config bad-request, conflict, and internal-error bodies contain top-level fields beyond `error`, so they remain flat-body `Ok((status, Json(...)))` responses rather than being folded into `AppError`

## Caller audit
- exhaustive `rg -n \"<fn_name>\" src/` run for `get_voice_config`, `put_voice_config`, `put_voice_config_inner`, `load_voice_config_response`, `load_editable_config`, `apply_voice_config_body`, `alias_collision_response`, and `get_receipt`
- route handlers are referenced only by axum registration in `domains/admin.rs` and `domains/analytics.rs`
- helper callers are confined to `voice_config.rs`; existing unit tests destructure `VoiceConfigError::Conflict` directly and require no Result adaptation
- no direct CLI or cross-module tuple-destructuring callers found

## Test plan
- [x] `git diff --check`
- [x] exhaustive caller grep
- [ ] compile/gates intentionally not run; orchestrator will aggregate `cargo check --workspace --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)