### PR TITLE
fix(cluster): reject routed nonportable attachments (#4781)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -447,6 +447,7 @@
 
 ### Audited touches
 
+- #4781 text-only routed attachment contract: leader-side `intake_router_hook.rs` rejects gateway-local attachment paths before a foreign-owner, `/node`, or preferred-label outbox insert. Queued nonportable uploads are notice-and-drop rather than indefinitely requeued; this changes no leader election, worker lease, or durable owner authority.
 - #4706 structural lint debt backfill: item-level Clippy annotations and their checked-in occurrence ratchet change no runtime ownership, leader election, PG lease, or multinode routing behavior.
 - #4515 worker-local recovery supervision: `src/server/worker_recovery.rs` owns
   bounded restart handling for the worker-local dispatch-outbox and session-discovery

--- a/docs/design/intake-node-routing.md
+++ b/docs/design/intake-node-routing.md
@@ -1000,7 +1000,7 @@ which is REST-safe and identical on both sides.
 | Worker post-accept turn failure (provider error, panic in tmux) | worker writes `failed_post_accept` via transition 6b | terminal; operator decides via CLI |
 | Discord token revoked on worker (REST 401) | worker writes `failed_post_accept` (we already POSTed placeholder under that token) | terminal; operator rotates token + `retry-as-new` |
 | PG pool/owner query unavailable in `Enforce` | central admission dependency guard | block local execution and emit a throttled operator-facing notice; retry after PG/owner visibility recovers |
-| Pending uploads on message | owner-aware admission | local owner/`NoOwner` runs local; foreign owner blocks and queued work is front-requeued |
+| Pending uploads on message | owner-aware admission | local owner/`NoOwner` runs local. Nonportable attachments are blocked before any outbox INSERT on foreign-owner routes **and** on `/node`/preferred-label foreign targets. A live nonportable attachment returns `Blocked`; a queued nonportable attachment (surfaced at `QueuedDrain`) is notified and terminated via `RejectedNonPortableAttachment` (consumed, **not** front-requeued) so it cannot loop |
 | Active session pinned to stale foreign worker | owner classification | block local/label fallback; operator stops/clears the old session before retry |
 | Single-PG-primary assumption violated | startup self-check at boot | refuse to start with intake_routing.enabled=true; log error |
 | Two same-channel forward attempts (round-2 P0 #1) | partial unique index `intake_outbox_one_open_route_per_channel` | same `(channel_id, user_msg_id)` is an idempotent skip; a distinct message returns `DeferredOpenRoute` and is preserved/retried, never executed locally |

--- a/docs/design/intake-node-routing.md
+++ b/docs/design/intake-node-routing.md
@@ -275,9 +275,11 @@ CREATE TRIGGER trg_intake_outbox_touch_updated_at
 its own bot token via `credential::read_bot_token()` at startup;
 nothing token-shaped is ever serialized into PG.
 
-**Column note: no attachment payload.** If the original message has
-file uploads, the leader handles it locally (see "Pending uploads"
-below); we never copy uploaded bytes into the outbox.
+**Column note: text-only attachment contract.** The initial routed pilot
+allows no attachment payload. Upload records contain node-local filesystem paths,
+not portable object references. Before any foreign-target `intake_outbox` insert,
+the router explicitly rejects uploads; only text-only requests are eligible for
+cross-node routing (see "Pending uploads" below).
 
 #### B-bis. Canonical state-transition SQL (codex round-2 P1 #3)
 
@@ -768,10 +770,12 @@ Decision tree (evaluation order is important):
    provider-capable worker advertisement, or two live owners, blocks
    intake. It never falls through to local or preference placement;
    only an explicit session stop/clear makes a new placement safe.
-5. **Non-portable uploads**: a foreign live owner plus raw attachments
-   or queued `pending_uploads` blocks intake. A local owner handles the
-   upload locally; a channel with no owner establishes its first
-   placement locally.
+5. **Text-only routed pilot**: raw attachments or queued `pending_uploads`
+   carry gateway-local filesystem paths, not portable references. Any decision
+   that would route to a foreign live owner, explicit `/node` target, or
+   preferred-label worker blocks before an outbox insert. A local live owner
+   may handle an upload locally; the routed pilot never creates a new local
+   fallback session for an upload.
 6. **Explicit `/node`**: only after owner lookup proves `NoOwner`.
    An unavailable explicit target blocks rather than silently falling
    through. `/node` does not migrate an existing tmux session.
@@ -945,17 +949,18 @@ during `handle_text_message` (today) and stores temp paths in
 `shared.pending_uploads`. **These local paths are not portable to
 worker.**
 
-Current policy is owner-aware. A local live owner handles uploads
-locally, and `NoOwner` establishes the first session locally. A live
-foreign owner returns `BlockedNonPortableAttachment`; queued drains
-front-requeue the original Intervention before marker teardown and arm
-only the slow backstop. Stale/conflicting owner blocks take precedence.
-No local absolute upload path is written to `intake_outbox`.
+The routed pilot is explicitly text-only. A local live owner may handle
+uploads locally. When a foreign owner, explicit `/node`, or preferred-label
+placement would route the request, `NonPortableAttachment` blocks before the
+outbox insert and the live notice says: “현재 mac-mini routed session은 파일
+첨부를 지원하지 않습니다.” The one-minute per-channel notice throttle prevents
+retry spam. Queued drains retain the original Intervention, but create neither
+an outbox row nor a local fallback session. Stale/conflicting owner blocks take
+precedence. No local absolute upload path is written to `intake_outbox`.
 
-v2 (out of scope for this PR): forward upload bytes through
-`message_outbox`-style payload table, or have worker re-download
-from Discord CDN (requires re-resolving attachment URLs from the
-message; possibly cleaner).
+Full attachment portability remains out of scope: either stage bytes through a
+durable object/payload store or let the worker securely re-download the Discord
+CDN attachment from its canonical URL.
 
 ### Worker → Discord response
 

--- a/docs/design/intake-node-routing.md
+++ b/docs/design/intake-node-routing.md
@@ -774,8 +774,9 @@ Decision tree (evaluation order is important):
    carry gateway-local filesystem paths, not portable references. Any decision
    that would route to a foreign live owner, explicit `/node` target, or
    preferred-label worker blocks before an outbox insert. A local live owner
-   may handle an upload locally; the routed pilot never creates a new local
-   fallback session for an upload.
+   may handle an upload locally. If no foreign route is selected (for example,
+   no eligible worker or no preference), normal local intake behavior remains
+   unchanged; this pilot does not make attachments portable across nodes.
 6. **Explicit `/node`**: only after owner lookup proves `NoOwner`.
    An unavailable explicit target blocks rather than silently falling
    through. `/node` does not migrate an existing tmux session.
@@ -951,12 +952,13 @@ worker.**
 
 The routed pilot is explicitly text-only. A local live owner may handle
 uploads locally. When a foreign owner, explicit `/node`, or preferred-label
-placement would route the request, `NonPortableAttachment` blocks before the
-outbox insert and the live notice says: “현재 mac-mini routed session은 파일
-첨부를 지원하지 않습니다.” The one-minute per-channel notice throttle prevents
-retry spam. Queued drains retain the original Intervention, but create neither
-an outbox row nor a local fallback session. Stale/conflicting owner blocks take
-precedence. No local absolute upload path is written to `intake_outbox`.
+placement would route the request, either `NonPortableAttachmentForeignOwner`
+or `NonPortableAttachmentRoutedTarget` blocks before the outbox insert and the
+live notice says: “현재 mac-mini routed session은 파일 첨부를 지원하지
+않습니다.” The one-minute per-channel notice throttle prevents retry spam. Queued
+drains notify and consume a nonportable attachment instead of requeueing it
+forever. Stale/conflicting owner blocks take precedence. No local absolute upload
+path is written to `intake_outbox`.
 
 Full attachment portability remains out of scope: either stage bytes through a
 durable object/payload store or let the worker securely re-download the Discord

--- a/src/services/cluster/intake_router_hook.rs
+++ b/src/services/cluster/intake_router_hook.rs
@@ -287,9 +287,6 @@ pub(crate) enum RanLocalReason {
     NodeOverrideRoutingDisabled,
     /// This instance is the durable live owner for the session.
     LiveSessionOwnerIsLocal,
-    /// A channel without an existing owner establishes its first placement
-    /// locally when the payload contains node-local upload paths.
-    NoOwnerWithNonPortableAttachment,
 }
 
 /// Inputs to the hook. Bundled into a struct so the intake gate can
@@ -510,14 +507,6 @@ pub(crate) async fn try_route_intake(
             unreachable!("owner fail-safe outcomes return before the open-route fence")
         }
         SessionOwnerResolution::NoOwner => {
-            if ctx.has_nonportable_uploads {
-                return apply_observe_mode(
-                    ctx.mode,
-                    IntakeRouterDecision::RanLocal {
-                        reason: RanLocalReason::NoOwnerWithNonPortableAttachment,
-                    },
-                );
-            }
             if let Some(target) = node_override {
                 route_node_override_without_owner(pool, ctx, target).await
             } else {
@@ -645,6 +634,19 @@ async fn route_by_preferred_labels(
         }
     };
 
+    // The text-only routed pilot has no attachment staging contract: upload
+    // records contain gateway-local paths and must not enter the outbox.
+    if ctx.has_nonportable_uploads {
+        return apply_observe_mode(
+            ctx.mode,
+            IntakeRouterDecision::Blocked {
+                reason: IntakeBlockedReason::NonPortableAttachment {
+                    owner_instance_id: target,
+                },
+            },
+        );
+    }
+
     route_to_instance(
         pool,
         ctx,
@@ -684,6 +686,19 @@ async fn route_node_override_without_owner(
             ctx.mode,
             IntakeRouterDecision::RanLocal {
                 reason: RanLocalReason::NodeOverrideIsLeader,
+            },
+        );
+    }
+
+    // The text-only routed pilot has no attachment staging contract: upload
+    // records contain gateway-local paths and must not enter the outbox.
+    if ctx.has_nonportable_uploads {
+        return apply_observe_mode(
+            ctx.mode,
+            IntakeRouterDecision::Blocked {
+                reason: IntakeBlockedReason::NonPortableAttachment {
+                    owner_instance_id: target.to_string(),
+                },
             },
         );
     }
@@ -1180,6 +1195,45 @@ mod pg_tests {
                 reason: RanLocalReason::DisabledButPreferenceSet
             }
         );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn eligible_worker_forwards_portable_text_to_outbox_pg() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        seed_agent_with_preference(
+            &pool,
+            "agent-portable-text",
+            "ch-portable-text",
+            serde_json::json!(["unreal"]),
+        )
+        .await;
+        seed_worker_node(&pool, "worker-mac", serde_json::json!(["unreal"]), "online").await;
+
+        let decision = try_route_intake(
+            &pool,
+            &ctx_for_channel(IntakeRoutingMode::Enforce, "ch-portable-text"),
+        )
+        .await;
+        assert!(matches!(
+            decision,
+            IntakeRouterDecision::Forwarded {
+                ref target_instance_id,
+                ..
+            } if target_instance_id == "worker-mac"
+        ));
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*)::BIGINT FROM intake_outbox WHERE channel_id = $1")
+                .bind("ch-portable-text")
+                .fetch_one(&pool)
+                .await
+                .expect("count");
+        assert_eq!(count, 1, "portable text must create the routed outbox row");
 
         pool.close().await;
         pg_db.drop().await;
@@ -2144,17 +2198,42 @@ mod pg_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn no_owner_attachment_establishes_local_first_placement_pg() {
+    async fn no_owner_attachment_is_blocked_before_preferred_target_outbox_pg() {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
+        seed_agent_with_preference(
+            &pool,
+            "agent-new-upload",
+            "ch-new-upload",
+            serde_json::json!(["mac-mini"]),
+        )
+        .await;
+        seed_worker_node(
+            &pool,
+            "worker-mac-mini",
+            serde_json::json!(["mac-mini"]),
+            "online",
+        )
+        .await;
         let mut ctx = ctx_for_channel(IntakeRoutingMode::Enforce, "ch-new-upload");
         ctx.has_nonportable_uploads = true;
-        let decision = try_route_intake(&pool, &ctx).await;
         assert_eq!(
-            decision,
-            IntakeRouterDecision::RanLocal {
-                reason: RanLocalReason::NoOwnerWithNonPortableAttachment
+            try_route_intake(&pool, &ctx).await,
+            IntakeRouterDecision::Blocked {
+                reason: IntakeBlockedReason::NonPortableAttachment {
+                    owner_instance_id: "worker-mac-mini".to_string()
+                }
             }
+        );
+        let outbox_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::BIGINT FROM intake_outbox WHERE channel_id = 'ch-new-upload'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count outbox rows");
+        assert_eq!(
+            outbox_count, 0,
+            "non-portable uploads must be rejected before outbox insertion"
         );
 
         pool.close().await;

--- a/src/services/cluster/intake_router_hook.rs
+++ b/src/services/cluster/intake_router_hook.rs
@@ -251,12 +251,11 @@ pub(crate) enum IntakeBlockedReason {
     ConflictingLiveSessionOwners { instance_ids: Vec<String> },
     OwnerProtocolIncompatible { instance_id: String },
     OverrideUnavailable { target_instance_id: String },
-    NonPortableAttachment { owner_instance_id: String },
+    NonPortableAttachmentForeignOwner { owner_instance_id: String },
+    NonPortableAttachmentRoutedTarget { target_instance_id: String },
     RoutingDependencyFailed { detail: String },
 }
 
-/// Diagnostic enum for `RanLocal` — keeps the metric surface and
-/// operator-log telemetry stable across the three "no-op" code paths.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RanLocalReason {
     /// Mode is `Disabled` (Phase 1-4 default).
@@ -420,7 +419,7 @@ pub(crate) async fn try_route_intake(
             return apply_observe_mode(
                 ctx.mode,
                 IntakeRouterDecision::Blocked {
-                    reason: IntakeBlockedReason::NonPortableAttachment {
+                    reason: IntakeBlockedReason::NonPortableAttachmentForeignOwner {
                         owner_instance_id: instance_id.clone(),
                     },
                 },
@@ -634,14 +633,12 @@ async fn route_by_preferred_labels(
         }
     };
 
-    // The text-only routed pilot has no attachment staging contract: upload
-    // records contain gateway-local paths and must not enter the outbox.
     if ctx.has_nonportable_uploads {
         return apply_observe_mode(
             ctx.mode,
             IntakeRouterDecision::Blocked {
-                reason: IntakeBlockedReason::NonPortableAttachment {
-                    owner_instance_id: target,
+                reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                    target_instance_id: target,
                 },
             },
         );
@@ -690,14 +687,12 @@ async fn route_node_override_without_owner(
         );
     }
 
-    // The text-only routed pilot has no attachment staging contract: upload
-    // records contain gateway-local paths and must not enter the outbox.
     if ctx.has_nonportable_uploads {
         return apply_observe_mode(
             ctx.mode,
             IntakeRouterDecision::Blocked {
-                reason: IntakeBlockedReason::NonPortableAttachment {
-                    owner_instance_id: target.to_string(),
+                reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                    target_instance_id: target.to_string(),
                 },
             },
         );
@@ -1420,7 +1415,7 @@ mod pg_tests {
             decision,
             IntakeRouterDecision::Observed {
                 outcome: ObservedIntakeOutcome::WouldBlock {
-                    reason: IntakeBlockedReason::NonPortableAttachment {
+                    reason: IntakeBlockedReason::NonPortableAttachmentForeignOwner {
                         owner_instance_id: "worker-owner".to_string()
                     }
                 }
@@ -2149,7 +2144,7 @@ mod pg_tests {
         assert_eq!(
             decision,
             IntakeRouterDecision::Blocked {
-                reason: IntakeBlockedReason::NonPortableAttachment {
+                reason: IntakeBlockedReason::NonPortableAttachmentForeignOwner {
                     owner_instance_id: "worker-upload-owner".to_string()
                 }
             }
@@ -2179,7 +2174,7 @@ mod pg_tests {
         assert_eq!(
             try_route_intake(&pool, &ctx).await,
             IntakeRouterDecision::Blocked {
-                reason: IntakeBlockedReason::NonPortableAttachment {
+                reason: IntakeBlockedReason::NonPortableAttachmentForeignOwner {
                     owner_instance_id: "worker-upload-owner".to_string()
                 }
             },
@@ -2220,8 +2215,8 @@ mod pg_tests {
         assert_eq!(
             try_route_intake(&pool, &ctx).await,
             IntakeRouterDecision::Blocked {
-                reason: IntakeBlockedReason::NonPortableAttachment {
-                    owner_instance_id: "worker-mac-mini".to_string()
+                reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                    target_instance_id: "worker-mac-mini".to_string()
                 }
             }
         );
@@ -2396,6 +2391,44 @@ mod pg_tests {
                 .await
                 .expect("count");
         assert_eq!(count, 0, "disabled /node override must not insert");
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_override_attachment_is_blocked_before_outbox_pg() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        seed_worker_node(
+            &pool,
+            "worker-selected",
+            serde_json::json!(["mac-mini"]),
+            "online",
+        )
+        .await;
+
+        let mut ctx = ctx_for_channel(IntakeRoutingMode::Enforce, "ch-node-upload");
+        ctx.node_override_instance_id = Some("worker-selected");
+        ctx.has_nonportable_uploads = true;
+        assert_eq!(
+            try_route_intake(&pool, &ctx).await,
+            IntakeRouterDecision::Blocked {
+                reason: IntakeBlockedReason::NonPortableAttachmentRoutedTarget {
+                    target_instance_id: "worker-selected".to_string()
+                }
+            }
+        );
+        let outbox_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::BIGINT FROM intake_outbox WHERE channel_id = 'ch-node-upload'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count outbox rows");
+        assert_eq!(
+            outbox_count, 0,
+            "attachment must be blocked before /node outbox insert"
+        );
 
         pool.close().await;
         pg_db.drop().await;

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -743,7 +743,10 @@ impl TurnGateway for DiscordGateway {
             .await
             {
                 router::QueuedAdmissionDisposition::Admitted(admitted) => admitted,
-                router::QueuedAdmissionDisposition::Deferred => return Ok(()),
+                router::QueuedAdmissionDisposition::Deferred
+                | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
+                    return Ok(());
+                }
             };
 
             let source_message_generations = intervention.source_message_queued_generations();

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3684,7 +3684,7 @@ async fn mailbox_requeue_intervention_front(
     }
 }
 
-async fn mailbox_abandon_pending_dispatch(
+pub(in crate::services::discord) async fn mailbox_abandon_pending_dispatch(
     shared: &SharedData,
     provider: &ProviderKind,
     channel_id: ChannelId,
@@ -4216,7 +4216,8 @@ async fn kickoff_idle_queue_channel(
     .await
     {
         router::QueuedAdmissionDisposition::Admitted(admitted) => admitted,
-        router::QueuedAdmissionDisposition::Deferred => {
+        router::QueuedAdmissionDisposition::Deferred
+        | router::QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
             drop(dispatch_lease);
             return IdleQueueKickoffChannelOutcome::default();
         }

--- a/src/services/discord/router/intake_dispatch.rs
+++ b/src/services/discord/router/intake_dispatch.rs
@@ -26,8 +26,13 @@ pub(crate) enum IntakeOrigin {
 }
 
 impl IntakeOrigin {
-    fn should_notify_blocked(self) -> bool {
+    fn should_notify_blocked(self, reason: &IntakeBlockedReason) -> bool {
         !matches!(self, Self::QueuedDrain)
+            || matches!(
+                reason,
+                IntakeBlockedReason::NonPortableAttachmentForeignOwner { .. }
+                    | IntakeBlockedReason::NonPortableAttachmentRoutedTarget { .. }
+            )
     }
 }
 
@@ -166,7 +171,9 @@ pub(crate) async fn dispatch_text_intake(
         IntakeAdmission::DeferredOpenRoute { .. } => {
             defer_live_submission(deps, submission).await;
         }
-        IntakeAdmission::Blocked { ref reason } if submission.origin.should_notify_blocked() => {
+        IntakeAdmission::Blocked { ref reason }
+            if submission.origin.should_notify_blocked(reason) =>
+        {
             notify_blocked_intake(deps, &submission, reason).await;
         }
         IntakeAdmission::Forwarded { .. }

--- a/src/services/discord/router/intake_dispatch/notice.rs
+++ b/src/services/discord/router/intake_dispatch/notice.rs
@@ -38,31 +38,53 @@ pub(super) async fn notify_blocked_intake(
         return;
     }
 
-    let detail = match reason {
-        IntakeBlockedReason::NonPortableAttachment { owner_instance_id } => format!(
-            "기존 세션 owner `{owner_instance_id}`는 다른 노드에 있고 첨부파일 경로는 현재 노드 전용입니다."
+    let (detail, recovery) = match reason {
+        IntakeBlockedReason::NonPortableAttachmentForeignOwner { owner_instance_id } => (
+            format!(
+                "기존 세션 owner `{owner_instance_id}`는 다른 노드에 있고 첨부파일 경로는 현재 노드 전용입니다."
+            ),
+            "현재 mac-mini routed session은 파일 첨부를 지원하지 않습니다. text-only로 다시 보내세요.",
         ),
-        IntakeBlockedReason::StaleSessionOwners { instance_ids } => format!(
-            "기존 세션 owner 상태를 확인할 수 없습니다: `{}`.",
-            instance_ids.join(", ")
+        IntakeBlockedReason::NonPortableAttachmentRoutedTarget { target_instance_id } => (
+            format!(
+                "새 routed target `{target_instance_id}`는 현재 노드 전용 첨부파일 경로를 받을 수 없습니다."
+            ),
+            "현재 mac-mini routed session은 파일 첨부를 지원하지 않습니다. text-only로 다시 보내세요.",
         ),
-        IntakeBlockedReason::ConflictingLiveSessionOwners { instance_ids } => format!(
-            "여러 live 세션 owner가 충돌합니다: `{}`.",
-            instance_ids.join(", ")
+        IntakeBlockedReason::StaleSessionOwners { instance_ids } => (
+            format!(
+                "기존 세션 owner 상태를 확인할 수 없습니다: `{}`.",
+                instance_ids.join(", ")
+            ),
+            "기존 세션을 stop/clear한 뒤 다시 보내세요.",
         ),
-        IntakeBlockedReason::OwnerProtocolIncompatible { instance_id } => format!(
-            "기존 세션 owner `{instance_id}`가 이 turn의 intake protocol을 지원하지 않습니다."
+        IntakeBlockedReason::ConflictingLiveSessionOwners { instance_ids } => (
+            format!(
+                "여러 live 세션 owner가 충돌합니다: `{}`.",
+                instance_ids.join(", ")
+            ),
+            "기존 세션을 stop/clear한 뒤 다시 보내세요.",
         ),
-        IntakeBlockedReason::OverrideUnavailable { target_instance_id } => format!(
-            "선택한 `/node` 대상 `{target_instance_id}`가 현재 이 provider의 intake를 받을 수 없습니다."
+        IntakeBlockedReason::OwnerProtocolIncompatible { instance_id } => (
+            format!(
+                "기존 세션 owner `{instance_id}`가 이 turn의 intake protocol을 지원하지 않습니다."
+            ),
+            "기존 세션을 stop/clear한 뒤 다시 보내세요.",
+        ),
+        IntakeBlockedReason::OverrideUnavailable { target_instance_id } => (
+            format!(
+                "선택한 `/node` 대상 `{target_instance_id}`가 현재 이 provider의 intake를 받을 수 없습니다."
+            ),
+            "기존 세션을 stop/clear한 뒤 다시 보내세요.",
         ),
         IntakeBlockedReason::OwnerLookupFailed { .. }
-        | IntakeBlockedReason::RoutingDependencyFailed { .. } => {
-            "세션 owner를 안전하게 확인하지 못했습니다.".to_string()
-        }
+        | IntakeBlockedReason::RoutingDependencyFailed { .. } => (
+            "세션 owner를 안전하게 확인하지 못했습니다.".to_string(),
+            "기존 세션을 stop/clear한 뒤 다시 보내세요.",
+        ),
     };
     let content = format!(
-        "⛔ {detail} 현재 mac-mini routed session은 파일 첨부를 지원하지 않습니다. 잘못된 노드에 새 세션을 만들지 않도록 turn을 시작하지 않았습니다. text-only로 다시 보내세요."
+        "⛔ {detail} 잘못된 노드에 새 세션을 만들지 않도록 turn을 시작하지 않았습니다. {recovery}"
     );
     if let Err(error) = crate::services::discord::http::send_channel_message(
         deps.http.as_ref(),

--- a/src/services/discord/router/intake_dispatch/notice.rs
+++ b/src/services/discord/router/intake_dispatch/notice.rs
@@ -62,7 +62,7 @@ pub(super) async fn notify_blocked_intake(
         }
     };
     let content = format!(
-        "⛔ {detail} 잘못된 노드에 새 세션을 만들지 않도록 turn을 시작하지 않았습니다. 기존 세션을 stop/clear한 뒤 다시 보내거나, 첨부가 있었다면 text-only로 다시 보내세요."
+        "⛔ {detail} 현재 mac-mini routed session은 파일 첨부를 지원하지 않습니다. 잘못된 노드에 새 세션을 만들지 않도록 turn을 시작하지 않았습니다. text-only로 다시 보내세요."
     );
     if let Err(error) = crate::services::discord::http::send_channel_message(
         deps.http.as_ref(),

--- a/src/services/discord/router/intake_dispatch/queued.rs
+++ b/src/services/discord/router/intake_dispatch/queued.rs
@@ -11,6 +11,7 @@ use crate::services::provider::ProviderKind;
 pub(crate) enum QueuedAdmissionDisposition {
     Admitted(AdmittedQueuedIntake),
     Deferred,
+    RejectedNonPortableAttachment,
 }
 
 pub(crate) struct AdmittedQueuedIntake {
@@ -58,6 +59,24 @@ pub(crate) async fn admit_queued_intake(
     let local_permit = match admission {
         IntakeAdmission::Local(permit) => Some(permit),
         IntakeAdmission::Forwarded { .. } | IntakeAdmission::SkippedDuplicate => None,
+        IntakeAdmission::Blocked {
+            reason:
+                reason @ (crate::services::cluster::intake_router_hook::IntakeBlockedReason::NonPortableAttachmentForeignOwner { .. }
+                | crate::services::cluster::intake_router_hook::IntakeBlockedReason::NonPortableAttachmentRoutedTarget { .. }),
+        } => {
+            // A queued local-path upload can never become portable through
+            // retry. Notify once and consume it instead of front-requeueing it
+            // forever without user-visible recovery guidance.
+            super::notice::notify_blocked_intake(deps, &submission, &reason).await;
+            super::super::super::mailbox_abandon_pending_dispatch(
+                deps.shared,
+                &submission.provider,
+                channel_id,
+                intervention.message_id,
+            )
+            .await;
+            return QueuedAdmissionDisposition::RejectedNonPortableAttachment;
+        }
         IntakeAdmission::DeferredOpenRoute { .. } | IntakeAdmission::Blocked { .. } => {
             // `requeue_front` also consumes the actor's pending-dispatch
             // reservation, matching the existing hosted-TUI pre-drain defer.

--- a/src/services/discord/router/intake_dispatch/tests.rs
+++ b/src/services/discord/router/intake_dispatch/tests.rs
@@ -424,7 +424,10 @@ async fn queued_foreign_owner_forwards_without_local_body_pg() {
     .await
     {
         QueuedAdmissionDisposition::Admitted(admitted) => admitted,
-        QueuedAdmissionDisposition::Deferred => panic!("live foreign owner should forward"),
+        QueuedAdmissionDisposition::Deferred
+        | QueuedAdmissionDisposition::RejectedNonPortableAttachment => {
+            panic!("live foreign owner should forward")
+        }
     };
     super::finish_admitted_queued_intake(&deps, admitted, &intervention)
         .await
@@ -455,7 +458,7 @@ async fn queued_foreign_owner_forwards_without_local_body_pg() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn queued_foreign_attachment_requeues_and_arms_slow_backstop_pg() {
+async fn queued_foreign_attachment_is_rejected_without_requeue_pg() {
     let _env = ScopedIntakeTestEnv::enforce();
     let pg_db = TestPostgresDb::create().await;
     let pool = pg_db.connect_and_migrate().await;
@@ -482,18 +485,13 @@ async fn queued_foreign_attachment_requeues_and_arms_slow_backstop_pg() {
             "owner_affinity_attachment_test",
         )
         .await,
-        QueuedAdmissionDisposition::Deferred
+        QueuedAdmissionDisposition::RejectedNonPortableAttachment
     ));
 
     let snapshot = shared.mailbox(channel_id).snapshot().await;
-    assert_eq!(snapshot.intervention_queue.len(), 1);
-    assert_eq!(
-        snapshot.intervention_queue[0].message_id,
-        intervention.message_id
-    );
-    assert_eq!(
-        snapshot.intervention_queue[0].pending_uploads,
-        vec![local_path]
+    assert!(
+        snapshot.intervention_queue.is_empty(),
+        "a nonportable queued attachment must be consumed, not requeued forever"
     );
     assert!(
         shared.core.lock().await.sessions.is_empty(),
@@ -511,8 +509,8 @@ async fn queued_foreign_attachment_requeues_and_arms_slow_backstop_pg() {
             .restart
             .deferred_hook_backlog
             .load(std::sync::atomic::Ordering::Relaxed),
-        1,
-        "blocked queued intake arms exactly one slow lost-wakeup backstop"
+        0,
+        "a rejected attachment must not arm a retry backstop"
     );
 
     pool.close().await;


### PR DESCRIPTION
## 요약
Routed text-only pilot에서 node-local attachment/pending upload를 foreign routing 전(outbox INSERT 전)에 fail-closed로 차단한다. portable text는 기존처럼 worker outbox 생성·전달 유지.

## 근거
현재 attachment는 gateway-local filesystem path → portable object reference가 아니므로 다른 노드로 전달 불가. outbox에 넣으면 worker에서 파일을 찾지 못함. portable 기준 = attachment payload 없는 text 요청.

## 변경
- `intake_router_hook.rs`: preferred-label / foreign `/node` 라우팅 전 attachment 차단; foreign owner와 no-owner routed target 차단 사유 분리; portable text / preferred target / `/node` 회귀 테스트 추가.
- `intake_dispatch/{notice,queued}.rs`: attachment 전용 안내와 일반 owner/routing 차단의 stop/clear 안내를 분리; queued attachment는 안내 후 소비하여 무한 재큐잉 방지.
- `docs/design/intake-node-routing.md`: portable 판정·사전 차단·실제 local fallback 경계 문서화.
- `docs/agent-maintenance/multinode-transition.md`: leader-side routing 권한 변경 audit 기록.

## 후속
- #4788 — admission 이전 local session state/attachment download를 permit 뒤로 이동.

## 검증
- `cargo fmt --all --check`
- `cargo check --lib`
- `cargo test intake_router_hook::pg_tests`
- `cargo test queued_foreign_attachment_is_rejected_without_requeue_pg`
- docs 게이트

Closes #4781

🤖 Generated with [Claude Code](https://claude.com/claude-code)