### PR TITLE
test(4724): guard de-committed inventory contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,14 @@
 CI가 강제하는 것을 로컬에서 미리 통과시키는 순서. **권위 있는 CI 정의는
 [`.github/workflows/ci-pr.yml`](.github/workflows/ci-pr.yml)와
 [`scripts/ci-script-checks.sh`](scripts/ci-script-checks.sh)** (실제 CI는 `cargo check --workspace --all-targets`,
-`cargo fmt --all --check`, docs 게이트 `generate_inventory_docs.py --check` +
+`cargo fmt --all --check`, docs 게이트 `generate_inventory_docs.py` + tracked-output `git diff` +
 `check_agent_maintenance_docs.py --warning-only --line-count-gate`로 더 넓다).
 
 1. `cargo fmt` → `cargo fmt --check` 클린
 2. `cargo check --lib` 클린 + 관련 `cargo test --lib <module>` 통과 (CI는 워크스페이스 전체)
 3. `python3 scripts/generate_inventory_docs.py` 실행 후 `python3 scripts/check_agent_maintenance_docs.py`가
    `agent-maintenance freshness check passed`를 낼 때까지 반복
-   - production line count 불일치 → `change-surfaces.md`를 module-inventory 진실값에 맞춤
+   - frozen giant surface membership/threshold 오류 → fresh module inventory와 `change-surfaces.md` marker를 대조
    - `multinode-transition.md must be touched` → `docs/agent-maintenance/multinode-transition.md`의 `### Audited touches`에 노트 추가
    - DB migration 추가 시 `migrations/postgres/immutable-checksums.json` checksum 등록
 

--- a/docs/agent-maintenance/merge-driver-inventory.md
+++ b/docs/agent-maintenance/merge-driver-inventory.md
@@ -1,16 +1,12 @@
 # Inventory Docs Merge Driver (`regen-inventory`)
 
-> Why: `docs/generated/module-inventory.md` and its siblings are **committed
-> generated files**. When two branches change the same module's line count (or a
-> shared summary line), they edit the same row, so a plain 3-way merge leaves
-> conflict markers there — and because the inventory is regenerated on every
-> prod-line change, concurrent PRs collide constantly, forcing O(N²) serial
-> rebases (#4724). The `regen-inventory` git merge driver removes that class of
-> conflict: it lets git's normal line merge handle independent rows, and only
-> when a row genuinely collides does it **regenerate** the inventory to drop the
-> markers. It is a best-effort ergonomic auto-resolver — the authoritative
-> correctness check is the server-side CI freshness gate (see *Correctness
-> backstops* below), not the driver.
+> `docs/generated/module-inventory.md` and
+> `docs/generated/giant-file-registry.md` are now untracked, checkout-local
+> views (#4724). This removes their production-line churn from git merges
+> entirely. The `regen-inventory` driver remains only for the two generated
+> inventories that are still committed: route and worker. It is a best-effort
+> ergonomic auto-resolver; source-of-truth invariants and tracked-doc drift are
+> enforced after generation in `scripts/ci-script-checks.sh`.
 
 ## One-time developer setup (REQUIRED)
 
@@ -31,13 +27,15 @@ git config --local --get merge.regen-inventory.driver
 
 ## What it covers
 
-`.gitattributes` assigns `merge=regen-inventory` to exactly the four files that
-`scripts/generate_inventory_docs.py` overwrites wholesale:
+`.gitattributes` assigns `merge=regen-inventory` to exactly the two generated
+files that remain tracked:
 
-- `docs/generated/module-inventory.md`
 - `docs/generated/route-inventory.md`
 - `docs/generated/worker-inventory.md`
-- `docs/generated/giant-file-registry.md`
+
+The generator also emits `module-inventory.md` and `giant-file-registry.md`, but
+`.gitignore` keeps those checkout-local. CI generates them before maintenance
+checks consume them, so no merge driver is needed for either file.
 
 **Deliberately excluded** (hand-authored, or emitted by a different generator —
 the driver would clobber real content): `docs/generated/README.md`,
@@ -98,22 +96,21 @@ partially-generated content.
 
 ## Correctness backstops (authoritative vs convenience)
 
-- **Authoritative, server-side, non-bypassable — the CI freshness gate.**
+- **Authoritative, server-side — generation plus focused tracked diff.**
   `scripts/ci-script-checks.sh` (run by the required *Script checks* job in
-  `.github/workflows/ci-pr.yml`) executes `python3
-  scripts/generate_inventory_docs.py --check` under `set -euo pipefail`;
-  generated-docs drift (exit 1) is a **hard PR failure**. It regenerates from the
-  merged source tree and compares, so **driver-produced drift can be pushed to a
-  branch but cannot reach `main`** — CI fails the PR, exactly as it would for a
-  human who committed a stale/incorrect manual resolution. This is the guarantee
-  the driver relies on. (Note: the `check_agent_maintenance_docs.py` invocation
-  in the same script is `--warning-only`; the hard gate is the
-  `generate_inventory_docs.py --check` call.)
+  `.github/workflows/ci-pr.yml`) first runs `python3
+  scripts/generate_inventory_docs.py`. Generation hard-fails source-of-truth
+  violations such as an unregistered giant or invalid registry metadata. CI
+  then runs `git diff --exit-code` for `ARCHITECTURE.md`, route inventory, and
+  worker inventory, the three generated outputs that remain tracked.
+  `check_agent_maintenance_docs.py` consumes the freshly generated, untracked
+  module inventory and keeps frozen-surface membership/threshold checks active.
 - **Local convenience — the pre-push hook.** `.githooks/pre-push` regenerates
-  inventory docs when `src` changed and blocks/amends before push, so most drift
-  never leaves the machine. It is a convenience only: it is skippable with
-  `git push --no-verify` and requires `core.hooksPath=.githooks` (set by
-  `scripts/setup-hooks.sh`). It is **not** the correctness authority — CI is.
+  inventory docs when `src` changed and blocks/amends before push, so most
+  tracked drift never leaves the machine. It is a convenience only: it is
+  skippable with `git push --no-verify` and requires
+  `core.hooksPath=.githooks` (set by `scripts/setup-hooks.sh`). CI remains the
+  correctness authority.
 
 ## CI note
 
@@ -121,6 +118,6 @@ CI needs no *driver* registration: `.github/workflows/ci-pr.yml` uses
 `actions/checkout@v4` and never performs a local `git merge`, and GitHub's
 server-side PR merge / merge-queue does **not** honor custom `.gitattributes`
 merge drivers. The driver's value is entirely local (developer rebases/merges).
-No existing CI gate is changed or weakened — in particular the hard
-`generate_inventory_docs.py --check` drift gate above remains the enforcement
-point.
+The server-side gate does not rely on the driver: it regenerates from the merged
+source tree, validates inventory invariants, and rejects drift in the remaining
+tracked outputs.

--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -7,6 +7,10 @@ about the generated report or its generator.
 
 ## Current Policy
 
+- `module-inventory.md` and `giant-file-registry.md` are deliberately untracked
+  checkout-local views. Generate them before reading them; CI does so before
+  maintenance checks. Their absence from git is what removes production-line
+  churn from concurrent PR merges (#4724).
 - PR CI in `.github/workflows/ci-pr.yml` does not hard-block solely on
   inventory-doc markdown freshness drift.
 - `ci-pr.yml` and `ci-main.yml` run `scripts/ci-script-checks.sh`, which calls
@@ -14,10 +18,10 @@ about the generated report or its generator.
   downstream maintainability checks on the current generated view, but generic
   committed markdown freshness drift is not the hard failure and does not need
   to be committed in unrelated PRs.
-- `ci-nightly.yml` runs `Generated docs drift (warn)` with
-  `python3 scripts/generate_inventory_docs.py --check` so accumulated drift is
-  visible without blocking ordinary PRs. That warning points contributors to
-  the weekly refresh workflow or to a local regeneration command.
+- `ci-nightly.yml` regenerates all inventory views, then reports drift only for
+  the tracked outputs: `ARCHITECTURE.md`, route inventory, and worker inventory.
+  The warning points contributors to the weekly refresh workflow or to a local
+  regeneration command.
 - `python3 scripts/audit_maintainability.py --check` is still allowed to fail
   for configured hard or baseline maintainability gates. The warning-only drift
   policy applies to the committed markdown report freshness, not to new

--- a/tests/test_inventory_giant_split.py
+++ b/tests/test_inventory_giant_split.py
@@ -11,6 +11,7 @@ Covers ``scripts/generate_inventory_docs.py``:
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import textwrap
 import unittest
@@ -28,6 +29,37 @@ _SPEC.loader.exec_module(GEN)
 
 def _src(body: str) -> str:
     return textwrap.dedent(body).lstrip("\n")
+
+
+class InventoryTrackingContractTest(unittest.TestCase):
+    def test_line_count_snapshots_remain_untracked(self) -> None:
+        snapshots = [
+            "docs/generated/module-inventory.md",
+            "docs/generated/giant-file-registry.md",
+        ]
+        for snapshot in snapshots:
+            tracked = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", snapshot],
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(
+                tracked.returncode,
+                0,
+                f"{snapshot} must stay de-committed to prevent O(N^2) PR conflicts",
+            )
+            ignored = subprocess.run(
+                ["git", "check-ignore", "--quiet", snapshot],
+                cwd=REPO_ROOT,
+                check=False,
+            )
+            self.assertEqual(
+                ignored.returncode,
+                0,
+                f"{snapshot} must remain ignored after de-commit",
+            )
 
 
 class ProdTestSplitTest(unittest.TestCase):


### PR DESCRIPTION
슬라이스 A(de-commit generated inventory docs, #4748) 이후 계약을 회귀 방지 테스트로 고정하고, 기여자 문서를 generated-at-check-time CI 계약에 정합화한다.

## 변경
- **test**: `tests/test_inventory_giant_split.py`에 `InventoryTrackingContractTest` 추가 — `module-inventory.md`/`giant-file-registry.md`가 계속 untracked + gitignore 상태로 남아 O(N²) 머지 충돌이 조용히 재발하지 못하게 가드.
- **docs**: `merge-driver-inventory.md`, `docs/generated/README.md` — 두 스냅샷이 checkout-local(untracked)임을 반영, merge driver는 여전히 tracked인 route/worker 인벤토리에만 적용됨을 명시.
- **CLAUDE.md**: 로컬 사전 점검의 docs 게이트 서술을 `generate_inventory_docs.py --check` → `generate_inventory_docs.py` + tracked-output `git diff`로, 라인수 불일치 대응을 frozen giant surface membership/threshold 대조로 갱신.

로직(.rs) 변경 없음. 핫파일 미접촉. 순수 test+docs+CLAUDE.md.

## 검증
- `test_inventory_giant_split.py` 57건 전체 통과(신규 가드 포함).
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed`.

Closes #4724

🤖 Generated with [Claude Code](https://claude.com/claude-code)