### PR TITLE
fix(watchdog): retire superseded relay gap owners

### DIFF
--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -1444,6 +1444,9 @@ class WatcherStateProbe:
     # `relay_stall_state` plus nested `relay_health`. `None` is a legacy server
     # with neither field and preserves the pre-#4458 desync behavior.
     relay_activity: CoverageActivityProbe | None = None
+    # Provider session identity is authoritative across runtime-mirror/provider-
+    # project path representations. It is optional for legacy watcher-state.
+    bound_session_id: str | None = None
 
 
 def parse_watcher_state_probe(
@@ -1458,15 +1461,23 @@ def parse_watcher_state_probe(
     attached_raw = payload.get("attached")
     desynced_raw = payload.get("desynced")
     bound_output_path = payload.get("bound_output_path")
+    bound_session_id_raw = payload.get("bound_session_id")
     attached = attached_raw if isinstance(attached_raw, bool) else None
     desynced = desynced_raw if isinstance(desynced_raw, bool) else None
     bound = bound_output_path if isinstance(bound_output_path, str) else None
+    bound_session_id = (
+        bound_session_id_raw
+        if isinstance(bound_session_id_raw, str) and bound_session_id_raw
+        else None
+    )
 
     has_activity_schema = (
         "relay_stall_state" in payload or "relay_health" in payload
     )
     if not has_activity_schema:
-        return WatcherStateProbe(200, attached, desynced, bound)
+        return WatcherStateProbe(
+            200, attached, desynced, bound, bound_session_id=bound_session_id
+        )
 
     malformed = False
     stall_raw = payload.get("relay_stall_state")
@@ -1489,6 +1500,7 @@ def parse_watcher_state_probe(
                 relay_stall_state=relay_stall_state,
                 malformed=True,
             ),
+            bound_session_id,
         )
 
     def string_field(key: str) -> tuple[str | None, bool]:
@@ -1571,6 +1583,7 @@ def parse_watcher_state_probe(
             desynced=relay_desynced,
             malformed=malformed,
         ),
+        bound_session_id,
     )
 
 
@@ -3634,9 +3647,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         None,
     )
     selected_probe = rt.watcher_state(cid) if selected_path else WatcherStateProbe(None)
-    successor_binding_proven = (
-        selected_probe.status == 200
-        and selected_probe.bound_output_path == selected_path
+    successor_binding_proven = selected_probe.status == 200 and (
+        selected_probe.bound_output_path == selected_path
+        or selected_probe.bound_session_id == selected.path.stem
     )
     superseded_gap_owners: list[str] = []
     if (

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3617,6 +3617,52 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
                 rt, chs, cid, retired_pending_paths
             )
         return
+
+    # A cleared/restarted provider session creates a new transcript. Once that
+    # selected successor has a delivered OK verdict, an idle prior transcript
+    # must remain historical evidence rather than own the channel's live outage
+    # forever. This is a retirement, not proof that the old LOST blocks arrived,
+    # so the normal RECOVERED notification must stay suppressed.
+    selected_path = str(selected.path) if selected is not None else None
+    selected_verdict = next(
+        (
+            verdict
+            for candidate, verdict in evaluated
+            if str(candidate.path) == selected_path
+        ),
+        None,
+    )
+    superseded_gap_owners: list[str] = []
+    if (
+        selected_path
+        and selected_verdict is not None
+        and selected_verdict.state == STATE_OK
+        and fresh_undelivered_by_path.get(selected_path, 0) == 0
+        and delivered_watermark_for_path(chs, selected_path) > 0
+    ):
+        for path in _validated_gap_owner_transcripts(chs):
+            if path == selected_path or path in semantic_growth_paths:
+                continue
+            candidate = candidate_by_path.get(path)
+            if candidate is None or selected is None:
+                continue
+            if candidate.mtime >= selected.mtime:
+                continue
+            superseded_gap_owners.append(path)
+            retired_transcripts[path] = (candidate.size, now)
+        if superseded_gap_owners:
+            _store_retired_transcripts(chs, retired_transcripts)
+            retired_pending_paths.extend(superseded_gap_owners)
+            evaluated = [
+                (candidate, verdict)
+                for candidate, verdict in evaluated
+                if str(candidate.path) not in superseded_gap_owners
+            ]
+            rt.log(
+                f"[{cid}] historical-gap-owner-retired "
+                f"successor={selected_path} count={len(superseded_gap_owners)}"
+            )
+
     state_rank = {STATE_OK: 0, STATE_LAGGING: 1, STATE_GAP: 2}
     verdict_candidate, v = max(
         evaluated,
@@ -3664,7 +3710,9 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
     _store_recovered_gap_guards(chs, recovered_gap_guards)
 
     next_gap_owners = [
-        path for path in previous_gap_owners if path not in evaluated_paths
+        path
+        for path in previous_gap_owners
+        if path not in evaluated_paths and path not in superseded_gap_owners
     ]
     for candidate, verdict in evaluated:
         path = str(candidate.path)

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -3618,11 +3618,12 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
             )
         return
 
-    # A cleared/restarted provider session creates a new transcript. Once that
-    # selected successor has a delivered OK verdict, an idle prior transcript
-    # must remain historical evidence rather than own the channel's live outage
-    # forever. This is a retirement, not proof that the old LOST blocks arrived,
-    # so the normal RECOVERED notification must stay suppressed.
+    # A cleared/restarted provider session creates a new transcript. Retire an
+    # old GAP owner only when dcserver proves that the channel is now bound to the
+    # delivered successor and the old file has crossed the normal idle boundary.
+    # File mtime ordering alone is not a session boundary: concurrent writers and
+    # delayed flushes can invert it. This is a retirement, not proof that the old
+    # LOST blocks arrived, so the normal RECOVERED notification stays suppressed.
     selected_path = str(selected.path) if selected is not None else None
     selected_verdict = next(
         (
@@ -3632,6 +3633,11 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         ),
         None,
     )
+    selected_probe = rt.watcher_state(cid) if selected_path else WatcherStateProbe(None)
+    successor_binding_proven = (
+        selected_probe.status == 200
+        and selected_probe.bound_output_path == selected_path
+    )
     superseded_gap_owners: list[str] = []
     if (
         selected_path
@@ -3639,24 +3645,46 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         and selected_verdict.state == STATE_OK
         and fresh_undelivered_by_path.get(selected_path, 0) == 0
         and delivered_watermark_for_path(chs, selected_path) > 0
+        and successor_binding_proven
     ):
         for path in _validated_gap_owner_transcripts(chs):
             if path == selected_path or path in semantic_growth_paths:
                 continue
             candidate = candidate_by_path.get(path)
-            if candidate is None or selected is None:
-                continue
-            if candidate.mtime >= selected.mtime:
+            if candidate is None or now - candidate.mtime < cfg.idle_quiet_secs:
                 continue
             superseded_gap_owners.append(path)
             retired_transcripts[path] = (candidate.size, now)
         if superseded_gap_owners:
+            superseded = set(superseded_gap_owners)
             _store_retired_transcripts(chs, retired_transcripts)
             retired_pending_paths.extend(superseded_gap_owners)
+            remaining_pending = [
+                path for path in remaining_pending if path not in superseded
+            ]
+            pending_failures = {
+                path: failures
+                for path, failures in pending_failures.items()
+                if path not in superseded
+            }
+            pending_since = {
+                path: since
+                for path, since in pending_since.items()
+                if path not in superseded
+            }
+            chs[PENDING_TRANSCRIPTS_KEY] = remaining_pending
+            if pending_failures:
+                chs[PENDING_TRANSCRIPT_FAILURES_KEY] = pending_failures
+            else:
+                chs.pop(PENDING_TRANSCRIPT_FAILURES_KEY, None)
+            if pending_since:
+                chs[PENDING_TRANSCRIPT_SINCE_KEY] = pending_since
+            else:
+                chs.pop(PENDING_TRANSCRIPT_SINCE_KEY, None)
             evaluated = [
                 (candidate, verdict)
                 for candidate, verdict in evaluated
-                if str(candidate.path) not in superseded_gap_owners
+                if str(candidate.path) not in superseded
             ]
             rt.log(
                 f"[{cid}] historical-gap-owner-retired "

--- a/scripts/relay_watchdog.py
+++ b/scripts/relay_watchdog.py
@@ -56,6 +56,7 @@ import shutil
 import stat as stat_mode
 import subprocess
 import time
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
@@ -1449,6 +1450,17 @@ class WatcherStateProbe:
     bound_session_id: str | None = None
 
 
+def canonical_session_uuid(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return None
+    canonical = str(parsed)
+    return canonical if value == canonical else None
+
+
 def parse_watcher_state_probe(
     status: int | None, payload: object
 ) -> WatcherStateProbe:
@@ -1465,11 +1477,7 @@ def parse_watcher_state_probe(
     attached = attached_raw if isinstance(attached_raw, bool) else None
     desynced = desynced_raw if isinstance(desynced_raw, bool) else None
     bound = bound_output_path if isinstance(bound_output_path, str) else None
-    bound_session_id = (
-        bound_session_id_raw
-        if isinstance(bound_session_id_raw, str) and bound_session_id_raw
-        else None
-    )
+    bound_session_id = canonical_session_uuid(bound_session_id_raw)
 
     has_activity_schema = (
         "relay_stall_state" in payload or "relay_health" in payload
@@ -3647,9 +3655,15 @@ def tick_channel(rt: Runtime, ch: ChannelConfig, state: dict[str, Any], now: flo
         None,
     )
     selected_probe = rt.watcher_state(cid) if selected_path else WatcherStateProbe(None)
+    selected_session_id = (
+        canonical_session_uuid(selected.path.stem) if selected is not None else None
+    )
     successor_binding_proven = selected_probe.status == 200 and (
         selected_probe.bound_output_path == selected_path
-        or selected_probe.bound_session_id == selected.path.stem
+        or (
+            selected_session_id is not None
+            and selected_probe.bound_session_id == selected_session_id
+        )
     )
     superseded_gap_owners: list[str] = []
     if (

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -4490,10 +4490,10 @@ class TickChannelTests(unittest.TestCase):
             )
 
         owner.write_text(
-            record(self.now - 4000, "historical block never delivered") + "\n",
+            record(self.now - 2000, "historical block never delivered") + "\n",
             encoding="utf-8",
         )
-        os.utime(owner, (self.now - 4000, self.now - 4000))
+        os.utime(owner, (self.now - 2000, self.now - 2000))
         rt = self.make_rt()
         rt.haystack = ""
         state: dict = {}
@@ -4503,13 +4503,17 @@ class TickChannelTests(unittest.TestCase):
         self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
         chs["issue_url"] = "https://example.test/issues/4715"
 
+        successor_at = self.now + rt.cfg.idle_quiet_secs + 1
         successor.write_text(
-            record(self.now + 1, "current session delivery proof") + "\n",
+            record(successor_at, "current session delivery proof") + "\n",
             encoding="utf-8",
         )
-        os.utime(successor, (self.now + 1, self.now + 1))
+        os.utime(successor, (successor_at, successor_at))
         rt.haystack = norm("current session delivery proof")
-        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+        rt.watcher_probe = WatcherStateProbe(
+            200, attached=True, desynced=False, bound_output_path=str(successor)
+        )
+        tick_channel(rt, TICK_CHANNEL, state, successor_at + 1)
 
         self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(successor))
         self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
@@ -4521,6 +4525,95 @@ class TickChannelTests(unittest.TestCase):
         self.assertTrue(
             any("historical-gap-owner-retired" in line for line in rt.log_lines)
         )
+
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 3)
+        self.assertNotIn(
+            str(owner), chs.get(relay_watchdog.PENDING_TRANSCRIPTS_KEY, [])
+        )
+        self.assertNotIn(
+            str(owner), chs.get(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, [])
+        )
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+
+    def test_4715_successor_without_runtime_binding_keeps_historical_gap_owner(self):
+        owner = self.proj_dir / "parallel-owner-gap.jsonl"
+        successor = self.proj_dir / "newer-delivered-unbound.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner.write_text(
+            record(self.now - 2000, "parallel owner remains missing") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(owner, (self.now - 2000, self.now - 2000))
+        rt = self.make_rt()
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+
+        successor_at = self.now + rt.cfg.idle_quiet_secs + 1
+        successor.write_text(
+            record(successor_at, "unbound successor delivered") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(successor, (successor_at, successor_at))
+        rt.haystack = norm("unbound successor delivered")
+        rt.watcher_probe = WatcherStateProbe(
+            200, attached=True, desynced=False, bound_output_path=str(owner)
+        )
+        tick_channel(rt, TICK_CHANNEL, state, successor_at + 1)
+
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
+        self.assertNotIn(str(owner), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}))
+
+    def test_4715_active_bound_predecessor_is_not_retired_by_mtime_order(self):
+        owner = self.proj_dir / "active-bound-owner.jsonl"
+        successor = self.proj_dir / "newer-delivered.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner.write_text(
+            record(self.now - 2000, "active owner remains missing") + "\n",
+            encoding="utf-8",
+        )
+        rt = self.make_rt()
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+
+        successor.write_text(
+            record(self.now + 1, "newer delivery does not prove predecessor ended") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(successor, (self.now + 1, self.now + 1))
+        rt.haystack = norm("newer delivery does not prove predecessor ended")
+        rt.watcher_probe = WatcherStateProbe(
+            200, attached=True, desynced=False, bound_output_path=str(successor)
+        )
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
+        self.assertNotIn(str(owner), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}))
 
     def test_invariant_4435_retiring_one_of_two_gap_owners_keeps_incident_clock(self):
         owner_a = self.proj_dir / "multi-gap-a.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -4474,6 +4474,54 @@ class TickChannelTests(unittest.TestCase):
         )
         self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
 
+    def test_4715_delivered_successor_retires_idle_historical_gap_owner(self):
+        owner = self.proj_dir / "cleared-session-gap.jsonl"
+        successor = self.proj_dir / "current-session-ok.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner.write_text(
+            record(self.now - 4000, "historical block never delivered") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(owner, (self.now - 4000, self.now - 4000))
+        rt = self.make_rt()
+        rt.haystack = ""
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+        self.assertTrue(chs.get("alerting"))
+        self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
+        chs["issue_url"] = "https://example.test/issues/4715"
+
+        successor.write_text(
+            record(self.now + 1, "current session delivery proof") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(successor, (self.now + 1, self.now + 1))
+        rt.haystack = norm("current session delivery proof")
+        tick_channel(rt, TICK_CHANNEL, state, self.now + 2)
+
+        self.assertEqual(chs[SELECTED_TRANSCRIPT_KEY], str(successor))
+        self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertNotIn("gap_since", chs)
+        self.assertNotIn(relay_watchdog.GAP_TRANSCRIPT_KEY, chs)
+        self.assertNotIn(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, chs)
+        self.assertIn(str(owner), chs[relay_watchdog.RETIRED_TRANSCRIPTS_KEY])
+        self.assertFalse(any("릴레이 갭 해소" in body for body, _ in rt.alerts))
+        self.assertTrue(
+            any("historical-gap-owner-retired" in line for line in rt.log_lines)
+        )
+
     def test_invariant_4435_retiring_one_of_two_gap_owners_keeps_incident_clock(self):
         owner_a = self.proj_dir / "multi-gap-a.jsonl"
         owner_b = self.proj_dir / "multi-gap-b.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -4476,7 +4476,9 @@ class TickChannelTests(unittest.TestCase):
 
     def test_4715_delivered_successor_retires_idle_historical_gap_owner(self):
         owner = self.proj_dir / "cleared-session-gap.jsonl"
-        successor = self.proj_dir / "current-session-ok.jsonl"
+        successor = (
+            self.proj_dir / "ea50ec55-d965-4ae4-86f1-05a4209f2b7c.jsonl"
+        )
 
         def record(epoch: float, text: str) -> str:
             return json.dumps(
@@ -4538,6 +4540,51 @@ class TickChannelTests(unittest.TestCase):
             str(owner), chs.get(relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY, [])
         )
         self.assertFalse(chs.get("alerting"), (chs, rt.log_lines))
+
+    def test_4715_malformed_matching_session_id_fails_closed(self):
+        owner = self.proj_dir / "malformed-owner-gap.jsonl"
+        successor = self.proj_dir / "not-a-session-uuid.jsonl"
+
+        def record(epoch: float, text: str) -> str:
+            return json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch)
+                    ),
+                    "message": {"content": [{"type": "text", "text": text}]},
+                }
+            )
+
+        owner.write_text(
+            record(self.now - 2000, "malformed binding owner remains missing") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(owner, (self.now - 2000, self.now - 2000))
+        rt = self.make_rt()
+        state: dict = {}
+        tick_channel(rt, TICK_CHANNEL, state, self.now)
+        chs = state["999"]
+
+        successor_at = self.now + rt.cfg.idle_quiet_secs + 1
+        successor.write_text(
+            record(successor_at, "malformed successor delivered") + "\n",
+            encoding="utf-8",
+        )
+        os.utime(successor, (successor_at, successor_at))
+        rt.haystack = norm("malformed successor delivered")
+        rt.watcher_probe = WatcherStateProbe(
+            200,
+            attached=True,
+            desynced=False,
+            bound_output_path="/runtime/sessions/channel-mirror.jsonl",
+            bound_session_id=successor.stem,
+        )
+        tick_channel(rt, TICK_CHANNEL, state, successor_at + 1)
+
+        self.assertTrue(chs.get("alerting"), (chs, rt.log_lines))
+        self.assertIn(str(owner), chs[relay_watchdog.GAP_OWNER_TRANSCRIPTS_KEY])
+        self.assertNotIn(str(owner), chs.get(relay_watchdog.RETIRED_TRANSCRIPTS_KEY, {}))
 
     def test_4715_successor_without_runtime_binding_keeps_historical_gap_owner(self):
         owner = self.proj_dir / "parallel-owner-gap.jsonl"

--- a/tests/test_relay_watchdog.py
+++ b/tests/test_relay_watchdog.py
@@ -4511,7 +4511,11 @@ class TickChannelTests(unittest.TestCase):
         os.utime(successor, (successor_at, successor_at))
         rt.haystack = norm("current session delivery proof")
         rt.watcher_probe = WatcherStateProbe(
-            200, attached=True, desynced=False, bound_output_path=str(successor)
+            200,
+            attached=True,
+            desynced=False,
+            bound_output_path="/runtime/sessions/channel-mirror.jsonl",
+            bound_session_id=successor.stem,
         )
         tick_channel(rt, TICK_CHANNEL, state, successor_at + 1)
 


### PR DESCRIPTION
## Summary
- retire a historical gap owner after a newer selected transcript proves successful Discord delivery
- preserve the old LOST blocks as retired historical evidence without emitting a false recovery notification
- add a regression and mutation guard for the clear/restart boundary seen in #4715

## Verification
- `python3 -m unittest tests.test_relay_watchdog` — 231 passed
- `python3 -m py_compile scripts/relay_watchdog.py`
- mutation: removing the superseded-owner exclusion makes the #4715 test fail its own `alerting` assertion (rc 1)

Refs #4715

🤖 Generated with [Claude Code](https://claude.com/claude-code)