### PR TITLE
refactor(4228): adopt AppError in skills_api and reviews routes

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -305,7 +305,7 @@
 | `server::routes::review_verdict::decision_route` | `src/server/routes/review_verdict/decision_route.rs` | 56 | 56 | 0 |  |
 | `server::routes::review_verdict::tuning_aggregate` | `src/server/routes/review_verdict/tuning_aggregate.rs` | 14 | 14 | 0 |  |
 | `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 702 | 638 | 64 |  |
-| `server::routes::reviews` | `src/server/routes/reviews.rs` | 760 | 671 | 89 |  |
+| `server::routes::reviews` | `src/server/routes/reviews.rs` | 733 | 644 | 89 |  |
 | `server::routes::routines` | `src/server/routes/routines.rs` | 252 | 154 | 98 |  |
 | `server::routes::routines::audit` | `src/server/routes/routines/audit.rs` | 190 | 115 | 75 |  |
 | `server::routes::routines::handlers` | `src/server/routes/routines/handlers.rs` | 501 | 501 | 0 |  |
@@ -315,7 +315,7 @@
 | `server::routes::session_activity` | `src/server/routes/session_activity.rs` | 13 | 13 | 0 |  |
 | `server::routes::settings` | `src/server/routes/settings.rs` | 91 | 91 | 0 |  |
 | `server::routes::skill_usage_analytics` | `src/server/routes/skill_usage_analytics.rs` | 425 | 425 | 0 |  |
-| `server::routes::skills_api` | `src/server/routes/skills_api.rs` | 684 | 684 | 0 |  |
+| `server::routes::skills_api` | `src/server/routes/skills_api.rs` | 640 | 640 | 0 |  |
 | `server::routes::stats` | `src/server/routes/stats.rs` | 722 | 589 | 133 |  |
 | `server::routes::termination_events` | `src/server/routes/termination_events.rs` | 152 | 152 | 0 |  |
 | `server::routes::tests::preflight_harness::types` | `src/server/routes/tests/preflight_harness/types.rs` | 217 | 0 | 217 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -152,8 +152,8 @@
 | `POST` | `/api/kanban-repos` | `kanban_repos::create_repo` | `src/server/routes/kanban_repos.rs:76` | `src/server/routes/domains/kanban.rs:52` |
 | `DELETE` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::delete_repo` | `src/server/routes/kanban_repos.rs:207` | `src/server/routes/domains/kanban.rs:56` |
 | `PATCH` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::update_repo` | `src/server/routes/kanban_repos.rs:139` | `src/server/routes/domains/kanban.rs:56` |
-| `PATCH` | `/api/kanban-reviews/{id}/decisions` | `reviews::update_decisions` | `src/server/routes/reviews.rs:573` | `src/server/routes/domains/reviews.rs:13` |
-| `POST` | `/api/kanban-reviews/{id}/trigger-rework` | `reviews::trigger_rework` | `src/server/routes/reviews.rs:627` | `src/server/routes/domains/reviews.rs:17` |
+| `PATCH` | `/api/kanban-reviews/{id}/decisions` | `reviews::update_decisions` | `src/server/routes/reviews.rs:576` | `src/server/routes/domains/reviews.rs:13` |
+| `POST` | `/api/kanban-reviews/{id}/trigger-rework` | `reviews::trigger_rework` | `src/server/routes/reviews.rs:619` | `src/server/routes/domains/reviews.rs:17` |
 | `GET` | `/api/machine-status` | `analytics::machine_status` | `src/server/routes/analytics.rs:496` | `src/server/routes/domains/admin.rs:77` |
 | `GET` | `/api/maintenance/jobs` | `maintenance::list_jobs` | `src/server/routes/maintenance.rs:7` | `src/server/routes/domains/ops.rs:229` |
 | `POST` | `/api/memory/forget` | `memory_api::memory_forget` | `src/server/routes/memory_api.rs:214` | `src/server/routes/domains/agents.rs:54` |
@@ -227,7 +227,7 @@
 | `GET` | `/api/rate-limits` | `analytics::rate_limits` | `src/server/routes/analytics.rs:504` | `src/server/routes/domains/admin.rs:78` |
 | `GET` | `/api/receipt` | `receipt::get_receipt` | `src/server/routes/receipt.rs:335` | `src/server/routes/domains/analytics.rs:18` |
 | `POST` | `/api/reviews/decision` | `review_verdict::submit_review_decision` | `src/server/routes/review_verdict/decision_route.rs:45` | `src/server/routes/domains/reviews.rs:23` |
-| `POST` | `/api/reviews/recovery` | `reviews::recover_review_target` | `src/server/routes/reviews.rs:609` | `src/server/routes/domains/reviews.rs:21` |
+| `POST` | `/api/reviews/recovery` | `reviews::recover_review_target` | `src/server/routes/reviews.rs:604` | `src/server/routes/domains/reviews.rs:21` |
 | `POST` | `/api/reviews/tuning/aggregate` | `review_verdict::aggregate_review_tuning` | `src/server/routes/review_verdict/tuning_aggregate.rs:10` | `src/server/routes/domains/reviews.rs:27` |
 | `POST` | `/api/reviews/verdict` | `review_verdict::submit_verdict` | `src/server/routes/review_verdict/verdict_route.rs:273` | `src/server/routes/domains/reviews.rs:22` |
 | `GET` | `/api/round-table-meetings` | `meetings::list_meetings` | `src/server/routes/meetings.rs:519` | `src/server/routes/domains/integrations.rs:55` |
@@ -277,9 +277,9 @@
 | `GET` | `/api/settings/runtime-config` | `settings::get_runtime_config` | `src/server/routes/settings.rs:63` | `src/server/routes/domains/admin.rs:56` |
 | `PUT` | `/api/settings/runtime-config` | `settings::put_runtime_config` | `src/server/routes/settings.rs:83` | `src/server/routes/domains/admin.rs:56` |
 | `GET` | `/api/skills-trend` | `analytics::skills_trend` | `src/server/routes/analytics.rs:517` | `src/server/routes/domains/admin.rs:80` |
-| `GET` | `/api/skills/catalog` | `skills_api::catalog` | `src/server/routes/skills_api.rs:351` | `src/server/routes/domains/ops.rs:225` |
-| `POST` | `/api/skills/prune` | `skills_api::prune` | `src/server/routes/skills_api.rs:642` | `src/server/routes/domains/ops.rs:227` |
-| `GET` | `/api/skills/ranking` | `skills_api::ranking` | `src/server/routes/skills_api.rs:470` | `src/server/routes/domains/ops.rs:226` |
+| `GET` | `/api/skills/catalog` | `skills_api::catalog` | `src/server/routes/skills_api.rs:352` | `src/server/routes/domains/ops.rs:225` |
+| `POST` | `/api/skills/prune` | `skills_api::prune` | `src/server/routes/skills_api.rs:604` | `src/server/routes/domains/ops.rs:227` |
+| `GET` | `/api/skills/ranking` | `skills_api::ranking` | `src/server/routes/skills_api.rs:454` | `src/server/routes/domains/ops.rs:226` |
 | `GET` | `/api/stats` | `stats::get_stats` | `src/server/routes/stats.rs:500` | `src/server/routes/domains/admin.rs:46` |
 | `GET` | `/api/stats/memento` | `stats::get_memento_stats` | `src/server/routes/stats.rs:520` | `src/server/routes/domains/admin.rs:47` |
 | `GET` | `/api/streaks` | `analytics::streaks` | `src/server/routes/analytics.rs:409` | `src/server/routes/domains/analytics.rs:15` |

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 use serde_json::json;
 use sqlx::Row;
 
-use crate::services as services_layer;
+use crate::{
+    error::{AppError, AppResult, ErrorCode},
+    services as services_layer,
+};
 
 use super::AppState;
 // #3863: reuse the verdict route's hardened SHA guard so the recovery route
@@ -574,84 +577,65 @@ pub async fn update_decisions(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(body): Json<UpdateDecisionsBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     for item in &body.decisions {
         if !validate_review_decision(&item.decision) {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    json!({"error": format!("invalid decision '{}', must be 'accept' or 'reject'", item.decision)}),
-                ),
-            );
+            return Err(AppError::bad_request(format!(
+                "invalid decision '{}', must be 'accept' or 'reject'",
+                item.decision
+            )));
         }
     }
 
     let Some(pg_pool) = state.pg_pool_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "postgres pool unavailable"})),
+        return Err(
+            AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database)
         );
     };
 
-    match update_decisions_pg(pg_pool, &id, &body.decisions).await {
-        Ok(decisions) => (
-            StatusCode::OK,
-            Json(json!({"review": {"dispatch_id": id, "decisions": decisions}})),
-        ),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": error})),
-        ),
-    }
+    let decisions = update_decisions_pg(pg_pool, &id, &body.decisions)
+        .await
+        .map_err(|error| AppError::internal(error).with_code(ErrorCode::Database))?;
+    Ok((
+        StatusCode::OK,
+        Json(json!({"review": {"dispatch_id": id, "decisions": decisions}})),
+    ))
 }
 
 /// POST /api/reviews/recovery
 pub async fn recover_review_target(
     State(state): State<AppState>,
     Json(body): Json<ReviewTargetRecoveryBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pg_pool) = state.pg_pool_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "postgres pool unavailable"})),
+        return Err(
+            AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database)
         );
     };
 
-    match recover_review_target_pg(pg_pool, body).await {
-        Ok(value) => (StatusCode::OK, Json(value)),
-        Err((status, error)) => (status, Json(json!({"error": error}))),
-    }
+    let value = recover_review_target_pg(pg_pool, body)
+        .await
+        .map_err(|(status, error)| AppError::new(status, ErrorCode::Validation, error))?;
+    Ok((StatusCode::OK, Json(value)))
 }
 
 /// POST /api/kanban-reviews/:id/trigger-rework
 pub async fn trigger_rework(
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pg_pool) = state.pg_pool_ref() else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "postgres pool unavailable"})),
+        return Err(
+            AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database)
         );
     };
 
-    let card_id = match resolve_review_card_id_pg(pg_pool, &id).await {
-        Ok(Some(card_id)) => card_id,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": "review or dispatch not found"})),
-            );
-        }
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": error})),
-            );
-        }
-    };
+    let card_id = resolve_review_card_id_pg(pg_pool, &id)
+        .await
+        .map_err(|error| AppError::internal(error).with_code(ErrorCode::Database))?
+        .ok_or_else(|| AppError::not_found("review or dispatch not found"))?;
 
-    match crate::kanban::transition_status_with_opts_pg_only(
+    crate::kanban::transition_status_with_opts_pg_only(
         pg_pool,
         &state.engine,
         &card_id,
@@ -660,13 +644,8 @@ pub async fn trigger_rework(
         crate::engine::transition::ForceIntent::OperatorOverride,
     )
     .await
-    {
-        Ok(_) => (StatusCode::OK, Json(json!({"ok": true}))),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{e}")})),
-        ),
-    }
+    .map_err(|error| AppError::internal(format!("{error}")))?;
+    Ok((StatusCode::OK, Json(json!({"ok": true}))))
 }
 
 #[cfg(test)]

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -588,9 +588,7 @@ pub async fn update_decisions(
     }
 
     let Some(pg_pool) = state.pg_pool_ref() else {
-        return Err(
-            AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database)
-        );
+        return Err(AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database));
     };
 
     let decisions = update_decisions_pg(pg_pool, &id, &body.decisions)
@@ -608,9 +606,7 @@ pub async fn recover_review_target(
     Json(body): Json<ReviewTargetRecoveryBody>,
 ) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pg_pool) = state.pg_pool_ref() else {
-        return Err(
-            AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database)
-        );
+        return Err(AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database));
     };
 
     let value = recover_review_target_pg(pg_pool, body)
@@ -625,9 +621,7 @@ pub async fn trigger_rework(
     Path(id): Path<String>,
 ) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pg_pool) = state.pg_pool_ref() else {
-        return Err(
-            AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database)
-        );
+        return Err(AppError::internal("postgres pool unavailable").with_code(ErrorCode::Database));
     };
 
     let card_id = resolve_review_card_id_pg(pg_pool, &id)

--- a/src/server/routes/skills_api.rs
+++ b/src/server/routes/skills_api.rs
@@ -20,6 +20,7 @@ use super::{
         collect_direct_skill_usage_summary_pg,
     },
 };
+use crate::error::{AppError, AppResult, ErrorCode};
 
 fn skill_description_from_markdown(content: &str) -> String {
     content
@@ -352,22 +353,17 @@ pub struct SkillCatalogQuery {
 pub async fn catalog(
     State(state): State<AppState>,
     Query(params): Query<SkillCatalogQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return (
+        return Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+            ErrorCode::Database,
+            "postgres pool unavailable",
+        ));
     };
-    let disk_skill_ids = match sync_skills_from_disk_pg(pool).await {
-        Ok(ids) => ids,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("skill sync failed: {e}")})),
-            );
-        }
-    };
+    let disk_skill_ids = sync_skills_from_disk_pg(pool).await.map_err(|error| {
+        AppError::internal(format!("skill sync failed: {error}")).with_code(ErrorCode::Database)
+    })?;
     let include_stale = params.include_stale.unwrap_or(false);
     // Dashboard catalog requests should stay cheap. Use the canonical
     // skill_usage table instead of reparsing large transcript JSON on every
@@ -376,24 +372,12 @@ pub async fn catalog(
         load_skill_metadata_pg(pool),
         collect_direct_skill_usage_summary_pg(pool, None),
     );
-    let metadata = match metadata_result {
-        Ok(data) => data,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("metadata query failed: {e}")})),
-            );
-        }
-    };
-    let usage = match usage_result {
-        Ok(data) => data,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("usage query failed: {e}")})),
-            );
-        }
-    };
+    let metadata = metadata_result.map_err(|error| {
+        AppError::internal(format!("metadata query failed: {error}")).with_code(ErrorCode::Database)
+    })?;
+    let usage = usage_result.map_err(|error| {
+        AppError::internal(format!("usage query failed: {error}")).with_code(ErrorCode::Database)
+    })?;
     let totals = aggregate_usage_summaries(usage);
     let known_ids: HashSet<String> = metadata.keys().cloned().collect();
 
@@ -450,13 +434,13 @@ pub async fn catalog(
             })
     });
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "catalog": catalog,
             "include_stale": include_stale,
         })),
-    )
+    ))
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -470,22 +454,17 @@ pub struct RankingQuery {
 pub async fn ranking(
     State(state): State<AppState>,
     Query(params): Query<RankingQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return (
+        return Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+            ErrorCode::Database,
+            "postgres pool unavailable",
+        ));
     };
-    let disk_skill_ids = match sync_skills_from_disk_pg(pool).await {
-        Ok(ids) => ids,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("skill sync failed: {e}")})),
-            );
-        }
-    };
+    let disk_skill_ids = sync_skills_from_disk_pg(pool).await.map_err(|error| {
+        AppError::internal(format!("skill sync failed: {error}")).with_code(ErrorCode::Database)
+    })?;
 
     let window = params.window.as_deref().unwrap_or("7d");
     let limit = params.limit.unwrap_or(20);
@@ -499,33 +478,16 @@ pub async fn ranking(
         collect_direct_skill_usage_summary_pg(pool, days),
         collect_direct_agent_skill_usage_summary_pg(pool, days),
     );
-    let metadata = match metadata_result {
-        Ok(data) => data,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("metadata query failed: {e}")})),
-            );
-        }
-    };
-    let usage = match usage_result {
-        Ok(data) => data,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("usage query failed: {e}")})),
-            );
-        }
-    };
-    let by_agent_usage = match by_agent_usage_result {
-        Ok(data) => data,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("agent usage query failed: {e}")})),
-            );
-        }
-    };
+    let metadata = metadata_result.map_err(|error| {
+        AppError::internal(format!("metadata query failed: {error}")).with_code(ErrorCode::Database)
+    })?;
+    let usage = usage_result.map_err(|error| {
+        AppError::internal(format!("usage query failed: {error}")).with_code(ErrorCode::Database)
+    })?;
+    let by_agent_usage = by_agent_usage_result.map_err(|error| {
+        AppError::internal(format!("agent usage query failed: {error}"))
+            .with_code(ErrorCode::Database)
+    })?;
 
     let mut overall = aggregate_usage_summaries(usage)
         .into_iter()
@@ -622,7 +584,7 @@ pub async fn ranking(
     });
     by_agent.truncate(100);
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "window": window,
@@ -630,7 +592,7 @@ pub async fn ranking(
             "overall": overall,
             "byAgent": by_agent,
         })),
-    )
+    ))
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -642,35 +604,29 @@ pub struct PruneSkillsQuery {
 pub async fn prune(
     State(state): State<AppState>,
     Query(params): Query<PruneSkillsQuery>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let Some(pool) = state.pg_pool_ref() else {
-        return (
+        return Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
+            ErrorCode::Database,
+            "postgres pool unavailable",
+        ));
     };
 
     let dry_run = params.dry_run.unwrap_or(false);
-    let disk_skill_ids = match sync_skills_from_disk_with_prune_pg(pool, !dry_run).await {
-        Ok(ids) => ids,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("skill sync failed: {e}")})),
-            );
-        }
-    };
-    let stale_skill_ids = match load_stale_skill_ids_pg(pool, &disk_skill_ids).await {
-        Ok(ids) => ids,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("stale skill query failed: {e}")})),
-            );
-        }
-    };
+    let disk_skill_ids = sync_skills_from_disk_with_prune_pg(pool, !dry_run)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!("skill sync failed: {error}")).with_code(ErrorCode::Database)
+        })?;
+    let stale_skill_ids = load_stale_skill_ids_pg(pool, &disk_skill_ids)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!("stale skill query failed: {error}"))
+                .with_code(ErrorCode::Database)
+        })?;
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "ok": true,
@@ -680,5 +636,5 @@ pub async fn prune(
             "soft_deleted_from_skills": if dry_run { 0 } else { stale_skill_ids.len() },
             "skill_usage_policy": "preserved",
         })),
-    )
+    ))
 }


### PR DESCRIPTION
#4228 apperror batch. skills_api.rs(catalog/ranking/prune)+reviews.rs(update_decisions/recover_review_target/trigger_rework) raw error JSON→AppError. 계약보존: status·top-level error 불변, 부가필드 없는 단일-error 분기만 전환. gate: check --all-targets✓ test✓(reviews 5) fresh✓ audit✓. Part of #4228