### PR TITLE
fix(4259): seal external blind save_inflight_state calls (slice 1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -528,6 +528,7 @@ src/
 │   │   │   ├── save_store/
 │   │   │   │   ├── identity_gate/
 │   │   │   │   │   └── claude_e_stamp.rs
+│   │   │   │   ├── delivery_rewind.rs
 │   │   │   │   ├── identity_gate.rs
 │   │   │   │   ├── post_loop_identity_guard_tests.rs
 │   │   │   │   └── rebind_adoption.rs
@@ -659,6 +660,7 @@ src/
 │   │   │   │   │   │   └── mailbox_reaction_tests.rs
 │   │   │   │   │   ├── adk_thread.rs
 │   │   │   │   │   ├── claim_bootstrap.rs
+│   │   │   │   │   ├── inflight_create_log.rs
 │   │   │   │   │   ├── race_loss.rs
 │   │   │   │   │   ├── stale_dispatch_guard.rs
 │   │   │   │   │   ├── steering_hook.rs

--- a/scripts/check_inflight_blind_save_ratchet.py
+++ b/scripts/check_inflight_blind_save_ratchet.py
@@ -60,7 +60,7 @@ from pathlib import Path
 #   turn_bridge/stream_loop.rs .......... 2
 #   turn_bridge/post_loop_finalize.rs ... 0  (#4259 post-loop slice converted 4)
 #   turn_bridge/mod.rs (hotfile, solo) .. 1
-#   external (router/session/tui) ....... 8
+#   external (router/session/tui) ....... 0  (#4259 slice 1 converted 8)
 #     (headless_turn, intake_turn, provider_isolation, watchdog,
 #      session_runtime/worktree, tui_prompt_relay/synthetic_start x2,
 #      tui_prompt_relay/codex_idle_rollout)
@@ -78,7 +78,7 @@ from pathlib import Path
 # helper) still (re)write identity-pinned `tmux_session_name`, beyond what the
 # output-restamp variant tolerates, so each needs per-flow session-name-stability
 # verification or an adoption-aware variant before converting.
-BASELINE = 21
+BASELINE = 13
 
 SCAN_ROOT = Path("src") / "services" / "discord"
 

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -13,18 +13,21 @@
 
 use super::*;
 
+#[path = "save_store/delivery_rewind.rs"]
+mod delivery_rewind;
 #[path = "save_store/identity_gate.rs"]
 pub(super) mod identity_gate;
 #[path = "save_store/rebind_adoption.rs"]
 mod rebind_adoption;
 
+pub(in crate::services::discord) use self::delivery_rewind::save_inflight_delivery_rewind_if_matches_identity;
 pub(in crate::services::discord) use self::identity_gate::{
     GuardedSaveOutcome, bind_recovery_anchor_if_matches_identity,
     mark_readopted_from_inflight_if_identity_unchanged,
     patch_restart_full_response_if_identity_unchanged,
     persist_leak_recovery_response_offset_if_matches_identity_locked,
     persist_recovery_output_path_if_matches_identity_locked,
-    recovery_anchor_msg_id_if_matches_identity, save_inflight_delivery_rewind_if_matches_identity,
+    recovery_anchor_msg_id_if_matches_identity,
     save_inflight_state_if_identity_matches_allow_output_restamp,
     save_inflight_state_if_identity_unchanged, save_inflight_state_if_matches_identity,
     stamp_claude_e_process_if_matches_identity,

--- a/src/services/discord/inflight/save_store.rs
+++ b/src/services/discord/inflight/save_store.rs
@@ -500,6 +500,7 @@ mod tests {
         let mut state = state_with_full_response(44_090, "seeded", "AgentDesk-codex-restamp-4259");
         save_inflight_state_in_root(temp.path(), &state).expect("seed intake-path row");
 
+        let expected = InflightTurnIdentity::from_state(&state);
         let seeded_output_path = state.output_path.clone();
         state.output_path = Some("/tmp/legacy/AgentDesk-codex-restamp-4259.jsonl".to_string());
         state.last_offset = 4096;
@@ -520,6 +521,7 @@ mod tests {
             save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
                 temp.path(),
                 &state,
+                &expected,
                 "test::output_restamp_saves",
             ),
             GuardedSaveOutcome::Saved
@@ -552,11 +554,13 @@ mod tests {
         let mut stale =
             state_with_full_response(44_091, "stale snapshot", "AgentDesk-codex-restamp-own-4259");
         stale.user_msg_id = 77_010;
+        let expected = InflightTurnIdentity::from_state(&stale);
         stale.output_path = Some("/tmp/legacy/AgentDesk-codex-restamp-own-4259.jsonl".to_string());
         assert_eq!(
             save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
                 temp.path(),
                 &stale,
+                &expected,
                 "test::output_restamp_identity_mismatch_skips",
             ),
             GuardedSaveOutcome::IdentityMismatch

--- a/src/services/discord/inflight/save_store/delivery_rewind.rs
+++ b/src/services/discord/inflight/save_store/delivery_rewind.rs
@@ -1,0 +1,59 @@
+//! Identity-guarded delivery-rewind save operations.
+
+use super::*;
+
+pub(in crate::services::discord) fn save_inflight_delivery_rewind_if_matches_identity(
+    state: &InflightTurnState,
+    reason: InflightDeliveryRewindReason,
+) -> Result<bool, String> {
+    let Some(root) = inflight_runtime_root() else {
+        return Err("Home directory not found".to_string());
+    };
+    save_inflight_delivery_rewind_if_matches_identity_in_root(&root, state, reason)
+}
+
+pub(in crate::services::discord::inflight) fn save_inflight_delivery_rewind_if_matches_identity_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+    reason: InflightDeliveryRewindReason,
+) -> Result<bool, String> {
+    let Some(provider) = state.provider_kind() else {
+        return Err(format!("Unknown provider '{}'", state.provider));
+    };
+    let path = inflight_state_path(root, &provider, state.channel_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let _lock = lock_inflight_state_path(&path)?;
+    let Some(on_disk) = load_inflight_state_unlocked(&path) else {
+        return Ok(false);
+    };
+    let expected = InflightTurnIdentity::from_state(state);
+    if !expected.matches_state(&on_disk) {
+        return Ok(false);
+    }
+    if on_disk.terminal_delivery_committed {
+        return Ok(false);
+    }
+    let mut updated = on_disk;
+    updated.full_response = state.full_response.clone();
+    updated.response_sent_offset = state.response_sent_offset;
+    updated.terminal_delivery_committed = state.terminal_delivery_committed;
+    updated.last_offset = updated.last_offset.max(state.last_offset);
+    updated.set_relay_owner_kind(state.effective_relay_owner_kind());
+    updated.ensure_finalizer_turn_id();
+    if !validate_inflight_state_for_save_with_delivery_rewind_reason(
+        root,
+        &path,
+        &updated,
+        "src/services/discord/inflight.rs:save_inflight_delivery_rewind_if_matches_identity_in_root",
+        Some(reason),
+    ) {
+        return Ok(false);
+    }
+    updated.updated_at = now_string();
+    bump_save_generation_for_write(&path, &mut updated);
+    let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
+    atomic_write(&path, &json)?;
+    Ok(true)
+}

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -18,14 +18,20 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     state: &InflightTurnState,
     caller: &'static str,
 ) -> GuardedSaveOutcome {
-    save_inflight_state_identity_gated_in_root(root, state, caller, false)
+    save_inflight_state_identity_gated_in_root(
+        root,
+        state,
+        &InflightTurnIdentity::from_state(state),
+        caller,
+        false,
+    )
 }
 
 /// #4259: identity-guarded save for runtime-handoff restamps. It pins the
-/// stable turn key (`user_msg_id`, `started_at`, `tmux_session_name`) plus the
-/// restart/rebind authority and id-0 offsetless fail-closed gates of
-/// [`save_inflight_state_if_identity_unchanged`], while deliberately allowing
-/// both `output_path` and `turn_start_offset` to advance.
+/// loaded turn identity (`user_msg_id`, `started_at`, `tmux_session_name`, and
+/// `turn_start_offset`) plus the restart/rebind authority and id-0 offsetless
+/// fail-closed gates of [`save_inflight_state_if_identity_unchanged`], while
+/// allowing the written state to advance `output_path` and `turn_start_offset`.
 ///
 /// Runtime-handoff stamps legitimately re-point the row at the output the live
 /// runtime actually writes: a warm follow-up reuses a resolved legacy `/tmp`
@@ -34,8 +40,9 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
 /// the strict `output_path` equality of the `_if_identity_unchanged` variant
 /// would refuse a legitimate same-turn stamp. Use THIS variant for
 /// runtime-handoff (re)stamp sites; it still refuses rows re-owned by another
-/// turn. `turn_start_offset` is intentionally not in this variant's comparison
-/// key because it is the cursor being restamped. The held-back blind sites in
+/// turn. The expected identity is captured before the caller mutates its
+/// restamp cursor, so the durable row must still have the loaded birth offset;
+/// the written state may then advance that cursor. The held-back blind sites in
 /// `turn_bridge/runtime_handoff_loop.rs`
 /// (RuntimeReady ProcessBackend/ClaudeEAdapter/ClaudeTui/CodexTui,
 /// ProcessReady, and the watcher-handoff helper — see
@@ -45,36 +52,30 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
 /// verified stable across the stamp.
 pub(in crate::services::discord) fn save_inflight_state_if_identity_matches_allow_output_restamp(
     state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
     caller: &'static str,
 ) -> GuardedSaveOutcome {
     let Some(root) = inflight_runtime_root() else {
         return GuardedSaveOutcome::IoError;
     };
-    save_inflight_state_if_identity_matches_allow_output_restamp_in_root(&root, state, caller)
+    save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
+        &root, state, expected, caller,
+    )
 }
 
 pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
     root: &Path,
     state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
     caller: &'static str,
 ) -> GuardedSaveOutcome {
-    save_inflight_state_identity_gated_in_root(root, state, caller, true)
-}
-
-/// Compare the stable identity fields for a restamp. The offset is deliberately
-/// excluded because a valid rollover/recovery restamp advances that cursor.
-fn restamp_identity_matches_state(
-    expected: &InflightTurnIdentity,
-    state: &InflightTurnState,
-) -> bool {
-    expected.user_msg_id == state.user_msg_id
-        && expected.started_at == state.started_at
-        && expected.tmux_session_name == state.tmux_session_name
+    save_inflight_state_identity_gated_in_root(root, state, expected, caller, true)
 }
 
 fn save_inflight_state_identity_gated_in_root(
     root: &Path,
     state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
     caller: &'static str,
     allow_output_restamp: bool,
 ) -> GuardedSaveOutcome {
@@ -110,16 +111,15 @@ fn save_inflight_state_identity_gated_in_root(
         );
         return GuardedSaveOutcome::IdentityMismatch;
     };
-    let expected = InflightTurnIdentity::from_state(state);
     let durable = InflightTurnIdentity::from_state(&on_disk);
-    if state.user_msg_id == 0 && state.turn_start_offset.is_none() {
+    if expected.user_msg_id == 0 && expected.turn_start_offset.is_none() {
         tracing::info!(
             provider = %provider.as_str(),
             channel_id = state.channel_id,
             caller = caller,
             snapshot_identity = ?expected,
             durable_identity = ?durable,
-            snapshot_turn_start_offset = ?state.turn_start_offset,
+            snapshot_turn_start_offset = ?expected.turn_start_offset,
             durable_turn_start_offset = ?on_disk.turn_start_offset,
             "inflight identity-refresh save skipped because offsetless id-0 snapshot cannot safely match a durable row"
         );
@@ -140,10 +140,7 @@ fn save_inflight_state_identity_gated_in_root(
         );
         return GuardedSaveOutcome::IdentityMismatch;
     }
-    if on_disk.restart_mode.is_some()
-        || on_disk.rebind_origin
-        || (allow_output_restamp && !restamp_identity_matches_state(&expected, &on_disk))
-        || (!allow_output_restamp && !expected.matches_state(&on_disk))
+    if on_disk.restart_mode.is_some() || on_disk.rebind_origin || !expected.matches_state(&on_disk)
     {
         tracing::info!(
             provider = %provider.as_str(),
@@ -1172,10 +1169,10 @@ mod tests {
         );
     }
 
-    // #4259: output restamps must advance the recovered cursor without turning
-    // the cursor itself into the CAS key. The three assertions below are mutation
-    // kills for the two callers: stale rollover offsets must save, while a
-    // different turn must remain sealed out.
+    // #4259: a restamp compares the durable row with the identity captured
+    // before its cursor mutation. The repaired write may advance the cursor,
+    // but a stale snapshot must not overwrite a newer turn which shares all
+    // other identity fields.
     #[test]
     fn output_restamp_advances_stale_offset_but_rejects_different_turn() {
         let _lock = crate::config::shared_test_env_lock()
@@ -1187,6 +1184,7 @@ mod tests {
         durable.output_path = Some("/tmp/old-rollout.jsonl".to_string());
         save_inflight_state_in_root(root.path(), &durable).expect("seed durable row");
 
+        let expected = InflightTurnIdentity::from_state(&durable);
         let mut restamped = durable.clone();
         restamped.turn_start_offset = Some(911);
         restamped.last_offset = 911;
@@ -1195,10 +1193,11 @@ mod tests {
             save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
                 root.path(),
                 &restamped,
+                &expected,
                 "test::codex_idle_rollout_stale_offset_repair",
             ),
             GuardedSaveOutcome::Saved,
-            "a rotated rollout's new offset must not be compared as the old CAS key",
+            "the durable row is matched against the loaded offset, then written with the advanced offset",
         );
         let path = inflight_state_path(root.path(), &ProviderKind::Codex, durable.channel_id);
         let persisted: InflightTurnState =
@@ -1210,6 +1209,7 @@ mod tests {
             Some("/tmp/rotated-rollout.jsonl")
         );
 
+        let expected = InflightTurnIdentity::from_state(&persisted);
         let mut synthetic_refresh = persisted.clone();
         synthetic_refresh.turn_start_offset = Some(1_337);
         synthetic_refresh.last_offset = 1_337;
@@ -1217,6 +1217,7 @@ mod tests {
             save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
                 root.path(),
                 &synthetic_refresh,
+                &expected,
                 "test::synthetic_start_advanced_offset_refresh",
             ),
             GuardedSaveOutcome::Saved,
@@ -1226,20 +1227,65 @@ mod tests {
         let mut different_turn = synthetic_refresh.clone();
         different_turn.user_msg_id += 1;
         different_turn.turn_start_offset = Some(2_048);
+        let different_expected = InflightTurnIdentity::from_state(&different_turn);
         assert_eq!(
             save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
                 root.path(),
                 &different_turn,
+                &different_expected,
                 "test::output_restamp_different_turn_rejected",
             ),
             GuardedSaveOutcome::IdentityMismatch,
-            "removing the stable user-message identity check would clobber another turn",
+            "a different user-message identity must not clobber the durable turn",
         );
         let preserved: InflightTurnState =
             serde_json::from_str(&std::fs::read_to_string(&path).expect("read sealed row"))
                 .expect("parse sealed row");
         assert_eq!(preserved.user_msg_id, synthetic_refresh.user_msg_id);
         assert_eq!(preserved.turn_start_offset, Some(1_337));
+
+        // Mutation proof: round-1's offset-dropping restamp predicate would see
+        // only {0, started_at, tmux_session_name} below and return Saved, thereby
+        // clobbering `newer_zero_id`. Full pre-mutation identity comparison must
+        // reject it because birth offset 3_001 differs from 3_002.
+        let mut older_zero_id = drain_restart_seed(42_591, "AgentDesk-codex-zero-id-4259");
+        older_zero_id.user_msg_id = 0;
+        older_zero_id.started_at = "2026-07-22T10:00:00Z".to_string();
+        older_zero_id.turn_start_offset = Some(3_001);
+        older_zero_id.last_offset = 3_001;
+        let older_expected = InflightTurnIdentity::from_state(&older_zero_id);
+        let mut newer_zero_id = older_zero_id.clone();
+        newer_zero_id.turn_start_offset = Some(3_002);
+        newer_zero_id.last_offset = 3_002;
+        newer_zero_id.output_path = Some("/tmp/newer-zero-id.jsonl".to_string());
+        save_inflight_state_in_root(root.path(), &newer_zero_id)
+            .expect("seed newer zero-id turn with same timestamp and tmux");
+        let mut stale_zero_id_restamp = older_zero_id.clone();
+        stale_zero_id_restamp.turn_start_offset = Some(4_001);
+        stale_zero_id_restamp.last_offset = 4_001;
+        stale_zero_id_restamp.output_path = Some("/tmp/stale-zero-id.jsonl".to_string());
+        assert_eq!(
+            save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
+                root.path(),
+                &stale_zero_id_restamp,
+                &older_expected,
+                "test::output_restamp_zero_id_collision_rejected",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+            "same-timestamp zero-id turns are disambiguated by their loaded birth offsets",
+        );
+        let zero_id_path =
+            inflight_state_path(root.path(), &ProviderKind::Codex, newer_zero_id.channel_id);
+        let zero_id_preserved: InflightTurnState = serde_json::from_str(
+            &std::fs::read_to_string(&zero_id_path).expect("read newer zero-id row"),
+        )
+        .expect("parse newer zero-id row");
+        assert_eq!(zero_id_preserved.turn_start_offset, Some(3_002));
+        assert_eq!(
+            zero_id_preserved.output_path.as_deref(),
+            Some("/tmp/newer-zero-id.jsonl"),
+            "the rejected stale snapshot leaves the newer durable row unchanged",
+        );
     }
 
     /// The zero-id headless row exactly as the #3107 watcher self-heal

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -21,11 +21,11 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
     save_inflight_state_identity_gated_in_root(root, state, caller, false)
 }
 
-/// #4259 PR-2a rework (codex r1): identity-guarded save that PINS the 4-field
-/// turn identity (`user_msg_id`, `started_at`, `tmux_session_name`,
-/// `turn_start_offset`) plus the restart/rebind authority and id-0 offsetless
-/// fail-closed gates of [`save_inflight_state_if_identity_unchanged`], but
-/// deliberately ALLOWS the snapshot to RESTAMP `output_path`.
+/// #4259: identity-guarded save for runtime-handoff restamps. It pins the
+/// stable turn key (`user_msg_id`, `started_at`, `tmux_session_name`) plus the
+/// restart/rebind authority and id-0 offsetless fail-closed gates of
+/// [`save_inflight_state_if_identity_unchanged`], while deliberately allowing
+/// both `output_path` and `turn_start_offset` to advance.
 ///
 /// Runtime-handoff stamps legitimately re-point the row at the output the live
 /// runtime actually writes: a warm follow-up reuses a resolved legacy `/tmp`
@@ -34,7 +34,9 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_un
 /// the strict `output_path` equality of the `_if_identity_unchanged` variant
 /// would refuse a legitimate same-turn stamp. Use THIS variant for
 /// runtime-handoff (re)stamp sites; it still refuses rows re-owned by another
-/// turn. The held-back blind sites in `turn_bridge/runtime_handoff_loop.rs`
+/// turn. `turn_start_offset` is intentionally not in this variant's comparison
+/// key because it is the cursor being restamped. The held-back blind sites in
+/// `turn_bridge/runtime_handoff_loop.rs`
 /// (RuntimeReady ProcessBackend/ClaudeEAdapter/ClaudeTui/CodexTui,
 /// ProcessReady, and the watcher-handoff helper — see
 /// `scripts/check_inflight_blind_save_ratchet.py`) are expected to convert to
@@ -57,6 +59,17 @@ pub(in crate::services::discord::inflight) fn save_inflight_state_if_identity_ma
     caller: &'static str,
 ) -> GuardedSaveOutcome {
     save_inflight_state_identity_gated_in_root(root, state, caller, true)
+}
+
+/// Compare the stable identity fields for a restamp. The offset is deliberately
+/// excluded because a valid rollover/recovery restamp advances that cursor.
+fn restamp_identity_matches_state(
+    expected: &InflightTurnIdentity,
+    state: &InflightTurnState,
+) -> bool {
+    expected.user_msg_id == state.user_msg_id
+        && expected.started_at == state.started_at
+        && expected.tmux_session_name == state.tmux_session_name
 }
 
 fn save_inflight_state_identity_gated_in_root(
@@ -127,7 +140,10 @@ fn save_inflight_state_identity_gated_in_root(
         );
         return GuardedSaveOutcome::IdentityMismatch;
     }
-    if on_disk.restart_mode.is_some() || on_disk.rebind_origin || !expected.matches_state(&on_disk)
+    if on_disk.restart_mode.is_some()
+        || on_disk.rebind_origin
+        || (allow_output_restamp && !restamp_identity_matches_state(&expected, &on_disk))
+        || (!allow_output_restamp && !expected.matches_state(&on_disk))
     {
         tracing::info!(
             provider = %provider.as_str(),
@@ -1210,6 +1226,76 @@ mod tests {
             GuardedSaveOutcome::IdentityMismatch,
             "an offsetless id-0 snapshot must be refused fail-closed even against a byte-identical durable row (#4370 R3-5)",
         );
+    }
+
+    // #4259: output restamps must advance the recovered cursor without turning
+    // the cursor itself into the CAS key. The three assertions below are mutation
+    // kills for the two callers: stale rollover offsets must save, while a
+    // different turn must remain sealed out.
+    #[test]
+    fn output_restamp_advances_stale_offset_but_rejects_different_turn() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let root = tempfile::tempdir().expect("runtime root");
+        let mut durable = drain_restart_seed(42_590, "AgentDesk-codex-4259");
+        durable.turn_start_offset = Some(17);
+        durable.output_path = Some("/tmp/old-rollout.jsonl".to_string());
+        save_inflight_state_in_root(root.path(), &durable).expect("seed durable row");
+
+        let mut restamped = durable.clone();
+        restamped.turn_start_offset = Some(911);
+        restamped.last_offset = 911;
+        restamped.output_path = Some("/tmp/rotated-rollout.jsonl".to_string());
+        assert_eq!(
+            save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
+                root.path(),
+                &restamped,
+                "test::codex_idle_rollout_stale_offset_repair",
+            ),
+            GuardedSaveOutcome::Saved,
+            "a rotated rollout's new offset must not be compared as the old CAS key",
+        );
+        let path = inflight_state_path(root.path(), &ProviderKind::Codex, durable.channel_id);
+        let persisted: InflightTurnState =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read restamped row"))
+                .expect("parse restamped row");
+        assert_eq!(persisted.turn_start_offset, Some(911));
+        assert_eq!(
+            persisted.output_path.as_deref(),
+            Some("/tmp/rotated-rollout.jsonl")
+        );
+
+        let mut synthetic_refresh = persisted.clone();
+        synthetic_refresh.turn_start_offset = Some(1_337);
+        synthetic_refresh.last_offset = 1_337;
+        assert_eq!(
+            save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
+                root.path(),
+                &synthetic_refresh,
+                "test::synthetic_start_advanced_offset_refresh",
+            ),
+            GuardedSaveOutcome::Saved,
+            "a same-turn synthetic refresh must re-own after its cursor advances",
+        );
+
+        let mut different_turn = synthetic_refresh.clone();
+        different_turn.user_msg_id += 1;
+        different_turn.turn_start_offset = Some(2_048);
+        assert_eq!(
+            save_inflight_state_if_identity_matches_allow_output_restamp_in_root(
+                root.path(),
+                &different_turn,
+                "test::output_restamp_different_turn_rejected",
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+            "removing the stable user-message identity check would clobber another turn",
+        );
+        let preserved: InflightTurnState =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read sealed row"))
+                .expect("parse sealed row");
+        assert_eq!(preserved.user_msg_id, synthetic_refresh.user_msg_id);
+        assert_eq!(preserved.turn_start_offset, Some(1_337));
     }
 
     /// The zero-id headless row exactly as the #3107 watcher self-heal

--- a/src/services/discord/inflight/save_store/identity_gate.rs
+++ b/src/services/discord/inflight/save_store/identity_gate.rs
@@ -326,62 +326,6 @@ pub(in crate::services::discord::inflight) fn patch_restart_full_response_if_ide
     }
 }
 
-pub(in crate::services::discord) fn save_inflight_delivery_rewind_if_matches_identity(
-    state: &InflightTurnState,
-    reason: InflightDeliveryRewindReason,
-) -> Result<bool, String> {
-    let Some(root) = inflight_runtime_root() else {
-        return Err("Home directory not found".to_string());
-    };
-    save_inflight_delivery_rewind_if_matches_identity_in_root(&root, state, reason)
-}
-
-pub(in crate::services::discord::inflight) fn save_inflight_delivery_rewind_if_matches_identity_in_root(
-    root: &Path,
-    state: &InflightTurnState,
-    reason: InflightDeliveryRewindReason,
-) -> Result<bool, String> {
-    let Some(provider) = state.provider_kind() else {
-        return Err(format!("Unknown provider '{}'", state.provider));
-    };
-    let path = inflight_state_path(root, &provider, state.channel_id);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    }
-    let _lock = lock_inflight_state_path(&path)?;
-    let Some(on_disk) = load_inflight_state_unlocked(&path) else {
-        return Ok(false);
-    };
-    let expected = InflightTurnIdentity::from_state(state);
-    if !expected.matches_state(&on_disk) {
-        return Ok(false);
-    }
-    if on_disk.terminal_delivery_committed {
-        return Ok(false);
-    }
-    let mut updated = on_disk;
-    updated.full_response = state.full_response.clone();
-    updated.response_sent_offset = state.response_sent_offset;
-    updated.terminal_delivery_committed = state.terminal_delivery_committed;
-    updated.last_offset = updated.last_offset.max(state.last_offset);
-    updated.set_relay_owner_kind(state.effective_relay_owner_kind());
-    updated.ensure_finalizer_turn_id();
-    if !validate_inflight_state_for_save_with_delivery_rewind_reason(
-        root,
-        &path,
-        &updated,
-        "src/services/discord/inflight.rs:save_inflight_delivery_rewind_if_matches_identity_in_root",
-        Some(reason),
-    ) {
-        return Ok(false);
-    }
-    updated.updated_at = now_string();
-    bump_save_generation_for_write(&path, &mut updated);
-    let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
-    atomic_write(&path, &json)?;
-    Ok(true)
-}
-
 /// Outcome of [`save_inflight_state_if_matches_identity`] — the #3041 P1-2 R3
 /// identity-guarded re-save used on a delivery-lease `Skip` epilogue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1164,11 +1164,25 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     inflight_state.delivery_bot = metadata_delivery_bot(metadata.as_ref());
     inflight_state.silent_turn = metadata_silent_flag(metadata.as_ref());
     inflight_state.source = metadata_turn_source(source, metadata.as_ref());
-    if let Err(error) =
-        crate::services::discord::inflight::save_inflight_state_create_new(&inflight_state)
-    {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!("  [{ts}]   ⚠ inflight state create failed: {error}");
+    match crate::services::discord::inflight::save_inflight_state_create_new(&inflight_state) {
+        Ok(()) => {}
+        Err(crate::services::discord::inflight::CreateNewInflightError::AlreadyExists) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = channel_id.get(),
+                user_msg_id = inflight_state.user_msg_id,
+                "inflight create skipped because a durable row already exists; continuing fail-closed"
+            );
+        }
+        Err(crate::services::discord::inflight::CreateNewInflightError::Internal(error)) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = channel_id.get(),
+                user_msg_id = inflight_state.user_msg_id,
+                %error,
+                "inflight create failed internally; continuing without durable row"
+            );
+        }
     }
 
     let _ = attach_paused_turn_watcher_for_inflight(

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1164,9 +1164,11 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     inflight_state.delivery_bot = metadata_delivery_bot(metadata.as_ref());
     inflight_state.silent_turn = metadata_silent_flag(metadata.as_ref());
     inflight_state.source = metadata_turn_source(source, metadata.as_ref());
-    if let Err(error) = save_inflight_state(&inflight_state) {
+    if let Err(error) =
+        crate::services::discord::inflight::save_inflight_state_create_new(&inflight_state)
+    {
         let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!("  [{ts}]   ⚠ inflight state save failed: {error}");
+        tracing::info!("  [{ts}]   ⚠ inflight state create failed: {error}");
     }
 
     let _ = attach_paused_turn_watcher_for_inflight(

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -1164,26 +1164,11 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
     inflight_state.delivery_bot = metadata_delivery_bot(metadata.as_ref());
     inflight_state.silent_turn = metadata_silent_flag(metadata.as_ref());
     inflight_state.source = metadata_turn_source(source, metadata.as_ref());
-    match crate::services::discord::inflight::save_inflight_state_create_new(&inflight_state) {
-        Ok(()) => {}
-        Err(crate::services::discord::inflight::CreateNewInflightError::AlreadyExists) => {
-            tracing::warn!(
-                provider = %provider.as_str(),
-                channel_id = channel_id.get(),
-                user_msg_id = inflight_state.user_msg_id,
-                "inflight create skipped because a durable row already exists; continuing fail-closed"
-            );
-        }
-        Err(crate::services::discord::inflight::CreateNewInflightError::Internal(error)) => {
-            tracing::warn!(
-                provider = %provider.as_str(),
-                channel_id = channel_id.get(),
-                user_msg_id = inflight_state.user_msg_id,
-                %error,
-                "inflight create failed internally; continuing without durable row"
-            );
-        }
-    }
+    super::intake_turn::inflight_create_log::log_create_new_inflight_outcome(
+        crate::services::discord::inflight::save_inflight_state_create_new(&inflight_state),
+        &provider,
+        &inflight_state,
+    );
 
     let _ = attach_paused_turn_watcher_for_inflight(
         shared,

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2390,9 +2390,23 @@ pub(super) async fn handle_text_message(
     // Persist identifiers for long-turn diagnostics (#130)
     inflight_state.session_key = adk_session_key.clone();
     inflight_state.dispatch_id = dispatch_id.clone();
-    if let Err(e) = super::super::super::inflight::save_inflight_state_create_new(&inflight_state) {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!("  [{ts}]   ⚠ inflight state create failed: {e}");
+    match super::super::super::inflight::save_inflight_state_create_new(&inflight_state) {
+        Ok(()) => {}
+        Err(super::super::super::inflight::CreateNewInflightError::AlreadyExists) => {
+            tracing::warn!(
+                channel_id = channel_id.get(),
+                user_msg_id = inflight_state.user_msg_id,
+                "inflight create skipped because a durable row already exists; continuing fail-closed"
+            );
+        }
+        Err(super::super::super::inflight::CreateNewInflightError::Internal(error)) => {
+            tracing::warn!(
+                channel_id = channel_id.get(),
+                user_msg_id = inflight_state.user_msg_id,
+                %error,
+                "inflight create failed internally; continuing without durable row"
+            );
+        }
     }
 
     // Create channel for streaming

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2390,9 +2390,9 @@ pub(super) async fn handle_text_message(
     // Persist identifiers for long-turn diagnostics (#130)
     inflight_state.session_key = adk_session_key.clone();
     inflight_state.dispatch_id = dispatch_id.clone();
-    if let Err(e) = save_inflight_state(&inflight_state) {
+    if let Err(e) = super::super::super::inflight::save_inflight_state_create_new(&inflight_state) {
         let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!("  [{ts}]   ⚠ inflight state save failed: {e}");
+        tracing::info!("  [{ts}]   ⚠ inflight state create failed: {e}");
     }
 
     // Create channel for streaming

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -8,6 +8,7 @@ use super::*;
 
 mod adk_thread;
 mod claim_bootstrap;
+pub(crate) mod inflight_create_log;
 mod race_loss;
 mod stale_dispatch_guard;
 mod steering_hook;
@@ -2387,27 +2388,13 @@ pub(super) async fn handle_text_message(
     if is_voice_announcement {
         inflight_state.source = crate::dispatch::Source::Voice;
     }
-    // Persist identifiers for long-turn diagnostics (#130)
     inflight_state.session_key = adk_session_key.clone();
     inflight_state.dispatch_id = dispatch_id.clone();
-    match super::super::super::inflight::save_inflight_state_create_new(&inflight_state) {
-        Ok(()) => {}
-        Err(super::super::super::inflight::CreateNewInflightError::AlreadyExists) => {
-            tracing::warn!(
-                channel_id = channel_id.get(),
-                user_msg_id = inflight_state.user_msg_id,
-                "inflight create skipped because a durable row already exists; continuing fail-closed"
-            );
-        }
-        Err(super::super::super::inflight::CreateNewInflightError::Internal(error)) => {
-            tracing::warn!(
-                channel_id = channel_id.get(),
-                user_msg_id = inflight_state.user_msg_id,
-                %error,
-                "inflight create failed internally; continuing without durable row"
-            );
-        }
-    }
+    inflight_create_log::log_create_new_inflight_outcome(
+        super::super::super::inflight::save_inflight_state_create_new(&inflight_state),
+        &provider,
+        &inflight_state,
+    );
 
     // Create channel for streaming
     let (tx, rx) = mpsc::channel();

--- a/src/services/discord/router/message_handler/intake_turn/inflight_create_log.rs
+++ b/src/services/discord/router/message_handler/intake_turn/inflight_create_log.rs
@@ -1,0 +1,31 @@
+use crate::services::discord::inflight::{CreateNewInflightError, InflightTurnState};
+use crate::services::provider::ProviderKind;
+
+pub(crate) fn log_create_new_inflight_outcome(
+    result: Result<(), CreateNewInflightError>,
+    provider: &ProviderKind,
+    state: &InflightTurnState,
+) {
+    let channel_id = state.channel_id;
+    let user_msg_id = state.user_msg_id;
+    match result {
+        Ok(()) => {}
+        Err(CreateNewInflightError::AlreadyExists) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id,
+                user_msg_id,
+                "inflight create skipped because a durable row already exists; continuing fail-closed"
+            );
+        }
+        Err(CreateNewInflightError::Internal(error)) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id,
+                user_msg_id,
+                %error,
+                "inflight create failed internally; continuing without durable row"
+            );
+        }
+    }
+}

--- a/src/services/discord/router/message_handler/provider_isolation.rs
+++ b/src/services/discord/router/message_handler/provider_isolation.rs
@@ -553,7 +553,10 @@ pub(super) async fn ensure_provider_worktree_isolation(
             Some(branch_name.clone()),
             base_commit,
         );
-        let _ = super::super::super::inflight::save_inflight_state(&inflight);
+        let _ = super::super::super::inflight::save_inflight_state_if_identity_unchanged(
+            &inflight,
+            "provider_worktree_isolation",
+        );
     }
 
     let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -822,11 +822,18 @@ pub(super) fn attach_paused_turn_watcher_for_inflight(
         initial_offset,
         source,
     );
-    if inflight_state.set_watcher_owner_channel_id(owner_channel_id.get())
-        && let Err(error) = save_inflight_state(inflight_state)
-    {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!("  [{ts}]   ⚠ inflight owner-channel save failed: {error}");
+    if inflight_state.set_watcher_owner_channel_id(owner_channel_id.get()) {
+        let outcome = crate::services::discord::inflight::save_inflight_state_if_identity_unchanged(
+            inflight_state,
+            "attach_paused_turn_watcher_for_inflight",
+        );
+        if !matches!(
+            outcome,
+            crate::services::discord::inflight::GuardedSaveOutcome::Saved
+        ) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::info!("  [{ts}]   ⚠ inflight owner-channel save skipped: {outcome:?}");
+        }
     }
     owner_channel_id
 }

--- a/src/services/discord/session_runtime/worktree.rs
+++ b/src/services/discord/session_runtime/worktree.rs
@@ -596,6 +596,9 @@ pub(super) fn sync_inflight_worktree_context(
 ) {
     if let Some(mut inflight) = super::super::inflight::load_inflight_state(provider, channel_id) {
         inflight.set_worktree_context(worktree_path, worktree_branch, base_commit);
-        let _ = super::super::inflight::save_inflight_state(&inflight);
+        let _ = super::super::inflight::save_inflight_state_if_identity_unchanged(
+            &inflight,
+            "sync_inflight_worktree_context",
+        );
     }
 }

--- a/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
+++ b/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
@@ -137,13 +137,17 @@ pub(super) fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                                 repaired.session_key = lease.session_key.clone();
                                 repaired.runtime_kind = lease.runtime_kind;
                                 repaired.set_relay_owner_kind(RelayOwnerKind::None);
-                                if let Err(error) = inflight::save_inflight_state(&repaired) {
+                                let outcome = inflight::save_inflight_state_if_identity_matches_allow_output_restamp(
+                                    &repaired,
+                                    "codex_idle_rollout_repair",
+                                );
+                                if !matches!(outcome, inflight::GuardedSaveOutcome::Saved) {
                                     tracing::warn!(
                                         tmux_session_name = %tmux_session_name,
                                         channel_id = channel_id.get(),
                                         rollout_path = %rollout_path.display(),
-                                        error = %error,
-                                        "failed to repair Codex ownerless external-input inflight with live rollout path"
+                                        ?outcome,
+                                        "skipped Codex ownerless external-input inflight repair"
                                     );
                                     continue;
                                 }

--- a/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
+++ b/src/services/discord/tui_prompt_relay/codex_idle_rollout.rs
@@ -129,6 +129,7 @@ pub(super) fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                                     &rollout_path,
                                     observed_at,
                                 );
+                                let expected = inflight::InflightTurnIdentity::from_state(&inflight);
                                 let mut repaired = inflight;
                                 repaired.output_path =
                                     rollout_path.to_str().map(ToString::to_string);
@@ -139,6 +140,7 @@ pub(super) fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                                 repaired.set_relay_owner_kind(RelayOwnerKind::None);
                                 let outcome = inflight::save_inflight_state_if_identity_matches_allow_output_restamp(
                                     &repaired,
+                                    &expected,
                                     "codex_idle_rollout_repair",
                                 );
                                 if !matches!(outcome, inflight::GuardedSaveOutcome::Saved) {

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -289,6 +289,7 @@ pub(super) async fn claim_tui_direct_synthetic_turn(
         && existing.turn_source == TurnSource::ExternalInput
         && existing.user_msg_id == anchor_message_id.get()
     {
+        let expected = super::super::inflight::InflightTurnIdentity::from_state(&existing);
         let mut existing = existing;
         existing.turn_nonce = active_turn_nonce.clone();
         existing.set_relay_owner_kind(relay_owner_kind);
@@ -306,6 +307,7 @@ pub(super) async fn claim_tui_direct_synthetic_turn(
         let outcome =
             super::super::inflight::save_inflight_state_if_identity_matches_allow_output_restamp(
                 &existing,
+                &expected,
                 "tui_direct_synthetic_refresh",
             );
         if !matches!(outcome, super::super::inflight::GuardedSaveOutcome::Saved) {

--- a/src/services/discord/tui_prompt_relay/synthetic_start.rs
+++ b/src/services/discord/tui_prompt_relay/synthetic_start.rs
@@ -303,13 +303,18 @@ pub(super) async fn claim_tui_direct_synthetic_turn(
         // pinned so completion cleanup never reads a later injection's overwrite of
         // the shared prompt-anchor slot.
         existing.injected_prompt_message_id = Some(anchor_message_id.get());
-        if let Err(error) = super::super::inflight::save_inflight_state(&existing) {
+        let outcome =
+            super::super::inflight::save_inflight_state_if_identity_matches_allow_output_restamp(
+                &existing,
+                "tui_direct_synthetic_refresh",
+            );
+        if !matches!(outcome, super::super::inflight::GuardedSaveOutcome::Saved) {
             tracing::warn!(
                 provider = %provider.as_str(),
                 channel_id = channel_id.get(),
                 tmux_session_name = %tmux_session_name,
-                error = %error,
-                "failed to refresh TUI-direct synthetic inflight ownership"
+                ?outcome,
+                "skipped TUI-direct synthetic inflight ownership refresh"
             );
             if mailbox_activation_occurred {
                 finish_tui_direct_synthetic_pre_save_failure(shared, provider, channel_id).await;
@@ -351,22 +356,41 @@ pub(super) async fn claim_tui_direct_synthetic_turn(
     // keep it relay-ownership-only so watcher completion Path B skips it.
     inflight_state.relay_ownership_only =
         classify_injected_prompt(prompt_text).suppresses_user_turn_lifecycle();
-    if let Err(error) = super::super::inflight::save_inflight_state(&inflight_state) {
-        tracing::warn!(
-            provider = %provider.as_str(),
-            channel_id = channel_id.get(),
-            tmux_session_name = %tmux_session_name,
-            error = %error,
-            "failed to save TUI-direct synthetic inflight"
-        );
-        if mailbox_activation_occurred {
-            finish_tui_direct_synthetic_pre_save_failure(shared, provider, channel_id).await;
+    match super::super::inflight::save_inflight_state_if_absent(&inflight_state) {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = channel_id.get(),
+                tmux_session_name = %tmux_session_name,
+                "skipped TUI-direct synthetic inflight because a durable row already exists"
+            );
+            if mailbox_activation_occurred {
+                finish_tui_direct_synthetic_pre_save_failure(shared, provider, channel_id).await;
+            }
+            return TuiDirectSyntheticTurnClaim {
+                relay_owner,
+                claimed: false,
+                turn_start_offset: start_offset,
+            };
         }
-        return TuiDirectSyntheticTurnClaim {
-            relay_owner,
-            claimed: false,
-            turn_start_offset: start_offset,
-        };
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = channel_id.get(),
+                tmux_session_name = %tmux_session_name,
+                error = %error,
+                "failed to save TUI-direct synthetic inflight"
+            );
+            if mailbox_activation_occurred {
+                finish_tui_direct_synthetic_pre_save_failure(shared, provider, channel_id).await;
+            }
+            return TuiDirectSyntheticTurnClaim {
+                relay_owner,
+                claimed: false,
+                turn_start_offset: start_offset,
+            };
+        }
     }
 
     if mailbox_activation_occurred {

--- a/src/services/discord/turn_bridge/runtime_handoff_loop/guarded_save.rs
+++ b/src/services/discord/turn_bridge/runtime_handoff_loop/guarded_save.rs
@@ -27,10 +27,15 @@ pub(super) fn guarded_runtime_handoff_save(
     caller: &'static str,
 ) -> crate::services::discord::inflight::GuardedSaveOutcome {
     use crate::services::discord::inflight::{
-        GuardedSaveOutcome, save_inflight_state_if_identity_matches_allow_output_restamp,
+        GuardedSaveOutcome, InflightTurnIdentity,
+        save_inflight_state_if_identity_matches_allow_output_restamp,
     };
-    let outcome =
-        save_inflight_state_if_identity_matches_allow_output_restamp(inflight_state, caller);
+    let expected = InflightTurnIdentity::from_state(inflight_state);
+    let outcome = save_inflight_state_if_identity_matches_allow_output_restamp(
+        inflight_state,
+        &expected,
+        caller,
+    );
     if matches!(
         outcome,
         GuardedSaveOutcome::Missing | GuardedSaveOutcome::IdentityMismatch


### PR DESCRIPTION
## Summary
- Convert all eight external `save_inflight_state` call sites to creation-only or identity-guarded persistence.
- Lower the #4259 blind-save ratchet baseline from 21 to 13 and refresh generated inventory.
- Keep `turn_bridge/mod.rs`, runtime handoff, stream loop, and stream tick out of this slice.

## Converted call sites
- `headless_turn`: `save_inflight_state_create_new` for fresh turn seed.
- `intake_turn`: `save_inflight_state_create_new` for fresh turn seed.
- `provider_isolation` and `session_runtime/worktree`: strict identity gate for loaded-row worktree metadata updates.
- `watchdog`: strict identity gate for watcher-owner update.
- `codex_idle_rollout` and synthetic refresh: identity gate allowing live output-path restamp.
- synthetic creation: `save_inflight_state_if_absent` so an existing durable row wins.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `CARGO_TARGET_DIR=/tmp/adk-target-4259 CARGO_BUILD_JOBS=5 cargo check --lib`
- [x] `env -u AGENTDESK_ROOT_DIR CARGO_TARGET_DIR=/tmp/adk-target-4259 cargo test --lib inflight -- --test-threads=1`
- [x] `python3 scripts/check_inflight_blind_save_ratchet.py`
- [x] `python3 scripts/generate_inventory_docs.py`
- [x] `python3 scripts/check_agent_maintenance_docs.py`
- [x] `python3 scripts/audit_maintainability.py --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)