### PR TITLE
fix(4678): fire auto-compact on unproven proxy window via max-window fallback

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -381,8 +381,8 @@
 | `services::claude::active_usage` | `src/services/claude/active_usage.rs` | 55 | 55 | 0 |  |
 | `services::claude::backend_routing` | `src/services/claude/backend_routing.rs` | 122 | 122 | 0 |  |
 | `services::claude_command` | `src/services/claude_command.rs` | 1055 | 473 | 582 |  |
-| `services::claude_compact_context` | `src/services/claude_compact_context.rs` | 1120 | 723 | 397 |  |
-| `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 1168 | 545 | 623 |  |
+| `services::claude_compact_context` | `src/services/claude_compact_context.rs` | 1116 | 719 | 397 |  |
+| `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 1162 | 545 | 617 |  |
 | `services::claude_e` | `src/services/claude_e/mod.rs` | 18 | 18 | 0 |  |
 | `services::claude_e::cancellation` | `src/services/claude_e/cancellation.rs` | 3 | 3 | 0 |  |
 | `services::claude_e::jsonl_parser` | `src/services/claude_e/jsonl_parser.rs` | 4 | 4 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -381,8 +381,8 @@
 | `services::claude::active_usage` | `src/services/claude/active_usage.rs` | 55 | 55 | 0 |  |
 | `services::claude::backend_routing` | `src/services/claude/backend_routing.rs` | 122 | 122 | 0 |  |
 | `services::claude_command` | `src/services/claude_command.rs` | 1055 | 473 | 582 |  |
-| `services::claude_compact_context` | `src/services/claude_compact_context.rs` | 1044 | 694 | 350 |  |
-| `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 952 | 457 | 495 |  |
+| `services::claude_compact_context` | `src/services/claude_compact_context.rs` | 1120 | 723 | 397 |  |
+| `services::claude_compact_trigger` | `src/services/claude_compact_trigger.rs` | 1168 | 545 | 623 |  |
 | `services::claude_e` | `src/services/claude_e/mod.rs` | 18 | 18 | 0 |  |
 | `services::claude_e::cancellation` | `src/services/claude_e/cancellation.rs` | 3 | 3 | 0 |  |
 | `services::claude_e::jsonl_parser` | `src/services/claude_e/jsonl_parser.rs` | 4 | 4 | 0 |  |
@@ -438,7 +438,7 @@
 | `services::cswap` | `src/services/cswap.rs` | 887 | 552 | 335 |  |
 | `services::discord` | `src/services/discord/mod.rs` | 5635 | 4165 | 1470 | giant-file |
 | `services::discord::abandon_request_store` | `src/services/discord/abandon_request_store.rs` | 477 | 355 | 122 |  |
-| `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 912 | 845 | 67 |  |
+| `services::discord::adk_session` | `src/services/discord/adk_session.rs` | 944 | 877 | 67 |  |
 | `services::discord::agent_handoff` | `src/services/discord/agent_handoff.rs` | 1078 | 651 | 427 |  |
 | `services::discord::agentdesk_config` | `src/services/discord/agentdesk_config.rs` | 1079 | 978 | 101 |  |
 | `services::discord::answer_flush_barrier` | `src/services/discord/answer_flush_barrier.rs` | 511 | 209 | 302 |  |

--- a/src/services/claude_compact_context.rs
+++ b/src/services/claude_compact_context.rs
@@ -20,7 +20,7 @@ const COMPACT_SAFETY_RESERVE_TOKENS: u64 = 64_000;
 const NATIVE_STANDARD_CONTEXT_WINDOW_TOKENS: u64 = 200_000;
 const ONE_MILLION_CONTEXT_WINDOW_TOKENS: u64 = 1_000_000;
 const CLAUDE_AUTO_COMPACT_MIN_TOKENS: u64 = 100_000;
-const CLAUDE_AUTO_COMPACT_MAX_TOKENS: u64 = 1_000_000;
+pub(crate) const CLAUDE_AUTO_COMPACT_MAX_TOKENS: u64 = 1_000_000;
 const CATALOG_TTL: Duration = Duration::from_secs(5 * 60);
 const LAUNCH_PROVENANCE_TTL: Duration = Duration::from_secs(4 * 60 * 60);
 const MAX_CATALOGS: usize = 32;
@@ -75,6 +75,12 @@ static LAUNCH_PROVENANCE: LazyLock<Mutex<HashMap<String, LaunchProvenanceEntry>>
 static CATALOG_STATE: LazyLock<Mutex<CatalogState>> =
     LazyLock::new(|| Mutex::new(CatalogState::default()));
 static CONTEXT_WINDOW_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TurnWindowResolution {
+    Proven(u64),
+    UnprovenLaunchBound,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct CompactThreshold {
@@ -141,23 +147,25 @@ pub(crate) fn clear_launch_provenance_for_tmux(tmux_session_name: &str) {
         .remove(tmux_session_name.trim());
 }
 
-/// Resolve a live interactive TUI's context window only when the completion
-/// evidence is sufficient to prove it. Launch provenance identifies the
-/// gateway that owns the pane; it is deliberately not a model/window fallback.
-/// Claude completion records canonicalize the selected model and can erase a
-/// `[1m]` choice, so inferring a native 200K window here could compact a 1M
-/// session early. `None` therefore means "do not auto-compact this TUI turn".
+/// Resolve a live interactive TUI's context window from launch-bound evidence.
+/// A fresh, unambiguous catalog hit proves the exact window. Otherwise, known
+/// launch provenance plus a non-empty model permits only the conservative
+/// maximum-window trigger bound. `None` remains reserved for panes without
+/// managed launch provenance or usable model evidence.
 pub(crate) fn context_window_for_turn(
     tmux_session_name: &str,
     current_model: Option<&str>,
-) -> Option<u64> {
+) -> Option<TurnWindowResolution> {
     let launch = launch_provenance_for_tmux(tmux_session_name)?;
     let current_model = current_model.and_then(preserve_model_selector)?;
     match launch.provenance {
         ClaudeLaunchProvenance::Inject { base_url } => {
-            live_catalog_context_window_for_selector(&base_url, &current_model)
+            match live_catalog_context_window_for_selector(&base_url, &current_model) {
+                Some(window) => Some(TurnWindowResolution::Proven(window)),
+                None => Some(TurnWindowResolution::UnprovenLaunchBound),
+            }
         }
-        ClaudeLaunchProvenance::Scrub => None,
+        ClaudeLaunchProvenance::Scrub => Some(TurnWindowResolution::UnprovenLaunchBound),
     }
 }
 
@@ -317,16 +325,37 @@ fn catalog_context_window_for_selector(base_url: &str, model: &str) -> Option<u6
 /// smaller auto-compact threshold for that potentially 1M session.
 fn live_catalog_context_window_for_selector(base_url: &str, model: &str) -> Option<u64> {
     let selector = preserve_model_selector(model)?;
-    let catalog = cached_catalog_and_schedule_refresh(base_url)?;
-    let window = catalog
+    let Some(catalog) = cached_catalog_and_schedule_refresh(base_url) else {
+        tracing::debug!(
+            proxy_url = base_url,
+            %selector,
+            "Claude context-window catalog is cold or stale; using launch-bound fallback"
+        );
+        return None;
+    };
+    let Some(window) = catalog
         .get(&selector)
         .copied()
-        .filter(|window| *window > 0)?;
+        .filter(|window| *window > 0)
+    else {
+        tracing::debug!(
+            proxy_url = base_url,
+            %selector,
+            catalog_key_count = catalog.len(),
+            "Claude context-window selector missed the live catalog; using launch-bound fallback"
+        );
+        return None;
+    };
     if !is_one_m_model_selector(&selector)
         && catalog
             .get(&format!("{selector}[1m]"))
             .is_some_and(|window| *window > 0)
     {
+        tracing::debug!(
+            proxy_url = base_url,
+            %selector,
+            "Claude context-window selector has an ambiguous [1m] sibling; using launch-bound fallback"
+        );
         return None;
     }
     Some(window)
@@ -663,7 +692,7 @@ fn reset_for_test() {
 }
 
 #[cfg(test)]
-fn put_catalog_for_test(proxy_url: &str, windows: HashMap<String, u64>) {
+pub(crate) fn put_catalog_for_test(proxy_url: &str, windows: HashMap<String, u64>) {
     CATALOG_STATE
         .lock()
         .unwrap_or_else(|error| error.into_inner())
@@ -712,6 +741,27 @@ mod tests {
                 threshold.rearm_floor_tokens,
                 expected.saturating_sub(window * 5 / 100)
             );
+        }
+    }
+
+    /// Mutation guard: replacing the unproven trigger bound with any sampled
+    /// smaller window breaks at least one comparison below. The maximum-window
+    /// threshold must never be earlier than the threshold for a supported window.
+    #[test]
+    fn compact_threshold_is_monotonic_through_the_maximum_supported_window() {
+        for percent in [1, 5, 25, 50, 60, 80, 100, 200] {
+            for lower in [1, 100_000, 300_000, 900_000, u64::MAX] {
+                let max = compact_threshold(CLAUDE_AUTO_COMPACT_MAX_TOKENS, percent, lower)
+                    .expect("maximum-window threshold");
+                for window in [64_001, 100_000, 128_000, 200_000, 372_000, 500_000, 999_999] {
+                    let current = compact_threshold(window, percent, lower)
+                        .expect("sampled supported-window threshold");
+                    assert!(
+                        current.effective_tokens <= max.effective_tokens,
+                        "window={window}, percent={percent}, lower={lower}"
+                    );
+                }
+            }
         }
     }
 
@@ -795,23 +845,49 @@ mod tests {
         register_launch_provenance("tmux-a", &gateway);
         assert_eq!(
             context_window_for_turn("tmux-a", Some("routed-sonnet")),
-            None,
-            "a mutable base completion is ambiguous while a fresh [1m] sibling exists"
+            Some(TurnWindowResolution::UnprovenLaunchBound),
+            "an ambiguous mutable completion must use only the maximum-window trigger bound"
         );
         assert_eq!(
             context_window_for_turn("tmux-a", Some("routed-sonnet[1m]")),
-            Some(1_000_000),
+            Some(TurnWindowResolution::Proven(1_000_000)),
             "an explicit [1m] selector must not fall through to its base route"
         );
         assert_eq!(
             context_window_for_turn("tmux-a", Some("claude-sonnet-5")),
-            None,
-            "a canonical completion id cannot prove its live [1m] state without a catalog hit"
+            Some(TurnWindowResolution::UnprovenLaunchBound),
+            "a canonical completion without an exact hit must use only the launch-bound fallback"
         );
         assert_eq!(
             context_window_for_turn("tmux-a", Some("unknown")),
-            None,
-            "a different catalog entry must never become an invented fallback"
+            Some(TurnWindowResolution::UnprovenLaunchBound),
+            "a different catalog entry must never become a falsely proven window"
+        );
+    }
+
+    /// Mutation guard: mapping an exact miss back to `None` reproduces #4678 and
+    /// fails this assertion for a proxy that advertises only suffixed route keys.
+    #[test]
+    fn suffixed_only_catalog_keeps_bare_completion_launch_bound() {
+        let _guard = state_test_guard();
+        let proxy = "http://proxy-suffixed-only.test";
+        put_catalog_for_test(
+            proxy,
+            HashMap::from([
+                ("claude-opus-4-8-hgq".to_string(), 1_000_000),
+                ("claude-opus-4-8-j97".to_string(), 1_000_000),
+            ]),
+        );
+        register_launch_provenance(
+            "tmux-suffixed-only",
+            &ClaudeGatewayProxyEnv::Inject {
+                base_url: proxy.to_string(),
+            },
+        );
+
+        assert_eq!(
+            context_window_for_turn("tmux-suffixed-only", Some("claude-opus-4-8")),
+            Some(TurnWindowResolution::UnprovenLaunchBound)
         );
     }
 
@@ -829,7 +905,7 @@ mod tests {
         // a real catalog rather than using the old 100K fallback.
         assert_eq!(
             context_window_for_turn("tmux-cold-routed", Some("routed-sonnet")),
-            None
+            Some(TurnWindowResolution::UnprovenLaunchBound)
         );
 
         put_catalog_for_test(
@@ -838,7 +914,7 @@ mod tests {
         );
         assert_eq!(
             context_window_for_turn("tmux-cold-routed", Some("routed-sonnet")),
-            Some(372_000)
+            Some(TurnWindowResolution::Proven(372_000))
         );
     }
 
@@ -921,19 +997,19 @@ mod tests {
     }
 
     #[test]
-    fn live_scrub_tui_fails_closed_when_completion_canonicalizes_the_model() {
+    fn live_scrub_tui_uses_launch_bound_fallback_only_with_a_model() {
         let _guard = state_test_guard();
         register_launch_provenance("tmux-native", &ClaudeGatewayProxyEnv::Scrub);
         assert_eq!(context_window_for_turn("tmux-native", None), None);
         assert_eq!(
             context_window_for_turn("tmux-native", Some("sonnet")),
-            None,
-            "a base completion id may represent sonnet[1m], so it cannot arm a 200K trigger"
+            Some(TurnWindowResolution::UnprovenLaunchBound),
+            "a canonicalized base selector must not be falsely proven as a 200K window"
         );
         assert_eq!(
             context_window_for_turn("tmux-native", Some("claude-sonnet-4-6")),
-            None,
-            "launch provenance must not retain a same-family [1m] interpretation"
+            Some(TurnWindowResolution::UnprovenLaunchBound),
+            "scrub provenance plus a model permits only the maximum-window trigger bound"
         );
     }
 

--- a/src/services/claude_compact_context.rs
+++ b/src/services/claude_compact_context.rs
@@ -333,11 +333,7 @@ fn live_catalog_context_window_for_selector(base_url: &str, model: &str) -> Opti
         );
         return None;
     };
-    let Some(window) = catalog
-        .get(&selector)
-        .copied()
-        .filter(|window| *window > 0)
-    else {
+    let Some(window) = catalog.get(&selector).copied().filter(|window| *window > 0) else {
         tracing::debug!(
             proxy_url = base_url,
             %selector,

--- a/src/services/claude_compact_trigger.rs
+++ b/src/services/claude_compact_trigger.rs
@@ -40,7 +40,9 @@
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
-use crate::services::claude_compact_context::{CompactThreshold, compact_threshold};
+use crate::services::claude_compact_context::{
+    CLAUDE_AUTO_COMPACT_MAX_TOKENS, CompactThreshold, TurnWindowResolution, compact_threshold,
+};
 use crate::services::claude_tui::input::CompactSubmitOutcome;
 use crate::services::discord::{ManagedCompactTurnIdentity, live_managed_turn_matches};
 use crate::services::provider::ProviderKind;
@@ -68,6 +70,22 @@ struct PaneArmState {
     generation: u64,
     last_occupied: u64,
     last_window_tokens: u64,
+    last_window_source: Option<CompactWindowSource>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::services) enum CompactWindowSource {
+    Proven,
+    FallbackMax,
+}
+
+impl CompactWindowSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Proven => "proven",
+            Self::FallbackMax => "fallback_max",
+        }
+    }
 }
 
 impl PaneArmState {
@@ -77,6 +95,7 @@ impl PaneArmState {
             generation: 0,
             last_occupied: 0,
             last_window_tokens: 0,
+            last_window_source: None,
         }
     }
 }
@@ -123,6 +142,15 @@ fn observe_and_decide(
     occupied: u64,
     threshold: CompactThreshold,
 ) -> Option<u64> {
+    observe_and_decide_with_source(pane, occupied, threshold, CompactWindowSource::Proven)
+}
+
+fn observe_and_decide_with_source(
+    pane: &CompactPaneKey,
+    occupied: u64,
+    threshold: CompactThreshold,
+    window_source: CompactWindowSource,
+) -> Option<u64> {
     let mut guard = COMPACT_TRIGGER_STATE
         .lock()
         .unwrap_or_else(|error| error.into_inner());
@@ -135,15 +163,18 @@ fn observe_and_decide(
             .entry(pane.clone())
             .or_insert_with(PaneArmState::fresh);
         if entry.last_window_tokens != 0
-            && entry.last_window_tokens != threshold.actual_window_tokens
+            && (entry.last_window_tokens != threshold.actual_window_tokens
+                || entry.last_window_source != Some(window_source))
         {
-            // A model/window switch starts a distinct fill cycle. Invalidate the
-            // prior worker before this observation can consume a fresh generation.
+            // A model/window or proof-source switch starts a distinct fill cycle.
+            // Invalidate the prior worker before this observation can consume a
+            // fresh generation, including fallback-to-proven transitions at 1M.
             entry.armed = true;
             entry.generation = 0;
         }
         entry.last_occupied = occupied;
         entry.last_window_tokens = threshold.actual_window_tokens;
+        entry.last_window_source = Some(window_source);
         entry.armed
     };
     // Re-arm first, independent of the inject check: a post-compact occupancy
@@ -269,6 +300,19 @@ fn submit_under_composer_lock(
     )
 }
 
+fn trigger_window_for_resolution(
+    resolution: Option<TurnWindowResolution>,
+) -> Option<(u64, CompactWindowSource)> {
+    match resolution {
+        None => None,
+        Some(TurnWindowResolution::Proven(window)) => Some((window, CompactWindowSource::Proven)),
+        Some(TurnWindowResolution::UnprovenLaunchBound) => Some((
+            CLAUDE_AUTO_COMPACT_MAX_TOKENS,
+            CompactWindowSource::FallbackMax,
+        )),
+    }
+}
+
 /// Validate and forward one complete active Claude usage snapshot. Missing model,
 /// launch provenance, or any usage component fails closed before pane state exists.
 pub(in crate::services) fn observe_active_usage(
@@ -293,22 +337,40 @@ pub(in crate::services) fn observe_active_usage(
     else {
         return false;
     };
-    let actual_window_tokens = crate::services::claude_compact_context::context_window_for_turn(
+    let occupied = input_tokens
+        .saturating_add(cache_create_tokens)
+        .saturating_add(cache_read_tokens);
+    let resolution = crate::services::claude_compact_context::context_window_for_turn(
         tmux_session_name,
         Some(model),
     );
-    if actual_window_tokens.is_none() {
+    let Some((actual_window_tokens, window_source)) = trigger_window_for_resolution(resolution)
+    else {
+        tracing::debug!(
+            tmux_session_name,
+            model,
+            occupied,
+            "skipping Claude auto compact without launch provenance or model evidence"
+        );
         return false;
+    };
+    if window_source == CompactWindowSource::FallbackMax {
+        tracing::debug!(
+            tmux_session_name,
+            model,
+            occupied,
+            fallback_window_tokens = CLAUDE_AUTO_COMPACT_MAX_TOKENS,
+            "using conservative maximum-window fallback for Claude auto compact"
+        );
     }
-    maybe_inject_compact(
+    maybe_inject_compact_with_source(
         turn_identity,
         provider,
-        input_tokens
-            .saturating_add(cache_create_tokens)
-            .saturating_add(cache_read_tokens),
-        actual_window_tokens,
+        occupied,
+        Some(actual_window_tokens),
         compact_percent,
         lower_bound_tokens,
+        window_source,
     );
     true
 }
@@ -318,9 +380,9 @@ pub(in crate::services) fn observe_active_usage(
 /// the model-aware token threshold this fill cycle.
 ///
 /// `usage_tokens` is the observable occupancy (`context_occupancy_input_tokens`);
-/// `actual_window_tokens` is the launch-provenance-resolved Claude context window
-/// for this turn (`None` when the window cannot be proven — fail closed, never
-/// invent a native fallback). The percentage/lower-bound are combined into an
+/// `actual_window_tokens` is the launch-provenance-resolved trigger window for
+/// this turn: either an exact proven window or the conservative maximum-window
+/// bound selected by the caller. The percentage/lower-bound are combined into an
 /// absolute token threshold each turn, so a model/window change simply changes
 /// the number on the next turn.
 ///
@@ -336,16 +398,39 @@ pub(in crate::services) fn maybe_inject_compact(
     compact_percent: u64,
     lower_bound_tokens: u64,
 ) {
+    maybe_inject_compact_with_source(
+        turn_identity,
+        provider,
+        usage_tokens,
+        actual_window_tokens,
+        compact_percent,
+        lower_bound_tokens,
+        CompactWindowSource::Proven,
+    );
+}
+
+pub(in crate::services) fn maybe_inject_compact_with_source(
+    turn_identity: ManagedCompactTurnIdentity,
+    provider: &ProviderKind,
+    usage_tokens: u64,
+    actual_window_tokens: Option<u64>,
+    compact_percent: u64,
+    lower_bound_tokens: u64,
+    window_source: CompactWindowSource,
+) {
     if !matches!(provider, ProviderKind::Claude) {
         return;
     }
     let channel_id = turn_identity.channel_id();
     let tmux_session_name = turn_identity.tmux_session_name();
-    // A window this turn could not prove is fail-closed to no-inject (the caller
-    // already applied the model-aware [1m] same-family guard). Unresolvable
-    // window / zero-percent degrade safely WITHOUT touching the armed flag, just
-    // like main's `threshold_pct == 0` short-circuit.
+    // Callers map launch-bound but unproven windows to the conservative maximum.
+    // Missing provenance/model and zero-percent still degrade safely WITHOUT
+    // touching the armed flag, like main's `threshold_pct == 0` short-circuit.
     let Some(actual_window_tokens) = actual_window_tokens else {
+        tracing::debug!(
+            tmux_session_name,
+            "skipping Claude auto compact without a resolved trigger window"
+        );
         return;
     };
     let Some(threshold) =
@@ -357,7 +442,9 @@ pub(in crate::services) fn maybe_inject_compact(
         channel_id,
         tmux_session_name: tmux_session_name.to_string(),
     };
-    let Some(generation) = observe_and_decide(&pane, usage_tokens, threshold) else {
+    let Some(generation) =
+        observe_and_decide_with_source(&pane, usage_tokens, threshold, window_source)
+    else {
         return;
     };
 
@@ -383,6 +470,7 @@ pub(in crate::services) fn maybe_inject_compact(
                 tmux_session_name = %pane.tmux_session_name,
                 usage_tokens,
                 threshold_tokens = threshold.effective_tokens,
+                window_source = window_source.as_str(),
                 "Claude auto compact accepted or queued"
             ),
             Some(CompactSubmitOutcome::PreMutationRefused) => {
@@ -529,6 +617,134 @@ mod tests {
             &pane,
             new_generation,
             new_threshold
+        ));
+    }
+
+    /// Mutation guards: mapping a catalog miss back to `None` fails the active
+    /// usage assertions, while lowering the maximum fallback fires at 499K.
+    #[test]
+    fn suffixed_only_catalog_bare_model_fires_at_max_window_threshold_only() {
+        let _context_guard =
+            crate::services::claude_compact_context::state_test_guard();
+        let _trigger_guard = state_test_guard();
+        let proxy = "http://proxy-4678-suffixed-only.test";
+        crate::services::claude_compact_context::put_catalog_for_test(
+            proxy,
+            HashMap::from([
+                ("claude-opus-4-8-hgq".to_string(), 1_000_000),
+                ("claude-opus-4-8-j97".to_string(), 1_000_000),
+            ]),
+        );
+        let gateway = crate::services::claude_gateway_proxy::ClaudeGatewayProxyEnv::Inject {
+            base_url: proxy.to_string(),
+        };
+        crate::services::claude_compact_context::register_launch_provenance(
+            "tmux-4678-high",
+            &gateway,
+        );
+        crate::services::claude_compact_context::register_launch_provenance(
+            "tmux-4678-low",
+            &gateway,
+        );
+
+        let high_resolution =
+            crate::services::claude_compact_context::context_window_for_turn(
+                "tmux-4678-high",
+                Some("claude-opus-4-8"),
+            );
+        let (window, source) =
+            trigger_window_for_resolution(high_resolution).expect("launch-bound trigger window");
+        let threshold = threshold_for(window);
+        let high = CompactPaneKey {
+            channel_id: 42,
+            tmux_session_name: "tmux-4678-high".to_string(),
+        };
+        assert!(observe_and_decide_with_source(&high, 552_000, threshold, source).is_some());
+
+        let low_resolution =
+            crate::services::claude_compact_context::context_window_for_turn(
+                "tmux-4678-low",
+                Some("claude-opus-4-8"),
+            );
+        let (window, source) =
+            trigger_window_for_resolution(low_resolution).expect("launch-bound trigger window");
+        let low = CompactPaneKey {
+            channel_id: 42,
+            tmux_session_name: "tmux-4678-low".to_string(),
+        };
+        assert!(
+            observe_and_decide_with_source(&low, 499_000, threshold_for(window), source).is_none()
+        );
+        assert_eq!(armed_state(&low), Some(true));
+        assert_eq!(last_window_tokens(&low), Some(CLAUDE_AUTO_COMPACT_MAX_TOKENS));
+    }
+
+    /// Mutation guard: replacing the conservative 1M fallback with a native 200K
+    /// window makes the 350K assertion inject early.
+    #[test]
+    fn scrub_fallback_never_uses_a_small_native_trigger() {
+        let _guard = state_test_guard();
+        let (window, source) = trigger_window_for_resolution(Some(
+            TurnWindowResolution::UnprovenLaunchBound,
+        ))
+        .expect("scrub launch-bound fallback");
+        let threshold = threshold_for(window);
+        for (channel_id, occupied) in [(42, 199_000), (43, 350_000)] {
+            let pane = CompactPaneKey {
+                channel_id,
+                tmux_session_name: format!("tmux-scrub-{occupied}"),
+            };
+            assert!(
+                observe_and_decide_with_source(&pane, occupied, threshold, source).is_none()
+            );
+        }
+    }
+
+    /// Mutation guard: routing a proven exact hit through the 1M fallback makes
+    /// the 350K crossing miss its 372K-window threshold.
+    #[test]
+    fn proven_window_takes_priority_over_maximum_fallback() {
+        let _guard = state_test_guard();
+        let (window, source) = trigger_window_for_resolution(Some(
+            TurnWindowResolution::Proven(372_000),
+        ))
+        .expect("proven exact hit");
+        assert_eq!(source, CompactWindowSource::Proven);
+        assert!(observe_and_decide_with_source(&pane(), 350_000, threshold_for(window), source)
+            .is_some());
+    }
+
+    /// Mutation guard: ignoring proof source when the numeric window remains 1M
+    /// lets the fallback worker survive and prevents a fresh proven generation.
+    #[test]
+    fn fallback_to_proven_transition_invalidates_old_generation() {
+        let _guard = state_test_guard();
+        let pane = pane();
+        let threshold = threshold_for(CLAUDE_AUTO_COMPACT_MAX_TOKENS);
+        let old_generation = observe_and_decide_with_source(
+            &pane,
+            552_000,
+            threshold,
+            CompactWindowSource::FallbackMax,
+        )
+        .expect("fallback crossing");
+        let new_generation = observe_and_decide_with_source(
+            &pane,
+            552_000,
+            threshold,
+            CompactWindowSource::Proven,
+        )
+        .expect("proven crossing starts a fresh generation");
+        assert_ne!(old_generation, new_generation);
+        assert!(!pane_still_disarmed_for_send(
+            &pane,
+            old_generation,
+            threshold
+        ));
+        assert!(pane_still_disarmed_for_send(
+            &pane,
+            new_generation,
+            threshold
         ));
     }
 

--- a/src/services/claude_compact_trigger.rs
+++ b/src/services/claude_compact_trigger.rs
@@ -624,8 +624,7 @@ mod tests {
     /// usage assertions, while lowering the maximum fallback fires at 499K.
     #[test]
     fn suffixed_only_catalog_bare_model_fires_at_max_window_threshold_only() {
-        let _context_guard =
-            crate::services::claude_compact_context::state_test_guard();
+        let _context_guard = crate::services::claude_compact_context::state_test_guard();
         let _trigger_guard = state_test_guard();
         let proxy = "http://proxy-4678-suffixed-only.test";
         crate::services::claude_compact_context::put_catalog_for_test(
@@ -647,11 +646,10 @@ mod tests {
             &gateway,
         );
 
-        let high_resolution =
-            crate::services::claude_compact_context::context_window_for_turn(
-                "tmux-4678-high",
-                Some("claude-opus-4-8"),
-            );
+        let high_resolution = crate::services::claude_compact_context::context_window_for_turn(
+            "tmux-4678-high",
+            Some("claude-opus-4-8"),
+        );
         let (window, source) =
             trigger_window_for_resolution(high_resolution).expect("launch-bound trigger window");
         let threshold = threshold_for(window);
@@ -661,11 +659,10 @@ mod tests {
         };
         assert!(observe_and_decide_with_source(&high, 552_000, threshold, source).is_some());
 
-        let low_resolution =
-            crate::services::claude_compact_context::context_window_for_turn(
-                "tmux-4678-low",
-                Some("claude-opus-4-8"),
-            );
+        let low_resolution = crate::services::claude_compact_context::context_window_for_turn(
+            "tmux-4678-low",
+            Some("claude-opus-4-8"),
+        );
         let (window, source) =
             trigger_window_for_resolution(low_resolution).expect("launch-bound trigger window");
         let low = CompactPaneKey {
@@ -676,7 +673,10 @@ mod tests {
             observe_and_decide_with_source(&low, 499_000, threshold_for(window), source).is_none()
         );
         assert_eq!(armed_state(&low), Some(true));
-        assert_eq!(last_window_tokens(&low), Some(CLAUDE_AUTO_COMPACT_MAX_TOKENS));
+        assert_eq!(
+            last_window_tokens(&low),
+            Some(CLAUDE_AUTO_COMPACT_MAX_TOKENS)
+        );
     }
 
     /// Mutation guard: replacing the conservative 1M fallback with a native 200K
@@ -684,19 +684,16 @@ mod tests {
     #[test]
     fn scrub_fallback_never_uses_a_small_native_trigger() {
         let _guard = state_test_guard();
-        let (window, source) = trigger_window_for_resolution(Some(
-            TurnWindowResolution::UnprovenLaunchBound,
-        ))
-        .expect("scrub launch-bound fallback");
+        let (window, source) =
+            trigger_window_for_resolution(Some(TurnWindowResolution::UnprovenLaunchBound))
+                .expect("scrub launch-bound fallback");
         let threshold = threshold_for(window);
         for (channel_id, occupied) in [(42, 199_000), (43, 350_000)] {
             let pane = CompactPaneKey {
                 channel_id,
                 tmux_session_name: format!("tmux-scrub-{occupied}"),
             };
-            assert!(
-                observe_and_decide_with_source(&pane, occupied, threshold, source).is_none()
-            );
+            assert!(observe_and_decide_with_source(&pane, occupied, threshold, source).is_none());
         }
     }
 
@@ -705,13 +702,14 @@ mod tests {
     #[test]
     fn proven_window_takes_priority_over_maximum_fallback() {
         let _guard = state_test_guard();
-        let (window, source) = trigger_window_for_resolution(Some(
-            TurnWindowResolution::Proven(372_000),
-        ))
-        .expect("proven exact hit");
+        let (window, source) =
+            trigger_window_for_resolution(Some(TurnWindowResolution::Proven(372_000)))
+                .expect("proven exact hit");
         assert_eq!(source, CompactWindowSource::Proven);
-        assert!(observe_and_decide_with_source(&pane(), 350_000, threshold_for(window), source)
-            .is_some());
+        assert!(
+            observe_and_decide_with_source(&pane(), 350_000, threshold_for(window), source)
+                .is_some()
+        );
     }
 
     /// Mutation guard: ignoring proof source when the numeric window remains 1M
@@ -728,13 +726,9 @@ mod tests {
             CompactWindowSource::FallbackMax,
         )
         .expect("fallback crossing");
-        let new_generation = observe_and_decide_with_source(
-            &pane,
-            552_000,
-            threshold,
-            CompactWindowSource::Proven,
-        )
-        .expect("proven crossing starts a fresh generation");
+        let new_generation =
+            observe_and_decide_with_source(&pane, 552_000, threshold, CompactWindowSource::Proven)
+                .expect("proven crossing starts a fresh generation");
         assert_ne!(old_generation, new_generation);
         assert!(!pane_still_disarmed_for_send(
             &pane,

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -858,7 +858,7 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
     // today's live config. Keep the provider fallback for panel display when a
     // legacy/unregistered pane cannot prove launch provenance, but never use it
     // to drive the authoritative compact trigger.
-    let claude_launch_window = matches!(provider, ProviderKind::Claude)
+    let claude_window_resolution = matches!(provider, ProviderKind::Claude)
         .then(|| {
             crate::services::claude_compact_context::context_window_for_turn(
                 tmux_session_name,
@@ -866,6 +866,26 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
             )
         })
         .flatten();
+    let claude_launch_window = match claude_window_resolution {
+        Some(crate::services::claude_compact_context::TurnWindowResolution::Proven(window)) => {
+            Some(window)
+        }
+        _ => None,
+    };
+    let claude_trigger_window = claude_window_resolution.map(|resolution| match resolution {
+        crate::services::claude_compact_context::TurnWindowResolution::Proven(window) => window,
+        crate::services::claude_compact_context::TurnWindowResolution::UnprovenLaunchBound => {
+            crate::services::claude_compact_context::CLAUDE_AUTO_COMPACT_MAX_TOKENS
+        }
+    });
+    let compact_window_source = claude_window_resolution.map(|resolution| match resolution {
+        crate::services::claude_compact_context::TurnWindowResolution::Proven(_) => {
+            crate::services::claude_compact_trigger::CompactWindowSource::Proven
+        }
+        crate::services::claude_compact_context::TurnWindowResolution::UnprovenLaunchBound => {
+            crate::services::claude_compact_trigger::CompactWindowSource::FallbackMax
+        }
+    });
     let context_window = claude_launch_window
         .unwrap_or_else(|| provider.resolve_context_window(state.last_model.as_deref()));
     let ctx_cfg = fetch_context_thresholds(shared.api_port).await;
@@ -890,23 +910,35 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
     }
 
     // The token trigger runs even when `occupied == 0`: a post-compact usage
-    // reset is the observable re-arm signal handled inside the trigger. It is
-    // deliberately gated on a proven launch-bound Claude window
-    // (`claude_launch_window`), rather than inventing a live-config fallback, so
-    // a window this turn cannot prove fails closed to no-inject. Idempotency is
-    // keyed on the observable USAGE occupancy (`occupied`), never on a cosmetic
-    // `auto_compacted` string heuristic.
+    // reset is the observable re-arm signal handled inside the trigger. Exact
+    // catalog evidence uses the proven window; launch-bound but unproven panes use
+    // the conservative maximum-window threshold. Missing provenance/model remains
+    // a no-op. Idempotency is keyed on observable USAGE occupancy (`occupied`),
+    // never on a cosmetic `auto_compacted` string heuristic.
     if matches!(provider, ProviderKind::Claude)
         && let Some(turn_identity) =
             super::ManagedCompactTurnIdentity::capture_live(channel_id.get(), tmux_session_name)
     {
-        crate::services::claude_compact_trigger::maybe_inject_compact(
-            turn_identity,
-            provider,
-            occupied,
-            claude_launch_window,
-            compact_pct,
-            ctx_cfg.compact_lower_bound_tokens,
-        );
+        match compact_window_source {
+            Some(window_source) => {
+                crate::services::claude_compact_trigger::maybe_inject_compact_with_source(
+                    turn_identity,
+                    provider,
+                    occupied,
+                    claude_trigger_window,
+                    compact_pct,
+                    ctx_cfg.compact_lower_bound_tokens,
+                    window_source,
+                );
+            }
+            None => crate::services::claude_compact_trigger::maybe_inject_compact(
+                turn_identity,
+                provider,
+                occupied,
+                None,
+                compact_pct,
+                ctx_cfg.compact_lower_bound_tokens,
+            ),
+        }
     }
 }


### PR DESCRIPTION
## 문제
opencodex 게이트웨이 프록시로 뜬 Claude 세션에서 auto-compact가 **구조적으로 영구 미발사**. 프록시 카탈로그는 suffixed 키(`claude-opus-4-8-hgq` 등)만 광고하는데 완료 이벤트 model은 bare `claude-opus-4-8` → `context_window_for_turn` exact-match miss → None → `observe_active_usage` silent `return false`. 선행 fix #4652(트리거 도입)·#4667(turn_source 게이트)은 상위 레이어만 고쳤고 셀렉터 어휘 불일치가 잔존.

## Fix — max-window conservative threshold fallback
`context_window_for_turn` 반환을 3분화: `Proven(w)`(카탈로그 exact) / `UnprovenLaunchBound`(provenance+model 있으나 창 미증명) / `None`(부재). Inject miss/cold/[1m]-ambiguity + Scrub → Unproven → 트리거가 1M(MAX) 창으로 threshold 계산해 발사.

**불변식 보존**: `compact_threshold`가 창 w에 단조 비감소 → effective(w) ≤ effective(1M). occupancy ≥ 500K면 실창이 무엇이든(≤1M) 조기압축 불가(occupancy는 실창 초과 못 하므로 500K 초과 = 실창>500K 증거). #4652의 '1M 세션 조기압축 금지' 보존.

부수효과: 네이티브(Scrub) 세션 서버측 compact도 구제. silent였던 2경로 로깅 봉인, 발사 로그에 window_source 필드.

## 테스트
신규 뮤테이션 6건(본버그 재현/Scrub 조기압축 금지/단조성/Proven 우선/generation 무효화/None 보존) + 기존 4건 갱신. 로컬 게이트: check --workspace --all-targets✓, test✓(37), fmt✓, agent-maintenance freshness✓, audit✓.

Closes #4678