### PR TITLE
fix(4594): placeholder sweeper detach revokes incarnation (late-PATCH tombstone guard)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -584,7 +584,7 @@
 | `services::discord::outbound::turn_output_controller` | `src/services/discord/outbound/turn_output_controller.rs` | 3519 | 1228 | 2291 | giant-file |
 | `services::discord::outbound::turn_output_controller::fresh_send` | `src/services/discord/outbound/turn_output_controller/fresh_send.rs` | 227 | 227 | 0 |  |
 | `services::discord::placeholder_cleanup` | `src/services/discord/placeholder_cleanup.rs` | 763 | 453 | 310 |  |
-| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1230 | 663 | 567 |  |
+| `services::discord::placeholder_controller` | `src/services/discord/placeholder_controller.rs` | 1262 | 673 | 589 |  |
 | `services::discord::placeholder_live_events` | `src/services/discord/placeholder_live_events/mod.rs` | 682 | 682 | 0 |  |
 | `services::discord::placeholder_live_events::background_task_events` | `src/services/discord/placeholder_live_events/background_task_events.rs` | 109 | 109 | 0 |  |
 | `services::discord::placeholder_live_events::common` | `src/services/discord/placeholder_live_events/common.rs` | 226 | 226 | 0 |  |
@@ -604,7 +604,7 @@
 | `services::discord::placeholder_live_events::turn_anchor` | `src/services/discord/placeholder_live_events/turn_anchor.rs` | 210 | 115 | 95 |  |
 | `services::discord::placeholder_live_events::workflow_panel` | `src/services/discord/placeholder_live_events/workflow_panel.rs` | 270 | 270 | 0 |  |
 | `services::discord::placeholder_sweeper` | `src/services/discord/placeholder_sweeper.rs` | 1293 | 998 | 295 |  |
-| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 915 | 493 | 422 |  |
+| `services::discord::placeholder_sweeper::abandon_guard` | `src/services/discord/placeholder_sweeper/abandon_guard.rs` | 922 | 500 | 422 |  |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder/mod.rs` | 689 | 689 | 0 |  |
 | `services::discord::prompt_builder::channel_recent_context` | `src/services/discord/prompt_builder/channel_recent_context.rs` | 496 | 220 | 276 |  |
 | `services::discord::prompt_builder::dispatch_contract` | `src/services/discord/prompt_builder/dispatch_contract.rs` | 576 | 576 | 0 |  |

--- a/src/services/discord/placeholder_controller.rs
+++ b/src/services/discord/placeholder_controller.rs
@@ -637,12 +637,22 @@ impl PlaceholderController {
         true
     }
 
+    /// Revoke one current incarnation and remove it without emitting a Discord
+    /// PATCH. The slot mutex serializes revocation with PATCH admission and
+    /// commit, so a caller retaining this slot cannot commit after detachment.
+    pub(super) async fn revoke_and_detach(&self, key: &PlaceholderKey) {
+        let Some(slot) = self.entries.get(key).map(|entry| entry.clone()) else {
+            return;
+        };
+        self.revoke_incarnation(&PlaceholderIncarnation {
+            key: key.clone(),
+            slot,
+        })
+        .await;
+    }
+
     /// Drop a key from the controller without emitting any Discord PATCH.
-    /// Used by the rollover retarget path on `turn_bridge`: when the old
-    /// `current_msg_id` is overwritten with a frozen response chunk, the
-    /// controller's old entry is no longer referenced and must not survive as
-    /// a non-evictable `Active` row in the cap-bounded map (codex round-4
-    /// #1308 P2).
+    /// Used by rollover-retarget paths that do not retain a PATCH incarnation.
     pub(super) fn detach(&self, key: &PlaceholderKey) {
         self.entries.remove(key);
     }
@@ -917,6 +927,28 @@ mod edit_retry_tests {
             1,
             "stale capability must not recreate"
         );
+    }
+
+    #[tokio::test]
+    async fn detach_tombstones_retained_incarnation_before_late_patch() {
+        let controller = PlaceholderController::default();
+        let gateway = ScriptedGateway::new(vec![Ok(())]);
+        let key = key();
+        let retained = controller.incarnation(&key);
+
+        controller.revoke_and_detach(&key).await;
+
+        assert!(!controller.entries.contains_key(&key));
+        assert!(retained.slot.state.lock().await.revoked);
+        assert_eq!(
+            controller
+                .ensure_active_incarnation(&gateway, &retained, input())
+                .await,
+            PlaceholderControllerOutcome::Rejected,
+            "a PATCH capability retained before detach must not commit to its tombstoned slot"
+        );
+        assert_eq!(gateway.calls.load(Ordering::SeqCst), 0);
+        assert!(!controller.entries.contains_key(&key));
     }
 
     #[tokio::test]

--- a/src/services/discord/placeholder_sweeper/abandon_guard.rs
+++ b/src/services/discord/placeholder_sweeper/abandon_guard.rs
@@ -391,9 +391,16 @@ fn abandoned_placeholder_key(
     })
 }
 
-fn detach_abandoned_placeholder_controller(shared: &Arc<SharedData>, state: &InflightTurnState) {
+async fn detach_abandoned_placeholder_controller(
+    shared: &Arc<SharedData>,
+    state: &InflightTurnState,
+) {
     if let Some(key) = abandoned_placeholder_key(state) {
-        shared.ui.placeholder_controller.detach(&key);
+        shared
+            .ui
+            .placeholder_controller
+            .revoke_and_detach(&key)
+            .await;
     }
 }
 
@@ -431,7 +438,7 @@ async fn finalize_cleanup_if_same_turn(
     let same_turn = super::inflight_state_still_same_turn(provider, state, age_secs);
     let deleted = same_turn && cleanup.delete_state_if_allowed(provider, state);
     if should_detach_after_cleanup(same_turn, deleted) {
-        detach_abandoned_placeholder_controller(shared, state);
+        detach_abandoned_placeholder_controller(shared, state).await;
     }
     deleted
 }
@@ -486,7 +493,7 @@ pub(super) async fn finalize_owner_dead_cleanup_if_same_turn(
     }
     let deleted = same_turn && cleanup.delete_state_if_allowed(provider, state);
     if should_detach_after_cleanup(same_turn, deleted) {
-        detach_abandoned_placeholder_controller(shared, state);
+        detach_abandoned_placeholder_controller(shared, state).await;
     }
     deleted
 }


### PR DESCRIPTION
#4594 on the #4703 incarnation-authority foundation. abandoned-cleanup detach now uses `revoke_and_detach()`: acquires the slot mutex, writes a `revoked=true` tombstone, then exact-Arc removes. A PATCH capability already holding the Arc re-checks the tombstone on slot re-acquire → `Rejected`, so it cannot commit state to a stale controller entry after detach. Regression test: retained incarnation → detach → late PATCH is Rejected, gateway PATCH calls 0, map entry absent. Mutation-proven (guard removed → test FAILED rc101). No #3016 hotfile.

Closes #4594.