### PR TITLE
feat(4221): extend trace context with turn correlation

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -205,7 +205,7 @@
 | `kanban::transition_core` | `src/kanban/transition_core.rs` | 674 | 674 | 0 |  |
 | `launch` | `src/launch.rs` | 67 | 67 | 0 |  |
 | `lib` | `src/lib.rs` | 276 | 276 | 0 |  |
-| `logging` | `src/logging.rs` | 592 | 391 | 201 |  |
+| `logging` | `src/logging.rs` | 626 | 402 | 224 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 35 | 35 | 0 |  |
 | `pipeline` | `src/pipeline.rs` | 1517 | 1383 | 134 | giant-file |
 | `receipt` | `src/receipt.rs` | 1842 | 1842 | 0 | giant-file |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -205,7 +205,7 @@
 | `kanban::transition_core` | `src/kanban/transition_core.rs` | 674 | 674 | 0 |  |
 | `launch` | `src/launch.rs` | 67 | 67 | 0 |  |
 | `lib` | `src/lib.rs` | 276 | 276 | 0 |  |
-| `logging` | `src/logging.rs` | 554 | 382 | 172 |  |
+| `logging` | `src/logging.rs` | 592 | 391 | 201 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 35 | 35 | 0 |  |
 | `pipeline` | `src/pipeline.rs` | 1517 | 1383 | 134 | giant-file |
 | `receipt` | `src/receipt.rs` | 1842 | 1842 | 0 | giant-file |

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -440,7 +440,7 @@ fn copy_tail(source: &Path, dest: &Path, max_bytes: u64) -> io::Result<()> {
     output.flush()
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct TraceContext<'a> {
     pub(crate) dispatch_id: Option<&'a str>,
     pub(crate) card_id: Option<&'a str>,
@@ -572,7 +572,7 @@ mod rotation_tests {
         let context = super::TraceContext::from_payload(&payload);
 
         assert_eq!(context.dispatch_id, Some("dispatch-4221"));
-        assert_eq!(context.channel_id, Some("channel-4221"));
+        assert_eq!(context.channel_id.as_deref(), Some("channel-4221"));
         assert_eq!(context.turn_id, Some("turn-4221"));
         assert_eq!(context.session_key, Some("session-4221"));
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::borrow::Cow;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -93,6 +94,29 @@ mod tests {
 
         tracing::subscriber::with_default(subscriber, emit);
         String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
+
+    #[test]
+    fn trace_context_span_records_turn_correlation_fields() {
+        let logs = capture_logs_with_default_filter(|| {
+            let payload = serde_json::json!({
+                "channel_id": 1473922824350601297_u64,
+                "turn_id": "turn-4221",
+                "session_key": "session-4221"
+            });
+            let span = TraceContext::from_payload(&payload).span("mutation-guard");
+            span.in_scope(|| tracing::info!("trace context mutation marker"));
+        });
+
+        assert!(
+            logs.contains("channel_id=Some(\"1473922824350601297\")"),
+            "logs={logs}"
+        );
+        assert!(logs.contains("turn_id=Some(\"turn-4221\")"), "logs={logs}");
+        assert!(
+            logs.contains("session_key=Some(\"session-4221\")"),
+            "logs={logs}"
+        );
     }
 
     #[test]
@@ -422,7 +446,7 @@ pub(crate) struct TraceContext<'a> {
     pub(crate) card_id: Option<&'a str>,
     pub(crate) agent_id: Option<&'a str>,
     pub(crate) hook_name: Option<&'a str>,
-    pub(crate) channel_id: Option<&'a str>,
+    pub(crate) channel_id: Option<Cow<'a, str>>,
     pub(crate) turn_id: Option<&'a str>,
     pub(crate) session_key: Option<&'a str>,
 }
@@ -442,7 +466,7 @@ impl<'a> TraceContext<'a> {
                 ],
             ),
             hook_name: None,
-            channel_id: find_string(payload, &["channel_id", "discord_channel_id"]),
+            channel_id: find_string_or_u64(payload, &["channel_id", "discord_channel_id"]),
             turn_id: find_string(payload, &["turn_id"]),
             session_key: find_string(payload, &["session_key"]),
         }
@@ -507,6 +531,16 @@ fn find_string<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<&'a st
         .find_map(|key| value.get(key).and_then(|v| v.as_str()))
 }
 
+fn find_string_or_u64<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<Cow<'a, str>> {
+    keys.iter().find_map(|key| {
+        let value = value.get(key)?;
+        value
+            .as_str()
+            .map(Cow::Borrowed)
+            .or_else(|| value.as_u64().map(|number| Cow::Owned(number.to_string())))
+    })
+}
+
 #[cfg(test)]
 mod rotation_tests {
     use super::{RotatingLogWriter, redacted_log_bytes};
@@ -544,15 +578,15 @@ mod rotation_tests {
     }
 
     #[test]
-    fn trace_context_prefers_canonical_channel_id_key() {
+    fn trace_context_prefers_numeric_canonical_channel_id_key() {
         let payload = serde_json::json!({
-            "channel_id": "canonical-channel",
+            "channel_id": 1473922824350601297_u64,
             "discord_channel_id": "legacy-channel"
         });
 
         let context = super::TraceContext::from_payload(&payload);
 
-        assert_eq!(context.channel_id, Some("canonical-channel"));
+        assert_eq!(context.channel_id.as_deref(), Some("1473922824350601297"));
     }
 
     #[test]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -422,6 +422,9 @@ pub(crate) struct TraceContext<'a> {
     pub(crate) card_id: Option<&'a str>,
     pub(crate) agent_id: Option<&'a str>,
     pub(crate) hook_name: Option<&'a str>,
+    pub(crate) channel_id: Option<&'a str>,
+    pub(crate) turn_id: Option<&'a str>,
+    pub(crate) session_key: Option<&'a str>,
 }
 
 impl<'a> TraceContext<'a> {
@@ -439,6 +442,9 @@ impl<'a> TraceContext<'a> {
                 ],
             ),
             hook_name: None,
+            channel_id: find_string(payload, &["channel_id", "discord_channel_id"]),
+            turn_id: find_string(payload, &["turn_id"]),
+            session_key: find_string(payload, &["session_key"]),
         }
     }
 
@@ -470,6 +476,9 @@ impl<'a> TraceContext<'a> {
             card_id = field::debug(self.card_id),
             agent_id = field::debug(self.agent_id),
             hook_name = field::debug(self.hook_name),
+            channel_id = field::debug(self.channel_id),
+            turn_id = field::debug(self.turn_id),
+            session_key = field::debug(self.session_key),
         )
     }
 }
@@ -515,6 +524,35 @@ mod rotation_tests {
         .unwrap();
 
         assert_eq!(redacted, "connection error carried *** into Display");
+    }
+
+    #[test]
+    fn trace_context_extracts_turn_correlation_fields_from_payload() {
+        let payload = serde_json::json!({
+            "dispatch_id": "dispatch-4221",
+            "discord_channel_id": "channel-4221",
+            "turn_id": "turn-4221",
+            "session_key": "session-4221"
+        });
+
+        let context = super::TraceContext::from_payload(&payload);
+
+        assert_eq!(context.dispatch_id, Some("dispatch-4221"));
+        assert_eq!(context.channel_id, Some("channel-4221"));
+        assert_eq!(context.turn_id, Some("turn-4221"));
+        assert_eq!(context.session_key, Some("session-4221"));
+    }
+
+    #[test]
+    fn trace_context_prefers_canonical_channel_id_key() {
+        let payload = serde_json::json!({
+            "channel_id": "canonical-channel",
+            "discord_channel_id": "legacy-channel"
+        });
+
+        let context = super::TraceContext::from_payload(&payload);
+
+        assert_eq!(context.channel_id, Some("canonical-channel"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the shared `TraceContext` with `channel_id`, `turn_id`, and `session_key`
- extract those fields from policy payloads, preferring canonical `channel_id` over the legacy `discord_channel_id` alias
- record all three fields on the existing shared tracing span without touching relay/turn lifecycle hotfiles

## Scope decision
This is the smallest contained acceptance slice from #4221 that is disjoint from current work: typed context expansion only. The `completion_guard.rs` async span leak remains a later slice because its enclosing `turn_bridge` surface is hot and explicitly excluded from this lane.

## Test plan
- [ ] `trace_context_extracts_turn_correlation_fields_from_payload` proves dispatch/channel/turn/session extraction from one payload
- [ ] `trace_context_prefers_canonical_channel_id_key` proves deterministic canonical-key precedence when both channel keys exist
- [ ] CI runs Rust formatting/check/tests and maintenance scripts; this parallel implementer intentionally did not run cargo or `scripts/*.py`

Closes no issue; partial acceptance slice for #4221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)