### PR TITLE
fix(4693): dedupe local slash control transcript halves (raw echo + envelope)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1138,10 +1138,9 @@
     normal long SILENT tool run (e.g. a big build) is never mistaken for an idle
     hang, with the 4h hard ceiling as the real backstop, and noted the limitation
     in the idle-kill error message + a delayed-event test).
-  - `src/services/tui_prompt_dedupe.rs` (2134 lines; +29 from #4567: classify start-anchored structured task notifications as status-only observations before generic external-input ownership, preserving task-card/status delivery while leaving the next human prompt immediately admissible; -41 from #4591 R4: remove
-    raw/envelope time-pair state so local slash-control representations may
-    duplicate rather than swallowing a later human command; local stable entry
-    IDs are now recorded only after the relay confirms its Discord session note,
+  - `src/services/tui_prompt_dedupe.rs` (2141 lines; +7 from #4693: seal a local-only raw/envelope half collapsed by the Discord marker gate so its stable entry ID remains replay-immune after a watermark reset; +29 from #4567: classify start-anchored structured task notifications as status-only observations before generic external-input ownership, preserving task-card/status delivery while leaving the next human prompt immediately admissible; -41 from #4591 R4: remove
+    observation-layer raw/envelope pairing while leaving local execution independent of Discord rendering; local stable entry
+    IDs are recorded after note delivery or when a duplicate marker half is sealed,
     while generic direct-input identity replay behavior remains eager; +4 from #4295: retain the
     stable provider source-event id on observed TUI prompts so terminal-card
     delivery can reject an exact post-compaction replay durably; +117 from #4423: adopt Claude's

--- a/docs/generated/giant-file-registry.md
+++ b/docs/generated/giant-file-registry.md
@@ -106,6 +106,6 @@
 | `src/services/routines/discord_log.rs` | 1594 |
 | `src/services/routines/store.rs` | 3559 |
 | `src/services/settings.rs` | 1112 |
-| `src/services/tui_prompt_dedupe.rs` | 2134 |
+| `src/services/tui_prompt_dedupe.rs` | 2141 |
 | `src/services/turn_orchestrator.rs` | 3283 |
 | `src/voice/receiver.rs` | 1108 |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -817,7 +817,7 @@
 | `services::discord::tui_direct_abort_marker::sweep` | `src/services/discord/tui_direct_abort_marker/sweep.rs` | 177 | 177 | 0 |  |
 | `services::discord::tui_direct_abort_marker::tombstone` | `src/services/discord/tui_direct_abort_marker/tombstone.rs` | 70 | 70 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 3815 | 1495 | 2320 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 866 | 866 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 872 | 872 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 454 | 218 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |
@@ -1093,8 +1093,8 @@
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 276 | 265 | 11 |  |
 | `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 898 | 787 | 111 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 286 | 220 | 66 |  |
-| `services::tui_prompt_control` | `src/services/tui_prompt_control.rs` | 246 | 208 | 38 |  |
-| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4759 | 2134 | 2625 | giant-file |
+| `services::tui_prompt_control` | `src/services/tui_prompt_control.rs` | 248 | 210 | 38 |  |
+| `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 4766 | 2141 | 2625 | giant-file |
 | `services::tui_prompt_dedupe::synthetic_prompt` | `src/services/tui_prompt_dedupe/synthetic_prompt.rs` | 34 | 34 | 0 |  |
 | `services::tui_turn_state` | `src/services/tui_turn_state.rs` | 2033 | 648 | 1385 |  |
 | `services::tui_turn_state::completion_scan` | `src/services/tui_turn_state/completion_scan.rs` | 360 | 360 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -817,7 +817,7 @@
 | `services::discord::tui_direct_abort_marker::sweep` | `src/services/discord/tui_direct_abort_marker/sweep.rs` | 177 | 177 | 0 |  |
 | `services::discord::tui_direct_abort_marker::tombstone` | `src/services/discord/tui_direct_abort_marker/tombstone.rs` | 70 | 70 | 0 |  |
 | `services::discord::tui_direct_pending_start` | `src/services/discord/tui_direct_pending_start.rs` | 3815 | 1495 | 2320 | giant-file |
-| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 854 | 854 | 0 |  |
+| `services::discord::tui_prompt_relay` | `src/services/discord/tui_prompt_relay.rs` | 866 | 866 | 0 |  |
 | `services::discord::tui_prompt_relay::anchor_completion` | `src/services/discord/tui_prompt_relay/anchor_completion.rs` | 454 | 218 | 236 |  |
 | `services::discord::tui_prompt_relay::bridge_completion` | `src/services/discord/tui_prompt_relay/bridge_completion.rs` | 167 | 81 | 86 |  |
 | `services::discord::tui_prompt_relay::bridge_gateway` | `src/services/discord/tui_prompt_relay/bridge_gateway.rs` | 199 | 199 | 0 |  |

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -341,7 +341,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     };
     if let Some(control) = relay_prompt_decision.local_only_control.as_ref() {
         let kind = control.kind.as_str();
-        if !local_only_slash_control_note_is_first_sighting(&prompt.tmux_session_name, kind) {
+        let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {
             tracing::info!(
                 provider = %prompt.provider,
                 channel_id = channel_id.get(),
@@ -350,7 +350,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 "deduped near-simultaneous local slash-command control half"
             );
             return;
-        }
+        };
         let Some(notify_http) = shared.serenity_http_or_token_fallback() else {
             tracing::warn!(
                 provider = %prompt.provider,
@@ -361,8 +361,6 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             );
             return;
         };
-        let note =
-            format_slash_command_control_note(&prompt.tmux_session_name, kind, &prompt.prompt);
         match channel_id.say(&*notify_http, note).await {
             Ok(message) => {
                 crate::services::tui_prompt_dedupe::record_local_only_entry_id_after_note_delivery(
@@ -838,8 +836,16 @@ fn slash_command_control_turn_is_first_sighting(tmux_session_name: &str, kind: &
     true
 }
 
-fn local_only_slash_control_note_is_first_sighting(tmux_session_name: &str, kind: &str) -> bool {
-    slash_command_control_turn_is_first_sighting(tmux_session_name, kind)
+fn prepare_local_only_slash_control_note(prompt: &ObservedTuiPrompt, kind: &str) -> Option<String> {
+    if !slash_command_control_turn_is_first_sighting(&prompt.tmux_session_name, kind) {
+        crate::services::tui_prompt_dedupe::seal_deduped_local_only_entry_id(prompt);
+        return None;
+    }
+    Some(format_slash_command_control_note(
+        &prompt.tmux_session_name,
+        kind,
+        &prompt.prompt,
+    ))
 }
 
 /// The two-second kind gate owns external machine controls such as `/loop`.

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -341,6 +341,16 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     };
     if let Some(control) = relay_prompt_decision.local_only_control.as_ref() {
         let kind = control.kind.as_str();
+        if !local_only_slash_control_note_is_first_sighting(&prompt.tmux_session_name, kind) {
+            tracing::info!(
+                provider = %prompt.provider,
+                channel_id = channel_id.get(),
+                tmux_session_name = %prompt.tmux_session_name,
+                slash_command_kind = %kind,
+                "deduped near-simultaneous local slash-command control half"
+            );
+            return;
+        }
         let Some(notify_http) = shared.serenity_http_or_token_fallback() else {
             tracing::warn!(
                 provider = %prompt.provider,
@@ -828,9 +838,11 @@ fn slash_command_control_turn_is_first_sighting(tmux_session_name: &str, kind: &
     true
 }
 
+fn local_only_slash_control_note_is_first_sighting(tmux_session_name: &str, kind: &str) -> bool {
+    slash_command_control_turn_is_first_sighting(tmux_session_name, kind)
+}
+
 /// The two-second kind gate owns external machine controls such as `/loop`.
-/// Local controls deliberately bypass it, so no text/time-only rule can
-/// collapse a nearby human `/compact`.
 fn slash_command_control_turn_is_duplicate_external_replay(
     decision: &RelayObservedPromptInjectionDecision,
     tmux_session_name: &str,

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1789,17 +1789,52 @@ fn slash_command_control_turn_dedupes_double_post_but_not_distinct_commands() {
 }
 
 #[test]
-fn local_compact_bypasses_the_two_second_external_slash_control_gate() {
-    let sess = format!("local-compact-gate-{:p}", &0u8 as *const u8);
+fn local_slash_control_note_dedupes_same_kind_but_not_distinct_kinds() {
+    let sess = format!("local-control-note-gate-{:p}", &0u8 as *const u8);
+
+    assert!(local_only_slash_control_note_is_first_sighting(
+        &sess, "/compact"
+    ));
+    assert!(
+        !local_only_slash_control_note_is_first_sighting(&sess, "/compact"),
+        "the local note emission gate must drop the near-simultaneous transcript half"
+    );
+    assert!(
+        local_only_slash_control_note_is_first_sighting(&sess, "/loop"),
+        "different command kinds must remain independent"
+    );
+}
+
+#[test]
+fn local_slash_control_note_allows_same_kind_after_window() {
+    let sess = format!("local-control-note-window-{:p}", &0u8 as *const u8);
+    assert!(local_only_slash_control_note_is_first_sighting(
+        &sess, "/compact"
+    ));
+
+    let key = format!("{sess}\u{0}/compact");
+    SLASH_COMMAND_CONTROL_LAST_POSTED
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .insert(
+            key,
+            std::time::Instant::now() - SLASH_COMMAND_CONTROL_DEDUPE_WINDOW,
+        );
+
+    assert!(
+        local_only_slash_control_note_is_first_sighting(&sess, "/compact"),
+        "the local note gate must allow a genuine command after the dedupe window"
+    );
+}
+
+#[test]
+fn local_compact_still_bypasses_the_external_replay_classifier() {
+    let sess = format!("local-compact-external-gate-{:p}", &0u8 as *const u8);
     let compact = relay_observed_prompt_injected_prompt_decision("/compact");
     assert!(compact.local_only_slash);
     assert!(
         !slash_command_control_turn_is_duplicate_external_replay(&compact, &sess),
-        "the first human local /compact must not enter the external /loop time gate"
-    );
-    assert!(
-        !slash_command_control_turn_is_duplicate_external_replay(&compact, &sess),
-        "a second human local /compact inside two seconds is still distinct"
+        "local controls must remain outside the external replay classifier"
     );
 
     let loop_control = relay_observed_prompt_injected_prompt_decision("/loop 5m inspect status");

--- a/src/services/discord/tui_prompt_relay/tests.rs
+++ b/src/services/discord/tui_prompt_relay/tests.rs
@@ -1788,19 +1788,60 @@ fn slash_command_control_turn_dedupes_double_post_but_not_distinct_commands() {
     ));
 }
 
-#[test]
-fn local_slash_control_note_dedupes_same_kind_but_not_distinct_kinds() {
-    let sess = format!("local-control-note-gate-{:p}", &0u8 as *const u8);
+fn local_control_prompt(tmux: &str, body: &str, entry_id: &str) -> ObservedTuiPrompt {
+    ObservedTuiPrompt {
+        provider: "claude".to_string(),
+        tmux_session_name: tmux.to_string(),
+        prompt: body.to_string(),
+        source_event_id: Some(entry_id.to_string()),
+        observed_at: chrono::Utc::now(),
+        external_input_lease_generation:
+            crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        ssh_direct_observation_generation:
+            crate::services::tui_prompt_dedupe::SSH_DIRECT_OBSERVATION_GENERATION_UNRECORDED,
+    }
+}
 
-    assert!(local_only_slash_control_note_is_first_sighting(
-        &sess, "/compact"
-    ));
+#[test]
+fn local_slash_control_note_emission_is_wired_through_prepare_gate() {
+    let relay_source = include_str!("../tui_prompt_relay.rs");
     assert!(
-        !local_only_slash_control_note_is_first_sighting(&sess, "/compact"),
-        "the local note emission gate must drop the near-simultaneous transcript half"
+        relay_source.contains(
+            "let Some(note) = prepare_local_only_slash_control_note(&prompt, kind) else {"
+        ),
+        "relay_observed_prompt must consume the gated note outcome before channel delivery"
+    );
+}
+
+#[test]
+fn local_slash_control_note_path_dedupes_and_seals_dropped_half() {
+    let sess = format!("local-control-note-path-{:p}", &0u8 as *const u8);
+    let raw = local_control_prompt(&sess, "/compact", "compact-half-a");
+    let envelope = local_control_prompt(&sess, compact_command_name_first_stub(), "compact-half-b");
+
+    assert!(
+        prepare_local_only_slash_control_note(&raw, "/compact").is_some(),
+        "the first transcript half must render one Discord marker"
     );
     assert!(
-        local_only_slash_control_note_is_first_sighting(&sess, "/loop"),
+        prepare_local_only_slash_control_note(&envelope, "/compact").is_none(),
+        "the near-simultaneous envelope half must not render a second marker"
+    );
+    assert_eq!(
+        crate::services::tui_prompt_dedupe::observe_prompt_by_tmux_with_entry_id_at(
+            "claude",
+            &sess,
+            compact_command_name_first_stub(),
+            Some("compact-half-b"),
+            chrono::Utc::now(),
+        ),
+        crate::services::tui_prompt_dedupe::PromptObservation::SuppressedReplayedEntry,
+        "the dropped half must be sealed against watermark-reset replay"
+    );
+
+    let loop_prompt = local_control_prompt(&sess, "/loop", "loop-entry");
+    assert!(
+        prepare_local_only_slash_control_note(&loop_prompt, "/loop").is_some(),
         "different command kinds must remain independent"
     );
 }
@@ -1808,9 +1849,8 @@ fn local_slash_control_note_dedupes_same_kind_but_not_distinct_kinds() {
 #[test]
 fn local_slash_control_note_allows_same_kind_after_window() {
     let sess = format!("local-control-note-window-{:p}", &0u8 as *const u8);
-    assert!(local_only_slash_control_note_is_first_sighting(
-        &sess, "/compact"
-    ));
+    let first = local_control_prompt(&sess, "/compact", "compact-window-a");
+    assert!(prepare_local_only_slash_control_note(&first, "/compact").is_some());
 
     let key = format!("{sess}\u{0}/compact");
     SLASH_COMMAND_CONTROL_LAST_POSTED
@@ -1821,8 +1861,9 @@ fn local_slash_control_note_allows_same_kind_after_window() {
             std::time::Instant::now() - SLASH_COMMAND_CONTROL_DEDUPE_WINDOW,
         );
 
+    let later = local_control_prompt(&sess, "/compact", "compact-window-b");
     assert!(
-        local_only_slash_control_note_is_first_sighting(&sess, "/compact"),
+        prepare_local_only_slash_control_note(&later, "/compact").is_some(),
         "the local note gate must allow a genuine command after the dedupe window"
     );
 }

--- a/src/services/tui_prompt_control.rs
+++ b/src/services/tui_prompt_control.rs
@@ -2,9 +2,11 @@
 //!
 //! Prompt observation runs below the Discord relay layer, so it must be able to
 //! decide whether a transcript record can create an external-turn lifecycle
-//! without depending on Discord command/rendering modules. Local command
-//! records are deliberately never text/time-paired: duplicate notes are safer
-//! than swallowing a later human command.
+//! without depending on Discord command/rendering modules. The Discord relay
+//! collapses a raw echo plus `<command-*>` envelope, and any sub-two-second
+//! same-kind machine repeat, into one cosmetic marker. This suppresses only the
+//! Discord note after local execution has completed; it cannot swallow command
+//! injection or execution, and the first marker is always retained.
 
 /// AgentDesk pass-through commands that complete locally in a Claude TUI.
 pub(crate) const LOCAL_ONLY_SLASH_COMMANDS: [&str; 4] =

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -1920,10 +1920,7 @@ fn record_relayed_entry_id(provider: &str, tmux_session_name: &str, entry_id: &s
     }
 }
 
-/// Mark a local-only entry as replayed only after its Discord session note was
-/// accepted. No subscriber, lagged receiver, missing route/http, or failed send
-/// calls this helper, so those paths cannot lose a later exact replay.
-pub(crate) fn record_local_only_entry_id_after_note_delivery(prompt: &ObservedTuiPrompt) {
+fn record_local_only_entry_id(prompt: &ObservedTuiPrompt) {
     if classify_local_only_slash_control(&prompt.prompt).is_none() {
         return;
     }
@@ -1936,6 +1933,16 @@ pub(crate) fn record_local_only_entry_id_after_note_delivery(prompt: &ObservedTu
         return;
     };
     record_relayed_entry_id(&prompt.provider, &prompt.tmux_session_name, entry_id);
+}
+
+/// Mark a local-only entry as replayed after its Discord session note was accepted.
+pub(crate) fn record_local_only_entry_id_after_note_delivery(prompt: &ObservedTuiPrompt) {
+    record_local_only_entry_id(prompt);
+}
+
+/// Seal a local-only transcript half collapsed into an already-rendered note.
+pub(crate) fn seal_deduped_local_only_entry_id(prompt: &ObservedTuiPrompt) {
+    record_local_only_entry_id(prompt);
 }
 
 pub(crate) fn prompts_match(expected: &str, observed: &str) -> bool {


### PR DESCRIPTION
## 요약
로컬 `/compact`·`/loop`·`/clear` 등 local-only 슬래시 컨트롤이 Claude Code transcript에 raw echo + `<command-*>` envelope 두 엔트리(다른 uuid, 수십 ms)로 남아 각각 시스템 note를 방출 → Discord에 중복 2줄로 뜨던 문제 수정.

external 슬래시 경로가 이미 쓰는 `slash_command_control_turn_is_first_sighting(tmux, kind)` 근접-2초 kind-window dedup을 local-only 방출 경로에도 적용. 억제 대상은 **cosmetic marker note뿐**이며 로컬 명령 실행/주입에는 무영향(local-only 경로는 note만 렌더). 첫 marker는 항상 유지.

## 적대 리뷰(Opus, 2라운드)에서 잡혀 해소된 결함
- **[회귀] 드롭 분기 entry-id 원장 미봉인**: 근접-2초 드롭 시 dropped half를 relayed-entry 원장에 안 남겨 watermark reset(TTL 30분 내) 재조우 시 스테일 note 부활. → `seal_deduped_local_only_entry_id`로 드롭된 half의 entry_id 봉인, reset 재조우 시 `SuppressedReplayedEntry`로 억제. #3540 계약 유지.
- **[주석 드리프트]** tui_prompt_control.rs 불변식 주석을 새 동작(marker collapse, 실행 무영향)에 맞게 갱신.
- **[테스트 갭]** 방출 호출사이트 wiring + ledger seal 뮤테이션 테스트 추가(가드/봉인 제거 시 FAILED).

Fixes #4693

## 검증
- 뮤테이션: 호출사이트 게이트 제거 rc=101 FAILED, ledger seal 제거 rc=101 FAILED, 복원 시 focused 3 passed + tui_prompt_relay 190 passed.
- fmt/check/test/inventory/docs-freshness/audit 전부 rc=0. #3016 핫파일 무접촉.
- 적대 리뷰: Opus 카운터리뷰 2라운드 → VERDICT: CLEAN(간단수정 예외, 단일 카운터리뷰 leg).
