### PR TITLE
refactor(4228): adopt AppError in github and provider_cli_api routes

### DIFF
--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -45,7 +45,7 @@
 | --- | ---: |
 | `src/cli/client.rs` | 2464 |
 | `src/cli/dcserver.rs` | 1650 |
-| `src/cli/direct.rs` | 1767 |
+| `src/cli/direct.rs` | 1771 |
 | `src/cli/doctor/orchestrator.rs` | 4381 |
 | `src/cli/init.rs` | 1444 |
 | `src/cli/migrate/apply.rs` | 3237 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -61,7 +61,7 @@
 | `cli::client::runtime_config` | `src/cli/client/runtime_config.rs` | 55 | 23 | 32 |  |
 | `cli::dcserver` | `src/cli/dcserver.rs` | 1650 | 1650 | 0 | giant-file |
 | `cli::dcserver_pg_bootstrap` | `src/cli/dcserver_pg_bootstrap.rs` | 1068 | 544 | 524 |  |
-| `cli::direct` | `src/cli/direct.rs` | 1767 | 1767 | 0 | giant-file |
+| `cli::direct` | `src/cli/direct.rs` | 1771 | 1771 | 0 | giant-file |
 | `cli::discord` | `src/cli/discord.rs` | 472 | 249 | 223 |  |
 | `cli::discord_thread_create` | `src/cli/discord_thread_create.rs` | 1468 | 415 | 1053 |  |
 | `cli::discord_thread_create_lock` | `src/cli/discord_thread_create_lock.rs` | 669 | 611 | 58 |  |
@@ -278,7 +278,7 @@
 | `server::routes::domains::ops` | `src/server/routes/domains/ops.rs` | 369 | 369 | 0 |  |
 | `server::routes::domains::reviews` | `src/server/routes/domains/reviews.rs` | 33 | 33 | 0 |  |
 | `server::routes::escalation` | `src/server/routes/escalation.rs` | 1644 | 1379 | 265 | giant-file |
-| `server::routes::github` | `src/server/routes/github.rs` | 949 | 680 | 269 |  |
+| `server::routes::github` | `src/server/routes/github.rs` | 940 | 663 | 277 |  |
 | `server::routes::github_dashboard` | `src/server/routes/github_dashboard.rs` | 190 | 190 | 0 |  |
 | `server::routes::health_api` | `src/server/routes/health_api.rs` | 2701 | 1775 | 926 | giant-file |
 | `server::routes::home_metrics` | `src/server/routes/home_metrics.rs` | 352 | 352 | 0 |  |
@@ -297,7 +297,7 @@
 | `server::routes::pipeline` | `src/server/routes/pipeline.rs` | 353 | 353 | 0 |  |
 | `server::routes::pr_summary` | `src/server/routes/pr_summary.rs` | 241 | 142 | 99 |  |
 | `server::routes::prompt_manifest_retention` | `src/server/routes/prompt_manifest_retention.rs` | 57 | 57 | 0 |  |
-| `server::routes::provider_cli_api` | `src/server/routes/provider_cli_api.rs` | 386 | 386 | 0 |  |
+| `server::routes::provider_cli_api` | `src/server/routes/provider_cli_api.rs` | 369 | 369 | 0 |  |
 | `server::routes::queue_api` | `src/server/routes/queue_api.rs` | 430 | 381 | 49 |  |
 | `server::routes::receipt` | `src/server/routes/receipt.rs` | 813 | 500 | 313 |  |
 | `server::routes::resume` | `src/server/routes/resume.rs` | 1260 | 1260 | 0 | giant-file |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -110,12 +110,12 @@
 | `GET` | `/api/github-issues` | `github_dashboard::list_issues` | `src/server/routes/github_dashboard.rs:61` | `src/server/routes/domains/integrations.rs:36` |
 | `PATCH` | `/api/github-issues/{owner}/{repo}/{number}/close` | `github_dashboard::close_issue` | `src/server/routes/github_dashboard.rs:104` | `src/server/routes/domains/integrations.rs:37` |
 | `GET` | `/api/github-repos` | `github_dashboard::list_repos` | `src/server/routes/github_dashboard.rs:27` | `src/server/routes/domains/integrations.rs:35` |
-| `POST` | `/api/github/issues/create` | `github::create_issue` | `src/server/routes/github.rs:299` | `src/server/routes/domains/integrations.rs:24` |
+| `POST` | `/api/github/issues/create` | `github::create_issue` | `src/server/routes/github.rs:300` | `src/server/routes/domains/integrations.rs:24` |
 | `GET` | `/api/github/pr-summary` | `pr_summary::get_pr_summary` | `src/server/routes/pr_summary.rs:88` | `src/server/routes/domains/integrations.rs:30` |
 | `POST` | `/api/github/pr-summary/invalidate` | `pr_summary::invalidate_pr_summary` | `src/server/routes/pr_summary.rs:131` | `src/server/routes/domains/integrations.rs:31` |
-| `GET` | `/api/github/repos` | `github::list_repos` | `src/server/routes/github.rs:771` | `src/server/routes/domains/integrations.rs:25` |
-| `POST` | `/api/github/repos` | `github::register_repo` | `src/server/routes/github.rs:809` | `src/server/routes/domains/integrations.rs:25` |
-| `POST` | `/api/github/repos/{owner}/{repo}/sync` | `github::sync_repo` | `src/server/routes/github.rs:861` | `src/server/routes/domains/integrations.rs:29` |
+| `GET` | `/api/github/repos` | `github::list_repos` | `src/server/routes/github.rs:787` | `src/server/routes/domains/integrations.rs:25` |
+| `POST` | `/api/github/repos` | `github::register_repo` | `src/server/routes/github.rs:820` | `src/server/routes/domains/integrations.rs:25` |
+| `POST` | `/api/github/repos/{owner}/{repo}/sync` | `github::sync_repo` | `src/server/routes/github.rs:864` | `src/server/routes/domains/integrations.rs:29` |
 | `GET` | `/api/health` | `health_api::health_handler` | `src/server/routes/health_api.rs:842` | `src/server/routes/domains/access.rs:10` |
 | `GET` | `/api/health/detail` | `health_api::health_detail_handler` | `src/server/routes/health_api.rs:847` | `src/server/routes/domains/ops.rs:22` |
 | `GET` | `/api/help` | `docs::api_help` | `src/server/routes/docs.rs:38` | `src/server/routes/domains/ops.rs:352` |
@@ -199,8 +199,8 @@
 | `POST` | `/api/pm-decision` | `kanban::pm_decision` | `src/server/routes/kanban.rs:1431` | `src/server/routes/domains/kanban.rs:60` |
 | `GET` | `/api/policies` | `agents_crud::list_policies` | `src/server/routes/agents_crud.rs:1256` | `src/server/routes/domains/agents.rs:50` |
 | `GET` | `/api/prompt-manifest/retention` | `prompt_manifest_retention::get_retention_status` | `src/server/routes/prompt_manifest_retention.rs:36` | `src/server/routes/domains/ops.rs:230` |
-| `GET` | `/api/provider-cli` | `provider_cli_api::get_provider_cli_status` | `src/server/routes/provider_cli_api.rs:28` | `src/server/routes/domains/ops.rs:359` |
-| `PATCH` | `/api/provider-cli/{provider}` | `provider_cli_api::patch_provider_cli` | `src/server/routes/provider_cli_api.rs:96` | `src/server/routes/domains/ops.rs:363` |
+| `GET` | `/api/provider-cli` | `provider_cli_api::get_provider_cli_status` | `src/server/routes/provider_cli_api.rs:29` | `src/server/routes/domains/ops.rs:359` |
+| `PATCH` | `/api/provider-cli/{provider}` | `provider_cli_api::patch_provider_cli` | `src/server/routes/provider_cli_api.rs:90` | `src/server/routes/domains/ops.rs:363` |
 | `GET` | `/api/quality/events` | `analytics::quality_events` | `src/server/routes/analytics.rs:316` | `src/server/routes/domains/analytics.rs:14` |
 | `POST` | `/api/queue/cancel` | `auto_queue::cancel` | `src/server/routes/auto_queue.rs:138` | `src/server/routes/domains/ops.rs:319` |
 | `POST` | `/api/queue/dispatch-next` | `auto_queue::activate` | `src/server/routes/auto_queue.rs:35` | `src/server/routes/domains/ops.rs:294` |

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -628,11 +628,15 @@ pub(crate) async fn cmd_github_sync(repo: Option<&str>) -> Result<(), String> {
     let mut any_failed = false;
     for repo_id in &repos {
         let (owner, repo_name) = split_repo(repo_id)?;
-        let (status, Json(value)) = crate::server::routes::github::sync_repo(
+        let (status, Json(value)) = match crate::server::routes::github::sync_repo(
             State(state.clone()),
             Path((owner, repo_name)),
         )
-        .await;
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => error.into_json_response(),
+        };
         if status.is_success() {
             results.push(value);
         } else {

--- a/src/server/routes/github.rs
+++ b/src/server/routes/github.rs
@@ -9,6 +9,7 @@ use sqlx::Row;
 use std::collections::BTreeSet;
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 use crate::github;
 use crate::services::github_issue_creation::{
     GitHubIssueCreateRequest, IssueAnnouncementSync, IssueAnnouncementSyncOptions,
@@ -299,18 +300,18 @@ fn issue_validation_error(error: String, dry_run: bool) -> (StatusCode, Json<ser
 pub async fn create_issue(
     State(state): State<AppState>,
     Json(body): Json<CreateIssueBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let dry_run = body.dry_run.unwrap_or(false);
     let unsupported_features = requested_unsupported_issue_create_features(&body);
     if !dry_run && !unsupported_features.is_empty() {
-        return (
+        return Ok((
             StatusCode::UNPROCESSABLE_ENTITY,
             Json(json!({
                 "error": unsupported_issue_create_error(&unsupported_features),
                 "capabilities": issue_create_capabilities(),
                 "unsupported_features": unsupported_features,
             })),
-        );
+        ));
     }
 
     if dry_run {
@@ -335,7 +336,7 @@ pub async fn create_issue(
                 .cloned()
                 .unwrap_or_else(|| "validation failed".to_string());
             validation_warnings.extend(unsupported_feature_warnings);
-            return (
+            return Ok((
                 StatusCode::UNPROCESSABLE_ENTITY,
                 Json(json!({
                     "dry_run": true,
@@ -345,7 +346,7 @@ pub async fn create_issue(
                     "unsupported_features": unsupported_features,
                     "block_on": block_on_issue_numbers,
                 })),
-            );
+            ));
         }
 
         let repo = repo.expect("validated repo must exist");
@@ -376,7 +377,7 @@ pub async fn create_issue(
             .as_deref()
             .and_then(trim_non_empty);
 
-        return (
+        return Ok((
             StatusCode::OK,
             Json(json!({
                 "dry_run": true,
@@ -400,24 +401,29 @@ pub async fn create_issue(
                 // deprecated alias kept for transition; remove after clients migrate
                 "pmd_format_version": ISSUE_FORMAT_VERSION,
             })),
-        );
+        ));
     }
 
     let repo = match resolve_issue_repo(&body.repo) {
         Ok(repo) => repo,
-        Err(error) => return issue_validation_error(error, dry_run),
+        Err(error) => return Ok(issue_validation_error(error, dry_run)),
     };
     let title = match trim_non_empty(&body.title) {
         Some(title) => title,
-        None => return issue_validation_error("title is required".to_string(), dry_run),
+        None => {
+            return Ok(issue_validation_error(
+                "title is required".to_string(),
+                dry_run,
+            ));
+        }
     };
     let issue_body = match build_pmd_issue_body(&body) {
         Ok(issue_body) => issue_body,
-        Err(error) => return issue_validation_error(error, dry_run),
+        Err(error) => return Ok(issue_validation_error(error, dry_run)),
     };
     let block_on_issue_numbers = match normalize_block_on_issue_numbers(&body) {
         Ok(block_on_issue_numbers) => block_on_issue_numbers,
-        Err(error) => return issue_validation_error(error, dry_run),
+        Err(error) => return Ok(issue_validation_error(error, dry_run)),
     };
 
     let applied_labels = body
@@ -461,7 +467,7 @@ pub async fn create_issue(
             let announcement_message_id = announcement.message_id.clone();
             let announcement_sync_error = announcement.error.clone();
 
-            (
+            Ok((
                 StatusCode::CREATED,
                 Json(json!({
                     "issue": {
@@ -484,16 +490,18 @@ pub async fn create_issue(
                     // deprecated alias kept for transition; remove after clients migrate
                     "pmd_format_version": ISSUE_FORMAT_VERSION,
                 })),
-            )
+            ))
         }
-        Err(IssueCreationError::GhUnavailable) => (
+        Err(IssueCreationError::GhUnavailable) => Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "gh CLI is not available on this system"})),
-        ),
-        Err(IssueCreationError::GitHub(error)) => (
+            ErrorCode::Config,
+            "gh CLI is not available on this system",
+        )),
+        Err(IssueCreationError::GitHub(error)) => Err(AppError::new(
             StatusCode::BAD_GATEWAY,
-            Json(json!({"error": format!("gh issue create failed: {error}")})),
-        ),
+            ErrorCode::Internal,
+            format!("gh issue create failed: {error}"),
+        )),
     }
 }
 
@@ -613,7 +621,9 @@ Write-Error "unexpected gh args: $Rest"; exit 2
         body.block_on = Some(vec![3718]);
         body.dry_run = Some(true);
 
-        let (status, Json(response)) = create_issue(State(test_state()), Json(body)).await;
+        let (status, Json(response)) = create_issue(State(test_state()), Json(body))
+            .await
+            .expect("create issue response");
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response["dry_run"], true);
@@ -680,7 +690,9 @@ Write-Error "unexpected gh args: $Rest"; exit 2
         let mut body = base_issue_body();
         body.auto_dispatch = Some(true);
 
-        let (status, Json(response)) = create_issue(State(test_state()), Json(body)).await;
+        let (status, Json(response)) = create_issue(State(test_state()), Json(body))
+            .await
+            .expect("create issue response");
 
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(response["unsupported_features"], json!(["auto_dispatch"]));
@@ -705,7 +717,9 @@ Write-Error "unexpected gh args: $Rest"; exit 2
         body.agent_id = Some("project-agentdesk".to_string());
         body.block_on = Some(vec![7, 42]);
 
-        let (status, Json(response)) = create_issue(State(test_state()), Json(body)).await;
+        let (status, Json(response)) = create_issue(State(test_state()), Json(body))
+            .await
+            .expect("create issue response");
 
         assert_eq!(status, StatusCode::CREATED, "{response}");
         assert_eq!(response["issue"]["number"], json!(4242));
@@ -748,8 +762,10 @@ Write-Error "unexpected gh args: $Rest"; exit 2
         let fake_gh = install_fake_gh(temp.path(), true);
         let _gh_guard = EnvVarGuard::set("AGENTDESK_GH_PATH", &fake_gh);
 
-        let (status, Json(response)) =
-            create_issue(State(test_state()), Json(base_issue_body())).await;
+        let (status, Json(response)) = create_issue(State(test_state()), Json(base_issue_body()))
+            .await
+            .expect_err("GitHub failure must return AppError")
+            .into_json_response();
 
         assert_eq!(status, StatusCode::BAD_GATEWAY);
         assert!(
@@ -768,29 +784,24 @@ Write-Error "unexpected gh args: $Rest"; exit 2
 }
 
 /// GET /api/github/repos
-pub async fn list_repos(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
-    let Some(pool) = state.pg_pool_ref() else {
-        return (
+pub async fn list_repos(
+    State(state): State<AppState>,
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
+    let pool = state.pg_pool_ref().ok_or_else(|| {
+        AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
-    };
-    let rows = match sqlx::query(
+            ErrorCode::Config,
+            "postgres pool unavailable",
+        )
+    })?;
+    let rows = sqlx::query(
         "SELECT id, display_name, sync_enabled, last_synced_at::text AS last_synced_at
          FROM github_repos
          ORDER BY id",
     )
     .fetch_all(pool)
     .await
-    {
-        Ok(rows) => rows,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("{error}")})),
-            );
-        }
-    };
+    .map_err(|error| AppError::internal(format!("{error}")).with_code(ErrorCode::Database))?;
     let items: Vec<serde_json::Value> = rows
         .into_iter()
         .map(|row| {
@@ -802,33 +813,28 @@ pub async fn list_repos(State(state): State<AppState>) -> (StatusCode, Json<serd
             })
         })
         .collect();
-    (StatusCode::OK, Json(json!({"repos": items})))
+    Ok((StatusCode::OK, Json(json!({"repos": items}))))
 }
 
 /// POST /api/github/repos
 pub async fn register_repo(
     State(state): State<AppState>,
     Json(body): Json<RegisterRepoBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     if body.id.is_empty() || !body.id.contains('/') {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "id must be in 'owner/repo' format"})),
-        );
+        return Err(AppError::bad_request("id must be in 'owner/repo' format"));
     }
 
-    let Some(pool) = state.pg_pool_ref() else {
-        return (
+    let pool = state.pg_pool_ref().ok_or_else(|| {
+        AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
-    };
-    if let Err(error) = crate::db::postgres::register_repo(pool, &body.id).await {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": error})),
-        );
-    }
+            ErrorCode::Config,
+            "postgres pool unavailable",
+        )
+    })?;
+    crate::db::postgres::register_repo(pool, &body.id)
+        .await
+        .map_err(|error| AppError::internal(error).with_code(ErrorCode::Database))?;
 
     match sqlx::query(
         "SELECT id, display_name, sync_enabled, last_synced_at::text AS last_synced_at
@@ -839,7 +845,7 @@ pub async fn register_repo(
     .fetch_one(pool)
     .await
     {
-        Ok(row) => (
+        Ok(row) => Ok((
             StatusCode::CREATED,
             Json(json!({
                 "repo": {
@@ -849,11 +855,8 @@ pub async fn register_repo(
                     "last_synced_at": row.try_get::<Option<String>, _>("last_synced_at").ok().flatten(),
                 }
             })),
-        ),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("{error}")})),
-        ),
+        )),
+        Err(error) => Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database)),
     }
 }
 
@@ -861,16 +864,17 @@ pub async fn register_repo(
 pub async fn sync_repo(
     State(state): State<AppState>,
     Path((owner, repo)): Path<(String, String)>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> AppResult<(StatusCode, Json<serde_json::Value>)> {
     let repo_id = format!("{owner}/{repo}");
 
     // Check repo exists
-    let Some(pool) = state.pg_pool_ref() else {
-        return (
+    let pool = state.pg_pool_ref().ok_or_else(|| {
+        AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "postgres pool unavailable"})),
-        );
-    };
+            ErrorCode::Config,
+            "postgres pool unavailable",
+        )
+    })?;
     let exists =
         match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM github_repos WHERE id = $1")
             .bind(&repo_id)
@@ -879,60 +883,47 @@ pub async fn sync_repo(
         {
             Ok(count) => count > 0,
             Err(error) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("{error}")})),
-                );
+                return Err(AppError::internal(format!("{error}")).with_code(ErrorCode::Database));
             }
         };
 
     if !exists {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": format!("repo '{}' not registered", repo_id)})),
-        );
+        return Err(AppError::not_found(format!(
+            "repo '{}' not registered",
+            repo_id
+        )));
     }
 
     // Check if gh is available
     if !github::gh_available() {
-        return (
+        return Err(AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "gh CLI is not available on this system"})),
-        );
+            ErrorCode::Config,
+            "gh CLI is not available on this system",
+        ));
     }
 
     // Fetch issues
-    let issues = match github::sync::fetch_issues(&repo_id) {
-        Ok(i) => i,
-        Err(e) => {
-            return (
-                StatusCode::BAD_GATEWAY,
-                Json(json!({"error": format!("gh fetch failed: {e}")})),
-            );
-        }
-    };
+    let issues = github::sync::fetch_issues(&repo_id).map_err(|e| {
+        AppError::new(
+            StatusCode::BAD_GATEWAY,
+            ErrorCode::Internal,
+            format!("gh fetch failed: {e}"),
+        )
+    })?;
 
-    let triaged = match github::triage::triage_new_issues_pg(pool, &repo_id, &issues).await {
-        Ok(count) => count,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("triage failed: {error}")})),
-            );
-        }
-    };
-    let sync_result =
-        match github::sync::sync_github_issues_for_repo_pg(pool, &repo_id, &issues).await {
-            Ok(result) => result,
-            Err(error) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": format!("sync failed: {error}")})),
-                );
-            }
-        };
+    let triaged = github::triage::triage_new_issues_pg(pool, &repo_id, &issues)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!("triage failed: {error}")).with_code(ErrorCode::Database)
+        })?;
+    let sync_result = github::sync::sync_github_issues_for_repo_pg(pool, &repo_id, &issues)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!("sync failed: {error}")).with_code(ErrorCode::Database)
+        })?;
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "synced": true,
@@ -945,5 +936,5 @@ pub async fn sync_repo(
             "stale_card_issue_batches": sync_result.stale_card_issue_batch_count,
             "stale_card_issue_errors": sync_result.stale_card_issue_error_count,
         })),
-    )
+    ))
 }

--- a/src/server/routes/provider_cli_api.rs
+++ b/src/server/routes/provider_cli_api.rs
@@ -21,27 +21,25 @@ use crate::services::provider_cli::{
 };
 
 use super::AppState;
+use crate::error::{AppError, AppResult, ErrorCode};
 
 const ALL_PROVIDERS: &[&str] = &["codex", "claude", "gemini", "qwen"];
 
 /// GET /api/provider-cli — current registry channels + migration states.
-pub async fn get_provider_cli_status(State(_state): State<AppState>) -> (StatusCode, Json<Value>) {
-    let Some(root) = crate::config::runtime_root() else {
-        return (
+pub async fn get_provider_cli_status(
+    State(_state): State<AppState>,
+) -> AppResult<(StatusCode, Json<Value>)> {
+    let root = crate::config::runtime_root().ok_or_else(|| {
+        AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "runtime root not configured"})),
-        );
-    };
+            ErrorCode::Config,
+            "runtime root not configured",
+        )
+    })?;
 
-    let registry = match load_registry(&root) {
-        Ok(r) => r.unwrap_or_default(),
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("load registry: {e}")})),
-            );
-        }
-    };
+    let registry = load_registry(&root)
+        .map_err(|e| AppError::internal(format!("load registry: {e}")))?
+        .unwrap_or_default();
 
     let providers: Vec<ProviderDiagnostics> = ALL_PROVIDERS
         .iter()
@@ -81,13 +79,9 @@ pub async fn get_provider_cli_status(State(_state): State<AppState>) -> (StatusC
         generated_at: Utc::now(),
     };
 
-    match serde_json::to_value(&response) {
-        Ok(v) => (StatusCode::OK, Json(v)),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("serialize: {e}")})),
-        ),
-    }
+    let value = serde_json::to_value(&response)
+        .map_err(|e| AppError::internal(format!("serialize: {e}")))?;
+    Ok((StatusCode::OK, Json(value)))
 }
 
 /// PATCH /api/provider-cli/{provider} — apply action to migration state.
@@ -97,53 +91,38 @@ pub async fn patch_provider_cli(
     State(_state): State<AppState>,
     Path(provider): Path<String>,
     Json(body): Json<ProviderCliActionRequest>,
-) -> (StatusCode, Json<Value>) {
+) -> AppResult<(StatusCode, Json<Value>)> {
     let action = match body.action.as_str() {
         "confirm_promote" => ProviderCliApiAction::ConfirmPromote,
         "rollback" => ProviderCliApiAction::Rollback,
         "rollback_to_previous" => ProviderCliApiAction::RollbackToPrevious,
-        action => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": format!("unknown action: {action}")})),
-            );
-        }
+        action => return Err(AppError::bad_request(format!("unknown action: {action}"))),
     };
 
     if !is_supported_provider(&provider) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": format!("unsupported provider: {provider}")})),
-        );
+        return Err(AppError::bad_request(format!(
+            "unsupported provider: {provider}"
+        )));
     }
 
-    let Some(root) = crate::config::runtime_root() else {
-        return (
+    let root = crate::config::runtime_root().ok_or_else(|| {
+        AppError::new(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": "runtime root not configured"})),
-        );
-    };
+            ErrorCode::Config,
+            "runtime root not configured",
+        )
+    })?;
 
-    let mut migration = match load_migration_state(&root, &provider) {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(json!({"error": format!("no migration state for provider: {provider}")})),
-            );
-        }
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("load migration state: {e}")})),
-            );
-        }
-    };
+    let mut migration = load_migration_state(&root, &provider)
+        .map_err(|e| AppError::internal(format!("load migration state: {e}")))?
+        .ok_or_else(|| {
+            AppError::not_found(format!("no migration state for provider: {provider}"))
+        })?;
 
     if matches!(action, ProviderCliApiAction::ConfirmPromote)
         && migration.state == MigrationState::ProviderAgentsMigrated
     {
-        return (
+        return Ok((
             StatusCode::OK,
             Json(json!({
                 "provider": provider,
@@ -151,7 +130,7 @@ pub async fn patch_provider_cli(
                 "state": migration_state_wire_value(&migration.state),
                 "updated_at": migration.updated_at,
             })),
-        );
+        ));
     }
 
     let transition_result = if matches!(action, ProviderCliApiAction::ConfirmPromote) {
@@ -334,18 +313,22 @@ pub async fn patch_provider_cli(
         })
     };
 
-    if let Err((status, message)) = transition_result {
-        return (status, Json(json!({"error": message})));
-    }
+    transition_result.map_err(|(status, message)| {
+        AppError::new(
+            status,
+            if status == StatusCode::UNPROCESSABLE_ENTITY {
+                ErrorCode::Validation
+            } else {
+                ErrorCode::Internal
+            },
+            message,
+        )
+    })?;
 
-    if let Err(e) = save_migration_state(&root, &migration) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("save migration state: {e}")})),
-        );
-    }
+    save_migration_state(&root, &migration)
+        .map_err(|e| AppError::internal(format!("save migration state: {e}")))?;
 
-    (
+    Ok((
         StatusCode::OK,
         Json(json!({
             "provider": provider,
@@ -353,7 +336,7 @@ pub async fn patch_provider_cli(
             "state": migration_state_wire_value(&migration.state),
             "updated_at": migration.updated_at,
         })),
-    )
+    ))
 }
 
 fn is_supported_provider(provider: &str) -> bool {


### PR DESCRIPTION
#4228 apperror batch. github.rs(16)+provider_cli_api.rs(10) raw error JSON→AppError + cli/direct.rs 호출자 갱신(E0308). 계약보존: status·top-level error 불변, 부가필드 실패분기 flat 유지. gate: check --all-targets✓ test✓(github 35) fresh✓ audit✓. Part of #4228