### PR TITLE
fix(watchdog): exclude persistent routine keep-alive sessions from long-turn alerts

### DIFF
--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -935,6 +935,87 @@ test("timeouts long turn monitor module alerts every 30-minute threshold", () =>
   assert.deepEqual(toPlain(state.executions[0].params), ["long_turn_tier:codex:channel-1", "90"]);
 });
 
+test("timeouts long turn monitor module skips persistent routine keep-alive sessions", () => {
+  const tmuxSession = "AgentDesk-claude-routine-warmup-obiseo-session---personal-obi";
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    inflights: [
+      {
+        provider: "claude",
+        channel_id: "routine-thread-1",
+        channel_name: "routine warmup-obiseo-session - personal-obi",
+        session_key: "provider:" + tmuxSession,
+        tmux_session_name: tmuxSession,
+        started_at: timestampMinutesAgo(91),
+        dispatch_id: null
+      }
+    ],
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT execution_strategy FROM routines WHERE discord_thread_id = ? LIMIT 1",
+        result(sql, params) {
+          assert.deepEqual(toPlain(params), ["routine-thread-1"]);
+          return [{ execution_strategy: "persistent" }];
+        }
+      },
+      { match: "SELECT value FROM kv_meta WHERE key = ?", result: [] },
+      {
+        match: "SELECT id FROM agents WHERE discord_channel_id = ? OR discord_channel_alt = ? OR discord_channel_cc = ? OR discord_channel_cdx = ? LIMIT 1",
+        result: []
+      },
+      { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'", result: [] },
+      { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_watchdog_extension:%'", result: [] }
+    ])
+  });
+
+  policy._section_L();
+
+  assert.equal(state.deadlockAlerts.length, 0);
+  assert.equal(
+    state.executions.filter((execution) => /INSERT OR REPLACE INTO kv_meta/.test(execution.sql)).length,
+    0
+  );
+  assert.equal(
+    state.logs.warn.filter((line) => line.includes("inflight scan error")).length,
+    0,
+    state.logs.warn.join("\n")
+  );
+});
+
+test("timeouts long turn monitor module still alerts fresh routine sessions", () => {
+  const tmuxSession = "AgentDesk-claude-routine-once-only---personal-obi";
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    inflights: [
+      {
+        provider: "claude",
+        channel_id: "routine-thread-2",
+        channel_name: "routine once-only - personal-obi",
+        session_key: "provider:" + tmuxSession,
+        tmux_session_name: tmuxSession,
+        started_at: timestampMinutesAgo(91),
+        dispatch_id: null
+      }
+    ],
+    dbQuery: createSqlRouter([
+      {
+        match: "SELECT execution_strategy FROM routines WHERE discord_thread_id = ? LIMIT 1",
+        result: [{ execution_strategy: "fresh" }]
+      },
+      { match: "SELECT value FROM kv_meta WHERE key = ?", result: [] },
+      {
+        match: "SELECT id FROM agents WHERE discord_channel_id = ? OR discord_channel_alt = ? OR discord_channel_cc = ? OR discord_channel_cdx = ? LIMIT 1",
+        result: []
+      },
+      { match: "SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'", result: [] }
+    ])
+  });
+
+  policy._section_L();
+
+  assert.equal(state.deadlockAlerts.length, 1);
+  assert.match(state.deadlockAlerts[0].message, /장시간 턴/);
+  assert.match(state.deadlockAlerts[0].message, /90분 단계/);
+});
+
 test("timeouts long turn monitor module skips synthetic reattach placeholders", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     inflights: [

--- a/policies/timeouts/long-turn-monitor.js
+++ b/policies/timeouts/long-turn-monitor.js
@@ -48,6 +48,16 @@ module.exports = function attachLongTurnMonitor(timeouts, helpers) {
         for (var li = 0; li < inflights.length; li++) {
           var inf = inflights[li];
           if (!inf.started_at) continue;
+          // Persistent routine sessions are intentionally reusable and may stay idle
+          // without accumulating progress, so elapsed time is not a hang signal.
+          var routineTmux = /^AgentDesk-[^-]+-routine-/.test(inf.tmux_session_name || "");
+          if (routineTmux) {
+            var routineRows = agentdesk.db.query(
+              "SELECT execution_strategy FROM routines WHERE discord_thread_id = ? LIMIT 1",
+              [inf.channel_id]
+            );
+            if (routineRows.length > 0 && routineRows[0].execution_strategy === "persistent") continue;
+          }
           // Stale inflight check: skip cleanup here — let InflightCleanupGuard handle it.
           // Previous approach (checking working sessions) caused false positives because
           // DB session status can lag behind actual tmux state.


### PR DESCRIPTION
## 문제
`policies/timeouts/long-turn-monitor.js`의 `_section_L`(장시간 턴 감지)가 persistent routine keep-alive 세션(obiseo warmup)을 30/60/90/120/150/180분마다 반복 오탐 알림. 이 세션은 설계상 idle(NO_REPLY, started_at 고정, elapsed 무한증가)이라 hang이 아님.

## 수정
started_at 가드 직후·tier/extension/alert 전에, tmux가 routine 패턴이고 `routines.execution_strategy='persistent'`이면 `continue`(알림 스킵).
- 조인키: `routines WHERE discord_thread_id = inf.channel_id`. thread 기반 routine은 inf.channel_id == discord_thread_id 성립(session_control.rs:376, agent_executor.rs:1434 update_discord_thread_id persist).
- 과잉억제 방지: persistent일 때만 스킵. fresh routine/일반 세션은 기존 알림 유지.

## 테스트
policies/__tests__/timeouts.test.js +2 케이스: persistent 91분→alert 0, fresh 91분→alert 1. 뮤테이션(continue 제거) 시 persistent 케이스 FAILED.

## 리뷰
Opus 독립 적대 리뷰 VERDICT: CLEAN (조인키 라이브 정합성 코드 확정). 간단수정 카운터리뷰 단독 예외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

deadlock-manager 핸드오프 대응.