### PR TITLE
fix(discord): steer queued native TUI followups

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -657,6 +657,7 @@ src/
 │   │   │   │   │   ├── race_loss/
 │   │   │   │   │   │   ├── mailbox_reaction.rs
 │   │   │   │   │   │   └── mailbox_reaction_tests.rs
+│   │   │   │   │   ├── adk_thread.rs
 │   │   │   │   │   ├── claim_bootstrap.rs
 │   │   │   │   │   ├── race_loss.rs
 │   │   │   │   │   ├── stale_dispatch_guard.rs

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -182,10 +182,12 @@ pub(crate) async fn finish_admitted_local(
     submission: IntakeSubmission,
 ) -> Result<(), super::super::Error> {
     let preserve_on_cancel = submission.preserve_on_cancel;
+    let queued_drain = matches!(submission.origin, IntakeOrigin::QueuedDrain);
     message_handler::finish_admitted_local(
         deps,
         submission.request,
         preserve_on_cancel,
+        queued_drain,
         submission.preloaded_uploads,
         submission.voice_announcement,
     )

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -163,6 +163,7 @@ pub(super) async fn finish_admitted_local(
     deps: &IntakeDeps<'_>,
     request: IntakeRequest,
     preserve_on_cancel: bool,
+    queued_drain: bool,
     preloaded_uploads: Vec<String>,
     voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
 ) -> Result<(), Error> {
@@ -198,6 +199,7 @@ pub(super) async fn finish_admitted_local(
         dm_hint,
         turn_kind,
         preserve_on_cancel,
+        queued_drain,
         preloaded_uploads,
         voice_announcement,
     )

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -6,6 +6,7 @@ use super::super::super::turn_view_reconciler::{
 use super::voice_announcement_route::route_voice_transcript_announcement_once;
 use super::*;
 
+mod adk_thread;
 mod claim_bootstrap;
 mod race_loss;
 mod stale_dispatch_guard;
@@ -1879,16 +1880,8 @@ pub(super) async fn handle_text_message(
         channel_name.as_deref(),
         Some(&current_path),
     );
-    let adk_thread_channel_id = adk_session_name
-        .as_deref()
-        .and_then(super::super::super::adk_session::parse_thread_channel_id_from_name)
-        .or_else(|| {
-            shared
-                .dispatch
-                .thread_parents
-                .contains_key(&channel_id)
-                .then_some(channel_id.get())
-        });
+    let adk_thread_channel_id =
+        adk_thread::resolve_channel_id(adk_session_name.as_deref(), shared, channel_id);
     // #222: DB-based dispatch lookup takes priority over text parsing.
     // In unified threads, user_text may contain a stale DISPATCH: prefix
     // from a previous dispatch in the same thread. DB lookup uses the

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -103,6 +103,7 @@ pub(crate) async fn execute_intake_turn_core(
         request.dm_hint,
         request.turn_kind,
         request.preserve_on_cancel,
+        false,
         Vec::new(),
         // Worker dispatch has no in-process gate carry-forward; it re-resolves
         // the durable announcement row for its `user_msg_id` (#3905).
@@ -127,6 +128,7 @@ pub(super) async fn handle_text_message(
     dm_hint: Option<bool>,
     turn_kind: TurnKind,
     preserve_on_cancel: bool,
+    queued_drain: bool,
     preloaded_uploads: Vec<String>,
     gate_resolved_voice_announcement: Option<crate::voice::prompt::VoiceTranscriptAnnouncement>,
 ) -> Result<(), Error> {
@@ -1970,6 +1972,7 @@ pub(super) async fn handle_text_message(
             foreground: matches!(turn_kind, TurnKind::Foreground),
             local: remote_profile.is_none(),
             wait_for_completion,
+            queued_drain,
             has_dispatch: dispatch_id.is_some() || dispatch_id_for_thread.is_some(),
             is_voice_announcement,
             has_pending_uploads: !pending_uploads.is_empty(),

--- a/src/services/discord/router/message_handler/intake_turn/adk_thread.rs
+++ b/src/services/discord/router/message_handler/intake_turn/adk_thread.rs
@@ -1,0 +1,18 @@
+use super::*;
+use crate::services::discord::adk_session;
+
+pub(super) fn resolve_channel_id(
+    adk_session_name: Option<&str>,
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+) -> Option<u64> {
+    adk_session_name
+        .and_then(adk_session::parse_thread_channel_id_from_name)
+        .or_else(|| {
+            shared
+                .dispatch
+                .thread_parents
+                .contains_key(&channel_id)
+                .then_some(channel_id.get())
+        })
+}

--- a/src/services/discord/router/message_handler/intake_turn/steering_hook.rs
+++ b/src/services/discord/router/message_handler/intake_turn/steering_hook.rs
@@ -32,9 +32,29 @@ pub(super) struct IntakeSteeringContext<'a> {
     pub(super) foreground: bool,
     pub(super) local: bool,
     pub(super) wait_for_completion: bool,
+    pub(super) queued_drain: bool,
     pub(super) has_dispatch: bool,
     pub(super) is_voice_announcement: bool,
     pub(super) has_pending_uploads: bool,
+}
+
+fn steering_intake_eligible(
+    provider: &ProviderKind,
+    foreground: bool,
+    local: bool,
+    wait_for_completion: bool,
+    queued_drain: bool,
+    has_dispatch: bool,
+    is_voice_announcement: bool,
+    has_pending_uploads: bool,
+) -> bool {
+    foreground
+        && matches!(provider, ProviderKind::Claude | ProviderKind::Codex)
+        && local
+        && (!wait_for_completion || queued_drain)
+        && !has_dispatch
+        && !is_voice_announcement
+        && !has_pending_uploads
 }
 
 pub(super) async fn maybe_handle_intake_steering(
@@ -58,18 +78,22 @@ pub(super) async fn maybe_handle_intake_steering(
         foreground,
         local,
         wait_for_completion,
+        queued_drain,
         has_dispatch,
         is_voice_announcement,
         has_pending_uploads,
     } = context;
     if !crate::services::tui_steering::tui_steering_enabled()
-        || !foreground
-        || !matches!(provider, ProviderKind::Claude | ProviderKind::Codex)
-        || !local
-        || wait_for_completion
-        || has_dispatch
-        || is_voice_announcement
-        || has_pending_uploads
+        || !steering_intake_eligible(
+            provider,
+            foreground,
+            local,
+            wait_for_completion,
+            queued_drain,
+            has_dispatch,
+            is_voice_announcement,
+            has_pending_uploads,
+        )
     {
         return None;
     }
@@ -150,6 +174,61 @@ pub(super) async fn maybe_handle_intake_steering(
 mod tests {
     use super::*;
     use crate::services::tui_steering::SteeringOutcome;
+
+    #[test]
+    fn queued_drain_waiting_for_completion_remains_steering_eligible() {
+        assert!(steering_intake_eligible(
+            &ProviderKind::Claude,
+            true,
+            true,
+            true,
+            true,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
+    fn steering_intake_eligibility_rejects_non_drain_and_other_exclusions() {
+        let eligible = |foreground,
+                        local,
+                        wait_for_completion,
+                        queued_drain,
+                        has_dispatch,
+                        is_voice_announcement,
+                        has_pending_uploads| {
+            steering_intake_eligible(
+                &ProviderKind::Claude,
+                foreground,
+                local,
+                wait_for_completion,
+                queued_drain,
+                has_dispatch,
+                is_voice_announcement,
+                has_pending_uploads,
+            )
+        };
+
+        assert!(!eligible(true, true, true, false, false, false, false));
+        assert!(!eligible(true, true, false, false, true, false, false));
+        assert!(!eligible(true, false, false, false, false, false, false));
+        assert!(!eligible(true, true, false, false, false, true, false));
+        assert!(!eligible(true, true, false, false, false, false, true));
+        assert!(!eligible(false, true, false, false, false, false, false));
+
+        assert_eq!(
+            crate::services::tui_steering::route_input_by_session_driver(
+                &crate::services::provider_hosting::ProviderSessionSelection {
+                    provider_id: "claude".to_string(),
+                    requested_tui_hosting: false,
+                    driver: crate::services::provider_hosting::ProviderSessionDriver::ClaudeE,
+                    fallback_reason: None,
+                },
+            ),
+            crate::services::tui_steering::SteeringRoute::ExistingMailbox,
+        );
+    }
 
     #[test]
     fn failed_or_unsafe_steering_falls_through_to_busy_followup_enqueue() {

--- a/src/services/discord/router/message_handler/intake_turn/steering_hook.rs
+++ b/src/services/discord/router/message_handler/intake_turn/steering_hook.rs
@@ -38,6 +38,13 @@ pub(super) struct IntakeSteeringContext<'a> {
     pub(super) has_pending_uploads: bool,
 }
 
+fn steering_route_is_native(
+    selection: &crate::services::provider_hosting::ProviderSessionSelection,
+) -> bool {
+    crate::services::tui_steering::route_input_by_session_driver(selection)
+        == crate::services::tui_steering::SteeringRoute::NativeTui
+}
+
 fn steering_intake_eligible(
     provider: &ProviderKind,
     foreground: bool,
@@ -104,8 +111,7 @@ pub(super) async fn maybe_handle_intake_steering(
             claude::is_tmux_available(),
             Some(channel_id.get()),
         );
-    if crate::services::tui_steering::route_input_by_session_driver(&selection)
-        != crate::services::tui_steering::SteeringRoute::NativeTui
+    if !steering_route_is_native(&selection)
         || !crate::services::tmux_diagnostics::tmux_session_has_live_pane(steering_tmux_name)
         || !tui_busy_followup_diagnostic(
             shared,
@@ -217,17 +223,40 @@ mod tests {
         assert!(!eligible(true, true, false, false, false, false, true));
         assert!(!eligible(false, true, false, false, false, false, false));
 
+        assert!(!steering_intake_eligible(
+            &ProviderKind::Gemini,
+            true,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
+    fn non_native_tui_driver_is_blocked_by_the_actual_hook_route_gate() {
+        let selection = crate::services::provider_hosting::ProviderSessionSelection {
+            provider_id: "claude".to_string(),
+            requested_tui_hosting: false,
+            driver: crate::services::provider_hosting::ProviderSessionDriver::ClaudeE,
+            fallback_reason: None,
+        };
         assert_eq!(
-            crate::services::tui_steering::route_input_by_session_driver(
-                &crate::services::provider_hosting::ProviderSessionSelection {
-                    provider_id: "claude".to_string(),
-                    requested_tui_hosting: false,
-                    driver: crate::services::provider_hosting::ProviderSessionDriver::ClaudeE,
-                    fallback_reason: None,
-                },
-            ),
+            crate::services::tui_steering::route_input_by_session_driver(&selection),
             crate::services::tui_steering::SteeringRoute::ExistingMailbox,
         );
+
+        assert!(!steering_route_is_native(&selection));
+
+        let native_selection = crate::services::provider_hosting::ProviderSessionSelection {
+            provider_id: "claude".to_string(),
+            requested_tui_hosting: true,
+            driver: crate::services::provider_hosting::ProviderSessionDriver::TuiHosting,
+            fallback_reason: None,
+        };
+        assert!(steering_route_is_native(&native_selection));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #4750.

Allow a queued-drain re-entry to pass the native-TUI steering eligibility gate even when it preserves `wait_for_completion=true` for queue sequencing. A scoped `queued_drain` discriminator keeps synchronous completion-wait callers excluded.

Validation:
- cargo fmt --all --check
- cargo check --lib
- env -u AGENTDESK_ROOT_DIR cargo test --lib steering_hook
- Mutation proof: restoring the old `wait_for_completion` exclusion fails `queued_drain_waiting_for_completion_remains_steering_eligible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)