### PR TITLE
fix(4080): render single-message completion footer subtext + suppress placeholder

### DIFF
--- a/src/services/discord/footer_view_reconciler/mod.rs
+++ b/src/services/discord/footer_view_reconciler/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use poise::serenity_prelude as serenity;
 use serenity::{ChannelId, MessageId};
+use sqlx::Row;
 
 use super::{ProviderKind, SharedData, single_message_panel as smp};
 use crate::services::agent_protocol::StatusEvent;
@@ -164,8 +165,75 @@ struct CompletedFooterPlan {
     terminal_edit: Option<CompletionFooterTerminalEdit>,
 }
 
+async fn append_terminal_relay_metadata(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    owner: CompletionFooterOwner,
+    mut block: String,
+) -> String {
+    if owner.started_at_unix > 0 {
+        let elapsed_secs = chrono::Utc::now()
+            .timestamp()
+            .saturating_sub(owner.started_at_unix);
+        if elapsed_secs > 0 {
+            block.push_str(&format!("\n\n⏱ {}", format_turn_duration(elapsed_secs)));
+        }
+    }
+
+    if let Some(rate_limit) = terminal_rate_limit_summary(shared, provider).await {
+        block.push_str(&format!("\n⏳ {rate_limit}"));
+    }
+
+    if crate::config_live_reload::current().is_some_and(|config| config.cluster.enabled) {
+        let node =
+            crate::services::cluster::node_registry::resolve_self_instance_id_without_config();
+        if !node.trim().is_empty() {
+            block.push_str(&format!("\n🖥️ {node}"));
+        }
+    }
+
+    block
+}
+
+fn format_turn_duration(total_secs: i64) -> String {
+    let minutes = total_secs / 60;
+    let seconds = total_secs % 60;
+    if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+async fn terminal_rate_limit_summary(
+    shared: &SharedData,
+    provider: &ProviderKind,
+) -> Option<String> {
+    let pool = shared.pg_pool.as_ref()?;
+    let provider = provider.as_str();
+    let row =
+        sqlx::query("SELECT data FROM rate_limit_cache WHERE lower(provider) = lower($1) LIMIT 1")
+            .bind(provider)
+            .fetch_optional(pool)
+            .await
+            .ok()??;
+    let data = row.try_get::<String, _>("data").ok()?;
+    let buckets = serde_json::from_str::<serde_json::Value>(&data)
+        .ok()?
+        .get("buckets")?
+        .as_array()?
+        .iter()
+        .filter_map(|bucket| {
+            let name = bucket.get("name")?.as_str()?;
+            let remaining = bucket.get("remaining")?.as_i64()?.clamp(0, 100);
+            matches!(name, "5h" | "7d").then(|| format!("{name} {remaining}%"))
+        })
+        .collect::<Vec<_>>();
+    (!buckets.is_empty()).then(|| buckets.join(" · "))
+}
+
 #[allow(clippy::too_many_arguments)]
-fn prepare_turn_completed_footer(
+async fn prepare_turn_completed_footer(
     shared: &SharedData,
     channel_id: ChannelId,
     terminal_msg_id: Option<MessageId>,
@@ -192,6 +260,8 @@ fn prepare_turn_completed_footer(
         rendered.block.unwrap_or_default(),
         wip_warning,
     );
+    let completion_block =
+        append_terminal_relay_metadata(shared, provider, owner, completion_block).await;
     let completion_block = (!completion_block.trim().is_empty()).then_some(completion_block);
     let Some(msg_id) = terminal_msg_id else {
         return CompletedFooterPlan {
@@ -258,7 +328,8 @@ pub(in crate::services::discord) async fn note_turn_completed_footer(
         background,
         background_agent_pending,
         wip_warning.as_ref(),
-    );
+    )
+    .await;
     if let Some(edit) = plan.supersede_edit
         && let Err(error) = writer
             .edit_channel_message(channel_id, edit.message_id, &edit.text, true)
@@ -471,6 +542,12 @@ pub(in crate::services::discord) fn register_completion_footer_target_for_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn format_turn_duration_renders_seconds_and_minutes_4080() {
+        assert_eq!(format_turn_duration(34), "34s");
+        assert_eq!(format_turn_duration(154), "2m 34s");
+    }
 
     fn push_unfinished_subagent(channel_id: ChannelId) -> Arc<SharedData> {
         let shared = super::super::make_shared_data_for_tests();

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -673,7 +673,7 @@ fn is_spinner_prefix_char(ch: char) -> bool {
 fn text_has_single_message_footer_surface(text: &str) -> bool {
     text.lines()
         .filter_map(|line| {
-            let line = line.trim();
+            let line = strip_subtext_prefix(line.trim());
             (!line.is_empty()).then_some(line)
         })
         .any(|line| {
@@ -1442,6 +1442,22 @@ mod tests {
         assert_eq!(
             super::finalize_streaming_footer(&rendered, &ProviderKind::Claude),
             None
+        );
+    }
+
+    #[test]
+    fn subtext_footer_only_completion_surface_is_exposed_4080() {
+        let footer = super::completion_footer_subtext(
+            "Context   📦 10 / 100 tokens\n\nTasks\n└ Bash Done ✓\n⏱ 2m 34s",
+        );
+
+        assert!(super::streaming_footer_only_surface_was_exposed(
+            &footer,
+            &ProviderKind::Claude
+        ));
+        assert_eq!(
+            super::strip_streaming_footer(&footer, &ProviderKind::Claude),
+            Some(String::new())
         );
     }
 

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -95,6 +95,22 @@ pub(in crate::services::discord) fn compose_footer_status_block(
     clamp_footer_status_block(status_block)
 }
 
+/// Render terminal relay context as Discord subtext. Every non-empty line is
+/// explicitly prefixed because Discord does not carry a multiline subtext span.
+pub(in crate::services::discord) fn completion_footer_subtext(block: &str) -> String {
+    block
+        .lines()
+        .map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else {
+                format!("-# {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub(in crate::services::discord) fn compose_completion_footer_text(
     body: &str,
     completion_block: Option<&str>,
@@ -106,8 +122,9 @@ pub(in crate::services::discord) fn compose_completion_footer_text(
     else {
         return body.to_string();
     };
+    let block = completion_footer_subtext(block);
     if body.is_empty() {
-        return clamp_footer_status_block(block.to_string());
+        return clamp_footer_status_block(block);
     }
 
     let suffix = format!("\n\n{block}");
@@ -490,11 +507,15 @@ fn line_is_truncation_marker(line: &str) -> bool {
 /// streaming/merged status line, a `Tasks`/`Subagents` header, a `└ ` slot line,
 /// or a `Context   ` summary. Used only by the tail-anchored reclaim split.
 fn line_is_footer_shaped(line: &str) -> bool {
-    let trimmed = line.trim();
+    let trimmed = strip_subtext_prefix(line.trim());
     is_single_message_footer_status_line(trimmed)
         || completion_footer_section_header(trimmed)
         || completion_footer_context_line(trimmed)
         || trimmed.starts_with("└ ")
+}
+
+fn strip_subtext_prefix(line: &str) -> &str {
+    line.strip_prefix("-# ").unwrap_or(line)
 }
 
 fn line_ends_with_spinner_glyph(line: &str) -> bool {
@@ -749,15 +770,17 @@ fn completion_footer_starts_after_body(footer: &str, body: &str) -> bool {
 }
 
 fn completion_footer_context_line(line: &str) -> bool {
-    line.starts_with("Context   ")
+    strip_subtext_prefix(line).starts_with("Context   ")
 }
 
 fn completion_footer_section_header(line: &str) -> bool {
-    line == "Tasks" || line == "Subagents"
+    matches!(strip_subtext_prefix(line), "Tasks" | "Subagents")
 }
 
 fn completion_footer_has_slot_shape(footer: &str) -> bool {
-    footer.lines().any(|line| line.starts_with("└ "))
+    footer
+        .lines()
+        .any(|line| strip_subtext_prefix(line).starts_with("└ "))
 }
 
 fn completion_footer_first_line_is_section_header(footer: &str) -> bool {
@@ -1245,6 +1268,25 @@ mod tests {
     /// #3394 round 2: a body with a BALANCED fence and a footer compose without
     /// any repair touching the body's closed fence — parity stays even and both
     /// the fenced body and the footer survive intact.
+    #[test]
+    fn completion_footer_subtext_prefixes_each_nonempty_line_4080() {
+        assert_eq!(
+            super::completion_footer_subtext(
+                "Context   📦 10 / 100 tokens\n\nTasks\n└ Bash Done ✓\n⏱ 2m 34s"
+            ),
+            "-# Context   📦 10 / 100 tokens\n\n-# Tasks\n-# └ Bash Done ✓\n-# ⏱ 2m 34s"
+        );
+    }
+
+    #[test]
+    fn subtext_completion_footer_is_stripped_at_terminal_reconciliation_4080() {
+        let text = "Final answer\n\n-# Context   📦 10 / 100 tokens\n\n-# Tasks\n-# └ Bash Done ✓\n-# ⏱ 2m 34s";
+        assert_eq!(
+            super::strip_streaming_footer(text, &ProviderKind::Claude),
+            Some("Final answer".to_string())
+        );
+    }
+
     #[test]
     fn compose_completion_footer_keeps_balanced_body_fence_intact_3394() {
         let body = "intro\n\n```text\nclosed body\n```\noutro";


### PR DESCRIPTION
Closes #4080

## 개요
Single-message 완료 footer의 subtext(\`-# \`) 렌더링 + placeholder suppression 수정. 멀티클러스터 활성 시 노드명 표기(🖥️) 포함.

## 변경
- relay tail 메타데이터를 Discord subtext(\`-# \`)로 렌더
- subtext-only footer 감지로 placeholder 억제

## 리뷰
교차모델 dual review 양측 완료:
- GPT: 구현
- Anthropic: 재검증 APPROVED

코드 리뷰 재실행 불필요 — CI 게이트만 통과시켜 머지.