### PR TITLE
ci: revert merge_group trigger (merge queue unavailable on user-owned repo)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -11,17 +11,12 @@ on:
   # source with no cancellation. Branch CI is obtained by opening a PR; main is
   # covered by ci-main.yml.
   pull_request:
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
   # A PR number is unique inside the base repository, unlike `head_ref`: two
   # forks can use the same source branch name and must never cancel each other.
   # Manual dispatch has no PR payload, so isolate it by the selected ref.
-  # Merge queue runs also have no PR payload; `github.ref` for a merge_group
-  # event is the unique `refs/heads/gh-readonly-queue/<base>/pr-N-<sha>` entry
-  # ref, so the existing fallback already isolates each queue run.
   group: ci-pr-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
   # A newer push makes every result from the older SHA stale, so release its
   # hosted runners immediately. The `*_required_context` mirrors remain


### PR DESCRIPTION
## Summary
Revert #4749. The `merge_group` CI trigger was added as option 1 (merge queue) of #4747 (CI wall-clock 병목 축2), but GitHub merge queue is **not available on user-owned repositories** — only org-owned public repos or Enterprise Cloud private repos support it.

Confirmed empirically: a `merge_queue` ruleset rule returns `422 Invalid rule 'merge_queue'` on this repo, while other ruleset rule types create fine. The repo is user-owned + public, so the merge_group trigger can never fire and is dead config.

## Change
- Remove `merge_group: types: [checks_requested]` from `.github/workflows/ci-pr.yml` on:
- Restore the original top-level concurrency comment (the group string was already reverted to the guard-mandated fork-safe policy).

## Follow-up
#4747's actual goal (cut CI wall-clock) remains reachable without merge queue via option 2 (long-pole test split: full non-PG matrix on main-push only, PRs run the 9s targeted tests) and option 3 (cargo/sccache cache). Those are owner-approval-free and autonomous.

## Verify
- [x] `check-ci-runner-hardening.sh` rc=0 (concurrency policy intact)
- [x] 0 `merge_group` occurrences remain in ci-pr.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)