### PR TITLE
fix(4042): sweep Discord leaked relay rows

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -995,6 +995,7 @@ src/
 │   │   ├── relay_recovery_circuit_alert_producer.rs
 │   │   ├── relay_recovery_circuit_breaker.rs
 │   │   ├── relay_recovery_completion_footer.rs
+│   │   ├── relay_recovery_leaked_row_sweep.rs
 │   │   ├── relay_recovery_reattach_apply.rs
 │   │   ├── replace_outcome_policy.rs
 │   │   ├── response_sanitizer.rs

--- a/src/services/discord/health/relay_auto_heal.rs
+++ b/src/services/discord/health/relay_auto_heal.rs
@@ -382,7 +382,7 @@ pub(super) async fn run_orphan_token_auto_heal_pass(
             }
         }
     }
-    applied
+    applied + relay_recovery::leaked_row_sweep::sweep_leaked_inflight_rows(registry, provider).await
 }
 
 async fn redrive_undelivered_backlog(

--- a/src/services/discord/relay_recovery.rs
+++ b/src/services/discord/relay_recovery.rs
@@ -4,10 +4,10 @@
 //! classifier into an operator-facing decision, and only applies local,
 //! idempotent cleanup when the evidence is strong enough.
 //!
-//! Known residual limitations for follow-up issues: a committed-but-leaked
-//! inflight row self-heals only when a pending-start backstop can prove the
-//! terminal envelope and complete it through the finalizer; relay recovery still
-//! has no independent sweep for that shape. Rows whose `output_path` is missing
+//! Known residual limitations for follow-up issues: committed-but-leaked and
+//! stale foreign inflight rows are swept independently of TUI-direct pending-start
+//! records, while retaining the same terminal/death-evidence and identity gates.
+//! Rows whose `output_path` is missing
 //! or points at a deleted file are permanently denied by the destructive cancel
 //! gate because no frozen-capture or terminal-envelope evidence can be re-probed.
 //! Stage-3 recovery where `watcher_attached=false` still relies on the
@@ -51,6 +51,8 @@ mod auto_heal_confirm;
 mod circuit_breaker;
 #[path = "relay_recovery_completion_footer.rs"]
 mod completion_footer;
+#[path = "relay_recovery_leaked_row_sweep.rs"]
+pub(super) mod leaked_row_sweep;
 #[path = "relay_recovery_reattach_apply.rs"]
 mod reattach_apply;
 #[path = "relay_recovery_circuit_alert_producer.rs"]

--- a/src/services/discord/relay_recovery_leaked_row_sweep.rs
+++ b/src/services/discord/relay_recovery_leaked_row_sweep.rs
@@ -1,0 +1,109 @@
+use std::collections::HashSet;
+
+use super::super::{inflight, tui_direct_pending_start};
+use super::HealthRegistry;
+use crate::services::provider::ProviderKind;
+
+fn leaked_row_sweep_candidate(state: &inflight::InflightTurnState) -> Option<(&str, u64)> {
+    let tmux_session = state
+        .tmux_session_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|session| !session.is_empty())?;
+    (state.channel_id != 0).then_some((tmux_session, state.channel_id))
+}
+
+async fn recover_candidate(
+    registry: &HealthRegistry,
+    provider: &ProviderKind,
+    state: &inflight::InflightTurnState,
+) -> bool {
+    let Some((tmux_session, channel_id)) = leaked_row_sweep_candidate(state) else {
+        return false;
+    };
+    let channel = poise::serenity_prelude::ChannelId::new(channel_id);
+    let Some(shared) = registry
+        .shared_for_provider_on_channel(provider, channel)
+        .await
+    else {
+        return false;
+    };
+
+    let record = tui_direct_pending_start::TuiDirectPendingStart {
+        provider: provider.as_str().to_string(),
+        channel_id,
+        tmux_session_name: tmux_session.to_string(),
+        prompt_text: String::new(),
+        // A sweep has no synthetic anchor. MAX cannot equal a real Discord id,
+        // so the existing foreign-row gate evaluates the durable row itself.
+        anchor_message_id: u64::MAX,
+        lease_relay_owner: String::new(),
+        lease_runtime_kind: None,
+        lease_turn_id: None,
+        lease_session_key: None,
+        generation: shared.restart.current_generation,
+        created_at_ms: 0,
+        observed_at_ms: 0,
+        state: tui_direct_pending_start::PendingStartState::Waiting,
+        attempt_count: 0,
+    };
+    tui_direct_pending_start::demote_stale_foreign_inflight_if_current(&shared, &record).await
+}
+
+pub(in crate::services::discord) async fn sweep_leaked_inflight_rows(
+    registry: &HealthRegistry,
+    provider: &ProviderKind,
+) -> usize {
+    let states = inflight::load_inflight_states_for_sweep(provider);
+    let mut seen = HashSet::new();
+    let mut applied = 0;
+    for (state, _) in states {
+        if !seen.insert(state.channel_id) {
+            continue;
+        }
+        if recover_candidate(registry, provider, &state).await {
+            applied += 1;
+        }
+    }
+    applied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::leaked_row_sweep_candidate;
+    use crate::services::discord::inflight::InflightTurnState;
+    use crate::services::provider::ProviderKind;
+
+    fn state(channel_id: u64, tmux_session: Option<&str>) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id,
+            None,
+            1,
+            2,
+            3,
+            "prompt".to_string(),
+            None,
+            tmux_session.map(str::to_string),
+            Some("/tmp/output.jsonl".to_string()),
+            None,
+            0,
+        )
+    }
+
+    #[test]
+    fn discord_row_is_sweep_candidate_without_pending_start() {
+        let state = state(4_042_001, Some("AgentDesk-claude-discord"));
+        assert_eq!(
+            leaked_row_sweep_candidate(&state),
+            Some(("AgentDesk-claude-discord", 4_042_001))
+        );
+    }
+
+    #[test]
+    fn sweep_rejects_rows_without_channel_or_tmux_identity() {
+        assert!(leaked_row_sweep_candidate(&state(0, Some("tmux"))).is_none());
+        assert!(leaked_row_sweep_candidate(&state(4_042_002, None)).is_none());
+        assert!(leaked_row_sweep_candidate(&state(4_042_003, Some("  "))).is_none());
+    }
+}


### PR DESCRIPTION
Closes #4042

## 요약
프로즌 giant `relay_recovery.rs`에서 leaked-row sweep 로직을 신규 파일 `src/services/discord/relay_recovery_leaked_row_sweep.rs`(~109줄)로 추출.

## 변경 파일
- `src/services/discord/relay_recovery_leaked_row_sweep.rs` (신규)
- `src/services/discord/relay_recovery.rs` (sweep 호출로 위임)
- `src/services/discord/health/relay_auto_heal.rs`
- `ARCHITECTURE.md`

## Review
교차모델 dual review 완료:
- Anthropic: CLEAN
- GPT: APPROVED

## 핫파일
핫파일 4개(turn_bridge/mod.rs, tmux_watcher.rs, session_relay_sink.rs, turn_finalizer.rs) 미접촉.