### PR TITLE
fix(4724): regen-inventory git merge driver (slice B — immediate O(N²) mitigation)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,19 @@
 scripts/** text eol=lf
 .githooks/** text eol=lf
 .github/workflows/*.yml text eol=lf
+
+# Custom merge driver for COMMITTED generated inventory docs (#4724 slice B).
+# These four files are the ones `scripts/generate_inventory_docs.py` overwrites
+# wholesale; line-count churn makes concurrent PRs collide on them. The
+# `regen-inventory` driver takes git's clean 3-way merge when rows are
+# independent, and only regenerates on a genuine same-row conflict. Requires
+# local registration (a .gitattributes driver is inert without it):
+#   bash scripts/setup-merge-drivers.sh   (run once; also via setup-hooks.sh)
+# Enumerated explicitly — NOT `docs/generated/*.md` — because the other
+# docs/generated/*.md files (README.md, db-file-duplication-audit.md,
+# maintainability-audit.md, pg-audit-checklist.md, policy-db-inventory.md) are
+# hand-authored / emitted by a different generator and must never be clobbered.
+docs/generated/module-inventory.md merge=regen-inventory
+docs/generated/route-inventory.md merge=regen-inventory
+docs/generated/worker-inventory.md merge=regen-inventory
+docs/generated/giant-file-registry.md merge=regen-inventory

--- a/docs/agent-maintenance/index.md
+++ b/docs/agent-maintenance/index.md
@@ -38,6 +38,11 @@
 - [`known-legacy.md`](known-legacy.md) — code paths that intentionally remain
   legacy, with the cleanup-owner issue number. Touch them only inside the
   scope of the listed issue or for narrow bugfix.
+- [`merge-driver-inventory.md`](merge-driver-inventory.md) — the
+  `regen-inventory` git merge driver that auto-resolves conflicts in the
+  committed generated inventory docs by regenerating from the merged tree
+  (#4724). Includes the one-time `scripts/setup-merge-drivers.sh` step every
+  developer must run.
 - [`multinode-transition.md`](multinode-transition.md) — transition map for
   moving AgentDesk from one dcserver node to leader/worker execution, including
   single-node assumptions, side-effect ownership, invariants, and #876-#884

--- a/docs/agent-maintenance/merge-driver-inventory.md
+++ b/docs/agent-maintenance/merge-driver-inventory.md
@@ -1,0 +1,126 @@
+# Inventory Docs Merge Driver (`regen-inventory`)
+
+> Why: `docs/generated/module-inventory.md` and its siblings are **committed
+> generated files**. When two branches change the same module's line count (or a
+> shared summary line), they edit the same row, so a plain 3-way merge leaves
+> conflict markers there — and because the inventory is regenerated on every
+> prod-line change, concurrent PRs collide constantly, forcing O(N²) serial
+> rebases (#4724). The `regen-inventory` git merge driver removes that class of
+> conflict: it lets git's normal line merge handle independent rows, and only
+> when a row genuinely collides does it **regenerate** the inventory to drop the
+> markers. It is a best-effort ergonomic auto-resolver — the authoritative
+> correctness check is the server-side CI freshness gate (see *Correctness
+> backstops* below), not the driver.
+
+## One-time developer setup (REQUIRED)
+
+A merge-driver assignment in `.gitattributes` is **inert** until the driver
+command is registered in your local git config. Run once per clone:
+
+```bash
+bash scripts/setup-merge-drivers.sh
+```
+
+This is also invoked by `bash scripts/setup-hooks.sh`, so if you already ran the
+hooks bootstrap you are covered. Verify with:
+
+```bash
+git config --local --get merge.regen-inventory.driver
+# → bash scripts/git-merge-regen-inventory.sh %O %A %B %P
+```
+
+## What it covers
+
+`.gitattributes` assigns `merge=regen-inventory` to exactly the four files that
+`scripts/generate_inventory_docs.py` overwrites wholesale:
+
+- `docs/generated/module-inventory.md`
+- `docs/generated/route-inventory.md`
+- `docs/generated/worker-inventory.md`
+- `docs/generated/giant-file-registry.md`
+
+**Deliberately excluded** (hand-authored, or emitted by a different generator —
+the driver would clobber real content): `docs/generated/README.md`,
+`db-file-duplication-audit.md`, `maintainability-audit.md` (written by
+`audit_maintainability.py`, not the inventory generator), `pg-audit-checklist.md`,
+`policy-db-inventory.md`. `ARCHITECTURE.md` is also excluded because it is a
+mixed hand-authored + marker-generated file; regenerating it would not resolve a
+conflict located in its hand-authored prose.
+
+## How it works (merge-file first, regenerate only on real conflict)
+
+git invokes a custom merge driver whenever **both** sides modify a covered file.
+`scripts/git-merge-regen-inventory.sh %O %A %B %P`:
+
+1. **Tries git's normal line-level 3-way merge** (`git merge-file`). When the two
+   sides changed **different** rows (independent modules), this merges cleanly
+   and the result is byte-identical to what git would have produced without the
+   driver — so independent inventory edits are **never** regressed.
+2. **Regenerates only on a genuine conflict.** A doc row collides when both sides
+   changed the **same** module (or a shared summary line). On that path the
+   driver runs `python3 scripts/generate_inventory_docs.py` and takes its output,
+   removing the conflict markers. The regenerated file is written over git's `%A`
+   (result) path and the driver exits 0.
+
+This two-step design is deliberate: an unconditional regenerate would be *worse*
+than the default merge for the common independent-edit case, because under git's
+`ort` strategy a source file changed on only one side is written to the working
+tree *after* the driver runs. Delegating independent rows to `git merge-file`
+sidesteps that entirely.
+
+### Honest limits (why the driver is best-effort, not authoritative)
+
+The driver is an **ergonomic auto-resolver**, not a correctness oracle. Two
+empirically-verified `ort` facts bound what it can guarantee:
+
+- On the **regenerate path**, `ort` does **not** reliably materialize the
+  colliding module's merged source into the working tree before invoking the
+  driver, so the regenerated counts for that module can be momentarily stale.
+- On the **clean-merge path**, in-driver regeneration would be actively harmful,
+  so we do **not** self-validate there. Measured directly: for two branches that
+  change *different* modules (a correct, independent-row merge), `git merge-file`
+  yields the correct `app_state=49`, but a regenerate at driver time yields a
+  **stale** `app_state=47` — because the other side's one-sided source change is
+  not yet in the working tree. Comparing the two would flag a *correct* merge as
+  a mismatch and either fail-closed (re-introducing the conflict the driver
+  exists to remove) or overwrite the correct result with the stale one. So the
+  clean 3-way result is taken verbatim.
+
+What the driver guarantees is narrow and sufficient: it **never leaves conflict
+markers on churn** (eliminating the O(N²) manual-resolution tax), and it **never
+emits content that is worse than a bad manual resolution would be today** — any
+residual drift it produces is caught by the same CI gate that catches a stale
+hand-resolved doc.
+
+**Fail-closed:** if the conflict path's regeneration fails, the driver exits
+non-zero, leaving the ordinary conflict in place for a human. It never emits
+partially-generated content.
+
+## Correctness backstops (authoritative vs convenience)
+
+- **Authoritative, server-side, non-bypassable — the CI freshness gate.**
+  `scripts/ci-script-checks.sh` (run by the required *Script checks* job in
+  `.github/workflows/ci-pr.yml`) executes `python3
+  scripts/generate_inventory_docs.py --check` under `set -euo pipefail`;
+  generated-docs drift (exit 1) is a **hard PR failure**. It regenerates from the
+  merged source tree and compares, so **driver-produced drift can be pushed to a
+  branch but cannot reach `main`** — CI fails the PR, exactly as it would for a
+  human who committed a stale/incorrect manual resolution. This is the guarantee
+  the driver relies on. (Note: the `check_agent_maintenance_docs.py` invocation
+  in the same script is `--warning-only`; the hard gate is the
+  `generate_inventory_docs.py --check` call.)
+- **Local convenience — the pre-push hook.** `.githooks/pre-push` regenerates
+  inventory docs when `src` changed and blocks/amends before push, so most drift
+  never leaves the machine. It is a convenience only: it is skippable with
+  `git push --no-verify` and requires `core.hooksPath=.githooks` (set by
+  `scripts/setup-hooks.sh`). It is **not** the correctness authority — CI is.
+
+## CI note
+
+CI needs no *driver* registration: `.github/workflows/ci-pr.yml` uses
+`actions/checkout@v4` and never performs a local `git merge`, and GitHub's
+server-side PR merge / merge-queue does **not** honor custom `.gitattributes`
+merge drivers. The driver's value is entirely local (developer rebases/merges).
+No existing CI gate is changed or weakened — in particular the hard
+`generate_inventory_docs.py --check` drift gate above remains the enforcement
+point.

--- a/scripts/git-merge-regen-inventory.sh
+++ b/scripts/git-merge-regen-inventory.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# git-merge-regen-inventory.sh — custom git merge driver for generated inventory
+# docs (#4724 slice B).
+#
+# Problem it solves: docs/generated/module-inventory.md (and its siblings) are
+# COMMITTED generated files. When two branches both change the SAME module's
+# line count (or a shared summary line), they edit the same row of the doc, so a
+# plain 3-way merge leaves conflict markers on that row — and with the inventory
+# regenerated on every prod-line change, concurrent PRs collide constantly →
+# O(N^2) serial rebases.
+#
+# Strategy (merge-file first, regenerate only on real conflict):
+#   1. Attempt git's normal line-level 3-way merge (`git merge-file`). When the
+#      two sides touched DIFFERENT rows this merges cleanly and the result is
+#      identical to what git would have produced without this driver — so we
+#      never regress independent, non-colliding inventory edits.
+#   2. Only when that 3-way genuinely CONFLICTS do we discard it and REGENERATE
+#      the inventory from the working tree, which removes the conflict markers so
+#      the merge/rebase is not blocked. NOTE: under `ort` the colliding module's
+#      merged source is not reliably materialized in the working tree at driver
+#      time, so the regenerated counts for that module may be momentarily stale.
+#      This is intentional and safe: the driver is a best-effort auto-resolver,
+#      and the AUTHORITATIVE correctness check is the server-side CI freshness
+#      gate (scripts/ci-script-checks.sh runs `generate_inventory_docs.py
+#      --check`, a hard PR failure on drift). Any residual drift the driver
+#      produces is caught there — exactly as a stale manual resolution would be —
+#      so it can never reach `main`. See docs/agent-maintenance/merge-driver-
+#      inventory.md ("Correctness backstops"). We deliberately do NOT regenerate
+#      on the clean-merge path: measured, an in-driver regen there reads stale
+#      one-sided sources and would corrupt/deadlock correct independent merges.
+#
+# git invokes it (see scripts/setup-merge-drivers.sh) as:
+#   bash scripts/git-merge-regen-inventory.sh %O %A %B %P
+#     %O = ancestor version (temp path)
+#     %A = ours/current version (temp path) — the driver MUST leave the merge
+#          result here; git reads it back as the resolved content
+#     %B = theirs version (temp path)
+#     %P = pathname in the repo (e.g. docs/generated/module-inventory.md)
+#
+# Fail-closed contract: if a conflict needs regeneration and regeneration fails
+# for ANY reason, exit non-zero. git then leaves the normal conflict in place
+# for a human. The driver never emits partially-generated or garbage content.
+# ──────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+ANCESTOR="${1:-}"   # %O
+CURRENT="${2:-}"    # %A — write the resolved content here
+OTHER="${3:-}"      # %B
+PATHNAME="${4:-}"   # %P — repo-relative path being merged
+
+if [ -z "$ANCESTOR" ] || [ -z "$CURRENT" ] || [ -z "$OTHER" ] || [ -z "$PATHNAME" ]; then
+  echo "git-merge-regen-inventory: expected %O %A %B %P arguments" >&2
+  exit 1
+fi
+
+PYTHON="${PYTHON:-python3}"
+
+# Step 1: try git's standard line-level 3-way merge into %A (ours). rc 0 means a
+# clean merge — keep it verbatim (matches default git behaviour, no regression).
+if git merge-file -q -p "$CURRENT" "$ANCESTOR" "$OTHER" >"$CURRENT.regen-merged" 2>/dev/null; then
+  mv "$CURRENT.regen-merged" "$CURRENT"
+  echo "git-merge-regen-inventory: clean 3-way merge for $PATHNAME (no regeneration needed)"
+  exit 0
+fi
+rm -f "$CURRENT.regen-merged"
+
+# Step 2: real conflict → regenerate from the working tree (the colliding
+# module's source has already been content-merged into the tree at this point).
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "git-merge-regen-inventory: not inside a git working tree" >&2
+  exit 1
+fi
+
+GENERATOR="$REPO_ROOT/scripts/generate_inventory_docs.py"
+if [ ! -f "$GENERATOR" ]; then
+  echo "git-merge-regen-inventory: generator not found at $GENERATOR" >&2
+  exit 1
+fi
+
+if ! regen_output="$(cd "$REPO_ROOT" && "$PYTHON" "$GENERATOR" 2>&1)"; then
+  echo "git-merge-regen-inventory: regeneration failed; leaving conflict for a human" >&2
+  printf '%s\n' "$regen_output" >&2
+  exit 1
+fi
+
+REGENERATED="$REPO_ROOT/$PATHNAME"
+if [ ! -f "$REGENERATED" ]; then
+  echo "git-merge-regen-inventory: regenerated file missing at $REGENERATED" >&2
+  echo "(is $PATHNAME actually emitted by generate_inventory_docs.py?)" >&2
+  exit 1
+fi
+
+if ! cp "$REGENERATED" "$CURRENT"; then
+  echo "git-merge-regen-inventory: failed to copy regenerated $PATHNAME into place" >&2
+  exit 1
+fi
+
+echo "git-merge-regen-inventory: conflict in $PATHNAME auto-resolved by regeneration"
+exit 0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -10,3 +10,6 @@ git config --local core.hooksPath .githooks
 chmod +x .githooks/pre-push
 
 echo "Configured core.hooksPath=.githooks"
+
+# Register custom merge drivers (regen-inventory for generated inventory docs, #4724).
+bash "$SCRIPT_DIR/setup-merge-drivers.sh"

--- a/scripts/setup-merge-drivers.sh
+++ b/scripts/setup-merge-drivers.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# setup-merge-drivers.sh — register AgentDesk custom git merge drivers (#4724).
+#
+# .gitattributes assigns `merge=regen-inventory` to the committed generated
+# inventory docs, but a merge-driver definition in .gitattributes is INERT
+# until the driver command is registered in this repo's local git config.
+# Run this once per clone (also invoked by scripts/setup-hooks.sh).
+# ──────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# %O ancestor, %A ours (result written here), %B theirs, %P repo-relative path.
+git config --local merge.regen-inventory.name \
+  "regenerate committed inventory docs from the merged tree (#4724)"
+git config --local merge.regen-inventory.driver \
+  "bash scripts/git-merge-regen-inventory.sh %O %A %B %P"
+
+chmod +x scripts/git-merge-regen-inventory.sh
+
+echo "Registered git merge driver: regen-inventory"
+echo "  name   = $(git config --local merge.regen-inventory.name)"
+echo "  driver = $(git config --local merge.regen-inventory.driver)"


### PR DESCRIPTION
## Slice B of #4724 (immediate mitigation)

Custom `regen-inventory` git merge driver so committed generated inventory docs auto-resolve instead of serially conflicting across every in-flight PR (last 40/40 commits all touched module-inventory.md → O(N²) rebases).

**Design**: driver tries normal 3-way `git merge-file` FIRST (independent rows merge byte-identical to default git — zero regression); only on a genuine same-row conflict does it regenerate from the working tree (marker-free), fail-closed on regen failure.

**Correctness backstop (authoritative vs convenience)**: The authoritative backstop is the required, non-bypassable server-side CI freshness gate — `generate_inventory_docs.py --check` in `scripts/ci-script-checks.sh` (under `set -euo pipefail`; generated-docs drift = exit 1 = hard PR failure). The driver is a best-effort ergonomic auto-resolver that eliminates conflict markers on churn; any drift it produces is caught by that CI gate exactly as a bad manual resolution is, so it **cannot reach main**. The `.githooks/pre-push` hook is a local convenience only (bypassable with `--no-verify`), NOT the authority.

**Why not self-validate the clean path**: proven harmful — under git's `ort`, at driver-invocation time the other side's one-sided source change isn't materialized yet, so an in-driver regenerate reads STALE source (measured: regen=47 vs correct merge-file=49). Regen-and-compare would flag a correct merge as mismatch → either fail-closed (re-introduce the O(N²) conflict) or overwrite correct-with-stale. Both strictly worse than taking the clean 3-way result.

**Scope**: `.gitattributes` (4 generator-owned docs explicitly enumerated; hand-authored README/audit docs EXCLUDED), `scripts/git-merge-regen-inventory.sh`, `scripts/setup-merge-drivers.sh` (local git config, wired into setup-hooks.sh), docs. CI unchanged.

**Proof**: same-module collision → default git conflicts (rc1, 3 markers), driver rc0 clean; driver best-effort stale=50 → CI gate rc=1 (blocks) → regen=52 → CI rc=0 (backstop verified with pre-push disabled). Well-separated rows → clean 3-way, correct, CI rc0. shellcheck -S warning rc0.

Counter-reviewed (finding on backstop-framing addressed: CI gate verified as authoritative hard-fail). A+C (de-commit generated docs + change-surfaces line-count decoupling) = follow-up slices in #4724.

Slice B of #4724.