### PR TITLE
fix(4724): decouple change-surfaces.md prose from exact generated LoC (slice C)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -31,11 +31,12 @@
 
 - "giant-file" = `>= 1000` **production** lines per
   `scripts/generate_inventory_docs.py` (lines inside `#[cfg(test)] mod` blocks
-  are excluded; see the `Prod` column in `module-inventory.md`). New logic added
-  to a giant file inherits the file's review surface — every reviewer must
-  re-read the entire module — so adding to it without an extraction plan is
-  rejected. A module whose production surface falls below the threshold is no
-  longer frozen and must be removed from the lists below.
+  are excluded; see the `Prod` column in `module-inventory.md`). Exact LoC
+  numbers in this page are contextual snapshots, not PR-freshness obligations.
+  New logic added to a giant file inherits the file's review surface — every
+  reviewer must re-read the entire module — so adding to it without an extraction
+  plan is rejected. A module whose production surface falls below the threshold
+  is no longer frozen and must be removed from the lists below.
 - `do_not_edit_without_migration_plan` columns below mean: even though the
   file builds and runs, the scheduled migration owner will roll back ad-hoc
   additions. If you must change behaviour there, scope it to a single bugfix
@@ -1853,8 +1854,10 @@
 ### `services_misc_giants`
 
 The remaining giant-file modules under `src/services/` not covered above.
-Line counts are *production* LoC (the `Prod` column in `module-inventory.md`,
-which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync.
+Line counts are *production* LoC snapshots (the `Prod` column in
+`module-inventory.md`, which excludes `#[cfg(test)] mod` blocks). The integrity
+gate verifies frozen paths remain current production giants; it does not require
+these contextual numbers to match ordinary LoC churn.
 
 - `src/services/auto_queue.rs` (1545) and
   `src/services/auto_queue/activate_command.rs` (1510); auto-queue route
@@ -2097,12 +2100,11 @@ reintroducing bespoke clamp expressions.
 
 ## Updating This Page
 
-- Re-run `python3 scripts/generate_inventory_docs.py` and reconcile the
-  giant-file list against the `Prod` column in `module-inventory.md`. Each
-  `(N lines)` token on this page must equal the measured production LoC;
-  `scripts/check_agent_maintenance_docs.py` fails CI when it drifts, when a
-  frozen entry's production surface grows (decomposition regression), or when a
-  frozen entry has fallen below the threshold (ghost — remove it).
+- Do not refresh contextual LoC numbers for ordinary churn. Update this page
+  only when ownership, canonical module mapping, giant-threshold membership, or
+  operational guidance changes. The integrity gate derives frozen-path status
+  from the `Prod` column in `module-inventory.md` and fails when a frozen path is
+  missing, non-production, or below the threshold (ghost — remove it).
 - When a giant file is split, move its canonical_module entry to the new
   module path, remove it from `do_not_edit_without_migration_plan`, and drop it
   from `scripts/giant_file_registry.toml`.

--- a/scripts/check_agent_maintenance_docs.py
+++ b/scripts/check_agent_maintenance_docs.py
@@ -9,8 +9,8 @@ surfaces. This script keeps that authority explicit:
 * referenced commits are ancestors of the current checkout when the header is
   commit-anchored;
 * PRs that touch guarded code paths also touch the matching maintenance page;
-* line counts copied into ``change-surfaces.md`` are compared with the
-  generated module inventory.
+* frozen ``change-surfaces.md`` paths are checked against the generated module
+  inventory for current giant-surface integrity.
 
 Warnings do not fail the script. Errors fail unless ``--warning-only`` is
 passed, which is the initial CI rollout mode for #1432.
@@ -339,8 +339,7 @@ def parse_module_inventory(path: Path) -> dict[str, int]:
 
     change-surfaces.md freezes modules by their review surface, which is the
     production line count (excluding `#[cfg(test)] mod` blocks). The inventory's
-    ``Prod`` column is the authority, so the freshness gate compares against it
-    rather than the raw total (#3036).
+    ``Prod`` column is the authority for frozen giant-surface integrity (#3036).
     """
 
     inventory: dict[str, int] = {}
@@ -362,7 +361,7 @@ def check_change_surface_line_counts(repo_root: Path) -> list[Finding]:
             Finding(
                 "warning",
                 "docs/generated/module-inventory.md",
-                "module inventory is missing or empty; cannot verify copied line counts.",
+                "module inventory is missing or empty; cannot verify frozen giant surfaces.",
             )
         ]
     if not change_surfaces.is_file():
@@ -455,26 +454,6 @@ def check_change_surface_line_counts(repo_root: Path) -> list[Finding]:
                     )
                 )
                 continue
-            if documented != actual:
-                # Stale numbers are an error so the page cannot silently rot, and
-                # an increase specifically signals a decomposition regression
-                # (the frozen surface grew instead of shrinking).
-                regression = " (production surface grew — decomposition regression)" \
-                    if actual > documented else ""
-                findings.append(
-                    Finding(
-                        "error",
-                        rel_doc,
-                        (
-                            f"{path} production line count is {documented} in "
-                            f"change-surfaces.md but {actual} in "
-                            f"module-inventory.md{regression}. Re-run "
-                            "`python3 scripts/generate_inventory_docs.py` and sync "
-                            "the freeze entry."
-                        ),
-                        line_no,
-                    )
-                )
     return findings
 
 
@@ -583,9 +562,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--line-count-gate",
         action="store_true",
         help=(
-            "hard-fail on change-surfaces.md production-LoC drift, ghost freeze "
-            "entries, and decomposition regressions even under --warning-only "
-            "(#3036 measurement integrity gate)"
+            "hard-fail on frozen giant-surface integrity errors, including "
+            "missing, non-production, and below-threshold ghost entries even "
+            "under --warning-only (#3036)"
         ),
     )
     parser.add_argument(
@@ -627,9 +606,9 @@ def main(argv: list[str] | None = None) -> int:
     has_errors = any(finding.severity == "error" for finding in findings)
     if has_errors and not args.warning_only:
         return 1
-    # Even in the #1432 warning-only rollout, production-LoC integrity is a hard
-    # gate when requested: stale numbers, ghost entries, and decomposition
-    # regressions must not slip through (#3036).
+    # Even in the #1432 warning-only rollout, frozen giant-surface integrity is
+    # a hard gate when requested: missing, non-production, and ghost entries
+    # must not slip through (#3036).
     if args.line_count_gate and any(
         finding.severity == "error" for finding in line_count_findings
     ):

--- a/tests/test_agent_maintenance_docs.py
+++ b/tests/test_agent_maintenance_docs.py
@@ -299,11 +299,11 @@ class ChangeSurfaceLineCountTest(unittest.TestCase):
         )
         _write(root, "docs/agent-maintenance/change-surfaces.md", surface_line)
 
-    def test_errors_when_copied_count_drifts_from_inventory_prod(self) -> None:
+    def test_ignores_copied_count_drift_from_inventory_prod(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
-            # total Lines=2100 but Prod=1500 (shrink, still giant); the gate
-            # compares the documented number against Prod, not the raw total.
+            # The frozen path remains a production giant even though the prose
+            # snapshot differs from current production LoC.
             self._setup(
                 root,
                 "| `services::foo` | `src/services/foo.rs` | 2100 | 1500 | 600 |  |",
@@ -311,10 +311,7 @@ class ChangeSurfaceLineCountTest(unittest.TestCase):
             )
             findings = CHECKER.check_change_surface_line_counts(root)
 
-        self.assertEqual(len(findings), 1)
-        self.assertEqual(findings[0].severity, "error")
-        self.assertIn("but 1500 in", findings[0].message)
-        self.assertNotIn("decomposition regression", findings[0].message)
+        self.assertEqual(findings, [])
 
     def test_no_finding_when_count_matches_prod(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -342,7 +339,7 @@ class ChangeSurfaceLineCountTest(unittest.TestCase):
         self.assertEqual(findings[0].severity, "error")
         self.assertIn("no longer a giant file", findings[0].message)
 
-    def test_errors_and_flags_decomposition_regression_on_growth(self) -> None:
+    def test_current_inventory_giant_remains_valid_despite_stale_snapshot(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             self._setup(
@@ -352,9 +349,47 @@ class ChangeSurfaceLineCountTest(unittest.TestCase):
             )
             findings = CHECKER.check_change_surface_line_counts(root)
 
-        self.assertEqual(len(findings), 1)
-        self.assertEqual(findings[0].severity, "error")
-        self.assertIn("decomposition regression", findings[0].message)
+        self.assertEqual(findings, [])
+
+    def test_warning_only_line_count_gate_hard_fails_ghost_entry(self) -> None:
+        with TemporaryDirectory() as tmp, patch.object(
+            CHECKER, "check_doc_headers", return_value=[]
+        ), patch.object(
+            CHECKER, "check_migration_0093_rollout_contract", return_value=[]
+        ), patch.object(
+            CHECKER, "check_doc_touch_rules", return_value=[]
+        ):
+            root = Path(tmp)
+            self._setup(
+                root,
+                "| `services::foo` | `src/services/foo.rs` | 4000 | 64 | 3936 |  |",
+                "- `src/services/foo.rs` (3550 lines, giant-file).\n",
+            )
+            result = CHECKER.main(
+                ["--repo-root", tmp, "--warning-only", "--line-count-gate"]
+            )
+
+        self.assertEqual(result, 1)
+
+    def test_warning_only_line_count_gate_allows_numeric_mismatch(self) -> None:
+        with TemporaryDirectory() as tmp, patch.object(
+            CHECKER, "check_doc_headers", return_value=[]
+        ), patch.object(
+            CHECKER, "check_migration_0093_rollout_contract", return_value=[]
+        ), patch.object(
+            CHECKER, "check_doc_touch_rules", return_value=[]
+        ):
+            root = Path(tmp)
+            self._setup(
+                root,
+                "| `services::foo` | `src/services/foo.rs` | 2200 | 2100 | 100 |  |",
+                "- `src/services/foo.rs` (1800 lines, giant-file).\n",
+            )
+            result = CHECKER.main(
+                ["--repo-root", tmp, "--warning-only", "--line-count-gate"]
+            )
+
+        self.assertEqual(result, 0)
 
     def test_gates_bare_shorthand_line_count(self) -> None:
         # The services_misc_giants list uses a bare `(N)` shorthand; the gate
@@ -372,7 +407,7 @@ class ChangeSurfaceLineCountTest(unittest.TestCase):
         self.assertEqual(findings[0].severity, "error")
         self.assertIn("no longer a giant file", findings[0].message)
 
-    def test_bare_shorthand_drift_is_error(self) -> None:
+    def test_bare_shorthand_drift_is_not_an_error(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             self._setup(
@@ -382,9 +417,7 @@ class ChangeSurfaceLineCountTest(unittest.TestCase):
             )
             findings = CHECKER.check_change_surface_line_counts(root)
 
-        self.assertEqual(len(findings), 1)
-        self.assertEqual(findings[0].severity, "error")
-        self.assertIn("but 1740 in", findings[0].message)
+        self.assertEqual(findings, [])
 
     def test_lines_form_not_double_counted_by_shorthand(self) -> None:
         # `(N lines …)` must be handled once, not also matched as `(N)`.


### PR DESCRIPTION
Closes part of #4724 (slice C). Slice B (merge-driver) already merged in #4725; slice A (de-commit) deferred.

## What
Removes the exact line-count hard-fail in `check_change_surface_line_counts()` — prose LoC numbers in `change-surfaces.md` were forced to match `module-inventory.md` byte-for-byte, a second O(N²) rebase-conflict amplifier and pure manual-sync churn. The authoritative prod count lives in the generated inventory (now merge-driver-handled).

## Safety contract preserved (still fail-closed)
- frozen path missing from current production inventory → hard error
- deleted/renamed frozen path → hard error
- non-production frozen path → hard error
- ghost freeze entry: frozen path now `< GIANT_FILE_THRESHOLD` → hard error

Only the `documented != actual` exact-number arm is removed. Generator freshness contract (`generate_inventory_docs.py --check`, `ci-script-checks.sh`) is UNCHANGED — this is slice C only.

## Tests
- exact-drift tests → assert no hard error
- ghost-below-threshold retained as hard error
- growth-regression-by-number replaced with current-inventory giant/ghost test
- new main-level gate test: `--warning-only --line-count-gate` returns 1 on ghost, 0 on pure numeric mismatch
- **mutation proof**: breaking the ghost-below-threshold fail-closed arm → `test_warning_only_line_count_gate_hard_fails_ghost_entry` FAILS (rc1, `0 != 1`); restore → ok (rc0)

## Gates (all green)
- `python3 -m unittest tests.test_agent_maintenance_docs` rc0 (32 tests)
- `python3 scripts/generate_inventory_docs.py --check` rc0
- `python3 scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate --migration-0093-rollout-gate` rc0
- `bash scripts/ci-script-checks.sh` rc0

0 Rust delta. Zero `src/` contact. Disjoint from #3016 relay hotfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)