### PR TITLE
fix(4714): no-inflight follow-up turn misjudged as content-fingerprint duplicate → Discord response blocked

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -810,7 +810,7 @@
 | `services::discord::tmux_watcher::terminal_long_chunks` | `src/services/discord/tmux_watcher/terminal_long_chunks.rs` | 303 | 303 | 0 |  |
 | `services::discord::tmux_watcher::terminal_readiness` | `src/services/discord/tmux_watcher/terminal_readiness.rs` | 628 | 582 | 46 |  |
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 643 | 589 | 54 |  |
-| `services::discord::tmux_watcher::turn_identity` | `src/services/discord/tmux_watcher/turn_identity.rs` | 512 | 512 | 0 |  |
+| `services::discord::tmux_watcher::turn_identity` | `src/services/discord/tmux_watcher/turn_identity.rs` | 576 | 576 | 0 |  |
 | `services::discord::tmux_watcher::turn_stream_collector` | `src/services/discord/tmux_watcher/turn_stream_collector.rs` | 1161 | 1161 | 0 | giant-file |
 | `services::discord::tmux_watcher::two_message_panel` | `src/services/discord/tmux_watcher/two_message_panel.rs` | 695 | 382 | 313 |  |
 | `services::discord::tmux_watcher::utf8_chunk_decoder` | `src/services/discord/tmux_watcher/utf8_chunk_decoder.rs` | 88 | 88 | 0 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -810,7 +810,7 @@
 | `services::discord::tmux_watcher::terminal_long_chunks` | `src/services/discord/tmux_watcher/terminal_long_chunks.rs` | 303 | 303 | 0 |  |
 | `services::discord::tmux_watcher::terminal_readiness` | `src/services/discord/tmux_watcher/terminal_readiness.rs` | 628 | 582 | 46 |  |
 | `services::discord::tmux_watcher::terminal_send` | `src/services/discord/tmux_watcher/terminal_send.rs` | 643 | 589 | 54 |  |
-| `services::discord::tmux_watcher::turn_identity` | `src/services/discord/tmux_watcher/turn_identity.rs` | 576 | 576 | 0 |  |
+| `services::discord::tmux_watcher::turn_identity` | `src/services/discord/tmux_watcher/turn_identity.rs` | 583 | 583 | 0 |  |
 | `services::discord::tmux_watcher::turn_stream_collector` | `src/services/discord/tmux_watcher/turn_stream_collector.rs` | 1161 | 1161 | 0 | giant-file |
 | `services::discord::tmux_watcher::two_message_panel` | `src/services/discord/tmux_watcher/two_message_panel.rs` | 695 | 382 | 313 |  |
 | `services::discord::tmux_watcher::utf8_chunk_decoder` | `src/services/discord/tmux_watcher/utf8_chunk_decoder.rs` | 88 | 88 | 0 |  |

--- a/src/services/discord/tmux_watcher/turn_identity.rs
+++ b/src/services/discord/tmux_watcher/turn_identity.rs
@@ -272,7 +272,52 @@ impl WatcherDirectTerminalResponseDecision {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Pure core of the #4081/#4714 degenerate-key duplicate decision: the guard
+/// refuses ONLY a byte-identical content re-post (`duplicate`) that has no fresh
+/// in-range assistant text AND no pending user turn awaiting a response. Split
+/// out so the refusal logic is unit-tested directly without the global-state /
+/// delivery-record I/O the wrapper performs.
+pub(super) fn degenerate_duplicate_refuses_delivery(
+    duplicate: bool,
+    fresh_assistant_text_in_observed_range: bool,
+    pending_user_boundary: bool,
+) -> bool {
+    // #4714: a pending user boundary means a live follow-up turn is awaiting a
+    // response — never suppress it. Only a true re-post (no boundary, no fresh
+    // text) is a #4081 phantom duplicate.
+    duplicate && !fresh_assistant_text_in_observed_range && !pending_user_boundary
+}
+
+/// #4081 introduced this degenerate-key content-fingerprint guard to block the
+/// phantom RE-RELAY of the immediately-prior (already-delivered) response at a
+/// no-inflight soft boundary: with no inflight identity the lease key degenerates
+/// to `id-0`, and if the body byte-matches a recently-delivered fingerprint AND
+/// no fresh assistant text appears in the observed range, the watcher would
+/// re-post the same answer. That refusal is correct ONLY when no user turn is
+/// actually awaiting a response.
+///
+/// #4714 (the over-fire this guard now corrects): when the prior watcher-owned
+/// turn reaches terminal but its terminal submission / inflight / dispatch
+/// identity are lost (#3277 backstop path), a genuinely NEW follow-up user turn
+/// also runs under the degenerate `id-0` key. If that follow-up's body collides
+/// with the prior fingerprint and no fresh in-range assistant text is seen yet,
+/// the #4081 guard misjudged it as a duplicate and refused delivery — stranding
+/// the live channel with `route="duplicate_guard_refused"` and zero user-visible
+/// response (both placeholder and streaming suppressed).
+///
+/// The discriminator that separates the two: a PENDING user boundary. A prompt
+/// anchor / external-input lease is recorded when a user turn arrives and CLEARED
+/// once that turn's response is delivered. So at a #4081 phantom re-relay (the
+/// prior turn already delivered) no boundary is present, while at a #4714
+/// follow-up a boundary IS present (a user is still awaiting a response). When a
+/// pending boundary exists the matching content is a new turn whose identity was
+/// lost — NOT a re-post — so the guard must NOT refuse it. A genuine re-post of an
+/// already-delivered turn (no pending boundary) is still caught, preserving #4081.
+///
+/// The boundary is read here (not threaded from the caller) to keep the hot
+/// `tmux_watcher.rs` relay-loop call site byte-identical (#3016 hot-file rule);
+/// this function already performs delivery-record I/O, so the extra
+/// `tui_prompt_dedupe` read is consistent with its impurity.
 pub(super) fn watcher_direct_terminal_response_decision(
     provider: &ProviderKind,
     channel_id: ChannelId,
@@ -300,13 +345,32 @@ pub(super) fn watcher_direct_terminal_response_decision(
             tmux_session_name,
             response,
         );
-    if duplicate && !fresh_assistant_text_in_observed_range {
+    // #4714: a pending prompt anchor or external-input lease marks a live
+    // follow-up turn awaiting a response — mirrors the caller's
+    // `prompt_anchor_present_before_relay || external_input_lease_before_relay`.
+    let pending_user_boundary = crate::services::tui_prompt_dedupe::prompt_anchor_for_response(
+        provider.as_str(),
+        tmux_session_name,
+        channel_id.get(),
+    )
+    .is_some()
+        || crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+            provider.as_str(),
+            tmux_session_name,
+            channel_id.get(),
+        );
+    if degenerate_duplicate_refuses_delivery(
+        duplicate,
+        fresh_assistant_text_in_observed_range,
+        pending_user_boundary,
+    ) {
         tracing::warn!(
             provider = %provider.as_str(),
             channel_id = channel_id.get(),
             tmux_session = %tmux_session_name,
             response_len = response.len(),
             fresh_assistant_text_in_observed_range,
+            pending_user_boundary,
             "watcher: suppressed degenerate-key duplicate terminal response by content fingerprint"
         );
         return WatcherDirectTerminalResponseDecision::RefusedDegenerateDuplicate;

--- a/src/services/discord/tmux_watcher/turn_identity.rs
+++ b/src/services/discord/tmux_watcher/turn_identity.rs
@@ -305,14 +305,21 @@ pub(super) fn degenerate_duplicate_refuses_delivery(
 /// the live channel with `route="duplicate_guard_refused"` and zero user-visible
 /// response (both placeholder and streaming suppressed).
 ///
-/// The discriminator that separates the two: a PENDING user boundary. A prompt
-/// anchor / external-input lease is recorded when a user turn arrives and CLEARED
-/// once that turn's response is delivered. So at a #4081 phantom re-relay (the
-/// prior turn already delivered) no boundary is present, while at a #4714
-/// follow-up a boundary IS present (a user is still awaiting a response). When a
-/// pending boundary exists the matching content is a new turn whose identity was
-/// lost — NOT a re-post — so the guard must NOT refuse it. A genuine re-post of an
-/// already-delivered turn (no pending boundary) is still caught, preserving #4081.
+/// The discriminator is a PENDING user boundary. A prompt anchor / external-input
+/// lease is recorded when a user turn arrives and CLEARED once that turn's
+/// response is delivered. Normally a #4081 phantom re-relay has no boundary,
+/// while a #4714 follow-up does, so the latter must not be refused.
+///
+/// Accepted cross-turn edge: the boundary is a single latest-turn slot, not an
+/// identity carried by this degenerate response. If turn A is delivered, turn B
+/// overwrites the slot, and A's phantom body is reconsidered while B is pending,
+/// A inherits B's boundary and can be sent once more. Neither the content
+/// fingerprint (which intentionally matches both a phantom and a legitimate
+/// byte-identical follow-up) nor the slot's message id / lease generation can
+/// identify the response after this path has lost its turn identity. Refusing
+/// that ambiguous overlap would recreate #4714 and strand B, so delivery wins.
+/// The exposure is bounded to a #4081 phantom overlapping a concurrently pending
+/// second message; ordinary re-posts with no pending boundary remain refused.
 ///
 /// The boundary is read here (not threaded from the caller) to keep the hot
 /// `tmux_watcher.rs` relay-loop call site byte-identical (#3016 hot-file rule);

--- a/src/services/discord/tmux_watcher/turn_identity_tests.rs
+++ b/src/services/discord/tmux_watcher/turn_identity_tests.rs
@@ -324,6 +324,95 @@ fn degenerate_key_content_guard_requires_no_fresh_output_4081() {
 }
 
 #[test]
+fn degenerate_duplicate_refusal_core_gates_on_pending_boundary_4714() {
+    // Pure decision core (#4081/#4714). A byte-identical re-post with no fresh
+    // in-range text and NO pending user boundary is the only refusal case.
+    assert!(
+        degenerate_duplicate_refuses_delivery(true, false, false),
+        "#4081: a true re-post (no fresh text, no pending boundary) must be refused"
+    );
+    // #4714: a pending user boundary marks a live follow-up turn — never suppress.
+    assert!(
+        !degenerate_duplicate_refuses_delivery(true, false, true),
+        "#4714: a pending user boundary must relay even on a fingerprint collision"
+    );
+    // Fresh in-range assistant text is a real new answer regardless of boundary.
+    assert!(!degenerate_duplicate_refuses_delivery(true, true, false));
+    // A non-duplicate body always relays.
+    assert!(!degenerate_duplicate_refuses_delivery(false, false, false));
+}
+
+#[test]
+fn pending_user_boundary_relays_fingerprint_collision_followup_4714() {
+    // #4714 regression (end-to-end through the real prompt-anchor gate): a
+    // no-inflight follow-up turn whose body byte-collides with a prior delivered
+    // fingerprint MUST still be relayed while a user boundary is pending (prompt
+    // anchor present), while a genuine re-post of the same delivered turn (anchor
+    // cleared, no boundary) MUST still be refused (#4081).
+    let temp = tempfile::TempDir::new().expect("temp runtime root");
+    let _root_guard = crate::config::set_agentdesk_root_for_test(temp.path());
+
+    let provider = ProviderKind::Codex;
+    let session = "AgentDesk-codex-adk-cdx-4714";
+    let channel_id = poise::serenity_prelude::ChannelId::new(7_4714);
+    let body = "identical answer body";
+    let gen_path = crate::services::tmux_common::session_temp_path(session, "generation");
+    std::fs::create_dir_all(std::path::Path::new(&gen_path).parent().unwrap()).unwrap();
+    std::fs::write(&gen_path, b"1").unwrap();
+    // The prior turn was already delivered — its content fingerprint is on record.
+    crate::services::discord::outbound::delivery_record::record_delivered_content_fingerprint(
+        &provider, channel_id, session, body,
+    );
+
+    // A new follow-up user turn arrives -> a prompt anchor is recorded and is still
+    // pending (no response delivered for it yet).
+    crate::services::tui_prompt_dedupe::record_prompt_anchor(
+        provider.as_str(),
+        session,
+        channel_id.get(),
+        1_528_976_408_649_531_434,
+    );
+
+    // #4714 core: identical fingerprint + no fresh in-range text + degenerate id-0
+    // key, BUT a user boundary is pending -> a genuinely new follow-up turn whose
+    // identity was lost. It must NOT be suppressed.
+    let followup_decision = watcher_direct_terminal_response_decision(
+        &provider, channel_id, 33, session, None, 50, false, body,
+    );
+    assert_eq!(
+        followup_decision,
+        WatcherDirectTerminalResponseDecision::Send,
+        "a no-inflight follow-up turn with a pending prompt anchor must relay even when its \
+         body collides with a prior delivered fingerprint (#4714)"
+    );
+    assert!(followup_decision.has_sendable_body());
+    assert!(!followup_decision.refused_duplicate());
+
+    // The follow-up's response is delivered -> its prompt anchor clears. The exact
+    // same collision with NO pending boundary is now a genuine re-post and must
+    // still be refused, preserving #4081.
+    let cleared = crate::services::tui_prompt_dedupe::take_prompt_anchor_for_response(
+        provider.as_str(),
+        session,
+        channel_id.get(),
+    );
+    assert!(
+        cleared.is_some(),
+        "the pending prompt anchor must clear on delivery"
+    );
+    let repost_decision = watcher_direct_terminal_response_decision(
+        &provider, channel_id, 33, session, None, 50, false, body,
+    );
+    assert_eq!(
+        repost_decision,
+        WatcherDirectTerminalResponseDecision::RefusedDegenerateDuplicate,
+        "a genuine re-post of an already-delivered turn (no pending boundary) must still be \
+         deduped so #4081 does not regress"
+    );
+    assert!(repost_decision.refused_duplicate());
+}
+
+#[test]
 fn long_chunk_delivery_fingerprint_refuses_phantom_rerelay_4081() {
     let temp = tempfile::TempDir::new().expect("temp runtime root");
     let _root_guard = crate::config::set_agentdesk_root_for_test(temp.path());


### PR DESCRIPTION
#4714. The #4081 degenerate-key dup-guard was stranding legitimate no-inflight follow-up turns. Root: turn_identity.rs `watcher_direct_terminal_response_decision` refused `duplicate && !fresh_text` with no way to tell a new user-awaited turn from a phantom re-relay. Fix: added a pending-user-boundary discriminator (prompt anchor / external-input lease present ⇒ user awaiting response ⇒ NOT a #4081 re-post). Guard now refuses only `duplicate && !fresh_text && !pending_user_boundary`. tmux_watcher.rs relay-loop call site byte-identical (#3016). Mutation-proven (58/0; revert→2 FAILED). No hotfile touched.

Closes #4714.