### PR TITLE
fix: preserve commentary after terminal bridge delivery

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -784,7 +784,7 @@
 | `services::discord::tmux_watcher::controller_heartbeat` | `src/services/discord/tmux_watcher/controller_heartbeat.rs` | 34 | 34 | 0 |  |
 | `services::discord::tmux_watcher::entry` | `src/services/discord/tmux_watcher/entry.rs` | 33 | 33 | 0 |  |
 | `services::discord::tmux_watcher::jsonl_rotation` | `src/services/discord/tmux_watcher/jsonl_rotation.rs` | 78 | 78 | 0 |  |
-| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 697 | 519 | 178 |  |
+| `services::discord::tmux_watcher::liveness` | `src/services/discord/tmux_watcher/liveness.rs` | 690 | 512 | 178 |  |
 | `services::discord::tmux_watcher::loop_poll_prologue` | `src/services/discord/tmux_watcher/loop_poll_prologue.rs` | 609 | 609 | 0 |  |
 | `services::discord::tmux_watcher::no_result_exits` | `src/services/discord/tmux_watcher/no_result_exits.rs` | 814 | 814 | 0 |  |
 | `services::discord::tmux_watcher::orphan_status_panel_cleanup` | `src/services/discord/tmux_watcher/orphan_status_panel_cleanup.rs` | 227 | 227 | 0 |  |
@@ -798,8 +798,8 @@
 | `services::discord::tmux_watcher::single_message_footer` | `src/services/discord/tmux_watcher/single_message_footer.rs` | 533 | 419 | 114 |  |
 | `services::discord::tmux_watcher::stall_exit` | `src/services/discord/tmux_watcher/stall_exit.rs` | 295 | 110 | 185 |  |
 | `services::discord::tmux_watcher::streaming_session_banner` | `src/services/discord/tmux_watcher/streaming_session_banner.rs` | 198 | 94 | 104 |  |
-| `services::discord::tmux_watcher::streaming_status_tick` | `src/services/discord/tmux_watcher/streaming_status_tick.rs` | 937 | 937 | 0 |  |
-| `services::discord::tmux_watcher::streaming_status_tick::types` | `src/services/discord/tmux_watcher/streaming_status_tick/types.rs` | 62 | 62 | 0 |  |
+| `services::discord::tmux_watcher::streaming_status_tick` | `src/services/discord/tmux_watcher/streaming_status_tick.rs` | 947 | 947 | 0 |  |
+| `services::discord::tmux_watcher::streaming_status_tick::types` | `src/services/discord/tmux_watcher/streaming_status_tick/types.rs` | 77 | 77 | 0 |  |
 | `services::discord::tmux_watcher::supervisor_relay` | `src/services/discord/tmux_watcher/supervisor_relay.rs` | 619 | 619 | 0 |  |
 | `services::discord::tmux_watcher::task_response_authority` | `src/services/discord/tmux_watcher/task_response_authority.rs` | 484 | 484 | 0 |  |
 | `services::discord::tmux_watcher::terminal_abort_exits` | `src/services/discord/tmux_watcher/terminal_abort_exits.rs` | 534 | 534 | 0 |  |

--- a/src/services/discord/tmux_watcher/liveness.rs
+++ b/src/services/discord/tmux_watcher/liveness.rs
@@ -208,13 +208,6 @@ pub(super) fn watcher_streaming_rollover_should_skip(current_portion: &str) -> b
     )
 }
 
-pub(super) fn watcher_should_suppress_streaming_after_bridge_delivery(
-    bridge_delivered_turn: bool,
-    has_assistant_response: bool,
-) -> bool {
-    bridge_delivered_turn && has_assistant_response
-}
-
 pub(in crate::services::discord::tmux) fn watcher_lifecycle_terminal_delivery_observed(
     terminal_delivery_observed: bool,
     bridge_delivered_turn: bool,

--- a/src/services/discord/tmux_watcher/streaming_status_tick.rs
+++ b/src/services/discord/tmux_watcher/streaming_status_tick.rs
@@ -197,9 +197,19 @@ pub(super) async fn update_streaming_status_tick(
         }
 
         let has_assistant_response_for_streaming = !full_response.trim().is_empty();
+        let bridge_committed_range =
+            crate::services::discord::outbound::delivery_frontier_probe::delivered_frontier_current_generation(
+                &watcher_provider,
+                channel_id,
+                &tmux_session_name,
+                Some(current_offset),
+            )
+            .map(|commit| commit.range);
         if watcher_should_suppress_streaming_after_bridge_delivery(
             turn_delivered.load(Ordering::Relaxed),
             has_assistant_response_for_streaming,
+            (data_start_offset, current_offset),
+            bridge_committed_range,
         ) {
             if let Some(msg_id) = placeholder_msg_id {
                 if watcher_should_delete_suppressed_placeholder(placeholder_from_restored_inflight)

--- a/src/services/discord/tmux_watcher/streaming_status_tick/types.rs
+++ b/src/services/discord/tmux_watcher/streaming_status_tick/types.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+pub(in crate::services::discord::tmux::tmux_watcher) fn watcher_should_suppress_streaming_after_bridge_delivery(
+    bridge_delivered_turn: bool,
+    has_assistant_response: bool,
+    observed_range: (u64, u64),
+    committed_range: Option<(u64, u64)>,
+) -> bool {
+    if !bridge_delivered_turn || !has_assistant_response {
+        return false;
+    }
+    committed_range.is_some_and(|(start, end)| {
+        let (observed_start, observed_end) = observed_range;
+        start <= observed_start && observed_start < observed_end && observed_end <= end
+    })
+}
+
 pub(in crate::services::discord::tmux::tmux_watcher) struct StreamingStatusTickContext<'a> {
     pub(in crate::services::discord::tmux::tmux_watcher) http: &'a Arc<serenity::Http>,
     pub(in crate::services::discord::tmux::tmux_watcher) shared: &'a Arc<SharedData>,

--- a/src/services/discord/tmux_watcher/tests.rs
+++ b/src/services/discord/tmux_watcher/tests.rs
@@ -17,7 +17,6 @@ use super::{
     watcher_should_delete_suppressed_placeholder,
     watcher_should_direct_send_after_session_bound_ack,
     watcher_should_reclaim_orphan_turn_placeholder,
-    watcher_should_suppress_streaming_after_bridge_delivery,
     watcher_stream_seed_after_restored_seed_discard, watcher_terminal_commit_side_effects_for_test,
     watcher_terminal_edit_consumes_placeholder, watcher_terminal_response_for_direct_send,
     watcher_terminal_rewind_seed, watcher_wait_inflight_retry_plan,
@@ -3821,16 +3820,57 @@ fn legacy_watcher_streaming_edit_keeps_processing_footer() {
 }
 
 #[test]
-fn watcher_streaming_suppresses_after_bridge_delivery_only_for_response() {
-    assert!(watcher_should_suppress_streaming_after_bridge_delivery(
-        true, true
-    ));
-    assert!(!watcher_should_suppress_streaming_after_bridge_delivery(
-        true, false
-    ));
-    assert!(!watcher_should_suppress_streaming_after_bridge_delivery(
-        false, true
-    ));
+fn watcher_streaming_suppression_stops_at_bridge_committed_frontier() {
+    let committed_terminal_range = Some((100, 200));
+
+    assert!(
+        super::streaming_status_tick::watcher_should_suppress_streaming_after_bridge_delivery(
+            true,
+            true,
+            (100, 200),
+            committed_terminal_range,
+        )
+    );
+    assert!(
+        !super::streaming_status_tick::watcher_should_suppress_streaming_after_bridge_delivery(
+            true,
+            true,
+            (200, 240),
+            committed_terminal_range,
+        )
+    );
+    assert!(
+        !super::streaming_status_tick::watcher_should_suppress_streaming_after_bridge_delivery(
+            true,
+            true,
+            (180, 240),
+            committed_terminal_range,
+        )
+    );
+    assert!(
+        !super::streaming_status_tick::watcher_should_suppress_streaming_after_bridge_delivery(
+            true,
+            false,
+            (100, 200),
+            committed_terminal_range,
+        )
+    );
+    assert!(
+        !super::streaming_status_tick::watcher_should_suppress_streaming_after_bridge_delivery(
+            false,
+            true,
+            (100, 200),
+            committed_terminal_range,
+        )
+    );
+    assert!(
+        !super::streaming_status_tick::watcher_should_suppress_streaming_after_bridge_delivery(
+            true,
+            true,
+            (100, 200),
+            None,
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace blanket `turn_delivered` streaming suppression with a boundary based on the existing durable bridge delivery frontier
- continue suppressing ranges fully covered by the terminal commit while allowing later task-notification and auto-turn commentary ranges
- add a deterministic regression whose commentary assertions fail under the old bool-only policy
- keep the hot `tmux_watcher.rs` root unchanged

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib`
- [x] `cargo test --lib tmux_watcher` (284 passed)
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `python3 scripts/audit_maintainability.py --check`
- [x] mutation proof: replacing the frontier predicate with bool-only suppression makes `watcher_streaming_suppression_stops_at_bridge_committed_frontier` fail by assertion; restoring it passes

Closes #4717

🤖 Generated with [Claude Code](https://claude.com/claude-code)